### PR TITLE
Add CoreTelephony to list of Cocoa dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you merely want to install the library for iOS and try it out as an Objective
    - `MapboxGL.bundle` is in your target's *Copy Bundle Resources* build phase.
    - `libMapboxGL.a` is in your target's *Link Binary With Libraries* build phase.
 3. Add the following Cocoa framework dependencies to your target's *Link Binary With Libraries* build phase:
+   - `CoreTelephony.framework`
    - `GLKit.framework`
    - `ImageIO.framework`
    - `MobileCoreServices.framework`


### PR DESCRIPTION
Will fix build error in client apps following merge of #1036