### PR TITLE
Initialize the atomic_flag in the class definition

### DIFF
--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -13,7 +13,6 @@ TileData::TileData(const TileID& id_, const SourceInfo& source_)
     : id(id_),
       name(id),
       state(State::initial),
-      parsing(ATOMIC_FLAG_INIT),
       source(source_),
       env(Environment::Get()),
       debugBucket(debugFontBuffer) {

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -62,7 +62,7 @@ public:
     const TileID id;
     const std::string name;
     std::atomic<State> state;
-    std::atomic_flag parsing;
+    std::atomic_flag parsing = ATOMIC_FLAG_INIT;
 
 protected:
     // Set the internal parsing state to true so we prevent


### PR DESCRIPTION
ATOMIC_FLAG_INIT is often defined to { 0 } or { false } and some
compilers might complain about initializing as flag(ATOMIC_FLAG_INIT).