### PR TITLE
break out version.hpp copy task into a separate gyp target

### DIFF
--- a/gyp/install.gypi
+++ b/gyp/install.gypi
@@ -17,7 +17,6 @@
             { 'files': [ '<(PRODUCT_DIR)/libmbgl-headless.a' ], 'destination': '<(install_prefix)/lib' },
             { 'files': [ '<(PRODUCT_DIR)/libmbgl-<(platform).a' ], 'destination': '<(install_prefix)/lib' },
             { 'files': [ '../include/mbgl' ], 'destination': '<(install_prefix)/include' },
-            { 'files': [ '<(SHARED_INTERMEDIATE_DIR)/include/mbgl/util/version.hpp' ], 'destination': '<(install_prefix)/include/mbgl/util' },
           ],
           'variables': {
             'conditions': [
@@ -55,6 +54,16 @@
               }
           ]
         },
+        { 'target_name': 'copy_version',
+          'type': 'none',
+          'hard_dependency': 1,
+          'dependencies': [
+            'install',
+          ],
+          'copies': [
+            { 'files': [ '<(SHARED_INTERMEDIATE_DIR)/include/mbgl/util/version.hpp' ], 'destination': '<(install_prefix)/include/mbgl/util' },
+          ],
+        }
       ]
     }],
   ],


### PR DESCRIPTION
to eliminate a possible race condition in parallel builds

/cc @springmeyer 