### PR TITLE
fix up Podspec (flatten, back to iOS subfolder)

### DIFF
--- a/ios/MapboxGL.podspec
+++ b/ios/MapboxGL.podspec
@@ -11,23 +11,24 @@ Pod::Spec.new do |m|
   m.screenshot       = 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/master/ios/screenshot.png'
   m.social_media_url = 'https://twitter.com/mapbox'
 
-  m.source = { :http => "http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-gl-ios-#{m.version.to_s}.zip" }
+  m.source = {
+    :http => "http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-gl-ios-#{m.version.to_s}.zip",
+    :flatten => true
+  }
 
   m.platform              = :ios
   m.ios.deployment_target = '7.0'
 
-  m.source_files = 'Headers/*.h'
-
   m.requires_arc = true
 
+  m.preserve_paths = '**'
+  m.source_files = 'Headers/*.h'
   m.resource_bundle = { 'MapboxGL' => 'MapboxGL.bundle/*' }
-
-  m.frameworks = 'CoreLocation', 'CoreTelephony', 'GLKit', 'ImageIO', 'MobileCoreServices', 'QuartzCore', 'SystemConfiguration'
-
-  m.libraries = 'c++', 'sqlite3', 'z'
-
   m.vendored_library = 'libMapboxGL.a'
 
+
+  m.frameworks = 'CoreLocation', 'CoreTelephony', 'GLKit', 'ImageIO', 'MobileCoreServices', 'QuartzCore', 'SystemConfiguration'
+  m.libraries = 'c++', 'sqlite3', 'z'
   m.xcconfig = { 'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++' }
 
 end


### PR DESCRIPTION
Fixes the hosted Podspec since it needs to be flattened when unzipped. Tested using `:podspec` to point to the raw GitHub-hosted branch URL and checks out. 

Also, moved back into `./ios` since `:podspec` was discovered and can point to direct URLs. 