### PR TITLE
Add long/lat/zoom to feedback URL

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1281,8 +1281,10 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 2)
     {
+        NSString *feedbackURL = [NSString stringWithFormat:@"https://www.mapbox.com/map-feedback/#/%.5f/%.5f/%.1f",
+                                 self.longitude, self.latitude, self.zoomLevel];
         [[UIApplication sharedApplication] openURL:
-         [NSURL URLWithString:@"https://www.mapbox.com/map-feedback/"]];
+         [NSURL URLWithString:feedbackURL]];
     }
 }
 


### PR DESCRIPTION
Carries over the user's map position to the feedback website.

Part of #1497, cc @1ec5.