### PR TITLE
Restore nullability compatibility shim

### DIFF
--- a/include/mbgl/ios/MGLTypes.h
+++ b/include/mbgl/ios/MGLTypes.h
@@ -1,5 +1,13 @@
 #import <Foundation/Foundation.h>
 
+#if !__has_feature(nullability)
+    #define NS_ASSUME_NONNULL_BEGIN
+    #define NS_ASSUME_NONNULL_END
+    #define nullable
+    #define nonnull
+    #define null_resettable
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSString * const MGLErrorDomain;


### PR DESCRIPTION
This PR reverts commit a425df0f95f5f0088444b8ebc67708756ff962aa (originally part of #1578) for compatibility with Xcode 6.1.

Fixes #1722.