### PR TITLE
Relax sqlite version check to major version only

### DIFF
--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -6,18 +6,11 @@
 
 // Check sqlite3 library version.
 const static bool sqliteVersionCheck = []() {
-    if (sqlite3_libversion_number() != SQLITE_VERSION_NUMBER) {
+    if (sqlite3_libversion_number() / 1000000 != SQLITE_VERSION_NUMBER / 1000000) {
         char message[96];
         snprintf(message, 96,
                  "sqlite3 libversion mismatch: headers report %d, but library reports %d",
                  SQLITE_VERSION_NUMBER, sqlite3_libversion_number());
-        throw std::runtime_error(message);
-    }
-    if (strcmp(sqlite3_sourceid(), SQLITE_SOURCE_ID) != 0) {
-        char message[256];
-        snprintf(message, 256,
-                 "sqlite3 sourceid mismatch: headers report \"%s\", but library reports \"%s\"",
-                 SQLITE_SOURCE_ID, sqlite3_sourceid());
         throw std::runtime_error(message);
     }
 


### PR DESCRIPTION
iOS 8.2 updates the included SQLite version to 3.8.4, while iOS 7.0 up
to iOS 8.1 provides version 3.7.13. When compiling with the 8.2 SDK and
running on 8.1 or below, or vice versa, a strict check fails.

(It'll probably never fail in this configuration, but :shrug:)

Fixes #968.