### PR TITLE
Setting styleURL immediately after initialization sometimes fails

### DIFF
--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -92,6 +92,8 @@ private:
     std::string styleURL;
     std::string styleJSON;
 
+    Request* styleRequest = nullptr;
+
     StillImageCallback callback;
     size_t sourceCacheSize;
     TransformState transformState;


### PR DESCRIPTION
Sometimes when I start my app (iOS) with Mapbox in it, it won't load the styles into the map. It generates the default MapKit styled map, without any markers. It's kind of annoying, because the problem is somewhat occurring on a random base. 

I load my custom stylesheet as a JSON file and link it to the map via the style url:

```mapView?.styleURL = NSURL(string: "asset://\(jsonFile)")```

Is it a known issue? 