### PR TITLE
Parse HTTPS URL in -[MGLMapView mapID]

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1376,7 +1376,14 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 - (NSString *)mapID
 {
     NSURL *styleURL = self.styleURL;
-    return [styleURL.scheme isEqualToString:@"mapbox"] ? styleURL.host.mgl_stringOrNilIfEmpty : nil;
+    if ([styleURL.host isEqualToString:@"api.tiles.mapbox.com"])
+    {
+        return styleURL.lastPathComponent.mgl_stringOrNilIfEmpty;
+    }
+    else
+    {
+        return nil;
+    }
 }
 
 - (void)setMapID:(NSString *)mapID


### PR DESCRIPTION
`-[MGLMapView styleURL]` returns an HTTPS URL, not a mapbox: URL. Extract the map ID from the HTTPS URL.

Fixes #1334.