### PR TITLE
Scope threads to an Environment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@ Standard: Cpp11
 IndentWidth: 4
 AccessModifierOffset: -4
 UseTab: Never
-BinPackParameters: true
+BinPackParameters: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortBlocksOnASingleLine: false
@@ -10,7 +10,7 @@ AllowShortFunctionsOnASingleLine: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 AlwaysBreakTemplateDeclarations: true
 NamespaceIndentation: None
-PointerBindsToType: false
+PointerBindsToType: true
 SpacesInParentheses: false
 BreakBeforeBraces: Attach
 ColumnLimit: 100

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -217,9 +217,6 @@ private:
     // Stores whether the map thread has been stopped already.
     std::atomic_bool isStopped;
 
-    const std::thread::id mainThread;
-    std::thread::id mapThread;
-
     Transform transform;
     TransformState state;
 

--- a/include/mbgl/platform/log.hpp
+++ b/include/mbgl/platform/log.hpp
@@ -68,7 +68,7 @@ private:
     // This method is the data sink that must be implemented by each platform we
     // support. It should ideally output the error message in a human readable
     // format to the developer.
-    static void platformRecord(EventSeverity severity, Event event, int64_t code, const std::string &msg);
+    static void platformRecord(EventSeverity severity, const std::string &msg);
 };
 
 }

--- a/platform/android/log_android.cpp
+++ b/platform/android/log_android.cpp
@@ -1,8 +1,5 @@
 #include <mbgl/platform/log.hpp>
 
-#define __STDC_FORMAT_MACROS // NDK bug workaround: https://code.google.com/p/android/issues/detail?id=72349
-#include <cinttypes>
-
 #include <android/log.h>
 
 namespace mbgl {
@@ -30,8 +27,8 @@ int severityToPriority(EventSeverity severity) {
 
 } // namespace
 
-void Log::platformRecord(EventSeverity severity, Event event, int64_t code, const std::string &msg) {
-    __android_log_print(severityToPriority(severity), EventClass(event).c_str(), "(%" PRId64 ") %s", code, msg.c_str());
+void Log::platformRecord(EventSeverity severity, const std::string &msg) {
+    __android_log_print(severityToPriority(severity), "mbgl", "%s", msg.c_str());
 }
 
 }

--- a/platform/darwin/log_nslog.mm
+++ b/platform/darwin/log_nslog.mm
@@ -4,12 +4,10 @@
 
 namespace mbgl {
 
-void Log::platformRecord(EventSeverity severity, Event event, int64_t code,
-                         const std::string &msg) {
+void Log::platformRecord(EventSeverity severity, const std::string &msg) {
     NSString *message =
         [[NSString alloc] initWithBytes:msg.data() length:msg.size() encoding:NSUTF8StringEncoding];
-    NSLog(@"[%s] %s: (%lld) %@", EventSeverityClass(severity).c_str(), EventClass(event).c_str(),
-          code, message);
+    NSLog(@"[%s] %@", EventSeverityClass(severity).c_str(), message);
 }
 
 }

--- a/platform/default/log_stderr.cpp
+++ b/platform/default/log_stderr.cpp
@@ -4,8 +4,8 @@
 
 namespace mbgl {
 
-void Log::platformRecord(EventSeverity severity, Event event, int64_t code, const std::string &msg) {
-    std::cerr << "[" << severity << "] " << event << ": (" << code << ") " << msg << std::endl;
+void Log::platformRecord(EventSeverity severity, const std::string &msg) {
+    std::cerr << "[" << severity << "] " << msg << std::endl;
 }
 
 }

--- a/src/mbgl/map/environment.cpp
+++ b/src/mbgl/map/environment.cpp
@@ -102,25 +102,17 @@ std::string Environment::threadName() {
     return threadInfoStore.getThreadInfo().name;
 }
 
-void Environment::setup() {
-    mapThread = std::this_thread::get_id();
-}
-
-bool Environment::inMapThread() const {
-    return std::this_thread::get_id() == mapThread;
-}
-
 void Environment::requestAsync(const Resource &resource, std::function<void(const Response &)> callback) {
     fileSource.request(resource, *this, std::move(callback));
 }
 
 Request *Environment::request(const Resource &resource, std::function<void(const Response &)> callback) {
-    assert(inMapThread());
+    assert(currentlyOn(ThreadType::Map));
     return fileSource.request(resource, loop, *this, std::move(callback));
 }
 
 void Environment::cancelRequest(Request *req) {
-    assert(inMapThread());
+    assert(currentlyOn(ThreadType::Map));
     fileSource.cancel(req);
 }
 

--- a/src/mbgl/map/environment.cpp
+++ b/src/mbgl/map/environment.cpp
@@ -4,10 +4,102 @@
 #include <uv.h>
 
 #include <cassert>
+#include <mutex>
+#include <unordered_map>
 
 namespace mbgl {
 
+namespace {
+
+class ThreadInfoStore {
+private:
+    struct ThreadInfo {
+        Environment* env;
+        ThreadType type;
+        std::string name;
+    };
+
+public:
+    ThreadInfoStore() {
+        registerThread(nullptr, ThreadType::Main, "Main");
+    }
+
+    ~ThreadInfoStore() {
+        unregisterThread();
+        assert(threadSet.size() == 0);
+    }
+
+    void registerThread(Environment* env, ThreadType type, const std::string& name) {
+        std::lock_guard<std::mutex> lock(mtx);
+
+        // FIXME: We should never need to overwrite a thread here and we only allow
+        // this today because on the Static mode, the Map thread and the Main thread
+        // are same. Replace this with emplace() when this gets fixed.
+        threadSet[std::this_thread::get_id()] = ThreadInfo{env, type, name};
+    }
+
+    void unregisterThread() {
+        std::lock_guard<std::mutex> lock(mtx);
+
+        ThreadSet::iterator it = threadSet.find(std::this_thread::get_id());
+        if (it != threadSet.end()) {
+            threadSet.erase(it);
+        }
+    }
+
+    const ThreadInfo& getThreadInfo() const {
+        static ThreadInfo emptyInfo;
+        std::lock_guard<std::mutex> lock(mtx);
+
+        ThreadSet::const_iterator it = threadSet.find(std::this_thread::get_id());
+        if (it != threadSet.end()) {
+            return it->second;
+        } else {
+            return emptyInfo;
+        }
+    }
+
+private:
+    typedef std::unordered_map<std::thread::id, ThreadInfo> ThreadSet;
+    ThreadSet threadSet;
+
+    mutable std::mutex mtx;
+};
+
+ThreadInfoStore threadInfoStore;
+
+} // namespace
+
+Environment::Scope::Scope(Environment& env, ThreadType type, const std::string& name)
+    : id(std::this_thread::get_id()) {
+    threadInfoStore.registerThread(&env, type, name);
+}
+
+Environment::Scope::~Scope() {
+    assert(id == std::this_thread::get_id());
+    threadInfoStore.unregisterThread();
+}
+
 Environment::Environment(FileSource &fs) : fileSource(fs), loop(uv_loop_new()) {
+}
+
+Environment& Environment::Get() {
+    Environment* env = threadInfoStore.getThreadInfo().env;
+    assert(env);
+
+    return *env;
+}
+
+bool Environment::inScope() {
+    return threadInfoStore.getThreadInfo().env;
+}
+
+bool Environment::currentlyOn(ThreadType type) {
+    return static_cast<uint8_t>(threadInfoStore.getThreadInfo().type) & static_cast<uint8_t>(type);
+}
+
+std::string Environment::threadName() {
+    return threadInfoStore.getThreadInfo().name;
 }
 
 void Environment::setup() {

--- a/src/mbgl/map/environment.cpp
+++ b/src/mbgl/map/environment.cpp
@@ -35,7 +35,7 @@ public:
         // FIXME: We should never need to overwrite a thread here and we only allow
         // this today because on the Static mode, the Map thread and the Main thread
         // are same. Replace this with emplace() when this gets fixed.
-        threadSet[std::this_thread::get_id()] = ThreadInfo{env, type, name};
+        threadSet[std::this_thread::get_id()] = ThreadInfo{ env, type, name };
     }
 
     void unregisterThread() {
@@ -80,7 +80,7 @@ Environment::Scope::~Scope() {
     threadInfoStore.unregisterThread();
 }
 
-Environment::Environment(FileSource &fs) : fileSource(fs), loop(uv_loop_new()) {
+Environment::Environment(FileSource& fs) : fileSource(fs), loop(uv_loop_new()) {
 }
 
 Environment& Environment::Get() {
@@ -102,16 +102,18 @@ std::string Environment::threadName() {
     return threadInfoStore.getThreadInfo().name;
 }
 
-void Environment::requestAsync(const Resource &resource, std::function<void(const Response &)> callback) {
+void Environment::requestAsync(const Resource& resource,
+                               std::function<void(const Response&)> callback) {
     fileSource.request(resource, *this, std::move(callback));
 }
 
-Request *Environment::request(const Resource &resource, std::function<void(const Response &)> callback) {
+Request* Environment::request(const Resource& resource,
+                              std::function<void(const Response&)> callback) {
     assert(currentlyOn(ThreadType::Map));
     return fileSource.request(resource, loop, *this, std::move(callback));
 }
 
-void Environment::cancelRequest(Request *req) {
+void Environment::cancelRequest(Request* req) {
     assert(currentlyOn(ThreadType::Map));
     fileSource.cancel(req);
 }

--- a/src/mbgl/map/environment.hpp
+++ b/src/mbgl/map/environment.hpp
@@ -16,9 +16,29 @@ class Request;
 class Response;
 struct Resource;
 
-class Environment : private util::noncopyable {
+enum class ThreadType : uint8_t {
+    Unknown    = 0,
+    Main       = 1 << 0,
+    Map        = 1 << 1,
+};
+
+class Environment final : private util::noncopyable {
 public:
+    class Scope final {
+    public:
+        Scope(Environment&, ThreadType, const std::string& name);
+        ~Scope();
+
+    private:
+        std::thread::id id;
+    };
+
     Environment(FileSource &);
+
+    static Environment& Get();
+    static bool inScope();
+    static bool currentlyOn(ThreadType);
+    static std::string threadName();
 
     void setup();
 
@@ -33,7 +53,6 @@ public:
 
 private:
     FileSource &fileSource;
-    std::thread::id mapThread;
 
 public:
     uv_loop_t *const loop;

--- a/src/mbgl/map/environment.hpp
+++ b/src/mbgl/map/environment.hpp
@@ -20,6 +20,7 @@ enum class ThreadType : uint8_t {
     Unknown    = 0,
     Main       = 1 << 0,
     Map        = 1 << 1,
+    TileWorker = 1 << 2,
 };
 
 class Environment final : private util::noncopyable {
@@ -33,25 +34,25 @@ public:
         std::thread::id id;
     };
 
-    Environment(FileSource &);
+    Environment(FileSource&);
 
     static Environment& Get();
     static bool inScope();
     static bool currentlyOn(ThreadType);
     static std::string threadName();
 
-    void requestAsync(const Resource &, std::function<void(const Response &)>);
-    Request *request(const Resource &, std::function<void(const Response &)>);
-    void cancelRequest(Request *);
+    void requestAsync(const Resource&, std::function<void(const Response&)>);
+    Request* request(const Resource&, std::function<void(const Response&)>);
+    void cancelRequest(Request*);
 
     // Request to terminate the environment.
     void terminate();
 
 private:
-    FileSource &fileSource;
+    FileSource& fileSource;
 
 public:
-    uv_loop_t *const loop;
+    uv_loop_t* const loop;
 };
 
 }

--- a/src/mbgl/map/environment.hpp
+++ b/src/mbgl/map/environment.hpp
@@ -41,6 +41,7 @@ public:
     static bool currentlyOn(ThreadType);
     static std::string threadName();
 
+    unsigned getID() const;
     void requestAsync(const Resource&, std::function<void(const Response&)>);
     Request* request(const Resource&, std::function<void(const Response&)>);
     void cancelRequest(Request*);
@@ -49,6 +50,7 @@ public:
     void terminate();
 
 private:
+    unsigned id;
     FileSource& fileSource;
 
 public:

--- a/src/mbgl/map/environment.hpp
+++ b/src/mbgl/map/environment.hpp
@@ -40,10 +40,6 @@ public:
     static bool currentlyOn(ThreadType);
     static std::string threadName();
 
-    void setup();
-
-    bool inMapThread() const;
-
     void requestAsync(const Resource &, std::function<void(const Response &)>);
     Request *request(const Resource &, std::function<void(const Response &)>);
     void cancelRequest(Request *);

--- a/src/mbgl/map/live_tile_data.cpp
+++ b/src/mbgl/map/live_tile_data.cpp
@@ -15,10 +15,9 @@ LiveTileData::LiveTileData(Tile::ID const& id_,
                            GlyphStore& glyphStore_,
                            SpriteAtlas& spriteAtlas_,
                            util::ptr<Sprite> sprite_,
-                           const SourceInfo& source_,
-                           Environment& env_)
+                           const SourceInfo& source_)
     : VectorTileData::VectorTileData(id_, mapMaxZoom, style_, glyphAtlas_, glyphStore_,
-                                     spriteAtlas_, sprite_, source_, env_),
+                                     spriteAtlas_, sprite_, source_),
       annotationManager(annotationManager_) {
     // live features are always ready
     state = State::loaded;

--- a/src/mbgl/map/live_tile_data.hpp
+++ b/src/mbgl/map/live_tile_data.hpp
@@ -17,8 +17,7 @@ public:
                  GlyphStore&,
                  SpriteAtlas&,
                  util::ptr<Sprite>,
-                 const SourceInfo&,
-                 Environment&);
+                 const SourceInfo&);
     ~LiveTileData();
 
     void parse() override;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -62,8 +62,6 @@ using namespace mbgl;
 Map::Map(View& view_, FileSource& fileSource_)
     : env(util::make_unique<Environment>(fileSource_)),
       view(view_),
-      mainThread(std::this_thread::get_id()),
-      mapThread(mainThread),
       transform(view_),
       fileSource(fileSource_),
       glyphAtlas(util::make_unique<GlyphAtlas>(1024, 1024)),
@@ -99,7 +97,7 @@ uv::worker &Map::getWorker() {
 }
 
 void Map::start(bool startPaused) {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     assert(mode == Mode::None);
 
     // When starting map rendering in another thread, we perform async/continuously
@@ -111,7 +109,7 @@ void Map::start(bool startPaused) {
 
     // Setup async notifications
     asyncTerminate = util::make_unique<uv::async>(env->loop, [this]() {
-        assert(std::this_thread::get_id() == mapThread);
+        assert(Environment::currentlyOn(ThreadType::Map));
 
         // Remove all of these to make sure they are destructed in the correct thread.
         style.reset();
@@ -127,7 +125,7 @@ void Map::start(bool startPaused) {
     });
 
     asyncUpdate = util::make_unique<uv::async>(env->loop, [this] {
-        assert(std::this_thread::get_id() == mapThread);
+        assert(Environment::currentlyOn(ThreadType::Map));
 
         if (state.hasSize()) {
             prepare();
@@ -136,7 +134,7 @@ void Map::start(bool startPaused) {
 
     asyncRender = util::make_unique<uv::async>(env->loop, [this] {
         // Must be called in Map thread.
-        assert(std::this_thread::get_id() == mapThread);
+        assert(Environment::currentlyOn(ThreadType::Map));
 
         render();
 
@@ -154,19 +152,11 @@ void Map::start(bool startPaused) {
     }
 
     thread = std::thread([this]() {
-#ifdef DEBUG
-        mapThread = std::this_thread::get_id();
-#endif
-
 #ifdef __APPLE__
         pthread_setname_np("Map");
 #endif
 
         run();
-
-#ifdef DEBUG
-        mapThread = std::thread::id();
-#endif
 
         // Make sure that the stop() function knows when to stop invoking the callback function.
         isStopped = true;
@@ -175,8 +165,7 @@ void Map::start(bool startPaused) {
 }
 
 void Map::stop(std::function<void ()> callback) {
-    assert(std::this_thread::get_id() == mainThread);
-    assert(mainThread != mapThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     assert(mode == Mode::Continuous);
 
     asyncTerminate->send();
@@ -203,7 +192,7 @@ void Map::stop(std::function<void ()> callback) {
 }
 
 void Map::pause(bool waitForPause) {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     assert(mode == Mode::Continuous);
     mutexRun.lock();
     pausing = true;
@@ -221,7 +210,7 @@ void Map::pause(bool waitForPause) {
 }
 
 void Map::resume() {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     assert(mode == Mode::Continuous);
 
     mutexRun.lock();
@@ -231,13 +220,20 @@ void Map::resume() {
 }
 
 void Map::run() {
+    ThreadType threadType = ThreadType::Map;
+    std::string threadName("Map");
+
     if (mode == Mode::None) {
-#ifdef DEBUG
-        mapThread = mainThread;
-#endif
         mode = Mode::Static;
+
+        // FIXME: Threads should have only one purpose. When running on Static mode,
+        // we are currently not spawning a Map thread and running the code on the
+        // Main thread, thus, the Main thread in this case is both Main and Map thread.
+        threadType = static_cast<ThreadType>(static_cast<uint8_t>(threadType) | static_cast<uint8_t>(ThreadType::Main));
+        threadName += "andMain";
     }
-    assert(std::this_thread::get_id() == mapThread);
+
+    Environment::Scope scope(*env, threadType, threadName);
 
     if (mode == Mode::Continuous) {
         checkForPause();
@@ -250,8 +246,6 @@ void Map::run() {
     view.activate();
 
     workers = util::make_unique<uv::worker>(env->loop, 4, "Tile Worker");
-
-    env->setup();
 
     setup();
     prepare();
@@ -273,9 +267,6 @@ void Map::run() {
     // *after* all events have been processed.
     if (mode == Mode::Static) {
         render();
-#ifdef DEBUG
-        mapThread = std::thread::id();
-#endif
         mode = Mode::None;
     }
 
@@ -284,7 +275,7 @@ void Map::run() {
 
 void Map::renderSync() {
     // Must be called in UI thread.
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
 
     triggerRender();
 
@@ -335,7 +326,7 @@ void Map::terminate() {
 #pragma mark - Setup
 
 void Map::setup() {
-    assert(std::this_thread::get_id() == mapThread);
+    assert(Environment::currentlyOn(ThreadType::Map));
     assert(painter);
     painter->setup();
 }
@@ -541,42 +532,42 @@ const std::string &Map::getAccessToken() const {
 #pragma mark - Annotations
 
 void Map::setDefaultPointAnnotationSymbol(std::string& symbol) {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     annotationManager->setDefaultPointAnnotationSymbol(symbol);
 }
 
 uint32_t Map::addPointAnnotation(LatLng point, std::string& symbol) {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     std::vector<LatLng> points({ point });
     std::vector<std::string> symbols({ symbol });
     return addPointAnnotations(points, symbols)[0];
 }
 
 std::vector<uint32_t> Map::addPointAnnotations(std::vector<LatLng> points, std::vector<std::string>& symbols) {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     auto result = annotationManager->addPointAnnotations(points, symbols, *this);
     updateAnnotationTiles(result.first);
     return result.second;
 }
 
 void Map::removeAnnotation(uint32_t annotation) {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     removeAnnotations({ annotation });
 }
 
 void Map::removeAnnotations(std::vector<uint32_t> annotations) {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     auto result = annotationManager->removeAnnotations(annotations);
     updateAnnotationTiles(result);
 }
 
 std::vector<uint32_t> Map::getAnnotationsInBounds(LatLngBounds bounds) const {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     return annotationManager->getAnnotationsInBounds(bounds, *this);
 }
 
 LatLngBounds Map::getBoundsForAnnotations(std::vector<uint32_t> annotations) const {
-    assert(std::this_thread::get_id() == mainThread);
+    assert(Environment::currentlyOn(ThreadType::Main));
     return annotationManager->getBoundsForAnnotations(annotations);
 }
 
@@ -658,7 +649,7 @@ std::chrono::steady_clock::duration Map::getDefaultTransitionDuration() {
 }
 
 void Map::updateSources() {
-    assert(std::this_thread::get_id() == mapThread);
+    assert(Environment::currentlyOn(ThreadType::Map));
 
     // First, disable all existing sources.
     for (const auto& source : activeSources) {
@@ -687,7 +678,7 @@ void Map::updateSources() {
 }
 
 void Map::updateSources(const util::ptr<StyleLayerGroup> &group) {
-    assert(std::this_thread::get_id() == mapThread);
+    assert(Environment::currentlyOn(ThreadType::Map));
     if (!group) {
         return;
     }
@@ -701,18 +692,18 @@ void Map::updateSources(const util::ptr<StyleLayerGroup> &group) {
 }
 
 void Map::updateTiles() {
-    assert(std::this_thread::get_id() == mapThread);
+    assert(Environment::currentlyOn(ThreadType::Map));
     for (const auto &source : activeSources) {
         source->source->update(*this, *env, getWorker(), style, *glyphAtlas, *glyphStore,
                                *spriteAtlas, getSprite(), *texturePool, [this]() {
-            assert(std::this_thread::get_id() == mapThread);
+            assert(Environment::currentlyOn(ThreadType::Map));
             triggerUpdate();
         });
     }
 }
 
 void Map::prepare() {
-    assert(std::this_thread::get_id() == mapThread);
+    assert(Environment::currentlyOn(ThreadType::Map));
 
     if (!style) {
         style = std::make_shared<Style>();
@@ -757,7 +748,7 @@ void Map::prepare() {
 }
 
 void Map::render() {
-    assert(std::this_thread::get_id() == mapThread);
+    assert(Environment::currentlyOn(ThreadType::Map));
     assert(painter);
     painter->render(*style, activeSources,
                     state, animationTime);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -694,7 +694,7 @@ void Map::updateSources(const util::ptr<StyleLayerGroup> &group) {
 void Map::updateTiles() {
     assert(Environment::currentlyOn(ThreadType::Map));
     for (const auto &source : activeSources) {
-        source->source->update(*this, *env, getWorker(), style, *glyphAtlas, *glyphStore,
+        source->source->update(*this, getWorker(), style, *glyphAtlas, *glyphStore,
                                *spriteAtlas, getSprite(), *texturePool, [this]() {
             assert(Environment::currentlyOn(ThreadType::Map));
             triggerUpdate();

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -5,8 +5,8 @@
 using namespace mbgl;
 
 RasterTileData::RasterTileData(Tile::ID const &id_, TexturePool &texturePool,
-                               const SourceInfo &source_, Environment &env_)
-    : TileData(id_, source_, env_), bucket(texturePool, layout) {
+                               const SourceInfo &source_)
+    : TileData(id_, source_), bucket(texturePool, layout) {
 }
 
 RasterTileData::~RasterTileData() {

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -17,7 +17,7 @@ class RasterTileData : public TileData {
     friend class TileParser;
 
 public:
-    RasterTileData(Tile::ID const &id, TexturePool &, const SourceInfo &, Environment &);
+    RasterTileData(Tile::ID const &id, TexturePool &, const SourceInfo &);
     ~RasterTileData();
 
     void parse() override;

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -155,7 +155,7 @@ TileData::State Source::hasTile(const Tile::ID& id) {
     return TileData::State::invalid;
 }
 
-TileData::State Source::addTile(Map &map, Environment &env, uv::worker &worker,
+TileData::State Source::addTile(Map &map, uv::worker &worker,
                                 util::ptr<Style> style, GlyphAtlas &glyphAtlas,
                                 GlyphStore &glyphStore, SpriteAtlas &spriteAtlas,
                                 util::ptr<Sprite> sprite, TexturePool &texturePool,
@@ -187,22 +187,18 @@ TileData::State Source::addTile(Map &map, Environment &env, uv::worker &worker,
     if (!new_tile.data) {
         // If we don't find working tile data, we're just going to load it.
         if (info.type == SourceType::Vector) {
-            new_tile.data = std::make_shared<VectorTileData>(normalized_id, map.getMaxZoom(), style,
-                                                             glyphAtlas, glyphStore,
-                                                             spriteAtlas, sprite,
-                                                             info, env);
+            new_tile.data =
+                std::make_shared<VectorTileData>(normalized_id, map.getMaxZoom(), style, glyphAtlas,
+                                                 glyphStore, spriteAtlas, sprite, info);
             new_tile.data->request(worker, map.getState().getPixelRatio(), callback);
         } else if (info.type == SourceType::Raster) {
-            new_tile.data = std::make_shared<RasterTileData>(normalized_id, texturePool, info, env);
+            new_tile.data = std::make_shared<RasterTileData>(normalized_id, texturePool, info);
             new_tile.data->request(worker, map.getState().getPixelRatio(), callback);
         } else if (info.type == SourceType::Annotations) {
             AnnotationManager& annotationManager = map.getAnnotationManager();
-            new_tile.data = std::make_shared<LiveTileData>(normalized_id,
-                                                           annotationManager,
-                                                           map.getMaxZoom(), style,
-                                                           glyphAtlas, glyphStore,
-                                                           spriteAtlas, sprite,
-                                                           info, env);
+            new_tile.data = std::make_shared<LiveTileData>(normalized_id, annotationManager,
+                                                           map.getMaxZoom(), style, glyphAtlas,
+                                                           glyphStore, spriteAtlas, sprite, info);
             new_tile.data->reparse(worker, callback);
         } else {
             throw std::runtime_error("source type not implemented");
@@ -293,7 +289,6 @@ bool Source::findLoadedParent(const Tile::ID& id, int32_t minCoveringZoom, std::
 }
 
 void Source::update(Map &map,
-                    Environment &env,
                     uv::worker &worker,
                     util::ptr<Style> style,
                     GlyphAtlas &glyphAtlas,
@@ -322,7 +317,7 @@ void Source::update(Map &map,
 
     // Add existing child/parent tiles if the actual tile is not yet loaded
     for (const Tile::ID& id : required) {
-        const TileData::State state = addTile(map, env, worker, style, glyphAtlas, glyphStore,
+        const TileData::State state = addTile(map, worker, style, glyphAtlas, glyphStore,
                                               spriteAtlas, sprite, texturePool, id, callback);
 
         if (state != TileData::State::parsed) {

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -35,7 +35,7 @@ public:
     Source(SourceInfo&);
 
     void load(Map &, Environment &);
-    void update(Map &, Environment &, uv::worker &, util::ptr<Style>, GlyphAtlas &, GlyphStore &,
+    void update(Map &, uv::worker &, util::ptr<Style>, GlyphAtlas &, GlyphStore &,
                 SpriteAtlas &, util::ptr<Sprite>, TexturePool &, std::function<void()> callback);
     void invalidateTiles(Map&, std::vector<Tile::ID>&);
 
@@ -56,7 +56,7 @@ private:
     int32_t coveringZoomLevel(const TransformState&) const;
     std::forward_list<Tile::ID> coveringTiles(const TransformState&) const;
 
-    TileData::State addTile(Map &, Environment &, uv::worker &, util::ptr<Style>, GlyphAtlas &,
+    TileData::State addTile(Map &, uv::worker &, util::ptr<Style>, GlyphAtlas &,
                             GlyphStore &, SpriteAtlas &, util::ptr<Sprite>, TexturePool &,
                             const Tile::ID &, std::function<void()> callback);
 

--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -12,12 +12,12 @@
 
 using namespace mbgl;
 
-TileData::TileData(Tile::ID const& id_, const SourceInfo& source_, Environment& env_)
+TileData::TileData(Tile::ID const& id_, const SourceInfo& source_)
     : id(id_),
       name(id),
       state(State::initial),
       source(source_),
-      env(env_),
+      env(Environment::Get()),
       debugBucket(debugFontBuffer) {
     // Initialize tile debug coordinates
     debugFontBuffer.addText(name.c_str(), 50, 200, 5);
@@ -96,7 +96,8 @@ void TileData::reparse(uv::worker& worker, std::function<void()> callback)
     // the after work handler
     new uv::work<util::ptr<TileData>>(
         worker,
-        [](util::ptr<TileData>& tile) {
+        [this](util::ptr<TileData>& tile) {
+            Environment::Scope scope(env, ThreadType::TileWorker, "TileWorker_" + tile->name);
             tile->parse();
         },
         [callback](util::ptr<TileData>&) {

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -48,7 +48,7 @@ public:
     };
 
 public:
-    TileData(Tile::ID const &id, const SourceInfo &, Environment &);
+    TileData(Tile::ID const &id, const SourceInfo &);
     ~TileData();
 
     void request(uv::worker&, float pixelRatio, std::function<void ()> callback);
@@ -72,7 +72,7 @@ public:
 
 public:
     const SourceInfo& source;
-    Environment &env;
+    Environment& env;
 
 protected:
     Request *req = nullptr;

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -17,9 +17,8 @@ VectorTileData::VectorTileData(Tile::ID const& id_,
                                GlyphStore& glyphStore_,
                                SpriteAtlas& spriteAtlas_,
                                util::ptr<Sprite> sprite_,
-                               const SourceInfo& source_,
-                               Environment& env_)
-    : TileData(id_, source_, env_),
+                               const SourceInfo& source_)
+    : TileData(id_, source_),
       glyphAtlas(glyphAtlas_),
       glyphStore(glyphStore_),
       spriteAtlas(spriteAtlas_),

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -37,8 +37,7 @@ public:
                    GlyphStore&,
                    SpriteAtlas&,
                    util::ptr<Sprite>,
-                   const SourceInfo&,
-                   Environment&);
+                   const SourceInfo&);
     ~VectorTileData();
 
     void parse() override;

--- a/src/mbgl/platform/log.cpp
+++ b/src/mbgl/platform/log.cpp
@@ -1,6 +1,9 @@
 #include <mbgl/platform/log.hpp>
 
+#include <mbgl/map/environment.hpp>
+
 #include <cstdarg>
+#include <sstream>
 
 namespace mbgl {
 
@@ -37,7 +40,28 @@ void Log::record(EventSeverity severity, Event event, int64_t code, const std::s
         return;
     }
 
-    platformRecord(severity, event, code, msg);
+    std::stringstream logStream;
+
+    if (Environment::inScope()) {
+        logStream << "{" << Environment::Get().getID() << "}";
+    }
+
+    const std::string threadName = Environment::threadName();
+    if (!threadName.empty()) {
+        logStream << "{" << threadName << "}";
+    }
+
+    logStream << "[" << event << "]";
+
+    if (code >= 0) {
+        logStream << "(" << code << ")";
+    }
+
+    if (!msg.empty()) {
+        logStream << ": " << msg;
+    }
+
+    platformRecord(severity, logStream.str());
 }
 
 }


### PR DESCRIPTION
By creating an Environment::Scope at the beginning of the thread, it will automatically register it to the Environment during its lifespan. The Main thread is registered automatically at startup.

Threads running within an Environment::Scope can at any moment query for the Environment and assert what is the current thread, to make sure the code is being executed on the right thread.

And finally, log messages will now show the Environment ID and the current thread name.