### PR TITLE
Reset applied style classes on Map::stop

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -128,6 +128,9 @@ void Map::start(bool startPaused) {
         // Remove all of these to make sure they are destructed in the correct thread.
         style.reset();
         activeSources.clear();
+        
+        // Reset active style classes
+        classes.clear();
 
         terminating = true;
 


### PR DESCRIPTION
Deeper, non-platform specific alternative to #1062.

> This fixes the issue of Hybrid's contours and labels still being applied to Satellite, which can happen if one keeps flipping through the styles in the demo app. The applied style classes never got reset, but only Satellite possesses those classes and would draw them.

I haven't noticed any side effects, but I could very well be blind to the larger picture. cc/@kkaefer