### PR TITLE
Animate the user dot

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.  If you’d like 
 
 - Applications linking against the SDK static framework no longer need to add `-ObjC` to the Other Linker Flags (`OTHER_LDFLAGS`) build setting. If you previously added this flag solely for this SDK, removing the flag may potentially reduce the overall size of your application. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Removed the `armv7s` slice from the SDK to reduce its size. iPhone 5 and iPhone 5c automatically use the `armv7` slice instead. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
+- The user dot now moves smoothly between user location updates while user location tracking is disabled. ([#1582](https://github.com/mapbox/mapbox-gl-native/pull/1582))
 - User location heading updates now resume properly when an app becomes active again. ([#4674](https://github.com/mapbox/mapbox-gl-native/pull/4674))
 - A more specific user agent string is now sent with style and tile requests. ([#4012](https://github.com/mapbox/mapbox-gl-native/pull/4012))
 - Removed unused SVG files from the SDK’s resource bundle. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))

--- a/platform/ios/app/MBXCustomCalloutView.m
+++ b/platform/ios/app/MBXCustomCalloutView.m
@@ -40,6 +40,11 @@ static CGFloat const tipWidth = 10.0;
 
 - (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view constrainedToView:(UIView *)constrainedView animated:(BOOL)animated
 {
+    if ([self.delegate respondsToSelector:@selector(calloutViewWillAppear:)])
+    {
+        [self.delegate performSelector:@selector(calloutViewWillAppear:) withObject:self];
+    }
+    
     [view addSubview:self];
     // prepare title label
     if ([self.representedObject respondsToSelector:@selector(title)])

--- a/platform/ios/include/MGLCalloutView.h
+++ b/platform/ios/include/MGLCalloutView.h
@@ -62,6 +62,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)calloutViewTapped:(UIView<MGLCalloutView> *)calloutView;
 
+/**
+ Called before the callout view appears on screen, or before the appearance animation will start.
+ */
+- (void)calloutViewWillAppear:(UIView<MGLCalloutView> *)calloutView;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Previously, the user dot would blit across the screen, and `MGLMapView` would try to keep up but would tragically remain one step behind. With this PR, the user and `MGLMapView` waltz happily together.

- [x] Animate the user dot using UIView block-based animation
- [x] Make the user annotation callout view track the user dot
- [x] ~~Make the viewport track the user dot more smoothly~~ (split out into #3589)
- [x] ~~Keep the user dot from drifting when panning the map view with gestures~~ (more or less addressed by #3683)

Depends on #3589. Fixes #1041. Ref #1125.