### PR TITLE
Fix compile with clang-3.6

### DIFF
--- a/include/mbgl/platform/default/jpeg_reader.hpp
+++ b/include/mbgl/platform/default/jpeg_reader.hpp
@@ -10,10 +10,9 @@ extern "C"
 }
 
 #pragma GCC diagnostic push
-#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wshadow"
-#endif
 #include <boost/iostreams/stream.hpp>
 #pragma GCC diagnostic pop
 

--- a/include/mbgl/platform/default/png_reader.hpp
+++ b/include/mbgl/platform/default/png_reader.hpp
@@ -12,10 +12,9 @@ extern "C"
 #include <memory>
 
 #pragma GCC diagnostic push
-#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wshadow"
-#endif
 #include <boost/iostreams/stream.hpp>
 #pragma GCC diagnostic pop
 

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -4,9 +4,8 @@
 #include <string>
 
 #pragma GCC diagnostic push
-#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/lexical_cast.hpp>
 #pragma GCC diagnostic pop
 

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -13,9 +13,8 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/algorithm/string.hpp>
 #pragma GCC diagnostic pop
 

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -11,9 +11,8 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/algorithm/string.hpp>
 #pragma GCC diagnostic pop
 

--- a/src/mbgl/text/collision.hpp
+++ b/src/mbgl/text/collision.hpp
@@ -9,12 +9,13 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wshadow"
 #ifdef __clang__
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#endif
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wdeprecated-register"
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
-#else
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point.hpp>
 #include <boost/geometry/geometries/box.hpp>


### PR DESCRIPTION
Clang 3.6 now understands the `-Wunused-local-typedef` warning. Because of this + our usage of `-Werror` this means that mbgl does not yet compile with clang-3.6. So, this pull request fixes our `pragma GCC` to correctly suppress unwanted clang-3.6 warnings as well as all the warnings from previous compiler versions as well.

Practically it fixes this error:

```
In file included from ../../src/mbgl/geometry/vao.cpp:3:
In file included from ../../include/mbgl/util/string.hpp:10:
In file included from /Users/dane/projects/mbgl/mason_packages/headers/boost/1.57.0/include/boost/lexical_cast.hpp:30:
In file included from /Users/dane/projects/mbgl/mason_packages/headers/boost/1.57.0/include/boost/range/iterator_range_core.hpp:38:
In file included from /Users/dane/projects/mbgl/mason_packages/headers/boost/1.57.0/include/boost/range/functions.hpp:20:
In file included from /Users/dane/projects/mbgl/mason_packages/headers/boost/1.57.0/include/boost/range/size.hpp:21:
In file included from /Users/dane/projects/mbgl/mason_packages/headers/boost/1.57.0/include/boost/range/size_type.hpp:20:
In file included from /Users/dane/projects/mbgl/mason_packages/headers/boost/1.57.0/include/boost/range/concepts.hpp:19:
/Users/dane/projects/mbgl/mason_packages/headers/boost/1.57.0/include/boost/concept_check.hpp:51:7: error: unused typedef 'boost_concept_check51'
      [-Werror,-Wunused-local-typedef]
      BOOST_CONCEPT_ASSERT((Model));
      ^
```