### PR TITLE
Look inside MapboxGL.bundle when present

### DIFF
--- a/platform/darwin/asset_root.mm
+++ b/platform/darwin/asset_root.mm
@@ -2,13 +2,22 @@
 
 #include <mbgl/platform/platform.hpp>
 
+@interface MGLApplicationRootBundleCanary : NSObject
+@end
+
+@implementation MGLApplicationRootBundleCanary
+@end
+
 namespace mbgl {
 namespace platform {
 
 // Returns the path to the root folder of the application.
 const std::string &assetRoot() {
     static const std::string root = []() -> std::string {
-        NSString *path = [[[NSBundle mainBundle] resourceURL] path];
+        NSString *path = [[NSBundle bundleForClass:[MGLApplicationRootBundleCanary class]] pathForResource:@"MapboxGL" ofType:@"bundle"];
+        if (!path) {
+            path = [[[NSBundle mainBundle] resourceURL] path];
+        }
         return {[path cStringUsingEncoding : NSUTF8StringEncoding],
                 [path lengthOfBytesUsingEncoding:NSUTF8StringEncoding]};
     }();


### PR DESCRIPTION
Fixes the use of bundled styles when incorporating the library into a project according to the README. Fixes #1011.