### PR TITLE
[not ready] refs #892: Cocoa support for map ID style URLs

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -33,6 +33,13 @@
 *   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
 - (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken bundledStyleNamed:(NSString *)styleName;
 
+/** Initialize a map view with a given frame, style URL, and access token.
+*   @param frame The frame with which to initialize the map view.
+*   @param accessToken A Mapbox API access token.
+*   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`).
+*   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
+- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(NSURL *)styleURL;
+
 /** Initialize a map view with a given frame, the default style, and an access token.
 *   @param frame The frame with which to initialize the map view.
 *   @param accessToken A Mapbox API access token.

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -196,6 +196,10 @@
 *   @param styleName The map style name to use. */
 - (void)useBundledStyleNamed:(NSString *)styleName;
 
+/** Sets the map style URL to use.
+*   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`). */
+- (void)setStyleURL:(NSURL *)styleURL;
+
 #pragma mark - Annotating the Map
 
 /** @name Annotating the Map */

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -132,6 +132,19 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(NSURL *)styleURL
+{
+    self = [super initWithFrame:frame];
+
+    if (self && [self commonInit])
+    {
+        if (accessToken) [self setAccessToken:accessToken];
+        if (styleURL) [self setStyleURL:[styleURL absoluteString]];
+    }
+
+    return self;
+}
+
 - (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken
 {
     return [self initWithFrame:frame accessToken:accessToken styleJSON:nil];

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -139,7 +139,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     if (self && [self commonInit])
     {
         if (accessToken) [self setAccessToken:accessToken];
-        if (styleURL) [self setStyleURL:[styleURL absoluteString]];
+        if (styleURL) [self setStyleURL:styleURL];
     }
 
     return self;
@@ -185,17 +185,17 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     }
 }
 
-- (void)setStyleURL:(NSString *)styleURLString
+- (void)setStyleURL:(NSURL *)styleURL
 {
-    std::string styleURL([styleURLString UTF8String]);
+    std::string styleURLString([[styleURL absoluteString] UTF8String]);
 
-    if ( ! [[NSURL URLWithString:styleURLString] scheme])
+    if ( ! [styleURL scheme])
     {
-        mbglMap->setStyleURL(std::string("asset://") + styleURL);
+        mbglMap->setStyleURL(std::string("asset://") + styleURLString);
     }
     else
     {
-        mbglMap->setStyleURL(styleURL);
+        mbglMap->setStyleURL(styleURLString);
     }
 }
 
@@ -1320,7 +1320,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     if (isHybrid) {
         styleName = [@"satellite-" stringByAppendingString:[styleName substringFromIndex:[hybridStylePrefix length]]];
     }
-    [self setStyleURL:[NSString stringWithFormat:@"styles/%@.json", styleName]];
+    [self setStyleURL:[NSURL URLWithString:[NSString stringWithFormat:@"styles/%@.json", styleName]]];
     if (isHybrid) {
         [self setStyleClasses:@[@"contours", @"labels"]];
     }


### PR DESCRIPTION
Blocked by https://github.com/mapbox/mapbox-gl-native/pull/1161. 

This adds a Cocoa initializer for map ID style URLs (e.g. `mapbox://<user.style>`). 