### PR TITLE
Fix multiple test-suite failures

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -115,7 +115,6 @@ public:
     void resetNorth();
     void startRotating();
     void stopRotating();
-    bool canRotate();
 
     // Debug
     void setDebug(bool value);

--- a/include/mbgl/map/transform.hpp
+++ b/include/mbgl/map/transform.hpp
@@ -51,7 +51,6 @@ public:
     double getAngle() const;
     void startRotating();
     void stopRotating();
-    bool canRotate();
 
     // Transitions
     bool needsTransition() const;

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -239,8 +239,11 @@ void GLFWView::swap() {
     glfwSetWindowTitle(window, title.c_str());
 }
 
-void GLFWView::notify_map_change(mbgl::MapChange /*change*/, mbgl::timestamp /*delay*/) {
-    // no-op
+void GLFWView::notify_map_change(mbgl::MapChange change, mbgl::timestamp /*delay*/) {
+    if ((change == mbgl::MapChange::MapChangeRegionDidChange || change == mbgl::MapChange::MapChangeRegionDidChangeAnimated)
+        && map->getZoom() <= 3 && map->getBearing() != 0) {
+        map->setBearing(0, 0.2);
+    }
 }
 
 void GLFWView::fps() {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -551,10 +551,6 @@ void Map::stopRotating() {
     update();
 }
 
-bool Map::canRotate() {
-    return transform.canRotate();
-}
-
 
 #pragma mark - Toggles
 

--- a/src/map/transform.cpp
+++ b/src/map/transform.cpp
@@ -14,7 +14,6 @@ using namespace mbgl;
 
 const double D2R = M_PI / 180.0;
 const double M2PI = 2 * M_PI;
-const double MIN_ROTATE_SCALE = 8;
 
 Transform::Transform(View &view_)
     : view(view_)
@@ -37,7 +36,6 @@ bool Transform::resize(const uint16_t w, const uint16_t h, const float ratio,
         current.pixelRatio = final.pixelRatio = ratio;
         current.framebuffer[0] = final.framebuffer[0] = fb_w;
         current.framebuffer[1] = final.framebuffer[1] = fb_h;
-        if (!canRotate() && current.angle) _setAngle(0);
         constrain(current.scale, current.y);
 
         view.notify_map_change(MapChangeRegionDidChange);
@@ -286,9 +284,6 @@ void Transform::_setScaleXY(const double new_scale, const double xn, const doubl
 
     constrain(final.scale, final.y);
 
-    // Undo rotation at low zooms.
-    if (!canRotate() && current.angle) _setAngle(0);
-
     if (duration == 0) {
         current.scale = final.scale;
         current.x = final.x;
@@ -398,9 +393,6 @@ void Transform::_setAngle(double new_angle, const timestamp duration) {
 
     final.angle = new_angle;
 
-    // Prevent rotation at low zooms.
-    if (!canRotate()) final.angle = 0;
-
     if (duration == 0) {
         current.angle = final.angle;
     } else {
@@ -447,10 +439,6 @@ void Transform::_clearRotating() {
         transitions.remove(rotate_timeout);
         rotate_timeout.reset();
     }
-}
-
-bool Transform::canRotate() {
-    return (current.scale > MIN_ROTATE_SCALE);
 }
 
 #pragma mark - Transition


### PR DESCRIPTION
This moves rotation constraints into the view in order to fix headless rendering and the other use cases mentioned in #458. This probably also fixes #463.

Along the way refactored rendering somewhat and addressed #491.

cc @kkaefer
