### PR TITLE
Fix ios-bench build

### DIFF
--- a/ios/benchmark/MBXBenchViewController.mm
+++ b/ios/benchmark/MBXBenchViewController.mm
@@ -33,7 +33,7 @@
     [super viewDidLoad];
 
     NSURL* url = [[NSURL alloc] initWithString:@"asset://styles/mapbox-streets-v7.json"];
-    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds accessToken:nil styleURL:url];
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:url];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.delegate = self;
     self.mapView.zoomEnabled = NO;


### PR DESCRIPTION
The `accessToken` parameter was removed from `MGLMapView`’s initializers in #1553. No access token was being passed in anyways.