### PR TITLE
Isolate Map data into separate object

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -139,7 +139,7 @@ public:
 
     // API
     void setAccessToken(const std::string &token);
-    const std::string &getAccessToken() const;
+    std::string getAccessToken() const;
 
     // Projection
     inline void getWorldBoundsMeters(ProjectedMeters &sw, ProjectedMeters &ne) const { Projection::getWorldBoundsMeters(sw, ne); }
@@ -252,7 +252,6 @@ private:
     const std::unique_ptr<MapData> data;
 
     std::vector<std::string> classes;
-    std::string accessToken;
 
     std::set<util::ptr<StyleSource>> activeSources;
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -82,6 +82,7 @@ public:
         StyleInfo                 = 1 << 0,
         Debug                     = 1 << 1,
         DefaultTransitionDuration = 1 << 2,
+        Classes                   = 1 << 3,
     };
     void triggerUpdate(Update = Update::Nothing);
 
@@ -250,8 +251,6 @@ private:
     util::ptr<AnnotationManager> annotationManager;
 
     const std::unique_ptr<MapData> data;
-
-    std::vector<std::string> classes;
 
     std::set<util::ptr<StyleSource>> activeSources;
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -164,7 +164,7 @@ public:
     bool getDebug() const;
 
     inline const TransformState &getState() const { return state; }
-    inline std::chrono::steady_clock::time_point getTime() const { return animationTime; }
+    std::chrono::steady_clock::time_point getTime() const;
     inline AnnotationManager& getAnnotationManager() const { return *annotationManager; }
 
 private:
@@ -254,8 +254,6 @@ private:
     std::string accessToken;
 
     std::chrono::steady_clock::duration defaultTransitionDuration;
-
-    std::chrono::steady_clock::time_point animationTime = std::chrono::steady_clock::time_point::min();
 
     std::set<util::ptr<StyleSource>> activeSources;
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -80,6 +80,7 @@ public:
     enum class Update : UpdateType {
         Nothing   = 0,
         StyleInfo = 1 << 0,
+        Debug     = 1 << 1,
     };
     void triggerUpdate(Update = Update::Nothing);
 
@@ -254,7 +255,6 @@ private:
 
     std::chrono::steady_clock::duration defaultTransitionDuration;
 
-    bool debug = false;
     std::chrono::steady_clock::time_point animationTime = std::chrono::steady_clock::time_point::min();
 
     std::set<util::ptr<StyleSource>> activeSources;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -78,9 +78,10 @@ public:
     // Notifies the Map thread that the state has changed and an update might be necessary.
     using UpdateType = uint32_t;
     enum class Update : UpdateType {
-        Nothing   = 0,
-        StyleInfo = 1 << 0,
-        Debug     = 1 << 1,
+        Nothing                   = 0,
+        StyleInfo                 = 1 << 0,
+        Debug                     = 1 << 1,
+        DefaultTransitionDuration = 1 << 2,
     };
     void triggerUpdate(Update = Update::Nothing);
 
@@ -252,8 +253,6 @@ private:
 
     std::vector<std::string> classes;
     std::string accessToken;
-
-    std::chrono::steady_clock::duration defaultTransitionDuration;
 
     std::set<util::ptr<StyleSource>> activeSources;
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -591,18 +591,17 @@ void Map::updateAnnotationTiles(std::vector<Tile::ID>& ids) {
 #pragma mark - Toggles
 
 void Map::setDebug(bool value) {
-    debug = value;
-    assert(painter);
-    painter->setDebug(debug);
-    triggerUpdate();
+    data->setDebug(value);
+    triggerUpdate(Update::Debug);
 }
 
 void Map::toggleDebug() {
-    setDebug(!debug);
+    data->toggleDebug();
+    triggerUpdate(Update::Debug);
 }
 
 bool Map::getDebug() const {
-    return debug;
+    return data->getDebug();
 }
 
 void Map::addClass(const std::string& klass) {
@@ -764,6 +763,10 @@ void Map::prepare() {
     const auto u = updated.exchange(static_cast<UpdateType>(Update::Nothing));
     if (u & static_cast<UpdateType>(Update::StyleInfo)) {
         reloadStyle();
+    }
+    if (u & static_cast<UpdateType>(Update::Debug)) {
+        assert(painter);
+        painter->setDebug(data->getDebug());
     }
 
     // Update transform transitions.

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -530,11 +530,11 @@ void Map::stopRotating() {
 #pragma mark - Access Token
 
 void Map::setAccessToken(const std::string &token) {
-    accessToken = token;
+    data->setAccessToken(token);
 }
 
-const std::string &Map::getAccessToken() const {
-    return accessToken;
+std::string Map::getAccessToken() const {
+    return data->getAccessToken();
 }
 
 #pragma mark - Annotations

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -604,6 +604,10 @@ bool Map::getDebug() const {
     return data->getDebug();
 }
 
+std::chrono::steady_clock::time_point Map::getTime() const {
+    return data->getAnimationTime();
+}
+
 void Map::addClass(const std::string& klass) {
     if (hasClass(klass)) return;
     classes.push_back(klass);
@@ -770,14 +774,14 @@ void Map::prepare() {
     }
 
     // Update transform transitions.
-    animationTime = std::chrono::steady_clock::now();
+
+    const auto animationTime = std::chrono::steady_clock::now();
+    data->setAnimationTime(animationTime);
     if (transform.needsTransition()) {
         transform.updateTransitions(animationTime);
     }
 
     state = transform.currentState();
-
-    animationTime = std::chrono::steady_clock::now();
 
     if (style) {
         updateSources();
@@ -803,7 +807,7 @@ void Map::render() {
 
     assert(painter);
     painter->render(*style, activeSources,
-                    state, animationTime);
+                    state, data->getAnimationTime());
     // Schedule another rerender when we definitely need a next frame.
     if (transform.needsTransition() || style->hasTransitions()) {
         triggerUpdate();

--- a/src/mbgl/map/map_data.cpp
+++ b/src/mbgl/map/map_data.cpp
@@ -1,0 +1,44 @@
+#include "map_data.hpp"
+
+#include <algorithm>
+
+namespace mbgl {
+
+// Adds the class if it's not yet set. Returns true when it added the class, and false when it
+// was already present.
+bool MapData::addClass(const std::string& klass) {
+    Lock lock(mtx);
+    if (std::find(classes.begin(), classes.end(), klass) != classes.end()) return false;
+    classes.push_back(klass);
+    return true;
+}
+
+// Removes the class if it's present. Returns true when it remvoed the class, and false when it
+// was not present.
+bool MapData::removeClass(const std::string& klass) {
+    Lock lock(mtx);
+    const auto it = std::find(classes.begin(), classes.end(), klass);
+    if (it != classes.end()) {
+        classes.erase(it);
+        return true;
+    }
+    return false;
+}
+
+// Returns true when class is present in the list of currently set classes.
+bool MapData::hasClass(const std::string& klass) const {
+    Lock lock(mtx);
+    return std::find(classes.begin(), classes.end(), klass) != classes.end();
+}
+
+void MapData::setClasses(const std::vector<std::string>& klasses) {
+    Lock lock(mtx);
+    classes = klasses;
+}
+
+std::vector<std::string> MapData::getClasses() const {
+    Lock lock(mtx);
+    return classes;
+}
+
+}

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -1,0 +1,36 @@
+#ifndef MBGL_MAP_MAP_DATA
+#define MBGL_MAP_MAP_DATA
+
+#include <string>
+#include <mutex>
+
+namespace mbgl {
+
+struct StyleInfo {
+    std::string url;
+    std::string base;
+    std::string json;
+};
+
+class MapData {
+    using Lock = std::lock_guard<std::mutex>;
+
+public:
+    inline StyleInfo getStyleInfo() const {
+        Lock lock(mtx);
+        return styleInfo;
+    }
+    inline void setStyleInfo(StyleInfo&& info) {
+        Lock lock(mtx);
+        styleInfo = info;
+    }
+
+private:
+    mutable std::mutex mtx;
+
+    StyleInfo styleInfo;
+};
+
+}
+
+#endif

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <mutex>
+#include <atomic>
 
 namespace mbgl {
 
@@ -25,10 +26,15 @@ public:
         styleInfo = info;
     }
 
+    inline bool getDebug() const { return debug; }
+    inline bool toggleDebug() { return debug ^= 1u; }
+    inline void setDebug(bool value) { debug = value; }
+
 private:
     mutable std::mutex mtx;
 
     StyleInfo styleInfo;
+    std::atomic<uint8_t> debug;
 };
 
 }

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -20,6 +20,7 @@ class MapData {
 public:
     inline MapData() {
         setAnimationTime(std::chrono::steady_clock::time_point::min());
+        setDefaultTransitionDuration(std::chrono::steady_clock::duration::zero());
     }
 
     inline StyleInfo getStyleInfo() const {
@@ -50,12 +51,20 @@ public:
         animationTime = timePoint.time_since_epoch();
     };
 
+    inline std::chrono::steady_clock::duration getDefaultTransitionDuration() const {
+        return defaultTransitionDuration;
+    }
+    inline void setDefaultTransitionDuration(std::chrono::steady_clock::duration duration) {
+        defaultTransitionDuration = duration;
+    };
+
 private:
     mutable std::mutex mtx;
 
     StyleInfo styleInfo;
     std::atomic<uint8_t> debug { false };
     std::atomic<std::chrono::steady_clock::time_point::duration> animationTime;
+    std::atomic<std::chrono::steady_clock::duration> defaultTransitionDuration;
 };
 
 }

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <atomic>
 #include <chrono>
+#include <vector>
 
 namespace mbgl {
 
@@ -41,6 +42,24 @@ public:
         accessToken = token;
     }
 
+    // Adds the class if it's not yet set. Returns true when it added the class, and false when it
+    // was already present.
+    bool addClass(const std::string& klass);
+
+    // Removes the class if it's present. Returns true when it remvoed the class, and false when it
+    // was not present.
+    bool removeClass(const std::string& klass);
+
+    // Returns true when class is present in the list of currently set classes.
+    bool hasClass(const std::string& klass) const;
+
+    // Changes the list of currently set classes to the new list.
+    void setClasses(const std::vector<std::string>& klasses);
+
+    // Returns a list of all currently set classes.
+    std::vector<std::string> getClasses() const;
+
+
     inline bool getDebug() const {
         return debug;
     }
@@ -72,6 +91,7 @@ private:
 
     StyleInfo styleInfo;
     std::string accessToken;
+    std::vector<std::string> classes;
     std::atomic<uint8_t> debug { false };
     std::atomic<std::chrono::steady_clock::time_point::duration> animationTime;
     std::atomic<std::chrono::steady_clock::duration> defaultTransitionDuration;

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -32,6 +32,15 @@ public:
         styleInfo = info;
     }
 
+    inline std::string getAccessToken() const {
+        Lock lock(mtx);
+        return accessToken;
+    }
+    inline void setAccessToken(const std::string &token) {
+        Lock lock(mtx);
+        accessToken = token;
+    }
+
     inline bool getDebug() const {
         return debug;
     }
@@ -62,6 +71,7 @@ private:
     mutable std::mutex mtx;
 
     StyleInfo styleInfo;
+    std::string accessToken;
     std::atomic<uint8_t> debug { false };
     std::atomic<std::chrono::steady_clock::time_point::duration> animationTime;
     std::atomic<std::chrono::steady_clock::duration> defaultTransitionDuration;


### PR DESCRIPTION
We should isolate data that is accessed from both threads into a separate Data object that controls access and ensures that no concurrent access occurs.