### PR TITLE
fixes #1189, #880: split OS X/iOS builds & deploy iOS to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,10 @@ matrix:
       env: BUILDTYPE=Release JOBS=8
       compiler: gcc
     - os: osx
-      env: BUILDTYPE=Debug JOBS=8
+      env: BUILDTYPE=Debug JOBS=8 MASON_PLATFORM=osx
+      compiler: clang
+    - os: osx
+      env: BUILDTYPE=Release JOBS=8 MASON_PLATFORM=ios
       compiler: clang
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ xproj: xosx-proj
 Xcode/ios: ios/app/mapboxgl-app.gyp config/ios.gypi styles/styles SMCalloutView
 	deps/run_gyp ios/app/mapboxgl-app.gyp $(CONFIG_ios) $(LIBS_ios) --generator-output=./build/ios -f xcode
 
-.PHONY: ios-proj ios run-ios
+.PHONY: ios-proj ios isim ipackage
 ios-proj: Xcode/ios
 	open ./build/ios/ios/app/mapboxgl-app.xcodeproj
 
@@ -123,6 +123,9 @@ ios: Xcode/ios
 
 isim: Xcode/ios
 	xcodebuild -sdk iphonesimulator ARCHS="x86_64 i386" -project ./build/ios/ios/app/mapboxgl-app.xcodeproj -configuration Debug -target iosapp -jobs $(JOBS)
+
+ipackage: clean Xcode/ios
+	./scripts/package_ios.sh
 
 # Legacy name
 iproj: ios-proj

--- a/scripts/publish_ios.sh
+++ b/scripts/publish_ios.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+#
+# iOS release tag format is `ios-vX.Y.Z`; `X.Y.Z` gets passed in
+#
+PUBLISH_VERSION="$1"
+
+#
+# zip
+#
+cd build/ios/pkg/static
+ZIP=mapbox-gl-ios-${PUBLISH_VERSION}.zip
+rm -f ../${ZIP}
+zip -r ../${ZIP} *
+#
+# upload
+#
+REPO_NAME=$(basename $TRAVIS_REPO_SLUG)
+aws s3 cp ../${ZIP} s3://mapbox/$REPO_NAME/ios/builds/ --acl public-read > /dev/null
+echo http://mapbox.s3.amazonaws.com/$REPO_NAME/ios/builds/${ZIP}


### PR DESCRIPTION
Factoring out some work in #1168 to push prebuilt zips of iOS from Travis up to S3 [Studio-style](https://github.com/mapbox/mapbox-studio/blob/mb-pages/scripts/build-travis.sh). This will help smooth testing and integration into apps (test or otherwise) on iOS, as well as make releases as simple as: 

1. `git tag ios-vX.Y.Z`
1. `git push --tags`
1. `git commit --allow-empty -m '[publish ios-vX.Y.Z]'`
1. `git push`