### PR TITLE
clang-3.7

### DIFF
--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -12,7 +12,10 @@ TileData::TileData(const TileID& id_, const SourceInfo& source_)
     : id(id_),
       name(id),
       state(State::initial),
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wbraced-scalar-init"
       parsing(ATOMIC_FLAG_INIT),
+#pragma GCC diagnostic pop
       source(source_),
       env(Environment::Get()),
       debugBucket(debugFontBuffer) {

--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -13,6 +13,7 @@ TileData::TileData(const TileID& id_, const SourceInfo& source_)
       name(id),
       state(State::initial),
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wbraced-scalar-init"
       parsing(ATOMIC_FLAG_INIT),
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Adds support for clang-3.7 on OS X by silencing a  -Wbraced-scalar-init coming from `<atomic>`.

```
../../src/mbgl/map/tile_data.cpp:15:15: error: braces around scalar initializer [-Werror,-Wbraced-scalar-init]
      parsing(ATOMIC_FLAG_INIT),
              ^~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/atomic:1762:26: note: expanded from macro 'ATOMIC_FLAG_INIT'
#define ATOMIC_FLAG_INIT {false}
                         ^~~~~~~
1 error generated.
make[1]: *** [Debug/obj.target/core/src/mbgl/map/tile_data.o] Error 1
make: *** [linux] Error 2
```

refs https://github.com/llvm-mirror/libcxx/blob/master/include/atomic#L1776

For reference I'm running clang source compiled from git:

```
$ /opt/llvm/bin/clang++ -v
clang version 3.7.0 (http://llvm.org/git/clang.git de723f5818e668f45fae30510c403eb7e4f09568) (http://llvm.org/git/llvm.git 89d0e99f863f906d64727f168686565248063a9a)
Target: x86_64-apple-darwin14.3.0
Thread model: posix
```

Built like: https://github.com/springmeyer/build-llvm