### PR TITLE
Use evenodd fill type for pre-tessellation union

### DIFF
--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -84,7 +84,7 @@ void FillBucket::tessellate() {
     hasVertices = false;
 
     std::vector<std::vector<ClipperLib::IntPoint>> polygons;
-    clipper.Execute(ClipperLib::ctUnion, polygons, ClipperLib::pftPositive);
+    clipper.Execute(ClipperLib::ctUnion, polygons, ClipperLib::pftEvenOdd, ClipperLib::pftEvenOdd);
     clipper.Clear();
 
     if (polygons.size() == 0) {
@@ -132,7 +132,7 @@ void FillBucket::tessellate() {
 
     lineGroup.elements_length += total_vertex_count;
 
-    if (tessTesselate(tesselator, TESS_WINDING_POSITIVE, TESS_POLYGONS, vertices_per_group, vertexSize, 0)) {
+    if (tessTesselate(tesselator, TESS_WINDING_ODD, TESS_POLYGONS, vertices_per_group, vertexSize, 0)) {
         const TESSreal *vertices = tessGetVertices(tesselator);
         const size_t vertex_count = tessGetVertexCount(tesselator);
         TESSindex *vertex_indices = const_cast<TESSindex *>(tessGetVertexIndices(tesselator));


### PR DESCRIPTION
The current Vector tile specification (1.x) does not specify a required winding order for polygons.

Therefore for correct filling of polygons an `even_odd` approach should be used which is not dependent on winding order. So, `pftEvenOdd` is the correct `subjFillType` to pass for the third argument to [clipper.Execute](http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Classes/Clipper/Methods/Execute.htm).

It also makes sense to be explicit about the fourth argument to `clipper.Execute`. If you do not provide the `fourth` arg the default is `pftEvenOdd` so this pull does not change behavior.

Finally, given `pftEvenOdd` is the return fill type for clipper I think it makes sense to request `TESS_WINDING_ODD` for tesselation.

Testing ad-hoc in the app shows:

 - No obvious changes to visual rendering with this change against `mapbox://mapbox.mapbox-streets-v6`.
 - Correct rendering of polygons that use `non_zero` filling (where the winding order of interior rings is the inverse of exterior rings) after this change, but incorrectly filled before.

refs http://www.angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Types/PolyFillType.htm

Background:

 - clipper.Execute is currently used to prepare geometries to be compatible with libtess2. But in the future it will be desirable to avoid needing clipper and so this pull request hopefully will become obsolete in the future.