### PR TITLE
Removed unused method from MapContext

### DIFF
--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -63,7 +63,6 @@ public:
     void onTileDataChanged() override;
 
 private:
-    util::ptr<Sprite> getSprite();
     void updateTiles();
 
     // Update the state indicated by the accumulated Update flags, then render.


### PR DESCRIPTION
getSprite() defined but not used.