### PR TITLE
wrap mbgl-core and mbgl-linux in -Wl,--start-group/-Wl,--end-group

### DIFF
--- a/utils/mbgl-config/mbgl-config.template.sh
+++ b/utils/mbgl-config/mbgl-config.template.sh
@@ -24,6 +24,12 @@ if test $# -eq 0; then
     usage 1
 fi
 
+if [ ${CONFIG_MBGL_PLATFORM} == 'linux' ]; then
+    LIBS="-Wl,--start-group -lmbgl-core -lmbgl-${CONFIG_MBGL_PLATFORM} -Wl,--end-group -lmbgl-headless"
+else
+    LIBS="-lmbgl-core -lmbgl-${CONFIG_MBGL_PLATFORM} -lmbgl-headless"
+fi
+
 while test $# -gt 0; do
     case "$1" in
     esac
@@ -43,7 +49,7 @@ while test $# -gt 0; do
       ;;
 
     --libs)
-      echo -L${CONFIG_MBGL_PREFIX}/lib -lmbgl-core -lmbgl-${CONFIG_MBGL_PLATFORM} -lmbgl-headless ${CONFIG_MBGL_LDFLAGS}
+      echo -L${CONFIG_MBGL_PREFIX}/lib ${LIBS} ${CONFIG_MBGL_LDFLAGS}
       ;;
 
     --includedir)


### PR DESCRIPTION
Wraps `mbgl-core` and `mbgl-linux` in start-group/end-group linker options to work around cyclic dependencies on Linux.

https://stackoverflow.com/questions/45135/linker-order-gcc/409470#409470

/cc @kkaefer @springmeyer for review
