### PR TITLE
Audit headers for nullability

### DIFF
--- a/include/mbgl/ios/MGLAccountManager.h
+++ b/include/mbgl/ios/MGLAccountManager.h
@@ -1,4 +1,6 @@
-#import <Foundation/Foundation.h>
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 /** The MGLAccountManager object provides a global way to set a Mapbox API access token, as well as other settings used framework-wide. */
 @interface MGLAccountManager : NSObject
@@ -9,13 +11,13 @@
 *
 *   You can set an access token on MGLAccountManager or on an individual map view. The same token is used throughout the framework.
 *   @param accessToken The Mapbox API access token. */
-+ (void)setAccessToken:(NSString *)accessToken;
++ (void)setAccessToken:(nullable NSString *)accessToken;
 
 /** Retreive the Mapbox API access token for the framework.
 *
 *   You can set an access token on MGLAccountManager or on an individual map view. The same token is used throughout the framework.
 *   @return accessToken The Mapbox API access token. */
-+ (NSString *)accessToken;
++ (nullable NSString *)accessToken;
 
 /** @name Providing User Metrics Opt-Out */
 
@@ -27,3 +29,5 @@
 + (BOOL)mapboxMetricsEnabledSettingShownInApp;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLAnnotation.h
+++ b/include/mbgl/ios/MGLAnnotation.h
@@ -1,5 +1,8 @@
-#import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
+
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 /** The MGLAnnotation protocol is used to provide annotation-related information to a map view. To use this protocol, you adopt it in any custom objects that store or represent annotation data. Each object then serves as the source of information about a single map annotation and provides critical information, such as the annotation’s location on the map. Annotation objects do not provide the visual representation of the annotation but typically coordinate (in conjunction with the map view’s delegate) the creation of an appropriate objects to handle the display.
 *
@@ -23,6 +26,8 @@
 /** The string containing the annotation’s subtitle.
 *
 *   This string is displayed in the callout for the associated annotation. */
-@property (nonatomic, readonly, copy) NSString *subtitle;
+@property (nonatomic, readonly, copy, nullable) NSString *subtitle;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -1,4 +1,7 @@
 #import "MGLMapView.h"
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface MGLMapView (IBAdditions)
 
@@ -8,7 +11,7 @@
 // inspectables declared in MGLMapView.h are always sorted before those in
 // MGLMapView+IBAdditions.h, due to ASCII sort order.
 
-@property (nonatomic) IBInspectable NSString *styleID;
+@property (nonatomic, nullable) IBInspectable NSString *styleID;
 
 // Convenience properties related to the initial viewport. These properties
 // are not meant to be used outside of Interface Builder. latitude and longitude
@@ -30,3 +33,5 @@
 @property (nonatomic) IBInspectable BOOL showsUserLocation;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -3,6 +3,8 @@
 #import <UIKit/UIKit.h>
 #import <CoreLocation/CoreLocation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class MGLUserLocation;
 
 @protocol MGLMapViewDelegate;
@@ -28,17 +30,17 @@ IB_DESIGNABLE
 
 /** Initializes and returns a newly allocated map view with the specified frame and style URL.
 *   @param frame The frame for the view, measured in points.
-*   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`).
+*   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`). Specify `nil` for the default style.
 *   @return An initialized map view. */
-- (instancetype)initWithFrame:(CGRect)frame styleURL:(NSURL *)styleURL;
-- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(NSURL *)styleURL __attribute__((unavailable("Use -initWithFrame:styleURL:. Set MGLMapboxAccessToken in the Info.plist or call +[MGLAccountManager setAccessToken:].")));
+- (instancetype)initWithFrame:(CGRect)frame styleURL:(nullable NSURL *)styleURL;
+- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(nullable NSURL *)styleURL __attribute__((unavailable("Use -initWithFrame:styleURL:. Set MGLMapboxAccessToken in the Info.plist or call +[MGLAccountManager setAccessToken:].")));
 
 #pragma mark - Authorizing Access
 
 /** @name Authorizing Access */
 
 /** Mapbox API access token for the map view. */
-@property (nonatomic) NSString *accessToken __attribute__((unavailable("Use +[MGLAccountManager accessToken] and +[MGLAccountManager setAccessToken:].")));
+@property (nonatomic, nullable) NSString *accessToken __attribute__((unavailable("Use +[MGLAccountManager accessToken] and +[MGLAccountManager setAccessToken:].")));
 
 #pragma mark - Managing Constraints
 
@@ -74,7 +76,7 @@ IB_DESIGNABLE
 /** @name Accessing the Delegate */
 
 // TODO
-@property(nonatomic, weak) IBOutlet id<MGLMapViewDelegate> delegate;
+@property(nonatomic, weak, nullable) IBOutlet id<MGLMapViewDelegate> delegate;
 
 #pragma mark - Manipulating the Visible Portion of the Map
 
@@ -137,13 +139,13 @@ IB_DESIGNABLE
 *   @param point The point you want to convert.
 *   @param view The view that serves as the reference coordinate system for the `point` parameter.
 *   @return The map coordinate at the specified point. */
-- (CLLocationCoordinate2D)convertPoint:(CGPoint)point toCoordinateFromView:(UIView *)view;
+- (CLLocationCoordinate2D)convertPoint:(CGPoint)point toCoordinateFromView:(nullable UIView *)view;
 
 /** Converts a map coordinate to a point in the specified view.
 *   @param coordinate The map coordinate for which you want to find the corresponding point.
 *   @param view The view in whose coordinate system you want to locate the specified map coordinate. If this parameter is `nil`, the returned point is specified in the window’s coordinate system. If `view` is not `nil`, it must belong to the same window as the map view.
 *   @return The point (in the appropriate view or window coordinate system) corresponding to the specified latitude and longitude value. */
-- (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(UIView *)view;
+- (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(nullable UIView *)view;
 
 /** Returns the distance spanned by one pixel at the specified latitude and current zoom level.
 *
@@ -162,18 +164,18 @@ IB_DESIGNABLE
 *   The style may lack an ID if it is located at an HTTP, HTTPS, or local file URL. Use `styleURL` to get the URL in these cases.
 *
 *   To display the default style, set this property to `nil`. */
-@property (nonatomic) NSString *styleID;
-@property (nonatomic) NSString *mapID __attribute__((unavailable("Use styleID.")));
+@property (nonatomic, nullable) NSString *styleID;
+@property (nonatomic, nullable) NSString *mapID __attribute__((unavailable("Use styleID.")));
 
 /** Returns the URLs to the styles bundled with the library. */
-- (NSArray *)bundledStyleURLs;
+@property (nonatomic, readonly) NSArray *bundledStyleURLs;
 
 /** URL of the style currently displayed in the receiver.
 *
 *   The URL may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map ID (`mapbox://<user.style>`).
 *
 *   To display the default style, set this property to `nil`. */
-@property (nonatomic) NSURL *styleURL;
+@property (nonatomic, null_resettable) NSURL *styleURL;
 
 /** Currently active style classes, represented as an array of string identifiers. */
 @property (nonatomic) NSArray *styleClasses;
@@ -198,7 +200,7 @@ IB_DESIGNABLE
 /** The complete list of annotations associated with the receiver. (read-only)
 *
 *   The objects in this array must adopt the MGLAnnotation protocol. If no annotations are associated with the map view, the value of this property is `nil`. */
-@property (nonatomic, readonly) NSArray *annotations;
+@property (nonatomic, readonly, nullable) NSArray *annotations;
 
 /** Adds the specified annotation to the map view.
 *   @param annotation The annotation object to add to the receiver. This object must conform to the MGLAnnotation protocol. The map view retains the specified object. */
@@ -257,7 +259,7 @@ IB_DESIGNABLE
 @property (nonatomic, assign, readonly, getter=isUserLocationVisible) BOOL userLocationVisible;
 
 /** Returns the annotation object indicating the user’s current location. */
-@property (nonatomic, readonly) MGLUserLocation *userLocation;
+@property (nonatomic, readonly, nullable) MGLUserLocation *userLocation;
 
 /** The mode used to track the user location. */
 @property (nonatomic, assign) MGLUserTrackingMode userTrackingMode;
@@ -300,7 +302,7 @@ IB_DESIGNABLE
 *   @param mapView The map view that requested the annotation symbol name.
 *   @param annotation The object representing the annotation that is about to be displayed. 
 *   @return The marker symbol to display for the specified annotation or `nil` if you want to display the default symbol. */
-- (NSString *)mapView:(MGLMapView *)mapView symbolNameForAnnotation:(id <MGLAnnotation>)annotation;
+- (nullable NSString *)mapView:(MGLMapView *)mapView symbolNameForAnnotation:(id <MGLAnnotation>)annotation;
 
 /** Returns a Boolean value indicating whether the annotation is able to display extra information in a callout bubble.
 *
@@ -322,7 +324,7 @@ IB_DESIGNABLE
 *   @param mapView The map view presenting the annotation callout.
 *   @param annotation The object representing the annotation with the callout.
 *   @return The accessory view to display. */
-- (UIView *)mapView:(MGLMapView *)mapView leftCalloutAccessoryViewForAnnotation:(id <MGLAnnotation>)annotation;
+- (nullable UIView *)mapView:(MGLMapView *)mapView leftCalloutAccessoryViewForAnnotation:(id <MGLAnnotation>)annotation;
 
 /** Return the view to display on the right side of the standard callout bubble.
 *
@@ -333,7 +335,7 @@ IB_DESIGNABLE
 *   @param mapView The map view presenting the annotation callout.
 *   @param annotation The object representing the annotation with the callout.
 *   @return The accessory view to display. */
-- (UIView *)mapView:(MGLMapView *)mapView rightCalloutAccessoryViewForAnnotation:(id <MGLAnnotation>)annotation;
+- (nullable UIView *)mapView:(MGLMapView *)mapView rightCalloutAccessoryViewForAnnotation:(id <MGLAnnotation>)annotation;
 
 #pragma mark - Responding to Map Position Changes
 
@@ -391,7 +393,7 @@ IB_DESIGNABLE
 *
 *   @param mapView The map view that is tracking the user’s location.
 *   @param userLocation The location object representing the user’s latest location. This property may be `nil`. */
-- (void)mapView:(MGLMapView *)mapView didUpdateUserLocation:(MGLUserLocation *)userLocation;
+- (void)mapView:(MGLMapView *)mapView didUpdateUserLocation:(nullable MGLUserLocation *)userLocation;
 
 /** Tells the delegate that an attempt to locate the user’s position failed.
 *   @param mapView The map view that is tracking the user’s location.
@@ -443,3 +445,5 @@ IB_DESIGNABLE
 - (void)mapView:(MGLMapView *)mapView didDeselectAnnotation:(id <MGLAnnotation>)annotation;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLTypes.h
+++ b/include/mbgl/ios/MGLTypes.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * const MGLErrorDomain;
 
 /** The mode used to track the user location on the map. */
@@ -12,3 +14,5 @@ typedef NS_ENUM(NSUInteger, MGLUserTrackingMode)
     /** The map follows the user location and rotates when the heading changes. */
     MGLUserTrackingModeFollowWithHeading
 };
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLUserLocation.h
+++ b/include/mbgl/ios/MGLUserLocation.h
@@ -1,5 +1,7 @@
 #import "MGLAnnotation.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The MGLUserLocation class defines a specific type of annotation that identifies the user’s current location. You do not create instances of this class directly. Instead, you retrieve an existing MGLUserLocation object from the userLocation property of the map view displayed in your application. */
 @interface MGLUserLocation : NSObject <MGLAnnotation>
 
@@ -8,7 +10,7 @@
 /** The current location of the device. (read-only)
 *
 *   This property contains `nil` if the map view is not currently showing the user location or if the user’s location has not yet been determined. */
-@property (nonatomic, readonly) CLLocation *location;
+@property (nonatomic, readonly, nullable) CLLocation *location;
 
 /** A Boolean value indicating whether the user’s location is currently being updated. (read-only) */
 @property (nonatomic, readonly, getter=isUpdating) BOOL updating;
@@ -16,7 +18,7 @@
 /** The heading of the user location. (read-only)
 *
 * This property is `nil` if the user location tracking mode is not `MGLUserTrackingModeFollowWithHeading`. */
-@property (nonatomic, readonly) CLHeading *heading;
+@property (nonatomic, readonly, nullable) CLHeading *heading;
 
 /** @name Accessing the User Annotation Text */
 
@@ -24,6 +26,8 @@
 @property (nonatomic, copy) NSString *title;
 
 /** The subtitle to display for the user location annotation. */
-@property (nonatomic, copy) NSString *subtitle;
+@property (nonatomic, copy, nullable) NSString *subtitle;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/MGLAccountManager.m
+++ b/platform/ios/MGLAccountManager.m
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "MGLAccountManager_Private.h"
 #import "MGLMapboxEvents.h"
 #import "NSProcessInfo+MGLAdditions.h"

--- a/platform/ios/MGLFileCache.h
+++ b/platform/ios/MGLFileCache.h
@@ -1,6 +1,8 @@
-#import <Foundation/Foundation.h>
+#import "MGLTypes.h"
 
 #include <mbgl/storage/sqlite_cache.hpp>
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface MGLFileCache : NSObject
 
@@ -8,3 +10,5 @@
 + (void)releaseSharedCacheForObject:(NSObject *)object;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -75,7 +75,6 @@ CLLocationDegrees MGLDegreesFromRadians(CGFloat radians)
 @property (nonatomic) UIPinchGestureRecognizer *pinch;
 @property (nonatomic) UIRotationGestureRecognizer *rotate;
 @property (nonatomic) UILongPressGestureRecognizer *quickZoom;
-@property (nonatomic) NSMutableArray *bundledStyleURLs;
 @property (nonatomic) NSMapTable *annotationIDsByAnnotation;
 @property (nonatomic) std::vector<uint32_t> annotationsNearbyLastTap;
 @property (nonatomic, weak) id <MGLAnnotation> selectedAnnotation;
@@ -97,6 +96,8 @@ CLLocationDegrees MGLDegreesFromRadians(CGFloat radians)
     mbgl::Map *_mbglMap;
     MBGLView *_mbglView;
     mbgl::DefaultFileSource *_mbglFileSource;
+    
+    NSMutableArray *_bundledStyleURLs;
 
     BOOL _isTargetingInterfaceBuilder;
     CLLocationDegrees _pendingLatitude;
@@ -122,7 +123,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     return self;
 }
 
-- (instancetype)initWithFrame:(CGRect)frame styleURL:(NSURL *)styleURL
+- (instancetype)initWithFrame:(CGRect)frame styleURL:(nullable NSURL *)styleURL
 {
     if (self = [super initWithFrame:frame])
     {
@@ -132,7 +133,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     return self;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)decoder
+- (instancetype)initWithCoder:(nonnull NSCoder *)decoder
 {
     if (self = [super initWithCoder:decoder])
     {
@@ -142,13 +143,13 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     return self;
 }
 
-- (NSString *)accessToken
+- (nullable NSString *)accessToken
 {
     NSAssert(NO, @"-[MGLMapView accessToken] has been removed. Use +[MGLAccountManager accessToken] or get MGLMapboxAccessToken from the Info.plist.");
     return nil;
 }
 
-- (void)setAccessToken:(NSString *)accessToken
+- (void)setAccessToken:(nullable NSString *)accessToken
 {
     NSAssert(NO, @"-[MGLMapView setAccessToken:] has been replaced by +[MGLAccountManager setAccessToken:].\n\nIf you previously set this access token in a storyboard inspectable, select the MGLMapView in Interface Builder and delete the “accessToken” entry from the User Defined Runtime Attributes section of the Identity inspector. Then go to the Info.plist file and set MGLMapboxAccessToken to “%@”.", accessToken);
 }
@@ -158,13 +159,14 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     return [NSSet setWithObject:@"styleID"];
 }
 
-- (NSURL *)styleURL
+- (nonnull NSURL *)styleURL
 {
     NSString *styleURLString = @(_mbglMap->getStyleURL().c_str()).mgl_stringOrNilIfEmpty;
+    NSAssert(styleURLString || _isTargetingInterfaceBuilder, @"Invalid style URL string %@", styleURLString);
     return styleURLString ? [NSURL URLWithString:styleURLString] : nil;
 }
 
-- (void)setStyleURL:(NSURL *)styleURL
+- (void)setStyleURL:(nullable NSURL *)styleURL
 {
     if (_isTargetingInterfaceBuilder) return;
 
@@ -422,7 +424,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }
 }
 
-- (void)setDelegate:(id<MGLMapViewDelegate>)delegate
+- (void)setDelegate:(nullable id<MGLMapViewDelegate>)delegate
 {
     if (_delegate == delegate) return;
 
@@ -1220,6 +1222,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 {
     if ([self.delegate respondsToSelector:@selector(mapView:annotation:calloutAccessoryControlTapped:)])
     {
+        NSAssert([tap.view isKindOfClass:[UIControl class]], @"Tapped view %@ is not a UIControl", tap.view);
         [self.delegate mapView:self annotation:self.selectedAnnotation
             calloutAccessoryControlTapped:(UIControl *)tap.view];
     }
@@ -1477,7 +1480,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     [self setDirection:direction animated:NO];
 }
 
-- (CLLocationCoordinate2D)convertPoint:(CGPoint)point toCoordinateFromView:(UIView *)view
+- (CLLocationCoordinate2D)convertPoint:(CGPoint)point toCoordinateFromView:(nullable UIView *)view
 {
     CGPoint convertedPoint = [self convertPoint:point fromView:view];
 
@@ -1488,7 +1491,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     return MGLLocationCoordinate2DFromLatLng(_mbglMap->latLngForPixel(mbgl::vec2<double>(convertedPoint.x, convertedPoint.y)));
 }
 
-- (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(UIView *)view
+- (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(nullable UIView *)view
 {
     mbgl::vec2<double> pixel = _mbglMap->pixelForLatLng(MGLLatLngFromLocationCoordinate2D(coordinate));
 
@@ -1555,24 +1558,24 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
     return [NSSet setWithObject:@"styleURL"];
 }
 
-- (NSString *)styleID
+- (nullable NSString *)styleID
 {
     NSURL *styleURL = self.styleURL;
     return [styleURL.scheme isEqualToString:@"mapbox"] ? styleURL.host.mgl_stringOrNilIfEmpty : nil;
 }
 
-- (void)setStyleID:(NSString *)styleID
+- (void)setStyleID:(nullable NSString *)styleID
 {
     self.styleURL = styleID ? [NSURL URLWithString:[NSString stringWithFormat:@"mapbox://%@", styleID]] : nil;
 }
 
-- (NSString *)mapID
+- (nullable NSString *)mapID
 {
     NSAssert(NO, @"-[MGLMapView mapID] has been renamed -[MGLMapView styleID].");
     return nil;
 }
 
-- (void)setMapID:(NSString *)mapID
+- (void)setMapID:(nullable NSString *)mapID
 {
     NSAssert(NO, @"-[MGLMapView setMapID:] has been renamed -[MGLMapView setStyleID:].\n\nIf you previously set this map ID in a storyboard inspectable, select the MGLMapView in Interface Builder and delete the “mapID” entry from the User Defined Runtime Attributes section of the Identity inspector. Then go to the Attributes inspector and enter “%@” into the “Style ID” field.", mapID);
 }
@@ -1632,7 +1635,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
 #pragma mark - Annotations -
 
-- (NSArray *)annotations
+- (nullable NSArray *)annotations
 {
     if ([_annotationIDsByAnnotation count])
     {
@@ -1941,7 +1944,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
     return [NSSet setWithObject:@"userLocationAnnotationView"];
 }
 
-- (MGLUserLocation *)userLocation
+- (nullable MGLUserLocation *)userLocation
 {
     return self.userLocationAnnotationView.annotation;
 }

--- a/platform/ios/MGLMapboxEvents.h
+++ b/platform/ios/MGLMapboxEvents.h
@@ -1,4 +1,6 @@
-#import <Foundation/Foundation.h>
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const MGLEventTypeAppUserTurnstile;
 extern NSString *const MGLEventTypeMapLoad;
@@ -31,7 +33,7 @@ extern NSString *const MGLEventGestureRotateStart;
 
 @interface MGLMapboxEvents : NSObject <NSURLSessionDelegate>
 
-+ (instancetype)sharedManager;
++ (nullable instancetype)sharedManager;
 
 // You must call these methods from the main thread.
 //
@@ -61,3 +63,5 @@ extern NSString *const MGLEventGestureRotateStart;
 + (void)validate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -304,7 +304,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 // Can be called from any thread. Called implicitly from any
 // public class convenience methods. May return nil if this feature is disabled.
 //
-+ (instancetype)sharedManager {
++ (nullable instancetype)sharedManager {
     if (NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent) {
         return nil;
     }
@@ -597,7 +597,9 @@ const NSTimeInterval MGLFlushInterval = 60;
             [request setHTTPBody:jsonData];
 
             // Send non blocking HTTP Request to server
-            NSURLSessionDataTask *task = [_session dataTaskWithRequest:request completionHandler: nil];
+            NSURLSessionDataTask *task = [_session dataTaskWithRequest:request completionHandler:^(__unused NSData * __nullable data, __unused NSURLResponse * __nullable response, __unused NSError * __nullable error)
+            {
+            }];
             [task resume];
         }
     });

--- a/platform/ios/MGLUserLocation.m
+++ b/platform/ios/MGLUserLocation.m
@@ -2,19 +2,24 @@
 
 #import "MGLMapView.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MGLUserLocation ()
 
 @property (nonatomic, weak) MGLMapView *mapView;
 
 @end
 
+NS_ASSUME_NONNULL_END
+
 @implementation MGLUserLocation
 
-- (instancetype)init
+- (instancetype)initWithMapView:(MGLMapView *)mapView
 {
     if (self = [super init])
     {
         _location = [[CLLocation alloc] initWithLatitude:MAXFLOAT longitude:MAXFLOAT];
+        _mapView = mapView;
     }
 
     return self;

--- a/platform/ios/MGLUserLocationAnnotationView.h
+++ b/platform/ios/MGLUserLocationAnnotationView.h
@@ -1,17 +1,23 @@
 #import <UIKit/UIKit.h>
 #import <CoreLocation/CoreLocation.h>
 
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
 @class MGLMapView;
 @class MGLUserLocation;
 
-/** The MGLUserLocationAnnotationView class defines a specific type of annotation that identifies the user’s current location. You do not create instances of this class directly. Instead, you retrieve an existing MGLUserLocationAnnotationView object from the userLocation property of the map view displayed in your application. */
+/** View representing an MGLUserLocation on screen. */
 @interface MGLUserLocationAnnotationView : UIView
 
 @property (nonatomic, weak) MGLMapView *mapView;
 @property (nonatomic) MGLUserLocation *annotation;
-@property (nonatomic, readonly) CALayer *haloLayer;
+@property (nonatomic, readonly, nullable) CALayer *haloLayer;
 
-- (instancetype)initInMapView:(MGLMapView *)mapView;
+- (instancetype)initInMapView:(MGLMapView *)mapView NS_DESIGNATED_INITIALIZER;
 - (void)setupLayers;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/MGLUserLocationAnnotationView.m
+++ b/platform/ios/MGLUserLocationAnnotationView.m
@@ -22,17 +22,28 @@ const CGFloat MGLTrackingDotRingWidth = 24.0;
     CALayer *_dotLayer;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    NSAssert(NO, @"No containing map view specified. Call -initInMapView: instead.");
+    return self = [self init];
+}
+
 - (instancetype)initInMapView:(MGLMapView *)mapView
 {
-    if (self = [super init])
+    if (self = [super initWithFrame:CGRectMake(0, 0, MGLTrackingDotRingWidth, MGLTrackingDotRingWidth)])
     {
-        self.annotation = [[MGLUserLocation alloc] init];
-        self.annotation.mapView = mapView;
+        self.annotation = [[MGLUserLocation alloc] initWithMapView:mapView];
         _mapView = mapView;
         [self setupLayers];
         self.accessibilityLabel = @"User location";
     }
     return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)decoder
+{
+    MGLMapView *mapView = [decoder valueForKey:@"mapView"];
+    return [self initInMapView:mapView];
 }
 
 - (void)setTintColor:(UIColor *)tintColor

--- a/platform/ios/MGLUserLocation_Private.h
+++ b/platform/ios/MGLUserLocation_Private.h
@@ -1,11 +1,17 @@
 #import "MGLUserLocation.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class MGLMapView;
 
 @interface MGLUserLocation (Private)
 
 @property (nonatomic, weak) MGLMapView *mapView;
-@property (nonatomic, readwrite) CLLocation *location;
-@property (nonatomic, readwrite) CLHeading *heading;
+@property (nonatomic, readwrite, nullable) CLLocation *location;
+@property (nonatomic, readwrite, nullable) CLHeading *heading;
+
+- (instancetype)initWithMapView:(MGLMapView *)mapView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/NSBundle+MGLAdditions.h
+++ b/platform/ios/NSBundle+MGLAdditions.h
@@ -1,7 +1,11 @@
-#import <Foundation/Foundation.h>
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSBundle (MGLAdditions)
 
 + (NSString *)mgl_resourceBundlePath;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/NSString+MGLAdditions.h
+++ b/platform/ios/NSString+MGLAdditions.h
@@ -1,8 +1,12 @@
-#import <Foundation/Foundation.h>
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSString (MGLAdditions)
 
 /** Returns the receiver if non-empty or nil if empty. */
-- (NSString *)mgl_stringOrNilIfEmpty;
+- (nullable NSString *)mgl_stringOrNilIfEmpty;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/NSString+MGLAdditions.m
+++ b/platform/ios/NSString+MGLAdditions.m
@@ -2,7 +2,7 @@
 
 @implementation NSString (MGLAdditions)
 
-- (NSString *)mgl_stringOrNilIfEmpty
+- (nullable NSString *)mgl_stringOrNilIfEmpty
 {
     return self.length ? self : nil;
 }


### PR DESCRIPTION
All the headers have been audited for nullability. This is a breaking change in the sense that Swift code written against Mapbox GL will likely fail to compile. However, Xcode will offer fix-its for every error that comes up, and the resulting code will be much less stressful (less `shouting!`) and more idiomatic.

Fixes #1054.

/cc @incanus