### PR TITLE
Add visibility property for v7

### DIFF
--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -102,6 +102,7 @@ std::unique_ptr<Bucket> TileParser::createBucket(util::ptr<StyleBucket> bucket_d
     // Skip this bucket if we are to not render this
     if (tile.id.z < std::floor(bucket_desc->min_zoom) && std::floor(bucket_desc->min_zoom) < tile.source.max_zoom) return nullptr;
     if (tile.id.z >= std::ceil(bucket_desc->max_zoom)) return nullptr;
+    if (bucket_desc->visibility == mbgl::VisibilityType::None) return nullptr;
 
     auto layer_it = vector_data.layers.find(bucket_desc->source_layer);
     if (layer_it != vector_data.layers.end()) {

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -290,6 +290,7 @@ void Painter::renderLayers(util::ptr<StyleLayerGroup> group) {
 }
 
 void Painter::renderLayer(util::ptr<StyleLayer> layer_desc, const Tile::ID* id, const mat4* matrix) {
+    if (layer_desc->bucket->visibility == VisibilityType::None) return;
     if (layer_desc->type == StyleLayerType::Background) {
         // This layer defines a background color/image.
 

--- a/src/mbgl/style/style_bucket.hpp
+++ b/src/mbgl/style/style_bucket.hpp
@@ -103,6 +103,7 @@ public:
     StyleBucketRender render = std::false_type();
     float min_zoom = -std::numeric_limits<float>::infinity();
     float max_zoom = std::numeric_limits<float>::infinity();
+    VisibilityType visibility = VisibilityType::Visible;
 };
 
 

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -743,6 +743,7 @@ void StyleParser::parseLayout(JSVal value, util::ptr<StyleLayer> &layer) {
     }
 
     StyleBucket &bucket = *layer->bucket;
+    parseRenderProperty<VisibilityTypeClass>(value, bucket.visibility, "visibility");
 
     switch (layer->type) {
     case StyleLayerType::Fill: {

--- a/src/mbgl/style/types.hpp
+++ b/src/mbgl/style/types.hpp
@@ -50,6 +50,18 @@ MBGL_DEFINE_ENUM_CLASS(SourceTypeClass, SourceType, {
 
 // -------------------------------------------------------------------------------------------------
 
+enum class VisibilityType : bool {
+    Visible,
+    None,
+};
+
+MBGL_DEFINE_ENUM_CLASS(VisibilityTypeClass, VisibilityType, {
+    { VisibilityType::Visible, "visible" },
+    { VisibilityType::None, "none" },
+});
+
+// -------------------------------------------------------------------------------------------------
+
 enum class WindingType : bool {
     EvenOdd,
     NonZero,


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-style-spec/issues/212 & https://github.com/mapbox/mapbox-gl-style-spec/pull/238.
Adds a `visibility` property for layout objects with enum values `visible`, `none`.