### PR TITLE
Substitute lightweight generics macros in docset

### DIFF
--- a/ios/docs/install_docs.sh
+++ b/ios/docs/install_docs.sh
@@ -11,18 +11,24 @@ VERSION=$( git tag --sort -v:refname | grep -v '\-rc.' | sed -n '1p' | sed 's/^v
 echo "Creating new docs for ${VERSION}..."
 echo
 
-README="/tmp/GL-README.md"
+rm -rf /tmp/mbgl
+mkdir -p /tmp/mbgl/
+README=/tmp/mbgl/GL-README.md
 cat ../README.md > ${README}
 echo >> ${README}
 echo -n "#" >> ${README}
 cat ../../CHANGELOG.md >> ${README}
-
+# Copy headers to a temporary location where we can substitute macros that appledoc doesn't understand.
+cp -r ../../include/mbgl/ios /tmp/mbgl
+perl \
+    -pi \
+    -e 's/NS_(?:(MUTABLE)_)?(ARRAY|SET|DICTIONARY)_OF\(\s*(.+?)\s*\)/NS\L\u$1\u$2\E <$3>/g' \
+    /tmp/mbgl/ios/*.h
 appledoc \
     --output ${OUTPUT} \
     --project-name "Mapbox GL for iOS ${VERSION}" \
     --project-company Mapbox \
     --create-docset \
     --company-id com.mapbox \
-    --ignore ../../include/mbgl/ios/private \
     --index-desc ${README} \
-    ../../include/mbgl/ios
+    /tmp/mbgl/ios


### PR DESCRIPTION
As suggested in https://github.com/mapbox/mapbox-gl-native/commit/91641ffb01dcf8d303b13216797bb41d1f770124#commitcomment-11772782, this PR also preprocesses the generics macros when generating a docset.

Followup to 91641ffb01dcf8d303b13216797bb41d1f770124 for #1711.

/cc @incanus