### PR TITLE
build should fail when headless tests that are expected to pass don't

### DIFF
--- a/scripts/compare_images.sh
+++ b/scripts/compare_images.sh
@@ -3,4 +3,4 @@
 set -e
 set -o pipefail
 
-(cd ./test/suite/ && (./bin/compare_images.py || true))
+(cd ./test/suite/ && ./bin/compare_images.py native)

--- a/scripts/linux/after_failure.sh
+++ b/scripts/linux/after_failure.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+if [ ! -z "${AWS_ACCESS_KEY_ID}" ] && [ ! -z "${AWS_SECRET_ACCESS_KEY}" ] ; then
+    # Install and add awscli to PATH for uploading the results
+    mapbox_time "install_awscli" \
+    pip install --user awscli
+    export PATH="`python -m site --user-base`/bin:${PATH}"
+
+    mapbox_time_start "deploy_results"
+    (cd ./test/suite/ && ./bin/deploy_results.sh)
+    mapbox_time_finish
+fi

--- a/scripts/linux/run.sh
+++ b/scripts/linux/run.sh
@@ -35,18 +35,3 @@ make test-* BUILDTYPE=${BUILDTYPE}
 
 mapbox_time "compare_results" \
 ./scripts/compare_images.sh
-
-################################################################################
-# Deploy
-################################################################################
-
-if [ ! -z "${AWS_ACCESS_KEY_ID}" ] && [ ! -z "${AWS_SECRET_ACCESS_KEY}" ] ; then
-    # Install and add awscli to PATH for uploading the results
-    mapbox_time "install_awscli" \
-    pip install --user awscli
-    export PATH="`python -m site --user-base`/bin:${PATH}"
-
-    mapbox_time_start "deploy_results"
-    (cd ./test/suite/ && ./bin/deploy_results.sh)
-    mapbox_time_finish
-fi


### PR DESCRIPTION
Several recent rendering regressions (#1478, #1514, #1523) should have been caught by our headless rendering tests but weren't because we don't fail the build when previously-passing tests start to fail.

We do have some expected failures, but rather than ignoring all test results, we should track the expected failures and ignore them one-by-one.