### PR TITLE
Change default cubic bezier for easings

### DIFF
--- a/src/util/transition.cpp
+++ b/src/util/transition.cpp
@@ -4,7 +4,7 @@
 
 namespace llmr { namespace util {
 
-UnitBezier ease(0.25, 0.1, 0.25, 1);
+UnitBezier ease(0, 0, 0.25, 1);
 
 transition::~transition() {}
 


### PR DESCRIPTION
This is needed for better panning/zooming inertia, because the latter needs predictable smooth speed dropoff instead of speeding up and down throughout the animation. Here's how the curves look:
old: http://cubic-bezier.com/#.25,.1,.25,1
new: http://cubic-bezier.com/#0,0,.25,1

Ideally we'd want to be able to pass easing params to `moveBy` and similar methods, but now lets just change the global — shouldn't affect other easings in a bad way I think.
