### PR TITLE
Fix libjpeg and libnu linking

### DIFF
--- a/gyp/mbgl-android.gypi
+++ b/gyp/mbgl-android.gypi
@@ -50,6 +50,8 @@
       'link_settings': {
         'libraries': [
           '<@(png_static_libs)',
+          '<@(jpeg_static_libs)',
+          '<@(nu_static_libs)'
         ],
       },
       'conditions': [

--- a/gyp/mbgl-linux.gypi
+++ b/gyp/mbgl-linux.gypi
@@ -48,6 +48,8 @@
       'link_settings': {
         'libraries': [
           '<@(png_static_libs)',
+          '<@(jpeg_static_libs)',
+          '<@(nu_static_libs)'
         ],
       },
       'conditions': [


### PR DESCRIPTION
@kkaefer made a few adjustments to libjpeg and libnu packages. I presume he planned to update mbgl to these changes accordingly. This is my attempt to do so to keep things passing in master.

 - refs  https://github.com/mapbox/mason/commit/c104c2f9721b793535e4ec658afe2582e57be164
 - refs https://github.com/mapbox/mason/commit/49fd47774032bf0f80efaad0143db3634385d2bf


This is passing other than unrelated issues:

  - Boost warnings: #801
  - android zlib conflict issue: #802