### PR TITLE
Fixed make test breakage

### DIFF
--- a/gyp/platform-osx.gypi
+++ b/gyp/platform-osx.gypi
@@ -28,6 +28,7 @@
         'ldflags': [
           '-framework ImageIO',
           '-framework CoreServices',
+          '-framework OpenGL',
           '-framework ApplicationServices',
         ],
       },


### PR DESCRIPTION
This PR fixes `make test`, specifically the `Xcode/test` target.

501f9701cd25c004b496dbdf96c8ac45845718be removed OpenGL.framework from the list of frameworks that MapboxGL links against. Unlike iOS, OS X doesn’t consider OpenGL.framework to be a standard library, so `LINK_WITH_STANDARD_LIBRARIES` doesn’t pull it in.

Ref #1099, #1105

/cc @kkaefer