### PR TITLE
Painter Render Crash

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -760,7 +760,7 @@ void Map::prepare() {
     assert(Environment::currentlyOn(ThreadType::Map));
 
     const auto u = updated.exchange(static_cast<UpdateType>(Update::Nothing));
-    if (u & static_cast<UpdateType>(Update::StyleInfo)) {
+    if ((u & static_cast<UpdateType>(Update::StyleInfo)) || !style) {
         reloadStyle();
     }
     if (u & static_cast<UpdateType>(Update::Debug)) {
@@ -810,6 +810,7 @@ void Map::render() {
     // Cleanup OpenGL objects that we abandoned since the last render call.
     env->performCleanup();
 
+    assert(style);
     assert(painter);
     painter->render(*style, activeSources,
                     state, data->getAnimationTime());


### PR DESCRIPTION
Close the app, open the app!

```
Thread : Crashed: Map
0  Embark                         0x00000001002ab214 mbgl::Painter::render(mbgl::Style const&, std::__1::set<mbgl::util::ptr<mbgl::StyleSource>, std::__1::less<mbgl::util::ptr<mbgl::StyleSource> >, std::__1::allocator<mbgl::util::ptr<mbgl::StyleSource> > > const&, mbgl::TransformState, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) (memory:3930)
1  Embark                         0x00000001002ab1e4 mbgl::Painter::render(mbgl::Style const&, std::__1::set<mbgl::util::ptr<mbgl::StyleSource>, std::__1::less<mbgl::util::ptr<mbgl::StyleSource> >, std::__1::allocator<mbgl::util::ptr<mbgl::StyleSource> > > const&, mbgl::TransformState, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) (painter.cpp:236)
2  Embark                         0x000000010028fb6c std::__1::__function::__func<mbgl::Map::start(bool)::$_3, std::__1::allocator<mbgl::Map::start(bool)::$_3>, void ()>::operator()() (map.cpp:814)
3  Embark                         0x000000010031d558 uv__async_event (async.c:80)
4  Embark                         0x000000010031d97c uv__async_io (async.c:156)
5  Embark                         0x0000000100329070 uv__io_poll (kqueue.c:233)
6  Embark                         0x000000010031dff4 uv_run (core.c:317)
7  Embark                         0x000000010028da88 mbgl::Map::run() (map.cpp:272)
8  Embark                         0x000000010028fa40 void* std::__1::__thread_proxy<std::__1::tuple<mbgl::Map::start(bool)::$_4> >(void*) (atomic:574)
9  libsystem_pthread.dylib        0x00000001958c7dc8 _pthread_body + 164
10 libsystem_pthread.dylib        0x00000001958c7d24 _pthread_body
```