### PR TITLE
animated scaleBy

### DIFF
--- a/include/llmr/map/map.hpp
+++ b/include/llmr/map/map.hpp
@@ -43,8 +43,8 @@ public:
     void resetPosition();
 
     /* scale */
-    void scaleBy(double ds, double cx, double cy);
-    void setScale(double scale);
+    void scaleBy(double ds, double cx = -1, double cy = -1, double duration = 0);
+    void setScale(double scale, double cx = -1, double cy = -1, double duration = 0);
     double getScale() const;
     // void setZoom(double zoom);
     // void setLonLatZoom(double lon, double lat, double zoom);

--- a/include/llmr/map/transform.hpp
+++ b/include/llmr/map/transform.hpp
@@ -27,11 +27,11 @@ public:
 
     // Relative changes
     void moveBy(double dx, double dy);
-    void scaleBy(double ds, double cx, double cy);
+    void scaleBy(double ds, double cx = -1, double cy = -1, double duration = 0);
     void rotateBy(double cx, double cy, double sx, double sy, double ex, double ey);
 
     // Absolute changes
-    void setScale(double scale);
+    void setScale(double scale, double cx = -1, double cy = -1, double duration = 0);
     void setAngle(double angle, double duration = 0);
     void setZoom(double zoom);
     void setLonLat(double lon, double lat);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -65,8 +65,8 @@ void Map::moveBy(double dx, double dy) {
     settings.save();
 }
 
-void Map::scaleBy(double ds, double cx, double cy) {
-    transform.scaleBy(ds, cx, cy);
+void Map::scaleBy(double ds, double cx, double cy, double duration) {
+    transform.scaleBy(ds, cx, cy, duration);
     style.cascade(transform.getZoom());
     update();
 
@@ -83,8 +83,8 @@ void Map::rotateBy(double cx, double cy, double sx, double sy, double ex, double
     settings.save();
 }
 
-void Map::setScale(double scale) {
-    transform.setScale(scale);
+void Map::setScale(double scale, double cx, double cy, double duration) {
+    transform.setScale(scale, cx, cy, duration);
     style.cascade(transform.getZoom());
     update();
 


### PR DESCRIPTION
This will close #30 animated `scaleBy`. There is one outstanding issue described below, though. 
- Allows for `duration` arguments to `scaleBy` and `setScale`
- Adds a scaling center point to `setScale`
- Animates the actual `Transform::setScale` if `duration` is present

This unlocks the duration arguments added for iOS in 74f3e5715acfece4e7c128bd3d3ce3706330eda2. 

Issues to resolve: 
- [ ] Occasionally after animated scale, some tiles remain undrawn until the map position, scale, or angle is further modified. 

@kkaefer any ideas? 
