### PR TITLE
Refs #986: Check TRAVIS_SECURE_ENV_VARS before iOS code signing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,18 +72,13 @@ install:
 before_script:
  # Set the core file limit to unlimited so a core file is generated upon crash
  - ulimit -c unlimited -S
- # begin iOS code signing
- - openssl aes-256-cbc -k "$IOS_ENCRYPTION_SECRET" -in scripts/ios_travis/ios-in-house.mobileprovision.enc -d -a -out scripts/ios_travis/ios-in-house.mobileprovision
- - openssl aes-256-cbc -k "$IOS_ENCRYPTION_SECRET" -in scripts/ios_travis/ios-dist.cer.enc                 -d -a -out scripts/ios_travis/ios-dist.cer
- - openssl aes-256-cbc -k "$IOS_ENCRYPTION_SECRET" -in scripts/ios_travis/ios-dist.p12.enc                 -d -a -out scripts/ios_travis/ios-dist.p12
- - ./scripts/ios_travis/add-key.sh
- # end iOS code signing
+ - if [[ ${TRAVIS_SECURE_ENV_VARS} == true ]]; then ./scripts/ios_travis/add-key.sh; fi
 
 script:
 - ./scripts/travis_script.sh
 
 after_script:
-- ./scripts/ios_travis/remove-key.sh
+- if [[ ${TRAVIS_SECURE_ENV_VARS} == true ]]; then ./scripts/ios_travis/remove-key.sh; fi
 
 notifications:
   slack:

--- a/scripts/ios_travis/add-key.sh
+++ b/scripts/ios_travis/add-key.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+openssl aes-256-cbc -k "$IOS_ENCRYPTION_SECRET" -in scripts/ios_travis/ios-in-house.mobileprovision.enc -d -a -out scripts/ios_travis/ios-in-house.mobileprovision
+openssl aes-256-cbc -k "$IOS_ENCRYPTION_SECRET" -in scripts/ios_travis/ios-dist.cer.enc                 -d -a -out scripts/ios_travis/ios-dist.cer
+openssl aes-256-cbc -k "$IOS_ENCRYPTION_SECRET" -in scripts/ios_travis/ios-dist.p12.enc                 -d -a -out scripts/ios_travis/ios-dist.p12
+
 # This is all taken from http://www.objc.io/issue-6/travis-ci.html
 
 # Create a custom keychain


### PR DESCRIPTION
I'm not aware of a way I can test this, so please give it an extra thorough look. It does pass linting, for what that's worth: http://lint.travis-ci.org/

Moved the OpenSSL certificate stuff to `scripts/travis_ios/add-key.sh`.

Potentially fixes #986.