### PR TITLE
Go dormant before termination

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -367,6 +367,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
     // observe app activity
     //
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(willTerminate) name:UIApplicationWillTerminateNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sleepGL:) name:UIApplicationWillResignActiveNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sleepGL:) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(wakeGL:) name:UIApplicationWillEnterForegroundNotification object:nil];
@@ -708,6 +709,18 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 }
 
 #pragma mark - Life Cycle -
+
+- (void)willTerminate
+{
+    MGLAssertIsMainThread();
+
+    if ( ! self.isDormant)
+    {
+        self.dormant = YES;
+        _mbglMap->pause();
+        [self.glView deleteDrawable];
+    }
+}
 
 - (void)sleepGL:(__unused NSNotification *)notification
 {


### PR DESCRIPTION
This is a speculative fix for #1460, ~~#1509~~, and #1680 per https://github.com/mapbox/mapbox-gl-native/issues/1460#issuecomment-99959434, building off the work in #1451. Once we get `UIApplicationWillTerminateNotification`, it’s unlikely that there will be any need to service further requests for rendering, programmatic viewport manipulation, or gesture recognition.

I’ll keep an eye on our HockeyApp stats to see if #1460 goes away at least.

/cc @incanus @friedbunny