### PR TITLE
fill-opacity not affecting outline

### DIFF
--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -87,6 +87,9 @@ void Painter::setup() {
     // Stencil test
     MBGL_CHECK_ERROR(glEnable(GL_STENCIL_TEST));
     MBGL_CHECK_ERROR(glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE));
+
+    // Depth test
+    glDepthFunc(GL_LEQUAL);
 }
 
 void Painter::setupShaders() {
@@ -193,7 +196,6 @@ void Painter::setOpaque() {
     if (pass != RenderPass::Opaque) {
         pass = RenderPass::Opaque;
         MBGL_CHECK_ERROR(glDisable(GL_BLEND));
-        depthMask(true);
     }
 }
 
@@ -201,7 +203,6 @@ void Painter::setTranslucent() {
     if (pass != RenderPass::Translucent) {
         pass = RenderPass::Translucent;
         MBGL_CHECK_ERROR(glEnable(GL_BLEND));
-        depthMask(false);
     }
 }
 

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -36,8 +36,8 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
 
     const bool pattern = properties.image.from.size();
 
-    bool outline = properties.antialias && !pattern && properties.stroke_color != properties.fill_color;
-    bool fringeline = properties.antialias && !pattern && properties.stroke_color == properties.fill_color;
+    bool outline = properties.antialias && !pattern && stroke_color != fill_color;
+    bool fringeline = properties.antialias && !pattern && stroke_color == fill_color;
 
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // befrom, we have to draw the outline first (!)

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -60,6 +60,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
     if (pattern) {
         // Image fill.
         if (pass == RenderPass::Translucent) {
+
             const SpriteAtlasPosition posA = spriteAtlas.getPosition(properties.image.from, true);
             const SpriteAtlasPosition posB = spriteAtlas.getPosition(properties.image.to, true);
             float factor = 8.0 / std::pow(2, state.getIntegerZoom() - id.z);
@@ -91,6 +92,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
             spriteAtlas.bind(true);
 
             // Draw the actual triangles into the color & stencil buffer.
+            depthMask(true);
             depthRange(strata, 1.0f);
             bucket.drawElements(*patternShader);
         }
@@ -107,6 +109,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
             plainShader->u_color = fill_color;
 
             // Draw the actual triangles into the color & stencil buffer.
+            depthMask(true);
             depthRange(strata + strata_epsilon, 1.0f);
             bucket.drawElements(*plainShader);
         }
@@ -127,7 +130,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
             static_cast<float>(state.getFramebufferHeight())
         }};
 
-        depthRange(strata + strata_epsilon, 1.0f);
+        depthRange(strata + strata_epsilon + strata_epsilon, 1.0f);
         bucket.drawVertices(*outlineShader);
     }
 }

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -15,6 +15,8 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
     if (pass == RenderPass::Opaque) return;
     if (!bucket.hasData()) return;
 
+    depthMask(false);
+
     const auto &properties = layer_desc.getProperties<LineProperties>();
     const auto &layout = *bucket.styleLayout;
 

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -122,6 +122,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
     const auto &layout = *bucket.styleLayout;
 
     MBGL_CHECK_ERROR(glDisable(GL_STENCIL_TEST));
+    depthMask(false);
 
     if (bucket.hasIconData()) {
         bool sdf = bucket.sdfIcons;


### PR DESCRIPTION
Should `fill-opacity` be applied to the fill outline? It looks like it is on js but not native.

JS:

![image](https://cloud.githubusercontent.com/assets/98601/3697783/af07ebd6-13b0-11e4-9257-fe0ddf80c5c2.png)

Native:

![image](https://cloud.githubusercontent.com/assets/98601/3697785/b78c2a9c-13b0-11e4-8b62-fe789235b1ab.png)

This is the `fill-opacity/literal` test in the test suite.