### PR TITLE
Do not call abandonTexture() if there is no texture

### DIFF
--- a/src/mbgl/geometry/sprite_atlas.cpp
+++ b/src/mbgl/geometry/sprite_atlas.cpp
@@ -299,6 +299,8 @@ void SpriteAtlas::bind(bool linear) {
 
 SpriteAtlas::~SpriteAtlas() {
     std::lock_guard<std::recursive_mutex> lock(mtx);
-    Environment::Get().abandonTexture(texture);
-    texture = 0;
+    if (texture) {
+        Environment::Get().abandonTexture(texture);
+        texture = 0;
+    }
 }

--- a/test/resources/resource_loader.cpp
+++ b/test/resources/resource_loader.cpp
@@ -59,8 +59,6 @@ public:
         spriteAtlas_.reset();
         glyphAtlas_.reset();
         glyphStore_.reset();
-
-        env_.performCleanup();
     }
 
     void update() {


### PR DESCRIPTION
Check if the texture was created before abandoning on SpriteAtlas
destructor. Linux driver was fine with that, but was crashing on Mac.