### PR TITLE
Accept nil access token

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -165,7 +165,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (void)setAccessToken:(NSString *)accessToken
 {
-    mbglMap->setAccessToken((std::string)[accessToken UTF8String]);
+    mbglMap->setAccessToken(accessToken ? (std::string)[accessToken UTF8String] : "");
     [MGLMapboxEvents setToken:accessToken.mgl_stringOrNilIfEmpty];
 }
 


### PR DESCRIPTION
This PR fixes a regression from #1184. I too aggressively removed redundant `nil` checks so that there were no `nil` checks around setting an access token. GL ended up crashing in `Map::setAccessToken()`. With this change, attempting to view a Mapbox-hosted style without an access token will still crash, but in `mbgl::util::mapbox::normalizeURL()`, where we provide a helpful error message.