### PR TITLE
Rename Static => Still

### DIFF
--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) {
     HeadlessView view;
     Map map(view, fileSource);
 
-    map.start(Map::Mode::Static);
+    map.start(Map::Mode::Still);
 
     // Set access token if present
     if (token.size()) {

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -51,7 +51,7 @@ public:
     enum class Mode : uint8_t {
         None, // we're not doing any processing
         Continuous, // continually updating map
-        Static, // a once-off static image.
+        Still, // a once-off still image.
     };
 
     explicit Map(View&, FileSource&);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -247,15 +247,15 @@ void Map::resume() {
 void Map::renderStill(StillImageCallback fn) {
     assert(Environment::currentlyOn(ThreadType::Main));
 
-    if (mode != Mode::Static) {
-        throw util::Exception("Map is not in static render mode");
+    if (mode != Mode::Still) {
+        throw util::Exception("Map is not in still image render mode");
     }
 
     if (callback) {
         throw util::Exception("Map is currently rendering an image");
     }
 
-    assert(mode == Mode::Static);
+    assert(mode == Mode::Still);
 
     callback = std::move(fn);
 
@@ -287,7 +287,7 @@ void Map::run() {
             uv_run(env->loop, UV_RUN_DEFAULT);
             checkForPause();
         }
-    } else if (mode == Mode::Static) {
+    } else if (mode == Mode::Still) {
         terminating = false;
         while (!terminating) {
             uv_run(env->loop, UV_RUN_DEFAULT);

--- a/test/api/repeated_render.cpp
+++ b/test/api/repeated_render.cpp
@@ -24,7 +24,7 @@ TEST(API, RepeatedRender) {
 
     Map map(view, fileSource);
 
-    map.start(Map::Mode::Static);
+    map.start(Map::Mode::Still);
 
     {
         view.resize(128, 512, 1);

--- a/test/api/set_style.cpp
+++ b/test/api/set_style.cpp
@@ -18,7 +18,7 @@ TEST(API, SetStyle) {
 
     Map map(view, fileSource);
 
-    map.start(Map::Mode::Static);
+    map.start(Map::Mode::Still);
 
     map.setStyleJSON("invalid", "test/suite");
 

--- a/test/headless/headless.cpp
+++ b/test/headless/headless.cpp
@@ -145,7 +145,7 @@ TEST_P(HeadlessTest, render) {
         DefaultFileSource fileSource(nullptr);
         Map map(view, fileSource);
 
-        map.start(Map::Mode::Static);
+        map.start(Map::Mode::Still);
 
         map.setClasses(classes);
         map.setStyleJSON(style, "test/suite");


### PR DESCRIPTION
Currently, our still image rendering mode is called `Mode::Static`, but the function is called `renderStill`. I think we should settle on `Still` since this has less of a naming conflict with `static` as a keyword in C++.