### PR TITLE
Ensure pkg-config in configure

### DIFF
--- a/configure
+++ b/configure
@@ -57,6 +57,12 @@ PYTHON=`which python || abort 'Cannot find python'`
 >&2 ${PYTHON} --version
 >&2 echo -en "\033[0m";
 
+PKG_CONFIG=`which pkg-config || abort 'Cannot find pkg-config'`
+
+>&2 echo -en "\033[1m\033[32m* Using pkg-config "
+>&2 ${PKG_CONFIG} --version
+>&2 echo -en "\033[0m";
+
 function quote_flags {
     ${PYTHON} -c "import sys, re; print filter(None, re.split('(?<!-framework)\s+', ' '.join(sys.argv[1:])))" "$@"
 }


### PR DESCRIPTION
This ensures pkg-config is found since mason depends on it (for now). If pkg-config is missing then the compile will eventually fail because headers like `png.h` will not be found. This prevents potential confusion from that error.