### PR TITLE
add missing git fetch for mapnik-packaging

### DIFF
--- a/setup-libraries.sh
+++ b/setup-libraries.sh
@@ -57,6 +57,7 @@ if [ ! -d 'mapnik-packaging/' ]; then
 fi
 
 cd mapnik-packaging
+git fetch
 git checkout ${MP_HASH}
 cd ./osx/
 


### PR DESCRIPTION
When there is a local mapnik-packaging repo, git checkout a future commit requires a git fetch.

Also `make distclean` will not remove the folder  _mapnik-packaging_. Is this needed?
