### PR TITLE
Fix end of acceptable glyph/unicode range

### DIFF
--- a/src/mbgl/text/glyph.cpp
+++ b/src/mbgl/text/glyph.cpp
@@ -7,7 +7,7 @@ GlyphRange getGlyphRange(char32_t glyph) {
     unsigned start = (glyph/256) * 256;
     unsigned end = (start + 255);
     if (start > 65280) start = 65280;
-    if (end > 65533) end = 65533;
+    if (end > 65535) end = 65535;
     return { start, end };
 }
 


### PR DESCRIPTION
Should fix #931 once mapbox/node-fontnik#72 lands.