### PR TITLE
fixes #1103: allow multiple maps by not using global pointers

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -30,6 +30,8 @@
 
 #import <algorithm>
 
+class MBGLView;
+
 // Returns the path to the default cache database on this system.
 const std::string &defaultCacheDatabase() {
     static const std::string path = []() -> std::string {
@@ -96,6 +98,11 @@ static NSURL *MGLURLForBundledStyleNamed(NSString *styleName)
 
 @implementation MGLMapView
 {
+    mbgl::Map *_mbglMap;
+    MBGLView *_mbglView;
+    mbgl::SQLiteCache *_mbglFileCache;
+    mbgl::DefaultFileSource *_mbglFileSource;
+
     BOOL _isTargetingInterfaceBuilder;
     CLLocationDegrees _pendingLatitude;
     CLLocationDegrees _pendingLongitude;
@@ -105,17 +112,10 @@ static NSURL *MGLURLForBundledStyleNamed(NSString *styleName)
 
 @dynamic debugActive;
 
-class MBGLView;
-
 std::chrono::steady_clock::duration secondsAsDuration(float duration)
 {
     return std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<float, std::chrono::seconds::period>(duration));
 }
-
-mbgl::Map *mbglMap = nullptr;
-MBGLView *mbglView = nullptr;
-mbgl::SQLiteCache *mbglFileCache = nullptr;
-mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -163,12 +163,12 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (NSString *)accessToken
 {
-    return @(mbglMap->getAccessToken().c_str()).mgl_stringOrNilIfEmpty;
+    return @(_mbglMap->getAccessToken().c_str()).mgl_stringOrNilIfEmpty;
 }
 
 - (void)setAccessToken:(NSString *)accessToken
 {
-    mbglMap->setAccessToken(accessToken ? (std::string)[accessToken UTF8String] : "");
+    _mbglMap->setAccessToken(accessToken ? (std::string)[accessToken UTF8String] : "");
     [MGLMapboxEvents setToken:accessToken.mgl_stringOrNilIfEmpty];
 }
 
@@ -179,7 +179,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (NSURL *)styleURL
 {
-    NSString *styleURLString = @(mbglMap->getStyleURL().c_str()).mgl_stringOrNilIfEmpty;
+    NSString *styleURLString = @(_mbglMap->getStyleURL().c_str()).mgl_stringOrNilIfEmpty;
     return styleURLString ? [NSURL URLWithString:styleURLString] : nil;
 }
 
@@ -200,7 +200,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
         styleURL = [[NSBundle mainBundle] URLForResource:styleURL.path withExtension:nil];
     }
     
-    mbglMap->setStyleURL([[styleURL absoluteString] UTF8String]);
+    _mbglMap->setStyleURL([[styleURL absoluteString] UTF8String]);
 }
 
 - (BOOL)commonInit
@@ -275,13 +275,13 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     // setup mbgl map
     //
-    mbglView = new MBGLView(self);
-    mbglFileCache  = new mbgl::SQLiteCache(defaultCacheDatabase());
-    mbglFileSource = new mbgl::DefaultFileSource(mbglFileCache);
+    _mbglView = new MBGLView(self);
+    _mbglFileCache  = new mbgl::SQLiteCache(defaultCacheDatabase());
+    _mbglFileSource = new mbgl::DefaultFileSource(_mbglFileCache);
 
     // Start paused on the IB canvas
-    mbglMap = new mbgl::Map(*mbglView, *mbglFileSource, mbgl::MapMode::Continuous, _isTargetingInterfaceBuilder);
-    mbglMap->resize(self.bounds.size.width, self.bounds.size.height, _glView.contentScaleFactor);
+    _mbglMap = new mbgl::Map(*_mbglView, *_mbglFileSource, mbgl::MapMode::Continuous, _isTargetingInterfaceBuilder);
+    _mbglMap->resize(self.bounds.size.width, self.bounds.size.height, _glView.contentScaleFactor);
 
     // Notify map object when network reachability status changes.
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -296,7 +296,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     //
     _annotationIDsByAnnotation = [NSMapTable mapTableWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableStrongMemory];
     std::string defaultSymbolName([MGLDefaultStyleMarkerSymbolName UTF8String]);
-    mbglMap->setDefaultPointAnnotationSymbol(defaultSymbolName);
+    _mbglMap->setDefaultPointAnnotationSymbol(defaultSymbolName);
 
     // setup logo bug
     //
@@ -374,7 +374,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     // set initial position
     //
-    mbglMap->setLatLngZoom(mbgl::LatLng(0, 0), mbglMap->getMinZoom());
+    _mbglMap->setLatLngZoom(mbgl::LatLng(0, 0), _mbglMap->getMinZoom());
     _pendingLatitude = NAN;
     _pendingLongitude = NAN;
 
@@ -384,8 +384,8 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     _regionChangeDelegateQueue.maxConcurrentOperationCount = 1;
 
     // metrics: map load event
-    const mbgl::LatLng latLng = mbglMap->getLatLng();
-    const double zoom = mbglMap->getZoom();
+    const mbgl::LatLng latLng = _mbglMap->getLatLng();
+    const double zoom = _mbglMap->getZoom();
 
     [MGLMapboxEvents pushEvent:MGLEventTypeMapLoad withAttributes:@{
         MGLEventKeyLatitude: @(latLng.latitude),
@@ -411,22 +411,22 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 
-    if (mbglMap)
+    if (_mbglMap)
     {
-        delete mbglMap;
-        mbglMap = nullptr;
+        delete _mbglMap;
+        _mbglMap = nullptr;
     }
 
-    if (mbglFileSource)
+    if (_mbglFileSource)
     {
-        delete mbglFileSource;
-        mbglFileSource = nullptr;
+        delete _mbglFileSource;
+        _mbglFileSource = nullptr;
     }
 
-    if (mbglView)
+    if (_mbglView)
     {
-        delete mbglView;
-        mbglView = nullptr;
+        delete _mbglView;
+        _mbglView = nullptr;
     }
 
     if ([[EAGLContext currentContext] isEqual:_context])
@@ -620,19 +620,19 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     if ( ! self.glSnapshotView || self.glSnapshotView.hidden)
     {
-        mbglMap->resize(rect.size.width, rect.size.height, view.contentScaleFactor);
+        _mbglMap->resize(rect.size.width, rect.size.height, view.contentScaleFactor);
 
-        CGFloat zoomFactor   = mbglMap->getMaxZoom() - mbglMap->getMinZoom() + 1;
+        CGFloat zoomFactor   = _mbglMap->getMaxZoom() - _mbglMap->getMinZoom() + 1;
         CGFloat cpuFactor    = (CGFloat)[[NSProcessInfo processInfo] processorCount];
         CGFloat memoryFactor = (CGFloat)[[NSProcessInfo processInfo] physicalMemory] / 1000 / 1000 / 1000;
-        CGFloat sizeFactor   = ((CGFloat)mbglMap->getWidth()  / mbgl::util::tileSize) *
-                               ((CGFloat)mbglMap->getHeight() / mbgl::util::tileSize);
+        CGFloat sizeFactor   = ((CGFloat)_mbglMap->getWidth()  / mbgl::util::tileSize) *
+                               ((CGFloat)_mbglMap->getHeight() / mbgl::util::tileSize);
 
         NSUInteger cacheSize = zoomFactor * cpuFactor * memoryFactor * sizeFactor * 0.5;
 
-        mbglMap->setSourceTileCacheSize(cacheSize);
+        _mbglMap->setSourceTileCacheSize(cacheSize);
 
-        mbglMap->renderSync();
+        _mbglMap->renderSync();
     }
 }
 
@@ -643,7 +643,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     
     if ( ! _isTargetingInterfaceBuilder)
     {
-        mbglMap->update();
+        _mbglMap->update();
     }
 }
 
@@ -666,7 +666,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     self.glSnapshotView.image = self.glView.snapshot;
     self.glSnapshotView.hidden = NO;
 
-    mbglMap->pause();
+    _mbglMap->pause();
 
     [self.glView deleteDrawable];
 }
@@ -677,7 +677,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     [self.glView bindDrawable];
 
-    mbglMap->resume();
+    _mbglMap->resume();
 }
 
 - (void)tintColorDidChange
@@ -707,8 +707,8 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     (void)touches;
     (void)event;
-    mbglMap->cancelTransitions();
-    mbglMap->setGestureInProgress(false);
+    _mbglMap->cancelTransitions();
+    _mbglMap->setGestureInProgress(false);
     self.animatingGesture = NO;
 }
 
@@ -716,13 +716,13 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     if ( ! self.isScrollEnabled) return;
 
-    mbglMap->cancelTransitions();
+    _mbglMap->cancelTransitions();
 
     if (pan.state == UIGestureRecognizerStateBegan)
     {
         [self trackGestureEvent:MGLEventGesturePanStart forRecognizer:pan];
 
-        mbglMap->setGestureInProgress(true);
+        _mbglMap->setGestureInProgress(true);
 
         self.centerPoint = CGPointMake(0, 0);
 
@@ -733,7 +733,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
         CGPoint delta = CGPointMake([pan translationInView:pan.view].x - self.centerPoint.x,
                                     [pan translationInView:pan.view].y - self.centerPoint.y);
 
-        mbglMap->moveBy(delta.x, delta.y);
+        _mbglMap->moveBy(delta.x, delta.y);
 
         self.centerPoint = CGPointMake(self.centerPoint.x + delta.x, self.centerPoint.y + delta.y);
         
@@ -758,9 +758,9 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
         CGPoint offset = CGPointMake(velocity.x * duration / 2, velocity.y * duration / 2);
 
-        mbglMap->moveBy(offset.x, offset.y, secondsAsDuration(duration));
+        _mbglMap->moveBy(offset.x, offset.y, secondsAsDuration(duration));
 
-        mbglMap->setGestureInProgress(false);
+        _mbglMap->setGestureInProgress(false);
 
         if (duration)
         {
@@ -797,17 +797,17 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     if ( ! self.isZoomEnabled) return;
 
-    if (mbglMap->getZoom() <= mbglMap->getMinZoom() && pinch.scale < 1) return;
+    if (_mbglMap->getZoom() <= _mbglMap->getMinZoom() && pinch.scale < 1) return;
 
-    mbglMap->cancelTransitions();
+    _mbglMap->cancelTransitions();
 
     if (pinch.state == UIGestureRecognizerStateBegan)
     {
         [self trackGestureEvent:MGLEventGesturePinchStart forRecognizer:pinch];
 
-        mbglMap->setGestureInProgress(true);
+        _mbglMap->setGestureInProgress(true);
 
-        self.scale = mbglMap->getScale();
+        self.scale = _mbglMap->getScale();
 
         self.userTrackingMode = MGLUserTrackingModeNone;
     }
@@ -815,15 +815,15 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     {
         CGFloat newScale = self.scale * pinch.scale;
 
-        if (log2(newScale) < mbglMap->getMinZoom()) return;
+        if (log2(newScale) < _mbglMap->getMinZoom()) return;
 
-        double scale = mbglMap->getScale();
+        double scale = _mbglMap->getScale();
 
-        mbglMap->scaleBy(newScale / scale, [pinch locationInView:pinch.view].x, [pinch locationInView:pinch.view].y);
+        _mbglMap->scaleBy(newScale / scale, [pinch locationInView:pinch.view].x, [pinch locationInView:pinch.view].y);
     }
     else if (pinch.state == UIGestureRecognizerStateEnded || pinch.state == UIGestureRecognizerStateCancelled)
     {
-        mbglMap->setGestureInProgress(false);
+        _mbglMap->setGestureInProgress(false);
 
         [self unrotateIfNeededAnimated:YES];
 
@@ -835,15 +835,15 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     if ( ! self.isRotateEnabled) return;
 
-    mbglMap->cancelTransitions();
+    _mbglMap->cancelTransitions();
 
     if (rotate.state == UIGestureRecognizerStateBegan)
     {
         [self trackGestureEvent:MGLEventGestureRotateStart forRecognizer:rotate];
 
-        mbglMap->setGestureInProgress(true);
+        _mbglMap->setGestureInProgress(true);
 
-        self.angle = [MGLMapView degreesToRadians:mbglMap->getBearing()] * -1;
+        self.angle = [MGLMapView degreesToRadians:_mbglMap->getBearing()] * -1;
 
         self.userTrackingMode = MGLUserTrackingModeNone;
     }
@@ -859,13 +859,13 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
             newDegrees = fmaxf(newDegrees, -30);
         }
 
-        mbglMap->setBearing(newDegrees,
+        _mbglMap->setBearing(newDegrees,
                             [rotate locationInView:rotate.view].x,
                             [rotate locationInView:rotate.view].y);
     }
     else if (rotate.state == UIGestureRecognizerStateEnded || rotate.state == UIGestureRecognizerStateCancelled)
     {
-        mbglMap->setGestureInProgress(false);
+        _mbglMap->setGestureInProgress(false);
 
         [self unrotateIfNeededAnimated:YES];
 
@@ -920,7 +920,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
         tapBounds.extend(coordinateToLatLng(coordinate));
 
         // query for nearby annotations
-        std::vector<uint32_t> nearbyAnnotations = mbglMap->getAnnotationsInBounds(tapBounds);
+        std::vector<uint32_t> nearbyAnnotations = _mbglMap->getAnnotationsInBounds(tapBounds);
 
         int32_t newSelectedAnnotationID = -1;
 
@@ -1003,7 +1003,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     if ( ! self.isZoomEnabled) return;
 
-    mbglMap->cancelTransitions();
+    _mbglMap->cancelTransitions();
 
     if (doubleTap.state == UIGestureRecognizerStateBegan)
     {
@@ -1031,7 +1031,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
             zoomInPoint = doubleTapPoint;
         }
 
-        mbglMap->scaleBy(2, zoomInPoint.x, zoomInPoint.y, secondsAsDuration(MGLAnimationDuration));
+        _mbglMap->scaleBy(2, zoomInPoint.x, zoomInPoint.y, secondsAsDuration(MGLAnimationDuration));
 
         self.animatingGesture = YES;
 
@@ -1052,9 +1052,9 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     if ( ! self.isZoomEnabled) return;
 
-    if (mbglMap->getZoom() == mbglMap->getMinZoom()) return;
+    if (_mbglMap->getZoom() == _mbglMap->getMinZoom()) return;
 
-    mbglMap->cancelTransitions();
+    _mbglMap->cancelTransitions();
 
     if (twoFingerTap.state == UIGestureRecognizerStateBegan)
     {
@@ -1075,7 +1075,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
             zoomOutPoint = CGPointMake([twoFingerTap locationInView:twoFingerTap.view].x, [twoFingerTap locationInView:twoFingerTap.view].y);
         }
 
-        mbglMap->scaleBy(0.5, zoomOutPoint.x, zoomOutPoint.y, secondsAsDuration(MGLAnimationDuration));
+        _mbglMap->scaleBy(0.5, zoomOutPoint.x, zoomOutPoint.y, secondsAsDuration(MGLAnimationDuration));
 
         self.animatingGesture = YES;
 
@@ -1096,13 +1096,13 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     if ( ! self.isZoomEnabled) return;
 
-    mbglMap->cancelTransitions();
+    _mbglMap->cancelTransitions();
 
     if (quickZoom.state == UIGestureRecognizerStateBegan)
     {
         [self trackGestureEvent:MGLEventGestureQuickZoom forRecognizer:quickZoom];
 
-        self.scale = mbglMap->getScale();
+        self.scale = _mbglMap->getScale();
 
         self.quickZoomStart = [quickZoom locationInView:quickZoom.view].y;
 
@@ -1114,9 +1114,9 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
         CGFloat newZoom = log2f(self.scale) + (distance / 100);
 
-        if (newZoom < mbglMap->getMinZoom()) return;
+        if (newZoom < _mbglMap->getMinZoom()) return;
 
-        mbglMap->scaleBy(powf(2, newZoom) / mbglMap->getScale(), self.bounds.size.width / 2, self.bounds.size.height / 2);
+        _mbglMap->scaleBy(powf(2, newZoom) / _mbglMap->getScale(), self.bounds.size.width / 2, self.bounds.size.height / 2);
     }
     else if (quickZoom.state == UIGestureRecognizerStateEnded || quickZoom.state == UIGestureRecognizerStateCancelled)
     {
@@ -1185,12 +1185,12 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (void)setDebugActive:(BOOL)debugActive
 {
-    mbglMap->setDebug(debugActive);
+    _mbglMap->setDebug(debugActive);
 }
 
 - (BOOL)isDebugActive
 {
-    return mbglMap->getDebug();
+    return _mbglMap->getDebug();
 }
 
 - (void)resetNorth
@@ -1204,7 +1204,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
-    mbglMap->setBearing(0, secondsAsDuration(duration));
+    _mbglMap->setBearing(0, secondsAsDuration(duration));
 
     [UIView animateWithDuration:duration
                      animations:^
@@ -1222,19 +1222,19 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (void)resetPosition
 {
-    mbglMap->resetPosition();
+    _mbglMap->resetPosition();
 
     [self notifyMapChange:@(mbgl::MapChangeRegionDidChange)];
 }
 
 - (void)toggleDebug
 {
-    mbglMap->toggleDebug();
+    _mbglMap->toggleDebug();
 }
 
 - (void)emptyMemoryCache
 {
-    mbglMap->onLowMemory();
+    _mbglMap->onLowMemory();
 }
 
 #pragma mark - Geography -
@@ -1255,9 +1255,9 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 {
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
-    mbglMap->setLatLngZoom(coordinateToLatLng(coordinate),
-                           fmaxf(mbglMap->getZoom(), self.currentMinimumZoom),
-                           secondsAsDuration(duration));
+    _mbglMap->setLatLngZoom(coordinateToLatLng(coordinate),
+                            fmaxf(_mbglMap->getZoom(), self.currentMinimumZoom),
+                            secondsAsDuration(duration));
 
     [self notifyMapChange:@(animated ? mbgl::MapChangeRegionDidChangeAnimated : mbgl::MapChangeRegionDidChange)];
 }
@@ -1269,7 +1269,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (CLLocationCoordinate2D)centerCoordinate
 {
-    return latLngToCoordinate(mbglMap->getLatLng());
+    return latLngToCoordinate(_mbglMap->getLatLng());
 }
 
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(double)zoomLevel animated:(BOOL)animated
@@ -1278,7 +1278,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
-    mbglMap->setLatLngZoom(coordinateToLatLng(centerCoordinate), zoomLevel, secondsAsDuration(duration));
+    _mbglMap->setLatLngZoom(coordinateToLatLng(centerCoordinate), zoomLevel, secondsAsDuration(duration));
 
     [self unrotateIfNeededAnimated:animated];
 
@@ -1287,7 +1287,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (double)zoomLevel
 {
-    return mbglMap->getZoom();
+    return _mbglMap->getZoom();
 }
 
 - (void)setZoomLevel:(double)zoomLevel animated:(BOOL)animated
@@ -1296,7 +1296,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
-    mbglMap->setLatLngZoom(mbglMap->getLatLng(),
+    _mbglMap->setLatLngZoom(_mbglMap->getLatLng(),
                            fmaxf(zoomLevel, self.currentMinimumZoom),
                            secondsAsDuration(duration));
 
@@ -1316,11 +1316,11 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     CLLocationCoordinate2D center = CLLocationCoordinate2DMake((northEastCoordinate.latitude + southWestCoordinate.latitude) / 2, (northEastCoordinate.longitude + southWestCoordinate.longitude) / 2);
     
-    CGFloat scale = mbglMap->getScale();
-    CGFloat scaleX = mbglMap->getWidth() / (northEastCoordinate.longitude - southWestCoordinate.longitude);
-    CGFloat scaleY = mbglMap->getHeight() / (northEastCoordinate.latitude - southWestCoordinate.latitude);
-    CGFloat minZoom = mbglMap->getMinZoom();
-    CGFloat maxZoom = mbglMap->getMaxZoom();
+    CGFloat scale = _mbglMap->getScale();
+    CGFloat scaleX = _mbglMap->getWidth() / (northEastCoordinate.longitude - southWestCoordinate.longitude);
+    CGFloat scaleY = _mbglMap->getHeight() / (northEastCoordinate.latitude - southWestCoordinate.latitude);
+    CGFloat minZoom = _mbglMap->getMinZoom();
+    CGFloat maxZoom = _mbglMap->getMaxZoom();
     CGFloat zoomLevel = MAX(MIN(log(scale * MIN(scaleX, scaleY)) / log(2), maxZoom), minZoom);
     
     [self setCenterCoordinate:center zoomLevel:zoomLevel animated:animated];
@@ -1328,7 +1328,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (CLLocationDirection)direction
 {
-    double direction = mbglMap->getBearing() * -1;
+    double direction = _mbglMap->getBearing() * -1;
 
     while (direction > 360) direction -= 360;
     while (direction < 0) direction += 360;
@@ -1344,7 +1344,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
-    mbglMap->setBearing(direction * -1, secondsAsDuration(duration));
+    _mbglMap->setBearing(direction * -1, secondsAsDuration(duration));
 
     [self notifyMapChange:@(animated ? mbgl::MapChangeRegionDidChangeAnimated : mbgl::MapChangeRegionDidChange)];
 }
@@ -1362,12 +1362,12 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
     //
     convertedPoint.y = self.bounds.size.height - convertedPoint.y;
 
-    return latLngToCoordinate(mbglMap->latLngForPixel(mbgl::vec2<double>(convertedPoint.x, convertedPoint.y)));
+    return latLngToCoordinate(_mbglMap->latLngForPixel(mbgl::vec2<double>(convertedPoint.x, convertedPoint.y)));
 }
 
 - (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(UIView *)view
 {
-    mbgl::vec2<double> pixel = mbglMap->pixelForLatLng(coordinateToLatLng(coordinate));
+    mbgl::vec2<double> pixel = _mbglMap->pixelForLatLng(coordinateToLatLng(coordinate));
 
     // flip y coordinate for iOS view origin in top left
     //
@@ -1378,7 +1378,7 @@ mbgl::DefaultFileSource *mbglFileSource = nullptr;
 
 - (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude
 {
-    return mbglMap->getMetersPerPixelAtLatitude(latitude, self.zoomLevel);
+    return _mbglMap->getMetersPerPixelAtLatitude(latitude, self.zoomLevel);
 }
 
 mbgl::LatLng coordinateToLatLng(CLLocationCoordinate2D coordinate)
@@ -1454,7 +1454,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 {
     NSMutableArray *returnArray = [NSMutableArray array];
 
-    const std::vector<std::string> &appliedClasses = mbglMap->getClasses();
+    const std::vector<std::string> &appliedClasses = _mbglMap->getClasses();
 
     for (auto class_it = appliedClasses.begin(); class_it != appliedClasses.end(); class_it++)
     {
@@ -1478,20 +1478,20 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
         newAppliedClasses.insert(newAppliedClasses.end(), [appliedClass UTF8String]);
     }
 
-    mbglMap->setDefaultTransitionDuration(secondsAsDuration(transitionDuration));
-    mbglMap->setClasses(newAppliedClasses);
+    _mbglMap->setDefaultTransitionDuration(secondsAsDuration(transitionDuration));
+    _mbglMap->setClasses(newAppliedClasses);
 }
 
 - (BOOL)hasStyleClass:(NSString *)styleClass
 {
-    return styleClass && mbglMap->hasClass([styleClass UTF8String]);
+    return styleClass && _mbglMap->hasClass([styleClass UTF8String]);
 }
 
 - (void)addStyleClass:(NSString *)styleClass
 {
     if (styleClass)
     {
-        mbglMap->addClass([styleClass UTF8String]);
+        _mbglMap->addClass([styleClass UTF8String]);
     }
 }
 
@@ -1499,7 +1499,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 {
     if (styleClass)
     {
-        mbglMap->removeClass([styleClass UTF8String]);
+        _mbglMap->removeClass([styleClass UTF8String]);
     }
 }
 
@@ -1563,7 +1563,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
         symbols.push_back((symbolName ? [symbolName UTF8String] : ""));
     }
 
-    std::vector<uint32_t> annotationIDs = mbglMap->addPointAnnotations(latLngs, symbols);
+    std::vector<uint32_t> annotationIDs = _mbglMap->addPointAnnotations(latLngs, symbols);
 
     for (size_t i = 0; i < annotationIDs.size(); ++i)
     {
@@ -1604,7 +1604,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
         }
     }
 
-    mbglMap->removeAnnotations(annotationIDsToRemove);
+    _mbglMap->removeAnnotations(annotationIDsToRemove);
 }
 
 - (NSArray *)selectedAnnotations
@@ -1664,7 +1664,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
             // determine anchor point based on symbol
             CGPoint calloutAnchorPoint = [self convertCoordinate:annotation.coordinate toPointToView:self];
-            double y = mbglMap->getTopOffsetPixelsForAnnotationSymbol(symbolName);
+            double y = _mbglMap->getTopOffsetPixelsForAnnotationSymbol(symbolName);
             calloutBounds = CGRectMake(calloutAnchorPoint.x - 1, calloutAnchorPoint.y + y, 0, 0);
         }
 
@@ -2009,7 +2009,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
     if (headingDirection > 0 && self.userTrackingMode == MGLUserTrackingModeFollowWithHeading)
     {
-        mbglMap->setBearing(headingDirection, secondsAsDuration(MGLAnimationDuration));
+        _mbglMap->setBearing(headingDirection, secondsAsDuration(MGLAnimationDuration));
     }
 }
 
@@ -2092,7 +2092,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
 - (CGFloat)currentMinimumZoom
 {
-    return fmaxf(mbglMap->getMinZoom(), MGLMinimumZoom);
+    return fmaxf(_mbglMap->getMinZoom(), MGLMinimumZoom);
 }
 
 - (BOOL)isRotationAllowed
@@ -2297,13 +2297,13 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
 - (void)updateCompass
 {
-    double degrees = mbglMap->getBearing() * -1;
+    double degrees = _mbglMap->getBearing() * -1;
     while (degrees >= 360) degrees -= 360;
     while (degrees < 0) degrees += 360;
 
     self.compass.transform = CGAffineTransformMakeRotation([MGLMapView degreesToRadians:degrees]);
 
-    if (mbglMap->getBearing() && self.compass.alpha < 1)
+    if (_mbglMap->getBearing() && self.compass.alpha < 1)
     {
         [UIView animateWithDuration:MGLAnimationDuration
                               delay:0
@@ -2314,7 +2314,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
                          }
                          completion:nil];
     }
-    else if (mbglMap->getBearing() == 0 && self.compass.alpha > 0)
+    else if (_mbglMap->getBearing() == 0 && self.compass.alpha > 0)
     {
         [UIView animateWithDuration:MGLAnimationDuration
                               delay:0
@@ -2639,7 +2639,7 @@ class MBGLView : public mbgl::View
 
 - (void)didReceiveMemoryWarning
 {
-    mbglMap->onLowMemory();
+    _mbglMap->onLowMemory();
 }
 
 @end


### PR DESCRIPTION
This moves the GL map and file cache stuff from global C++ namespace to be internal to each `MGLMapView` so that we can have multiple `MGLMapView` instances at once. 

Works well (pending cache collision issues in #1102) and passes CI, so gonna merge. 