### PR TITLE
Wait for initial region change notification from reset before testing (Fixes #1360)

### DIFF
--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -395,16 +395,18 @@
                                                       }
                                                   }];
 
-    [tester waitForTimeInterval:1];
+    // wait for initial reset before proceeding to actual tests
+    NSNotification *notification = [system waitForNotificationName:@"regionDidChangeAnimated"
+                                                            object:tester.mapView];
 
     unanimatedCount = 0;
     animatedCount = 0;
 
-    NSNotification *notification = [system waitForNotificationName:@"regionDidChangeAnimated"
-                                                            object:tester.mapView
-                                               whileExecutingBlock:^{
-                                                   tester.mapView.centerCoordinate = CLLocationCoordinate2DMake(0, 0);
-                                               }];
+    notification = [system waitForNotificationName:@"regionDidChangeAnimated"
+                                            object:tester.mapView
+                               whileExecutingBlock:^{
+                                   tester.mapView.centerCoordinate = CLLocationCoordinate2DMake(0, 0);
+                               }];
 
     [tester waitForTimeInterval:1];
 
@@ -421,7 +423,7 @@
                                    [tester.mapView setCenterCoordinate:CLLocationCoordinate2DMake(45, 100) animated:YES];
                                }];
 
-    [tester waitForTimeInterval:1];
+    [tester waitForAnimationsToFinishWithTimeout:1];
 
     XCTAssertEqual([notification.userInfo[@"animated"] boolValue],
                    YES,


### PR DESCRIPTION
The `beforeEach` reset of `tester.mapView.centerCoordinate` will emit a `regionDidChangeAnimated` notification that `testDelegateRegionDidChange` sees but should ignore before proceeding.

This PR inserts a `waitForNotificationName:@"regionDidChangeAnimated"` that should hear from `beforeEach` before continuing on to the actual tests.

This test was passing locally, but failing on Travis (presumably because of performance issues on their end).

Fixes #1360.

/cc @incanus @kkaefer