### PR TITLE
Add curl to Ubuntu apt-get install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Target devices: iPhone 4 and above (4S, 5, 5c, 5s) and iPad 2 and above (3, 4, m
 Ensure you have git and other build essentials:
 
     sudo apt-get update
-    sudo apt-get install git build-essential zlib1g-dev automake libtool xutils-dev make cmake pkg-config nodejs-legacy
+    sudo apt-get install git build-essential zlib1g-dev automake libtool xutils-dev make cmake pkg-config nodejs-legacy curl
 
 Install a `-std=c++11` capable compiler
 


### PR DESCRIPTION
`make setup` barfed when it couldn't find curl in the path, so we need to add it to the pre-build installs on Ubuntu.
