### PR TITLE
Simplify render path

### DIFF
--- a/gyp/platform-android.gypi
+++ b/gyp/platform-android.gypi
@@ -12,6 +12,7 @@
       'sources': [
         '../platform/android/log_android.cpp',
         '../platform/android/asset_root.cpp',
+        '../platform/default/thread.cpp',
         '../platform/default/string_stdlib.cpp',
         '../platform/default/image.cpp',
         '../platform/default/image_reader.cpp',

--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -15,6 +15,7 @@
         '../platform/darwin/application_root.mm',
         '../platform/darwin/asset_root.mm',
         '../platform/darwin/image.mm',
+        '../platform/darwin/nsthread.mm',
         '../platform/darwin/reachability.m',
         '../include/mbgl/ios/MapboxGL.h',
         '../include/mbgl/ios/MGLMapboxEvents.h',

--- a/gyp/platform-linux.gypi
+++ b/gyp/platform-linux.gypi
@@ -14,6 +14,7 @@
         '../platform/default/string_stdlib.cpp',
         '../platform/default/application_root.cpp',
         '../platform/default/asset_root.cpp',
+        '../platform/default/thread.cpp',
         '../platform/default/image.cpp',
         '../platform/default/image_reader.cpp',
         '../platform/default/png_reader.cpp',

--- a/gyp/platform-osx.gypi
+++ b/gyp/platform-osx.gypi
@@ -15,6 +15,7 @@
         '../platform/darwin/application_root.mm',
         '../platform/darwin/asset_root.mm',
         '../platform/darwin/image.mm',
+        '../platform/darwin/nsthread.mm',
       ],
 
       'variables': {

--- a/include/mbgl/platform/gl.hpp
+++ b/include/mbgl/platform/gl.hpp
@@ -159,7 +159,7 @@ inline void start_group(const std::string &str) {
     if (gl::PushDebugGroup != nullptr) {
         MBGL_CHECK_ERROR(gl::PushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, GLsizei(str.size()), str.c_str()));
     } else if (gl::PushGroupMarkerEXT != nullptr) {
-        MBGL_CHECK_ERROR(gl::PushGroupMarkerEXT(GLsizei(str.size()), str.c_str()));
+        MBGL_CHECK_ERROR(gl::PushGroupMarkerEXT(GLsizei(str.size() + 1), str.c_str()));
     }
     // fprintf(stderr, "%s%s\n", std::string(indent * 4, ' ').c_str(), str.c_str());
     // indent++;

--- a/include/mbgl/platform/platform.hpp
+++ b/include/mbgl/platform/platform.hpp
@@ -21,6 +21,9 @@ const std::string &applicationRoot();
 // Returns the path to the asset location.
 const std::string &assetRoot();
 
+// Makes the current thread low priority.
+void makeThreadLowPriority();
+
 // Shows an alpha image with the specified dimensions in a named window.
 void showDebugImage(std::string name, const char *data, size_t width, size_t height);
 

--- a/include/mbgl/util/gl_helper.hpp
+++ b/include/mbgl/util/gl_helper.hpp
@@ -1,0 +1,87 @@
+#ifndef MBGL_UTIL_GL_HELPER
+#define MBGL_UTIL_GL_HELPER
+
+#include <mbgl/platform/gl.hpp>
+
+#include <array>
+
+namespace {
+
+template <typename T, T (*Create)(), void (*Destroy)(const T&)>
+class Preserve {
+public:
+    Preserve() : data(Create()) {}
+    ~Preserve() { Destroy(data); }
+
+private:
+    const T data;
+};
+
+inline bool getBlend() {
+    return glIsEnabled(GL_BLEND);
+}
+
+inline void setBlend(const bool& enabled) {
+    enabled ? MBGL_CHECK_ERROR(glEnable(GL_BLEND)) : MBGL_CHECK_ERROR(glDisable(GL_BLEND));
+}
+
+inline std::array<double, 4> getClearColor() {
+    std::array<double, 4> color;
+    MBGL_CHECK_ERROR(glGetDoublev(GL_COLOR_CLEAR_VALUE, color.data()));
+    return color;
+}
+
+inline void setClearColor(const std::array<double, 4>& color) {
+    MBGL_CHECK_ERROR(glClearColor(color[0], color[1], color[2], color[3]));
+}
+
+
+inline std::array<GLenum, 2> getBlendFunc() {
+    GLint func[2];
+    glGetIntegerv(GL_BLEND_SRC, &func[0]);
+    glGetIntegerv(GL_BLEND_DST, &func[1]);
+    return {{ static_cast<GLenum>(func[0]), static_cast<GLenum>(func[1]) }};
+}
+
+inline void setBlendFunc(const std::array<GLenum, 2>& func) {
+    MBGL_CHECK_ERROR(glBlendFunc(func[0], func[1]));
+}
+
+
+inline std::array<double, 2> getPixelZoom() {
+    std::array<double, 2> zoom;
+    glGetDoublev(GL_ZOOM_X, &zoom[0]);
+    glGetDoublev(GL_ZOOM_Y, &zoom[1]);
+    return zoom;
+}
+
+inline void setPixelZoom(const std::array<double, 2>& func) {
+    MBGL_CHECK_ERROR(glPixelZoom(func[0], func[1]));
+}
+
+
+inline std::array<double, 4> getRasterPos() {
+    std::array<double, 4> pos;
+    MBGL_CHECK_ERROR(glGetDoublev(GL_CURRENT_RASTER_POSITION, pos.data()));
+    return pos;
+}
+
+inline void setRasterPos(const std::array<double, 4>& pos) {
+    MBGL_CHECK_ERROR(glRasterPos4d(pos[0], pos[1], pos[2], pos[3]));
+}
+
+} // end anonymous namespace
+
+namespace mbgl {
+namespace gl {
+
+using PreserveBlend = Preserve<bool, getBlend, setBlend>;
+using PreserveClearColor = Preserve<std::array<double, 4>, getClearColor, setClearColor>;
+using PreserveBlendFunc = Preserve<std::array<GLenum, 2>, getBlendFunc, setBlendFunc>;
+using PreservePixelZoom = Preserve<std::array<double, 2>, getPixelZoom, setPixelZoom>;
+using PreserveRasterPos = Preserve<std::array<double, 4>, getRasterPos, setRasterPos>;
+
+}
+}
+
+#endif

--- a/platform/darwin/nsthread.mm
+++ b/platform/darwin/nsthread.mm
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+#include <mbgl/platform/platform.hpp>
+
+namespace mbgl {
+namespace platform {
+
+void makeThreadLowPriority() {
+    [[NSThread currentThread] setThreadPriority:0.0];
+}
+
+}
+}

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/platform/default/glfw_view.hpp>
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/platform/log.hpp>
+#include <mbgl/util/gl_helper.hpp>
 
 #include <cassert>
 #include <pthread.h>
@@ -333,14 +334,19 @@ void showDebugImage(std::string name, const char *data, size_t width, size_t hei
     glfwGetFramebufferSize(debugWindow, &fbWidth, &fbHeight);
     float scale = static_cast<float>(fbWidth) / static_cast<float>(width);
 
-    MBGL_CHECK_ERROR(glPixelZoom(scale, -scale));
-    MBGL_CHECK_ERROR(glRasterPos2f(-1.0f, 1.0f));
-    MBGL_CHECK_ERROR(glDrawPixels(width, height, GL_LUMINANCE, GL_UNSIGNED_BYTE, data));
+    {
+        gl::PreservePixelZoom pixelZoom;
+        gl::PreserveRasterPos rasterPos;
+
+        MBGL_CHECK_ERROR(glPixelZoom(scale, -scale));
+        MBGL_CHECK_ERROR(glRasterPos2f(-1.0f, 1.0f));
+        MBGL_CHECK_ERROR(glDrawPixels(width, height, GL_LUMINANCE, GL_UNSIGNED_BYTE, data));
+    }
+
     glfwSwapBuffers(debugWindow);
 
     glfwMakeContextCurrent(currentWindow);
 }
-
 
 void showColorDebugImage(std::string name, const char *data, size_t logicalWidth, size_t logicalHeight, size_t width, size_t height) {
     glfwInit();
@@ -365,14 +371,22 @@ void showColorDebugImage(std::string name, const char *data, size_t logicalWidth
     float xScale = static_cast<float>(fbWidth) / static_cast<float>(width);
     float yScale = static_cast<float>(fbHeight) / static_cast<float>(height);
 
-    MBGL_CHECK_ERROR(glClearColor(0.8, 0.8, 0.8, 1));
-    MBGL_CHECK_ERROR(glClear(GL_COLOR_BUFFER_BIT));
-    MBGL_CHECK_ERROR(glEnable(GL_BLEND));
-    MBGL_CHECK_ERROR(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+    {
+        gl::PreserveClearColor clearColor;
+        gl::PreserveBlend blend;
+        gl::PreserveBlendFunc blendFunc;
+        gl::PreservePixelZoom pixelZoom;
+        gl::PreserveRasterPos rasterPos;
 
-    MBGL_CHECK_ERROR(glPixelZoom(xScale, -yScale));
-    MBGL_CHECK_ERROR(glRasterPos2f(-1.0f, 1.0f));
-    MBGL_CHECK_ERROR(glDrawPixels(width, height, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, data));
+        MBGL_CHECK_ERROR(glClearColor(0.8, 0.8, 0.8, 1));
+        MBGL_CHECK_ERROR(glClear(GL_COLOR_BUFFER_BIT));
+        MBGL_CHECK_ERROR(glEnable(GL_BLEND));
+        MBGL_CHECK_ERROR(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+        MBGL_CHECK_ERROR(glPixelZoom(xScale, -yScale));
+        MBGL_CHECK_ERROR(glRasterPos2f(-1.0f, 1.0f));
+        MBGL_CHECK_ERROR(glDrawPixels(width, height, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, data));
+    }
+
     glfwSwapBuffers(debugWindow);
 
     glfwMakeContextCurrent(currentWindow);

--- a/platform/default/sqlite_cache.cpp
+++ b/platform/default/sqlite_cache.cpp
@@ -62,7 +62,7 @@ std::string unifyMapboxURLs(const std::string &url) {
 using namespace mapbox::sqlite;
 
 SQLiteCache::SQLiteCache(const std::string& path_)
-    : thread(util::make_unique<util::Thread<Impl>>("SQLite Cache", path_)) {
+    : thread(util::make_unique<util::Thread<Impl>>("SQLite Cache", util::ThreadPriority::Low, path_)) {
 }
 
 SQLiteCache::~SQLiteCache() = default;

--- a/platform/default/thread.cpp
+++ b/platform/default/thread.cpp
@@ -1,0 +1,11 @@
+#include <mbgl/platform/platform.hpp>
+
+namespace mbgl {
+namespace platform {
+
+void makeThreadLowPriority() {
+    // no-op
+}
+
+}
+}

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -249,6 +249,12 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
             gl::IsVertexArray = glIsVertexArrayOES;
         }
 
+        if (extensions.find("GL_EXT_debug_marker") != std::string::npos) {
+            gl::InsertEventMarkerEXT = glInsertEventMarkerEXT;
+            gl::PushGroupMarkerEXT = glPushGroupMarkerEXT;
+            gl::PopGroupMarkerEXT = glPopGroupMarkerEXT;
+        }
+
         if (extensions.find("GL_OES_packed_depth_stencil") != std::string::npos) {
             gl::isPackedDepthStencilSupported = YES;
         }

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -67,6 +67,7 @@ public:
         return buffer;
     }
 
+    // Uploads the buffer to the GPU to be available when we need it.
     inline void upload() {
         if (!buffer) {
             bind();

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -140,6 +140,12 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
     }
 }
 
+void GlyphAtlas::upload() {
+    if (dirty) {
+        bind();
+    }
+}
+
 void GlyphAtlas::bind() {
     if (!texture) {
         MBGL_CHECK_ERROR(glGenTextures(1, &texture));

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -124,8 +124,6 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
                     }
                 }
 
-                dirty = true;
-
                 bin.release(rect);
 
                 // Make sure to post-increment the iterator: This will return the
@@ -142,7 +140,42 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
 
 void GlyphAtlas::upload() {
     if (dirty) {
+        const bool first = !texture;
         bind();
+
+        std::lock_guard<std::mutex> lock(mtx);
+
+        if (first) {
+            MBGL_CHECK_ERROR(glTexImage2D(
+                GL_TEXTURE_2D, // GLenum target
+                0, // GLint level
+                GL_ALPHA, // GLint internalformat
+                width, // GLsizei width
+                height, // GLsizei height
+                0, // GLint border
+                GL_ALPHA, // GLenum format
+                GL_UNSIGNED_BYTE, // GLenum type
+                data.get() // const GLvoid* data
+            ));
+        } else {
+            MBGL_CHECK_ERROR(glTexSubImage2D(
+                GL_TEXTURE_2D, // GLenum target
+                0, // GLint level
+                0, // GLint xoffset
+                0, // GLint yoffset
+                width, // GLsizei width
+                height, // GLsizei height
+                GL_ALPHA, // GLenum format
+                GL_UNSIGNED_BYTE, // GLenum type
+                data.get() // const GLvoid* data
+            ));
+        }
+
+        dirty = false;
+
+#if defined(DEBUG)
+        // platform::showDebugImage("Glyph Atlas", data.get(), width, height);
+#endif
     }
 }
 
@@ -159,15 +192,5 @@ void GlyphAtlas::bind() {
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     } else {
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
-    }
-
-    if (dirty) {
-        std::lock_guard<std::mutex> lock(mtx);
-        MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, width, height, 0, GL_ALPHA, GL_UNSIGNED_BYTE, data.get()));
-        dirty = false;
-
-#if defined(DEBUG)
-        // platform::showDebugImage("Glyph Atlas", data, width, height);
-#endif
     }
 };

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -24,7 +24,12 @@ public:
                    GlyphPositions&);
     void removeGlyphs(uintptr_t tileUID);
 
+    // Binds the atlas texture to the GPU, and uploads data if it is out of date.
     void bind();
+
+    // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
+    // the texture is only bound when the data is out of date (=dirty).
+    void upload();
 
     const uint16_t width = 0;
     const uint16_t height = 0;

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -129,6 +129,12 @@ LinePatternPos LineAtlas::addDash(const std::vector<float> &dasharray, bool roun
     return position;
 };
 
+void LineAtlas::upload() {
+    if (dirty) {
+        bind();
+    }
+}
+
 void LineAtlas::bind() {
     std::lock_guard<std::recursive_mutex> lock(mtx);
 

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -153,7 +153,7 @@ void LineAtlas::bind() {
 
     if (dirty) {
         if (first) {
-            glTexImage2D(
+            MBGL_CHECK_ERROR(glTexImage2D(
                 GL_TEXTURE_2D, // GLenum target
                 0, // GLint level
                 GL_ALPHA, // GLint internalformat
@@ -163,9 +163,9 @@ void LineAtlas::bind() {
                 GL_ALPHA, // GLenum format
                 GL_UNSIGNED_BYTE, // GLenum type
                 data // const GLvoid * data
-            );
+            ));
         } else {
-            glTexSubImage2D(
+            MBGL_CHECK_ERROR(glTexSubImage2D(
                 GL_TEXTURE_2D, // GLenum target
                 0, // GLint level
                 0, // GLint xoffset
@@ -175,7 +175,7 @@ void LineAtlas::bind() {
                 GL_ALPHA, // GLenum format
                 GL_UNSIGNED_BYTE, // GLenum type
                 data // const GLvoid *pixels
-            );
+            ));
         }
 
 

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -19,7 +19,12 @@ public:
     LineAtlas(uint16_t width, uint16_t height);
     ~LineAtlas();
 
+    // Binds the atlas texture to the GPU, and uploads data if it is out of date.
     void bind();
+
+    // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
+    // the texture is only bound when the data is out of date (=dirty).
+    void upload();
 
     LinePatternPos getDashPosition(const std::vector<float>&, bool);
     LinePatternPos addDash(const std::vector<float> &dasharray, bool round);

--- a/src/mbgl/geometry/sprite_atlas.cpp
+++ b/src/mbgl/geometry/sprite_atlas.cpp
@@ -230,6 +230,12 @@ void SpriteAtlas::setSprite(util::ptr<Sprite> sprite_) {
     });
 }
 
+void SpriteAtlas::upload() {
+    if (dirty) {
+        bind();
+    }
+}
+
 void SpriteAtlas::bind(bool linear) {
     bool first = false;
     if (!texture) {

--- a/src/mbgl/geometry/sprite_atlas.hpp
+++ b/src/mbgl/geometry/sprite_atlas.hpp
@@ -79,6 +79,7 @@ private:
     std::set<std::string> uninitialized;
     uint32_t *data = nullptr;
     std::atomic<bool> dirty;
+    bool fullUploadRequired = true;
     uint32_t texture = 0;
     uint32_t filter = 0;
     static const int buffer = 1;

--- a/src/mbgl/geometry/sprite_atlas.hpp
+++ b/src/mbgl/geometry/sprite_atlas.hpp
@@ -50,9 +50,12 @@ public:
 
     SpriteAtlasPosition getPosition(const std::string& name, bool repeating = false);
 
-    // Binds the image buffer of this sprite atlas to the GPU, and uploads data if it is out
-    // of date.
+    // Binds the atlas texture to the GPU, and uploads data if it is out of date.
     void bind(bool linear = false);
+
+    // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
+    // the texture is only bound when the data is out of date (=dirty).
+    void upload();
 
     inline float getWidth() const { return width; }
     inline float getHeight() const { return height; }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -11,7 +11,7 @@ namespace mbgl {
 
 Map::Map(View& view, FileSource& fileSource, MapMode mode, bool startPaused)
     : data(util::make_unique<MapData>(view, mode)),
-      context(util::make_unique<util::Thread<MapContext>>("Map", view, fileSource, *data, startPaused))
+      context(util::make_unique<util::Thread<MapContext>>("Map", util::ThreadPriority::Regular, view, fileSource, *data, startPaused))
 {
     view.initialize(this);
 }

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -24,9 +24,5 @@ void RasterTileData::parse() {
 }
 
 Bucket* RasterTileData::getBucket(StyleLayer const&) {
-    if (bucket.hasData()) {
-        return &bucket;
-    } else {
-        return nullptr;
-    }
+    return &bucket;
 }

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -23,10 +23,10 @@ void RasterTileData::parse() {
     }
 }
 
-void RasterTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) {
-    bucket.render(painter, layer_desc, id, matrix);
-}
-
-bool RasterTileData::hasData(StyleLayer const& /*layer_desc*/) const {
-    return bucket.hasData();
+Bucket* RasterTileData::getBucket(StyleLayer const&) {
+    if (bucket.hasData()) {
+        return &bucket;
+    } else {
+        return nullptr;
+    }
 }

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -20,8 +20,7 @@ public:
     ~RasterTileData();
 
     void parse() override;
-    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) override;
-    bool hasData(StyleLayer const &layer_desc) const override;
+    Bucket* getBucket(StyleLayer const &layer_desc) override;
 
 protected:
     StyleLayoutRaster layout;

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -184,16 +184,6 @@ void Source::drawClippingMasks(Painter &painter) {
     }
 }
 
-void Source::render(Painter &painter, const StyleLayer &layer_desc) {
-    gl::group group(std::string { "layer: " } + layer_desc.id);
-    for (const auto& pair : tiles) {
-        Tile &tile = *pair.second;
-        if (tile.data && tile.data->state == TileData::State::parsed) {
-            painter.renderTileLayer(tile, layer_desc, tile.matrix);
-        }
-    }
-}
-
 void Source::finishRender(Painter &painter) {
     for (const auto& pair : tiles) {
         Tile &tile = *pair.second;

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -202,6 +202,9 @@ std::forward_list<Tile *> Source::getLoadedTiles() const {
     return ptrs;
 }
 
+const std::vector<Tile*>& Source::getTiles() const {
+    return tilePtrs;
+}
 
 TileData::State Source::hasTile(const TileID& id) {
     auto it = tiles.find(id);
@@ -445,6 +448,8 @@ void Source::update(MapData& data,
         }
     });
 
+    updateTilePtrs();
+
     updated = data.getAnimationTime();
 }
 
@@ -453,6 +458,14 @@ void Source::invalidateTiles(const std::vector<TileID>& ids) {
     for (auto& id : ids) {
         tiles.erase(id);
         tile_data.erase(id);
+    }
+    updateTilePtrs();
+}
+
+void Source::updateTilePtrs() {
+    tilePtrs.clear();
+    for (const auto& pair : tiles) {
+        tilePtrs.push_back(pair.second.get());
     }
 }
 

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -78,6 +78,7 @@ public:
     void finishRender(Painter &painter);
 
     std::forward_list<Tile *> getLoadedTiles() const;
+    const std::vector<Tile*>& getTiles() const;
 
     void setCacheSize(size_t);
     void onLowMemory();
@@ -103,6 +104,7 @@ private:
                             std::function<void()> callback);
 
     TileData::State hasTile(const TileID& id);
+    void updateTilePtrs();
 
     double getZoom(const TransformState &state) const;
 
@@ -112,6 +114,7 @@ private:
     TimePoint updated = TimePoint::min();
 
     std::map<TileID, std::unique_ptr<Tile>> tiles;
+    std::vector<Tile*> tilePtrs;
     std::map<TileID, std::weak_ptr<TileData>> tile_data;
     TileCache cache;
 };

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -29,7 +29,6 @@ class Sprite;
 class TexturePool;
 class Style;
 class Painter;
-class StyleLayer;
 class TransformState;
 class Tile;
 struct ClipID;
@@ -76,7 +75,6 @@ public:
 
     void updateMatrices(const mat4 &projMatrix, const TransformState &transform);
     void drawClippingMasks(Painter &painter);
-    void render(Painter &painter, const StyleLayer &layer_desc);
     void finishRender(Painter &painter);
 
     std::forward_list<Tile *> getLoadedTiles() const;

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -47,8 +47,7 @@ public:
 
     // Override this in the child class.
     virtual void parse() = 0;
-    virtual void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) = 0;
-    virtual bool hasData(StyleLayer const &layer_desc) const = 0;
+    virtual Bucket* getBucket(StyleLayer const &layer_desc) = 0;
 
     const TileID id;
     const std::string name;

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -157,7 +157,7 @@ std::unique_ptr<Bucket> TileParser::createFillBucket(const GeometryTileLayer& la
                                                 tile.triangleElementsBuffer,
                                                 tile.lineElementsBuffer);
     addBucketGeometries(bucket, layer, bucket_desc.filter);
-    return std::move(bucket);
+    return bucket->hasData() ? std::move(bucket) : nullptr;
 }
 
 std::unique_ptr<Bucket> TileParser::createLineBucket(const GeometryTileLayer& layer,
@@ -174,7 +174,7 @@ std::unique_ptr<Bucket> TileParser::createLineBucket(const GeometryTileLayer& la
     applyLayoutProperty(PropertyKey::LineRoundLimit, bucket_desc.layout, layout.round_limit, z);
 
     addBucketGeometries(bucket, layer, bucket_desc.filter);
-    return std::move(bucket);
+    return bucket->hasData() ? std::move(bucket) : nullptr;
 }
 
 std::unique_ptr<Bucket> TileParser::createSymbolBucket(const GeometryTileLayer& layer,
@@ -224,6 +224,6 @@ std::unique_ptr<Bucket> TileParser::createSymbolBucket(const GeometryTileLayer& 
 
     bucket->addFeatures(
         layer, bucket_desc.filter, reinterpret_cast<uintptr_t>(&tile), spriteAtlas, *sprite, glyphAtlas, glyphStore);
-    return std::move(bucket);
+    return bucket->hasData() ? std::move(bucket) : nullptr;
 }
 }

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -60,9 +60,7 @@ Bucket* VectorTileData::getBucket(StyleLayer const& layer) {
         const auto it = buckets.find(layer.bucket->name);
         if (it != buckets.end()) {
             assert(it->second);
-            if (it->second->hasData()) {
-                return it->second.get();
-            }
+            return it->second.get();
         }
     }
     return nullptr;

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -55,23 +55,15 @@ void VectorTileData::parse() {
     }
 }
 
-void VectorTileData::render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) {
-    if (state == State::parsed && layer_desc.bucket) {
-        auto databucket_it = buckets.find(layer_desc.bucket->name);
-        if (databucket_it != buckets.end()) {
-            assert(databucket_it->second);
-            databucket_it->second->render(painter, layer_desc, id, matrix);
+Bucket* VectorTileData::getBucket(StyleLayer const& layer) {
+    if (state == State::parsed && layer.bucket) {
+        const auto it = buckets.find(layer.bucket->name);
+        if (it != buckets.end()) {
+            assert(it->second);
+            if (it->second->hasData()) {
+                return it->second.get();
+            }
         }
     }
-}
-
-bool VectorTileData::hasData(const StyleLayer &layer_desc) const {
-    if (state == State::parsed && layer_desc.bucket) {
-        auto databucket_it = buckets.find(layer_desc.bucket->name);
-        if (databucket_it != buckets.end()) {
-            assert(databucket_it->second);
-            return databucket_it->second->hasData();
-        }
-    }
-    return false;
+    return nullptr;
 }

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -40,8 +40,7 @@ public:
     ~VectorTileData();
 
     void parse() override;
-    void render(Painter &painter, const StyleLayer &layer_desc, const mat4 &matrix) override;
-    bool hasData(StyleLayer const& layer_desc) const override;
+    virtual Bucket* getBucket(StyleLayer const &layer_desc) override;
 
 protected:
     // Holds the actual geometries in this tile.

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -13,7 +13,6 @@ class TileID;
 class Bucket : private util::noncopyable {
 public:
     virtual void render(Painter&, const StyleLayer&, const TileID&, const mat4&) = 0;
-    virtual bool hasData() const = 0;
     virtual ~Bucket() {}
 
 };

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -10,10 +10,31 @@ class Painter;
 class StyleLayer;
 class TileID;
 
+enum class RenderPass : uint8_t {
+    Prepare = 1 << 0,
+    Opaque = 1 << 1,
+    Translucent = 1 << 2,
+};
+
 class Bucket : private util::noncopyable {
 public:
+    // As long as this bucket has a Prepare render pass, this function is getting called. Typically,
+    // this only happens once when the bucket is being rendered for the first time.
+    virtual void prepare() = 0;
+
+    // Every time this bucket is getting rendered, this function is called. This happens either
+    // once or twice (for Opaque and Transparent render passes).
     virtual void render(Painter&, const StyleLayer&, const TileID&, const mat4&) = 0;
+
     virtual ~Bucket() {}
+
+    inline bool hasRenderPass(RenderPass pass) const {
+        return static_cast<std::underlying_type<RenderPass>::type>(renderPass) &
+               static_cast<std::underlying_type<RenderPass>::type>(pass);
+    }
+
+protected:
+    RenderPass renderPass = RenderPass::Prepare;
 
 };
 

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_RENDERER_BUCKET
 #define MBGL_RENDERER_BUCKET
 
+#include <mbgl/renderer/render_pass.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/mat4.hpp>
 
@@ -10,17 +11,11 @@ class Painter;
 class StyleLayer;
 class TileID;
 
-enum class RenderPass : uint8_t {
-    Prepare = 1 << 0,
-    Opaque = 1 << 1,
-    Translucent = 1 << 2,
-};
-
 class Bucket : private util::noncopyable {
 public:
     // As long as this bucket has a Prepare render pass, this function is getting called. Typically,
     // this only happens once when the bucket is being rendered for the first time.
-    virtual void prepare() = 0;
+    virtual void upload() = 0;
 
     // Every time this bucket is getting rendered, this function is called. This happens either
     // once or twice (for Opaque and Transparent render passes).
@@ -28,13 +23,12 @@ public:
 
     virtual ~Bucket() {}
 
-    inline bool hasRenderPass(RenderPass pass) const {
-        return static_cast<std::underlying_type<RenderPass>::type>(renderPass) &
-               static_cast<std::underlying_type<RenderPass>::type>(pass);
+    inline bool needsUpload() const {
+        return uploaded;
     }
 
 protected:
-    RenderPass renderPass = RenderPass::Prepare;
+    bool uploaded = false;
 
 };
 

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -24,7 +24,7 @@ public:
     virtual ~Bucket() {}
 
     inline bool needsUpload() const {
-        return uploaded;
+        return !uploaded;
     }
 
 protected:

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -17,6 +17,9 @@ DebugBucket::DebugBucket(DebugFontBuffer& fontBuffer_)
 }
 
 void DebugBucket::prepare() {
+    fontBuffer.upload();
+
+    renderPass = RenderPass::Translucent;
 }
 
 void DebugBucket::render(Painter& painter, const StyleLayer&, const TileID&, const mat4& matrix) {

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -16,10 +16,10 @@ DebugBucket::DebugBucket(DebugFontBuffer& fontBuffer_)
     : fontBuffer(fontBuffer_) {
 }
 
-void DebugBucket::prepare() {
+void DebugBucket::upload() {
     fontBuffer.upload();
 
-    renderPass = RenderPass::Translucent;
+    uploaded = true;
 }
 
 void DebugBucket::render(Painter& painter, const StyleLayer&, const TileID&, const mat4& matrix) {

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -16,8 +16,10 @@ DebugBucket::DebugBucket(DebugFontBuffer& fontBuffer_)
     : fontBuffer(fontBuffer_) {
 }
 
-void DebugBucket::render(Painter &painter, const StyleLayer & /*layer_desc*/,
-                         const TileID & /*id*/, const mat4 &matrix) {
+void DebugBucket::prepare() {
+}
+
+void DebugBucket::render(Painter& painter, const StyleLayer&, const TileID&, const mat4& matrix) {
     painter.renderDebugText(*this, matrix);
 }
 

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -21,10 +21,6 @@ void DebugBucket::render(Painter &painter, const StyleLayer & /*layer_desc*/,
     painter.renderDebugText(*this, matrix);
 }
 
-bool DebugBucket::hasData() const {
-    return fontBuffer.index() > 0;
-}
-
 void DebugBucket::drawLines(PlainShader& shader) {
     array.bind(shader, fontBuffer, BUFFER_OFFSET(0));
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, (GLsizei)(fontBuffer.index())));

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -15,7 +15,7 @@ class DebugBucket : public Bucket {
 public:
     DebugBucket(DebugFontBuffer& fontBuffer);
 
-    void prepare() override;
+    void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
 
     void drawLines(PlainShader& shader);

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -15,8 +15,8 @@ class DebugBucket : public Bucket {
 public:
     DebugBucket(DebugFontBuffer& fontBuffer);
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
-                const mat4 &matrix) override;
+    void prepare() override;
+    void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
 
     void drawLines(PlainShader& shader);
     void drawPoints(PlainShader& shader);

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -17,7 +17,6 @@ public:
 
     void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
                 const mat4 &matrix) override;
-    bool hasData() const override;
 
     void drawLines(PlainShader& shader);
     void drawPoints(PlainShader& shader);

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -200,8 +200,13 @@ void FillBucket::tessellate() {
     lineGroup.vertex_length += total_vertex_count;
 }
 
-void FillBucket::render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
-                        const mat4 &matrix) {
+void FillBucket::prepare() {
+}
+
+void FillBucket::render(Painter& painter,
+                        const StyleLayer& layer_desc,
+                        const TileID& id,
+                        const mat4& matrix) {
     painter.renderFill(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -200,15 +200,13 @@ void FillBucket::tessellate() {
     lineGroup.vertex_length += total_vertex_count;
 }
 
-void FillBucket::prepare() {
+void FillBucket::upload() {
     vertexBuffer.upload();
     triangleElementsBuffer.upload();
     lineElementsBuffer.upload();
 
     // From now on, we're going to render during the opaque and translucent pass.
-    renderPass = static_cast<RenderPass>(
-        static_cast<std::underlying_type<RenderPass>::type>(RenderPass::Opaque) |
-        static_cast<std::underlying_type<RenderPass>::type>(RenderPass::Translucent));
+    uploaded = true;
 }
 
 void FillBucket::render(Painter& painter,

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -201,6 +201,14 @@ void FillBucket::tessellate() {
 }
 
 void FillBucket::prepare() {
+    vertexBuffer.upload();
+    triangleElementsBuffer.upload();
+    lineElementsBuffer.upload();
+
+    // From now on, we're going to render during the opaque and translucent pass.
+    renderPass = static_cast<RenderPass>(
+        static_cast<std::underlying_type<RenderPass>::type>(RenderPass::Opaque) |
+        static_cast<std::underlying_type<RenderPass>::type>(RenderPass::Translucent));
 }
 
 void FillBucket::render(Painter& painter,

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -33,8 +33,8 @@ public:
                LineElementsBuffer &lineElementsBuffer);
     ~FillBucket() override;
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
-                const mat4 &matrix) override;
+    void prepare() override;
+    void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const;
 
     void addGeometry(const GeometryCollection&);

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -35,7 +35,7 @@ public:
 
     void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
                 const mat4 &matrix) override;
-    bool hasData() const override;
+    bool hasData() const;
 
     void addGeometry(const GeometryCollection&);
     void tessellate();

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -33,7 +33,7 @@ public:
                LineElementsBuffer &lineElementsBuffer);
     ~FillBucket() override;
 
-    void prepare() override;
+    void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const;
 

--- a/src/mbgl/renderer/gl_config.cpp
+++ b/src/mbgl/renderer/gl_config.cpp
@@ -1,0 +1,19 @@
+#include "gl_config.hpp"
+
+namespace mbgl {
+namespace gl {
+
+const ClearDepth::Type ClearDepth::Default = 0;
+const ClearColor::Type ClearColor::Default = { 0, 0, 0, 0 };
+const ClearStencil::Type ClearStencil::Default = 0;
+const StencilMask::Type StencilMask::Default = ~0u;
+const DepthMask::Type DepthMask::Default = GL_TRUE;
+const ColorMask::Type ColorMask::Default = { false, false, false, false };
+const StencilFunc::Type StencilFunc::Default = { GL_ALWAYS, 0, ~0u };
+const StencilTest::Type StencilTest::Default = false;
+const DepthRange::Type DepthRange::Default = { 0, 1 };
+const DepthTest::Type DepthTest::Default = false;
+const Blend::Type Blend::Default = false;
+
+}
+}

--- a/src/mbgl/renderer/gl_config.hpp
+++ b/src/mbgl/renderer/gl_config.hpp
@@ -1,0 +1,149 @@
+#ifndef MBGL_RENDERER_GL_CONFIG
+#define MBGL_RENDERER_GL_CONFIG
+
+#include <cstdint>
+#include <tuple>
+#include <array>
+
+#include <mbgl/platform/gl.hpp>
+
+namespace mbgl {
+namespace gl {
+
+template <typename T>
+class Value {
+public:
+    inline void operator=(const typename T::Type& value) {
+        if (current != value) {
+            current = value;
+            MBGL_CHECK_ERROR(T::Set(current));
+        }
+    }
+
+private:
+    typename T::Type current = T::Default;
+};
+
+struct ClearDepth {
+    using Type = GLfloat;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glClearDepth(value));
+    }
+};
+
+struct ClearColor {
+    struct Type { float r, g, b, a; };
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glClearColor(value.r, value.g, value.b, value.a));
+    }
+};
+
+inline bool operator!=(const ClearColor::Type& a, const ClearColor::Type& b) {
+    return a.r != b.r || a.g != b.g || a.b != b.b || a.a != b.a;
+}
+
+struct ClearStencil {
+    using Type = GLint;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glClearStencil(value));
+    }
+};
+
+struct StencilMask {
+    using Type = GLuint;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glStencilMask(value));
+    }
+};
+
+struct DepthMask {
+    using Type = GLboolean;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glDepthMask(value));
+    }
+};
+
+struct ColorMask {
+    struct Type { bool r, g, b, a; };
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glColorMask(value.r, value.g, value.b, value.a));
+    }
+};
+
+inline bool operator!=(const ColorMask::Type& a, const ColorMask::Type& b) {
+    return a.r != b.r || a.g != b.g || a.b != b.b || a.a != b.a;
+}
+
+struct StencilFunc {
+    struct Type { GLenum func; GLint ref; GLuint mask; };
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glStencilFunc(value.func, value.ref, value.mask));
+    }
+};
+
+inline bool operator!=(const StencilFunc::Type& a, const StencilFunc::Type& b) {
+    return a.func != b.func || a.ref != b.ref || a.mask != b.mask;
+}
+
+struct StencilTest {
+    using Type = bool;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(value ? glEnable(GL_STENCIL_TEST) : glDisable(GL_STENCIL_TEST));
+    }
+};
+
+struct DepthRange {
+    struct Type { GLfloat near, far; };
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glDepthRange(value.near, value.far));
+    }
+};
+
+inline bool operator!=(const DepthRange::Type& a, const DepthRange::Type& b) {
+    return a.near != b.near || a.far != b.far;
+}
+
+struct DepthTest {
+    using Type = bool;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(value ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST));
+    }
+};
+
+struct Blend {
+    using Type = bool;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(value ? glEnable(GL_BLEND) : glDisable(GL_BLEND));
+    }
+};
+
+class Config {
+public:
+    Value<StencilFunc> stencilFunc;
+    Value<StencilMask> stencilMask;
+    Value<StencilTest> stencilTest;
+    Value<DepthRange> depthRange;
+    Value<DepthMask> depthMask;
+    Value<DepthTest> depthTest;
+    Value<Blend> blend;
+    Value<ColorMask> colorMask;
+    Value<ClearDepth> clearDepth;
+    Value<ClearColor> clearColor;
+    Value<ClearStencil> clearStencil;
+};
+
+}
+}
+
+#endif

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -342,6 +342,9 @@ void LineBucket::addCurrentVertex(const Coordinate& currentVertex,
     e2 = e3;
 }
 
+void LineBucket::prepare() {
+}
+
 void LineBucket::render(Painter& painter,
                         const StyleLayer& layer_desc,
                         const TileID& id,

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -342,12 +342,12 @@ void LineBucket::addCurrentVertex(const Coordinate& currentVertex,
     e2 = e3;
 }
 
-void LineBucket::prepare() {
+void LineBucket::upload() {
     vertexBuffer.upload();
     triangleElementsBuffer.upload();
 
     // From now on, we're only going to render during the translucent pass.
-    renderPass = RenderPass::Translucent;
+    uploaded = true;
 }
 
 void LineBucket::render(Painter& painter,

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -343,6 +343,11 @@ void LineBucket::addCurrentVertex(const Coordinate& currentVertex,
 }
 
 void LineBucket::prepare() {
+    vertexBuffer.upload();
+    triangleElementsBuffer.upload();
+
+    // From now on, we're only going to render during the translucent pass.
+    renderPass = RenderPass::Translucent;
 }
 
 void LineBucket::render(Painter& painter,

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -30,7 +30,7 @@ public:
 
     void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
                 const mat4 &matrix) override;
-    bool hasData() const override;
+    bool hasData() const;
 
     void addGeometry(const GeometryCollection&);
     void addGeometry(const std::vector<Coordinate>& line);

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -28,8 +28,8 @@ public:
     LineBucket(LineVertexBuffer &vertexBuffer, TriangleElementsBuffer &triangleElementsBuffer);
     ~LineBucket() override;
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
-                const mat4 &matrix) override;
+    void prepare() override;
+    void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const;
 
     void addGeometry(const GeometryCollection&);

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -28,7 +28,7 @@ public:
     LineBucket(LineVertexBuffer &vertexBuffer, TriangleElementsBuffer &triangleElementsBuffer);
     ~LineBucket() override;
 
-    void prepare() override;
+    void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const;
 

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -332,10 +332,10 @@ std::vector<RenderItem> Painter::determineRenderOrder(const Style& style) {
             continue;
         }
 
-        auto tiles = layer.bucket->source->getLoadedTiles();
+        const auto& tiles = layer.bucket->source->getTiles();
         for (auto tile : tiles) {
             assert(tile);
-            if (!tile->data) {
+            if (!tile->data && !tile->data->ready()) {
                 continue;
             }
 

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/transform_state.hpp>
 
 #include <mbgl/renderer/frame_history.hpp>
+#include <mbgl/renderer/bucket.hpp>
 
 #include <mbgl/geometry/vao.hpp>
 #include <mbgl/geometry/static_vertex_buffer.hpp>
@@ -20,8 +21,6 @@
 #include <set>
 
 namespace mbgl {
-
-enum class RenderPass : bool { Opaque, Translucent };
 
 class Style;
 class StyleLayer;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -57,6 +57,18 @@ class GaussianShader;
 
 struct ClipID;
 
+struct RenderItem {
+    inline RenderItem(const StyleLayer& layer_,
+                      const Tile* tile_ = nullptr,
+                      Bucket* bucket_ = nullptr)
+        : tile(tile_), bucket(bucket_), layer(layer_) {
+    }
+
+    const Tile* const tile;
+    Bucket* const bucket;
+    const StyleLayer& layer;
+};
+
 class Painter : private util::noncopyable {
 public:
     Painter(SpriteAtlas&, GlyphAtlas&, LineAtlas&);
@@ -74,11 +86,6 @@ public:
     void render(const Style& style,
                 TransformState state,
                 TimePoint time);
-
-    void renderLayer(const StyleLayer&);
-
-    // Renders a particular layer from a tile.
-    void renderTileLayer(const Tile& tile, const StyleLayer &layer_desc, const mat4 &matrix);
 
     // Renders debug information for a tile.
     void renderTileDebug(const Tile& tile);
@@ -130,6 +137,8 @@ public:
 private:
     void setupShaders();
     mat4 translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const TileID &id, TranslateAnchorType anchor);
+
+    std::vector<RenderItem> determineRenderOrder(const Style& style);
 
     void prepareTile(const Tile& tile);
 

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -9,6 +9,8 @@
 #include <mbgl/geometry/vao.hpp>
 #include <mbgl/geometry/static_vertex_buffer.hpp>
 
+#include <mbgl/renderer/gl_config.hpp>
+
 #include <mbgl/style/types.hpp>
 
 #include <mbgl/platform/gl.hpp>
@@ -162,8 +164,6 @@ private:
 public:
     void useProgram(uint32_t program);
     void lineWidth(float lineWidth);
-    void depthMask(bool value);
-    void depthRange(float near, float far);
 
 public:
     mat4 projMatrix;
@@ -190,11 +190,11 @@ private:
     bool debug = false;
     int indent = 0;
 
+    gl::Config config;
+
     uint32_t gl_program = 0;
     float gl_lineWidth = 0;
-    bool gl_depthMask = true;
     std::array<uint16_t, 2> gl_viewport = {{ 0, 0 }};
-    std::array<float, 2> gl_depthRange = {{ 0, 1 }};
     float strata = 0;
     RenderPass pass = RenderPass::Opaque;
     const float strata_epsilon = 1.0f / (1 << 16);

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -59,13 +59,19 @@ struct ClipID;
 struct RenderItem {
     inline RenderItem(const StyleLayer& layer_,
                       const Tile* tile_ = nullptr,
-                      Bucket* bucket_ = nullptr)
-        : tile(tile_), bucket(bucket_), layer(layer_) {
+                      Bucket* bucket_ = nullptr,
+                      RenderPass passes_ = RenderPass::Opaque)
+        : tile(tile_), bucket(bucket_), layer(layer_), passes(passes_) {
     }
 
     const Tile* const tile;
     Bucket* const bucket;
     const StyleLayer& layer;
+    const RenderPass passes;
+
+    inline bool hasRenderPass(RenderPass pass) const {
+        return bool(passes & pass);
+    }
 };
 
 class Painter : private util::noncopyable {
@@ -138,6 +144,7 @@ private:
     mat4 translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const TileID &id, TranslateAnchorType anchor);
 
     std::vector<RenderItem> determineRenderOrder(const Style& style);
+    static RenderPass determineRenderPasses(const StyleLayer&);
 
     void prepareTile(const Tile& tile);
 

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -13,10 +13,11 @@ void Painter::drawClippingMasks(const std::set<Source*>& sources) {
     gl::group group("clipping masks");
 
     useProgram(plainShader->program);
-    MBGL_CHECK_ERROR(glDisable(GL_DEPTH_TEST));
-    depthMask(false);
-    MBGL_CHECK_ERROR(glColorMask(false, false, false, false));
-    depthRange(1.0f, 1.0f);
+    config.stencilTest = true;
+    config.depthTest = true;
+    config.depthMask = GL_FALSE;
+    config.colorMask = { false, false, false, false };
+    config.depthRange = { 1.0f, 1.0f };
 
     coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET(0));
 
@@ -24,10 +25,10 @@ void Painter::drawClippingMasks(const std::set<Source*>& sources) {
         source->drawClippingMasks(*this);
     }
 
-    MBGL_CHECK_ERROR(glEnable(GL_DEPTH_TEST));
-    MBGL_CHECK_ERROR(glColorMask(true, true, true, true));
-    depthMask(true);
-    MBGL_CHECK_ERROR(glStencilMask(0x0));
+    config.depthTest = true;
+    config.colorMask = { true, true, true, true };
+    config.depthMask = GL_TRUE;
+    config.stencilMask = 0x0;
 }
 
 void Painter::drawClippingMask(const mat4& matrix, const ClipID &clip) {
@@ -35,8 +36,7 @@ void Painter::drawClippingMask(const mat4& matrix, const ClipID &clip) {
 
     const GLint ref = (GLint)(clip.reference.to_ulong());
     const GLuint mask = (GLuint)(clip.mask.to_ulong());
-    MBGL_CHECK_ERROR(glStencilFunc(GL_ALWAYS, ref, mask));
-    MBGL_CHECK_ERROR(glStencilMask(mask));
-
+    config.stencilFunc = { GL_ALWAYS, ref, mask };
+    config.stencilMask = mask;
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)tileStencilBuffer.index()));
 }

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -24,7 +24,7 @@ void Painter::renderTileDebug(const Tile& tile) {
 void Painter::renderDebugText(DebugBucket& bucket, const mat4 &matrix) {
     gl::group group("debug text");
 
-    MBGL_CHECK_ERROR(glDisable(GL_DEPTH_TEST));
+    config.depthTest = false;
 
     useProgram(plainShader->program);
     plainShader->u_matrix = matrix;
@@ -45,7 +45,7 @@ void Painter::renderDebugText(DebugBucket& bucket, const mat4 &matrix) {
     lineWidth(2.0f * state.getPixelRatio());
     bucket.drawLines(*plainShader);
 
-    MBGL_CHECK_ERROR(glEnable(GL_DEPTH_TEST));
+    config.depthTest = true;
 }
 
 void Painter::renderDebugFrame(const mat4 &matrix) {
@@ -54,7 +54,8 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     // Disable depth test and don't count this towards the depth buffer,
     // but *don't* disable stencil test, as we want to clip the red tile border
     // to the tile viewport.
-    MBGL_CHECK_ERROR(glDisable(GL_DEPTH_TEST));
+    config.depthTest = false;
+    config.stencilTest = true;
 
     useProgram(plainShader->program);
     plainShader->u_matrix = matrix;
@@ -64,8 +65,6 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     plainShader->u_color = {{ 1.0f, 0.0f, 0.0f, 1.0f }};
     lineWidth(4.0f * state.getPixelRatio());
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, (GLsizei)tileBorderBuffer.index()));
-
-    MBGL_CHECK_ERROR(glEnable(GL_DEPTH_TEST));
 }
 
 void Painter::renderDebugText(const std::vector<std::string> &strings) {
@@ -75,8 +74,9 @@ void Painter::renderDebugText(const std::vector<std::string> &strings) {
 
     gl::group group("debug text");
 
-    MBGL_CHECK_ERROR(glDisable(GL_DEPTH_TEST));
-    MBGL_CHECK_ERROR(glStencilFunc(GL_ALWAYS, 0xFF, 0xFF));
+    config.depthTest = false;
+    config.stencilTest = true;
+    config.stencilFunc = { GL_ALWAYS, 0xFF, 0xFF };
 
     useProgram(plainShader->program);
     plainShader->u_matrix = nativeMatrix;
@@ -103,6 +103,4 @@ void Painter::renderDebugText(const std::vector<std::string> &strings) {
         lineWidth(2.0f * state.getPixelRatio());
         MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, (GLsizei)debugFontBuffer.index()));
     }
-
-    MBGL_CHECK_ERROR(glEnable(GL_DEPTH_TEST));
 }

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -39,6 +39,9 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
     bool outline = properties.antialias && !pattern && stroke_color != fill_color;
     bool fringeline = properties.antialias && !pattern && stroke_color == fill_color;
 
+    config.stencilTest = true;
+    config.depthTest = true;
+
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // befrom, we have to draw the outline first (!)
     if (outline && pass == RenderPass::Translucent) {
@@ -53,7 +56,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
             static_cast<float>(state.getFramebufferWidth()),
             static_cast<float>(state.getFramebufferHeight())
         }};
-        depthRange(strata, 1.0f);
+        config.depthRange = { strata, 1.0f };
         bucket.drawVertices(*outlineShader);
     }
 
@@ -92,8 +95,8 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
             spriteAtlas.bind(true);
 
             // Draw the actual triangles into the color & stencil buffer.
-            depthMask(true);
-            depthRange(strata, 1.0f);
+            config.depthMask = GL_TRUE;
+            config.depthRange = { strata, 1.0f };
             bucket.drawElements(*patternShader);
         }
     }
@@ -109,8 +112,8 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
             plainShader->u_color = fill_color;
 
             // Draw the actual triangles into the color & stencil buffer.
-            depthMask(true);
-            depthRange(strata + strata_epsilon, 1.0f);
+            config.depthMask = GL_TRUE;
+            config.depthRange = { strata + strata_epsilon, 1.0f };
             bucket.drawElements(*plainShader);
         }
     }
@@ -130,7 +133,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
             static_cast<float>(state.getFramebufferHeight())
         }};
 
-        depthRange(strata + strata_epsilon + strata_epsilon, 1.0f);
+        config.depthRange = { strata + strata_epsilon + strata_epsilon, 1.0f };
         bucket.drawVertices(*outlineShader);
     }
 }

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -15,9 +15,6 @@
 using namespace mbgl;
 
 void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix) {
-    // Abort early.
-    if (!bucket.hasData()) return;
-
     const FillProperties &properties = layer_desc.getProperties<FillProperties>();
     mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);
 

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -16,7 +16,6 @@ using namespace mbgl;
 void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) return;
-    if (!bucket.hasData()) return;
 
     depthMask(false);
 

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -17,7 +17,9 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
-    depthMask(false);
+    config.stencilTest = true;
+    config.depthTest = true;
+    config.depthMask = GL_FALSE;
 
     const auto &properties = layer_desc.getProperties<LineProperties>();
     const auto &layout = bucket.layout;
@@ -51,7 +53,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
     float ratio = state.getPixelRatio();
     mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);
 
-    depthRange(strata, 1.0f);
+    config.depthRange = { strata, 1.0f };
 
     if (properties.dash_array.from.size()) {
 
@@ -109,7 +111,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
 
         MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0));
         spriteAtlas.bind(true);
-        MBGL_CHECK_ERROR(glDepthRange(strata + strata_epsilon, 1.0f));  // may or may not matter
+        config.depthRange = { strata + strata_epsilon, 1.0f };  // may or may not matter
 
         bucket.drawLinePatterns(*linepatternShader);
 

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -23,8 +23,9 @@ void Painter::renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, c
         rasterShader->u_contrast_factor = contrastFactor(properties.contrast);
         rasterShader->u_spin_weights = spinWeights(properties.hue_rotate);
 
-        depthRange(strata + strata_epsilon, 1.0f);
-
+        config.stencilTest = true;
+        config.depthTest = true;
+        config.depthRange = { strata + strata_epsilon, 1.0f };
         bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray);
     }
 }

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -87,7 +87,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
 
         sdfShader.u_buffer = (haloOffset - styleProperties.halo_width / fontScale) / sdfPx;
 
-        depthRange(strata, 1.0f);
+        config.depthRange = { strata, 1.0f };
         (bucket.*drawSDF)(sdfShader);
     }
 
@@ -108,7 +108,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
 
         sdfShader.u_buffer = (256.0f - 64.0f) / 256.0f;
 
-        depthRange(strata + strata_epsilon, 1.0f);
+        config.depthRange = { strata + strata_epsilon, 1.0f };
         (bucket.*drawSDF)(sdfShader);
     }
 }
@@ -122,8 +122,9 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
     const auto &properties = layer_desc.getProperties<SymbolProperties>();
     const auto &layout = bucket.layout;
 
-    MBGL_CHECK_ERROR(glDisable(GL_STENCIL_TEST));
-    depthMask(false);
+    config.stencilTest = false;
+    config.depthTest = true;
+    config.depthMask = GL_FALSE;
 
     if (bucket.hasIconData()) {
         bool sdf = bucket.sdfIcons;
@@ -185,7 +186,7 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
             iconShader->u_fadezoom = state.getNormalizedZoom() * 10;
             iconShader->u_opacity = properties.icon.opacity;
 
-            depthRange(strata, 1.0f);
+            config.depthRange = { strata, 1.0f };
             bucket.drawIcons(*iconShader);
         }
     }
@@ -203,6 +204,4 @@ void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, c
                   *sdfGlyphShader,
                   &SymbolBucket::drawGlyphs);
     }
-
-    MBGL_CHECK_ERROR(glEnable(GL_STENCIL_TEST));
 }

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -13,9 +13,10 @@ RasterBucket::RasterBucket(TexturePool& texturePool, const StyleLayoutRaster& la
   raster(texturePool) {
 }
 
-void RasterBucket::prepare() {
+void RasterBucket::upload() {
     if (hasData()) {
         raster.upload();
+        uploaded = true;
     }
 }
 

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -13,8 +13,13 @@ RasterBucket::RasterBucket(TexturePool& texturePool, const StyleLayoutRaster& la
   raster(texturePool) {
 }
 
-void RasterBucket::render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
-                          const mat4 &matrix) {
+void RasterBucket::prepare() {
+}
+
+void RasterBucket::render(Painter& painter,
+                          const StyleLayer& layer_desc,
+                          const TileID& id,
+                          const mat4& matrix) {
     painter.renderRaster(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -29,13 +29,6 @@ void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
 }
 
-void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array, GLuint texture_) {
-    raster.bind(texture_);
-    shader.u_image = 0;
-    array.bind(shader, vertices, BUFFER_OFFSET(0));
-    MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
-}
-
 bool RasterBucket::hasData() const {
     return raster.isLoaded();
 }

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -14,6 +14,9 @@ RasterBucket::RasterBucket(TexturePool& texturePool, const StyleLayoutRaster& la
 }
 
 void RasterBucket::prepare() {
+    if (hasData()) {
+        raster.upload();
+    }
 }
 
 void RasterBucket::render(Painter& painter,

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -26,8 +26,6 @@ public:
 
     void drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array);
 
-    void drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array, GLuint texture);
-
     Raster raster;
 };
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -18,7 +18,7 @@ public:
 
     void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
                 const mat4 &matrix) override;
-    bool hasData() const override;
+    bool hasData() const;
 
     bool setImage(const std::string &data);
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -16,7 +16,7 @@ class RasterBucket : public Bucket {
 public:
     RasterBucket(TexturePool&, const StyleLayoutRaster&);
 
-    void prepare() override;
+    void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const;
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -16,8 +16,8 @@ class RasterBucket : public Bucket {
 public:
     RasterBucket(TexturePool&, const StyleLayoutRaster&);
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
-                const mat4 &matrix) override;
+    void prepare() override;
+    void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const;
 
     bool setImage(const std::string &data);

--- a/src/mbgl/renderer/render_pass.hpp
+++ b/src/mbgl/renderer/render_pass.hpp
@@ -1,0 +1,31 @@
+#ifndef MBGL_RENDERER_RENDER_PASS
+#define MBGL_RENDERER_RENDER_PASS
+
+#include <cstdint>
+#include <type_traits>
+
+namespace mbgl {
+
+enum class RenderPass : uint8_t {
+    None = 0,
+    Opaque = 1 << 0,
+    Translucent = 1 << 1,
+};
+
+constexpr inline RenderPass operator|(RenderPass a, RenderPass b) {
+    return static_cast<RenderPass>(static_cast<std::underlying_type<RenderPass>::type>(a) |
+                                   static_cast<std::underlying_type<RenderPass>::type>(b));
+}
+
+inline RenderPass operator|=(RenderPass& a, RenderPass b) {
+    return (a = a | b);
+}
+
+constexpr inline RenderPass operator&(RenderPass a, RenderPass b) {
+    return static_cast<RenderPass>(static_cast<std::underlying_type<RenderPass>::type>(a) &
+                                   static_cast<std::underlying_type<RenderPass>::type>(b));
+}
+
+}
+
+#endif

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -36,8 +36,13 @@ SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void SymbolBucket::render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
-                          const mat4 &matrix) {
+void SymbolBucket::prepare() {
+}
+
+void SymbolBucket::render(Painter& painter,
+                          const StyleLayer& layer_desc,
+                          const TileID& id,
+                          const mat4& matrix) {
     painter.renderSymbol(*this, layer_desc, id, matrix);
 }
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -36,7 +36,7 @@ SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void SymbolBucket::prepare() {
+void SymbolBucket::upload() {
     if (hasTextData()) {
         text.vertices.upload();
         text.triangles.upload();
@@ -46,8 +46,7 @@ void SymbolBucket::prepare() {
         icon.triangles.upload();
     }
 
-    // From now on, we're going to render during the opaque and translucent pass.
-    renderPass = RenderPass::Translucent;
+    uploaded = true;
 }
 
 void SymbolBucket::render(Painter& painter,

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -37,6 +37,17 @@ SymbolBucket::~SymbolBucket() {
 }
 
 void SymbolBucket::prepare() {
+    if (hasTextData()) {
+        text.vertices.upload();
+        text.triangles.upload();
+    }
+    if (hasIconData()) {
+        icon.vertices.upload();
+        icon.triangles.upload();
+    }
+
+    // From now on, we're going to render during the opaque and translucent pass.
+    renderPass = RenderPass::Translucent;
 }
 
 void SymbolBucket::render(Painter& painter,

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -55,8 +55,8 @@ public:
     SymbolBucket(Collision &collision);
     ~SymbolBucket() override;
 
-    void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
-                const mat4 &matrix) override;
+    void prepare() override;
+    void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const;
     bool hasTextData() const;
     bool hasIconData() const;

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -57,7 +57,7 @@ public:
 
     void render(Painter &painter, const StyleLayer &layer_desc, const TileID &id,
                 const mat4 &matrix) override;
-    bool hasData() const override;
+    bool hasData() const;
     bool hasTextData() const;
     bool hasIconData() const;
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -55,7 +55,7 @@ public:
     SymbolBucket(Collision &collision);
     ~SymbolBucket() override;
 
-    void prepare() override;
+    void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const;
     bool hasTextData() const;

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -27,7 +27,7 @@ namespace algo = boost::algorithm;
 namespace mbgl {
 
 DefaultFileSource::DefaultFileSource(FileCache* cache, const std::string& root)
-    : thread(util::make_unique<util::Thread<Impl>>("FileSource", cache, root)) {
+    : thread(util::make_unique<util::Thread<Impl>>("FileSource", util::ThreadPriority::Low, cache, root)) {
 }
 
 DefaultFileSource::~DefaultFileSource() {

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -13,6 +13,21 @@ bool StyleLayer::isBackground() const {
     return type == StyleLayerType::Background;
 }
 
+bool StyleLayer::isVisible() const {
+    switch (type) {
+        case StyleLayerType::Fill:
+            return getProperties<FillProperties>().isVisible();
+        case StyleLayerType::Line:
+            return getProperties<LineProperties>().isVisible();
+        case StyleLayerType::Symbol:
+            return getProperties<SymbolProperties>().isVisible();
+        case StyleLayerType::Raster:
+            return getProperties<RasterProperties>().isVisible();
+        default:
+            return false;
+    }
+}
+
 void StyleLayer::setClasses(const std::vector<std::string> &class_names, const TimePoint now,
                             const PropertyTransition &defaultTransition) {
     // Stores all keys that we have already added transitions for.

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -35,6 +35,9 @@ public:
     // Determines whether this layer is the background layer.
     bool isBackground() const;
 
+    // Checks whether the layer is currently visible at all.
+    bool isVisible() const;
+
     // Updates the StyleProperties information in this layer by evaluating all
     // pending transitions and applied classes in order.
     void updateProperties(float z, TimePoint now, ZoomHistory &zoomHistory);

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -46,16 +46,7 @@ void Raster::bind(bool linear) {
     }
 
     if (img && !textured) {
-        texture = texturePool.getTextureID();
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
-#ifndef GL_ES_VERSION_2_0
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
-#endif
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-        MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, img->getData()));
-        img.reset();
-        textured = true;
+        upload();
     } else if (textured) {
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
     }
@@ -68,24 +59,17 @@ void Raster::bind(bool linear) {
     }
 }
 
-// overload ::bind for prerendered raster textures
-void Raster::bind(const GLuint custom_texture) {
+void Raster::upload() {
     if (img && !textured) {
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, custom_texture));
+        texture = texturePool.getTextureID();
+        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
+#ifndef GL_ES_VERSION_2_0
+        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
+#endif
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
         MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, img->getData()));
         img.reset();
         textured = true;
-    } else if (textured) {
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, custom_texture));
     }
-
-    GLuint new_filter = GL_LINEAR;
-    if (new_filter != this->filter) {
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, new_filter));
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, new_filter));
-        filter = new_filter;
-    }
-
 }

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -25,8 +25,8 @@ public:
     // bind current texture
     void bind(bool linear = false);
 
-    // bind prerendered texture
-    void bind(const GLuint texture);
+    // uploads the texture if it hasn't been uploaded yet.
+    void upload();
 
     // loaded status
     bool isLoaded() const;

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/util/worker.hpp>
+#include <mbgl/platform/platform.hpp>
 
 #include <cassert>
 
@@ -15,7 +16,7 @@ public:
 
 Worker::Worker(std::size_t count) {
     for (std::size_t i = 0; i < count; i++) {
-        threads.emplace_back(util::make_unique<util::Thread<Impl>>("Worker"));
+        threads.emplace_back(util::make_unique<util::Thread<Impl>>("Worker", util::ThreadPriority::Low));
     }
 }
 


### PR DESCRIPTION
We're currently have a pretty complicated way of rendering a tile, going through many layers of objects and some double dispatching along the way. This makes the code hard to follow and we need to traverse the hierarchy several times, for rendering opaque and translucent objects. We also want to add an additional step before that, giving renderable objects (=buckets) an opportunity to upload data to the GPU before we kick off rendering a frame.