### PR TITLE
Circle render type

### DIFF
--- a/include/mbgl/style/style_properties.hpp
+++ b/include/mbgl/style/style_properties.hpp
@@ -45,6 +45,17 @@ struct LineProperties {
     }
 };
 
+struct CircleProperties {
+    inline CircleProperties() {}
+    float radius = 1.0f;
+    Color color = {{ 0, 0, 0, 1 }};
+    float blur = 0;
+
+    inline bool isVisible() const {
+        return radius > 0 && color[3] > 0;
+    }
+};
+
 struct SymbolProperties {
     inline SymbolProperties() {}
 
@@ -100,6 +111,7 @@ struct BackgroundProperties {
 typedef mapbox::util::variant<
     FillProperties,
     LineProperties,
+    CircleProperties,
     SymbolProperties,
     RasterProperties,
     BackgroundProperties,

--- a/include/mbgl/style/style_properties.hpp
+++ b/include/mbgl/style/style_properties.hpp
@@ -49,10 +49,11 @@ struct CircleProperties {
     inline CircleProperties() {}
     float radius = 1.0f;
     Color color = {{ 0, 0, 0, 1 }};
+    float opacity = 1.0f;
     float blur = 0;
 
     inline bool isVisible() const {
-        return radius > 0 && color[3] > 0;
+        return radius > 0 && color[3] > 0 && opacity > 0;
     }
 };
 

--- a/include/mbgl/style/types.hpp
+++ b/include/mbgl/style/types.hpp
@@ -27,6 +27,7 @@ enum class StyleLayerType : uint8_t {
     Unknown,
     Fill,
     Line,
+    Circle,
     Symbol,
     Raster,
     Background
@@ -36,6 +37,7 @@ MBGL_DEFINE_ENUM_CLASS(StyleLayerTypeClass, StyleLayerType, {
     { StyleLayerType::Unknown, "unknown" },
     { StyleLayerType::Fill, "fill" },
     { StyleLayerType::Line, "line" },
+    { StyleLayerType::Circle, "circle" },
     { StyleLayerType::Symbol, "symbol" },
     { StyleLayerType::Raster, "raster" },
     { StyleLayerType::Background, "background" },

--- a/src/mbgl/geometry/circle_buffer.cpp
+++ b/src/mbgl/geometry/circle_buffer.cpp
@@ -1,0 +1,13 @@
+#include <mbgl/geometry/circle_buffer.hpp>
+
+#include <mbgl/platform/gl.hpp>
+
+#include <climits>
+
+using namespace mbgl;
+
+void CircleVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey) {
+    vertex_type *vertices = static_cast<vertex_type *>(addElement());
+    vertices[0] = (x * 2) + ((ex + 1) / 2);
+    vertices[1] = (y * 2) + ((ey + 1) / 2);
+}

--- a/src/mbgl/geometry/circle_buffer.hpp
+++ b/src/mbgl/geometry/circle_buffer.hpp
@@ -1,0 +1,27 @@
+#ifndef MBGL_GEOMETRY_CIRCLE_BUFFER
+#define MBGL_GEOMETRY_CIRCLE_BUFFER
+
+#include <mbgl/geometry/buffer.hpp>
+
+namespace mbgl {
+
+class CircleVertexBuffer : public Buffer<
+    4 // 2 bytes per short * 4 of them.
+> {
+public:
+    typedef int16_t vertex_type;
+
+    /*
+     * Add a vertex to this buffer
+     *
+     * @param {number} x vertex position
+     * @param {number} y vertex position
+     * @param {number} ex extrude normal
+     * @param {number} ey extrude normal
+     */
+    void add(vertex_type x, vertex_type y, float ex, float ey);
+};
+
+}
+
+#endif // MBGL_GEOMETRY_CIRCLE_BUFFER

--- a/src/mbgl/map/tile_worker.cpp
+++ b/src/mbgl/map/tile_worker.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/geometry/glyph_atlas.hpp>
 #include <mbgl/renderer/fill_bucket.hpp>
 #include <mbgl/renderer/line_bucket.hpp>
+#include <mbgl/renderer/circle_bucket.hpp>
 #include <mbgl/renderer/symbol_bucket.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/util/constants.hpp>
@@ -144,15 +145,22 @@ void TileWorker::parseLayer(const StyleLayer& layer, const GeometryTile& geometr
 
     std::unique_ptr<Bucket> bucket;
 
-    if (styleBucket.type == StyleLayerType::Fill) {
+    switch (styleBucket.type) {
+    case StyleLayerType::Fill:
         bucket = createFillBucket(*geometryLayer, styleBucket);
-    } else if (styleBucket.type == StyleLayerType::Line) {
+        break;
+    case StyleLayerType::Line:
         bucket = createLineBucket(*geometryLayer, styleBucket);
-    } else if (styleBucket.type == StyleLayerType::Symbol) {
+        break;
+    case StyleLayerType::Circle:
+        bucket = createCircleBucket(*geometryLayer, styleBucket);
+        break;
+    case StyleLayerType::Symbol:
         bucket = createSymbolBucket(*geometryLayer, styleBucket);
-    } else if (styleBucket.type == StyleLayerType::Raster) {
+        break;
+    case StyleLayerType::Raster:
         return;
-    } else {
+    default:
         Log::Warning(Event::ParseTile, "unknown bucket render type for layer '%s' (source layer '%s')",
                 styleBucket.name.c_str(), styleBucket.source_layer.c_str());
     }
@@ -203,6 +211,17 @@ std::unique_ptr<Bucket> TileWorker::createLineBucket(const GeometryTileLayer& la
     applyLayoutProperty(PropertyKey::LineJoin, bucket_desc.layout, layout.join, z);
     applyLayoutProperty(PropertyKey::LineMiterLimit, bucket_desc.layout, layout.miter_limit, z);
     applyLayoutProperty(PropertyKey::LineRoundLimit, bucket_desc.layout, layout.round_limit, z);
+
+    addBucketGeometries(bucket, layer, bucket_desc.filter);
+    return bucket->hasData() ? std::move(bucket) : nullptr;
+}
+
+std::unique_ptr<Bucket> TileWorker::createCircleBucket(const GeometryTileLayer& layer,
+                                                       const StyleBucket& bucket_desc) {
+    auto bucket = std::make_unique<CircleBucket>(circleVertexBuffer,
+                                                 triangleElementsBuffer);
+
+    // Circle does not have layout properties to apply.
 
     addBucketGeometries(bucket, layer, bucket_desc.filter);
     return bucket->hasData() ? std::move(bucket) : nullptr;

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/geometry/fill_buffer.hpp>
 #include <mbgl/geometry/line_buffer.hpp>
+#include <mbgl/geometry/circle_buffer.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/style/filter_expression.hpp>
@@ -53,6 +54,7 @@ private:
 
     std::unique_ptr<Bucket> createFillBucket(const GeometryTileLayer&, const StyleBucket&);
     std::unique_ptr<Bucket> createLineBucket(const GeometryTileLayer&, const StyleBucket&);
+    std::unique_ptr<Bucket> createCircleBucket(const GeometryTileLayer&, const StyleBucket&);
     std::unique_ptr<Bucket> createSymbolBucket(const GeometryTileLayer&, const StyleBucket&);
 
     template <class Bucket>
@@ -69,6 +71,7 @@ private:
 
     FillVertexBuffer fillVertexBuffer;
     LineVertexBuffer lineVertexBuffer;
+    CircleVertexBuffer circleVertexBuffer;
 
     TriangleElementsBuffer triangleElementsBuffer;
     LineElementsBuffer lineElementsBuffer;

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -1,11 +1,16 @@
 #include <mbgl/renderer/circle_bucket.hpp>
+#include <mbgl/renderer/painter.hpp>
+
+#include <mbgl/shader/circle_shader.hpp>
 
 using namespace mbgl;
 
 CircleBucket::CircleBucket(CircleVertexBuffer& vertexBuffer,
                            TriangleElementsBuffer& elementsBuffer)
     : vertexBuffer_(vertexBuffer)
-    , elementsBuffer_(elementsBuffer) {
+    , elementsBuffer_(elementsBuffer)
+    , vertexStart_(vertexBuffer_.index())
+    , elementsStart_(elementsBuffer_.index()) {
 }
 
 CircleBucket::~CircleBucket() {
@@ -18,18 +23,70 @@ void CircleBucket::upload() {
     uploaded = true;
 }
 
-void CircleBucket::render(Painter& /* painter */,
-                        const StyleLayer& /* layer_desc */,
-                        const TileID& /* id */,
-                        const mat4& /* matrix */) {
-    // XXX Just a stub for now.
-    //painter.renderCircle(*this, layer_desc, id, matrix);
+void CircleBucket::render(Painter& painter,
+                        const StyleLayer& layer_desc,
+                        const TileID& id,
+                        const mat4& matrix) {
+    painter.renderCircle(*this, layer_desc, id, matrix);
 }
 
 bool CircleBucket::hasData() const {
     return !triangleGroups_.empty();
 }
 
-void CircleBucket::addGeometry(const GeometryCollection& /* geometryCollection */) {
-    // XXX Just a stub for now.
+void CircleBucket::addGeometry(const GeometryCollection& geometryCollection) {
+    for (auto& circle : geometryCollection) {
+        for(auto & geometry : circle) {
+            auto x = geometry.x;
+            auto y = geometry.y;
+
+            // this geometry will be of the Point type, and we'll derive
+            // two triangles from it.
+            //
+            // ┌─────────┐
+            // │ 4     3 │
+            // │         │
+            // │ 1     2 │
+            // └─────────┘
+            //
+            vertexBuffer_.add(x, y, -1, -1); // 1
+            vertexBuffer_.add(x, y, 1, -1); // 2
+            vertexBuffer_.add(x, y, 1, 1); // 3
+            vertexBuffer_.add(x, y, -1, 1); // 4
+
+            if (!triangleGroups_.size() || (triangleGroups_.back()->vertex_length + 4 > 65535)) {
+                // Move to a new group because the old one can't hold the geometry.
+                triangleGroups_.emplace_back(std::make_unique<TriangleGroup>());
+            }
+
+            TriangleGroup& group = *triangleGroups_.back();
+            auto index = group.vertex_length;
+
+            // 1, 2, 3
+            // 1, 4, 3
+            elementsBuffer_.add(index, index + 1, index + 2);
+            elementsBuffer_.add(index, index + 3, index + 2);
+
+            group.vertex_length += 4;
+            group.elements_length += 2;
+        }
+    }
+}
+
+void CircleBucket::drawCircles(CircleShader& shader) {
+    char* vertexIndex = BUFFER_OFFSET(vertexStart_ * vertexBuffer_.itemSize);
+    char* elementsIndex = BUFFER_OFFSET(elementsStart_ * elementsBuffer_.itemSize);
+
+    for (auto& group : triangleGroups_) {
+        assert(group);
+
+        if (!group->elements_length) continue;
+
+        group->array[0].bind(shader, vertexBuffer_, elementsBuffer_, vertexIndex);
+
+        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elementsIndex));
+
+        vertexIndex += group->vertex_length * vertexBuffer_.itemSize;
+        elementsIndex += group->elements_length * elementsBuffer_.itemSize;
+    }
 }

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -1,0 +1,35 @@
+#include <mbgl/renderer/circle_bucket.hpp>
+
+using namespace mbgl;
+
+CircleBucket::CircleBucket(CircleVertexBuffer& vertexBuffer,
+                           TriangleElementsBuffer& elementsBuffer)
+    : vertexBuffer_(vertexBuffer)
+    , elementsBuffer_(elementsBuffer) {
+}
+
+CircleBucket::~CircleBucket() {
+    // Do not remove. header file only contains forward definitions to unique pointers.
+}
+
+void CircleBucket::upload() {
+    vertexBuffer_.upload();
+    elementsBuffer_.upload();
+    uploaded = true;
+}
+
+void CircleBucket::render(Painter& /* painter */,
+                        const StyleLayer& /* layer_desc */,
+                        const TileID& /* id */,
+                        const mat4& /* matrix */) {
+    // XXX Just a stub for now.
+    //painter.renderCircle(*this, layer_desc, id, matrix);
+}
+
+bool CircleBucket::hasData() const {
+    return !triangleGroups_.empty();
+}
+
+void CircleBucket::addGeometry(const GeometryCollection& /* geometryCollection */) {
+    // XXX Just a stub for now.
+}

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -14,6 +14,7 @@
 namespace mbgl {
 
 class CircleVertexBuffer;
+class CircleShader;
 
 class CircleBucket : public Bucket {
     using TriangleGroup = ElementGroup<3>;
@@ -28,9 +29,14 @@ public:
     bool hasData() const;
     void addGeometry(const GeometryCollection&);
 
+    void drawCircles(CircleShader& shader);
+
 private:
     CircleVertexBuffer& vertexBuffer_;
     TriangleElementsBuffer& elementsBuffer_;
+
+    const size_t vertexStart_;
+    const size_t elementsStart_;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups_;
 };

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -1,0 +1,40 @@
+#ifndef MBGL_RENDERER_CIRCLE_BUCKET
+#define MBGL_RENDERER_CIRCLE_BUCKET
+
+#include <mbgl/renderer/bucket.hpp>
+
+#include <mbgl/map/geometry_tile.hpp>
+
+#include <mbgl/geometry/elements_buffer.hpp>
+#include <mbgl/geometry/circle_buffer.hpp>
+
+#include <mbgl/style/style_bucket.hpp>
+#include <mbgl/style/style_layout.hpp>
+
+namespace mbgl {
+
+class CircleVertexBuffer;
+
+class CircleBucket : public Bucket {
+    using TriangleGroup = ElementGroup<3>;
+
+public:
+    CircleBucket(CircleVertexBuffer &vertexBuffer, TriangleElementsBuffer &elementsBuffer);
+    ~CircleBucket() override;
+
+    void upload() override;
+    void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
+
+    bool hasData() const;
+    void addGeometry(const GeometryCollection&);
+
+private:
+    CircleVertexBuffer& vertexBuffer_;
+    TriangleElementsBuffer& elementsBuffer_;
+
+    std::vector<std::unique_ptr<TriangleGroup>> triangleGroups_;
+};
+
+} // namespace mbgl
+
+#endif // MBGL_RENDERER_CIRCLE_BUCKET

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -27,6 +27,7 @@
 #include <mbgl/shader/dot_shader.hpp>
 #include <mbgl/shader/gaussian_shader.hpp>
 #include <mbgl/shader/box_shader.hpp>
+#include <mbgl/shader/circle_shader.hpp>
 
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/mat3.hpp>
@@ -67,6 +68,7 @@ void Painter::setup() {
     assert(sdfIconShader);
     assert(dotShader);
     assert(gaussianShader);
+    assert(circleShader);
 
 
     // Blending
@@ -102,6 +104,7 @@ void Painter::setupShaders() {
     if (!dotShader) dotShader = std::make_unique<DotShader>();
     if (!gaussianShader) gaussianShader = std::make_unique<GaussianShader>();
     if (!collisionBoxShader) collisionBoxShader = std::make_unique<CollisionBoxShader>();
+    if (!circleShader) circleShader = std::make_unique<CircleShader>();
 }
 
 void Painter::resize() {

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -38,6 +38,7 @@ struct FrameData;
 class DebugBucket;
 class FillBucket;
 class LineBucket;
+class CircleBucket;
 class SymbolBucket;
 class RasterBucket;
 
@@ -108,6 +109,7 @@ public:
     void renderDebugText(DebugBucket& bucket, const mat4 &matrix);
     void renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
     void renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
+    void renderCircle(CircleBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
     void renderSymbol(SymbolBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
     void renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
     void renderBackground(const StyleLayer &layer_desc);

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -50,6 +50,7 @@ class LineShader;
 class LinejoinShader;
 class LineSDFShader;
 class LinepatternShader;
+class CircleShader;
 class PatternShader;
 class IconShader;
 class RasterShader;
@@ -228,6 +229,7 @@ public:
     std::unique_ptr<DotShader> dotShader;
     std::unique_ptr<GaussianShader> gaussianShader;
     std::unique_ptr<CollisionBoxShader> collisionBoxShader;
+    std::unique_ptr<CircleShader> circleShader;
 
     StaticVertexBuffer backgroundBuffer = {
         { -1, -1 }, { 1, -1 },

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -8,14 +8,35 @@
 #include <mbgl/map/sprite.hpp>
 #include <mbgl/map/tile_id.hpp>
 
+#include <mbgl/shader/circle_shader.hpp>
+
 using namespace mbgl;
 
-void Painter::renderCircle(CircleBucket& /* bucket */,
-                           const StyleLayer& /* layer_desc */,
-                           const TileID& /* id */,
-                           const mat4& /* matrix */) {
+void Painter::renderCircle(CircleBucket& bucket,
+                           const StyleLayer& layer_desc,
+                           const TileID& id,
+                           const mat4& matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
-    // XXX Just a stub for now.
+    config.stencilTest = false;
+
+    const CircleProperties& properties = layer_desc.getProperties<CircleProperties>();
+    mat4 vtxMatrix = translatedMatrix(matrix, {{ 0, 0 }}, id, TranslateAnchorType::Map);
+
+    // Antialiasing factor: this is a minimum blur distance that serves as
+    // a faux-antialiasing for the circle. since blur is a ratio of the circle's
+    // size and the intent is to keep the blur at roughly 1px, the two
+    // are inversely related.
+    float antialiasing = 1 / pixelRatio / properties.radius;
+
+    useProgram(circleShader->program);
+
+    circleShader->u_matrix = vtxMatrix;
+    circleShader->u_exmatrix = projMatrix;
+    circleShader->u_color = properties.color;
+    circleShader->u_blur = std::max(properties.blur, antialiasing);
+    circleShader->u_size = properties.radius;
+
+    bucket.drawCircles(*circleShader);
 }

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -24,6 +24,12 @@ void Painter::renderCircle(CircleBucket& bucket,
     const CircleProperties& properties = layer_desc.getProperties<CircleProperties>();
     mat4 vtxMatrix = translatedMatrix(matrix, {{ 0, 0 }}, id, TranslateAnchorType::Map);
 
+    Color color = properties.color;
+    color[0] *= properties.opacity;
+    color[1] *= properties.opacity;
+    color[2] *= properties.opacity;
+    color[3] *= properties.opacity;
+
     // Antialiasing factor: this is a minimum blur distance that serves as
     // a faux-antialiasing for the circle. since blur is a ratio of the circle's
     // size and the intent is to keep the blur at roughly 1px, the two
@@ -34,7 +40,7 @@ void Painter::renderCircle(CircleBucket& bucket,
 
     circleShader->u_matrix = vtxMatrix;
     circleShader->u_exmatrix = projMatrix;
-    circleShader->u_color = properties.color;
+    circleShader->u_color = color;
     circleShader->u_blur = std::max(properties.blur, antialiasing);
     circleShader->u_size = properties.radius;
 

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -1,0 +1,21 @@
+#include <mbgl/renderer/painter.hpp>
+#include <mbgl/renderer/circle_bucket.hpp>
+
+#include <mbgl/style/style.hpp>
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/style/style_layout.hpp>
+
+#include <mbgl/map/sprite.hpp>
+#include <mbgl/map/tile_id.hpp>
+
+using namespace mbgl;
+
+void Painter::renderCircle(CircleBucket& /* bucket */,
+                           const StyleLayer& /* layer_desc */,
+                           const TileID& /* id */,
+                           const mat4& /* matrix */) {
+    // Abort early.
+    if (pass == RenderPass::Opaque) return;
+
+    // XXX Just a stub for now.
+}

--- a/src/mbgl/shader/circle.fragment.glsl
+++ b/src/mbgl/shader/circle.fragment.glsl
@@ -1,0 +1,10 @@
+uniform vec4 u_color;
+uniform float u_blur;
+uniform float u_size;
+
+varying vec2 v_extrude;
+
+void main() {
+    float t = smoothstep(1.0 - u_blur, 1.0, length(v_extrude));
+    gl_FragColor = u_color * (1.0 - t);
+}

--- a/src/mbgl/shader/circle.vertex.glsl
+++ b/src/mbgl/shader/circle.vertex.glsl
@@ -1,0 +1,23 @@
+// set by gl_util
+uniform float u_size;
+
+attribute vec2 a_pos;
+
+uniform mat4 u_matrix;
+uniform mat4 u_exmatrix;
+
+varying vec2 v_extrude;
+
+void main(void) {
+    // unencode the extrusion vector that we snuck into the a_pos vector
+    v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
+
+    vec4 extrude = u_exmatrix * vec4(v_extrude * u_size, 0, 0);
+    // multiply a_pos by 0.5, since we had it * 2 in order to sneak
+    // in extrusion data
+    gl_Position = u_matrix * vec4(a_pos * 0.5, 0, 1);
+
+    // gl_Position is divided by gl_Position.w after this shader runs.
+    // Multiply the extrude by it so that it isn't affected by it.
+    gl_Position += extrude * gl_Position.w;
+}

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -1,0 +1,21 @@
+#include <mbgl/shader/circle_shader.hpp>
+#include <mbgl/shader/shaders.hpp>
+#include <mbgl/platform/gl.hpp>
+
+#include <cstdio>
+
+using namespace mbgl;
+
+CircleShader::CircleShader()
+    : Shader(
+        "circle",
+        shaders[CIRCLE_SHADER].vertex,
+        shaders[CIRCLE_SHADER].fragment
+    ) {
+    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
+}
+
+void CircleShader::bind(char *offset) {
+    MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
+    MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 4, offset));
+}

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -1,0 +1,27 @@
+#ifndef MBGL_SHADER_CIRCLE_SHADER
+#define MBGL_SHADER_CIRCLE_SHADER
+
+#include <mbgl/shader/shader.hpp>
+#include <mbgl/shader/uniform.hpp>
+
+namespace mbgl {
+
+class CircleShader : public Shader {
+public:
+    CircleShader();
+
+    void bind(char *offset);
+
+    UniformMatrix<4>               u_matrix   = {"u_matrix",   *this};
+    UniformMatrix<4>               u_exmatrix = {"u_exmatrix", *this};
+    Uniform<std::array<float, 4>>  u_color    = {"u_color",    *this};
+    Uniform<float>                 u_size     = {"u_size",     *this};
+    Uniform<float>                 u_blur     = {"u_blur",     *this};
+
+private:
+    int32_t a_pos = -1;
+};
+
+}
+
+#endif // MBGL_SHADER_CIRCLE_SHADER

--- a/src/mbgl/style/property_fallback.cpp
+++ b/src/mbgl/style/property_fallback.cpp
@@ -23,6 +23,7 @@ const std::map<PropertyKey, PropertyValue> PropertyFallbackValue::properties = {
 
     { PropertyKey::CircleRadius, defaultStyleProperties<CircleProperties>().radius },
     { PropertyKey::CircleColor, defaultStyleProperties<CircleProperties>().color },
+    { PropertyKey::CircleOpacity, defaultStyleProperties<CircleProperties>().opacity },
     { PropertyKey::CircleBlur, defaultStyleProperties<CircleProperties>().blur },
 
     { PropertyKey::IconOpacity, defaultStyleProperties<SymbolProperties>().icon.opacity },

--- a/src/mbgl/style/property_fallback.cpp
+++ b/src/mbgl/style/property_fallback.cpp
@@ -21,6 +21,10 @@ const std::map<PropertyKey, PropertyValue> PropertyFallbackValue::properties = {
     { PropertyKey::LineGapWidth, defaultStyleProperties<LineProperties>().gap_width },
     { PropertyKey::LineBlur, defaultStyleProperties<LineProperties>().blur },
 
+    { PropertyKey::CircleRadius, defaultStyleProperties<CircleProperties>().radius },
+    { PropertyKey::CircleColor, defaultStyleProperties<CircleProperties>().color },
+    { PropertyKey::CircleBlur, defaultStyleProperties<CircleProperties>().blur },
+
     { PropertyKey::IconOpacity, defaultStyleProperties<SymbolProperties>().icon.opacity },
     { PropertyKey::IconSize, defaultStyleProperties<SymbolProperties>().icon.size },
     { PropertyKey::IconColor, defaultStyleProperties<SymbolProperties>().icon.color },

--- a/src/mbgl/style/property_key.hpp
+++ b/src/mbgl/style/property_key.hpp
@@ -29,6 +29,7 @@ enum class PropertyKey {
 
     CircleRadius,
     CircleColor,
+    CircleOpacity,
     CircleBlur,
 
     SymbolPlacement,

--- a/src/mbgl/style/property_key.hpp
+++ b/src/mbgl/style/property_key.hpp
@@ -27,6 +27,10 @@ enum class PropertyKey {
     LineMiterLimit,
     LineRoundLimit,
 
+    CircleRadius,
+    CircleColor,
+    CircleBlur,
+
     SymbolPlacement,
     SymbolMinDistance,
     SymbolAvoidEdges,

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -19,6 +19,8 @@ bool StyleLayer::isVisible() const {
             return getProperties<FillProperties>().isVisible();
         case StyleLayerType::Line:
             return getProperties<LineProperties>().isVisible();
+        case StyleLayerType::Circle:
+            return getProperties<CircleProperties>().isVisible();
         case StyleLayerType::Symbol:
             return getProperties<SymbolProperties>().isVisible();
         case StyleLayerType::Raster:

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -212,6 +212,7 @@ void StyleLayer::applyStyleProperties<CircleProperties>(const float z, const Tim
     CircleProperties& circle = properties.get<CircleProperties>();
     applyTransitionedStyleProperty(PropertyKey::CircleRadius, circle.radius, z, now, zoomHistory);
     applyTransitionedStyleProperty(PropertyKey::CircleColor, circle.color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::CircleOpacity, circle.opacity, z, now, zoomHistory);
     applyTransitionedStyleProperty(PropertyKey::CircleBlur, circle.blur, z, now, zoomHistory);
 }
 

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -207,6 +207,15 @@ void StyleLayer::applyStyleProperties<LineProperties>(const float z, const TimeP
 }
 
 template <>
+void StyleLayer::applyStyleProperties<CircleProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
+    properties.set<CircleProperties>();
+    CircleProperties& circle = properties.get<CircleProperties>();
+    applyTransitionedStyleProperty(PropertyKey::CircleRadius, circle.radius, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::CircleColor, circle.color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::CircleBlur, circle.blur, z, now, zoomHistory);
+}
+
+template <>
 void StyleLayer::applyStyleProperties<SymbolProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
     properties.set<SymbolProperties>();
     SymbolProperties &symbol = properties.get<SymbolProperties>();
@@ -257,6 +266,7 @@ void StyleLayer::updateProperties(float z, const TimePoint now, ZoomHistory &zoo
     switch (type) {
         case StyleLayerType::Fill: applyStyleProperties<FillProperties>(z, now, zoomHistory); break;
         case StyleLayerType::Line: applyStyleProperties<LineProperties>(z, now, zoomHistory); break;
+        case StyleLayerType::Circle: applyStyleProperties<CircleProperties>(z, now, zoomHistory); break;
         case StyleLayerType::Symbol: applyStyleProperties<SymbolProperties>(z, now, zoomHistory); break;
         case StyleLayerType::Raster: applyStyleProperties<RasterProperties>(z, now, zoomHistory); break;
         case StyleLayerType::Background: applyStyleProperties<BackgroundProperties>(z, now, zoomHistory); break;

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -819,6 +819,10 @@ void StyleParser::parsePaint(JSVal value, ClassProperties &klass) {
     parseOptionalProperty<PiecewiseConstantFunction<Faded<std::vector<float>>>>("line-dasharray", Key::LineDashArray, klass, value, "line-dasharray-transition");
     parseOptionalProperty<PiecewiseConstantFunction<Faded<std::string>>>("line-image", Key::LineImage, klass, value, "line-image-transition");
 
+    parseOptionalProperty<Function<float>>("circle-radius", Key::CircleRadius, klass, value);
+    parseOptionalProperty<Function<Color>>("circle-color", Key::CircleColor, klass, value);
+    parseOptionalProperty<Function<float>>("circle-blur", Key::CircleBlur, klass, value);
+
     parseOptionalProperty<Function<float>>("icon-opacity", Key::IconOpacity, klass, value);
     parseOptionalProperty<PropertyTransition>("icon-opacity-transition", Key::IconOpacity, klass, value);
     parseOptionalProperty<Function<float>>("icon-size", Key::IconSize, klass, value);

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -821,6 +821,7 @@ void StyleParser::parsePaint(JSVal value, ClassProperties &klass) {
 
     parseOptionalProperty<Function<float>>("circle-radius", Key::CircleRadius, klass, value);
     parseOptionalProperty<Function<Color>>("circle-color", Key::CircleColor, klass, value);
+    parseOptionalProperty<Function<float>>("circle-opacity", Key::CircleOpacity, klass, value);
     parseOptionalProperty<Function<float>>("circle-blur", Key::CircleBlur, klass, value);
 
     parseOptionalProperty<Function<float>>("icon-opacity", Key::IconOpacity, klass, value);

--- a/src/mbgl/style/style_properties.cpp
+++ b/src/mbgl/style/style_properties.cpp
@@ -5,6 +5,7 @@ namespace mbgl {
 
 template<> const FillProperties &defaultStyleProperties() { static const FillProperties p; return p; }
 template<> const LineProperties &defaultStyleProperties() { static const LineProperties p; return p; }
+template<> const CircleProperties &defaultStyleProperties() { static const CircleProperties p; return p; }
 template<> const SymbolProperties &defaultStyleProperties() { static const SymbolProperties p; return p; }
 template<> const RasterProperties &defaultStyleProperties() { static const RasterProperties p; return p; }
 template<> const BackgroundProperties &defaultStyleProperties() { static const BackgroundProperties p; return p; }

--- a/test/fixtures/style_parser/circle-blur.info.json
+++ b/test/fixtures/style_parser/circle-blur.info.json
@@ -1,0 +1,7 @@
+{
+    "default": {
+        "log": [
+            [1, "WARNING", "ParseStyle", "value of 'circle-blur' must be a number, or a number function"]
+        ]
+    }
+}

--- a/test/fixtures/style_parser/circle-blur.style.json
+++ b/test/fixtures/style_parser/circle-blur.style.json
@@ -1,0 +1,18 @@
+{
+  "version": 6,
+  "sources": {
+    "mapbox": {
+      "type": "vector",
+      "url": "mapbox://mapbox.mapbox-terrain-v1,mapbox.mapbox-streets-v5",
+      "maxzoom": 14
+    }
+  },
+  "layers": [{
+    "id": "circle_blur_example",
+    "type": "circle",
+    "source": "mapbox",
+    "paint": {
+      "circle-blur": null
+    }
+  }]
+}

--- a/test/fixtures/style_parser/circle-color.info.json
+++ b/test/fixtures/style_parser/circle-color.info.json
@@ -1,0 +1,7 @@
+{
+    "default": {
+        "log": [
+            [1, "WARNING", "ParseStyle", "color value must be a string"]
+        ]
+    }
+}

--- a/test/fixtures/style_parser/circle-color.style.json
+++ b/test/fixtures/style_parser/circle-color.style.json
@@ -1,0 +1,18 @@
+{
+  "version": 6,
+  "sources": {
+    "mapbox": {
+      "type": "vector",
+      "url": "mapbox://mapbox.mapbox-terrain-v1,mapbox.mapbox-streets-v5",
+      "maxzoom": 14
+    }
+  },
+  "layers": [{
+    "id": "circle_color_example",
+    "type": "circle",
+    "source": "mapbox",
+    "paint": {
+      "circle-color": null
+    }
+  }]
+}

--- a/test/fixtures/style_parser/circle-opacity.info.json
+++ b/test/fixtures/style_parser/circle-opacity.info.json
@@ -1,0 +1,7 @@
+{
+    "default": {
+        "log": [
+            [1, "WARNING", "ParseStyle", "value of 'circle-opacity' must be a number, or a number function"]
+        ]
+    }
+}

--- a/test/fixtures/style_parser/circle-opacity.style.json
+++ b/test/fixtures/style_parser/circle-opacity.style.json
@@ -1,0 +1,18 @@
+{
+  "version": 6,
+  "sources": {
+    "mapbox": {
+      "type": "vector",
+      "url": "mapbox://mapbox.mapbox-terrain-v1,mapbox.mapbox-streets-v5",
+      "maxzoom": 14
+    }
+  },
+  "layers": [{
+    "id": "circle_opacity_example",
+    "type": "circle",
+    "source": "mapbox",
+    "paint": {
+      "circle-opacity": null
+    }
+  }]
+}

--- a/test/fixtures/style_parser/circle-radius.info.json
+++ b/test/fixtures/style_parser/circle-radius.info.json
@@ -1,0 +1,7 @@
+{
+    "default": {
+        "log": [
+            [1, "WARNING", "ParseStyle", "value of 'circle-radius' must be a number, or a number function"]
+        ]
+    }
+}

--- a/test/fixtures/style_parser/circle-radius.style.json
+++ b/test/fixtures/style_parser/circle-radius.style.json
@@ -1,0 +1,18 @@
+{
+  "version": 6,
+  "sources": {
+    "mapbox": {
+      "type": "vector",
+      "url": "mapbox://mapbox.mapbox-terrain-v1,mapbox.mapbox-streets-v5",
+      "maxzoom": 14
+    }
+  },
+  "layers": [{
+    "id": "circle_radius_example",
+    "type": "circle",
+    "source": "mapbox",
+    "paint": {
+      "circle-radius": null
+    }
+  }]
+}


### PR DESCRIPTION
Changes:
- Added support for the circle render style according to https://github.com/mapbox/mapbox-gl-style-spec/blob/v8/reference/v8.json
- Copied vertex and fragment shader code from https://github.com/mapbox/mapbox-gl-js
- Added support for the following paint properties: `circle-radius`, `circle-color`, `circle-opacity` and `circle-blur`
- Added `StyleParser` fixture tests

/cc @tmpsantos @kkaefer @tmcw @ansis