### PR TITLE
fixes #1053: umbrella Cocoa header

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -16,6 +16,7 @@
         '../platform/darwin/asset_root.mm',
         '../platform/darwin/image.mm',
         '../platform/darwin/reachability.m',
+        '../include/mbgl/ios/MapboxGL.h',
         '../include/mbgl/ios/MGLMapView.h',
         '../platform/ios/MGLMapView.mm',
         '../include/mbgl/ios/MGLAnnotation.h',

--- a/include/mbgl/ios/MapboxGL.h
+++ b/include/mbgl/ios/MapboxGL.h
@@ -1,0 +1,7 @@
+#import "MGLAnnotation.h"
+#import "MGLMapView.h"
+#import "MGLStyleFunctionValue.h"
+#import "MGLTypes.h"
+#import "NSArray+MGLAdditions.h"
+#import "NSDictionary+MGLAdditions.h"
+#import "UIColor+MGLAdditions.h"

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -1,6 +1,6 @@
 #import "MBXViewController.h"
 
-#import <mbgl/ios/MGLMapView.h>
+#import <mbgl/ios/MapboxGL.h>
 
 #import <mbgl/platform/darwin/settings_nsuserdefaults.hpp>
 


### PR DESCRIPTION
Single header for easier setup on iOS / eventual framework use. 