### PR TITLE
Configure OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ render: build/render/Makefile
 
 .PHONY: clear_xcode_cache
 clear_xcode_cache:
+ifeq ($(PLATFORM), osx)
 	@CUSTOM_DD=`defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null`; \
 	if [[ $$CUSTOM_DD ]]; then \
 		echo clearing files in $$CUSTOM_DD older than one day; \
@@ -130,6 +131,7 @@ clear_xcode_cache:
 		echo 'removing ~/Library/Application\ Support/Mapbox\ GL/cache.db'; \
 		rm ~/Library/Application\ Support/Mapbox\ GL/cache.db; \
 	fi
+endif
 
 xproj: build/macosx/mapboxgl-app.xcodeproj
 	open ./build/macosx/mapboxgl-app.xcodeproj

--- a/bin/render.gyp
+++ b/bin/render.gyp
@@ -21,8 +21,6 @@
           '<@(uv_ldflags)',
           '<@(sqlite3_static_libs)',
           '<@(sqlite3_ldflags)',
-          '<@(curl_static_libs)',
-          '<@(curl_ldflags)',
           '<@(png_ldflags)',
           '<@(uv_static_libs)',
           '-L<(boost_root)/lib',
@@ -40,7 +38,11 @@
           },
           {
             'cflags': ['<@(cflags)'],
-            'libraries': ['<@(ldflags)'],
+            'libraries': [
+              '<@(ldflags)',
+              '<@(curl_static_libs)',
+              '<@(curl_ldflags)',
+            ],
           }],
       ],
       'include_dirs': [ '../src' ],

--- a/bin/render.gyp
+++ b/bin/render.gyp
@@ -19,7 +19,9 @@
         'ldflags': [
           '<@(glfw3_ldflags)',
           '<@(uv_ldflags)',
+          '<@(sqlite3_static_libs)',
           '<@(sqlite3_ldflags)',
+          '<@(curl_static_libs)',
           '<@(curl_ldflags)',
           '<@(png_ldflags)',
           '<@(uv_static_libs)',

--- a/configure
+++ b/configure
@@ -29,7 +29,7 @@ case ${MASON_PLATFORM} in
         SQLITE_VERSION=3.8.6
         LIBPNG_VERSION=1.6.13
         LIBJPEG_VERSION=v8d
-        LIBCURL_VERSION=system
+        LIBCURL_VERSION=7.38.0
         LIBUV_VERSION=0.10.28
         ZLIB_VERSION=system
         BOOST_VERSION=system

--- a/configure
+++ b/configure
@@ -24,6 +24,15 @@ case ${MASON_PLATFORM} in
         ZLIB_VERSION=system
         BOOST_VERSION=system
         ;;
+    'osx')
+        GLFW_VERSION=e1ae9af5
+        SQLITE_VERSION=3.8.6
+        LIBPNG_VERSION=1.6.13
+        LIBJPEG_VERSION=v8d
+        LIBUV_VERSION=0.10.28
+        ZLIB_VERSION=system
+        BOOST_VERSION=system
+        ;;
     *)
         GLFW_VERSION=e1ae9af5
         SQLITE_VERSION=3.8.6

--- a/gyp/install.gypi
+++ b/gyp/install.gypi
@@ -22,6 +22,8 @@
             'conditions': [
               ['OS == "linux"', {
                   'other_ldflags': [
+                      '<@(curl_static_libs)',
+                      '<@(curl_ldflags)',
                       '<@(nu_static_libs)',
                       '<@(png_static_libs)',
                       '<@(jpeg_static_libs)',
@@ -48,8 +50,6 @@
                     '<(platform)',
                     '<@(sqlite3_static_libs)',
                     '<@(sqlite3_ldflags)',
-                    '<@(curl_static_libs)',
-                    '<@(curl_ldflags)',
                     '<@(png_ldflags)',
                     '<@(other_ldflags)'
                 ]

--- a/gyp/install.gypi
+++ b/gyp/install.gypi
@@ -48,6 +48,7 @@
                     '<(platform)',
                     '<@(sqlite3_static_libs)',
                     '<@(sqlite3_ldflags)',
+                    '<@(curl_static_libs)',
                     '<@(curl_ldflags)',
                     '<@(png_ldflags)',
                     '<@(other_ldflags)'

--- a/gyp/mbgl-linux.gypi
+++ b/gyp/mbgl-linux.gypi
@@ -25,6 +25,7 @@
           '<@(png_ldflags)',
           '<@(jpeg_ldflags)',
           '<@(uv_ldflags)',
+          '<@(curl_static_libs)',
           '<@(curl_ldflags)',
           '<@(nu_ldflags)',
         ],

--- a/linux/mapboxgl-app.gyp
+++ b/linux/mapboxgl-app.gyp
@@ -33,6 +33,7 @@
           '<@(sqlite3_ldflags)',
           '<@(glfw3_static_libs)',
           '<@(glfw3_ldflags)',
+          '<@(curl_static_libs)',
           '<@(curl_ldflags)',
           '<@(zlib_ldflags)',
         ],

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -9,8 +9,6 @@
       '<@(uv_ldflags)',
       '<@(sqlite3_static_libs)',
       '<@(sqlite3_ldflags)',
-      '<@(curl_static_libs)',
-      '<@(curl_ldflags)',
       '<@(png_ldflags)',
     ],
   },
@@ -30,7 +28,11 @@
       'conditions': [
         ['OS == "mac"', { 'xcode_settings': { 'OTHER_LDFLAGS': [ '<@(ldflags)' ] }
         }, {
-          'libraries': [ '<@(ldflags)' ],
+          'libraries': [
+            '<@(ldflags)',
+            '<@(curl_static_libs)',
+            '<@(curl_ldflags)',
+          ],
         }]
       ]
     },

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -9,6 +9,7 @@
       '<@(uv_ldflags)',
       '<@(sqlite3_static_libs)',
       '<@(sqlite3_ldflags)',
+      '<@(curl_static_libs)',
       '<@(curl_ldflags)',
       '<@(png_ldflags)',
     ],


### PR DESCRIPTION
Break out a separate `configure` profile for OS X builds to skip unnecessarily linking `libcurl` and `nunicode`.