### PR TITLE
Linux build instruction updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Be sure to pull down all submodules first:
 
 ## OS X
 
-Prerequisites include the Boost headers (for routines provided therein) and ImageMagick (for tests). To install all prerequisites, use [Homebrew](http://brew.sh/) and type `brew install pkg-config boost imagemagick`.
+ImageMagick is required for tests. It's recommended to install it with [Homebrew](http://brew.sh/) via `brew install imagemagick`.
 
 To create projects, you can run:
 
@@ -58,7 +58,6 @@ pod 'MapboxGL'
 
 #### Manually
 
-1. Use [Homebrew](http://brew.sh/) to install Boost headers: `brew install boost`.
 1. Install [appledoc](http://appledoc.gentlebytes.com/appledoc/) for API docs generation. We recommend [`2.2v963`](https://github.com/tomaz/appledoc/releases/tag/v2.2-963), which currently isn't available in Homebrew.
 1. Run `make ipackage`. The packaging script will produce the statically-linked `libMapboxGL.a`, `MapboxGL.bundle` for resources, a `Headers` folder, and a `Docs` folder with HTML API documentation.
 1. Copy the contents of `build/ios/pkg/static` into your project. It should happen automatically, but ensure that:
@@ -114,16 +113,6 @@ Install glfw3 dependencies:
                          x11proto-xext-dev libxrandr-dev \
                          x11proto-xf86vidmode-dev libxxf86vm-dev \
                          libxcursor-dev libxinerama-dev
-
-Finally, install Boost. If you're running Ubuntu 12.04 or older, you need to install a backport PPA since the version provided by APT doesn't contain Boost Geometry:
-
-    sudo add-apt-repository --yes ppa:boost-latest/ppa
-    sudo apt-get update
-    sudo apt-get install libboost1.55-dev
-
-Otherwise, you can just install
-
-    sudo apt-get install libboost1.55-dev libboost-program-options1.55-dev
 
 Then, you can then proceed to build the library:
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Target iOS: 7.0 through latest 8.x.
 
 We are using Ubuntu for development. While the software should work on other distributions as well, we are not providing explicit build instructions here.
 
-Install GCC 4.9+ if you are running Ubuntu 13.10 or older. Alternatively, you can also use Clang 3.5+.
+Install GCC 4.9+ if you are running Ubuntu 14.04 or older. Alternatively, you can also use Clang 3.5+.
 
     sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
     sudo apt-get update
@@ -105,7 +105,8 @@ Ensure you have git and other build essentials:
 
     sudo apt-get install curl git build-essential zlib1g-dev automake \
                          libtool xutils-dev make cmake pkg-config python-pip \
-                         libcurl4-openssl-dev libpng-dev libsqlite3-dev
+                         libcurl4-openssl-dev libpng-dev libsqlite3-dev \
+                         libllvm3.4
 
 Install glfw3 dependencies:
 
@@ -122,7 +123,7 @@ Finally, install Boost. If you're running Ubuntu 12.04 or older, you need to ins
 
 Otherwise, you can just install
 
-    sudo apt-get install libboost-dev libboost-program-options-dev
+    sudo apt-get install libboost1.55-dev libboost-program-options1.55-dev
 
 Then, you can then proceed to build the library:
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Target iOS: 7.0 through latest 8.x.
 
 We are using Ubuntu for development. While the software should work on other distributions as well, we are not providing explicit build instructions here.
 
-Install GCC 4.9+ if you are running Ubuntu 14.04 or older. Alternatively, you can also use Clang 3.5+.
+Install GCC 4.9+ if you are running Ubuntu 14.04 or older. Alternatively, you can also use [Clang 3.5+](http://llvm.org/apt/).
 
     sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
     sudo apt-get update


### PR DESCRIPTION
Some changes to the README... I just ran through a build on Ubuntu 14.04 (LTS) and this is what I ran into.

- GCC 4.9 is only available starting with Ubuntu 14.10, needs to be installed from the backport PPA
- The default version of Boost in 14.04 is 1.54, but 1.55 is available from the main repos if specified
- I got a build error about some missing LLVM-3.4 libraries. Installing `libllvm3.4` fixed it.

Do these changes look ok?