### PR TITLE
Use array of structs rather than parallel arrays for annotations

### DIFF
--- a/include/mbgl/annotation/point_annotation.hpp
+++ b/include/mbgl/annotation/point_annotation.hpp
@@ -1,0 +1,22 @@
+#ifndef MBGL_ANNOTATION_POINT_ANNOTATION
+#define MBGL_ANNOTATION_POINT_ANNOTATION
+
+#include <mbgl/util/geo.hpp>
+
+#include <string>
+
+namespace mbgl {
+
+class PointAnnotation {
+public:
+    inline PointAnnotation(const LatLng& position_, const std::string& icon_ = "")
+        : position(position_), icon(icon_) {
+    }
+
+    const LatLng position;
+    const std::string icon;
+};
+
+}
+
+#endif

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -21,6 +21,7 @@ class View;
 class MapData;
 class MapContext;
 class StillImage;
+class PointAnnotation;
 
 namespace util {
 template <class T> class Thread;
@@ -111,9 +112,8 @@ public:
     // Annotations
     void setDefaultPointAnnotationSymbol(const std::string&);
     double getTopOffsetPixelsForAnnotationSymbol(const std::string&);
-    uint32_t addPointAnnotation(const LatLng&, const std::string& symbol);
-    std::vector<uint32_t> addPointAnnotations(const std::vector<LatLng>&,
-                                              const std::vector<std::string>& symbols);
+    uint32_t addPointAnnotation(const PointAnnotation&);
+    std::vector<uint32_t> addPointAnnotations(const std::vector<PointAnnotation>&);
     void removeAnnotation(uint32_t);
     void removeAnnotations(const std::vector<uint32_t>&);
     std::vector<uint32_t> getAnnotationsInBounds(const LatLngBounds&);

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -1,3 +1,4 @@
+#include <mbgl/annotation/point_annotation.hpp>
 #include <mbgl/platform/default/glfw_view.hpp>
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/platform/log.hpp>
@@ -130,8 +131,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
 }
 
 void GLFWView::addRandomPointAnnotations(int count) {
-    std::vector<mbgl::LatLng> points;
-    std::vector<std::string> markers;
+    std::vector<mbgl::PointAnnotation> points;
 
     const auto sw = map->latLngForPixel({ 0, 0 });
     const auto ne = map->latLngForPixel({ double(width), double(height) });
@@ -140,11 +140,10 @@ void GLFWView::addRandomPointAnnotations(int count) {
         const double lon = sw.longitude + (ne.longitude - sw.longitude) * (double(std::rand()) / RAND_MAX);
         const double lat = sw.latitude + (ne.latitude - sw.latitude) * (double(std::rand()) / RAND_MAX);
 
-        points.push_back({ lat, lon });
-        markers.push_back("default_marker");
+        points.emplace_back(mbgl::LatLng{ lat, lon }, "default_marker");
     }
 
-    map->addPointAnnotations(points, markers);
+    map->addPointAnnotations(points);
 }
 
 void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) {

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -8,6 +8,7 @@
 #import <OpenGLES/EAGL.h>
 
 #include <mbgl/mbgl.hpp>
+#include <mbgl/annotation/point_annotation.hpp>
 #include <mbgl/platform/platform.hpp>
 #include <mbgl/platform/darwin/reachability.h>
 #include <mbgl/storage/default_file_source.hpp>
@@ -1669,19 +1670,14 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 {
     if ( ! annotations) return;
 
-    std::vector<mbgl::LatLng> latLngs;
-    latLngs.reserve(annotations.count);
-
-    std::vector<std::string> symbols;
-    symbols.reserve(annotations.count);
+    std::vector<mbgl::PointAnnotation> points;
+    points.reserve(annotations.count);
 
     BOOL delegateImplementsSymbolLookup = [self.delegate respondsToSelector:@selector(mapView:symbolNameForAnnotation:)];
 
     for (id <MGLAnnotation> annotation in annotations)
     {
         assert([annotation conformsToProtocol:@protocol(MGLAnnotation)]);
-
-        latLngs.push_back(MGLLatLngFromLocationCoordinate2D(annotation.coordinate));
 
         NSString *symbolName = nil;
 
@@ -1690,10 +1686,10 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
             symbolName = [self.delegate mapView:self symbolNameForAnnotation:annotation];
         }
 
-        symbols.push_back((symbolName ? [symbolName UTF8String] : ""));
+        points.emplace_back(MGLLatLngFromLocationCoordinate2D(annotation.coordinate), (symbolName ? [symbolName UTF8String] : ""));
     }
 
-    std::vector<uint32_t> annotationIDs = _mbglMap->addPointAnnotations(latLngs, symbols);
+    std::vector<uint32_t> annotationIDs = _mbglMap->addPointAnnotations(points);
 
     for (size_t i = 0; i < annotationIDs.size(); ++i)
     {

--- a/src/mbgl/map/annotation.hpp
+++ b/src/mbgl/map/annotation.hpp
@@ -2,6 +2,7 @@
 #define MBGL_MAP_ANNOTATIONS
 
 #include <mbgl/map/tile_id.hpp>
+#include <mbgl/annotation/point_annotation.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/vec.hpp>
@@ -29,7 +30,7 @@ public:
 
     void setDefaultPointAnnotationSymbol(const std::string& symbol);
     std::pair<std::vector<TileID>, AnnotationIDs> addPointAnnotations(
-        const std::vector<LatLng>&, const std::vector<std::string>& symbols, const MapData&);
+        const std::vector<PointAnnotation>&, const MapData&);
     std::vector<TileID> removeAnnotations(const AnnotationIDs&, const MapData&);
     AnnotationIDs getAnnotationsInBounds(const LatLngBounds&, const MapData&) const;
     LatLngBounds getBoundsForAnnotations(const AnnotationIDs&) const;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -235,12 +235,12 @@ double Map::getTopOffsetPixelsForAnnotationSymbol(const std::string& symbol) {
     return context->invokeSync<double>(&MapContext::getTopOffsetPixelsForAnnotationSymbol, symbol);
 }
 
-uint32_t Map::addPointAnnotation(const LatLng& point, const std::string& symbol) {
-    return addPointAnnotations({ point }, { symbol }).front();
+uint32_t Map::addPointAnnotation(const PointAnnotation& annotation) {
+    return addPointAnnotations({ annotation }).front();
 }
 
-std::vector<uint32_t> Map::addPointAnnotations(const std::vector<LatLng>& points, const std::vector<std::string>& symbols) {
-    auto result = data->annotationManager.addPointAnnotations(points, symbols, *data);
+std::vector<uint32_t> Map::addPointAnnotations(const std::vector<PointAnnotation>& annotations) {
+    auto result = data->annotationManager.addPointAnnotations(annotations, *data);
     context->invoke(&MapContext::updateAnnotationTiles, result.first);
     return result.second;
 }


### PR DESCRIPTION
Our current point annotations API uses two parallel vectors for points and icon names which leaves room for errors due to mismatched annotations. Instead, we should use an array of structs so the association between point and icon is fixed and not through the index.