### PR TITLE
pass png_static_libs to other_ldflags in install.gypi on Linux

### DIFF
--- a/gyp/install.gypi
+++ b/gyp/install.gypi
@@ -22,6 +22,7 @@
             'conditions': [
               ['OS == "linux"', {
                   'other_ldflags': [
+                      '<@(png_static_libs)',
                       '<@(glfw3_static_libs)',
                       '<@(glfw3_ldflags)',
                   ]


### PR DESCRIPTION
Fixes #581
