### PR TITLE
Automatically find view controller for layout guides

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -46,11 +46,6 @@ IB_DESIGNABLE
 
 /** @name Managing Constraints */
 
-/** A view controller whose top and bottom layout guides to use for proper setup of constraints in the map view internals.
-*
-*   Certain components of the map view, such as the heading compass and the data attribution button, need to be aware of the view controller layout in order to avoid positioning content under a top navigation bar or a bottom toolbar. */
-@property (nonatomic, weak) IBOutlet UIViewController *viewControllerForLayoutGuides;
-
 #pragma mark - Accessing Map Properties
 
 /** @name Accessing Map Properties */

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -67,7 +67,6 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
 
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds accessToken:accessToken];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.mapView.viewControllerForLayoutGuides = self;
     self.mapView.showsUserLocation = YES;
     self.mapView.delegate = self;
     [self.view addSubview:self.mapView];

--- a/test/ios/MGLTViewController.m
+++ b/test/ios/MGLTViewController.m
@@ -12,7 +12,6 @@
 
     _mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds
                                                 accessToken:@"pk.eyJ1IjoianVzdGluIiwiYSI6Ik9RX3RRQzAifQ.dmOg_BAp1ywuDZMM7YsXRg"];
-    _mapView.viewControllerForLayoutGuides = self;
     _mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
     [self.view addSubview:_mapView];


### PR DESCRIPTION
We inherited an annoying, easy-to-overlook setup step from the iOS SDK: [`MGLMapView`’s `viewControllerForLayoutGuides` outlet must be hooked up to the managing view controller](https://github.com/mapbox/mapbox-gl-native/wiki/Installing-Mapbox-GL-for-iOS/_compare/a551a579d1e03dd83340868416603e882e890ffe...6e8c9508f285741401ef62501d352308223bc99c) in order for the ornaments (logo, :information_source:, compass) to be laid out properly.

Based on the [`-[UIResponder nextResponder]` documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIResponder_Class/index.html#//apple_ref/occ/instm/UIResponder/nextResponder) and the fixes for ornament layout in #1328, this PR causes `MGLMapView` to compute the managing view controller on its own by traversing the responder chain. (If there is a legitimate need to lay out the ornaments based on some view controller not in the responder chain, that would be a good opportunity to subclass `MGLMapView`; in that case, we’d need to re-expose `-viewControllerForLayoutGuides` publicly, but there would still be no need for a stored property.)

Once this PR is merged and contained in a tag, I’ll remove the step from the installation guide.

/cc @incanus @friedbunny