### PR TITLE
Refs #1027 Icon burning: Switch to postbuild action

### DIFF
--- a/ios/app/icon_burn.sh
+++ b/ios/app/icon_burn.sh
@@ -20,7 +20,7 @@ echo "Burning app icons..."
 #
 commit=`git rev-parse --short HEAD`
 branch=`git rev-parse --abbrev-ref HEAD`
-repo=`git remote show -n origin | grep 'Fetch URL' | sed -e 's/.*github\.com:mapbox\///' -e 's/\.git$//' -e 's/^mapbox-//'`
+repo=`git remote show -n origin | grep 'Fetch URL' | sed -e 's/.*github\.com\/.*\///' -e 's/\.git$//' -e 's/^mapbox-//'`
 
 #
 # work directly in app bundle

--- a/ios/app/mapboxgl-app.gyp
+++ b/ios/app/mapboxgl-app.gyp
@@ -30,12 +30,12 @@
         '../../platform/darwin/settings_nsuserdefaults.mm',
       ],
 
-      'actions': [
+      'postbuilds': [
         {
-          'action_name': 'Icon Burning',
-          'inputs': [ './icon_burn.sh' ],
-          'outputs': [],
-          'action': ['<@(_inputs)'],
+          'postbuild_name': 'Icon Burning',
+          'action': [
+            './icon_burn.sh',
+          ],
         },
       ],
 


### PR DESCRIPTION
Part of #1027, cc @incanus.

Switched to the apparently undocumented `postbuilds` GYP section, which works presuming you have `iconoblast` locally installed. Also changed the `repo` string formatting to be more accepting of forks.

![ios simulator screen shot mar 25 2015 10 23 44 pm](https://cloud.githubusercontent.com/assets/1198851/6840886/109044aa-d33e-11e4-8b73-a36ea9191ceb.png)

```
PhaseScriptExecution Postbuild\ \"Icon\ Burning\" /Users/jason/Library/Developer/Xcode/DerivedData/mapboxgl-app-gjhaotbyabhkrwascyegdaadflha/Build/Intermediates/mapboxgl-app.build/Debug-iphonesimulator/iosapp.build/Script-8F3899DC209D3AE87006491C.sh
    cd /Users/jason/Documents/Mapbox/mapbox-gl-native/ios/app
    /bin/sh -c /Users/jason/Library/Developer/Xcode/DerivedData/mapboxgl-app-gjhaotbyabhkrwascyegdaadflha/Build/Intermediates/mapboxgl-app.build/Debug-iphonesimulator/iosapp.build/Script-8F3899DC209D3AE87006491C.sh

Burning app icons...
working in /Users/jason/Library/Developer/Xcode/DerivedData/mapboxgl-app-gjhaotbyabhkrwascyegdaadflha/Build/Products/Debug-iphonesimulator/Mapbox GL.app
burning file ./Icon-40.png
burning caption:
gl-native\nicon-burning\nb0a8017
libpng warning: Input PNG is not optimized for iPhone OS.  Copying source file to destination...
image dimensions 40x40 - band height 18 @ 22 - point size 5
burned ./Icon-40.png
burning file ./Icon-40@2x.png
...
burning caption:
gl-native\nicon-burning\nb0a8017
libpng warning: Input PNG is not optimized for iPhone OS.  Copying source file to destination...
image dimensions 114x114 - band height 53 @ 61 - point size 14
burned ./Icon@2x.png
```

Seriously, had to go digging through the [Xcode config generator](https://chromium.googlesource.com/external/gyp/+/master/pylib/gyp/generator/xcode.py) and ["experimental"(?) tests](https://chromium.googlesource.com/experimental/external/gyp/+/master/test/mac/postbuilds/test.gyp) to find `postbuilds`.