### PR TITLE
Fix tile parsing performance regression

### DIFF
--- a/src/mbgl/map/vector_tile.hpp
+++ b/src/mbgl/map/vector_tile.hpp
@@ -22,7 +22,7 @@ private:
     const VectorTileLayer& layer;
     uint64_t id = 0;
     FeatureType type = FeatureType::Unknown;
-    std::unordered_map<uint32_t, uint32_t> properties;
+    pbf tags_pbf;
     pbf geometry_pbf;
 };
 


### PR DESCRIPTION
50b5c1565366e223bf657d68ddac70b25ad13bcf introduced a performance regression for tile parsing, which slowed down parsing by ~50%. More information in https://github.com/mapbox/mapbox-gl-native/commit/50b5c1565366e223bf657d68ddac70b25ad13bcf#commitcomment-10491046