### PR TITLE
404 errors when style uses functions for text-font

### DIFF
--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -45,8 +45,8 @@ std::vector<SymbolFeature> SymbolBucket::processFeatures(const GeometryTileLayer
                                                          const FilterExpression& filter,
                                                          GlyphStore &glyphStore,
                                                          const Sprite &sprite) {
-    const bool has_text = layout.text.field.size();
-    const bool has_icon = layout.icon.image.size();
+    const bool has_text = !layout.text.field.empty() && !layout.text.font.empty();
+    const bool has_icon = !layout.icon.image.empty();
 
     std::vector<SymbolFeature> features;
 

--- a/src/mbgl/style/style_layout.hpp
+++ b/src/mbgl/style/style_layout.hpp
@@ -61,7 +61,7 @@ public:
     struct {
         RotationAlignmentType rotation_alignment = RotationAlignmentType::Viewport;
         std::string field;
-        std::string font;
+        std::string font = "Open Sans Regular, Arial Unicode MS Regular";
         float max_size = 16.0f;
         float max_width = 15.0f /* em */;
         float line_height = 1.2f /* em */;


### PR DESCRIPTION
With #1236, the iOS demo app is able to load the Mapbox Streets style, but often only the raster terrain layer loads:

![greenstreets](https://cloud.githubusercontent.com/assets/1231218/7058579/c73515c0-de18-11e4-8c65-19694d75e3ac.PNG)

Errors like this appear in the console:

```
2015-04-08 17:33:32.329 Mapbox GL[4971:43873] [ERROR] {0}{TileWorker_12/659/1589}[ParseTile]: Parsing [12/659/1589] failed: [ERROR] failed to load glyphs: HTTP status code 404
```

We’re requesting .pbfs like `https://api.tiles.mapbox.com/v4/fontstack//0-255.pbf?access_token=sk.deadbeef`, whereas we should be requesting .pbfs like `https://api.tiles.mapbox.com/v4/fontstack/Open%20Sans%20Semibold%20Italic%2c%20Arial%20Unicode%20MS%20Regular/0-255.pbf?access_token=sk.deadbeef`. The difference with Mapbox Streets is that it’s [setting `text-font` to a function rather than a string](https://github.com/mapbox/mapbox-gl-styles/blob/9712aa66eb164eac159768a208914ee10608ca34/styles/mapbox-streets.json#L2101). I take it functional `text-font`s are valid, correct?