### PR TITLE
mapID → styleID

### DIFF
--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -9,7 +9,7 @@
 // MGLMapView+IBAdditions.h, due to ASCII sort order.
 
 @property (nonatomic) IBInspectable NSString *accessToken;
-@property (nonatomic) IBInspectable NSString *mapID;
+@property (nonatomic) IBInspectable NSString *styleID;
 
 // Convenience properties related to the initial viewport. These properties
 // are not meant to be used outside of Interface Builder. latitude and longitude

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -162,12 +162,13 @@ IB_DESIGNABLE
 
 /** @name Styling the Map */
 
-/** Mapbox map ID of the style currently displayed in the receiver, or `nil` if the style does not have a map ID.
+/** Mapbox ID of the style currently displayed in the receiver, or `nil` if the style does not have an ID.
 *
-*   The style may lack a map ID if it is located at an HTTP, HTTPS, or local file URL. Use `styleURL` to get the URL in these cases.
+*   The style may lack an ID if it is located at an HTTP, HTTPS, or local file URL. Use `styleURL` to get the URL in these cases.
 *
 *   To display the default style, set this property to `nil`. */
-@property (nonatomic) NSString *mapID;
+@property (nonatomic) NSString *styleID;
+@property (nonatomic) NSString *mapID __attribute__((unavailable("Use styleID.")));
 
 /** Returns the URLs to the styles bundled with the library. */
 - (NSArray *)bundledStyleURLs;

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -162,7 +162,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 + (NSSet *)keyPathsForValuesAffectingStyleURL
 {
-    return [NSSet setWithObjects:@"mapID", @"accessToken", nil];
+    return [NSSet setWithObjects:@"styleID", @"accessToken", nil];
 }
 
 - (NSURL *)styleURL
@@ -1543,27 +1543,31 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     return [NSArray arrayWithArray:_bundledStyleURLs];
 }
 
-+ (NSSet *)keyPathsForValuesAffectingMapID
++ (NSSet *)keyPathsForValuesAffectingStyleID
 {
     return [NSSet setWithObjects:@"styleURL", @"accessToken", nil];
 }
 
-- (NSString *)mapID
+- (NSString *)styleID
 {
     NSURL *styleURL = self.styleURL;
     return [styleURL.scheme isEqualToString:@"mapbox"] ? styleURL.host.mgl_stringOrNilIfEmpty : nil;
 }
 
+- (void)setStyleID:(NSString *)styleID
+{
+    self.styleURL = styleID ? [NSURL URLWithString:[NSString stringWithFormat:@"mapbox://%@", styleID]] : nil;
+}
+
+- (NSString *)mapID
+{
+    NSAssert(NO, @"-[MGLMapView mapID] has been renamed -[MGLMapView styleID].");
+    return nil;
+}
+
 - (void)setMapID:(NSString *)mapID
 {
-    if (mapID)
-    {
-        self.styleURL = [NSURL URLWithString:[NSString stringWithFormat:@"mapbox://%@", mapID]];
-    }
-    else
-    {
-        self.styleURL = nil;
-    }
+    NSAssert(NO, @"-[MGLMapView setMapID:] has been renamed -[MGLMapView setStyleID:].\n\nIf you previously set this map ID in a storyboard inspectable, select the MGLMapView in Interface Builder and delete the “mapID” entry from the User Defined Runtime Attributes section of the Identity inspector. Then go to the Attributes inspector and enter “%@” into the “Style ID” field.", mapID);
 }
 
 - (NSArray *)styleClasses


### PR DESCRIPTION
Renamed `-mapID` and `-setMapID:` to `-styleID` and `-setStyleID:`, respectively, to accurately reflect the APIs the ID is used for. Marked the property unavailable but reimplemented its getter and setter to assert with helpful messages. Even if no one has reason to use `mapID` in beta 1, a developer could have tried to put a raster map ID in the storyboard inspectable; if we remove the old property entirely, there’s no longer any UI to recover from that situation. The assertion I’ve implemented is the best way to communicate the rename in that case.

Fixes #1500.

/cc @willwhite @incanus