### PR TITLE
resize glfw to window size, not 0

### DIFF
--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -64,7 +64,7 @@ void GLFWView::initialize(mbgl::Map *map_) {
     int fbWidth, fbHeight;
     glfwGetFramebufferSize(window, &fbWidth, &fbHeight);
 
-    resize(window, 0, 0);
+    resize(window, width, height);
 
     glfwSetCursorPosCallback(window, mouseMove);
     glfwSetMouseButtonCallback(window, mouseClick);


### PR DESCRIPTION
Before this change the window was completely blank and nothing was drawn. Was there any reason to have it set to zero initially?