### PR TITLE
Rename settings keys

### DIFF
--- a/ios/app/Settings.bundle/Root.plist
+++ b/ios/app/Settings.bundle/Root.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>PreferenceSpecifiers</key>
 	<array>
-        <dict>
+		<dict>
 			<key>Title</key>
 			<string>Privacy Settings</string>
 			<key>Type</key>
@@ -16,7 +16,7 @@
 			<key>DefaultValue</key>
 			<true/>
 			<key>Key</key>
-			<string>mapbox_metrics_enabled_preference</string>
+			<string>MGLMapboxMetricsEnabled</string>
 			<key>Title</key>
 			<string>Mapbox Metrics</string>
 			<key>Type</key>

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -154,7 +154,7 @@ void HTTPRequest::start() {
     @autoreleasepool {
         
         NSMutableString *url = [NSMutableString stringWithString:@(resource.url.c_str())];
-        if ([[NSUserDefaults standardUserDefaults] objectForKey:@"mapbox_metrics_disabled"] == nil) {
+        if ([[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"] == 0) {
             if ([url rangeOfString:@"?"].location == NSNotFound) {
                 [url appendString:@"?"];
             } else {

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -221,7 +221,7 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
     static MGLMapboxEvents *_sharedManager;
     dispatch_once(&onceToken, ^{
         if ( ! NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent &&
-            [[NSUserDefaults standardUserDefaults] objectForKey:@"mapbox_metrics_disabled"] == nil) {
+            [[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"] == 0) {
             void (^setupBlock)() = ^{
                 _sharedManager = [[self alloc] init];
             };
@@ -326,8 +326,8 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
         MGLMapboxEvents *strongSelf = weakSelf;
         if ( ! strongSelf) return;
         
-        // Opt Out Checking When Built
-        if (![[NSUserDefaults standardUserDefaults] boolForKey:@"mapbox_metrics_enabled_preference"]) {
+        // User has opted out
+        if (![[NSUserDefaults standardUserDefaults] boolForKey:@"MGLMapboxMetricsEnabled"]) {
             [_eventQueue removeAllObjects];
             return;
         }


### PR DESCRIPTION
The new keys fit the standard naming convention for Info.plist keys and more clearly communicate how they’re to be used. [The documentation](https://github.com/mapbox/mapbox-gl-native/wiki/Installing-Mapbox-GL-for-iOS#configuring-mapbox-metrics) needs to be updated in tandem with merging this PR.

/cc @bleege