### PR TITLE
Static analyzer warning in Sprite::parseJSON()

### DIFF
--- a/src/mbgl/map/sprite.cpp
+++ b/src/mbgl/map/sprite.cpp
@@ -128,7 +128,7 @@ void Sprite::parseJSON(const std::string& jsonURL) {
         emitSpriteLoadingFailed(message.str());
     } else if (d.IsObject()) {
         for (rapidjson::Value::ConstMemberIterator itr = d.MemberBegin(); itr != d.MemberEnd(); ++itr) {
-            const std::string& name = itr->name.GetString();
+            const std::string name = { itr->name.GetString(), itr->name.GetStringLength() };
             const rapidjson::Value& value = itr->value;
 
             if (value.IsObject()) {


### PR DESCRIPTION
Caught by Xcode 7:

```
/path/to/mapbox-gl-native/src/mbgl/map/sprite.cpp
/path/to/mapbox-gl-native/src/mbgl/map/sprite.cpp:148:17: Function call argument is an uninitialized value
/path/to/mapbox-gl-native/src/mbgl/map/sprite.cpp:48:13: Calling 'Sprite::parseJSON'
/path/to/mapbox-gl-native/src/mbgl/map/sprite.cpp:120:1: Entered call from 'operator()'
/path/to/mapbox-gl-native/src/mbgl/map/sprite.cpp:130:75: Entering loop body
/path/to/mapbox-gl-native/src/mbgl/map/sprite.cpp:131:13: 'name' initialized to a garbage value
/path/to/mapbox-gl-native/src/mbgl/map/sprite.cpp:148:17: Function call argument is an uninitialized value
```

/cc @kkaefer