### PR TITLE
fix division by zero conditions

### DIFF
--- a/include/mbgl/util/math.hpp
+++ b/include/mbgl/util/math.hpp
@@ -100,7 +100,11 @@ inline T mag(const S& a) {
 
 template <typename S>
 inline S unit(const S& a) {
-    return a * (1 / mag(a));
+    auto magnitude = mag(a);
+    if (magnitude == 0) {
+        return a;
+    }
+    return a * (1 / magnitude);
 }
 
 template <typename T>

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -143,7 +143,7 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
         // Find the cosine of the angle between the next and join normals
         // using dot product. The inverse of that is the miter length.
         const float cosHalfAngle = joinNormal.x * nextNormal.x + joinNormal.y * nextNormal.y;
-        const float miterLength = 1 / cosHalfAngle;
+        const float miterLength = cosHalfAngle != 0 ? 1 / cosHalfAngle: 1;
 
         // The join if a middle vertex, otherwise the cap
         const bool middleVertex = prevVertex && nextVertex;

--- a/src/mbgl/text/collision.cpp
+++ b/src/mbgl/text/collision.cpp
@@ -157,14 +157,24 @@ float Collision::getPlacementScale(const GlyphBoxes &glyphs, float minPlacementS
                 float padding = std::fmax(pad, placement.padding) * 8.0f;
 
                 // Original algorithm:
-                float s1 = (ob.tl.x - nb.br.x - padding) /
-                           (na.x - oa.x); // scale at which new box is to the left of old box
-                float s2 = (ob.br.x - nb.tl.x + padding) /
-                           (na.x - oa.x); // scale at which new box is to the right of old box
-                float s3 = (ob.tl.y - nb.br.y - padding) /
-                           (na.y - oa.y); // scale at which new box is to the top of old box
-                float s4 = (ob.br.y - nb.tl.y + padding) /
-                           (na.y - oa.y); // scale at which new box is to the bottom of old box
+                float sx = (na.x - oa.x);
+                float s1 = 1;
+                float s2 = 1;
+                if (sx != 0) {
+                   s1 = (ob.tl.x - nb.br.x - padding) /
+                           sx; // scale at which new box is to the left of old box
+                   s2 = (ob.br.x - nb.tl.x + padding) /
+                           sx; // scale at which new box is to the right of old box
+                }
+                float sy = (na.y - oa.y);
+                float s3 = 1;
+                float s4 = 1;
+                if (sy != 0) {
+                    s3 = (ob.tl.y - nb.br.y - padding) /
+                           sy; // scale at which new box is to the top of old box
+                    s4 = (ob.br.y - nb.tl.y + padding) /
+                           sy; // scale at which new box is to the bottom of old box
+                }
 
                 if (std::isnan(s1) || std::isnan(s2)) {
                     s1 = s2 = 1;

--- a/src/mbgl/text/placement.cpp
+++ b/src/mbgl/text/placement.cpp
@@ -53,6 +53,9 @@ void getSegmentGlyphs(std::back_insert_iterator<GlyphInstances> glyphs, Anchor &
 
     while (true) {
         const float dist = util::dist<float>(newAnchor, end);
+        if (dist == 0) {
+            break;
+        }
         const float scale = offset / dist;
         float angle =
             -std::atan2(end.x - newAnchor.x, end.y - newAnchor.y) + direction * M_PI / 2.0f;


### PR DESCRIPTION
Spotted thanks to `clang++ -fsanitize=undefined`:

These occurred while panning the map (clang catches and reports them at runtime).  None were easy to trigger - all took some extensive panning to hit. Below is an aggregate of all encountered:

```
../../src/mbgl/text/placement.cpp:56:36: runtime error: division by zero
../../include/mbgl/util/math.hpp:103:19: runtime error: division by zero
../../src/mbgl/text/collision.cpp:160:58: runtime error: division by zero
../../src/mbgl/text/collision.cpp:162:58: runtime error: division by zero
../../src/mbgl/text/collision.cpp:164:58: runtime error: division by zero
../../src/mbgl/text/collision.cpp:166:58: runtime error: division by zero
../../src/mbgl/renderer/line_bucket.cpp:146:37: runtime error: division by zero
```