### PR TITLE
Make std::chrono use less painful

### DIFF
--- a/include/mbgl/android/native_map_view.hpp
+++ b/include/mbgl/android/native_map_view.hpp
@@ -25,7 +25,7 @@ public:
     void notify() override;
     void invalidate() override;
 
-    void notifyMapChange(mbgl::MapChange change, std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero()) override;
+    void notifyMapChange(mbgl::MapChange change, Duration delay = Duration::zero()) override;
 
     mbgl::Map &getMap();
     mbgl::DefaultFileSource &getFileSource();

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -2,6 +2,7 @@
 #define MBGL_MAP_MAP
 
 #include <mbgl/map/transform.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/noncopyable.hpp>
@@ -19,7 +20,6 @@
 #include <mutex>
 #include <condition_variable>
 #include <functional>
-#include <chrono>
 
 namespace mbgl {
 
@@ -99,8 +99,8 @@ public:
     void setClasses(const std::vector<std::string>&);
     std::vector<std::string> getClasses() const;
 
-    void setDefaultTransitionDuration(std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    std::chrono::steady_clock::duration getDefaultTransitionDuration();
+    void setDefaultTransitionDuration(Duration = Duration::zero());
+    Duration getDefaultTransitionDuration();
     void setStyleURL(const std::string& url);
     void setStyleJSON(const std::string& json, const std::string& base = "");
     std::string getStyleJSON() const;
@@ -109,20 +109,20 @@ public:
     void cancelTransitions();
 
     // Position
-    void moveBy(double dx, double dy, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setLatLng(LatLng latLng, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void moveBy(double dx, double dy, Duration = Duration::zero());
+    void setLatLng(LatLng latLng, Duration = Duration::zero());
     LatLng getLatLng() const;
     void startPanning();
     void stopPanning();
     void resetPosition();
 
     // Scale
-    void scaleBy(double ds, double cx = -1, double cy = -1, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setScale(double scale, double cx = -1, double cy = -1, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void scaleBy(double ds, double cx = -1, double cy = -1, Duration = Duration::zero());
+    void setScale(double scale, double cx = -1, double cy = -1, Duration = Duration::zero());
     double getScale() const;
-    void setZoom(double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void setZoom(double zoom, Duration = Duration::zero());
     double getZoom() const;
-    void setLatLngZoom(LatLng latLng, double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
     void resetZoom();
     void startScaling();
     void stopScaling();
@@ -130,8 +130,8 @@ public:
     double getMaxZoom() const;
 
     // Rotation
-    void rotateBy(double sx, double sy, double ex, double ey, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setBearing(double degrees, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void rotateBy(double sx, double sy, double ex, double ey, Duration = Duration::zero());
+    void setBearing(double degrees, Duration = Duration::zero());
     void setBearing(double degrees, double cx, double cy);
     double getBearing() const;
     void resetNorth();
@@ -168,7 +168,7 @@ public:
     bool getDebug() const;
 
     inline const TransformState &getState() const { return state; }
-    std::chrono::steady_clock::time_point getTime() const;
+    TimePoint getTime() const;
     inline AnnotationManager& getAnnotationManager() const { return *annotationManager; }
 
 private:

--- a/include/mbgl/map/transform.hpp
+++ b/include/mbgl/map/transform.hpp
@@ -2,6 +2,7 @@
 #define MBGL_MAP_TRANSFORM
 
 #include <mbgl/map/transform_state.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/vec.hpp>
@@ -10,7 +11,6 @@
 #include <cmath>
 #include <forward_list>
 #include <mutex>
-#include <chrono>
 
 namespace mbgl {
 
@@ -27,17 +27,17 @@ public:
                 uint16_t fb_width, uint16_t fb_height);
 
     // Position
-    void moveBy(double dx, double dy, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setLatLng(LatLng latLng, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setLatLngZoom(LatLng latLng, double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void moveBy(double dx, double dy, Duration = Duration::zero());
+    void setLatLng(LatLng latLng, Duration = Duration::zero());
+    void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
     inline const LatLng getLatLng() const { return current.getLatLng(); }
     void startPanning();
     void stopPanning();
 
     // Zoom
-    void scaleBy(double ds, double cx = -1, double cy = -1, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setScale(double scale, double cx = -1, double cy = -1, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setZoom(double zoom, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void scaleBy(double ds, double cx = -1, double cy = -1, Duration = Duration::zero());
+    void setScale(double scale, double cx = -1, double cy = -1, Duration = Duration::zero());
+    void setZoom(double zoom, Duration = Duration::zero());
     double getZoom() const;
     double getScale() const;
     void startScaling();
@@ -46,8 +46,8 @@ public:
     double getMaxZoom() const;
 
     // Angle
-    void rotateBy(double sx, double sy, double ex, double ey, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void setAngle(double angle, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void rotateBy(double sx, double sy, double ex, double ey, Duration = Duration::zero());
+    void setAngle(double angle, Duration = Duration::zero());
     void setAngle(double angle, double cx, double cy);
     double getAngle() const;
     void startRotating();
@@ -55,7 +55,7 @@ public:
 
     // Transitions
     bool needsTransition() const;
-    void updateTransitions(std::chrono::steady_clock::time_point now);
+    void updateTransitions(TimePoint now);
     void cancelTransitions();
 
     // Transform state
@@ -65,10 +65,10 @@ public:
 private:
     // Functions prefixed with underscores will *not* perform any locks. It is the caller's
     // responsibility to lock this object.
-    void _moveBy(double dx, double dy, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void _setScale(double scale, double cx, double cy, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void _setScaleXY(double new_scale, double xn, double yn, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
-    void _setAngle(double angle, std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero());
+    void _moveBy(double dx, double dy, Duration = Duration::zero());
+    void _setScale(double scale, double cx, double cy, Duration = Duration::zero());
+    void _setScaleXY(double new_scale, double xn, double yn, Duration = Duration::zero());
+    void _setAngle(double angle, Duration = Duration::zero());
     void _clearPanning();
     void _clearRotating();
     void _clearScaling();

--- a/include/mbgl/map/view.hpp
+++ b/include/mbgl/map/view.hpp
@@ -1,7 +1,7 @@
 #ifndef MBGL_MAP_VIEW
 #define MBGL_MAP_VIEW
 
-#include <chrono>
+#include <mbgl/util/chrono.hpp>
 
 namespace mbgl {
 
@@ -45,7 +45,7 @@ public:
     // Must not be called from the render thread.
     virtual void notifyMapChange(
         MapChange change,
-        std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero());
+        Duration delay = Duration::zero());
 
 protected:
     // Resizes the view

--- a/include/mbgl/util/chrono.hpp
+++ b/include/mbgl/util/chrono.hpp
@@ -1,0 +1,16 @@
+#ifndef MBGL_UTIL_CHRONO
+#define MBGL_UTIL_CHRONO
+
+#include <chrono>
+
+namespace mbgl {
+
+using Clock = std::chrono::steady_clock;
+using SystemClock = std::chrono::system_clock;
+
+using TimePoint = Clock::time_point;
+using Duration  = Clock::duration;
+
+}
+
+#endif

--- a/platform/default/http_request_curl.cpp
+++ b/platform/default/http_request_curl.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/storage/default/http_request.hpp>
 #include <mbgl/storage/default/http_context.hpp>
 #include <mbgl/storage/response.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/platform/log.hpp>
 
 #include <mbgl/util/time.hpp>
@@ -551,7 +552,7 @@ int64_t parseCacheControl(const char *value) {
         // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
         if (std::sscanf(value, "max-age=%llu", &seconds) == 1) {
             return std::chrono::duration_cast<std::chrono::seconds>(
-                       std::chrono::system_clock::now().time_since_epoch()).count() +
+                       SystemClock::now().time_since_epoch()).count() +
                    seconds;
         }
     }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -456,12 +456,12 @@ void Map::cancelTransitions() {
 
 #pragma mark - Position
 
-void Map::moveBy(double dx, double dy, std::chrono::steady_clock::duration duration) {
+void Map::moveBy(double dx, double dy, Duration duration) {
     transform.moveBy(dx, dy, duration);
     triggerUpdate();
 }
 
-void Map::setLatLng(LatLng latLng, std::chrono::steady_clock::duration duration) {
+void Map::setLatLng(LatLng latLng, Duration duration) {
     transform.setLatLng(latLng, duration);
     triggerUpdate();
 }
@@ -490,12 +490,12 @@ void Map::resetPosition() {
 
 #pragma mark - Scale
 
-void Map::scaleBy(double ds, double cx, double cy, std::chrono::steady_clock::duration duration) {
+void Map::scaleBy(double ds, double cx, double cy, Duration duration) {
     transform.scaleBy(ds, cx, cy, duration);
     triggerUpdate();
 }
 
-void Map::setScale(double scale, double cx, double cy, std::chrono::steady_clock::duration duration) {
+void Map::setScale(double scale, double cx, double cy, Duration duration) {
     transform.setScale(scale, cx, cy, duration);
     triggerUpdate();
 }
@@ -504,7 +504,7 @@ double Map::getScale() const {
     return transform.getScale();
 }
 
-void Map::setZoom(double zoom, std::chrono::steady_clock::duration duration) {
+void Map::setZoom(double zoom, Duration duration) {
     transform.setZoom(zoom, duration);
     triggerUpdate();
 }
@@ -513,7 +513,7 @@ double Map::getZoom() const {
     return transform.getZoom();
 }
 
-void Map::setLatLngZoom(LatLng latLng, double zoom, std::chrono::steady_clock::duration duration) {
+void Map::setLatLngZoom(LatLng latLng, double zoom, Duration duration) {
     transform.setLatLngZoom(latLng, zoom, duration);
     triggerUpdate();
 }
@@ -543,12 +543,12 @@ double Map::getMaxZoom() const {
 
 #pragma mark - Rotation
 
-void Map::rotateBy(double sx, double sy, double ex, double ey, std::chrono::steady_clock::duration duration) {
+void Map::rotateBy(double sx, double sy, double ex, double ey, Duration duration) {
     transform.rotateBy(sx, sy, ex, ey, duration);
     triggerUpdate();
 }
 
-void Map::setBearing(double degrees, std::chrono::steady_clock::duration duration) {
+void Map::setBearing(double degrees, Duration duration) {
     transform.setAngle(-degrees * M_PI / 180, duration);
     triggerUpdate();
 }
@@ -671,7 +671,7 @@ bool Map::getDebug() const {
     return data->getDebug();
 }
 
-std::chrono::steady_clock::time_point Map::getTime() const {
+TimePoint Map::getTime() const {
     return data->getAnimationTime();
 }
 
@@ -700,14 +700,14 @@ std::vector<std::string> Map::getClasses() const {
     return data->getClasses();
 }
 
-void Map::setDefaultTransitionDuration(std::chrono::steady_clock::duration duration) {
+void Map::setDefaultTransitionDuration(Duration duration) {
     assert(Environment::currentlyOn(ThreadType::Main));
 
     data->setDefaultTransitionDuration(duration);
     triggerUpdate(Update::DefaultTransitionDuration);
 }
 
-std::chrono::steady_clock::duration Map::getDefaultTransitionDuration() {
+Duration Map::getDefaultTransitionDuration() {
     assert(Environment::currentlyOn(ThreadType::Main));
     return data->getDefaultTransitionDuration();
 }
@@ -829,7 +829,7 @@ void Map::prepare() {
 
     // Update transform transitions.
 
-    const auto animationTime = std::chrono::steady_clock::now();
+    const auto animationTime = Clock::now();
     data->setAnimationTime(animationTime);
     if (transform.needsTransition()) {
         transform.updateTransitions(animationTime);

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -1,10 +1,11 @@
 #ifndef MBGL_MAP_MAP_DATA
 #define MBGL_MAP_MAP_DATA
 
+#include <mbgl/util/chrono.hpp>
+
 #include <string>
 #include <mutex>
 #include <atomic>
-#include <chrono>
 #include <vector>
 
 namespace mbgl {
@@ -20,8 +21,8 @@ class MapData {
 
 public:
     inline MapData() {
-        setAnimationTime(std::chrono::steady_clock::time_point::min());
-        setDefaultTransitionDuration(std::chrono::steady_clock::duration::zero());
+        setAnimationTime(TimePoint::min());
+        setDefaultTransitionDuration(Duration::zero());
     }
 
     inline StyleInfo getStyleInfo() const {
@@ -70,19 +71,19 @@ public:
         debug = value;
     }
 
-    inline std::chrono::steady_clock::time_point getAnimationTime() const {
-        // We're casting the time_point to and from a duration because libstdc++
-        // has a bug that doesn't allow time_points to be atomic.
-        return std::chrono::steady_clock::time_point(animationTime);
+    inline TimePoint getAnimationTime() const {
+        // We're casting the TimePoint to and from a Duration because libstdc++
+        // has a bug that doesn't allow TimePoints to be atomic.
+        return TimePoint(animationTime);
     }
-    inline void setAnimationTime(std::chrono::steady_clock::time_point timePoint) {
+    inline void setAnimationTime(TimePoint timePoint) {
         animationTime = timePoint.time_since_epoch();
     };
 
-    inline std::chrono::steady_clock::duration getDefaultTransitionDuration() const {
+    inline Duration getDefaultTransitionDuration() const {
         return defaultTransitionDuration;
     }
-    inline void setDefaultTransitionDuration(std::chrono::steady_clock::duration duration) {
+    inline void setDefaultTransitionDuration(Duration duration) {
         defaultTransitionDuration = duration;
     };
 
@@ -93,8 +94,8 @@ private:
     std::string accessToken;
     std::vector<std::string> classes;
     std::atomic<uint8_t> debug { false };
-    std::atomic<std::chrono::steady_clock::time_point::duration> animationTime;
-    std::atomic<std::chrono::steady_clock::duration> defaultTransitionDuration;
+    std::atomic<Duration> animationTime;
+    std::atomic<Duration> defaultTransitionDuration;
 };
 
 }

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -8,12 +8,12 @@
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/ptr.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <cstdint>
 #include <forward_list>
 #include <iosfwd>
 #include <map>
-#include <chrono>
 
 namespace mbgl {
 
@@ -68,7 +68,7 @@ private:
     bool loaded = false;
 
     // Stores the time when this source was most recently updated.
-    std::chrono::steady_clock::time_point updated = std::chrono::steady_clock::time_point::min();
+    TimePoint updated = TimePoint::min();
 
     std::map<Tile::ID, std::unique_ptr<Tile>> tiles;
     std::map<Tile::ID, std::weak_ptr<TileData>> tile_data;

--- a/src/mbgl/map/view.cpp
+++ b/src/mbgl/map/view.cpp
@@ -13,7 +13,7 @@ void View::resize(uint16_t width, uint16_t height, float ratio, uint16_t fbWidth
     map->resize(width, height, ratio, fbWidth, fbHeight);
 }
 
-void View::notifyMapChange(MapChange, std::chrono::steady_clock::duration) {
+void View::notifyMapChange(MapChange, Duration) {
     // no-op
 }
 

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -3,11 +3,11 @@
 using namespace mbgl;
 
 // Record frame history that will be used to calculate fading params
-void FrameHistory::record(std::chrono::steady_clock::time_point now, float zoom) {
+void FrameHistory::record(TimePoint now, float zoom) {
     // first frame ever
     if (!history.size()) {
-        history.emplace_back(FrameSnapshot{std::chrono::steady_clock::time_point::min(), zoom});
-        history.emplace_back(FrameSnapshot{std::chrono::steady_clock::time_point::min(), zoom});
+        history.emplace_back(FrameSnapshot{TimePoint::min(), zoom});
+        history.emplace_back(FrameSnapshot{TimePoint::min(), zoom});
     }
 
     if (history.size() > 0 || history.back().z != zoom) {
@@ -15,7 +15,7 @@ void FrameHistory::record(std::chrono::steady_clock::time_point now, float zoom)
     }
 }
 
-bool FrameHistory::needsAnimation(const std::chrono::steady_clock::duration duration) const {
+bool FrameHistory::needsAnimation(const Duration duration) const {
     if (!history.size()) {
         return false;
     }
@@ -47,9 +47,8 @@ bool FrameHistory::needsAnimation(const std::chrono::steady_clock::duration dura
     return false;
 }
 
-FadeProperties FrameHistory::getFadeProperties(std::chrono::steady_clock::duration duration)
-{
-    const std::chrono::steady_clock::time_point currentTime = std::chrono::steady_clock::now();
+FadeProperties FrameHistory::getFadeProperties(Duration duration) {
+    const TimePoint currentTime = Clock::now();
 
     // Remove frames until only one is outside the duration, or until there are only three
     while (history.size() > 3 && history[1].now + duration < currentTime) {

--- a/src/mbgl/renderer/frame_history.hpp
+++ b/src/mbgl/renderer/frame_history.hpp
@@ -4,15 +4,15 @@
 #include <deque>
 #include <cassert>
 #include <cmath>
-#include <chrono>
 
 #include <mbgl/platform/platform.hpp>
+#include <mbgl/util/chrono.hpp>
 
 namespace mbgl {
 
 struct FrameSnapshot {
-    explicit inline FrameSnapshot(std::chrono::steady_clock::time_point now_, float z_) : now(now_), z(z_) {}
-    std::chrono::steady_clock::time_point now;
+    explicit inline FrameSnapshot(TimePoint now_, float z_) : now(now_), z(z_) {}
+    TimePoint now;
     float z;
 };
 
@@ -26,10 +26,10 @@ struct FadeProperties {
 class FrameHistory {
 public:
     // Record frame history that will be used to calculate fading params
-    void record(std::chrono::steady_clock::time_point now, float zoom);
+    void record(TimePoint now, float zoom);
 
-    bool needsAnimation(std::chrono::steady_clock::duration duration) const;
-    FadeProperties getFadeProperties(std::chrono::steady_clock::duration duration);
+    bool needsAnimation(Duration) const;
+    FadeProperties getFadeProperties(Duration);
 
 public:
     std::deque<FrameSnapshot> history;

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -216,7 +216,7 @@ void Painter::prepareTile(const Tile& tile) {
 }
 
 void Painter::render(const Style& style, const std::set<util::ptr<StyleSource>>& sources,
-                     TransformState state_, std::chrono::steady_clock::time_point time) {
+                     TransformState state_, TimePoint time) {
     state = state_;
 
     clear();

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -24,11 +24,11 @@
 
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/util/ptr.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <map>
 #include <unordered_map>
 #include <set>
-#include <chrono>
 
 namespace mbgl {
 
@@ -78,7 +78,7 @@ public:
     void render(const Style& style,
                 const std::set<util::ptr<StyleSource>>& sources,
                 TransformState state,
-                std::chrono::steady_clock::time_point time);
+                TimePoint time);
 
     void renderLayer(const StyleLayer &layer_desc, const Tile::ID* id = nullptr, const mat4* matrix = nullptr);
 

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -10,6 +10,7 @@
 #include <mbgl/util/util.hpp>
 
 #include <mbgl/util/variant.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/platform/log.hpp>
 
 #pragma GCC diagnostic push
@@ -200,7 +201,7 @@ void DefaultFileSource::process(ResultAction &action) {
         if (action.response) {
             // This entry was stored in the cache. Now determine if we need to revalidate.
             const int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
-                                    std::chrono::system_clock::now().time_since_epoch()).count();
+                                    SystemClock::now().time_since_epoch()).count();
             if (action.response->expires > now) {
                 // The response is fresh. We're good to notify the caller.
                 sharedRequest->notify(std::move(action.response), FileCache::Hint::No);

--- a/src/mbgl/style/applied_class_properties.cpp
+++ b/src/mbgl/style/applied_class_properties.cpp
@@ -2,7 +2,7 @@
 
 namespace mbgl {
 
-AppliedClassProperty::AppliedClassProperty(ClassID class_id, std::chrono::steady_clock::time_point begin_, std::chrono::steady_clock::time_point end_, const PropertyValue &value_)
+AppliedClassProperty::AppliedClassProperty(ClassID class_id, TimePoint begin_, TimePoint end_, const PropertyValue &value_)
     : name(class_id),
     begin(begin_),
     end(end_),
@@ -13,7 +13,7 @@ ClassID AppliedClassProperties::mostRecent() const {
     return properties.size() ? properties.back().name : ClassID::Fallback;
 }
 
-void AppliedClassProperties::add(ClassID class_id, std::chrono::steady_clock::time_point begin, std::chrono::steady_clock::time_point end, const PropertyValue &value) {
+void AppliedClassProperties::add(ClassID class_id, TimePoint begin, TimePoint end, const PropertyValue &value) {
     properties.emplace_back(class_id, begin, end, value);
 }
 
@@ -23,7 +23,7 @@ bool AppliedClassProperties::hasTransitions() const {
 
 // Erase all items in the property list that are before a completed transition.
 // Then, if the only remaining property is a Fallback value, remove it too.
-void AppliedClassProperties::cleanup(std::chrono::steady_clock::time_point now) {
+void AppliedClassProperties::cleanup(TimePoint now) {
     // Iterate backwards, but without using the rbegin/rend interface since we need forward
     // iterators to use .erase().
     for (auto it = properties.end(), begin = properties.begin(); it != begin;) {

--- a/src/mbgl/style/applied_class_properties.hpp
+++ b/src/mbgl/style/applied_class_properties.hpp
@@ -3,20 +3,20 @@
 
 #include <mbgl/style/property_value.hpp>
 #include <mbgl/style/class_dictionary.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <list>
-#include <chrono>
 
 namespace mbgl {
 
 class AppliedClassProperty {
 public:
-    AppliedClassProperty(ClassID class_id, std::chrono::steady_clock::time_point begin, std::chrono::steady_clock::time_point end, const PropertyValue &value);
+    AppliedClassProperty(ClassID class_id, TimePoint begin, TimePoint end, const PropertyValue &value);
 
 public:
     const ClassID name;
-    const std::chrono::steady_clock::time_point begin;
-    const std::chrono::steady_clock::time_point end;
+    const TimePoint begin;
+    const TimePoint end;
     const PropertyValue value;
 };
 
@@ -28,9 +28,9 @@ public:
 public:
     // Returns the ID of the most recent
     ClassID mostRecent() const;
-    void add(ClassID class_id, std::chrono::steady_clock::time_point begin, std::chrono::steady_clock::time_point end, const PropertyValue &value);
+    void add(ClassID class_id, TimePoint begin, TimePoint end, const PropertyValue &value);
     bool hasTransitions() const;
-    void cleanup(std::chrono::steady_clock::time_point now);
+    void cleanup(TimePoint now);
     bool empty() const;
 };
 

--- a/src/mbgl/style/piecewisefunction_properties.cpp
+++ b/src/mbgl/style/piecewisefunction_properties.cpp
@@ -20,7 +20,7 @@ T PiecewiseConstantFunction<T>::evaluate(float z, const ZoomHistory &zh) const {
     T result;
 
     float fraction = std::fmod(z, 1.0f);
-    float t = std::min((std::chrono::steady_clock::now() - zh.lastIntegerZoomTime) / duration, 1.0f);
+    float t = std::min((Clock::now() - zh.lastIntegerZoomTime) / duration, 1.0f);
     float fromScale = 1.0f;
     float toScale = 1.0f;
     size_t from, to;

--- a/src/mbgl/style/property_transition.hpp
+++ b/src/mbgl/style/property_transition.hpp
@@ -1,14 +1,15 @@
 #ifndef MBGL_STYLE_PROPERTY_TRANSITION
 #define MBGL_STYLE_PROPERTY_TRANSITION
 
+#include <mbgl/util/chrono.hpp>
+
 #include <cstdint>
-#include <chrono>
 
 namespace mbgl {
 
 struct PropertyTransition {
-    std::chrono::steady_clock::duration duration = std::chrono::steady_clock::duration::zero();
-    std::chrono::steady_clock::duration delay = std::chrono::steady_clock::duration::zero();
+    Duration duration = Duration::zero();
+    Duration delay = Duration::zero();
 };
 
 }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -26,14 +26,14 @@ Style::Style()
 Style::~Style() {}
 
 void Style::cascade(const std::vector<std::string>& classes) {
-    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    TimePoint now = Clock::now();
 
     for (const auto& layer : layers) {
         layer->setClasses(classes, now, defaultTransition);
     }
 }
 
-void Style::recalculate(float z, std::chrono::steady_clock::time_point now) {
+void Style::recalculate(float z, TimePoint now) {
     uv::writelock lock(mtx);
 
     zoomHistory.update(z, now);
@@ -47,7 +47,7 @@ const std::string &Style::getSpriteURL() const {
     return sprite_url;
 }
 
-void Style::setDefaultTransitionDuration(std::chrono::steady_clock::duration duration) {
+void Style::setDefaultTransitionDuration(Duration duration) {
     defaultTransition.duration = duration;
 }
 

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -7,11 +7,11 @@
 #include <mbgl/util/uv.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <cstdint>
 #include <string>
 #include <vector>
-#include <chrono>
 
 namespace mbgl {
 
@@ -25,9 +25,9 @@ public:
     void loadJSON(const uint8_t *const data);
 
     void cascade(const std::vector<std::string>&);
-    void recalculate(float z, std::chrono::steady_clock::time_point now);
+    void recalculate(float z, TimePoint now);
 
-    void setDefaultTransitionDuration(std::chrono::steady_clock::duration);
+    void setDefaultTransitionDuration(Duration);
     bool hasTransitions() const;
 
     const std::string &getSpriteURL() const;

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -13,7 +13,7 @@ bool StyleLayer::isBackground() const {
     return type == StyleLayerType::Background;
 }
 
-void StyleLayer::setClasses(const std::vector<std::string> &class_names, const std::chrono::steady_clock::time_point now,
+void StyleLayer::setClasses(const std::vector<std::string> &class_names, const TimePoint now,
                             const PropertyTransition &defaultTransition) {
     // Stores all keys that we have already added transitions for.
     std::set<PropertyKey> already_applied;
@@ -44,8 +44,8 @@ void StyleLayer::setClasses(const std::vector<std::string> &class_names, const s
         if (appliedProperties.mostRecent() != ClassID::Fallback) {
             // This property key hasn't been set by a previous class, so we need to add a transition
             // to the fallback value for that key.
-            const std::chrono::steady_clock::time_point begin = now + defaultTransition.delay;
-            const std::chrono::steady_clock::time_point end = begin + defaultTransition.duration;
+            const TimePoint begin = now + defaultTransition.delay;
+            const TimePoint end = begin + defaultTransition.duration;
             const PropertyValue &value = PropertyFallbackValue::Get(key);
             appliedProperties.add(ClassID::Fallback, begin, end, value);
         }
@@ -54,7 +54,7 @@ void StyleLayer::setClasses(const std::vector<std::string> &class_names, const s
 
 // Helper function for applying all properties of a a single class that haven't been applied yet.
 void StyleLayer::applyClassProperties(const ClassID class_id,
-                                      std::set<PropertyKey> &already_applied, std::chrono::steady_clock::time_point now,
+                                      std::set<PropertyKey> &already_applied, TimePoint now,
                                       const PropertyTransition &defaultTransition) {
     auto style_it = styles.find(class_id);
     if (style_it == styles.end()) {
@@ -82,8 +82,8 @@ void StyleLayer::applyClassProperties(const ClassID class_id,
         if (appliedProperties.mostRecent() != class_id) {
             const PropertyTransition &transition =
                 class_properties.getTransition(key, defaultTransition);
-            const std::chrono::steady_clock::time_point begin = now + transition.delay;
-            const std::chrono::steady_clock::time_point end = begin + transition.duration;
+            const TimePoint begin = now + transition.delay;
+            const TimePoint end = begin + transition.duration;
             const PropertyValue &value = property_pair.second;
             appliedProperties.add(class_id, begin, end, value);
         }
@@ -119,7 +119,7 @@ private:
 };
 
 template <typename T>
-void StyleLayer::applyStyleProperty(PropertyKey key, T &target, const float z, const std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperty(PropertyKey key, T &target, const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
     auto it = appliedStyle.find(key);
     if (it != appliedStyle.end()) {
         AppliedClassProperties &applied = it->second;
@@ -137,7 +137,7 @@ void StyleLayer::applyStyleProperty(PropertyKey key, T &target, const float z, c
 }
 
 template <typename T>
-void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, const float z, const std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
     auto it = appliedStyle.find(key);
     if (it != appliedStyle.end()) {
         AppliedClassProperties &applied = it->second;
@@ -159,7 +159,7 @@ void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, cons
 }
 
 template <>
-void StyleLayer::applyStyleProperties<FillProperties>(const float z, const std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<FillProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
     properties.set<FillProperties>();
     FillProperties &fill = properties.get<FillProperties>();
     applyStyleProperty(PropertyKey::FillAntialias, fill.antialias, z, now, zoomHistory);
@@ -172,7 +172,7 @@ void StyleLayer::applyStyleProperties<FillProperties>(const float z, const std::
 }
 
 template <>
-void StyleLayer::applyStyleProperties<LineProperties>(const float z, const std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<LineProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
     properties.set<LineProperties>();
     LineProperties &line = properties.get<LineProperties>();
     applyTransitionedStyleProperty(PropertyKey::LineOpacity, line.opacity, z, now, zoomHistory);
@@ -186,11 +186,11 @@ void StyleLayer::applyStyleProperties<LineProperties>(const float z, const std::
     applyStyleProperty(PropertyKey::LineImage, line.image, z, now, zoomHistory);
 
     // for scaling dasharrays
-    applyStyleProperty(PropertyKey::LineWidth, line.dash_line_width, std::floor(z), std::chrono::steady_clock::time_point::max(), zoomHistory);
+    applyStyleProperty(PropertyKey::LineWidth, line.dash_line_width, std::floor(z), TimePoint::max(), zoomHistory);
 }
 
 template <>
-void StyleLayer::applyStyleProperties<SymbolProperties>(const float z, const std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<SymbolProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
     properties.set<SymbolProperties>();
     SymbolProperties &symbol = properties.get<SymbolProperties>();
     applyTransitionedStyleProperty(PropertyKey::IconOpacity, symbol.icon.opacity, z, now, zoomHistory);
@@ -214,7 +214,7 @@ void StyleLayer::applyStyleProperties<SymbolProperties>(const float z, const std
 }
 
 template <>
-void StyleLayer::applyStyleProperties<RasterProperties>(const float z, const std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<RasterProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
     properties.set<RasterProperties>();
     RasterProperties &raster = properties.get<RasterProperties>();
     applyTransitionedStyleProperty(PropertyKey::RasterOpacity, raster.opacity, z, now, zoomHistory);
@@ -227,7 +227,7 @@ void StyleLayer::applyStyleProperties<RasterProperties>(const float z, const std
 }
 
 template <>
-void StyleLayer::applyStyleProperties<BackgroundProperties>(const float z, const std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<BackgroundProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
     properties.set<BackgroundProperties>();
     BackgroundProperties &background = properties.get<BackgroundProperties>();
     applyTransitionedStyleProperty(PropertyKey::BackgroundOpacity, background.opacity, z, now, zoomHistory);
@@ -235,7 +235,7 @@ void StyleLayer::applyStyleProperties<BackgroundProperties>(const float z, const
     applyStyleProperty(PropertyKey::BackgroundImage, background.image, z, now, zoomHistory);
 }
 
-void StyleLayer::updateProperties(float z, const std::chrono::steady_clock::time_point now, ZoomHistory &zoomHistory) {
+void StyleLayer::updateProperties(float z, const TimePoint now, ZoomHistory &zoomHistory) {
     cleanupAppliedStyleProperties(now);
 
     switch (type) {
@@ -258,7 +258,7 @@ bool StyleLayer::hasTransitions() const {
 }
 
 
-void StyleLayer::cleanupAppliedStyleProperties(std::chrono::steady_clock::time_point now) {
+void StyleLayer::cleanupAppliedStyleProperties(TimePoint now) {
     auto it = appliedStyle.begin();
     const auto end = appliedStyle.end();
     while (it != end) {

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -9,12 +9,12 @@
 
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <vector>
 #include <string>
 #include <map>
 #include <set>
-#include <chrono>
 
 namespace mbgl {
 
@@ -37,10 +37,10 @@ public:
 
     // Updates the StyleProperties information in this layer by evaluating all
     // pending transitions and applied classes in order.
-    void updateProperties(float z, std::chrono::steady_clock::time_point now, ZoomHistory &zoomHistory);
+    void updateProperties(float z, TimePoint now, ZoomHistory &zoomHistory);
 
     // Sets the list of classes and creates transitions to the currently applied values.
-    void setClasses(const std::vector<std::string> &class_names, std::chrono::steady_clock::time_point now,
+    void setClasses(const std::vector<std::string> &class_names, TimePoint now,
                     const PropertyTransition &defaultTransition);
 
     bool hasTransitions() const;
@@ -48,16 +48,16 @@ public:
 private:
     // Applies all properties from a class, if they haven't been applied already.
     void applyClassProperties(ClassID class_id, std::set<PropertyKey> &already_applied,
-                              std::chrono::steady_clock::time_point now, const PropertyTransition &defaultTransition);
+                              TimePoint now, const PropertyTransition &defaultTransition);
 
     // Sets the properties of this object by evaluating all pending transitions and
     // aplied classes in order.
-    template <typename T> void applyStyleProperties(float z, std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory);
-    template <typename T> void applyStyleProperty(PropertyKey key, T &, float z, std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory);
-    template <typename T> void applyTransitionedStyleProperty(PropertyKey key, T &, float z, std::chrono::steady_clock::time_point now, const ZoomHistory &zoomHistory);
+    template <typename T> void applyStyleProperties(float z, TimePoint now, const ZoomHistory &zoomHistory);
+    template <typename T> void applyStyleProperty(PropertyKey key, T &, float z, TimePoint now, const ZoomHistory &zoomHistory);
+    template <typename T> void applyTransitionedStyleProperty(PropertyKey key, T &, float z, TimePoint now, const ZoomHistory &zoomHistory);
 
     // Removes all expired style transitions.
-    void cleanupAppliedStyleProperties(std::chrono::steady_clock::time_point now);
+    void cleanupAppliedStyleProperties(TimePoint now);
 
 public:
     // The name of this layer.

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -385,7 +385,7 @@ std::tuple<bool, Function<T>> StyleParser::parseFunction(JSVal value, const char
 }
 
 template <typename T>
-std::tuple<bool, PiecewiseConstantFunction<T>> StyleParser::parsePiecewiseConstantFunction(JSVal value, std::chrono::steady_clock::duration duration) {
+std::tuple<bool, PiecewiseConstantFunction<T>> StyleParser::parsePiecewiseConstantFunction(JSVal value, Duration duration) {
     if (!value.HasMember("stops")) {
         Log::Warning(Event::ParseStyle, "function must specify a function type");
         return std::tuple<bool, PiecewiseConstantFunction<T>> { false, {} };
@@ -577,7 +577,7 @@ template<> std::tuple<bool, PropertyTransition> StyleParser::parseProperty(JSVal
         }
     }
 
-    if (transition.duration == std::chrono::steady_clock::duration::zero() && transition.delay == std::chrono::steady_clock::duration::zero()) {
+    if (transition.duration == Duration::zero() && transition.delay == Duration::zero()) {
         return std::tuple<bool, PropertyTransition> { false, std::move(transition) };
     }
 
@@ -642,7 +642,7 @@ template<> std::tuple<bool, Function<Color>> StyleParser::parseProperty(JSVal va
 }
 
 template<> std::tuple<bool, PiecewiseConstantFunction<Faded<std::vector<float>>>> StyleParser::parseProperty(JSVal value, const char *property_name, JSVal transition) {
-    std::chrono::steady_clock::duration duration = std::chrono::milliseconds(300);
+    Duration duration = std::chrono::milliseconds(300);
     if (transition.HasMember("duration")) {
         duration = std::chrono::milliseconds(transition["duration"].GetUint());
     }
@@ -662,7 +662,7 @@ template<> std::tuple<bool, PiecewiseConstantFunction<Faded<std::vector<float>>>
 
 template<> std::tuple<bool, PiecewiseConstantFunction<Faded<std::string>>> StyleParser::parseProperty(JSVal value, const char *property_name, JSVal transition) {
 
-    std::chrono::steady_clock::duration duration = std::chrono::milliseconds(300);
+    Duration duration = std::chrono::milliseconds(300);
     if (transition.HasMember("duration")) {
         duration = std::chrono::milliseconds(transition["duration"].GetUint());
     }

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -79,7 +79,7 @@ private:
     template <typename T>
     std::tuple<bool, Function<T>> parseFunction(JSVal value, const char *);
     template <typename T>
-    std::tuple<bool, PiecewiseConstantFunction<T>> parsePiecewiseConstantFunction(JSVal value, std::chrono::steady_clock::duration duration);
+    std::tuple<bool, PiecewiseConstantFunction<T>> parsePiecewiseConstantFunction(JSVal value, Duration duration);
     template <typename T>
     std::tuple<bool, std::vector<std::pair<float, T>>> parseStops(JSVal value, const char *property_name);
 

--- a/src/mbgl/style/zoom_history.hpp
+++ b/src/mbgl/style/zoom_history.hpp
@@ -1,7 +1,8 @@
 #ifndef MBGL_STYLE_ZOOM_HISTORY
 #define MBGL_STYLE_ZOOM_HISTORY
 
-#include <chrono>
+#include <mbgl/util/chrono.hpp>
+
 #include <cmath>
 
 namespace mbgl {
@@ -9,15 +10,15 @@ namespace mbgl {
 struct ZoomHistory {
     float lastZoom;
     float lastIntegerZoom;
-    std::chrono::steady_clock::time_point lastIntegerZoomTime;
+    TimePoint lastIntegerZoomTime;
     bool first = true;
 
-    void update(float z, std::chrono::steady_clock::time_point now) {
+    void update(float z, TimePoint now) {
         if (first) {
             first = false;
 
             lastIntegerZoom = std::floor(z);
-            lastIntegerZoomTime = std::chrono::steady_clock::time_point(std::chrono::steady_clock::duration(0));
+            lastIntegerZoomTime = TimePoint(Duration(0));
             lastZoom = z;
         }
 

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -91,7 +91,7 @@ void Raster::bind(const GLuint custom_texture) {
 }
 
 void Raster::beginFadeInTransition() {
-    std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
+    TimePoint start = Clock::now();
     fade_transition = std::make_shared<util::ease_transition<double>>(opacity, 1.0, opacity, start, std::chrono::milliseconds(250));
 }
 
@@ -99,7 +99,7 @@ bool Raster::needsTransition() const {
     return fade_transition != nullptr;
 }
 
-void Raster::updateTransitions(std::chrono::steady_clock::time_point now) {
+void Raster::updateTransitions(TimePoint now) {
     if (fade_transition->update(now) == util::transition::complete) {
         fade_transition = nullptr;
     }

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -5,10 +5,10 @@
 #include <mbgl/util/texture_pool.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/ptr.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <string>
 #include <mutex>
-#include <chrono>
 
 typedef struct uv_loop_s uv_loop_t;
 
@@ -35,7 +35,7 @@ public:
     // transitions
     void beginFadeInTransition();
     bool needsTransition() const;
-    void updateTransitions(std::chrono::steady_clock::time_point now);
+    void updateTransitions(TimePoint now);
 
 public:
     // loaded image dimensions

--- a/src/mbgl/util/stopwatch.cpp
+++ b/src/mbgl/util/stopwatch.cpp
@@ -9,19 +9,19 @@
 using namespace mbgl::util;
 
 stopwatch::stopwatch(Event event_)
-    : event(event_), start(std::chrono::steady_clock::now()) {}
+    : event(event_), start(Clock::now()) {}
 
 stopwatch::stopwatch(EventSeverity severity_, Event event_)
-    : severity(severity_), event(event_), start(std::chrono::steady_clock::now()) {}
+    : severity(severity_), event(event_), start(Clock::now()) {}
 
 stopwatch::stopwatch(const std::string &name_, Event event_)
-    : name(name_), event(event_), start(std::chrono::steady_clock::now()) {}
+    : name(name_), event(event_), start(Clock::now()) {}
 
 stopwatch::stopwatch(const std::string &name_, EventSeverity severity_, Event event_)
-    : name(name_), severity(severity_), event(event_), start(std::chrono::steady_clock::now()) {}
+    : name(name_), severity(severity_), event(event_), start(Clock::now()) {}
 
 void stopwatch::report(const std::string &name_) {
-    std::chrono::steady_clock::duration duration = std::chrono::steady_clock::now() - start;
+    Duration duration = Clock::now() - start;
 
     Log::Record(severity, event, name_ + ": " + util::toString(std::chrono::duration_cast<std::chrono::milliseconds>(duration).count()) + "ms");
     start += duration;

--- a/src/mbgl/util/stopwatch.hpp
+++ b/src/mbgl/util/stopwatch.hpp
@@ -2,9 +2,9 @@
 #define MBGL_UTIL_STOPWATCH
 
 #include <mbgl/platform/event.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <string>
-#include <chrono>
 
 namespace mbgl {
 namespace util {
@@ -23,7 +23,7 @@ private:
     const std::string name;
     EventSeverity severity = EventSeverity::Debug;
     Event event = Event::General;
-    std::chrono::steady_clock::time_point start;
+    TimePoint start;
 };
 #else
 class stopwatch {

--- a/src/mbgl/util/transition.cpp
+++ b/src/mbgl/util/transition.cpp
@@ -10,7 +10,7 @@ UnitBezier ease(0, 0, 0.25, 1);
 transition::~transition() {}
 
 template <typename T>
-transition::state ease_transition<T>::update(std::chrono::steady_clock::time_point now) const {
+transition::state ease_transition<T>::update(TimePoint now) const {
     float t = progress(now);
     if (t >= 1) {
         value = to;

--- a/src/mbgl/util/transition.hpp
+++ b/src/mbgl/util/transition.hpp
@@ -2,7 +2,7 @@
 #define MBGL_UTIL_TRANSITION
 
 #include <mbgl/util/noncopyable.hpp>
-#include <chrono>
+#include <mbgl/util/chrono.hpp>
 
 namespace mbgl {
 namespace util {
@@ -14,35 +14,35 @@ public:
         complete
     };
 
-    inline transition(std::chrono::steady_clock::time_point start_, std::chrono::steady_clock::duration duration_)
+    inline transition(TimePoint start_, Duration duration_)
         : start(start_),
           duration(duration_) {}
 
-    inline float progress(std::chrono::steady_clock::time_point now) const {
-        if (duration == std::chrono::steady_clock::duration::zero()) return 1;
+    inline float progress(TimePoint now) const {
+        if (duration == Duration::zero()) return 1;
         if (start > now) return 0;
 
         return std::chrono::duration<float>(now - start) / duration;
     }
 
-    virtual state update(std::chrono::steady_clock::time_point now) const = 0;
+    virtual state update(TimePoint now) const = 0;
     virtual ~transition();
 
 protected:
-    const std::chrono::steady_clock::time_point start;
-    const std::chrono::steady_clock::duration duration;
+    const TimePoint start;
+    const Duration duration;
 };
 
 template <typename T>
 class ease_transition : public transition {
 public:
-    ease_transition(T from_, T to_, T& value_, std::chrono::steady_clock::time_point start_, std::chrono::steady_clock::duration duration_)
+    ease_transition(T from_, T to_, T& value_, TimePoint start_, Duration duration_)
         : transition(start_, duration_),
           from(from_),
           to(to_),
           value(value_) {}
 
-    state update(std::chrono::steady_clock::time_point now) const;
+    state update(TimePoint now) const;
 
 private:
     const T from, to;
@@ -53,12 +53,12 @@ private:
 template <typename T>
 class timeout : public transition {
 public:
-    timeout(T final_value_, T& value_, std::chrono::steady_clock::time_point start_, std::chrono::steady_clock::duration duration_)
+    timeout(T final_value_, T& value_, TimePoint start_, Duration duration_)
         : transition(start_, duration_),
           final_value(final_value_),
           value(value_) {}
 
-    state update(std::chrono::steady_clock::time_point now) const {
+    state update(TimePoint now) const {
         if (progress(now) >= 1) {
             value = final_value;
             return complete;

--- a/test/storage/http_header_parsing.cpp
+++ b/test/storage/http_header_parsing.cpp
@@ -3,6 +3,7 @@
 #include <uv.h>
 
 #include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <cmath>
 
@@ -29,7 +30,7 @@ TEST_F(Storage, HTTPHeaderParsing) {
     });
 
     int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
-                       std::chrono::system_clock::now().time_since_epoch()).count();
+                       SystemClock::now().time_since_epoch()).count();
 
     fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" },
                uv_default_loop(), env, [&](const Response &res) {


### PR DESCRIPTION
Core of this is

```diff
+namespace mbgl {
+
+using clock = std::chrono::steady_clock;
+
+using time_point = clock::time_point;
+using duration   = clock::duration;
+
+}
```