### PR TITLE
Reset applied style classes when not Hybrid

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1145,6 +1145,8 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     [self setStyleURL:[NSString stringWithFormat:@"styles/%@.json", styleName]];
     if (isHybrid) {
         [self setStyleClasses:@[@"contours", @"labels"]];
+    } else {
+        [self setStyleClasses:nil];
     }
 }
 


### PR DESCRIPTION
This fixes the issue of Hybrid's contours and labels still being applied to Satellite, which can happen if one keeps flipping through the styles in the demo app. The applied style classes never got reset, but only Satellite possesses those classes and would draw them.

@incanus, @1ec5: Is there/will there be a better way to do this? My patch would seem to lack any finesse.