### PR TITLE
Use iOS 8.2 SDK to package for iOS

### DIFF
--- a/MapboxGL.podspec
+++ b/MapboxGL.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |m|
+
+  m.name    = 'MapboxGL'
+  m.version = '0.1.0'
+
+  m.summary          = 'Open source vector map solution for iOS with full styling capabilities.'
+  m.description      = 'Open source OpenGL-based vector map solution for iOS with full styling capabilities and Cocoa bindings.'
+  m.homepage         = 'https://www.mapbox.com/blog/mapbox-gl/'
+  m.license          = 'BSD'
+  m.author           = { 'Mapbox' => 'mobile@mapbox.com' }
+  m.screenshot       = 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/master/ios/screenshot.png'
+  m.social_media_url = 'https://twitter.com/mapbox'
+
+  m.source = { :http => "http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/mapbox-gl-ios-#{m.version.to_s}.zip" }
+
+  m.platform              = :ios
+  m.ios.deployment_target = '7.0'
+
+  m.source_files = 'Headers/*.h'
+
+  m.requires_arc = true
+
+  m.resource_bundle = { 'MapboxGL' => 'MapboxGL.bundle/*' }
+
+  m.frameworks = 'CoreLocation', 'GLKit', 'ImageIO', 'MobileCoreServices', 'SystemConfiguration'
+
+  m.libraries = 'c++', 'sqlite3', 'z'
+
+  m.vendored_library = 'libMapboxGL.a'
+
+  m.xcconfig = { 'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++' }
+
+end

--- a/scripts/package_ios.sh
+++ b/scripts/package_ios.sh
@@ -6,7 +6,7 @@ set -u
 
 NAME=MapboxGL
 OUTPUT=build/ios/pkg
-IOS_SDK_VERSION=8.1
+IOS_SDK_VERSION=8.2
 LIBUV_VERSION=0.10.28
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }


### PR DESCRIPTION
Maybe this is too early, but it successfully produced package against iOS 8.2 SDK so there was no need to install iOS 8.1 simulator.