### PR TITLE
Formalize NSURLSession lifetime; streamline MGLMetricsLocationManager methods

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -33,7 +33,7 @@
         '../include/mbgl/ios/MGLTypes.h',
         '../platform/ios/NSBundle+MGLAdditions.h',
         '../platform/ios/NSBundle+MGLAdditions.m',
-        '../platform/ios/NSException+MGLAdditions.m',
+        '../platform/ios/NSException+MGLAdditions.h',
         '../platform/ios/NSProcessInfo+MGLAdditions.h',
         '../platform/ios/NSProcessInfo+MGLAdditions.m',
         '../platform/ios/NSString+MGLAdditions.h',

--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -33,6 +33,7 @@
         '../include/mbgl/ios/MGLTypes.h',
         '../platform/ios/NSBundle+MGLAdditions.h',
         '../platform/ios/NSBundle+MGLAdditions.m',
+        '../platform/ios/NSException+MGLAdditions.m',
         '../platform/ios/NSProcessInfo+MGLAdditions.h',
         '../platform/ios/NSProcessInfo+MGLAdditions.m',
         '../platform/ios/NSString+MGLAdditions.h',

--- a/include/mbgl/ios/MGLMetricsLocationManager.h
+++ b/include/mbgl/ios/MGLMetricsLocationManager.h
@@ -5,9 +5,9 @@
 // These methods can be called from any thread.
 //
 + (instancetype)sharedManager;
-+ (void) startUpdatingLocation;
-+ (void) stopUpdatingLocation;
-+ (void) startMonitoringVisits;
-+ (void) stopMonitoringVisits;
+- (void) startUpdatingLocation;
+- (void) stopUpdatingLocation;
+- (void) startMonitoringVisits;
+- (void) stopMonitoringVisits;
 
 @end

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -20,6 +20,7 @@
 #import "NSBundle+MGLAdditions.h"
 #import "NSString+MGLAdditions.h"
 #import "NSProcessInfo+MGLAdditions.h"
+#import "NSException+MGLAdditions.h"
 #import "MGLAnnotation.h"
 #import "MGLUserLocationAnnotationView.h"
 #import "MGLUserLocation_Private.h"
@@ -2348,7 +2349,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
 - (void)invalidate
 {
-    assert([[NSThread currentThread] isMainThread]);
+    MGLAssertIsMainThread();
 
     [self.glView setNeedsDisplay];
 

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -237,6 +237,10 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
     return _sharedManager;
 }
 
+- (void)dealloc {
+    [self pauseMetricsCollection];
+}
+
 // Must be called from the main thread.
 //
 + (void) setToken:(NSString *)token {

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -266,28 +266,38 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
     [MGLMapboxEvents sharedManager].appBuildNumber = appBuildNumber;
 }
 
-// Must be called from the main thread.
-//
-+ (void) pauseMetricsCollection {
-    MGLAssertIsMainThread();
-    if ([MGLMapboxEvents sharedManager].paused) {
-        return;
-    }
-    [MGLMapboxEvents sharedManager].paused = YES;
-    [MGLMetricsLocationManager stopUpdatingLocation];
-    [MGLMetricsLocationManager stopMonitoringVisits];
++ (void)pauseMetricsCollection {
+    [[MGLMapboxEvents sharedManager] pauseMetricsCollection];
 }
 
 // Must be called from the main thread.
 //
-+ (void) resumeMetricsCollection {
+- (void)pauseMetricsCollection {
     MGLAssertIsMainThread();
-    if (![MGLMapboxEvents sharedManager].paused) {
+    if (self.paused) {
         return;
     }
-    [MGLMapboxEvents sharedManager].paused = NO;
-    [MGLMetricsLocationManager startUpdatingLocation];
-    [MGLMetricsLocationManager startMonitoringVisits];
+    self.paused = YES;
+    MGLMetricsLocationManager *sharedLocationManager = [MGLMetricsLocationManager sharedManager];
+    [sharedLocationManager stopUpdatingLocation];
+    [sharedLocationManager stopMonitoringVisits];
+}
+
++ (void)resumeMetricsCollection {
+    [[MGLMapboxEvents sharedManager] resumeMetricsCollection];
+}
+
+// Must be called from the main thread.
+//
+- (void)resumeMetricsCollection {
+    MGLAssertIsMainThread();
+    if (!self.isPaused) {
+        return;
+    }
+    self.paused = NO;
+    MGLMetricsLocationManager *sharedLocationManager = [MGLMetricsLocationManager sharedManager];
+    [sharedLocationManager startUpdatingLocation];
+    [sharedLocationManager startMonitoringVisits];
 }
 
 // Can be called from any thread. Can be called rapidly from

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -143,7 +143,8 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
         // Configure Events Infrastructure
         // ===============================
 
-         _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
+        _paused = YES;
+        [self resumeMetricsCollection];
         NSBundle *resourceBundle = [NSBundle bundleWithPath:[NSBundle mgl_resourceBundlePath]];
 
         // Load Local Copy of Server's Public Key
@@ -222,8 +223,6 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
         if ( ! NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent) {
             void (^setupBlock)() = ^{
                 _sharedManager = [[self alloc] init];
-                // setup dedicated location manager on first use
-                [MGLMetricsLocationManager sharedManager];
             };
             if ( ! [[NSThread currentThread] isMainThread]) {
                 dispatch_sync(dispatch_get_main_queue(), ^{
@@ -278,6 +277,8 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
         return;
     }
     self.paused = YES;
+    [_session invalidateAndCancel];
+    _session = nil;
     MGLMetricsLocationManager *sharedLocationManager = [MGLMetricsLocationManager sharedManager];
     [sharedLocationManager stopUpdatingLocation];
     [sharedLocationManager stopMonitoringVisits];
@@ -295,6 +296,7 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
         return;
     }
     self.paused = NO;
+    _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
     MGLMetricsLocationManager *sharedLocationManager = [MGLMetricsLocationManager sharedManager];
     [sharedLocationManager startUpdatingLocation];
     [sharedLocationManager startMonitoringVisits];

--- a/platform/ios/MGLMetricsLocationManager.m
+++ b/platform/ios/MGLMetricsLocationManager.m
@@ -39,24 +39,20 @@
     return sharedManager;
 }
 
-+ (void) startUpdatingLocation {
-    [[MGLMetricsLocationManager sharedManager].locationManager startUpdatingLocation];
+- (void)startUpdatingLocation {
+    [self.locationManager startUpdatingLocation];
 }
 
-+ (void) stopUpdatingLocation {
-    [[MGLMetricsLocationManager sharedManager].locationManager stopUpdatingLocation];
+- (void)stopUpdatingLocation {
+    [self.locationManager stopUpdatingLocation];
 }
 
-+ (void) startMonitoringVisits {
-    if ([[MGLMetricsLocationManager sharedManager].locationManager respondsToSelector:@selector(startMonitoringVisits)]) {
-        [[MGLMetricsLocationManager sharedManager].locationManager startMonitoringVisits];
-    }
+- (void)startMonitoringVisits {
+    [self.locationManager startMonitoringVisits];
 }
 
-+ (void) stopMonitoringVisits {
-    if ([[MGLMetricsLocationManager sharedManager].locationManager respondsToSelector:@selector(stopMonitoringVisits)]) {
-        [[MGLMetricsLocationManager sharedManager].locationManager stopMonitoringVisits];
-    }
+- (void)stopMonitoringVisits {
+    [self.locationManager stopMonitoringVisits];
 }
 
 #pragma mark CLLocationManagerDelegate
@@ -96,21 +92,21 @@
             break;
         case kCLAuthorizationStatusDenied:
             newStatus = @"User Explcitly Denied";
-            [MGLMetricsLocationManager stopUpdatingLocation];
-            [MGLMetricsLocationManager stopMonitoringVisits];
+            [self stopUpdatingLocation];
+            [self stopMonitoringVisits];
             break;
         case kCLAuthorizationStatusAuthorized:
             newStatus = @"User Has Authorized / Authorized Always";
-            [MGLMetricsLocationManager startUpdatingLocation];
-            [MGLMetricsLocationManager startMonitoringVisits];
+            [self startUpdatingLocation];
+            [self startMonitoringVisits];
             break;
-            //        case kCLAuthorizationStatusAuthorizedAlways:
-            //            newStatus = @"Not Determined";
-            //            break;
+//        case kCLAuthorizationStatusAuthorizedAlways:
+//            newStatus = @"Not Determined";
+//            break;
         case kCLAuthorizationStatusAuthorizedWhenInUse:
             newStatus = @"User Has Authorized When In Use Only";
-            [MGLMetricsLocationManager startUpdatingLocation];
-            [MGLMetricsLocationManager startMonitoringVisits];
+            [self startUpdatingLocation];
+            [self startMonitoringVisits];
             break;
         default:
             newStatus = @"Unknown";

--- a/platform/ios/NSException+MGLAdditions.h
+++ b/platform/ios/NSException+MGLAdditions.h
@@ -1,0 +1,3 @@
+#import <Foundation/Foundation.h>
+
+#define MGLAssertIsMainThread() NSAssert([[NSThread currentThread] isMainThread], @"-[%@ %@] must be accessed on the main thread, not %@", [self class], NSStringFromSelector(_cmd), [NSThread currentThread])


### PR DESCRIPTION
This PR streamlines how the shared `MGLMapboxEvents` instance manages the shared `MGLMetricsLocationManager` instance. Setting up or resuming the `MGLMetricsLocationManager` is bottlenecked in `-resumeMetricsCollection`, which is called when initializing the `MGLMapboxEvents`. When pausing metrics collection, we tear down the `NSURLSession` to a) avoid sending additional events and b) break a reference cycle (thereby fixing #1354).

Along the way, I cleaned up a property to conform to modern Objective-C style, refactored `MGLMetricsLocationEvents` so that its instances can call themselves directly, and introduced a convenient macro for main thread assertions.

/cc @bleege