### PR TITLE
Rework map threading

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ Standard: Cpp11
 IndentWidth: 4
 AccessModifierOffset: -4
 UseTab: Never
-BinPackParameters: false
+BinPackParameters: true
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortBlocksOnASingleLine: false

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,16 @@ android-deploy: $(ANDROID_ABIS)
 	cd android/java/MapboxGLAndroidSDK && chmod ugo+x deploy.sh && ./deploy.sh
 
 
+##### Render builds ############################################################
+
+.PRECIOUS: Makefile/render
+Makefile/render: bin/render.gyp config/$(HOST).gypi
+	deps/run_gyp bin/render.gyp $(CONFIG_$(HOST)) $(LIBS_$(HOST)) --generator-output=./build/$(HOST) -f make
+
+render: Makefile/render
+	$(MAKE) -C build/$(HOST) BUILDTYPE=$(BUILDTYPE) mbgl-render
+
+
 ##### Maintenace operations ####################################################
 
 .PHONY: clear_xcode_cache

--- a/Makefile
+++ b/Makefile
@@ -183,13 +183,8 @@ android-deploy: $(ANDROID_ABIS)
 
 ##### Render builds ############################################################
 
-.PRECIOUS: Makefile/render
-Makefile/render: bin/render.gyp config/$(HOST).gypi
-	deps/run_gyp bin/render.gyp $(CONFIG_$(HOST)) $(LIBS_$(HOST)) --generator-output=./build/$(HOST) -f make
-
-render: Makefile/render
+render: Makefile/mbgl
 	$(MAKE) -C build/$(HOST) BUILDTYPE=$(BUILDTYPE) mbgl-render
-
 
 ##### Maintenace operations ####################################################
 

--- a/Makefile
+++ b/Makefile
@@ -181,10 +181,13 @@ android-deploy: $(ANDROID_ABIS)
 	cd android/java/MapboxGLAndroidSDK && chmod ugo+x deploy.sh && ./deploy.sh
 
 
-##### Render builds ############################################################
+##### CLI builds ###############################################################
 
 render: Makefile/mbgl
 	$(MAKE) -C build/$(HOST) BUILDTYPE=$(BUILDTYPE) mbgl-render
+
+load-test: Makefile/mbgl
+	$(MAKE) -C build/$(HOST) BUILDTYPE=$(BUILDTYPE) mbgl-load-test
 
 ##### Maintenace operations ####################################################
 

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ load-test: Makefile/mbgl
 
 .PHONY: clear_xcode_cache
 clear_xcode_cache:
-ifeq ($(PLATFORM), osx)
+ifeq ($(HOST), osx)
 	@CUSTOM_DD=`defaults read com.apple.dt.Xcode IDECustomDerivedDataLocation 2>/dev/null`; \
 	if [ $$CUSTOM_DD ]; then \
 		echo clearing files in $$CUSTOM_DD older than one day; \

--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -250,42 +250,14 @@ void JNICALL nativeStart(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeStart");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->start();
+    nativeMapView->getMap().start();
 }
 
 void JNICALL nativeStop(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeStop");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->stop();
-}
-
-void JNICALL nativePause(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativePause");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->pause();
-}
-
-void JNICALL nativeResume(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeResume");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->resume();
-}
-
-void JNICALL nativeRun(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeRun");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().run();
-}
-
-void JNICALL nativeRerender(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeRerender");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().rerender();
+    nativeMapView->getMap().stop();
 }
 
 void JNICALL nativeUpdate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
@@ -293,39 +265,6 @@ void JNICALL nativeUpdate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
     nativeMapView->getMap().update();
-}
-
-void JNICALL nativeTerminate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeTerminate");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().terminate();
-}
-
-jboolean JNICALL nativeNeedsSwap(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeNeedsSwap");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    return nativeMapView->getMap().needsSwap();
-}
-
-void JNICALL nativeSwapped(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeSwapped");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().swapped();
-}
-
-void JNICALL nativeResize(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jint width, jint height,
-                          jfloat ratio) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeResize");
-    assert(nativeMapViewPtr != 0);
-    assert(width >= 0);
-    assert(height >= 0);
-    assert(width <= UINT16_MAX);
-    assert(height <= UINT16_MAX);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().resize(width, height, ratio);
 }
 
 void JNICALL nativeResize(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jint width, jint height,
@@ -341,7 +280,7 @@ void JNICALL nativeResize(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jint
     assert(fbWidth <= UINT16_MAX);
     assert(fbHeight <= UINT16_MAX);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().resize(width, height, ratio, fbWidth, fbHeight);
+    nativeMapView->resize(width, height, ratio, fbWidth, fbHeight);
 }
 
 void JNICALL nativeRemoveClass(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jstring clazz) {
@@ -837,7 +776,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
 
     // NOTE: if you get java.lang.UnsatisfiedLinkError you likely forgot to set the size of the
     // array correctly (too large)
-    std::array<JNINativeMethod, 62> methods = {{ // Can remove the extra brace in C++14
+    std::array<JNINativeMethod, 54> methods = {{ // Can remove the extra brace in C++14
         {"nativeCreate", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)J",
          reinterpret_cast<void *>(&nativeCreate)},
         {"nativeDestroy", "(J)V", reinterpret_cast<void *>(&nativeDestroy)},
@@ -850,18 +789,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         {"nativeDestroySurface", "(J)V", reinterpret_cast<void *>(&nativeDestroySurface)},
         {"nativeStart", "(J)V", reinterpret_cast<void *>(&nativeStart)},
         {"nativeStop", "(J)V", reinterpret_cast<void *>(&nativeStop)},
-        {"nativePause", "(J)V", reinterpret_cast<void *>(&nativePause)},
-        {"nativeResume", "(J)V", reinterpret_cast<void *>(&nativeResume)},
-        {"nativeRun", "(J)V", reinterpret_cast<void *>(&nativeRun)},
-        {"nativeRerender", "(J)V", reinterpret_cast<void *>(&nativeRerender)},
         {"nativeUpdate", "(J)V", reinterpret_cast<void *>(&nativeUpdate)},
-        {"nativeTerminate", "(J)V", reinterpret_cast<void *>(&nativeTerminate)},
-        {"nativeNeedsSwap", "(J)Z", reinterpret_cast<void *>(&nativeNeedsSwap)},
-        {"nativeSwapped", "(J)V", reinterpret_cast<void *>(&nativeSwapped)},
-        {"nativeResize", "(JIIF)V",
-         reinterpret_cast<void *>(
-             static_cast<void JNICALL (*)(JNIEnv *, jobject, jlong, jint, jint, jfloat)>(
-                 &nativeResize))},
         {"nativeResize", "(JIIFII)V",
          reinterpret_cast<void *>(static_cast<void JNICALL (
              *)(JNIEnv *, jobject, jlong, jint, jint, jfloat, jint, jint)>(&nativeResize))},

--- a/android/cpp/native_map_view.cpp
+++ b/android/cpp/native_map_view.cpp
@@ -16,6 +16,9 @@
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/util/std.hpp>
 
+
+pthread_once_t loadGLExtensions = PTHREAD_ONCE_INIT;
+
 namespace mbgl {
 namespace android {
 
@@ -337,7 +340,7 @@ void NativeMapView::createSurface(ANativeWindow *window_) {
         }
         log_gl_string(GL_EXTENSIONS, "Extensions");
 
-        loadExtensions();
+        pthread_once(&loadGLExtensions, loadExtensions);
 
         if (!eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
             mbgl::Log::Error(mbgl::Event::OpenGL,

--- a/android/cpp/native_map_view.cpp
+++ b/android/cpp/native_map_view.cpp
@@ -332,8 +332,12 @@ void NativeMapView::createSurface(ANativeWindow *window_) {
 void NativeMapView::destroySurface() {
     mbgl::Log::Debug(mbgl::Event::Android, "NativeMapView::destroySurface");
 
+    if (surface == EGL_NO_SURFACE) {
+        mbgl::Log::Debug(mbgl::Event::Android, "Surface was already destroyed!");
+        return;
+    }
+
     assert(display != EGL_NO_DISPLAY);
-    assert(surface != EGL_NO_SURFACE);
     assert(window != nullptr);
 
     if (!eglDestroySurface(display, surface)) {

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/lib/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/lib/NativeMapView.java
@@ -81,62 +81,8 @@ class NativeMapView {
         nativeStop(mNativeMapViewPtr);
     }
 
-    public void pause() {
-        nativePause(mNativeMapViewPtr);
-    }
-
-    public void resume() {
-        nativeResume(mNativeMapViewPtr);
-    }
-
-    public void run() {
-        nativeRun(mNativeMapViewPtr);
-    }
-
-    public void rerender() {
-        nativeRerender(mNativeMapViewPtr);
-    }
-
     public void update() {
         nativeUpdate(mNativeMapViewPtr);
-    }
-
-    public void terminate() {
-        nativeTerminate(mNativeMapViewPtr);
-    }
-
-    public boolean needsSwap() {
-        return nativeNeedsSwap(mNativeMapViewPtr);
-    }
-
-    public void swapped() {
-        nativeSwapped(mNativeMapViewPtr);
-    }
-
-    public void resize(int width, int height) {
-        resize(width, height, 1.0f);
-    }
-
-    public void resize(int width, int height, float ratio) {
-        if (width < 0) {
-            throw new IllegalArgumentException("width cannot be negative.");
-        }
-
-        if (height < 0) {
-            throw new IllegalArgumentException("height cannot be negative.");
-        }
-
-        if (width > 65535) {
-            throw new IllegalArgumentException(
-                    "width cannot be greater than 65535.");
-        }
-
-        if (height > 65535) {
-            throw new IllegalArgumentException(
-                    "height cannot be greater than 65535.");
-        }
-
-        nativeResize(mNativeMapViewPtr, width, height, ratio);
     }
 
     public void resize(int width, int height, float ratio, int fbWidth,
@@ -436,24 +382,7 @@ class NativeMapView {
 
     private native void nativeStop(long nativeMapViewPtr);
 
-    private native void nativePause(long nativeMapViewPtr);
-
-    private native void nativeResume(long nativeMapViewPtr);
-
-    private native void nativeRun(long nativeMapViewPtr);
-
-    private native void nativeRerender(long nativeMapViewPtr);
-
     private native void nativeUpdate(long nativeMapViewPtr);
-
-    private native void nativeTerminate(long nativeMapViewPtr);
-
-    private native boolean nativeNeedsSwap(long nativeMapViewPtr);
-
-    private native void nativeSwapped(long nativeMapViewPtr);
-
-    private native void nativeResize(long nativeMapViewPtr, int width,
-            int height, float ratio);
 
     private native void nativeResize(long nativeMapViewPtr, int width,
             int height, float ratio, int fbWidth, int fbHeight);

--- a/bin/load_test.cpp
+++ b/bin/load_test.cpp
@@ -1,0 +1,91 @@
+#include <mbgl/map/map.hpp>
+#include <mbgl/map/still_image.hpp>
+#include <mbgl/util/image.hpp>
+#include <mbgl/util/std.hpp>
+#include <mbgl/util/io.hpp>
+
+#include <mbgl/platform/default/headless_view.hpp>
+#include <mbgl/platform/default/headless_display.hpp>
+#include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/storage/default/sqlite_cache.hpp>
+
+#if __APPLE__
+#include <mbgl/platform/darwin/log_nslog.hpp>
+#else
+#include <mbgl/platform/default/log_stderr.hpp>
+#endif
+
+#include <uv.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+
+int main(int, char *[]) {
+    const std::string style_path = "styles/styles/bright-v7.json";
+
+    int width = 1024;
+    int height = 1024;
+    double pixelRatio = 1.0;
+
+    using namespace mbgl;
+
+#if __APPLE__
+    Log::Set<NSLogBackend>();
+#else
+    Log::Set<StderrLogBackend>();
+#endif
+
+    mbgl::SQLiteCache cache("cache.sqlite");
+    mbgl::DefaultFileSource fileSource(&cache);
+
+
+    HeadlessView view;
+    view.resize(width, height, pixelRatio);
+
+    Map map(view, fileSource, Map::RenderMode::Still);
+
+    // Try to load the token from the environment.
+    const char *token = getenv("MAPBOX_ACCESS_TOKEN");
+    if (token) {
+        map.setAccessToken(token);
+    }
+
+    const std::string style = mbgl::util::read_file(style_path);
+    map.setStyleJSON(style, ".");
+
+    static int remaining = 10000;
+
+    srand(time(NULL));
+
+    uv_async_t *async = new uv_async_t;
+
+    static auto render = [&]() {
+        const double longitude = ((double(rand()) / RAND_MAX) - 0.5) * 2 * 180;
+        const double latitude = ((double(rand()) / RAND_MAX) - 0.5) * 2 * 80;
+        const double zoom = (double(rand()) / RAND_MAX) * 9;
+        const double bearing = ((double(rand()) / RAND_MAX) - 0.5) * 2 * 180;
+
+        map.setLonLatZoom(longitude, latitude, zoom);
+        map.setBearing(bearing);
+        fprintf(stderr, "lon: %f, lat: %f, zoom: %f, bearing: %f\n", longitude, latitude, zoom, bearing);
+        map.renderStill([async](std::unique_ptr<const StillImage>) {
+            uv_async_send(async);
+        });
+    };
+
+    uv_async_init(uv_default_loop(), async, [](uv_async_t *as, int) {
+        if (remaining-- > 0) {
+            render();
+        } else {
+            uv_close(reinterpret_cast<uv_handle_t *>(as), [](uv_handle_t *handle) {
+                delete reinterpret_cast<uv_async_t *>(handle);
+            });
+        }
+    });
+
+    render();
+
+    // This loop will terminate once the async was fired.
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+}

--- a/bin/load_test.cpp
+++ b/bin/load_test.cpp
@@ -40,8 +40,7 @@ int main(int, char *[]) {
     mbgl::DefaultFileSource fileSource(&cache);
 
 
-    HeadlessView view;
-    view.resize(width, height, pixelRatio);
+    HeadlessView view(width, height, pixelRatio);
 
     Map map(view, fileSource, Map::RenderMode::Still);
 

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -84,8 +84,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    HeadlessView view;
-    view.resize(width, height, pixelRatio);
+    HeadlessView view(width, height, pixelRatio);
 
     Map map(view, fileSource, Map::RenderMode::Still);
 

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -32,8 +32,8 @@ int main(int argc, char *argv[]) {
     double zoom = 0;
     double bearing = 0;
 
-    int width = 256;
-    int height = 256;
+    int width = 512;
+    int height = 512;
     double pixelRatio = 1.0;
     std::string output = "out.png";
     std::string cache_file = "cache.sqlite";

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
     map.setStyleJSON(style, ".");
     map.setClasses(classes);
 
-    map.setLatLonZoom(LatLng(lat, lon), zoom);
+    map.setLatLngZoom(LatLng(lat, lon), zoom);
     map.setBearing(bearing);
 
     uv_async_t *async = new uv_async_t;

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -3,10 +3,6 @@
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/io.hpp>
 
-#include <rapidjson/document.h>
-#include <rapidjson/writer.h>
-#include <rapidjson/stringbuffer.h>
-
 #include <mbgl/platform/default/headless_view.hpp>
 #include <mbgl/platform/default/headless_display.hpp>
 #include <mbgl/storage/default_file_source.hpp>
@@ -103,13 +99,11 @@ int main(int argc, char *argv[]) {
     map.setLatLonZoom(LatLng(lat, lon), zoom);
     map.setBearing(bearing);
 
-    std::unique_ptr<uint32_t[]> pixels;
-
     // Run the loop. It will terminate when we don't have any further listeners.
     map.run();
 
     // Get the data from the GPU.
-    pixels = view.readPixels();
+    auto pixels = view.readPixels();
 
     const unsigned int w = width * pixelRatio;
     const unsigned int h = height * pixelRatio;

--- a/bin/render.gypi
+++ b/bin/render.gypi
@@ -8,13 +8,13 @@
       'type': 'executable',
 
       'dependencies': [
-        '../mbgl.gyp:core',
-        '../mbgl.gyp:platform-<(platform_lib)',
-        '../mbgl.gyp:headless-<(headless_lib)',
-        '../mbgl.gyp:http-<(http_lib)',
-        '../mbgl.gyp:asset-<(asset_lib)',
-        '../mbgl.gyp:cache-<(cache_lib)',
-        '../mbgl.gyp:copy_certificate_bundle',
+        'core',
+        'platform-<(platform_lib)',
+        'headless-<(headless_lib)',
+        'http-<(http_lib)',
+        'asset-<(asset_lib)',
+        'cache-<(cache_lib)',
+        'copy_certificate_bundle',
       ],
 
       'include_dirs': [
@@ -28,15 +28,18 @@
       'variables' : {
         'cflags_cc': [
           '<@(glfw3_cflags)',
+          '<@(uv_cflags)',
           '<@(boost_cflags)',
         ],
         'ldflags': [
           '<@(glfw3_ldflags)',
+          '<@(uv_ldflags)',
           '<@(boost_ldflags)',
           '-lboost_program_options'
         ],
         'libraries': [
           '<@(glfw3_static_libs)',
+          '<@(uv_static_libs)',
         ],
       },
 

--- a/bin/render.gypi
+++ b/bin/render.gypi
@@ -3,9 +3,8 @@
     '../gyp/common.gypi',
   ],
   'targets': [
-    { 'target_name': 'mbgl-render',
-      'product_name': 'mbgl-render',
-      'type': 'executable',
+    { 'target_name': 'cli-deps',
+      'type': 'none',
 
       'dependencies': [
         'core',
@@ -17,44 +16,66 @@
         'copy_certificate_bundle',
       ],
 
-      'include_dirs': [
-        '../src',
+      'export_dependent_settings': [
+        'core',
+        'platform-<(platform_lib)',
+        'headless-<(headless_lib)',
+        'http-<(http_lib)',
+        'asset-<(asset_lib)',
+        'cache-<(cache_lib)',
+        'copy_certificate_bundle',
       ],
 
-      'sources': [
-        './render.cpp',
-      ],
+      'direct_dependent_settings': {
+        'include_dirs': [
+          '../src',
+        ],
 
-      'variables' : {
-        'cflags_cc': [
-          '<@(glfw3_cflags)',
-          '<@(uv_cflags)',
-          '<@(boost_cflags)',
-        ],
-        'ldflags': [
-          '<@(glfw3_ldflags)',
-          '<@(uv_ldflags)',
-          '<@(boost_ldflags)',
-          '-lboost_program_options'
-        ],
-        'libraries': [
-          '<@(glfw3_static_libs)',
-          '<@(uv_static_libs)',
+        'variables' : {
+          'cflags_cc': [
+            '<@(glfw3_cflags)',
+            '<@(uv_cflags)',
+            '<@(boost_cflags)',
+          ],
+          'ldflags': [
+            '<@(glfw3_ldflags)',
+            '<@(uv_ldflags)',
+            '<@(boost_ldflags)',
+            '-lboost_program_options'
+          ],
+          'libraries': [
+            '<@(glfw3_static_libs)',
+            '<@(uv_static_libs)',
+          ],
+        },
+
+        'conditions': [
+          ['OS == "mac"', {
+            'libraries': [ '<@(libraries)' ],
+            'xcode_settings': {
+              'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
+              'OTHER_LDFLAGS': [ '<@(ldflags)' ],
+            }
+          }, {
+            'cflags_cc': [ '<@(cflags_cc)' ],
+            'libraries': [ '<@(libraries)', '<@(ldflags)' ],
+          }]
         ],
       },
+    },
 
-      'conditions': [
-        ['OS == "mac"', {
-          'libraries': [ '<@(libraries)' ],
-          'xcode_settings': {
-            'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
-            'OTHER_LDFLAGS': [ '<@(ldflags)' ],
-          }
-        }, {
-          'cflags_cc': [ '<@(cflags_cc)' ],
-          'libraries': [ '<@(libraries)', '<@(ldflags)' ],
-        }]
-      ],
+    { 'target_name': 'mbgl-render',
+      'product_name': 'mbgl-render',
+      'type': 'executable',
+      'dependencies': [ 'cli-deps' ],
+      'sources': [ './render.cpp' ],
+    },
+
+    { 'target_name': 'mbgl-load-test',
+      'product_name': 'mbgl-load-test',
+      'type': 'executable',
+      'dependencies': [ 'cli-deps' ],
+      'sources': [ './load_test.cpp' ],
     },
   ],
 }

--- a/configure
+++ b/configure
@@ -37,7 +37,7 @@ case ${MASON_PLATFORM} in
         LIBZIP_VERSION=0.11.2
         ;;
     *)
-        GLFW_VERSION=e1ae9af5
+        GLFW_VERSION=3.1
         SQLITE_VERSION=3.8.8.1
         LIBPNG_VERSION=1.6.16
         LIBJPEG_VERSION=v9a

--- a/gyp/http-curl.gypi
+++ b/gyp/http-curl.gypi
@@ -14,6 +14,25 @@
         '../include',
       ],
 
+      'variables': {
+        'cflags_cc': [
+          '<@(uv_cflags)',
+          '<@(curl_cflags)',
+          '<@(boost_cflags)',
+        ],
+        'ldflags': [
+          '<@(uv_ldflags)',
+          '<@(curl_ldflags)',
+        ],
+        'libraries': [
+          '<@(uv_static_libs)',
+          '<@(curl_static_libs)',
+        ],
+        'defines': [
+          '-DMBGL_HTTP_CURL'
+        ],
+      },
+
       'conditions': [
         ['host == "android"', {
           'variables': {
@@ -32,19 +51,17 @@
         }],
       ],
 
-      'variables': {
-        'cflags_cc': [
-          '<@(uv_cflags)',
-          '<@(curl_cflags)',
-          '<@(boost_cflags)',
-        ],
-        'ldflags': [
-          '<@(uv_ldflags)',
-          '<@(curl_ldflags)',
-        ],
-        'libraries': [
-          '<@(uv_static_libs)',
-          '<@(curl_static_libs)',
+      'direct_dependent_settings': {
+        'conditions': [
+          ['OS == "mac"', {
+            'xcode_settings': {
+              'OTHER_CFLAGS': [ '<@(defines)' ],
+              'OTHER_CPLUSPLUSFLAGS': [ '<@(defines)' ],
+            }
+          }, {
+            'cflags': [ '<@(defines)' ],
+            'cflags_cc': [ '<@(defines)' ],
+          }]
         ],
       },
 

--- a/gyp/http-nsurl.gypi
+++ b/gyp/http-nsurl.gypi
@@ -25,11 +25,21 @@
         'libraries': [
           '<@(uv_static_libs)',
         ],
+        'defines': [
+          '-DMBGL_HTTP_NSURL'
+        ],
       },
 
       'xcode_settings': {
         'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
         'CLANG_ENABLE_OBJC_ARC': 'NO',
+      },
+
+      'direct_dependent_settings': {
+        'xcode_settings': {
+          'OTHER_CFLAGS': [ '<@(defines)' ],
+          'OTHER_CPLUSPLUSFLAGS': [ '<@(defines)' ],
+        }
       },
 
       'link_settings': {

--- a/include/mbgl/android/native_map_view.hpp
+++ b/include/mbgl/android/native_map_view.hpp
@@ -15,17 +15,18 @@
 namespace mbgl {
 namespace android {
 
-class NativeMapView : public mbgl::View, private mbgl::util::noncopyable {
+class NativeMapView : public mbgl::View {
 public:
     NativeMapView(JNIEnv *env, jobject obj);
     virtual ~NativeMapView();
+
+    void initialize(Map *) override {};
 
     void activate() override;
     void deactivate() override;
 
     void swap() override;
 
-    void notify() override;
     void notifyMapChange(mbgl::MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero()) override;
 
     mbgl::Map &getMap();
@@ -40,19 +41,15 @@ public:
     void createSurface(ANativeWindow *window);
     void destroySurface();
 
-    void start();
-    void stop();
-
-    void resume();
-    void pause(bool waitForPause = false);
-
     void enableFps(bool enable);
     void updateFps();
+
+    void resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight);
 
 private:
     EGLConfig chooseConfig(const EGLConfig configs[], EGLint numConfigs);
 
-    void loadExtensions();
+    static void loadExtensions();
 
     bool inEmulator();
 
@@ -75,10 +72,6 @@ private:
 
     std::string styleUrl;
     std::string apiKey;
-
-    bool firstTime = false;
-
-    bool usingDepth24 = false;
 
     bool fpsEnabled = false;
     double fps = 0.0;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -37,6 +37,11 @@ class GlyphAtlas;
 class SpriteAtlas;
 class LineAtlas;
 
+struct exception : std::runtime_error {
+    inline exception(const char *msg) : std::runtime_error(msg) {
+    }
+};
+
 class Map : private util::noncopyable {
 public:
     explicit Map(View&, FileSource&);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -43,6 +43,8 @@ struct exception : std::runtime_error {
 };
 
 class Map : private util::noncopyable {
+    friend class View;
+
 public:
     explicit Map(View&, FileSource&);
     ~Map();
@@ -79,10 +81,6 @@ public:
     // Controls buffer swapping.
     bool needsSwap();
     void swapped();
-
-    // Size
-    void resize(uint16_t width, uint16_t height, float ratio = 1);
-    void resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight);
 
     // Styling
     void addClass(const std::string&);
@@ -152,6 +150,10 @@ public:
     inline std::chrono::steady_clock::time_point getTime() const { return animationTime; }
 
 private:
+    // This may only be called by the View object.
+    void resize(uint16_t width, uint16_t height, float ratio = 1);
+    void resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight);
+
     util::ptr<Sprite> getSprite();
     uv::worker& getWorker();
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -200,6 +200,7 @@ private:
 
     std::thread thread;
 
+    std::mutex rendering;
 
     std::atomic<bool> active;
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -65,6 +65,9 @@ public:
     bool isRendering() const;
 
 private:
+    // Will start the Map thread if it's not yet started.
+    void initialize();
+
     // Runs the map event loop. ONLY run this function when you want to get render a single frame
     // with this map object. It will *not* spawn a separate thread and instead block until the
     // frame is completely rendered.

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -209,7 +209,6 @@ private:
 
     TransformState state;
 
-
     util::ptr<Style> style;
     std::unique_ptr<GlyphAtlas> glyphAtlas;
     util::ptr<GlyphStore> glyphStore;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -61,6 +61,9 @@ public:
     using StillImageCallback = std::function<void(std::unique_ptr<const StillImage>)>;
     void renderStill(StillImageCallback callback);
 
+    // Returns true when the Map object is currently used to render a map.
+    bool isRendering() const;
+
 private:
     // Runs the map event loop. ONLY run this function when you want to get render a single frame
     // with this map object. It will *not* spawn a separate thread and instead block until the

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -37,6 +37,7 @@ class GlyphAtlas;
 class SpriteAtlas;
 class LineAtlas;
 class StillImage;
+class Environment;
 
 class Map : private util::noncopyable {
     friend class View;
@@ -188,11 +189,11 @@ private:
     void updated();
 
 private:
+    const std::unique_ptr<Environment> env;
     View &view;
-    FileSource& fileSource;
+
     const RenderMode renderMode;
-public: // TODO: Make this private again.
-    std::unique_ptr<uv::loop> loop;
+
 private:
     const std::thread::id uiThread;
     std::thread::id mapThread;

--- a/include/mbgl/map/still_image.hpp
+++ b/include/mbgl/map/still_image.hpp
@@ -12,7 +12,8 @@ class StillImage : util::noncopyable {
 public:
     uint16_t width = 0;
     uint16_t height = 0;
-    std::unique_ptr<uint32_t[]> pixels;
+    using Pixel = uint32_t;
+    std::unique_ptr<Pixel[]> pixels;
 };
 
 }

--- a/include/mbgl/map/still_image.hpp
+++ b/include/mbgl/map/still_image.hpp
@@ -1,0 +1,20 @@
+#ifndef MBGL_MAP_STILL_IMAGE
+#define MBGL_MAP_STILL_IMAGE
+
+#include <mbgl/util/noncopyable.hpp>
+
+#include <string>
+#include <cstdint>
+
+namespace mbgl {
+
+class StillImage : util::noncopyable {
+public:
+    uint16_t width = 0;
+    uint16_t height = 0;
+    std::unique_ptr<uint32_t[]> pixels;
+};
+
+}
+
+#endif

--- a/include/mbgl/map/view.hpp
+++ b/include/mbgl/map/view.hpp
@@ -47,6 +47,10 @@ public:
     virtual void notifyMapChange(MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero()) = 0;
 
 protected:
+    // Resizes the view
+    void resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight);
+
+protected:
     mbgl::Map *map = nullptr;
 };
 }

--- a/include/mbgl/map/view.hpp
+++ b/include/mbgl/map/view.hpp
@@ -2,10 +2,13 @@
 #define MBGL_MAP_VIEW
 
 #include <chrono>
+#include <memory>
+#include <cassert>
 
 namespace mbgl {
 
 class Map;
+class StillImage;
 
 enum MapChange : uint8_t {
     MapChangeRegionWillChange = 0,
@@ -22,7 +25,8 @@ enum MapChange : uint8_t {
 
 class View {
 public:
-    virtual void initialize(Map *map_) {
+    inline virtual void initialize(Map *map_) {
+        assert(!map);
         map = map_;
     }
 
@@ -40,6 +44,10 @@ public:
     virtual void deactivate() = 0;
 
     virtual void notify() = 0;
+
+    // Reads the pixel data from the current framebuffer. If your View implementation
+    // doesn't support reading from the framebuffer, return a null pointer.
+    virtual std::unique_ptr<StillImage> readStillImage();
 
     // Notifies a watcher of map x/y/scale/rotation changes.
     // Must only be called from the same thread that caused the change.

--- a/include/mbgl/map/view.hpp
+++ b/include/mbgl/map/view.hpp
@@ -30,9 +30,13 @@ public:
         map = map_;
     }
 
+    // Called from the render (=GL) thread. Signals that the contents of the contents
+    // may be discarded. The default is a no-op.
+    virtual void discard();
+
     // Called from the render (=GL) thread. Signals that the context should
-    // swap the front and the back buffer.
-    virtual void swap() = 0;
+    // swap the front and the back buffer. The default is a no-op.
+    virtual void swap();
 
     // Called from the render thread. Makes the GL context active in the current
     // thread. This is typically just called once at the beginning of the
@@ -43,8 +47,6 @@ public:
     // thread. This is called once just before the rendering thread terminates.
     virtual void deactivate() = 0;
 
-    virtual void notify() = 0;
-
     // Reads the pixel data from the current framebuffer. If your View implementation
     // doesn't support reading from the framebuffer, return a null pointer.
     virtual std::unique_ptr<StillImage> readStillImage();
@@ -52,7 +54,8 @@ public:
     // Notifies a watcher of map x/y/scale/rotation changes.
     // Must only be called from the same thread that caused the change.
     // Must not be called from the render thread.
-    virtual void notifyMapChange(MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero()) = 0;
+    // The default is a no-op.
+    virtual void notifyMapChange(MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero());
 
 protected:
     // Resizes the view

--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -20,11 +20,11 @@ public:
     void notify();
     void notifyMapChange(mbgl::MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero());
 
-    static void key(GLFWwindow *window, int key, int scancode, int action, int mods);
-    static void scroll(GLFWwindow *window, double xoffset, double yoffset);
-    static void resize(GLFWwindow *window, int width, int height);
-    static void mouseClick(GLFWwindow *window, int button, int action, int modifiers);
-    static void mouseMove(GLFWwindow *window, double x, double y);
+    static void onKey(GLFWwindow *window, int key, int scancode, int action, int mods);
+    static void onScroll(GLFWwindow *window, double xoffset, double yoffset);
+    static void onResize(GLFWwindow *window, int width, int height);
+    static void onMouseClick(GLFWwindow *window, int button, int action, int modifiers);
+    static void onMouseMove(GLFWwindow *window, double x, double y);
 
     static void eventloop(void *arg);
 

--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -17,8 +17,6 @@ public:
     void swap();
     void activate();
     void deactivate();
-    void notify();
-    void notifyMapChange(mbgl::MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero());
 
     static void onKey(GLFWwindow *window, int key, int scancode, int action, int mods);
     static void onScroll(GLFWwindow *window, double xoffset, double yoffset);

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -32,8 +32,9 @@ public:
     void loadExtensions();
 
     void resize(uint16_t width, uint16_t height, float pixelRatio);
-    std::unique_ptr<uint32_t[]> readPixels();
+    std::unique_ptr<StillImage> readStillImage();
 
+    void initialize(Map *map_);
     void notify();
     void notifyMapChange(MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero());
     void activate();

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -18,7 +18,7 @@ typedef XID GLXPbuffer;
 
 #include <memory>
 #include <thread>
-#include <atomic>
+#include <mutex>
 
 namespace mbgl {
 
@@ -47,7 +47,7 @@ private:
     std::shared_ptr<HeadlessDisplay> display;
 
     struct Dimensions {
-        inline Dimensions(uint16_t width = 0, uint16_t height = 0, float pixelRatio = 0) noexcept;
+        inline Dimensions(uint16_t width = 0, uint16_t height = 0, float pixelRatio = 0);
         inline uint16_t pixelWidth() const { return width * pixelRatio; }
         inline uint16_t pixelHeight() const { return height * pixelRatio; }
 
@@ -60,7 +60,8 @@ private:
     Dimensions current;
 
     // These are the values that will be used after the next discard() event.
-    std::atomic<Dimensions> prospective;
+    std::mutex prospectiveMutex;
+    Dimensions prospective;
 
 #if MBGL_USE_CGL
     CGLContextObj glContext = nullptr;

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -18,6 +18,7 @@ typedef XID GLXPbuffer;
 
 #include <memory>
 #include <thread>
+#include <atomic>
 
 namespace mbgl {
 
@@ -46,7 +47,7 @@ private:
     std::shared_ptr<HeadlessDisplay> display;
 
     struct Dimensions {
-        inline Dimensions(uint16_t width = 0, uint16_t height = 0, float pixelRatio = 0);
+        inline Dimensions(uint16_t width = 0, uint16_t height = 0, float pixelRatio = 0) noexcept;
         inline uint16_t pixelWidth() const { return width * pixelRatio; }
         inline uint16_t pixelHeight() const { return height * pixelRatio; }
 

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -24,8 +24,8 @@ class HeadlessDisplay;
 
 class HeadlessView : public View {
 public:
-    HeadlessView();
-    HeadlessView(std::shared_ptr<HeadlessDisplay> display);
+    HeadlessView(uint16_t width = 256, uint16_t height = 256, float pixelRatio = 1);
+    HeadlessView(std::shared_ptr<HeadlessDisplay> display, uint16_t width = 256, uint16_t height = 256, float pixelRatio = 1);
     ~HeadlessView();
 
     void createContext();
@@ -46,9 +46,9 @@ private:
 
 private:
     std::shared_ptr<HeadlessDisplay> display_;
-    uint16_t width_;
-    uint16_t height_;
-    float pixelRatio_;
+    uint16_t width_ = 0;
+    uint16_t height_ = 0;
+    float pixelRatio_ = 0;
 
 #if MBGL_USE_CGL
     CGLContextObj glContext;

--- a/include/mbgl/platform/event.hpp
+++ b/include/mbgl/platform/event.hpp
@@ -68,11 +68,11 @@ struct EventPermutation {
 };
 
 constexpr EventSeverity disabledEventSeverities[] = {
-#if DEBUG
+//#if DEBUG
     EventSeverity(-1) // Avoid zero size array
-#else
-    EventSeverity::Debug
-#endif
+//#else
+//    EventSeverity::Debug
+//#endif
 };
 
 constexpr Event disabledEvents[] = {
@@ -80,7 +80,8 @@ constexpr Event disabledEvents[] = {
 };
 
 constexpr EventPermutation disabledEventPermutations[] = {
-    { EventSeverity::Debug, Event::Shader }
+    { EventSeverity(-1),  Event(-1) }
+    //{ EventSeverity::Debug, Event::Shader }
 };
 
 }

--- a/include/mbgl/platform/log.hpp
+++ b/include/mbgl/platform/log.hpp
@@ -61,7 +61,7 @@ public:
     template<typename T, typename ...Args>
     static inline const T &Set(Args&& ...args) {
         Backend = util::make_unique<T>(::std::forward<Args>(args)...);
-        return *dynamic_cast<T *>(Backend.get());
+        return *reinterpret_cast<T *>(Backend.get());
     }
 
 private:

--- a/include/mbgl/storage/default/request.hpp
+++ b/include/mbgl/storage/default/request.hpp
@@ -15,13 +15,14 @@ typedef struct uv_loop_s uv_loop_t;
 namespace mbgl {
 
 class Response;
+class Environment;
 
 class Request : private util::noncopyable {
     MBGL_STORE_THREAD(tid)
 
 public:
     using Callback = std::function<void(const Response &)>;
-    Request(const Resource &resource, uv_loop_t *loop, Callback callback);
+    Request(const Resource &resource, uv_loop_t *loop, const Environment &env, Callback callback);
 
 public:
     // May be called from any thread.
@@ -45,6 +46,11 @@ private:
 
 public:
     const Resource resource;
+
+    // The environment ref is used to associate requests with a particular environment. This allows
+    // us to only terminate requests associated with that environment, e.g. when the map the env
+    // belongs to is discarded.
+    const Environment &env;
 };
 
 }

--- a/include/mbgl/storage/default/shared_request_base.hpp
+++ b/include/mbgl/storage/default/shared_request_base.hpp
@@ -34,7 +34,7 @@ public:
         MBGL_VERIFY_THREAD(tid);
 
         if (source) {
-            source->notify(this, observers, std::shared_ptr<const Response>(response.release()),
+            source->notify(this, observers, std::shared_ptr<const Response>(std::move(response)),
                            hint);
         }
     }

--- a/include/mbgl/storage/file_source.hpp
+++ b/include/mbgl/storage/file_source.hpp
@@ -15,6 +15,7 @@ typedef struct uv_loop_s uv_loop_t;
 namespace mbgl {
 
 class Request;
+class Environment;
 
 class FileSource : private util::noncopyable {
 protected:
@@ -27,12 +28,19 @@ public:
 
     // These can be called from any thread. The callback will be invoked in the loop.
     // You can only cancel a request from the same thread it was created in.
-    virtual Request *request(const Resource &resource, uv_loop_t *loop, Callback callback) = 0;
+    virtual Request *request(const Resource &resource, uv_loop_t *loop, const Environment &env,
+                             Callback callback) = 0;
     virtual void cancel(Request *request) = 0;
 
     // These can be called from any thread. The callback will be invoked in an arbitrary other thread.
     // You cannot cancel these requests.
-    virtual void request(const Resource &resource, Callback callback) = 0;
+    virtual void request(const Resource &resource, const Environment &env, Callback callback) = 0;
+
+    // This can be called from any thread. All requests with the environment pointer env should be
+    // notified as errored. Note that this is /different/ from canceling requests; a canceled
+    // request's callback is never called, while an aborted request's callback is called with
+    // a error message.
+    virtual void abort(const Environment &env) = 0;
 };
 
 }

--- a/include/mbgl/util/exception.hpp
+++ b/include/mbgl/util/exception.hpp
@@ -8,10 +8,17 @@ namespace util {
 
 struct Exception : std::runtime_error {
     inline Exception(const char *msg) : std::runtime_error(msg) {}
+    inline Exception(const std::string &msg) : std::runtime_error(msg) {}
 };
 
 struct MisuseException : Exception {
     inline MisuseException(const char *msg) : Exception(msg) {}
+    inline MisuseException(const std::string &msg) : Exception(msg) {}
+};
+
+struct ShaderException : Exception {
+    inline ShaderException(const char *msg) : Exception(msg) {}
+    inline ShaderException(const std::string &msg) : Exception(msg) {}
 };
 
 }

--- a/include/mbgl/util/exception.hpp
+++ b/include/mbgl/util/exception.hpp
@@ -1,0 +1,20 @@
+#ifndef MBGL_UTIL_EXCEPTION
+#define MBGL_UTIL_EXCEPTION
+
+#include <stdexcept>
+
+namespace mbgl {
+namespace util {
+
+struct Exception : std::runtime_error {
+    inline Exception(const char *msg) : std::runtime_error(msg) {}
+};
+
+struct MisuseException : Exception {
+    inline MisuseException(const char *msg) : Exception(msg) {}
+};
+
+}
+}
+
+#endif

--- a/include/mbgl/util/uv.hpp
+++ b/include/mbgl/util/uv.hpp
@@ -89,7 +89,7 @@ public:
 
 private:
     T *ptr = nullptr;
-    lock lock;
+    class lock lock;
 };
 
 

--- a/include/mbgl/util/uv.hpp
+++ b/include/mbgl/util/uv.hpp
@@ -20,6 +20,46 @@ class worker;
 class mutex;
 class cond;
 
+class lock {
+public:
+    lock(mutex &);
+    lock(const std::unique_ptr<mutex> &);
+    lock(const lock &) = delete;
+    lock(lock &&lock);
+    lock &operator=(const lock &lock) = delete;
+    lock &operator=(lock &&lock);
+    ~lock();
+private:
+    mutex *mtx = nullptr;
+};
+
+class readlock {
+public:
+    readlock(rwlock &);
+    readlock(const std::unique_ptr<rwlock> &);
+    readlock(const readlock &) = delete;
+    readlock(readlock &&lock);
+    readlock &operator=(const readlock &lock) = delete;
+    readlock &operator=(readlock &&lock);
+    ~readlock();
+private:
+    rwlock *mtx = nullptr;
+};
+
+class writelock {
+public:
+    writelock(rwlock &);
+    writelock(const std::unique_ptr<rwlock> &);
+    writelock(const writelock &) = delete;
+    writelock(writelock &&lock);
+    writelock &operator=(const writelock &lock) = delete;
+    writelock &operator=(writelock &&lock);
+    ~writelock();
+private:
+    rwlock *mtx = nullptr;
+};
+
+
 const char *getFileRequestError(uv_fs_t *req);
 
 template <typename T>

--- a/include/mbgl/util/uv.hpp
+++ b/include/mbgl/util/uv.hpp
@@ -2,6 +2,7 @@
 #define MBGL_UTIL_UV
 
 #include <string>
+#include <memory>
 
 typedef struct uv_handle_s uv_handle_t;
 typedef struct uv_async_s uv_async_t;

--- a/include/mbgl/util/uv.hpp
+++ b/include/mbgl/util/uv.hpp
@@ -59,6 +59,39 @@ private:
     rwlock *mtx = nullptr;
 };
 
+template <class T>
+class exclusive {
+public:
+    exclusive(T& val, mutex &mtx) : ptr(&val), lock(mtx) {}
+    exclusive(T *val, mutex &mtx) : ptr(val), lock(mtx) {}
+    exclusive(mutex &mtx) : lock(mtx) {}
+    exclusive(const std::unique_ptr<mutex> &mtx) : lock(mtx) {}
+    exclusive(const exclusive &) = delete;
+    exclusive(exclusive &&) = default;
+    exclusive &operator=(const exclusive &) = delete;
+    exclusive &operator=(exclusive &&) = default;
+
+    T *operator->() { return ptr; }
+    const T *operator->() const { return ptr; }
+    T *operator*() { return ptr; }
+    const T *operator*() const { return ptr; }
+    operator T&() { return *ptr; }
+    operator const T&() const { return *ptr; }
+
+    void operator<<(T& val) { operator<<(&val); }
+    void operator<<(T *val) {
+        if (ptr) {
+            throw std::runtime_error("exclusive<> was assigned before");
+        }
+        ptr = val;
+    }
+
+private:
+    T *ptr = nullptr;
+    lock lock;
+};
+
+
 
 const char *getFileRequestError(uv_fs_t *req);
 

--- a/include/mbgl/util/variant.hpp
+++ b/include/mbgl/util/variant.hpp
@@ -251,13 +251,13 @@ struct unwrapper<recursive_wrapper<T>>
 };
 
 
-template <typename F, typename V, typename...Types>
+template <typename F, typename V, typename R, typename...Types>
 struct dispatcher;
 
-template <typename F, typename V, typename T, typename...Types>
-struct dispatcher<F, V, T, Types...>
+template <typename F, typename V, typename R, typename T, typename...Types>
+struct dispatcher<F, V, R, T, Types...>
 {
-    using result_type = typename detail::result_of_unary_visit<F, V>::type;
+    using result_type = R;
     VARIANT_INLINE static result_type apply_const(V const& v, F f)
     {
         if (v.get_type_index() == sizeof...(Types))
@@ -266,7 +266,7 @@ struct dispatcher<F, V, T, Types...>
         }
         else
         {
-            return dispatcher<F, V, Types...>::apply_const(v, f);
+            return dispatcher<F, V, R, Types...>::apply_const(v, f);
         }
     }
 
@@ -278,15 +278,15 @@ struct dispatcher<F, V, T, Types...>
         }
         else
         {
-            return dispatcher<F, V, Types...>::apply(v, f);
+            return dispatcher<F, V, R, Types...>::apply(v, f);
         }
     }
 };
 
-template<typename F, typename V>
-struct dispatcher<F, V>
+template<typename F, typename V, typename R>
+struct dispatcher<F, V, R>
 {
-    using result_type = typename detail::result_of_unary_visit<F, V>::type;
+    using result_type = R;
     VARIANT_INLINE static result_type apply_const(V const&, F)
     {
         throw std::runtime_error(std::string("unary dispatch: FAIL ") + typeid(V).name());
@@ -299,13 +299,13 @@ struct dispatcher<F, V>
 };
 
 
-template <typename F, typename V, typename T, typename...Types>
+template <typename F, typename V, typename R, typename T, typename...Types>
 struct binary_dispatcher_rhs;
 
-template <typename F, typename V, typename T0, typename T1, typename...Types>
-struct binary_dispatcher_rhs<F, V, T0, T1, Types...>
+template <typename F, typename V, typename R, typename T0, typename T1, typename...Types>
+struct binary_dispatcher_rhs<F, V, R, T0, T1, Types...>
 {
-    using result_type = typename detail::result_of_binary_visit<F, V>::type;
+    using result_type = R;
     VARIANT_INLINE static result_type apply_const(V const& lhs, V const& rhs, F f)
     {
         if (rhs.get_type_index() == sizeof...(Types)) // call binary functor
@@ -315,7 +315,7 @@ struct binary_dispatcher_rhs<F, V, T0, T1, Types...>
         }
         else
         {
-            return binary_dispatcher_rhs<F, V, T0, Types...>::apply_const(lhs, rhs, f);
+            return binary_dispatcher_rhs<F, V, R, T0, Types...>::apply_const(lhs, rhs, f);
         }
     }
 
@@ -328,16 +328,16 @@ struct binary_dispatcher_rhs<F, V, T0, T1, Types...>
         }
         else
         {
-            return binary_dispatcher_rhs<F, V, T0, Types...>::apply(lhs, rhs, f);
+            return binary_dispatcher_rhs<F, V, R, T0, Types...>::apply(lhs, rhs, f);
         }
     }
 
 };
 
-template<typename F, typename V, typename T>
-struct binary_dispatcher_rhs<F, V, T>
+template<typename F, typename V, typename R, typename T>
+struct binary_dispatcher_rhs<F, V, R, T>
 {
-    using result_type = typename detail::result_of_binary_visit<F, V>::type;
+    using result_type = R;
     VARIANT_INLINE static result_type apply_const(V const&, V const&, F)
     {
         throw std::runtime_error("binary dispatch: FAIL");
@@ -349,13 +349,13 @@ struct binary_dispatcher_rhs<F, V, T>
 };
 
 
-template <typename F, typename V, typename T, typename...Types>
+template <typename F, typename V, typename R,  typename T, typename...Types>
 struct binary_dispatcher_lhs;
 
-template <typename F, typename V, typename T0, typename T1, typename...Types>
-struct binary_dispatcher_lhs<F, V, T0, T1, Types...>
+template <typename F, typename V, typename R, typename T0, typename T1, typename...Types>
+struct binary_dispatcher_lhs<F, V, R, T0, T1, Types...>
 {
-    using result_type = typename detail::result_of_binary_visit<F, V>::type;
+    using result_type = R;
     VARIANT_INLINE static result_type apply_const(V const& lhs, V const& rhs, F f)
     {
         if (lhs.get_type_index() == sizeof...(Types)) // call binary functor
@@ -364,7 +364,7 @@ struct binary_dispatcher_lhs<F, V, T0, T1, Types...>
         }
         else
         {
-            return binary_dispatcher_lhs<F, V, T0, Types...>::apply_const(lhs, rhs, f);
+            return binary_dispatcher_lhs<F, V, R, T0, Types...>::apply_const(lhs, rhs, f);
         }
     }
 
@@ -376,16 +376,16 @@ struct binary_dispatcher_lhs<F, V, T0, T1, Types...>
         }
         else
         {
-            return binary_dispatcher_lhs<F, V, T0, Types...>::apply(lhs, rhs, f);
+            return binary_dispatcher_lhs<F, V, R, T0, Types...>::apply(lhs, rhs, f);
         }
     }
 
 };
 
-template<typename F, typename V, typename T>
-struct binary_dispatcher_lhs<F, V, T>
+template<typename F, typename V, typename R, typename T>
+struct binary_dispatcher_lhs<F, V, R, T>
 {
-    using result_type = typename detail::result_of_binary_visit<F, V>::type;
+    using result_type = R;
     VARIANT_INLINE static result_type apply_const(V const&, V const&, F)
     {
         throw std::runtime_error("binary dispatch: FAIL");
@@ -397,13 +397,13 @@ struct binary_dispatcher_lhs<F, V, T>
     }
 };
 
-template <typename F, typename V, typename...Types>
+template <typename F, typename V, typename R, typename...Types>
 struct binary_dispatcher;
 
-template <typename F, typename V, typename T, typename...Types>
-struct binary_dispatcher<F, V, T, Types...>
+template <typename F, typename V, typename R, typename T, typename...Types>
+struct binary_dispatcher<F, V, R, T, Types...>
 {
-    using result_type = typename detail::result_of_binary_visit<F, V>::type;
+    using result_type = R;
     VARIANT_INLINE static result_type apply_const(V const& v0, V const& v1, F f)
     {
         if (v0.get_type_index() == sizeof...(Types))
@@ -414,14 +414,14 @@ struct binary_dispatcher<F, V, T, Types...>
             }
             else
             {
-                return binary_dispatcher_rhs<F, V, T, Types...>::apply_const(v0, v1, f);
+                return binary_dispatcher_rhs<F, V, R, T, Types...>::apply_const(v0, v1, f);
             }
         }
         else if (v1.get_type_index() == sizeof...(Types))
         {
-            return binary_dispatcher_lhs<F, V, T, Types...>::apply_const(v0, v1, f);
+            return binary_dispatcher_lhs<F, V, R, T, Types...>::apply_const(v0, v1, f);
         }
-        return binary_dispatcher<F, V, Types...>::apply_const(v0, v1, f);
+        return binary_dispatcher<F, V, R, Types...>::apply_const(v0, v1, f);
     }
 
     VARIANT_INLINE static result_type apply(V & v0, V & v1, F f)
@@ -434,21 +434,21 @@ struct binary_dispatcher<F, V, T, Types...>
             }
             else
             {
-                return binary_dispatcher_rhs<F, V, T, Types...>::apply(v0, v1, f);
+                return binary_dispatcher_rhs<F, V, R, T, Types...>::apply(v0, v1, f);
             }
         }
         else if (v1.get_type_index() == sizeof...(Types))
         {
-            return binary_dispatcher_lhs<F, V, T, Types...>::apply(v0, v1, f);
+            return binary_dispatcher_lhs<F, V, R, T, Types...>::apply(v0, v1, f);
         }
-        return binary_dispatcher<F, V, Types...>::apply(v0, v1, f);
+        return binary_dispatcher<F, V, R, Types...>::apply(v0, v1, f);
     }
 };
 
-template<typename F, typename V>
-struct binary_dispatcher<F, V>
+template<typename F, typename V, typename R>
+struct binary_dispatcher<F, V, R>
 {
-    using result_type = typename detail::result_of_binary_visit<F, V>::type;
+    using result_type = R;
     VARIANT_INLINE static result_type apply_const(V const&, V const&, F)
     {
         throw std::runtime_error("binary dispatch: FAIL");
@@ -497,24 +497,6 @@ private:
     Variant const& lhs_;
 };
 
-// operator<< helper
-template <typename Out>
-class printer
-{
-public:
-    explicit printer(Out & out)
-        : out_(out) {}
-    printer& operator=(printer const&) = delete;
-
-// visitor
-    template <typename T>
-    void operator()(T const& operand) const
-    {
-        out_ << operand;
-    }
-private:
-    Out & out_;
-};
 
 } // namespace detail
 
@@ -535,7 +517,6 @@ private:
     data_type data;
 
 public:
-
 
     VARIANT_INLINE variant()
         : type_index(sizeof...(Types) - 1)
@@ -656,17 +637,23 @@ public:
     template <typename F, typename V>
     auto VARIANT_INLINE
     static visit(V const& v, F f)
-        -> decltype(detail::dispatcher<F, V, Types...>::apply_const(v, f))
+        -> decltype(detail::dispatcher<F, V,
+                    typename detail::result_of_unary_visit<F,
+                    typename detail::select_type<0, Types...>::type>::type, Types...>::apply_const(v, f))
     {
-        return detail::dispatcher<F, V, Types...>::apply_const(v, f);
+        using R = typename detail::result_of_unary_visit<F, typename detail::select_type<0, Types...>::type>::type;
+        return detail::dispatcher<F, V, R, Types...>::apply_const(v, f);
     }
     // non-const
     template <typename F, typename V>
     auto VARIANT_INLINE
     static visit(V & v, F f)
-        -> decltype(detail::dispatcher<F, V, Types...>::apply(v, f))
+        -> decltype(detail::dispatcher<F, V,
+                    typename detail::result_of_unary_visit<F,
+                    typename detail::select_type<0, Types...>::type>::type, Types...>::apply(v, f))
     {
-        return detail::dispatcher<F, V, Types...>::apply(v, f);
+        using R = typename detail::result_of_unary_visit<F, typename detail::select_type<0, Types...>::type>::type;
+        return detail::dispatcher<F, V, R, Types...>::apply(v, f);
     }
 
     // binary
@@ -674,17 +661,23 @@ public:
     template <typename F, typename V>
     auto VARIANT_INLINE
     static binary_visit(V const& v0, V const& v1, F f)
-        -> decltype(detail::binary_dispatcher<F, V, Types...>::apply_const(v0, v1, f))
+        -> decltype(detail::binary_dispatcher<F, V,
+                    typename detail::result_of_binary_visit<F,
+                    typename detail::select_type<0, Types...>::type>::type, Types...>::apply_const(v0, v1, f))
     {
-        return detail::binary_dispatcher<F, V, Types...>::apply_const(v0, v1, f);
+        using R = typename detail::result_of_binary_visit<F,typename detail::select_type<0, Types...>::type>::type;
+        return detail::binary_dispatcher<F, V, R, Types...>::apply_const(v0, v1, f);
     }
     // non-const
     template <typename F, typename V>
     auto VARIANT_INLINE
     static binary_visit(V& v0, V& v1, F f)
-        -> decltype(detail::binary_dispatcher<F, V, Types...>::apply(v0, v1, f))
+        -> decltype(detail::binary_dispatcher<F, V,
+                    typename detail::result_of_binary_visit<F,
+                    typename detail::select_type<0, Types...>::type>::type, Types...>::apply(v0, v1, f))
     {
-        return detail::binary_dispatcher<F, V, Types...>::apply(v0, v1, f);
+        using R = typename detail::result_of_binary_visit<F,typename detail::select_type<0, Types...>::type>::type;
+        return detail::binary_dispatcher<F, V, R, Types...>::apply(v0, v1, f);
     }
 
     ~variant() noexcept
@@ -756,16 +749,6 @@ ResultType const&  get(T const& var)
     return var.template get<ResultType>();
 }
 
-
-// operator<<
-template <typename charT, typename traits, typename... Types>
-VARIANT_INLINE std::basic_ostream<charT, traits>&
-operator<< (std::basic_ostream<charT, traits>& out, variant<Types...> const& rhs)
-{
-    detail::printer<std::basic_ostream<charT, traits>> visitor(out);
-    apply_visitor(visitor, rhs);
-    return out;
-}
 
 }}
 

--- a/include/mbgl/util/variant_io.hpp
+++ b/include/mbgl/util/variant_io.hpp
@@ -1,0 +1,41 @@
+#ifndef MAPBOX_UTIL_VARIANT_IO_HPP
+#define MAPBOX_UTIL_VARIANT_IO_HPP
+
+#include "variant.hpp"
+
+namespace mapbox { namespace util {
+
+namespace detail {
+// operator<< helper
+template <typename Out>
+class printer
+{
+public:
+    explicit printer(Out & out)
+        : out_(out) {}
+    printer& operator=(printer const&) = delete;
+
+// visitor
+    template <typename T>
+    void operator()(T const& operand) const
+    {
+        out_ << operand;
+    }
+private:
+    Out & out_;
+};
+}
+
+// operator<<
+template <typename charT, typename traits, typename... Types>
+VARIANT_INLINE std::basic_ostream<charT, traits>&
+operator<< (std::basic_ostream<charT, traits>& out, variant<Types...> const& rhs)
+{
+    detail::printer<std::basic_ostream<charT, traits>> visitor(out);
+    apply_visitor(visitor, rhs);
+    return out;
+}
+
+}}
+
+#endif //MAPBOX_UTIL_VARIANT_IO_HPP

--- a/mbgl.gyp
+++ b/mbgl.gyp
@@ -8,6 +8,7 @@
     './gyp/standalone.gypi',
     './gyp/core.gypi',
     './gyp/none.gypi',
+    './gyp/install.gypi',
   ],
   'conditions': [
     ['headless_lib == "cgl" and host == "osx"', { 'includes': [ './gyp/headless-cgl.gypi' ] } ],
@@ -22,6 +23,6 @@
     ['asset_lib == "zip"', { 'includes': [ './gyp/asset-zip.gypi' ] } ],
     ['cache_lib == "sqlite"', { 'includes': [ './gyp/cache-sqlite.gypi' ] } ],
 
-    ['install_prefix != ""', { 'includes': ['./gyp/install.gypi' ] } ],
+    ['host == "osx" or host == "linux"', { 'includes': [ './bin/render.gypi' ] } ],
   ],
 }

--- a/platform/android/log_android.cpp
+++ b/platform/android/log_android.cpp
@@ -29,7 +29,7 @@ int AndroidLogBackend::severityToPriority(EventSeverity severity) {
 }
 
 void AndroidLogBackend::record(EventSeverity severity, Event event, const std::string &msg) {
-    __android_log_print(severityToPriority(severity), EventClass(event).c_str(), "%s", msg.c_str());
+    __android_log_print(severityToPriority(severity), (std::string {"MBGL."} + EventClass(event).str()).c_str(), "%s", msg.c_str());
 }
 
 void AndroidLogBackend::record(EventSeverity severity, Event event, const char* format, ...) {
@@ -42,18 +42,18 @@ void AndroidLogBackend::record(EventSeverity severity, Event event, const char* 
 
     va_end(args);
 
-    __android_log_print(severityToPriority(severity), EventClass(event).c_str(), "%s", buf);
+    __android_log_print(severityToPriority(severity), (std::string {"MBGL."} + EventClass(event).str()).c_str(), "%s", buf);
 
     delete buf;
     buf  = nullptr;
 }
 
 void AndroidLogBackend::record(EventSeverity severity, Event event, int64_t code) {
-    __android_log_print(severityToPriority(severity), EventClass(event).c_str(), "(%" PRId64 ")", code);
+    __android_log_print(severityToPriority(severity), (std::string {"MBGL."} + EventClass(event).str()).c_str(), "(%" PRId64 ")", code);
 }
 
 void AndroidLogBackend::record(EventSeverity severity, Event event, int64_t code, const std::string &msg) {
-    __android_log_print(severityToPriority(severity), EventClass(event).c_str(), "(%" PRId64 ") %s", code, msg.c_str());
+    __android_log_print(severityToPriority(severity), (std::string {"MBGL."} + EventClass(event).str()).c_str(), "(%" PRId64 ") %s", code, msg.c_str());
 }
 
 }

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -188,6 +188,7 @@ void HTTPRequestImpl::handleResponse() {
         }
 
         context->removeRequest(request);
+        request->ptr = nullptr;
         delete request;
         request = nullptr;
     }
@@ -206,6 +207,8 @@ void HTTPRequestImpl::cancel() {
         [task cancel];
         [task release];
         task = nullptr;
+    } else {
+        delete this;
     }
 }
 

--- a/platform/darwin/image.mm
+++ b/platform/darwin/image.mm
@@ -108,7 +108,6 @@ Image::Image(const std::string &source_data) {
         CFRelease(data);
         width = 0;
         height = 0;
-        img.release();
         return;
     }
 

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -62,14 +62,14 @@ void GLFWView::initialize(mbgl::Map *map_) {
 
     int width, height;
     glfwGetWindowSize(window, &width, &height);
-    resize(window, width, height);
+    onResize(window, width, height);
 
-    glfwSetCursorPosCallback(window, mouseMove);
-    glfwSetMouseButtonCallback(window, mouseClick);
-    glfwSetWindowSizeCallback(window, resize);
-    glfwSetFramebufferSizeCallback(window, resize);
-    glfwSetScrollCallback(window, scroll);
-    glfwSetKeyCallback(window, key);
+    glfwSetCursorPosCallback(window, onMouseMove);
+    glfwSetMouseButtonCallback(window, onMouseClick);
+    glfwSetWindowSizeCallback(window, onResize);
+    glfwSetFramebufferSizeCallback(window, onResize);
+    glfwSetScrollCallback(window, onScroll);
+    glfwSetKeyCallback(window, onKey);
 
     const std::string extensions = reinterpret_cast<const char *>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)));
     {
@@ -157,7 +157,7 @@ void GLFWView::initialize(mbgl::Map *map_) {
     glfwMakeContextCurrent(nullptr);
 }
 
-void GLFWView::key(GLFWwindow *window, int key, int /*scancode*/, int action, int mods) {
+void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, int mods) {
     GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
 
     if (action == GLFW_RELEASE) {
@@ -190,7 +190,7 @@ void GLFWView::key(GLFWwindow *window, int key, int /*scancode*/, int action, in
     }
 }
 
-void GLFWView::scroll(GLFWwindow *window, double /*xOffset*/, double yOffset) {
+void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) {
     GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     double delta = yOffset * 40;
 
@@ -213,16 +213,16 @@ void GLFWView::scroll(GLFWwindow *window, double /*xOffset*/, double yOffset) {
     view->map->scaleBy(scale, view->lastX, view->lastY);
 }
 
-void GLFWView::resize(GLFWwindow *window, int width, int height ) {
+void GLFWView::onResize(GLFWwindow *window, int width, int height ) {
     GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
 
     int fbWidth, fbHeight;
     glfwGetFramebufferSize(window, &fbWidth, &fbHeight);
 
-    view->map->resize(width, height, static_cast<float>(fbWidth) / static_cast<float>(width), fbWidth, fbHeight);
+    view->resize(width, height, static_cast<float>(fbWidth) / static_cast<float>(width), fbWidth, fbHeight);
 }
 
-void GLFWView::mouseClick(GLFWwindow *window, int button, int action, int modifiers) {
+void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modifiers) {
     GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
 
     if (button == GLFW_MOUSE_BUTTON_RIGHT ||
@@ -249,7 +249,7 @@ void GLFWView::mouseClick(GLFWwindow *window, int button, int action, int modifi
     }
 }
 
-void GLFWView::mouseMove(GLFWwindow *window, double x, double y) {
+void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
     GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     if (view->tracking) {
         double dx = x - view->lastX;

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/platform/default/glfw_view.hpp>
+#include <mbgl/map/still_image.hpp>
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/platform/log.hpp>
 
@@ -273,12 +274,7 @@ int GLFWView::run() {
         glfwWaitEvents();
     }
 
-    map->stop([]() {
-        glfwWaitEvents();
-    });
-
-    // Terminate here to save binary shaders
-    map->terminate();
+    map->stop();
 
     return 0;
 }
@@ -297,7 +293,6 @@ void GLFWView::notify() {
 
 void GLFWView::swap() {
     glfwSwapBuffers(window);
-    map->swapped();
     fps();
 }
 

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -287,17 +287,9 @@ void GLFWView::deactivate() {
     glfwMakeContextCurrent(nullptr);
 }
 
-void GLFWView::notify() {
-    glfwPostEmptyEvent();
-}
-
 void GLFWView::swap() {
     glfwSwapBuffers(window);
     fps();
-}
-
-void GLFWView::notifyMapChange(mbgl::MapChange /*change*/, std::chrono::steady_clock::duration /*delay*/) {
-    // no-op
 }
 
 void GLFWView::fps() {

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -3,6 +3,8 @@
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/platform/log.hpp>
 
+pthread_once_t loadGLExtensions = PTHREAD_ONCE_INIT;
+
 GLFWView::GLFWView(bool fullscreen_) : fullscreen(fullscreen_) {
 #ifdef NVIDIA
     glDiscardFramebufferEXT = reinterpret_cast<PFNGLDISCARDFRAMEBUFFEREXTPROC>(glfwGetProcAddress("glDiscardFramebufferEXT"));
@@ -72,8 +74,8 @@ void GLFWView::initialize(mbgl::Map *map_) {
     glfwSetScrollCallback(window, onScroll);
     glfwSetKeyCallback(window, onKey);
 
-    const std::string extensions = reinterpret_cast<const char *>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)));
-    {
+    pthread_once(&loadGLExtensions, [] {
+        const std::string extensions = reinterpret_cast<const char *>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)));
         using namespace mbgl;
 
         if (extensions.find("GL_KHR_debug") != std::string::npos) {
@@ -153,7 +155,7 @@ void GLFWView::initialize(mbgl::Map *map_) {
         // Require packed depth stencil
         gl::isPackedDepthStencilSupported = true;
         gl::isDepth24Supported = true;
-    }
+    });
 
     glfwMakeContextCurrent(nullptr);
 }

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -131,7 +131,7 @@ void HeadlessView::createContext() {
 #endif
 }
 
-void HeadlessView::resize(uint16_t width, uint16_t height, float pixelRatio) {
+void HeadlessView::resize(const uint16_t width, const uint16_t height, const float pixelRatio) {
     clearBuffers();
 
     width_ = width;
@@ -176,6 +176,8 @@ void HeadlessView::resize(uint16_t width, uint16_t height, float pixelRatio) {
         }
         throw std::runtime_error(error.str());
     }
+
+    View::resize(width, height, pixelRatio, w, h);
 
     deactivate();
 }

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -100,6 +100,10 @@ void HeadlessView::loadExtensions() {
 }
 
 void HeadlessView::createContext() {
+    if (!display_) {
+        throw std::runtime_error("Display is not set");
+    }
+
 #if MBGL_USE_CGL
     CGLError error = CGLCreateContext(display_->pixelFormat, NULL, &glContext);
     if (error != kCGLNoError) {

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -247,7 +247,9 @@ void HeadlessView::clearBuffers() {
 }
 
 HeadlessView::~HeadlessView() {
+    activate();
     clearBuffers();
+    deactivate();
 
 #if MBGL_USE_CGL
     CGLDestroyContext(glContext);

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -35,17 +35,22 @@ CGLProc CGLGetProcAddress(const char *proc) {
 
 namespace mbgl {
 
-
-HeadlessView::HeadlessView()
+HeadlessView::HeadlessView(uint16_t width, uint16_t height, float pixelRatio)
     : display_(std::make_shared<HeadlessDisplay>()) {
     createContext();
     loadExtensions();
+    resize(width, height, pixelRatio);
 }
 
-HeadlessView::HeadlessView(std::shared_ptr<HeadlessDisplay> display)
-    : display_(display) {
+HeadlessView::HeadlessView(std::shared_ptr<HeadlessDisplay> display,
+                           uint16_t width, uint16_t height, float pixelRatio)
+    : display_(display),
+      width_(width),
+      height_(height),
+      pixelRatio_(pixelRatio) {
     createContext();
     loadExtensions();
+    resize(width, height, pixelRatio);
 }
 
 void HeadlessView::initialize(Map *map_) {

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -144,6 +144,7 @@ void HeadlessView::createContext() {
 }
 
 void HeadlessView::resize(const uint16_t width, const uint16_t height, const float pixelRatio) {
+    // TODO: don't drop the framebuffer when the new width/height/pixelRatio are identical.
     // TODO: lazy resizing, so this is done in the Map thread.
     clearBuffers();
 

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -145,7 +145,7 @@ void HeadlessView::resize(const uint16_t width, const uint16_t height, const flo
     prospective = { width, height, pixelRatio };
 }
 
-HeadlessView::Dimensions::Dimensions(uint16_t width_, uint16_t height_, float pixelRatio_)
+HeadlessView::Dimensions::Dimensions(uint16_t width_, uint16_t height_, float pixelRatio_) noexcept
     : width(width_), height(height_), pixelRatio(pixelRatio_) {
 }
 

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -11,6 +11,8 @@
 #include <cstring>
 #include <cassert>
 
+pthread_once_t loadGLExtensions = PTHREAD_ONCE_INIT;
+
 #ifdef MBGL_USE_CGL
 #include <CoreFoundation/CoreFoundation.h>
 
@@ -51,9 +53,12 @@ void HeadlessView::loadExtensions() {
         return;
     }
 
-    const char *extensionPtr = reinterpret_cast<const char *>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)));
+    pthread_once(&loadGLExtensions, [] {
+        const char *extensionPtr = reinterpret_cast<const char *>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)));
 
-    if (extensionPtr) {
+        if (!extensionPtr) {
+            return;
+        }
         const std::string extensions = extensionPtr;
 
 #ifdef MBGL_USE_CGL
@@ -80,7 +85,7 @@ void HeadlessView::loadExtensions() {
             assert(gl::IsVertexArray != nullptr);
         }
 #endif
-    }
+    });
 
     // HeadlessView requires packed depth stencil
     gl::isPackedDepthStencilSupported = true;

--- a/platform/default/sqlite_cache.cpp
+++ b/platform/default/sqlite_cache.cpp
@@ -163,7 +163,7 @@ void SQLiteCache::createDatabase() {
             db->exec(sql);
         } catch (mapbox::sqlite::Exception &ex) {
             Log::Error(Event::Database, "Failed to create database: %s", ex.what());
-            db.release();
+            db.reset();
         }
     }
 }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -37,6 +37,7 @@ const std::string &defaultCacheDatabase() {
     return path;
 }
 
+static dispatch_once_t loadGLExtensions;
 
 extern NSString *const MGLStyleKeyGeneric;
 extern NSString *const MGLStyleKeyFill;
@@ -213,8 +214,9 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     // load extensions
     //
-    const std::string extensions = (char *)glGetString(GL_EXTENSIONS);
-    {
+    dispatch_once(&loadGLExtensions, ^{
+        const std::string extensions = (char *)glGetString(GL_EXTENSIONS);
+
         using namespace mbgl;
 
         if (extensions.find("GL_OES_vertex_array_object") != std::string::npos) {
@@ -231,7 +233,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
         if (extensions.find("GL_OES_depth24") != std::string::npos) {
             gl::isDepth24Supported = YES;
         }
-    }
+    });
 
     // setup mbgl map
     //

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -236,10 +236,10 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     // setup mbgl map
     //
     mbglView = new MBGLView(self);
+    mbglView->resize(self.bounds.size.width, self.bounds.size.height, _glView.contentScaleFactor, _glView.drawableWidth, _glView.drawableHeight);
     mbglFileCache  = new mbgl::SQLiteCache(defaultCacheDatabase());
     mbglFileSource = new mbgl::DefaultFileSource(mbglFileCache);
     mbglMap = new mbgl::Map(*mbglView, *mbglFileSource);
-    mbglMap->resize(self.bounds.size.width, self.bounds.size.height, _glView.contentScaleFactor, _glView.drawableWidth, _glView.drawableHeight);
 
     // Notify map object when network reachability status changes.
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -489,7 +489,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect
 {
-    mbglMap->resize(rect.size.width, rect.size.height, view.contentScaleFactor, view.drawableWidth, view.drawableHeight);
+    mbglView->resize(rect.size.width, rect.size.height, view.contentScaleFactor, view.drawableWidth, view.drawableHeight);
 }
 
 - (void)layoutSubviews
@@ -1578,15 +1578,6 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     return resourceBundlePath;
 }
 
-- (void)swap
-{
-    if (mbglMap->needsSwap())
-    {
-        [self.glView display];
-        mbglMap->swapped();
-    }
-}
-
 class MBGLView : public mbgl::View
 {
     public:
@@ -1621,6 +1612,11 @@ class MBGLView : public mbgl::View
         }
     }
 
+    void resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight) {
+        View::resize(width, height, ratio, fbWidth, fbHeight);
+    }
+
+
     void activate()
     {
         [EAGLContext setCurrentContext:nativeView.context];
@@ -1633,9 +1629,7 @@ class MBGLView : public mbgl::View
 
     void swap()
     {
-        [nativeView performSelectorOnMainThread:@selector(swap)
-                                     withObject:nil
-                                  waitUntilDone:NO];
+        [nativeView.glView display];
     }
 
     private:

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1584,12 +1584,6 @@ class MBGLView : public mbgl::View
         MBGLView(MGLMapView *nativeView_) : nativeView(nativeView_) {}
         virtual ~MBGLView() {}
 
-
-    void notify()
-    {
-        // no-op
-    }
-
     void notifyMapChange(mbgl::MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero())
     {
         if (delay != std::chrono::steady_clock::duration::zero())

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -40,6 +40,9 @@ public:
     void bind(bool force = false) {
         if (buffer == 0) {
             MBGL_CHECK_ERROR(glGenBuffers(1, &buffer));
+            if (!buffer) {
+                throw std::runtime_error("Could not generate OpenGL buffer");
+            }
             force = true;
         }
         MBGL_CHECK_ERROR(glBindBuffer(bufferType, buffer));

--- a/src/mbgl/map/environment.cpp
+++ b/src/mbgl/map/environment.cpp
@@ -27,9 +27,9 @@ Request *Environment::request(const Resource &resource, std::function<void(const
     return fileSource.request(resource, loop, *this, std::move(callback));
 }
 
-void Environment::cancelRequest(Request *request) {
+void Environment::cancelRequest(Request *req) {
     assert(inMapThread());
-    fileSource.cancel(request);
+    fileSource.cancel(req);
 }
 
 void Environment::terminate() {

--- a/src/mbgl/map/environment.cpp
+++ b/src/mbgl/map/environment.cpp
@@ -1,0 +1,39 @@
+#include <mbgl/map/environment.hpp>
+#include <mbgl/storage/file_source.hpp>
+
+#include <uv.h>
+
+#include <cassert>
+
+namespace mbgl {
+
+Environment::Environment(FileSource &fs) : fileSource(fs), loop(uv_loop_new()) {
+}
+
+void Environment::setup() {
+    mapThread = std::this_thread::get_id();
+}
+
+bool Environment::inMapThread() const {
+    return std::this_thread::get_id() == mapThread;
+}
+
+void Environment::requestAsync(const Resource &resource, std::function<void(const Response &)> callback) {
+    fileSource.request(resource, *this, std::move(callback));
+}
+
+Request *Environment::request(const Resource &resource, std::function<void(const Response &)> callback) {
+    assert(inMapThread());
+    return fileSource.request(resource, loop, *this, std::move(callback));
+}
+
+void Environment::cancelRequest(Request *request) {
+    assert(inMapThread());
+    fileSource.cancel(request);
+}
+
+void Environment::terminate() {
+    fileSource.abort(*this);
+}
+
+}

--- a/src/mbgl/map/environment.hpp
+++ b/src/mbgl/map/environment.hpp
@@ -1,0 +1,44 @@
+#ifndef MBGL_MAP_MAP_ENVIRONMENT
+#define MBGL_MAP_MAP_ENVIRONMENT
+
+#include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/util.hpp>
+
+#include <thread>
+#include <functional>
+
+typedef struct uv_loop_s uv_loop_t;
+
+namespace mbgl {
+
+class FileSource;
+class Request;
+class Response;
+struct Resource;
+
+class Environment : private util::noncopyable {
+public:
+    Environment(FileSource &);
+
+    void setup();
+
+    bool inMapThread() const;
+
+    void requestAsync(const Resource &, std::function<void(const Response &)>);
+    Request *request(const Resource &, std::function<void(const Response &)>);
+    void cancelRequest(Request *);
+
+    // Request to terminate the environment.
+    void terminate();
+
+private:
+    FileSource &fileSource;
+    std::thread::id mapThread;
+
+public:
+    uv_loop_t *const loop;
+};
+
+}
+
+#endif

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -401,7 +401,7 @@ void Map::setLatLng(LatLng latLng, std::chrono::steady_clock::duration duration)
     update();
 }
 
-const LatLng getLatLng() const {
+const LatLng Map::getLatLng() const {
     assert(inUIThread());
     return state.getLatLng();
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -140,6 +140,10 @@ void Map::renderStill(StillImageCallback fn) {
     assert(!active);
     assert(!callback);
 
+    if (!style) {
+        throw util::Exception("Style is not set");
+    }
+
     callback = std::move(fn);
 
     active = true;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -131,7 +131,9 @@ void Map::stop() {
 
     active = false;
 
-    // TODO: Send a notification to the thread to stop rendering.
+    // Acquire and release the lock so that this call blocks until the current
+    // render call in the Map thread is finished.
+    std::lock_guard<std::mutex> lock(rendering);
 }
 
 void Map::renderStill(StillImageCallback fn) {
@@ -717,6 +719,8 @@ void Map::prepare() {
 }
 
 void Map::render() {
+    std::lock_guard<std::mutex> lock(rendering);
+
     view.discard();
 
     assert(painter);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -179,6 +179,8 @@ void Map::run() {
 
     view.activate();
 
+    view.discard();
+
     glyphAtlas = util::make_unique<GlyphAtlas>(1024, 1024);
     glyphStore = std::make_shared<GlyphStore>(fileSource);
     spriteAtlas = util::make_unique<SpriteAtlas>(512, 512);
@@ -235,7 +237,6 @@ void Map::updatedContinuous() {
     if (active) {
         prepare();
         render();
-        view.swap();
     }
 }
 
@@ -704,6 +705,8 @@ void Map::prepare() {
 }
 
 void Map::render() {
+    view.discard();
+
     assert(painter);
     painter->render(*style, activeSources, state, animationTime, debug);
 
@@ -711,4 +714,6 @@ void Map::render() {
     if (transform.needsTransition() || style->hasTransitions()) {
         update();
     }
+
+    view.swap();
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -241,6 +241,10 @@ void Map::run() {
         checkForPause();
     }
 
+    if (!style) {
+        throw exception("Style is not set");
+    }
+
     view.activate();
 
     workers = util::make_unique<uv::worker>(**loop, 4, "Tile Worker");

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -75,6 +75,13 @@ Map::Map(View& view_, FileSource& fileSource_, RenderMode mode_)
     view.initialize(this);
 }
 
+void Map::initialize() {
+    if (thread.get_id() == std::thread::id()) {
+        // Start the Map thread
+        thread = std::thread([this]() { run(); });
+    }
+}
+
 Map::~Map() {
     assert(inUIThread());
 
@@ -114,12 +121,9 @@ void Map::start() {
     assert(renderMode == RenderMode::Continuous);
     assert(!active);
 
-    active = true;
+    initialize();
 
-    if (!thread.joinable()) {
-        // Start the Map thread
-        thread = std::thread([this]() { run(); });
-    }
+    active = true;
 
     update();
 
@@ -149,6 +153,8 @@ void Map::renderStill(StillImageCallback fn) {
     }
 
     callback = std::move(fn);
+
+    initialize();
 
     active = true;
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -147,6 +147,10 @@ void Map::renderStill(StillImageCallback fn) {
     update();
 }
 
+bool Map::isRendering() const {
+    return active;
+}
+
 // Triggers a refresh of the map based on changed UI state, e.g. the user moved the map viewport,
 // or changed any other externally accessible value of the Map object.
 void Map::update() {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -550,8 +550,6 @@ const std::string &Map::getAccessToken() const {
 void Map::setDebug(bool value) {
     assert(inUIThread());
     debug = value;
-    assert(painter);
-    painter->setDebug(debug);
     update();
 }
 
@@ -703,7 +701,7 @@ void Map::prepare() {
 
 void Map::render() {
     assert(painter);
-    painter->render(*style, activeSources, state, animationTime);
+    painter->render(*style, activeSources, state, animationTime, debug);
 
     // Schedule another rerender when we definitely need a next frame.
     if (transform.needsTransition() || style->hasTransitions()) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -241,7 +241,7 @@ void Map::run() {
         checkForPause();
     }
 
-    if (!style) {
+    if (!style && styleURL.empty()) {
         throw exception("Style is not set");
     }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -88,7 +88,9 @@ Map::~Map() {
     assert(asyncTerminate);
     asyncTerminate->send();
 
-    thread.join();
+    if (thread.get_id() != std::thread::id()) {
+        thread.join();
+    }
 
     // Make sure that all of these are empty.
     assert(!sprite);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -400,10 +400,12 @@ util::ptr<Sprite> Map::getSprite() {
 #pragma mark - Size
 
 void Map::resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight) {
+    mbgl::Log::Debug(mbgl::Event::Android, "Map::resize");
     // This may be called from the UI and Map thread.
     if (transform.resize(width, height, ratio, fbWidth, fbHeight)) {
         update();
     }
+    mbgl::Log::Debug(mbgl::Event::Android, "Map::resize exit");
 }
 
 #pragma mark - Transitions

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -4,10 +4,9 @@
 
 using namespace mbgl;
 
-
-RasterTileData::RasterTileData(Tile::ID const& id_, TexturePool& texturePool, const SourceInfo& source_, FileSource& fileSource_)
-    : TileData(id_, source_, fileSource_),
-    bucket(texturePool, layout) {
+RasterTileData::RasterTileData(Tile::ID const &id_, TexturePool &texturePool,
+                               const SourceInfo &source_, Environment &env_)
+    : TileData(id_, source_, env_), bucket(texturePool, layout) {
 }
 
 RasterTileData::~RasterTileData() {

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -24,7 +24,7 @@ void RasterTileData::parse() {
     }
 }
 
-void RasterTileData::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix) {
+void RasterTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) {
     bucket.render(painter, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -17,7 +17,7 @@ class RasterTileData : public TileData {
     friend class TileParser;
 
 public:
-    RasterTileData(Tile::ID const& id, TexturePool&, const SourceInfo&, FileSource &);
+    RasterTileData(Tile::ID const &id, TexturePool &, const SourceInfo &, Environment &);
     ~RasterTileData();
 
     virtual void parse();

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -20,9 +20,9 @@ public:
     RasterTileData(Tile::ID const &id, TexturePool &, const SourceInfo &, Environment &);
     ~RasterTileData();
 
-    virtual void parse();
-    virtual void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix);
-    virtual bool hasData(StyleLayer const& layer_desc) const;
+    void parse() override;
+    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) override;
+    bool hasData(StyleLayer const &layer_desc) const override;
 
 protected:
     StyleLayoutRaster layout;

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -58,8 +58,7 @@ void Source::load(Map& map, FileSource& fileSource) {
         source->info.parseTileJSONProperties(d);
         source->loaded = true;
 
-        map.update();
-
+        map.rerender();
     });
 }
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -111,7 +111,7 @@ void Source::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Ti
     }
 }
 
-void Source::finishRender(Painter &painter) {
+void Source::renderDebug(Painter &painter) {
     for (std::pair<const Tile::ID, std::unique_ptr<Tile>> &pair : tiles) {
         Tile &tile = *pair.second;
         painter.renderTileDebug(tile);

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -1,12 +1,14 @@
 #include <mbgl/map/source.hpp>
 #include <mbgl/map/map.hpp>
+#include <mbgl/map/environment.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/raster.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/texture_pool.hpp>
-#include <mbgl/storage/file_source.hpp>
+#include <mbgl/storage/resource.hpp>
+#include <mbgl/storage/response.hpp>
 #include <mbgl/util/vec.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/std.hpp>
@@ -32,7 +34,7 @@ Source::Source(SourceInfo& info_)
 // Note: This is a separate function that must be called exactly once after creation
 // The reason this isn't part of the constructor is that calling shared_from_this() in
 // the constructor fails.
-void Source::load(Map& map, FileSource& fileSource) {
+void Source::load(Map &map, Environment &env) {
     if (info.url.empty()) {
         loaded = true;
         return;
@@ -41,7 +43,7 @@ void Source::load(Map& map, FileSource& fileSource) {
     util::ptr<Source> source = shared_from_this();
 
     const std::string url = util::mapbox::normalizeSourceURL(info.url, map.getAccessToken());
-    fileSource.request({ Resource::Kind::JSON, url }, **map.loop, [source, &map](const Response &res) {
+    env.request({ Resource::Kind::JSON, url }, [source, &map](const Response &res) {
         if (res.status != Response::Successful) {
             Log::Warning(Event::General, "Failed to load source TileJSON: %s", res.message.c_str());
             return;
@@ -152,13 +154,11 @@ TileData::State Source::hasTile(const Tile::ID& id) {
     return TileData::State::invalid;
 }
 
-TileData::State Source::addTile(Map& map, uv::worker& worker,
-                                util::ptr<Style> style,
-                                GlyphAtlas& glyphAtlas, GlyphStore& glyphStore,
-                                SpriteAtlas& spriteAtlas, util::ptr<Sprite> sprite,
-                                FileSource& fileSource, uv_loop_t &loop, TexturePool& texturePool,
-                                const Tile::ID& id,
-                                std::function<void ()> callback) {
+TileData::State Source::addTile(Map &map, Environment &env, uv::worker &worker,
+                                util::ptr<Style> style, GlyphAtlas &glyphAtlas,
+                                GlyphStore &glyphStore, SpriteAtlas &spriteAtlas,
+                                util::ptr<Sprite> sprite, TexturePool &texturePool,
+                                const Tile::ID &id, std::function<void()> callback) {
     const TileData::State state = hasTile(id);
 
     if (state != TileData::State::invalid) {
@@ -189,14 +189,14 @@ TileData::State Source::addTile(Map& map, uv::worker& worker,
             new_tile.data = std::make_shared<VectorTileData>(normalized_id, map.getMaxZoom(), style,
                                                              glyphAtlas, glyphStore,
                                                              spriteAtlas, sprite,
-                                                             info, fileSource);
+                                                             info, env);
         } else if (info.type == SourceType::Raster) {
-            new_tile.data = std::make_shared<RasterTileData>(normalized_id, texturePool, info, fileSource);
+            new_tile.data = std::make_shared<RasterTileData>(normalized_id, texturePool, info, env);
         } else {
             throw std::runtime_error("source type not implemented");
         }
 
-        new_tile.data->request(worker, loop, map.getState().getPixelRatio(), callback);
+        new_tile.data->request(worker, map.getState().getPixelRatio(), callback);
         tile_data.emplace(new_tile.data->id, new_tile.data);
     }
 
@@ -283,12 +283,16 @@ bool Source::findLoadedParent(const Tile::ID& id, int32_t minCoveringZoom, std::
     return false;
 }
 
-void Source::update(Map& map, uv::worker& worker,
+void Source::update(Map &map,
+                    Environment &env,
+                    uv::worker &worker,
                     util::ptr<Style> style,
-                    GlyphAtlas& glyphAtlas, GlyphStore& glyphStore,
-                    SpriteAtlas& spriteAtlas, util::ptr<Sprite> sprite,
-                    TexturePool& texturePool, FileSource& fileSource, uv_loop_t& loop,
-                    std::function<void ()> callback) {
+                    GlyphAtlas &glyphAtlas,
+                    GlyphStore &glyphStore,
+                    SpriteAtlas &spriteAtlas,
+                    util::ptr<Sprite> sprite,
+                    TexturePool &texturePool,
+                    std::function<void()> callback) {
     if (!loaded || map.getTime() <= updated)
         return;
 
@@ -308,11 +312,8 @@ void Source::update(Map& map, uv::worker& worker,
 
     // Add existing child/parent tiles if the actual tile is not yet loaded
     for (const Tile::ID& id : required) {
-        const TileData::State state = addTile(map, worker, style,
-                                              glyphAtlas, glyphStore,
-                                              spriteAtlas, sprite,
-                                              fileSource, loop, texturePool,
-                                              id, callback);
+        const TileData::State state = addTile(map, env, worker, style, glyphAtlas, glyphStore,
+                                              spriteAtlas, sprite, texturePool, id, callback);
 
         if (state != TileData::State::parsed) {
             // The tile we require is not yet loaded. Try to find a parent or

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -205,7 +205,6 @@ TileData::State Source::addTile(Map &map, Environment &env, uv::worker &worker,
 
 double Source::getZoom(const TransformState& state) const {
     double offset = std::log(util::tileSize / info.tile_size) / std::log(2);
-    offset += (state.getPixelRatio() > 1.0 ? 1 :0);
     return state.getZoom() + offset;
 }
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -96,8 +96,8 @@ void Source::drawClippingMasks(Painter &painter) {
     }
 }
 
-void Source::render(Painter &painter, util::ptr<StyleLayer> layer_desc) {
-    gl::group group(std::string { "layer: " } + layer_desc->id);
+void Source::render(Painter &painter, const StyleLayer &layer_desc) {
+    gl::group group(std::string { "layer: " } + layer_desc.id);
     for (const std::pair<const Tile::ID, std::unique_ptr<Tile>> &pair : tiles) {
         Tile &tile = *pair.second;
         if (tile.data && tile.data->state == TileData::State::parsed) {
@@ -106,7 +106,7 @@ void Source::render(Painter &painter, util::ptr<StyleLayer> layer_desc) {
     }
 }
 
-void Source::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix) {
+void Source::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id, const mat4 &matrix) {
     auto it = tiles.find(id);
     if (it != tiles.end() && it->second->data && it->second->data->state == TileData::State::parsed) {
         painter.renderTileLayer(*it->second, layer_desc, matrix);

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -18,11 +18,11 @@
 namespace mbgl {
 
 class Map;
+class Environment;
 class GlyphAtlas;
 class GlyphStore;
 class SpriteAtlas;
 class Sprite;
-class FileSource;
 class TexturePool;
 class Style;
 class Painter;
@@ -34,13 +34,9 @@ class Source : public std::enable_shared_from_this<Source>, private util::noncop
 public:
     Source(SourceInfo&);
 
-    void load(Map&, FileSource&);
-    void update(Map&, uv::worker&,
-                util::ptr<Style>,
-                GlyphAtlas&, GlyphStore&,
-                SpriteAtlas&, util::ptr<Sprite>,
-                TexturePool&, FileSource&, uv_loop_t& loop,
-                std::function<void ()> callback);
+    void load(Map &, Environment &);
+    void update(Map &, Environment &, uv::worker &, util::ptr<Style>, GlyphAtlas &, GlyphStore &,
+                SpriteAtlas &, util::ptr<Sprite>, TexturePool &, std::function<void()> callback);
 
     void updateMatrices(const mat4 &projMatrix, const TransformState &transform);
     void drawClippingMasks(Painter &painter);
@@ -59,13 +55,9 @@ private:
     int32_t coveringZoomLevel(const TransformState&) const;
     std::forward_list<Tile::ID> coveringTiles(const TransformState&) const;
 
-    TileData::State addTile(Map&, uv::worker&,
-                            util::ptr<Style>,
-                            GlyphAtlas&, GlyphStore&,
-                            SpriteAtlas&, util::ptr<Sprite>,
-                            FileSource&, uv_loop_t &, TexturePool&,
-                            const Tile::ID&,
-                            std::function<void ()> callback);
+    TileData::State addTile(Map &, Environment &, uv::worker &, util::ptr<Style>, GlyphAtlas &,
+                            GlyphStore &, SpriteAtlas &, util::ptr<Sprite>, TexturePool &,
+                            const Tile::ID &, std::function<void()> callback);
 
     TileData::State hasTile(const Tile::ID& id);
 

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -47,7 +47,7 @@ public:
     size_t getTileCount() const;
     void render(Painter &painter, util::ptr<StyleLayer> layer_desc);
     void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix);
-    void finishRender(Painter &painter);
+    void renderDebug(Painter &painter);
 
     std::forward_list<Tile::ID> getIDs() const;
     std::forward_list<Tile *> getLoadedTiles() const;

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -41,8 +41,8 @@ public:
     void updateMatrices(const mat4 &projMatrix, const TransformState &transform);
     void drawClippingMasks(Painter &painter);
     size_t getTileCount() const;
-    void render(Painter &painter, util::ptr<StyleLayer> layer_desc);
-    void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix);
+    void render(Painter &painter, const StyleLayer &layer_desc);
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id, const mat4 &matrix);
     void renderDebug(Painter &painter);
 
     std::forward_list<Tile::ID> getIDs() const;

--- a/src/mbgl/map/sprite.cpp
+++ b/src/mbgl/map/sprite.cpp
@@ -54,7 +54,6 @@ Sprite::operator bool() const {
 // The reason this isn't part of the constructor is that calling shared_from_this() in
 // the constructor fails.
 void Sprite::load(Environment &env) {
-
     if (!valid) {
         // Treat a non-existent sprite as a successfully loaded empty sprite.
         loadedImage = true;
@@ -69,22 +68,22 @@ void Sprite::load(Environment &env) {
         if (res.status == Response::Successful) {
             sprite->body = res.data;
             sprite->parseJSON();
-            sprite->complete();
         } else {
             Log::Warning(Event::Sprite, "Failed to load sprite info: %s", res.message.c_str());
-            sprite->promise.set_exception(std::make_exception_ptr(std::runtime_error(res.message)));
         }
+        sprite->loadedJSON = true;
+        sprite->complete();
     });
 
     env.request({ Resource::Kind::Image, spriteURL }, [sprite](const Response &res) {
         if (res.status == Response::Successful) {
             sprite->image = res.data;
             sprite->parseImage();
-            sprite->complete();
         } else {
             Log::Warning(Event::Sprite, "Failed to load sprite image: %s", res.message.c_str());
-            sprite->promise.set_exception(std::make_exception_ptr(std::runtime_error(res.message)));
         }
+        sprite->loadedImage = true;
+        sprite->complete();
     });
 }
 
@@ -104,7 +103,6 @@ void Sprite::parseImage() {
         raster.reset();
     }
     image.clear();
-    loadedImage = true;
 }
 
 void Sprite::parseJSON() {
@@ -139,8 +137,6 @@ void Sprite::parseJSON() {
     } else {
         Log::Warning(Event::Sprite, "sprite JSON root is not an object");
     }
-
-    loadedJSON = true;
 }
 
 const SpritePosition &Sprite::getSpritePosition(const std::string& name) const {

--- a/src/mbgl/map/sprite.hpp
+++ b/src/mbgl/map/sprite.hpp
@@ -14,7 +14,7 @@
 
 namespace mbgl {
 
-class FileSource;
+class Environment;
 
 class SpritePosition {
 public:
@@ -34,11 +34,12 @@ public:
 class Sprite : public std::enable_shared_from_this<Sprite>, private util::noncopyable {
 private:
     struct Key {};
-    void load(FileSource& fileSource);
+    void load(Environment &env);
 
 public:
     Sprite(const Key &, const std::string& base_url, float pixelRatio);
-    static util::ptr<Sprite> Create(const std::string& base_url, float pixelRatio, FileSource& fileSource);
+    static util::ptr<Sprite>
+    Create(const std::string &base_url, float pixelRatio, Environment &env);
 
     const SpritePosition &getSpritePosition(const std::string& name) const;
 

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -62,9 +62,8 @@ public:
 
     // Override this in the child class.
     virtual void parse() = 0;
-    virtual void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix) = 0;
-    virtual bool hasData(StyleLayer const& layer_desc) const = 0;
-
+    virtual void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) = 0;
+    virtual bool hasData(StyleLayer const &layer_desc) const = 0;
 
 public:
     const Tile::ID id;

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -23,7 +23,7 @@ typedef struct uv_loop_s uv_loop_t;
 namespace mbgl {
 
 class Map;
-class FileSource;
+class Environment;
 class Painter;
 class SourceInfo;
 class StyleLayer;
@@ -48,10 +48,10 @@ public:
     };
 
 public:
-    TileData(Tile::ID const& id, const SourceInfo&, FileSource&);
+    TileData(Tile::ID const &id, const SourceInfo &, Environment &);
     ~TileData();
 
-    void request(uv::worker&, uv_loop_t&, float pixelRatio, std::function<void ()> callback);
+    void request(uv::worker&, float pixelRatio, std::function<void ()> callback);
     void reparse(uv::worker&, std::function<void ()> callback);
     void cancel();
     const std::string toString() const;
@@ -73,7 +73,7 @@ public:
 
 public:
     const SourceInfo& source;
-    FileSource& fileSource;
+    Environment &env;
 
 protected:
     Request *req = nullptr;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/transition.hpp>
 #include <mbgl/platform/platform.hpp>
+#include <mbgl/platform/log.hpp>
 
 #include <cstdio>
 
@@ -20,7 +21,9 @@ Transform::Transform(View &view_)
 
 bool Transform::resize(const uint16_t w, const uint16_t h, const float ratio,
                        const uint16_t fb_w, const uint16_t fb_h) {
+    mbgl::Log::Debug(mbgl::Event::Android, "Transform::resize");
     std::lock_guard<std::recursive_mutex> lock(mtx);
+    mbgl::Log::Debug(mbgl::Event::Android, "Transform::resize post lock");
 
     if (final.width != w || final.height != h || final.pixelRatio != ratio ||
         final.framebuffer[0] != fb_w || final.framebuffer[1] != fb_h) {
@@ -36,8 +39,12 @@ bool Transform::resize(const uint16_t w, const uint16_t h, const float ratio,
 
         view.notifyMapChange(MapChangeRegionDidChange);
 
+
+        mbgl::Log::Debug(mbgl::Event::Android, "Transform ::resize exit true");
         return true;
     } else {
+
+        mbgl::Log::Debug(mbgl::Event::Android, "Transform ::resize exit true");
         return false;
     }
 }

--- a/src/mbgl/map/vector_tile.cpp
+++ b/src/mbgl/map/vector_tile.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/map/vector_tile.hpp>
 #include <mbgl/style/filter_expression_private.hpp>
+#include <mbgl/util/variant_io.hpp>
 
 #include <algorithm>
 #include <iostream>

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/style/style_layer.hpp>
 #include <mbgl/style/style_bucket.hpp>
+#include <mbgl/style/style_source.hpp>
 #include <mbgl/geometry/glyph_atlas.hpp>
 #include <mbgl/platform/log.hpp>
 

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -14,8 +14,8 @@ VectorTileData::VectorTileData(Tile::ID const& id_,
                                float mapMaxZoom, util::ptr<Style> style_,
                                GlyphAtlas& glyphAtlas_, GlyphStore& glyphStore_,
                                SpriteAtlas& spriteAtlas_, util::ptr<Sprite> sprite_,
-                               const SourceInfo& source_, FileSource &fileSource_)
-    : TileData(id_, source_, fileSource_),
+                               const SourceInfo& source_, Environment &env_)
+    : TileData(id_, source_, env_),
       glyphAtlas(glyphAtlas_),
       glyphStore(glyphStore_),
       spriteAtlas(spriteAtlas_),

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -60,9 +60,9 @@ void VectorTileData::parse() {
     }
 }
 
-void VectorTileData::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix) {
-    if (state == State::parsed && layer_desc->bucket) {
-        auto databucket_it = buckets.find(layer_desc->bucket->name);
+void VectorTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) {
+    if (state == State::parsed && layer_desc.bucket) {
+        auto databucket_it = buckets.find(layer_desc.bucket->name);
         if (databucket_it != buckets.end()) {
             assert(databucket_it->second);
             databucket_it->second->render(painter, layer_desc, id, matrix);
@@ -70,7 +70,7 @@ void VectorTileData::render(Painter &painter, util::ptr<StyleLayer> layer_desc, 
     }
 }
 
-bool VectorTileData::hasData(StyleLayer const& layer_desc) const {
+bool VectorTileData::hasData(const StyleLayer &layer_desc) const {
     if (state == State::parsed && layer_desc.bucket) {
         auto databucket_it = buckets.find(layer_desc.bucket->name);
         if (databucket_it != buckets.end()) {

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -34,9 +34,9 @@ public:
                    SpriteAtlas &, util::ptr<Sprite>, const SourceInfo &, Environment &);
     ~VectorTileData();
 
-    virtual void parse();
-    virtual void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix);
-    virtual bool hasData(StyleLayer const& layer_desc) const;
+    void parse() override;
+    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) override;
+    bool hasData(StyleLayer const& layer_desc) const override;
 
 protected:
     // Holds the actual geometries in this tile.

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -30,11 +30,8 @@ class VectorTileData : public TileData {
     friend class TileParser;
 
 public:
-    VectorTileData(Tile::ID const&,
-                   float mapMaxZoom, util::ptr<Style>,
-                   GlyphAtlas&, GlyphStore&,
-                   SpriteAtlas&, util::ptr<Sprite>,
-                   const SourceInfo&, FileSource &);
+    VectorTileData(Tile::ID const &, float mapMaxZoom, util::ptr<Style>, GlyphAtlas &, GlyphStore &,
+                   SpriteAtlas &, util::ptr<Sprite>, const SourceInfo &, Environment &);
     ~VectorTileData();
 
     virtual void parse();

--- a/src/mbgl/map/view.cpp
+++ b/src/mbgl/map/view.cpp
@@ -1,0 +1,11 @@
+#include <mbgl/map/view.hpp>
+#include <mbgl/map/map.hpp>
+
+namespace mbgl {
+
+void View::resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight) {
+    assert(map);
+    map->resize(width, height, ratio, fbWidth, fbHeight);
+}
+
+}

--- a/src/mbgl/map/view.cpp
+++ b/src/mbgl/map/view.cpp
@@ -4,6 +4,14 @@
 
 namespace mbgl {
 
+void View::discard() {
+    // no-op
+}
+
+void View::swap() {
+    // no-op
+}
+
 void View::resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight) {
     if (map) {
         map->resize(width, height, ratio, fbWidth, fbHeight);
@@ -12,6 +20,10 @@ void View::resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth
 
 std::unique_ptr<StillImage> View::readStillImage() {
     return nullptr;
+}
+
+void View::notifyMapChange(MapChange, std::chrono::steady_clock::duration) {
+    // no-op
 }
 
 }

--- a/src/mbgl/map/view.cpp
+++ b/src/mbgl/map/view.cpp
@@ -1,11 +1,17 @@
 #include <mbgl/map/view.hpp>
 #include <mbgl/map/map.hpp>
+#include <mbgl/map/still_image.hpp>
 
 namespace mbgl {
 
 void View::resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight) {
-    assert(map);
-    map->resize(width, height, ratio, fbWidth, fbHeight);
+    if (map) {
+        map->resize(width, height, ratio, fbWidth, fbHeight);
+    }
+}
+
+std::unique_ptr<StillImage> View::readStillImage() {
+    return nullptr;
 }
 
 }

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -13,7 +13,8 @@ class StyleLayer;
 
 class Bucket : private util::noncopyable {
 public:
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) = 0;
+    virtual void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                        const mat4 &matrix) = 0;
     virtual bool hasData() const = 0;
     virtual ~Bucket() {}
 

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -13,7 +13,8 @@ DebugBucket::DebugBucket(DebugFontBuffer& fontBuffer_)
     : fontBuffer(fontBuffer_) {
 }
 
-void DebugBucket::render(Painter& painter, util::ptr<StyleLayer> /*layer_desc*/, const Tile::ID& /*id*/, const mat4 &matrix) {
+void DebugBucket::render(Painter &painter, const StyleLayer & /*layer_desc*/,
+                         const Tile::ID & /*id*/, const mat4 &matrix) {
     painter.renderDebugText(*this, matrix);
 }
 

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -19,8 +19,9 @@ class DebugBucket : public Bucket {
 public:
     DebugBucket(DebugFontBuffer& fontBuffer);
 
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    virtual bool hasData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
 
     void drawLines(PlainShader& shader);
     void drawPoints(PlainShader& shader);

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -213,7 +213,8 @@ void FillBucket::tessellate() {
     lineGroup.vertex_length += total_vertex_count;
 }
 
-void FillBucket::render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) {
+void FillBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                        const mat4 &matrix) {
     painter.renderFill(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -43,10 +43,11 @@ public:
                FillVertexBuffer &vertexBuffer,
                TriangleElementsBuffer &triangleElementsBuffer,
                LineElementsBuffer &lineElementsBuffer);
-    ~FillBucket();
+    ~FillBucket() override;
 
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    virtual bool hasData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
 
     void addGeometry(pbf& data);
     void tessellate();

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -351,7 +351,8 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
     }
 }
 
-void LineBucket::render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) {
+void LineBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                        const mat4 &matrix) {
     painter.renderLine(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -31,10 +31,11 @@ public:
                LineVertexBuffer &vertexBuffer,
                TriangleElementsBuffer &triangleElementsBuffer,
                PointElementsBuffer &pointElementsBuffer);
-    ~LineBucket();
+    ~LineBucket() override;
 
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    virtual bool hasData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
 
     void addGeometry(pbf& data);
     void addGeometry(const std::vector<Coordinate>& line);

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -131,10 +131,6 @@ void Painter::resize() {
     }
 }
 
-void Painter::setDebug(bool enabled) {
-    debug = enabled;
-}
-
 void Painter::useProgram(uint32_t program) {
     if (gl_program != program) {
         MBGL_CHECK_ERROR(glUseProgram(program));
@@ -215,7 +211,8 @@ void Painter::prepareTile(const Tile& tile) {
 }
 
 void Painter::render(const Style& style, const std::set<util::ptr<StyleSource>>& sources,
-                     TransformState state_, std::chrono::steady_clock::time_point time) {
+                     TransformState state_, std::chrono::steady_clock::time_point time,
+                     bool debug) {
     state = state_;
 
     clear();
@@ -242,8 +239,10 @@ void Painter::render(const Style& style, const std::set<util::ptr<StyleSource>>&
     // This guarantees that we have at least one function per tile called.
     // When only rendering layers via the stylesheet, it's possible that we don't
     // ever visit a tile during rendering.
-    for (const util::ptr<StyleSource> &source : sources) {
-        source->source->finishRender(*this);
+    if (debug) {
+        for (const util::ptr<StyleSource> &source : sources) {
+            source->source->renderDebug(*this);
+        }
     }
 }
 

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -232,7 +232,9 @@ void Painter::render(const Style& style, const std::set<util::ptr<StyleSource>>&
 
     // Actually render the layers
     if (debug::renderTree) { std::cout << "{" << std::endl; indent++; }
-    renderLayers(style.layers);
+    if (style.layers) {
+        renderLayers(*style.layers);
+    }
     if (debug::renderTree) { std::cout << "}" << std::endl; indent--; }
 
     // Finalize the rendering, e.g. by calling debug render calls per tile.
@@ -246,14 +248,9 @@ void Painter::render(const Style& style, const std::set<util::ptr<StyleSource>>&
     }
 }
 
-void Painter::renderLayers(util::ptr<StyleLayerGroup> group) {
-    if (!group) {
-        // Make sure that we actually do have a layer group.
-        return;
-    }
-
+void Painter::renderLayers(const StyleLayerGroup &group) {
     // TODO: Correctly compute the number of layers recursively beforehand.
-    float strata_thickness = 1.0f / (group->layers.size() + 1);
+    float strata_thickness = 1.0f / (group.layers.size() + 1);
 
     // - FIRST PASS ------------------------------------------------------------
     // Render everything top-to-bottom by using reverse iterators. Render opaque
@@ -263,10 +260,10 @@ void Painter::renderLayers(util::ptr<StyleLayerGroup> group) {
         std::cout << std::string(indent++ * 4, ' ') << "OPAQUE {" << std::endl;
     }
     int i = 0;
-    for (auto it = group->layers.rbegin(), end = group->layers.rend(); it != end; ++it, ++i) {
+    for (auto it = group.layers.rbegin(), end = group.layers.rend(); it != end; ++it, ++i) {
         setOpaque();
         setStrata(i * strata_thickness);
-        renderLayer(*it);
+        renderLayer(**it);
     }
     if (debug::renderTree) {
         std::cout << std::string(--indent * 4, ' ') << "}" << std::endl;
@@ -279,40 +276,40 @@ void Painter::renderLayers(util::ptr<StyleLayerGroup> group) {
         std::cout << std::string(indent++ * 4, ' ') << "TRANSLUCENT {" << std::endl;
     }
     --i;
-    for (auto it = group->layers.begin(), end = group->layers.end(); it != end; ++it, --i) {
+    for (auto it = group.layers.begin(), end = group.layers.end(); it != end; ++it, --i) {
         setTranslucent();
         setStrata(i * strata_thickness);
-        renderLayer(*it);
+        renderLayer(**it);
     }
     if (debug::renderTree) {
         std::cout << std::string(--indent * 4, ' ') << "}" << std::endl;
     }
 }
 
-void Painter::renderLayer(util::ptr<StyleLayer> layer_desc, const Tile::ID* id, const mat4* matrix) {
-    if (layer_desc->bucket->visibility == VisibilityType::None) return;
-    if (layer_desc->type == StyleLayerType::Background) {
+void Painter::renderLayer(const StyleLayer &layer_desc, const Tile::ID* id, const mat4* matrix) {
+    if (layer_desc.bucket->visibility == VisibilityType::None) return;
+    if (layer_desc.type == StyleLayerType::Background) {
         // This layer defines a background color/image.
 
         if (debug::renderTree) {
-            std::cout << std::string(indent * 4, ' ') << "- " << layer_desc->id << " ("
-                      << layer_desc->type << ")" << std::endl;
+            std::cout << std::string(indent * 4, ' ') << "- " << layer_desc.id << " ("
+                      << layer_desc.type << ")" << std::endl;
         }
 
         renderBackground(layer_desc);
     } else {
         // This is a singular layer.
-        if (!layer_desc->bucket) {
-            fprintf(stderr, "[WARNING] layer '%s' is missing bucket\n", layer_desc->id.c_str());
+        if (!layer_desc.bucket) {
+            fprintf(stderr, "[WARNING] layer '%s' is missing bucket\n", layer_desc.id.c_str());
             return;
         }
 
-        if (!layer_desc->bucket->style_source) {
-            fprintf(stderr, "[WARNING] can't find source for layer '%s'\n", layer_desc->id.c_str());
+        if (!layer_desc.bucket->style_source) {
+            fprintf(stderr, "[WARNING] can't find source for layer '%s'\n", layer_desc.id.c_str());
             return;
         }
 
-        StyleSource const& style_source = *layer_desc->bucket->style_source;
+        StyleSource const& style_source = *layer_desc.bucket->style_source;
 
         // Skip this layer if there is no data.
         if (!style_source.source) {
@@ -323,36 +320,36 @@ void Painter::renderLayer(util::ptr<StyleLayer> layer_desc, const Tile::ID* id, 
         // This may occur when there /is/ a bucket created for this layer, but the min/max-zoom
         // is set to a fractional value, or value that is larger than the source maxzoom.
         const double zoom = state.getZoom();
-        if (layer_desc->bucket->min_zoom > zoom ||
-            layer_desc->bucket->max_zoom <= zoom) {
+        if (layer_desc.bucket->min_zoom > zoom ||
+            layer_desc.bucket->max_zoom <= zoom) {
             return;
         }
 
         // Abort early if we can already deduce from the bucket type that
         // we're not going to render anything anyway during this pass.
-        switch (layer_desc->type) {
+        switch (layer_desc.type) {
             case StyleLayerType::Fill:
-                if (!layer_desc->getProperties<FillProperties>().isVisible()) return;
+                if (!layer_desc.getProperties<FillProperties>().isVisible()) return;
                 break;
             case StyleLayerType::Line:
                 if (pass == RenderPass::Opaque) return;
-                if (!layer_desc->getProperties<LineProperties>().isVisible()) return;
+                if (!layer_desc.getProperties<LineProperties>().isVisible()) return;
                 break;
             case StyleLayerType::Symbol:
                 if (pass == RenderPass::Opaque) return;
-                if (!layer_desc->getProperties<SymbolProperties>().isVisible()) return;
+                if (!layer_desc.getProperties<SymbolProperties>().isVisible()) return;
                 break;
             case StyleLayerType::Raster:
                 if (pass == RenderPass::Opaque) return;
-                if (!layer_desc->getProperties<RasterProperties>().isVisible()) return;
+                if (!layer_desc.getProperties<RasterProperties>().isVisible()) return;
                 break;
             default:
                 break;
         }
 
         if (debug::renderTree) {
-            std::cout << std::string(indent * 4, ' ') << "- " << layer_desc->id << " ("
-                      << layer_desc->type << ")" << std::endl;
+            std::cout << std::string(indent * 4, ' ') << "- " << layer_desc.id << " ("
+                      << layer_desc.type << ")" << std::endl;
         }
         if (!id) {
             style_source.source->render(*this, layer_desc);
@@ -362,17 +359,17 @@ void Painter::renderLayer(util::ptr<StyleLayer> layer_desc, const Tile::ID* id, 
     }
 }
 
-void Painter::renderTileLayer(const Tile& tile, util::ptr<StyleLayer> layer_desc, const mat4 &matrix) {
+void Painter::renderTileLayer(const Tile& tile, const StyleLayer &layer_desc, const mat4 &matrix) {
     assert(tile.data);
-    if (tile.data->hasData(*layer_desc) || layer_desc->type == StyleLayerType::Raster) {
+    if (tile.data->hasData(layer_desc) || layer_desc.type == StyleLayerType::Raster) {
         gl::group group(std::string { "render " } + tile.data->name);
         prepareTile(tile);
         tile.data->render(*this, layer_desc, matrix);
     }
 }
 
-void Painter::renderBackground(util::ptr<StyleLayer> layer_desc) {
-    const BackgroundProperties& properties = layer_desc->getProperties<BackgroundProperties>();
+void Painter::renderBackground(const StyleLayer &layer_desc) {
+    const BackgroundProperties& properties = layer_desc.getProperties<BackgroundProperties>();
 
     if (properties.image.to.size()) {
         if ((properties.opacity >= 1.0f) != (pass == RenderPass::Opaque))

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -79,7 +79,8 @@ public:
     void render(const Style& style,
                 const std::set<util::ptr<StyleSource>>& sources,
                 TransformState state,
-                std::chrono::steady_clock::time_point time);
+                std::chrono::steady_clock::time_point time,
+                bool debug = false);
 
     void renderLayers(util::ptr<StyleLayerGroup> group);
     void renderLayer(util::ptr<StyleLayer> layer_desc, const Tile::ID* id = nullptr, const mat4* matrix = nullptr);
@@ -112,9 +113,6 @@ public:
     void createPrerendered(RasterBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id);
 
     void resize();
-
-    // Changes whether debug information is drawn onto the map
-    void setDebug(bool enabled);
 
     // Opaque/Translucent pass setting
     void setOpaque();
@@ -180,7 +178,6 @@ public:
 private:
     TransformState state;
 
-    bool debug = false;
     int indent = 0;
 
     uint32_t gl_program = 0;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -82,11 +82,11 @@ public:
                 std::chrono::steady_clock::time_point time,
                 bool debug = false);
 
-    void renderLayers(util::ptr<StyleLayerGroup> group);
-    void renderLayer(util::ptr<StyleLayer> layer_desc, const Tile::ID* id = nullptr, const mat4* matrix = nullptr);
+    void renderLayers(const StyleLayerGroup &group);
+    void renderLayer(const StyleLayer &layer_desc, const Tile::ID* id = nullptr, const mat4* matrix = nullptr);
 
     // Renders a particular layer from a tile.
-    void renderTileLayer(const Tile& tile, util::ptr<StyleLayer> layer_desc, const mat4 &matrix);
+    void renderTileLayer(const Tile& tile, const StyleLayer &layer_desc, const mat4 &matrix);
 
     // Renders debug information for a tile.
     void renderTileDebug(const Tile& tile);
@@ -96,11 +96,11 @@ public:
 
     void renderDebugText(DebugBucket& bucket, const mat4 &matrix);
     void renderDebugText(const std::vector<std::string> &strings);
-    void renderFill(FillBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    void renderLine(LineBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    void renderSymbol(SymbolBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    void renderRaster(RasterBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    void renderBackground(util::ptr<StyleLayer> layer_desc);
+    void renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix);
+    void renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix);
+    void renderSymbol(SymbolBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix);
+    void renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix);
+    void renderBackground(const StyleLayer &layer_desc);
 
     float saturationFactor(float saturation);
     float contrastFactor(float contrast);
@@ -110,7 +110,7 @@ public:
 
     void renderPrerenderedTexture(RasterBucket &bucket, const mat4 &matrix, const RasterProperties& properties);
 
-    void createPrerendered(RasterBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id);
+    void createPrerendered(RasterBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id);
 
     void resize();
 

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -8,11 +8,9 @@ using namespace mbgl;
 void Painter::renderTileDebug(const Tile& tile) {
     gl::group group(std::string { "debug " } + std::string(tile.id));
     assert(tile.data);
-    if (debug) {
-        prepareTile(tile);
-        renderDebugText(tile.data->debugBucket, tile.matrix);
-        renderDebugFrame(tile.matrix);
-    }
+    prepareTile(tile);
+    renderDebugText(tile.data->debugBucket, tile.matrix);
+    renderDebugFrame(tile.matrix);
 }
 
 void Painter::renderDebugText(DebugBucket& bucket, const mat4 &matrix) {

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -11,11 +11,11 @@
 
 using namespace mbgl;
 
-void Painter::renderFill(FillBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) {
+void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix) {
     // Abort early.
     if (!bucket.hasData()) return;
 
-    const FillProperties &properties = layer_desc->getProperties<FillProperties>();
+    const FillProperties &properties = layer_desc.getProperties<FillProperties>();
     mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);
 
     Color fill_color = properties.fill_color;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -10,12 +10,12 @@
 
 using namespace mbgl;
 
-void Painter::renderLine(LineBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) {
+void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) return;
     if (!bucket.hasData()) return;
 
-    const auto &properties = layer_desc->getProperties<LineProperties>();
+    const auto &properties = layer_desc.getProperties<LineProperties>();
     const auto &layout = *bucket.styleLayout;
 
     // the distance over which the line edge fades out.

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -8,10 +8,10 @@
 
 using namespace mbgl;
 
-void Painter::renderRaster(RasterBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID&, const mat4 &matrix) {
+void Painter::renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const Tile::ID&, const mat4 &matrix) {
     if (pass != RenderPass::Translucent) return;
 
-    const RasterProperties &properties = layer_desc->getProperties<RasterProperties>();
+    const RasterProperties &properties = layer_desc.getProperties<RasterProperties>();
 
     if (bucket.hasData()) {
         depthMask(false);

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -112,13 +112,13 @@ void Painter::renderSDF(SymbolBucket &bucket,
     }
 }
 
-void Painter::renderSymbol(SymbolBucket &bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix) {
+void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, const Tile::ID &id, const mat4 &matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) {
         return;
     }
 
-    const auto &properties = layer_desc->getProperties<SymbolProperties>();
+    const auto &properties = layer_desc.getProperties<SymbolProperties>();
     const auto &layout = *bucket.styleLayout;
 
     MBGL_CHECK_ERROR(glDisable(GL_STENCIL_TEST));

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -8,7 +8,8 @@ RasterBucket::RasterBucket(TexturePool& texturePool, const StyleLayoutRaster& la
   raster(texturePool) {
 }
 
-void RasterBucket::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix) {
+void RasterBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                          const mat4 &matrix) {
     painter.renderRaster(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -18,8 +18,9 @@ class RasterBucket : public Bucket {
 public:
     RasterBucket(TexturePool&, const StyleLayoutRaster&);
 
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    virtual bool hasData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
 
     bool setImage(const std::string &data);
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -172,7 +172,7 @@ void SymbolBucket::addFeatures(const VectorTileLayer &layer, const FilterExpress
     if (layout.text.justify == TextJustifyType::Right) justify = 1;
     else if (layout.text.justify == TextJustifyType::Left) justify = 0;
 
-    const FontStack &fontStack = glyphStore.getFontStack(layout.text.font);
+    const auto &fontStack = glyphStore.getFontStack(layout.text.font);
 
     for (const SymbolFeature &feature : features) {
         if (!feature.geometry.size()) continue;
@@ -183,7 +183,7 @@ void SymbolBucket::addFeatures(const VectorTileLayer &layer, const FilterExpress
 
         // if feature has text, shape the text
         if (feature.label.length()) {
-            shaping = fontStack.getShaping(
+            shaping = fontStack->getShaping(
                 /* string */ feature.label,
                 /* maxWidth: ems */ layout.text.max_width * 24,
                 /* lineHeight: ems */ layout.text.line_height * 24,

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -30,8 +30,8 @@ SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void SymbolBucket::render(Painter &painter, util::ptr<StyleLayer> layer_desc,
-                          const Tile::ID &id, const mat4 &matrix) {
+void SymbolBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                          const mat4 &matrix) {
     painter.renderSymbol(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -56,12 +56,13 @@ class SymbolBucket : public Bucket {
 
 public:
     SymbolBucket(std::unique_ptr<const StyleLayoutSymbol> styleLayout, Collision &collision);
-    ~SymbolBucket();
+    ~SymbolBucket() override;
 
-    virtual void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix);
-    virtual bool hasData() const;
-    virtual bool hasTextData() const;
-    virtual bool hasIconData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
+    bool hasTextData() const;
+    bool hasIconData() const;
 
     void addFeatures(const VectorTileLayer &layer, const FilterExpression &filter,
                      const Tile::ID &id, SpriteAtlas &spriteAtlas, Sprite &sprite,

--- a/src/mbgl/shader/dot_shader.cpp
+++ b/src/mbgl/shader/dot_shader.cpp
@@ -12,11 +12,6 @@ DotShader::DotShader()
          shaders[DOT_SHADER].vertex,
          shaders[DOT_SHADER].fragment
          ) {
-    if (!valid) {
-        fprintf(stderr, "invalid dot shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 

--- a/src/mbgl/shader/gaussian_shader.cpp
+++ b/src/mbgl/shader/gaussian_shader.cpp
@@ -12,13 +12,6 @@ GaussianShader::GaussianShader()
          shaders[GAUSSIAN_SHADER].vertex,
          shaders[GAUSSIAN_SHADER].fragment
          ) {
-    if (!valid) {
-#if defined(DEBUG)
-        fprintf(stderr, "invalid raster shader\n");
-#endif
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -12,11 +12,6 @@ IconShader::IconShader()
          shaders[ICON_SHADER].vertex,
          shaders[ICON_SHADER].fragment
          ) {
-    if (!valid) {
-        fprintf(stderr, "invalid icon shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_offset"));
     a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data1"));

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -12,11 +12,6 @@ LineShader::LineShader()
         shaders[LINE_SHADER].vertex,
         shaders[LINE_SHADER].fragment
     ) {
-    if (!valid) {
-        fprintf(stderr, "invalid line shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }

--- a/src/mbgl/shader/linejoin_shader.cpp
+++ b/src/mbgl/shader/linejoin_shader.cpp
@@ -12,11 +12,6 @@ LinejoinShader::LinejoinShader()
         shaders[LINEJOIN_SHADER].vertex,
         shaders[LINEJOIN_SHADER].fragment
     ) {
-    if (!valid) {
-        fprintf(stderr, "invalid line shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -12,11 +12,6 @@ LinepatternShader::LinepatternShader()
          shaders[LINEPATTERN_SHADER].vertex,
          shaders[LINEPATTERN_SHADER].fragment
     ) {
-    if (!valid) {
-        fprintf(stderr, "invalid line pattern shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -12,11 +12,6 @@ LineSDFShader::LineSDFShader()
         shaders[LINESDF_SHADER].vertex,
         shaders[LINESDF_SHADER].fragment
     ) {
-    if (!valid) {
-        fprintf(stderr, "invalid line shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -12,11 +12,6 @@ OutlineShader::OutlineShader()
         shaders[OUTLINE_SHADER].vertex,
         shaders[OUTLINE_SHADER].fragment
     ) {
-    if (!valid) {
-        fprintf(stderr, "invalid outline shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 

--- a/src/mbgl/shader/pattern_shader.cpp
+++ b/src/mbgl/shader/pattern_shader.cpp
@@ -12,11 +12,6 @@ PatternShader::PatternShader()
         shaders[PATTERN_SHADER].vertex,
         shaders[PATTERN_SHADER].fragment
     ) {
-    if (!valid) {
-        fprintf(stderr, "invalid pattern shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -12,11 +12,6 @@ PlainShader::PlainShader()
         shaders[PLAIN_SHADER].vertex,
         shaders[PLAIN_SHADER].fragment
     ) {
-    if (!valid) {
-        fprintf(stderr, "invalid plain shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -12,13 +12,6 @@ RasterShader::RasterShader()
          shaders[RASTER_SHADER].vertex,
          shaders[RASTER_SHADER].fragment
          ) {
-    if (!valid) {
-#if defined(DEBUG)
-        fprintf(stderr, "invalid raster shader\n");
-#endif
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -12,11 +12,6 @@ SDFShader::SDFShader()
         shaders[SDF_SHADER].vertex,
         shaders[SDF_SHADER].fragment
     ) {
-    if (!valid) {
-        fprintf(stderr, "invalid sdf shader\n");
-        return;
-    }
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_offset"));
     a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data1"));

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -129,7 +129,7 @@ bool Shader::compileShader(GLuint *shader, GLenum type, const GLchar *source) {
 
     MBGL_CHECK_ERROR(glGetShaderiv(*shader, GL_COMPILE_STATUS, &status));
     if (status == GL_FALSE) {
-    Log::Error(Event::Shader, "Shader %s failed to compile.", name, type);
+        Log::Error(Event::Shader, "Shader %s failed to compile.", name);
         MBGL_CHECK_ERROR(glDeleteShader(*shader));
         *shader = 0;
         return false;

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -88,6 +88,7 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
             fragShader = 0;
             MBGL_CHECK_ERROR(glDeleteProgram(program));
             program = 0;
+            return;
         }
     }
 

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/shader/shader.hpp>
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/util/stopwatch.hpp>
+#include <mbgl/util/exception.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
 
@@ -14,7 +15,6 @@ using namespace mbgl;
 
 Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSource)
     : name(name_),
-      valid(false),
       program(0) {
     util::stopwatch stopwatch("shader compilation", Event::Shader);
 
@@ -26,7 +26,7 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
         Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertSource);
         MBGL_CHECK_ERROR(glDeleteProgram(program));
         program = 0;
-        return;
+        throw util::ShaderException(std::string { "Vertex shader " } + name + " failed to compile");
     }
 
     if (!compileShader(&fragShader, GL_FRAGMENT_SHADER, fragSource)) {
@@ -35,7 +35,7 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
         vertShader = 0;
         MBGL_CHECK_ERROR(glDeleteProgram(program));
         program = 0;
-        return;
+        throw util::ShaderException(std::string { "Fragment shader " } + name + " failed to compile");
     }
 
     // Attach shaders
@@ -51,8 +51,8 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
         if (status == 0) {
             GLint logLength;
             MBGL_CHECK_ERROR(glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength));
+            std::unique_ptr<GLchar[]> log = mbgl::util::make_unique<GLchar[]>(logLength);
             if (logLength > 0) {
-                std::unique_ptr<GLchar[]> log = mbgl::util::make_unique<GLchar[]>(logLength);
                 MBGL_CHECK_ERROR(glGetProgramInfoLog(program, logLength, &logLength, log.get()));
                 Log::Error(Event::Shader, "Program failed to link: %s", log.get());
             }
@@ -63,7 +63,7 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
             fragShader = 0;
             MBGL_CHECK_ERROR(glDeleteProgram(program));
             program = 0;
-            return;
+            throw util::ShaderException(std::string { "Program " } + name + " failed to link: " + log.get());
         }
     }
 
@@ -76,8 +76,8 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
         if (status == 0) {
             GLint logLength;
             MBGL_CHECK_ERROR(glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength));
+            std::unique_ptr<GLchar[]> log = mbgl::util::make_unique<GLchar[]>(logLength);
             if (logLength > 0) {
-                std::unique_ptr<GLchar[]> log = mbgl::util::make_unique<GLchar[]>(logLength);
                 MBGL_CHECK_ERROR(glGetProgramInfoLog(program, logLength, &logLength, log.get()));
                 Log::Error(Event::Shader, "Program failed to validate: %s", log.get());
             }
@@ -88,7 +88,7 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
             fragShader = 0;
             MBGL_CHECK_ERROR(glDeleteProgram(program));
             program = 0;
-            return;
+            throw util::ShaderException(std::string { "Program " } + name + " failed to link: " + log.get());
         }
     }
 
@@ -97,8 +97,6 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
     MBGL_CHECK_ERROR(glDeleteShader(vertShader));
     MBGL_CHECK_ERROR(glDetachShader(program, fragShader));
     MBGL_CHECK_ERROR(glDeleteShader(fragShader));
-
-    valid = true;
 }
 
 
@@ -142,6 +140,5 @@ Shader::~Shader() {
     if (program) {
         MBGL_CHECK_ERROR(glDeleteProgram(program));
         program = 0;
-        valid = false;
     }
 }

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -13,7 +13,6 @@ public:
     Shader(const char *name, const char *vertex, const char *fragment);
     ~Shader();
     const char *name;
-    bool valid;
     uint32_t program;
 
     inline uint32_t getID() const {

--- a/src/mbgl/shader/uniform.hpp
+++ b/src/mbgl/shader/uniform.hpp
@@ -4,13 +4,16 @@
 #include <mbgl/shader/shader.hpp>
 #include <mbgl/platform/gl.hpp>
 
+#include <cassert>
+
 namespace mbgl {
 
 template <typename T>
 class Uniform {
 public:
     Uniform(const GLchar* name, const Shader& shader) {
-         location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.program, name));
+        assert(shader.program);
+        location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.program, name));
     }
 
     void operator=(const T& t) {
@@ -33,6 +36,7 @@ public:
     typedef std::array<float, C*R> T;
 
     UniformMatrix(const GLchar* name, const Shader& shader) {
+        assert(shader.program);
         location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.program, name));
     }
 

--- a/src/mbgl/storage/request.cpp
+++ b/src/mbgl/storage/request.cpp
@@ -13,8 +13,8 @@
 namespace mbgl {
 
 // Note: This requires that loop is running in the current thread (or not yet running).
-Request::Request(const Resource &resource_, uv_loop_t *loop, Callback callback_)
-    : callback(callback_), resource(resource_) {
+Request::Request(const Resource &resource_, uv_loop_t *loop, const Environment &env_, Callback callback_)
+    : callback(callback_), resource(resource_), env(env_) {
     // When there is no loop supplied (== nullptr), the callback will be fired in an arbitrary
     // thread (the thread notify() is called from) rather than kicking back to the calling thread.
     if (loop) {

--- a/src/mbgl/style/style_bucket.hpp
+++ b/src/mbgl/style/style_bucket.hpp
@@ -1,23 +1,23 @@
 #ifndef MBGL_STYLE_STYLE_BUCKET
 #define MBGL_STYLE_STYLE_BUCKET
 
-#include <mbgl/style/types.hpp>
 #include <mbgl/style/filter_expression.hpp>
-#include <mbgl/style/style_source.hpp>
 #include <mbgl/style/class_properties.hpp>
 
-#include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
+#include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/uv.hpp>
 
 namespace mbgl {
 
-class Source;
+class StyleSource;
 
 class StyleBucket : public util::noncopyable {
 public:
     typedef util::ptr<StyleBucket> Ptr;
 
     inline StyleBucket(StyleLayerType type_) : type(type_) {}
+
     const StyleLayerType type;
     std::string name;
     util::ptr<StyleSource> style_source;

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -24,7 +24,7 @@ class StyleLayer {
 public:
     StyleLayer(const std::string &id, std::map<ClassID, ClassProperties> &&styles);
 
-    template <typename T> const T &getProperties() {
+    template <typename T> const T &getProperties() const {
         if (properties.is<T>()) {
             return properties.get<T>();
         } else {

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/vec.hpp>
+#include <mbgl/util/uv_detail.hpp>
 #include <mbgl/platform/log.hpp>
 #include <csscolorparser/csscolorparser.hpp>
 
@@ -319,7 +320,6 @@ template <> inline float defaultBaseValue<Color>() { return 1.0; }
 
 template <typename T>
 std::tuple<bool, Function<T>> StyleParser::parseFunction(JSVal value, const char *property_name) {
-    
     if (!value.IsObject()) {
         return std::tuple<bool, Function<T>> { true, ConstantFunction<T>(std::get<1>(parseProperty<T>(value, property_name))) };
     }

--- a/src/mbgl/text/glyph.cpp
+++ b/src/mbgl/text/glyph.cpp
@@ -7,7 +7,7 @@ GlyphRange getGlyphRange(char32_t glyph) {
     unsigned start = (glyph/256) * 256;
     unsigned end = (start + 255);
     if (start > 65280) start = 65280;
-    if (end > 65533) end = 65533;
+    if (end > 65535) end = 65535;
     return { start, end };
 }
 

--- a/src/mbgl/text/glyph_store.hpp
+++ b/src/mbgl/text/glyph_store.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/pbf.hpp>
 #include <mbgl/util/vec.hpp>
 #include <mbgl/util/ptr.hpp>
+#include <mbgl/util/uv.hpp>
 
 #include <cstdint>
 #include <vector>
@@ -76,7 +77,7 @@ public:
     // Block until all specified GlyphRanges of the specified font stack are loaded.
     void waitForGlyphRanges(const std::string &fontStack, const std::set<GlyphRange> &glyphRanges);
 
-    FontStack &getFontStack(const std::string &fontStack);
+    uv::exclusive<FontStack> getFontStack(const std::string &fontStack);
 
     void setURL(const std::string &url);
 
@@ -90,7 +91,7 @@ private:
     FileSource& fileSource;
     std::unordered_map<std::string, std::map<GlyphRange, std::unique_ptr<GlyphPBF>>> ranges;
     std::unordered_map<std::string, std::unique_ptr<FontStack>> stacks;
-    std::mutex mtx;
+    std::unique_ptr<uv::mutex> mtx;
 };
 
 

--- a/src/mbgl/text/glyph_store.hpp
+++ b/src/mbgl/text/glyph_store.hpp
@@ -17,6 +17,7 @@
 namespace mbgl {
 
 class FileSource;
+class Environment;
 
 class SDFGlyph {
 public:
@@ -49,7 +50,10 @@ private:
 
 class GlyphPBF {
 public:
-    GlyphPBF(const std::string &glyphURL, const std::string &fontStack, GlyphRange glyphRange, FileSource& fileSource);
+    GlyphPBF(const std::string &glyphURL,
+             const std::string &fontStack,
+             GlyphRange glyphRange,
+             Environment &env);
 
 private:
     GlyphPBF(const GlyphPBF &) = delete;
@@ -72,7 +76,7 @@ private:
 // Manages Glyphrange PBF loading.
 class GlyphStore {
 public:
-    GlyphStore(FileSource& fileSource);
+    GlyphStore(Environment &);
 
     // Block until all specified GlyphRanges of the specified font stack are loaded.
     void waitForGlyphRanges(const std::string &fontStack, const std::set<GlyphRange> &glyphRanges);
@@ -88,7 +92,7 @@ private:
     FontStack &createFontStack(const std::string &fontStack);
 
     std::string glyphURL;
-    FileSource& fileSource;
+    Environment &env;
     std::unordered_map<std::string, std::map<GlyphRange, std::unique_ptr<GlyphPBF>>> ranges;
     std::unordered_map<std::string, std::unique_ptr<FontStack>> stacks;
     std::unique_ptr<uv::mutex> mtx;

--- a/src/mbgl/util/uv.cpp
+++ b/src/mbgl/util/uv.cpp
@@ -33,11 +33,11 @@ lock::lock(const std::unique_ptr<mutex> &mtx_) : mtx(mtx_.get()) {
 lock::~lock() {
     if (mtx) { mtx->unlock(); }
 }
-lock::lock(lock &&lock) {
-    std::swap(mtx, lock.mtx);
+lock::lock(lock &&other) {
+    std::swap(mtx, other.mtx);
 }
-lock &lock::operator=(lock &&lock) {
-    std::swap(mtx, lock.mtx);
+lock &lock::operator=(lock &&other) {
+    std::swap(mtx, other.mtx);
     return *this;
 }
 

--- a/src/mbgl/util/uv.cpp
+++ b/src/mbgl/util/uv.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/util/uv.hpp>
+#include <mbgl/util/uv_detail.hpp>
 
 #include <uv.h>
 
@@ -20,6 +21,60 @@ std::string cwd() {
     dir.resize(max - 1);
     return dir;
 #endif
+}
+
+
+lock::lock(mutex &mtx_) : mtx(&mtx_) {
+    if (mtx) { mtx->lock(); }
+}
+lock::lock(const std::unique_ptr<mutex> &mtx_) : mtx(mtx_.get()) {
+    if (mtx) { mtx->lock(); }
+}
+lock::~lock() {
+    if (mtx) { mtx->unlock(); }
+}
+lock::lock(lock &&lock) {
+    std::swap(mtx, lock.mtx);
+}
+lock &lock::operator=(lock &&lock) {
+    std::swap(mtx, lock.mtx);
+    return *this;
+}
+
+
+readlock::readlock(rwlock &mtx_) : mtx(&mtx_) {
+    if (mtx) { mtx->rdlock(); }
+}
+readlock::readlock(const std::unique_ptr<rwlock> &mtx_) : mtx(mtx_.get()) {
+    if (mtx) { mtx->rdlock(); }
+}
+readlock::~readlock() {
+    if (mtx) { mtx->rdunlock(); }
+}
+readlock::readlock(readlock &&lock) {
+    std::swap(mtx, lock.mtx);
+}
+readlock &readlock::operator=(readlock &&lock) {
+    std::swap(mtx, lock.mtx);
+    return *this;
+}
+
+
+writelock::writelock(rwlock &mtx_) : mtx(&mtx_) {
+    if (mtx) { mtx->wrlock(); }
+}
+writelock::writelock(const std::unique_ptr<rwlock> &mtx_) : mtx(mtx_.get()) {
+    if (mtx) { mtx->wrlock(); }
+}
+writelock::~writelock() {
+    if (mtx) { mtx->wrunlock(); }
+}
+writelock::writelock(writelock &&lock) {
+    std::swap(mtx, lock.mtx);
+}
+writelock &writelock::operator=(writelock &&lock) {
+    std::swap(mtx, lock.mtx);
+    return *this;
 }
 
 const char *getFileRequestError(uv_fs_t *req) {

--- a/src/mbgl/util/uv_detail.hpp
+++ b/src/mbgl/util/uv_detail.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_UTIL_UV_DETAIL
 #define MBGL_UTIL_UV_DETAIL
 
+#include <mbgl/util/uv.hpp>
 #include <mbgl/util/uv-worker.h>
 #include <mbgl/util/noncopyable.hpp>
 
@@ -93,6 +94,20 @@ private:
     std::function<void ()> fn;
 };
 
+class mutex : public mbgl::util::noncopyable {
+public:
+    inline mutex() {
+        if (uv_mutex_init(&mtx) != 0) {
+            throw std::runtime_error("failed to initialize mutex lock");
+        }
+    }
+    inline ~mutex() { uv_mutex_destroy(&mtx); }
+    inline void lock() { uv_mutex_lock(&mtx); }
+    inline void unlock() { uv_mutex_unlock(&mtx); }
+private:
+    uv_mutex_t mtx;
+};
+
 class rwlock : public mbgl::util::noncopyable {
 public:
     inline rwlock() {
@@ -108,26 +123,6 @@ public:
 
 private:
     uv_rwlock_t mtx;
-};
-
-class readlock : public mbgl::util::noncopyable {
-public:
-    inline readlock(rwlock &mtx_) : mtx(mtx_) { mtx.rdlock(); }
-    inline readlock(const std::unique_ptr<rwlock> &mtx_) : mtx(*mtx_) { mtx.rdlock(); }
-    inline ~readlock() { mtx.rdunlock(); }
-
-private:
-    rwlock &mtx;
-};
-
-class writelock : public mbgl::util::noncopyable {
-public:
-    inline writelock(rwlock &mtx_) : mtx(mtx_) { mtx.wrlock(); }
-    inline writelock(const std::unique_ptr<rwlock> &mtx_) : mtx(*mtx_) { mtx.wrlock(); }
-    inline ~writelock() { mtx.wrunlock(); }
-
-private:
-    rwlock &mtx;
 };
 
 class worker : public mbgl::util::noncopyable {

--- a/src/mbgl/util/uv_detail.hpp
+++ b/src/mbgl/util/uv_detail.hpp
@@ -62,6 +62,14 @@ public:
         }
     }
 
+    inline void unref() {
+        uv_unref(reinterpret_cast<uv_handle_t *>(a.get()));
+    }
+
+    inline void ref() {
+        uv_ref(reinterpret_cast<uv_handle_t *>(a.get()));
+    }
+
     inline ~async() {
         close(std::move(a));
     }

--- a/test/headless/headless.cpp
+++ b/test/headless/headless.cpp
@@ -146,7 +146,6 @@ TEST_P(HeadlessTest, render) {
         map.setStyleJSON(style, "test/suite");
 
         view.resize(width, height, pixelRatio);
-        map.resize(width, height, pixelRatio);
         map.setLatLngZoom(mbgl::LatLng(latitude, longitude), zoom);
         map.setBearing(bearing);
 

--- a/test/headless/headless.cpp
+++ b/test/headless/headless.cpp
@@ -141,8 +141,7 @@ TEST_P(HeadlessTest, render) {
             }
         }
 
-        HeadlessView view(display);
-        view.resize(width, height, pixelRatio);
+        HeadlessView view(display, width, height, pixelRatio);
 
         mbgl::DefaultFileSource fileSource(nullptr);
         Map map(view, fileSource, Map::RenderMode::Still);

--- a/test/storage/cache_response.cpp
+++ b/test/storage/cache_response.cpp
@@ -14,8 +14,9 @@ TEST_F(Storage, CacheResponse) {
     DefaultFileSource fs(&cache, uv_default_loop());
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/cache" };
+    auto &env = *static_cast<const Environment *>(nullptr);
 
-    fs.request(resource, uv_default_loop(), [&](const Response &res) {
+    fs.request(resource, uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Response 1", res.data);
         EXPECT_LT(0, res.expires);
@@ -23,7 +24,7 @@ TEST_F(Storage, CacheResponse) {
         EXPECT_EQ("", res.etag);
         EXPECT_EQ("", res.message);
 
-        fs.request(resource, uv_default_loop(), [&, res](const Response &res2) {
+        fs.request(resource, uv_default_loop(), env, [&, res](const Response &res2) {
             EXPECT_EQ(res.status, res2.status);
             EXPECT_EQ(res.data, res2.data);
             EXPECT_EQ(res.expires, res2.expires);

--- a/test/storage/cache_revalidate.cpp
+++ b/test/storage/cache_revalidate.cpp
@@ -15,8 +15,10 @@ TEST_F(Storage, CacheRevalidate) {
     SQLiteCache cache(":memory:");
     DefaultFileSource fs(&cache);
 
+    auto &env = *static_cast<const Environment *>(nullptr);
+
     const Resource revalidateSame { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
-    fs.request(revalidateSame, uv_default_loop(), [&](const Response &res) {
+    fs.request(revalidateSame, uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Response", res.data);
         EXPECT_EQ(0, res.expires);
@@ -24,7 +26,7 @@ TEST_F(Storage, CacheRevalidate) {
         EXPECT_EQ("snowfall", res.etag);
         EXPECT_EQ("", res.message);
 
-        fs.request(revalidateSame, uv_default_loop(), [&, res](const Response &res2) {
+        fs.request(revalidateSame, uv_default_loop(), env, [&, res](const Response &res2) {
             EXPECT_EQ(Response::Successful, res2.status);
             EXPECT_EQ("Response", res2.data);
             // We use this to indicate that a 304 reply came back.
@@ -38,8 +40,9 @@ TEST_F(Storage, CacheRevalidate) {
         });
     });
 
-    const Resource revalidateModified { Resource::Unknown, "http://127.0.0.1:3000/revalidate-modified" };
-    fs.request(revalidateModified, uv_default_loop(), [&](const Response &res) {
+    const Resource revalidateModified{ Resource::Unknown,
+                                       "http://127.0.0.1:3000/revalidate-modified" };
+    fs.request(revalidateModified, uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Response", res.data);
         EXPECT_EQ(0, res.expires);
@@ -47,7 +50,7 @@ TEST_F(Storage, CacheRevalidate) {
         EXPECT_EQ("", res.etag);
         EXPECT_EQ("", res.message);
 
-        fs.request(revalidateModified, uv_default_loop(), [&, res](const Response &res2) {
+        fs.request(revalidateModified, uv_default_loop(), env, [&, res](const Response &res2) {
             EXPECT_EQ(Response::Successful, res2.status);
             EXPECT_EQ("Response", res2.data);
             // We use this to indicate that a 304 reply came back.
@@ -61,7 +64,7 @@ TEST_F(Storage, CacheRevalidate) {
     });
 
     const Resource revalidateEtag { Resource::Unknown, "http://127.0.0.1:3000/revalidate-etag" };
-    fs.request(revalidateEtag, uv_default_loop(), [&](const Response &res) {
+    fs.request(revalidateEtag, uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Response 1", res.data);
         EXPECT_EQ(0, res.expires);
@@ -69,7 +72,7 @@ TEST_F(Storage, CacheRevalidate) {
         EXPECT_EQ("response-1", res.etag);
         EXPECT_EQ("", res.message);
 
-        fs.request(revalidateEtag, uv_default_loop(), [&, res](const Response &res2) {
+        fs.request(revalidateEtag, uv_default_loop(), env, [&, res](const Response &res2) {
             EXPECT_EQ(Response::Successful, res2.status);
             EXPECT_EQ("Response 2", res2.data);
             EXPECT_EQ(0, res2.expires);

--- a/test/storage/directory_reading.cpp
+++ b/test/storage/directory_reading.cpp
@@ -15,7 +15,10 @@ TEST_F(Storage, AssetReadDirectory) {
     DefaultFileSource fs(nullptr, uv_default_loop());
 #endif
 
-    fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage" }, uv_default_loop(), [&](const Response &res) {
+    auto &env = *static_cast<const Environment *>(nullptr);
+
+    fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage" }, uv_default_loop(),
+               env, [&](const Response &res) {
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);
@@ -24,7 +27,7 @@ TEST_F(Storage, AssetReadDirectory) {
 #ifdef MBGL_ASSET_ZIP
         EXPECT_EQ("No such file", res.message);
 #elif MBGL_ASSET_FS
-        EXPECT_EQ("illegal operation on a directory", res.message);
+                            EXPECT_EQ("illegal operation on a directory", res.message);
 #endif
         ReadDirectory.finish();
     });

--- a/test/storage/file_reading.cpp
+++ b/test/storage/file_reading.cpp
@@ -16,9 +16,10 @@ TEST_F(Storage, AssetEmptyFile) {
     DefaultFileSource fs(nullptr, uv_default_loop());
 #endif
 
-    fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/empty" },
-               uv_default_loop(),
-               [&](const Response &res) {
+    auto &env = *static_cast<const Environment *>(nullptr);
+
+    fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/empty" }, uv_default_loop(),
+               env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);
@@ -42,9 +43,10 @@ TEST_F(Storage, AssetNonEmptyFile) {
     DefaultFileSource fs(nullptr, uv_default_loop());
 #endif
 
+    auto &env = *static_cast<const Environment *>(nullptr);
+
     fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/nonempty" },
-               uv_default_loop(),
-               [&](const Response &res) {
+               uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(16ul, res.data.size());
         EXPECT_EQ(0, res.expires);
@@ -69,9 +71,10 @@ TEST_F(Storage, AssetNonExistentFile) {
     DefaultFileSource fs(nullptr, uv_default_loop());
 #endif
 
+    auto &env = *static_cast<const Environment *>(nullptr);
+
     fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/does_not_exist" },
-               uv_default_loop(),
-               [&](const Response &res) {
+               uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);

--- a/test/storage/http_cancel.cpp
+++ b/test/storage/http_cancel.cpp
@@ -14,9 +14,11 @@ TEST_F(Storage, HTTPCancel) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
-    auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(), [&](const Response &) {
-        ADD_FAILURE() << "Callback should not be called";
-    });
+    auto &env = *static_cast<const Environment *>(nullptr);
+
+    auto req =
+        fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(), env,
+                   [&](const Response &) { ADD_FAILURE() << "Callback should not be called"; });
 
     fs.cancel(req);
     HTTPCancel.finish();
@@ -31,11 +33,13 @@ TEST_F(Storage, HTTPCancelMultiple) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
+    auto &env = *static_cast<const Environment *>(nullptr);
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
-    auto req2 = fs.request(resource, uv_default_loop(), [&](const Response &) {
+
+    auto req2 = fs.request(resource, uv_default_loop(), env, [&](const Response &) {
         ADD_FAILURE() << "Callback should not be called";
     });
-    fs.request(resource, uv_default_loop(), [&](const Response &res) {
+    fs.request(resource, uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);

--- a/test/storage/http_coalescing.cpp
+++ b/test/storage/http_coalescing.cpp
@@ -14,6 +14,8 @@ TEST_F(Storage, HTTPCoalescing) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
+    auto &env = *static_cast<const Environment *>(nullptr);
+
     static const Response *reference = nullptr;
 
     const auto complete = [&](const Response &res) {
@@ -41,7 +43,7 @@ TEST_F(Storage, HTTPCoalescing) {
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 
     for (int i = 0; i < total; i++) {
-        fs.request(resource, uv_default_loop(), complete);
+        fs.request(resource, uv_default_loop(), env, complete);
     }
 
     uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/storage/http_environment.cpp
+++ b/test/storage/http_environment.cpp
@@ -1,0 +1,54 @@
+#include "storage.hpp"
+
+#include <uv.h>
+
+#include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/storage/network_status.hpp>
+
+#include <cmath>
+
+TEST_F(Storage, HTTPCancelEnvironment) {
+    SCOPED_TEST(HTTPRetainedEnvironment)
+    SCOPED_TEST(HTTPCanceledEnvironment)
+
+    using namespace mbgl;
+
+    DefaultFileSource fs(nullptr, uv_default_loop());
+
+    // Create two fake environment pointers. The FileSource implementation treats these as opaque
+    // pointers and doesn't reach into them.
+    auto &env1 = *reinterpret_cast<const Environment *>(1);
+    auto &env2 = *reinterpret_cast<const Environment *>(2);
+
+    const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/delayed" };
+
+    // Environment 1
+    fs.request(resource, uv_default_loop(), env1, [&](const Response &res) {
+        // This environment gets aborted below. This means the request is marked as failing and
+        // will return an error here.
+        EXPECT_EQ(Response::Error, res.status);
+        EXPECT_EQ("", res.data);
+        EXPECT_EQ(0, res.expires);
+        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ("", res.etag);
+        EXPECT_EQ("Environment is terminating", res.message);
+        HTTPCanceledEnvironment.finish();
+    });
+
+    // Environment 2
+    fs.request(resource, uv_default_loop(), env2, [&](const Response &res) {
+        // The same request as above, but in a different environment which doesn't get aborted. This
+        // means the request should succeed.
+        EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ("Response", res.data);
+        EXPECT_EQ(0, res.expires);
+        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ("", res.etag);
+        EXPECT_EQ("", res.message);
+        HTTPRetainedEnvironment.finish();
+    });
+
+    fs.abort(env1);
+
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+}

--- a/test/storage/http_error.cpp
+++ b/test/storage/http_error.cpp
@@ -22,9 +22,12 @@ TEST_F(Storage, HTTPError) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
+    auto &env = *static_cast<const Environment *>(nullptr);
+
     auto start = uv_hrtime();
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/temporary-error" }, uv_default_loop(), [&](const Response &res) {
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/temporary-error" }, uv_default_loop(),
+               env, [&](const Response &res) {
         const auto duration = double(uv_hrtime() - start) / 1e9;
         EXPECT_LT(1, duration) << "Backoff timer didn't wait 1 second";
         EXPECT_GT(1.2, duration) << "Backoff timer fired too late";
@@ -38,20 +41,27 @@ TEST_F(Storage, HTTPError) {
         HTTPTemporaryError.finish();
     });
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3001/" }, uv_default_loop(), [&](const Response &res) {
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3001/" }, uv_default_loop(), env,
+               [&](const Response &res) {
         const auto duration = double(uv_hrtime() - start) / 1e9;
         // 1.5 seconds == 4 retries, with a 500ms timeout (see above).
         EXPECT_LT(1.5, duration) << "Resource wasn't retried the correct number of times";
         EXPECT_GT(1.7, duration) << "Resource wasn't retried the correct number of times";
         EXPECT_EQ(Response::Error, res.status);
-        EXPECT_TRUE(res.message == "Couldn't connect to server: couldn't connect to host" || res.message == "The operation couldn’t be completed. (NSURLErrorDomain error -1004.)") << res.message;
+#ifdef MBGL_HTTP_NSURL
+        EXPECT_STREQ(res.message.c_str(), "The operation couldn’t be completed. (NSURLErrorDomain error -1004.)");
+#elif MBGL_HTTP_CURL
+        const std::string prefix { "Couldn't connect to server: " };
+        EXPECT_STREQ(prefix.c_str(), res.message.substr(0, prefix.size()).c_str()) << "Full message is: \"" << res.message << "\"";
+#else
+        FAIL();
+#endif
         EXPECT_EQ("", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);
         HTTPConnectionError.finish();
     });
-
 
     uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/storage/http_header_parsing.cpp
+++ b/test/storage/http_header_parsing.cpp
@@ -14,7 +14,11 @@ TEST_F(Storage, HTTPHeaderParsing) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?modified=1420794326&expires=1420797926&etag=foo" }, uv_default_loop(), [&](const Response &res) {
+    auto &env = *static_cast<const Environment *>(nullptr);
+
+    fs.request({ Resource::Unknown,
+                 "http://127.0.0.1:3000/test?modified=1420794326&expires=1420797926&etag=foo" },
+               uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(1420797926, res.expires);
@@ -24,11 +28,11 @@ TEST_F(Storage, HTTPHeaderParsing) {
         HTTPExpiresTest.finish();
     });
 
-
     int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
                        std::chrono::system_clock::now().time_since_epoch()).count();
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" }, uv_default_loop(), [&](const Response &res) {
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" },
+               uv_default_loop(), env, [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_GT(2, std::abs(res.expires - now - 120)) << "Expiration date isn't about 120 seconds in the future";

--- a/test/storage/http_load.cpp
+++ b/test/storage/http_load.cpp
@@ -11,13 +11,17 @@ TEST_F(Storage, HTTPLoad) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
+    auto &env = *static_cast<const Environment *>(nullptr);
+
     const int concurrency = 50;
     const int max = 10000;
     int number = 1;
 
     std::function<void()> req = [&]() {
         const auto current = number++;
-        fs.request({ Resource::Unknown, std::string("http://127.0.0.1:3000/load/") +  std::to_string(current) }, uv_default_loop(), [&, current](const Response &res) {
+        fs.request({ Resource::Unknown,
+                     std::string("http://127.0.0.1:3000/load/") + std::to_string(current) },
+                   uv_default_loop(), env, [&, current](const Response &res) {
             EXPECT_EQ(Response::Successful, res.status);
             EXPECT_EQ(std::string("Request ") +  std::to_string(current), res.data);
             EXPECT_EQ(0, res.expires);

--- a/test/storage/http_noloop.cpp
+++ b/test/storage/http_noloop.cpp
@@ -12,6 +12,8 @@ TEST_F(Storage, HTTPNoLoop) {
 
     DefaultFileSource fs(nullptr);
 
+    auto &env = *static_cast<const Environment *>(nullptr);
+
     const auto mainThread = uv_thread_self();
 
     // Async handle that keeps the main loop alive until the thread finished
@@ -20,7 +22,8 @@ TEST_F(Storage, HTTPNoLoop) {
         uv::close(as);
     });
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/temporary-error" }, [&](const Response &res) {
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/temporary-error" }, nullptr, env,
+               [&](const Response &res) {
         EXPECT_NE(uv_thread_self(), mainThread) << "Response was called in the same thread";
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);

--- a/test/storage/http_other_loop.cpp
+++ b/test/storage/http_other_loop.cpp
@@ -12,7 +12,10 @@ TEST_F(Storage, HTTPOtherLoop) {
     // This file source launches a separate thread to do the processing.
     DefaultFileSource fs(nullptr);
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(), [&](const Response &res) {
+    auto &env = *static_cast<const Environment *>(nullptr);
+
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(), env,
+               [&](const Response &res) {
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);

--- a/test/storage/http_reading.cpp
+++ b/test/storage/http_reading.cpp
@@ -12,9 +12,12 @@ TEST_F(Storage, HTTPReading) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
+    auto &env = *static_cast<const Environment *>(nullptr);
+
     const auto mainThread = uv_thread_self();
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(), [&](const Response &res) {
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(), env,
+               [&](const Response &res) {
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
@@ -25,7 +28,8 @@ TEST_F(Storage, HTTPReading) {
         HTTPTest.finish();
     });
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/doesnotexist" }, uv_default_loop(), [&](const Response &res) {
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/doesnotexist" }, uv_default_loop(),
+               env, [&](const Response &res) {
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ("HTTP status code 404", res.message);
@@ -45,7 +49,10 @@ TEST_F(Storage, HTTPNoCallback) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(), nullptr);
+    auto &env = *static_cast<const Environment *>(nullptr);
+
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(), env,
+               nullptr);
 
     uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
@@ -59,7 +66,9 @@ TEST_F(Storage, HTTPNoCallbackNoLoop) {
 
     DefaultFileSource fs(nullptr, uv_default_loop());
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, nullptr);
+    auto &env = *static_cast<const Environment *>(nullptr);
+
+    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, env, nullptr);
 
     uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 

--- a/test/storage/server.js
+++ b/test/storage/server.js
@@ -85,6 +85,13 @@ app.get('/temporary-error', function(req, res) {
     temporaryErrorCounter++;
 });
 
+app.get('/delayed', function(req, res) {
+    setTimeout(function() {
+        res.status(200).send('Response');
+    }, 200);
+});
+
+
 app.get('/load/:number(\\d+)', function(req, res) {
     res.send('Request ' + req.params.number);
 });

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -32,6 +32,8 @@
         'fixtures/main.cpp',
         'fixtures/util.hpp',
         'fixtures/util.cpp',
+        '../include/mbgl/platform/default/log_stderr.hpp',
+        '../platform/default/log_stderr.cpp',
         'fixtures/fixture_log.hpp',
         'fixtures/fixture_log.cpp',
 

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -58,6 +58,7 @@
         'storage/file_reading.cpp',
         'storage/http_cancel.cpp',
         'storage/http_coalescing.cpp',
+        'storage/http_environment.cpp',
         'storage/http_error.cpp',
         'storage/http_header_parsing.cpp',
         'storage/http_load.cpp',


### PR DESCRIPTION
This changes the way Map objects are being rendered. Instead of `start()` and `stop()` launching a new thread, we're now starting a new thread as soon as the Map object is constructed, which runs until the Map object is destructed. This means that we don't have to start/stop thread for static rendering and overall simplifies the way we access OpenGL from multiple threads (we don't anymore).

- [x] OpenGL initialization in Map thread
- [x] Handle HeadlessView resizes 
- [x] Make stop() wait until rendering is finished
- [x] Guard OpenGL extension function pointer acquisition against race conditions (=> uv_once)
- [x] Terminate must terminate all pending requests from this map. This likely requires that the FileSource knows about Map object and keeps track of which Request objects belong to what Maps so we can cancel those automatically
- [ ] Fix android builds
- [ ] Get iOS backgrounding/foregrounding actions right
- [ ] ~~Disable fading for static map renders~~ (see #942)