### PR TITLE
Fix round-tripping between pixelForLatLng() / latLngForPixel()

### DIFF
--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -218,8 +218,8 @@ const LatLng TransformState::latLngForPixel(const vec2<double> pixel) const {
     LatLng ll = getLatLng();
     double zoom = getZoom();
 
-    const double centerX = width  / 2;
-    const double centerY = height / 2;
+    const double centerX = static_cast<double>(width) / 2.0;
+    const double centerY = static_cast<double>(height) / 2.0;
 
     const double m = Projection::getMetersPerPixelAtLatitude(0, zoom);
 


### PR DESCRIPTION
Followup to cfa2eaf5c21858483cd12ee0768b43315ef29e95 for #1406. iPhone 6 has an odd width and an odd height. Dividing both figures by 2 but truncating the result leads to egregious errors when fitting to bounds at low zoom levels.

Fixes #1817.