### PR TITLE
Override file name for Mapbox Streets style JSON

### DIFF
--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -20,6 +20,10 @@ static NSArray *const kStyleNames = @[
     @"Satellite",
 ];
 
+static NSDictionary *const kStyleFileNames = @{
+    @"Mapbox Streets": @"mapbox-streets",
+};
+
 static NSString *const kStyleVersion = @"7";
 
 @interface MBXViewController () <UIActionSheetDelegate, MGLMapViewDelegate>
@@ -246,11 +250,16 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
         if (index == [kStyleNames count]) index = 0;
         styleName = [kStyleNames objectAtIndex:index];
     }
+    
+    NSString *styleFileName = kStyleFileNames[styleName];
+    if (!styleFileName) {
+        styleFileName = [NSString stringWithFormat:@"%@-v%@",
+                         [styleName.lowercaseString stringByReplacingOccurrencesOfString:@" " withString:@"-"],
+                         kStyleVersion];
+    }
 
     self.mapView.styleURL = [NSURL URLWithString:
-        [NSString stringWithFormat:@"asset://styles/%@-v%@.json",
-            [[styleName lowercaseString] stringByReplacingOccurrencesOfString:@" " withString:@"-"],
-            kStyleVersion]];
+        [NSString stringWithFormat:@"asset://styles/%@.json", styleFileName]];
 
     [titleButton setTitle:styleName forState:UIControlStateNormal];
 }


### PR DESCRIPTION
Some styles have nonstandard file names that don’t end with “-v7”. This commit adds a special case for Mapbox Streets that can be extended in the future for other styles.

Ref #1228