### PR TITLE
emit libuv version mismatch as mbgl::Log::Warning

### DIFF
--- a/src/mbgl/util/uv.cpp
+++ b/src/mbgl/util/uv.cpp
@@ -16,7 +16,7 @@ const static bool uvVersionCheck = []() {
     const unsigned int UV_VERSION_PATCH = version & 0xFF;
 #endif
 
-    if (major != UV_VERSION_MAJOR || minor != UV_VERSION_MINOR || patch != UV_VERSION_PATCH) {
+    if (major != UV_VERSION_MAJOR || (major == 0 && minor != UV_VERSION_MINOR)) {
         throw std::runtime_error(mbgl::util::sprintf<96>(
             "libuv version mismatch: headers report %d.%d.%d, but library reports %d.%d.%d", UV_VERSION_MAJOR,
             UV_VERSION_MINOR, UV_VERSION_PATCH, major, minor, patch));


### PR DESCRIPTION
Instead of throwing a `std::runtime_error`, fixes https://github.com/mapbox/node-mapbox-gl-native/issues/137

Looks like this and continues running now:
```
2015-06-17 13:57:27.646 node[80295:1113516] [WARNING] {Main}[General]: libuv version mismatch: headers report 1.0.2, but library reports 1.5.0
```
instead of exiting with:
```
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: libuv version mismatch: headers report 1.0.2, but library reports 1.5.0
```

/cc @springmeyer 