### PR TITLE
Avoid -Werror.

### DIFF
--- a/gyp/common.gypi
+++ b/gyp/common.gypi
@@ -15,7 +15,6 @@
           'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
           'GCC_ENABLE_CPP_RTTI':'YES',
           'OTHER_CPLUSPLUSFLAGS': [
-            '-Werror',
             '-Wall',
             '-Wextra',
             '-Wshadow',
@@ -50,7 +49,7 @@
         ],
       }],
     ],
-    'cflags_cc': [ '-std=c++11', '-Werror', '-Wall', '-Wextra', '-Wshadow', '-frtti', '-fexceptions' ],
+    'cflags_cc': [ '-std=c++11', '-Wall', '-Wextra', '-Wshadow', '-frtti', '-fexceptions' ],
     'configurations': {
       'Debug': {
         'cflags_cc': [ '-g', '-O0', '-fno-omit-frame-pointer','-fwrapv', '-fstack-protector-all', '-fno-common' ],


### PR DESCRIPTION
-Werror is pretty dangerous, since it will needlessly break the build on any warning. For example, I tried to build on OpenBSD with GCC 4.8.4, and got this:

    gmake -C build/mbgl BUILDTYPE=Release V=1 mbgl-core
    gmake[1]: Entering directory '/tmp/mapbox-gl-native/build/mbgl'
      eg++ '-DNDEBUG' -I../../include -I../../src -I../Release/obj/gen/include -I../Release/obj/gen/include  -I/tmp/mapbox-gl-native/mason_packages/linux-amd64/libuv/0.10.28/include -fPIC -std=c++11 -Werror -Wall -Wextra -Wshadow -frtti -fexceptions -I/tmp/mapbox-gl-native/mason_packages/linux-amd64/libuv/0.10.28/include -I/tmp/mapbox-gl-native/mason_packages/linux-amd64/sqlite/3.8.8.1/include -I/usr/include -I/usr/local/include -fPIC -O3 -MMD -MF ../Release/.deps/../Release/obj.target/mbgl-core/src/mbgl/map/map.o.d.raw -I/usr/X11R6/include -c -o ../Release/obj.target/mbgl-core/src/mbgl/map/map.o ../../src/mbgl/map/map.cpp
    ../../src/mbgl/map/map.cpp:363:0: error: ignoring #pragma mark  [-Werror=unknown-pragmas]
     #pragma mark - Setup
     ^
    ../../src/mbgl/map/map.cpp:415:0: error: ignoring #pragma mark  [-Werror=unknown-pragmas]
     #pragma mark - Size
     ^
    ../../src/mbgl/map/map.cpp:427:0: error: ignoring #pragma mark  [-Werror=unknown-pragmas]
     #pragma mark - Transitions
     ^
    ../../src/mbgl/map/map.cpp:436:0: error: ignoring #pragma mark  [-Werror=unknown-pragmas]
     #pragma mark - Position
     ^
    ../../src/mbgl/map/map.cpp:470:0: error: ignoring #pragma mark  [-Werror=unknown-pragmas]
     #pragma mark - Scale
     ^
    ../../src/mbgl/map/map.cpp:527:0: error: ignoring #pragma mark  [-Werror=unknown-pragmas]
     #pragma mark - Rotation
     ^
    ../../src/mbgl/map/map.cpp:564:0: error: ignoring #pragma mark  [-Werror=unknown-pragmas]
     #pragma mark - Toggles
     ^
    ../../src/mbgl/map/map.cpp:38:19: error: 'uvVersionCheck' defined but not used [-Werror=unused-variable]
     const static bool uvVersionCheck = []() {
                       ^
    ../../src/mbgl/map/map.cpp:60:19: error: 'zlibVersionCheck' defined but not used [-Werror=unused-variable]
     const static bool zlibVersionCheck = []() {
                       ^
    ../../src/mbgl/map/map.cpp:73:19: error: 'sqliteVersionCheck' defined but not used [-Werror=unused-variable]
     const static bool sqliteVersionCheck = []() {
                       ^
    cc1plus: all warnings being treated as errors
    mbgl-core.target.mk:207: recipe for target '../Release/obj.target/mbgl-core/src/mbgl/map/map.o' failed
    gmake[1]: *** [../Release/obj.target/mbgl-core/src/mbgl/map/map.o] Error 1
    gmake[1]: Leaving directory '/tmp/mapbox-gl-native/build/mbgl'
    Makefile:25: recipe for target 'mbgl-core' failed
    gmake: *** [mbgl-core] Error 2

There's no way to know in advance what things other compilers will warn about. Better to avoid breaking the build in this way.