### PR TITLE
Corrected Settings.bundle assertion message

### DIFF
--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -123,7 +123,7 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
             // Put Settings bundle into memory
             NSString *appSettingsBundle = [[NSBundle mainBundle] pathForResource:@"Settings" ofType:@"bundle"];
 
-            NSAssert(appSettingsBundle, @"End users must be able to opt out of Metrics in your app, either via the Settings.bundle or in the app itself which must be noted via setting +[MGLAccountManager setShowsOptOutInApp:YES]");
+            NSAssert(appSettingsBundle, @"End users must be able to opt out of Metrics in your app, either inside Settings (via Settings.bundle) or inside this app. If you implement the opt-out control inside this app, disable this assertion by setting [MGLAccountManager setMapboxMetricsEnabledSettingShownInApp:YES] before initializing any MGLMapView.");
 
             // Dynamic Settings.bundle loading based on:
             // http://stackoverflow.com/questions/510216/can-you-make-the-settings-in-settings-bundle-default-even-if-you-dont-open-the

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -123,7 +123,7 @@ NSString *const MGLEventGestureRotateStart = @"Rotation";
             // Put Settings bundle into memory
             NSString *appSettingsBundle = [[NSBundle mainBundle] pathForResource:@"Settings" ofType:@"bundle"];
 
-            NSAssert(appSettingsBundle, @"End users must be able to opt out of Metrics in your app, either inside Settings (via Settings.bundle) or inside this app. If you implement the opt-out control inside this app, disable this assertion by setting [MGLAccountManager setMapboxMetricsEnabledSettingShownInApp:YES] before initializing any MGLMapView.");
+            NSAssert(appSettingsBundle, @"End users must be able to opt out of Metrics in your app, either inside Settings (via Settings.bundle) or inside this app. If you implement the opt-out control inside this app, disable this assertion by setting [MGLAccountManager setMapboxMetricsEnabledSettingShownInApp:YES] before the app initializes any Mapbox GL classes.");
 
             // Dynamic Settings.bundle loading based on:
             // http://stackoverflow.com/questions/510216/can-you-make-the-settings-in-settings-bundle-default-even-if-you-dont-open-the


### PR DESCRIPTION
87551c6d0e189cd6d98cc75e93ba4f0f176a3464 renamed the setter to `-[MGLAccountManager setMapboxMetricsEnabledSettingShownInApp:]`. Also clarified when it has to be called.

/cc @bleege