### PR TITLE
Add compass/bearing snapping to iOS map view

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1473,6 +1473,8 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
             if (self.isAnimatingGesture) return;
 
+            [self snapCompassIfNeeded];
+
             [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(unsuspendRegionChangeDelegateQueue) object:nil];
             [self performSelector:@selector(unsuspendRegionChangeDelegateQueue) withObject:nil afterDelay:0];
 
@@ -1547,6 +1549,18 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
                              self.compass.alpha = 1;
                          }
                          completion:nil];
+    }
+}
+
+- (void)snapCompassIfNeeded
+{
+    double degrees = mbglMap->getBearing() * -1;
+    while (degrees >= 360) degrees -= 360;
+    while (degrees < 0) degrees += 360;
+    
+    if ((degrees < 7 || degrees > 353) && self.compass.alpha > 0)
+    {
+        [self resetNorthAnimated:YES];
     }
 }
 


### PR DESCRIPTION
À la Apple Maps' compass snapping action. If map rotation ends oriented within ±7º of north, assume it was accidental or the user was trying to get back to true and reset the map view to 0º for them.

[Video of this in action.](https://www.dropbox.com/s/whvr60fqgm7jycf/snapCompassIfNeeded.mp4?dl=0)

I don't know what Apple's snap-back threshold is, but 7º seemed like a decent balance between actual rotation and friendly UX.