### PR TITLE
don't stop/start map in related to style changes anymore since safe

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -192,17 +192,13 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     }
     else
     {
-        if ([@(mbglMap->getStyleJSON().c_str()) length]) mbglMap->stop();
         mbglMap->setStyleJSON((std::string)[styleJSON cStringUsingEncoding:[NSString defaultCStringEncoding]]);
-        mbglMap->start();
     }
 }
 
 - (void)setStyleURL:(NSString *)filePathURL
 {
-    if ([@(mbglMap->getStyleJSON().c_str()) length]) mbglMap->stop();
     mbglMap->setStyleURL(std::string("asset://") + [filePathURL UTF8String]);
-    mbglMap->start();
 }
 
 - (BOOL)commonInit
@@ -369,6 +365,9 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     //
     _regionChangeDelegateQueue = [NSOperationQueue new];
     _regionChangeDelegateQueue.maxConcurrentOperationCount = 1;
+
+    // start the main loop
+    mbglMap->start();
 
     return YES;
 }


### PR DESCRIPTION
This behaves like OS X, where the map is started once at init, and then only ever again after being stopped from app backgrounding. Nothing to do with styling, which can happen before or after start, from the main thread, without otherwise touching the map since it triggers its own updates. 