### PR TITLE
Corrupt data not handled properly

### DIFF
--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -104,6 +104,8 @@ public:
     bool enabled;
 
 private:
+    void tileLoadingCompleteCallback(const TileID& normalized_id);
+
     void emitSourceLoaded();
     void emitSourceLoadingFailed(const std::string& message);
     void emitTileLoaded(bool isNewTile);

--- a/src/mbgl/map/sprite.hpp
+++ b/src/mbgl/map/sprite.hpp
@@ -59,8 +59,8 @@ private:
     void emitSpriteLoadedIfComplete();
     void emitSpriteLoadingFailed(const std::string& message);
 
-    void parseJSON();
-    void parseImage();
+    void parseJSON(const std::string& jsonURL);
+    void parseImage(const std::string& spriteURL);
 
     std::string body;
     std::string image;

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -44,10 +44,7 @@ public:
     TileData(const TileID&, const SourceInfo&);
     ~TileData();
 
-    void request(Worker&,
-                 float pixelRatio,
-                 const std::function<void()>& successCallback,
-                 const std::function<void(const std::string& message)>& failureCallback);
+    void request(Worker&, float pixelRatio, const std::function<void()>& callback);
 
     // Schedule a tile reparse on a worker thread and call the callback on
     // completion. It will return true if the work was schedule or false it was
@@ -71,12 +68,19 @@ public:
     // We let subclasses override setState() so they
     // can intercept the state change and react accordingly.
     virtual void setState(const State& state);
-
     inline State getState() const {
         return state;
     }
 
     void endParsing();
+
+    // Error message to be set in case of request
+    // and parsing errors.
+    void setError(const std::string& message);
+
+    std::string getError() const {
+        return error;
+    }
 
     // Override this in the child class.
     virtual void parse() = 0;
@@ -105,6 +109,8 @@ protected:
 
 private:
     std::atomic<State> state;
+
+    std::string error;
 
 protected:
     // Contains the tile ID string for painting debug information.

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -59,9 +59,9 @@ void VectorTileData::parse() {
             setState(State::parsed);
         }
     } catch (const std::exception& ex) {
-        Log::Error(Event::ParseTile, "Parsing [%d/%d/%d] failed: %s", id.z, id.x, id.y, ex.what());
-        setState(State::obsolete);
-        return;
+        std::stringstream message;
+        message << "Failed to parse [" << int(id.z) << "/" << id.x << "/" << id.y << "]: " << ex.what();
+        setError(message.str());
     }
 }
 

--- a/src/mbgl/text/glyph_pbf.cpp
+++ b/src/mbgl/text/glyph_pbf.cpp
@@ -23,14 +23,14 @@ GlyphPBF::GlyphPBF(const std::string& glyphURL,
                    const GlyphLoadingFailedCallback& failureCallback)
     : parsed(false), env(env_) {
     // Load the glyph set URL
-    std::string url = util::replaceTokens(glyphURL, [&](const std::string &name) -> std::string {
+    url = util::replaceTokens(glyphURL, [&](const std::string &name) -> std::string {
         if (name == "fontstack") return util::percentEncode(fontStack);
         if (name == "range") return util::toString(glyphRange.first) + "-" + util::toString(glyphRange.second);
         return "";
     });
 
     // The prepare call jumps back to the main thread.
-    req = env.request({ Resource::Kind::Glyphs, url }, [&, url, successCallback, failureCallback](const Response &res) {
+    req = env.request({ Resource::Kind::Glyphs, url }, [&, successCallback, failureCallback](const Response &res) {
         req = nullptr;
 
         if (res.status != Response::Successful) {

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -29,6 +29,10 @@ public:
     void parse(FontStack &stack);
     bool isParsed() const;
 
+    std::string getURL() const {
+        return url;
+    }
+
 private:
     GlyphPBF(const GlyphPBF &) = delete;
     GlyphPBF(GlyphPBF &&) = delete;
@@ -36,6 +40,7 @@ private:
     GlyphPBF &operator=(GlyphPBF &&) = delete;
 
     std::string data;
+    std::string url;
     std::atomic<bool> parsed;
 
     Environment& env;

--- a/test/resources/mock_file_source.cpp
+++ b/test/resources/mock_file_source.cpp
@@ -1,3 +1,4 @@
+#include "../fixtures/util.hpp"
 #include "mock_file_source.hpp"
 
 #include <mbgl/storage/request.hpp>
@@ -8,30 +9,64 @@ namespace mbgl {
 
 class MockFileSource::Impl {
 public:
-    Impl(uv_loop_t*, const std::string& matchFail) : matchFail_(matchFail) {}
+    Impl(uv_loop_t*, Type type, const std::string& match) : type_(type), match_(match) {}
 
     void handleRequest(Request* req) const;
 
 private:
-    std::string matchFail_;
+    void replyWithFailure(Response* res) const;
+    void replyWithCorruptedData(Response* res, const std::string& url) const;
+    void replyWithSuccess(Response* res, const std::string& url) const;
+
+    Type type_;
+    std::string match_;
 };
 
-void MockFileSource::Impl::handleRequest(Request* req) const {
-    const Resource& resource = req->resource;
+void MockFileSource::Impl::replyWithFailure(Response* res) const {
+    res->status = Response::Status::Error;
+    res->message = "Failed by the test case";
+}
 
+void MockFileSource::Impl::replyWithCorruptedData(Response* res, const std::string& url) const {
+    res->status = Response::Status::Successful;
+    res->data = util::read_file(url);
+    res->data.insert(0, "CORRUPTED");
+}
+
+void MockFileSource::Impl::replyWithSuccess(Response* res, const std::string& url) const {
+    res->status = Response::Status::Successful;
+    res->data = util::read_file(url);
+}
+
+void MockFileSource::Impl::handleRequest(Request* req) const {
+    const std::string& url = req->resource.url;
     std::shared_ptr<Response> response = std::make_shared<Response>();
-    if (matchFail_.empty() || resource.url.find(matchFail_) == std::string::npos) {
-        response->status = Response::Status::Successful;
-        response->data = util::read_file(resource.url.c_str());
-    } else {
-        response->message = "Failed by the test case";
+
+    if (url.find(match_) == std::string::npos) {
+        replyWithSuccess(response.get(), url);
+        req->notify(response);
+        return;
+    }
+
+    switch (type_) {
+    case Type::Success:
+        replyWithSuccess(response.get(), url);
+        break;
+    case Type::RequestFail:
+        replyWithFailure(response.get());
+        break;
+    case Type::RequestWithCorruptedData:
+        replyWithCorruptedData(response.get(), url);
+        break;
+    default:
+        EXPECT_TRUE(false) << "Should never be reached.";
     }
 
     req->notify(response);
 }
 
-MockFileSource::MockFileSource(const std::string& matchFail)
-    : thread_(std::make_unique<util::Thread<Impl>>("FileSource", util::ThreadPriority::Low, matchFail)) {
+MockFileSource::MockFileSource(Type type, const std::string& match)
+    : thread_(std::make_unique<util::Thread<Impl>>("FileSource", util::ThreadPriority::Low, type, match)) {
 }
 
 Request* MockFileSource::request(const Resource& resource, uv_loop_t* loop, Callback callback) {

--- a/test/resources/mock_file_source.hpp
+++ b/test/resources/mock_file_source.hpp
@@ -13,12 +13,18 @@ template <typename T> class Thread;
 }
 
 // This mock FileSource will read data from the disk and will fail
-// the request if the URL matches the 'matchFail' string.
+// the request if the URL matches a string.
 class MockFileSource : public FileSource {
 public:
+    enum Type {
+        Success,
+        RequestFail,
+        RequestWithCorruptedData
+    };
+
     class Impl;
 
-    MockFileSource(const std::string& matchFail);
+    MockFileSource(Type type, const std::string& match);
     ~MockFileSource() override = default;
 
     // FileSource implementation.


### PR DESCRIPTION
We currently report correctly if a network request fails but we don't when the network request succeed but the data returned is corrupted. This is specially bad when using renderStill() because in some cases it never returns or the result of the rendering is wrong.

* For most of the resources we just silently ignore the error.
* In some cases like when loading the Source JSON, we do detect parsing errors but we report as network error.
* In case of vector tiles, the Map thread deadlocks.

The idea is to handle errors similarly how we do today with connection errors. 