### PR TITLE
Fix mips-64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ matrix:
     - os: osx
       env: BUILDTYPE=Debug JOBS=8
       compiler: clang
-  allow_failures:
-    - os: linux
-      env: CONFIG=release MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64 TESTMUNK=no
-      compiler: clang
 
 env:
   global:

--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ case ${MASON_PLATFORM} in
     'ios')
         SQLITE_VERSION=system
         LIBUV_VERSION=0.10.28
-        ZLIB_VERSION=system2
+        ZLIB_VERSION=system
         BOOST_VERSION=system
         ;;
     'android')
@@ -31,7 +31,7 @@ case ${MASON_PLATFORM} in
         OPENSSL_VERSION=1.0.1l
         LIBCURL_VERSION=7.40.0
         LIBUV_VERSION=0.11.29
-        ZLIB_VERSION=system2
+        ZLIB_VERSION=system
         BOOST_VERSION=1.57.0
         NUNICODE_VERSION=1.5.1
         LIBZIP_VERSION=0.11.2
@@ -43,7 +43,7 @@ case ${MASON_PLATFORM} in
         LIBJPEG_VERSION=v9a
         LIBCURL_VERSION=system
         LIBUV_VERSION=0.10.28
-        ZLIB_VERSION=system2
+        ZLIB_VERSION=system
         BOOST_VERSION=system
         NUNICODE_VERSION=1.5.1
         ;;

--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ case ${MASON_PLATFORM} in
     'ios')
         SQLITE_VERSION=system
         LIBUV_VERSION=0.10.28
-        ZLIB_VERSION=system
+        ZLIB_VERSION=system2
         BOOST_VERSION=system
         ;;
     'android')
@@ -31,7 +31,7 @@ case ${MASON_PLATFORM} in
         OPENSSL_VERSION=1.0.1l
         LIBCURL_VERSION=7.40.0
         LIBUV_VERSION=0.11.29
-        ZLIB_VERSION=system
+        ZLIB_VERSION=system2
         BOOST_VERSION=1.57.0
         NUNICODE_VERSION=1.5.1
         LIBZIP_VERSION=0.11.2
@@ -43,7 +43,7 @@ case ${MASON_PLATFORM} in
         LIBJPEG_VERSION=v9a
         LIBCURL_VERSION=system
         LIBUV_VERSION=0.10.28
-        ZLIB_VERSION=system
+        ZLIB_VERSION=system2
         BOOST_VERSION=system
         NUNICODE_VERSION=1.5.1
         ;;


### PR DESCRIPTION
 - Will pull in updated mason package for `zlib-system`
 - Removes `mips-64` from `allow_failures` since it should be working now


refs #802