### PR TITLE
Fit to coordinates

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -134,6 +134,13 @@ IB_DESIGNABLE
 *   @param animated Specify `YES` to animate the change by smoothly scrolling and zooming or `NO` to immediately display the given bounds. */
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated;
 
+/** Changes the receiver’s viewport to fit all of the given coordinates and optionally some additional padding on each side.
+*   @param coordinates The coordinates that the viewport will show.
+*   @param count The number of coordinates. This number must not be greater than the number of elements in `coordinates`.
+*   @param insets The minimum padding (in screen points) that will be visible around the given coordinate bounds.
+*   @param animated Specify `YES` to animate the change by smoothly scrolling and zooming or `NO` to immediately display the given bounds. */
+- (void)setVisibleCoordinates:(CLLocationCoordinate2D *)coordinates count:(NSUInteger)count edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated;
+
 /** The heading of the map (measured in degrees) relative to true north. 
 *
 *   The value `0` means that the top edge of the map view corresponds to true north. The value `90` means the top of the map is pointing due east. The value `180` means the top of the map points due south, and so on. */

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -100,6 +100,7 @@ public:
     double getZoom() const;
     void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
     void fitBounds(LatLngBounds bounds, EdgeInsets padding, Duration duration = Duration::zero());
+    void fitBounds(AnnotationSegment segment, EdgeInsets padding, Duration duration = Duration::zero());
     void resetZoom();
     double getMinZoom() const;
     double getMaxZoom() const;

--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -183,6 +183,27 @@
                           @"after panning 30° to the east, setting visible coordinate bounds back to %@ should not leave them at %@",
                           MGLStringFromCoordinateBounds(initialBounds),
                           MGLStringFromCoordinateBounds(tester.mapView.visibleCoordinateBounds));
+    
+    // Inscribed shapes with rotation
+    tester.mapView.direction = 45;
+    // https://en.wikipedia.org/wiki/Boundary_Markers_of_the_Original_District_of_Columbia
+    CLLocationCoordinate2D dcCoordinates[] = {
+        {38.790339, -77.040583},
+        {38.893219, -77.172304},
+        {38.995946, -77.040947},
+        {38.892829, -76.909229},
+    };
+    MGLCoordinateBounds dcBounds = {{38.790339, -77.172304}, {38.995946, -76.909229}};
+    [tester.mapView setVisibleCoordinateBounds:dcBounds
+                                      animated:NO];
+    double zoomLevel = tester.mapView.zoomLevel;
+    [tester.mapView setVisibleCoordinates:dcCoordinates
+                                    count:sizeof(dcCoordinates) / sizeof(dcCoordinates[0])
+                              edgePadding:UIEdgeInsetsZero
+                                 animated:NO];
+    XCTAssertGreaterThan(tester.mapView.zoomLevel, zoomLevel,
+                         @"when the map is rotated, DC should fit at a zoom level higher than %f, but instead the zoom level is %f",
+                         zoomLevel, tester.mapView.zoomLevel);
 }
 
 - (void)testPan {


### PR DESCRIPTION
Whoever determined the [boundaries of the District of Columbia](https://en.wikipedia.org/wiki/Boundary_Markers_of_the_Original_District_of_Columbia) did not have #1783 in mind. This PR generalizes the fit to bounds functionality added in #1783 so that shapes other than unrotated rectangles still fit well when the map view is rotated. Here’s iosapp without this PR, fitted to the District with just enough padding for the top bar:

![district before](https://cloud.githubusercontent.com/assets/1231218/8387849/ea1f8f30-1c10-11e5-9523-8efbf5abfa96.png)

and with this PR:

![district after](https://cloud.githubusercontent.com/assets/1231218/8387852/f5666616-1c10-11e5-9796-2f9fe9ef336b.png)

Here’s a decidedly non-rectangular trace (Add Test Shapes in the gear menu) without this PR:

![orcas before](https://cloud.githubusercontent.com/assets/1231218/8387806/6b305948-1c10-11e5-8045-1d3be8fa7c5b.png)

and with:

![orcas after](https://cloud.githubusercontent.com/assets/1231218/8387814/791d53b2-1c10-11e5-89c8-c12991f1feab.png)

This functionality belongs in mbgl::Map, as opposed to client code, because much larger shapes may be distorted by the projection; apps linked against Mapbox GL don’t have enough information to reliably account for that distortion.

/cc @incanus @friedbunny @kelvinabrokwa