### PR TITLE
Remove usage of stringstream for line dash atlas

### DIFF
--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -33,7 +33,7 @@ private:
     std::atomic<bool> dirty;
     uint32_t texture = 0;
     int nextRow = 0;
-    std::map<std::string, LinePatternPos> positions;
+    std::map<size_t, LinePatternPos> positions;
 };
 
 };


### PR DESCRIPTION
The current implementation of `LineAtlas::getDashPosition` uses STL stringstream to build a string of the float land/gap values to use as a lookup key. This is really slow on iOS. This patch changes the key from a string to a cumulative hash of all floats.

Before (10 seconds of forced rendering):

![instruments 2015-04-01 15-34-36](https://cloud.githubusercontent.com/assets/52399/6942006/a124bbb8-d884-11e4-8eb4-08a108f561f3.png)

After (10 seconds of forced rendering):

![instruments 2015-04-01 15-37-50](https://cloud.githubusercontent.com/assets/52399/6942054/10ca44e2-d885-11e4-834c-f7e21873329a.png)


