### PR TITLE
Make WorkRequests cancelable

### DIFF
--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -4,6 +4,7 @@
 
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/util/worker.hpp>
+#include <mbgl/util/work_request.hpp>
 #include <mbgl/platform/log.hpp>
 
 using namespace mbgl;
@@ -56,9 +57,7 @@ void TileData::cancel() {
         env.cancelRequest(req);
         req = nullptr;
     }
-    if (workRequest) {
-        workRequest.join();
-    }
+    workRequest.reset();
 }
 
 bool TileData::mayStartParsing() {

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -7,7 +7,6 @@
 
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
-#include <mbgl/util/work_request.hpp>
 
 #include <atomic>
 #include <string>
@@ -21,6 +20,7 @@ class SourceInfo;
 class StyleLayer;
 class Request;
 class Worker;
+class WorkRequest;
 
 class TileData : private util::noncopyable {
 public:
@@ -79,7 +79,7 @@ protected:
     Request *req = nullptr;
     std::string data;
 
-    WorkRequest workRequest;
+    std::unique_ptr<WorkRequest> workRequest;
 
     // Contains the tile ID string for painting debug information.
     DebugFontBuffer debugFontBuffer;

--- a/src/mbgl/util/work_request.cpp
+++ b/src/mbgl/util/work_request.cpp
@@ -1,38 +1,16 @@
 #include <mbgl/util/work_request.hpp>
+#include <mbgl/util/work_task.hpp>
+
+#include <cassert>
 
 namespace mbgl {
 
-WorkRequest::WorkRequest() = default;
-
-WorkRequest::WorkRequest(Future&& future, JoinedFlag flag)
-    : complete(std::move(future)),
-      joinedFlag(flag) {
-}
-
-WorkRequest::WorkRequest(WorkRequest&& o)
-    : complete(std::move(o.complete)),
-      joinedFlag(std::move(o.joinedFlag)) {
+WorkRequest::WorkRequest(Task task_) : task(task_) {
+    assert(task);
 }
 
 WorkRequest::~WorkRequest() {
-    if (complete.valid()) {
-        join();
-    }
-}
-
-WorkRequest& WorkRequest::operator=(WorkRequest&& o) {
-    complete = std::move(o.complete);
-    joinedFlag = std::move(o.joinedFlag);
-    return *this;
-}
-
-WorkRequest::operator bool() const {
-    return complete.valid();
-}
-
-void WorkRequest::join() {
-    *joinedFlag = true;
-    complete.get();
+    task->cancel();
 }
 
 }

--- a/src/mbgl/util/work_request.hpp
+++ b/src/mbgl/util/work_request.hpp
@@ -3,29 +3,20 @@
 
 #include <mbgl/util/noncopyable.hpp>
 
-#include <future>
+#include <memory>
 
 namespace mbgl {
 
+class WorkTask;
+
 class WorkRequest : public util::noncopyable {
 public:
-    using Future = std::future<void>;
-    using JoinedFlag = std::shared_ptr<std::atomic<bool>>;
-
-    WorkRequest();
-    WorkRequest(Future&&, JoinedFlag);
-    WorkRequest(WorkRequest&&);
+    using Task = std::shared_ptr<WorkTask>;
+    WorkRequest(Task);
     ~WorkRequest();
 
-    WorkRequest& operator=(WorkRequest&&);
-    operator bool() const;
-
-    // Wait for the worker task to complete.
-    void join();
-
 private:
-    Future complete;
-    JoinedFlag joinedFlag;
+    std::shared_ptr<WorkTask> task;
 };
 
 }

--- a/src/mbgl/util/work_task.cpp
+++ b/src/mbgl/util/work_task.cpp
@@ -1,0 +1,37 @@
+#include <mbgl/util/work_task.hpp>
+
+#include <cassert>
+
+namespace mbgl {
+
+WorkTask::WorkTask(std::function<void()> task_, std::function<void()> after_)
+    : task(task_), after(after_) {
+    assert(after);
+}
+
+void WorkTask::runTask() {
+    // We are only running the task when there's an after callback to call. This means that an
+    // empty after callback will be treated as a cancelled request. The mutex will be locked while
+    // processing so that the cancel() callback will block.
+    std::lock_guard<std::mutex> lock(mutex);
+    if (after) {
+        task();
+    }
+}
+
+void WorkTask::runAfter() {
+    if (after) {
+        after();
+    }
+}
+
+void WorkTask::cancel() {
+    // Remove the after callback to indicate that this callback has been canceled. The mutex will
+    // block when the task is currently in progres. When the task has not begun yet, the runTask()
+    // method will not do anything. When the task has been completed already, and the after callback
+    // was run as well, this will also do nothing.
+    std::lock_guard<std::mutex> lock(mutex);
+    after = {};
+}
+
+} // end namespace mbgl

--- a/src/mbgl/util/work_task.hpp
+++ b/src/mbgl/util/work_task.hpp
@@ -1,0 +1,27 @@
+#ifndef MBGL_UTIL_WORK_TASK
+#define MBGL_UTIL_WORK_TASK
+
+#include <mbgl/util/noncopyable.hpp>
+
+#include <functional>
+#include <mutex>
+
+namespace mbgl {
+
+class WorkTask : private util::noncopyable {
+public:
+    WorkTask(std::function<void()> task, std::function<void()> after);
+
+    void runTask();
+    void runAfter();
+    void cancel();
+
+private:
+    const std::function<void()> task;
+    std::function<void()> after;
+    std::mutex mutex;
+};
+
+} // end namespace mbgl
+
+#endif

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -2,12 +2,14 @@
 #define MBGL_UTIL_WORKER
 
 #include <mbgl/util/noncopyable.hpp>
-#include <mbgl/util/work_request.hpp>
 #include <mbgl/util/thread.hpp>
 
 #include <functional>
+#include <memory>
 
 namespace mbgl {
+
+class WorkRequest;
 
 class Worker : public mbgl::util::noncopyable {
 public:
@@ -26,7 +28,7 @@ public:
     // Together, this means that an object may make a work request with lambdas which
     // bind references to itself, and if and when those lambdas execute, the references
     // will still be valid.
-    WorkRequest send(Fn work, Fn after);
+    std::unique_ptr<WorkRequest> send(Fn work, Fn after);
 
 private:
     class Impl;


### PR DESCRIPTION
From #1455:

> When submitting WorkRequests, they are put into a queue until they are being processed. If the queue clogs up, the WorkRequests that are in the queue cannot be canceled, so joining the WorkRequest does a blocking wait until all previous WorkRequests in the queue have been processed, only to discover that the tile's state was marked as obsolete in the very first iteration.