### PR TITLE
Fix xcode_clear_cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,16 +115,21 @@ render: build/render/Makefile
 
 ##### Xcode projects ###########################################################
 
+.PHONY: clear_xcode_cache
 clear_xcode_cache:
-    @CUSTOM_DD=`defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null`; \
-    if [[ $$CUSTOM_DD ]]; then \
-        echo clearing files in $$CUSTOM_DD older than one day; \
-        find $$CUSTOM_DD/mapboxgl-app-* -mtime +1 | xargs rm -rf; \
-    fi; \
-    if [[ -d ~/Library/Developer/Xcode/DerivedData/ ]] && [[ ! $$CUSTOM_DD ]]; then \
-        echo 'clearing files in ~/Library/Developer/Xcode/DerivedData/mapboxgl-app-* older than one day'; \
-        find ~/Library/Developer/Xcode/DerivedData/mapboxgl-app-* -mtime +1 | xargs rm -rf; \
-    fi
+	@CUSTOM_DD=`defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null`; \
+	if [[ $$CUSTOM_DD ]]; then \
+		echo clearing files in $$CUSTOM_DD older than one day; \
+		find $$CUSTOM_DD/mapboxgl-app-* -mtime +1 | xargs rm -rf; \
+	fi; \
+	if [[ -d ~/Library/Developer/Xcode/DerivedData/ ]] && [[ ! $$CUSTOM_DD ]]; then \
+		echo 'clearing files in ~/Library/Developer/Xcode/DerivedData/mapboxgl-app-* older than one day'; \
+		find ~/Library/Developer/Xcode/DerivedData/mapboxgl-app-* -mtime +1 | xargs rm -rf; \
+	fi; \
+	if [[ -e ~/Library/Application\ Support/Mapbox\ GL/cache.db ]]; then \
+		echo 'removing ~/Library/Application\ Support/Mapbox\ GL/cache.db'; \
+		rm ~/Library/Application\ Support/Mapbox\ GL/cache.db; \
+	fi
 
 xproj: build/macosx/mapboxgl-app.xcodeproj
 	open ./build/macosx/mapboxgl-app.xcodeproj


### PR DESCRIPTION
Fix hard tabs in Makefile so `clear_xcode_cache` task actually runs and remove `~/Library/Application Support/Mapbox GL/cache.db` if it exists. Fixes #749 

/cc @incanus 