### PR TITLE
post-glyphrange cleanup

### DIFF
--- a/include/llmr/geometry/glyph_atlas.hpp
+++ b/include/llmr/geometry/glyph_atlas.hpp
@@ -12,8 +12,6 @@
 
 namespace llmr {
 
-class VectorTileGlyph;
-
 class GlyphAtlas {
 public:
 

--- a/include/llmr/map/tile_parser.hpp
+++ b/include/llmr/map/tile_parser.hpp
@@ -42,7 +42,6 @@ private:
     GlyphAtlas& glyphAtlas;
     GlyphStore &glyphStore;
     SpriteAtlas &spriteAtlas;
-    Faces faces;
     Placement placement;
 };
 

--- a/include/llmr/map/vector_tile.hpp
+++ b/include/llmr/map/vector_tile.hpp
@@ -83,37 +83,8 @@ public:
     uint32_t extent = 4096;
     std::vector<std::string> keys;
     std::vector<Value> values;
-    std::vector<std::string> faces;
     std::map<std::string, std::map<Value, Shaping>> shaping;
 };
-
-class VectorTileGlyph {
-public:
-    VectorTileGlyph();
-    VectorTileGlyph(pbf data);
-
-    uint32_t id = 0;
-
-    // A signed distance field of the glyph with a border of 3 pixels.
-    std::string bitmap;
-
-    // Glyph metrics
-    GlyphMetrics metrics;
-};
-
-std::ostream& operator<<(std::ostream&, const VectorTileGlyph& glyph);
-
-class VectorTileFace {
-public:
-    VectorTileFace(pbf data);
-
-    std::string name;
-    std::string family;
-    std::string style;
-    std::vector<VectorTileGlyph> glyphs;
-};
-
-std::ostream& operator<<(std::ostream&, const VectorTileFace& face);
 
 class VectorTile {
 public:
@@ -122,7 +93,6 @@ public:
     VectorTile& operator=(VectorTile&& other);
 
     std::map<std::string, const VectorTileLayer> layers;
-    std::map<std::string, const VectorTileFace> faces;
 };
 
 

--- a/include/llmr/text/glyph.hpp
+++ b/include/llmr/text/glyph.hpp
@@ -43,8 +43,6 @@ struct Glyph {
 };
 
 typedef std::map<uint32_t, Glyph> GlyphPositions;
-typedef std::map<std::string, GlyphPositions> Faces;
-typedef std::vector<const GlyphPositions *> IndexedFaces;
 
 class GlyphPlacement {
 public:

--- a/proto/vector_tile.proto
+++ b/proto/vector_tile.proto
@@ -75,43 +75,6 @@ message feature {
     optional uint32 vertex_count = 6;
 }
 
-// Stores a glyph with metrics and optional SDF bitmap information.
-message glyph {
-    required uint32 id = 1;
-
-    // A signed distance field of the glyph with a border of 3 pixels.
-    optional bytes bitmap = 2;
-
-    // Glyph metrics.
-    required uint32 width = 3;
-    required uint32 height = 4;
-    required sint32 left = 5;
-    required sint32 top = 6;
-    required uint32 advance = 7;
-}
-
-// Stores font face information and a list of glyphs.
-message face {
-    required string family = 1;
-    required string style = 2;
-    repeated glyph glyphs = 5;
-}
-
-// Stores the shaping information for the label with a given text
-message label {
-    // The original value ID this shaping information is for.
-    required uint32 text = 1;
-
-    // References the index of the font stack in the layer's fontstack array.
-    required uint32 stack = 2;
-
-    // Parallel arrays of face ID, glyph ID and position.
-    repeated uint32 faces = 3  [packed = true];
-    repeated uint32 glyphs = 4 [packed = true];
-    repeated uint32 x = 5  [packed = true];
-    repeated uint32 y = 6  [packed = true];
-}
-
 message layer {
     // Any compliant implementation must first read the version
     // number encoded in this message and choose the correct
@@ -136,18 +99,11 @@ message layer {
     // Total vertex count in this layer.
     optional uint32 vertex_count = 6;
 
-    // Shaping information for labels contained in this tile.
-    repeated string faces = 7;
-    repeated label labels = 8;
-    repeated string stacks = 9;
-
     extensions 16 to max;
 }
 
 message tile {
     repeated layer layers = 3;
-
-    repeated face faces = 4;
 
     extensions 16 to 8191;
 }


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-gl-native/issues/274, returns vt proto back to more closely resembling canonical mapnik-vector-tile.
