### PR TITLE
Insert {ratio} before extension, not inside access token

### DIFF
--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -53,8 +53,8 @@ std::string normalizeTileURL(const std::string& url, const std::string& sourceUR
         urlSansParams.pop_back();
     }
     
-    std::string::size_type basenameIdx = url.rfind("/");
-    std::string::size_type extensionIdx = url.rfind(".");
+    std::string::size_type basenameIdx = url.rfind("/", queryIdx);
+    std::string::size_type extensionIdx = url.rfind(".", queryIdx);
     if (basenameIdx == std::string::npos || extensionIdx == std::string::npos ||
         basenameIdx > extensionIdx) {
         // No file extension: probably not a file name we can tack a ratio onto.

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -28,6 +28,10 @@ TEST(Mapbox, TileURL) {
         EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.png", "mapbox://user.map", SourceType::Vector), "http://path.png/tile.png");
         EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.pbf");
         EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf", "mapbox://user.map", SourceType::Vector), "http://path.png/tile.pbf");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf?access_token=foo", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.pbf?access_token=foo");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf?access_token=foo.png", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.pbf?access_token=foo.png");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf?access_token=foo.png/bar", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.pbf?access_token=foo.png/bar");
+        EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf?access_token=foo.png/bar.png", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.pbf?access_token=foo.png/bar.png");
     } catch (const std::regex_error& e) {
         std::cout << "regex_error caught: " << e.what() << '\n';
         std::cout << e.code() << '\n';


### PR DESCRIPTION
Fixes #959. Also adds tests to confirm that the bug is gone. And I actually tested in the simulator this time – no last-minute changes. :smiley: