### PR TITLE
Avoid null-change KVO notifications

### DIFF
--- a/platform/ios/MGLAccountManager.m
+++ b/platform/ios/MGLAccountManager.m
@@ -21,7 +21,10 @@
     if (shownInAppNumber) {
         [MGLAccountManager sharedManager].mapboxMetricsEnabledSettingShownInApp = [shownInAppNumber boolValue];
     }
-    self.accessToken = [bundle objectForInfoDictionaryKey:@"MGLMapboxAccessToken"];
+    NSString *accessToken = [bundle objectForInfoDictionaryKey:@"MGLMapboxAccessToken"];
+    if (accessToken.length) {
+        self.accessToken = accessToken;
+    }
 }
 
 // Can be called from any thread.

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1290,7 +1290,9 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     if ([keyPath isEqualToString:@"accessToken"] && object == [MGLAccountManager sharedManager])
     {
         NSString *accessToken = change[NSKeyValueChangeNewKey];
-        _mbglFileSource->setAccessToken(accessToken ? (std::string)[accessToken UTF8String] : "");
+        if (![accessToken isKindOfClass:[NSNull class]]) {
+            _mbglFileSource->setAccessToken((std::string)[accessToken UTF8String]);
+        }
     }
 }
 


### PR DESCRIPTION
If no access token is set in the Info.plist, avoid triggering a KVO notification about the access token changing. By the same token (heh), avoid pulling a C string out of the change dictionary if the access token is being nilled out.

Fixes a bug introduced in 90a50c0c4150080f725cc6b66909eef58a2a9b4a for #1553.

/cc @incanus