### PR TITLE
break out setup.sh from run.sh, take two

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,14 @@ env:
     - secure: "nQqSM8rd7OHtV4MqmNqVnkrVHqxKqQsaWRYk4/nPdhbeVWtTtkk0df711LrF1TUtbEPEewHxYUvTZ/UXmwJNeoKdzTHavI8hnatRkgjyxGERPn1il1Otelht9I+LQQHf+plrpRjVWBrNIW0Zox1B3cqn6d3NglpbXrEQ2EjYGNA="
     - KIF_SCREENSHOTS="${TRAVIS_BUILD_DIR}/screenshots"
 
+before_install:
+- source ./scripts/travis_helper.sh
+
 install:
 - ./scripts/${FLAVOR}/install.sh
+
+before_script:
+- if [ -f ./scripts/${FLAVOR}/setup.sh ]; then source ./scripts/${FLAVOR}/setup.sh; fi
 
 script:
 - ./scripts/${FLAVOR}/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_install:
 - source ./scripts/travis_helper.sh
 
 install:
-- ./scripts/${FLAVOR}/install.sh
+- source ./scripts/${FLAVOR}/install.sh
 
 before_script:
 - if [ -f ./scripts/${FLAVOR}/setup.sh ]; then source ./scripts/${FLAVOR}/setup.sh; fi

--- a/scripts/android/install.sh
+++ b/scripts/android/install.sh
@@ -3,8 +3,6 @@
 set -e
 set -o pipefail
 
-source ./scripts/travis_helper.sh
-
 mapbox_time "checkout_mason" \
 git submodule update --init .mason
 

--- a/scripts/android/run.sh
+++ b/scripts/android/run.sh
@@ -9,8 +9,6 @@ export HOST=android
 export MASON_PLATFORM=android
 export MASON_ANDROID_ABI=${ANDROID_ABI:-arm-v7}
 
-source ./scripts/travis_helper.sh
-
 # Add Mason to PATH
 export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
 

--- a/scripts/ios/install.sh
+++ b/scripts/ios/install.sh
@@ -3,8 +3,6 @@
 set -e
 set -o pipefail
 
-source ./scripts/travis_helper.sh
-
 mapbox_time "checkout_mason" \
 git submodule update --init .mason
 export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"

--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -4,8 +4,6 @@ set -e
 set -o pipefail
 set -u
 
-source ./scripts/travis_helper.sh
-
 NAME=MapboxGL
 OUTPUT=build/ios/pkg
 IOS_SDK_VERSION=`xcrun --sdk iphoneos --show-sdk-version`

--- a/scripts/ios/run.sh
+++ b/scripts/ios/run.sh
@@ -6,8 +6,6 @@ set -u
 
 BUILDTYPE=${BUILDTYPE:-Release}
 
-source ./scripts/travis_helper.sh
-
 # Add Mason to PATH
 export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
 

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -3,8 +3,6 @@
 set -e
 set -o pipefail
 
-source ./scripts/travis_helper.sh
-
 mapbox_time "checkout_mason" \
 git submodule update --init .mason
 export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"

--- a/scripts/linux/run.sh
+++ b/scripts/linux/run.sh
@@ -5,34 +5,6 @@ set -o pipefail
 
 BUILDTYPE=${BUILDTYPE:-Release}
 
-source ./scripts/travis_helper.sh
-
-# Add Mason to PATH
-export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
-
-# Set the core file limit to unlimited so a core file is generated upon crash
-ulimit -c unlimited -S
-
-################################################################################
-# X Server setup
-################################################################################
-
-# Start the mock X server
-if [ -f /etc/init.d/xvfb ] ; then
-    mapbox_time "start_xvfb" \
-    sh -e /etc/init.d/xvfb start
-    sleep 2 # sometimes, xvfb takes some time to start up
-fi
-
-# Make sure we're connecting to xvfb
-export DISPLAY=:99.0
-
-# Make sure we're loading the 10.4.3 libs we installed manually
-export LD_LIBRARY_PATH="`mason prefix mesa 10.4.3`/lib:${LD_LIBRARY_PATH:-}"
-
-mapbox_time "glxinfo" \
-glxinfo
-
 ################################################################################
 # Build
 ################################################################################

--- a/scripts/linux/setup.sh
+++ b/scripts/linux/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Set the core file limit to unlimited so a core file is generated upon crash
+ulimit -c unlimited -S
+
+################################################################################
+# X Server setup
+################################################################################
+
+# Start the mock X server
+if [ -f /etc/init.d/xvfb ] ; then
+    mapbox_time "start_xvfb" \
+    sh -e /etc/init.d/xvfb start
+    sleep 2 # sometimes, xvfb takes some time to start up
+fi
+
+# Make sure we're connecting to xvfb
+export DISPLAY=:99.0
+
+# Make sure we're loading the 10.4.3 libs we installed manually
+export LD_LIBRARY_PATH="`mason prefix mesa 10.4.3`/lib:${LD_LIBRARY_PATH:-}"
+
+mapbox_time "glxinfo" \
+glxinfo

--- a/scripts/osx/install.sh
+++ b/scripts/osx/install.sh
@@ -3,8 +3,6 @@
 set -e
 set -o pipefail
 
-source ./scripts/travis_helper.sh
-
 mapbox_time "checkout_mason" \
 git submodule update --init .mason
 export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"

--- a/scripts/osx/run.sh
+++ b/scripts/osx/run.sh
@@ -5,14 +5,6 @@ set -o pipefail
 
 BUILDTYPE=${BUILDTYPE:-Release}
 
-source ./scripts/travis_helper.sh
-
-# Add Mason to PATH
-export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
-
-# Set the core file limit to unlimited so a core file is generated upon crash
-ulimit -c unlimited -S
-
 ################################################################################
 # Build
 ################################################################################

--- a/scripts/osx/setup.sh
+++ b/scripts/osx/setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Set the core file limit to unlimited so a core file is generated upon crash
+ulimit -c unlimited -S


### PR DESCRIPTION
`source ./scripts/${FLAVOR}/install.sh` this time to properly export `mason` on `PATH` and fix regression in headless tests.

/cc @jfirebaugh 