### PR TITLE
Crash when calling renderStill() without a style set or without callback

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -279,12 +279,24 @@ void MapContext::update() {
 }
 
 void MapContext::renderStill(StillImageCallback fn) {
+    if (!fn) {
+        Log::Error(Event::General, "StillImageCallback not set");
+        return;
+    }
+
     if (data.mode != MapMode::Still) {
-        throw util::Exception("Map is not in still image render mode");
+        fn(std::make_exception_ptr(util::MisuseException("Map is not in still image render mode")), nullptr);
+        return;
     }
 
     if (callback) {
-        throw util::Exception("Map is currently rendering an image");
+        fn(std::make_exception_ptr(util::MisuseException("Map is currently rendering an image")), nullptr);
+        return;
+    }
+
+    if (!style) {
+        fn(std::make_exception_ptr(util::MisuseException("Map doesn't have a style")), nullptr);
+        return;
     }
 
     if (style->getLastError()) {

--- a/test/api/api_misuse.cpp
+++ b/test/api/api_misuse.cpp
@@ -1,0 +1,60 @@
+#include "../fixtures/util.hpp"
+#include "../fixtures/fixture_log_observer.hpp"
+
+#include <mbgl/map/map.hpp>
+#include <mbgl/map/still_image.hpp>
+#include <mbgl/platform/default/headless_display.hpp>
+#include <mbgl/platform/default/headless_view.hpp>
+#include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/util/exception.hpp>
+
+#include <future>
+
+using namespace mbgl;
+
+TEST(API, RenderWithoutCallback) {
+    FixtureLogObserver* log = new FixtureLogObserver();
+    Log::setObserver(std::unique_ptr<Log::Observer>(log));
+
+    auto display = std::make_shared<mbgl::HeadlessDisplay>();
+    HeadlessView view(display);
+    DefaultFileSource fileSource(nullptr);
+
+    std::unique_ptr<Map> map = std::make_unique<Map>(view, fileSource, MapMode::Still);
+    map->resize(128, 512, 1);
+    map->renderStill(nullptr);
+
+    // Force Map thread to join.
+    map.reset();
+
+    const FixtureLogObserver::LogMessage logMessage {
+        EventSeverity::Error,
+        Event::General,
+        int64_t(-1),
+        "StillImageCallback not set",
+    };
+
+    EXPECT_EQ(log->count(logMessage), 1u);
+}
+
+TEST(API, RenderWithoutStyle) {
+    auto display = std::make_shared<mbgl::HeadlessDisplay>();
+    HeadlessView view(display);
+    DefaultFileSource fileSource(nullptr);
+
+    Map map(view, fileSource, MapMode::Still);
+    map.resize(128, 512, 1);
+
+    std::promise<std::exception_ptr> promise;
+    map.renderStill([&promise](std::exception_ptr error, std::unique_ptr<const StillImage>) {
+        promise.set_value(error);
+    });
+
+    try {
+        std::rethrow_exception(promise.get_future().get());
+    } catch (const util::MisuseException& ex) {
+        EXPECT_EQ(std::string(ex.what()), "Map doesn't have a style");
+    } catch (const std::exception&) {
+        EXPECT_TRUE(false) << "Unhandled exception.";
+    }
+}

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -35,8 +35,9 @@
         'fixtures/fixture_log_observer.hpp',
         'fixtures/fixture_log_observer.cpp',
 
-        'api/set_style.cpp',
+        'api/api_misuse.cpp',
         'api/repeated_render.cpp',
+        'api/set_style.cpp',
 
         'headless/headless.cpp',
 


### PR DESCRIPTION
We should report errors accordingly instead of crashing.