### PR TITLE
Properly fail to load the map

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -35,6 +35,7 @@
         '../platform/ios/MGLUserLocationAnnotationView.h',
         '../platform/ios/MGLUserLocationAnnotationView.m',
         '../include/mbgl/ios/MGLTypes.h',
+        '../platform/ios/MGLTypes.m',
         '../platform/ios/NSBundle+MGLAdditions.h',
         '../platform/ios/NSBundle+MGLAdditions.m',
         '../platform/ios/NSException+MGLAdditions.h',

--- a/include/mbgl/ios/MGLTypes.h
+++ b/include/mbgl/ios/MGLTypes.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+extern NSString * const MGLErrorDomain;
+
 /** The mode used to track the user location on the map. */
 typedef NS_ENUM(NSUInteger, MGLUserTrackingMode)
 {

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2352,9 +2352,10 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
         }
         case mbgl::MapChangeDidFailLoadingMap:
         {
-            if ([self.delegate respondsToSelector:@selector(mapViewDidFailLoadingMap:withError::)])
+            if ([self.delegate respondsToSelector:@selector(mapViewDidFailLoadingMap:withError:)])
             {
-                [self.delegate mapViewDidFailLoadingMap:self withError:nil];
+                NSError *error = [NSError errorWithDomain:MGLErrorDomain code:0 userInfo:nil];
+                [self.delegate mapViewDidFailLoadingMap:self withError:error];
             }
             break;
         }

--- a/platform/ios/MGLTypes.m
+++ b/platform/ios/MGLTypes.m
@@ -1,0 +1,3 @@
+#import "MGLTypes.h"
+
+NSString * const MGLErrorDomain = @"MGLErrorDomain";


### PR DESCRIPTION
This PR fixes a latent bug. A typo in a selector literal meant that `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` would never be sent to delegates even if `MGLMapView` had called it. Along for the ride, create a proper `NSError` to pass into that callback and an error domain for that error.