### PR TITLE
Run static analyzer on iOS targets on Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ ipackage-sim: clean Xcode/ios
 itest: ipackage-sim KIF
 	./scripts/ios/test.sh
 
-ianalyze: clean Xcode/ios
+ianalyze: Xcode/ios
 	./scripts/ios/analyze.sh
 
 # Legacy name

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,9 @@ ipackage-sim: clean Xcode/ios
 itest: ipackage-sim KIF
 	./scripts/ios/test.sh
 
+ianalyze: Xcode/ios
+	./scripts/ios/analyze.sh
+
 # Legacy name
 iproj: ios-proj
 

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ ipackage-sim: clean Xcode/ios
 itest: ipackage-sim KIF
 	./scripts/ios/test.sh
 
-ianalyze: Xcode/ios
+ianalyze:
 	./scripts/ios/analyze.sh
 
 # Legacy name

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ ipackage-sim: clean Xcode/ios
 itest: ipackage-sim KIF
 	./scripts/ios/test.sh
 
-ianalyze: Xcode/ios
+ianalyze: clean Xcode/ios
 	./scripts/ios/analyze.sh
 
 # Legacy name

--- a/scripts/ios/analyze.sh
+++ b/scripts/ios/analyze.sh
@@ -15,4 +15,6 @@ xcodebuild \
     -project ./build/ios/gyp/ios.xcodeproj \
     -configuration Debug \
     -target All \
-    analyze | xcpretty -c | grep -qF 'The following commands produced analyzer issues'
+    analyze | xcpretty | tee ./build/ios/analyze.txt
+
+! grep -q 'The following commands produced analyzer issues' ./build/ios/analyze.txt

--- a/scripts/ios/analyze.sh
+++ b/scripts/ios/analyze.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+xcodebuild \
+    -sdk iphoneos \
+    -project ./build/ios/gyp/ios.xcodeproj \
+    -configuration Debug \
+    -target All \
+    analyze | xcpretty | grep -q 'The following commands produced analyzer issues'

--- a/scripts/ios/analyze.sh
+++ b/scripts/ios/analyze.sh
@@ -4,6 +4,12 @@ set -e
 set -o pipefail
 set -u
 
+# Disable static analyzer in third-party libraries with known issues:
+# https://github.com/memononen/libtess2/pull/19
+# https://sourceforge.net/p/polyclipping/bugs/134/
+perl -pi -e 's/(isa = PBXBuildFile; fileRef = [0-9A-F]+ \/\* (clipper\.cpp|mesh\.c) \*\/;) }/$1 settings = {COMPILER_FLAGS = "-Qunused-arguments -Xanalyzer -analyzer-disable-all-checks"; }; }/g' \
+    ./build/ios/mbgl.xcodeproj/project.pbxproj
+
 xcodebuild \
     -sdk iphoneos \
     -project ./build/ios/gyp/ios.xcodeproj \

--- a/scripts/ios/analyze.sh
+++ b/scripts/ios/analyze.sh
@@ -15,4 +15,4 @@ xcodebuild \
     -project ./build/ios/gyp/ios.xcodeproj \
     -configuration Debug \
     -target All \
-    analyze | xcpretty | grep -q 'The following commands produced analyzer issues'
+    analyze | xcpretty -c | grep -qF 'The following commands produced analyzer issues'

--- a/scripts/ios/run.sh
+++ b/scripts/ios/run.sh
@@ -29,4 +29,7 @@ else
     # build & test iOS
     mapbox_time "run_ios_tests" \
     make ipackage-sim
+
+    # run the static analyzer
+    make ianalyze
 fi

--- a/scripts/ios/run.sh
+++ b/scripts/ios/run.sh
@@ -31,5 +31,6 @@ else
     make ipackage-sim
 
     # run the static analyzer
+    mapbox_time "analyze_ios" \
     make ianalyze
 fi


### PR DESCRIPTION
This PR adds a make target for performing static analysis everything that goes into an iOS build, as well as the demo app and benchmark app. It fails on any warning but also excludes two files from third-party libraries with known warnings.

Fixes #1549.

/cc @jfirebaugh @incanus @springmeyer