### PR TITLE
DefaultFileSource::Impl::notify crash at default_file_source.cpp:166

### DIFF
--- a/include/mbgl/storage/file_cache.hpp
+++ b/include/mbgl/storage/file_cache.hpp
@@ -11,6 +11,22 @@ namespace mbgl {
 struct Resource;
 class Response;
 
+class CacheRequest : public util::noncopyable {
+public:
+    CacheRequest();
+    CacheRequest(std::shared_ptr<bool>);
+    CacheRequest(CacheRequest&&);
+    ~CacheRequest();
+
+    CacheRequest& operator=(CacheRequest&&);
+    operator bool() const;
+
+    void cancel();
+
+private:
+    std::shared_ptr<bool> cancelled;
+};
+
 class FileCache : private util::noncopyable {
 public:
     virtual ~FileCache() = default;
@@ -18,7 +34,7 @@ public:
     enum class Hint : uint8_t { Full, Refresh, No };
     using Callback = std::function<void(std::unique_ptr<Response>)>;
 
-    virtual void get(const Resource &resource, Callback callback) = 0;
+    virtual CacheRequest get(const Resource &resource, Callback callback) = 0;
     virtual void put(const Resource &resource, std::shared_ptr<const Response> response, Hint hint) = 0;
 };
 

--- a/include/mbgl/storage/sqlite_cache.hpp
+++ b/include/mbgl/storage/sqlite_cache.hpp
@@ -17,7 +17,7 @@ public:
     ~SQLiteCache() override;
 
     // FileCache API
-    void get(const Resource &resource, Callback callback) override;
+    CacheRequest get(const Resource &resource, Callback callback) override;
     void put(const Resource &resource, std::shared_ptr<const Response> response, Hint hint) override;
 
     class Impl;

--- a/platform/default/sqlite_cache.cpp
+++ b/platform/default/sqlite_cache.cpp
@@ -126,12 +126,23 @@ void SQLiteCache::Impl::createSchema() {
     }
 }
 
-void SQLiteCache::get(const Resource &resource, Callback callback) {
+CacheRequest SQLiteCache::get(const Resource &resource, Callback callback) {
     // Can be called from any thread, but most likely from the file source thread.
     // Will try to load the URL from the SQLite database and call the callback when done.
     // Note that the callback is probably going to invoked from another thread, so the caller
     // must make sure that it can run in that thread.
-    thread->invokeWithResult(&Impl::get, std::move(callback), resource);
+    std::shared_ptr<bool> cancelled = std::make_shared<bool>();
+    *cancelled = false;
+
+    std::function<void (std::unique_ptr<Response>)> wrapped = [cancelled, callback] (std::unique_ptr<Response> response) {
+        if (!*cancelled) {
+            callback(std::move(response));
+        }
+    };
+
+    thread->invokeWithResult(&Impl::get, std::move(wrapped), resource);
+
+    return CacheRequest(cancelled);
 }
 
 std::unique_ptr<Response> SQLiteCache::Impl::get(const Resource &resource) {

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -71,7 +71,7 @@ DefaultFileSource::Impl::Impl(uv_loop_t* loop_, FileCache* cache_, const std::st
 DefaultFileRequest* DefaultFileSource::Impl::find(const Resource& resource) {
     const auto it = pending.find(resource);
     if (it != pending.end()) {
-        return &it->second;
+        return it->second.get();
     }
     return nullptr;
 }
@@ -85,7 +85,8 @@ void DefaultFileSource::Impl::add(Request* req) {
         return;
     }
 
-    request = &pending.emplace(resource, DefaultFileRequest(resource)).first->second;
+    request = pending.emplace(resource, util::make_unique<DefaultFileRequest>(resource))
+                  .first->second.get();
     request->observers.insert(req);
 
     if (cache) {

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -90,24 +90,16 @@ void DefaultFileSource::Impl::add(Request* req) {
     request->observers.insert(req);
 
     if (cache) {
-        startCacheRequest(resource);
+        startCacheRequest(request);
     } else {
-        startRealRequest(resource);
+        startRealRequest(request);
     }
 }
 
-void DefaultFileSource::Impl::startCacheRequest(const Resource& resource) {
+void DefaultFileSource::Impl::startCacheRequest(DefaultFileRequest* request) {
     // Check the cache for existing data so that we can potentially
     // revalidate the information without having to redownload everything.
-    cache->get(resource, [this, resource](std::unique_ptr<Response> response) {
-        DefaultFileRequest* request = find(resource);
-
-        if (!request) {
-            // There is no request for this URL anymore. Likely, the request was canceled
-            // before we got around to process the cache result.
-            return;
-        }
-
+    request->cacheRequest = cache->get(request->resource, [this, request](std::unique_ptr<Response> response) {
         auto expired = [&response] {
             const int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
                                     SystemClock::now().time_since_epoch()).count();
@@ -116,7 +108,7 @@ void DefaultFileSource::Impl::startCacheRequest(const Resource& resource) {
 
         if (!response || expired()) {
             // No response or stale cache. Run the real request.
-            startRealRequest(resource, std::move(response));
+            startRealRequest(request, std::move(response));
         } else {
             // The response is fresh. We're good to notify the caller.
             notify(request, std::move(response), FileCache::Hint::No);
@@ -124,17 +116,15 @@ void DefaultFileSource::Impl::startCacheRequest(const Resource& resource) {
     });
 }
 
-void DefaultFileSource::Impl::startRealRequest(const Resource& resource, std::shared_ptr<const Response> response) {
-    DefaultFileRequest* request = find(resource);
-
+void DefaultFileSource::Impl::startRealRequest(DefaultFileRequest* request, std::shared_ptr<const Response> response) {
     auto callback = [request, this] (std::shared_ptr<const Response> res, FileCache::Hint hint) {
         notify(request, res, hint);
     };
 
-    if (algo::starts_with(resource.url, "asset://")) {
-        request->request = assetContext->createRequest(resource, callback, loop, assetRoot);
+    if (algo::starts_with(request->resource.url, "asset://")) {
+        request->realRequest = assetContext->createRequest(request->resource, callback, loop, assetRoot);
     } else {
-        request->request = httpContext->createRequest(resource, callback, loop, response);
+        request->realRequest = httpContext->createRequest(request->resource, callback, loop, response);
     }
 }
 
@@ -146,8 +136,11 @@ void DefaultFileSource::Impl::cancel(Request* req) {
         // cancel the request and remove it from the pending list.
         request->observers.erase(req);
         if (request->observers.empty()) {
-            if (request->request) {
-                request->request->cancel();
+            if (request->cacheRequest) {
+                request->cacheRequest.cancel();
+            }
+            if (request->realRequest) {
+                request->realRequest->cancel();
             }
             pending.erase(request->resource);
         }

--- a/src/mbgl/storage/default_file_source_impl.hpp
+++ b/src/mbgl/storage/default_file_source_impl.hpp
@@ -14,12 +14,12 @@ namespace mbgl {
 
 class RequestBase;
 
-struct DefaultFileRequest {
+struct DefaultFileRequest : private util::noncopyable {
     const Resource resource;
     std::set<Request*> observers;
     RequestBase* request = nullptr;
 
-    DefaultFileRequest(const Resource& resource_)
+    inline DefaultFileRequest(const Resource& resource_)
         : resource(resource_) {}
 };
 
@@ -37,7 +37,7 @@ private:
     void startRealRequest(const Resource&, std::shared_ptr<const Response> = nullptr);
     void notify(DefaultFileRequest*, std::shared_ptr<const Response>, FileCache::Hint);
 
-    std::unordered_map<Resource, DefaultFileRequest, Resource::Hash> pending;
+    std::unordered_map<Resource, std::unique_ptr<DefaultFileRequest>, Resource::Hash> pending;
     uv_loop_t* loop = nullptr;
     FileCache* cache = nullptr;
     const std::string assetRoot;

--- a/src/mbgl/storage/default_file_source_impl.hpp
+++ b/src/mbgl/storage/default_file_source_impl.hpp
@@ -17,7 +17,8 @@ class RequestBase;
 struct DefaultFileRequest : private util::noncopyable {
     const Resource resource;
     std::set<Request*> observers;
-    RequestBase* request = nullptr;
+    CacheRequest cacheRequest;
+    RequestBase* realRequest = nullptr;
 
     inline DefaultFileRequest(const Resource& resource_)
         : resource(resource_) {}
@@ -33,8 +34,8 @@ public:
 private:
     DefaultFileRequest* find(const Resource&);
 
-    void startCacheRequest(const Resource&);
-    void startRealRequest(const Resource&, std::shared_ptr<const Response> = nullptr);
+    void startCacheRequest(DefaultFileRequest*);
+    void startRealRequest(DefaultFileRequest*, std::shared_ptr<const Response> = nullptr);
     void notify(DefaultFileRequest*, std::shared_ptr<const Response>, FileCache::Hint);
 
     std::unordered_map<Resource, std::unique_ptr<DefaultFileRequest>, Resource::Hash> pending;

--- a/src/mbgl/storage/file_cache.cpp
+++ b/src/mbgl/storage/file_cache.cpp
@@ -1,0 +1,34 @@
+#include <mbgl/storage/file_cache.hpp>
+
+namespace mbgl {
+
+CacheRequest::CacheRequest() = default;
+
+CacheRequest::CacheRequest(std::shared_ptr<bool> cancelled_)
+    : cancelled(cancelled_) {
+}
+
+CacheRequest::CacheRequest(CacheRequest&& o)
+    : cancelled(std::move(o.cancelled)) {
+}
+
+CacheRequest::~CacheRequest() {
+    if (cancelled) {
+        cancel();
+    }
+}
+
+CacheRequest& CacheRequest::operator=(CacheRequest&& o) {
+    cancelled = std::move(o.cancelled);
+    return *this;
+}
+
+CacheRequest::operator bool() const {
+    return cancelled.operator bool();
+}
+
+void CacheRequest::cancel() {
+    *cancelled = true;
+}
+
+}


### PR DESCRIPTION
iPad Mini, `master` @ 226799e811f2e885956660ea02649cf121b485e5

```c
* thread #11: tid = 0x80a8e, 0x0013e3f4 Mapbox GL`mbgl::DefaultFileSource::Impl::notify(this=0x03767de8, request=0x17f359a8, response=<unavailable>, hint=<unavailable>) + 92 at default_file_source.cpp:166, name = 'FileSource', stop reason = EXC_BAD_ACCESS (code=1, address=0x71)
frame #0: 0x0013e3f4 Mapbox GL`mbgl::DefaultFileSource::Impl::notify(this=0x03767de8, request=0x17f359a8, response=<unavailable>, hint=<unavailable>) + 92 at default_file_source.cpp:166
frame #1: 0x0013e58a Mapbox GL`std::__1::__function::__func<mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1, std::__1::allocator<mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1>, void (std::__1::shared_ptr<mbgl::Response const>, mbgl::FileCache::Hint)>::operator()(std::__1::shared_ptr<mbgl::Response const>&&, mbgl::FileCache::Hint&&) [inlined] mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1::operator()(std::__1::shared_ptr<mbgl::Response const>, mbgl::FileCache::Hint) const + 66 at default_file_source.cpp:127
frame #2: 0x0013e548 Mapbox GL`std::__1::__function::__func<mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1, std::__1::allocator<mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1>, void (std::__1::shared_ptr<mbgl::Response const>, mbgl::FileCache::Hint)>::operator()(std::__1::shared_ptr<mbgl::Response const>&&, mbgl::FileCache::Hint&&) [inlined] decltype(std::__1::forward<mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1&>(fp)(std::__1::forward<std::__1::shared_ptr<mbgl::Response const>, mbgl::FileCache::Hint>(fp0))) std::__1::__invoke<mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1&, std::__1::shared_ptr<mbgl::Response const>, mbgl::FileCache::Hint>(mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1&&&, std::__1::shared_ptr<mbgl::Response const>&&, mbgl::FileCache::Hint&&) + 22 at __functional_base:413
frame #3: 0x0013e532 Mapbox GL`std::__1::__function::__func<mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1, std::__1::allocator<mbgl::DefaultFileSource::Impl::startRealRequest(mbgl::Resource const&, std::__1::shared_ptr<mbgl::Response const>)::$_1>, void (std::__1::shared_ptr<mbgl::Response const>, mbgl::FileCache::Hint)>::operator(this=<unavailable>, __arg=<unavailable>, __arg=<unavailable>)(std::__1::shared_ptr<mbgl::Response const>&&, mbgl::FileCache::Hint&&) + 38 at functional:1370
frame #4: 0x001a305c Mapbox GL`mbgl::HTTPRequestImpl::handleResponse() [inlined] std::__1::function<void (std::__1::shared_ptr<mbgl::Response const>, mbgl::FileCache::Hint)>::operator(__arg=Refresh)(std::__1::shared_ptr<mbgl::Response const>, mbgl::FileCache::Hint) const + 228 at functional:1756
frame #5: 0x001a3044 Mapbox GL`mbgl::HTTPRequestImpl::handleResponse(this=0x17f452b0) + 204 at http_request_nsurl.mm:197
frame #6: 0x001a9eaa Mapbox GL`uv__async_event(loop=0x15e983e0, w=0x15e984b8, nevents=1) + 118 at async.c:80
frame #7: 0x001aa118 Mapbox GL`uv__async_io(loop=0x15e983e0, w=0x15e984bc, events=1) + 164 at async.c:156
frame #8: 0x001bb494 Mapbox GL`uv__io_poll(loop=0x15e983e0, timeout=-1) + 2076 at kqueue.c:233
frame #9: 0x001aa57a Mapbox GL`uv_run(loop=0x15e983e0, mode=UV_RUN_DEFAULT) + 122 at core.c:317
frame #10: 0x00178160 Mapbox GL`mbgl::util::RunLoop::run() [inlined] uv::loop::run() + 32 at uv_detail.hpp:62
frame #11: 0x00178158 Mapbox GL`mbgl::util::RunLoop::run(this=0x03767e40) + 24 at run_loop.cpp:30
frame #12: 0x00140034 Mapbox GL`mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::FileCache*&&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&)::'lambda'()::operator()() const [inlined] void mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::run<std::__1::tuple<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>, 0ul, 1ul>(std::__1::tuple<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&&, (anonymous namespace)::index_sequence<0ul, 1ul>) + 50 at thread.hpp:106
frame #13: 0x00140002 Mapbox GL`mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(this=<unavailable>)::'lambda'()::operator()() const + 126 at thread.hpp:90
frame #14: 0x0013ff20 Mapbox GL`std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::FileCache*&&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&)::'lambda'()> >(void*, void*) [inlined] std::__1::__invoke<mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::FileCache*&&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&)::'lambda'()>(__f=<unavailable>)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::FileCache*&&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&)::'lambda'()&&) + 148 at __functional_base:413
frame #15: 0x0013ff1a Mapbox GL`std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::FileCache*&&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&)::'lambda'()> >(void*, void*) [inlined] _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_17DefaultFileSource4ImplEEC1IJRPNS1_9FileCacheERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEEESI_DpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE at thread:332
frame #16: 0x0013ff1a Mapbox GL`std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::FileCache*&&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&)::'lambda'()> >(__vp=<unavailable>) + 142 at thread:342
frame #17: 0x37369dea libsystem_pthread.dylib`_pthread_body + 138
frame #18: 0x37369d5e libsystem_pthread.dylib`_pthread_start + 118
frame #19: 0x37367b08 libsystem_pthread.dylib`thread_start + 8
```

... and then Xcode used "59.41GB" of (compressed) memory and the system made me force quit because it had run out of application memory. Thanks @1ec5! :scream: