### PR TITLE
Heavy use of tiles causes eventual crash in TileParser::parse()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,9 @@ isim: Xcode/ios
 ipackage: Xcode/ios
 	JOBS=$(JOBS) ./scripts/ios/package.sh
 
+ipackage-strip: Xcode/ios
+	JOBS=$(JOBS) ./scripts/ios/package.sh strip
+
 ipackage-sim: Xcode/ios
 	JOBS=$(JOBS) ./scripts/ios/package.sh sim
 

--- a/include/mbgl/ios/MGLAnnotation.h
+++ b/include/mbgl/ios/MGLAnnotation.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** The string containing the annotation’s title.
 *
 * Although this property is optional, if you support the selection of annotations in your map view, you are expected to provide this property. This string is displayed in the callout for the associated annotation. */
-@property (nonatomic, readonly, copy) NSString *title;
+@property (nonatomic, readonly, copy, nullable) NSString *title;
 
 /** The string containing the annotation’s subtitle.
 *

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -170,7 +170,7 @@ IB_DESIGNABLE
 @property (nonatomic, nullable) NSString *styleID;
 @property (nonatomic, nullable) NSString *mapID __attribute__((unavailable("Use styleID.")));
 
-/** Returns the URLs to the styles bundled with the library. */
+/** URLs of the styles bundled with the library. */
 @property (nonatomic, readonly) NSArray *bundledStyleURLs;
 
 /** URL of the style currently displayed in the receiver.

--- a/include/mbgl/ios/MGLMultiPoint.h
+++ b/include/mbgl/ios/MGLMultiPoint.h
@@ -3,6 +3,8 @@
 
 #import "MGLShape.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLMultiPoint` class is an abstract superclass used to define shapes composed of multiple points. You should not create instances of this class directly. Instead, you should create instances of the `MGLPolyline` or `MGLPolygon` classes. However, you can use the method and properties of this class to access information about the specific points associated with the line or polygon. */
 @interface MGLMultiPoint : MGLShape
 
@@ -15,3 +17,5 @@
 - (void)getCoordinates:(CLLocationCoordinate2D *)coords range:(NSRange)range;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLOverlay.h
+++ b/include/mbgl/ios/MGLOverlay.h
@@ -4,6 +4,8 @@
 #import "MGLAnnotation.h"
 #import "MGLTypes.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLOverlay` protocol defines a specific type of annotation that represents both a point and an area on a map. Overlay objects are essentially data objects that contain the geographic data needed to represent the map area. For example, overlays can take the form of common shapes such as rectangles and circles. They can also describe polygons and other complex shapes.
 *
 *   You use overlays to layer more sophisticated content on top of a map view. For example, you could use an overlay to show the boundaries of a national park or trace a bus route along city streets. Mapbox GL defines several concrete classes that conform to this protocol and define standard shapes.
@@ -29,3 +31,5 @@
 - (BOOL)intersectsOverlayBounds:(MGLCoordinateBounds)overlayBounds;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLPointAnnotation.h
+++ b/include/mbgl/ios/MGLPointAnnotation.h
@@ -3,6 +3,8 @@
 
 #import "MGLShape.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLPointAnnotation` class defines a concrete annotation object located at a specified point. You can use this class, rather than define your own, in situations where all you want to do is associate a point on the map with a title. */
 @interface MGLPointAnnotation : MGLShape
 
@@ -10,3 +12,5 @@
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLPolygon.h
+++ b/include/mbgl/ios/MGLPolygon.h
@@ -4,6 +4,8 @@
 #import "MGLMultiPoint.h"
 #import "MGLOverlay.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLPolygon` class represents a shape consisting of one or more points that define a closed polygon. The points are connected end-to-end in the order they are provided. The first and last points are connected to each other to create the closed shape. */
 @interface MGLPolygon : MGLMultiPoint <MGLOverlay>
 
@@ -15,3 +17,5 @@
                                  count:(NSUInteger)count;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLPolyline.h
+++ b/include/mbgl/ios/MGLPolyline.h
@@ -4,6 +4,8 @@
 #import "MGLMultiPoint.h"
 #import "MGLOverlay.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLPolyline` class represents a shape consisting of one or more points that define connecting line segments. The points are connected end-to-end in the order they are provided. The first and last points are not connected to each other. */
 @interface MGLPolyline : MGLMultiPoint <MGLOverlay>
 
@@ -15,3 +17,5 @@
                                   count:(NSUInteger)count;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLShape.h
+++ b/include/mbgl/ios/MGLShape.h
@@ -2,13 +2,17 @@
 
 #import "MGLAnnotation.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** The `MGLShape` class is an abstract class that defines the basic properties for all shape-based annotation objects. This class must be subclassed and cannot be used as is. Subclasses are responsible for defining the geometry of the shape and providing an appropriate value for the coordinate property inherited from the `MGLAnnotation` protocol. */
 @interface MGLShape : NSObject <MGLAnnotation>
 
 /** The title of the shape annotation. The default value of this property is `nil`. */
-@property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy, nullable) NSString *title;
 
 /** The subtitle of the shape annotation. The default value of this property is `nil`. */
-@property (nonatomic, copy) NSString *subtitle;
+@property (nonatomic, copy, nullable) NSString *subtitle;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -37,7 +37,15 @@ public:
     void fps();
 
 private:
+    mbgl::LatLng makeRandomPoint() const;
+
     void addRandomPointAnnotations(int count);
+    void addRandomShapeAnnotations(int count);
+
+    void clearAnnotations();
+    void popAnnotation();
+
+    mbgl::AnnotationIDs annotationIDs;
 
 private:
     bool fullscreen = false;

--- a/platform/ios/MGLPolygon.m
+++ b/platform/ios/MGLPolygon.m
@@ -4,7 +4,7 @@
 
 @implementation MGLPolygon
 
-@synthesize overlayBounds;
+@dynamic overlayBounds;
 
 + (instancetype)polygonWithCoordinates:(CLLocationCoordinate2D *)coords
                                  count:(NSUInteger)count

--- a/platform/ios/MGLPolyline.m
+++ b/platform/ios/MGLPolyline.m
@@ -4,7 +4,7 @@
 
 @implementation MGLPolyline
 
-@synthesize overlayBounds;
+@dynamic overlayBounds;
 
 + (instancetype)polylineWithCoordinates:(CLLocationCoordinate2D *)coords
                                   count:(NSUInteger)count

--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -9,10 +9,15 @@ OUTPUT=build/ios/pkg
 IOS_SDK_VERSION=`xcrun --sdk iphoneos --show-sdk-version`
 LIBUV_VERSION=0.10.28
 
-if [[ ${#} -eq 0 ]]; then
+if [[ ${#} -eq 0 ]]; then # e.g. "make ipackage"
     BUILD_FOR_DEVICE=true
-else
+    GCC_GENERATE_DEBUGGING_SYMBOLS="YES"
+elif [[ ${1} == "sim" ]]; then # e.g. "make ipackage-sim"
     BUILD_FOR_DEVICE=false
+    GCC_GENERATE_DEBUGGING_SYMBOLS="YES"
+else # e.g. "make ipackage-strip"
+    BUILD_FOR_DEVICE=true
+    GCC_GENERATE_DEBUGGING_SYMBOLS="NO"
 fi
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
@@ -44,6 +49,7 @@ if [[ "${BUILD_FOR_DEVICE}" == true ]]; then
     xcodebuild -sdk iphoneos${IOS_SDK_VERSION} \
         ARCHS="arm64 armv7 armv7s" \
         ONLY_ACTIVE_ARCH=NO \
+        GCC_GENERATE_DEBUGGING_SYMBOLS=${GCC_GENERATE_DEBUGGING_SYMBOLS} \
         -project ./build/ios/mbgl.xcodeproj \
         -configuration ${BUILDTYPE} \
         -target everything \
@@ -54,6 +60,7 @@ step "Building iOS Simulator targets..."
 xcodebuild -sdk iphonesimulator${IOS_SDK_VERSION} \
     ARCHS="x86_64 i386" \
     ONLY_ACTIVE_ARCH=NO \
+    GCC_GENERATE_DEBUGGING_SYMBOLS=${GCC_GENERATE_DEBUGGING_SYMBOLS} \
     -project ./build/ios/mbgl.xcodeproj \
     -configuration ${BUILDTYPE} \
     -target everything \

--- a/scripts/ios/publish.sh
+++ b/scripts/ios/publish.sh
@@ -6,14 +6,21 @@ set -u
 
 #
 # iOS release tag format is `vX.Y.Z`; `X.Y.Z` gets passed in
+# In the case of symbolicated builds, we also append the `style`.
 #
 PUBLISH_VERSION="$1"
+
+if [[ ${#} -eq 2 ]]; then
+    PUBLISH_STYLE="-$2"
+else
+    PUBLISH_STYLE=""
+fi
 
 #
 # zip
 #
 cd build/ios/pkg/static
-ZIP=mapbox-gl-ios-${PUBLISH_VERSION}.zip
+ZIP=mapbox-gl-ios-${PUBLISH_VERSION}${PUBLISH_STYLE}.zip
 rm -f ../${ZIP}
 zip -r ../${ZIP} *
 #

--- a/scripts/ios/run.sh
+++ b/scripts/ios/run.sh
@@ -18,12 +18,18 @@ PUBLISH_VERSION=${PUBLISH_TAG[1],-}
 ################################################################################
 
 if [[ ${PUBLISH_PLATFORM} = 'ios' ]]; then
-    # build & package iOS
-    mapbox_time "package_ios" \
+    # default, with debug symbols
+    mapbox_time "package_ios_symbols" \
     make ipackage
 
-    # publish iOS build
-    mapbox_time "deploy_ios" \
+    mapbox_time "deploy_ios_symbols"
+    ./scripts/ios/publish.sh "${PUBLISH_VERSION}" symbols
+
+    # no debug symbols, for smaller distribution
+    mapbox_time "package_ios_stripped" \
+    make ipackage-strip
+
+    mapbox_time "deploy_ios_stripped"
     ./scripts/ios/publish.sh "${PUBLISH_VERSION}"
 else
     # build & test iOS

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -21,8 +21,10 @@ LineAtlas::LineAtlas(uint16_t w, uint16_t h)
 LineAtlas::~LineAtlas() {
     std::lock_guard<std::recursive_mutex> lock(mtx);
 
-    Environment::Get().abandonTexture(texture);
-    texture = 0;
+    if (texture) {
+        Environment::Get().abandonTexture(texture);
+        texture = 0;
+    }
 }
 
 LinePatternPos LineAtlas::getDashPosition(const std::vector<float> &dasharray, bool round) {

--- a/src/mbgl/map/live_tile_data.cpp
+++ b/src/mbgl/map/live_tile_data.cpp
@@ -10,7 +10,8 @@ using namespace mbgl;
 
 LiveTileData::LiveTileData(const TileID& id_,
                            AnnotationManager& annotationManager_,
-                           Style& style_,
+                           const std::vector<util::ptr<StyleLayer>>& layers_,
+                           Worker& workers_,
                            GlyphAtlas& glyphAtlas_,
                            GlyphStore& glyphStore_,
                            SpriteAtlas& spriteAtlas_,
@@ -18,7 +19,7 @@ LiveTileData::LiveTileData(const TileID& id_,
                            const SourceInfo& source_,
                            float angle_,
                            bool collisionDebug_)
-    : VectorTileData::VectorTileData(id_, style_, glyphAtlas_, glyphStore_,
+    : VectorTileData::VectorTileData(id_, layers_, workers_, glyphAtlas_, glyphStore_,
                                      spriteAtlas_, sprite_, source_, angle_, collisionDebug_),
       annotationManager(annotationManager_) {
     // live features are always ready
@@ -43,7 +44,7 @@ void LiveTileData::parse() {
             // Parsing creates state that is encapsulated in TileParser. While parsing,
             // the TileParser object writes results into this objects. All other state
             // is going to be discarded afterwards.
-            TileParser parser(*tile, *this, style, glyphAtlas, glyphStore, spriteAtlas, sprite);
+            TileParser parser(*tile, *this, layers, glyphAtlas, glyphStore, spriteAtlas, sprite);
             parser.parse();
         } catch (const std::exception& ex) {
             Log::Error(Event::ParseTile, "Live-parsing [%d/%d/%d] failed: %s", id.z, id.x, id.y, ex.what());

--- a/src/mbgl/map/live_tile_data.hpp
+++ b/src/mbgl/map/live_tile_data.hpp
@@ -11,7 +11,8 @@ class LiveTileData : public VectorTileData {
 public:
     LiveTileData(const TileID&,
                  AnnotationManager&,
-                 Style&,
+                 const std::vector<util::ptr<StyleLayer>>&,
+                 Worker&,
                  GlyphAtlas&,
                  GlyphStore&,
                  SpriteAtlas&,

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -139,13 +139,7 @@ void MapContext::updateAnnotationTiles(const std::unordered_set<TileID, TileID::
 
     // grab existing, single shape annotations source
     const auto& shapeID = AnnotationManager::ShapeLayerID;
-
-    const auto source_it = std::find_if(style->sources.begin(), style->sources.end(),
-        [&shapeID](util::ptr<Source> source) {
-        return (source->info.source_id == shapeID);
-    });
-    assert(source_it != style->sources.end());
-    source_it->get()->enabled = true;
+    style->getSource(shapeID)->enabled = true;
 
     // create (if necessary) layers and buckets for each shape
     for (const auto &shapeAnnotationID : data.annotationManager.getOrderedShapeAnnotations()) {
@@ -202,8 +196,8 @@ void MapContext::updateAnnotationTiles(const std::unordered_set<TileID, TileID::
             // create shape bucket & connect to source
             util::ptr<StyleBucket> shapeBucket = std::make_shared<StyleBucket>(shapeLayer->type);
             shapeBucket->name = shapeLayer->id;
+            shapeBucket->source = shapeID;
             shapeBucket->source_layer = shapeLayer->id;
-            shapeBucket->source = *source_it;
 
             // apply line layout properties to bucket
             if (shapeStyle.is<LineProperties>()) {

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -294,7 +294,7 @@ TileData::State Source::addTile(MapData& data,
         // If we don't find working tile data, we're just going to load it.
         if (info.type == SourceType::Vector) {
             new_tile.data =
-                std::make_shared<VectorTileData>(normalized_id, style, glyphAtlas,
+                std::make_shared<VectorTileData>(normalized_id, style.layers, style.workers, glyphAtlas,
                                                  glyphStore, spriteAtlas, sprite, info,
                                                  transformState.getAngle(), data.getCollisionDebug());
             new_tile.data->request(style.workers, transformState.getPixelRatio(), callback);
@@ -304,7 +304,7 @@ TileData::State Source::addTile(MapData& data,
                 style.workers, transformState.getPixelRatio(), callback);
         } else if (info.type == SourceType::Annotations) {
             new_tile.data = std::make_shared<LiveTileData>(normalized_id, data.annotationManager,
-                                                           style, glyphAtlas,
+                                                           style.layers, style.workers, glyphAtlas,
                                                            glyphStore, spriteAtlas, sprite, info,
                                                            transformState.getAngle(), data.getCollisionDebug());
             new_tile.data->reparse(style.workers, callback);

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -570,9 +570,8 @@ void Source::tileLoadingCompleteCallback(const TileID& normalized_id, const Tran
         return;
     }
 
-    emitTileLoaded(true);
     data->redoPlacement(transformState.getAngle(), collisionDebug);
-
+    emitTileLoaded(true);
 }
 
 void Source::emitSourceLoaded() {

--- a/src/mbgl/map/tile_parser.cpp
+++ b/src/mbgl/map/tile_parser.cpp
@@ -8,7 +8,6 @@
 #include <mbgl/renderer/line_bucket.hpp>
 #include <mbgl/renderer/symbol_bucket.hpp>
 #include <mbgl/util/constants.hpp>
-#include <mbgl/style/style.hpp>
 
 #include <locale>
 
@@ -21,14 +20,14 @@ TileParser::~TileParser() = default;
 
 TileParser::TileParser(const GeometryTile& geometryTile_,
                        VectorTileData& tile_,
-                       const Style& style_,
+                       const std::vector<util::ptr<StyleLayer>>& layers_,
                        GlyphAtlas& glyphAtlas_,
                        GlyphStore& glyphStore_,
                        SpriteAtlas& spriteAtlas_,
                        const util::ptr<Sprite>& sprite_)
     : geometryTile(geometryTile_),
       tile(tile_),
-      style(style_),
+      layers(layers_),
       glyphAtlas(glyphAtlas_),
       glyphStore(glyphStore_),
       spriteAtlas(spriteAtlas_),
@@ -42,7 +41,7 @@ bool TileParser::obsolete() const {
 }
 
 void TileParser::parse() {
-    for (const auto& layer_desc : style.layers) {
+    for (const auto& layer_desc : layers) {
         // Cancel early when parsing.
         if (obsolete()) {
             return;

--- a/src/mbgl/map/tile_parser.hpp
+++ b/src/mbgl/map/tile_parser.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/filter_expression.hpp>
 #include <mbgl/style/class_properties.hpp>
 #include <mbgl/style/style_bucket.hpp>
+#include <mbgl/style/style_layer.hpp>
 #include <mbgl/text/glyph.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/noncopyable.hpp>
@@ -22,7 +23,6 @@ class GlyphAtlas;
 class GlyphStore;
 class SpriteAtlas;
 class Sprite;
-class Style;
 class StyleBucket;
 class StyleLayoutFill;
 class StyleLayoutRaster;
@@ -34,7 +34,7 @@ class TileParser : private util::noncopyable {
 public:
     TileParser(const GeometryTile& geometryTile,
                VectorTileData& tile,
-               const Style& style,
+               const std::vector<util::ptr<StyleLayer>>& layers,
                GlyphAtlas& glyphAtlas,
                GlyphStore& glyphStore,
                SpriteAtlas& spriteAtlas,
@@ -61,8 +61,9 @@ private:
     const GeometryTile& geometryTile;
     VectorTileData& tile;
 
+    std::vector<util::ptr<StyleLayer>> layers;
+
     // Cross-thread shared data.
-    const Style& style;
     GlyphAtlas& glyphAtlas;
     GlyphStore& glyphStore;
     SpriteAtlas& spriteAtlas;

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -9,12 +9,12 @@
 #include <mbgl/util/pbf.hpp>
 #include <mbgl/util/worker.hpp>
 #include <mbgl/util/work_request.hpp>
-#include <mbgl/style/style.hpp>
 
 using namespace mbgl;
 
 VectorTileData::VectorTileData(const TileID& id_,
-                               Style& style_,
+                               const std::vector<util::ptr<StyleLayer>>& layers_,
+                               Worker& workers_,
                                GlyphAtlas& glyphAtlas_,
                                GlyphStore& glyphStore_,
                                SpriteAtlas& spriteAtlas_,
@@ -23,11 +23,12 @@ VectorTileData::VectorTileData(const TileID& id_,
                                float angle,
                                bool collisionDebug)
     : TileData(id_, source_),
+      layers(layers_),
+      workers(workers_),
       glyphAtlas(glyphAtlas_),
       glyphStore(glyphStore_),
       spriteAtlas(spriteAtlas_),
       sprite(sprite_),
-      style(style_),
       collision(std::make_unique<CollisionTile>(id_.z, 4096, source_.tile_size * id.overscaling, angle, collisionDebug)),
       lastAngle(angle),
       currentAngle(angle) {
@@ -51,7 +52,7 @@ void VectorTileData::parse() {
         // is going to be discarded afterwards.
         VectorTile vectorTile(pbf((const uint8_t *)data.data(), data.size()));
         const VectorTile* vt = &vectorTile;
-        TileParser parser(*vt, *this, style, glyphAtlas, glyphStore, spriteAtlas, sprite);
+        TileParser parser(*vt, *this, layers, glyphAtlas, glyphStore, spriteAtlas, sprite);
         parser.parse();
 
         if (getState() == State::obsolete) {
@@ -128,15 +129,14 @@ void VectorTileData::redoPlacement(float angle, bool collisionDebug) {
         currentCollisionDebug = collisionDebug;
 
         auto callback = std::bind(&VectorTileData::endRedoPlacement, this);
-        workRequest = style.workers.send([this, angle, collisionDebug] { workerRedoPlacement(angle, collisionDebug); }, callback);
-
+        workRequest = workers.send([this, angle, collisionDebug] { workerRedoPlacement(angle, collisionDebug); }, callback);
     }
 }
 
 void VectorTileData::workerRedoPlacement(float angle, bool collisionDebug) {
     collision->reset(angle, 0);
     collision->setDebug(collisionDebug);
-    for (const auto& layer_desc : style.layers) {
+    for (const auto& layer_desc : layers) {
         auto bucket = getBucket(*layer_desc);
         if (bucket) {
             bucket->placeFeatures();
@@ -145,7 +145,7 @@ void VectorTileData::workerRedoPlacement(float angle, bool collisionDebug) {
 }
 
 void VectorTileData::endRedoPlacement() {
-    for (const auto& layer_desc : style.layers) {
+    for (const auto& layer_desc : layers) {
         auto bucket = getBucket(*layer_desc);
         if (bucket) {
             bucket->swapRenderData();

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -26,14 +26,14 @@ class GlyphAtlas;
 class GlyphStore;
 class SpriteAtlas;
 class Sprite;
-class Style;
 
 class VectorTileData : public TileData {
     friend class TileParser;
 
 public:
     VectorTileData(const TileID&,
-                   Style&,
+                   const std::vector<util::ptr<StyleLayer>>&,
+                   Worker&,
                    GlyphAtlas&,
                    GlyphStore&,
                    SpriteAtlas&,
@@ -66,11 +66,12 @@ protected:
     TriangleElementsBuffer triangleElementsBuffer;
     LineElementsBuffer lineElementsBuffer;
 
+    std::vector<util::ptr<StyleLayer>> layers;
+    Worker& workers;
     GlyphAtlas& glyphAtlas;
     GlyphStore& glyphStore;
     SpriteAtlas& spriteAtlas;
     util::ptr<Sprite> sprite;
-    Style& style;
 
 private:
     // Contains all the Bucket objects for the tile. Buckets are render

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -323,7 +323,8 @@ std::vector<RenderItem> Painter::determineRenderOrder(const Style& style) {
             continue;
         }
 
-        if (!layer.bucket->source) {
+        util::ptr<Source> source = style.getSource(layer.bucket->source);
+        if (!source) {
             Log::Warning(Event::Render, "can't find source for layer '%s'", layer.id.c_str());
             continue;
         }
@@ -345,7 +346,7 @@ std::vector<RenderItem> Painter::determineRenderOrder(const Style& style) {
         // Determine what render passes we need for this layer.
         const RenderPass passes = determineRenderPasses(layer);
 
-        const auto& tiles = layer.bucket->source->getTiles();
+        const auto& tiles = source->getTiles();
         for (auto tile : tiles) {
             assert(tile);
             if (!tile->data && !tile->data->isReady()) {

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -110,10 +110,25 @@ void Style::recalculate(float z, TimePoint now) {
 
     for (const auto& layer : layers) {
         layer->updateProperties(z, now, zoomHistory);
-        if (layer->bucket && layer->bucket->source) {
-            layer->bucket->source->enabled = true;
+        if (!layer->bucket) {
+            continue;
         }
+
+        util::ptr<Source> source = getSource(layer->bucket->source);
+        if (!source) {
+            continue;
+        }
+
+        source->enabled = true;
     }
+}
+
+util::ptr<Source> Style::getSource(const std::string& id) const {
+    const auto it = std::find_if(sources.begin(), sources.end(), [&](util::ptr<Source> source) {
+        return source->info.source_id == id;
+    });
+
+    return it != sources.end() ? *it : nullptr;
 }
 
 void Style::setDefaultTransitionDuration(Duration duration) {

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -63,6 +63,8 @@ public:
         return lastError;
     }
 
+    util::ptr<Source> getSource(const std::string& id) const;
+
     std::unique_ptr<GlyphStore> glyphStore;
     std::unique_ptr<GlyphAtlas> glyphAtlas;
     util::ptr<Sprite> sprite;

--- a/src/mbgl/style/style_bucket.hpp
+++ b/src/mbgl/style/style_bucket.hpp
@@ -10,8 +10,6 @@
 
 namespace mbgl {
 
-class Source;
-
 class StyleBucket : public util::noncopyable {
 public:
     typedef util::ptr<StyleBucket> Ptr;
@@ -20,7 +18,7 @@ public:
 
     const StyleLayerType type;
     std::string name;
-    util::ptr<Source> source;
+    std::string source;
     std::string source_layer;
     FilterExpression filter;
     ClassProperties layout;


### PR DESCRIPTION
I’ve got a demo app that draws the user’s path on the map. The path is implemented as an MGLPolyline. Each time the user location updates, the annotation is removed and a new one added with the updated set of coordinates. I run into #1735 every few steps; eventually, after about a minute, I get crashes like the following in the iOS 8.3 Simulator with the Freeway Drive simulated location:

```
Worker (23)#0	0x0000000108a0dda3 in std::__1::shared_ptr<mbgl::StyleBucket const>::operator*() const [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3917
#1	0x0000000108a0dda3 in mbgl::util::ptr<mbgl::StyleBucket const>::operator*() const [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/include/mbgl/util/ptr.hpp:23
#2	0x0000000108a0dda3 in mbgl::TileParser::parse() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/map/tile_parser.cpp:63
#3	0x00000001089f0305 in mbgl::LiveTileData::parse() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/map/live_tile_data.cpp:47
#4	0x0000000108a0c693 in mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1::operator()() const [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/map/tile_data.cpp:89
#5	0x0000000108a0c68a in decltype(std::__1::forward<mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1&>(mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#6	0x0000000108a0c68a in std::__1::__function::__func<mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1, std::__1::allocator<mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1>, void ()>::operator()() at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1370
#7	0x0000000108a9b9af in std::__1::function<void ()>::operator()() const [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1756
#8	0x0000000108a9b99d in mbgl::WorkTask::runTask() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/work_task.cpp:18
#9	0x0000000108a9c79b in auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)::operator()(std::__1::shared_ptr<mbgl::WorkTask>&) const [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/thread.hpp:80
#10	0x0000000108a9c785 in void mbgl::util::RunLoop::invokeWithResult<auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)&&, std::__1::function<void ()>, std::__1::shared_ptr<mbgl::WorkTask>&&&)::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)::operator()(std::__1::shared_ptr<mbgl::WorkTask>&) [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/run_loop.hpp:51
#11	0x0000000108a9c77d in void mbgl::util::RunLoop::Invoker<void mbgl::util::RunLoop::invokeWithResult<auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)&&, std::__1::function<void ()>, std::__1::shared_ptr<mbgl::WorkTask>&&&)::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::tuple<std::__1::shared_ptr<mbgl::WorkTask> >, std::__1::shared_ptr<mbgl::WorkTask>&>::invoke<0ul>(std::__1::integer_sequence<unsigned long, 0ul>) [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/run_loop.hpp:82
#12	0x0000000108a9c779 in mbgl::util::RunLoop::Invoker<void mbgl::util::RunLoop::invokeWithResult<auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)&&, std::__1::function<void ()>, std::__1::shared_ptr<mbgl::WorkTask>&&&)::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::tuple<std::__1::shared_ptr<mbgl::WorkTask> >, std::__1::shared_ptr<mbgl::WorkTask>&>::operator()() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/run_loop.hpp:77
#13	0x0000000108a975c7 in mbgl::util::RunLoop::process() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/run_loop.cpp:27
#14	0x0000000108ad341e in uv__async_event at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/async.c:80
#15	0x0000000108ad3808 in uv__async_io at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/async.c:156
#16	0x0000000108aef21e in uv__io_poll at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/kqueue.c:233
#17	0x0000000108ad3f13 in uv_run at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/core.c:317
#18	0x0000000108a9d538 in uv::loop::run() [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/uv_detail.hpp:55
#19	0x0000000108a9d52e in void mbgl::util::Thread<mbgl::Worker::Impl>::run<std::__1::tuple<> >(std::__1::tuple<>&&, std::__1::integer_sequence<unsigned long>) at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/thread.hpp:132
#20	0x0000000108a9d47f in mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()::operator()() const [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/thread.hpp:113
#21	0x0000000108a9d44e in std::__1::__invoke<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()>(decltype(std::__1::forward<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#22	0x0000000108a9d44b in _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_6Worker4ImplEEC1IJEEERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS2_14ThreadPriorityEDpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:332
#23	0x0000000108a9d44b in std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()> >(void*, void*) at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:342
#24	0x000000010e77f268 in _pthread_body ()
#25	0x000000010e77f1e5 in _pthread_start ()
#26	0x000000010e77d41d in thread_start ()
```

```
Worker (20)#0	0x00000001055b1484 in mbgl::StyleLayer::isBackground() const at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/style/style_layer.cpp:13
#1	0x000000010556ed78 in mbgl::TileParser::parse() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/map/tile_parser.cpp:51
#2	0x0000000105551305 in mbgl::LiveTileData::parse() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/map/live_tile_data.cpp:47
#3	0x000000010556d693 in mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1::operator()() const [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/map/tile_data.cpp:89
#4	0x000000010556d68a in decltype(std::__1::forward<mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1&>(mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#5	0x000000010556d68a in std::__1::__function::__func<mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1, std::__1::allocator<mbgl::TileData::reparse(mbgl::Worker&, std::__1::function<void ()>)::$_1>, void ()>::operator()() at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1370
#6	0x00000001055fc9af in std::__1::function<void ()>::operator()() const [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1756
#7	0x00000001055fc99d in mbgl::WorkTask::runTask() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/work_task.cpp:18
#8	0x00000001055fd79b in auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)::operator()(std::__1::shared_ptr<mbgl::WorkTask>&) const [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/thread.hpp:80
#9	0x00000001055fd785 in void mbgl::util::RunLoop::invokeWithResult<auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)&&, std::__1::function<void ()>, std::__1::shared_ptr<mbgl::WorkTask>&&&)::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)::operator()(std::__1::shared_ptr<mbgl::WorkTask>&) [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/run_loop.hpp:51
#10	0x00000001055fd77d in void mbgl::util::RunLoop::Invoker<void mbgl::util::RunLoop::invokeWithResult<auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)&&, std::__1::function<void ()>, std::__1::shared_ptr<mbgl::WorkTask>&&&)::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::tuple<std::__1::shared_ptr<mbgl::WorkTask> >, std::__1::shared_ptr<mbgl::WorkTask>&>::invoke<0ul>(std::__1::integer_sequence<unsigned long, 0ul>) [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/run_loop.hpp:82
#11	0x00000001055fd779 in mbgl::util::RunLoop::Invoker<void mbgl::util::RunLoop::invokeWithResult<auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(auto mbgl::util::Thread<mbgl::Worker::Impl>::bind<void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::shared_ptr<mbgl::WorkTask>&>(void (mbgl::Worker::Impl::*)(std::__1::shared_ptr<mbgl::WorkTask>&))::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&)&&, std::__1::function<void ()>, std::__1::shared_ptr<mbgl::WorkTask>&&&)::'lambda'(std::__1::shared_ptr<mbgl::WorkTask>&), std::__1::tuple<std::__1::shared_ptr<mbgl::WorkTask> >, std::__1::shared_ptr<mbgl::WorkTask>&>::operator()() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/run_loop.hpp:77
#12	0x00000001055f85c7 in mbgl::util::RunLoop::process() at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/run_loop.cpp:27
#13	0x000000010563441e in uv__async_event at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/async.c:80
#14	0x0000000105634808 in uv__async_io at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/async.c:156
#15	0x000000010565021e in uv__io_poll at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/kqueue.c:233
#16	0x0000000105634f13 in uv_run at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/core.c:317
#17	0x00000001055fe538 in uv::loop::run() [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/uv_detail.hpp:55
#18	0x00000001055fe52e in void mbgl::util::Thread<mbgl::Worker::Impl>::run<std::__1::tuple<> >(std::__1::tuple<>&&, std::__1::integer_sequence<unsigned long>) at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/thread.hpp:132
#19	0x00000001055fe47f in mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()::operator()() const [inlined] at /Users/travis/build/mapbox/mapbox-gl-native/src/mbgl/util/thread.hpp:113
#20	0x00000001055fe44e in std::__1::__invoke<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()>(decltype(std::__1::forward<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#21	0x00000001055fe44b in _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_6Worker4ImplEEC1IJEEERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS2_14ThreadPriorityEDpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:332
#22	0x00000001055fe44b in std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority)::'lambda'()> >(void*, void*) at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:342
#23	0x000000010b2e0268 in _pthread_body ()
#24	0x000000010b2e01e5 in _pthread_start ()
#25	0x000000010b2de41d in thread_start ()
```

/cc @incanus