### PR TITLE
Style API cleanup, designables, inspectables

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -20,6 +20,7 @@
         '../include/mbgl/ios/MGLMapboxEvents.h',
         '../platform/ios/MGLMapboxEvents.m',
         '../include/mbgl/ios/MGLMapView.h',
+        '../include/mbgl/ios/MGLMapView+IBAdditions.h',
         '../platform/ios/MGLMapView.mm',
         '../include/mbgl/ios/MGLAnnotation.h',
         '../include/mbgl/ios/MGLUserLocation.h',

--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -30,6 +30,8 @@
         '../include/mbgl/ios/MGLMetricsLocationManager.h',
         '../platform/ios/MGLMetricsLocationManager.m',
         '../include/mbgl/ios/MGLTypes.h',
+        '../platform/ios/NSProcessInfo+MGLAdditions.h',
+        '../platform/ios/NSProcessInfo+MGLAdditions.m',
         '../platform/ios/NSString+MGLAdditions.h',
         '../platform/ios/NSString+MGLAdditions.m',
         '../platform/ios/vendor/SMCalloutView/SMCalloutView.h',

--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -30,6 +30,8 @@
         '../include/mbgl/ios/MGLMetricsLocationManager.h',
         '../platform/ios/MGLMetricsLocationManager.m',
         '../include/mbgl/ios/MGLTypes.h',
+        '../platform/ios/NSString+MGLAdditions.h',
+        '../platform/ios/NSString+MGLAdditions.m',
         '../platform/ios/vendor/SMCalloutView/SMCalloutView.h',
         '../platform/ios/vendor/SMCalloutView/SMCalloutView.m',
       ],
@@ -50,6 +52,7 @@
           '-framework MobileCoreServices',
           '-framework QuartzCore',
           '-framework SystemConfiguration',
+          '-ObjC',
         ],
       },
 

--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -1,0 +1,29 @@
+#import "MGLMapView.h"
+
+@interface MGLMapView (IBAdditions)
+
+// Core properties that can be manipulated in the Attributes inspector in
+// Interface Builder. These redeclarations merely add the IBInspectable keyword.
+// They appear here to ensure that they appear above the convenience properties;
+// inspectables declared in MGLMapView.h are always sorted before those in
+// MGLMapView+IBAdditions.h, due to ASCII sort order.
+
+@property (nonatomic) IBInspectable NSString *accessToken;
+@property (nonatomic) IBInspectable NSString *mapID;
+
+// Some convenience properties related to the initial viewport. These properties
+// are not meant to be used outside of Interface Builder. latitude and longitude
+// are backed by properties of type CLLocationDegrees, but these declarations
+// must use the type double because Interface Builder is unaware that
+// CLLocationDegrees is a typedef for double.
+
+/// Initial latitude at which the receiver is centered.
+@property (nonatomic) IBInspectable double latitude;
+
+/// Initial longitude at which the receiver is centered.
+@property (nonatomic) IBInspectable double longitude;
+
+/// Initial zoom level of the receiver.
+@property (nonatomic) IBInspectable double zoomLevel;
+
+@end

--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -11,7 +11,7 @@
 @property (nonatomic) IBInspectable NSString *accessToken;
 @property (nonatomic) IBInspectable NSString *mapID;
 
-// Some convenience properties related to the initial viewport. These properties
+// Convenience properties related to the initial viewport. These properties
 // are not meant to be used outside of Interface Builder. latitude and longitude
 // are backed by properties of type CLLocationDegrees, but these declarations
 // must use the type double because Interface Builder is unaware that
@@ -20,5 +20,14 @@
 @property (nonatomic) IBInspectable double latitude;
 @property (nonatomic) IBInspectable double longitude;
 @property (nonatomic) IBInspectable double zoomLevel;
+
+// Renamed properties. Interface Builder derives the display name of each
+// inspectable from the runtime name, but runtime names don’t always make sense
+// in UI.
+
+@property (nonatomic) IBInspectable BOOL allowsZooming;
+@property (nonatomic) IBInspectable BOOL allowsScrolling;
+@property (nonatomic) IBInspectable BOOL allowsRotating;
+@property (nonatomic) IBInspectable BOOL showsUserLocation;
 
 @end

--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -17,13 +17,8 @@
 // must use the type double because Interface Builder is unaware that
 // CLLocationDegrees is a typedef for double.
 
-/// Initial latitude at which the receiver is centered.
 @property (nonatomic) IBInspectable double latitude;
-
-/// Initial longitude at which the receiver is centered.
 @property (nonatomic) IBInspectable double longitude;
-
-/// Initial zoom level of the receiver.
 @property (nonatomic) IBInspectable double zoomLevel;
 
 @end

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -39,9 +39,8 @@ IB_DESIGNABLE
 
 /** @name Authorizing Access */
 
-/** Sets a Mapbox API access token for the map view. 
-*   @param accessToken A Mapbox API token. */
-@property (nonatomic) IBInspectable NSString *accessToken;
+/** Mapbox API access token for the map view. */
+@property (nonatomic) NSString *accessToken;
 
 #pragma mark - Managing Constraints
 
@@ -166,10 +165,11 @@ IB_DESIGNABLE
 /** @name Styling the Map */
 
 /** Mapbox map ID of the style currently displayed in the receiver, or `nil` if the style does not have a map ID.
- 
-    The style may lack a map ID if it is located at an HTTP, HTTPS, or asset: URL. Use -styleURL to get the URL in these cases.
- */
-@property (nonatomic) IBInspectable NSString *mapID;
+*
+*   The style may lack a map ID if it is located at an HTTP, HTTPS, or local file URL. Use `styleURL` to get the URL in these cases. 
+*
+*   To display the default style, set this property to `nil`. */
+@property (nonatomic) NSString *mapID;
 
 /** Returns the URLs to the styles bundled with the library. */
 - (NSArray *)bundledStyleURLs;

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -13,20 +13,21 @@
 *   Use of MGLMapView requires a Mapbox API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/account/apps/). If you instantiate an MGLMapView from Interface Builder, rendering of the map won't begin until the accessToken property has been set.
 *
 *   @warning Please note that you are responsible for getting permission to use the map data, and for ensuring your use adheres to the relevant terms of use. */
+IB_DESIGNABLE
 @interface MGLMapView : UIView
 
 #pragma mark - Initializing a Map View
 
 /** @name Initializing a Map View */
 
-/** Initialize a map view with a given frame, style URL, and access token.
+/** Initialize a map view with a given frame, access token, and style URL.
 *   @param frame The frame with which to initialize the map view.
 *   @param accessToken A Mapbox API access token.
 *   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`).
 *   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
 - (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(NSURL *)styleURL;
 
-/** Initialize a map view with a given frame, the default style, and an access token.
+/** Initialize a map view with the default style given a frame and access token.
 *   @param frame The frame with which to initialize the map view.
 *   @param accessToken A Mapbox API access token.
 *   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
@@ -49,7 +50,7 @@
 /** A view controller whose top and bottom layout guides to use for proper setup of constraints in the map view internals.
 *
 *   Certain components of the map view, such as the heading compass and the data attribution button, need to be aware of the view controller layout in order to avoid positioning content under a top navigation bar or a bottom toolbar. */
-@property (nonatomic, weak) UIViewController *viewControllerForLayoutGuides;
+@property (nonatomic, weak) IBOutlet UIViewController *viewControllerForLayoutGuides;
 
 #pragma mark - Accessing Map Properties
 
@@ -81,7 +82,7 @@
 /** @name Accessing the Delegate */
 
 // TODO
-@property(nonatomic, weak) id<MGLMapViewDelegate> delegate;
+@property(nonatomic, weak) IBOutlet id<MGLMapViewDelegate> delegate;
 
 #pragma mark - Manipulating the Visible Portion of the Map
 
@@ -134,7 +135,7 @@
 - (void)setDirection:(CLLocationDirection)direction animated:(BOOL)animated;
 
 /** Resets the map rotation to a northern heading. */
-- (void)resetNorth;
+- (IBAction)resetNorth;
 
 #pragma mark - Converting Map Coordinates
 

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -176,7 +176,9 @@ IB_DESIGNABLE
 
 /** URL of the style currently displayed in the receiver.
 *
-*   The URL may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map ID (`mapbox://<user.style>`). To display the default style, set this property to `nil`. */
+*   The URL may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map ID (`mapbox://<user.style>`).
+*
+*   To display the default style, set this property to `nil`. */
 @property (nonatomic) NSURL *styleURL;
 
 #pragma mark - Annotating the Map

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -19,20 +19,6 @@
 
 /** @name Initializing a Map View */
 
-/** Initialize a map view with a given frame, style, and access token.
-*   @param frame The frame with which to initialize the map view.
-*   @param accessToken A Mapbox API access token.
-*   @param styleJSON The map stylesheet as JSON text.
-*   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
-- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleJSON:(NSString *)styleJSON;
-
-/** Initialize a map view with a given frame, bundled style name, and access token.
-*   @param frame The frame with which to initialize the map view.
-*   @param accessToken A Mapbox API access token.
-*   @param styleName The map style name to use.
-*   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
-- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken bundledStyleNamed:(NSString *)styleName;
-
 /** Initialize a map view with a given frame, style URL, and access token.
 *   @param frame The frame with which to initialize the map view.
 *   @param accessToken A Mapbox API access token.
@@ -178,26 +164,19 @@
 
 /** @name Styling the Map */
 
-/** Sets the map style.
-*   @param styleJSON The map stylesheet as JSON text. */
-- (void)setStyleJSON:(NSString *)styleJSON;
+/** Mapbox map ID of the style currently displayed in the receiver, or `nil` if the style does not have a map ID.
+ 
+    The style may lack a map ID if it is located at an HTTP, HTTPS, or asset: URL. Use -styleURL to get the URL in these cases.
+ */
+@property (nonatomic) IBInspectable NSString *mapID;
 
-/** Returns the raw JSON style as a native dictionary object. */
-- (NSDictionary *)getRawStyle;
+/** Returns the URLs to the styles bundled with the library. */
+- (NSArray *)bundledStyleURLs;
 
-/** Sets the raw JSON style as a native dictionary object with a transition animation.
-*   @param style The style JSON as a dictionary object. */
-- (void)setRawStyle:(NSDictionary *)style;
-
-/** Returns the names of the styles bundled with the library. */
-- (NSArray *)bundledStyleNames;
-
-/** Sets the map style to a named, bundled style.
-*   @param styleName The map style name to use. */
-@property (nonatomic) IBInspectable NSString *styleName;
-
-/** Sets the map style URL to use.
-*   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`). */
+/** URL of the style currently displayed in the receiver.
+    
+    The URL may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map ID (`mapbox://<user.style>`). To display the default style, set this property to `nil`.
+ */
 @property (nonatomic) NSURL *styleURL;
 
 #pragma mark - Annotating the Map

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -20,18 +20,18 @@ IB_DESIGNABLE
 
 /** @name Initializing a Map View */
 
-/** Initialize a map view with a given frame, access token, and style URL.
-*   @param frame The frame with which to initialize the map view.
-*   @param accessToken A Mapbox API access token.
-*   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`).
-*   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
-- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(NSURL *)styleURL;
-
-/** Initialize a map view with the default style given a frame and access token.
+/** Initialize a map view with the default style and a given frame and access token.
 *   @param frame The frame with which to initialize the map view.
 *   @param accessToken A Mapbox API access token.
 *   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
 - (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken;
+
+/** Initialize a map view with a given frame, access token, and style URL.
+ *   @param frame The frame with which to initialize the map view.
+ *   @param accessToken A Mapbox API access token.
+ *   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`).
+ *   @return An initialized map view, or `nil` if the map view was unable to be initialized. */
+- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(NSURL *)styleURL;
 
 - (instancetype)initWithFrame:(CGRect)frame __attribute__((unavailable("Instantiating an MGLMapView requires setting a style and/or an access token.")));
 
@@ -166,7 +166,7 @@ IB_DESIGNABLE
 
 /** Mapbox map ID of the style currently displayed in the receiver, or `nil` if the style does not have a map ID.
 *
-*   The style may lack a map ID if it is located at an HTTP, HTTPS, or local file URL. Use `styleURL` to get the URL in these cases. 
+*   The style may lack a map ID if it is located at an HTTP, HTTPS, or local file URL. Use `styleURL` to get the URL in these cases.
 *
 *   To display the default style, set this property to `nil`. */
 @property (nonatomic) NSString *mapID;
@@ -175,9 +175,8 @@ IB_DESIGNABLE
 - (NSArray *)bundledStyleURLs;
 
 /** URL of the style currently displayed in the receiver.
-    
-    The URL may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map ID (`mapbox://<user.style>`). To display the default style, set this property to `nil`.
- */
+*
+*   The URL may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map ID (`mapbox://<user.style>`). To display the default style, set this property to `nil`. */
 @property (nonatomic) NSURL *styleURL;
 
 #pragma mark - Annotating the Map

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -54,7 +54,7 @@
 
 /** Sets a Mapbox API access token for the map view. 
 *   @param accessToken A Mapbox API token. */
-- (void)setAccessToken:(NSString *)accessToken;
+@property (nonatomic) IBInspectable NSString *accessToken;
 
 #pragma mark - Managing Constraints
 
@@ -194,11 +194,11 @@
 
 /** Sets the map style to a named, bundled style.
 *   @param styleName The map style name to use. */
-- (void)useBundledStyleNamed:(NSString *)styleName;
+@property (nonatomic) IBInspectable NSString *styleName;
 
 /** Sets the map style URL to use.
 *   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`). */
-- (void)setStyleURL:(NSURL *)styleURL;
+@property (nonatomic) NSURL *styleURL;
 
 #pragma mark - Annotating the Map
 

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -96,6 +96,7 @@ public:
     Duration getDefaultTransitionDuration();
     void setStyleURL(const std::string& url);
     void setStyleJSON(const std::string& json, const std::string& base = "");
+    std::string getStyleURL() const;
     std::string getStyleJSON() const;
 
     // Transition

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -19,7 +19,7 @@ static NSArray *const kStyleNames = @[
     @"Hybrid",
 ];
 
-static NSString *const kStyleVersion = @"v7";
+static NSString *const kStyleVersion = @"7";
 
 @interface MBXViewController () <UIActionSheetDelegate, MGLMapViewDelegate>
 
@@ -246,10 +246,7 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
         styleName = [kStyleNames objectAtIndex:index];
     }
 
-    [self.mapView useBundledStyleNamed:
-        [[[styleName lowercaseString]
-        stringByAppendingString:@"-"]
-        stringByAppendingString:kStyleVersion]];
+    self.mapView.styleName = [NSString stringWithFormat:@"%@-v%@", styleName.lowercaseString, kStyleVersion];
 
     [titleButton setTitle:styleName forState:UIControlStateNormal];
 }

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -16,7 +16,6 @@ static NSArray *const kStyleNames = @[
     @"Basic",
     @"Outdoors",
     @"Satellite",
-    @"Hybrid",
 ];
 
 static NSString *const kStyleVersion = @"7";
@@ -246,7 +245,7 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
         styleName = [kStyleNames objectAtIndex:index];
     }
 
-    self.mapView.styleName = [NSString stringWithFormat:@"%@-v%@", styleName.lowercaseString, kStyleVersion];
+    self.mapView.styleURL = [NSURL URLWithString:[NSString stringWithFormat:@"asset://styles/%@-v%@.json", styleName.lowercaseString, kStyleVersion]];
 
     [titleButton setTitle:styleName forState:UIControlStateNormal];
 }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1064,6 +1064,21 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 #pragma mark - Properties -
 
++ (NSSet *)keyPathsForValuesAffectingZoomEnabled
+{
+    return [NSSet setWithObject:@"allowsZooming"];
+}
+
++ (NSSet *)keyPathsForValuesAffectingScrollEnabled
+{
+    return [NSSet setWithObject:@"allowsScrolling"];
+}
+
++ (NSSet *)keyPathsForValuesAffectingRotateEnabled
+{
+    return [NSSet setWithObject:@"allowsRotating"];
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 
@@ -2461,6 +2476,51 @@ class MBGLView : public mbgl::View
         // longitude away until the latitude is set too.
         _pendingLongitude = longitude;
     }
+}
+
++ (NSSet *)keyPathsForValuesAffectingAllowsZooming
+{
+    return [NSSet setWithObject:@"zoomEnabled"];
+}
+
+- (BOOL)allowsZooming
+{
+    return self.zoomEnabled;
+}
+
+- (void)setAllowsZooming:(BOOL)allowsZooming
+{
+    self.zoomEnabled = allowsZooming;
+}
+
++ (NSSet *)keyPathsForValuesAffectingAllowsScrolling
+{
+    return [NSSet setWithObject:@"scrollEnabled"];
+}
+
+- (BOOL)allowsScrolling
+{
+    return self.scrollEnabled;
+}
+
+- (void)setAllowsScrolling:(BOOL)allowsScrolling
+{
+    self.scrollEnabled = allowsScrolling;
+}
+
++ (NSSet *)keyPathsForValuesAffectingAllowsRotating
+{
+    return [NSSet setWithObject:@"rotateEnabled"];
+}
+
+- (BOOL)allowsRotating
+{
+    return self.rotateEnabled;
+}
+
+- (void)setAllowsRotating:(BOOL)allowsRotating
+{
+    self.rotateEnabled = allowsRotating;
 }
 
 @end

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1332,7 +1332,14 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
 - (void)setMapID:(NSString *)mapID
 {
-    self.styleURL = [NSURL URLWithString:[NSString stringWithFormat:@"mapbox://%@", mapID]];
+    if (mapID)
+    {
+        self.styleURL = [NSURL URLWithString:[NSString stringWithFormat:@"mapbox://%@", mapID]];
+    }
+    else
+    {
+        self.styleURL = nil;
+    }
 }
 
 - (NSArray *)getAppliedStyleClasses

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -91,7 +91,8 @@ static NSURL *MGLURLForBundledStyleNamed(NSString *styleName)
 
 @end
 
-@implementation MGLMapView {
+@implementation MGLMapView
+{
     BOOL _isTargetingInterfaceBuilder;
     CLLocationDegrees _pendingLatitude;
     CLLocationDegrees _pendingLongitude;
@@ -168,7 +169,8 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     [MGLMapboxEvents setToken:accessToken.mgl_stringOrNilIfEmpty];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingStyleURL {
++ (NSSet *)keyPathsForValuesAffectingStyleURL
+{
     return [NSSet setWithObjects:@"mapID", @"accessToken", nil];
 }
 
@@ -180,10 +182,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (void)setStyleURL:(NSURL *)styleURL
 {
-    if ( _isTargetingInterfaceBuilder )
-    {
-        return;
-    }
+    if (_isTargetingInterfaceBuilder) return;
     
     if ( ! styleURL)
     {
@@ -245,7 +244,8 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     // load extensions
     //
-    dispatch_once(&loadGLExtensions, ^{
+    dispatch_once(&loadGLExtensions, ^
+    {
         const std::string extensions = (char *)glGetString(GL_EXTENSIONS);
 
         using namespace mbgl;
@@ -1319,16 +1319,19 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     return [NSArray arrayWithArray:_bundledStyleURLs];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingMapID {
++ (NSSet *)keyPathsForValuesAffectingMapID
+{
     return [NSSet setWithObjects:@"styleURL", @"accessToken", nil];
 }
 
-- (NSString *)mapID {
+- (NSString *)mapID
+{
     NSURL *styleURL = self.styleURL;
     return [styleURL.scheme isEqualToString:@"mapbox"] ? styleURL.host.mgl_stringOrNilIfEmpty : nil;
 }
 
-- (void)setMapID:(NSString *)mapID {
+- (void)setMapID:(NSString *)mapID
+{
     self.styleURL = [NSURL URLWithString:[NSString stringWithFormat:@"mapbox://%@", mapID]];
 }
 

--- a/platform/ios/NSProcessInfo+MGLAdditions.h
+++ b/platform/ios/NSProcessInfo+MGLAdditions.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSProcessInfo (MGLAdditions)
+
+- (BOOL)mgl_isInterfaceBuilderDesignablesAgent;
+
+@end

--- a/platform/ios/NSProcessInfo+MGLAdditions.m
+++ b/platform/ios/NSProcessInfo+MGLAdditions.m
@@ -1,0 +1,10 @@
+#import "NSProcessInfo+MGLAdditions.h"
+
+@implementation NSProcessInfo (MGLAdditions)
+
+- (BOOL)mgl_isInterfaceBuilderDesignablesAgent
+{
+    return [self.processName isEqualToString:@"IBDesignablesAgentCocoaTouch"];
+}
+
+@end

--- a/platform/ios/NSString+MGLAdditions.h
+++ b/platform/ios/NSString+MGLAdditions.h
@@ -2,7 +2,7 @@
 
 @interface NSString (MGLAdditions)
 
-/// Returns the receiver if non-empty or \c nil if empty.
+/** Returns the receiver if non-empty or nil if empty. */
 - (NSString *)mgl_stringOrNilIfEmpty;
 
 @end

--- a/platform/ios/NSString+MGLAdditions.h
+++ b/platform/ios/NSString+MGLAdditions.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@interface NSString (MGLAdditions)
+
+/// Returns the receiver if non-empty or \c nil if empty.
+- (NSString *)mgl_stringOrNilIfEmpty;
+
+@end

--- a/platform/ios/NSString+MGLAdditions.m
+++ b/platform/ios/NSString+MGLAdditions.m
@@ -1,0 +1,10 @@
+#import "NSString+MGLAdditions.h"
+
+@implementation NSString (MGLAdditions)
+
+- (NSString *)mgl_stringOrNilIfEmpty
+{
+    return self.length ? self : nil;
+}
+
+@end

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -396,6 +396,10 @@ void Map::setup() {
     painter->setup();
 }
 
+std::string Map::getStyleURL() const {
+    return data->getStyleInfo().url;
+}
+
 void Map::setStyleURL(const std::string &url) {
     assert(Environment::currentlyOn(ThreadType::Main));
 
@@ -756,7 +760,7 @@ void Map::reloadStyle() {
                 Log::Error(Event::Setup, "loading style failed: %s", res.message.c_str());
             }
         });
-    } else {
+    } else if (!styleInfo.json.empty()) {
         // We got JSON data directly.
         loadStyleJSON(styleInfo.json, styleInfo.base);
     }


### PR DESCRIPTION
This PR addresses the following:

- Fixes a race condition on launch (fixes #1147)
- Cleans up various initializers and style APIs, removing raw JSON access and fixes KVO compliance (fixes #1070)
- Frictionless, codeless setup story for developers via designables and inspectables (fixes #929)

So, what’s the easiest way to get started with Mapbox GL?

1. Add MapboxGL to your Podfile and run `pod install`.
1. Drag a UIView out from the Object library into a `UIViewController` in a storyboard.
1. In the Identity inspector, set the custom class to “MGLMapView”.
1. In the Attributes inspector, set your access token. Optionally set an access token, initial coordinates, and initial zoom level.
1. Build and run.

![designable](https://cloud.githubusercontent.com/assets/1231218/6969674/3bc96d8a-d925-11e4-97a9-2bca4cf707f4.gif)

Will squash before merging.