### PR TITLE
[not ready] anno remove bug fix & in-app settings to flex annotations

### DIFF
--- a/include/mbgl/map/annotation.hpp
+++ b/include/mbgl/map/annotation.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <mutex>
 #include <memory>
+#include <unordered_map>
 
 namespace mbgl {
 
@@ -46,7 +47,7 @@ private:
     std::mutex mtx;
     std::string defaultPointAnnotationSymbol;
     std::map<uint32_t, std::unique_ptr<Annotation>> annotations;
-    std::map<Tile::ID, std::pair<std::vector<uint32_t>, std::unique_ptr<LiveTile>>> annotationTiles;
+    std::unordered_map<Tile::ID, std::pair<std::vector<uint32_t>, std::unique_ptr<LiveTile>>, Tile::ID::Hash> annotationTiles;
     std::unique_ptr<LiveTile> nullTile;
     uint32_t nextID_ = 0;
 };
@@ -63,7 +64,7 @@ private:
 private:
     const AnnotationType type = AnnotationType::Point;
     const std::vector<AnnotationSegment> geometry;
-    std::map<Tile::ID, std::vector<std::weak_ptr<const LiveTileFeature>>> tileFeatures;
+    std::unordered_map<Tile::ID, std::vector<std::weak_ptr<const LiveTileFeature>>, Tile::ID::Hash> tileFeatures;
     LatLngBounds bounds;
 };
 

--- a/include/mbgl/map/annotation.hpp
+++ b/include/mbgl/map/annotation.hpp
@@ -32,7 +32,7 @@ public:
 
     void setDefaultPointAnnotationSymbol(std::string& symbol) { defaultPointAnnotationSymbol = symbol; }
     std::pair<std::vector<Tile::ID>, std::vector<uint32_t>> addPointAnnotations(std::vector<LatLng>, std::vector<std::string>& symbols, const Map&);
-    std::vector<Tile::ID> removeAnnotations(std::vector<uint32_t>);
+    std::vector<Tile::ID> removeAnnotations(std::vector<uint32_t>, const Map&);
     std::vector<uint32_t> getAnnotationsInBounds(LatLngBounds, const Map&) const;
     LatLngBounds getBoundsForAnnotations(std::vector<uint32_t>) const;
 
@@ -46,7 +46,7 @@ private:
     std::mutex mtx;
     std::string defaultPointAnnotationSymbol;
     std::unordered_map<uint32_t, std::unique_ptr<Annotation>> annotations;
-    std::unordered_map<Tile::ID, std::pair<std::vector<uint32_t>, std::unique_ptr<LiveTile>>, Tile::ID::Hash> annotationTiles;
+    std::unordered_map<Tile::ID, std::pair<std::vector<uint32_t>, std::unique_ptr<LiveTile>>, Tile::ID::Hash> tiles;
     std::unique_ptr<LiveTile> nullTile;
     uint32_t nextID_ = 0;
 };

--- a/include/mbgl/map/annotation.hpp
+++ b/include/mbgl/map/annotation.hpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace mbgl {
 
@@ -46,7 +47,7 @@ private:
     std::mutex mtx;
     std::string defaultPointAnnotationSymbol;
     std::unordered_map<uint32_t, std::unique_ptr<Annotation>> annotations;
-    std::unordered_map<Tile::ID, std::pair<std::vector<uint32_t>, std::unique_ptr<LiveTile>>, Tile::ID::Hash> tiles;
+    std::unordered_map<Tile::ID, std::pair<std::unordered_set<uint32_t>, std::unique_ptr<LiveTile>>, Tile::ID::Hash> tiles;
     std::unique_ptr<LiveTile> nullTile;
     uint32_t nextID_ = 0;
 };

--- a/include/mbgl/map/annotation.hpp
+++ b/include/mbgl/map/annotation.hpp
@@ -63,7 +63,7 @@ private:
 private:
     const AnnotationType type = AnnotationType::Point;
     const std::vector<AnnotationSegment> geometry;
-    std::unordered_map<Tile::ID, std::vector<std::size_t>, Tile::ID::Hash> tileFeatures;
+    std::unordered_map<Tile::ID, std::vector<std::weak_ptr<const LiveTileFeature>>, Tile::ID::Hash> tileFeatures;
     LatLngBounds bounds;
 };
 

--- a/include/mbgl/map/annotation.hpp
+++ b/include/mbgl/map/annotation.hpp
@@ -64,7 +64,7 @@ private:
 private:
     const AnnotationType type = AnnotationType::Point;
     const std::vector<AnnotationSegment> geometry;
-    std::unordered_map<Tile::ID, std::vector<std::weak_ptr<const LiveTileFeature>>, Tile::ID::Hash> tileFeatures;
+    std::unordered_map<Tile::ID, std::weak_ptr<const LiveTileFeature>, Tile::ID::Hash> tileFeatures;
     LatLngBounds bounds;
 };
 

--- a/include/mbgl/map/annotation.hpp
+++ b/include/mbgl/map/annotation.hpp
@@ -10,7 +10,6 @@
 
 #include <string>
 #include <vector>
-#include <map>
 #include <mutex>
 #include <memory>
 #include <unordered_map>
@@ -46,7 +45,7 @@ private:
 private:
     std::mutex mtx;
     std::string defaultPointAnnotationSymbol;
-    std::map<uint32_t, std::unique_ptr<Annotation>> annotations;
+    std::unordered_map<uint32_t, std::unique_ptr<Annotation>> annotations;
     std::unordered_map<Tile::ID, std::pair<std::vector<uint32_t>, std::unique_ptr<LiveTile>>, Tile::ID::Hash> annotationTiles;
     std::unique_ptr<LiveTile> nullTile;
     uint32_t nextID_ = 0;

--- a/include/mbgl/map/annotation.hpp
+++ b/include/mbgl/map/annotation.hpp
@@ -63,7 +63,7 @@ private:
 private:
     const AnnotationType type = AnnotationType::Point;
     const std::vector<AnnotationSegment> geometry;
-    std::unordered_map<Tile::ID, std::vector<std::weak_ptr<const LiveTileFeature>>, Tile::ID::Hash> tileFeatures;
+    std::unordered_map<Tile::ID, std::vector<std::size_t>, Tile::ID::Hash> tileFeatures;
     LatLngBounds bounds;
 };
 

--- a/include/mbgl/map/tile.hpp
+++ b/include/mbgl/map/tile.hpp
@@ -12,6 +12,7 @@
 #include <forward_list>
 #include <iosfwd>
 #include <string>
+#include <functional>
 
 namespace mbgl {
 
@@ -43,6 +44,12 @@ public:
         inline uint64_t to_uint64() const {
             return ((std::pow(2, z) * y + x) * 32) + z;
         }
+
+        struct Hash {
+            std::size_t operator()(ID const& i) const {
+                return std::hash<uint64_t>()(i.to_uint64());
+            }
+        };
 
         inline bool operator==(const ID& rhs) const {
             return w == rhs.w && z == rhs.z && x == rhs.x && y == rhs.y;

--- a/ios/app/MBXAnnotation.h
+++ b/ios/app/MBXAnnotation.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+#import <CoreLocation/CoreLocation.h>
+
+#import <mbgl/ios/MGLAnnotation.h>
+
+@interface MBXAnnotation : NSObject <MGLAnnotation>
+
++ (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle;
+
+- (instancetype)initWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle;
+
+@end

--- a/ios/app/MBXAnnotation.m
+++ b/ios/app/MBXAnnotation.m
@@ -1,0 +1,30 @@
+#import "MBXAnnotation.h"
+
+@interface MBXAnnotation ()
+
+@property (nonatomic) CLLocationCoordinate2D coordinate;
+@property (nonatomic) NSString *title;
+@property (nonatomic) NSString *subtitle;
+
+@end
+
+@implementation MBXAnnotation
+
++ (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle
+{
+    return [[self alloc] initWithLocation:coordinate title:title subtitle:subtitle];
+}
+
+- (instancetype)initWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle
+{
+    if (self = [super init])
+    {
+        _coordinate = coordinate;
+        _title = title;
+        _subtitle = subtitle;
+    }
+
+    return self;
+}
+
+@end

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -6,6 +6,8 @@
 
 #import <CoreLocation/CoreLocation.h>
 
+#import "MBXAnnotation.h"
+
 static UIColor *const kTintColor = [UIColor colorWithRed:0.120 green:0.550 blue:0.670 alpha:1.000];
 
 static NSArray *const kStyleNames = @[
@@ -134,7 +136,14 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
                                                        delegate:self
                                               cancelButtonTitle:@"Cancel"
                                          destructiveButtonTitle:nil
-                                              otherButtonTitles:@"Reset North", @"Reset Position", @"Toggle Debug", nil];
+                                              otherButtonTitles:@"Reset North",
+                                                                @"Reset Position",
+                                                                @"Toggle Debug",
+                                                                @"100 Annotations",
+                                                                @"1,000 Annotations",
+                                                                @"10,000 Annotations",
+                                                                @"Remove Annotations",
+                                                                nil];
 
     [sheet showFromBarButtonItem:self.navigationItem.leftBarButtonItem animated:YES];
 }
@@ -153,6 +162,67 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
     {
         [self.mapView toggleDebug];
     }
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 3)
+    {
+        [self parseFeaturesAddingCount:100];
+    }
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 4)
+    {
+        [self parseFeaturesAddingCount:1000];
+    }
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 5)
+    {
+        [self parseFeaturesAddingCount:10000];
+    }
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 6)
+    {
+        [self.mapView removeAnnotations:self.mapView.annotations];
+    }
+}
+
+- (void)parseFeaturesAddingCount:(NSUInteger)featuresCount
+{
+    [self.mapView removeAnnotations:self.mapView.annotations];
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^
+    {
+        NSData *featuresData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"features" ofType:@"geojson"]];
+
+        id features = [NSJSONSerialization JSONObjectWithData:featuresData
+                                                      options:0
+                                                        error:nil];
+
+        if ([features isKindOfClass:[NSDictionary class]])
+        {
+            NSMutableArray *annotations = [NSMutableArray array];
+
+            for (NSDictionary *feature in features[@"features"])
+            {
+                CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake([feature[@"geometry"][@"coordinates"][1] doubleValue],
+                                                                               [feature[@"geometry"][@"coordinates"][0] doubleValue]);
+                NSString *title = feature[@"properties"][@"NAME"];
+
+                MBXAnnotation *annotation = [MBXAnnotation annotationWithLocation:coordinate
+                                                                            title:title
+                                                                         subtitle:nil];
+
+                [annotations addObject:annotation];
+
+                if (annotations.count == featuresCount) break;
+            }
+
+            dispatch_async(dispatch_get_main_queue(), ^
+            {
+                [self.mapView addAnnotations:annotations];
+
+                [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(38.904722, -77.016389)
+                                        zoomLevel:10
+                                         animated:NO];
+
+                [self.mapView setDirection:0];
+            });
+        }
+    });
 }
 
 - (void)cycleStyles

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -139,10 +139,10 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
                                               otherButtonTitles:@"Reset North",
                                                                 @"Reset Position",
                                                                 @"Toggle Debug",
-                                                                @"100 Annotations",
-                                                                @"1,000 Annotations",
-                                                                @"10,000 Annotations",
-                                                                @"Remove Annotations",
+                                                                @"Add 100 Points",
+                                                                @"Add 1,000 Points",
+                                                                @"Add 10,000 Points",
+                                                                @"Remove Points",
                                                                 nil];
 
     [sheet showFromBarButtonItem:self.navigationItem.leftBarButtonItem animated:YES];

--- a/ios/app/mapboxgl-app.gyp
+++ b/ios/app/mapboxgl-app.gyp
@@ -10,6 +10,7 @@
       'mac_bundle': 1,
       'mac_bundle_resources': [
         '<!@(find ./img -type f)',
+        './features.geojson'
       ],
 
       'dependencies': [
@@ -27,6 +28,8 @@
         './MBXAppDelegate.m',
         './MBXViewController.h',
         './MBXViewController.mm',
+        './MBXAnnotation.h',
+        './MBXAnnotation.m',
         '../../platform/darwin/settings_nsuserdefaults.mm',
       ],
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1643,7 +1643,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     {
         assert([annotation conformsToProtocol:@protocol(MGLAnnotation)]);
 
-        annotationIDsToRemove.push_back([[self.annotationsStore objectForKey:annotation] unsignedIntValue]);
+        annotationIDsToRemove.push_back([[[self.annotationsStore objectForKey:annotation] objectForKey:MGLAnnotationIDKey] unsignedIntValue]);
         [self.annotationsStore removeObjectForKey:annotation];
     }
 

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -79,13 +79,13 @@ std::pair<std::vector<Tile::ID>, std::vector<uint32_t>> AnnotationManager::addPo
                 auto layer = tile_it->second.second->getMutableLayer(util::ANNOTATIONS_POINTS_LAYER_ID);
                 layer->addFeature(feature);
                 // record annotation association with tile
-                tile_it->second.first.push_back(annotationID);
+                tile_it->second.first.insert(annotationID);
             } else {
                 // create point layer & add feature
                 util::ptr<LiveTileLayer> layer = std::make_shared<LiveTileLayer>();
                 layer->addFeature(feature);
                 // create tile & record annotation association
-                auto tile_pos = tiles.emplace(tileID, std::make_pair(std::vector<uint32_t>({ annotationID }), util::make_unique<LiveTile>()));
+                auto tile_pos = tiles.emplace(tileID, std::make_pair(std::unordered_set<uint32_t>({ annotationID }), util::make_unique<LiveTile>()));
                 // add point layer to tile
                 tile_pos.first->second.second->addLayer(util::ANNOTATIONS_POINTS_LAYER_ID, layer);
             }
@@ -136,10 +136,7 @@ std::vector<Tile::ID> AnnotationManager::removeAnnotations(std::vector<uint32_t>
                 Tile::ID tid(z, x, y);
                 // erase annotation from tile's list
                 auto& tileAnnotations = tiles[tid].first;
-                util::erase_if(tileAnnotations, tileAnnotations.begin(),
-                               tileAnnotations.end(), [&annotationID](const uint32_t annotationID_) -> bool {
-                                   return (annotationID_ == annotationID);
-                               });
+                tileAnnotations.erase(annotationID);
                 // remove annotation's features from tile
                 const auto& features_it = annotation->tileFeatures.find(tid);
                 if (features_it != annotation->tileFeatures.end()) {

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -74,17 +74,16 @@ std::pair<std::vector<Tile::ID>, std::vector<uint32_t>> AnnotationManager::addPo
                                                                    properties);
 
             auto tile_it = tiles.find(tileID);
-            size_t featureIndex;
             if (tile_it != tiles.end()) {
                 // get point layer & add feature
                 auto layer = tile_it->second.second->getMutableLayer(util::ANNOTATIONS_POINTS_LAYER_ID);
-                featureIndex = layer->addFeature(feature);
+                layer->addFeature(feature);
                 // record annotation association with tile
                 tile_it->second.first.push_back(annotationID);
             } else {
                 // create point layer & add feature
                 util::ptr<LiveTileLayer> layer = std::make_shared<LiveTileLayer>();
-                featureIndex = layer->addFeature(feature);
+                layer->addFeature(feature);
                 // create tile & record annotation association
                 auto tile_pos = tiles.emplace(tileID, std::make_pair(std::vector<uint32_t>({ annotationID }), util::make_unique<LiveTile>()));
                 // add point layer to tile
@@ -92,7 +91,7 @@ std::pair<std::vector<Tile::ID>, std::vector<uint32_t>> AnnotationManager::addPo
             }
 
             // record annotation association with tile feature
-            anno_it.first->second->tileFeatures.emplace(tileID, std::vector<size_t>({ featureIndex }));
+            anno_it.first->second->tileFeatures.emplace(tileID, std::vector<std::weak_ptr<const LiveTileFeature>>({ feature }));
 
             z2 /= 2;
             x /= 2;

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -74,16 +74,17 @@ std::pair<std::vector<Tile::ID>, std::vector<uint32_t>> AnnotationManager::addPo
                                                                    properties);
 
             auto tile_it = tiles.find(tileID);
+            size_t featureIndex;
             if (tile_it != tiles.end()) {
                 // get point layer & add feature
                 auto layer = tile_it->second.second->getMutableLayer(util::ANNOTATIONS_POINTS_LAYER_ID);
-                layer->addFeature(feature);
+                featureIndex = layer->addFeature(feature);
                 // record annotation association with tile
                 tile_it->second.first.push_back(annotationID);
             } else {
                 // create point layer & add feature
                 util::ptr<LiveTileLayer> layer = std::make_shared<LiveTileLayer>();
-                layer->addFeature(feature);
+                featureIndex = layer->addFeature(feature);
                 // create tile & record annotation association
                 auto tile_pos = tiles.emplace(tileID, std::make_pair(std::vector<uint32_t>({ annotationID }), util::make_unique<LiveTile>()));
                 // add point layer to tile
@@ -91,7 +92,7 @@ std::pair<std::vector<Tile::ID>, std::vector<uint32_t>> AnnotationManager::addPo
             }
 
             // record annotation association with tile feature
-            anno_it.first->second->tileFeatures.emplace(tileID, std::vector<std::weak_ptr<const LiveTileFeature>>({ feature }));
+            anno_it.first->second->tileFeatures.emplace(tileID, std::vector<size_t>({ featureIndex }));
 
             z2 /= 2;
             x /= 2;

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -91,7 +91,7 @@ std::pair<std::vector<Tile::ID>, std::vector<uint32_t>> AnnotationManager::addPo
             }
 
             // record annotation association with tile feature
-            anno_it.first->second->tileFeatures.emplace(tileID, std::vector<std::weak_ptr<const LiveTileFeature>>({ feature }));
+            anno_it.first->second->tileFeatures.emplace(tileID, std::weak_ptr<const LiveTileFeature>(feature ));
 
             z2 /= 2;
             x /= 2;
@@ -138,7 +138,7 @@ std::vector<Tile::ID> AnnotationManager::removeAnnotations(std::vector<uint32_t>
                 const auto& features_it = annotation->tileFeatures.find(tid);
                 if (features_it != annotation->tileFeatures.end()) {
                     const auto& layer = tiles[tid].second->getMutableLayer(util::ANNOTATIONS_POINTS_LAYER_ID);
-                    layer->removeFeature(features_it->second[0]);
+                    layer->removeFeature(features_it->second);
                     affectedTiles.push_back(tid);
                 }
             }

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -144,8 +144,7 @@ std::vector<Tile::ID> AnnotationManager::removeAnnotations(std::vector<uint32_t>
                 const auto& features_it = annotation->tileFeatures.find(tid);
                 if (features_it != annotation->tileFeatures.end()) {
                     const auto& layer = tiles[tid].second->getMutableLayer(util::ANNOTATIONS_POINTS_LAYER_ID);
-                    const auto& features = features_it->second;
-                    layer->removeFeature(features[0]);
+                    layer->removeFeature(features_it->second[0]);
                     affectedTiles.push_back(tid);
                 }
             }

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -114,9 +114,6 @@ std::vector<Tile::ID> AnnotationManager::removeAnnotations(std::vector<uint32_t>
         z2s.emplace_back(1<< z);
     }
 
-    std::vector<Tile::ID> annotationTiles;
-    annotationTiles.reserve(zoomCount);
-
     LatLng latLng;
     vec2<double> p;
     uint32_t x, y;

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -107,20 +107,20 @@ std::pair<std::vector<Tile::ID>, std::vector<uint32_t>> AnnotationManager::addPo
 std::vector<Tile::ID> AnnotationManager::removeAnnotations(std::vector<uint32_t> ids) {
     std::vector<Tile::ID> affectedTiles;
 
-    for (auto& annotationID : ids) {
-        auto annotation_it = annotations.find(annotationID);
+    for (const auto& annotationID : ids) {
+        const auto& annotation_it = annotations.find(annotationID);
         if (annotation_it != annotations.end()) {
-            auto& annotation = annotation_it->second;
+            const auto& annotation = annotation_it->second;
             for (auto& tile_it : annotationTiles) {
                 auto& tileAnnotations = tile_it.second.first;
                 util::erase_if(tileAnnotations, tileAnnotations.begin(),
-                               tileAnnotations.end(), [&](const uint32_t annotationID_) -> bool {
+                               tileAnnotations.end(), [&annotationID](const uint32_t annotationID_) -> bool {
                                    return (annotationID_ == annotationID);
                                });
-                auto features_it = annotation->tileFeatures.find(tile_it.first);
+                const auto& features_it = annotation->tileFeatures.find(tile_it.first);
                 if (features_it != annotation->tileFeatures.end()) {
-                    auto layer = tile_it.second.second->getMutableLayer(util::ANNOTATIONS_POINTS_LAYER_ID);
-                    auto& features = features_it->second;
+                    const auto& layer = tile_it.second.second->getMutableLayer(util::ANNOTATIONS_POINTS_LAYER_ID);
+                    const auto& features = features_it->second;
                     layer->removeFeature(features[0]);
                     affectedTiles.push_back(tile_it.first);
                 }

--- a/src/mbgl/map/live_tile.cpp
+++ b/src/mbgl/map/live_tile.cpp
@@ -18,16 +18,21 @@ mapbox::util::optional<Value> LiveTileFeature::getValue(const std::string& key) 
 
 LiveTileLayer::LiveTileLayer() {}
 
-std::size_t LiveTileLayer::addFeature(util::ptr<const LiveTileFeature> feature) {
-    std::size_t i = nextID();
-    features.emplace(i, std::move(feature));
-    return i;
+void LiveTileLayer::prepareToAddFeatures(size_t count) {
+    features.reserve(features.size() + count);
 }
 
-util::ptr<const GeometryTileFeature> LiveTileLayer::getFeature(std::size_t i) const {
-    auto it = features.begin();
-    std::advance(it, i);
-    return it->second;
+void LiveTileLayer::addFeature(util::ptr<const LiveTileFeature> feature) {
+    features.push_back(std::move(feature));
+}
+
+void LiveTileLayer::removeFeature(util::ptr<const LiveTileFeature> feature) {
+    for (auto it = features.begin(); it != features.end(); ++it) {
+        if (feature == *it) {
+            features.erase(it);
+            return;
+        }
+    }
 }
 
 LiveTile::LiveTile() {}

--- a/src/mbgl/map/live_tile.cpp
+++ b/src/mbgl/map/live_tile.cpp
@@ -18,21 +18,16 @@ mapbox::util::optional<Value> LiveTileFeature::getValue(const std::string& key) 
 
 LiveTileLayer::LiveTileLayer() {}
 
-void LiveTileLayer::prepareToAddFeatures(size_t count) {
-    features.reserve(features.size() + count);
+std::size_t LiveTileLayer::addFeature(util::ptr<const LiveTileFeature> feature) {
+    std::size_t i = nextID();
+    features.emplace(i, std::move(feature));
+    return i;
 }
 
-void LiveTileLayer::addFeature(util::ptr<const LiveTileFeature> feature) {
-    features.push_back(std::move(feature));
-}
-
-void LiveTileLayer::removeFeature(util::ptr<const LiveTileFeature> feature) {
-    for (auto it = features.begin(); it != features.end(); ++it) {
-        if (feature == *it) {
-            features.erase(it);
-            return;
-        }
-    }
+util::ptr<const GeometryTileFeature> LiveTileLayer::getFeature(std::size_t i) const {
+    auto it = features.begin();
+    std::advance(it, i);
+    return it->second;
 }
 
 LiveTile::LiveTile() {}

--- a/src/mbgl/map/live_tile.hpp
+++ b/src/mbgl/map/live_tile.hpp
@@ -22,7 +22,7 @@ private:
     GeometryCollection geometries;
 };
 
-    class LiveTileLayer : public GeometryTileLayer {
+class LiveTileLayer : public GeometryTileLayer {
 public:
     LiveTileLayer();
 

--- a/src/mbgl/map/live_tile.hpp
+++ b/src/mbgl/map/live_tile.hpp
@@ -2,6 +2,7 @@
 #define MBGL_MAP_LIVE_TILE
 
 #include <map>
+#include <unordered_map>
 
 #include <mbgl/map/geometry_tile.hpp>
 
@@ -25,14 +26,17 @@ private:
 public:
     LiveTileLayer();
 
-    void prepareToAddFeatures(size_t count);
-    void addFeature(util::ptr<const LiveTileFeature>);
-    void removeFeature(util::ptr<const LiveTileFeature>);
+    std::size_t addFeature(util::ptr<const LiveTileFeature>);
+    void removeFeature(std::size_t i) { features.erase(i); }
     std::size_t featureCount() const override { return features.size(); }
-    util::ptr<const GeometryTileFeature> getFeature(std::size_t i) const override { return features[i]; }
+    util::ptr<const GeometryTileFeature> getFeature(std::size_t) const override;
 
 private:
-    std::vector<util::ptr<const LiveTileFeature>> features;
+    std::size_t nextID() { return nextID_++; }
+
+private:
+    std::unordered_map<std::size_t, util::ptr<const LiveTileFeature>> features;
+    std::size_t nextID_ = 0;
 };
 
 class LiveTile : public GeometryTile {

--- a/src/mbgl/map/live_tile.hpp
+++ b/src/mbgl/map/live_tile.hpp
@@ -2,7 +2,6 @@
 #define MBGL_MAP_LIVE_TILE
 
 #include <map>
-#include <unordered_map>
 
 #include <mbgl/map/geometry_tile.hpp>
 
@@ -26,17 +25,14 @@ class LiveTileLayer : public GeometryTileLayer {
 public:
     LiveTileLayer();
 
-    std::size_t addFeature(util::ptr<const LiveTileFeature>);
-    void removeFeature(std::size_t i) { features.erase(i); }
+    void prepareToAddFeatures(size_t count);
+    void addFeature(util::ptr<const LiveTileFeature>);
+    void removeFeature(util::ptr<const LiveTileFeature>);
     std::size_t featureCount() const override { return features.size(); }
-    util::ptr<const GeometryTileFeature> getFeature(std::size_t) const override;
+    util::ptr<const GeometryTileFeature> getFeature(std::size_t i) const override { return features[i]; }
 
 private:
-    std::size_t nextID() { return nextID_++; }
-
-private:
-    std::unordered_map<std::size_t, util::ptr<const LiveTileFeature>> features;
-    std::size_t nextID_ = 0;
+    std::vector<util::ptr<const LiveTileFeature>> features;
 };
 
 class LiveTile : public GeometryTile {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -570,7 +570,7 @@ void Map::removeAnnotation(uint32_t annotation) {
 
 void Map::removeAnnotations(std::vector<uint32_t> annotations) {
     assert(Environment::currentlyOn(ThreadType::Main));
-    auto result = annotationManager->removeAnnotations(annotations);
+    auto result = annotationManager->removeAnnotations(annotations, *this);
     updateAnnotationTiles(result);
 }
 


### PR DESCRIPTION
Add a GeoJSON with ~10,000 point features and allow for addition of 100, 1000, or 10000 of them in-app, plus removal. 

Fixes a crasher in annotation removal. 

Needs some work for removal of 10000 features per: 

![screen shot 2015-03-22 at 1 38 30 pm](https://cloud.githubusercontent.com/assets/17722/6771296/c62ac1ee-d098-11e4-9c87-4e7594f6488f.png)
