### PR TITLE
add iOS icon burning for Release builds

### DIFF
--- a/ios/app/icon_burn.sh
+++ b/ios/app/icon_burn.sh
@@ -1,0 +1,36 @@
+export PATH=$HOME/bin:/usr/local/bin:/usr/bin
+
+#
+# don't burn during Debug builds
+#
+if [[ ${CONFIGURATION} != "Release" ]]; then
+    echo "Skipping icon burning due to ${CONFIGURATION} configuration"
+    exit 0
+fi
+
+if [ -z "`which iconoblast`" ]; then
+    echo "iconoblast not found in path"
+    exit 1
+fi
+
+echo "Burning app icons..."
+
+#
+# retrieve git info
+#
+commit=`git rev-parse --short HEAD`
+branch=`git rev-parse --abbrev-ref HEAD`
+repo=`git remote show -n origin | grep 'Fetch URL' | sed -e 's/.*github\.com:mapbox\///' -e 's/\.git$//' -e 's/^mapbox-//'`
+
+#
+# work directly in app bundle
+#
+bundle_path="${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+echo "working in ${bundle_path}"
+cd "${bundle_path}"
+
+for file in `find . -type f -name Icon\*.png`
+do
+    iconoblast "$file" $commit $branch $repo
+done
+cd "$OLDPWD"

--- a/ios/app/mapboxgl-app.gyp
+++ b/ios/app/mapboxgl-app.gyp
@@ -30,6 +30,15 @@
         '../../platform/darwin/settings_nsuserdefaults.mm',
       ],
 
+      'actions': [
+        {
+          'action_name': 'Icon Burning',
+          'inputs': [ './icon_burn.sh' ],
+          'outputs': [],
+          'action': ['<@(_inputs)'],
+        },
+      ],
+
       'xcode_settings': {
         'SDKROOT': 'iphoneos',
         'SUPPORTED_PLATFORMS': 'iphonesimulator iphoneos',


### PR DESCRIPTION
This adds in icon burning using [iconoblast](https://github.com/mapbox/iconoblast) as a GYP build phase for the iOS testing app. It only applies to `Release` builds, but we need this in here so that we don't keep losing/forgetting it for internal builds of the app for testing. 

If this is problematic for anyone's workflow, post with some info and we can try to find other environment variables or something similar that can work around it. 