### PR TITLE
fixes #1128: convert metrics BOOLs to strings internally

### DIFF
--- a/include/mbgl/ios/MGLMapboxEvents.h
+++ b/include/mbgl/ios/MGLMapboxEvents.h
@@ -33,7 +33,7 @@ extern NSString *const MGLEventMapLocation;
 
 // You can call these methods from any thread.
 //
-+ (NSString *) checkEmailEnabled;
++ (BOOL) checkEmailEnabled;
 + (BOOL) checkPushEnabled;
 
 // You can call this method from any thread.

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -360,7 +360,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
         @"lng": @(latLng.longitude),
         @"zoom": @(zoom),
         @"enabled.push": @([MGLMapboxEvents checkPushEnabled]),
-        @"enabled.email": [MGLMapboxEvents checkEmailEnabled]
+        @"enabled.email": @([MGLMapboxEvents checkEmailEnabled])
     }];
 
     return YES;

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -216,6 +216,22 @@ NSString *const MGLEventMapLocation = @"Location";
 // use of +pushEvent:withAttributes:.
 //
 - (void) pushEvent:(NSString *)event withAttributes:(NSDictionary *)attributeDictionary {
+    // convert any BOOL types to string values written out like JS
+    NSMutableDictionary *newAttributeDictionary = [NSMutableDictionary dictionaryWithCapacity:[attributeDictionary count]];
+    NSString *key;
+    NSObject *value;
+    for (key in attributeDictionary) {
+        value = attributeDictionary[key];
+        if ([value isKindOfClass:[NSNumber class]]) {
+            // if of character type, treat as bool
+            if (strncmp([(NSNumber *)value objCType], "c", 1) == 0) {
+                value = ([(NSNumber *)value boolValue] ? @"true" : @"false");
+            }
+        }
+        newAttributeDictionary[key] = value;
+    }
+    attributeDictionary = newAttributeDictionary;
+
     __weak MGLMapboxEvents *weakSelf = self;
 
     dispatch_async(_serialQueue, ^{
@@ -546,20 +562,18 @@ NSString *const MGLEventMapLocation = @"Location";
 
 // Can be called from any thread.
 //
-+ (NSString *) checkEmailEnabled {
-    __block NSString *result;
-
-    NSString *(^mailCheckBlock)(void) = ^{
-        NSString *email = @"Unknown";
++ (BOOL) checkEmailEnabled {
+    BOOL (^mailCheckBlock)(void) = ^{
+        BOOL blockResult;
         Class MFMailComposeViewController = NSClassFromString(@"MFMailComposeViewController");
         if (MFMailComposeViewController) {
             SEL canSendMail = NSSelectorFromString(@"canSendMail");
-            BOOL sendMail = ((BOOL (*)(id, SEL))[MFMailComposeViewController methodForSelector:canSendMail])
-            (MFMailComposeViewController, canSendMail);
-            email = [NSString stringWithFormat:@"%i", sendMail];
+            blockResult = ((BOOL (*)(id, SEL))[MFMailComposeViewController methodForSelector:canSendMail])(MFMailComposeViewController, canSendMail);
         }
-        return email;
+        return blockResult;
     };
+
+    __block BOOL result;
 
     if ( ! [[NSThread currentThread] isMainThread]) {
         dispatch_sync(dispatch_get_main_queue(), ^{
@@ -575,22 +589,23 @@ NSString *const MGLEventMapLocation = @"Location";
 // Can be called from any thread.
 //
 + (BOOL) checkPushEnabled {
-    __block BOOL result;
-
     BOOL (^pushCheckBlock)(void) = ^{
+        BOOL blockResult;
         if ([[UIApplication sharedApplication] respondsToSelector:@selector(isRegisteredForRemoteNotifications)]) {
             // iOS 8+
-            result = [[UIApplication sharedApplication] isRegisteredForRemoteNotifications];
+            blockResult = [[UIApplication sharedApplication] isRegisteredForRemoteNotifications];
         } else {
             // iOS 7
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             UIRemoteNotificationType types = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
-            result = (types == UIRemoteNotificationTypeNone) ? NO : YES;
+            blockResult = (types == UIRemoteNotificationTypeNone) ? NO : YES;
 #pragma clang diagnostic pop
         }
-        return result;
+        return blockResult;
     };
+
+    __block BOOL result;
 
     if ( ! [[NSThread currentThread] isMainThread]) {
         dispatch_sync(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
This fixes #1128 and keeps the logic around converting a `BOOL` like `YES` to `true` internal to the metrics engine. 

@bleege Want to take a look? 