### PR TITLE
Pass StyleLayer objects as const ref instead of a shared pointer

### DIFF
--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -25,7 +25,7 @@ void RasterTileData::parse() {
     }
 }
 
-void RasterTileData::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix) {
+void RasterTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) {
     bucket.render(painter, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -20,9 +20,9 @@ public:
     RasterTileData(Tile::ID const& id, TexturePool&, const SourceInfo&, FileSource &);
     ~RasterTileData();
 
-    virtual void parse();
-    virtual void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix);
-    virtual bool hasData(StyleLayer const& layer_desc) const;
+    void parse() override;
+    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) override;
+    bool hasData(StyleLayer const &layer_desc) const override;
 
 protected:
     StyleLayoutRaster layout;

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -95,8 +95,8 @@ void Source::drawClippingMasks(Painter &painter) {
     }
 }
 
-void Source::render(Painter &painter, util::ptr<StyleLayer> layer_desc) {
-    gl::group group(std::string { "layer: " } + layer_desc->id);
+void Source::render(Painter &painter, const StyleLayer &layer_desc) {
+    gl::group group(std::string { "layer: " } + layer_desc.id);
     for (const std::pair<const Tile::ID, std::unique_ptr<Tile>> &pair : tiles) {
         Tile &tile = *pair.second;
         if (tile.data && tile.data->state == TileData::State::parsed) {
@@ -105,7 +105,7 @@ void Source::render(Painter &painter, util::ptr<StyleLayer> layer_desc) {
     }
 }
 
-void Source::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix) {
+void Source::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id, const mat4 &matrix) {
     auto it = tiles.find(id);
     if (it != tiles.end() && it->second->data && it->second->data->state == TileData::State::parsed) {
         painter.renderTileLayer(*it->second, layer_desc, matrix);

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -45,8 +45,8 @@ public:
     void updateMatrices(const mat4 &projMatrix, const TransformState &transform);
     void drawClippingMasks(Painter &painter);
     size_t getTileCount() const;
-    void render(Painter &painter, util::ptr<StyleLayer> layer_desc);
-    void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix);
+    void render(Painter &painter, const StyleLayer &layer_desc);
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id, const mat4 &matrix);
     void finishRender(Painter &painter);
 
     std::forward_list<Tile::ID> getIDs() const;

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -62,9 +62,8 @@ public:
 
     // Override this in the child class.
     virtual void parse() = 0;
-    virtual void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix) = 0;
-    virtual bool hasData(StyleLayer const& layer_desc) const = 0;
-
+    virtual void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) = 0;
+    virtual bool hasData(StyleLayer const &layer_desc) const = 0;
 
 public:
     const Tile::ID id;

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -59,9 +59,9 @@ void VectorTileData::parse() {
     }
 }
 
-void VectorTileData::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix) {
-    if (state == State::parsed && layer_desc->bucket) {
-        auto databucket_it = buckets.find(layer_desc->bucket->name);
+void VectorTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) {
+    if (state == State::parsed && layer_desc.bucket) {
+        auto databucket_it = buckets.find(layer_desc.bucket->name);
         if (databucket_it != buckets.end()) {
             assert(databucket_it->second);
             databucket_it->second->render(painter, layer_desc, id, matrix);
@@ -69,7 +69,7 @@ void VectorTileData::render(Painter &painter, util::ptr<StyleLayer> layer_desc, 
     }
 }
 
-bool VectorTileData::hasData(StyleLayer const& layer_desc) const {
+bool VectorTileData::hasData(const StyleLayer &layer_desc) const {
     if (state == State::parsed && layer_desc.bucket) {
         auto databucket_it = buckets.find(layer_desc.bucket->name);
         if (databucket_it != buckets.end()) {

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -37,9 +37,9 @@ public:
                    const SourceInfo&, FileSource &);
     ~VectorTileData();
 
-    virtual void parse();
-    virtual void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const mat4 &matrix);
-    virtual bool hasData(StyleLayer const& layer_desc) const;
+    void parse() override;
+    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) override;
+    bool hasData(StyleLayer const& layer_desc) const override;
 
 protected:
     // Holds the actual geometries in this tile.

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -13,7 +13,8 @@ class StyleLayer;
 
 class Bucket : private util::noncopyable {
 public:
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) = 0;
+    virtual void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                        const mat4 &matrix) = 0;
     virtual bool hasData() const = 0;
     virtual ~Bucket() {}
 

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -13,7 +13,8 @@ DebugBucket::DebugBucket(DebugFontBuffer& fontBuffer_)
     : fontBuffer(fontBuffer_) {
 }
 
-void DebugBucket::render(Painter& painter, util::ptr<StyleLayer> /*layer_desc*/, const Tile::ID& /*id*/, const mat4 &matrix) {
+void DebugBucket::render(Painter &painter, const StyleLayer & /*layer_desc*/,
+                         const Tile::ID & /*id*/, const mat4 &matrix) {
     painter.renderDebugText(*this, matrix);
 }
 

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -19,8 +19,9 @@ class DebugBucket : public Bucket {
 public:
     DebugBucket(DebugFontBuffer& fontBuffer);
 
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    virtual bool hasData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
 
     void drawLines(PlainShader& shader);
     void drawPoints(PlainShader& shader);

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -213,7 +213,8 @@ void FillBucket::tessellate() {
     lineGroup.vertex_length += total_vertex_count;
 }
 
-void FillBucket::render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) {
+void FillBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                        const mat4 &matrix) {
     painter.renderFill(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -43,10 +43,11 @@ public:
                FillVertexBuffer &vertexBuffer,
                TriangleElementsBuffer &triangleElementsBuffer,
                LineElementsBuffer &lineElementsBuffer);
-    ~FillBucket();
+    ~FillBucket() override;
 
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    virtual bool hasData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
 
     void addGeometry(pbf& data);
     void tessellate();

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -351,7 +351,8 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
     }
 }
 
-void LineBucket::render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) {
+void LineBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                        const mat4 &matrix) {
     painter.renderLine(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -31,10 +31,11 @@ public:
                LineVertexBuffer &vertexBuffer,
                TriangleElementsBuffer &triangleElementsBuffer,
                PointElementsBuffer &pointElementsBuffer);
-    ~LineBucket();
+    ~LineBucket() override;
 
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    virtual bool hasData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
 
     void addGeometry(pbf& data);
     void addGeometry(const std::vector<Coordinate>& line);

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -81,11 +81,11 @@ public:
                 TransformState state,
                 std::chrono::steady_clock::time_point time);
 
-    void renderLayers(util::ptr<StyleLayerGroup> group);
-    void renderLayer(util::ptr<StyleLayer> layer_desc, const Tile::ID* id = nullptr, const mat4* matrix = nullptr);
+    void renderLayers(const StyleLayerGroup &group);
+    void renderLayer(const StyleLayer &layer_desc, const Tile::ID* id = nullptr, const mat4* matrix = nullptr);
 
     // Renders a particular layer from a tile.
-    void renderTileLayer(const Tile& tile, util::ptr<StyleLayer> layer_desc, const mat4 &matrix);
+    void renderTileLayer(const Tile& tile, const StyleLayer &layer_desc, const mat4 &matrix);
 
     // Renders debug information for a tile.
     void renderTileDebug(const Tile& tile);
@@ -95,11 +95,11 @@ public:
 
     void renderDebugText(DebugBucket& bucket, const mat4 &matrix);
     void renderDebugText(const std::vector<std::string> &strings);
-    void renderFill(FillBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    void renderLine(LineBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    void renderSymbol(SymbolBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    void renderRaster(RasterBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    void renderBackground(util::ptr<StyleLayer> layer_desc);
+    void renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix);
+    void renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix);
+    void renderSymbol(SymbolBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix);
+    void renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix);
+    void renderBackground(const StyleLayer &layer_desc);
 
     float saturationFactor(float saturation);
     float contrastFactor(float contrast);
@@ -109,7 +109,7 @@ public:
 
     void renderPrerenderedTexture(RasterBucket &bucket, const mat4 &matrix, const RasterProperties& properties);
 
-    void createPrerendered(RasterBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id);
+    void createPrerendered(RasterBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id);
 
     void resize();
 

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -11,11 +11,11 @@
 
 using namespace mbgl;
 
-void Painter::renderFill(FillBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) {
+void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix) {
     // Abort early.
     if (!bucket.hasData()) return;
 
-    const FillProperties &properties = layer_desc->getProperties<FillProperties>();
+    const FillProperties &properties = layer_desc.getProperties<FillProperties>();
     mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);
 
     Color fill_color = properties.fill_color;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -10,12 +10,12 @@
 
 using namespace mbgl;
 
-void Painter::renderLine(LineBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix) {
+void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const Tile::ID& id, const mat4 &matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) return;
     if (!bucket.hasData()) return;
 
-    const auto &properties = layer_desc->getProperties<LineProperties>();
+    const auto &properties = layer_desc.getProperties<LineProperties>();
     const auto &layout = *bucket.styleLayout;
 
     // the distance over which the line edge fades out.

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -8,10 +8,10 @@
 
 using namespace mbgl;
 
-void Painter::renderRaster(RasterBucket& bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID&, const mat4 &matrix) {
+void Painter::renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const Tile::ID&, const mat4 &matrix) {
     if (pass != RenderPass::Translucent) return;
 
-    const RasterProperties &properties = layer_desc->getProperties<RasterProperties>();
+    const RasterProperties &properties = layer_desc.getProperties<RasterProperties>();
 
     if (bucket.hasData()) {
         depthMask(false);

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -112,13 +112,13 @@ void Painter::renderSDF(SymbolBucket &bucket,
     }
 }
 
-void Painter::renderSymbol(SymbolBucket &bucket, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix) {
+void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, const Tile::ID &id, const mat4 &matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) {
         return;
     }
 
-    const auto &properties = layer_desc->getProperties<SymbolProperties>();
+    const auto &properties = layer_desc.getProperties<SymbolProperties>();
     const auto &layout = *bucket.styleLayout;
 
     MBGL_CHECK_ERROR(glDisable(GL_STENCIL_TEST));

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -8,7 +8,8 @@ RasterBucket::RasterBucket(TexturePool& texturePool, const StyleLayoutRaster& la
   raster(texturePool) {
 }
 
-void RasterBucket::render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix) {
+void RasterBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                          const mat4 &matrix) {
     painter.renderRaster(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -18,8 +18,9 @@ class RasterBucket : public Bucket {
 public:
     RasterBucket(TexturePool&, const StyleLayoutRaster&);
 
-    virtual void render(Painter& painter, util::ptr<StyleLayer> layer_desc, const Tile::ID& id, const mat4 &matrix);
-    virtual bool hasData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
 
     bool setImage(const std::string &data);
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -30,8 +30,8 @@ SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void SymbolBucket::render(Painter &painter, util::ptr<StyleLayer> layer_desc,
-                          const Tile::ID &id, const mat4 &matrix) {
+void SymbolBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                          const mat4 &matrix) {
     painter.renderSymbol(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -56,12 +56,13 @@ class SymbolBucket : public Bucket {
 
 public:
     SymbolBucket(std::unique_ptr<const StyleLayoutSymbol> styleLayout, Collision &collision);
-    ~SymbolBucket();
+    ~SymbolBucket() override;
 
-    virtual void render(Painter &painter, util::ptr<StyleLayer> layer_desc, const Tile::ID &id, const mat4 &matrix);
-    virtual bool hasData() const;
-    virtual bool hasTextData() const;
-    virtual bool hasIconData() const;
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile::ID &id,
+                const mat4 &matrix) override;
+    bool hasData() const override;
+    bool hasTextData() const;
+    bool hasIconData() const;
 
     void addFeatures(const VectorTileLayer &layer, const FilterExpression &filter,
                      const Tile::ID &id, SpriteAtlas &spriteAtlas, Sprite &sprite,

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -24,7 +24,7 @@ class StyleLayer {
 public:
     StyleLayer(const std::string &id, std::map<ClassID, ClassProperties> &&styles);
 
-    template <typename T> const T &getProperties() {
+    template <typename T> const T &getProperties() const {
         if (properties.is<T>()) {
             return properties.get<T>();
         } else {


### PR DESCRIPTION
Also marks overridden methods with the `override` keyword.