### PR TITLE
Fix sprite bundling for non-bundle-apps on OS X

### DIFF
--- a/gyp/styles.gypi
+++ b/gyp/styles.gypi
@@ -14,21 +14,22 @@
       ],
     },
     {
-      'target_name': 'bundle_styles',
+      'target_name': 'bundle_styles', # use this only for targets that create an App bundle
       'type': 'none',
       'hard_dependency': 1,
       'dependencies': [ 'touch_styles' ], # required for xcode http://openradar.appspot.com/7232149
-      'conditions': [
-        ['platform_lib == "osx" or platform_lib == "ios"', {
-          'direct_dependent_settings': {
-            'mac_bundle_resources': [ '../styles/styles' ],
-          }
-        }, {
-          'direct_dependent_settings': {
-            'copies': [{ 'files': [ '../styles/styles' ], 'destination': '<(PRODUCT_DIR)' }],
-          }
-        }]
-      ],
-    }
+      'direct_dependent_settings': {
+        'mac_bundle_resources': [ '../styles/styles' ],
+      }
+    },
+    {
+      'target_name': 'copy_styles', # use this only for targets that don't create an App bundle
+      'type': 'none',
+      'hard_dependency': 1,
+      'dependencies': [ 'touch_styles' ],
+      'direct_dependent_settings': {
+        'copies': [{ 'files': [ '../styles/styles' ], 'destination': '<(PRODUCT_DIR)' }],
+      }
+    },
   ]
 }

--- a/linux/mapboxgl-app.gypi
+++ b/linux/mapboxgl-app.gypi
@@ -13,7 +13,7 @@
         '../mbgl.gyp:http-<(http_lib)',
         '../mbgl.gyp:asset-<(asset_lib)',
         '../mbgl.gyp:cache-<(cache_lib)',
-        '../mbgl.gyp:bundle_styles',
+        '../mbgl.gyp:copy_styles',
         '../mbgl.gyp:copy_certificate_bundle',
       ],
 


### PR DESCRIPTION
Apps that are not in an app bundle (folder with .app extension) don't work because they don't get the styles bundled correctly.