### PR TITLE
Don't copy VT keys / values into each feature

### DIFF
--- a/src/mbgl/map/geometry_tile.cpp
+++ b/src/mbgl/map/geometry_tile.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/map/geometry_tile.hpp>
+#include <mbgl/style/filter_expression.hpp>
 #include <mbgl/style/filter_expression_private.hpp>
 
 namespace mbgl {

--- a/src/mbgl/map/geometry_tile.hpp
+++ b/src/mbgl/map/geometry_tile.hpp
@@ -1,9 +1,7 @@
 #ifndef MBGL_MAP_GEOMETRY_TILE
 #define MBGL_MAP_GEOMETRY_TILE
 
-#include <mbgl/style/filter_expression.hpp>
 #include <mbgl/style/value.hpp>
-#include <mbgl/text/glyph.hpp>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/variant.hpp>
@@ -11,10 +9,7 @@
 #include <mbgl/util/noncopyable.hpp>
 
 #include <cstdint>
-#include <map>
 #include <string>
-#include <type_traits>
-#include <unordered_map>
 #include <vector>
 
 namespace mbgl {

--- a/src/mbgl/map/vector_tile.hpp
+++ b/src/mbgl/map/vector_tile.hpp
@@ -4,7 +4,7 @@
 #include <mbgl/map/geometry_tile.hpp>
 #include <mbgl/util/pbf.hpp>
 
-#include <map>
+#include <unordered_map>
 
 namespace mbgl {
 
@@ -19,9 +19,10 @@ public:
     GeometryCollection getGeometries() const override;
 
 private:
+    const VectorTileLayer& layer;
     uint64_t id = 0;
     FeatureType type = FeatureType::Unknown;
-    std::map<std::string, Value> properties;
+    std::unordered_map<uint32_t, uint32_t> properties;
     pbf geometry_pbf;
 };
 
@@ -38,7 +39,7 @@ private:
 
     std::string name;
     uint32_t extent = 4096;
-    std::vector<std::string> keys;
+    std::unordered_map<std::string, uint32_t> keys;
     std::vector<Value> values;
     std::vector<pbf> features;
 };
@@ -50,7 +51,7 @@ public:
     util::ptr<const GeometryTileLayer> getLayer(const std::string&) const override;
 
 private:
-    std::map<std::string, util::ptr<const GeometryTileLayer>> layers;
+    std::unordered_map<std::string, util::ptr<const GeometryTileLayer>> layers;
 };
 
 }

--- a/src/mbgl/map/vector_tile.hpp
+++ b/src/mbgl/map/vector_tile.hpp
@@ -4,6 +4,8 @@
 #include <mbgl/map/geometry_tile.hpp>
 #include <mbgl/util/pbf.hpp>
 
+#include <map>
+
 namespace mbgl {
 
 class VectorTileLayer;

--- a/src/mbgl/style/filter_expression.cpp
+++ b/src/mbgl/style/filter_expression.cpp
@@ -1,3 +1,4 @@
+#include <mbgl/style/filter_expression.hpp>
 #include <mbgl/map/geometry_tile.hpp>
 #include <mbgl/platform/log.hpp>
 


### PR DESCRIPTION
Instead, maintain a key index ⇢ value index map and look up the value in
   getValue().