### PR TITLE
fix SSL pinning for apps including the framework

### DIFF
--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -111,13 +111,13 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
     if (self) {
         
         // Put Settings bundle into memory
-        NSString *settingsBundle = [[NSBundle mainBundle] pathForResource:@"Settings" ofType:@"bundle"];
-        if(!settingsBundle) {
+        NSString *appSettingsBundle = [[NSBundle mainBundle] pathForResource:@"Settings" ofType:@"bundle"];
+        if(!appSettingsBundle) {
             NSLog(@"Could not find Settings.bundle");
         } else {
             // Dynamic Settings.bundle loading based on:
             // http://stackoverflow.com/questions/510216/can-you-make-the-settings-in-settings-bundle-default-even-if-you-dont-open-the
-            NSDictionary *settings = [NSDictionary dictionaryWithContentsOfFile:[settingsBundle stringByAppendingPathComponent:@"Root.plist"]];
+            NSDictionary *settings = [NSDictionary dictionaryWithContentsOfFile:[appSettingsBundle stringByAppendingPathComponent:@"Root.plist"]];
             NSArray *preferences = [settings objectForKey:@"PreferenceSpecifiers"];
             NSMutableDictionary *defaultsToRegister = [[NSMutableDictionary alloc] initWithCapacity:[preferences count]];
             for(NSDictionary *prefSpecification in preferences) {
@@ -143,7 +143,7 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
         NSArray *bundles = [NSBundle allFrameworks];
         for (int lc = 0; lc < bundles.count; lc++) {
             NSBundle *b = [bundles objectAtIndex:lc];
-            cerPath = [[NSBundle mainBundle] pathForResource:@"api_mapbox_com-geotrust" ofType:@"der"];
+            cerPath = [[NSBundle bundleForClass:[MGLMapboxEvents class]] pathForResource:@"api_mapbox_com-geotrust" ofType:@"der"];
             if (cerPath != nil) {
                 break;
             }

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -140,14 +140,7 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
 
         // Load Local Copy of Server's Public Key
         NSString *cerPath = nil;
-        NSArray *bundles = [NSBundle allFrameworks];
-        for (int lc = 0; lc < bundles.count; lc++) {
-            NSBundle *b = [bundles objectAtIndex:lc];
-            cerPath = [[NSBundle bundleForClass:[MGLMapboxEvents class]] pathForResource:@"api_mapbox_com-geotrust" ofType:@"der"];
-            if (cerPath != nil) {
-                break;
-            }
-        }
+        cerPath = [[NSBundle bundleForClass:[MGLMapboxEvents class]] pathForResource:@"api_mapbox_com-geotrust" ofType:@"der"];
         if (cerPath != nil) {
             _geoTrustCert = [NSData dataWithContentsOfFile:cerPath];
         }


### PR DESCRIPTION
Made it clearer when we are referring to the **app** bundle and when we need to get the **framework** bundle for resources such as pinned certificates.

Uses of `+[NSBundle mainBundle]` refer to the host app's bundle, which in the case of the GL dev app could include framework-level resources since GYP makes it tricky to build non-app target resource bundles and that's how we roll the app. That's why the current `master` worked in testing. 

Uses `+[NSBundle bundleForClass:]` for cases when we specifically mean the framework bundle, such as we do in [`+[MGLMapView resourceBundlePath]`](https://github.com/mapbox/mapbox-gl-native/blob/8aa2e2fef76eb4dfdb6e5b28a815babd27647322/platform/ios/MGLMapView.mm#L2338). We use `MGLMapboxEvents ` in this fix since the `MGLMapboxEvents` class should be unaware of `MGLMapView` specifically and should be entirely self-contained. 

/cc @bleege @camilleanne @1ec5 @kkaefer 