### PR TITLE
Fix crash with Nvidia 331.38 drivers on Linux

### DIFF
--- a/src/renderer/painter_framebuffers.cpp
+++ b/src/renderer/painter_framebuffers.cpp
@@ -22,7 +22,8 @@ void Painter::clearFramebuffers() {
         fbo_depth_stencil = 0;
     }
 
-    glDeleteFramebuffers((int)fbos.size(), fbos.data());
+    if (fbos.size())
+        glDeleteFramebuffers((int)fbos.size(), fbos.data());
     fbos.clear();
 }
 


### PR DESCRIPTION
glDeleteFramebuffers appears to crash when called with zero FBOs to
delete.
