### PR TITLE
Fixed account type setting; reworded IB designable message

### DIFF
--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -8,7 +8,6 @@
 // inspectables declared in MGLMapView.h are always sorted before those in
 // MGLMapView+IBAdditions.h, due to ASCII sort order.
 
-@property (nonatomic) IBInspectable NSString *accessToken;
 @property (nonatomic) IBInspectable NSString *mapID;
 
 // Convenience properties related to the initial viewport. These properties

--- a/platform/ios/MGLAccountManager.m
+++ b/platform/ios/MGLAccountManager.m
@@ -15,13 +15,15 @@
 @implementation MGLAccountManager
 
 + (void)load {
-    // Read initial configuration from Info.plist.
-    NSBundle *bundle = [NSBundle bundleForClass:self];
-    self.accessToken = [bundle objectForInfoDictionaryKey:@"MGLMapboxAccessToken"];
+    // Read the initial configuration from Info.plist. The shown-in-app setting
+    // preempts the Settings bundle check in -[MGLMapboxEvents init] triggered
+    // by setting the access token.
+    NSBundle *bundle = [NSBundle mainBundle];
     NSNumber *shownInAppNumber = [bundle objectForInfoDictionaryKey:@"MGLMapboxMetricsEnabledSettingShownInApp"];
     if (shownInAppNumber) {
         [MGLAccountManager sharedManager].mapboxMetricsEnabledSettingShownInApp = [shownInAppNumber boolValue];
     }
+    self.accessToken = [bundle objectForInfoDictionaryKey:@"MGLMapboxAccessToken"];
 }
 
 // Can be called from any thread.

--- a/platform/ios/MGLAccountManager.m
+++ b/platform/ios/MGLAccountManager.m
@@ -50,10 +50,6 @@
     return _sharedManager;
 }
 
-+ (void) setMapboxMetricsEnabledSettingShownInApp:(BOOL)shown {
-    [MGLAccountManager sharedManager].mapboxMetricsEnabledSettingShownInApp = shown;
-}
-
 + (BOOL) mapboxMetricsEnabledSettingShownInApp {
     return [MGLAccountManager sharedManager].mapboxMetricsEnabledSettingShownInApp;
 }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -36,7 +36,7 @@ class MBGLView;
 NSString *const MGLDefaultStyleName = @"mapbox-streets";
 NSString *const MGLStyleVersion = @"7";
 NSString *const MGLDefaultStyleMarkerSymbolName = @"default_marker";
-NSString *const MGLMapboxAccessTokenManagerURLDisplayString = @"mapbox.com/account/apps";
+NSString *const MGLMapboxSetupDocumentationURLDisplayString = @"mapbox.com/guides/first-steps-gl-ios";
 
 const NSTimeInterval MGLAnimationDuration = 0.3;
 const CGSize MGLAnnotationUpdateViewportOutset = {150, 150};
@@ -2473,129 +2473,106 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 {
     [super prepareForInterfaceBuilder];
 
-    self.layer.borderColor = [UIColor colorWithWhite:184/255. alpha:1].CGColor;
-    self.layer.borderWidth = 1;
+    self.layer.borderColor = [UIColor colorWithRed:59/255.
+                                             green:178/255.
+                                              blue:208/255.
+                                             alpha:0.8].CGColor;
+    self.layer.borderWidth = 4;
+    self.layer.backgroundColor = [UIColor whiteColor].CGColor;
 
-    if ([MGLAccountManager accessToken])
-    {
-        self.layer.backgroundColor = [UIColor colorWithRed:59/255.
-                                                     green:178/255.
-                                                      blue:208/255.
-                                                     alpha:0.8].CGColor;
+    UIView *diagnosticView = [[UIView alloc] init];
+    diagnosticView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:diagnosticView];
 
-        UIImage *image = [[self class] resourceImageNamed:@"mapbox.png"];
-        UIImageView *previewView = [[UIImageView alloc] initWithImage:image];
-        previewView.translatesAutoresizingMaskIntoConstraints = NO;
-        [self addSubview:previewView];
-        [self addConstraint:
-         [NSLayoutConstraint constraintWithItem:previewView
-                                      attribute:NSLayoutAttributeCenterXWithinMargins
-                                      relatedBy:NSLayoutRelationEqual
-                                         toItem:self
-                                      attribute:NSLayoutAttributeCenterXWithinMargins
-                                     multiplier:1
-                                       constant:0]];
-        [self addConstraint:
-         [NSLayoutConstraint constraintWithItem:previewView
-                                      attribute:NSLayoutAttributeCenterYWithinMargins
-                                      relatedBy:NSLayoutRelationEqual
-                                         toItem:self
-                                      attribute:NSLayoutAttributeCenterYWithinMargins
-                                     multiplier:1
-                                       constant:0]];
-    }
-    else
-    {
-        UIView *diagnosticView = [[UIView alloc] init];
-        diagnosticView.translatesAutoresizingMaskIntoConstraints = NO;
-        [self addSubview:diagnosticView];
+    // Headline
+    UILabel *headlineLabel = [[UILabel alloc] init];
+    headlineLabel.text = @"MGLMapView";
+    headlineLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    headlineLabel.textAlignment = NSTextAlignmentCenter;
+    headlineLabel.numberOfLines = 1;
+    headlineLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [headlineLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
+                                                   forAxis:UILayoutConstraintAxisHorizontal];
+    [diagnosticView addSubview:headlineLabel];
 
-        // Headline
-        UILabel *headlineLabel = [[UILabel alloc] init];
-        headlineLabel.text = @"No Access Token";
-        headlineLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
-        headlineLabel.textAlignment = NSTextAlignmentCenter;
-        headlineLabel.numberOfLines = 1;
-        headlineLabel.translatesAutoresizingMaskIntoConstraints = NO;
-        [headlineLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
-                                                       forAxis:UILayoutConstraintAxisHorizontal];
-        [diagnosticView addSubview:headlineLabel];
+    // Explanation
+    UILabel *explanationLabel = [[UILabel alloc] init];
+    explanationLabel.text = (@"To display a Mapbox-hosted map here:\n\n"
+                             @"1. Set MGLMapboxAccessToken to your access token in Info.plist\n"
+                             @"2. Add a Settings bundle that allows the user to turn Mapbox Metrics on and off\n\n"
+                             @"For detailed instructions, see:");
+    explanationLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    explanationLabel.numberOfLines = 0;
+    explanationLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [explanationLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
+                                                      forAxis:UILayoutConstraintAxisHorizontal];
+    [diagnosticView addSubview:explanationLabel];
 
-        // Explanation
-        UILabel *explanationLabel = [[UILabel alloc] init];
-        explanationLabel.text = @"To display a Mapbox-hosted map here, you must provide an access token. Get an access token from:";
-        explanationLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-        explanationLabel.numberOfLines = 0;
-        explanationLabel.translatesAutoresizingMaskIntoConstraints = NO;
-        [explanationLabel setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
-                                                          forAxis:UILayoutConstraintAxisHorizontal];
-        [diagnosticView addSubview:explanationLabel];
+    // Link
+    UIButton *linkButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [linkButton setTitle:MGLMapboxSetupDocumentationURLDisplayString forState:UIControlStateNormal];
+    linkButton.translatesAutoresizingMaskIntoConstraints = NO;
+    linkButton.titleLabel.numberOfLines = 0;
+    [linkButton setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
+                                                forAxis:UILayoutConstraintAxisHorizontal];
+    [diagnosticView addSubview:linkButton];
 
-        // Link
-        UIButton *linkButton = [UIButton buttonWithType:UIButtonTypeSystem];
-        [linkButton setTitle:MGLMapboxAccessTokenManagerURLDisplayString forState:UIControlStateNormal];
-        linkButton.translatesAutoresizingMaskIntoConstraints = NO;
-        [linkButton setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
-                                                    forAxis:UILayoutConstraintAxisHorizontal];
-        [diagnosticView addSubview:linkButton];
-
-        // More explanation
-        UILabel *explanationLabel2 = [[UILabel alloc] init];
-        explanationLabel2.text = @"and set it as the value of MGLMapboxAccessToken in the Info.plist file.";
-        explanationLabel2.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-        explanationLabel2.numberOfLines = 0;
-        explanationLabel2.translatesAutoresizingMaskIntoConstraints = NO;
-        [explanationLabel2 setContentCompressionResistancePriority:UILayoutPriorityDefaultLow
-                                                           forAxis:UILayoutConstraintAxisHorizontal];
-        [diagnosticView addSubview:explanationLabel2];
-
-        // Constraints
-        NSDictionary *views = @{
-            @"container": diagnosticView,
-            @"headline": headlineLabel,
-            @"explanation": explanationLabel,
-            @"link": linkButton,
-            @"explanation2": explanationLabel2,
-        };
-        [self addConstraint:
-         [NSLayoutConstraint constraintWithItem:diagnosticView
-                                      attribute:NSLayoutAttributeCenterYWithinMargins
-                                      relatedBy:NSLayoutRelationEqual
-                                         toItem:self
-                                      attribute:NSLayoutAttributeCenterYWithinMargins
-                                     multiplier:1
-                                       constant:0]];
-        [self addConstraints:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[container(20@20)]-|"
-                                                 options:NSLayoutFormatAlignAllCenterY
-                                                 metrics:nil
-                                                   views:views]];
-        [self addConstraints:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[headline]-[explanation]-[link]-[explanation2]|"
-                                                 options:0
-                                                 metrics:nil
-                                                   views:views]];
-        [self addConstraints:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[headline]|"
-                                                 options:0
-                                                 metrics:nil
-                                                   views:views]];
-        [self addConstraints:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[explanation]|"
-                                                 options:0
-                                                 metrics:nil
-                                                   views:views]];
-        [self addConstraints:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[link]|"
-                                                 options:0
-                                                 metrics:nil
-                                                   views:views]];
-        [self addConstraints:
-         [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[explanation2]|"
-                                                 options:0
-                                                 metrics:nil
-                                                   views:views]];
-    }
+    // Constraints
+    NSDictionary *views = @{
+        @"container": diagnosticView,
+        @"headline": headlineLabel,
+        @"explanation": explanationLabel,
+        @"link": linkButton,
+    };
+    [self addConstraint:
+     [NSLayoutConstraint constraintWithItem:diagnosticView
+                                  attribute:NSLayoutAttributeCenterYWithinMargins
+                                  relatedBy:NSLayoutRelationEqual
+                                     toItem:self
+                                  attribute:NSLayoutAttributeCenterYWithinMargins
+                                 multiplier:1
+                                   constant:0]];
+    [self addConstraint:
+     [NSLayoutConstraint constraintWithItem:diagnosticView
+                                  attribute:NSLayoutAttributeTopMargin
+                                  relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                     toItem:self
+                                  attribute:NSLayoutAttributeTopMargin
+                                 multiplier:1
+                                   constant:8]];
+    [self addConstraint:
+     [NSLayoutConstraint constraintWithItem:self
+                                  attribute:NSLayoutAttributeBottomMargin
+                                  relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                     toItem:diagnosticView
+                                  attribute:NSLayoutAttributeBottomMargin
+                                 multiplier:1
+                                   constant:8]];
+    [self addConstraints:
+     [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[container(20@20)]-|"
+                                             options:NSLayoutFormatAlignAllCenterY
+                                             metrics:nil
+                                               views:views]];
+    [self addConstraints:
+     [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[headline]-[explanation]-[link]|"
+                                             options:0
+                                             metrics:nil
+                                               views:views]];
+    [self addConstraints:
+     [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[headline]|"
+                                             options:0
+                                             metrics:nil
+                                               views:views]];
+    [self addConstraints:
+     [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[explanation]|"
+                                             options:0
+                                             metrics:nil
+                                               views:views]];
+    [self addConstraints:
+     [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[link]|"
+                                             options:0
+                                             metrics:nil
+                                               views:views]];
 }
 
 class MBGLView : public mbgl::View

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2523,7 +2523,7 @@ CLLocationCoordinate2D latLngToCoordinate(mbgl::LatLng latLng)
 
         // Explanation
         UILabel *explanationLabel = [[UILabel alloc] init];
-        explanationLabel.text = @"To display a map here, you must provide a Mapbox access token. Get an access token from:";
+        explanationLabel.text = @"To display a Mapbox-hosted map here, you must provide an access token. Get an access token from:";
         explanationLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
         explanationLabel.numberOfLines = 0;
         explanationLabel.translatesAutoresizingMaskIntoConstraints = NO;

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -177,7 +177,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 
 + (void)initialize {
     if (self == [MGLMapboxEvents class]) {
-        NSBundle *bundle = [NSBundle bundleForClass:self];
+        NSBundle *bundle = [NSBundle mainBundle];
         NSNumber *accountTypeNumber = [bundle objectForInfoDictionaryKey:@"MGLMapboxAccountType"];
         [[NSUserDefaults standardUserDefaults] registerDefaults:@{
              @"MGLMapboxAccountType": accountTypeNumber ? accountTypeNumber : @0,
@@ -198,7 +198,8 @@ const NSTimeInterval MGLFlushInterval = 60;
 
     self = [super init];
     if (self) {
-        if (! [MGLAccountManager mapboxMetricsEnabledSettingShownInApp]) {
+        if (! [MGLAccountManager mapboxMetricsEnabledSettingShownInApp] &&
+            [[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"] == 0) {
             // Opt Out is not configured in UI, so check for Settings.bundle
             // Put Settings bundle into memory
             id defaultEnabledValue;


### PR DESCRIPTION
This PR fixes some regressions from #1553, as well as some bugs that’ve been lingering for longer:

* We need to look in the host app’s Info.plist, not MapboxGL.framework’s.
* Currently, if you set `MGLMapboxMetricsEnabledSettingShownInApp = YES` in Info.plist, you still get the assertion failure in `-[MGLMapboxEvents init]` because the access token is read in first, causing the shared `MGLMapboxEvents` to be created. This change rearranges the order that the settings are read in, since one is dependent on the other.
* Interface Builder was still showing an “Access Token” inspectable, which would’ve led to an assertion failure if set.
* The IB designable message is only relevant to developers displaying Mapbox-hosted maps, so the message should reflect that scope.
* The IB designable message can’t detect whether the access token is set in Info.plist, and it can’t detect whether a Settings bundle has been added. So I nixed the “A-OK” Mapbox blue designable screen – we just show steps to get started no matter what and point to the “[First steps with Mapbox GL for iOS](https://www.mapbox.com/guides/first-steps-gl-ios/)” guide.

Fixes #1613.