### PR TITLE
Get the number of CPUs correctly on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 
 ifeq ($(shell uname -s), Linux)
 HOST = linux
-JOBS ?= $(shell sysctl -n hw.ncpu)
+JOBS ?= $(shell grep --count processor /proc/cpuinfo)
 endif
 
 JOBS ?= 1


### PR DESCRIPTION
I'm using a more generic approach as the actual one doesn't seem to be using a Linux interface.