### PR TITLE
Xcode builds use mbgl-core.a from build directory instead of the one it built itself

### DIFF
--- a/gyp/common.gypi
+++ b/gyp/common.gypi
@@ -1,7 +1,6 @@
 {
   'variables': {
     'install_prefix%': '',
-    'standalone_product_dir':'<!@(pwd)/build'
   },
   'target_defaults': {
     'default_configuration': 'Release',

--- a/gyp/install.gypi
+++ b/gyp/install.gypi
@@ -12,7 +12,7 @@
             'mbgl-<(platform)',
           ],
           'copies': [
-            { 'files': [ '<(standalone_product_dir)/libmbgl.a' ], 'destination': '<(install_prefix)/lib' },
+            { 'files': [ '<(PRODUCT_DIR)/libmbgl.a' ], 'destination': '<(install_prefix)/lib' },
             { 'files': [ '<(PRODUCT_DIR)/libmbgl-core.a' ], 'destination': '<(install_prefix)/lib' },
             { 'files': [ '<(PRODUCT_DIR)/libmbgl-headless.a' ], 'destination': '<(install_prefix)/lib' },
             { 'files': [ '<(PRODUCT_DIR)/libmbgl-<(platform).a' ], 'destination': '<(install_prefix)/lib' },

--- a/gyp/mbgl-core.gypi
+++ b/gyp/mbgl-core.gypi
@@ -55,7 +55,7 @@
       ],
       'variables': {
         'core_lib':'<(PRODUCT_DIR)/libmbgl-core.a',
-        'standalone_lib':'<(standalone_product_dir)/libmbgl.a'
+        'standalone_lib':'<(PRODUCT_DIR)/libmbgl.a'
       },
       'direct_dependent_settings': {
         'include_dirs': [


### PR DESCRIPTION
This means that changes to the actual code won't get picked up when building in Xcode.