### PR TITLE
Fix Linux GCC Debug build

### DIFF
--- a/include/mbgl/platform/gl.hpp
+++ b/include/mbgl/platform/gl.hpp
@@ -39,7 +39,7 @@ struct Error : ::std::runtime_error {
 void checkError(const char *cmd, const char *file, int line);
 
 #if defined(DEBUG)
-#define MBGL_CHECK_ERROR(cmd) ([&]() { struct _ { inline ~_() { ::mbgl::gl::checkError(#cmd, __FILE__, __LINE__); } } _; return cmd; }())
+#define MBGL_CHECK_ERROR(cmd) ([&]() { struct __MBGL_C_E { inline ~__MBGL_C_E() { ::mbgl::gl::checkError(#cmd, __FILE__, __LINE__); } } __MBGL_C_E; return cmd; }())
 #else
 #define MBGL_CHECK_ERROR(cmd) (cmd)
 #endif


### PR DESCRIPTION
Compiler was complaining about shadowed variable after
macro expansion.