### PR TITLE
Refs #1256 - Fix some erronenous tracking mode resets

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1106,8 +1106,6 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (void)resetNorthAnimated:(BOOL)animated
 {
-    self.userTrackingMode = MGLUserTrackingModeNone;
-
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
     mbglMap->setBearing(0, secondsAsDuration(duration));
@@ -1179,17 +1177,22 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     return latLngToCoordinate(mbglMap->getLatLng());
 }
 
+- (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(double)zoomLevel animated:(BOOL)animated preservingTracking:(BOOL)tracking
+{
+    self.userTrackingMode = (tracking ? self.userTrackingMode : MGLUserTrackingModeNone);
+    
+    CGFloat duration = (animated ? MGLAnimationDuration : 0);
+    
+    mbglMap->setLatLngZoom(coordinateToLatLng(centerCoordinate), zoomLevel, secondsAsDuration(duration));
+    
+    [self unrotateIfNeededAnimated:animated];
+    
+    [self notifyMapChange:@(animated ? mbgl::MapChangeRegionDidChangeAnimated : mbgl::MapChangeRegionDidChange)];
+}
+
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(double)zoomLevel animated:(BOOL)animated
 {
-    self.userTrackingMode = MGLUserTrackingModeNone;
-
-    CGFloat duration = (animated ? MGLAnimationDuration : 0);
-
-    mbglMap->setLatLngZoom(coordinateToLatLng(centerCoordinate), zoomLevel, secondsAsDuration(duration));
-
-    [self unrotateIfNeededAnimated:animated];
-
-    [self notifyMapChange:@(animated ? mbgl::MapChangeRegionDidChangeAnimated : mbgl::MapChangeRegionDidChange)];
+    [self setCenterCoordinate:centerCoordinate zoomLevel:zoomLevel animated:animated preservingTracking:NO];
 }
 
 - (double)zoomLevel
@@ -1219,8 +1222,6 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (void)zoomToSouthWestCoordinate:(CLLocationCoordinate2D)southWestCoordinate northEastCoordinate:(CLLocationCoordinate2D)northEastCoordinate animated:(BOOL)animated
 {
-    // NOTE: does not disrupt tracking mode
-
     CLLocationCoordinate2D center = CLLocationCoordinate2DMake((northEastCoordinate.latitude + southWestCoordinate.latitude) / 2, (northEastCoordinate.longitude + southWestCoordinate.longitude) / 2);
     
     CGFloat scale = mbglMap->getScale();
@@ -1230,7 +1231,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     CGFloat maxZoom = mbglMap->getMaxZoom();
     CGFloat zoomLevel = MAX(MIN(log(scale * MIN(scaleX, scaleY)) / log(2), maxZoom), minZoom);
     
-    [self setCenterCoordinate:center zoomLevel:zoomLevel animated:animated];
+    [self setCenterCoordinate:center zoomLevel:zoomLevel animated:animated preservingTracking:YES];
 }
 
 - (CLLocationDirection)direction


### PR DESCRIPTION
- Adds private `preservingTracking:` version of `setCenterCoordinate:zoomLevel:animated:`
- Changes `zoomToSouthWestCoordinate:northEastCoordinate:animated:` to above `preservingTracking:`, fixes an untended tracking mode reset
- Removes tracking mode reset from `resetNorthAnimated:`
  - [`handleCompassTapGesture:`](https://github.com/mapbox/mapbox-gl-native/blob/e6e340afd17a29ee4d183540e716376cdb1ef88e/platform/ios/MGLMapView.mm#L612-L617) was intending to simply bump down to `MGLUserTrackingModeFollow` if it was following with heading, but it was getting clobbered by `resetNorthAnimated:`.

Only fixes half of #1256.