### PR TITLE
Correct build-version.py indentation — fixes #1315

### DIFF
--- a/scripts/build-version.py
+++ b/scripts/build-version.py
@@ -13,9 +13,9 @@ else:
     if sys.argv[2] == sys.argv[3]:
         tag = [0, 0, 0]
     else:
-	ver = re.sub("[^0-9.]", "", sys.argv[2])
+        ver = re.sub("[^0-9.]", "", sys.argv[2])
         tag = map(int, ver.split('.'))
-    rev = sys.argv[3][0:8]
+        rev = sys.argv[3][0:8]
 
 
 def mkdir_p(path):


### PR DESCRIPTION
Convert to spaces for indentation and indent the rest of the `else` statement to match. Fix #1315.

(Testing/abusing my newly-bestowed superpowers. Will resist the urge to merge.)