### PR TITLE
fix integer overflow in line_buffer.cpp

### DIFF
--- a/src/mbgl/geometry/line_buffer.cpp
+++ b/src/mbgl/geometry/line_buffer.cpp
@@ -14,8 +14,8 @@ size_t LineVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey, i
     coords[1] = (y * 2) | ty;
 
     int8_t *extrude = static_cast<int8_t *>(data);
-    extrude[4] = std::round(extrudeScale * ex);
-    extrude[5] = std::round(extrudeScale * ey);
+    extrude[4] = fmax(-128, fmin(127, std::round(extrudeScale * ex)));
+    extrude[5] = fmax(-128, fmin(127, std::round(extrudeScale * ey)));
     extrude[6] = static_cast<int8_t>(linesofar / 128);
     extrude[7] = static_cast<int8_t>(linesofar % 128);
 


### PR DESCRIPTION
Spotted thanks to `clang++ -fsanitize=undefined`:


```
line_buffer.cpp:18: runtime error: value -146 is outside the range of representable values of type 'signed char'
line_buffer.cpp:18: runtime error: value -761 is outside the range of representable values of type 'signed char'
line_buffer.cpp:18: runtime error: value 761 is outside the range of representable values of type 'signed char'
```