### PR TITLE
reparse overscaled tiles

### DIFF
--- a/include/mbgl/map/transform_state.hpp
+++ b/include/mbgl/map/transform_state.hpp
@@ -19,7 +19,7 @@ class TransformState {
 
 public:
     // Matrix
-    void matrixFor(mat4& matrix, const TileID& id) const;
+    void matrixFor(mat4& matrix, const TileID& id, const int8_t z, const float tileSize) const;
     box cornersToBox(uint32_t z) const;
 
     // Dimensions

--- a/src/mbgl/map/live_tile_data.cpp
+++ b/src/mbgl/map/live_tile_data.cpp
@@ -16,9 +16,10 @@ LiveTileData::LiveTileData(const TileID& id_,
                            GlyphStore& glyphStore_,
                            SpriteAtlas& spriteAtlas_,
                            util::ptr<Sprite> sprite_,
-                           const SourceInfo& source_)
+                           const SourceInfo& source_,
+                           const float overscaling_)
     : VectorTileData::VectorTileData(id_, mapMaxZoom, style_, glyphAtlas_, glyphStore_,
-                                     spriteAtlas_, sprite_, source_),
+                                     spriteAtlas_, sprite_, source_, overscaling_),
       annotationManager(annotationManager_) {
     // live features are always ready
     state = State::loaded;

--- a/src/mbgl/map/live_tile_data.cpp
+++ b/src/mbgl/map/live_tile_data.cpp
@@ -10,7 +10,6 @@ using namespace mbgl;
 
 LiveTileData::LiveTileData(const TileID& id_,
                            AnnotationManager& annotationManager_,
-                           float mapMaxZoom,
                            util::ptr<Style> style_,
                            GlyphAtlas& glyphAtlas_,
                            GlyphStore& glyphStore_,
@@ -18,7 +17,7 @@ LiveTileData::LiveTileData(const TileID& id_,
                            util::ptr<Sprite> sprite_,
                            const SourceInfo& source_,
                            const float overscaling_)
-    : VectorTileData::VectorTileData(id_, mapMaxZoom, style_, glyphAtlas_, glyphStore_,
+    : VectorTileData::VectorTileData(id_, style_, glyphAtlas_, glyphStore_,
                                      spriteAtlas_, sprite_, source_, overscaling_),
       annotationManager(annotationManager_) {
     // live features are always ready

--- a/src/mbgl/map/live_tile_data.hpp
+++ b/src/mbgl/map/live_tile_data.hpp
@@ -11,7 +11,6 @@ class LiveTileData : public VectorTileData {
 public:
     LiveTileData(const TileID&,
                  AnnotationManager&,
-                 float mapMaxZoom,
                  util::ptr<Style>,
                  GlyphAtlas&,
                  GlyphStore&,

--- a/src/mbgl/map/live_tile_data.hpp
+++ b/src/mbgl/map/live_tile_data.hpp
@@ -17,7 +17,8 @@ public:
                  GlyphStore&,
                  SpriteAtlas&,
                  util::ptr<Sprite>,
-                 const SourceInfo&);
+                 const SourceInfo&,
+                 const float overscaling_);
     ~LiveTileData();
 
     void parse() override;

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/map/map.hpp>
+#include <mbgl/map/tile.hpp>
 #include <mbgl/map/raster_tile_data.hpp>
 #include <mbgl/style/style.hpp>
 
@@ -24,8 +25,8 @@ void RasterTileData::parse() {
     }
 }
 
-void RasterTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) {
-    bucket.render(painter, layer_desc, id, matrix);
+void RasterTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix, const Tile& tile) {
+    bucket.render(painter, layer_desc, tile, matrix);
 }
 
 bool RasterTileData::hasData(StyleLayer const& /*layer_desc*/) const {

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -20,7 +20,7 @@ public:
     ~RasterTileData();
 
     void parse() override;
-    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) override;
+    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix, const Tile& tile) override;
     bool hasData(StyleLayer const &layer_desc) const override;
 
 protected:

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -249,7 +249,7 @@ TileData::State Source::addTile(Map &map, uv::worker &worker,
         // If we don't find working tile data, we're just going to load it.
         if (info.type == SourceType::Vector) {
             new_tile.data =
-                std::make_shared<VectorTileData>(normalized_id, map.getMaxZoom(), style, glyphAtlas,
+                std::make_shared<VectorTileData>(normalized_id, style, glyphAtlas,
                                                  glyphStore, spriteAtlas, sprite, info, overscaling);
             new_tile.data->request(worker, map.getState().getPixelRatio(), callback);
         } else if (info.type == SourceType::Raster) {
@@ -258,7 +258,7 @@ TileData::State Source::addTile(Map &map, uv::worker &worker,
         } else if (info.type == SourceType::Annotations) {
             AnnotationManager& annotationManager = map.getAnnotationManager();
             new_tile.data = std::make_shared<LiveTileData>(normalized_id, annotationManager,
-                                                           map.getMaxZoom(), style, glyphAtlas,
+                                                           style, glyphAtlas,
                                                            glyphStore, spriteAtlas, sprite, info, overscaling);
             new_tile.data->reparse(worker, callback);
         } else {

--- a/src/mbgl/map/tile.hpp
+++ b/src/mbgl/map/tile.hpp
@@ -28,10 +28,11 @@ struct ClipID {
 
 class Tile : private util::noncopyable {
 public:
-    explicit Tile(const TileID& id_)
-        : id(id_) {}
+    explicit Tile(const TileID& id_, const float tileSize_)
+        : id(id_), tileSize(tileSize_) {}
 
     const TileID id;
+    const float tileSize;
     ClipID clip;
     mat4 matrix;
     util::ptr<TileData> data;

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -25,6 +25,7 @@ class Painter;
 class SourceInfo;
 class StyleLayer;
 class Request;
+class Tile;
 
 class TileData : public std::enable_shared_from_this<TileData>,
              private util::noncopyable {
@@ -52,7 +53,7 @@ public:
 
     // Override this in the child class.
     virtual void parse() = 0;
-    virtual void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) = 0;
+    virtual void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix, const Tile& tile) = 0;
     virtual bool hasData(StyleLayer const &layer_desc) const = 0;
 
     const TileID id;

--- a/src/mbgl/map/tile_id.cpp
+++ b/src/mbgl/map/tile_id.cpp
@@ -5,26 +5,42 @@
 
 namespace mbgl {
 
-TileID TileID::parent(int8_t parent_z) const {
+TileID TileID::parent(int8_t parent_z, int8_t sourceMaxZoom) const {
     assert(parent_z < z);
-    int32_t dim = std::pow(2, z - parent_z);
-    return TileID{
-        parent_z,
-        (x >= 0 ? x : x - dim + 1) / dim,
-        y / dim
-    };
-}
 
-std::forward_list<TileID> TileID::children(int32_t child_z) const {
-    assert(child_z > z);
-    int32_t factor = std::pow(2, child_z - z);
-
-    std::forward_list<TileID> child_ids;
-    for (int32_t ty = y * factor, y_max = (y + 1) * factor; ty < y_max; ++ty) {
-        for (int32_t tx = x * factor, x_max = (x + 1) * factor; tx < x_max; ++tx) {
-            child_ids.emplace_front(child_z, tx, ty);
+    auto newX = x;
+    auto newY = y;
+    for (auto newZ = z; newZ > parent_z; newZ--) {
+        if (newZ > sourceMaxZoom) {
+            // the id represents an overscaled tile, return the same coordinates with a lower z
+            // do nothing
+        } else {
+            newX = newX / 2;
+            newY = newY / 2;
         }
     }
+
+    return TileID{parent_z, newX, newY};
+}
+
+std::forward_list<TileID> TileID::children(int8_t sourceMaxZoom) const {
+
+    auto childZ = z + 1;
+
+    std::forward_list<TileID> child_ids;
+    if (z >= sourceMaxZoom) {
+        // return a single tile id representing a an overscaled tile
+        child_ids.emplace_front(childZ, x, y);
+
+    } else {
+        auto childX = x * 2;
+        auto childY = y * 2;
+        child_ids.emplace_front(childZ, childX, childY);
+        child_ids.emplace_front(childZ, childX + 1, childY);
+        child_ids.emplace_front(childZ, childX, childY + 1);
+        child_ids.emplace_front(childZ, childX + 1, childY + 1);
+    }
+
     return child_ids;
 }
 

--- a/src/mbgl/map/tile_id.hpp
+++ b/src/mbgl/map/tile_id.hpp
@@ -43,9 +43,9 @@ public:
         return y < rhs.y;
     }
 
-    TileID parent(int8_t z) const;
+    TileID parent(int8_t z, int8_t sourceMaxZoom) const;
     TileID normalized() const;
-    std::forward_list<TileID> children(int32_t z) const;
+    std::forward_list<TileID> children(int8_t sourceMaxZoom) const;
     bool isChildOf(const TileID&) const;
     operator std::string() const;
 };

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -42,7 +42,7 @@ TileParser::TileParser(const GeometryTile& geometryTile_,
       glyphStore(glyphStore_),
       spriteAtlas(spriteAtlas_),
       sprite(sprite_),
-      collision(util::make_unique<Collision>(tile.id.z, 4096, tile.source.tile_size, tile.depth)) {
+      collision(util::make_unique<Collision>(tile.id.z, 4096, tile.source.tile_size, 1)) {
     assert(style);
     assert(sprite);
     assert(collision);

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -173,7 +173,8 @@ std::unique_ptr<Bucket> TileParser::createLineBucket(const GeometryTileLayer& la
                                                      const StyleBucket& bucket_desc) {
     auto bucket = util::make_unique<LineBucket>(tile.lineVertexBuffer,
                                                 tile.triangleElementsBuffer,
-                                                tile.pointElementsBuffer);
+                                                tile.pointElementsBuffer,
+                                                tile.overscaling);
 
     const float z = tile.id.z;
     auto& layout = bucket->layout;

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -8,8 +8,8 @@ using namespace mbgl;
 
 #pragma mark - Matrix
 
-void TransformState::matrixFor(mat4& matrix, const TileID& id) const {
-    const double tile_scale = std::pow(2, id.z);
+void TransformState::matrixFor(mat4& matrix, const TileID& id, const int8_t z, const float) const {
+    const double tile_scale = std::pow(2, z);
     const double tile_size = scale * util::tileSize / tile_scale;
 
     matrix::identity(matrix);

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -17,14 +17,16 @@ VectorTileData::VectorTileData(const TileID& id_,
                                GlyphStore& glyphStore_,
                                SpriteAtlas& spriteAtlas_,
                                util::ptr<Sprite> sprite_,
-                               const SourceInfo& source_)
+                               const SourceInfo& source_,
+                               const float overscaling_)
     : TileData(id_, source_),
       glyphAtlas(glyphAtlas_),
       glyphStore(glyphStore_),
       spriteAtlas(spriteAtlas_),
       sprite(sprite_),
       style(style_),
-      depth(id.z >= source.max_zoom ? mapMaxZoom - id.z : 1) {
+      depth(id.z >= source.max_zoom ? mapMaxZoom - id.z : 1),
+      overscaling(overscaling_) {
 }
 
 VectorTileData::~VectorTileData() {
@@ -63,12 +65,12 @@ void VectorTileData::parse() {
     }
 }
 
-void VectorTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) {
+void VectorTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix, const Tile& tile) {
     if (state == State::parsed && layer_desc.bucket) {
         auto databucket_it = buckets.find(layer_desc.bucket->name);
         if (databucket_it != buckets.end()) {
             assert(databucket_it->second);
-            databucket_it->second->render(painter, layer_desc, id, matrix);
+            databucket_it->second->render(painter, layer_desc, tile, matrix);
         }
     }
 }

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -11,7 +11,6 @@
 using namespace mbgl;
 
 VectorTileData::VectorTileData(const TileID& id_,
-                               float mapMaxZoom,
                                util::ptr<Style> style_,
                                GlyphAtlas& glyphAtlas_,
                                GlyphStore& glyphStore_,
@@ -25,7 +24,6 @@ VectorTileData::VectorTileData(const TileID& id_,
       spriteAtlas(spriteAtlas_),
       sprite(sprite_),
       style(style_),
-      depth(id.z >= source.max_zoom ? mapMaxZoom - id.z : 1),
       overscaling(overscaling_) {
 }
 

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -2,6 +2,7 @@
 #define MBGL_MAP_VECTOR_TILE_DATA
 
 #include <mbgl/map/tile_data.hpp>
+#include <mbgl/map/tile.hpp>
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/geometry/fill_buffer.hpp>
 #include <mbgl/geometry/icon_buffer.hpp>
@@ -36,11 +37,12 @@ public:
                    GlyphStore&,
                    SpriteAtlas&,
                    util::ptr<Sprite>,
-                   const SourceInfo&);
+                   const SourceInfo&,
+                   const float overscaling_);
     ~VectorTileData();
 
     void parse() override;
-    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) override;
+    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix, const Tile& tile) override;
     bool hasData(StyleLayer const& layer_desc) const override;
 
 protected:
@@ -64,6 +66,7 @@ protected:
 
 public:
     const float depth;
+    const float overscaling;
 };
 
 }

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -31,7 +31,6 @@ class VectorTileData : public TileData {
 
 public:
     VectorTileData(const TileID&,
-                   float mapMaxZoom,
                    util::ptr<Style>,
                    GlyphAtlas&,
                    GlyphStore&,
@@ -65,7 +64,6 @@ protected:
     util::ptr<Style> style;
 
 public:
-    const float depth;
     const float overscaling;
 };
 

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -3,16 +3,16 @@
 
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/mat4.hpp>
+#include <mbgl/map/tile.hpp>
 
 namespace mbgl {
 
 class Painter;
 class StyleLayer;
-class TileID;
 
 class Bucket : private util::noncopyable {
 public:
-    virtual void render(Painter&, const StyleLayer&, const TileID&, const mat4&) = 0;
+    virtual void render(Painter&, const StyleLayer&, const Tile&, const mat4&) = 0;
     virtual bool hasData() const = 0;
     virtual ~Bucket() {}
 

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -12,7 +12,7 @@ DebugBucket::DebugBucket(DebugFontBuffer& fontBuffer_)
 }
 
 void DebugBucket::render(Painter &painter, const StyleLayer & /*layer_desc*/,
-                         const TileID & /*id*/, const mat4 &matrix) {
+                         const Tile & /*id*/, const mat4 &matrix) {
     painter.renderDebugText(*this, matrix);
 }
 

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -19,7 +19,7 @@ class DebugBucket : public Bucket {
 public:
     DebugBucket(DebugFontBuffer& fontBuffer);
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile &tile,
                 const mat4 &matrix) override;
     bool hasData() const override;
 

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -195,9 +195,9 @@ void FillBucket::tessellate() {
     lineGroup.vertex_length += total_vertex_count;
 }
 
-void FillBucket::render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+void FillBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile &tile,
                         const mat4 &matrix) {
-    painter.renderFill(*this, layer_desc, id, matrix);
+    painter.renderFill(*this, layer_desc, tile, matrix);
 }
 
 bool FillBucket::hasData() const {

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -37,7 +37,7 @@ public:
                LineElementsBuffer &lineElementsBuffer);
     ~FillBucket() override;
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile &id,
                 const mat4 &matrix) override;
     bool hasData() const override;
 

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -16,13 +16,15 @@ using namespace mbgl;
 
 LineBucket::LineBucket(LineVertexBuffer &vertexBuffer_,
                        TriangleElementsBuffer &triangleElementsBuffer_,
-                       PointElementsBuffer &pointElementsBuffer_)
+                       PointElementsBuffer &pointElementsBuffer_,
+                       const float overscaling_)
     : vertexBuffer(vertexBuffer_),
       triangleElementsBuffer(triangleElementsBuffer_),
       pointElementsBuffer(pointElementsBuffer_),
       vertex_start(vertexBuffer_.index()),
       triangle_elements_start(triangleElementsBuffer_.index()),
-      point_elements_start(pointElementsBuffer_.index()) {
+      point_elements_start(pointElementsBuffer_.index()),
+      overscaling(overscaling_) {
 }
 
 LineBucket::~LineBucket() {
@@ -93,7 +95,7 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
         currentVertex = vertices[i];
         currentJoin = layout.join;
 
-        if (prevVertex) distance += util::dist<double>(currentVertex, prevVertex);
+        if (prevVertex) distance += util::dist<double>(currentVertex, prevVertex) * overscaling;
 
         // Find the next vertex.
         if (i + 1 < vertices.size()) {
@@ -326,9 +328,9 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
     }
 }
 
-void LineBucket::render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+void LineBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile &tile,
                         const mat4 &matrix) {
-    painter.renderLine(*this, layer_desc, id, matrix);
+    painter.renderLine(*this, layer_desc, tile, matrix);
 }
 
 bool LineBucket::hasData() const {

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -29,10 +29,11 @@ class LineBucket : public Bucket {
 public:
     LineBucket(LineVertexBuffer &vertexBuffer,
                TriangleElementsBuffer &triangleElementsBuffer,
-               PointElementsBuffer &pointElementsBuffer);
+               PointElementsBuffer &pointElementsBuffer,
+               const float overscaling);
     ~LineBucket() override;
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile &tile,
                 const mat4 &matrix) override;
     bool hasData() const override;
 
@@ -57,6 +58,7 @@ private:
     const size_t vertex_start;
     const size_t triangle_elements_start;
     const size_t point_elements_start;
+    const float overscaling;
 
     std::vector<std::unique_ptr<triangle_group_type>> triangleGroups;
     std::vector<std::unique_ptr<point_group_type>> pointGroups;

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -359,7 +359,7 @@ void Painter::renderTileLayer(const Tile& tile, const StyleLayer &layer_desc, co
     if (tile.data->hasData(layer_desc) || layer_desc.type == StyleLayerType::Raster) {
         gl::group group(std::string { "render " } + tile.data->name);
         prepareTile(tile);
-        tile.data->render(*this, layer_desc, matrix);
+        tile.data->render(*this, layer_desc, matrix, tile);
     }
 }
 
@@ -443,12 +443,12 @@ void Painter::renderBackground(const StyleLayer &layer_desc) {
     MBGL_CHECK_ERROR(glEnable(GL_STENCIL_TEST));
 }
 
-mat4 Painter::translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const TileID &id, TranslateAnchorType anchor) {
+mat4 Painter::translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const Tile &tile, TranslateAnchorType anchor) {
     if (translation[0] == 0 && translation[1] == 0) {
         return matrix;
     } else {
         // TODO: Get rid of the 8 (scaling from 4096 to tile size)
-        const double factor = ((double)(1 << id.z)) / state.getScale() * (4096.0 / util::tileSize);
+        const double factor = ((double)(1 << tile.id.z)) / state.getScale() * (4096.0 / tile.tileSize);
 
         mat4 vtxMatrix;
         if (anchor == TranslateAnchorType::Viewport) {

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -92,10 +92,10 @@ public:
 
     void renderDebugText(DebugBucket& bucket, const mat4 &matrix);
     void renderDebugText(const std::vector<std::string> &strings);
-    void renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
-    void renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
-    void renderSymbol(SymbolBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
-    void renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
+    void renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const Tile& tile, const mat4 &matrix);
+    void renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const Tile& tile, const mat4 &matrix);
+    void renderSymbol(SymbolBucket& bucket, const StyleLayer &layer_desc, const Tile& tile, const mat4 &matrix);
+    void renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const Tile& tile, const mat4 &matrix);
     void renderBackground(const StyleLayer &layer_desc);
 
     float saturationFactor(float saturation);
@@ -134,13 +134,13 @@ public:
 private:
     void setupShaders();
     void deleteShaders();
-    mat4 translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const TileID &id, TranslateAnchorType anchor);
+    mat4 translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const Tile &tile, TranslateAnchorType anchor);
 
     void prepareTile(const Tile& tile);
 
     template <typename BucketProperties, typename StyleProperties>
     void renderSDF(SymbolBucket &bucket,
-                   const TileID &id,
+                   const Tile &tile,
                    const mat4 &matrixSymbol,
                    const BucketProperties& bucketProperties,
                    const StyleProperties& styleProperties,

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -11,12 +11,12 @@
 
 using namespace mbgl;
 
-void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix) {
+void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const Tile& tile, const mat4 &matrix) {
     // Abort early.
     if (!bucket.hasData()) return;
 
     const FillProperties &properties = layer_desc.getProperties<FillProperties>();
-    mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);
+    mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, tile, properties.translateAnchor);
 
     Color fill_color = properties.fill_color;
     fill_color[0] *= properties.opacity;
@@ -63,7 +63,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
 
             const SpriteAtlasPosition posA = spriteAtlas.getPosition(properties.image.from, true);
             const SpriteAtlasPosition posB = spriteAtlas.getPosition(properties.image.to, true);
-            float factor = 8.0 / std::pow(2, state.getIntegerZoom() - id.z);
+            float factor = (4096 / tile.tileSize) / std::pow(2, state.getIntegerZoom() - tile.id.z);
 
             mat3 patternMatrixA;
             matrix::identity(patternMatrixA);

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -10,7 +10,7 @@
 
 using namespace mbgl;
 
-void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix) {
+void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const Tile& tile, const mat4 &matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) return;
     if (!bucket.hasData()) return;
@@ -47,7 +47,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
     color[3] *= properties.opacity;
 
     float ratio = state.getPixelRatio();
-    mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);
+    mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, tile, properties.translateAnchor);
 
     depthRange(strata, 1.0f);
 
@@ -89,7 +89,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         LinePatternPos posB = lineAtlas.getDashPosition(properties.dash_array.to, layout.cap == CapType::Round);
         lineAtlas.bind();
 
-        float patternratio = std::pow(2.0, std::floor(std::log2(state.getScale())) - id.z) / 8.0;
+        float patternratio = std::pow(2.0, std::floor(std::log2(state.getScale())) - tile.id.z) / 8.0;
         float scaleXA = patternratio / posA.width / properties.dash_line_width / properties.dash_array.fromScale;
         float scaleYA = -posA.height / 2.0;
         float scaleXB = patternratio / posB.width / properties.dash_line_width / properties.dash_array.toScale;
@@ -109,7 +109,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         SpriteAtlasPosition imagePosA = spriteAtlas.getPosition(properties.image.from, true);
         SpriteAtlasPosition imagePosB = spriteAtlas.getPosition(properties.image.to, true);
 
-        float factor = 8.0 / std::pow(2, state.getIntegerZoom() - id.z);
+        float factor = 8.0 / std::pow(2, state.getIntegerZoom() - tile.id.z);
 
         useProgram(linepatternShader->program);
 

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -7,7 +7,7 @@
 
 using namespace mbgl;
 
-void Painter::renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const TileID&, const mat4 &matrix) {
+void Painter::renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const Tile&, const mat4 &matrix) {
     if (pass != RenderPass::Translucent) return;
 
     const RasterProperties &properties = layer_desc.getProperties<RasterProperties>();

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -13,7 +13,7 @@ using namespace mbgl;
 
 template <typename BucketProperties, typename StyleProperties>
 void Painter::renderSDF(SymbolBucket &bucket,
-                        const TileID &id,
+                        const Tile &tile,
                         const mat4 &matrix,
                         const BucketProperties& bucketProperties,
                         const StyleProperties& styleProperties,
@@ -22,7 +22,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
                         SDFShader& sdfShader,
                         void (SymbolBucket::*drawSDF)(SDFShader&))
 {
-    mat4 vtxMatrix = translatedMatrix(matrix, styleProperties.translate, id, styleProperties.translate_anchor);
+    mat4 vtxMatrix = translatedMatrix(matrix, styleProperties.translate, tile, styleProperties.translate_anchor);
 
     mat4 exMatrix;
     matrix::copy(exMatrix, projMatrix);
@@ -112,7 +112,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
     }
 }
 
-void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, const TileID &id, const mat4 &matrix) {
+void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, const Tile &tile, const mat4 &matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) {
         return;
@@ -140,7 +140,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
 
         if (sdf) {
             renderSDF(bucket,
-                      id,
+                      tile,
                       matrix,
                       layout.icon,
                       properties.icon,
@@ -149,7 +149,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
                       *sdfIconShader,
                       &SymbolBucket::drawIcons);
         } else {
-            mat4 vtxMatrix = translatedMatrix(matrix, properties.icon.translate, id, properties.icon.translate_anchor);
+            mat4 vtxMatrix = translatedMatrix(matrix, properties.icon.translate, tile, properties.icon.translate_anchor);
 
             mat4 exMatrix;
             matrix::copy(exMatrix, projMatrix);
@@ -193,7 +193,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
         glyphAtlas.bind();
 
         renderSDF(bucket,
-                  id,
+                  tile,
                   matrix,
                   layout.text,
                   properties.text,

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -8,9 +8,9 @@ RasterBucket::RasterBucket(TexturePool& texturePool, const StyleLayoutRaster& la
   raster(texturePool) {
 }
 
-void RasterBucket::render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+void RasterBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile &tile,
                           const mat4 &matrix) {
-    painter.renderRaster(*this, layer_desc, id, matrix);
+    painter.renderRaster(*this, layer_desc, tile, matrix);
 }
 
 bool RasterBucket::setImage(const std::string &data) {

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -18,7 +18,7 @@ class RasterBucket : public Bucket {
 public:
     RasterBucket(TexturePool&, const StyleLayoutRaster&);
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile &tile,
                 const mat4 &matrix) override;
     bool hasData() const override;
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -30,9 +30,9 @@ SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void SymbolBucket::render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+void SymbolBucket::render(Painter &painter, const StyleLayer &layer_desc, const Tile &tile,
                           const mat4 &matrix) {
-    painter.renderSymbol(*this, layer_desc, id, matrix);
+    painter.renderSymbol(*this, layer_desc, tile, matrix);
 }
 
 bool SymbolBucket::hasData() const { return hasTextData() || hasIconData(); }

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -55,7 +55,7 @@ public:
     SymbolBucket(Collision &collision);
     ~SymbolBucket() override;
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
+    void render(Painter &painter, const StyleLayer &layer_desc, const Tile &tile,
                 const mat4 &matrix) override;
     bool hasData() const override;
     bool hasTextData() const;

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -65,7 +65,7 @@ static void scanTriangle(const mbgl::vec2<double> a, const mbgl::vec2<double> b,
     if (bc.dy) scanSpans(ca, bc, ymin, ymax, scanLine);
 }
 
-std::forward_list<TileID> tileCover(int8_t z, const mbgl::box &bounds) {
+std::forward_list<TileID> tileCover(int8_t z, const mbgl::box &bounds, int8_t actualZ) {
     int32_t tiles = 1 << z;
     std::forward_list<mbgl::TileID> t;
 
@@ -73,7 +73,7 @@ std::forward_list<TileID> tileCover(int8_t z, const mbgl::box &bounds) {
         int32_t x;
         if (y >= 0 && y <= tiles) {
             for (x = x0; x < x1; x++) {
-                t.emplace_front(z, x, y);
+                t.emplace_front(actualZ, x, y);
             }
         }
     };

--- a/src/mbgl/util/tile_cover.hpp
+++ b/src/mbgl/util/tile_cover.hpp
@@ -8,7 +8,7 @@
 
 namespace mbgl {
 
-std::forward_list<TileID> tileCover(int8_t z, const box& bounds);
+std::forward_list<TileID> tileCover(int8_t z, const box& bounds, int8_t actualZ);
 
 }
 

--- a/test/miscellaneous/clip_ids.cpp
+++ b/test/miscellaneous/clip_ids.cpp
@@ -30,11 +30,11 @@ template <typename T> void print(const T &sources) {
 TEST(ClipIDs, ParentAndFourChildren) {
     const std::vector<std::vector<std::shared_ptr<Tile>>> sources = {
         {
-            std::make_shared<Tile>(TileID { 1, 0, 0 }),
-            std::make_shared<Tile>(TileID { 1, 0, 1 }),
-            std::make_shared<Tile>(TileID { 1, 1, 0 }),
-            std::make_shared<Tile>(TileID { 1, 1, 1 }),
-            std::make_shared<Tile>(TileID { 0, 0, 0 }),
+            std::make_shared<Tile>(TileID { 1, 0, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, 0, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, 1, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, 1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 0, 0, 0 }, 512.0f),
         },
     };
 
@@ -51,11 +51,11 @@ TEST(ClipIDs, ParentAndFourChildren) {
 TEST(ClipIDs, ParentAndFourChildrenNegative) {
     const std::vector<std::vector<std::shared_ptr<Tile>>> sources = {
         {
-            std::make_shared<Tile>(TileID { 1, -2, 0 }),
-            std::make_shared<Tile>(TileID { 1, -2, 1 }),
-            std::make_shared<Tile>(TileID { 1, -1, 0 }),
-            std::make_shared<Tile>(TileID { 1, -1, 1 }),
-            std::make_shared<Tile>(TileID { 0, -1, 0 }),
+            std::make_shared<Tile>(TileID { 1, -2, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, -2, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, -1, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, -1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 0, -1, 0 }, 512.0f),
         },
     };
 
@@ -72,11 +72,11 @@ TEST(ClipIDs, ParentAndFourChildrenNegative) {
 TEST(ClipIDs, NegativeParentAndMissingLevel) {
     const std::vector<std::vector<std::shared_ptr<Tile>>> sources = {
         {
-            std::make_shared<Tile>(TileID { 1, -1, 0 }),
-            std::make_shared<Tile>(TileID { 2, -1, 0 }),
-            std::make_shared<Tile>(TileID { 2, -2, 1 }),
-            std::make_shared<Tile>(TileID { 2, -1, 1 }),
-            std::make_shared<Tile>(TileID { 2, -2, 0 }),
+            std::make_shared<Tile>(TileID { 1, -1, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, -1, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, -2, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, -1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, -2, 0 }, 512.0f),
         },
     };
 
@@ -94,13 +94,13 @@ TEST(ClipIDs, NegativeParentAndMissingLevel) {
 TEST(ClipIDs, SevenOnSameLevel) {
     const std::vector<std::vector<std::shared_ptr<Tile>>> sources = {
         {
-            std::make_shared<Tile>(TileID { 2, 0, 0 }),
-            std::make_shared<Tile>(TileID { 2, 0, 1 }),
-            std::make_shared<Tile>(TileID { 2, 0, 2 }),
-            std::make_shared<Tile>(TileID { 2, 1, 0 }),
-            std::make_shared<Tile>(TileID { 2, 1, 1 }),
-            std::make_shared<Tile>(TileID { 2, 1, 2 }),
-            std::make_shared<Tile>(TileID { 2, 2, 0 }),
+            std::make_shared<Tile>(TileID { 2, 0, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 0, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 0, 2 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 1, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 1, 2 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 2, 0 }, 512.0f),
         },
     };
 
@@ -119,18 +119,18 @@ TEST(ClipIDs, SevenOnSameLevel) {
 TEST(ClipIDs, MultipleLevels) {
     const std::vector<std::vector<std::shared_ptr<Tile>>> sources = {
         {
-            std::make_shared<Tile>(TileID { 2, 0, 0 }),
-                std::make_shared<Tile>(TileID { 3, 0, 0 }),
-                std::make_shared<Tile>(TileID { 3, 0, 1 }),
-                    std::make_shared<Tile>(TileID { 4, 0, 2 }),
-                    std::make_shared<Tile>(TileID { 4, 1, 2 }),
-                    std::make_shared<Tile>(TileID { 4, 0, 3 }),
-                    std::make_shared<Tile>(TileID { 4, 1, 3 }),
-                std::make_shared<Tile>(TileID { 3, 1, 0 }),
-                std::make_shared<Tile>(TileID { 3, 1, 1 }),
-            std::make_shared<Tile>(TileID { 2, 1, 0 }),
-                std::make_shared<Tile>(TileID { 3, 2, 0 }),
-                std::make_shared<Tile>(TileID { 3, 2, 1 }),
+            std::make_shared<Tile>(TileID { 2, 0, 0 }, 512.0f),
+                std::make_shared<Tile>(TileID { 3, 0, 0 }, 512.0f),
+                std::make_shared<Tile>(TileID { 3, 0, 1 }, 512.0f),
+                    std::make_shared<Tile>(TileID { 4, 0, 2 }, 512.0f),
+                    std::make_shared<Tile>(TileID { 4, 1, 2 }, 512.0f),
+                    std::make_shared<Tile>(TileID { 4, 0, 3 }, 512.0f),
+                    std::make_shared<Tile>(TileID { 4, 1, 3 }, 512.0f),
+                std::make_shared<Tile>(TileID { 3, 1, 0 }, 512.0f),
+                std::make_shared<Tile>(TileID { 3, 1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 1, 0 }, 512.0f),
+                std::make_shared<Tile>(TileID { 3, 2, 0 }, 512.0f),
+                std::make_shared<Tile>(TileID { 3, 2, 1 }, 512.0f),
         },
     };
 
@@ -155,17 +155,17 @@ TEST(ClipIDs, MultipleLevels) {
 TEST(ClipIDs, Bug206) {
     const std::vector<std::vector<std::shared_ptr<Tile>>> sources = {
         {
-            std::make_shared<Tile>(TileID { 10, 162, 395 }),
-            std::make_shared<Tile>(TileID { 10, 162, 396 }),
-            std::make_shared<Tile>(TileID { 10, 163, 395 }),
-                std::make_shared<Tile>(TileID { 11, 326, 791 }),
-                std::make_shared<Tile>(TileID { 12, 654, 1582 }),
-                std::make_shared<Tile>(TileID { 12, 654, 1583 }),
-                std::make_shared<Tile>(TileID { 12, 655, 1582 }),
-                std::make_shared<Tile>(TileID { 12, 655, 1583 }),
-            std::make_shared<Tile>(TileID { 10, 163, 396 }),
-            std::make_shared<Tile>(TileID { 10, 164, 395 }),
-            std::make_shared<Tile>(TileID { 10, 164, 396 }),
+            std::make_shared<Tile>(TileID { 10, 162, 395 }, 512.0f),
+            std::make_shared<Tile>(TileID { 10, 162, 396 }, 512.0f),
+            std::make_shared<Tile>(TileID { 10, 163, 395 }, 512.0f),
+                std::make_shared<Tile>(TileID { 11, 326, 791 }, 512.0f),
+                std::make_shared<Tile>(TileID { 12, 654, 1582 }, 512.0f),
+                std::make_shared<Tile>(TileID { 12, 654, 1583 }, 512.0f),
+                std::make_shared<Tile>(TileID { 12, 655, 1582 }, 512.0f),
+                std::make_shared<Tile>(TileID { 12, 655, 1583 }, 512.0f),
+            std::make_shared<Tile>(TileID { 10, 163, 396 }, 512.0f),
+            std::make_shared<Tile>(TileID { 10, 164, 395 }, 512.0f),
+            std::make_shared<Tile>(TileID { 10, 164, 396 }, 512.0f),
         },
     };
 
@@ -189,23 +189,23 @@ TEST(ClipIDs, Bug206) {
 TEST(ClipIDs, MultipleSources) {
     const std::vector<std::vector<std::shared_ptr<Tile>>> sources = {
         {
-            std::make_shared<Tile>(TileID { 0, 0, 0 }),
-            std::make_shared<Tile>(TileID { 1, 1, 1 }),
-            std::make_shared<Tile>(TileID { 2, 2, 1 }),
-            std::make_shared<Tile>(TileID { 2, 2, 2 }),
+            std::make_shared<Tile>(TileID { 0, 0, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, 1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 2, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 2, 2 }, 512.0f),
         },
         {
-            std::make_shared<Tile>(TileID { 0, 0, 0 }),
-            std::make_shared<Tile>(TileID { 1, 1, 1 }),
-            std::make_shared<Tile>(TileID { 2, 1, 1 }),
-            std::make_shared<Tile>(TileID { 2, 2, 2 }),
+            std::make_shared<Tile>(TileID { 0, 0, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, 1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 2, 2 }, 512.0f),
         },
         {
-            std::make_shared<Tile>(TileID { 1, 0, 0 }),
-            std::make_shared<Tile>(TileID { 1, 0, 1 }),
-            std::make_shared<Tile>(TileID { 1, 1, 0 }),
-            std::make_shared<Tile>(TileID { 1, 1, 1 }),
-            std::make_shared<Tile>(TileID { 2, 1, 1 }),
+            std::make_shared<Tile>(TileID { 1, 0, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, 0, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, 1, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 1, 1, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 1, 1 }, 512.0f),
         },
     };
 
@@ -231,13 +231,13 @@ TEST(ClipIDs, MultipleSources) {
 TEST(ClipIDs, DuplicateIDs) {
         const std::vector<std::vector<std::shared_ptr<Tile>>> sources = {
         {
-            std::make_shared<Tile>(TileID { 2, 0, 0 }),
-            std::make_shared<Tile>(TileID { 2, 0, 1 }),
+            std::make_shared<Tile>(TileID { 2, 0, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 0, 1 }, 512.0f),
         },
         {
-            std::make_shared<Tile>(TileID { 2, 0, 0 }),
-            std::make_shared<Tile>(TileID { 2, 0, 1 }),
-            std::make_shared<Tile>(TileID { 2, 0, 1 }),
+            std::make_shared<Tile>(TileID { 2, 0, 0 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 0, 1 }, 512.0f),
+            std::make_shared<Tile>(TileID { 2, 0, 1 }, 512.0f),
         }
     };
 


### PR DESCRIPTION
This ports https://github.com/mapbox/mapbox-gl-js/pull/1005 and https://github.com/mapbox/mapbox-gl-js/commit/794c1eb304de0b3851c6d81528c0a97721d1735c

This reparses tiles at zoom levels > the sources maxzoom so that layout property functions are applied and label are replaced.

This will make symbol parsing performance worse at high zoom levels until the labeling improvements are merged.