### PR TITLE
fixes #1181: fix lat/lng & zoom ordering problems

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -48,7 +48,7 @@ NSString *const MGLDefaultStyleMarkerSymbolName = @"default_marker";
 
 const NSTimeInterval MGLAnimationDuration = 0.3;
 const CGSize MGLAnnotationUpdateViewportOutset = {150, 150};
-const CGFloat MGLMinZoom = 3;
+const CGFloat MGLMinimumZoom = 3;
 
 NSString *const MGLAnnotationIDKey = @"MGLAnnotationIDKey";
 
@@ -1131,7 +1131,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
     mbglMap->setLatLngZoom(coordinateToLatLng(coordinate),
-                           fmaxf(mbglMap->getZoom(), MGLMinZoom),
+                           fmaxf(mbglMap->getZoom(), self.currentMinimumZoom),
                            secondsAsDuration(duration));
 
     [self notifyMapChange:@(animated ? mbgl::MapChangeRegionDidChangeAnimated : mbgl::MapChangeRegionDidChange)];
@@ -1172,7 +1172,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
     mbglMap->setLatLngZoom(mbglMap->getLatLng(),
-                           fmaxf(zoomLevel, MGLMinZoom),
+                           fmaxf(zoomLevel, self.currentMinimumZoom),
                            secondsAsDuration(duration));
 
     [self unrotateIfNeededAnimated:animated];
@@ -1743,7 +1743,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
         {
             self.showsUserLocation = YES;
 
-            if (self.zoomLevel < MGLMinZoom) [self setZoomLevel:MGLMinZoom animated:YES];
+            if (self.zoomLevel < self.currentMinimumZoom) [self setZoomLevel:self.currentMinimumZoom animated:YES];
 
             if (self.userLocationAnnotationView)
             {
@@ -1952,9 +1952,14 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), animations);
 }
 
+- (CGFloat)currentMinimumZoom
+{
+    return fmaxf(mbglMap->getMinZoom(), MGLMinimumZoom);
+}
+
 - (BOOL)isRotationAllowed
 {
-    return (self.zoomLevel > MGLMinZoom);
+    return (self.zoomLevel >= self.currentMinimumZoom);
 }
 
 // correct rotations to north as needed

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -46,8 +46,9 @@ NSString *const MGLDefaultStyleName = @"Emerald";
 NSString *const MGLStyleVersion = @"v7";
 NSString *const MGLDefaultStyleMarkerSymbolName = @"default_marker";
 
-NSTimeInterval const MGLAnimationDuration = 0.3;
+const NSTimeInterval MGLAnimationDuration = 0.3;
 const CGSize MGLAnnotationUpdateViewportOutset = {150, 150};
+const CGFloat MGLMinZoom = 3;
 
 NSString *const MGLAnnotationIDKey = @"MGLAnnotationIDKey";
 
@@ -1129,7 +1130,9 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
-    mbglMap->setLatLng(coordinateToLatLng(coordinate), secondsAsDuration(duration));
+    mbglMap->setLatLngZoom(coordinateToLatLng(coordinate),
+                           fmaxf(mbglMap->getZoom(), MGLMinZoom),
+                           secondsAsDuration(duration));
 
     [self notifyMapChange:@(animated ? mbgl::MapChangeRegionDidChangeAnimated : mbgl::MapChangeRegionDidChange)];
 }
@@ -1168,7 +1171,9 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
-    mbglMap->setZoom(zoomLevel, secondsAsDuration(duration));
+    mbglMap->setLatLngZoom(mbglMap->getLatLng(),
+                           fmaxf(zoomLevel, MGLMinZoom),
+                           secondsAsDuration(duration));
 
     [self unrotateIfNeededAnimated:animated];
 
@@ -1738,7 +1743,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
         {
             self.showsUserLocation = YES;
 
-            if (self.zoomLevel < 3) [self setZoomLevel:3 animated:YES];
+            if (self.zoomLevel < MGLMinZoom) [self setZoomLevel:MGLMinZoom animated:YES];
 
             if (self.userLocationAnnotationView)
             {
@@ -1949,7 +1954,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
 - (BOOL)isRotationAllowed
 {
-    return (self.zoomLevel > 3);
+    return (self.zoomLevel > MGLMinZoom);
 }
 
 // correct rotations to north as needed

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -470,7 +470,7 @@ void Map::setLatLng(LatLng latLng, Duration duration) {
 }
 
 LatLng Map::getLatLng() const {
-    return state.getLatLng();
+    return transform.getLatLng();
 }
 
 void Map::resetPosition() {


### PR DESCRIPTION
There were two things going on here: 

* On iOS, we limit the minimum zoom to `3` like MapKit so that we don't ever see world edges or a wrapping, repeating map. However, in various center set routines, we weren't checking that the level was at least `3` before trying to move the map, which could have limited it artificially and failed at setting the center desired. This abstracts out an `MGLMinimumZoom` constant since we use it in various places anyway, plus ensures that we are at the minimum zoom on iOS before changing viewport properties. 

* The second problem was more subtle. In C++, all of the setters and getters for center and zoom queried `Map`'s `transform` _except for `getLatLng()`_, which queried `state` instead. This could cause things to be out of sync when setting properties one after the other in the same run loop pass. 

/cc @kkaefer just to be sure. 