### PR TITLE
fixes #782: ignore iOS 64-bit conversion warnings for Boost

### DIFF
--- a/src/mbgl/text/collision.hpp
+++ b/src/mbgl/text/collision.hpp
@@ -7,9 +7,9 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wdeprecated-register"
+#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #else
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"

--- a/src/mbgl/text/collision.hpp
+++ b/src/mbgl/text/collision.hpp
@@ -7,6 +7,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Wdeprecated-register"
 #else


### PR DESCRIPTION
Follows our convention of using `#pragma` for various ignores for Boost. Checks out on Travis so going to merge. 