### PR TITLE
Metrics: Remote-notifications-enabled support for iOS 7

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -365,10 +365,12 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
         
         NSMutableDictionary *evt = [[NSMutableDictionary alloc] init];
-        [evt setValue:[[NSNumber alloc] initWithDouble:mbglMap->getLatLng().latitude] forKey:@"lat"];
-        [evt setValue:[[NSNumber alloc] initWithDouble:mbglMap->getLatLng().longitude] forKey:@"lng"];
-        [evt setValue:[[NSNumber alloc] initWithDouble:mbglMap->getZoom()] forKey:@"zoom"];
-        [evt setValue:[[NSNumber alloc] initWithBool:[[UIApplication sharedApplication] isRegisteredForRemoteNotifications]] forKey:@"enabled.push"];
+        [evt setValue:@(mbglMap->getLatLng().latitude) forKey:@"lat"];
+        [evt setValue:@(mbglMap->getLatLng().longitude) forKey:@"lng"];
+        [evt setValue:@(mbglMap->getZoom()) forKey:@"zoom"];
+        BOOL isRegisteredForRemoteNotifications = ([[UIApplication sharedApplication] respondsToSelector:@selector(isRegisteredForRemoteNotifications)]
+                                                   && [[UIApplication sharedApplication] isRegisteredForRemoteNotifications]);
+        [evt setValue:@(isRegisteredForRemoteNotifications) forKey:@"enabled.push"];
         
         NSString *email = @"Unknown";
         Class MFMailComposeViewController = NSClassFromString(@"MFMailComposeViewController");

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -368,8 +368,19 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
         [evt setValue:@(mbglMap->getLatLng().latitude) forKey:@"lat"];
         [evt setValue:@(mbglMap->getLatLng().longitude) forKey:@"lng"];
         [evt setValue:@(mbglMap->getZoom()) forKey:@"zoom"];
-        BOOL isRegisteredForRemoteNotifications = ([[UIApplication sharedApplication] respondsToSelector:@selector(isRegisteredForRemoteNotifications)]
-                                                   && [[UIApplication sharedApplication] isRegisteredForRemoteNotifications]);
+        
+        BOOL isRegisteredForRemoteNotifications;
+        if ([[UIApplication sharedApplication] respondsToSelector:@selector(isRegisteredForRemoteNotifications)]) {
+            // iOS 8+
+            isRegisteredForRemoteNotifications = [[UIApplication sharedApplication] isRegisteredForRemoteNotifications];
+        } else {
+            // iOS 7
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            UIRemoteNotificationType types = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+            isRegisteredForRemoteNotifications = (types == UIRemoteNotificationTypeNone) ? NO : YES;
+            #pragma clang diagnostic pop
+        }
         [evt setValue:@(isRegisteredForRemoteNotifications) forKey:@"enabled.push"];
         
         NSString *email = @"Unknown";


### PR DESCRIPTION
Rides on @1ec5's #1127 `[UIApplication isRegisteredForRemoteNotifications]` safety fix for #1117 and adds metrics support for the iOS 7 way of determining remote notification status.

Sorry to jump the gun before #1127 is merged, saw the low hanging fruit and gorged myself on it.