### PR TITLE
Do not process partial tiles if no new resources have arrived

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -36,7 +36,7 @@ MapContext::MapContext(uv_loop_t* loop, View& view_, FileSource& fileSource, Map
       envScope(env, ThreadType::Map, "Map"),
       updated(static_cast<UpdateType>(Update::Nothing)),
       asyncUpdate(util::make_unique<uv::async>(loop, [this] { update(); })),
-      glyphStore(util::make_unique<GlyphStore>(env)),
+      glyphStore(util::make_unique<GlyphStore>(loop, env)),
       glyphAtlas(util::make_unique<GlyphAtlas>(1024, 1024)),
       spriteAtlas(util::make_unique<SpriteAtlas>(512, 512)),
       lineAtlas(util::make_unique<LineAtlas>(512, 512)),

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -134,6 +134,7 @@ void MapContext::loadStyleJSON(const std::string& json, const std::string& base)
     resourceLoader->setAccessToken(data.getAccessToken());
     resourceLoader->setObserver(this);
     resourceLoader->setStyle(style.get());
+    resourceLoader->setGlyphStore(glyphStore.get());
 
     triggerUpdate(Update::Zoom);
 }
@@ -141,8 +142,7 @@ void MapContext::loadStyleJSON(const std::string& json, const std::string& base)
 void MapContext::updateTiles() {
     assert(Environment::currentlyOn(ThreadType::Map));
 
-    resourceLoader->update(data, transformState, *glyphAtlas, *glyphStore,
-                           *spriteAtlas, *texturePool);
+    resourceLoader->update(data, transformState, *glyphAtlas, *spriteAtlas, *texturePool);
 }
 
 void MapContext::updateAnnotationTiles(const std::vector<TileID>& ids) {

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -85,11 +85,15 @@ void ResourceLoader::update(MapData& data,
 
     for (const auto& source : style_->sources) {
         source->update(data, transform, *style_, glyphAtlas, *glyphStore_,
-                       spriteAtlas, sprite_, texturePool);
+                       spriteAtlas, sprite_, texturePool, shouldReparsePartialTiles_);
     }
+
+    shouldReparsePartialTiles_ = false;
 }
 
 void ResourceLoader::onGlyphRangeLoaded() {
+    shouldReparsePartialTiles_ = true;
+
     emitTileDataChanged();
 }
 
@@ -102,6 +106,8 @@ void ResourceLoader::onTileLoaded() {
 }
 
 void ResourceLoader::onSpriteLoaded() {
+    shouldReparsePartialTiles_ = true;
+
     emitTileDataChanged();
 }
 

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -83,12 +83,19 @@ void ResourceLoader::update(MapData& data,
         spriteAtlas.setSprite(sprite_);
     }
 
+    bool allTilesUpdated = true;
     for (const auto& source : style_->sources) {
-        source->update(data, transform, *style_, glyphAtlas, *glyphStore_,
-                       spriteAtlas, sprite_, texturePool, shouldReparsePartialTiles_);
+        if (!source->update(data, transform, *style_, glyphAtlas, *glyphStore_,
+                       spriteAtlas, sprite_, texturePool, shouldReparsePartialTiles_)) {
+            allTilesUpdated = false;
+        }
     }
 
-    shouldReparsePartialTiles_ = false;
+    // We can only stop updating "partial" tiles when all of them
+    // were notified of the arrival of the new resources.
+    if (allTilesUpdated) {
+        shouldReparsePartialTiles_ = false;
+    }
 }
 
 void ResourceLoader::onGlyphRangeLoaded() {

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -101,7 +101,11 @@ void ResourceLoader::onSourceLoaded() {
     emitTileDataChanged();
 }
 
-void ResourceLoader::onTileLoaded() {
+void ResourceLoader::onTileLoaded(bool isNewTile) {
+    if (isNewTile) {
+        shouldReparsePartialTiles_ = true;
+    }
+
     emitTileDataChanged();
 }
 

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -25,6 +25,10 @@ ResourceLoader::~ResourceLoader() {
     if (sprite_) {
         sprite_->setObserver(nullptr);
     }
+
+    if (glyphStore_) {
+        glyphStore_->setObserver(nullptr);
+    }
 }
 
 void ResourceLoader::setObserver(Observer* observer) {
@@ -45,6 +49,18 @@ void ResourceLoader::setStyle(Style* style) {
     }
 }
 
+void ResourceLoader::setGlyphStore(GlyphStore* glyphStore) {
+    assert(glyphStore);
+
+    if (glyphStore_) {
+        glyphStore_->setObserver(nullptr);
+    }
+
+    glyphStore_ = glyphStore;
+    glyphStore_->setObserver(this);
+}
+
+
 void ResourceLoader::setAccessToken(const std::string& accessToken) {
     accessToken_ = accessToken;
 }
@@ -52,7 +68,6 @@ void ResourceLoader::setAccessToken(const std::string& accessToken) {
 void ResourceLoader::update(MapData& data,
                             const TransformState& transform,
                             GlyphAtlas& glyphAtlas,
-                            GlyphStore& glyphStore,
                             SpriteAtlas& spriteAtlas,
                             TexturePool& texturePool) {
     if (!style_) {
@@ -69,8 +84,8 @@ void ResourceLoader::update(MapData& data,
     }
 
     for (const auto& source : style_->sources) {
-        source->update(
-            data, transform, *style_, glyphAtlas, glyphStore, spriteAtlas, sprite_, texturePool);
+        source->update(data, transform, *style_, glyphAtlas, *glyphStore_,
+                       spriteAtlas, sprite_, texturePool);
     }
 }
 

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -73,6 +73,8 @@ public:
 private:
     void emitTileDataChanged();
 
+    bool shouldReparsePartialTiles_ = false;
+
     std::string accessToken_;
     util::ptr<Sprite> sprite_;
 

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -43,13 +43,17 @@ public:
     // a new style we will go through all of them and try to load.
     void setStyle(Style* style);
 
+    // TODO: Move GlyphStore to ResourceLoader. We cannot do it now
+    // because we reset the ResourceLoader every time we change the
+    // style.
+    void setGlyphStore(GlyphStore* glyphStore);
+
     // Set the access token to be used for loading the tile data.
     void setAccessToken(const std::string& accessToken);
 
     // Fetch the tiles needed by the current viewport and emit a signal when
     // a tile is ready so observers can render the tile.
-    void update(MapData&, const TransformState&, GlyphAtlas&, GlyphStore&,
-                SpriteAtlas&, TexturePool&);
+    void update(MapData&, const TransformState&, GlyphAtlas&, SpriteAtlas&, TexturePool&);
 
     // FIXME: There is probably a better place for this.
     inline util::ptr<Sprite> getSprite() const {
@@ -71,7 +75,10 @@ private:
 
     std::string accessToken_;
     util::ptr<Sprite> sprite_;
+
+    GlyphStore* glyphStore_ = nullptr;
     Style* style_ = nullptr;
+
     Observer* observer_ = nullptr;
 };
 

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -65,7 +65,7 @@ public:
 
     // Source::Observer implementation.
     void onSourceLoaded() override;
-    void onTileLoaded() override;
+    void onTileLoaded(bool isNewTile) override;
 
     // Sprite::Observer implementation.
     void onSpriteLoaded() override;

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -384,7 +384,8 @@ void Source::update(MapData& data,
                     GlyphStore& glyphStore,
                     SpriteAtlas& spriteAtlas,
                     util::ptr<Sprite> sprite,
-                    TexturePool& texturePool) {
+                    TexturePool& texturePool,
+                    bool shouldReparsePartialTiles) {
     if (!loaded || data.getAnimationTime() <= updated) {
         return;
     }
@@ -407,7 +408,8 @@ void Source::update(MapData& data,
 
         switch (state) {
         case TileData::State::partial:
-            handlePartialTile(id, style.workers);
+            if (shouldReparsePartialTiles)
+                handlePartialTile(id, style.workers);
             break;
         case TileData::State::invalid:
             state = addTile(data, transformState, style, glyphAtlas, glyphStore,

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -232,7 +232,7 @@ void Source::handlePartialTile(const TileID& id, Worker& worker) {
         return;
     }
 
-    auto callback = std::bind(&Source::emitTileLoaded, this);
+    auto callback = std::bind(&Source::emitTileLoaded, this, false);
     data->reparse(worker, callback);
 }
 
@@ -273,7 +273,7 @@ TileData::State Source::addTile(MapData& data,
         new_tile.data = cache.get(normalized_id.to_uint64());
     }
 
-    auto callback = std::bind(&Source::emitTileLoaded, this);
+    auto callback = std::bind(&Source::emitTileLoaded, this, true);
     if (!new_tile.data) {
         // If we don't find working tile data, we're just going to load it.
         if (info.type == SourceType::Vector) {
@@ -520,9 +520,9 @@ void Source::emitSourceLoaded() {
     }
 }
 
-void Source::emitTileLoaded() {
+void Source::emitTileLoaded(bool isNewTile) {
     if (observer_) {
-        observer_->onTileLoaded();
+        observer_->onTileLoaded(isNewTile);
     }
 }
 

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -58,7 +58,7 @@ public:
         virtual ~Observer() = default;
 
         virtual void onSourceLoaded() = 0;
-        virtual void onTileLoaded() = 0;
+        virtual void onTileLoaded(bool isNewTile) = 0;
     };
 
     Source();
@@ -97,7 +97,7 @@ public:
 
 private:
     void emitSourceLoaded();
-    void emitTileLoaded();
+    void emitTileLoaded(bool isNewTile);
 
     void handlePartialTile(const TileID &id, Worker &worker);
     bool findLoadedChildren(const TileID& id, int32_t maxCoveringZoom, std::forward_list<TileID>& retain);

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -68,7 +68,12 @@ public:
     bool isLoaded() const;
 
     void load(MapData&, Environment&, std::function<void()> callback);
-    void update(MapData&,
+
+    // Request or parse all the tiles relevant for the "TransformState". This method
+    // will return true if all the tiles were scheduled for updating of false if
+    // they were not. shouldReparsePartialTiles must be set to "true" if there is
+    // new data available that a tile in the "partial" state might be interested at.
+    bool update(MapData&,
                 const TransformState&,
                 Style&,
                 GlyphAtlas&,
@@ -99,7 +104,7 @@ private:
     void emitSourceLoaded();
     void emitTileLoaded(bool isNewTile);
 
-    void handlePartialTile(const TileID &id, Worker &worker);
+    bool handlePartialTile(const TileID &id, Worker &worker);
     bool findLoadedChildren(const TileID& id, int32_t maxCoveringZoom, std::forward_list<TileID>& retain);
     bool findLoadedParent(const TileID& id, int32_t minCoveringZoom, std::forward_list<TileID>& retain);
     int32_t coveringZoomLevel(const TransformState&) const;

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -75,7 +75,8 @@ public:
                 GlyphStore&,
                 SpriteAtlas&,
                 util::ptr<Sprite>,
-                TexturePool&);
+                TexturePool&,
+                bool shouldReparsePartialTiles);
 
     void invalidateTiles(const std::vector<TileID>&);
 

--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -73,10 +73,11 @@ void TileData::endParsing() {
     parsing.clear(std::memory_order_release);
 }
 
-void TileData::reparse(Worker& worker, std::function<void()> callback) {
+bool TileData::reparse(Worker& worker, std::function<void()> callback) {
     if (!mayStartParsing()) {
-        return;
+        return false;
     }
 
     workRequest = worker.send([this] { parse(); endParsing(); }, callback);
+    return true;
 }

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -45,7 +45,13 @@ public:
     ~TileData();
 
     void request(Worker&, float pixelRatio, std::function<void ()> callback);
-    void reparse(Worker&, std::function<void ()> callback);
+
+    // Schedule a tile reparse on a worker thread and call the callback on
+    // completion. It will return true if the work was schedule or false it was
+    // not, which can occur if the tile is already being parsed by another
+    // worker (see "mayStartParsing()").
+    bool reparse(Worker&, std::function<void ()> callback);
+
     void cancel();
     const std::string toString() const;
 

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -82,6 +82,12 @@ Bucket* VectorTileData::getBucket(StyleLayer const& layer) {
     return it->second.get();
 }
 
+size_t VectorTileData::countBuckets() const {
+    std::lock_guard<std::mutex> lock(bucketsMutex);
+
+    return buckets.size();
+}
+
 void VectorTileData::setBucket(StyleLayer const& layer, std::unique_ptr<Bucket> bucket) {
     assert(layer.bucket);
 

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -44,6 +44,7 @@ public:
     void parse() override;
     virtual Bucket* getBucket(StyleLayer const &layer_desc) override;
 
+    size_t countBuckets() const;
     void setBucket(StyleLayer const &layer_desc, std::unique_ptr<Bucket> bucket);
 
     void setState(const State& state) override;

--- a/src/mbgl/text/glyph_store.hpp
+++ b/src/mbgl/text/glyph_store.hpp
@@ -13,6 +13,14 @@
 #include <string>
 #include <unordered_map>
 
+typedef struct uv_loop_s uv_loop_t;
+
+namespace uv {
+
+class async;
+
+}
+
 namespace mbgl {
 
 class FileSource;
@@ -87,7 +95,7 @@ public:
         virtual void onGlyphRangeLoaded() = 0;
     };
 
-    GlyphStore(Environment &);
+    GlyphStore(uv_loop_t* loop, Environment &);
     ~GlyphStore();
 
     // Asynchronously request for GlyphRanges and when it gets loaded, notifies the
@@ -115,6 +123,8 @@ private:
 
     std::unordered_map<std::string, std::unique_ptr<FontStack>> stacks;
     std::mutex stacksMutex;
+
+    std::unique_ptr<uv::async> asyncEmitGlyphRangeLoaded;
 
     Observer* observer;
 };


### PR DESCRIPTION
Partial tiles are now only processed again when there is a new resource available. If we don't have new resources - like new glyphs - the end result of the reparsing is the same, because no new SymbolBuckets would are created.

In my tests debugging with PowerTOP, this patch drops the CPU utilization during the sampling period from 100ms/s to 40ms/s. The improvements on slow connections (i.e. more time waiting for resources) are even more noticeable.

Fixes #1458