### PR TITLE
fixes #476 & #853: pixel/meter/latlng conversion routines in core & iOS

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -467,17 +467,16 @@ void JNICALL nativeSetLonLat(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, j
         return;
     }
 
-    nativeMapView->getMap().setLonLat(lon, lat, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().setLatLng(mbgl::LatLng(lat, lon), std::chrono::milliseconds(duration));
 }
 
 jobject JNICALL nativeGetLonLat(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetLonLat");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    double lon = 0.0, lat = 0.0;
-    nativeMapView->getMap().getLonLat(lon, lat);
+    mbgl::LatLng latLng = nativeMapView->getMap().getLatLng();
 
-    jobject ret = env->NewObject(lonLatClass, lonLatConstructorId, lon, lat);
+    jobject ret = env->NewObject(lonLatClass, lonLatConstructorId, latLng.longitude, latLng.latitude);
     if (ret == nullptr) {
         env->ExceptionDescribe();
         return nullptr;
@@ -569,17 +568,17 @@ void JNICALL nativeSetLonLatZoom(JNIEnv *env, jobject obj, jlong nativeMapViewPt
         return;
     }
 
-    nativeMapView->getMap().setLonLatZoom(lon, lat, zoom, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().setLatLngZoom(mbgl::LatLng(lat, lon), zoom, std::chrono::milliseconds(duration));
 }
 
 jobject JNICALL nativeGetLonLatZoom(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetLonLatZoom");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    double lon = 0.0, lat = 0.0, zoom = 0.0;
-    nativeMapView->getMap().getLonLatZoom(lon, lat, zoom);
+    mbgl::LatLng latLng = nativeMapView->getMap().getLatLng();
+    double zoom = nativeMapView->getMap().getZoom();
 
-    jobject ret = env->NewObject(lonLatZoomClass, lonLatZoomConstructorId, lon, lat, zoom);
+    jobject ret = env->NewObject(lonLatZoomClass, lonLatZoomConstructorId, latLng.longitude, latLng.latitude, zoom);
     if (ret == nullptr) {
         env->ExceptionDescribe();
         return nullptr;

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
 
     view.resize(width, height, pixelRatio);
     map.resize(width, height, pixelRatio);
-    map.setLonLatZoom(lon, lat, zoom);
+    map.setLatLonZoom(LatLng(lat, lon), zoom);
     map.setBearing(bearing);
 
     std::unique_ptr<uint32_t[]> pixels;

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -131,6 +131,30 @@
 /** Resets the map rotation to a northern heading. */
 - (void)resetNorth;
 
+#pragma mark - Converting Map Coordinates
+
+/** @name Converting Map Coordinates */
+
+/** Converts a point in the specified view’s coordinate system to a map coordinate.
+*   @param point The point you want to convert.
+*   @param view The view that serves as the reference coordinate system for the `point` parameter.
+*   @return The map coordinate at the specified point. */
+- (CLLocationCoordinate2D)convertPoint:(CGPoint)point toCoordinateFromView:(UIView *)view;
+
+/** Converts a map coordinate to a point in the specified view.
+*   @param coordinate The map coordinate for which you want to find the corresponding point.
+*   @param view The view in whose coordinate system you want to locate the specified map coordinate. If this parameter is `nil`, the returned point is specified in the window’s coordinate system. If `view` is not `nil`, it must belong to the same window as the map view.
+*   @return The point (in the appropriate view or window coordinate system) corresponding to the specified latitude and longitude value. */
+- (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(UIView *)view;
+
+/** Returns the distance spanned by one pixel at the specified latitude and current zoom level.
+*
+*   The distance between pixels decreases as the latitude approaches the poles. This relationship parallels the relationship between longitudinal coordinates at different latitudes.
+*
+*   @param latitude The latitude for which to return the value.
+*   @return The distance (in meters) spanned by a single pixel. */
+- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude;
+
 #pragma mark - Styling the Map
 
 /** @name Styling the Map */

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -2,9 +2,12 @@
 #define MBGL_MAP_MAP
 
 #include <mbgl/map/transform.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/projection.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/uv.hpp>
 #include <mbgl/util/ptr.hpp>
+#include <mbgl/util/vec.hpp>
 
 #include <cstdint>
 #include <atomic>
@@ -94,8 +97,8 @@ public:
 
     // Position
     void moveBy(double dx, double dy, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setLonLat(double lon, double lat, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void getLonLat(double &lon, double &lat) const;
+    void setLatLng(LatLng latLng, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    inline const LatLng getLatLng() const { return state.getLatLng(); }
     void startPanning();
     void stopPanning();
     void resetPosition();
@@ -106,8 +109,7 @@ public:
     double getScale() const;
     void setZoom(double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
     double getZoom() const;
-    void setLonLatZoom(double lon, double lat, double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void getLonLatZoom(double &lon, double &lat, double &zoom) const;
+    void setLatLngZoom(LatLng latLng, double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
     void resetZoom();
     void startScaling();
     void stopScaling();
@@ -126,6 +128,15 @@ public:
     // API
     void setAccessToken(const std::string &token);
     const std::string &getAccessToken() const;
+
+    // Projection
+    inline void getWorldBoundsMeters(ProjectedMeters &sw, ProjectedMeters &ne) const { Projection::getWorldBoundsMeters(sw, ne); }
+    inline void getWorldBoundsLatLng(LatLng &sw, LatLng &ne) const { Projection::getWorldBoundsLatLng(sw, ne); }
+    inline double getMetersPerPixelAtLatitude(const double lat, const double zoom) const { return Projection::getMetersPerPixelAtLatitude(lat, zoom); }
+    inline const ProjectedMeters projectedMetersForLatLng(const LatLng latLng) const { return Projection::projectedMetersForLatLng(latLng); }
+    inline const LatLng latLngForProjectedMeters(const ProjectedMeters projectedMeters) const { return Projection::latLngForProjectedMeters(projectedMeters); }
+    inline const vec2<double> pixelForLatLng(const LatLng latLng) const { return state.pixelForLatLng(latLng); }
+    inline const LatLng latLngForPixel(const vec2<double> pixel) const { return state.latLngForPixel(pixel); }
 
     // Debug
     void setDebug(bool value);

--- a/include/mbgl/map/transform.hpp
+++ b/include/mbgl/map/transform.hpp
@@ -2,7 +2,9 @@
 #define MBGL_MAP_TRANSFORM
 
 #include <mbgl/map/transform_state.hpp>
+#include <mbgl/util/geo.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/vec.hpp>
 
 #include <cstdint>
 #include <cmath>
@@ -26,10 +28,9 @@ public:
 
     // Position
     void moveBy(double dx, double dy, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setLonLat(double lon, double lat, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setLonLatZoom(double lon, double lat, double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void getLonLat(double& lon, double& lat) const;
-    void getLonLatZoom(double& lon, double& lat, double& zoom) const;
+    void setLatLng(LatLng latLng, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void setLatLngZoom(LatLng latLng, double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    inline const LatLng getLatLng() const { return current.getLatLng(); }
     void startPanning();
     void stopPanning();
 
@@ -90,9 +91,6 @@ private:
     // Limit the amount of zooming possible on the map.
     const double min_scale = std::pow(2, 0);
     const double max_scale = std::pow(2, 18);
-
-    // cache values for spherical mercator math
-    double Bc, Cc;
 
     std::forward_list<util::ptr<util::transition>> transitions;
     util::ptr<util::transition> scale_timeout;

--- a/include/mbgl/map/transform_state.hpp
+++ b/include/mbgl/map/transform_state.hpp
@@ -4,6 +4,8 @@
 #include <mbgl/map/tile.hpp>
 
 #include <mbgl/util/mat4.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/vec.hpp>
 
 #include <cstdint>
 #include <array>
@@ -34,6 +36,9 @@ public:
     std::array<float, 2> locationCoordinate(float lon, float lat) const;
     void getLonLat(double &lon, double &lat) const;
 
+    // Position
+    const LatLng getLatLng() const;
+
     // Zoom
     float getNormalizedZoom() const;
     double getZoom() const;
@@ -43,6 +48,10 @@ public:
 
     // Rotation
     float getAngle() const;
+
+    // Projection
+    const vec2<double> pixelForLatLng(const LatLng latLng) const;
+    const LatLng latLngForPixel(const vec2<double> pixel) const;
 
     // Changing
     bool isChanging() const;
@@ -60,6 +69,9 @@ private:
 
     // map scale factor
     float pixelRatio = 0;
+
+    // cache values for spherical mercator math
+    double Bc, Cc;
 
     // animation state
     bool rotating = false;

--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -8,6 +8,13 @@ namespace mbgl {
 namespace util {
 
 extern const float tileSize;
+
+extern const double DEG2RAD;
+extern const double RAD2DEG;
+extern const double M2PI;
+extern const double EARTH_RADIUS_M;
+extern const double LATITUDE_MAX;
+
 }
 
 namespace debug {

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -1,0 +1,24 @@
+#ifndef MBGL_UTIL_GEO
+#define MBGL_UTIL_GEO
+
+namespace mbgl {
+
+struct LatLng {
+    double latitude = 0;
+    double longitude = 0;
+
+    inline LatLng(double lat = 0, double lon = 0)
+        : latitude(lat), longitude(lon) {}
+};
+
+struct ProjectedMeters {
+    double northing = 0;
+    double easting = 0;
+
+    inline ProjectedMeters(double n = 0, double e = 0)
+        : northing(n), easting(e) {}
+};
+
+}
+
+#endif

--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -1,0 +1,65 @@
+#ifndef MBGL_UTIL_PROJECTION
+#define MBGL_UTIL_PROJECTION
+
+#include <mbgl/util/constants.hpp>
+#include <mbgl/util/geo.hpp>
+
+#include <cmath>
+
+namespace mbgl {
+
+class Projection {
+
+public:
+    static inline void getWorldBoundsMeters(ProjectedMeters &sw, ProjectedMeters &ne) {
+        const double d = util::EARTH_RADIUS_M * M_PI;
+
+        sw.easting  = -d;
+        sw.northing = -d;
+
+        ne.easting  =  d;
+        ne.northing =  d;
+    }
+
+    static inline void getWorldBoundsLatLng(LatLng &sw, LatLng &ne) {
+        ProjectedMeters projectedMetersSW = ProjectedMeters();
+        ProjectedMeters projectedMetersNE = ProjectedMeters();
+
+        getWorldBoundsMeters(projectedMetersSW, projectedMetersNE);
+
+        sw = latLngForProjectedMeters(projectedMetersSW);
+        ne = latLngForProjectedMeters(projectedMetersNE);
+    }
+
+    static inline double getMetersPerPixelAtLatitude(const double lat, const double zoom) {
+        const double mapPixelWidthAtZoom = std::pow(2.0, zoom) * util::tileSize;
+        const double constrainedLatitude = std::fmin(std::fmax(lat, -util::LATITUDE_MAX), util::LATITUDE_MAX);
+
+        return std::cos(constrainedLatitude * util::DEG2RAD) * util::M2PI * util::EARTH_RADIUS_M / mapPixelWidthAtZoom;
+    }
+
+    static inline const ProjectedMeters projectedMetersForLatLng(const LatLng latLng) {
+        const double constrainedLatitude = std::fmin(std::fmax(latLng.latitude, -util::LATITUDE_MAX), util::LATITUDE_MAX);
+
+        const double m = 1 - 1e-15;
+        const double f = std::fmin(std::fmax(std::sin(util::DEG2RAD * constrainedLatitude), -m), m);
+
+        const double easting  = util::EARTH_RADIUS_M * latLng.longitude * util::DEG2RAD;
+        const double northing = 0.5 * util::EARTH_RADIUS_M * std::log((1 + f) / (1 - f));
+
+        return ProjectedMeters(northing, easting);
+    }
+
+    static inline const LatLng latLngForProjectedMeters(const ProjectedMeters projectedMeters) {
+        double latitude = (2 * std::atan(std::exp(projectedMeters.northing / util::EARTH_RADIUS_M)) - (M_PI / 2)) * util::RAD2DEG;
+        double longitude = projectedMeters.easting * util::RAD2DEG / util::EARTH_RADIUS_M;
+
+        latitude = std::fmin(std::fmax(latitude, -util::LATITUDE_MAX), util::LATITUDE_MAX);
+        
+        return LatLng(latitude, longitude);
+    }
+};
+
+}
+
+#endif

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
 
     // Load settings
     mbgl::Settings_JSON settings;
-    map.setLonLatZoom(settings.longitude, settings.latitude, settings.zoom);
+    map.setLatLngZoom(mbgl::LatLng(settings.latitude, settings.longitude), settings.zoom);
     map.setBearing(settings.bearing);
     map.setDebug(settings.debug);
 
@@ -94,7 +94,10 @@ int main(int argc, char *argv[]) {
     int ret = view->run();
 
     // Save settings
-    map.getLonLatZoom(settings.longitude, settings.latitude, settings.zoom);
+    mbgl::LatLng latLng = map.getLatLng();
+    settings.latitude = latLng.latitude;
+    settings.longitude = latLng.longitude;
+    settings.zoom = map.getZoom();
     settings.bearing = map.getBearing();
     settings.debug = map.getDebug();
     settings.save();

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -407,13 +407,9 @@ void Map::moveBy(double dx, double dy, std::chrono::steady_clock::duration durat
     update();
 }
 
-void Map::setLonLat(double lon, double lat, std::chrono::steady_clock::duration duration) {
-    transform.setLonLat(lon, lat, duration);
+void Map::setLatLng(LatLng latLng, std::chrono::steady_clock::duration duration) {
+    transform.setLatLng(latLng, duration);
     update();
-}
-
-void Map::getLonLat(double& lon, double& lat) const {
-    transform.getLonLat(lon, lat);
 }
 
 void Map::startPanning() {
@@ -428,7 +424,7 @@ void Map::stopPanning() {
 
 void Map::resetPosition() {
     transform.setAngle(0);
-    transform.setLonLat(0, 0);
+    transform.setLatLng(LatLng(0, 0));
     transform.setZoom(0);
     update();
 }
@@ -459,13 +455,9 @@ double Map::getZoom() const {
     return transform.getZoom();
 }
 
-void Map::setLonLatZoom(double lon, double lat, double zoom, std::chrono::steady_clock::duration duration) {
-    transform.setLonLatZoom(lon, lat, zoom, duration);
+void Map::setLatLngZoom(LatLng latLng, double zoom, std::chrono::steady_clock::duration duration) {
+    transform.setLatLngZoom(latLng, zoom, duration);
     update();
-}
-
-void Map::getLonLatZoom(double& lon, double& lat, double& zoom) const {
-    transform.getLonLatZoom(lon, lat, zoom);
 }
 
 void Map::resetZoom() {
@@ -697,7 +689,7 @@ void Map::prepare() {
 void Map::render() {
     assert(painter);
     painter->render(*style, activeSources,
-                   state, animationTime);
+                    state, animationTime);
     // Schedule another rerender when we definitely need a next frame.
     if (transform.needsTransition() || style->hasTransitions()) {
         update();

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -392,9 +392,8 @@ void Painter::renderBackground(util::ptr<StyleLayer> layer_desc) {
         patternShader->u_mix = properties.image.t;
         patternShader->u_opacity = properties.opacity;
 
-        double lon, lat;
-        state.getLonLat(lon, lat);
-        std::array<float, 2> center = state.locationCoordinate(lon, lat);
+        LatLng latLng = state.getLatLng();
+        vec2<double> center = state.pixelForLatLng(latLng);
         float scale = 1 / std::pow(2, zoomFraction);
 
         std::array<float, 2> sizeA = imagePosA.size;
@@ -404,8 +403,8 @@ void Painter::renderBackground(util::ptr<StyleLayer> layer_desc) {
                       1.0f / (sizeA[0] * properties.image.fromScale),
                       1.0f / (sizeA[1] * properties.image.fromScale));
         matrix::translate(matrixA, matrixA,
-                          std::fmod(center[0] * 512, sizeA[0] * properties.image.fromScale),
-                          std::fmod(center[1] * 512, sizeA[1] * properties.image.fromScale));
+                          std::fmod(center.x * 512, sizeA[0] * properties.image.fromScale),
+                          std::fmod(center.y * 512, sizeA[1] * properties.image.fromScale));
         matrix::rotate(matrixA, matrixA, -state.getAngle());
         matrix::scale(matrixA, matrixA,
                        scale * state.getWidth()  / 2,
@@ -418,8 +417,8 @@ void Painter::renderBackground(util::ptr<StyleLayer> layer_desc) {
                       1.0f / (sizeB[0] * properties.image.toScale),
                       1.0f / (sizeB[1] * properties.image.toScale));
         matrix::translate(matrixB, matrixB,
-                          std::fmod(center[0] * 512, sizeB[0] * properties.image.toScale),
-                          std::fmod(center[1] * 512, sizeB[1] * properties.image.toScale));
+                          std::fmod(center.x * 512, sizeB[0] * properties.image.toScale),
+                          std::fmod(center.y * 512, sizeB[1] * properties.image.toScale));
         matrix::rotate(matrixB, matrixB, -state.getAngle());
         matrix::scale(matrixB, matrixB,
                        scale * state.getWidth()  / 2,

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -5,7 +5,6 @@
 #include <mbgl/style/style_layer_group.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/map/map.hpp>
-#include <mbgl/map/transform.hpp>
 
 using namespace mbgl;
 

--- a/src/mbgl/util/constants.cpp
+++ b/src/mbgl/util/constants.cpp
@@ -2,6 +2,12 @@
 
 const float mbgl::util::tileSize = 512.0f;
 
+const double mbgl::util::DEG2RAD = M_PI / 180.0;
+const double mbgl::util::RAD2DEG = 180.0 / M_PI;
+const double mbgl::util::M2PI = 2 * M_PI;
+const double mbgl::util::EARTH_RADIUS_M = 6378137;
+const double mbgl::util::LATITUDE_MAX = 85.05112878;
+
 #if defined(DEBUG)
 const bool mbgl::debug::tileParseWarnings = false;
 const bool mbgl::debug::styleParseWarnings = false;

--- a/test/headless/headless.cpp
+++ b/test/headless/headless.cpp
@@ -147,7 +147,7 @@ TEST_P(HeadlessTest, render) {
 
         view.resize(width, height, pixelRatio);
         map.resize(width, height, pixelRatio);
-        map.setLonLatZoom(longitude, latitude, zoom);
+        map.setLatLngZoom(mbgl::LatLng(latitude, longitude), zoom);
         map.setBearing(bearing);
 
         // Run the loop. It will terminate when we don't have any further listeners.


### PR DESCRIPTION
The squash of #853. 