### PR TITLE
Enable modules in iOS demo app

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -47,16 +47,13 @@
           '<@(uv_static_libs)',
         ],
         'ldflags': [
-          '-framework CoreGraphics',
           '-framework CoreLocation',
           '-framework CoreTelephony',
-          '-framework ImageIO',
           '-framework GLKit',
+          '-framework ImageIO',
           '-framework MobileCoreServices',
-          '-framework OpenGLES',
           '-framework QuartzCore',
           '-framework SystemConfiguration',
-          '-framework UIKit',
         ],
       },
 
@@ -67,6 +64,7 @@
       'xcode_settings': {
         'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
         'CLANG_ENABLE_OBJC_ARC': 'YES',
+        'CLANG_ENABLE_MODULES': 'YES',
       },
 
       'link_settings': {

--- a/gyp/platform-osx.gypi
+++ b/gyp/platform-osx.gypi
@@ -26,10 +26,8 @@
           '<@(uv_static_libs)',
         ],
         'ldflags': [
-          '-framework Foundation',
           '-framework ImageIO',
           '-framework CoreServices',
-          '-framework OpenGL',
           '-framework ApplicationServices',
         ],
       },
@@ -42,6 +40,7 @@
       'xcode_settings': {
         'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
         'CLANG_ENABLE_OBJC_ARC': 'YES',
+        'CLANG_ENABLE_MODULES': 'YES',
       },
 
       'link_settings': {

--- a/ios/app/mapboxgl-app.gyp
+++ b/ios/app/mapboxgl-app.gyp
@@ -42,6 +42,7 @@
         'TARGETED_DEVICE_FAMILY': '1,2',
         'COMBINE_HIDPI_IMAGES': 'NO', # don't merge @2x.png images into .tiff files
         'CLANG_ENABLE_OBJC_ARC': 'YES',
+        'CLANG_ENABLE_MODULES': 'YES',
       },
 
       'configurations': {


### PR DESCRIPTION
No longer need to explicitly link system frameworks like UIKit.

Fixes #1099.