### PR TITLE
API for initializing with bundled style

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -16,10 +16,17 @@
 
 /** Initialize a map view with a given frame, style, and access token.
 *   @param frame The frame with which to initialize the map view.
-*   @param styleJSON The map stylesheet as JSON text.
 *   @param accessToken A Mapbox API access token.
+*   @param styleJSON The map stylesheet as JSON text.
 *   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
-- (instancetype)initWithFrame:(CGRect)frame styleJSON:(NSString *)styleJSON accessToken:(NSString *)accessToken;
+- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleJSON:(NSString *)styleJSON;
+
+/** Initialize a map view with a given frame, bundled style name, and access token.
+*   @param frame The frame with which to initialize the map view.
+*   @param accessToken A Mapbox API access token.
+*   @param styleName The map style name to use.
+*   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
+- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken bundledStyleNamed:(NSString *)styleName;
 
 /** Initialize a map view with a given frame, the default style, and an access token.
 *   @param frame The frame with which to initialize the map view.

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -113,7 +113,7 @@ MBGLView *mbglView = nullptr;
 mbgl::SQLiteCache *mbglFileCache = nullptr;
 mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
-- (instancetype)initWithFrame:(CGRect)frame styleJSON:(NSString *)styleJSON accessToken:(NSString *)accessToken
+- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleJSON:(NSString *)styleJSON
 {
     self = [super initWithFrame:frame];
 
@@ -133,9 +133,22 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken bundledStyleNamed:(NSString *)styleName
+{
+    self = [super initWithFrame:frame];
+    
+    if (self && [self commonInit])
+    {
+        if (accessToken) [self setAccessToken:accessToken];
+        if (styleName) [self useBundledStyleNamed:styleName];
+    }
+    
+    return self;
+}
+
 - (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken
 {
-    return [self initWithFrame:frame styleJSON:nil accessToken:accessToken];
+    return [self initWithFrame:frame accessToken:accessToken styleJSON:nil];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder


### PR DESCRIPTION
This PR adds `-[MGLMapView initWithFrame:bundledStyleNamed:accessToken:]`. Developers can use this API to work around #1014, and it’s a convenient way to get started regardless.