### PR TITLE
fixes #1283

### DIFF
--- a/src/mbgl/map/tile_cache.cpp
+++ b/src/mbgl/map/tile_cache.cpp
@@ -16,7 +16,6 @@ void TileCache::setSize(size_t size_) {
     assert(orderedKeys.size() <= size);
 
     tiles.reserve(size);
-    orderedKeys.resize(size);
 }
 
 void TileCache::add(uint64_t key, std::shared_ptr<TileData> data) {


### PR DESCRIPTION
Trying to be smart and reserve known size, but we can't really do this for `std::list` so punt instead of buggily filling with zeros. 