### PR TITLE
repair undef None GLX wrapper, pass 0 instead of None to GLX functions

### DIFF
--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -5,7 +5,7 @@
 #define MBGL_USE_CGL 1
 #else
 #define GL_GLEXT_PROTOTYPES
-#include <GL/glx.h>
+#include <mbgl/platform/default/glx.h>
 #define MBGL_USE_GLX 1
 #endif
 

--- a/platform/default/headless_display.cpp
+++ b/platform/default/headless_display.cpp
@@ -48,7 +48,7 @@ HeadlessDisplay::HeadlessDisplay() {
     // We're creating a dummy pbuffer anyway that we're not using.
     static int pixelFormat[] = {
         GLX_DRAWABLE_TYPE, GLX_PBUFFER_BIT,
-        None
+        0
     };
 
     int configs = 0;

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -107,7 +107,7 @@ GLXContext createCoreProfile(Display *dpy, GLXFBConfig fbconfig) {
         const int context_flags[] = {
             GLX_CONTEXT_MAJOR_VERSION_ARB, core_profile_versions[i].major,
             GLX_CONTEXT_MINOR_VERSION_ARB, core_profile_versions[i].minor,
-            None
+            0
         };
         ctx = glXCreateContextAttribsARB(dpy, fbconfig, 0, True, context_flags);
         if (context_creation_failed) {
@@ -172,7 +172,7 @@ void HeadlessView::createContext() {
     int pbuffer_attributes[] = {
         GLX_PBUFFER_WIDTH, 8,
         GLX_PBUFFER_HEIGHT, 8,
-        None
+        0
     };
     glx_pbuffer = glXCreatePbuffer(x_display, fb_configs[0], pbuffer_attributes);
 #endif


### PR DESCRIPTION
Fixes issues that crop up using `None` in a completely different context at https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/style/types.hpp#L181-L191
