### PR TITLE
Add collision box debugging to the global debug toggle

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1424,6 +1424,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 - (void)toggleDebug
 {
     _mbglMap->toggleDebug();
+    _mbglMap->toggleCollisionDebug();
 }
 
 - (void)emptyMemoryCache


### PR DESCRIPTION
@ansis was awesome enough to give us a collision box debug mode in https://github.com/mapbox/mapbox-gl-native/commit/8962442b1b838445efaf8dc12003225facac2a06, so let's enable it with `-[MGLMapView toggleDebug]`.

We *could* make it a separate public method, but for simplicity's sake this PR assumes everyone wants all the debug modes all the time.

/cc @incanus @1ec5