### PR TITLE
Constrain user dot to superview margins

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1701,6 +1701,8 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
         }
         
         self.userLocationAnnotationView = [[MGLUserLocationAnnotationView alloc] initInMapView:self];
+        self.userLocationAnnotationView.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin |
+                                                            UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin);
         
         self.locationManager = [CLLocationManager new];
         


### PR DESCRIPTION
When the screen changes orientation, the user dot should always appear over the correct location. Previously it appeared to animate from a spot to the southwest or southeast of the user’s location as the device was rotated.

Fixes #1313.