### PR TITLE
Compare hostname for adding events=true

### DIFF
--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -91,6 +91,7 @@ public:
 
     NSURLSession *session = nil;
     NSString *userAgent = nil;
+    NSInteger accountType = 0;
 };
 
 HTTPNSURLContext::HTTPNSURLContext(uv_loop_t *loop_) : HTTPContext(loop_) {
@@ -107,6 +108,8 @@ HTTPNSURLContext::HTTPNSURLContext(uv_loop_t *loop_) : HTTPContext(loop_) {
 
         // Write user agent string
         userAgent = @"MapboxGL";
+        
+        accountType = [[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"];
     }
 }
 
@@ -155,7 +158,7 @@ void HTTPRequest::start() {
         
         NSURL *url = [NSURL URLWithString:@(resource.url.c_str())];
         if ([url.host isEqualToString:@"mapbox.com"] || [url.host hasSuffix:@".mapbox.com"]) {
-            if ([[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"] == 0) {
+            if (context->accountType == 0) {
                 NSString *absoluteString = [url.absoluteString stringByAppendingFormat:
                                             (url.query ? @"&%@" : @"?%@"), @"events=true"];
                 url = [NSURL URLWithString:absoluteString];

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -157,12 +157,11 @@ void HTTPRequest::start() {
     @autoreleasepool {
         
         NSURL *url = [NSURL URLWithString:@(resource.url.c_str())];
-        if ([url.host isEqualToString:@"mapbox.com"] || [url.host hasSuffix:@".mapbox.com"]) {
-            if (context->accountType == 0) {
-                NSString *absoluteString = [url.absoluteString stringByAppendingFormat:
-                                            (url.query ? @"&%@" : @"?%@"), @"events=true"];
-                url = [NSURL URLWithString:absoluteString];
-            }
+        if (context->accountType == 0 &&
+            ([url.host isEqualToString:@"mapbox.com"] || [url.host hasSuffix:@".mapbox.com"])) {
+            NSString *absoluteString = [url.absoluteString stringByAppendingFormat:
+                                        (url.query ? @"&%@" : @"?%@"), @"events=true"];
+            url = [NSURL URLWithString:absoluteString];
         }
 
         NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -153,19 +153,16 @@ void HTTPRequest::start() {
 
     @autoreleasepool {
         
-        NSMutableString *url = [NSMutableString stringWithString:@(resource.url.c_str())];
-        if ([url rangeOfString:@"mapbox.com"].location != NSNotFound) {
+        NSURL *url = [NSURL URLWithString:@(resource.url.c_str())];
+        if ([url.host isEqualToString:@"mapbox.com"] || [url.host hasSuffix:@".mapbox.com"]) {
             if ([[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"] == 0) {
-                if ([url rangeOfString:@"?"].location == NSNotFound) {
-                    [url appendString:@"?"];
-                } else {
-                    [url appendString:@"&"];
-                }
-                [url appendString:@"events=true"];
+                NSString *absoluteString = [url.absoluteString stringByAppendingFormat:
+                                            (url.query ? @"&%@" : @"?%@"), @"events=true"];
+                url = [NSURL URLWithString:absoluteString];
             }
         }
 
-        NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
+        NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
         if (existingResponse) {
             if (!existingResponse->etag.empty()) {
                 [req addValue:@(existingResponse->etag.c_str()) forHTTPHeaderField:@"If-None-Match"];


### PR DESCRIPTION
If you happen to have “mapbox.com” in the URL but not in the hostname, or if your non-Mapbox server is called “mapbox.commonexamplecompany.com”, we shouldn’t append “events=true” either.

ref #1596, #1599  
cc @bleege