### PR TITLE
Return nil upon failure to initialize

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -132,9 +132,10 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     if (self && [self commonInit])
     {
         self.styleURL = styleURL;
+        return self;
     }
 
-    return self;
+    return nil;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder


### PR DESCRIPTION
This PR fixes a latent bug that would only rear its head if the GL context failed to initialize for some reason.