### PR TITLE
Adapt iOS metrics tests to constant flush timer

### DIFF
--- a/test/ios/ios-tests.xcodeproj/xcshareddata/xcschemes/Mapbox GL Tests.xcscheme
+++ b/test/ios/ios-tests.xcodeproj/xcshareddata/xcschemes/Mapbox GL Tests.xcscheme
@@ -55,6 +55,15 @@
                <Test
                   Identifier = "MapViewTests/testDelegateRegionWillChange">
                </Test>
+               <Test
+                  Identifier = "MetricsTests/testFlushPostsEvents">
+               </Test>
+               <Test
+                  Identifier = "MetricsTests/testPostEventsNetworkRequest">
+               </Test>
+               <Test
+                  Identifier = "MetricsTests/testTimerFiresFlush">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>


### PR DESCRIPTION
Fixes iOS `MetricsTests` to run again and pass after the changes to the flush timing outlined in #1616.

Disables three tests:

- `testTimerFiresFlush`: **passes** but takes 60 seconds (full `MGLFlushInterval`)
- `testFlushPostsEvents`: **fails**, but passes individually
- `testPostEventsNetworkRequest`: **fails**, but passes individually

`testFlushPostsEvents` and `testPostEventsNetworkRequest` seem to be failing when run with the group because of contention for the `MGLMapboxEvents` singleton. I'm not sure if this has to do with `OCMock` or @1ec5's recent refactoring — maybe you could look at this, @incanus?

I also didn't see a way to bring in the new `MGLMaximumEventsPerFlush` and `MGLFlushInterval` constants, so they've been unceremoniously copy-pasted.

/cc @bleege