### PR TITLE
Remove promises from the parsing pipeline

### DIFF
--- a/include/mbgl/storage/request.hpp
+++ b/include/mbgl/storage/request.hpp
@@ -19,8 +19,6 @@ namespace mbgl {
 class Response;
 
 class Request : private util::noncopyable {
-    MBGL_STORE_THREAD(tid)
-
 public:
     using Callback = std::function<void(const Response &)>;
     Request(const Resource &resource, uv_loop_t *loop, Callback callback);

--- a/src/mbgl/map/environment.cpp
+++ b/src/mbgl/map/environment.cpp
@@ -128,7 +128,6 @@ void Environment::requestAsync(const Resource& resource,
 
 Request* Environment::request(const Resource& resource,
                               std::function<void(const Response&)> callback) {
-    assert(currentlyOn(ThreadType::Map));
     return fileSource.request(resource, util::RunLoop::current.get()->get(), std::move(callback));
 }
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -168,10 +168,7 @@ void MapContext::updateTiles() {
     if (!style) return;
     for (const auto& source : style->sources) {
         source->update(data, transformState, *style, *glyphAtlas, *glyphStore, *spriteAtlas,
-                       getSprite(), *texturePool, [this]() {
-            assert(Environment::currentlyOn(ThreadType::Map));
-            triggerUpdate();
-        });
+                       getSprite(), *texturePool);
     }
 }
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -165,11 +165,9 @@ void MapContext::loadStyleJSON(const std::string& json, const std::string& base)
 
 void MapContext::updateTiles() {
     assert(Environment::currentlyOn(ThreadType::Map));
-    if (!style) return;
-    for (const auto& source : style->sources) {
-        source->update(data, transformState, *style, *glyphAtlas, *glyphStore, *spriteAtlas,
-                       getSprite(), *texturePool);
-    }
+
+    resourceLoader->update(data, transformState, *glyphAtlas, *glyphStore,
+                           *spriteAtlas, getSprite(), *texturePool);
 }
 
 void MapContext::updateAnnotationTiles(const std::vector<TileID>& ids) {

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/map/update.hpp>
 #include <mbgl/map/environment.hpp>
+#include <mbgl/map/resource_loader.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/util/ptr.hpp>
 
@@ -32,7 +33,7 @@ class StillImage;
 struct LatLng;
 struct LatLngBounds;
 
-class MapContext {
+class MapContext : public ResourceLoader::Observer {
 public:
     MapContext(uv_loop_t*, View&, FileSource&, MapData&, bool startPaused);
     ~MapContext();
@@ -57,6 +58,9 @@ public:
 
     void setSourceTileCacheSize(size_t size);
     void onLowMemory();
+
+    // ResourceLoader::Observer implementation.
+    void onTileDataChanged() override;
 
 private:
     util::ptr<Sprite> getSprite();
@@ -84,6 +88,7 @@ private:
     std::unique_ptr<TexturePool> texturePool;
     std::unique_ptr<Painter> painter;
     std::unique_ptr<Style> style;
+    std::unique_ptr<ResourceLoader> resourceLoader;
 
     util::ptr<Sprite> sprite;
 

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -90,8 +90,6 @@ private:
     std::unique_ptr<Style> style;
     std::unique_ptr<ResourceLoader> resourceLoader;
 
-    util::ptr<Sprite> sprite;
-
     std::string styleURL;
     std::string styleJSON;
 

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -73,6 +73,10 @@ void ResourceLoader::update(MapData& data,
     }
 }
 
+void ResourceLoader::onGlyphRangeLoaded() {
+    emitTileDataChanged();
+}
+
 void ResourceLoader::onSourceLoaded() {
     emitTileDataChanged();
 }

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -1,0 +1,48 @@
+#include <mbgl/map/resource_loader.hpp>
+
+#include <mbgl/map/environment.hpp>
+#include <mbgl/map/source.hpp>
+#include <mbgl/style/style.hpp>
+
+#include <cassert>
+#include <functional>
+
+namespace mbgl {
+
+ResourceLoader::ResourceLoader() {
+    assert(Environment::currentlyOn(ThreadType::Map));
+}
+
+ResourceLoader::~ResourceLoader() {
+    assert(Environment::currentlyOn(ThreadType::Map));
+}
+
+void ResourceLoader::setObserver(Observer* observer) {
+    assert(Environment::currentlyOn(ThreadType::Map));
+    assert(!observer_);
+
+    observer_ = observer;
+}
+
+void ResourceLoader::setStyle(Style* style) {
+    style_ = style;
+
+    Environment& env = Environment::Get();
+    for (const auto& source : style->sources) {
+        source->load(accessToken_, env, std::bind(&ResourceLoader::emitTileDataChanged, this));
+    }
+}
+
+void ResourceLoader::setAccessToken(const std::string& accessToken) {
+    accessToken_ = accessToken;
+}
+
+void ResourceLoader::emitTileDataChanged() {
+    assert(Environment::currentlyOn(ThreadType::Map));
+
+    if (observer_) {
+        observer_->onTileDataChanged();
+    }
+}
+
+}

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -37,10 +37,9 @@ void ResourceLoader::setStyle(Style* style) {
 
     style_ = style;
 
-    Environment& env = Environment::Get();
     for (const auto& source : style->sources) {
         source->setObserver(this);
-        source->load(accessToken_, env);
+        source->load(accessToken_);
     }
 }
 

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -41,6 +41,23 @@ void ResourceLoader::setAccessToken(const std::string& accessToken) {
     accessToken_ = accessToken;
 }
 
+void ResourceLoader::update(MapData& data,
+                            const TransformState& transform,
+                            GlyphAtlas& glyphAtlas,
+                            GlyphStore& glyphStore,
+                            SpriteAtlas& spriteAtlas,
+                            util::ptr<Sprite> sprite,
+                            TexturePool& texturePool) {
+    if (!style_) {
+        return;
+    }
+
+    for (const auto& source : style_->sources) {
+        source->update(
+            data, transform, *style_, glyphAtlas, glyphStore, spriteAtlas, sprite, texturePool);
+    }
+}
+
 void ResourceLoader::onSourceLoaded() {
     emitTileDataChanged();
 }

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -5,7 +5,6 @@
 #include <mbgl/style/style.hpp>
 
 #include <cassert>
-#include <functional>
 
 namespace mbgl {
 
@@ -15,6 +14,10 @@ ResourceLoader::ResourceLoader() {
 
 ResourceLoader::~ResourceLoader() {
     assert(Environment::currentlyOn(ThreadType::Map));
+
+    for (const auto& source : style_->sources) {
+        source->setObserver(nullptr);
+    }
 }
 
 void ResourceLoader::setObserver(Observer* observer) {
@@ -29,12 +32,21 @@ void ResourceLoader::setStyle(Style* style) {
 
     Environment& env = Environment::Get();
     for (const auto& source : style->sources) {
-        source->load(accessToken_, env, std::bind(&ResourceLoader::emitTileDataChanged, this));
+        source->setObserver(this);
+        source->load(accessToken_, env);
     }
 }
 
 void ResourceLoader::setAccessToken(const std::string& accessToken) {
     accessToken_ = accessToken;
+}
+
+void ResourceLoader::onSourceLoaded() {
+    emitTileDataChanged();
+}
+
+void ResourceLoader::onTileLoaded() {
+    emitTileDataChanged();
 }
 
 void ResourceLoader::emitTileDataChanged() {

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_MAP_RESOURCE_LOADER
 #define MBGL_MAP_RESOURCE_LOADER
 
+#include <mbgl/map/source.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
 #include <string>
@@ -13,7 +14,7 @@ class Style;
 // by the Style. The Source object currently owns all the tiles, thus this
 // class will notify its observers of any change on these tiles which will
 // ultimately cause a new rendering to be triggered.
-class ResourceLoader : private util::noncopyable {
+class ResourceLoader : public Source::Observer, private util::noncopyable {
 public:
     class Observer {
     public:
@@ -33,6 +34,10 @@ public:
 
     // Set the access token to be used for loading the tile data.
     void setAccessToken(const std::string& accessToken);
+
+    // Source::Observer implementation.
+    void onSourceLoaded() override;
+    void onTileLoaded() override;
 
 private:
     void emitTileDataChanged();

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/map/source.hpp>
 #include <mbgl/map/sprite.hpp>
+#include <mbgl/text/glyph_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
 #include <string>
@@ -21,7 +22,10 @@ class TransformState;
 // by the Style. The Source object currently owns all the tiles, thus this
 // class will notify its observers of any change on these tiles which will
 // ultimately cause a new rendering to be triggered.
-class ResourceLoader : public Source::Observer, public Sprite::Observer, private util::noncopyable {
+class ResourceLoader : public GlyphStore::Observer,
+                       public Source::Observer,
+                       public Sprite::Observer,
+                       private util::noncopyable {
 public:
     class Observer {
     public:
@@ -51,6 +55,9 @@ public:
     inline util::ptr<Sprite> getSprite() const {
         return sprite_;
     }
+
+    // GlyphStore::Observer implementation.
+    void onGlyphRangeLoaded() override;
 
     // Source::Observer implementation.
     void onSourceLoaded() override;

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -8,7 +8,13 @@
 
 namespace mbgl {
 
+class GlyphAtlas;
+class GlyphStore;
+class MapData;
+class SpriteAtlas;
 class Style;
+class TexturePool;
+class TransformState;
 
 // ResourceLoader is responsible for loading and updating the Source(s) owned
 // by the Style. The Source object currently owns all the tiles, thus this
@@ -34,6 +40,11 @@ public:
 
     // Set the access token to be used for loading the tile data.
     void setAccessToken(const std::string& accessToken);
+
+    // Fetch the tiles needed by the current viewport and emit a signal when
+    // a tile is ready so observers can render the tile.
+    void update(MapData&, const TransformState&, GlyphAtlas&, GlyphStore&,
+                SpriteAtlas&, util::ptr<Sprite>, TexturePool&);
 
     // Source::Observer implementation.
     void onSourceLoaded() override;

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -2,6 +2,7 @@
 #define MBGL_MAP_RESOURCE_LOADER
 
 #include <mbgl/map/source.hpp>
+#include <mbgl/map/sprite.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
 #include <string>
@@ -20,7 +21,7 @@ class TransformState;
 // by the Style. The Source object currently owns all the tiles, thus this
 // class will notify its observers of any change on these tiles which will
 // ultimately cause a new rendering to be triggered.
-class ResourceLoader : public Source::Observer, private util::noncopyable {
+class ResourceLoader : public Source::Observer, public Sprite::Observer, private util::noncopyable {
 public:
     class Observer {
     public:
@@ -44,16 +45,25 @@ public:
     // Fetch the tiles needed by the current viewport and emit a signal when
     // a tile is ready so observers can render the tile.
     void update(MapData&, const TransformState&, GlyphAtlas&, GlyphStore&,
-                SpriteAtlas&, util::ptr<Sprite>, TexturePool&);
+                SpriteAtlas&, TexturePool&);
+
+    // FIXME: There is probably a better place for this.
+    inline util::ptr<Sprite> getSprite() const {
+        return sprite_;
+    }
 
     // Source::Observer implementation.
     void onSourceLoaded() override;
     void onTileLoaded() override;
 
+    // Sprite::Observer implementation.
+    void onSpriteLoaded() override;
+
 private:
     void emitTileDataChanged();
 
     std::string accessToken_;
+    util::ptr<Sprite> sprite_;
     Style* style_ = nullptr;
     Observer* observer_ = nullptr;
 };

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -1,0 +1,47 @@
+#ifndef MBGL_MAP_RESOURCE_LOADER
+#define MBGL_MAP_RESOURCE_LOADER
+
+#include <mbgl/util/noncopyable.hpp>
+
+#include <string>
+
+namespace mbgl {
+
+class Style;
+
+// ResourceLoader is responsible for loading and updating the Source(s) owned
+// by the Style. The Source object currently owns all the tiles, thus this
+// class will notify its observers of any change on these tiles which will
+// ultimately cause a new rendering to be triggered.
+class ResourceLoader : private util::noncopyable {
+public:
+    class Observer {
+    public:
+        virtual ~Observer() = default;
+
+        virtual void onTileDataChanged() = 0;
+    };
+
+    ResourceLoader();
+    ~ResourceLoader();
+
+    void setObserver(Observer* observer);
+
+    // The style object currently owns all the sources. When setting
+    // a new style we will go through all of them and try to load.
+    void setStyle(Style* style);
+
+    // Set the access token to be used for loading the tile data.
+    void setAccessToken(const std::string& accessToken);
+
+private:
+    void emitTileDataChanged();
+
+    std::string accessToken_;
+    Style* style_ = nullptr;
+    Observer* observer_ = nullptr;
+};
+
+}
+
+#endif

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -52,12 +52,18 @@ public:
 
 class Source : public std::enable_shared_from_this<Source>, private util::noncopyable {
 public:
+    class Observer {
+    public:
+        virtual ~Observer() = default;
+
+        virtual void onSourceLoaded() = 0;
+        virtual void onTileLoaded() = 0;
+    };
+
     Source();
     ~Source();
 
-    void load(const std::string& accessToken,
-              Environment&,
-              std::function<void()> callback);
+    void load(const std::string& accessToken, Environment&);
     bool isLoaded() const;
 
     void load(MapData&, Environment&, std::function<void()> callback);
@@ -68,8 +74,7 @@ public:
                 GlyphStore&,
                 SpriteAtlas&,
                 util::ptr<Sprite>,
-                TexturePool&,
-                std::function<void()> callback);
+                TexturePool&);
 
     void invalidateTiles(const std::vector<TileID>&);
 
@@ -83,10 +88,15 @@ public:
     void setCacheSize(size_t);
     void onLowMemory();
 
+    void setObserver(Observer* observer);
+
     SourceInfo info;
     bool enabled;
 
 private:
+    void emitSourceLoaded();
+    void emitTileLoaded();
+
     bool findLoadedChildren(const TileID& id, int32_t maxCoveringZoom, std::forward_list<TileID>& retain);
     bool findLoadedParent(const TileID& id, int32_t minCoveringZoom, std::forward_list<TileID>& retain);
     int32_t coveringZoomLevel(const TransformState&) const;
@@ -100,8 +110,7 @@ private:
                             SpriteAtlas&,
                             util::ptr<Sprite>,
                             TexturePool&,
-                            const TileID&,
-                            std::function<void()> callback);
+                            const TileID&);
 
     TileData::State hasTile(const TileID& id);
     void updateTilePtrs();
@@ -117,6 +126,9 @@ private:
     std::vector<Tile*> tilePtrs;
     std::map<TileID, std::weak_ptr<TileData>> tile_data;
     TileCache cache;
+
+
+    Observer* observer_ = nullptr;
 };
 
 }

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -97,6 +97,7 @@ private:
     void emitSourceLoaded();
     void emitTileLoaded();
 
+    void handlePartialTile(const TileID &id, Worker &worker);
     bool findLoadedChildren(const TileID& id, int32_t maxCoveringZoom, std::forward_list<TileID>& retain);
     bool findLoadedParent(const TileID& id, int32_t minCoveringZoom, std::forward_list<TileID>& retain);
     int32_t coveringZoomLevel(const TransformState&) const;

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -29,6 +29,7 @@ class Sprite;
 class TexturePool;
 class Style;
 class Painter;
+class Request;
 class TransformState;
 class Tile;
 struct ClipID;
@@ -63,7 +64,7 @@ public:
     Source();
     ~Source();
 
-    void load(const std::string& accessToken, Environment&);
+    void load(const std::string& accessToken);
     bool isLoaded() const;
 
     void load(MapData&, Environment&, std::function<void()> callback);
@@ -87,6 +88,7 @@ public:
 
     void setCacheSize(size_t);
     void onLowMemory();
+    void clearRequest();
 
     void setObserver(Observer* observer);
 
@@ -128,7 +130,7 @@ private:
     std::map<TileID, std::weak_ptr<TileData>> tile_data;
     TileCache cache;
 
-
+    Request* req = nullptr;
     Observer* observer_ = nullptr;
 };
 

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -29,9 +29,17 @@ public:
         initial,
         loading,
         loaded,
+        partial,
         parsed,
         obsolete
     };
+
+    // Tile data considered "Ready" can be used for rendering. Data in
+    // partial state is still waiting for network resources but can also
+    // be rendered, although layers will be missing.
+    inline static bool isReadyState(const State& state) {
+        return state == State::partial || state == State::parsed;
+    }
 
     TileData(const TileID&, const SourceInfo&);
     ~TileData();
@@ -42,8 +50,10 @@ public:
     const std::string toString() const;
 
     inline bool ready() const {
-        return state == State::parsed;
+        return isReadyState(state);
     }
+
+    void endParsing();
 
     // Override this in the child class.
     virtual void parse() = 0;
@@ -52,8 +62,17 @@ public:
     const TileID id;
     const std::string name;
     std::atomic<State> state;
+    std::atomic_flag parsing;
 
 protected:
+    // Set the internal parsing state to true so we prevent
+    // multiple workers to parse the same tile in parallel,
+    // which can happen if the tile is in the "partial" state.
+    // It will return true if is possible to start pasing the
+    // tile or false if not (so some other worker is already
+    // parsing the tile).
+    bool mayStartParsing();
+
     const SourceInfo& source;
     Environment& env;
 

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/platform/log.hpp>
 #include <mbgl/style/style_layer.hpp>
 #include <mbgl/map/source.hpp>
+#include <mbgl/map/sprite.hpp>
 #include <mbgl/renderer/fill_bucket.hpp>
 #include <mbgl/renderer/line_bucket.hpp>
 #include <mbgl/renderer/symbol_bucket.hpp>
@@ -117,7 +118,11 @@ std::unique_ptr<Bucket> TileParser::createBucket(const StyleBucket &bucketDesc) 
         } else if (bucketDesc.type == StyleLayerType::Line) {
             return createLineBucket(*layer, bucketDesc);
         } else if (bucketDesc.type == StyleLayerType::Symbol) {
-            return createSymbolBucket(*layer, bucketDesc);
+            if (sprite->isLoaded()) {
+                return createSymbolBucket(*layer, bucketDesc);
+            } else {
+                return nullptr;
+            }
         } else if (bucketDesc.type == StyleLayerType::Raster) {
             return nullptr;
         } else {

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -35,7 +35,8 @@ TileParser::TileParser(const GeometryTile& geometryTile_,
       glyphStore(glyphStore_),
       spriteAtlas(spriteAtlas_),
       sprite(sprite_),
-      collision(util::make_unique<Collision>(tile.id.z, 4096, tile.source.tile_size, tile.depth)) {
+      collision(util::make_unique<Collision>(tile.id.z, 4096, tile.source.tile_size, tile.depth)),
+      partialParse(false) {
     assert(sprite);
     assert(collision);
 }
@@ -57,15 +58,15 @@ void TileParser::parse() {
         if (layer_desc->bucket) {
             // This is a singular layer. Check if this bucket already exists. If not,
             // parse this bucket.
-            auto bucket_it = tile.buckets.find(layer_desc->bucket->name);
-            if (bucket_it == tile.buckets.end()) {
-                // We need to create this bucket since it doesn't exist yet.
-                std::unique_ptr<Bucket> bucket = createBucket(*layer_desc->bucket);
-                if (bucket) {
-                    // Bucket creation might fail because the data tile may not
-                    // contain any data that falls into this bucket.
-                    tile.buckets[layer_desc->bucket->name] = std::move(bucket);
-                }
+            if (tile.getBucket(*layer_desc)) {
+                continue;
+            }
+
+            std::unique_ptr<Bucket> bucket = createBucket(*layer_desc->bucket);
+            if (bucket) {
+                // Bucket creation might fail because the data tile may not
+                // contain any data that falls into this bucket.
+                tile.setBucket(*layer_desc, std::move(bucket));
             }
         } else {
             Log::Warning(Event::ParseTile, "layer '%s' does not have buckets", layer_desc->id.c_str());
@@ -121,6 +122,7 @@ std::unique_ptr<Bucket> TileParser::createBucket(const StyleBucket &bucketDesc) 
             if (sprite->isLoaded()) {
                 return createSymbolBucket(*layer, bucketDesc);
             } else {
+                partialParse = true;
                 return nullptr;
             }
         } else if (bucketDesc.type == StyleLayerType::Raster) {

--- a/src/mbgl/map/tile_parser.hpp
+++ b/src/mbgl/map/tile_parser.hpp
@@ -44,6 +44,9 @@ public:
 
 public:
     void parse();
+    inline bool isPartialParse() const {
+        return partialParse;
+    }
 
 private:
     bool obsolete() const;
@@ -67,6 +70,7 @@ private:
     util::ptr<Sprite> sprite;
 
     std::unique_ptr<Collision> collision;
+    bool partialParse;
 };
 
 }

--- a/src/mbgl/map/tile_parser.hpp
+++ b/src/mbgl/map/tile_parser.hpp
@@ -54,7 +54,7 @@ private:
     std::unique_ptr<Bucket> createBucket(const StyleBucket&);
     std::unique_ptr<Bucket> createFillBucket(const GeometryTileLayer&, const StyleBucket&);
     std::unique_ptr<Bucket> createLineBucket(const GeometryTileLayer&, const StyleBucket&);
-    std::unique_ptr<Bucket> createSymbolBucket(const GeometryTileLayer&, const StyleBucket&);
+    std::unique_ptr<Bucket> createSymbolBucket(const GeometryTileLayer&, const StyleBucket&, bool& needsResources);
 
     template <class Bucket>
     void addBucketGeometries(Bucket&, const GeometryTileLayer&, const FilterExpression&);

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -10,6 +10,7 @@
 
 #include <iosfwd>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 namespace mbgl {
@@ -42,6 +43,8 @@ public:
     void parse() override;
     virtual Bucket* getBucket(StyleLayer const &layer_desc) override;
 
+    void setBucket(StyleLayer const &layer_desc, std::unique_ptr<Bucket> bucket);
+
 protected:
     // Holds the actual geometries in this tile.
     FillVertexBuffer fillVertexBuffer;
@@ -50,15 +53,21 @@ protected:
     TriangleElementsBuffer triangleElementsBuffer;
     LineElementsBuffer lineElementsBuffer;
 
-    // Holds the buckets of this tile.
-    // They contain the location offsets in the buffers stored above
-    std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
-
     GlyphAtlas& glyphAtlas;
     GlyphStore& glyphStore;
     SpriteAtlas& spriteAtlas;
     util::ptr<Sprite> sprite;
     Style& style;
+
+private:
+    // Contains all the Bucket objects for the tile. Buckets are render
+    // objects and they get added to this std::map<> by the workers doing
+    // the actual tile parsing as they get processed. Tiles partially
+    // parsed can get new buckets at any moment but are also fit for
+    // rendering. That said, access to this list needs locking unless
+    // the tile is completely parsed.
+    std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
+    mutable std::mutex bucketsMutex;
 
 public:
     const float depth;

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -64,8 +64,7 @@ bool SymbolBucket::hasIconData() const { return !icon.groups.empty(); }
 
 std::vector<SymbolFeature> SymbolBucket::processFeatures(const GeometryTileLayer& layer,
                                                          const FilterExpression& filter,
-                                                         GlyphStore &glyphStore,
-                                                         const Sprite &sprite) {
+                                                         GlyphStore &glyphStore) {
     const bool has_text = !layout.text.field.empty() && !layout.text.font.empty();
     const bool has_icon = !layout.icon.image.empty();
 
@@ -136,7 +135,6 @@ std::vector<SymbolFeature> SymbolBucket::processFeatures(const GeometryTileLayer
     }
 
     glyphStore.waitForGlyphRanges(layout.text.font, ranges);
-    sprite.waitUntilLoaded();
 
     return features;
 }
@@ -148,7 +146,7 @@ void SymbolBucket::addFeatures(const GeometryTileLayer& layer,
                                Sprite& sprite,
                                GlyphAtlas& glyphAtlas,
                                GlyphStore& glyphStore) {
-    const std::vector<SymbolFeature> features = processFeatures(layer, filter, glyphStore, sprite);
+    const std::vector<SymbolFeature> features = processFeatures(layer, filter, glyphStore);
 
     float horizontalAlign = 0.5;
     float verticalAlign = 0.5;
@@ -221,7 +219,6 @@ void SymbolBucket::addFeatures(const GeometryTileLayer& layer,
 
         // if feature has icon, get sprite atlas position
         if (feature.sprite.length()) {
-            sprite.waitUntilLoaded();
             image = spriteAtlas.getImage(feature.sprite, false);
 
             if (sprite.getSpritePosition(feature.sprite).sdf) {

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -76,8 +76,7 @@ public:
 private:
     std::vector<SymbolFeature> processFeatures(const GeometryTileLayer&,
                                                const FilterExpression&,
-                                               GlyphStore&,
-                                               const Sprite&);
+                                               GlyphStore&);
 
     void addFeature(const std::vector<Coordinate> &line, const Shaping &shaping, const GlyphPositions &face, const Rect<uint16_t> &image);
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -69,6 +69,8 @@ public:
                      GlyphAtlas&,
                      GlyphStore&);
 
+    inline bool needsGlyphs() const { return needsGlyphs_; }
+
     void drawGlyphs(SDFShader& shader);
     void drawIcons(SDFShader& shader);
     void drawIcons(IconShader& shader);
@@ -103,6 +105,7 @@ private:
         std::vector<std::unique_ptr<IconElementGroup>> groups;
     } icon;
 
+    bool needsGlyphs_;
 };
 }
 

--- a/src/mbgl/storage/request.cpp
+++ b/src/mbgl/storage/request.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/storage/request.hpp>
 
+#include <mbgl/map/environment.hpp>
 #include <mbgl/storage/response.hpp>
 
 #include <mbgl/util/util.hpp>
@@ -33,7 +34,6 @@ Request::Request(const Resource &resource_, uv_loop_t *loop, Callback callback_)
 
 // Called in the originating thread.
 void Request::notifyCallback() {
-    MBGL_VERIFY_THREAD(tid)
     if (!canceled) {
         invoke();
     } else {
@@ -84,7 +84,6 @@ void Request::notify(const std::shared_ptr<const Response> &response_) {
 
 // Called in the originating thread.
 void Request::cancel() {
-    MBGL_VERIFY_THREAD(tid)
     assert(async);
     assert(!canceled);
     canceled = util::make_unique<Canceled>();

--- a/src/mbgl/text/glyph_store.cpp
+++ b/src/mbgl/text/glyph_store.cpp
@@ -10,6 +10,7 @@
 #include <mbgl/util/token.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/storage/file_source.hpp>
+#include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
 #include <mbgl/util/uv_detail.hpp>
 #include <algorithm>
@@ -138,11 +139,12 @@ void FontStack::lineWrap(Shaping &shaping, const float lineHeight, const float m
     align(shaping, justify, horizontalAlign, verticalAlign, maxLineLength, lineHeight, line);
 }
 
-GlyphPBF::GlyphPBF(const std::string &glyphURL,
-                   const std::string &fontStack,
+GlyphPBF::GlyphPBF(const std::string& glyphURL,
+                   const std::string& fontStack,
                    GlyphRange glyphRange,
-                   Environment &env)
-    : future(promise.get_future().share()) {
+                   Environment& env,
+                   const GlyphLoadedCallback& callback)
+    : parsed(false) {
     // Load the glyph set URL
     std::string url = util::replaceTokens(glyphURL, [&](const std::string &name) -> std::string {
         if (name == "fontstack") return util::percentEncode(fontStack);
@@ -151,25 +153,21 @@ GlyphPBF::GlyphPBF(const std::string &glyphURL,
     });
 
     // The prepare call jumps back to the main thread.
-    env.requestAsync({ Resource::Kind::Glyphs, url }, [&, url](const Response &res) {
+    env.requestAsync({ Resource::Kind::Glyphs, url }, [&, url, callback](const Response &res) {
         if (res.status != Response::Successful) {
-            // Something went wrong with loading the glyph pbf. Pass on the error to the future listeners.
+            // Something went wrong with loading the glyph pbf.
             const std::string msg = std::string { "[ERROR] failed to load glyphs: " } + url + " message: " + res.message;
-            promise.set_exception(std::make_exception_ptr(std::runtime_error(msg)));
+            Log::Error(Event::HttpRequest, msg);
         } else {
             // Transfer the data to the GlyphSet and signal its availability.
             // Once it is available, the caller will need to call parse() to actually
             // parse the data we received. We are not doing this here since this callback is being
             // called from another (unknown) thread.
             data = res.data;
-            promise.set_value(*this);
+            parsed = true;
+            callback(this);
         }
     });
-}
-
-
-std::shared_future<GlyphPBF &> GlyphPBF::getFuture() {
-    return future;
 }
 
 void GlyphPBF::parse(FontStack &stack) {
@@ -226,8 +224,12 @@ void GlyphPBF::parse(FontStack &stack) {
     data.clear();
 }
 
+bool GlyphPBF::isParsed() const {
+    return parsed;
+}
+
 GlyphStore::GlyphStore(Environment& env_)
-    : env(env_), mtx(util::make_unique<uv::mutex>()), observer(nullptr) {
+    : env(env_), observer(nullptr) {
 }
 
 GlyphStore::~GlyphStore() {
@@ -238,61 +240,59 @@ void GlyphStore::setURL(const std::string &url) {
     glyphURL = url;
 }
 
+bool GlyphStore::requestGlyphRangesIfNeeded(const std::string& fontStack,
+                                            const std::set<GlyphRange>& glyphRanges) {
+    bool requestIsNeeded = false;
 
-void GlyphStore::waitForGlyphRanges(const std::string &fontStack, const std::set<GlyphRange> &glyphRanges) {
-    // We are implementing a blocking wait with futures: Every GlyphSet has a future that we are
-    // waiting for until it is loaded.
     if (glyphRanges.empty()) {
-        return;
+        return requestIsNeeded;
     }
 
-    uv::exclusive<FontStack> stack(mtx);
+    auto callback = [this, fontStack](GlyphPBF* glyph) {
+        glyph->parse(*createFontStack(fontStack));
+        emitGlyphRangeLoaded();
+    };
 
-    std::vector<std::shared_future<GlyphPBF &>> futures;
-    futures.reserve(glyphRanges.size());
-    {
-        auto &rangeSets = ranges[fontStack];
+    std::lock_guard<std::mutex> lock(rangesMutex);
+    auto& rangeSets = ranges[fontStack];
 
-        stack << createFontStack(fontStack);
+    for (const auto& range : glyphRanges) {
+        const auto& rangeSets_it = rangeSets.find(range);
+        if (rangeSets_it == rangeSets.end()) {
+            auto glyph = util::make_unique<GlyphPBF>(glyphURL, fontStack, range, env, callback);
+            rangeSets.emplace(range, std::move(glyph));
+            requestIsNeeded = true;
+            continue;
+        }
 
-        // Attempt to load the glyph range. If the GlyphSet already exists, we are getting back
-        // the same shared_future.
-        for (const auto range : glyphRanges) {
-            futures.emplace_back(loadGlyphRange(fontStack, rangeSets, range));
+        if (!rangeSets_it->second->isParsed()) {
+            requestIsNeeded = true;
         }
     }
 
-    // Now that we potentially created all GlyphSets, we are waiting for the results, one by one.
-    // When we get a result (or the GlyphSet is aready loaded), we are attempting to parse the
-    // GlyphSet.
-    for (const auto& future : futures) {
-        future.get().parse(stack);
-    }
+    return requestIsNeeded;
 }
 
-std::shared_future<GlyphPBF &> GlyphStore::loadGlyphRange(const std::string &fontStack, std::map<GlyphRange, std::unique_ptr<GlyphPBF>> &rangeSets, const GlyphRange range) {
-    auto range_it = rangeSets.find(range);
-    if (range_it == rangeSets.end()) {
-        // We don't have this glyph set yet for this font stack.
-        range_it = rangeSets.emplace(range, util::make_unique<GlyphPBF>(glyphURL, fontStack, range, env)).first;
-    }
+FontStack* GlyphStore::createFontStack(const std::string &fontStack) {
+    std::lock_guard<std::mutex> lock(stacksMutex);
 
-    return range_it->second->getFuture();
-}
-
-FontStack &GlyphStore::createFontStack(const std::string &fontStack) {
     auto stack_it = stacks.find(fontStack);
     if (stack_it == stacks.end()) {
         stack_it = stacks.emplace(fontStack, util::make_unique<FontStack>()).first;
     }
 
-    return *stack_it->second.get();
+    return stack_it->second.get();
 }
 
-uv::exclusive<FontStack> GlyphStore::getFontStack(const std::string &fontStack) {
-    uv::exclusive<FontStack> stack(mtx);
-    stack << createFontStack(fontStack);
-    return stack;
+FontStack* GlyphStore::getFontStack(const std::string &fontStack) {
+    std::lock_guard<std::mutex> lock(stacksMutex);
+
+    const auto& stack_it = stacks.find(fontStack);
+    if (stack_it == stacks.end()) {
+        return nullptr;
+    }
+
+    return stack_it->second.get();
 }
 
 void GlyphStore::setObserver(Observer* observer_) {

--- a/src/mbgl/text/glyph_store.cpp
+++ b/src/mbgl/text/glyph_store.cpp
@@ -226,7 +226,13 @@ void GlyphPBF::parse(FontStack &stack) {
     data.clear();
 }
 
-GlyphStore::GlyphStore(Environment& env_) : env(env_), mtx(util::make_unique<uv::mutex>()) {}
+GlyphStore::GlyphStore(Environment& env_)
+    : env(env_), mtx(util::make_unique<uv::mutex>()), observer(nullptr) {
+}
+
+GlyphStore::~GlyphStore() {
+    observer = nullptr;
+}
 
 void GlyphStore::setURL(const std::string &url) {
     glyphURL = url;
@@ -289,5 +295,14 @@ uv::exclusive<FontStack> GlyphStore::getFontStack(const std::string &fontStack) 
     return stack;
 }
 
+void GlyphStore::setObserver(Observer* observer_) {
+    observer = observer_;
+}
+
+void GlyphStore::emitGlyphRangeLoaded() {
+    if (observer) {
+        observer->onGlyphRangeLoaded();
+    }
+}
 
 }

--- a/src/mbgl/text/glyph_store.hpp
+++ b/src/mbgl/text/glyph_store.hpp
@@ -17,6 +17,7 @@ namespace mbgl {
 
 class FileSource;
 class Environment;
+class Request;
 
 class SDFGlyph {
 public:
@@ -56,6 +57,7 @@ public:
              GlyphRange glyphRange,
              Environment &env,
              const GlyphLoadedCallback& callback);
+    ~GlyphPBF();
 
     void parse(FontStack &stack);
     bool isParsed() const;
@@ -68,6 +70,10 @@ private:
 
     std::string data;
     std::atomic_bool parsed;
+
+    Environment& env;
+    Request* req = nullptr;
+
     mutable std::mutex mtx;
 };
 

--- a/src/mbgl/text/glyph_store.hpp
+++ b/src/mbgl/text/glyph_store.hpp
@@ -75,7 +75,15 @@ private:
 // Manages Glyphrange PBF loading.
 class GlyphStore {
 public:
+    class Observer {
+    public:
+        virtual ~Observer() = default;
+
+        virtual void onGlyphRangeLoaded() = 0;
+    };
+
     GlyphStore(Environment &);
+    ~GlyphStore();
 
     // Block until all specified GlyphRanges of the specified font stack are loaded.
     void waitForGlyphRanges(const std::string &fontStack, const std::set<GlyphRange> &glyphRanges);
@@ -84,7 +92,11 @@ public:
 
     void setURL(const std::string &url);
 
+    void setObserver(Observer* observer);
+
 private:
+    void emitGlyphRangeLoaded();
+
     // Loads an individual glyph range from the font stack and adds it to rangeSets
     std::shared_future<GlyphPBF &> loadGlyphRange(const std::string &fontStack, std::map<GlyphRange, std::unique_ptr<GlyphPBF>> &rangeSets, GlyphRange range);
 
@@ -95,6 +107,8 @@ private:
     std::unordered_map<std::string, std::map<GlyphRange, std::unique_ptr<GlyphPBF>>> ranges;
     std::unordered_map<std::string, std::unique_ptr<FontStack>> stacks;
     std::unique_ptr<uv::mutex> mtx;
+
+    Observer* observer;
 };
 
 


### PR DESCRIPTION
This branch removes promises (and thus blocking) from the parsing pipeline by introducing two new concepts:

* ResourceLoader: which is an object that will manage the tile loading and emit signals to the Map thread when the data changes. A bunch of stuff that was previously on the Map thread is now living inside this object scope, most notably the worker pool. This will make our lives easier to write unit tests for parsing since we don't need anymore to bootstrap the whole stack.

* Partial tile parsing: tiles can now skip buckets that have resources pending. When the resources arrive, we just trigger another update() and the full tile gets rendered.

Fixes #925 