### PR TITLE
Remove tracking mode reset from resetNorthAnimated

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1384,8 +1384,6 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 - (void)resetNorthAnimated:(BOOL)animated
 {
-    self.userTrackingMode = MGLUserTrackingModeNone;
-
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
     _mbglMap->setBearing(0, secondsAsDuration(duration));


### PR DESCRIPTION
Removes tracking mode reset from `resetNorthAnimated:`.

[`handleCompassTapGesture:`](https://github.com/mapbox/mapbox-gl-native/blob/e6e340afd17a29ee4d183540e716376cdb1ef88e/platform/ios/MGLMapView.mm#L612-L617) intends to simply bump down to `MGLUserTrackingModeFollow` if it is following with heading, but the user tracking mode was getting clobbered by `resetNorthAnimated:`.

Supercedes #1257.

/cc @1ec5 @incanus