### PR TITLE
Thread safety for AnnotationManager

### DIFF
--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -49,17 +49,14 @@ AnnotationManager::~AnnotationManager() {
 }
 
 void AnnotationManager::markStaleTiles(std::unordered_set<TileID, TileID::Hash> ids) {
-    std::lock_guard<std::mutex> lock(mtx);
     std::copy(ids.begin(), ids.end(), std::inserter(staleTiles, staleTiles.begin()));
 }
 
 std::unordered_set<TileID, TileID::Hash> AnnotationManager::resetStaleTiles() {
-    std::lock_guard<std::mutex> lock(mtx);
     return std::move(staleTiles);
 }
 
 void AnnotationManager::setDefaultPointAnnotationSymbol(const std::string& symbol) {
-    std::lock_guard<std::mutex> lock(mtx);
     defaultPointAnnotationSymbol = symbol;
 }
 
@@ -261,8 +258,6 @@ AnnotationManager::addTileFeature(const uint32_t annotationID,
 std::pair<std::unordered_set<TileID, TileID::Hash>, AnnotationIDs>
 AnnotationManager::addPointAnnotations(const std::vector<PointAnnotation>& points,
                                        const uint8_t maxZoom) {
-    std::lock_guard<std::mutex> lock(mtx);
-
     // We pre-generate tiles to contain each annotation up to the map's max zoom.
     // We do this for fast rendering without projection conversions on the fly, as well as
     // to simplify bounding box queries of annotations later. Tiles get invalidated when
@@ -310,8 +305,6 @@ AnnotationManager::addPointAnnotations(const std::vector<PointAnnotation>& point
 std::pair<std::unordered_set<TileID, TileID::Hash>, AnnotationIDs>
 AnnotationManager::addShapeAnnotations(const std::vector<ShapeAnnotation>& shapes,
                                        const uint8_t maxZoom) {
-    std::lock_guard<std::mutex> lock(mtx);
-
     // We pre-generate tiles to contain each annotation up to the map's max zoom.
     // We do this for fast rendering without projection conversions on the fly, as well as
     // to simplify bounding box queries of annotations later. Tiles get invalidated when
@@ -348,8 +341,6 @@ AnnotationManager::addShapeAnnotations(const std::vector<ShapeAnnotation>& shape
 
 std::unordered_set<TileID, TileID::Hash> AnnotationManager::removeAnnotations(const AnnotationIDs& ids,
                                                                               const uint8_t maxZoom) {
-    std::lock_guard<std::mutex> lock(mtx);
-
     std::unordered_set<TileID, TileID::Hash> affectedTiles;
 
     std::vector<uint32_t> z2s;
@@ -416,8 +407,6 @@ std::unordered_set<TileID, TileID::Hash> AnnotationManager::removeAnnotations(co
 }
 
 const StyleProperties AnnotationManager::getAnnotationStyleProperties(uint32_t annotationID) const {
-    std::lock_guard<std::mutex> lock(mtx);
-
     auto anno_it = annotations.find(annotationID);
     assert(anno_it != annotations.end());
 
@@ -427,8 +416,6 @@ const StyleProperties AnnotationManager::getAnnotationStyleProperties(uint32_t a
 AnnotationIDs AnnotationManager::getAnnotationsInBounds(const LatLngBounds& queryBounds,
                                                         const uint8_t maxZoom,
                                                         const AnnotationType& type) const {
-    std::lock_guard<std::mutex> lock(mtx);
-
     const uint8_t z = maxZoom;
     const uint32_t z2 = 1 << z;
     const vec2<double> swPoint = projectPoint(queryBounds.sw);
@@ -493,8 +480,6 @@ AnnotationIDs AnnotationManager::getAnnotationsInBounds(const LatLngBounds& quer
 }
 
 LatLngBounds AnnotationManager::getBoundsForAnnotations(const AnnotationIDs& ids) const {
-    std::lock_guard<std::mutex> lock(mtx);
-
     LatLngBounds bounds;
     for (auto id : ids) {
         const auto annotation_it = annotations.find(id);
@@ -507,8 +492,6 @@ LatLngBounds AnnotationManager::getBoundsForAnnotations(const AnnotationIDs& ids
 }
 
 const LiveTile* AnnotationManager::getTile(const TileID& id) {
-    std::lock_guard<std::mutex> lock(mtx);
-
     // look up any existing annotation tile
     LiveTile *renderTile = nullptr;
     const auto tile_lookup_it = tiles.find(id);

--- a/src/mbgl/map/annotation.hpp
+++ b/src/mbgl/map/annotation.hpp
@@ -13,7 +13,6 @@
 
 #include <string>
 #include <vector>
-#include <mutex>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -90,7 +89,6 @@ private:
         const uint8_t maxZoom);
 
 private:
-    mutable std::mutex mtx;
     std::string defaultPointAnnotationSymbol;
     std::unordered_map<uint32_t, std::unique_ptr<Annotation>> annotations;
     std::vector<uint32_t> orderedShapeAnnotations;

--- a/src/mbgl/map/live_tile_data.hpp
+++ b/src/mbgl/map/live_tile_data.hpp
@@ -1,26 +1,32 @@
 #ifndef MBGL_MAP_LIVE_TILE_DATA
 #define MBGL_MAP_LIVE_TILE_DATA
 
-#include <mbgl/map/vector_tile_data.hpp>
+#include <mbgl/map/tile_data.hpp>
+#include <mbgl/map/tile_worker.hpp>
 
 namespace mbgl {
 
-class AnnotationManager;
+class Style;
+class SourceInfo;
+class WorkRequest;
+class LiveTile;
 
-class LiveTileData : public VectorTileData {
+class LiveTileData : public TileData {
 public:
     LiveTileData(const TileID&,
-                 AnnotationManager&,
+                 const LiveTile*,
                  Style&,
                  const SourceInfo&,
-                 float angle_,
-                 bool collisionDebug_);
+                 std::function<void ()> callback);
     ~LiveTileData();
 
-    bool reparse(std::function<void ()> callback) override;
+    void cancel() override;
+    Bucket* getBucket(const StyleLayer&) override;
 
 private:
-    AnnotationManager& annotationManager;
+    Worker& worker;
+    TileWorker tileWorker;
+    std::unique_ptr<WorkRequest> workRequest;
 };
 
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -304,7 +304,7 @@ const LatLng Map::latLngForPixel(const vec2<double> pixel) const {
 #pragma mark - Annotations
 
 void Map::setDefaultPointAnnotationSymbol(const std::string& symbol) {
-    data->annotationManager.setDefaultPointAnnotationSymbol(symbol);
+    data->getAnnotationManager()->setDefaultPointAnnotationSymbol(symbol);
 }
 
 double Map::getTopOffsetPixelsForAnnotationSymbol(const std::string& symbol) {
@@ -316,7 +316,7 @@ uint32_t Map::addPointAnnotation(const PointAnnotation& annotation) {
 }
 
 AnnotationIDs Map::addPointAnnotations(const std::vector<PointAnnotation>& annotations) {
-    auto result = data->annotationManager.addPointAnnotations(annotations, getMaxZoom());
+    auto result = data->getAnnotationManager()->addPointAnnotations(annotations, getMaxZoom());
     context->invoke(&MapContext::updateAnnotationTiles, result.first);
     return result.second;
 }
@@ -326,7 +326,7 @@ uint32_t Map::addShapeAnnotation(const ShapeAnnotation& annotation) {
 }
 
 AnnotationIDs Map::addShapeAnnotations(const std::vector<ShapeAnnotation>& annotations) {
-    auto result = data->annotationManager.addShapeAnnotations(annotations, getMaxZoom());
+    auto result = data->getAnnotationManager()->addShapeAnnotations(annotations, getMaxZoom());
     context->invoke(&MapContext::updateAnnotationTiles, result.first);
     return result.second;
 }
@@ -336,16 +336,16 @@ void Map::removeAnnotation(uint32_t annotation) {
 }
 
 void Map::removeAnnotations(const std::vector<uint32_t>& annotations) {
-    auto result = data->annotationManager.removeAnnotations(annotations, getMaxZoom());
+    auto result = data->getAnnotationManager()->removeAnnotations(annotations, getMaxZoom());
     context->invoke(&MapContext::updateAnnotationTiles, result);
 }
 
 std::vector<uint32_t> Map::getAnnotationsInBounds(const LatLngBounds& bounds, const AnnotationType& type) {
-    return data->annotationManager.getAnnotationsInBounds(bounds, getMaxZoom(), type);
+    return data->getAnnotationManager()->getAnnotationsInBounds(bounds, getMaxZoom(), type);
 }
 
 LatLngBounds Map::getBoundsForAnnotations(const std::vector<uint32_t>& annotations) {
-    return data->annotationManager.getBoundsForAnnotations(annotations);
+    return data->getAnnotationManager()->getBoundsForAnnotations(annotations);
 }
 
 

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -12,6 +12,7 @@
 
 #include <mbgl/map/mode.hpp>
 #include <mbgl/map/annotation.hpp>
+#include <mbgl/util/exclusive.hpp>
 
 namespace mbgl {
 
@@ -78,11 +79,19 @@ public:
         defaultTransitionDuration = duration;
     };
 
+    util::exclusive<AnnotationManager> getAnnotationManager() {
+        return util::exclusive<AnnotationManager>(
+            &annotationManager,
+            std::make_unique<std::lock_guard<std::mutex>>(annotationManagerMutex));
+    }
+
 public:
-    AnnotationManager annotationManager;
     const MapMode mode;
 
 private:
+    mutable std::mutex annotationManagerMutex;
+    AnnotationManager annotationManager;
+
     mutable std::mutex mtx;
 
     std::vector<std::string> classes;

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -60,11 +60,6 @@ void RasterTileData::request(float pixelRatio,
     });
 }
 
-bool RasterTileData::reparse(std::function<void()>) {
-    assert(false);
-    return false;
-}
-
 Bucket* RasterTileData::getBucket(StyleLayer const&) {
     return &bucket;
 }

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -19,9 +19,7 @@ public:
     ~RasterTileData();
 
     void request(float pixelRatio,
-                 const std::function<void()>& callback) override;
-
-    bool reparse(std::function<void ()> callback) override;
+                 const std::function<void()>& callback);
 
     void cancel() override;
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -300,7 +300,7 @@ TileData::State Source::addTile(MapData& data,
             new_tile.data = tileData;
         } else if (info.type == SourceType::Annotations) {
             new_tile.data = std::make_shared<LiveTileData>(normalized_id,
-                data.annotationManager.getTile(normalized_id), style, info, callback);
+                data.getAnnotationManager()->getTile(normalized_id), style, info, callback);
         } else {
             throw std::runtime_error("source type not implemented");
         }

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -235,7 +235,7 @@ bool Source::handlePartialTile(const TileID& id, Worker&) {
 
     // Note: this uses a raw pointer; we don't want the callback binding to have a
     // shared pointer.
-    VectorTileData* data = static_cast<VectorTileData*>(it->second.lock().get());
+    VectorTileData* data = dynamic_cast<VectorTileData*>(it->second.lock().get());
     if (!data) {
         return true;
     }
@@ -299,11 +299,8 @@ TileData::State Source::addTile(MapData& data,
             tileData->request(transformState.getPixelRatio(), callback);
             new_tile.data = tileData;
         } else if (info.type == SourceType::Annotations) {
-            auto tileData = std::make_shared<LiveTileData>(normalized_id, data.annotationManager,
-                                                           style, info,
-                                                           transformState.getAngle(), data.getCollisionDebug());
-            tileData->reparse(callback);
-            new_tile.data = tileData;
+            new_tile.data = std::make_shared<LiveTileData>(normalized_id,
+                data.annotationManager.getTile(normalized_id), style, info, callback);
         } else {
             throw std::runtime_error("source type not implemented");
         }

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -290,18 +290,20 @@ TileData::State Source::addTile(MapData& data,
 
         // If we don't find working tile data, we're just going to load it.
         if (info.type == SourceType::Vector) {
-            new_tile.data =
-                std::make_shared<VectorTileData>(normalized_id, style, info,
+            auto tileData = std::make_shared<VectorTileData>(normalized_id, style, info,
                                                  transformState.getAngle(), data.getCollisionDebug());
-            new_tile.data->request(transformState.getPixelRatio(), callback);
+            tileData->request(transformState.getPixelRatio(), callback);
+            new_tile.data = tileData;
         } else if (info.type == SourceType::Raster) {
-            new_tile.data = std::make_shared<RasterTileData>(normalized_id, texturePool, info, style.workers);
-            new_tile.data->request(transformState.getPixelRatio(), callback);
+            auto tileData = std::make_shared<RasterTileData>(normalized_id, texturePool, info, style.workers);
+            tileData->request(transformState.getPixelRatio(), callback);
+            new_tile.data = tileData;
         } else if (info.type == SourceType::Annotations) {
-            new_tile.data = std::make_shared<LiveTileData>(normalized_id, data.annotationManager,
+            auto tileData = std::make_shared<LiveTileData>(normalized_id, data.annotationManager,
                                                            style, info,
                                                            transformState.getAngle(), data.getCollisionDebug());
-            new_tile.data->reparse(callback);
+            tileData->reparse(callback);
+            new_tile.data = tileData;
         } else {
             throw std::runtime_error("source type not implemented");
         }

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -70,15 +70,6 @@ public:
     TileData(const TileID&);
     virtual ~TileData() = default;
 
-    virtual void request(float pixelRatio,
-                         const std::function<void()>& callback) = 0;
-
-    // Schedule a tile reparse on a worker thread and call the callback on
-    // completion. It will return true if the work was schedule or false it was
-    // not, which can occur if the tile is already being parsed by another
-    // worker.
-    virtual bool reparse(std::function<void ()> callback) = 0;
-
     // Mark this tile as no longer needed and cancel any pending work.
     virtual void cancel() = 0;
 

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -8,13 +8,10 @@
 
 namespace mbgl {
 
-class SourceInfo;
-class Request;
-class Bucket;
-class SourceInfo;
-class StyleLayer;
 class Style;
+class SourceInfo;
 class WorkRequest;
+class Request;
 
 class VectorTileData : public TileData {
 public:
@@ -31,23 +28,20 @@ public:
     void request(float pixelRatio,
                  const std::function<void()>& callback);
 
-    virtual bool reparse(std::function<void ()> callback);
+    bool reparse(std::function<void ()> callback);
 
     void redoPlacement(float angle, bool collisionDebug) override;
 
     void cancel() override;
 
-protected:
+private:
     Worker& worker;
     TileWorker tileWorker;
     std::unique_ptr<WorkRequest> workRequest;
     bool parsing = false;
-
-private:
     const SourceInfo& source;
     Request* req = nullptr;
     std::string data;
-
     float lastAngle = 0;
     float currentAngle;
     bool lastCollisionDebug = 0;

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -29,9 +29,9 @@ public:
     size_t countBuckets() const;
 
     void request(float pixelRatio,
-                 const std::function<void()>& callback) override;
+                 const std::function<void()>& callback);
 
-    bool reparse(std::function<void ()> callback) override;
+    virtual bool reparse(std::function<void ()> callback);
 
     void redoPlacement(float angle, bool collisionDebug) override;
 


### PR DESCRIPTION
Internal synchronization is insufficient for AnnotationManager -- it's used in ways that demand synchronization at a higher level. For instance, `MapContext::updateAnnotationTiles` does `getOrderedShapeAnnotations()` followed by `getAnnotationStyleProperties()` for each shape annotation ID. This requires that no annotations are removed in between.

Refs #1790