### PR TITLE
make 1.0 the default base for all types

### DIFF
--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -347,9 +347,6 @@ std::tuple<bool, std::vector<std::pair<float, T>>> StyleParser::parseStops(JSVal
     return std::tuple<bool, std::vector<std::pair<float, T>>>(true, stops);
 }
 
-template <typename T> inline float defaultBaseValue() { return 1.75; }
-template <> inline float defaultBaseValue<Color>() { return 1.0; }
-
 template <typename T>
 std::tuple<bool, Function<T>> StyleParser::parseFunction(JSVal value, const char *property_name) {
     if (!value.IsObject()) {
@@ -361,7 +358,7 @@ std::tuple<bool, Function<T>> StyleParser::parseFunction(JSVal value, const char
         return std::tuple<bool, Function<T>> { false, ConstantFunction<T>(T()) };
     }
 
-    float base = defaultBaseValue<T>();
+    float base = 1.0f;
 
     if (value.HasMember("base")) {
         JSVal value_base = value["base"];


### PR DESCRIPTION
At some point -js switched to having one default base value for all types instead of 1.0 for color and 1.75 for other types like width. This switches -native to match -js.

Or we could change -js back to having different default base values for different types.

@jfirebaugh was the change in -js intentional?

The mismatch is causing issues like https://github.com/mapbox/mapbox-gl-native/issues/1081#event-263932060