### PR TITLE
Update Android ABIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,25 @@ matrix:
     - os: linux
   include:
     - os: linux
-      env: CONFIG=release MASON_PLATFORM=android TESTMUNK=yes
+      env: CONFIG=release MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7 TESTMUNK=yes
       compiler: clang
     - os: linux
-      env: CONFIG=debug MASON_PLATFORM=android TESTMUNK=no
+      env: CONFIG=debug MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7 TESTMUNK=no
+      compiler: clang
+    - os: linux
+      env: CONFIG=release MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5 TESTMUNK=no
+      compiler: clang
+    - os: linux
+      env: CONFIG=release MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8 TESTMUNK=no
+      compiler: clang
+    - os: linux
+      env: CONFIG=release MASON_PLATFORM=android MASON_ANDROID_ABI=x86 TESTMUNK=no
+      compiler: clang
+    - os: linux
+      env: CONFIG=release MASON_PLATFORM=android MASON_ANDROID_ABI=mips TESTMUNK=no
+      compiler: clang
+    - os: linux
+      env: CONFIG=release MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64 TESTMUNK=no
       compiler: clang
     - os: linux
       env: BUILDTYPE=Release JOBS=16

--- a/Makefile
+++ b/Makefile
@@ -81,25 +81,22 @@ build/linux/mapboxgl-app.xcodeproj: linux/mapboxgl-app.gyp config.gypi
 .PHONY: android
 android:
 	./scripts/local_mason.sh && \
-	MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env PATH && \
-	export CXX="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env CXX`" && \
-	export CC="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env CC`" && \
-	export LD="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env LD`" && \
-	export LINK="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env CXX`" && \
-	export AR="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env AR`" && \
-	export RANLIB="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env RANLIB`" && \
-	export LDFLAGS="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env LDFLAGS` ${LDFLAGS}" && \
-	export CFLAGS="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env CFLAGS` ${CFLAGS}" && \
-	export CPPFLAGS="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env CPPFLAGS` ${CPPFLAGS}" && \
-	export PATH="`MASON_DIR=./.mason MASON_PLATFORM=android ./.mason/mason env PATH`:${PATH}" && \
-	MASON_PLATFORM=android ./configure config-android.gypi && \
+	MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=$(MASON_ANDROID_ABI) ./.mason/mason env PATH && \
+	export CXX="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env CXX`" && \
+	export CC="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env CC`" && \
+	export LD="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env LD`" && \
+	export LINK="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env CXX`" && \
+	export AR="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env AR`" && \
+	export RANLIB="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env RANLIB`" && \
+	export LDFLAGS="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env LDFLAGS` ${LDFLAGS}" && \
+	export CFLAGS="`MASON_DIR=./.mason MASON_PLATFORM= MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env CFLAGS` ${CFLAGS}" && \
+	export CPPFLAGS="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env CPPFLAGS` ${CPPFLAGS}" && \
+	export PATH="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env PATH`:${PATH}" && \
+	export JNIDIR="`MASON_DIR=./.mason MASON_PLATFORM=android MASON_ANDROID_ABI=${MASON_ANDROID_ABI} ./.mason/mason env JNIDIR`" && \
+	MASON_PLATFORM=android MASON_ANDROID_ABI=$(MASON_ANDROID_ABI) ./configure config-android.gypi && \
 	deps/run_gyp android/mapboxgl-app.gyp -Iconfig-android.gypi -Dplatform=android --depth=. --generator-output=./build/android -f make-android && \
 	$(MAKE) -C build/android -j$(JOBS) BUILDTYPE=$(BUILDTYPE) V=$(V) androidapp && \
-	mkdir -p android/java/lib/src/main/jniLibs/armeabi-v7a && \
-	cp build/android/out/$(BUILDTYPE)/lib.target/libmapbox-gl.so android/java/lib/src/main/jniLibs/armeabi-v7a/libmapbox-gl.so && \
-	mkdir -p android/java/lib/src/main/assets && \
-	cp build/android/out/$(BUILDTYPE)/ca-bundle.crt android/java/lib/src/main/assets/ca-bundle.crt && \
-	cp -r build/android/out/$(BUILDTYPE)/styles android/java/lib/src/main/assets/styles && \
+	BUILDTYPE=$(BUILDTYPE) ./android/scripts/copy-files.sh && \
 	cd android/java && \
 	./gradlew --parallel-threads=$(JOBS) build
 

--- a/android/scripts/build-release.sh
+++ b/android/scripts/build-release.sh
@@ -4,6 +4,5 @@ set -e
 set -o pipefail
 
 export BUILDTYPE=Release
-export TESTMUNK=yes
 
 ./android/scripts/common.sh $1

--- a/android/scripts/copy-files.sh
+++ b/android/scripts/copy-files.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+mkdir -p android/java/lib/src/main/jniLibs/${JNIDIR}
+cp build/android/out/${BUILDTYPE}/lib.target/libmapbox-gl.so android/java/lib/src/main/jniLibs/${JNIDIR}/libmapbox-gl.so
+mkdir -p android/java/lib/src/main/assets
+cp build/android/out/${BUILDTYPE}/ca-bundle.crt android/java/lib/src/main/assets/ca-bundle.crt
+cp -r build/android/out/${BUILDTYPE}/styles android/java/lib/src/main/assets/styles

--- a/android/scripts/run-build.sh
+++ b/android/scripts/run-build.sh
@@ -32,6 +32,8 @@ user_data="#!/bin/bash
     export PATH=\$PATH:/android/jdk1.7.0_71/bin
     export MAPBOX_ACCESS_TOKEN=$MAPBOX_ACCESS_TOKEN
     export TESTMUNK_KEY=$TESTMUNK_KEY
+    export TESTMUNK=$TESTMUNK
+    export MASON_ANDROID_ABI=$MASON_ANDROID_ABI
 
     if ./android/scripts/build-$CONFIG.sh $NAME &>../build.log; then
         echo 'ANDROID BUILD PASSED'

--- a/configure
+++ b/configure
@@ -25,11 +25,11 @@ case ${MASON_PLATFORM} in
         BOOST_VERSION=system
         ;;
     'android')
-        SQLITE_VERSION=3.8.6
-        LIBPNG_VERSION=1.6.13
-        LIBJPEG_VERSION=v8d
-        OPENSSL_VERSION=1.0.1i
-        LIBCURL_VERSION=7.38.0
+        SQLITE_VERSION=3.8.8.1
+        LIBPNG_VERSION=1.6.16
+        LIBJPEG_VERSION=v9a
+        OPENSSL_VERSION=1.0.1l
+        LIBCURL_VERSION=7.40.0
         LIBUV_VERSION=0.11.29
         ZLIB_VERSION=system
         BOOST_VERSION=1.57.0
@@ -38,9 +38,9 @@ case ${MASON_PLATFORM} in
         ;;
     *)
         GLFW_VERSION=e1ae9af5
-        SQLITE_VERSION=3.8.6
-        LIBPNG_VERSION=1.6.13
-        LIBJPEG_VERSION=v8d
+        SQLITE_VERSION=3.8.8.1
+        LIBPNG_VERSION=1.6.16
+        LIBJPEG_VERSION=v9a
         LIBCURL_VERSION=system
         LIBUV_VERSION=0.10.28
         ZLIB_VERSION=system


### PR DESCRIPTION
This updates to latest mason and enables building all Android ABIs except x86-64 due to openssl build problem.

I also updated to the latest mason libs.

I plan to do more work in the future to allow building a 'fat' APK with all the ABIs in one file rather than the current separate APKs.