### PR TITLE
Defer to MGLMultiPoint for overlayBounds implementation

### DIFF
--- a/platform/ios/MGLPolygon.m
+++ b/platform/ios/MGLPolygon.m
@@ -4,7 +4,7 @@
 
 @implementation MGLPolygon
 
-@synthesize overlayBounds;
+@dynamic overlayBounds;
 
 + (instancetype)polygonWithCoordinates:(CLLocationCoordinate2D *)coords
                                  count:(NSUInteger)count

--- a/platform/ios/MGLPolyline.m
+++ b/platform/ios/MGLPolyline.m
@@ -4,7 +4,7 @@
 
 @implementation MGLPolyline
 
-@synthesize overlayBounds;
+@dynamic overlayBounds;
 
 + (instancetype)polylineWithCoordinates:(CLLocationCoordinate2D *)coords
                                   count:(NSUInteger)count


### PR DESCRIPTION
The synthesized `overlayBounds` shadows the MGLMultiPoint implementation with one that reads an `_overlayBounds` ivar. This PR causes the subclasses to look at MGLMultiPoint’s implementation.

Fixes #1730.

/cc @incanus