### PR TITLE
annotations perf improvements & iOS app testing

### DIFF
--- a/include/mbgl/map/annotation.hpp
+++ b/include/mbgl/map/annotation.hpp
@@ -9,9 +9,10 @@
 
 #include <string>
 #include <vector>
-#include <map>
 #include <mutex>
 #include <memory>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace mbgl {
 
@@ -29,7 +30,7 @@ public:
     void setDefaultPointAnnotationSymbol(const std::string& symbol);
     std::pair<std::vector<Tile::ID>, AnnotationIDs> addPointAnnotations(
         const std::vector<LatLng>&, const std::vector<std::string>& symbols, const Map&);
-    std::vector<Tile::ID> removeAnnotations(const AnnotationIDs&);
+    std::vector<Tile::ID> removeAnnotations(const AnnotationIDs&, const Map&);
     AnnotationIDs getAnnotationsInBounds(const LatLngBounds&, const Map&) const;
     LatLngBounds getBoundsForAnnotations(const AnnotationIDs&) const;
 
@@ -44,8 +45,8 @@ private:
 private:
     mutable std::mutex mtx;
     std::string defaultPointAnnotationSymbol;
-    std::map<uint32_t, std::unique_ptr<Annotation>> annotations;
-    std::map<Tile::ID, std::pair<AnnotationIDs, std::unique_ptr<LiveTile>>> annotationTiles;
+    std::unordered_map<uint32_t, std::unique_ptr<Annotation>> annotations;
+    std::unordered_map<Tile::ID, std::pair<std::unordered_set<uint32_t>, std::unique_ptr<LiveTile>>, Tile::ID::Hash> tiles;
     uint32_t nextID_ = 0;
 };
 

--- a/include/mbgl/map/tile.hpp
+++ b/include/mbgl/map/tile.hpp
@@ -12,6 +12,7 @@
 #include <forward_list>
 #include <iosfwd>
 #include <string>
+#include <functional>
 
 namespace mbgl {
 
@@ -43,6 +44,12 @@ public:
         inline uint64_t to_uint64() const {
             return ((std::pow(2, z) * y + x) * 32) + z;
         }
+
+        struct Hash {
+            std::size_t operator()(ID const& i) const {
+                return std::hash<uint64_t>()(i.to_uint64());
+            }
+        };
 
         inline bool operator==(const ID& rhs) const {
             return w == rhs.w && z == rhs.z && x == rhs.x && y == rhs.y;

--- a/ios/app/MBXAnnotation.h
+++ b/ios/app/MBXAnnotation.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+#import <CoreLocation/CoreLocation.h>
+
+#import <mbgl/ios/MGLAnnotation.h>
+
+@interface MBXAnnotation : NSObject <MGLAnnotation>
+
++ (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle;
+
+- (instancetype)initWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle;
+
+@end

--- a/ios/app/MBXAnnotation.m
+++ b/ios/app/MBXAnnotation.m
@@ -1,0 +1,30 @@
+#import "MBXAnnotation.h"
+
+@interface MBXAnnotation ()
+
+@property (nonatomic) CLLocationCoordinate2D coordinate;
+@property (nonatomic) NSString *title;
+@property (nonatomic) NSString *subtitle;
+
+@end
+
+@implementation MBXAnnotation
+
++ (instancetype)annotationWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle
+{
+    return [[self alloc] initWithLocation:coordinate title:title subtitle:subtitle];
+}
+
+- (instancetype)initWithLocation:(CLLocationCoordinate2D)coordinate title:(NSString *)title subtitle:(NSString *)subtitle
+{
+    if (self = [super init])
+    {
+        _coordinate = coordinate;
+        _title = title;
+        _subtitle = subtitle;
+    }
+
+    return self;
+}
+
+@end

--- a/ios/app/mapboxgl-app.gyp
+++ b/ios/app/mapboxgl-app.gyp
@@ -10,6 +10,7 @@
       'mac_bundle': 1,
       'mac_bundle_resources': [
         '<!@(find ./img -type f)',
+        './features.geojson'
       ],
 
       'dependencies': [
@@ -27,6 +28,8 @@
         './MBXAppDelegate.m',
         './MBXViewController.h',
         './MBXViewController.mm',
+        './MBXAnnotation.h',
+        './MBXAnnotation.m',
         '../../platform/darwin/settings_nsuserdefaults.mm',
       ],
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1643,7 +1643,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     {
         assert([annotation conformsToProtocol:@protocol(MGLAnnotation)]);
 
-        annotationIDsToRemove.push_back([[self.annotationsStore objectForKey:annotation] unsignedIntValue]);
+        annotationIDsToRemove.push_back([[[self.annotationsStore objectForKey:annotation] objectForKey:MGLAnnotationIDKey] unsignedIntValue]);
         [self.annotationsStore removeObjectForKey:annotation];
     }
 

--- a/src/mbgl/map/live_tile.hpp
+++ b/src/mbgl/map/live_tile.hpp
@@ -21,7 +21,7 @@ private:
     GeometryCollection geometries;
 };
 
-    class LiveTileLayer : public GeometryTileLayer {
+class LiveTileLayer : public GeometryTileLayer {
 public:
     LiveTileLayer();
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -566,7 +566,7 @@ void Map::removeAnnotation(uint32_t annotation) {
 
 void Map::removeAnnotations(const std::vector<uint32_t>& annotations) {
     assert(Environment::currentlyOn(ThreadType::Main));
-    auto result = annotationManager->removeAnnotations(annotations);
+    auto result = annotationManager->removeAnnotations(annotations, *this);
     updateAnnotationTiles(result);
 }
 


### PR DESCRIPTION
Squash of #1061. 

* Various C++ performance improvements for annotation adds/removes up to 10,000 points. 

* Added small GeoJSON points data file to iOS app and in-app settings menu entries for testing 100, 1000, and 10000 points. 

* iOS test app implementation of `MBXAnnotation` class adopting `MGLAnnotation` protocol for use in points. 