### PR TITLE
Add simple non-semantic version support to build script

### DIFF
--- a/scripts/build-version.py
+++ b/scripts/build-version.py
@@ -13,6 +13,8 @@ else:
     if sys.argv[2] == sys.argv[3]:
         tag = [0, 0, 0]
     else:
+        if "v" in sys.argv[2][-6:]:
+            sys.argv[2] = sys.argv[2][-6:].replace('v', '.')
         ver = re.sub("[^0-9.]", "", sys.argv[2])
         tag = map(int, ver.split('.'))
         rev = sys.argv[3][0:8]

--- a/scripts/build-version.py
+++ b/scripts/build-version.py
@@ -13,9 +13,11 @@ else:
     if sys.argv[2] == sys.argv[3]:
         tag = [0, 0, 0]
     else:
-	ver = re.sub("[^0-9.]", "", sys.argv[2])
+        ver = re.sub("[^0-9.]", "", sys.argv[2])
         tag = map(int, ver.split('.'))
-    rev = sys.argv[3][0:8]
+        rev = sys.argv[3][0:8]
+        while (len(tag) < 3):
+            tag.append(0)
 
 
 def mkdir_p(path):


### PR DESCRIPTION
With version string ` ios-beta-preview-sirius-1.0v2` I was getting the following Xcode build error:

```
Traceback (most recent call last):
  File "/Users/jason/Documents/Mapbox/mapbox-gl-native/scripts/build-version.py", line 56, in <module>
    patch = tag[2],
IndexError: list index out of range
Command /bin/sh failed with exit code 1
```

My fixes would result in version `1.0.2` in this case, which is wrongish but builds.