### PR TITLE
iOS demo app: Prompt users to open Settings.app if location access previously denied

### DIFF
--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -190,10 +190,37 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
 
     if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusDenied)
     {
-        [[[UIAlertView alloc] initWithTitle:@"Authorization Denied"
-                                    message:@"Please enable location services for this app in Privacy settings."
-                                   delegate:nil
-                          cancelButtonTitle:nil otherButtonTitles:@"OK", nil] show];
+        // iOS 8+: Prompt users to open Settings.app if authorization was denied
+        if (&UIApplicationOpenSettingsURLString != NULL)
+        {
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Authorization Denied"
+                                                                           message:@"Please enable location services for this app in Privacy settings."
+                                                                    preferredStyle:UIAlertControllerStyleAlert];
+
+            UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel"
+                                                                   style:UIAlertActionStyleCancel
+                                                                 handler:nil];
+
+            UIAlertAction *ok = [UIAlertAction actionWithTitle:@"Open Settings"
+                                                         style:UIAlertActionStyleDefault
+                                                       handler:^(UIAlertAction __unused *action)
+                                                        {
+                                                            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+                                                        }];
+
+            // added in the order that they'll appear, left to right
+            [alert addAction:cancel];
+            [alert addAction:ok];
+
+            [self presentViewController:alert animated:YES completion:nil];
+        }
+        else
+        {
+            [[[UIAlertView alloc] initWithTitle:@"Authorization Denied"
+                                        message:@"Please enable location services for this app in Privacy settings."
+                                       delegate:nil
+                              cancelButtonTitle:nil otherButtonTitles:@"OK", nil] show];
+        }
     }
     else
     {


### PR DESCRIPTION
With iOS 8 it became possible to redirect users to an app's panel in Settings.app, so let's do that if the user hits the locate button but has previously denied access. Clearly this isn't terribly important, but I see this as an example of a best practice that we can pass along to developers.

This also happens to use `UIAlertController` — another iOS 8 addition — largely because I didn't want to bother with a `UIAlertView` delegate.

![ios-simulator-screen-shot-mar-23 -2015 -4 39 08-pm](https://cloud.githubusercontent.com/assets/1198851/6792963/8ae6b776-d17b-11e4-91fd-875c1998925d.png)

iOS 7 and lower will continue to show the old alert. (Tested in simulator.)

The one downside to this is that there's no direct way to return from Settings.app to the demo app. Maybe iOS 9...