### PR TITLE
HTTPRequest handleResponse

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -129,8 +129,15 @@ void Map::start(bool startPaused) {
 
         // Remove all of these to make sure they are destructed in the correct thread.
         style.reset();
+
+        // Since we don't have a stylesheet anymore, this will disable all Sources and cancel
+        // their associated requests.
+        updateSources();
+        assert(activeSources.empty());
+
+        // It's now safe to destroy/join the workers since there won't be any more callbacks that
+        // could dispatch to the worker pool.
         workers.reset();
-        activeSources.clear();
 
         terminating = true;
 


### PR DESCRIPTION
Turn off the connection and scroll around on map,

```ruby
Thread : Crashed: FileSource
0  Embark                         0x000000010025a7f4 mbgl::HTTPRequestImpl::handleResponse() (http_request_nsurl.mm:192)
1  Embark                         0x000000010025a738 mbgl::HTTPRequestImpl::handleResponse() (http_request_nsurl.mm:190)
2  Embark                         0x000000010025b858 uv__async_event (async.c:80)
3  Embark                         0x000000010025bc7c uv__async_io (async.c:156)
4  Embark                         0x0000000100267370 uv__io_poll (kqueue.c:233)
5  Embark                         0x000000010025c2f4 uv_run (core.c:317)
6  Embark                         0x0000000100203198 std::__1::__thread_proxy<std::__1::tuple<mbgl::DefaultFileSource::DefaultFileSource(mbgl::FileCache*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_1> >(void*, void*) (default_file_source.cpp:69)
7  libsystem_pthread.dylib        0x0000000193c27dc8 _pthread_body + 164
8  libsystem_pthread.dylib        0x0000000193c27d24 _pthread_body
```