### PR TITLE
Get rid of printf and cout by using Log::*

### DIFF
--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -17,7 +17,7 @@ GLFWView *view = nullptr;
 
 void quit_handler(int) {
     if (view) {
-        fprintf(stderr, "waiting for quit...\n");
+        mbgl::Log::Info(mbgl::Event::Setup, "waiting for quit...");
         glfwSetWindowShouldClose(view->window, true);
         glfwPostEmptyEvent();
     } else {

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -25,7 +25,7 @@ void GLFWView::initialize(mbgl::Map *map_) {
     glfwSetErrorCallback(glfwError);
 
     if (!glfwInit()) {
-        fprintf(stderr, "Failed to initialize glfw\n");
+        mbgl::Log::Error(mbgl::Event::OpenGL, "failed to initialize glfw");
         exit(1);
     }
 
@@ -54,7 +54,7 @@ void GLFWView::initialize(mbgl::Map *map_) {
     window = glfwCreateWindow(1024, 768, "Mapbox GL", monitor, NULL);
     if (!window) {
         glfwTerminate();
-        fprintf(stderr, "Failed to initialize window\n");
+        mbgl::Log::Error(mbgl::Event::OpenGL, "failed to initialize window");
         exit(1);
     }
 
@@ -312,7 +312,7 @@ void GLFWView::fps() {
     double currentTime = glfwGetTime();
 
     if (currentTime - timeElapsed >= 1) {
-        fprintf(stderr, "FPS: %4.2f\n", frames / (currentTime - timeElapsed));
+        mbgl::Log::Info(mbgl::Event::OpenGL, "FPS: %4.2f", frames / (currentTime - timeElapsed));
         timeElapsed = currentTime;
         frames = 0;
     }

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -125,7 +125,7 @@ void HeadlessView::createContext() {
         glContext = glXCreateNewContext(xDisplay, fbConfigs[0], GLX_RGBA_TYPE, None, True);
         if (glContext) {
             if (!glXIsDirect(xDisplay, glContext)) {
-                mbgl::Log::Error(mbgl::Event::OpenGL, "Failed to create direct OpenGL Legacy context");
+                Log::Error(Event::OpenGL, "failed to create direct OpenGL Legacy context");
                 glXDestroyContext(xDisplay, glContext);
                 glContext = 0;
             }

--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -32,14 +32,14 @@ std::string compress_png(int width, int height, void *rgba) {
     png_voidp error_ptr = 0;
     png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, error_ptr, NULL, NULL);
     if (!png_ptr) {
-        Log::Error(Event::Image, "Couldn't create png_ptr");
+        Log::Error(Event::Image, "couldn't create png_ptr");
         return "";
     }
 
     png_infop info_ptr = png_create_info_struct(png_ptr);
     if (!png_ptr) {
         png_destroy_write_struct(&png_ptr, (png_infopp)0);
-        Log::Error(Event::Image, "Couldn't create info_ptr");
+        Log::Error(Event::Image, "couldn't create info_ptr");
         return "";
     }
 
@@ -87,7 +87,7 @@ Image::Image(std::string const& data)
     }
     catch (ImageReaderException const& ex)
     {
-        fprintf(stderr, "Image: %s\n", ex.what());
+        Log::Error(Event::Image, ex.what());
         img.reset();
         width = 0;
         height = 0;
@@ -95,7 +95,7 @@ Image::Image(std::string const& data)
     }
     catch (...) // catch the rest
     {
-        fprintf(stderr, "Image: exception in constructor");
+        Log::Error(Event::Image, "exception in constructor");
         img.reset();
         width = 0;
         height = 0;

--- a/platform/default/png_reader.cpp
+++ b/platform/default/png_reader.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/platform/default/png_reader.hpp>
+#include <mbgl/platform/log.hpp>
 #include <iostream>
 extern "C"
 {
@@ -23,8 +24,7 @@ void user_error_fn(png_structp /*png_ptr*/, png_const_charp error_msg)
 
 void user_warning_fn(png_structp /*png_ptr*/, png_const_charp warning_msg)
 {
-    fprintf(stderr, "ImageReader (PNG): %s\n", warning_msg);
-
+    Log::Warning(Event::Image, "ImageReader (PNG): %s", warning_msg);
 }
 
 template <typename T>

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -187,7 +187,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     if ( ! _context)
     {
-        mbgl::Log::Error(mbgl::Event::Setup, "Failed to create OpenGL ES context");
+        mbgl::Log::Error(mbgl::Event::Setup, "failed to create OpenGL ES context");
 
         return NO;
     }

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/geometry/glyph_atlas.hpp>
 
 #include <mbgl/platform/gl.hpp>
+#include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
 
 #include <cassert>
@@ -60,7 +61,7 @@ Rect<uint16_t> GlyphAtlas::addGlyph_impl(uint64_t tile_id, const std::string& fa
 
     Rect<uint16_t> rect = bin.allocate(pack_width, pack_height);
     if (rect.w == 0) {
-        fprintf(stderr, "glyph bitmap overflow");
+        Log::Error(Event::OpenGL, "glyph bitmap overflow");
         return rect;
     }
 

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/geometry/line_atlas.hpp>
 #include <mbgl/platform/gl.hpp>
+#include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
 
 #include <sstream>
@@ -46,7 +47,7 @@ LinePatternPos LineAtlas::addDash(const std::vector<float> &dasharray, bool roun
     const uint8_t offset = 128;
 
     if (nextRow + dashheight > height) {
-        fprintf(stderr, "[WARNING] line atlas bitmap overflow\n");
+        Log::Warning(Event::OpenGL, "line atlas bitmap overflow");
         return LinePatternPos();
     }
 

--- a/src/mbgl/geometry/sprite_atlas.cpp
+++ b/src/mbgl/geometry/sprite_atlas.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/geometry/sprite_atlas.hpp>
 #include <mbgl/platform/gl.hpp>
+#include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/std.hpp>
@@ -129,7 +130,7 @@ Rect<SpriteAtlas::dimension> SpriteAtlas::getImage(const std::string& name, cons
     Rect<dimension> rect = allocateImage(pos.width / pos.pixelRatio, pos.height / pos.pixelRatio);
     if (rect.w == 0) {
         if (debug::spriteWarnings) {
-            fprintf(stderr, "[WARNING] sprite atlas bitmap overflow\n");
+            Log::Warning(Event::Sprite, "sprite atlas bitmap overflow");
         }
         return rect;
     }
@@ -210,7 +211,7 @@ void SpriteAtlas::setSprite(util::ptr<Sprite> sprite_) {
         const SpritePosition& src = sprite->getSpritePosition(name);
         if (!src) {
             if (debug::spriteWarnings) {
-                fprintf(stderr, "[WARNING] sprite doesn't have image with name '%s'\n", name.c_str());
+                Log::Warning(Event::Sprite, "sprite doesn't have image with name '%s'", name.c_str());
             }
             return true;
         }
@@ -220,7 +221,7 @@ void SpriteAtlas::setSprite(util::ptr<Sprite> sprite_) {
             return true;
         } else {
             if (debug::spriteWarnings) {
-                fprintf(stderr, "[WARNING] sprite icon dimension mismatch\n");
+                Log::Warning(Event::Sprite, "sprite icon dimension mismatch");
             }
             return false;
         }

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/map/tile_parser.hpp>
 #include <mbgl/map/vector_tile_data.hpp>
+#include <mbgl/platform/log.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_layer.hpp>
 #include <mbgl/style/style_layer_group.hpp>
@@ -85,7 +86,7 @@ void TileParser::parseStyleLayers(util::ptr<const StyleLayerGroup> group) {
                 }
             }
         } else {
-            fprintf(stderr, "[WARNING] layer '%s' does not have buckets\n", layer_desc->id.c_str());
+            Log::Warning(Event::ParseTile, "layer '%s' does not have buckets", layer_desc->id.c_str());
         }
     }
 }
@@ -198,12 +199,13 @@ std::unique_ptr<Bucket> TileParser::createBucket(const StyleBucket &bucketDesc) 
         } else if (bucketDesc.type == StyleLayerType::Raster) {
             return nullptr;
         } else {
-            fprintf(stderr, "[WARNING] unknown bucket render type for layer '%s' (source layer '%s')\n", bucketDesc.name.c_str(), bucketDesc.source_layer.c_str());
+            Log::Warning(Event::ParseTile, "unknown bucket render type for layer '%s' (source layer '%s')",
+                    bucketDesc.name.c_str(), bucketDesc.source_layer.c_str());
         }
     } else {
         // The layer specified in the bucket does not exist. Do nothing.
         if (debug::tileParseWarnings) {
-            fprintf(stderr, "[WARNING] layer '%s' does not exist in tile %d/%d/%d\n",
+            Log::Warning(Event::ParseTile, "layer '%s' does not exist in tile %d/%d/%d",
                     bucketDesc.source_layer.c_str(), tile.id.z, tile.id.x, tile.id.y);
         }
     }

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/style_layout.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/platform/gl.hpp>
+#include <mbgl/platform/log.hpp>
 
 #include <cassert>
 
@@ -173,12 +174,12 @@ void FillBucket::tessellate() {
                 } else {
 #if defined(DEBUG)
                     // TODO: We're missing a vertex that was not part of the line.
-                    fprintf(stderr, "undefined element buffer\n");
+                    Log::Error(Event::OpenGL, "undefined element buffer");
 #endif
                 }
             } else {
 #if defined(DEBUG)
-                fprintf(stderr, "undefined element buffer\n");
+                Log::Error(Event::OpenGL, "undefined element buffer");
 #endif
             }
         }
@@ -187,7 +188,7 @@ void FillBucket::tessellate() {
         triangleGroup.elements_length += triangle_count;
     } else {
 #if defined(DEBUG)
-        fprintf(stderr, "tessellation failed\n");
+        Log::Error(Event::OpenGL, "tessellation failed");
 #endif
     }
 

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -75,7 +75,7 @@ template<> bool StyleParser::parseRenderProperty(JSVal value, bool &target, cons
             target = property.GetBool();
             return true;
         } else {
-            fprintf(stderr, "[WARNING] '%s' must be a boolean\n", name);
+            Log::Warning(Event::ParseStyle, "'%s' must be a boolean", name);
         }
     }
     return false;

--- a/src/mbgl/util/clip_ids.cpp
+++ b/src/mbgl/util/clip_ids.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/util/clip_ids.hpp>
 #include <mbgl/map/tile.hpp>
 
+#include <mbgl/platform/log.hpp>
 #include <mbgl/util/math.hpp>
 
 #include <list>
@@ -89,7 +90,7 @@ void ClipIDGenerator::update(std::forward_list<Tile *> tiles) {
     }
 
     if (bit_offset > 8) {
-        fprintf(stderr, "stencil mask overflow\n");
+        Log::Error(Event::OpenGL, "stencil mask overflow");
     }
 }
 

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/platform/platform.hpp>
 #include <mbgl/platform/gl.hpp>
+#include <mbgl/platform/log.hpp>
 
 #include <mbgl/util/raster.hpp>
 #include <mbgl/util/uv_detail.hpp>
@@ -40,7 +41,7 @@ bool Raster::load(const std::string &data) {
 
 void Raster::bind(bool linear) {
     if (!width || !height) {
-        fprintf(stderr, "trying to bind texture without dimension\n");
+        Log::Error(Event::OpenGL, "trying to bind texture without dimension");
         return;
     }
 

--- a/test/fixtures/util.cpp
+++ b/test/fixtures/util.cpp
@@ -1,5 +1,7 @@
 #include "util.hpp"
 
+#include <mbgl/platform/log.hpp>
+
 #include <csignal>
 
 namespace mbgl {
@@ -17,7 +19,7 @@ pid_t startServer(const char *executable) {
         int ret = execv(executable, args);
         // This call should not return. In case execve failed, we exit anyway.
         if (ret < 0) {
-            fprintf(stderr, "Failed to start server: %s\n", strerror(errno));
+            Log::Error(Event::Setup, "failed to start server: %s", strerror(errno));
         }
         exit(0);
     } else {

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -1,5 +1,6 @@
 #include "../fixtures/util.hpp"
 
+#include <mbgl/platform/log.hpp>
 #include <mbgl/util/mapbox.hpp>
 #include <regex>
 #include <iostream>
@@ -33,37 +34,36 @@ TEST(Mapbox, TileURL) {
         EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf?access_token=foo.png/bar", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.pbf?access_token=foo.png/bar");
         EXPECT_EQ(mbgl::util::mapbox::normalizeTileURL("http://path.png/tile.pbf?access_token=foo.png/bar.png", "mapbox://user.map", SourceType::Raster), "http://path.png/tile{ratio}.pbf?access_token=foo.png/bar.png");
     } catch (const std::regex_error& e) {
-        std::cout << "regex_error caught: " << e.what() << '\n';
-        std::cout << e.code() << '\n';
+        const char *error = "unknown";
         switch (e.code()) {
             case std::regex_constants::error_collate:
-                std::cout << "error_collate" << '\n'; break;
+                error = "error_collate"; break;
             case std::regex_constants::error_ctype:
-                std::cout << "error_ctype" << '\n'; break;
+                error = "error_ctype"; break;
             case std::regex_constants::error_escape:
-                std::cout << "error_escape" << '\n'; break;
+                error = "error_escape"; break;
             case std::regex_constants::error_backref:
-                std::cout << "error_backref" << '\n'; break;
+                error = "error_backref"; break;
             case std::regex_constants::error_paren:
-                std::cout << "error_paren" << '\n'; break;
+                error = "error_paren"; break;
             case std::regex_constants::error_brace:
-                std::cout << "error_brace" << '\n'; break;
+                error = "error_brace"; break;
             case std::regex_constants::error_badbrace:
-                std::cout << "error_badbrace" << '\n'; break;
+                error = "error_badbrace"; break;
             case std::regex_constants::error_range:
-                std::cout << "error_range" << '\n'; break;
+                error = "error_range"; break;
             case std::regex_constants::error_space:
-                std::cout << "error_space" << '\n'; break;
+                error = "error_space"; break;
             case std::regex_constants::error_badrepeat:
-                std::cout << "error_badrepeat" << '\n'; break;
+                error = "error_badrepeat"; break;
             case std::regex_constants::error_complexity:
-                std::cout << "error_complexity" << '\n'; break;
+                error = "error_complexity"; break;
             case std::regex_constants::error_stack:
-                std::cout << "error_stack" << '\n'; break;
-                
+                error = "error_stack"; break;
             default:
                 break;
         }
+        mbgl::Log::Error(mbgl::Event::General, "regex_error caught: %s - %s (%d)", e.what(), error, e.code());
         throw e;
     }
 }


### PR DESCRIPTION
Use our logging system that will route the message accordingly on
the target platform.

Fixes #613