### PR TITLE
Fix fit to bounds

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -36,6 +36,8 @@
         '../platform/ios/MGLUserLocationAnnotationView.m',
         '../include/mbgl/ios/MGLTypes.h',
         '../platform/ios/MGLTypes.m',
+        '../include/mbgl/ios/MGLGeometry.h',
+        '../platform/ios/MGLGeometry.m',
         '../include/mbgl/ios/MGLMultiPoint.h',
         '../platform/ios/MGLMultiPoint_Private.h',
         '../platform/ios/MGLMultiPoint.mm',

--- a/include/mbgl/ios/MGLGeometry.h
+++ b/include/mbgl/ios/MGLGeometry.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#import "MGLTypes.h"
+
+#import <CoreLocation/CoreLocation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** Defines the area spanned by an MGLCoordinateBounds. */
+typedef struct {
+    CLLocationDegrees latitudeDelta;
+    CLLocationDegrees longitudeDelta;
+} MGLCoordinateSpan;
+
+/** Creates a new MGLCoordinateSpan from the given latitudinal and longitudinal deltas. */
+NS_INLINE MGLCoordinateSpan MGLCoordinateSpanMake(CLLocationDegrees latitudeDelta, CLLocationDegrees longitudeDelta) {
+    MGLCoordinateSpan span;
+    span.latitudeDelta = latitudeDelta;
+    span.longitudeDelta = longitudeDelta;
+    return span;
+}
+
+/** Returns `YES` if the two coordinate spans represent the same latitudinal change and the same longitudinal change. */
+NS_INLINE BOOL MGLCoordinateSpanEqualToCoordinateSpan(MGLCoordinateSpan span1, MGLCoordinateSpan span2) {
+    return (span1.latitudeDelta == span2.latitudeDelta &&
+            span1.longitudeDelta == span2.longitudeDelta);
+}
+
+/** An area of zero width and zero height. */
+extern const MGLCoordinateSpan MGLCoordinateSpanZero;
+
+/** A rectangular area as measured on a two-dimensional map projection. */
+typedef struct {
+    CLLocationCoordinate2D sw;
+    CLLocationCoordinate2D ne;
+} MGLCoordinateBounds;
+
+/** Creates a new MGLCoordinateBounds structure from the given southwest and northeast coordinates. */
+NS_INLINE MGLCoordinateBounds MGLCoordinateBoundsMake(CLLocationCoordinate2D sw, CLLocationCoordinate2D ne) {
+    MGLCoordinateBounds bounds;
+    bounds.sw = sw;
+    bounds.ne = ne;
+    return bounds;
+}
+
+/** Returns `YES` if the two coordinate bounds are equal to each other. */
+NS_INLINE BOOL MGLCoordinateBoundsEqualToCoordinateBounds(MGLCoordinateBounds bounds1, MGLCoordinateBounds bounds2) {
+    return (bounds1.sw.latitude == bounds2.sw.latitude &&
+            bounds1.sw.longitude == bounds2.sw.longitude &&
+            bounds1.ne.latitude == bounds2.ne.latitude &&
+            bounds1.ne.longitude == bounds2.ne.longitude);
+}
+
+/** Returns the area spanned by the coordinate bounds. */
+NS_INLINE MGLCoordinateSpan MGLCoordinateBoundsGetCoordinateSpan(MGLCoordinateBounds bounds) {
+    return MGLCoordinateSpanMake(bounds.ne.latitude - bounds.sw.latitude,
+                                 bounds.ne.longitude - bounds.sw.longitude);
+}
+
+/** Returns a coordinate bounds with southwest and northeast coordinates that are offset from those of the source bounds. */
+NS_INLINE MGLCoordinateBounds MGLCoordinateBoundsOffset(MGLCoordinateBounds bounds, MGLCoordinateSpan offset) {
+    MGLCoordinateBounds offsetBounds = bounds;
+    offsetBounds.sw.latitude += offset.latitudeDelta;
+    offsetBounds.sw.longitude += offset.longitudeDelta;
+    offsetBounds.ne.latitude += offset.latitudeDelta;
+    offsetBounds.ne.longitude += offset.longitudeDelta;
+    return offsetBounds;
+}
+
+/** Returns `YES` if the coordinate bounds covers no area.
+*   
+*   Note that a bounds may be empty but have a non-zero coordinate span (e.g., when its northeast point lies due north of its southwest point). */
+NS_INLINE BOOL MGLCoordinateBoundsIsEmpty(MGLCoordinateBounds bounds) {
+    MGLCoordinateSpan span = MGLCoordinateBoundsGetCoordinateSpan(bounds);
+    return span.latitudeDelta == 0 || span.longitudeDelta == 0;
+}
+
+/** Returns a formatted string for the given coordinate bounds. */
+NS_INLINE NSString *MGLStringFromCoordinateBounds(MGLCoordinateBounds bounds) {
+    return [NSString stringWithFormat:@"{{%.1f, %.1f}, {%.1f, %.1f}}",
+            bounds.sw.latitude, bounds.sw.longitude,
+            bounds.ne.latitude, bounds.ne.longitude];
+}
+
+NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -126,6 +126,12 @@ IB_DESIGNABLE
 *   @param animated Specify `YES` to animate the change by smoothly scrolling and zooming or `NO` to immediately display the given bounds. */
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds animated:(BOOL)animated;
 
+/** Changes the receiver’s viewport to fit the given coordinate bounds, optionally animating the change.
+*   @param bounds The bounds that the viewport will show in its entirety.
+*   @param insets The minimum padding (in screen points) that will be visible around the given coordinate bounds.
+*   @param animated Specify `YES` to animate the change by smoothly scrolling and zooming or `NO` to immediately display the given bounds. */
+- (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated;
+
 /** The heading of the map (measured in degrees) relative to true north. 
 *
 *   The value `0` means that the top edge of the map view corresponds to true north. The value `90` means the top of the map is pointing due east. The value `180` means the top of the map points due south, and so on. */

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -1,4 +1,4 @@
-#import "MGLTypes.h"
+#import "MGLGeometry.h"
 
 #import <UIKit/UIKit.h>
 #import <CoreLocation/CoreLocation.h>

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -118,6 +118,14 @@ IB_DESIGNABLE
 *   @param animated Specify `YES` if you want the map view to animate scrolling and zooming to the new location or `NO` if you want the map to display the new location immediately. */
 - (void)setCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(double)zoomLevel animated:(BOOL)animated;
 
+/** Returns the coordinate bounds visible in the receiver’s viewport. */
+- (MGLCoordinateBounds)visibleCoordinateBounds;
+
+/** Changes the receiver’s viewport to fit the given coordinate bounds, optionally animating the change.
+*   @param bounds The bounds that the viewport will show in its entirety.
+*   @param animated Specify `YES` to animate the change by smoothly scrolling and zooming or `NO` to immediately display the given bounds. */
+- (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds animated:(BOOL)animated;
+
 /** The heading of the map (measured in degrees) relative to true north. 
 *
 *   The value `0` means that the top edge of the map view corresponds to true north. The value `90` means the top of the map is pointing due east. The value `180` means the top of the map points due south, and so on. */

--- a/include/mbgl/ios/MGLOverlay.h
+++ b/include/mbgl/ios/MGLOverlay.h
@@ -2,7 +2,7 @@
 #import <CoreLocation/CoreLocation.h>
 
 #import "MGLAnnotation.h"
-#import "MGLTypes.h"
+#import "MGLGeometry.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/mbgl/ios/MGLTypes.h
+++ b/include/mbgl/ios/MGLTypes.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
-#import <CoreLocation/CoreLocation.h>
+
+#pragma once
 
 #if !__has_feature(nullability)
     #define NS_ASSUME_NONNULL_BEGIN
@@ -22,18 +23,6 @@ typedef NS_ENUM(NSUInteger, MGLUserTrackingMode) {
     /** The map follows the user location and rotates when the heading changes. */
     MGLUserTrackingModeFollowWithHeading
 };
-
-typedef struct {
-    CLLocationCoordinate2D sw;
-    CLLocationCoordinate2D ne;
-} MGLCoordinateBounds;
-
-NS_INLINE MGLCoordinateBounds MGLCoordinateBoundsMake(CLLocationCoordinate2D sw, CLLocationCoordinate2D ne) {
-    MGLCoordinateBounds bounds;
-    bounds.sw = sw;
-    bounds.ne = ne;
-    return bounds;
-}
 
 NS_ASSUME_NONNULL_END
 

--- a/include/mbgl/ios/MGLTypes.h
+++ b/include/mbgl/ios/MGLTypes.h
@@ -28,6 +28,13 @@ typedef struct {
     CLLocationCoordinate2D ne;
 } MGLCoordinateBounds;
 
+NS_INLINE MGLCoordinateBounds MGLCoordinateBoundsMake(CLLocationCoordinate2D sw, CLLocationCoordinate2D ne) {
+    MGLCoordinateBounds bounds;
+    bounds.sw = sw;
+    bounds.ne = ne;
+    return bounds;
+}
+
 NS_ASSUME_NONNULL_END
 
 #pragma clang diagnostic push

--- a/include/mbgl/ios/MapboxGL.h
+++ b/include/mbgl/ios/MapboxGL.h
@@ -1,5 +1,6 @@
 #import "MGLAccountManager.h"
 #import "MGLAnnotation.h"
+#import "MGLGeometry.h"
 #import "MGLMapView.h"
 #import "MGLMultiPoint.h"
 #import "MGLOverlay.h"

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -38,6 +38,10 @@ using AnnotationIDs = std::vector<uint32_t>;
 using AnnotationSegment = std::vector<LatLng>;
 using AnnotationSegments = std::vector<AnnotationSegment>;
 
+using EdgeInsets = struct {
+    double top, left, bottom, right;
+};
+
 class Map : private util::noncopyable {
     friend class View;
 
@@ -95,7 +99,7 @@ public:
     void setZoom(double zoom, Duration = Duration::zero());
     double getZoom() const;
     void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
-    void fitBounds(LatLngBounds bounds, Duration = Duration::zero());
+    void fitBounds(LatLngBounds bounds, EdgeInsets padding, Duration duration = Duration::zero());
     void resetZoom();
     double getMinZoom() const;
     double getMaxZoom() const;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -95,6 +95,7 @@ public:
     void setZoom(double zoom, Duration = Duration::zero());
     double getZoom() const;
     void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
+    void fitBounds(LatLngBounds bounds, Duration = Duration::zero());
     void resetZoom();
     double getMinZoom() const;
     double getMaxZoom() const;

--- a/platform/ios/MGLGeometry.m
+++ b/platform/ios/MGLGeometry.m
@@ -1,0 +1,3 @@
+#import "MGLGeometry.h"
+
+const MGLCoordinateSpan MGLCoordinateSpanZero = {0, 0};

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1463,10 +1463,16 @@ mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBounds coord
 
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds animated:(BOOL)animated
 {
+    [self setVisibleCoordinateBounds:bounds edgePadding:UIEdgeInsetsZero animated:animated];
+}
+
+- (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated
+{
     // NOTE: does not disrupt tracking mode
     CGFloat duration = animated ? MGLAnimationDuration : 0;
     
-    _mbglMap->fitBounds(MGLLatLngBoundsFromCoordinateBounds(bounds), secondsAsDuration(duration));
+    mbgl::EdgeInsets mbglInsets = {insets.top, insets.left, insets.bottom, insets.right};
+    _mbglMap->fitBounds(MGLLatLngBoundsFromCoordinateBounds(bounds), mbglInsets, secondsAsDuration(duration));
     
     [self unrotateIfNeededAnimated:animated];
     

--- a/platform/ios/MGLMultiPoint.mm
+++ b/platform/ios/MGLMultiPoint.mm
@@ -1,5 +1,5 @@
 #import "MGLMultiPoint.h"
-#import "MGLTypes.h"
+#import "MGLGeometry.h"
 
 #import <mbgl/util/geo.hpp>
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -146,6 +146,27 @@ void Map::setLatLngZoom(LatLng latLng, double zoom, Duration duration) {
     update(Update::Zoom);
 }
 
+void Map::fitBounds(LatLngBounds bounds, Duration duration) {
+    // Zoom level calculation below assumes no rotation.
+    setBearing(0);
+
+    // Calculate the center point, respecting the projection.
+    vec2<double> nePixel = pixelForLatLng(bounds.ne);
+    vec2<double> swPixel = pixelForLatLng(bounds.sw);
+    vec2<double> centerPixel = (nePixel + swPixel) * 0.5;
+    LatLng centerLatLng = latLngForPixel(centerPixel);
+
+    // Calculate the zoom level.
+    double scaleX = getWidth() / (nePixel.x - swPixel.x);
+    double scaleY = getHeight() / (nePixel.y - swPixel.y);
+    double minZoom = getMinZoom();
+    double maxZoom = getMaxZoom();
+    double zoom = std::log2(getScale() * std::fmin(scaleX, scaleY));
+    zoom = std::fmax(std::fmin(zoom, maxZoom), minZoom);
+
+    setLatLngZoom(centerLatLng, zoom, duration);
+}
+
 void Map::resetZoom() {
     setZoom(0);
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -146,23 +146,33 @@ void Map::setLatLngZoom(LatLng latLng, double zoom, Duration duration) {
     update(Update::Zoom);
 }
 
-void Map::fitBounds(LatLngBounds bounds, Duration duration) {
+void Map::fitBounds(LatLngBounds bounds, EdgeInsets padding, Duration duration) {
     // Zoom level calculation below assumes no rotation.
     setBearing(0);
 
-    // Calculate the center point, respecting the projection.
+    // Calculate the zoom level.
     vec2<double> nePixel = pixelForLatLng(bounds.ne);
     vec2<double> swPixel = pixelForLatLng(bounds.sw);
-    vec2<double> centerPixel = (nePixel + swPixel) * 0.5;
-    LatLng centerLatLng = latLngForPixel(centerPixel);
-
-    // Calculate the zoom level.
-    double scaleX = getWidth() / (nePixel.x - swPixel.x);
-    double scaleY = getHeight() / (nePixel.y - swPixel.y);
+    vec2<double> size = nePixel - swPixel;
+    double scaleX = (getWidth() - padding.left - padding.right) / size.x;
+    double scaleY = (getHeight() - padding.top - padding.bottom) / size.y;
     double minZoom = getMinZoom();
     double maxZoom = getMaxZoom();
-    double zoom = std::log2(getScale() * std::fmin(scaleX, scaleY));
+    double minScale = std::fmin(scaleX, scaleY);
+    double zoom = std::log2(getScale() * minScale);
     zoom = std::fmax(std::fmin(zoom, maxZoom), minZoom);
+
+    // Calculate the center point of a virtual bounds that is extended in all directions by padding.
+    vec2<double> paddedNEPixel = {
+        nePixel.x + padding.right / minScale,
+        nePixel.y + padding.top / minScale,
+    };
+    vec2<double> paddedSWPixel = {
+        swPixel.x - padding.left / minScale,
+        swPixel.y - padding.bottom / minScale,
+    };
+    vec2<double> centerPixel = (paddedNEPixel + paddedSWPixel) * 0.5;
+    LatLng centerLatLng = latLngForPixel(centerPixel);
 
     setLatLngZoom(centerLatLng, zoom, duration);
 }

--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -150,6 +150,41 @@
                    @"disabling zoom gesture should disallow pinching");
 }
 
+- (void)testFitToBounds {
+    // No-op
+    MGLCoordinateBounds initialBounds = tester.mapView.visibleCoordinateBounds;
+    [tester.mapView setVisibleCoordinateBounds:initialBounds animated:NO];
+    XCTAssertEqualObjects(MGLStringFromCoordinateBounds(initialBounds),
+                          MGLStringFromCoordinateBounds(tester.mapView.visibleCoordinateBounds),
+                          @"setting visible coordinate bounds to currently visible coordinate bounds should be a no-op");
+    
+    // Roundtrip after zooming
+    tester.mapView.zoomLevel -= 3;
+    [tester.mapView setVisibleCoordinateBounds:initialBounds animated:NO];
+    XCTAssertEqualObjects(MGLStringFromCoordinateBounds(initialBounds),
+                          MGLStringFromCoordinateBounds(tester.mapView.visibleCoordinateBounds),
+                          @"after zooming out, setting visible coordinate bounds back to %@ should not leave them at %@",
+                          MGLStringFromCoordinateBounds(initialBounds),
+                          MGLStringFromCoordinateBounds(tester.mapView.visibleCoordinateBounds));
+    tester.mapView.zoomLevel += 3;
+    [tester.mapView setVisibleCoordinateBounds:initialBounds animated:NO];
+    XCTAssertEqualObjects(MGLStringFromCoordinateBounds(initialBounds),
+                          MGLStringFromCoordinateBounds(tester.mapView.visibleCoordinateBounds),
+                          @"after zooming in, setting visible coordinate bounds back to %@ should not leave them at %@",
+                          MGLStringFromCoordinateBounds(initialBounds),
+                          MGLStringFromCoordinateBounds(tester.mapView.visibleCoordinateBounds));
+    
+    // Roundtrip after panning
+    MGLCoordinateBounds offsetBounds = MGLCoordinateBoundsOffset(initialBounds, MGLCoordinateSpanMake(0, 30));
+    [tester.mapView setVisibleCoordinateBounds:offsetBounds animated:NO];
+    [tester.mapView setVisibleCoordinateBounds:initialBounds animated:NO];
+    XCTAssertEqualObjects(MGLStringFromCoordinateBounds(initialBounds),
+                          MGLStringFromCoordinateBounds(tester.mapView.visibleCoordinateBounds),
+                          @"after panning 30° to the east, setting visible coordinate bounds back to %@ should not leave them at %@",
+                          MGLStringFromCoordinateBounds(initialBounds),
+                          MGLStringFromCoordinateBounds(tester.mapView.visibleCoordinateBounds));
+}
+
 - (void)testPan {
     CLLocationCoordinate2D centerCoordinate = tester.mapView.centerCoordinate;
 


### PR DESCRIPTION
This PR reimplements “fit to bounds” functionality to take advantage of MGLCoordinateBounds and additionally exposes the method publicly. I started by re-porting [`Camera.prototype.fitBounds()`](https://github.com/mapbox/mapbox-gl-js/blob/37145b8b9bb0de022811ad46f3e89a2714896b18/js/ui/camera.js#L345) in mapbox/mapbox-gl-js to ensure correct baseline behavior. Then I wrote some logic for edge insets and rotation. Along for the ride, I added a bunch of public utility functions related to MGLCoordinateBounds.

* [x] Refactor the method to use MGLCoordinateBounds
* [x] Derive center and zoom level from projected pixels (to fix #1433)
* [x] Expose the method publicly (to fix #1092)
* [x] Push the logic down into mbgl
* [x] Stop resetting the user tracking mode (to fix #1256)
* [x] Account for rotation (ref mapbox/mapbox-gl-js#1338)
* [x] ~~Adjust the viewport to account for top and bottom layout guides~~
* [x] Take an `edgePadding` parameter for parity with MapKit and mapbox-gl-js (to fix #1775)
* [x] Test “round-tripping” the visible bounds

@friedbunny @incanus, can you try out this implementation and see if there are any other edge cases that MapKit and Google Maps handle differently?