### PR TITLE
Still image rendering doesn't wait until all tiles are parsed

### DIFF
--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -39,6 +39,7 @@ int main(int argc, char *argv[]) {
     std::string cache_file = "cache.sqlite";
     std::vector<std::string> classes;
     std::string token;
+    bool debug = false;
 
     po::options_description desc("Allowed options");
     desc.add_options()
@@ -51,6 +52,7 @@ int main(int argc, char *argv[]) {
         ("height,h", po::value(&height)->value_name("pixels")->default_value(height), "Image height")
         ("class,c", po::value(&classes)->value_name("name"), "Class name")
         ("token,t", po::value(&token)->value_name("key")->default_value(token), "Mapbox access token")
+        ("debug", po::bool_switch(&debug)->default_value(debug), "Debug mode")
         ("output,o", po::value(&output)->value_name("file")->default_value(output), "Output file name")
         ("cache,d", po::value(&cache_file)->value_name("file")->default_value(cache_file), "Cache database file name")
     ;
@@ -93,6 +95,10 @@ int main(int argc, char *argv[]) {
     map.resize(width, height, pixelRatio);
     map.setLatLngZoom({ lat, lon }, zoom);
     map.setBearing(bearing);
+
+    if (debug) {
+        map.setDebug(debug);
+    }
 
     uv_async_t *async = new uv_async_t;
     uv_async_init(uv_default_loop(), async, [](uv_async_t *as, int) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -216,6 +216,11 @@ void MapContext::render() {
     // Cleanup OpenGL objects that we abandoned since the last render call.
     env.performCleanup();
 
+    if (data.mode == MapMode::Still && (!callback || !data.getFullyLoaded())) {
+        // We are either not waiting for a map to be rendered, or we don't have all resources yet.
+        return;
+    }
+
     assert(style);
 
     if (!painter) {
@@ -226,7 +231,7 @@ void MapContext::render() {
     painter->setDebug(data.getDebug());
     painter->render(*style, transformState, data.getAnimationTime());
 
-    if (data.mode == MapMode::Still && callback && style->isLoaded() && resourceLoader->getSprite()->isLoaded()) {
+    if (data.mode == MapMode::Still) {
         callback(view.readStillImage());
         callback = nullptr;
     }


### PR DESCRIPTION
In headless tests, I'm observing render failures:

Actual:

![image](https://cloud.githubusercontent.com/assets/52399/7586226/0cf9dc1a-f8ab-11e4-88be-767e702de4d9.png)

Expected:

![image](https://cloud.githubusercontent.com/assets/52399/7586227/0f98ced6-f8ab-11e4-98f7-db9b34511e3a.png)


