### PR TITLE
boringssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ render: build/render/Makefile
 
 .PHONY: clear_xcode_cache
 clear_xcode_cache:
+ifeq ($(PLATFORM), osx)
 	@CUSTOM_DD=`defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null`; \
 	if [[ $$CUSTOM_DD ]]; then \
 		echo clearing files in $$CUSTOM_DD older than one day; \
@@ -130,6 +131,7 @@ clear_xcode_cache:
 		echo 'removing ~/Library/Application\ Support/Mapbox\ GL/cache.db'; \
 		rm ~/Library/Application\ Support/Mapbox\ GL/cache.db; \
 	fi
+endif
 
 xproj: build/macosx/mapboxgl-app.xcodeproj
 	open ./build/macosx/mapboxgl-app.xcodeproj

--- a/bin/render.gyp
+++ b/bin/render.gyp
@@ -22,7 +22,7 @@
           '<@(sqlite3_static_libs)',
           '<@(sqlite3_ldflags)',
           '<@(curl_static_libs)',
-          '<@(curl_ldflags)',
+          '<@(boringssl_static_libs)',
           '<@(png_ldflags)',
           '<@(uv_static_libs)',
           '-L<(boost_root)/lib',

--- a/bin/render.gyp
+++ b/bin/render.gyp
@@ -19,7 +19,9 @@
         'ldflags': [
           '<@(glfw3_ldflags)',
           '<@(uv_ldflags)',
+          '<@(sqlite3_static_libs)',
           '<@(sqlite3_ldflags)',
+          '<@(curl_static_libs)',
           '<@(curl_ldflags)',
           '<@(png_ldflags)',
           '<@(uv_static_libs)',

--- a/configure
+++ b/configure
@@ -29,7 +29,7 @@ case ${MASON_PLATFORM} in
         SQLITE_VERSION=3.8.6
         LIBPNG_VERSION=1.6.13
         LIBJPEG_VERSION=v8d
-        LIBCURL_VERSION=7.38.0
+        LIBCURL_VERSION=7.38.0-boringssl
         LIBUV_VERSION=0.10.28
         ZLIB_VERSION=system
         BOOST_VERSION=system

--- a/configure
+++ b/configure
@@ -29,7 +29,7 @@ case ${MASON_PLATFORM} in
         SQLITE_VERSION=3.8.6
         LIBPNG_VERSION=1.6.13
         LIBJPEG_VERSION=v8d
-        LIBCURL_VERSION=system
+        LIBCURL_VERSION=7.38.0
         LIBUV_VERSION=0.10.28
         ZLIB_VERSION=system
         BOOST_VERSION=system

--- a/configure
+++ b/configure
@@ -30,6 +30,7 @@ case ${MASON_PLATFORM} in
         LIBPNG_VERSION=1.6.13
         LIBJPEG_VERSION=v8d
         LIBCURL_VERSION=7.38.0-boringssl
+        BORINGSSL_VERSION=d3bcf13
         LIBUV_VERSION=0.10.28
         ZLIB_VERSION=system
         BOOST_VERSION=system
@@ -76,6 +77,15 @@ if [ ! -z ${LIBCURL_VERSION} ]; then
     CONFIG+="    'curl_ldflags': $(quote_flags $(mason ldflags libcurl ${LIBCURL_VERSION})),"$LN
 else
     CONFIG+="    'curl_static_libs': [],"$LN
+fi
+
+if [ ! -z ${BORINGSSL_VERSION} ]; then
+    mason install boringssl ${BORINGSSL_VERSION}
+    CONFIG+="    'boringssl_static_libs': $(quote_flags $(mason static_libs boringssl ${BORINGSSL_VERSION})),"$LN
+    CONFIG+="    'boringssl_cflags': $(quote_flags $(mason cflags boringssl ${BORINGSSL_VERSION})),"$LN
+    CONFIG+="    'boringssl_ldflags': $(quote_flags $(mason ldflags boringssl ${BORINGSSL_VERSION})),"$LN
+else
+    CONFIG+="    'boringssl_static_libs': [],"$LN
 fi
 
 if [ ! -z ${GLFW_VERSION} ]; then

--- a/gyp/install.gypi
+++ b/gyp/install.gypi
@@ -49,7 +49,7 @@
                     '<@(sqlite3_static_libs)',
                     '<@(sqlite3_ldflags)',
                     '<@(curl_static_libs)',
-                    '<@(curl_ldflags)',
+                    '<@(boringssl_static_libs)',
                     '<@(png_ldflags)',
                     '<@(other_ldflags)'
                 ]

--- a/gyp/install.gypi
+++ b/gyp/install.gypi
@@ -48,6 +48,7 @@
                     '<(platform)',
                     '<@(sqlite3_static_libs)',
                     '<@(sqlite3_ldflags)',
+                    '<@(curl_static_libs)',
                     '<@(curl_ldflags)',
                     '<@(png_ldflags)',
                     '<@(other_ldflags)'

--- a/gyp/mbgl-linux.gypi
+++ b/gyp/mbgl-linux.gypi
@@ -14,6 +14,7 @@
           '<@(jpeg_cflags)',
           '<@(uv_cflags)',
           '<@(curl_cflags)',
+          '<@(boringssl_cflags)',
           '<@(nu_cflags)',
           '-I<(boost_root)/include',
         ],

--- a/linux/mapboxgl-app.gyp
+++ b/linux/mapboxgl-app.gyp
@@ -34,7 +34,7 @@
           '<@(glfw3_static_libs)',
           '<@(glfw3_ldflags)',
           '<@(curl_static_libs)',
-          '<@(curl_ldflags)',
+          '<@(boringssl_static_libs)',
           '<@(zlib_ldflags)',
         ],
       },

--- a/linux/mapboxgl-app.gyp
+++ b/linux/mapboxgl-app.gyp
@@ -33,6 +33,7 @@
           '<@(sqlite3_ldflags)',
           '<@(glfw3_static_libs)',
           '<@(glfw3_ldflags)',
+          '<@(curl_static_libs)',
           '<@(curl_ldflags)',
           '<@(zlib_ldflags)',
         ],

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -9,6 +9,7 @@
       '<@(uv_ldflags)',
       '<@(sqlite3_static_libs)',
       '<@(sqlite3_ldflags)',
+      '<@(curl_static_libs)',
       '<@(curl_ldflags)',
       '<@(png_ldflags)',
     ],

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -10,7 +10,7 @@
       '<@(sqlite3_static_libs)',
       '<@(sqlite3_ldflags)',
       '<@(curl_static_libs)',
-      '<@(curl_ldflags)',
+      '<@(boringssl_static_libs)',
       '<@(png_ldflags)',
     ],
   },


### PR DESCRIPTION
Move to mason-installed `libcurl-7.38.0-boringssl` instead of relying on system `libcurl`

/cc @ljbade @springmeyer 