### PR TITLE
Fix integer division in transform.cpp

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -199,14 +199,14 @@ void Transform::_setScale(double new_scale, double cx, double cy, const Duration
 
     // Zoom in on the center if we don't have click or gesture anchor coordinates.
     if (cx < 0 || cy < 0) {
-        cx = current.width / 2;
-        cy = current.height / 2;
+        cx = static_cast<double>(current.width) / 2.0;
+        cy = static_cast<double>(current.height) / 2.0;
     }
 
     // Account for the x/y offset from the center (= where the user clicked or pinched)
     const double factor = new_scale / current.scale;
-    const double dx = (cx - current.width / 2) * (1.0 - factor);
-    const double dy = (cy - current.height / 2) * (1.0 - factor);
+    const double dx = (cx - static_cast<double>(current.width) / 2.0) * (1.0 - factor);
+    const double dy = (cy - static_cast<double>(current.height) / 2.0) * (1.0 - factor);
 
     // Account for angle
     const double angle_sin = std::sin(-current.angle);
@@ -289,7 +289,7 @@ void Transform::rotateBy(const double start_x, const double start_y, const doubl
                          const double end_y, const Duration duration) {
     std::lock_guard<std::recursive_mutex> lock(mtx);
 
-    double center_x = current.width / 2, center_y = current.height / 2;
+    double center_x = static_cast<double>(current.width) / 2.0, center_y = static_cast<double>(current.height) / 2.0;
 
     const double begin_center_x = start_x - center_x;
     const double begin_center_y = start_y - center_y;
@@ -328,8 +328,8 @@ void Transform::setAngle(const double new_angle, const double cx, const double c
     double dx = 0, dy = 0;
 
     if (cx >= 0 && cy >= 0) {
-        dx = (final.width / 2) - cx;
-        dy = (final.height / 2) - cy;
+        dx = (static_cast<double>(final.width) / 2.0) - cx;
+        dy = (static_cast<double>(final.height) / 2.0) - cy;
         _moveBy(dx, dy, Duration::zero());
     }
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -31,8 +31,8 @@ box TransformState::cornersToBox(uint32_t z) const {
     const double angle_sin = std::sin(-angle);
     const double angle_cos = std::cos(-angle);
 
-    const double w_2 = width / 2;
-    const double h_2 = height / 2;
+    const double w_2 = static_cast<double>(width) / 2.0;
+    const double h_2 = static_cast<double>(height) / 2.0;
     const double ss_0 = scale * util::tileSize;
     const double ss_1 = ref_scale / ss_0;
     const double ss_2 = ss_0 / 2.0;
@@ -166,8 +166,8 @@ const vec2<double> TransformState::pixelForLatLng(const LatLng latLng) const {
     LatLng ll = getLatLng();
     double zoom = getZoom();
 
-    const double centerX = width  / 2;
-    const double centerY = height / 2;
+    const double centerX = static_cast<double>(width) / 2.0;
+    const double centerY = static_cast<double>(height) / 2.0;
 
     const double m = Projection::getMetersPerPixelAtLatitude(0, zoom);
 


### PR DESCRIPTION
Ran mbgl-native through coverity static analysis tonight. Coverity oncovered that our transform code has been doing integer division. This may be leading to loss of precision / truncated values - a classic C/C++ bug. If anyone is not familiar with this behavior have a look at: http://coliru.stacked-crooked.com/a/62dd1db484efeac8

The report looked like:

![screen shot 2015-05-03 at 11 30 59 pm](https://cloud.githubusercontent.com/assets/20300/7449495/7d8be0e2-f1ec-11e4-9987-deeeee92fd83.png)

Fuller report at https://scan4.coverity.com/reports.htm#v13662/p11099 (you should be able to login via github account).

Overall: I hit two coverity bugs that prevented most files from being able to be processed that I've emailed coverity support about. It looks like coverity does not support `atomic` and there are some libc++ coverity issues. I'll post more bug reports when I can process the entire libmgbl-core.
