### PR TITLE
Parse feature types in set filters

### DIFF
--- a/src/mbgl/style/filter_expression.cpp
+++ b/src/mbgl/style/filter_expression.cpp
@@ -59,7 +59,11 @@ FilterExpression parseSetFilter(const rapidjson::Value& value) {
     Expression expression;
     expression.key = { value[1u].GetString(), value[1u].GetStringLength() };
     for (rapidjson::SizeType i = 2; i < value.Size(); ++i) {
-        expression.values.push_back(parseValue(value[i]));
+        Value parsedValue = parseValue(value[i]);
+        if (expression.key == "$type") {
+            parsedValue = parseFeatureType(parsedValue);
+        }
+        expression.values.push_back(parsedValue);
     }
     return expression;
 }

--- a/test/miscellaneous/comparisons.cpp
+++ b/test/miscellaneous/comparisons.cpp
@@ -72,6 +72,13 @@ TEST(FilterComparison, EqualsType) {
     ASSERT_TRUE(evaluate(f, {{}}, FeatureType::LineString));
 }
 
+TEST(FilterComparison, InType) {
+    FilterExpression f = parse("[\"in\", \"$type\", \"LineString\", \"Polygon\"]");
+    ASSERT_FALSE(evaluate(f, {{}}, FeatureType::Point));
+    ASSERT_TRUE(evaluate(f, {{}}, FeatureType::LineString));
+    ASSERT_TRUE(evaluate(f, {{}}, FeatureType::Polygon));
+}
+
 TEST(FilterComparison, Any) {
     ASSERT_FALSE(evaluate(parse("[\"any\"]"), {{}}));
     ASSERT_TRUE(evaluate(parse("[\"any\", [\"==\", \"foo\", 1]]"),


### PR DESCRIPTION
A filter key of `$type` should work in an `in` filter, just like in an `==` filter. This fixes an issue exposed by mapbox/mapbox-gl-styles@4a89b5d and mapbox/mapbox-gl-styles@eb477f6, wherein minor streets and their casings completely dropped out of the map.

/cc @jfirebaugh @peterqliu