### PR TITLE
Add action sheet shortcut to Settings.app metrics opt-out

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -82,7 +82,7 @@ static NSURL *MGLURLForBundledStyleNamed(NSString *styleName)
 @property (nonatomic, getter=isDormant) BOOL dormant;
 @property (nonatomic, getter=isAnimatingGesture) BOOL animatingGesture;
 @property (nonatomic, readonly, getter=isRotationAllowed) BOOL rotationAllowed;
-@property (nonatomic, readonly, getter=hasSettingsBundleMetricsOptOut) BOOL settingsBundleMetricsOptOut;
+@property (nonatomic, readonly) BOOL hasSettingsBundleMetricsOptOut;
 
 @end
 


### PR DESCRIPTION
Dynamically checks if `Settings.bundle` has `MGLMapboxMetricsEnabled` key and only adds button to the :information_source: action sheet if that key exists.

Only applicable to iOS 8+, tested to be safe with iOS 7.

Fixes #1519.

/cc @1ec5