### PR TITLE
Ensure correct spin direction

### DIFF
--- a/include/mbgl/util/math.hpp
+++ b/include/mbgl/util/math.hpp
@@ -99,6 +99,12 @@ T clamp(T value, T min, T max) {
 }
 
 template <typename T>
+T wrap(T value, T min, T max) {
+    T d = max - min;
+    return value == max ? value : std::fmod((std::fmod((value - min), d) + d), d) + min;
+}
+
+template <typename T>
 T smoothstep(T edge0, T edge1, T x) {
     T t = clamp((x - edge0) / (edge1 - edge0), T(0), T(1));
     return t * t * (T(3) - T(2) * t);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -12,6 +12,21 @@
 
 using namespace mbgl;
 
+/** Converts the given angle (in radians) to be numerically close to the anchor angle, allowing it to be interpolated properly without sudden jumps. */
+static double _normalizeAngle(double angle, double anchorAngle)
+{
+    angle = util::wrap(angle, -M_PI, M_PI);
+    double diff = std::abs(angle - anchorAngle);
+    if (std::abs(angle - util::M2PI - anchorAngle) < diff) {
+        angle -= util::M2PI;
+    }
+    if (std::abs(angle + util::M2PI - anchorAngle) < diff) {
+        angle += util::M2PI;
+    }
+    
+    return angle;
+}
+
 Transform::Transform(View &view_)
     : view(view_)
 {
@@ -330,12 +345,7 @@ void Transform::_setAngle(double new_angle, const Duration duration) {
                            MapChangeRegionWillChangeAnimated :
                            MapChangeRegionWillChange);
 
-    while (new_angle > M_PI)
-        new_angle -= util::M2PI;
-    while (new_angle <= -M_PI)
-        new_angle += util::M2PI;
-
-    final.angle = new_angle;
+    final.angle = _normalizeAngle(new_angle, current.angle);
 
     if (duration == Duration::zero()) {
         current.angle = final.angle;


### PR DESCRIPTION
Ported mapbox/mapbox-gl-js#821 as well as `util.wrap()` from mapbox-gl-js.

Fixes #1199.

/cc @mourner