### PR TITLE
Rework easing transition code

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/map/transform.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/map/update.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/noncopyable.hpp>
@@ -76,14 +77,6 @@ public:
     void render();
 
     // Notifies the Map thread that the state has changed and an update might be necessary.
-    using UpdateType = uint32_t;
-    enum class Update : UpdateType {
-        Nothing                   = 0,
-        StyleInfo                 = 1 << 0,
-        Debug                     = 1 << 1,
-        DefaultTransitionDuration = 1 << 2,
-        Classes                   = 1 << 3,
-    };
     void triggerUpdate(Update = Update::Nothing);
 
     // Triggers a render. Can be called from any thread.

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -105,8 +105,6 @@ public:
     void moveBy(double dx, double dy, Duration = Duration::zero());
     void setLatLng(LatLng latLng, Duration = Duration::zero());
     LatLng getLatLng() const;
-    void startPanning();
-    void stopPanning();
     void resetPosition();
 
     // Scale
@@ -117,8 +115,6 @@ public:
     double getZoom() const;
     void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
     void resetZoom();
-    void startScaling();
-    void stopScaling();
     double getMinZoom() const;
     double getMaxZoom() const;
 
@@ -128,8 +124,6 @@ public:
     void setBearing(double degrees, double cx, double cy);
     double getBearing() const;
     void resetNorth();
-    void startRotating();
-    void stopRotating();
 
     // API
     void setAccessToken(const std::string &token);

--- a/include/mbgl/map/transform.hpp
+++ b/include/mbgl/map/transform.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/map/update.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/vec.hpp>
@@ -31,8 +32,6 @@ public:
     void setLatLng(LatLng latLng, Duration = Duration::zero());
     void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
     inline const LatLng getLatLng() const { return current.getLatLng(); }
-    void startPanning();
-    void stopPanning();
 
     // Zoom
     void scaleBy(double ds, double cx = -1, double cy = -1, Duration = Duration::zero());
@@ -40,8 +39,6 @@ public:
     void setZoom(double zoom, Duration = Duration::zero());
     double getZoom() const;
     double getScale() const;
-    void startScaling();
-    void stopScaling();
     double getMinZoom() const;
     double getMaxZoom() const;
 
@@ -50,12 +47,10 @@ public:
     void setAngle(double angle, Duration = Duration::zero());
     void setAngle(double angle, double cx, double cy);
     double getAngle() const;
-    void startRotating();
-    void stopRotating();
 
     // Transitions
     bool needsTransition() const;
-    void updateTransitions(TimePoint now);
+    UpdateType updateTransitions(TimePoint now);
     void cancelTransitions();
 
     // Transform state
@@ -69,13 +64,9 @@ private:
     void _setScale(double scale, double cx, double cy, Duration = Duration::zero());
     void _setScaleXY(double new_scale, double xn, double yn, Duration = Duration::zero());
     void _setAngle(double angle, Duration = Duration::zero());
-    void _clearPanning();
-    void _clearRotating();
-    void _clearScaling();
 
     void constrain(double& scale, double& y) const;
 
-private:
     View &view;
 
     mutable std::recursive_mutex mtx;
@@ -92,10 +83,14 @@ private:
     const double min_scale = std::pow(2, 0);
     const double max_scale = std::pow(2, 18);
 
-    std::forward_list<util::ptr<util::transition>> transitions;
-    util::ptr<util::transition> scale_timeout;
-    util::ptr<util::transition> rotate_timeout;
-    util::ptr<util::transition> pan_timeout;
+    void startTransition(std::function<Update(double)> frame,
+                         std::function<void()> finish,
+                         Duration);
+
+    TimePoint transitionStart;
+    Duration transitionDuration;
+    std::function<Update(TimePoint)> transitionFrameFn;
+    std::function<void()> transitionFinishFn;
 };
 
 }

--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -1,0 +1,18 @@
+#ifndef MBGL_MAP_UPDATE
+#define MBGL_MAP_UPDATE
+
+namespace mbgl {
+
+using UpdateType = uint32_t;
+
+enum class Update : UpdateType {
+    Nothing                   = 0,
+    StyleInfo                 = 1 << 0,
+    Debug                     = 1 << 1,
+    DefaultTransitionDuration = 1 << 2,
+    Classes                   = 1 << 3,
+};
+
+}
+
+#endif

--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -11,6 +11,7 @@ enum class Update : UpdateType {
     Debug                     = 1 << 1,
     DefaultTransitionDuration = 1 << 2,
     Classes                   = 1 << 3,
+    Zoom                      = 1 << 4,
 };
 
 }

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -212,7 +212,6 @@ void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) 
         scale = 1.0 / scale;
     }
 
-    view->map->startScaling();
     view->map->scaleBy(scale, view->lastX, view->lastY);
 }
 
@@ -231,14 +230,10 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
     if (button == GLFW_MOUSE_BUTTON_RIGHT ||
         (button == GLFW_MOUSE_BUTTON_LEFT && modifiers & GLFW_MOD_CONTROL)) {
         view->rotating = action == GLFW_PRESS;
-        if (!view->rotating) {
-            view->map->stopRotating();
-        }
     } else if (button == GLFW_MOUSE_BUTTON_LEFT) {
         view->tracking = action == GLFW_PRESS;
 
         if (action == GLFW_RELEASE) {
-            view->map->stopPanning();
             double now = glfwGetTime();
             if (now - view->lastClick < 0.4 /* ms */) {
                 if (modifiers & GLFW_MOD_SHIFT) {
@@ -258,11 +253,9 @@ void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
         double dx = x - view->lastX;
         double dy = y - view->lastY;
         if (dx || dy) {
-            view->map->startPanning();
             view->map->moveBy(dx, dy);
         }
     } else if (view->rotating) {
-        view->map->startRotating();
         view->map->rotateBy(view->lastX, view->lastY, x, y);
     }
     view->lastX = x;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -7,7 +7,6 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/map/annotation.hpp>
 #include <mbgl/map/sprite.hpp>
-#include <mbgl/util/transition.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/clip_ids.hpp>
 #include <mbgl/util/string.hpp>
@@ -72,7 +71,8 @@ Map::Map(View& view_, FileSource& fileSource_)
       texturePool(std::make_shared<TexturePool>()),
       painter(util::make_unique<Painter>(*spriteAtlas, *glyphAtlas, *lineAtlas)),
       annotationManager(util::make_unique<AnnotationManager>()),
-      data(util::make_unique<MapData>())
+      data(util::make_unique<MapData>()),
+      updated(static_cast<UpdateType>(Update::Nothing))
 {
     view.initialize(this);
 }
@@ -470,21 +470,11 @@ LatLng Map::getLatLng() const {
     return state.getLatLng();
 }
 
-void Map::startPanning() {
-    transform.startPanning();
-    triggerUpdate();
-}
-
-void Map::stopPanning() {
-    transform.stopPanning();
-    triggerUpdate();
-}
-
 void Map::resetPosition() {
     transform.setAngle(0);
     transform.setLatLng(LatLng(0, 0));
     transform.setZoom(0);
-    triggerUpdate();
+    triggerUpdate(Update::Zoom);
 }
 
 
@@ -492,12 +482,12 @@ void Map::resetPosition() {
 
 void Map::scaleBy(double ds, double cx, double cy, Duration duration) {
     transform.scaleBy(ds, cx, cy, duration);
-    triggerUpdate();
+    triggerUpdate(Update::Zoom);
 }
 
 void Map::setScale(double scale, double cx, double cy, Duration duration) {
     transform.setScale(scale, cx, cy, duration);
-    triggerUpdate();
+    triggerUpdate(Update::Zoom);
 }
 
 double Map::getScale() const {
@@ -506,7 +496,7 @@ double Map::getScale() const {
 
 void Map::setZoom(double zoom, Duration duration) {
     transform.setZoom(zoom, duration);
-    triggerUpdate();
+    triggerUpdate(Update::Zoom);
 }
 
 double Map::getZoom() const {
@@ -515,21 +505,11 @@ double Map::getZoom() const {
 
 void Map::setLatLngZoom(LatLng latLng, double zoom, Duration duration) {
     transform.setLatLngZoom(latLng, zoom, duration);
-    triggerUpdate();
+    triggerUpdate(Update::Zoom);
 }
 
 void Map::resetZoom() {
     setZoom(0);
-}
-
-void Map::startScaling() {
-    transform.startScaling();
-    triggerUpdate();
-}
-
-void Map::stopScaling() {
-    transform.stopScaling();
-    triggerUpdate();
 }
 
 double Map::getMinZoom() const {
@@ -567,15 +547,6 @@ void Map::resetNorth() {
     triggerUpdate();
 }
 
-void Map::startRotating() {
-    transform.startRotating();
-    triggerUpdate();
-}
-
-void Map::stopRotating() {
-    transform.stopRotating();
-    triggerUpdate();
-}
 
 #pragma mark - Access Token
 
@@ -802,44 +773,49 @@ void Map::loadStyleJSON(const std::string& json, const std::string& base) {
     const std::string glyphURL = util::mapbox::normalizeGlyphsURL(style->glyph_url, getAccessToken());
     glyphStore->setURL(glyphURL);
 
-    triggerUpdate();
+    triggerUpdate(Update::Zoom);
 }
 
 void Map::prepare() {
     assert(Environment::currentlyOn(ThreadType::Map));
 
-    const auto u = updated.exchange(static_cast<UpdateType>(Update::Nothing));
-    if ((u & static_cast<UpdateType>(Update::StyleInfo)) || !style) {
-        reloadStyle();
-    }
-    if (u & static_cast<UpdateType>(Update::Debug)) {
-        assert(painter);
-        painter->setDebug(data->getDebug());
-    }
-    if (u & static_cast<UpdateType>(Update::DefaultTransitionDuration)) {
-        if (style) {
-            style->setDefaultTransitionDuration(data->getDefaultTransitionDuration());
-        }
-    }
-    if (u & static_cast<UpdateType>(Update::Classes)) {
-        if (style) {
-            style->cascade(data->getClasses());
-        }
-    }
+    const auto now = Clock::now();
+    data->setAnimationTime(now);
 
-    // Update transform transitions.
+    auto u = updated.exchange(static_cast<UpdateType>(Update::Nothing)) |
+             transform.updateTransitions(now);
 
-    const auto animationTime = Clock::now();
-    data->setAnimationTime(animationTime);
-    if (transform.needsTransition()) {
-        transform.updateTransitions(animationTime);
+    if (!style) {
+        u |= static_cast<UpdateType>(Update::StyleInfo);
     }
 
     state = transform.currentState();
 
+    if (u & static_cast<UpdateType>(Update::StyleInfo)) {
+        reloadStyle();
+    }
+
+    if (u & static_cast<UpdateType>(Update::Debug)) {
+        assert(painter);
+        painter->setDebug(data->getDebug());
+    }
+
     if (style) {
+        if (u & static_cast<UpdateType>(Update::DefaultTransitionDuration)) {
+            style->setDefaultTransitionDuration(data->getDefaultTransitionDuration());
+        }
+
+        if (u & static_cast<UpdateType>(Update::Classes)) {
+            style->cascade(data->getClasses());
+        }
+
+        if (u & static_cast<UpdateType>(Update::StyleInfo) ||
+            u & static_cast<UpdateType>(Update::Classes) ||
+            u & static_cast<UpdateType>(Update::Zoom)) {
+            style->recalculate(state.getNormalizedZoom(), now);
+        }
+
         updateSources();
-        style->recalculate(state.getNormalizedZoom(), animationTime);
 
         // Allow the sprite atlas to potentially pull new sprite images if needed.
         spriteAtlas->resize(state.getPixelRatio());
@@ -863,6 +839,7 @@ void Map::render() {
     assert(painter);
     painter->render(*style, activeSources,
                     state, data->getAnimationTime());
+
     // Schedule another rerender when we definitely need a next frame.
     if (transform.needsTransition() || style->hasTransitions()) {
         triggerUpdate();

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -4,7 +4,8 @@
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/math.hpp>
-#include <mbgl/util/transition.hpp>
+#include <mbgl/util/unitbezier.hpp>
+#include <mbgl/util/interpolate.hpp>
 #include <mbgl/platform/platform.hpp>
 
 #include <cstdio>
@@ -66,12 +67,19 @@ void Transform::_moveBy(const double dx, const double dy, const Duration duratio
         current.x = final.x;
         current.y = final.y;
     } else {
-        // Use a common start time for all of the transitions to avoid divergent transitions.
-        TimePoint start = Clock::now();
-        transitions.emplace_front(
-            std::make_shared<util::ease_transition<double>>(current.x, final.x, current.x, start, duration));
-        transitions.emplace_front(
-            std::make_shared<util::ease_transition<double>>(current.y, final.y, current.y, start, duration));
+        const double startX = current.x;
+        const double startY = current.y;
+        current.panning = true;
+
+        startTransition(
+            [=](double t) {
+                current.x = util::interpolate(startX, final.x, t);
+                current.y = util::interpolate(startY, final.y, t);
+                return Update::Nothing;
+            },
+            [=] {
+                current.panning = false;
+            }, duration);
     }
 
     view.notifyMapChange(duration != Duration::zero() ?
@@ -110,31 +118,6 @@ void Transform::setLatLngZoom(const LatLng latLng, const double zoom, const Dura
     _setScaleXY(new_scale, xn, yn, duration);
 }
 
-void Transform::startPanning() {
-    std::lock_guard<std::recursive_mutex> lock(mtx);
-
-    _clearPanning();
-
-    // Add a 200ms timeout for resetting this to false
-    current.panning = true;
-    TimePoint start = Clock::now();
-    pan_timeout = std::make_shared<util::timeout<bool>>(false, current.panning, start, std::chrono::milliseconds(200));
-    transitions.emplace_front(pan_timeout);
-}
-
-void Transform::stopPanning() {
-    std::lock_guard<std::recursive_mutex> lock(mtx);
-
-    _clearPanning();
-}
-
-void Transform::_clearPanning() {
-    current.panning = false;
-    if (pan_timeout) {
-        transitions.remove(pan_timeout);
-        pan_timeout.reset();
-    }
-}
 
 #pragma mark - Zoom
 
@@ -177,24 +160,6 @@ double Transform::getScale() const {
     return final.scale;
 }
 
-void Transform::startScaling() {
-    std::lock_guard<std::recursive_mutex> lock(mtx);
-
-    _clearScaling();
-
-    // Add a 200ms timeout for resetting this to false
-    current.scaling = true;
-    TimePoint start = Clock::now();
-    scale_timeout = std::make_shared<util::timeout<bool>>(false, current.scaling, start, std::chrono::milliseconds(200));
-    transitions.emplace_front(scale_timeout);
-}
-
-void Transform::stopScaling() {
-    std::lock_guard<std::recursive_mutex> lock(mtx);
-
-    _clearScaling();
-}
-
 double Transform::getMinZoom() const {
     double test_scale = current.scale;
     double test_y = current.y;
@@ -205,16 +170,6 @@ double Transform::getMinZoom() const {
 
 double Transform::getMaxZoom() const {
     return std::log2(max_scale);
-}
-
-void Transform::_clearScaling() {
-    // This is only called internally, so we don't need a lock here.
-
-    current.scaling = false;
-    if (scale_timeout) {
-        transitions.remove(scale_timeout);
-        scale_timeout.reset();
-    }
 }
 
 void Transform::_setScale(double new_scale, double cx, double cy, const Duration duration) {
@@ -269,14 +224,23 @@ void Transform::_setScaleXY(const double new_scale, const double xn, const doubl
         current.x = final.x;
         current.y = final.y;
     } else {
-        // Use a common start time for all of the transitions to avoid divergent transitions.
-        TimePoint start = Clock::now();
-        transitions.emplace_front(std::make_shared<util::ease_transition<double>>(
-            current.scale, final.scale, current.scale, start, duration));
-        transitions.emplace_front(
-            std::make_shared<util::ease_transition<double>>(current.x, final.x, current.x, start, duration));
-        transitions.emplace_front(
-            std::make_shared<util::ease_transition<double>>(current.y, final.y, current.y, start, duration));
+        const double startS = current.scale;
+        const double startX = current.x;
+        const double startY = current.y;
+        current.panning = true;
+        current.scaling = true;
+
+        startTransition(
+            [=](double t) {
+                current.scale = util::interpolate(startS, final.scale, t);
+                current.x = util::interpolate(startX, final.x, t);
+                current.y = util::interpolate(startY, final.y, t);
+                return Update::Zoom;
+            },
+            [=] {
+                current.panning = false;
+                current.scaling = false;
+            }, duration);
     }
 
     const double s = final.scale * util::tileSize;
@@ -376,9 +340,17 @@ void Transform::_setAngle(double new_angle, const Duration duration) {
     if (duration == Duration::zero()) {
         current.angle = final.angle;
     } else {
-        TimePoint start = Clock::now();
-        transitions.emplace_front(std::make_shared<util::ease_transition<double>>(
-            current.angle, final.angle, current.angle, start, duration));
+        const double startA = current.angle;
+        current.rotating = true;
+
+        startTransition(
+            [=](double t) {
+                current.angle = util::interpolate(startA, final.angle, t);
+                return Update::Nothing;
+            },
+            [=] {
+                current.rotating = false;
+            }, duration);
     }
 
     view.notifyMapChange(duration != Duration::zero() ?
@@ -393,55 +365,55 @@ double Transform::getAngle() const {
     return final.angle;
 }
 
-void Transform::startRotating() {
-    std::lock_guard<std::recursive_mutex> lock(mtx);
-
-    _clearRotating();
-
-    // Add a 200ms timeout for resetting this to false
-    current.rotating = true;
-    TimePoint start = Clock::now();
-    rotate_timeout = std::make_shared<util::timeout<bool>>(false, current.rotating, start, std::chrono::milliseconds(200));
-    transitions.emplace_front(rotate_timeout);
-}
-
-void Transform::stopRotating() {
-    std::lock_guard<std::recursive_mutex> lock(mtx);
-
-    _clearRotating();
-}
-
-void Transform::_clearRotating() {
-    // This is only called internally, so we don't need a lock here.
-
-    current.rotating = false;
-    if (rotate_timeout) {
-        transitions.remove(rotate_timeout);
-        rotate_timeout.reset();
-    }
-}
-
 
 #pragma mark - Transition
 
-bool Transform::needsTransition() const {
-    std::lock_guard<std::recursive_mutex> lock(mtx);
+void Transform::startTransition(std::function<Update(double)> frame,
+                                std::function<void()> finish,
+                                Duration duration) {
+    if (transitionFinishFn) {
+        transitionFinishFn();
+    }
 
-    return !transitions.empty();
+    transitionStart = Clock::now();
+    transitionDuration = duration;
+
+    transitionFrameFn = [frame, this](TimePoint now) {
+        float t = std::chrono::duration<float>(now - transitionStart) / transitionDuration;
+        if (t >= 1.0) {
+            Update result = frame(1.0);
+            transitionFinishFn();
+            transitionFrameFn = nullptr;
+            transitionFinishFn = nullptr;
+            return result;
+        } else {
+            util::UnitBezier ease(0, 0, 0.25, 1);
+            return frame(ease.solve(t, 0.001));
+        }
+    };
+
+    transitionFinishFn = finish;
 }
 
-void Transform::updateTransitions(const TimePoint now) {
+bool Transform::needsTransition() const {
     std::lock_guard<std::recursive_mutex> lock(mtx);
+    return !!transitionFrameFn;
+}
 
-    transitions.remove_if([now](const util::ptr<util::transition> &transition) {
-        return transition->update(now) == util::transition::complete;
-    });
+UpdateType Transform::updateTransitions(const TimePoint now) {
+    std::lock_guard<std::recursive_mutex> lock(mtx);
+    return static_cast<UpdateType>(transitionFrameFn ? transitionFrameFn(now) : Update::Nothing);
 }
 
 void Transform::cancelTransitions() {
     std::lock_guard<std::recursive_mutex> lock(mtx);
 
-    transitions.clear();
+    if (transitionFinishFn) {
+        transitionFinishFn();
+    }
+
+    transitionFrameFn = nullptr;
+    transitionFinishFn = nullptr;
 }
 
 #pragma mark - Transform state

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -89,18 +89,3 @@ void Raster::bind(const GLuint custom_texture) {
     }
 
 }
-
-void Raster::beginFadeInTransition() {
-    TimePoint start = Clock::now();
-    fade_transition = std::make_shared<util::ease_transition<double>>(opacity, 1.0, opacity, start, std::chrono::milliseconds(250));
-}
-
-bool Raster::needsTransition() const {
-    return fade_transition != nullptr;
-}
-
-void Raster::updateTransitions(TimePoint now) {
-    if (fade_transition->update(now) == util::transition::complete) {
-        fade_transition = nullptr;
-    }
-}

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -1,7 +1,6 @@
 #ifndef MBGL_UTIL_RASTER
 #define MBGL_UTIL_RASTER
 
-#include <mbgl/util/transition.hpp>
 #include <mbgl/util/texture_pool.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/ptr.hpp>
@@ -32,11 +31,6 @@ public:
     // loaded status
     bool isLoaded() const;
 
-    // transitions
-    void beginFadeInTransition();
-    bool needsTransition() const;
-    void updateTransitions(TimePoint now);
-
 public:
     // loaded image dimensions
     uint32_t width = 0, height = 0;
@@ -64,9 +58,6 @@ private:
 
     // the raw pixels
     std::unique_ptr<util::Image> img;
-
-    // fade in transition
-    util::ptr<util::transition> fade_transition = nullptr;
 };
 
 }


### PR DESCRIPTION
Note: PR targets the `chrono` branch so that the diff is better, but this will merge to master.

This brings the easing transition code a bit closer to how easings work in gl-js. Instead of having an array of individual transitions for scale, rotate, and pan, there is a single transition function that does all the required calculations. This permits us to:

* Eliminate the "timeout" transition. (Fixes #126)
* Remove the start/stopPanning() and similar functions from the API. The transform is capable of determining when a transition that affects the pan position is in effect. (Fixes #79)
* Run style recalculations only when an ease transition that affects the zoom is in progress. (Fixes #1155)

@kkaefer can you review please?