### PR TITLE
Build with current iOS SDK

### DIFF
--- a/scripts/package_ios.sh
+++ b/scripts/package_ios.sh
@@ -6,7 +6,7 @@ set -u
 
 NAME=MapboxGL
 OUTPUT=build/ios/pkg
-IOS_SDK_VERSION=8.1
+IOS_SDK_VERSION=`xcrun --sdk iphoneos --show-sdk-version`
 LIBUV_VERSION=0.10.28
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }


### PR DESCRIPTION
`xcodebuild` does not require a specific SDK version, but Mason puts packages in a version-specific directory. So this change uses [the logic for `$MASON_PLATFORM_VERSION`](https://github.com/mapbox/mason/blob/67a20e92a93c555808b25e660d86243a3cf0b4df/mason.sh#L61) in mason.sh in mapbox/mason.

Fixes #974.