### PR TITLE
don't use SIGSTOP/SIGCONT for flow control in tests

### DIFF
--- a/test/fixtures/util.cpp
+++ b/test/fixtures/util.cpp
@@ -4,27 +4,51 @@
 
 #include <csignal>
 
+#include <unistd.h>
+
 namespace mbgl {
 namespace test {
 
 pid_t startServer(const char *executable) {
     const std::string parent_pid = std::to_string(getpid());
+    int pipefd[2];
+
+    if (pipe(pipefd)) {
+        throw std::runtime_error("Cannot create server pipe");
+    }
+
     pid_t pid = fork();
     if (pid < 0) {
         throw std::runtime_error("Cannot create server process");
     } else if (pid == 0) {
+        close(STDIN_FILENO);
+
+        if (dup(pipefd[1])) {
+            Log::Error(Event::Setup, "Failed to start server: %s", strerror(errno));
+        }
+
+        close(pipefd[0]);
+        close(pipefd[1]);
+
         char *args[] = { const_cast<char *>(executable),
                          const_cast<char *>(parent_pid.c_str()),
                          nullptr };
         int ret = execv(executable, args);
         // This call should not return. In case execve failed, we exit anyway.
         if (ret < 0) {
-            Log::Error(Event::Setup, "failed to start server: %s", strerror(errno));
+            Log::Error(Event::Setup, "Failed to start server: %s", strerror(errno));
         }
         exit(0);
     } else {
-        // Wait until the server process sends SIGCONT.
-        raise(SIGSTOP);
+        char buffer[8];
+
+        // Wait until the server process sends something on the pipe.
+        if (!read(pipefd[0], buffer, sizeof(buffer))) {
+            throw std::runtime_error("Error reading a message from the server");
+        }
+
+        close(pipefd[0]);
+        close(pipefd[1]);
     }
     return pid;
 }

--- a/test/headless/server.js
+++ b/test/headless/server.js
@@ -14,6 +14,6 @@ var server = app.listen(2900, function () {
 
     if (process.argv[2]) {
         // Allow the test to continue running.
-        process.kill(+process.argv[2], 'SIGCONT');
+        process.stdin.write("Go!\n");
     }
 });

--- a/test/storage/server.js
+++ b/test/storage/server.js
@@ -103,6 +103,6 @@ var server = app.listen(3000, function () {
 
     if (process.argv[2]) {
         // Allow the test to continue running.
-        process.kill(+process.argv[2], 'SIGCONT');
+        process.stdin.write("Go!\n");
     }
 });


### PR DESCRIPTION
SIGSTOP and SIGCONT are being used to ensure that the server spawned by the headless and storage tests is ready. But they have several weird side effects:

* Debuggers break on SIGSTOP by default, so you have to continue several times if you are debugging the tests.
* SIGSTOP is a shell job control mechanism, so the test process winds up running as a background process in the shell.