### PR TITLE
Add location tests for iOS

### DIFF
--- a/test/ios/App-Info.plist
+++ b/test/ios/App-Info.plist
@@ -40,6 +40,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Strictly for testing purposes, promise!</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/test/ios/LocationMocker/CLLocationManager+MockLocation.h
+++ b/test/ios/LocationMocker/CLLocationManager+MockLocation.h
@@ -1,0 +1,39 @@
+//
+// Based on gist by Eric Allam
+// https://gist.github.com/ericallam/5689235
+//
+
+#import <CoreLocation/CoreLocation.h>
+
+@interface CLLocationManager (MockLocation)
+
+- (void)custom_startUpdatingLocation;
+- (CLLocation *)custom_location;
+
+- (void)custom_startUpdatingHeading;
+- (CLHeading *)custom_heading;
++ (BOOL)custom_headingAvailable;
+
+@end
+
+// private setter struct for CLHeading
+typedef struct {
+    double x;
+    double y;
+    double z;
+    double magneticHeading;
+    double trueHeading;
+    double accuracy;
+    double timestamp;
+    double temperature;
+    double magnitude;
+    double inclination;
+    int calibration;
+} CLHeadingStruct;
+
+// create reference to private API method
+@interface CLHeading ()
+
+- (id)initWithClientHeading:(CLHeadingStruct)heading;
+
+@end

--- a/test/ios/LocationMocker/CLLocationManager+MockLocation.m
+++ b/test/ios/LocationMocker/CLLocationManager+MockLocation.m
@@ -1,0 +1,81 @@
+//
+// Based on gist by Eric Allam
+// https://gist.github.com/ericallam/5689235
+//
+
+#import "CLLocationManager+MockLocation.h"
+#import "LocationMocker.h"
+
+// This category implements methods that will be swizzled to replace key methods
+// in CLLocationManager to mock out the user location.
+@implementation CLLocationManager (MockLocation)
+
+// Replaces startUpdatingLocation, will send the locationManager:didUpdateLocations: message
+// to the delegate after a wait of 0.1 seconds using dispatch_after to simulate how 
+// startUpdatingLocation actually works. This will not simulate any kind of location errors.
+- (void)custom_startUpdatingLocation
+{
+    if (self.delegate)
+    {
+        if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateLocations:)])
+        {
+            // delay the locationManager:didUpdateLocations: message 0.1 seconds
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                NSArray *locations = @[self.location];
+                [self.delegate locationManager:self didUpdateLocations:locations];
+            });
+        }
+        
+        if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateToLocation:fromLocation:)])
+        {
+            // delay the locationManager:didUpdateToLocation:fromLocation: message 0.1 seconds
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                #pragma clang diagnostic push
+                #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                [self.delegate locationManager:self didUpdateToLocation:self.location fromLocation:nil];
+                #pragma clang diagnostic pop
+            });
+        }
+    }
+}
+
+// Replaces location, returns the mocked CLLocation object
+- (CLLocation *)custom_location;
+{
+    return [[CLLocation alloc] initWithLatitude:kMockedLatitude longitude:kMockedLongitude];
+}
+
+
+// Replaces startUpdatingHeading, sends locationManager:didUpdateHeading:
+- (void)custom_startUpdatingHeading
+{
+    if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateHeading:)])
+    {
+        // delay the locationManager:didUpdateHeading: message 0.1 seconds
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            [self.delegate locationManager:self didUpdateHeading:self.heading];
+        });
+    }
+}
+
+// Replaces heading, returns the mocked CLHeading object
+- (CLHeading *)custom_heading;
+{
+    CLHeadingStruct heading;
+    heading.accuracy = kMockedHeadingAccuracy;
+    heading.trueHeading = kMockedHeadingTrueHeading;
+    heading.magneticHeading = kMockedHeadingMagneticHeading;
+    heading.x = kMockedHeadingX;
+    heading.y = kMockedHeadingY;
+    heading.z = kMockedHeadingZ;
+    
+    return [[CLHeading alloc] initWithClientHeading:heading];
+}
+
++ (BOOL)custom_headingAvailable
+{
+    return YES;
+}
+
+@end
+

--- a/test/ios/LocationMocker/CSSwizzler.h
+++ b/test/ios/LocationMocker/CSSwizzler.h
@@ -1,0 +1,22 @@
+//
+// Based on gist by Eric Allam
+// https://gist.github.com/ericallam/5689235
+//
+
+#import <Foundation/Foundation.h>
+
+@interface CSSwizzler : NSObject
+
++ (void)swizzleClass:(id)cls
+  replaceClassMethod:(SEL)origMethodSelector
+          withMethod:(SEL)replacementMethodSelector;
+
++ (void)swizzleClass:(id)cls
+       replaceMethod:(SEL)origMethodSelector
+          withMethod:(SEL)replacementMethodSelector;
+
++ (void)swizzleClassOfInstance:(id)inst
+                 replaceMethod:(SEL)origMethodSelector
+                    withMethod:(SEL)replacementMethodSelector;
+
+@end

--- a/test/ios/LocationMocker/CSSwizzler.m
+++ b/test/ios/LocationMocker/CSSwizzler.m
@@ -1,0 +1,44 @@
+//
+// Based on gist by Eric Allam
+// https://gist.github.com/ericallam/5689235
+//
+
+#import "CSSwizzler.h"
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+@implementation CSSwizzler
+
++ (void)swizzleClass:(id)cls
+ replaceClassMethod:(SEL)origMethodSelector
+         withMethod:(SEL)replacementMethodSelector;
+{
+    Method origMethod = nil, altMethod = nil;
+    origMethod = class_getClassMethod(cls, origMethodSelector);
+    altMethod = class_getClassMethod(cls, replacementMethodSelector);
+    method_exchangeImplementations(origMethod, altMethod);
+}
+
++ (void)swizzleClass:(id)cls
+      replaceMethod:(SEL)origMethodSelector
+         withMethod:(SEL)replacementMethodSelector;
+{
+    Method origMethod = nil, altMethod = nil;
+    origMethod = class_getInstanceMethod(cls, origMethodSelector);
+    altMethod = class_getInstanceMethod(cls, replacementMethodSelector);
+    method_exchangeImplementations(origMethod, altMethod);
+}
+
++ (void)swizzleClassOfInstance:(id)inst
+                replaceMethod:(SEL)origMethodSelector
+                   withMethod:(SEL)replacementMethodSelector;
+{
+    const char *str = [[[inst class] description] UTF8String];
+    Class cls = objc_getClass(str);
+    Method origMethod = nil, altMethod = nil;
+    origMethod = class_getInstanceMethod(cls, origMethodSelector);
+    altMethod = class_getInstanceMethod(cls, replacementMethodSelector);
+    method_exchangeImplementations(origMethod, altMethod);
+}
+
+@end

--- a/test/ios/LocationMocker/LocationMocker.h
+++ b/test/ios/LocationMocker/LocationMocker.h
@@ -1,0 +1,25 @@
+//
+// Based on gist by Eric Allam
+// https://gist.github.com/ericallam/5689235
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
+
+// lat and long of the mocked current location (Mapbox San Francisco)
+static const CLLocationDegrees kMockedLatitude = 37.775716;
+static const CLLocationDegrees kMockedLongitude = -122.413688;
+
+// heading (values pulled from south-facing device)
+static const double kMockedHeadingAccuracy = 20.0;
+static const double kMockedHeadingTrueHeading = 170.53;
+static const double kMockedHeadingMagneticHeading = 154.83;
+static const double kMockedHeadingX = -7.079;
+static const double kMockedHeadingY = -16.548;
+static const double kMockedHeadingZ = -44.194;
+
+@interface LocationMocker : NSObject
+
++ (void)load;
+
+@end

--- a/test/ios/LocationMocker/LocationMocker.m
+++ b/test/ios/LocationMocker/LocationMocker.m
@@ -1,0 +1,35 @@
+//
+// Based on gist by Eric Allam
+// https://gist.github.com/ericallam/5689235
+//
+
+#import "LocationMocker.h"
+#import "CSSwizzler.h"
+#import "CLLocationManager+MockLocation.h"
+
+@implementation LocationMocker
+
++ (void)load
+{
+    [CSSwizzler swizzleClass:[CLLocationManager class]
+               replaceMethod:@selector(startUpdatingLocation)
+                  withMethod:@selector(custom_startUpdatingLocation)];
+    
+    [CSSwizzler swizzleClass:[CLLocationManager class]
+               replaceMethod:@selector(location)
+                  withMethod:@selector(custom_location)];
+    
+    [CSSwizzler swizzleClass:[CLLocationManager class]
+               replaceMethod:@selector(startUpdatingHeading)
+                  withMethod:@selector(custom_startUpdatingHeading)];
+    
+    [CSSwizzler swizzleClass:[CLLocationManager class]
+               replaceMethod:@selector(heading)
+                  withMethod:@selector(custom_heading)];
+    
+    [CSSwizzler swizzleClass:[CLLocationManager class]
+          replaceClassMethod:@selector(headingAvailable)
+                  withMethod:@selector(custom_headingAvailable)];
+}
+
+@end

--- a/test/ios/ios-tests.xcodeproj/project.pbxproj
+++ b/test/ios/ios-tests.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		96567A231B0E84CD00D78776 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 96567A221B0E84CD00D78776 /* LaunchScreen.xib */; };
 		96567A311B0E8BB900D78776 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 96567A301B0E8BB900D78776 /* Images.xcassets */; };
+		96992E581B0FBB6F008978C0 /* CSSwizzler.m in Sources */ = {isa = PBXBuildFile; fileRef = 96992E541B0FBB6F008978C0 /* CSSwizzler.m */; };
+		96992E591B0FBB6F008978C0 /* LocationMocker.m in Sources */ = {isa = PBXBuildFile; fileRef = 96992E561B0FBB6F008978C0 /* LocationMocker.m */; };
+		96992E621B0FBC4F008978C0 /* CLLocationManager+MockLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 96992E611B0FBC4F008978C0 /* CLLocationManager+MockLocation.m */; };
 		DD043363196DBBD500E6F39D /* MGLTAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DD04335F196DBBD500E6F39D /* MGLTAppDelegate.m */; };
 		DD043364196DBBD500E6F39D /* MGLTViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DD043360196DBBD500E6F39D /* MGLTViewController.m */; };
 		DD043366196DBBE000E6F39D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DD043365196DBBE000E6F39D /* main.m */; };
@@ -85,6 +88,12 @@
 /* Begin PBXFileReference section */
 		96567A221B0E84CD00D78776 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = SOURCE_ROOT; };
 		96567A301B0E8BB900D78776 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = SOURCE_ROOT; };
+		96992E531B0FBB6F008978C0 /* CSSwizzler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSwizzler.h; sourceTree = "<group>"; };
+		96992E541B0FBB6F008978C0 /* CSSwizzler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSSwizzler.m; sourceTree = "<group>"; };
+		96992E551B0FBB6F008978C0 /* LocationMocker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LocationMocker.h; sourceTree = "<group>"; };
+		96992E561B0FBB6F008978C0 /* LocationMocker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocationMocker.m; sourceTree = "<group>"; };
+		96992E601B0FBC4F008978C0 /* CLLocationManager+MockLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CLLocationManager+MockLocation.h"; sourceTree = "<group>"; };
+		96992E611B0FBC4F008978C0 /* CLLocationManager+MockLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CLLocationManager+MockLocation.m"; sourceTree = "<group>"; };
 		DACAD7111B08719F009119DC /* MGLMapboxEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MGLMapboxEvents.h; path = ../../platform/ios/MGLMapboxEvents.h; sourceTree = SOURCE_ROOT; };
 		DD043323196DB9BC00E6F39D /* Mapbox GL Tests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mapbox GL Tests.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD04335F196DBBD500E6F39D /* MGLTAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLTAppDelegate.m; sourceTree = SOURCE_ROOT; };
@@ -167,6 +176,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		96992E501B0FBB6F008978C0 /* LocationMocker */ = {
+			isa = PBXGroup;
+			children = (
+				96992E601B0FBC4F008978C0 /* CLLocationManager+MockLocation.h */,
+				96992E611B0FBC4F008978C0 /* CLLocationManager+MockLocation.m */,
+				96992E531B0FBB6F008978C0 /* CSSwizzler.h */,
+				96992E541B0FBB6F008978C0 /* CSSwizzler.m */,
+				96992E551B0FBB6F008978C0 /* LocationMocker.h */,
+				96992E561B0FBB6F008978C0 /* LocationMocker.m */,
+			);
+			path = LocationMocker;
+			sourceTree = SOURCE_ROOT;
+		};
 		DD04331A196DB9BC00E6F39D = {
 			isa = PBXGroup;
 			children = (
@@ -293,6 +315,7 @@
 				DD0E6F661B01806600DC035A /* MetricsTests.m */,
 				DDBD0167196DC46B0033959E /* Supporting Files */,
 				DDBD014D196DC3B00033959E /* KIF */,
+				96992E501B0FBB6F008978C0 /* LocationMocker */,
 				DD0E6F6B1B01906600DC035A /* OCMock */,
 				DD0E6F861B01B67100DC035A /* OHHTTPStubs */,
 			);
@@ -470,9 +493,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96992E581B0FBB6F008978C0 /* CSSwizzler.m in Sources */,
+				96992E591B0FBB6F008978C0 /* LocationMocker.m in Sources */,
 				DD043366196DBBE000E6F39D /* main.m in Sources */,
 				DD043363196DBBD500E6F39D /* MGLTAppDelegate.m in Sources */,
 				DD043364196DBBD500E6F39D /* MGLTViewController.m in Sources */,
+				96992E621B0FBC4F008978C0 /* CLLocationManager+MockLocation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/test/ios/ios-tests.xcodeproj/project.xcworkspace/xcshareddata/ios-tests.xccheckout
+++ b/test/ios/ios-tests.xcodeproj/project.xcworkspace/xcshareddata/ios-tests.xccheckout
@@ -24,7 +24,7 @@
 		<key>10265E242415D473A6A613214DB7AC3EE3D43F93</key>
 		<string>../../../..test/ios/KIF</string>
 		<key>38C2A0D4F62B675E8C16C8BC1437C7753846C8AC</key>
-		<string>../../../../test/ios/OHHTTPStubs/</string>
+		<string>../../../../test/ios/OHHTTPStubs</string>
 		<key>7E68CB584078A487C0535CC191D3B7551EEE2095</key>
 		<string>../../../..</string>
 	</dict>

--- a/test/ios/ios-tests.xcodeproj/xcshareddata/xcschemes/Mapbox GL Tests.xcscheme
+++ b/test/ios/ios-tests.xcodeproj/xcshareddata/xcschemes/Mapbox GL Tests.xcscheme
@@ -56,6 +56,9 @@
                   Identifier = "MapViewTests/testDelegateRegionWillChange">
                </Test>
                <Test
+                  Identifier = "MapViewTests/testUserTrackingModeFollowWithHeading">
+               </Test>
+               <Test
                   Identifier = "MetricsTests/testFlushPostsEvents">
                </Test>
                <Test


### PR DESCRIPTION
Fakes user location via swizzled `CLLocationManager` and hard-coded mock coordinates and heading.

- Adds `testDelegatesStartStopLocatingUser`
  - Tests `mapViewWillStartLocatingUser` and `mapViewDidStopLocatingUser` delegate methods
- Adds `testUserTrackingModeFollow`
- Adds `testUserTrackingModeFollowWithHeading` (disabled because of #1145)

I've had this sitting around for a bit and finally cleaned it up for a pull request. This uses manual swizzling and predates our use of `OCMock`, but I plan to look into whether or not this would be better if switched.

One thing to note: The test app no longer pops-up the location permission alert because the mock `CLLocationManager` does an end-run around permissions. This saves time before every test (by not calling `[tester acknowledgeSystemAlert]`), but does diverge significantly from the norm and isn't ideal.

I plan to add tests for location permissions handling, so I'll have to confront this problem soon.

/cc @1ec5 @bleege @incanus