### PR TITLE
Screen stretched on rotation

### DIFF
--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -203,6 +203,9 @@ void Painter::render(const Style& style, TransformState state_, TimePoint time) 
         }
     }
 
+    resize();
+    changeMatrix();
+
     // Figure out what buckets we have to draw and what order we have to draw them in.
     const auto order = determineRenderOrder(style);
 
@@ -238,8 +241,6 @@ void Painter::render(const Style& style, TransformState state_, TimePoint time) 
         }
 
         clear();
-        resize();
-        changeMatrix();
 
         drawClippingMasks(sources);
     }


### PR DESCRIPTION
Steps to reproduce:

1. Rotate screen to landscape on demo app
1. If it's not stretched, keep rotating!
1. Underlying GL view is stretched until interacted with again (taps, pans, etc)

Happens on device (iPhone 5) and in the simulator. Running `master` da8aaa2114f4bbc8d0b2ee8308e440f0b7e8c4fa.

![screen-shot-2015-05-04-at-5 55 08-pm](https://cloud.githubusercontent.com/assets/1198851/7465633/c854e366-f288-11e4-9197-ad398d828888.png)

/cc @jfirebaugh @kkaefer