### PR TITLE
Support for text-transform

### DIFF
--- a/include/llmr/style/style_bucket.hpp
+++ b/include/llmr/style/style_bucket.hpp
@@ -40,6 +40,7 @@ class StyleBucketText {
 public:
     std::string field;
     TextPathType path = TextPathType::Default;
+    TextTransformType transform = TextTransformType::Default;
     std::string font;
     float max_size = 16.0f;
     float max_width = 15.0f * 24;

--- a/include/llmr/style/types.hpp
+++ b/include/llmr/style/types.hpp
@@ -52,6 +52,13 @@ enum class TextPathType : uint8_t {
     Default = Horizontal
 };
 
+enum class TextTransformType : uint8_t {
+    None,
+    Uppercase,
+    Lowercase,
+    Default = None
+};
+
 enum class TranslateAnchorType : uint8_t {
     Map,
     Viewport,
@@ -97,6 +104,12 @@ inline TextPathType parseTextPathType(const std::string &path) {
     if (path == "curve") return TextPathType::Curve;
     return TextPathType::Default;
 }
+
+inline TextTransformType parseTextTransformType(const std::string& transform) {
+    if (transform == "uppercase") return TextTransformType::Uppercase;
+    if (transform == "lowercase") return TextTransformType::Lowercase;
+    return TextTransformType::Default;
+};
 
 inline TranslateAnchorType parseTranslateAnchorType(const std::string &anchor) {
     if (anchor == "map") return TranslateAnchorType::Map;

--- a/src/style/style_parser.cpp
+++ b/src/style/style_parser.cpp
@@ -890,6 +890,7 @@ void StyleParser::parseRender(JSVal value, std::shared_ptr<StyleLayer> &layer) {
 
         parseRenderProperty(value, render.field, "text-field");
         parseRenderProperty(value, render.path, "text-path", parseTextPathType);
+        parseRenderProperty(value, render.transform, "text-transform", parseTextTransformType);
         parseRenderProperty(value, render.font, "text-font");
         parseRenderProperty(value, render.max_size, "text-max-size");
         if (parseRenderProperty(value, render.max_width, "text-max-width")) {


### PR DESCRIPTION
This is 1-1 locale-unaware text transform using std::ctype. If we want a transform that cares for things like ß -> SS, we need to switch to boost::locale.
