### PR TITLE
Reverse direction to be clockwise

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1463,7 +1463,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 - (CLLocationDirection)direction
 {
-    double direction = _mbglMap->getBearing() * -1;
+    double direction = _mbglMap->getBearing();
 
     while (direction > 360) direction -= 360;
     while (direction < 0) direction += 360;
@@ -1479,7 +1479,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
-    _mbglMap->setBearing(direction * -1, secondsAsDuration(duration));
+    _mbglMap->setBearing(direction, secondsAsDuration(duration));
 
     [self notifyMapChange:@(animated ? mbgl::MapChangeRegionDidChangeAnimated : mbgl::MapChangeRegionDidChange)];
 }

--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -53,7 +53,7 @@
                    @"compass should be visible when map is rotated");
 
     XCTAssertEqualObjects([NSValue valueWithCGAffineTransform:tester.compass.transform],
-                          [NSValue valueWithCGAffineTransform:CGAffineTransformMakeRotation(M_PI * 1.5)],
+                          [NSValue valueWithCGAffineTransform:CGAffineTransformMakeRotation(M_PI * 0.5)],
                           @"compass rotation should indicate map rotation");
 }
 


### PR DESCRIPTION
This PR reverses the direction of `direction` to be clockwise instead of counterclockwise, for consistency with MapKit, the Google Maps SDK, mapbox/mapbox-gl-js, and these methods’ own documentation.

Fixes #1780.