### PR TITLE
Use more auto

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -160,7 +160,7 @@ jobject std_vector_string_to_jobject(JNIEnv *env, std::vector<std::string> vecto
         return nullptr;
     }
 
-    for (std::string str : vector) {
+    for (const auto& str : vector) {
         env->CallBooleanMethod(jlist, arrayListAddId, std_string_to_jstring(env, str));
         if (env->ExceptionCheck()) {
             env->ExceptionDescribe();

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -58,7 +58,7 @@ LinePatternPos LineAtlas::addDash(const std::vector<float> &dasharray, bool roun
     }
 
     float length = 0;
-    for (const float &part : dasharray) {
+    for (const float part : dasharray) {
         length += part;
     }
 

--- a/src/mbgl/geometry/static_vertex_buffer.cpp
+++ b/src/mbgl/geometry/static_vertex_buffer.cpp
@@ -4,7 +4,7 @@
 namespace mbgl {
 
 StaticVertexBuffer::StaticVertexBuffer(std::initializer_list<std::pair<int16_t, int16_t>> init) {
-    for (const std::pair<int16_t, int16_t> &vertex : init) {
+    for (const auto& vertex : init) {
         vertex_type *vertices = static_cast<vertex_type *>(addElement());
         vertices[0] = vertex.first;
         vertices[1] = vertex.second;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -749,7 +749,7 @@ void Map::updateSources(const util::ptr<StyleLayerGroup> &group) {
     if (!group) {
         return;
     }
-    for (const util::ptr<StyleLayer> &layer : group->layers) {
+    for (const auto& layer : group->layers) {
         if (!layer) continue;
         if (layer->bucket && layer->bucket->style_source) {
             (*activeSources.emplace(layer->bucket->style_source).first)->enabled = true;
@@ -760,7 +760,7 @@ void Map::updateSources(const util::ptr<StyleLayerGroup> &group) {
 
 void Map::updateTiles() {
     assert(Environment::currentlyOn(ThreadType::Map));
-    for (const auto &source : activeSources) {
+    for (const auto& source : activeSources) {
         source->source->update(*this, getWorker(), style, *glyphAtlas, *glyphStore,
                                *spriteAtlas, getSprite(), *texturePool, [this]() {
             assert(Environment::currentlyOn(ThreadType::Map));

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -78,7 +78,7 @@ void Source::updateClipIDs(const std::map<Tile::ID, ClipID> &mapping) {
 }
 
 void Source::updateMatrices(const mat4 &projMatrix, const TransformState &transform) {
-    for (std::pair<const Tile::ID, std::unique_ptr<Tile>> &pair : tiles) {
+    for (const auto& pair : tiles) {
         Tile &tile = *pair.second;
         transform.matrixFor(tile.matrix, tile.id);
         matrix::multiply(tile.matrix, projMatrix, tile.matrix);
@@ -90,7 +90,7 @@ size_t Source::getTileCount() const {
 }
 
 void Source::drawClippingMasks(Painter &painter) {
-    for (std::pair<const Tile::ID, std::unique_ptr<Tile>> &pair : tiles) {
+    for (const auto& pair : tiles) {
         Tile &tile = *pair.second;
         gl::group group(std::string { "mask: " } + std::string(tile.id));
         painter.drawClippingMask(tile.matrix, tile.clip);
@@ -99,7 +99,7 @@ void Source::drawClippingMasks(Painter &painter) {
 
 void Source::render(Painter &painter, const StyleLayer &layer_desc) {
     gl::group group(std::string { "layer: " } + layer_desc.id);
-    for (const std::pair<const Tile::ID, std::unique_ptr<Tile>> &pair : tiles) {
+    for (const auto& pair : tiles) {
         Tile &tile = *pair.second;
         if (tile.data && tile.data->state == TileData::State::parsed) {
             painter.renderTileLayer(tile, layer_desc, tile.matrix);
@@ -115,7 +115,7 @@ void Source::render(Painter &painter, const StyleLayer &layer_desc, const Tile::
 }
 
 void Source::finishRender(Painter &painter) {
-    for (std::pair<const Tile::ID, std::unique_ptr<Tile>> &pair : tiles) {
+    for (const auto& pair : tiles) {
         Tile &tile = *pair.second;
         painter.renderTileDebug(tile);
     }
@@ -252,7 +252,7 @@ bool Source::findLoadedChildren(const Tile::ID& id, int32_t maxCoveringZoom, std
     bool complete = true;
     int32_t z = id.z;
     auto ids = id.children(z + 1);
-    for (const Tile::ID& child_id : ids) {
+    for (const auto& child_id : ids) {
         const TileData::State state = hasTile(child_id);
         if (state == TileData::State::parsed) {
             retain.emplace_front(child_id);
@@ -314,7 +314,7 @@ void Source::update(Map &map,
     std::forward_list<Tile::ID> retain(required);
 
     // Add existing child/parent tiles if the actual tile is not yet loaded
-    for (const Tile::ID& id : required) {
+    for (const auto& id : required) {
         const TileData::State state = addTile(map, worker, style, glyphAtlas, glyphStore,
                                               spriteAtlas, sprite, texturePool, id, callback);
 

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -56,7 +56,7 @@ void TileParser::parse() {
         return;
     }
 
-    for (const util::ptr<const StyleLayer> &layer_desc : group->layers) {
+    for (const auto& layer_desc : group->layers) {
         // Cancel early when parsing.
         if (obsolete()) {
             return;

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -92,7 +92,7 @@ void FillBucket::tessellate() {
     }
 
     size_t total_vertex_count = 0;
-    for (const std::vector<ClipperLib::IntPoint>& polygon : polygons) {
+    for (const auto& polygon : polygons) {
         total_vertex_count += polygon.size();
     }
 
@@ -109,12 +109,12 @@ void FillBucket::tessellate() {
     line_group_type& lineGroup = *lineGroups.back();
     uint32_t lineIndex = lineGroup.vertex_length;
 
-    for (const std::vector<ClipperLib::IntPoint>& polygon : polygons) {
+    for (const auto& polygon : polygons) {
         const size_t group_count = polygon.size();
         assert(group_count >= 3);
 
         std::vector<TESSreal> clipped_line;
-        for (const ClipperLib::IntPoint& pt : polygon) {
+        for (const auto& pt : polygon) {
             clipped_line.push_back(pt.X);
             clipped_line.push_back(pt.Y);
             vertexBuffer.add(pt.X, pt.Y);

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -296,7 +296,7 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
 
         assert(triangleGroups.back());
         triangle_group_type& group = *triangleGroups.back();
-        for (const TriangleElement& triangle : triangle_store) {
+        for (const auto& triangle : triangle_store) {
             triangleElementsBuffer.add(
                 group.vertex_length + triangle.a,
                 group.vertex_length + triangle.b,
@@ -317,7 +317,7 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
 
         assert(pointGroups.back());
         point_group_type& group = *pointGroups.back();
-        for (PointElement point : point_store) {
+        for (const auto point : point_store) {
             pointElementsBuffer.add(group.vertex_length + point);
         }
 

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -226,7 +226,7 @@ void Painter::render(const Style& style, const std::set<util::ptr<StyleSource>>&
 
     // Update all clipping IDs.
     ClipIDGenerator generator;
-    for (const util::ptr<StyleSource> &source : sources) {
+    for (const auto& source : sources) {
         generator.update(source->source->getLoadedTiles());
         source->source->updateMatrices(projMatrix, state);
     }
@@ -246,7 +246,7 @@ void Painter::render(const Style& style, const std::set<util::ptr<StyleSource>>&
     // This guarantees that we have at least one function per tile called.
     // When only rendering layers via the stylesheet, it's possible that we don't
     // ever visit a tile during rendering.
-    for (const util::ptr<StyleSource> &source : sources) {
+    for (const auto& source : sources) {
         source->source->finishRender(*this);
     }
 }

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -17,7 +17,7 @@ void Painter::drawClippingMasks(const std::set<util::ptr<StyleSource>> &sources)
 
     coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET(0));
 
-    for (const util::ptr<StyleSource> &source : sources) {
+    for (const auto& source : sources) {
         source->source->drawClippingMasks(*this);
     }
 

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -77,7 +77,7 @@ void Painter::renderDebugText(const std::vector<std::string> &strings) {
 
     DebugFontBuffer debugFontBuffer;
     int line = 25;
-    for (const std::string &str : strings) {
+    for (const auto& str : strings) {
         debugFontBuffer.addText(str.c_str(), 10, line, 0.75);
         line += 20;
     }

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -172,7 +172,7 @@ void SymbolBucket::addFeatures(const GeometryTileLayer& layer,
 
     const auto &fontStack = glyphStore.getFontStack(layout.text.font);
 
-    for (const SymbolFeature &feature : features) {
+    for (const auto& feature : features) {
         if (!feature.geometry.size()) continue;
 
         Shaping shaping;
@@ -209,7 +209,7 @@ void SymbolBucket::addFeatures(const GeometryTileLayer& layer,
 
         // if either shaping or icon position is present, add the feature
         if (shaping.size() || image) {
-            for (const std::vector<Coordinate> &line : feature.geometry) {
+            for (const auto& line : feature.geometry) {
                 if (line.size()) {
                     addFeature(line, shaping, face, image);
                 }
@@ -272,7 +272,7 @@ void SymbolBucket::addFeature(const std::vector<Coordinate> &line, const Shaping
     // TODO: figure out correct ascender height.
     const vec2<float> origin = {0, -17};
 
-    for (Anchor &anchor : anchors) {
+    for (auto& anchor : anchors) {
 
         // Calculate the scales at which the text and icons can be first shown without overlap
         Placement glyphPlacement;
@@ -359,7 +359,7 @@ void SymbolBucket::addSymbols(Buffer &buffer, const PlacedGlyphs &symbols, float
 
     const float placementZoom = std::log(scale) / std::log(2) + zoom;
 
-    for (const PlacedGlyph &symbol : symbols) {
+    for (const auto& symbol : symbols) {
         const auto &tl = symbol.tl;
         const auto &tr = symbol.tr;
         const auto &bl = symbol.bl;

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -32,7 +32,7 @@ void StyleLayer::setClasses(const std::vector<std::string> &class_names, const s
 
     // Make sure that we also transition to the fallback value for keys that aren't changed by
     // any applied classes.
-    for (std::pair<const PropertyKey, AppliedClassProperties> &property_pair : appliedStyle) {
+    for (auto& property_pair : appliedStyle) {
         const PropertyKey key = property_pair.first;
         if (already_applied.find(key) != already_applied.end()) {
             // This property has already been set by a previous class, so we don't need to
@@ -66,7 +66,7 @@ void StyleLayer::applyClassProperties(const ClassID class_id,
     // Loop through all the properties in this style, and add transitions to them, if they're
     // not already the most recent transition.
     const ClassProperties &class_properties = style_it->second;
-    for (const std::pair<PropertyKey, PropertyValue> &property_pair : class_properties)  {
+    for (const auto& property_pair : class_properties) {
         PropertyKey key = property_pair.first;
         if (already_applied.find(key) != already_applied.end()) {
             // This property has already been set by a previous class.
@@ -126,7 +126,7 @@ void StyleLayer::applyStyleProperty(PropertyKey key, T &target, const float z, c
         AppliedClassProperties &applied = it->second;
         // Iterate through all properties that we need to apply in order.
         const PropertyEvaluator<T> evaluator(z, zoomHistory);
-        for (AppliedClassProperty &property : applied.properties) {
+        for (auto& property : applied.properties) {
             if (now >= property.begin) {
                 // We overwrite the current property with the new value.
                 target = mapbox::util::apply_visitor(evaluator, property.value);
@@ -144,7 +144,7 @@ void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, cons
         AppliedClassProperties &applied = it->second;
         // Iterate through all properties that we need to apply in order.
         const PropertyEvaluator<T> evaluator(z, zoomHistory);
-        for (AppliedClassProperty &property : applied.properties) {
+        for (auto& property : applied.properties) {
             if (now >= property.end) {
                 // We overwrite the current property with the new value.
                 target = mapbox::util::apply_visitor(evaluator, property.value);
@@ -250,7 +250,7 @@ void StyleLayer::updateProperties(float z, const std::chrono::steady_clock::time
 }
 
 bool StyleLayer::hasTransitions() const {
-    for (const std::pair<PropertyKey, AppliedClassProperties> &pair : appliedStyle) {
+    for (const auto& pair : appliedStyle) {
         if (pair.second.hasTransitions()) {
             return true;
         }

--- a/src/mbgl/style/style_layer_group.cpp
+++ b/src/mbgl/style/style_layer_group.cpp
@@ -4,7 +4,7 @@ namespace mbgl {
 
 void StyleLayerGroup::setClasses(const std::vector<std::string> &class_names, std::chrono::steady_clock::time_point now,
                                  const PropertyTransition &defaultTransition) {
-    for (const util::ptr<StyleLayer> &layer : layers) {
+    for (const auto& layer : layers) {
         if (layer) {
             layer->setClasses(class_names, now, defaultTransition);
         }
@@ -12,7 +12,7 @@ void StyleLayerGroup::setClasses(const std::vector<std::string> &class_names, st
 }
 
 void StyleLayerGroup::updateProperties(float z, std::chrono::steady_clock::time_point now, ZoomHistory &zoomHistory) {
-    for (const util::ptr<StyleLayer> &layer: layers) {
+    for (const auto& layer : layers) {
         if (layer) {
             layer->updateProperties(z, now, zoomHistory);
         }
@@ -20,7 +20,7 @@ void StyleLayerGroup::updateProperties(float z, std::chrono::steady_clock::time_
 }
 
 bool StyleLayerGroup::hasTransitions() const {
-    for (const util::ptr<const StyleLayer> &layer: layers) {
+    for (const auto& layer : layers) {
         if (layer) {
             if (layer->hasTransitions()) {
                 return true;

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -736,7 +736,7 @@ util::ptr<StyleLayer> StyleParser::createLayer(JSVal value) {
 }
 
 void StyleParser::parseLayers() {
-    for (std::pair<const std::string, std::pair<JSVal, util::ptr<StyleLayer>>> &pair : layers) {
+    for (auto &pair : layers) {
         parseLayer(pair.second);
     }
 }

--- a/src/mbgl/text/collision.cpp
+++ b/src/mbgl/text/collision.cpp
@@ -91,7 +91,7 @@ GlyphBox getMergedGlyphs(const GlyphBoxes &boxes, const CollisionAnchor &anchor)
     mergedGlyphs.anchor = anchor;
 
     CollisionRect &box = mergedGlyphs.box;
-    for (const GlyphBox &glyph : boxes) {
+    for (const auto& glyph : boxes) {
         const CollisionRect &gbox = glyph.box;
         box.tl.x = util::min(box.tl.x, gbox.tl.x);
         box.tl.y = util::min(box.tl.y, gbox.tl.y);
@@ -105,7 +105,7 @@ GlyphBox getMergedGlyphs(const GlyphBoxes &boxes, const CollisionAnchor &anchor)
 
 float Collision::getPlacementScale(const GlyphBoxes &glyphs, float minPlacementScale, bool avoidEdges) {
 
-    for (const GlyphBox &glyph : glyphs) {
+    for (const auto& glyph : glyphs) {
         const CollisionRect &box = glyph.box;
         const CollisionRect &bbox = glyph.hBox ? glyph.hBox.get() : glyph.box;
         const CollisionAnchor &anchor = glyph.anchor;
@@ -141,7 +141,7 @@ float Collision::getPlacementScale(const GlyphBoxes &glyphs, float minPlacementS
             const CollisionAnchor &na = anchor; // new anchor
             const CollisionRect &nb = box;      // new box
 
-            for (const PlacementValue &value : blocking) {
+            for (const auto& value : blocking) {
                 const PlacementBox &placement = std::get<1>(value);
                 const CollisionAnchor &oa = placement.anchor; // old anchor
                 const CollisionRect &ob = placement.box;      // old box
@@ -198,7 +198,7 @@ PlacementRange Collision::getPlacementRange(const GlyphBoxes &glyphs, float plac
                                             bool horizontal) {
     PlacementRange placementRange = {{2.0f * M_PI, 0}};
 
-    for (const GlyphBox &glyph : glyphs) {
+    for (const auto& glyph : glyphs) {
         const CollisionRect &bbox = glyph.hBox ? glyph.hBox.get() : glyph.box;
         const CollisionAnchor &anchor = glyph.anchor;
 
@@ -216,7 +216,7 @@ PlacementRange Collision::getPlacementRange(const GlyphBoxes &glyphs, float plac
             cTree.query(bgi::intersects(query_box), std::back_inserter(blocking));
         }
 
-        for (const PlacementValue &value : blocking) {
+        for (const auto& value : blocking) {
             const Box &s = std::get<0>(value);
             const PlacementBox &b = std::get<1>(value);
             const CollisionRect &bbox2 = b.hBox ? b.hBox.get() : b.box;
@@ -265,7 +265,7 @@ void Collision::insert(const GlyphBoxes &glyphs, const CollisionAnchor &anchor,
     std::vector<PlacementValue> allBounds;
     allBounds.reserve(glyphs.size());
 
-    for (const GlyphBox &glyph : glyphs) {
+    for (const auto& glyph : glyphs) {
         const CollisionRect &box = glyph.box;
         const CollisionRect &bbox = glyph.hBox ? glyph.hBox.get() : glyph.box;
 

--- a/src/mbgl/text/glyph_store.cpp
+++ b/src/mbgl/text/glyph_store.cpp
@@ -68,7 +68,7 @@ void align(Shaping &shaping, const float justify, const float horizontalAlign,
     const float shiftX = (justify - horizontalAlign) * maxLineLength;
     const float shiftY = (-verticalAlign * (line + 1) + 0.5) * lineHeight;
 
-    for (PositionedGlyph &glyph : shaping) {
+    for (auto& glyph : shaping) {
         glyph.x += shiftX;
         glyph.y += shiftY;
     }
@@ -251,7 +251,7 @@ void GlyphStore::waitForGlyphRanges(const std::string &fontStack, const std::set
 
         // Attempt to load the glyph range. If the GlyphSet already exists, we are getting back
         // the same shared_future.
-        for (GlyphRange range : glyphRanges) {
+        for (const auto range : glyphRanges) {
             futures.emplace_back(loadGlyphRange(fontStack, rangeSets, range));
         }
     }
@@ -259,7 +259,7 @@ void GlyphStore::waitForGlyphRanges(const std::string &fontStack, const std::set
     // Now that we potentially created all GlyphSets, we are waiting for the results, one by one.
     // When we get a result (or the GlyphSet is aready loaded), we are attempting to parse the
     // GlyphSet.
-    for (std::shared_future<GlyphPBF &> &future : futures) {
+    for (const auto& future : futures) {
         future.get().parse(stack);
     }
 }

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -110,7 +110,7 @@ GlyphBox getMergedBoxes(const GlyphBoxes &glyphs, const Anchor &anchor) {
 
     CollisionRect &box = mergedglyphs.box;
 
-    for (const GlyphBox &glyph : glyphs) {
+    for (const auto& glyph : glyphs) {
         const CollisionRect &gbox = glyph.box;
         box.tl.x = util::min(box.tl.x, gbox.tl.x);
         box.tl.y = util::min(box.tl.y, gbox.tl.y);
@@ -211,7 +211,7 @@ Placement Placement::getGlyphs(Anchor &anchor, const vec2<float> &origin, const 
 
     const uint32_t buffer = 3;
 
-    for (const PositionedGlyph &shape : shaping) {
+    for (const auto& shape : shaping) {
         auto face_it = face.find(shape.glyph);
         if (face_it == face.end())
             continue;
@@ -250,7 +250,7 @@ Placement Placement::getGlyphs(Anchor &anchor, const vec2<float> &origin, const 
 
         const CollisionRect obox{boxScale * x1, boxScale * y1, boxScale * x2, boxScale * y2};
 
-        for (const GlyphInstance &instance : glyphInstances) {
+        for (const auto& instance : glyphInstances) {
             vec2<float> tl = otl;
             vec2<float> tr = otr;
             vec2<float> bl = obl;
@@ -301,7 +301,7 @@ Placement Placement::getGlyphs(Anchor &anchor, const vec2<float> &origin, const 
 
     const float minPlacementScale = anchor.scale;
     placement.minScale = std::numeric_limits<float>::infinity();
-    for (const GlyphBox &box : placement.boxes) {
+    for (const auto& box : placement.boxes) {
         placement.minScale = util::min(placement.minScale, box.minScale);
     }
     placement.minScale = util::max(minPlacementScale, Placement::globalMinScale);

--- a/src/mbgl/text/rotation_range.cpp
+++ b/src/mbgl/text/rotation_range.cpp
@@ -17,7 +17,7 @@ CollisionRange mergeCollisions(const CollisionList &collisions,
     float min = 2.0f * M_PI;
     float max = 0.0f;
 
-    for (CollisionRange collision : collisions) {
+    for (const auto& collision : collisions) {
         bool entryOutside =
             ignoreRange[0] <= collision[0] && collision[0] <= ignoreRange[1];
         bool exitOutside =

--- a/src/mbgl/util/clip_ids.cpp
+++ b/src/mbgl/util/clip_ids.cpp
@@ -18,7 +18,7 @@ ClipIDGenerator::Leaf::Leaf(Tile &tile_) : tile(tile_) {}
 void ClipIDGenerator::Leaf::add(const Tile::ID &p) {
     if (p.isChildOf(tile.id)) {
         // Ensure that no already present child is a parent of the new p.
-        for (const Tile::ID &child : children) {
+        for (const auto& child : children) {
             if (p.isChildOf(child))
                 return;
         }
@@ -31,7 +31,7 @@ bool ClipIDGenerator::Leaf::operator==(const Leaf &other) const {
 }
 
 bool ClipIDGenerator::reuseExisting(Leaf &leaf) {
-    for (const std::vector<Leaf> &pool : pools) {
+    for (const auto& pool : pools) {
         auto existing = std::find(pool.begin(), pool.end(), leaf);
         if (existing != pool.end()) {
             leaf.tile.clip = existing->tile.clip;
@@ -80,7 +80,7 @@ void ClipIDGenerator::update(std::forward_list<Tile *> tiles) {
         // We are starting our count with 1 since we need at least 1 bit set to distinguish between
         // areas without any tiles whatsoever and the current area.
         uint8_t count = 1;
-        for (Leaf &leaf : pool) {
+        for (auto& leaf : pool) {
             leaf.tile.clip.mask = mask;
             leaf.tile.clip.reference = count++ << bit_offset;
         }

--- a/src/mbgl/util/merge_lines.cpp
+++ b/src/mbgl/util/merge_lines.cpp
@@ -41,7 +41,7 @@ std::string
 getKey(const std::u32string &text, const std::vector<std::vector<Coordinate>> &geom, bool onRight) {
     const Coordinate &coord = onRight ? geom[0].back() : geom[0].front();
     std::ostringstream key;
-    for (const char32_t &c : text) {
+    for (const auto c : text) {
         key << (char)c;
     }
     key << ":" << coord.x << ":" << coord.y;

--- a/test/fixtures/fixture_log_observer.cpp
+++ b/test/fixtures/fixture_log_observer.cpp
@@ -28,7 +28,7 @@ bool FixtureLogObserver::onRecord(EventSeverity severity, Event event, int64_t c
 
 size_t FixtureLogObserver::count(const LogMessage &message) const {
     size_t message_count = 0;
-    for (const LogMessage &msg : messages) {
+    for (const auto& msg : messages) {
         if (msg == message) {
             message_count++;
             msg.checked = true;
@@ -39,7 +39,7 @@ size_t FixtureLogObserver::count(const LogMessage &message) const {
 
 std::vector<FixtureLogObserver::LogMessage> FixtureLogObserver::unchecked() const {
     std::vector<LogMessage> unchecked_messages;
-    for (const LogMessage &msg : messages) {
+    for (const auto& msg : messages) {
         if (!msg.checked) {
             unchecked_messages.push_back(msg);
             msg.checked = true;
@@ -50,7 +50,7 @@ std::vector<FixtureLogObserver::LogMessage> FixtureLogObserver::unchecked() cons
 
 ::std::ostream &operator<<(::std::ostream &os,
                            const std::vector<FixtureLogObserver::LogMessage> &messages) {
-    for (const FixtureLogObserver::LogMessage &message : messages) {
+    for (const auto& message : messages) {
         os << "- " << message;
     }
     return os;


### PR DESCRIPTION
In some locations, our iterators created copies of the iterated elements since the loop variable type didn't match the iterator value type. This patch replaces them with `auto` so they're deduced automatically. It also changes lots of other occurrences that had the correct type.