### PR TITLE
CocoaPod podspec for beta 1

### DIFF
--- a/ios/MapboxGL.podspec
+++ b/ios/MapboxGL.podspec
@@ -8,25 +8,25 @@ Pod::Spec.new do |m|
   m.homepage         = 'https://www.mapbox.com/blog/mapbox-gl/'
   m.license          = 'BSD'
   m.author           = { 'Mapbox' => 'mobile@mapbox.com' }
-  m.screenshot       = 'https://raw.githubusercontent.com/mapbox/mapbox-gl-cocoa/master/pkg/screenshot.png'
-  m.social_media_url = 'https://twitter.com/Mapbox'
+  m.screenshot       = 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/master/ios/screenshot.png'
+  m.social_media_url = 'https://twitter.com/mapbox'
 
-  m.source = { :git => 'https://github.com/mapbox/mapbox-gl-cocoa.git', :tag => m.version.to_s }
+  m.source = { :http => "http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/mapbox-gl-ios-#{m.version.to_s}.zip" }
 
   m.platform              = :ios
   m.ios.deployment_target = '7.0'
 
-  m.source_files = 'dist/static/Headers/*.h'
+  m.source_files = 'Headers/*.h'
 
   m.requires_arc = true
 
-  m.resource_bundle = { 'MapboxGL' => 'dist/static/MapboxGL.bundle/*' }
+  m.resource_bundle = { 'MapboxGL' => 'MapboxGL.bundle/*' }
 
-  m.frameworks = 'CoreLocation', 'Foundation', 'GLKit', 'SystemConfiguration', 'UIKit'
+  m.frameworks = 'CoreLocation', 'GLKit', 'ImageIO', 'MobileCoreServices', 'SystemConfiguration'
 
-  m.libraries = 'MapboxGL', 'c++', 'sqlite3', 'z'
+  m.libraries = 'c++', 'sqlite3', 'z'
 
-  m.vendored_libraries = 'dist/static/libMapboxGL.a'
+  m.vendored_library = 'libMapboxGL.a'
 
   m.xcconfig = { 'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++' }
 

--- a/scripts/package_ios.sh
+++ b/scripts/package_ios.sh
@@ -70,6 +70,7 @@ cp -pv include/mbgl/ios/* "${OUTPUT}/static/Headers"
 # complications between faked GYP bundles-as-executables, device build
 # dependencies, and code signing.
 step "Copying Resources..."
+cp -pv LICENSE.md "${OUTPUT}/static"
 mkdir -p "${OUTPUT}/static/${NAME}.bundle"
 cp -pv platform/ios/resources/* "${OUTPUT}/static/${NAME}.bundle"
 cp -prv styles/styles "${OUTPUT}/static/${NAME}.bundle/styles"


### PR DESCRIPTION
The podspec in this project was originally lifted from mapbox/mapbox-ios-sdk, which was structured and built quite differently. We could have the podspec build this repo as is, using scripts/package_ios.sh, but that would require developers to install the same version of Xcode as Travis is using (see #977). So this podspec instead pulls a prebuilt library. Much simpler.

Also package a LICENSE with the archive to satisfy a CocoaPods warning.

Fixes #829.