### PR TITLE
Fix linux app on osx host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ANDROID_ABI ?= arm-v7
 
 ifeq ($(shell uname -s), Darwin)
 HOST ?= osx
+HEADLESS ?= cgl
 JOBS ?= $(shell sysctl -n hw.ncpu)
 endif
 HOST ?= linux

--- a/gyp/styles.gypi
+++ b/gyp/styles.gypi
@@ -19,7 +19,7 @@
       'hard_dependency': 1,
       'dependencies': [ 'touch_styles' ], # required for xcode http://openradar.appspot.com/7232149
       'conditions': [
-        ['OS == "mac"', {
+        ['platform_lib == "osx"', {
           'direct_dependent_settings': {
             'mac_bundle_resources': [ '../styles/styles' ],
           }


### PR DESCRIPTION
Work in progress fixing a few issues with building and running the linux app on OS X like `make run-linux`:

 - [x] GYP dependency error #1206
 - [x] Style loading broken since e69beba4d164. Note, the workaround of `./build/osx/Release/mapbox-gl -s $(pwd)/styles/styles/bright-v7.json` is not viable because then the path to the ca-bundle is wrong and you get errors like: `Problem with the SSL CA cert (path? access rights?)` (refs https://github.com/mapbox/mapbox-gl-native/issues/534#issuecomment-61378587)