### PR TITLE
Working towards GlyphAtlas safety

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -23,7 +23,6 @@
 namespace mbgl {
 
 class Painter;
-class GlyphStore;
 class LayerDescription;
 class Sprite;
 class Style;
@@ -33,9 +32,6 @@ class StyleSource;
 class TexturePool;
 class FileSource;
 class View;
-class GlyphAtlas;
-class SpriteAtlas;
-class LineAtlas;
 class Environment;
 
 class Map : private util::noncopyable {
@@ -153,7 +149,6 @@ private:
     void resize(uint16_t width, uint16_t height, float ratio = 1);
     void resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth, uint16_t fbHeight);
 
-    util::ptr<Sprite> getSprite();
     uv::worker& getWorker();
 
     // Checks if render thread needs to pause
@@ -163,8 +158,6 @@ private:
     void setup();
 
     void updateTiles();
-    void updateSources();
-    void updateSources(const util::ptr<StyleLayerGroup> &group);
 
     // Prepares a map render by updating the tiles we need for the current view, as well as updating
     // the stylesheet.
@@ -213,11 +206,6 @@ private:
     FileSource& fileSource;
 
     util::ptr<Style> style;
-    const std::unique_ptr<GlyphAtlas> glyphAtlas;
-    util::ptr<GlyphStore> glyphStore;
-    const std::unique_ptr<SpriteAtlas> spriteAtlas;
-    util::ptr<Sprite> sprite;
-    const std::unique_ptr<LineAtlas> lineAtlas;
     util::ptr<TexturePool> texturePool;
 
     const std::unique_ptr<Painter> painter;
@@ -231,8 +219,6 @@ private:
 
     bool debug = false;
     std::chrono::steady_clock::time_point animationTime = std::chrono::steady_clock::time_point::min();
-
-    std::set<util::ptr<StyleSource>> activeSources;
 };
 
 }

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -18,26 +18,43 @@ GlyphAtlas::GlyphAtlas(uint16_t width_, uint16_t height_)
       dirty(true) {
 }
 
-Rect<uint16_t> GlyphAtlas::addGlyph(uint64_t tile_id, const std::string& face_name,
-                                    const SDFGlyph& glyph)
+void GlyphAtlas::addGlyphs(uint64_t tileID,
+                           const std::u32string& text,
+                           const std::string& stackName,
+                           const FontStack& fontStack,
+                           GlyphPositions& face)
 {
     std::lock_guard<std::mutex> lock(mtx);
-    return addGlyph_impl(tile_id, face_name, glyph);
+
+    const std::map<uint32_t, SDFGlyph>& sdfs = fontStack.getSDFs();
+
+    for (uint32_t chr : text)
+    {
+        auto sdf_it = sdfs.find(chr);
+        if (sdf_it == sdfs.end()) {
+            continue;
+        }
+
+        const SDFGlyph& sdf = sdf_it->second;
+        Rect<uint16_t> rect = addGlyph(tileID, stackName, sdf);
+        face.emplace(chr, Glyph{rect, sdf.metrics});
+    }
 }
 
-Rect<uint16_t> GlyphAtlas::addGlyph_impl(uint64_t tile_id, const std::string& face_name,
+Rect<uint16_t> GlyphAtlas::addGlyph(uint64_t tileID,
+                                    const std::string& stackName,
                                     const SDFGlyph& glyph)
 {
     // Use constant value for now.
     const uint8_t buffer = 3;
 
-    std::map<uint32_t, GlyphValue>& face = index[face_name];
+    std::map<uint32_t, GlyphValue>& face = index[stackName];
     std::map<uint32_t, GlyphValue>::iterator it = face.find(glyph.id);
 
     // The glyph is already in this texture.
     if (it != face.end()) {
         GlyphValue& value = it->second;
-        value.ids.insert(tile_id);
+        value.ids.insert(tileID);
         return value.rect;
     }
 
@@ -68,7 +85,7 @@ Rect<uint16_t> GlyphAtlas::addGlyph_impl(uint64_t tile_id, const std::string& fa
     assert(rect.x + rect.w <= width);
     assert(rect.y + rect.h <= height);
 
-    face.emplace(glyph.id, GlyphValue { rect, tile_id });
+    face.emplace(glyph.id, GlyphValue { rect, tileID });
 
     // Copy the bitmap
     char *target = data.get();
@@ -84,23 +101,6 @@ Rect<uint16_t> GlyphAtlas::addGlyph_impl(uint64_t tile_id, const std::string& fa
     dirty = true;
 
     return rect;
-}
-
-void GlyphAtlas::addGlyphs(uint64_t tileid, std::u32string const& text, std::string const& stackname, FontStack const& fontStack, GlyphPositions & face)
-{
-    std::lock_guard<std::mutex> lock(mtx);
-
-    std::map<uint32_t, SDFGlyph> const& sdfs = fontStack.getSDFs();
-    for (uint32_t chr : text)
-    {
-        auto sdf_it = sdfs.find(chr);
-        if (sdf_it != sdfs.end())
-        {
-            SDFGlyph const& sdf = sdf_it->second;
-            Rect<uint16_t> rect = addGlyph_impl(tileid, stackname, sdf);
-            face.emplace(chr, Glyph{rect, sdf.metrics});
-        }
-    }
 }
 
 void GlyphAtlas::removeGlyphs(uint64_t tile_id) {

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -18,7 +18,7 @@ GlyphAtlas::GlyphAtlas(uint16_t width_, uint16_t height_)
       dirty(true) {
 }
 
-void GlyphAtlas::addGlyphs(uint64_t tileID,
+void GlyphAtlas::addGlyphs(uintptr_t tileUID,
                            const std::u32string& text,
                            const std::string& stackName,
                            const FontStack& fontStack,
@@ -36,12 +36,12 @@ void GlyphAtlas::addGlyphs(uint64_t tileID,
         }
 
         const SDFGlyph& sdf = sdf_it->second;
-        Rect<uint16_t> rect = addGlyph(tileID, stackName, sdf);
+        Rect<uint16_t> rect = addGlyph(tileUID, stackName, sdf);
         face.emplace(chr, Glyph{rect, sdf.metrics});
     }
 }
 
-Rect<uint16_t> GlyphAtlas::addGlyph(uint64_t tileID,
+Rect<uint16_t> GlyphAtlas::addGlyph(uintptr_t tileUID,
                                     const std::string& stackName,
                                     const SDFGlyph& glyph)
 {
@@ -54,7 +54,7 @@ Rect<uint16_t> GlyphAtlas::addGlyph(uint64_t tileID,
     // The glyph is already in this texture.
     if (it != face.end()) {
         GlyphValue& value = it->second;
-        value.ids.insert(tileID);
+        value.ids.insert(tileUID);
         return value.rect;
     }
 
@@ -85,7 +85,7 @@ Rect<uint16_t> GlyphAtlas::addGlyph(uint64_t tileID,
     assert(rect.x + rect.w <= width);
     assert(rect.y + rect.h <= height);
 
-    face.emplace(glyph.id, GlyphValue { rect, tileID });
+    face.emplace(glyph.id, GlyphValue { rect, tileUID });
 
     // Copy the bitmap
     char *target = data.get();
@@ -103,14 +103,14 @@ Rect<uint16_t> GlyphAtlas::addGlyph(uint64_t tileID,
     return rect;
 }
 
-void GlyphAtlas::removeGlyphs(uint64_t tile_id) {
+void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
     std::lock_guard<std::mutex> lock(mtx);
 
     for (auto& faces : index) {
         std::map<uint32_t, GlyphValue>& face = faces.second;
         for (auto it = face.begin(); it != face.end(); /* we advance in the body */) {
             GlyphValue& value = it->second;
-            value.ids.erase(tile_id);
+            value.ids.erase(tileUID);
 
             if (!value.ids.size()) {
                 const Rect<uint16_t>& rect = value.rect;

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -15,6 +15,19 @@ namespace mbgl {
 
 class GlyphAtlas : public util::noncopyable {
 public:
+    GlyphAtlas(uint16_t width, uint16_t height);
+
+    void addGlyphs(uint64_t tileID,
+                   const std::u32string& text,
+                   const std::string& stackName,
+                   const FontStack&,
+                   GlyphPositions&);
+    void removeGlyphs(uint64_t tile_id);
+
+    void bind();
+
+    const uint16_t width = 0;
+    const uint16_t height = 0;
 
 private:
     struct GlyphValue {
@@ -24,23 +37,10 @@ private:
         std::set<uint64_t> ids;
     };
 
-    Rect<uint16_t> addGlyph_impl(uint64_t tile_id, const std::string& face_name,
-                                 const SDFGlyph& glyph);
-public:
-    GlyphAtlas(uint16_t width, uint16_t height);
+    Rect<uint16_t> addGlyph(uint64_t tileID,
+                            const std::string& stackName,
+                            const SDFGlyph&);
 
-    Rect<uint16_t> addGlyph(uint64_t tile_id, const std::string& face_name,
-                            const SDFGlyph& glyph);
-    void addGlyphs(uint64_t tileid, std::u32string const& text, std::string const& stackname,
-                   FontStack const& fontStack, GlyphPositions & face);
-    void removeGlyphs(uint64_t tile_id);
-    void bind();
-
-public:
-    const uint16_t width = 0;
-    const uint16_t height = 0;
-
-private:
     std::mutex mtx;
     BinPack<uint16_t> bin;
     std::map<std::string, std::map<uint32_t, GlyphValue>> index;

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -17,12 +17,12 @@ class GlyphAtlas : public util::noncopyable {
 public:
     GlyphAtlas(uint16_t width, uint16_t height);
 
-    void addGlyphs(uint64_t tileID,
+    void addGlyphs(uintptr_t tileUID,
                    const std::u32string& text,
                    const std::string& stackName,
                    const FontStack&,
                    GlyphPositions&);
-    void removeGlyphs(uint64_t tile_id);
+    void removeGlyphs(uintptr_t tileUID);
 
     void bind();
 
@@ -31,13 +31,13 @@ public:
 
 private:
     struct GlyphValue {
-        GlyphValue(const Rect<uint16_t>& rect_, uint64_t id)
+        GlyphValue(const Rect<uint16_t>& rect_, uintptr_t id)
             : rect(rect_), ids({ id }) {}
         Rect<uint16_t> rect;
-        std::set<uint64_t> ids;
+        std::set<uintptr_t> ids;
     };
 
-    Rect<uint16_t> addGlyph(uint64_t tileID,
+    Rect<uint16_t> addGlyph(uintptr_t tileID,
                             const std::string& stackName,
                             const SDFGlyph&);
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -2,7 +2,6 @@
 #include <mbgl/map/environment.hpp>
 #include <mbgl/map/view.hpp>
 #include <mbgl/platform/platform.hpp>
-#include <mbgl/map/source.hpp>
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/map/sprite.hpp>
 #include <mbgl/util/transition.hpp>
@@ -13,19 +12,14 @@
 #include <mbgl/util/uv_detail.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/text/glyph_store.hpp>
-#include <mbgl/geometry/glyph_atlas.hpp>
 #include <mbgl/style/style_layer.hpp>
 #include <mbgl/style/style_layer_group.hpp>
 #include <mbgl/style/style_bucket.hpp>
 #include <mbgl/util/texture_pool.hpp>
-#include <mbgl/geometry/sprite_atlas.hpp>
-#include <mbgl/geometry/line_atlas.hpp>
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/uv.hpp>
-#include <mbgl/util/mapbox.hpp>
 #include <mbgl/util/exception.hpp>
 
 #include <algorithm>
@@ -65,12 +59,8 @@ Map::Map(View& view_, FileSource& fileSource_)
       mapThread(mainThread),
       transform(view_),
       fileSource(fileSource_),
-      glyphAtlas(util::make_unique<GlyphAtlas>(1024, 1024)),
-      glyphStore(std::make_shared<GlyphStore>(*env)),
-      spriteAtlas(util::make_unique<SpriteAtlas>(512, 512)),
-      lineAtlas(util::make_unique<LineAtlas>(512, 512)),
       texturePool(std::make_shared<TexturePool>()),
-      painter(util::make_unique<Painter>(*spriteAtlas, *glyphAtlas, *lineAtlas))
+      painter(util::make_unique<Painter>())
 {
     view.initialize(this);
 }
@@ -81,9 +71,6 @@ Map::~Map() {
     }
 
     // Explicitly reset all pointers.
-    activeSources.clear();
-    sprite.reset();
-    glyphStore.reset();
     style.reset();
     texturePool.reset();
     workers.reset();
@@ -114,7 +101,6 @@ void Map::start(bool startPaused) {
         // Remove all of these to make sure they are destructed in the correct thread.
         style.reset();
         workers.reset();
-        activeSources.clear();
 
         terminating = true;
 
@@ -351,9 +337,9 @@ void Map::setStyleURL(const std::string &url) {
 void Map::setStyleJSON(std::string newStyleJSON, const std::string &base) {
     // TODO: Make threadsafe.
     styleJSON.swap(newStyleJSON);
-    sprite.reset();
+
     if (!style) {
-        style = std::make_shared<Style>();
+        style = std::make_shared<Style>(*env);
     }
 
     style->base = base;
@@ -361,24 +347,11 @@ void Map::setStyleJSON(std::string newStyleJSON, const std::string &base) {
     style->cascadeClasses(classes);
     style->setDefaultTransitionDuration(defaultTransitionDuration);
 
-    const std::string glyphURL = util::mapbox::normalizeGlyphsURL(style->glyph_url, getAccessToken());
-    glyphStore->setURL(glyphURL);
-
     triggerUpdate();
 }
 
 std::string Map::getStyleJSON() const {
     return styleJSON;
-}
-
-util::ptr<Sprite> Map::getSprite() {
-    const float pixelRatio = state.getPixelRatio();
-    const std::string &sprite_url = style->getSpriteURL();
-    if (!sprite || sprite->pixelRatio != pixelRatio) {
-        sprite = Sprite::Create(sprite_url, pixelRatio, *env);
-    }
-
-    return sprite;
 }
 
 
@@ -604,64 +577,11 @@ std::chrono::steady_clock::duration Map::getDefaultTransitionDuration() {
     return defaultTransitionDuration;
 }
 
-void Map::updateSources() {
-    assert(std::this_thread::get_id() == mapThread);
-
-    // First, disable all existing sources.
-    for (const auto& source : activeSources) {
-        source->enabled = false;
-    }
-
-    // Then, reenable all of those that we actually use when drawing this layer.
-    updateSources(style->layers);
-
-    // Then, construct or destroy the actual source object, depending on enabled state.
-    for (const auto& source : activeSources) {
-        if (source->enabled) {
-            if (!source->source) {
-                source->source = std::make_shared<Source>(source->info);
-                source->source->load(*this, *env);
-            }
-        } else {
-            source->source.reset();
-        }
-    }
-
-    // Finally, remove all sources that are disabled.
-    util::erase_if(activeSources, [](util::ptr<StyleSource> source){
-        return !source->enabled;
-    });
-}
-
-void Map::updateSources(const util::ptr<StyleLayerGroup> &group) {
-    assert(std::this_thread::get_id() == mapThread);
-    if (!group) {
-        return;
-    }
-    for (const util::ptr<StyleLayer> &layer : group->layers) {
-        if (!layer) continue;
-        if (layer->bucket && layer->bucket->style_source) {
-            (*activeSources.emplace(layer->bucket->style_source).first)->enabled = true;
-        }
-    }
-}
-
-void Map::updateTiles() {
-    assert(std::this_thread::get_id() == mapThread);
-    for (const auto &source : activeSources) {
-        source->source->update(*this, *env, getWorker(), style, *glyphAtlas, *glyphStore,
-                               *spriteAtlas, getSprite(), *texturePool, [this]() {
-            assert(std::this_thread::get_id() == mapThread);
-            triggerUpdate();
-        });
-    }
-}
-
 void Map::prepare() {
     assert(std::this_thread::get_id() == mapThread);
 
     if (!style) {
-        style = std::make_shared<Style>();
+        style = std::make_shared<Style>(*env);
 
         env->request({ Resource::Kind::JSON, styleURL}, [&](const Response &res) {
             if (res.status == Response::Successful) {
@@ -688,14 +608,13 @@ void Map::prepare() {
     state = transform.currentState();
 
     animationTime = std::chrono::steady_clock::now();
-    updateSources();
+
+    style->updateSources(*this, *env, *workers, *texturePool, [this]() {
+        assert(std::this_thread::get_id() == mapThread);
+        triggerUpdate();
+    });
+
     style->updateProperties(state.getNormalizedZoom(), animationTime);
-
-    // Allow the sprite atlas to potentially pull new sprite images if needed.
-    spriteAtlas->resize(state.getPixelRatio());
-    spriteAtlas->setSprite(getSprite());
-
-    updateTiles();
 
     if (mode == Mode::Continuous) {
         view.invalidate();
@@ -705,7 +624,7 @@ void Map::prepare() {
 void Map::render() {
     assert(std::this_thread::get_id() == mapThread);
     assert(painter);
-    painter->render(*style, activeSources,
+    painter->render(*style, style->activeSources,
                     state, animationTime);
     // Schedule another rerender when we definitely need a next frame.
     if (transform.needsTransition() || style->hasTransitions()) {

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -256,7 +256,7 @@ std::unique_ptr<Bucket> TileParser::createSymbolBucket(const GeometryTileLayer& 
     auto symbol = parseStyleLayoutSymbol(bucket_desc, tile.id.z);
     auto bucket = util::make_unique<SymbolBucket>(std::move(symbol), *collision);
     bucket->addFeatures(
-        layer, bucket_desc.filter, tile.id, spriteAtlas, *sprite, glyphAtlas, glyphStore);
+        layer, bucket_desc.filter, reinterpret_cast<uintptr_t>(&tile), spriteAtlas, *sprite, glyphAtlas, glyphStore);
     return obsolete() ? nullptr : std::move(bucket);
 }
 }

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -25,7 +25,7 @@ VectorTileData::VectorTileData(Tile::ID const& id_,
 }
 
 VectorTileData::~VectorTileData() {
-    glyphAtlas.removeGlyphs(id.to_uint64());
+    glyphAtlas.removeGlyphs(reinterpret_cast<uintptr_t>(this));
 }
 
 

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -24,11 +24,7 @@ using namespace mbgl;
 
 #define BUFFER_OFFSET(i) ((char *)nullptr + (i))
 
-Painter::Painter(SpriteAtlas& spriteAtlas_, GlyphAtlas& glyphAtlas_, LineAtlas& lineAtlas_)
-    : spriteAtlas(spriteAtlas_)
-    , glyphAtlas(glyphAtlas_)
-    , lineAtlas(lineAtlas_)
-{
+Painter::Painter() {
 }
 
 Painter::~Painter() {
@@ -219,6 +215,10 @@ void Painter::render(const Style& style, const std::set<util::ptr<StyleSource>>&
                      TransformState state_, std::chrono::steady_clock::time_point time) {
     state = state_;
 
+    glyphAtlas = style.glyphAtlas.get();
+    spriteAtlas = style.spriteAtlas.get();
+    lineAtlas = style.lineAtlas.get();
+
     clear();
     resize();
     changeMatrix();
@@ -377,8 +377,8 @@ void Painter::renderBackground(const StyleLayer &layer_desc) {
         if ((properties.opacity >= 1.0f) != (pass == RenderPass::Opaque))
             return;
 
-        SpriteAtlasPosition imagePosA = spriteAtlas.getPosition(properties.image.from, true);
-        SpriteAtlasPosition imagePosB = spriteAtlas.getPosition(properties.image.to, true);
+        SpriteAtlasPosition imagePosA = spriteAtlas->getPosition(properties.image.from, true);
+        SpriteAtlasPosition imagePosB = spriteAtlas->getPosition(properties.image.to, true);
         float zoomFraction = state.getZoomFraction();
 
         useProgram(patternShader->program);
@@ -427,7 +427,7 @@ void Painter::renderBackground(const StyleLayer &layer_desc) {
 
         backgroundBuffer.bind();
         patternShader->bind(0);
-        spriteAtlas.bind(true);
+        spriteAtlas->bind(true);
     } else {
         Color color = properties.color;
         color[0] *= properties.opacity;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -59,7 +59,7 @@ class RasterTileData;
 
 class Painter : private util::noncopyable {
 public:
-    Painter(SpriteAtlas&, GlyphAtlas&, LineAtlas&);
+    Painter();
     ~Painter();
 
     void setup();
@@ -195,9 +195,9 @@ private:
 public:
     FrameHistory frameHistory;
 
-    SpriteAtlas& spriteAtlas;
-    GlyphAtlas& glyphAtlas;
-    LineAtlas& lineAtlas;
+    SpriteAtlas* spriteAtlas;
+    GlyphAtlas* glyphAtlas;
+    LineAtlas* lineAtlas;
 
     std::unique_ptr<PlainShader> plainShader;
     std::unique_ptr<OutlineShader> outlineShader;

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -60,8 +60,8 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
     if (pattern) {
         // Image fill.
         if (pass == RenderPass::Translucent) {
-            const SpriteAtlasPosition posA = spriteAtlas.getPosition(properties.image.from, true);
-            const SpriteAtlasPosition posB = spriteAtlas.getPosition(properties.image.to, true);
+            const SpriteAtlasPosition posA = spriteAtlas->getPosition(properties.image.from, true);
+            const SpriteAtlasPosition posB = spriteAtlas->getPosition(properties.image.to, true);
             float factor = 8.0 / std::pow(2, state.getIntegerZoom() - id.z);
 
             mat3 patternMatrixA;
@@ -88,7 +88,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
             patternShader->u_patternmatrix_b = patternMatrixB;
 
             MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0));
-            spriteAtlas.bind(true);
+            spriteAtlas->bind(true);
 
             // Draw the actual triangles into the color & stencil buffer.
             depthRange(strata, 1.0f);

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -83,9 +83,9 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         linesdfShader->u_blur = blur;
         linesdfShader->u_color = color;
 
-        LinePatternPos posA = lineAtlas.getDashPosition(properties.dash_array.from, layout.cap == CapType::Round);
-        LinePatternPos posB = lineAtlas.getDashPosition(properties.dash_array.to, layout.cap == CapType::Round);
-        lineAtlas.bind();
+        LinePatternPos posA = lineAtlas->getDashPosition(properties.dash_array.from, layout.cap == CapType::Round);
+        LinePatternPos posB = lineAtlas->getDashPosition(properties.dash_array.to, layout.cap == CapType::Round);
+        lineAtlas->bind();
 
         float patternratio = std::pow(2.0, std::floor(std::log2(state.getScale())) - id.z) / 8.0;
         float scaleXA = patternratio / posA.width / properties.dash_line_width / properties.dash_array.fromScale;
@@ -98,14 +98,14 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         linesdfShader->u_patternscale_b = {{ scaleXB, scaleYB }};
         linesdfShader->u_tex_y_b = posB.y;
         linesdfShader->u_image = 0;
-        linesdfShader->u_sdfgamma = lineAtlas.width / (properties.dash_line_width * std::min(posA.width, posB.width) * 256.0 * state.getPixelRatio()) / 2;
+        linesdfShader->u_sdfgamma = lineAtlas->width / (properties.dash_line_width * std::min(posA.width, posB.width) * 256.0 * state.getPixelRatio()) / 2;
         linesdfShader->u_mix = properties.dash_array.t;
 
         bucket.drawLineSDF(*linesdfShader);
 
     } else if (properties.image.from.size()) {
-        SpriteAtlasPosition imagePosA = spriteAtlas.getPosition(properties.image.from, true);
-        SpriteAtlasPosition imagePosB = spriteAtlas.getPosition(properties.image.to, true);
+        SpriteAtlasPosition imagePosA = spriteAtlas->getPosition(properties.image.from, true);
+        SpriteAtlasPosition imagePosB = spriteAtlas->getPosition(properties.image.to, true);
 
         float factor = 8.0 / std::pow(2, state.getIntegerZoom() - id.z);
 
@@ -127,7 +127,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         linepatternShader->u_opacity = properties.opacity;
 
         MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0));
-        spriteAtlas.bind(true);
+        spriteAtlas->bind(true);
         MBGL_CHECK_ERROR(glDepthRange(strata + strata_epsilon, 1.0f));  // may or may not matter
 
         bucket.drawLinePatterns(*linepatternShader);

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -135,7 +135,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
         const float fontSize = properties.icon.size != 0 ? properties.icon.size : layout.icon.max_size;
         const float fontScale = fontSize / 1.0f;
 
-        spriteAtlas.bind(state.isChanging() || layout.placement == PlacementType::Line || angleOffset != 0 || fontScale != 1 || sdf);
+        spriteAtlas->bind(state.isChanging() || layout.placement == PlacementType::Line || angleOffset != 0 || fontScale != 1 || sdf);
 
         if (sdf) {
             renderSDF(bucket,
@@ -144,7 +144,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
                       layout.icon,
                       properties.icon,
                       1.0f,
-                      {{ float(spriteAtlas.getWidth()) / 4.0f, float(spriteAtlas.getHeight()) / 4.0f }},
+                      {{ float(spriteAtlas->getWidth()) / 4.0f, float(spriteAtlas->getHeight()) / 4.0f }},
                       *sdfIconShader,
                       &SymbolBucket::drawIcons);
         } else {
@@ -162,7 +162,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
             useProgram(iconShader->program);
             iconShader->u_matrix = vtxMatrix;
             iconShader->u_exmatrix = exMatrix;
-            iconShader->u_texsize = {{ float(spriteAtlas.getWidth()) / 4.0f, float(spriteAtlas.getHeight()) / 4.0f }};
+            iconShader->u_texsize = {{ float(spriteAtlas->getWidth()) / 4.0f, float(spriteAtlas->getHeight()) / 4.0f }};
 
             // Convert the -pi..pi to an int8 range.
             const float angle = std::round(state.getAngle() / M_PI * 128);
@@ -189,7 +189,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
     }
 
     if (bucket.hasTextData()) {
-        glyphAtlas.bind();
+        glyphAtlas->bind();
 
         renderSDF(bucket,
                   id,
@@ -197,7 +197,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
                   layout.text,
                   properties.text,
                   24.0f,
-                  {{ float(glyphAtlas.width) / 4, float(glyphAtlas.height) / 4 }},
+                  {{ float(glyphAtlas->width) / 4, float(glyphAtlas->height) / 4 }},
                   *sdfGlyphShader,
                   &SymbolBucket::drawGlyphs);
     }

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -42,12 +42,6 @@ bool SymbolBucket::hasTextData() const { return !text.groups.empty(); }
 
 bool SymbolBucket::hasIconData() const { return !icon.groups.empty(); }
 
-void SymbolBucket::addGlyphsToAtlas(uint64_t tileid, const std::string stackname,
-                                    const std::u32string &text, const FontStack &fontStack,
-                                    GlyphAtlas &glyphAtlas, GlyphPositions &face) {
-    glyphAtlas.addGlyphs(tileid, text, stackname, fontStack,face);
-}
-
 std::vector<SymbolFeature> SymbolBucket::processFeatures(const GeometryTileLayer& layer,
                                                          const FilterExpression& filter,
                                                          GlyphStore &glyphStore,
@@ -199,8 +193,7 @@ void SymbolBucket::addFeatures(const GeometryTileLayer& layer,
 
             // Add the glyphs we need for this label to the glyph atlas.
             if (shaping.size()) {
-                SymbolBucket::addGlyphsToAtlas(id.to_uint64(), layout.text.font, feature.label, fontStack,
-                                               glyphAtlas, face);
+                glyphAtlas.addGlyphs(id.to_uint64(), feature.label, layout.text.font, fontStack, face);
             }
         }
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -124,8 +124,11 @@ std::vector<SymbolFeature> SymbolBucket::processFeatures(const GeometryTileLayer
 
 void SymbolBucket::addFeatures(const GeometryTileLayer& layer,
                                const FilterExpression& filter,
-                               const Tile::ID &id, SpriteAtlas &spriteAtlas, Sprite &sprite,
-                               GlyphAtlas & glyphAtlas, GlyphStore &glyphStore) {
+                               uintptr_t tileUID,
+                               SpriteAtlas& spriteAtlas,
+                               Sprite& sprite,
+                               GlyphAtlas& glyphAtlas,
+                               GlyphStore& glyphStore) {
     auto &layout = *styleLayout;
     const std::vector<SymbolFeature> features = processFeatures(layer, filter, glyphStore, sprite);
 
@@ -193,7 +196,7 @@ void SymbolBucket::addFeatures(const GeometryTileLayer& layer,
 
             // Add the glyphs we need for this label to the glyph atlas.
             if (shaping.size()) {
-                glyphAtlas.addGlyphs(id.to_uint64(), feature.label, layout.text.font, fontStack, face);
+                glyphAtlas.addGlyphs(tileUID, feature.label, layout.text.font, fontStack, face);
             }
         }
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -73,9 +73,6 @@ public:
                      GlyphAtlas&,
                      GlyphStore&);
 
-    void addGlyphs(const PlacedGlyphs &glyphs, float placementZoom, PlacementRange placementRange,
-                   float zoom);
-
     void drawGlyphs(SDFShader& shader);
     void drawIcons(SDFShader& shader);
     void drawIcons(IconShader& shader);

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -92,10 +92,6 @@ private:
     template <typename Buffer, typename GroupType>
     void addSymbols(Buffer &buffer, const PlacedGlyphs &symbols, float scale, PlacementRange placementRange);
 
-    // Adds glyphs to the glyph atlas so that they have a left/top/width/height coordinates associated to them that we can use for writing to a buffer.
-    static void addGlyphsToAtlas(uint64_t tileid, const std::string stackname, const std::u32string &string,
-                          const FontStack &fontStack, GlyphAtlas &glyphAtlas, GlyphPositions &face);
-
 public:
     const std::unique_ptr<const StyleLayoutSymbol> styleLayout;
     bool sdfIcons = false;

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -67,7 +67,7 @@ public:
 
     void addFeatures(const GeometryTileLayer&,
                      const FilterExpression&,
-                     const Tile::ID&,
+                     uintptr_t tileUID,
                      SpriteAtlas&,
                      Sprite&,
                      GlyphAtlas&,

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/map/sprite.hpp>
+#include <mbgl/map/source.hpp>
 #include <mbgl/style/style_layer_group.hpp>
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/style/style_bucket.hpp>
@@ -8,6 +9,13 @@
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/uv_detail.hpp>
 #include <mbgl/platform/log.hpp>
+#include <mbgl/text/glyph_store.hpp>
+#include <mbgl/geometry/glyph_atlas.hpp>
+#include <mbgl/geometry/sprite_atlas.hpp>
+#include <mbgl/geometry/line_atlas.hpp>
+#include <mbgl/util/mapbox.hpp>
+#include <mbgl/map/map.hpp>
+
 #include <csscolorparser/csscolorparser.hpp>
 
 #include <rapidjson/document.h>
@@ -16,14 +24,76 @@
 
 namespace mbgl {
 
-Style::Style()
-    : mtx(util::make_unique<uv::rwlock>()) {
+Style::Style(Environment& env)
+    : glyphAtlas(util::make_unique<GlyphAtlas>(1024, 1024)),
+    spriteAtlas(util::make_unique<SpriteAtlas>(512, 512)),
+    lineAtlas(util::make_unique<LineAtlas>(512, 512)),
+    mtx(util::make_unique<uv::rwlock>()),
+    glyphStore(util::make_unique<GlyphStore>(env))
+{
 }
 
 // Note: This constructor is seemingly empty, but we need to declare it anyway
 // because this file includes uv_detail.hpp, which has the declarations necessary
 // for deleting the std::unique_ptr<uv::rwlock>.
-Style::~Style() {}
+Style::~Style() {
+}
+
+void Style::updateSources(Map& map,
+                          Environment& env,
+                          uv::worker& worker,
+                          TexturePool& texturePool,
+                          std::function<void()> callback) {
+    // First, disable all existing sources.
+    for (const auto& source : activeSources) {
+        source->enabled = false;
+    }
+
+    // Then, reenable all of those that we actually use when drawing this layer.
+    if (!layers) {
+        return;
+    }
+    for (const util::ptr<StyleLayer> &layer : layers->layers) {
+        if (!layer) continue;
+        if (layer->bucket && layer->bucket->style_source) {
+            (*activeSources.emplace(layer->bucket->style_source).first)->enabled = true;
+        }
+    }
+
+    // Then, construct or destroy the actual source object, depending on enabled state.
+    for (const auto& source : activeSources) {
+        if (source->enabled) {
+            if (!source->source) {
+                source->source = std::make_shared<Source>(source->info);
+                source->source->load(map, env);
+            }
+        } else {
+            source->source.reset();
+        }
+    }
+
+    // Finally, remove all sources that are disabled.
+    util::erase_if(activeSources, [](util::ptr<StyleSource> source){
+        return !source->enabled;
+    });
+
+    // Allow the sprite atlas to potentially pull new sprite images if needed.
+    const float pixelRatio = map.getState().getPixelRatio();
+    if (!sprite || sprite->pixelRatio != pixelRatio) {
+        sprite = Sprite::Create(sprite_url, pixelRatio, env);
+        spriteAtlas->resize(pixelRatio);
+        spriteAtlas->setSprite(sprite);
+    }
+
+    glyphStore->setURL(util::mapbox::normalizeGlyphsURL(glyph_url, map.getAccessToken()));
+
+    for (const auto &source : activeSources) {
+        source->source->update(map, env, worker, shared_from_this(),
+                               *glyphAtlas, *glyphStore,
+                               *spriteAtlas, sprite,
+                               texturePool, callback);
+    }
+}
 
 void Style::updateProperties(float z, std::chrono::steady_clock::time_point now) {
     uv::writelock lock(mtx);
@@ -39,10 +109,6 @@ void Style::updateProperties(float z, std::chrono::steady_clock::time_point now)
         initial_render_complete = true;
         return;
     }
-}
-
-const std::string &Style::getSpriteURL() const {
-    return sprite_url;
 }
 
 void Style::setDefaultTransitionDuration(std::chrono::steady_clock::duration duration) {
@@ -63,7 +129,6 @@ bool Style::hasTransitions() const {
     }
     return false;
 }
-
 
 void Style::loadJSON(const uint8_t *const data) {
     uv::writelock lock(mtx);

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -15,23 +15,39 @@
 #include <vector>
 #include <set>
 #include <chrono>
+#include <memory>
 
 namespace mbgl {
 
+class Map;
+class Environment;
+class GlyphAtlas;
+class GlyphStore;
+class SpriteAtlas;
 class Sprite;
+class LineAtlas;
 class StyleLayer;
 class StyleLayerGroup;
+class TexturePool;
 
-class Style : public util::noncopyable {
+class Style : public util::noncopyable,
+              public std::enable_shared_from_this<Style> {
 public:
     struct exception : std::runtime_error { exception(const char *msg) : std::runtime_error(msg) {} };
 
-    Style();
+    Style(Environment&);
     ~Style();
 
     void loadJSON(const uint8_t *const data);
 
     size_t layerCount() const;
+
+    void updateSources(Map&,
+                       Environment&,
+                       uv::worker&,
+                       TexturePool&,
+                       std::function<void()> callback);
+
     void updateProperties(float z, std::chrono::steady_clock::time_point now);
 
     void setDefaultTransitionDuration(std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
@@ -39,19 +55,24 @@ public:
 
     bool hasTransitions() const;
 
-    const std::string &getSpriteURL() const;
+    const std::unique_ptr<GlyphAtlas> glyphAtlas;
+    const std::unique_ptr<SpriteAtlas> spriteAtlas;
+    const std::unique_ptr<LineAtlas> lineAtlas;
 
     util::ptr<StyleLayerGroup> layers;
-    std::vector<std::string> appliedClasses;
-    std::string glyph_url;
+    std::set<util::ptr<StyleSource>> activeSources;
     std::string base;
 
 private:
     std::string sprite_url;
+    std::string glyph_url;
     PropertyTransition defaultTransition;
     bool initial_render_complete = false;
     std::unique_ptr<uv::rwlock> mtx;
     ZoomHistory zoomHistory;
+
+    const std::unique_ptr<GlyphStore> glyphStore;
+    util::ptr<Sprite> sprite;
 };
 
 }


### PR DESCRIPTION
Refs #957

First part: move atlas ownership to Style. This follows gl-js and just makes sense -- whenever the style changes the atlases should be blown away.

@kkaefer, is it safe yet to pass Style by reference into `Source::update` ⇢ `VectorTileData` ⇢ `TileParser` as I've done here? I'm still not clear on what parts are running in a different thread that's not guaranteed to be shut down before the Style is deallocated. If this isn't safe I can fall back to a `shared_from_this` solution.

Second part: Index glyph use by tile pointer value, not tile ID. There can be multiple tiles with the same ID, but from different sources.