### PR TITLE
Show Emerald by default

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -175,7 +175,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     if ( ! styleJSON)
     {
-        [self useBundledStyleNamed:@"bright-v7"];
+        [self useBundledStyleNamed:@"emerald-v7"];
     }
     else
     {


### PR DESCRIPTION
a1a7ab62e176afb354109ba23360c668f84771e8 added an Emerald option to the test app, but `MGLMapView` itself has its own default style.

Fixes #964.