### PR TITLE
Only run Style::updateProperties when required

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -461,20 +461,6 @@ jobject JNICALL nativeGetLatLng(JNIEnv *env, jobject obj, jlong nativeMapViewPtr
     return ret;
 }
 
-void JNICALL nativeStartPanning(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeStartPanning");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().startPanning();
-}
-
-void JNICALL nativeStopPanning(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeStopPanning");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().stopPanning();
-}
-
 void JNICALL nativeResetPosition(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeResetPosition");
     assert(nativeMapViewPtr != 0);
@@ -570,20 +556,6 @@ void JNICALL nativeResetZoom(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     nativeMapView->getMap().resetZoom();
 }
 
-void JNICALL nativeStartScaling(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeStartScaling");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().startScaling();
-}
-
-void JNICALL nativeStopScaling(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeStopScaling");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    return nativeMapView->getMap().stopScaling();
-}
-
 jdouble JNICALL nativeGetMinZoom(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetMinZoom");
     assert(nativeMapViewPtr != 0);
@@ -634,20 +606,6 @@ void JNICALL nativeResetNorth(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) 
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
     nativeMapView->getMap().resetNorth();
-}
-
-void JNICALL nativeStartRotating(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeStartRotating");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().startRotating();
-}
-
-void JNICALL nativeStopRotating(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeStopRotating");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().stopRotating();
 }
 
 void JNICALL nativeSetDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jboolean debug) {
@@ -1029,8 +987,6 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
          reinterpret_cast<void *>(&nativeSetLatLng)},
         {"nativeGetLatLng", "(J)Lcom/mapbox/mapboxgl/geometry/LatLng;",
          reinterpret_cast<void *>(&nativeGetLatLng)},
-        {"nativeStartPanning", "(J)V", reinterpret_cast<void *>(&nativeStartPanning)},
-        {"nativeStopPanning", "(J)V", reinterpret_cast<void *>(&nativeStopPanning)},
         {"nativeResetPosition", "(J)V", reinterpret_cast<void *>(&nativeResetPosition)},
         {"nativeScaleBy", "(JDDDJ)V", reinterpret_cast<void *>(&nativeScaleBy)},
         {"nativeSetScale", "(JDDDJ)V", reinterpret_cast<void *>(&nativeSetScale)},
@@ -1042,8 +998,6 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         {"nativeGetLatLngZoom", "(J)Lcom/mapbox/mapboxgl/geometry/LatLngZoom;",
          reinterpret_cast<void *>(&nativeGetLatLngZoom)},
         {"nativeResetZoom", "(J)V", reinterpret_cast<void *>(&nativeResetZoom)},
-        {"nativeStartPanning", "(J)V", reinterpret_cast<void *>(&nativeStartScaling)},
-        {"nativeStopPanning", "(J)V", reinterpret_cast<void *>(&nativeStopScaling)},
         {"nativeGetMinZoom", "(J)D", reinterpret_cast<void *>(&nativeGetMinZoom)},
         {"nativeGetMaxZoom", "(J)D", reinterpret_cast<void *>(&nativeGetMaxZoom)},
         {"nativeRotateBy", "(JDDDDJ)V", reinterpret_cast<void *>(&nativeRotateBy)},
@@ -1057,8 +1011,6 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
                  &nativeSetBearing))},
         {"nativeGetBearing", "(J)D", reinterpret_cast<void *>(&nativeGetBearing)},
         {"nativeResetNorth", "(J)V", reinterpret_cast<void *>(&nativeResetNorth)},
-        {"nativeStartRotating", "(J)V", reinterpret_cast<void *>(&nativeStartRotating)},
-        {"nativeStopRotating", "(J)V", reinterpret_cast<void *>(&nativeStopRotating)},
         {"nativeSetDebug", "(JZ)V", reinterpret_cast<void *>(&nativeSetDebug)},
         {"nativeToggleDebug", "(J)V", reinterpret_cast<void *>(&nativeToggleDebug)},
         {"nativeGetDebug", "(J)Z", reinterpret_cast<void *>(&nativeGetDebug)},

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -213,14 +213,6 @@ class NativeMapView {
         return nativeGetLatLng(mNativeMapViewPtr);
     }
 
-    public void startPanning() {
-        nativeStartPanning(mNativeMapViewPtr);
-    }
-
-    public void stopPanning() {
-        nativeStopPanning(mNativeMapViewPtr);
-    }
-
     public void resetPosition() {
         nativeResetPosition(mNativeMapViewPtr);
     }
@@ -281,14 +273,6 @@ class NativeMapView {
         nativeResetZoom(mNativeMapViewPtr);
     }
 
-    public void startScaling() {
-        nativeStartScaling(mNativeMapViewPtr);
-    }
-
-    public void stopScaling() {
-        nativeStopScaling(mNativeMapViewPtr);
-    }
-
     public double getMinZoom() {
         return nativeGetMinZoom(mNativeMapViewPtr);
     }
@@ -324,14 +308,6 @@ class NativeMapView {
 
     public void resetNorth() {
         nativeResetNorth(mNativeMapViewPtr);
-    }
-
-    public void startRotating() {
-        nativeStartRotating(mNativeMapViewPtr);
-    }
-
-    public void stopRotating() {
-        nativeStopRotating(mNativeMapViewPtr);
     }
 
     public void setDebug(boolean debug) {
@@ -468,10 +444,6 @@ class NativeMapView {
 
     private native LatLng nativeGetLatLng(long nativeMapViewPtr);
 
-    private native void nativeStartPanning(long nativeMapViewPtr);
-
-    private native void nativeStopPanning(long nativeMapViewPtr);
-
     private native void nativeResetPosition(long nativeMapViewPtr);
 
     private native void nativeScaleBy(long nativeMapViewPtr, double ds,
@@ -494,10 +466,6 @@ class NativeMapView {
 
     private native void nativeResetZoom(long nativeMapViewPtr);
 
-    private native void nativeStartScaling(long nativeMapViewPtr);
-
-    private native void nativeStopScaling(long nativeMapViewPtr);
-
     private native double nativeGetMinZoom(long nativeMapViewPtr);
 
     private native double nativeGetMaxZoom(long nativeMapViewPtr);
@@ -514,10 +482,6 @@ class NativeMapView {
     private native double nativeGetBearing(long nativeMapViewPtr);
 
     private native void nativeResetNorth(long nativeMapViewPtr);
-
-    private native void nativeStartRotating(long nativeMapViewPtr);
-
-    private native void nativeStopRotating(long nativeMapViewPtr);
 
     private native void nativeSetDebug(long nativeMapViewPtr, boolean debug);
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -100,13 +100,12 @@ public:
 
     // Transition
     void cancelTransitions();
+    void setGestureInProgress(bool);
 
     // Position
     void moveBy(double dx, double dy, Duration = Duration::zero());
     void setLatLng(LatLng latLng, Duration = Duration::zero());
     LatLng getLatLng() const;
-    void startPanning();
-    void stopPanning();
     void resetPosition();
 
     // Scale
@@ -117,8 +116,6 @@ public:
     double getZoom() const;
     void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
     void resetZoom();
-    void startScaling();
-    void stopScaling();
     double getMinZoom() const;
     double getMaxZoom() const;
 
@@ -128,8 +125,6 @@ public:
     void setBearing(double degrees, double cx, double cy);
     double getBearing() const;
     void resetNorth();
-    void startRotating();
-    void stopRotating();
 
     // API
     void setAccessToken(const std::string &token);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/map/transform.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/map/update.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/noncopyable.hpp>
@@ -76,14 +77,6 @@ public:
     void render();
 
     // Notifies the Map thread that the state has changed and an update might be necessary.
-    using UpdateType = uint32_t;
-    enum class Update : UpdateType {
-        Nothing                   = 0,
-        StyleInfo                 = 1 << 0,
-        Debug                     = 1 << 1,
-        DefaultTransitionDuration = 1 << 2,
-        Classes                   = 1 << 3,
-    };
     void triggerUpdate(Update = Update::Nothing);
 
     // Triggers a render. Can be called from any thread.

--- a/include/mbgl/map/transform_state.hpp
+++ b/include/mbgl/map/transform_state.hpp
@@ -77,6 +77,7 @@ private:
     bool rotating = false;
     bool scaling = false;
     bool panning = false;
+    bool gestureInProgress = false;
 
     // map position
     double x = 0, y = 0;

--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -1,0 +1,18 @@
+#ifndef MBGL_MAP_UPDATE
+#define MBGL_MAP_UPDATE
+
+namespace mbgl {
+
+using UpdateType = uint32_t;
+
+enum class Update : UpdateType {
+    Nothing                   = 0,
+    StyleInfo                 = 1 << 0,
+    Debug                     = 1 << 1,
+    DefaultTransitionDuration = 1 << 2,
+    Classes                   = 1 << 3,
+};
+
+}
+
+#endif

--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -11,6 +11,7 @@ enum class Update : UpdateType {
     Debug                     = 1 << 1,
     DefaultTransitionDuration = 1 << 2,
     Classes                   = 1 << 3,
+    Zoom                      = 1 << 4,
 };
 
 }

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -212,7 +212,6 @@ void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) 
         scale = 1.0 / scale;
     }
 
-    view->map->startScaling();
     view->map->scaleBy(scale, view->lastX, view->lastY);
 }
 
@@ -231,14 +230,12 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
     if (button == GLFW_MOUSE_BUTTON_RIGHT ||
         (button == GLFW_MOUSE_BUTTON_LEFT && modifiers & GLFW_MOD_CONTROL)) {
         view->rotating = action == GLFW_PRESS;
-        if (!view->rotating) {
-            view->map->stopRotating();
-        }
+        view->map->setGestureInProgress(view->rotating);
     } else if (button == GLFW_MOUSE_BUTTON_LEFT) {
         view->tracking = action == GLFW_PRESS;
+        view->map->setGestureInProgress(view->tracking);
 
         if (action == GLFW_RELEASE) {
-            view->map->stopPanning();
             double now = glfwGetTime();
             if (now - view->lastClick < 0.4 /* ms */) {
                 if (modifiers & GLFW_MOD_SHIFT) {
@@ -258,11 +255,9 @@ void GLFWView::onMouseMove(GLFWwindow *window, double x, double y) {
         double dx = x - view->lastX;
         double dy = y - view->lastY;
         if (dx || dy) {
-            view->map->startPanning();
             view->map->moveBy(dx, dy);
         }
     } else if (view->rotating) {
-        view->map->startRotating();
         view->map->rotateBy(view->lastX, view->lastY, x, y);
     }
     view->lastX = x;

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -615,6 +615,8 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     {
         [self trackGestureEvent:MGLEventGesturePanStart forRecognizer:pan];
 
+        mbglMap->setGestureInProgress(true);
+
         self.centerPoint = CGPointMake(0, 0);
 
         self.userTrackingMode = MGLUserTrackingModeNone;
@@ -650,6 +652,8 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
         CGPoint offset = CGPointMake(velocity.x * duration / 2, velocity.y * duration / 2);
 
         mbglMap->moveBy(offset.x, offset.y, secondsAsDuration(duration));
+
+        mbglMap->setGestureInProgress(false);
 
         if (duration)
         {
@@ -694,7 +698,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     {
         [self trackGestureEvent:MGLEventGesturePinchStart forRecognizer:pinch];
 
-        mbglMap->startScaling();
+        mbglMap->setGestureInProgress(true);
 
         self.scale = mbglMap->getScale();
 
@@ -712,7 +716,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     }
     else if (pinch.state == UIGestureRecognizerStateEnded || pinch.state == UIGestureRecognizerStateCancelled)
     {
-        mbglMap->stopScaling();
+        mbglMap->setGestureInProgress(false);
 
         [self unrotateIfNeededAnimated:YES];
 
@@ -730,7 +734,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     {
         [self trackGestureEvent:MGLEventGestureRotateStart forRecognizer:rotate];
 
-        mbglMap->startRotating();
+        mbglMap->setGestureInProgress(true);
 
         self.angle = [MGLMapView degreesToRadians:mbglMap->getBearing()] * -1;
 
@@ -754,7 +758,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     }
     else if (rotate.state == UIGestureRecognizerStateEnded || rotate.state == UIGestureRecognizerStateCancelled)
     {
-        mbglMap->stopRotating();
+        mbglMap->setGestureInProgress(false);
 
         [self unrotateIfNeededAnimated:YES];
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -249,7 +249,7 @@ const LatLng TransformState::latLngForPixel(const vec2<double> pixel) const {
 #pragma mark - Changing
 
 bool TransformState::isChanging() const {
-    return rotating || scaling || panning;
+    return rotating || scaling || panning || gestureInProgress;
 }
 
 

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -89,18 +89,3 @@ void Raster::bind(const GLuint custom_texture) {
     }
 
 }
-
-void Raster::beginFadeInTransition() {
-    TimePoint start = Clock::now();
-    fade_transition = std::make_shared<util::ease_transition<double>>(opacity, 1.0, opacity, start, std::chrono::milliseconds(250));
-}
-
-bool Raster::needsTransition() const {
-    return fade_transition != nullptr;
-}
-
-void Raster::updateTransitions(TimePoint now) {
-    if (fade_transition->update(now) == util::transition::complete) {
-        fade_transition = nullptr;
-    }
-}

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -1,7 +1,6 @@
 #ifndef MBGL_UTIL_RASTER
 #define MBGL_UTIL_RASTER
 
-#include <mbgl/util/transition.hpp>
 #include <mbgl/util/texture_pool.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/ptr.hpp>
@@ -32,11 +31,6 @@ public:
     // loaded status
     bool isLoaded() const;
 
-    // transitions
-    void beginFadeInTransition();
-    bool needsTransition() const;
-    void updateTransitions(TimePoint now);
-
 public:
     // loaded image dimensions
     uint32_t width = 0, height = 0;
@@ -64,9 +58,6 @@ private:
 
     // the raw pixels
     std::unique_ptr<util::Image> img;
-
-    // fade in transition
-    util::ptr<util::transition> fade_transition = nullptr;
 };
 
 }


### PR DESCRIPTION
We're currently running `Style::updateProperties` too often; whenever anything about the transform changes. However, we only need to run it on zoom, or when adding/removing classes.