### PR TITLE
Link with X11 explicitly

### DIFF
--- a/configure
+++ b/configure
@@ -128,8 +128,8 @@ if [ ! -z ${GLFW_VERSION} ]; then
 fi
 
 if [ ${MASON_PLATFORM} == 'linux' ]; then
-    CONFIG+="    'opengl_cflags%': $(quote_flags $(pkg-config gl --cflags)),"$LN
-    CONFIG+="    'opengl_ldflags%': $(quote_flags $(pkg-config gl --libs)),"$LN
+    CONFIG+="    'opengl_cflags%': $(quote_flags $(pkg-config gl x11 --cflags)),"$LN
+    CONFIG+="    'opengl_ldflags%': $(quote_flags $(pkg-config gl x11 --libs)),"$LN
 else
     CONFIG+="    'opengl_cflags%': $(quote_flags),"$LN
     CONFIG+="    'opengl_ldflags%': $(quote_flags),"$LN


### PR DESCRIPTION
We are using X11 symbols directly like XFree() so we need to link
with it explicitly. Previously these symbols were being resolved
somehow by libGL, but apparently they are now hidden - good - in
the custom version we are using since 5e40f72b7.