### PR TITLE
reapply #1710 - array of structs rather than parallel arrays for annotations

### DIFF
--- a/include/mbgl/annotation/point_annotation.hpp
+++ b/include/mbgl/annotation/point_annotation.hpp
@@ -1,0 +1,22 @@
+#ifndef MBGL_ANNOTATION_POINT_ANNOTATION
+#define MBGL_ANNOTATION_POINT_ANNOTATION
+
+#include <mbgl/util/geo.hpp>
+
+#include <string>
+
+namespace mbgl {
+
+class PointAnnotation {
+public:
+    inline PointAnnotation(const LatLng& position_, const std::string& icon_ = "")
+        : position(position_), icon(icon_) {
+    }
+
+    const LatLng position;
+    const std::string icon;
+};
+
+}
+
+#endif

--- a/include/mbgl/annotation/shape_annotation.hpp
+++ b/include/mbgl/annotation/shape_annotation.hpp
@@ -1,0 +1,24 @@
+#ifndef MBGL_ANNOTATION_SHAPE_ANNOTATION
+#define MBGL_ANNOTATION_SHAPE_ANNOTATION
+
+#include <mbgl/util/geo.hpp>
+#include <mbgl/map/map.hpp>
+#include <mbgl/style/style_properties.hpp>
+
+#include <string>
+
+namespace mbgl {
+
+class ShapeAnnotation {
+public:
+    inline ShapeAnnotation(const AnnotationSegments& segments_, const StyleProperties& styleProperties_)
+        : segments(segments_), styleProperties(styleProperties_) {
+    }
+
+    const AnnotationSegments segments;
+    const StyleProperties styleProperties;
+};
+
+}
+
+#endif

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -4,7 +4,6 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/map/update.hpp>
 #include <mbgl/map/mode.hpp>
-#include <mbgl/style/style_properties.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/vec.hpp>
@@ -14,7 +13,6 @@
 #include <functional>
 #include <vector>
 #include <memory>
-#include <unordered_map>
 
 namespace mbgl {
 
@@ -24,6 +22,8 @@ class MapData;
 class MapContext;
 class StillImage;
 class Transform;
+class PointAnnotation;
+class ShapeAnnotation;
 
 namespace util {
 template <class T> class Thread;
@@ -129,15 +129,16 @@ public:
     // Annotations
     void setDefaultPointAnnotationSymbol(const std::string&);
     double getTopOffsetPixelsForAnnotationSymbol(const std::string&);
-    uint32_t addPointAnnotation(const LatLng&, const std::string& symbol);
-    AnnotationIDs addPointAnnotations(const AnnotationSegment&,
-                                      const std::vector<std::string>& symbols);
-    uint32_t addShapeAnnotation(const AnnotationSegments&,
-                                const StyleProperties&);
-    AnnotationIDs addShapeAnnotations(const std::vector<AnnotationSegments>&,
-                                      const std::vector<StyleProperties>&);
+
+    uint32_t addPointAnnotation(const PointAnnotation&);
+    AnnotationIDs addPointAnnotations(const std::vector<PointAnnotation>&);
+
+    uint32_t addShapeAnnotation(const ShapeAnnotation&);
+    AnnotationIDs addShapeAnnotations(const std::vector<ShapeAnnotation>&);
+
     void removeAnnotation(uint32_t);
     void removeAnnotations(const AnnotationIDs&);
+
     AnnotationIDs getAnnotationsInBounds(const LatLngBounds&, const AnnotationType& = AnnotationType::Any);
     LatLngBounds getBoundsForAnnotations(const AnnotationIDs&);
 

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -1,3 +1,5 @@
+#include <mbgl/annotation/point_annotation.hpp>
+#include <mbgl/annotation/shape_annotation.hpp>
 #include <mbgl/platform/default/glfw_view.hpp>
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/platform/log.hpp>
@@ -149,21 +151,18 @@ mbgl::LatLng GLFWView::makeRandomPoint() const {
 
 
 void GLFWView::addRandomPointAnnotations(int count) {
-    std::vector<mbgl::LatLng> points;
-    std::vector<std::string> markers;
+    std::vector<mbgl::PointAnnotation> points;
 
     for (int i = 0; i < count; i++) {
-        points.push_back(makeRandomPoint());
-        markers.push_back("default_marker");
+        points.emplace_back(makeRandomPoint(), "default_marker");
     }
 
-    auto newIDs = map->addPointAnnotations(points, markers);
+    auto newIDs = map->addPointAnnotations(points);
     annotationIDs.insert(annotationIDs.end(), newIDs.begin(), newIDs.end());
 }
 
 void GLFWView::addRandomShapeAnnotations(int count) {
-    std::vector<mbgl::AnnotationSegments> shapes;
-    std::vector<mbgl::StyleProperties> shapesProperties;
+    std::vector<mbgl::ShapeAnnotation> shapes;
 
     mbgl::FillProperties fillProperties;
     fillProperties.opacity = .1;
@@ -180,11 +179,10 @@ void GLFWView::addRandomShapeAnnotations(int count) {
         mbgl::AnnotationSegments segments;
         segments.push_back(triangle);
 
-        shapes.push_back(segments);
-        shapesProperties.push_back(properties);
+        shapes.emplace_back(segments, properties);
     }
 
-    auto newIDs = map->addShapeAnnotations(shapes, shapesProperties);
+    auto newIDs = map->addShapeAnnotations(shapes);
     annotationIDs.insert(annotationIDs.end(), newIDs.begin(), newIDs.end());
 }
 

--- a/src/mbgl/map/annotation.hpp
+++ b/src/mbgl/map/annotation.hpp
@@ -21,11 +21,10 @@
 namespace mbgl {
 
 class Annotation;
-class Map;
+class PointAnnotation;
+class ShapeAnnotation;
 class LiveTile;
 class LiveTileFeature;
-
-using AnnotationsProperties = std::unordered_map<std::string, std::vector<std::string>>;
 
 using GeoJSONVT = mapbox::util::geojsonvt::GeoJSONVT;
 
@@ -57,18 +56,19 @@ public:
     std::unordered_set<TileID, TileID::Hash> resetStaleTiles();
 
     void setDefaultPointAnnotationSymbol(const std::string& symbol);
-    std::pair<std::unordered_set<TileID, TileID::Hash>, AnnotationIDs> addPointAnnotations(
-        const AnnotationSegment&,
-        const AnnotationsProperties&,
-        const uint8_t maxZoom);
-    std::pair<std::unordered_set<TileID, TileID::Hash>, AnnotationIDs> addShapeAnnotations(
-        const std::vector<AnnotationSegments>&,
-        const std::vector<StyleProperties>&,
-        const AnnotationsProperties&,
-        const uint8_t maxZoom);
+
+    std::pair<std::unordered_set<TileID, TileID::Hash>, AnnotationIDs>
+    addPointAnnotations(const std::vector<PointAnnotation>&,
+                        const uint8_t maxZoom);
+
+    std::pair<std::unordered_set<TileID, TileID::Hash>, AnnotationIDs>
+    addShapeAnnotations(const std::vector<ShapeAnnotation>&,
+                        const uint8_t maxZoom);
+
     std::unordered_set<TileID, TileID::Hash> removeAnnotations(const AnnotationIDs&, const uint8_t maxZoom);
     AnnotationIDs getOrderedShapeAnnotations() const { return orderedShapeAnnotations; }
     const StyleProperties getAnnotationStyleProperties(uint32_t) const;
+
     AnnotationIDs getAnnotationsInBounds(const LatLngBounds&, const uint8_t maxZoom, const AnnotationType& = AnnotationType::Any) const;
     LatLngBounds getBoundsForAnnotations(const AnnotationIDs&) const;
 
@@ -80,12 +80,6 @@ public:
 private:
     inline uint32_t nextID();
     static vec2<double> projectPoint(const LatLng& point);
-    std::pair<std::unordered_set<TileID, TileID::Hash>, AnnotationIDs> addAnnotations(
-        const AnnotationType,
-        const std::vector<AnnotationSegments>&,
-        const std::vector<StyleProperties>&,
-        const AnnotationsProperties&,
-        const uint8_t maxZoom);
     std::unordered_set<TileID, TileID::Hash> addTileFeature(
         const uint32_t annotationID,
         const AnnotationSegments&,

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -4,11 +4,11 @@
 #include <mbgl/map/transform.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/map/map_data.hpp>
+#include <mbgl/annotation/point_annotation.hpp>
+#include <mbgl/annotation/shape_annotation.hpp>
 
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/thread.hpp>
-
-#include <unordered_map>
 
 namespace mbgl {
 
@@ -292,26 +292,22 @@ double Map::getTopOffsetPixelsForAnnotationSymbol(const std::string& symbol) {
     return context->invokeSync<double>(&MapContext::getTopOffsetPixelsForAnnotationSymbol, symbol);
 }
 
-uint32_t Map::addPointAnnotation(const LatLng& point, const std::string& symbol) {
-    return addPointAnnotations({ point }, { symbol }).front();
+uint32_t Map::addPointAnnotation(const PointAnnotation& annotation) {
+    return addPointAnnotations({ annotation }).front();
 }
 
-AnnotationIDs Map::addPointAnnotations(const AnnotationSegment& points,
-                                       const std::vector<std::string>& symbols) {
-    AnnotationsProperties properties = { { "symbols", symbols } };
-    auto result = data->annotationManager.addPointAnnotations(points, properties, getMaxZoom());
+AnnotationIDs Map::addPointAnnotations(const std::vector<PointAnnotation>& annotations) {
+    auto result = data->annotationManager.addPointAnnotations(annotations, getMaxZoom());
     context->invoke(&MapContext::updateAnnotationTiles, result.first);
     return result.second;
 }
 
-uint32_t Map::addShapeAnnotation(const AnnotationSegments& shape,
-                                 const StyleProperties& styleProperties) {
-    return addShapeAnnotations({ shape }, { styleProperties }).front();
+uint32_t Map::addShapeAnnotation(const ShapeAnnotation& annotation) {
+    return addShapeAnnotations({ annotation }).front();
 }
 
-AnnotationIDs Map::addShapeAnnotations(const std::vector<AnnotationSegments>& shapes,
-                                       const std::vector<StyleProperties>& styleProperties) {
-    auto result = data->annotationManager.addShapeAnnotations(shapes, styleProperties, {{}}, getMaxZoom());
+AnnotationIDs Map::addShapeAnnotations(const std::vector<ShapeAnnotation>& annotations) {
+    auto result = data->annotationManager.addShapeAnnotations(annotations, getMaxZoom());
     context->invoke(&MapContext::updateAnnotationTiles, result.first);
     return result.second;
 }


### PR DESCRIPTION
#1710 got reverted in 714b68f7b325c30d0646c8b237d65b013fb12f04 due to merge difficulties at deadline. We should now reapply it.