### PR TITLE
fixes #1308: normalize tile memory cache keys & allow dupe inserts

### DIFF
--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -245,7 +245,7 @@ TileData::State Source::addTile(Map &map, Worker &worker,
     }
 
     if (!new_tile.data) {
-        new_tile.data = cache.get(id.to_uint64());
+        new_tile.data = cache.get(normalized_id.to_uint64());
     }
 
     if (!new_tile.data) {
@@ -418,7 +418,7 @@ void Source::update(Map &map,
         if (!obsolete) {
             retain_data.insert(tile.data->id);
         } else if (type != SourceType::Raster && tile.data->ready()) {
-            tileCache.add(tile.id.to_uint64(), tile.data);
+            tileCache.add(tile.id.normalized().to_uint64(), tile.data);
         }
         return obsolete;
     });
@@ -432,7 +432,7 @@ void Source::update(Map &map,
 
         bool obsolete = retain_data.find(tile->id) == retain_data.end();
         if (obsolete) {
-            if (!tileCache.has(tile->id.to_uint64())) {
+            if (!tileCache.has(tile->id.normalized().to_uint64())) {
                 tile->cancel();
             }
             return true;

--- a/src/mbgl/map/tile_cache.cpp
+++ b/src/mbgl/map/tile_cache.cpp
@@ -20,11 +20,16 @@ void TileCache::setSize(size_t size_) {
 
 void TileCache::add(uint64_t key, std::shared_ptr<TileData> data) {
 
-    assert(tiles.find(key) == tiles.end());
+    // insert new or query existing data
+    if (tiles.emplace(key, data).second) {
+        // remove existing data key
+        orderedKeys.remove(key);
+    }
 
-    tiles.emplace(key, data);
+    // (re-)insert data key as newest
     orderedKeys.push_back(key);
 
+    // purge oldest key/data if necessary
     if (orderedKeys.size() > size) {
         get(orderedKeys.front());
     }


### PR DESCRIPTION
See write-up in https://github.com/mapbox/mapbox-gl-native/issues/1308#issuecomment-95047478. 

- We need to normalize tile IDs for cache operations so that low zooms that show e.g. `1/-1/0` and `1/1/0` at the same time benefit from a shared cache object. 

- As a result, we need to allow for duplicate cache inserts / touching recently-used cache entries since both of those source tiles could go obsolete within a time period that keeps their shared object in the cache. 

/cc @jfirebaugh @ansis @1ec5 