### PR TITLE
Set accessToken in initWithCoder

### DIFF
--- a/ios/app/MBXAppDelegate.m
+++ b/ios/app/MBXAppDelegate.m
@@ -1,8 +1,6 @@
 #import "MBXAppDelegate.h"
 #import "MBXViewController.h"
 #import <mbgl/ios/MapboxGL.h>
-#import <mbgl/ios/MGLAccountManager.h>
-#import <mbgl/ios/MGLMapboxEvents.h>
 
 @implementation MBXAppDelegate
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -142,6 +142,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     if (self && [self commonInit])
     {
         self.styleURL = nil;
+        self.accessToken = [MGLAccountManager accessToken];
         return self;
     }
 


### PR DESCRIPTION
Fix `[MGLMapView initWithCoder:]` by adding support for `[MGLAccountManager setAccessToken:]`, which is useful when using storyboards.

Also cleans up unnecessary header imports in the demo app.

/cc @bleege @1ec5 @incanus