### PR TITLE
clean up members, arguments, and formatting

### DIFF
--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -29,14 +29,14 @@ namespace mbgl {
 // its header file.
 TileParser::~TileParser() = default;
 
-TileParser::TileParser(const std::string& raw_data_,
+TileParser::TileParser(const std::string& rawData_,
                        VectorTileData& tile_,
                        const util::ptr<const Style>& style_,
                        GlyphAtlas& glyphAtlas_,
                        GlyphStore& glyphStore_,
                        SpriteAtlas& spriteAtlas_,
                        const util::ptr<Sprite>& sprite_)
-    : vector_tile(pbf((const uint8_t *)raw_data_.data(), raw_data_.size())),
+    : vectorTile(pbf((const uint8_t *)rawData_.data(), rawData_.size())),
       tile(tile_),
       style(style_),
       glyphAtlas(glyphAtlas_),
@@ -181,31 +181,31 @@ std::unique_ptr<StyleLayoutSymbol> parseStyleLayoutSymbol(const StyleBucket &buc
     return symbolPtr;
 }
 
-std::unique_ptr<Bucket> TileParser::createBucket(const StyleBucket &bucket_desc) {
+std::unique_ptr<Bucket> TileParser::createBucket(const StyleBucket &bucketDesc) {
     // Skip this bucket if we are to not render this
-    if (tile.id.z < std::floor(bucket_desc.min_zoom) && std::floor(bucket_desc.min_zoom) < tile.source.max_zoom) return nullptr;
-    if (tile.id.z >= std::ceil(bucket_desc.max_zoom)) return nullptr;
-    if (bucket_desc.visibility == mbgl::VisibilityType::None) return nullptr;
+    if (tile.id.z < std::floor(bucketDesc.min_zoom) && std::floor(bucketDesc.min_zoom) < tile.source.max_zoom) return nullptr;
+    if (tile.id.z >= std::ceil(bucketDesc.max_zoom)) return nullptr;
+    if (bucketDesc.visibility == mbgl::VisibilityType::None) return nullptr;
 
-    auto layer_it = vector_tile.layers.find(bucket_desc.source_layer);
-    if (layer_it != vector_tile.layers.end()) {
+    auto layer_it = vectorTile.layers.find(bucketDesc.source_layer);
+    if (layer_it != vectorTile.layers.end()) {
         const VectorTileLayer &layer = layer_it->second;
-        if (bucket_desc.type == StyleLayerType::Fill) {
-            return createFillBucket(layer, bucket_desc);
-        } else if (bucket_desc.type == StyleLayerType::Line) {
-            return createLineBucket(layer, bucket_desc);
-        } else if (bucket_desc.type == StyleLayerType::Symbol) {
-            return createSymbolBucket(layer, bucket_desc);
-        } else if (bucket_desc.type == StyleLayerType::Raster) {
+        if (bucketDesc.type == StyleLayerType::Fill) {
+            return createFillBucket(layer, bucketDesc);
+        } else if (bucketDesc.type == StyleLayerType::Line) {
+            return createLineBucket(layer, bucketDesc);
+        } else if (bucketDesc.type == StyleLayerType::Symbol) {
+            return createSymbolBucket(layer, bucketDesc);
+        } else if (bucketDesc.type == StyleLayerType::Raster) {
             return nullptr;
         } else {
-            fprintf(stderr, "[WARNING] unknown bucket render type for layer '%s' (source layer '%s')\n", bucket_desc.name.c_str(), bucket_desc.source_layer.c_str());
+            fprintf(stderr, "[WARNING] unknown bucket render type for layer '%s' (source layer '%s')\n", bucketDesc.name.c_str(), bucketDesc.source_layer.c_str());
         }
     } else {
         // The layer specified in the bucket does not exist. Do nothing.
         if (debug::tileParseWarnings) {
             fprintf(stderr, "[WARNING] layer '%s' does not exist in tile %d/%d/%d\n",
-                    bucket_desc.source_layer.c_str(), tile.id.z, tile.id.x, tile.id.y);
+                    bucketDesc.source_layer.c_str(), tile.id.z, tile.id.x, tile.id.y);
         }
     }
 

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -29,13 +29,14 @@ namespace mbgl {
 // its header file.
 TileParser::~TileParser() = default;
 
-TileParser::TileParser(const std::string &data, VectorTileData &tile_,
-                       const util::ptr<const Style> &style_,
-                       GlyphAtlas & glyphAtlas_,
-                       GlyphStore & glyphStore_,
-                       SpriteAtlas & spriteAtlas_,
-                       const util::ptr<Sprite> &sprite_)
-    : vector_data(pbf((const uint8_t *)data.data(), data.size())),
+TileParser::TileParser(const std::string& raw_data_,
+                       VectorTileData& tile_,
+                       const util::ptr<const Style>& style_,
+                       GlyphAtlas& glyphAtlas_,
+                       GlyphStore& glyphStore_,
+                       SpriteAtlas& spriteAtlas_,
+                       const util::ptr<Sprite>& sprite_)
+    : vector_tile(pbf((const uint8_t *)raw_data_.data(), raw_data_.size())),
       tile(tile_),
       style(style_),
       glyphAtlas(glyphAtlas_),
@@ -186,8 +187,8 @@ std::unique_ptr<Bucket> TileParser::createBucket(const StyleBucket &bucket_desc)
     if (tile.id.z >= std::ceil(bucket_desc.max_zoom)) return nullptr;
     if (bucket_desc.visibility == mbgl::VisibilityType::None) return nullptr;
 
-    auto layer_it = vector_data.layers.find(bucket_desc.source_layer);
-    if (layer_it != vector_data.layers.end()) {
+    auto layer_it = vector_tile.layers.find(bucket_desc.source_layer);
+    if (layer_it != vector_tile.layers.end()) {
         const VectorTileLayer &layer = layer_it->second;
         if (bucket_desc.type == StyleLayerType::Fill) {
             return createFillBucket(layer, bucket_desc);

--- a/src/mbgl/map/tile_parser.hpp
+++ b/src/mbgl/map/tile_parser.hpp
@@ -35,7 +35,7 @@ class TexturePool;
 class TileParser : private util::noncopyable
 {
 public:
-    TileParser(const std::string& raw_data,
+    TileParser(const std::string& rawData,
                VectorTileData& tile,
                const util::ptr<const Style>& style,
                GlyphAtlas& glyphAtlas,
@@ -51,22 +51,22 @@ private:
     bool obsolete() const;
     void parseStyleLayers(util::ptr<const StyleLayerGroup> group);
 
-    std::unique_ptr<Bucket> createBucket(const StyleBucket& bucket_desc);
-    std::unique_ptr<Bucket> createFillBucket(const VectorTileLayer& layer, const StyleBucket& bucket_desc);
-    std::unique_ptr<Bucket> createLineBucket(const VectorTileLayer& layer, const StyleBucket& bucket_desc);
-    std::unique_ptr<Bucket> createSymbolBucket(const VectorTileLayer& layer, const StyleBucket& bucket_desc);
+    std::unique_ptr<Bucket> createBucket(const StyleBucket& bucketDesc);
+    std::unique_ptr<Bucket> createFillBucket(const VectorTileLayer& layer, const StyleBucket& bucketDesc);
+    std::unique_ptr<Bucket> createLineBucket(const VectorTileLayer& layer, const StyleBucket& bucketDesc);
+    std::unique_ptr<Bucket> createSymbolBucket(const VectorTileLayer& layer, const StyleBucket& bucketDesc);
 
     template <class Bucket> void addBucketGeometries(Bucket& bucket, const VectorTileLayer& layer, const FilterExpression& filter);
 
 private:
-    const VectorTile vector_tile;
+    const VectorTile vectorTile;
     VectorTileData& tile;
 
     // Cross-thread shared data.
     util::ptr<const Style> style;
-    GlyphAtlas & glyphAtlas;
-    GlyphStore & glyphStore;
-    SpriteAtlas & spriteAtlas;
+    GlyphAtlas& glyphAtlas;
+    GlyphStore& glyphStore;
+    SpriteAtlas& spriteAtlas;
     util::ptr<Sprite> sprite;
 
     std::unique_ptr<Collision> collision;

--- a/src/mbgl/map/tile_parser.hpp
+++ b/src/mbgl/map/tile_parser.hpp
@@ -35,12 +35,13 @@ class TexturePool;
 class TileParser : private util::noncopyable
 {
 public:
-    TileParser(const std::string &data, VectorTileData &tile,
-               const util::ptr<const Style> &style,
-               GlyphAtlas & glyphAtlas,
-               GlyphStore & glyphStore,
-               SpriteAtlas & spriteAtlas,
-               const util::ptr<Sprite> &sprite);
+    TileParser(const std::string& raw_data,
+               VectorTileData& tile,
+               const util::ptr<const Style>& style,
+               GlyphAtlas& glyphAtlas,
+               GlyphStore& glyphStore,
+               SpriteAtlas& spriteAtlas,
+               const util::ptr<Sprite>& sprite);
     ~TileParser();
 
 public:
@@ -50,15 +51,15 @@ private:
     bool obsolete() const;
     void parseStyleLayers(util::ptr<const StyleLayerGroup> group);
 
-    std::unique_ptr<Bucket> createBucket(const StyleBucket &bucket_desc);
-    std::unique_ptr<Bucket> createFillBucket(const VectorTileLayer &layer, const StyleBucket &bucket_desc);
-    std::unique_ptr<Bucket> createLineBucket(const VectorTileLayer& layer, const StyleBucket &bucket_desc);
-    std::unique_ptr<Bucket> createSymbolBucket(const VectorTileLayer& layer, const StyleBucket &bucket_desc);
+    std::unique_ptr<Bucket> createBucket(const StyleBucket& bucket_desc);
+    std::unique_ptr<Bucket> createFillBucket(const VectorTileLayer& layer, const StyleBucket& bucket_desc);
+    std::unique_ptr<Bucket> createLineBucket(const VectorTileLayer& layer, const StyleBucket& bucket_desc);
+    std::unique_ptr<Bucket> createSymbolBucket(const VectorTileLayer& layer, const StyleBucket& bucket_desc);
 
-    template <class Bucket> void addBucketGeometries(Bucket& bucket, const VectorTileLayer& layer, const FilterExpression &filter);
+    template <class Bucket> void addBucketGeometries(Bucket& bucket, const VectorTileLayer& layer, const FilterExpression& filter);
 
 private:
-    const VectorTile vector_data;
+    const VectorTile vector_tile;
     VectorTileData& tile;
 
     // Cross-thread shared data.


### PR DESCRIPTION
Hit some weirdness over in #928 with the naming here and posting some cleanups. 

 * Since we're dealing with both `VectorTileData` (base: `TileData`) and `VectorTile` classes, we should refer to raw data retrieved from a vector tile download and used to instantiate a `VectorTile` as `raw_data`, not just `data`. 

* The `VectorTile` instantiated is now called `vector_tile`, not `vector_data`. 

* The `VectorTileData& tile` is not ideal, since elsewhere in the project we *also* have a `Tile` class, but for the purposes of convenience throughout the implementation, it stays. 

* Overall formatting changes like `ClassName& argument_name` — reference `&` next to type, then a space, then the variable name with `_` and not `camelCase`. 

![kyleve_2015-jan-07](https://cloud.githubusercontent.com/assets/17722/6454648/0b931ac2-c100-11e4-8ba8-dcea003b74ab.gif)
