### PR TITLE
Load 2× raster tiles on HiDPI screens

### DIFF
--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -38,7 +38,8 @@ void TileData::request(uv::worker &worker, float pixelRatio, std::function<void(
         return;
 
     std::string url = source.tiles[(id.x + id.y) % source.tiles.size()];
-    url = util::replaceTokens(util::mapbox::normalizeTileURL(url, source.url), [&](const std::string &token) -> std::string {
+    url = util::mapbox::normalizeTileURL(url, source.url, source.type);
+    url = util::replaceTokens(url, [&](const std::string &token) -> std::string {
         if (token == "z") return util::toString(id.z);
         if (token == "x") return util::toString(id.x);
         if (token == "y") return util::toString(id.y);

--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -5,6 +5,7 @@
 
 #include <mbgl/util/token.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/mapbox.hpp>
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/util/uv_detail.hpp>
 #include <mbgl/platform/log.hpp>
@@ -37,7 +38,7 @@ void TileData::request(uv::worker &worker, float pixelRatio, std::function<void(
         return;
 
     std::string url = source.tiles[(id.x + id.y) % source.tiles.size()];
-    url = util::replaceTokens(url, [&](const std::string &token) -> std::string {
+    url = util::replaceTokens(util::mapbox::normalizeTileURL(url, source.url), [&](const std::string &token) -> std::string {
         if (token == "z") return util::toString(id.z);
         if (token == "x") return util::toString(id.x);
         if (token == "y") return util::toString(id.y);

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/util/mapbox.hpp>
 
 #include <stdexcept>
+#include <regex>
 
 namespace mbgl {
 namespace util {
@@ -37,6 +38,14 @@ std::string normalizeGlyphsURL(const std::string& url, const std::string& access
         return url;
 
     return normalizeURL(url, accessToken);
+}
+
+std::string normalizeTileURL(const std::string& url, const std::string& sourceURL) {
+    if (sourceURL.empty() || sourceURL.compare(0, mapbox.length(), mapbox) != 0)
+        return url;
+    
+    static std::regex extension_re("\\.((?:png|jpg)\\d*)(?=$|\\?)");
+    return std::regex_replace(url, extension_re, std::string("{ratio}.$1"));
 }
 
 }

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -39,23 +39,27 @@ std::string normalizeGlyphsURL(const std::string& url, const std::string& access
     return normalizeURL(url, accessToken);
 }
 
-std::string normalizeTileURL(const std::string& url, const std::string& sourceURL) {
-    if (sourceURL.empty() || sourceURL.compare(0, mapbox.length(), mapbox) != 0)
+std::string normalizeTileURL(const std::string& url, const std::string& sourceURL, SourceType sourceType) {
+    if (sourceURL.empty() || sourceURL.compare(0, mapbox.length(), mapbox) != 0 ||
+        sourceType != SourceType::Raster) {
         return url;
+    }
     
     std::string::size_type queryIdx = url.rfind("?");
     // Trim off the right end but never touch anything before the extension dot.
     std::string urlSansParams((queryIdx == std::string::npos) ? url : url.substr(0, queryIdx));
     
-    while (!urlSansParams.empty() && isdigit(urlSansParams.back()))
+    while (!urlSansParams.empty() && isdigit(urlSansParams.back())) {
         urlSansParams.pop_back();
+    }
     
-    std::string::size_type extensionIdx = urlSansParams.length() - 4;
-    if (extensionIdx <= 0)
+    std::string::size_type basenameIdx = url.rfind("/");
+    std::string::size_type extensionIdx = url.rfind(".");
+    if (basenameIdx == std::string::npos || extensionIdx == std::string::npos ||
+        basenameIdx > extensionIdx) {
+        // No file extension: probably not a file name we can tack a ratio onto.
         return url;
-    std::string extension = urlSansParams.substr(extensionIdx);
-    if (extension.compare(".png") != 0 && extension.compare(".jpg") != 0)
-        return url;
+    }
     
     std::string normalizedURL(url);
     normalizedURL.insert(extensionIdx, "{ratio}");

--- a/src/mbgl/util/mapbox.hpp
+++ b/src/mbgl/util/mapbox.hpp
@@ -2,6 +2,7 @@
 #define MBGL_UTIL_MAPBOX
 
 #include <string>
+#include <mbgl/style/types.hpp>
 
 namespace mbgl {
 namespace util {
@@ -9,7 +10,7 @@ namespace mapbox {
 
 std::string normalizeSourceURL(const std::string& url, const std::string& accessToken);
 std::string normalizeGlyphsURL(const std::string& url, const std::string& accessToken);
-std::string normalizeTileURL(const std::string& url, const std::string& sourceURL);
+std::string normalizeTileURL(const std::string& url, const std::string& sourceURL, SourceType sourceType);
 
 }
 }

--- a/src/mbgl/util/mapbox.hpp
+++ b/src/mbgl/util/mapbox.hpp
@@ -9,6 +9,7 @@ namespace mapbox {
 
 std::string normalizeSourceURL(const std::string& url, const std::string& accessToken);
 std::string normalizeGlyphsURL(const std::string& url, const std::string& accessToken);
+std::string normalizeTileURL(const std::string& url, const std::string& sourceURL);
 
 }
 }

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -1,0 +1,61 @@
+#include "../fixtures/util.hpp"
+
+#include <mbgl/util/mapbox.hpp>
+#include <regex>
+#include <iostream>
+
+using namespace mbgl;
+
+TEST(Mapbox, SourceURL) {
+    EXPECT_EQ(mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "key"), "https://api.tiles.mapbox.com/v4/user.map.json?access_token=key");
+    EXPECT_EQ(mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "token"), "https://api.tiles.mapbox.com/v4/user.map.json?access_token=token");
+    EXPECT_THROW(mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", ""), std::runtime_error);
+}
+
+TEST(Mapbox, GlyphsURL) {
+    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fontstack/{fontstack}/{range}.pbf", "key"), "https://api.tiles.mapbox.com/v4/fontstack/{fontstack}/{range}.pbf?access_token=key");
+    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("http://path", "key"), "http://path");
+}
+
+TEST(Mapbox, TileURL) {
+    try {
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png", "mapbox://user.map"), "http://path.png/tile{ratio}.png");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png32", "mapbox://user.map"), "http://path.png/tile{ratio}.png32");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png70", "mapbox://user.map"), "http://path.png/tile{ratio}.png70");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png?access_token=foo", "mapbox://user.map"), "http://path.png/tile{ratio}.png?access_token=foo");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png", "http://path"), "http://path.png");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png", ""), "http://path.png");
+    } catch (const std::regex_error& e) {
+        std::cout << "regex_error caught: " << e.what() << '\n';
+        std::cout << e.code() << '\n';
+        switch (e.code()) {
+            case std::regex_constants::error_collate:
+                std::cout << "error_collate" << '\n'; break;
+            case std::regex_constants::error_ctype:
+                std::cout << "error_ctype" << '\n'; break;
+            case std::regex_constants::error_escape:
+                std::cout << "error_escape" << '\n'; break;
+            case std::regex_constants::error_backref:
+                std::cout << "error_backref" << '\n'; break;
+            case std::regex_constants::error_paren:
+                std::cout << "error_paren" << '\n'; break;
+            case std::regex_constants::error_brace:
+                std::cout << "error_brace" << '\n'; break;
+            case std::regex_constants::error_badbrace:
+                std::cout << "error_badbrace" << '\n'; break;
+            case std::regex_constants::error_range:
+                std::cout << "error_range" << '\n'; break;
+            case std::regex_constants::error_space:
+                std::cout << "error_space" << '\n'; break;
+            case std::regex_constants::error_badrepeat:
+                std::cout << "error_badrepeat" << '\n'; break;
+            case std::regex_constants::error_complexity:
+                std::cout << "error_complexity" << '\n'; break;
+            case std::regex_constants::error_stack:
+                std::cout << "error_stack" << '\n'; break;
+                
+            default:
+                break;
+        }
+    }
+}

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -19,12 +19,15 @@ TEST(Mapbox, GlyphsURL) {
 
 TEST(Mapbox, TileURL) {
     try {
-        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png", "mapbox://user.map"), "http://path.png/tile{ratio}.png");
-        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png32", "mapbox://user.map"), "http://path.png/tile{ratio}.png32");
-        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png70", "mapbox://user.map"), "http://path.png/tile{ratio}.png70");
-        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png?access_token=foo", "mapbox://user.map"), "http://path.png/tile{ratio}.png?access_token=foo");
-        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png", "http://path"), "http://path.png");
-        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png", ""), "http://path.png");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.png");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png32", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.png32");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png70", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.png70");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png?access_token=foo", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.png?access_token=foo");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png", "http://path", SourceType::Raster), "http://path.png");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png", "", SourceType::Raster), "http://path.png");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png", "mapbox://user.map", SourceType::Vector), "http://path.png/tile.png");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.pbf");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf", "mapbox://user.map", SourceType::Vector), "http://path.png/tile.pbf");
     } catch (const std::regex_error& e) {
         std::cout << "regex_error caught: " << e.what() << '\n';
         std::cout << e.code() << '\n';
@@ -57,5 +60,6 @@ TEST(Mapbox, TileURL) {
             default:
                 break;
         }
+        throw e;
     }
 }

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -41,6 +41,7 @@
         'miscellaneous/comparisons.cpp',
         'miscellaneous/enums.cpp',
         'miscellaneous/functions.cpp',
+        'miscellaneous/mapbox.cpp',
         'miscellaneous/merge_lines.cpp',
         'miscellaneous/rotation_range.cpp',
         'miscellaneous/style_parser.cpp',


### PR DESCRIPTION
Based on `mapbox.normalizeTileURL()` in mapbox/mapbox-gl-js, but insert a `{ratio}` placeholder instead of `@2x` in order to keep the `pixelRatio` logic in `TileData::request()`.

Fixes #919, so Satellite should look like it did before feae53fb3f81b4a09372324c7c839a03d31d9b66:

![fixed](https://cloud.githubusercontent.com/assets/1231218/6407224/c5687806-bdf0-11e4-9c38-1e910a47740f.png)