### PR TITLE
Removed special cased zoom level for HiDPI

### DIFF
--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -206,7 +206,6 @@ TileData::State Source::addTile(Map& map, uv::worker& worker,
 
 double Source::getZoom(const TransformState& state) const {
     double offset = std::log(util::tileSize / info.tile_size) / std::log(2);
-    offset += (state.getPixelRatio() > 1.0 ? 1 :0);
     return state.getZoom() + offset;
 }
 


### PR DESCRIPTION
No need to load higher-resolution vector tiles for HiDPI displays. This PR does change the zoom levels at which features appear on HiDPI screens, but it should be consistent with LoDPI:

![before](https://cloud.githubusercontent.com/assets/1231218/6362461/303204c8-bc42-11e4-86ed-40a600277bf8.png) ![after](https://cloud.githubusercontent.com/assets/1231218/6362463/344ec168-bc42-11e4-9236-de9ad92d5ed4.png)
