### PR TITLE
Style parser readability

### DIFF
--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -286,7 +286,7 @@ std::tuple<bool, std::array<float, 2>> StyleParser::parseProperty(JSVal value, c
 
         float first = value[rapidjson::SizeType(0)].GetDouble();
         float second = value[rapidjson::SizeType(1)].GetDouble();
-        return std::tuple<bool, std::array<float, 2>> { false, {{ first, second }} };
+        return std::tuple<bool, std::array<float, 2>> { true, {{ first, second }} };
     } else {
         Log::Warning(Event::ParseStyle, "value must be array of two numbers");
         return std::tuple<bool, std::array<float, 2>> { false, {{ 0.0f, 0.0f }} };
@@ -367,7 +367,7 @@ std::tuple<bool, std::vector<std::pair<float, T>>> StyleParser::parseStops(JSVal
 template <typename T>
 std::tuple<bool, Function<T>> StyleParser::parseFunction(JSVal value, const char *property_name) {
     if (!value.IsObject()) {
-        return std::tuple<bool, Function<T>> { true, ConstantFunction<T>(std::get<1>(parseProperty<T>(value, property_name))) };
+        return parseProperty<T>(value, property_name);
     }
 
     if (!value.HasMember("stops")) {

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -23,6 +23,14 @@ class StyleParser {
 public:
     using JSVal = const rapidjson::Value&;
 
+    enum Status : bool {
+        StyleParserFailure = 0,
+        StyleParserSuccess
+    };
+
+    template<typename T>
+    using Result = std::pair<Status, T>;
+
     StyleParser();
 
     void parse(JSVal document);
@@ -77,18 +85,18 @@ private:
     bool setProperty(JSVal value, const char *property_name, PropertyKey key, ClassProperties &klass, JSVal transition);
 
     template <typename T>
-    std::tuple<bool, T> parseProperty(JSVal value, const char *property_name);
+    Result<T> parseProperty(JSVal value, const char *property_name);
     template <typename T>
-    std::tuple<bool, T> parseProperty(JSVal value, const char *property_name, JSVal transition);
+    Result<T> parseProperty(JSVal value, const char *property_name, JSVal transition);
 
     template <typename T>
-    std::tuple<bool, Function<T>> parseFunction(JSVal value, const char *);
+    Result<Function<T>> parseFunction(JSVal value, const char *);
     template <typename T>
-    std::tuple<bool, PiecewiseConstantFunction<T>> parsePiecewiseConstantFunction(JSVal value, Duration duration);
+    Result<PiecewiseConstantFunction<T>> parsePiecewiseConstantFunction(JSVal value, Duration duration);
     template <typename T>
-    std::tuple<bool, std::vector<std::pair<float, T>>> parseStops(JSVal value, const char *property_name);
+    Result<std::vector<std::pair<float, T>>> parseStops(JSVal value, const char *property_name);
 
-    std::tuple<bool,std::vector<float>> parseFloatArray(JSVal value);
+    Result<std::vector<float>> parseFloatArray(JSVal value);
 
     FilterExpression parseFilter(JSVal);
 

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -68,21 +68,21 @@ private:
 
     // Parses optional properties into a render bucket.
     template<typename T>
-    bool parseRenderProperty(JSVal value, T &target, const char *name);
+    Status parseRenderProperty(JSVal value, T &target, const char *name);
     template <typename Parser, typename T>
-    bool parseRenderProperty(JSVal value, T &target, const char *name);
+    Status parseRenderProperty(JSVal value, T &target, const char *name);
 
     // Parses optional properties into style class properties.
     template <typename T>
     void parseVisibility(StyleBucket &bucket, JSVal value);
     template <typename T>
-    bool parseOptionalProperty(const char *property_name, PropertyKey key, ClassProperties &klass, JSVal value);
+    Status parseOptionalProperty(const char *property_name, PropertyKey key, ClassProperties &klass, JSVal value);
     template <typename T>
-    bool parseOptionalProperty(const char *property_name, PropertyKey key, ClassProperties &klass, JSVal value, const char *transition_name);
+    Status parseOptionalProperty(const char *property_name, PropertyKey key, ClassProperties &klass, JSVal value, const char *transition_name);
     template <typename T>
-    bool setProperty(JSVal value, const char *property_name, PropertyKey key, ClassProperties &klass);
+    Status setProperty(JSVal value, const char *property_name, PropertyKey key, ClassProperties &klass);
     template <typename T>
-    bool setProperty(JSVal value, const char *property_name, PropertyKey key, ClassProperties &klass, JSVal transition);
+    Status setProperty(JSVal value, const char *property_name, PropertyKey key, ClassProperties &klass, JSVal transition);
 
     template <typename T>
     Result<T> parseProperty(JSVal value, const char *property_name);

--- a/test/fixtures/style_parser/line-translate.info.json
+++ b/test/fixtures/style_parser/line-translate.info.json
@@ -1,0 +1,7 @@
+{
+    "default": {
+        "log": [
+            [1, "WARNING", "ParseStyle", "value must be array of two numbers"]
+        ]
+    }
+}

--- a/test/fixtures/style_parser/line-translate.style.json
+++ b/test/fixtures/style_parser/line-translate.style.json
@@ -1,0 +1,18 @@
+{
+  "version": 6,
+  "sources": {
+    "mapbox": {
+      "type": "vector",
+      "url": "mapbox://mapbox.mapbox-terrain-v1,mapbox.mapbox-streets-v5",
+      "maxzoom": 14
+    }
+  },
+  "layers": [{
+    "id": "line_translate_example",
+    "type": "line",
+    "source": "mapbox",
+    "paint": {
+      "line-translate": null
+    }
+  }]
+}


### PR DESCRIPTION
I took a moment to understand what the `bool` being passed on the `std::tuple` means. Replacing `bool` values with `enum` is a good way to improve code readability without damaging performance. Found a minor issue along the way causing `parseProperty` to return failure when `T = std::array<float, 2>`.

/cc @tmpsantos @kkaefer @jfirebaugh 