### PR TITLE
Audit shape annotation classes for nullability

### DIFF
--- a/include/mbgl/ios/MGLAnnotation.h
+++ b/include/mbgl/ios/MGLAnnotation.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** The string containing the annotation’s title.
 *
 * Although this property is optional, if you support the selection of annotations in your map view, you are expected to provide this property. This string is displayed in the callout for the associated annotation. */
-@property (nonatomic, readonly, copy) NSString *title;
+@property (nonatomic, readonly, copy, nullable) NSString *title;
 
 /** The string containing the annotation’s subtitle.
 *

--- a/include/mbgl/ios/MGLMultiPoint.h
+++ b/include/mbgl/ios/MGLMultiPoint.h
@@ -3,6 +3,8 @@
 
 #import "MGLShape.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLMultiPoint` class is an abstract superclass used to define shapes composed of multiple points. You should not create instances of this class directly. Instead, you should create instances of the `MGLPolyline` or `MGLPolygon` classes. However, you can use the method and properties of this class to access information about the specific points associated with the line or polygon. */
 @interface MGLMultiPoint : MGLShape
 
@@ -15,3 +17,5 @@
 - (void)getCoordinates:(CLLocationCoordinate2D *)coords range:(NSRange)range;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLOverlay.h
+++ b/include/mbgl/ios/MGLOverlay.h
@@ -4,6 +4,8 @@
 #import "MGLAnnotation.h"
 #import "MGLTypes.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLOverlay` protocol defines a specific type of annotation that represents both a point and an area on a map. Overlay objects are essentially data objects that contain the geographic data needed to represent the map area. For example, overlays can take the form of common shapes such as rectangles and circles. They can also describe polygons and other complex shapes.
 *
 *   You use overlays to layer more sophisticated content on top of a map view. For example, you could use an overlay to show the boundaries of a national park or trace a bus route along city streets. Mapbox GL defines several concrete classes that conform to this protocol and define standard shapes.
@@ -29,3 +31,5 @@
 - (BOOL)intersectsOverlayBounds:(MGLCoordinateBounds)overlayBounds;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLPointAnnotation.h
+++ b/include/mbgl/ios/MGLPointAnnotation.h
@@ -3,6 +3,8 @@
 
 #import "MGLShape.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLPointAnnotation` class defines a concrete annotation object located at a specified point. You can use this class, rather than define your own, in situations where all you want to do is associate a point on the map with a title. */
 @interface MGLPointAnnotation : MGLShape
 
@@ -10,3 +12,5 @@
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLPolygon.h
+++ b/include/mbgl/ios/MGLPolygon.h
@@ -4,6 +4,8 @@
 #import "MGLMultiPoint.h"
 #import "MGLOverlay.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLPolygon` class represents a shape consisting of one or more points that define a closed polygon. The points are connected end-to-end in the order they are provided. The first and last points are connected to each other to create the closed shape. */
 @interface MGLPolygon : MGLMultiPoint <MGLOverlay>
 
@@ -15,3 +17,5 @@
                                  count:(NSUInteger)count;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLPolyline.h
+++ b/include/mbgl/ios/MGLPolyline.h
@@ -4,6 +4,8 @@
 #import "MGLMultiPoint.h"
 #import "MGLOverlay.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLPolyline` class represents a shape consisting of one or more points that define connecting line segments. The points are connected end-to-end in the order they are provided. The first and last points are not connected to each other. */
 @interface MGLPolyline : MGLMultiPoint <MGLOverlay>
 
@@ -15,3 +17,5 @@
                                   count:(NSUInteger)count;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLShape.h
+++ b/include/mbgl/ios/MGLShape.h
@@ -2,13 +2,17 @@
 
 #import "MGLAnnotation.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLShape` class is an abstract class that defines the basic properties for all shape-based annotation objects. This class must be subclassed and cannot be used as is. Subclasses are responsible for defining the geometry of the shape and providing an appropriate value for the coordinate property inherited from the `MGLAnnotation` protocol. */
 @interface MGLShape : NSObject <MGLAnnotation>
 
 /** The title of the shape annotation. The default value of this property is `nil`. */
-@property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy, nullable) NSString *title;
 
 /** The subtitle of the shape annotation. The default value of this property is `nil`. */
-@property (nonatomic, copy) NSString *subtitle;
+@property (nonatomic, copy, nullable) NSString *subtitle;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Audited various classes to match MapKit. Also, `-[MGLAnnotation title]` is nullable because titles are optional for shape annotations.

/ref #1578
/cc @incanus