### PR TITLE
SQLite 3.8.6

### DIFF
--- a/configure
+++ b/configure
@@ -26,7 +26,7 @@ case ${MASON_PLATFORM} in
         ;;
     *)
         GLFW_VERSION=e1ae9af5
-        SQLITE_VERSION=system
+        SQLITE_VERSION=3.8.6
         LIBPNG_VERSION=1.6.13
         LIBJPEG_VERSION=v8d
         LIBCURL_VERSION=system

--- a/gyp/install.gypi
+++ b/gyp/install.gypi
@@ -46,6 +46,7 @@
                     './utils/mbgl-config/build.sh',
                     '<(install_prefix)',
                     '<(platform)',
+                    '<@(sqlite3_static_libs)',
                     '<@(sqlite3_ldflags)',
                     '<@(curl_ldflags)',
                     '<@(png_ldflags)',

--- a/gyp/mbgl-core.gypi
+++ b/gyp/mbgl-core.gypi
@@ -85,6 +85,7 @@
               '<(standalone_lib)',
               '<@(uv_static_libs)',
               '<@(curl_static_libs)',
+              '<@(sqlite3_static_libs)',
               '<(core_lib)'
           ],
         }

--- a/linux/mapboxgl-app.gyp
+++ b/linux/mapboxgl-app.gyp
@@ -29,6 +29,7 @@
       'variables': {
         'ldflags': [
           '<@(png_ldflags)',
+          '<@(sqlite3_static_libs)',
           '<@(sqlite3_ldflags)',
           '<@(glfw3_static_libs)',
           '<@(glfw3_ldflags)',

--- a/macosx/mapboxgl-app.gyp
+++ b/macosx/mapboxgl-app.gyp
@@ -39,6 +39,7 @@
         'ldflags': [
           '<@(uv_ldflags)',
           '<@(uv_static_libs)',
+          '<@(sqlite3_static_libs)',
           '<@(sqlite3_ldflags)',
           '<@(glfw3_static_libs)',
           '<@(glfw3_ldflags)',

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -7,6 +7,7 @@
   'variables' : {
     'ldflags': [
       '<@(uv_ldflags)',
+      '<@(sqlite3_static_libs)',
       '<@(sqlite3_ldflags)',
       '<@(curl_ldflags)',
       '<@(png_ldflags)',


### PR DESCRIPTION
Switch to mason-installed SQLite 3.8.6 instead of using whatever system version is provided.