### PR TITLE
Clear sqlite cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,6 @@ ifeq ($(PLATFORM), osx)
 		echo 'clearing files in ~/Library/Developer/Xcode/DerivedData/mapboxgl-app-* older than one day'; \
 		find ~/Library/Developer/Xcode/DerivedData/mapboxgl-app-* -mtime +1 | xargs rm -rf; \
 	fi; \
-	if [[ -e ~/Library/Application\ Support/Mapbox\ GL/cache.db ]]; then \
-		echo 'removing ~/Library/Application\ Support/Mapbox\ GL/cache.db'; \
-		rm ~/Library/Application\ Support/Mapbox\ GL/cache.db; \
-	fi
 endif
 
 xproj: build/macosx/mapboxgl-app.xcodeproj
@@ -149,7 +145,21 @@ lproj: build/linux/mapboxgl-app.xcodeproj
 
 ##### Maintenace operations ####################################################
 
-clean: clear_xcode_cache
+.PHONY: clear_sqlite_cache
+clear_sqlite_cache:
+ifeq ($(PLATFORM), osx)
+	if [ -e ~/Library/Application\ Support/Mapbox\ GL/cache.db ]; then \
+		echo 'removing ~/Library/Application\ Support/Mapbox\ GL/cache.db'; \
+		rm ~/Library/Application\ Support/Mapbox\ GL/cache.db; \
+	fi
+else
+	if [ -e /tmp/mbgl-cache.db ]; then \
+		echo 'removing /tmp/mbgl-cache.db'; \
+		rm /tmp/mbgl-cache.db; \
+	fi
+endif
+
+clean: clear_sqlite_cache clear_xcode_cache
 	-find ./deps/gyp -name "*.pyc" -exec rm {} \;
 	-rm -rf ./build/
 	-rm -rf ./macosx/build/

--- a/Makefile
+++ b/Makefile
@@ -148,15 +148,9 @@ lproj: build/linux/mapboxgl-app.xcodeproj
 .PHONY: clear_sqlite_cache
 clear_sqlite_cache:
 ifeq ($(PLATFORM), osx)
-	if [ -e ~/Library/Application\ Support/Mapbox\ GL/cache.db ]; then \
-		echo 'removing ~/Library/Application\ Support/Mapbox\ GL/cache.db'; \
-		rm ~/Library/Application\ Support/Mapbox\ GL/cache.db; \
-	fi
+	rm -f ~/Library/Application\ Support/Mapbox\ GL/cache.db
 else
-	if [ -e /tmp/mbgl-cache.db ]; then \
-		echo 'removing /tmp/mbgl-cache.db'; \
-		rm /tmp/mbgl-cache.db; \
-	fi
+	rm -f /tmp/mbgl-cache.db
 endif
 
 clean: clear_sqlite_cache clear_xcode_cache

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ render: build/render/Makefile
 
 .PHONY: clear_xcode_cache
 clear_xcode_cache:
+ifeq ($(PLATFORM), osx)
 	@CUSTOM_DD=`defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null`; \
 	if [[ $$CUSTOM_DD ]]; then \
 		echo clearing files in $$CUSTOM_DD older than one day; \
@@ -130,6 +131,7 @@ clear_xcode_cache:
 		echo 'removing ~/Library/Application\ Support/Mapbox\ GL/cache.db'; \
 		rm ~/Library/Application\ Support/Mapbox\ GL/cache.db; \
 	fi
+endif
 
 xproj: build/macosx/mapboxgl-app.xcodeproj
 	open ./build/macosx/mapboxgl-app.xcodeproj

--- a/Makefile
+++ b/Makefile
@@ -119,14 +119,14 @@ render: build/render/Makefile
 clear_xcode_cache:
 ifeq ($(PLATFORM), osx)
 	@CUSTOM_DD=`defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null`; \
-	if [[ $$CUSTOM_DD ]]; then \
+	if [ $$CUSTOM_DD ]; then \
 		echo clearing files in $$CUSTOM_DD older than one day; \
 		find $$CUSTOM_DD/mapboxgl-app-* -mtime +1 | xargs rm -rf; \
 	fi; \
-	if [[ -d ~/Library/Developer/Xcode/DerivedData/ ]] && [[ ! $$CUSTOM_DD ]]; then \
+	if [ -d ~/Library/Developer/Xcode/DerivedData/ ] && [ ! $$CUSTOM_DD ]; then \
 		echo 'clearing files in ~/Library/Developer/Xcode/DerivedData/mapboxgl-app-* older than one day'; \
 		find ~/Library/Developer/Xcode/DerivedData/mapboxgl-app-* -mtime +1 | xargs rm -rf; \
-	fi; \
+	fi
 endif
 
 xproj: build/macosx/mapboxgl-app.xcodeproj


### PR DESCRIPTION
Fixes #766 and sticky cached requests with old tokens attached.

~~But why does the full conditional keep getting spewed out on the command line?~~

Apparently `make` just works this way, so I simplified the command.

```
if [ -e ~/Library/Application\ Support/Mapbox\ GL/cache.db ]; then \
                echo 'removing ~/Library/Application\ Support/Mapbox\ GL/cache.db'; \
                rm ~/Library/Application\ Support/Mapbox\ GL/cache.db; \
        fi
```
```
if [ -e /tmp/mbgl-cache.db ]; then \
                echo 'removing /tmp/mbgl-cache.db'; \
                rm /tmp/mbgl-cache.db; \
        fi
removing /tmp/mbgl-cache.db
```