### PR TITLE
Update iOS tests for access token changes

### DIFF
--- a/test/ios/App-Info.plist
+++ b/test/ios/App-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>MGLMapboxAccessToken</key>
+	<string>pk.eyJ1IjoianVzdGluIiwiYSI6Ik9RX3RRQzAifQ.dmOg_BAp1ywuDZMM7YsXRg</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -34,6 +36,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/test/ios/MGLTAppDelegate.m
+++ b/test/ios/MGLTAppDelegate.m
@@ -13,8 +13,6 @@
     wrapper.toolbarHidden = YES;
     [self.window makeKeyAndVisible];
 
-    [MGLAccountManager setMapboxMetricsEnabledSettingShownInApp:YES]; // a lie, but a convenient one
-
     return YES;
 }
 

--- a/test/ios/MGLTViewController.m
+++ b/test/ios/MGLTViewController.m
@@ -10,8 +10,7 @@
 {
     [super viewDidLoad];
 
-    _mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds
-                                                accessToken:@"pk.eyJ1IjoianVzdGluIiwiYSI6Ik9RX3RRQzAifQ.dmOg_BAp1ywuDZMM7YsXRg"];
+    _mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     _mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
     [self.view addSubview:_mapView];

--- a/test/ios/MetricsTests.m
+++ b/test/ios/MetricsTests.m
@@ -60,12 +60,6 @@
     XCTAssertEqualObjects([[MGLMapboxEvents sharedManager] appBundleId], @"com.mapbox.Mapbox-GL-Tests");
 }
 
-- (void)testTokenSetViaMapView {
-    [tester.mapView setAccessToken:@"test_token"];
-
-    XCTAssertEqualObjects([[MGLMapboxEvents sharedManager] token], @"test_token");
-}
-
 - (void)testResumeMetricsCollection {
     [MGLMapboxEvents resumeMetricsCollection];
 


### PR DESCRIPTION
Updates the iOS testing apparatus to work with the access token changes introduced in #1553.

Moves the access token setting to `App-Info.plist`.

Also sets `MGLMapboxMetricsEnabledSettingShownInApp` in `App-Info.plist`.

/cc @incanus @1ec5 @bleege