### PR TITLE
Namespace Reachability notification constant

### DIFF
--- a/include/mbgl/platform/darwin/reachability.h
+++ b/include/mbgl/platform/darwin/reachability.h
@@ -38,7 +38,7 @@
 #define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
 #endif
 
-extern NSString *const kReachabilityChangedNotification;
+extern NSString *const kMGLReachabilityChangedNotification;
 
 typedef NS_ENUM(NSInteger, NetworkStatus) {
     // Apple NetworkStatus Compatible Names.

--- a/platform/darwin/reachability.m
+++ b/platform/darwin/reachability.m
@@ -35,7 +35,7 @@
 #import <netdb.h>
 
 
-NSString *const kReachabilityChangedNotification = @"kReachabilityChangedNotification";
+NSString *const kMGLReachabilityChangedNotification = @"kMGLReachabilityChangedNotification";
 
 
 @interface MGLReachability ()
@@ -452,7 +452,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
     // this makes sure the change notification happens on the MAIN THREAD
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:kReachabilityChangedNotification
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMGLReachabilityChangedNotification
                                                             object:self];
     });
 }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -256,7 +256,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     // Notify map object when network reachability status changes.
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(reachabilityChanged:)
-                                                 name:kReachabilityChangedNotification
+                                                 name:kMGLReachabilityChangedNotification
                                                object:nil];
 
     MGLReachability* reachability = [MGLReachability reachabilityForInternetConnection];


### PR DESCRIPTION
This PR renames the Reachability library’s notification constant so that clients can use their own copies of Reachability.

Fixes #1717.