### PR TITLE
define MACOSX_DEPLOYMENT_TARGET in common.gypi

### DIFF
--- a/gyp/common.gypi
+++ b/gyp/common.gypi
@@ -23,6 +23,7 @@
           ],
           'GCC_WARN_PEDANTIC': 'YES',
           'GCC_WARN_UNINITIALIZED_AUTOS': 'YES_AGGRESSIVE',
+          'MACOSX_DEPLOYMENT_TARGET': '10.9',
         },
       }, {
         'cflags_cc': [

--- a/macosx/mapboxgl-app.gyp
+++ b/macosx/mapboxgl-app.gyp
@@ -54,7 +54,6 @@
         'OTHER_LDFLAGS': [ '<@(ldflags)' ],
         'SDKROOT': 'macosx',
         'INFOPLIST_FILE': 'Info.plist',
-        'MACOSX_DEPLOYMENT_TARGET': '10.9',
         'CLANG_ENABLE_OBJC_ARC': 'YES'
       },
     }


### PR DESCRIPTION
Needed to prevent node-gyp from overriding this everywhere with '10.5'
from https://github.com/joyent/node/blob/master/common.gypi

Does this seem reasonable @springmeyer @incanus?