### PR TITLE
Attribute Mapbox and OpenStreetMap in-app

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -54,7 +54,7 @@ static NSURL *MGLURLForBundledStyleNamed(NSString *styleName)
 
 #pragma mark - Private -
 
-@interface MGLMapView () <UIGestureRecognizerDelegate, GLKViewDelegate, CLLocationManagerDelegate>
+@interface MGLMapView () <UIGestureRecognizerDelegate, GLKViewDelegate, CLLocationManagerDelegate, UIActionSheetDelegate>
 
 @property (nonatomic) EAGLContext *context;
 @property (nonatomic) GLKView *glView;
@@ -303,7 +303,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     //
     _attributionButton = [UIButton buttonWithType:UIButtonTypeInfoLight];
     _attributionButton.accessibilityLabel = @"Attribution info";
-    [_attributionButton addTarget:self action:@selector(showAttribution:) forControlEvents:UIControlEventTouchUpInside];
+    [_attributionButton addTarget:self action:@selector(showAttribution) forControlEvents:UIControlEventTouchUpInside];
     _attributionButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:_attributionButton];
 
@@ -1251,6 +1251,35 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }];
 }
 
+#pragma mark - Attribution -
+
+- (void)showAttribution
+{
+    UIActionSheet *sheet = [[UIActionSheet alloc] initWithTitle:@"© Mapbox © OpenStreetMap"
+                                                       delegate:self
+                                              cancelButtonTitle:@"Cancel"
+                                         destructiveButtonTitle:nil
+                                              otherButtonTitles:
+                            @"About This Map",
+                            @"Improve This Map",
+                            nil];
+    [sheet showFromRect:self.attributionButton.frame inView:self animated:YES];
+}
+
+- (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
+{
+    if (buttonIndex == actionSheet.firstOtherButtonIndex)
+    {
+        [[UIApplication sharedApplication] openURL:
+         [NSURL URLWithString:@"https://www.mapbox.com/about/maps/"]];
+    }
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 1)
+    {
+        [[UIApplication sharedApplication] openURL:
+         [NSURL URLWithString:@"https://www.mapbox.com/map-feedback/"]];
+    }
+}
+
 #pragma mark - Properties -
 
 + (NSSet *)keyPathsForValuesAffectingZoomEnabled
@@ -1267,16 +1296,6 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 {
     return [NSSet setWithObject:@"allowsRotating"];
 }
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-
-- (void)showAttribution:(id)sender
-{
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://www.mapbox.com/about/maps/"]];
-}
-
-#pragma clang diagnostic pop
 
 - (void)setDebugActive:(BOOL)debugActive
 {

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1255,12 +1255,13 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 - (void)showAttribution
 {
-    UIActionSheet *sheet = [[UIActionSheet alloc] initWithTitle:@"© Mapbox © OpenStreetMap"
+    UIActionSheet *sheet = [[UIActionSheet alloc] initWithTitle:@"Mapbox GL for iOS"
                                                        delegate:self
                                               cancelButtonTitle:@"Cancel"
                                          destructiveButtonTitle:nil
                                               otherButtonTitles:
-                            @"About This Map",
+                            @"© Mapbox",
+                            @"© OpenStreetMap",
                             @"Improve This Map",
                             nil];
     [sheet showFromRect:self.attributionButton.frame inView:self animated:YES];
@@ -1274,6 +1275,11 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
          [NSURL URLWithString:@"https://www.mapbox.com/about/maps/"]];
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 1)
+    {
+        [[UIApplication sharedApplication] openURL:
+         [NSURL URLWithString:@"http://www.openstreetmap.org/about/"]];
+    }
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 2)
     {
         [[UIApplication sharedApplication] openURL:
          [NSURL URLWithString:@"https://www.mapbox.com/map-feedback/"]];

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1288,8 +1288,8 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 2)
     {
-        NSString *feedbackURL = [NSString stringWithFormat:@"https://www.mapbox.com/map-feedback/#/%.5f/%.5f/%.1f",
-                                 self.longitude, self.latitude, self.zoomLevel];
+        NSString *feedbackURL = [NSString stringWithFormat:@"https://www.mapbox.com/map-feedback/#/%.5f/%.5f/%i",
+                                 self.longitude, self.latitude, (int)round(self.zoomLevel)];
         [[UIApplication sharedApplication] openURL:
          [NSURL URLWithString:feedbackURL]];
     }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -63,6 +63,7 @@ static NSURL *MGLURLForBundledStyleNamed(NSString *styleName)
 @property (nonatomic) UIImageView *compass;
 @property (nonatomic) UIImageView *logoBug;
 @property (nonatomic) UIButton *attributionButton;
+@property (nonatomic) UIActionSheet *attributionSheet;
 @property (nonatomic) UIPanGestureRecognizer *pan;
 @property (nonatomic) UIPinchGestureRecognizer *pinch;
 @property (nonatomic) UIRotationGestureRecognizer *rotate;
@@ -306,6 +307,16 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     [_attributionButton addTarget:self action:@selector(showAttribution) forControlEvents:UIControlEventTouchUpInside];
     _attributionButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:_attributionButton];
+    
+    _attributionSheet = [[UIActionSheet alloc] initWithTitle:@"Mapbox GL for iOS"
+                                                    delegate:self
+                                           cancelButtonTitle:@"Cancel"
+                                      destructiveButtonTitle:nil
+                                           otherButtonTitles:
+                         @"© Mapbox",
+                         @"© OpenStreetMap",
+                         @"Improve This Map",
+                         nil];
 
     // setup compass
     //
@@ -646,6 +657,11 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     if ( ! _isTargetingInterfaceBuilder)
     {
         _mbglMap->update();
+    }
+    
+    if (self.attributionSheet.visible)
+    {
+        [self.attributionSheet dismissWithClickedButtonIndex:self.attributionSheet.cancelButtonIndex animated:YES];
     }
 }
 
@@ -1255,16 +1271,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 - (void)showAttribution
 {
-    UIActionSheet *sheet = [[UIActionSheet alloc] initWithTitle:@"Mapbox GL for iOS"
-                                                       delegate:self
-                                              cancelButtonTitle:@"Cancel"
-                                         destructiveButtonTitle:nil
-                                              otherButtonTitles:
-                            @"© Mapbox",
-                            @"© OpenStreetMap",
-                            @"Improve This Map",
-                            nil];
-    [sheet showFromRect:self.attributionButton.frame inView:self animated:YES];
+    [self.attributionSheet showFromRect:self.attributionButton.frame inView:self animated:YES];
 }
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex


### PR DESCRIPTION
With this change, :information_source: pops up an action sheet with [the required attribution](https://www.mapbox.com/help/attribution/) and a direct link to the Map Feedback tool. Eventually we’ll tackle something more along the lines of https://github.com/mapbox/mapbox-gl-native/issues/1265#issuecomment-92964800, but this should be sufficient for beta 1.

/cc @lxbarth @incanus