### PR TITLE
DefaultFileSource has responsibility for handling mapbox:// URLs

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -373,14 +373,14 @@ nativeSetAccessToken(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jstring a
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeSetAccessToken");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().setAccessToken(std_string_from_jstring(env, accessToken));
+    nativeMapView->getFileSource().setAccessToken(std_string_from_jstring(env, accessToken));
 }
 
 jstring JNICALL nativeGetAccessToken(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetAccessToken");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    return std_string_to_jstring(env, nativeMapView->getMap().getAccessToken());
+    return std_string_to_jstring(env, nativeMapView->getFileSource().getAccessToken());
 }
 
 void JNICALL nativeCancelTransitions(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -81,13 +81,13 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    HeadlessView view;
-    Map map(view, fileSource, MapMode::Still);
-
     // Set access token if present
     if (token.size()) {
-        map.setAccessToken(std::string(token));
+        fileSource.setAccessToken(std::string(token));
     }
+
+    HeadlessView view;
+    Map map(view, fileSource, MapMode::Still);
 
     map.setStyleJSON(style, ".");
     map.setClasses(classes);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -99,10 +99,6 @@ public:
     uint16_t getWidth() const;
     uint16_t getHeight() const;
 
-    // API
-    void setAccessToken(const std::string &token);
-    std::string getAccessToken() const;
-
     // Projection
     void getWorldBoundsMeters(ProjectedMeters &sw, ProjectedMeters &ne) const;
     void getWorldBoundsLatLng(LatLng &sw, LatLng &ne) const;

--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -15,6 +15,9 @@ public:
     DefaultFileSource(FileCache *cache, const std::string &root = "");
     ~DefaultFileSource() override;
 
+    void setAccessToken(const std::string& t) { accessToken = t; }
+    std::string getAccessToken() const { return accessToken; }
+
     // FileSource API
     Request* request(const Resource&, uv_loop_t*, Callback) override;
     void cancel(Request*) override;
@@ -23,6 +26,7 @@ public:
     class Impl;
 private:
     const std::unique_ptr<util::Thread<Impl>> thread;
+    std::string accessToken;
 };
 
 }

--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -9,10 +9,12 @@ namespace mbgl {
 struct Resource {
     enum Kind : uint8_t {
         Unknown = 0,
-        Tile = 1,
-        Glyphs = 2,
-        Image = 3,
-        JSON = 4,
+        Style,
+        Source,
+        Tile,
+        Glyphs,
+        JSON,
+        Image
     };
 
     const Kind kind;

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -70,6 +70,15 @@ int main(int argc, char *argv[]) {
 
     mbgl::SQLiteCache cache("/tmp/mbgl-cache.db");
     mbgl::DefaultFileSource fileSource(&cache);
+
+    // Set access token if present
+    const char *token = getenv("MAPBOX_ACCESS_TOKEN");
+    if (token == nullptr) {
+        mbgl::Log::Warning(mbgl::Event::Setup, "no access token set. mapbox.com tiles won't work.");
+    } else {
+        fileSource.setAccessToken(std::string(token));
+    }
+
     mbgl::Map map(*view, fileSource);
 
     // Load settings
@@ -91,14 +100,6 @@ int main(int argc, char *argv[]) {
 
         mbgl::Log::Info(mbgl::Event::Setup, std::string("Changed style to: ") + newStyle.first);
     });
-
-    // Set access token if present
-    const char *token = getenv("MAPBOX_ACCESS_TOKEN");
-    if (token == nullptr) {
-        mbgl::Log::Warning(mbgl::Event::Setup, "no access token set. mapbox.com tiles won't work.");
-    } else {
-        map.setAccessToken(std::string(token));
-    }
 
     // Load style
     if (style.empty()) {

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -106,6 +106,12 @@ int main() {
 
     mbgl::SQLiteCache cache(defaultCacheDatabase());
     mbgl::DefaultFileSource fileSource(&cache);
+
+    // Set access token if present
+    NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
+    if (!accessToken) mbgl::Log::Warning(mbgl::Event::Setup, "No access token set. Mapbox vector tiles won't work.");
+    if (accessToken) fileSource.setAccessToken([accessToken cStringUsingEncoding:[NSString defaultCStringEncoding]]);
+
     mbgl::Map map(view, fileSource);
 
     URLHandler *handler = [[URLHandler alloc] init];
@@ -139,11 +145,6 @@ int main() {
 
         mbgl::Log::Info(mbgl::Event::Setup, std::string("Changed style to: ") + newStyle.first);
     });
-
-    // Set access token if present
-    NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
-    if (!accessToken) mbgl::Log::Warning(mbgl::Event::Setup, "No access token set. Mapbox vector tiles won't work.");
-    if (accessToken) map.setAccessToken([accessToken cStringUsingEncoding:[NSString defaultCStringEncoding]]);
 
     // Load style
     const auto& newStyle = mbgl::util::defaultStyles.front();

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1303,7 +1303,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     if ([keyPath isEqualToString:@"accessToken"] && object == [MGLAccountManager sharedManager])
     {
         NSString *accessToken = change[NSKeyValueChangeNewKey];
-        _mbglMap->setAccessToken(accessToken ? (std::string)[accessToken UTF8String] : "");
+        _mbglFileSource->setAccessToken(accessToken ? (std::string)[accessToken UTF8String] : "");
     }
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -195,17 +195,6 @@ void Map::resetNorth() {
 }
 
 
-#pragma mark - Access Token
-
-void Map::setAccessToken(const std::string &token) {
-    data->setAccessToken(token);
-}
-
-std::string Map::getAccessToken() const {
-    return data->getAccessToken();
-}
-
-
 #pragma mark - Projection
 
 void Map::getWorldBoundsMeters(ProjectedMeters& sw, ProjectedMeters& ne) const {

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -27,15 +27,6 @@ public:
         setDefaultTransitionDuration(Duration::zero());
     }
 
-    inline std::string getAccessToken() const {
-        Lock lock(mtx);
-        return accessToken;
-    }
-    inline void setAccessToken(const std::string &token) {
-        Lock lock(mtx);
-        accessToken = token;
-    }
-
     // Adds the class if it's not yet set. Returns true when it added the class, and false when it
     // was already present.
     bool addClass(const std::string& klass);
@@ -95,7 +86,6 @@ public:
 private:
     mutable std::mutex mtx;
 
-    std::string accessToken;
     std::vector<std::string> classes;
     std::atomic<uint8_t> debug { false };
     std::atomic<bool> loaded { false };

--- a/src/mbgl/map/resource_loader.cpp
+++ b/src/mbgl/map/resource_loader.cpp
@@ -45,7 +45,7 @@ void ResourceLoader::setStyle(Style* style) {
 
     for (const auto& source : style->sources) {
         source->setObserver(this);
-        source->load(accessToken_);
+        source->load();
     }
 }
 
@@ -58,11 +58,6 @@ void ResourceLoader::setGlyphStore(GlyphStore* glyphStore) {
 
     glyphStore_ = glyphStore;
     glyphStore_->setObserver(this);
-}
-
-
-void ResourceLoader::setAccessToken(const std::string& accessToken) {
-    accessToken_ = accessToken;
 }
 
 void ResourceLoader::update(MapData& data,

--- a/src/mbgl/map/resource_loader.hpp
+++ b/src/mbgl/map/resource_loader.hpp
@@ -49,9 +49,6 @@ public:
     // style.
     void setGlyphStore(GlyphStore* glyphStore);
 
-    // Set the access token to be used for loading the tile data.
-    void setAccessToken(const std::string& accessToken);
-
     // Fetch the tiles needed by the current viewport and emit a signal when
     // a tile is ready so observers can render the tile.
     void update(MapData&, const TransformState&, GlyphAtlas&, SpriteAtlas&, TexturePool&);
@@ -81,7 +78,6 @@ private:
 
     bool shouldReparsePartialTiles_ = false;
 
-    std::string accessToken_;
     util::ptr<Sprite> sprite_;
 
     GlyphStore* glyphStore_ = nullptr;

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -140,14 +140,13 @@ bool Source::isLoaded() const {
 // Note: This is a separate function that must be called exactly once after creation
 // The reason this isn't part of the constructor is that calling shared_from_this() in
 // the constructor fails.
-void Source::load(const std::string& accessToken) {
+void Source::load() {
     if (info.url.empty()) {
         loaded = true;
         return;
     }
 
-    const std::string url = util::mapbox::normalizeSourceURL(info.url, accessToken);
-    req = Environment::Get().request({ Resource::Kind::JSON, url }, [this](const Response &res) {
+    req = Environment::Get().request({ Resource::Kind::Source, info.url }, [this](const Response &res) {
         req = nullptr;
 
         if (res.status != Response::Successful) {

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -67,7 +67,7 @@ public:
     Source();
     ~Source();
 
-    void load(const std::string& accessToken);
+    void load();
     bool isLoaded() const;
 
     void load(MapData&, Environment&, std::function<void()> callback);

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -5,11 +5,12 @@
 
 #include <mbgl/storage/response.hpp>
 #include <mbgl/platform/platform.hpp>
+#include <mbgl/platform/log.hpp>
 
 #include <mbgl/util/uv_detail.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/thread.hpp>
-#include <mbgl/platform/log.hpp>
+#include <mbgl/util/mapbox.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -38,7 +39,27 @@ Request* DefaultFileSource::request(const Resource& resource,
                                     uv_loop_t* l,
                                     Callback callback) {
     assert(l);
-    auto req = new Request(resource, l, std::move(callback));
+
+    std::string url;
+
+    switch (resource.kind) {
+    case Resource::Kind::Style:
+        url = mbgl::util::mapbox::normalizeStyleURL(resource.url, accessToken);
+        break;
+
+    case Resource::Kind::Source:
+        url = util::mapbox::normalizeSourceURL(resource.url, accessToken);
+        break;
+
+    case Resource::Kind::Glyphs:
+        url = util::mapbox::normalizeGlyphsURL(resource.url, accessToken);
+        break;
+
+    default:
+        url = resource.url;
+    }
+
+    auto req = new Request({ resource.kind, url }, l, std::move(callback));
     thread->invoke(&Impl::add, req);
     return req;
 }


### PR DESCRIPTION
This moves `Map::setAccessToken` to `DefaultFileSource::setAccessToken` and passes `mapbox://` URLs through the `FileSource` interface. No change to the iOS or Android SDK public API. The node bindings will need the following changes (cc @mikemorris):

* [New values for `kind` enum](https://github.com/mapbox/mapbox-gl-native/blob/f9753043decc82733a0eb4b25a246b536b0f09ba/include/mbgl/storage/resource.hpp#L10-18).
* `FileSource` implementations need to handle `mapbox://` URLs.
* Remove `setAccessToken` from `Map` interface. node-mapbox-gl-native itself no longer needs to concern itself with access tokens. This is a task for `FileSource` implementations now.

Before merging this I'm planning to make another change to the interface, removing the `kind` enum in favor of specific `FileSource` methods like `requestStyle`, `requestTile`, etc.