### PR TITLE
Normalize angle of 360 degrees to 0 degrees

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -24,6 +24,11 @@ static double _normalizeAngle(double angle, double anchorAngle)
         angle += util::M2PI;
     }
 
+    // 360 degrees should be normalized as 0
+    if (std::abs(angle) == util::M2PI) {
+        angle = 0;
+    }
+
     return angle;
 }
 


### PR DESCRIPTION
This fixes the compass not disappearing after it is reset, especially when returning from the background.

When interpolating across 180º, [`_normalizeAngle`](https://github.com/mapbox/mapbox-gl-native/blob/24ea920810d13700094b44b08ac737eb613ea1de/src/mbgl/map/transform.cpp#L15-L28) will return >180º. Then, trying to reset the bearing to 0º would result in interpolation to 360º. Because [`[MGLMapView updateCompass]` expects bearing to equal 0º when the compass is done resetting](https://github.com/mapbox/mapbox-gl-native/blob/54a703bcb21e567559caf691759bb207c611d776/platform/ios/MGLMapView.mm#L2444), the compass was never disappearing.

**Steps to reproduce**

1. Turn on heading-follow location tracking in iOS demo app
1. Rotate device to a heading less than 180º (due south)
1. Lock device
1. While locked, rotate beyond 180º
1. Unlock device, tap compass to reset heading
1. Compass will reset, but not disappear because bearing is 360º, not 0º

You can also test this by setting a breakpoint in `/src/mbgl/map/transform.cpp` `_normalizeAngle` and doing this:

Start by moving to 171º from 196º:
```
(lldb) po _normalizeAngle(-2.999457083051174, 3.4266856461794291)
3.2837282241284118 = 189º
```

When it comes time to reset to 0º from 189º:
```
(lldb) po _normalizeAngle(0, 3.2837282241284118)
6.2831853071795862 = 360º
```

Which is the same as 0º, but not what we're looking for.

/cc @1ec5 @incanus