### PR TITLE
iOS projects require -ObjC in OTHER_LDFLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ If you merely want to install the library for iOS and try it out as an Objective
    - `libc++.dylib`
    - `libsqlite3.dylib`
    - `libz.dylib`
-4. [Set the Mapbox API access token](#mapbox-api-access-tokens).
-5. `#import "MGLMapView.h"`
+4. Add `-ObjC` to your target's "Other Linker Flags" build setting (`OTHER_LDFLAGS`).
+5. [Set the Mapbox API access token](#mapbox-api-access-tokens).
+6. `#import "MGLMapView.h"`
 
 If you want to build from source and/or contribute to development of the project, run `make iproj`, which will create and open an Xcode project which can build the entire library from source as well as an Objective-C test app.
 


### PR DESCRIPTION
#1184 added `-[NSProcessInfo(MGLAdditions) mgl_isInterfaceBuilderDesignablesAgent]`, which only gets pulled in if you add `-ObjC` to `OTHER_LDFLAGS`.