### PR TITLE
compile OS X with --std=c++1y

### DIFF
--- a/gyp/common.gypi
+++ b/gyp/common.gypi
@@ -8,11 +8,11 @@
       ['OS=="mac"', {
         'xcode_settings': {
           'CLANG_CXX_LIBRARY': 'libc++',
-          'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
           'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
           'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
           'GCC_ENABLE_CPP_RTTI': 'YES',
           'OTHER_CPLUSPLUSFLAGS': [
+            '-std=c++1y',
             '-Werror',
             '-Wall',
             '-Wextra',


### PR DESCRIPTION
because Travis uses Apple LLVM 6.0 and full c++14 support landed in 6.1

https://developer.apple.com/library/ios/documentation/DeveloperTools/Conceptual/WhatsNewXcode/WhatsNewXcode.pdf

/cc @incanus @1ec5 