### PR TITLE
Cancel animations on touch down

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -647,6 +647,15 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 #pragma clang diagnostic pop
 
+- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    (void)touches;
+    (void)event;
+    mbglMap->cancelTransitions();
+    mbglMap->setGestureInProgress(false);
+    self.animatingGesture = NO;
+}
+
 - (void)handlePanGesture:(UIPanGestureRecognizer *)pan
 {
     if ( ! self.isScrollEnabled) return;


### PR DESCRIPTION
Cancel any map animations as soon as a finger is set upon the screen.

Fixes #1258.

/cc @incanus