### PR TITLE
Thread-safety for http_request_nsurl.mm

### DIFF
--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -9,6 +9,12 @@ class Response {
 public:
     enum Status : bool { Error, Successful };
 
+    Response() = default;
+    Response(Status status_, std::string message_)
+        : status(status_),
+          message(message_) {
+    }
+
     Status status = Error;
     std::string message;
     int64_t modified = 0;


### PR DESCRIPTION
Don't access the response pointer from two threads, perhaps simultaneously.

`HTTPRequest::completionHandler`, a static method (so that it has no access to member variables), takes the place of `HTTPRequest::handleResult`. The result is transferred to the FileSource thread via a promise.

This is a speculative fix for the occasional `HTTPRequest::handleResult` crashes we've seen.

CC @kkaefer @1ec5 for review.