### PR TITLE
Mark unused parameters with __unused

### DIFF
--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -83,10 +83,7 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
     [self restoreState:nil];
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-
-- (void)saveState:(NSNotification *)notification
+- (void)saveState:(__unused NSNotification *)notification
 {
     if (self.mapView && settings)
     {
@@ -101,7 +98,7 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
     }
 }
 
-- (void)restoreState:(NSNotification *)notification
+- (void)restoreState:(__unused NSNotification *)notification
 {
     if (self.mapView && settings) {
         settings->load();
@@ -112,8 +109,6 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
         [self.mapView setDebugActive:settings->debug];
     }
 }
-
-#pragma clang diagnostic pop
 
 - (NSUInteger)supportedInterfaceOrientations
 {
@@ -277,17 +272,14 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
     }
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-
 #pragma mark - MGLMapViewDelegate
 
-- (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id <MGLAnnotation>)annotation
+- (BOOL)mapView:(__unused MGLMapView *)mapView annotationCanShowCallout:(__unused id <MGLAnnotation>)annotation
 {
     return YES;
 }
 
-- (void)mapView:(MGLMapView *)mapView didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated
+- (void)mapView:(__unused MGLMapView *)mapView didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(__unused BOOL)animated
 {
     UIImage *newButtonImage;
     
@@ -309,7 +301,5 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
         self.navigationItem.rightBarButtonItem.image = newButtonImage;
     }];
 }
-
-#pragma clang diagnostic pop
 
 @end

--- a/ios/benchmark/MBXBenchViewController.mm
+++ b/ios/benchmark/MBXBenchViewController.mm
@@ -88,11 +88,8 @@ static const int benchmarkDuration = 200; // frames
     }
 }
 
-- (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered
+- (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(__unused BOOL)fullyRendered
 {
-    (void)mapView;
-    (void)fullyRendered;
-
     if (state == State::Benchmarking)
     {
         frames++;

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -649,10 +649,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 #pragma mark - Life Cycle -
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-
-- (void)sleepGL:(NSNotification *)notification
+- (void)sleepGL:(__unused NSNotification *)notification
 {
     MGLAssertIsMainThread();
 
@@ -686,7 +683,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }
 }
 
-- (void)wakeGL:(NSNotification *)notification
+- (void)wakeGL:(__unused NSNotification *)notification
 {
     MGLAssertIsMainThread();
 
@@ -720,19 +717,15 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 #pragma mark - Gestures -
 
-- (void)handleCompassTapGesture:(id)sender
+- (void)handleCompassTapGesture:(__unused id)sender
 {
     [self resetNorthAnimated:YES];
 
     if (self.userTrackingMode == MGLUserTrackingModeFollowWithHeading) self.userTrackingMode = MGLUserTrackingModeFollow;
 }
 
-#pragma clang diagnostic pop
-
-- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
+- (void)touchesBegan:(__unused NSSet *)touches withEvent:(__unused UIEvent *)event
 {
-    (void)touches;
-    (void)event;
     _mbglMap->cancelTransitions();
     _mbglMap->setGestureInProgress(false);
     self.animatingGesture = NO;
@@ -2018,10 +2011,8 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     }
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation
+- (void)locationManager:(__unused CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation
 {
-    (void)manager;
-
     if ( ! _showsUserLocation || ! newLocation || ! CLLocationCoordinate2DIsValid(newLocation.coordinate)) return;
 
     if ([newLocation distanceFromLocation:oldLocation] || ! oldLocation)
@@ -2094,19 +2085,15 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
 - (BOOL)locationManagerShouldDisplayHeadingCalibration:(CLLocationManager *)manager
 {
-    (void)manager;
-
-    if (self.displayHeadingCalibration) [self.locationManager performSelector:@selector(dismissHeadingCalibrationDisplay)
-                                                                   withObject:nil
-                                                                   afterDelay:10.0];
+    if (self.displayHeadingCalibration) [manager performSelector:@selector(dismissHeadingCalibrationDisplay)
+                                                      withObject:nil
+                                                      afterDelay:10.0];
 
     return self.displayHeadingCalibration;
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading
+- (void)locationManager:(__unused CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading
 {
-    (void)manager;
-
     if ( ! _showsUserLocation || self.pan.state == UIGestureRecognizerStateBegan || newHeading.headingAccuracy < 0) return;
 
     self.userLocation.heading = newHeading;
@@ -2126,10 +2113,8 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     }
 }
 
-- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
+- (void)locationManager:(__unused CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
 {
-    (void)manager;
-
     if (status == kCLAuthorizationStatusDenied || status == kCLAuthorizationStatusRestricted)
     {
         self.userTrackingMode  = MGLUserTrackingModeNone;
@@ -2137,10 +2122,8 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     }
 }
 
-- (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
+- (void)locationManager:(__unused CLLocationManager *)manager didFailWithError:(NSError *)error
 {
-    (void)manager;
-
     if ([error code] == kCLErrorDenied)
     {
         self.userTrackingMode  = MGLUserTrackingModeNone;


### PR DESCRIPTION
This PR replaces haphazard usage of pragmas and `(void)` expressions with the [`__unused` keyword](http://nshipster.com/__attribute__/#unused).

/cc @incanus