### PR TITLE
Fill outline fix

### DIFF
--- a/src/renderer/painter_fill.cpp
+++ b/src/renderer/painter_fill.cpp
@@ -35,6 +35,7 @@ void Painter::renderFill(FillBucket& bucket, const FillProperties& properties, c
     if (fringeline) {
         outline = true;
         stroke_color = fill_color;
+        stroke_color[3] *= properties.opacity;
     }
 
 

--- a/src/renderer/painter_fill.cpp
+++ b/src/renderer/painter_fill.cpp
@@ -136,7 +136,7 @@ void Painter::renderFill(FillBucket& bucket, const FillProperties& properties, c
         outlineShader->setMatrix(vtxMatrix);
         lineWidth(2.0f); // This is always fixed and does not depend on the pixelRatio!
 
-        outlineShader->setColor(fill_color);
+        outlineShader->setColor(stroke_color);
 
         // Draw the entire line
         outlineShader->setWorld({{

--- a/src/renderer/painter_fill.cpp
+++ b/src/renderer/painter_fill.cpp
@@ -19,8 +19,10 @@ void Painter::renderFill(FillBucket& bucket, const FillProperties& properties, c
     fill_color[3] *= properties.opacity;
 
     Color stroke_color = properties.stroke_color;
+    
     if (stroke_color[3] < 0) {
         stroke_color = fill_color;
+        stroke_color[3] *= properties.opacity;
     } else {
         stroke_color[0] *= properties.opacity;
         stroke_color[1] *= properties.opacity;


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/381 by applying fill-opacity to the outline.