### PR TITLE
split renderSync and transition nudging to allow client view syncing

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -63,7 +63,10 @@ public:
     void renderStill(StillImageCallback callback);
 
     // Triggers a synchronous or asynchronous render.
-    void renderSync();
+    bool renderSync();
+
+    // Nudges transitions one step, possibly notifying of the need for a rerender.
+    void nudgeTransitions(bool forceRerender);
 
     // Notifies the Map thread that the state has changed and an update might be necessary.
     void update(Update update = Update::Nothing);

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -682,7 +682,8 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
         _mbglMap->setSourceTileCacheSize(cacheSize);
 
-        _mbglMap->renderSync();
+        bool needsRerender = _mbglMap->renderSync();
+        _mbglMap->nudgeTransitions(needsRerender);
     }
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -46,7 +46,7 @@ void Map::renderStill(StillImageCallback callback) {
     context->invoke(&MapContext::renderStill, transform->getState(), callback);
 }
 
-void Map::renderSync() {
+bool Map::renderSync() {
     if (renderState == RenderState::never) {
         view.notifyMapChange(MapChangeWillStartRenderingMap);
     }
@@ -67,9 +67,13 @@ void Map::renderSync() {
         view.notifyMapChange(MapChangeDidFinishRenderingMapFullyRendered);
     }
 
+    return result.needsRerender;
+}
+
+void Map::nudgeTransitions(bool forceRerender) {
     if (transform->needsTransition()) {
         update(Update(transform->updateTransitions(Clock::now())));
-    } else if (result.needsRerender) {
+    } else if (forceRerender) {
         update();
     }
 }


### PR DESCRIPTION
Picking up from stuff learned in https://github.com/mapbox/mapbox-gl-native/issues/1125#issuecomment-117256712, this breaks the current `renderSync` into two parts — the actual render call and a `nudgeTransitions` which moves a step in the `Transform`, possibly calling `Map::update` if needed. 

The reason for this is needing to sync client-side view (i.e. `UIView` objects) positions with the GL map, and that step needing to come in between these two to remain in sync. 

Todo: 

* [ ] Review terminology used (@jfirebaugh @kkaefer?)
* [ ] Review for other possible side effects
* [ ] Update other platforms besides iOS if approach is :ok_hand: 