### PR TITLE
Child GLKView should be bottommost child

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -212,7 +212,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     }
     _glView.delegate = self;
     [_glView bindDrawable];
-    [self addSubview:_glView];
+    [self insertSubview:_glView atIndex:0];
 
     _glView.contentMode = UIViewContentModeCenter;
     [self setBackgroundColor:[UIColor clearColor]];


### PR DESCRIPTION
Otherwise, any subviews added to an `MGLMapView` in a XIB or storyboard (#1070) are completely obscured by the `GLKView`, because they’re inserted during the course of `-[UIView initWithCoder:]`, before `-[MGLMapView commonInit]` gets called.