### PR TITLE
fixes #892: support mapbox:// style URLs

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -172,9 +172,18 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     }
 }
 
-- (void)setStyleURL:(NSString *)filePathURL
+- (void)setStyleURL:(NSString *)styleURLString
 {
-    mbglMap->setStyleURL(std::string("asset://") + [filePathURL UTF8String]);
+    std::string styleURL([styleURLString UTF8String]);
+
+    if ( ! [[NSURL URLWithString:styleURLString] scheme])
+    {
+        mbglMap->setStyleURL(std::string("asset://") + styleURL);
+    }
+    else
+    {
+        mbglMap->setStyleURL(styleURL);
+    }
 }
 
 - (BOOL)commonInit

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -400,13 +400,15 @@ void Map::setup() {
 void Map::setStyleURL(const std::string &url) {
     assert(Environment::currentlyOn(ThreadType::Main));
 
-    const size_t pos = url.rfind('/');
+    const std::string styleURL = mbgl::util::mapbox::normalizeStyleURL(url, getAccessToken());
+
+    const size_t pos = styleURL.rfind('/');
     std::string base = "";
     if (pos != std::string::npos) {
-        base = url.substr(0, pos + 1);
+        base = styleURL.substr(0, pos + 1);
     }
 
-    data->setStyleInfo({ url, base, "" });
+    data->setStyleInfo({ styleURL, base, "" });
     triggerUpdate(Update::StyleInfo);
 }
 

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -8,11 +8,12 @@ namespace mapbox {
 
 const std::string mapbox = "mapbox://";
 
-std::string normalizeURL(const std::string& url, const std::string& accessToken) {
+std::string normalizeURL(const std::string& url, const std::string& pathPrefix, const std::string& accessToken) {
     if (accessToken.empty())
         throw std::runtime_error("You must provide a Mapbox API access token for Mapbox tile sources");
 
-    return std::string("https://api.tiles.mapbox.com/v4/")
+    return std::string("https://api.tiles.mapbox.com")
+        + pathPrefix
         + url.substr(mapbox.length())
         + "?access_token="
         + accessToken;
@@ -22,7 +23,7 @@ std::string normalizeSourceURL(const std::string& url, const std::string& access
     if (url.compare(0, mapbox.length(), mapbox) != 0)
         return url;
 
-    std::string result = normalizeURL(url + ".json", accessToken);
+    std::string result = normalizeURL(url + ".json", "/v4/", accessToken);
 
     // TileJSON requests need a secure flag appended to their URLs so
     // that the server knows to send SSL-ified resource references.
@@ -31,11 +32,20 @@ std::string normalizeSourceURL(const std::string& url, const std::string& access
     return result;
 }
 
+std::string normalizeStyleURL(const std::string& url, const std::string& accessToken) {
+    if (url.compare(0, mapbox.length(), mapbox) != 0)
+        return url;
+
+    const std::string user = url.substr(mapbox.length(), url.find('.') - mapbox.length());
+
+    return normalizeURL(url, "/styles/v1/" + user + "/", accessToken);
+}
+
 std::string normalizeGlyphsURL(const std::string& url, const std::string& accessToken) {
     if (url.compare(0, mapbox.length(), mapbox) != 0)
         return url;
 
-    return normalizeURL(url, accessToken);
+    return normalizeURL(url, "/v4/", accessToken);
 }
 
 std::string normalizeTileURL(const std::string& url, const std::string& sourceURL, SourceType sourceType) {

--- a/src/mbgl/util/mapbox.hpp
+++ b/src/mbgl/util/mapbox.hpp
@@ -9,6 +9,7 @@ namespace util {
 namespace mapbox {
 
 std::string normalizeSourceURL(const std::string& url, const std::string& accessToken);
+std::string normalizeStyleURL(const std::string& url, const std::string& accessToken);
 std::string normalizeGlyphsURL(const std::string& url, const std::string& accessToken);
 std::string normalizeTileURL(const std::string& url, const std::string& sourceURL, SourceType sourceType);
 


### PR DESCRIPTION
Addresses #892 and ports over https://github.com/mapbox/mapbox-gl-js/commit/699826a4d5fec8c04fec35d0454f70a6e14db382. 

This lets the user continue to pass a bundled style like `styles/emerald-v7.json` from Cocoa, which will get converted into an `asset://` URL as before. 

But if a style URL like `mapbox://justin.80b0e36d` is passed instead, it gets converted to the style API format and loaded via the regular remote style URL facility. 

One thing I'm not clear on: 

* I'm not quite sure what `base` should be in `StyleInfo`. Does this matter for URL-based styles @kkaefer @jfirebaugh? Going to keep digging into this but can't quite figure it out yet. 