### PR TITLE
Remove redundant didChangeAuthorizationStatus: in favor of didFailWithError:

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2113,15 +2113,6 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
     }
 }
 
-- (void)locationManager:(__unused CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status
-{
-    if (status == kCLAuthorizationStatusDenied || status == kCLAuthorizationStatusRestricted)
-    {
-        self.userTrackingMode  = MGLUserTrackingModeNone;
-        self.showsUserLocation = NO;
-    }
-}
-
 - (void)locationManager:(__unused CLLocationManager *)manager didFailWithError:(NSError *)error
 {
     if ([error code] == kCLErrorDenied)


### PR DESCRIPTION
This PR removes `locationManager:didChangeAuthorizationStatus:` in favor of `locationManager:didFailWithError:` for turning off the map's location features and for notifying the developer of location permission changes.

[Setting `showsUserLocation = NO` in `locationManager:didChangeAuthorizationStatus:`](https://github.com/mapbox/mapbox-gl-native/blob/51618c35d79cfb237e62e70993182e87903c3ccd/platform/ios/MGLMapView.mm#L2121) would turn off the location manager, which meant that the subsequent call to `locationManager:didFailWithError:` would never happen, nor would the call to our  `mapView:didFailToLocateUserWithError:` delegate method.

Supercedes #1598.

/cc @incanus @1ec5 @bleege 