### PR TITLE
Return nil for IB designables agent

### DIFF
--- a/platform/ios/MGLAccountManager.m
+++ b/platform/ios/MGLAccountManager.m
@@ -18,7 +18,7 @@
 //
 + (instancetype) sharedManager {
     if (NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent) {
-        return;
+        return nil;
     }
     static dispatch_once_t onceToken;
     static MGLAccountManager *_sharedManager;

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -280,7 +280,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 //
 + (instancetype)sharedManager {
     if (NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent) {
-        return;
+        return nil;
     }
     static dispatch_once_t onceToken;
     static MGLMapboxEvents *_sharedManager;


### PR DESCRIPTION
This PR fixes #1538, a regression from 190e91120927ea2e48a72c8337ba923dabe31f85 for #1491. In Objective-C, the return value for a non-void method is the last receiver by default. Hello NeXTSTEP.

/cc @friedbunny @incanus