### PR TITLE
Expose style class API publicly

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -181,6 +181,18 @@ IB_DESIGNABLE
 *   To display the default style, set this property to `nil`. */
 @property (nonatomic) NSURL *styleURL;
 
+/** Currently active style classes, represented as an array of string identifiers. */
+@property (nonatomic) NSArray *styleClasses;
+
+/** Returns a Boolean value indicating whether the style class with the given identifier is currently active. */
+- (BOOL)hasStyleClass:(NSString *)styleClass;
+
+/** Activates the style class with the given identifier. */
+- (void)addStyleClass:(NSString *)styleClass;
+
+/** Deactivates the style class with the given identifier. */
+- (void)removeStyleClass:(NSString *)styleClass;
+
 #pragma mark - Annotating the Map
 
 /** @name Annotating the Map */

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1357,7 +1357,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     }
 }
 
-- (NSArray *)getAppliedStyleClasses
+- (NSArray *)styleClasses
 {
     NSMutableArray *returnArray = [NSMutableArray array];
 
@@ -1387,6 +1387,27 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
     mbglMap->setDefaultTransitionDuration(secondsAsDuration(transitionDuration));
     mbglMap->setClasses(newAppliedClasses);
+}
+
+- (BOOL)hasStyleClass:(NSString *)styleClass
+{
+    return styleClass && mbglMap->hasClass([styleClass UTF8String]);
+}
+
+- (void)addStyleClass:(NSString *)styleClass
+{
+    if (styleClass)
+    {
+        mbglMap->addClass([styleClass UTF8String]);
+    }
+}
+
+- (void)removeStyleClass:(NSString *)styleClass
+{
+    if (styleClass)
+    {
+        mbglMap->removeClass([styleClass UTF8String]);
+    }
 }
 
 #pragma mark - Annotations -


### PR DESCRIPTION
Also added some convenience methods to match the underlying C++ API.

One question I have: does order matter for style classes? If so, we should add a method to insert at a particular index. If not, we should use an `NSSet` and probably a `std::set` beneath it.