### PR TITLE
Make init methods unfailable

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -22,14 +22,14 @@ IB_DESIGNABLE
 
 /** Initializes and returns a newly allocated map view with the specified frame and the default style.
 *   @param frame The frame for the view, measured in points.
-*   @return An initialized map view or `nil` if the map view couldn’t be created. */
+*   @return An initialized map view. */
 - (instancetype)initWithFrame:(CGRect)frame;
 - (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken __attribute__((unavailable("Use -initWithFrame:. Set MGLMapboxAccessToken in the Info.plist or call +[MGLAccountManager setAccessToken:].")));
 
 /** Initializes and returns a newly allocated map view with the specified frame and style URL.
 *   @param frame The frame for the view, measured in points.
 *   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://<user.style>`).
-*   @return An initialized map view or `nil` if the map view couldn’t be created. */
+*   @return An initialized map view. */
 - (instancetype)initWithFrame:(CGRect)frame styleURL:(NSURL *)styleURL;
 - (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(NSURL *)styleURL __attribute__((unavailable("Use -initWithFrame:styleURL:. Set MGLMapboxAccessToken in the Info.plist or call +[MGLAccountManager setAccessToken:].")));
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -114,41 +114,32 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:frame];
-
-    if (self && [self commonInit])
+    if (self = [super initWithFrame:frame])
     {
+        [self commonInit];
         self.styleURL = nil;
-        return self;
     }
-
-    return nil;
+    return self;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame styleURL:(NSURL *)styleURL
 {
-    self = [super initWithFrame:frame];
-
-    if (self && [self commonInit])
+    if (self = [super initWithFrame:frame])
     {
+        [self commonInit];
         self.styleURL = styleURL;
-        return self;
     }
-
-    return nil;
+    return self;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder
 {
-    self = [super initWithCoder:decoder];
-
-    if (self && [self commonInit])
+    if (self = [super initWithCoder:decoder])
     {
+        [self commonInit];
         self.styleURL = nil;
-        return self;
     }
-
-    return nil;
+    return self;
 }
 
 - (NSString *)accessToken
@@ -193,20 +184,14 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     _mbglMap->setStyleURL([[styleURL absoluteString] UTF8String]);
 }
 
-- (BOOL)commonInit
+- (void)commonInit
 {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
 
     // create context
     //
     _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-
-    if ( ! _context)
-    {
-        mbgl::Log::Error(mbgl::Event::Setup, "failed to create OpenGL ES context");
-
-        return NO;
-    }
+    NSAssert(_context, @"Failed to create OpenGL ES context.");
 
     // setup accessibility
     //
@@ -394,8 +379,6 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         MGLEventKeyZoomLevel: @(zoom),
         MGLEventKeyPushEnabled: @([MGLMapboxEvents checkPushEnabled])
     }];
-
-    return YES;
 }
 
 -(void)reachabilityChanged:(NSNotification*)notification


### PR DESCRIPTION
If an OpenGL context couldn’t be created, there’s just no point to soldiering on. Things are going to fall apart pretty quickly anyways. Assert and be done with it.

This change will also help to de-exclamatize any Swift projects using `MGLMapView` (#1578).

/cc @incanus