### PR TITLE
implement `line-blur` and fix retina antialiasing

### DIFF
--- a/include/mbgl/shader/line_shader.hpp
+++ b/include/mbgl/shader/line_shader.hpp
@@ -16,6 +16,7 @@ public:
     void setLineWidth(const std::array<float, 2>& linewidth);
     void setRatio(float ratio);
     void setDashArray(const std::array<float, 2>& dasharray);
+    void setBlur(float blur);
     void setDebug(float debug);
 
 private:
@@ -37,6 +38,9 @@ private:
 
     std::array<float, 2> dasharray = {{}};
     int32_t u_dasharray = -1;
+
+    float blur = 0.0f;
+    int32_t u_blur = -1;
 };
 
 

--- a/src/renderer/painter_line.cpp
+++ b/src/renderer/painter_line.cpp
@@ -14,11 +14,13 @@ void Painter::renderLine(LineBucket& bucket, std::shared_ptr<StyleLayer> layer_d
 
     float width = properties.width;
     float offset = properties.offset / 2;
+    float antialiasing = 1 / map.getState().getPixelRatio();
+    float blur = properties.blur + antialiasing;
 
     // These are the radii of the line. We are limiting it to 16, which will result
     // in a point size of 64 on retina.
-    float inset = std::fmin((std::fmax(-1, offset - width / 2 - 0.5) + 1), 16.0f);
-    float outset = std::fmin(offset + width / 2 + 0.5, 16.0f);
+    float inset = std::fmin((std::fmax(-1, offset - width / 2 - antialiasing / 2) + 1), 16.0f);
+    float outset = std::fmin(offset + width / 2 + antialiasing / 2, 16.0f);
 
     Color color = properties.color;
     color[0] *= properties.opacity;
@@ -80,6 +82,7 @@ void Painter::renderLine(LineBucket& bucket, std::shared_ptr<StyleLayer> layer_d
         lineShader->setDashArray({{ dash_length, dash_gap }});
         lineShader->setLineWidth({{ outset, inset }});
         lineShader->setRatio(map.getState().getPixelRatio());
+        lineShader->setBlur(blur);
         lineShader->setColor(color);
         bucket.drawLines(*lineShader);
     }

--- a/src/shader/line.fragment.glsl
+++ b/src/shader/line.fragment.glsl
@@ -1,5 +1,6 @@
 uniform vec2 u_linewidth;
 uniform vec4 u_color;
+uniform float u_blur;
 
 uniform vec2 u_dasharray;
 
@@ -13,7 +14,7 @@ void main() {
     // Calculate the antialiasing fade factor. This is either when fading in
     // the line in case of an offset line (v_linewidth.t) or when fading out
     // (v_linewidth.s)
-    float alpha = clamp(min(dist - (u_linewidth.t - 1.0), u_linewidth.s - dist), 0.0, 1.0);
+    float alpha = clamp(min(dist - (u_linewidth.t - u_blur), u_linewidth.s - dist) / u_blur, 0.0, 1.0);
 
     // Calculate the antialiasing fade factor based on distance to the dash.
     // Only affects alpha when line is dashed

--- a/src/shader/line_shader.cpp
+++ b/src/shader/line_shader.cpp
@@ -26,6 +26,7 @@ LineShader::LineShader()
     u_color = glGetUniformLocation(program, "u_color");
     u_ratio = glGetUniformLocation(program, "u_ratio");
     u_dasharray = glGetUniformLocation(program, "u_dasharray");
+    u_blur = glGetUniformLocation(program, "u_blur");
 
     // fprintf(stderr, "LineShader:\n");
     // fprintf(stderr, "    - u_matrix: %d\n", u_matrix);
@@ -79,5 +80,12 @@ void LineShader::setDashArray(const std::array<float, 2>& new_dasharray) {
     if (dasharray != new_dasharray) {
         glUniform2fv(u_dasharray, 1, new_dasharray.data());
         dasharray = new_dasharray;
+    }
+}
+
+void LineShader::setBlur(float new_blur) {
+    if (blur != new_blur) {
+        glUniform1f(u_blur, new_blur);
+        blur = new_blur;
     }
 }


### PR DESCRIPTION
Implements `line-blur` (#383) and makes antialiasing distance dependent on device pixel density. All four line-blur rendering tests pass (with slight differences caused by round linejoin implementation differences).

based on https://github.com/mapbox/mapbox-gl-js/pull/618

@jfirebaugh 
