### PR TITLE
Prevent full-circle spin during animated rotation

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -348,6 +348,7 @@ void Transform::_setAngle(double new_angle, const Duration duration) {
                            MapChangeRegionWillChange);
 
     final.angle = _normalizeAngle(new_angle, current.angle);
+    current.angle = _normalizeAngle(current.angle, final.angle);
 
     if (duration == Duration::zero()) {
         current.angle = final.angle;


### PR DESCRIPTION
#1295 made #1199 a lot less common, but it was still possible for the map to do a full 180° when drift-rotating past due-south. With this PR, the map is atomically rotated to a bearing in the same cycle as the final bearing.

/cc @kkaefer @friedbunny