### PR TITLE
Check for IO errors when loading binary shader

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -250,6 +250,8 @@ void Map::run() {
         mode = Mode::None;
         fileSource.clearLoop();
     }
+
+    terminate();
 }
 
 void Map::rerender() {
@@ -258,8 +260,9 @@ void Map::rerender() {
     } else if (mode == Mode::Continuous) {
         // We only send render events if we want to continuously update the map
         // (== async rendering).
-        assert(asyncRender);
-        asyncRender->send();
+        if (asyncRender) {
+            asyncRender->send();
+        }
     }
 }
 
@@ -279,7 +282,9 @@ void Map::swapped() {
 
 void Map::terminate() {
     assert(painter);
+    view.activate();
     painter->terminate();
+    view.deactivate();
 }
 
 #pragma mark - Setup


### PR DESCRIPTION
This fixes #740 

I had to add checks for IO errors (I thought iostream threw on errors).

I also put in the sanity check code from android-mason for good measure.