### PR TITLE
[WIP] Defer initialization until app enters foreground

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -206,58 +206,28 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 - (void)commonInit
 {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
+    
+    BOOL background = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
+    if (!background)
+    {
+        [self createGLView];
+    }
 
-    // create context
-    //
-    _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-    NSAssert(_context, @"Failed to create OpenGL ES context.");
 
-    // setup accessibility
-    //
     self.accessibilityLabel = @"Map";
-
-    // create GL view
-    //
-    _glView = [[GLKView alloc] initWithFrame:self.bounds context:_context];
-    _glView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    _glView.enableSetNeedsDisplay = YES;
-    _glView.drawableStencilFormat = GLKViewDrawableStencilFormat8;
-    _glView.drawableDepthFormat = GLKViewDrawableDepthFormat16;
-
-    const float scaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
-    _glView.contentScaleFactor = scaleFactor;
-    _glView.delegate = self;
-    [_glView bindDrawable];
-    [self insertSubview:_glView atIndex:0];
-
-    _glView.contentMode = UIViewContentModeCenter;
-
     self.backgroundColor = [UIColor clearColor];
     self.clipsToBounds = YES;
 
-    // load extensions
-    //
-    mbgl::gl::InitializeExtensions([](const char * name) {
-        static CFBundleRef framework = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.opengles"));
-        if (!framework) {
-            throw std::runtime_error("Failed to load OpenGL framework.");
-        }
-
-        CFStringRef str = CFStringCreateWithCString(kCFAllocatorDefault, name, kCFStringEncodingASCII);
-        void* symbol = CFBundleGetFunctionPointerForName(framework, str);
-        CFRelease(str);
-
-        return reinterpret_cast<mbgl::gl::glProc>(symbol);
-    });
-
     // setup mbgl map
     //
+    const float scaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
     _mbglView = new MBGLView(self, scaleFactor);
     _mbglFileSource = new mbgl::DefaultFileSource([MGLFileCache obtainSharedCacheWithObject:self]);
 
-    // Start paused on the IB canvas
+    // Start paused
     _mbglMap = new mbgl::Map(*_mbglView, *_mbglFileSource, mbgl::MapMode::Continuous);
-    if (_isTargetingInterfaceBuilder) {
+    if (_isTargetingInterfaceBuilder || background) {
+        self.dormant = YES;
         _mbglMap->pause();
     }
 
@@ -404,7 +374,59 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }];
 }
 
--(void)reachabilityChanged:(NSNotification*)notification
+- (void)createGLView
+{
+    if (_context || [UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
+        return;
+    }
+    
+    // create context
+    //
+    _context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
+    NSAssert(_context, @"Failed to create OpenGL ES context.");
+
+    // create GL view
+    //
+    _glView = [[GLKView alloc] initWithFrame:self.bounds context:_context];
+    _glView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _glView.enableSetNeedsDisplay = YES;
+    _glView.drawableStencilFormat = GLKViewDrawableStencilFormat8;
+    _glView.drawableDepthFormat = GLKViewDrawableDepthFormat16;
+    _glView.contentScaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
+    _glView.delegate = self;
+    [_glView bindDrawable];
+    [self insertSubview:_glView atIndex:0];
+
+    _glView.contentMode = UIViewContentModeCenter;
+
+    // load extensions
+    //
+    mbgl::gl::InitializeExtensions([](const char * name) {
+        static CFBundleRef framework = CFBundleGetBundleWithIdentifier(CFSTR("com.apple.opengles"));
+        if (!framework) {
+            throw std::runtime_error("Failed to load OpenGL framework.");
+        }
+
+        CFStringRef str = CFStringCreateWithCString(kCFAllocatorDefault, name, kCFStringEncodingASCII);
+        void* symbol = CFBundleGetFunctionPointerForName(framework, str);
+        CFRelease(str);
+
+        return reinterpret_cast<mbgl::gl::glProc>(symbol);
+    });
+}
+
+- (void)viewWillEnterForeground
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UIApplicationWillEnterForegroundNotification
+                                                  object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UIApplicationDidBecomeActiveNotification
+                                                  object:nil];
+    [self commonInit];
+}
+
+- (void)reachabilityChanged:(NSNotification *)notification
 {
     MGLReachability *reachability = [notification object];
     if ([reachability isReachable]) {
@@ -775,6 +797,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 {
     MGLAssertIsMainThread();
 
+    [self createGLView];
     if (self.isDormant)
     {
         self.dormant = NO;


### PR DESCRIPTION
Another speculative fix for #1460, since #1805 didn’t quite do the trick. If MGLMapView is initialized while the app is in the background, defer the nitty-gritty details of initialization (~~particularly~~ setting up the GL context and GL subview, ~~but also things like events and background snapshotting~~) until the app enters the foreground for the first time.

~~This fix assumes that the developer won’t be doing things like switching styles or setting the global access token while the app is still in the background. Correctly handling such cases would require checking for the presence of a map at all times and queueing up changes to map view properties until the app enters the foreground.~~

Areas to test include backgrounding and foregrounding the app, launching the app via a URL handler, and switching between view controllers that do or do not contain an MGLMapView.

/cc @incanus @friedbunny