### PR TITLE
Don't do things that set -e in Travis's shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,10 +86,7 @@ before_install:
 - source ./scripts/travis_helper.sh
 
 install:
-- source ./scripts/${FLAVOR}/install.sh
-
-before_script:
-- if [ -f ./scripts/${FLAVOR}/setup.sh ]; then source ./scripts/${FLAVOR}/setup.sh; fi
+- ./scripts/${FLAVOR}/install.sh
 
 script:
 - ./scripts/${FLAVOR}/run.sh

--- a/scripts/ios/install.sh
+++ b/scripts/ios/install.sh
@@ -5,7 +5,6 @@ set -o pipefail
 
 mapbox_time "checkout_mason" \
 git submodule update --init .mason
-export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
 
 mapbox_time "install_xcpretty" \
 gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/scripts/ios/run.sh
+++ b/scripts/ios/run.sh
@@ -4,10 +4,9 @@ set -e
 set -o pipefail
 set -u
 
-BUILDTYPE=${BUILDTYPE:-Release}
+source ./scripts/ios/setup.sh
 
-# Add Mason to PATH
-export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
+BUILDTYPE=${BUILDTYPE:-Release}
 
 PUBLISH_TAG=($(git show -s --format=%B | sed -n 's/.*\[publish \([a-z]\{1,\}\)-v\([0-9.]\{1,\}\)\].*/\1 \2/p'))
 PUBLISH_PLATFORM=${PUBLISH_TAG[0],-}

--- a/scripts/ios/setup.sh
+++ b/scripts/ios/setup.sh
@@ -3,6 +3,3 @@
 
 # Ensure mason is on the PATH
 export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
-
-# Set the core file limit to unlimited so a core file is generated upon crash
-ulimit -c unlimited -S

--- a/scripts/linux/install.sh
+++ b/scripts/linux/install.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 mapbox_time "checkout_mason" \
 git submodule update --init .mason
-export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
 
+PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason" \
 mapbox_time "install_mesa" \
 mason install mesa 10.4.3

--- a/scripts/linux/run.sh
+++ b/scripts/linux/run.sh
@@ -3,6 +3,8 @@
 set -e
 set -o pipefail
 
+source ./scripts/linux/setup.sh
+
 BUILDTYPE=${BUILDTYPE:-Release}
 
 ################################################################################

--- a/scripts/linux/setup.sh
+++ b/scripts/linux/setup.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+# This script is sourced; do not set -e or -o pipefail here.
 
-set -e
-set -o pipefail
+# Ensure mason is on the PATH
+export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
 
 # Set the core file limit to unlimited so a core file is generated upon crash
 ulimit -c unlimited -S

--- a/scripts/osx/install.sh
+++ b/scripts/osx/install.sh
@@ -5,7 +5,6 @@ set -o pipefail
 
 mapbox_time "checkout_mason" \
 git submodule update --init .mason
-export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
 
 mapbox_time "install_xcpretty" \
 gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/scripts/osx/run.sh
+++ b/scripts/osx/run.sh
@@ -3,6 +3,8 @@
 set -e
 set -o pipefail
 
+source ./scripts/osx/setup.sh
+
 BUILDTYPE=${BUILDTYPE:-Release}
 
 ################################################################################

--- a/scripts/travis_helper.sh
+++ b/scripts/travis_helper.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# This script is sourced, so do not set -e or -o pipefail here. Doing so would
+# bleed into Travis' wrapper script, which messes with their workflow, e.g.
+# preventing after_failure scripts to be triggered.
+
 case `uname -s` in
     'Darwin') JOBS=$((`sysctl -n hw.ncpu` + 2)) ;;
     'Linux')  JOBS=$((`nproc` + 2)) ;;


### PR DESCRIPTION
Sourcing files that set flags bleed into Travis' wrapper script, which
messes with their workflow, e.g. preventing after_failure scripts from
triggering.

These changes fix that:

* Move exported variables from install.sh to setup.sh, so install.sh
  doesn't have to be sourced.
* Source setup.sh from run.sh, rather than directly from .travis.yml.

In addition, as a good practice, remove `set -e` etc. from setup.sh,
and add a comment not to add them back. It's the sourcing script's
responsibility to set these flags.

Fixes #1545