### PR TITLE
Refactor iOS location authorization delegate method

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -397,11 +397,6 @@ IB_DESIGNABLE
 *   @param userLocation The location object representing the user’s latest location. This property may be `nil`. */
 - (void)mapView:(MGLMapView *)mapView didUpdateUserLocation:(MGLUserLocation *)userLocation;
 
-/** Tells the delegate that an attempt to locate the user’s position failed.
-*   @param mapView The map view that is tracking the user’s location.
-*   @param error An error object containing the reason why location tracking failed. */
-- (void)mapView:(MGLMapView *)mapView didFailToLocateUserWithError:(NSError *)error;
-
 /** Tells the delegate that location authorization status has changed.
 *
 *   When the user allows or denies use of their location, this method is called with the appropriate status. When explicitly denied, status will be set to kCLAuthorizationStatusDenied.

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -397,6 +397,11 @@ IB_DESIGNABLE
 *   @param userLocation The location object representing the user’s latest location. This property may be `nil`. */
 - (void)mapView:(MGLMapView *)mapView didUpdateUserLocation:(MGLUserLocation *)userLocation;
 
+/** Tells the delegate that an attempt to locate the user’s position failed.
+*   @param mapView The map view that is tracking the user’s location.
+*   @param error An error object containing the reason why location tracking failed. */
+- (void)mapView:(MGLMapView *)mapView didFailToLocateUserWithError:(NSError *)error;
+
 /** Tells the delegate that location authorization status has changed.
 *
 *   When the user allows or denies use of their location, this method is called with the appropriate status. When explicitly denied, status will be set to kCLAuthorizationStatusDenied.

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -402,6 +402,16 @@ IB_DESIGNABLE
 *   @param error An error object containing the reason why location tracking failed. */
 - (void)mapView:(MGLMapView *)mapView didFailToLocateUserWithError:(NSError *)error;
 
+/** Tells the delegate that location authorization status has changed.
+*
+*   When the user allows or denies use of their location, this method is called with the appropriate status. When explicitly denied, status will be set to kCLAuthorizationStatusDenied.
+*
+*   See [Apple's CoreLocation Framework Reference](https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocationManager_Class/index.html#//apple_ref/c/tdef/CLAuthorizationStatus) for other possible statuses.
+*
+*   @param mapView The map view that is tracking the user’s location.
+*   @param status A CLAuthorizationStatus constant indicating whether the app is authorized to use location services. */
+- (void)mapView:(MGLMapView *)mapView didChangeLocationAuthorizationStatus:(CLAuthorizationStatus)status;
+
 /** Tells the delegate that the map view’s user tracking mode has changed.
 *
 *   This method is called after the map view asynchronously changes to reflect the new user tracking mode, for example by beginning to zoom or rotate.

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2127,20 +2127,6 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     }
 }
 
-- (void)locationManager:(__unused CLLocationManager *)manager didFailWithError:(NSError *)error
-{
-    if ([error code] == kCLErrorDenied)
-    {
-        self.userTrackingMode  = MGLUserTrackingModeNone;
-        self.showsUserLocation = NO;
-
-        if ([self.delegate respondsToSelector:@selector(mapView:didFailToLocateUserWithError:)])
-        {
-            [self.delegate mapView:self didFailToLocateUserWithError:error];
-        }
-    }
-}
-
 - (void)updateHeadingForDeviceOrientation
 {
     if (self.locationManager)

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2127,6 +2127,21 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     }
 }
 
+- (void)locationManager:(__unused CLLocationManager *)manager didFailWithError:(NSError *)error
+{
+    // never called?
+    if ([error code] == kCLErrorDenied)
+    {
+        self.userTrackingMode  = MGLUserTrackingModeNone;
+        self.showsUserLocation = NO;
+    }
+
+    if ([self.delegate respondsToSelector:@selector(mapView:didFailToLocateUserWithError:)])
+    {
+        [self.delegate mapView:self didFailToLocateUserWithError:error];
+    }
+}
+
 - (void)updateHeadingForDeviceOrientation
 {
     if (self.locationManager)

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2120,6 +2120,11 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
         self.userTrackingMode  = MGLUserTrackingModeNone;
         self.showsUserLocation = NO;
     }
+
+    if ([self.delegate respondsToSelector:@selector(mapView:didChangeLocationAuthorizationStatus:)])
+    {
+        [self.delegate mapView:self didChangeLocationAuthorizationStatus:status];
+    }
 }
 
 - (void)locationManager:(__unused CLLocationManager *)manager didFailWithError:(NSError *)error


### PR DESCRIPTION
This pull request adds `[MGLMapView mapView:didChangeLocationAuthorizationStatus:]` as a pass-thru delegate method for `[CLLocationManager locationManager:didChangeAuthorizationStatus:]`.

This PR ~~also removes~~ `[MGLMapView mapView:didFailToLocateUserWithError:]`, because it was never being called when user location permissions changed. In my testing on iOS 7 & 8, on device and in sim, I never got this method to fire. It may still be useful for other purposes or catastrophic cases that I can't easily test for, but not for reliably indicating location permission authorization.

~~I didn't deprecate `[MGLMapView mapView:didFailToLocateUserWithError:]` — should we?~~ Update: [readded `mapView:didFailToLocateUserWithError:`](#issuecomment-103649440) for MapKit parity.

/cc @1ec5 @incanus @bleege