### PR TITLE
Remove cleanup call on the ResourceLoading test case

### DIFF
--- a/test/style/resource_loading.cpp
+++ b/test/style/resource_loading.cpp
@@ -38,7 +38,6 @@ public:
 
     ~MockMapContext() {
         style_.reset();
-        env_.performCleanup();
     }
 
     void update() {


### PR DESCRIPTION
We should not be able to create GL objects with a no-op view, so
there is nothing to cleanup.