### PR TITLE
Fix rotation edge cases and compass overspinning

### DIFF
--- a/include/mbgl/util/math.hpp
+++ b/include/mbgl/util/math.hpp
@@ -112,10 +112,12 @@ T clamp(T value, T min, T max) {
     return value < min ? min : (value > max ? max : value);
 }
 
+// Constrains n to the given range (including min, excluding max) via modular
+// arithmetic.
 template <typename T>
 T wrap(T value, T min, T max) {
     T d = max - min;
-    return value == max ? value : std::fmod((std::fmod((value - min), d) + d), d) + min;
+    return std::fmod((std::fmod((value - min), d) + d), d) + min;
 }
 
 template <typename T>

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -15,6 +15,7 @@
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/network_status.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/math.hpp>
 #include <mbgl/util/constants.hpp>
 
 #import "MapboxGL.h"
@@ -1568,12 +1569,7 @@ mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBounds coord
 
 - (CLLocationDirection)direction
 {
-    double direction = _mbglMap->getBearing();
-
-    while (direction > 360) direction -= 360;
-    while (direction < 0) direction += 360;
-
-    return direction;
+    return mbgl::util::wrap(_mbglMap->getBearing(), 0., 360.);
 }
 
 - (void)setDirection:(CLLocationDirection)direction animated:(BOOL)animated
@@ -2624,9 +2620,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
 - (void)updateCompass
 {
-    double degrees = _mbglMap->getBearing() * -1;
-    while (degrees >= 360) degrees -= 360;
-    while (degrees < 0) degrees += 360;
+    CLLocationDirection degrees = -self.direction;
 
     self.compassView.transform = CGAffineTransformMakeRotation(MGLRadiansFromDegrees(degrees));
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1400,19 +1400,6 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 
     _mbglMap->setBearing(0, secondsAsDuration(duration));
-
-    [UIView animateWithDuration:duration
-                     animations:^
-                     {
-                         self.compassView.transform = CGAffineTransformIdentity;
-                     }
-                     completion:^(BOOL finished)
-                     {
-                         if (finished)
-                         {
-                             [self notifyMapChange:(animated ? mbgl::MapChangeRegionDidChangeAnimated : mbgl::MapChangeRegionDidChange)];
-                         }
-                     }];
 }
 
 - (void)resetPosition
@@ -2468,7 +2455,6 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         case mbgl::MapChangeRegionWillChangeAnimated:
         {
             [self updateUserLocationAnnotationView];
-            [self updateCompass];
 
             [self deselectAnnotation:self.selectedAnnotation animated:NO];
 
@@ -2511,6 +2497,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
             {
                 [self.delegate mapViewRegionIsChanging:self];
             }
+            break;
         }
         case mbgl::MapChangeRegionDidChange:
         case mbgl::MapChangeRegionDidChangeAnimated:
@@ -2620,7 +2607,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
 - (void)updateCompass
 {
-    CLLocationDirection degrees = -self.direction;
+    CLLocationDirection degrees = mbgl::util::wrap(-self.direction, 0., 360.);
 
     self.compassView.transform = CGAffineTransformMakeRotation(MGLRadiansFromDegrees(degrees));
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -15,6 +15,7 @@ using namespace mbgl;
 static double _normalizeAngle(double angle, double anchorAngle)
 {
     angle = util::wrap(angle, -M_PI, M_PI);
+    if (angle == -M_PI) angle = M_PI;
     double diff = std::abs(angle - anchorAngle);
     if (std::abs(angle - util::M2PI - anchorAngle) < diff) {
         angle -= util::M2PI;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -337,7 +337,7 @@ void Transform::_setAngle(double new_angle, const Duration duration) {
 
         startTransition(
             [=](double t) {
-                state.angle = util::interpolate(startA, angle, t);
+                state.angle = util::wrap(util::interpolate(startA, angle, t), -M_PI, M_PI);
                 view.notifyMapChange(MapChangeRegionIsChanging);
                 return Update::Nothing;
             },


### PR DESCRIPTION
This PR addresses some edge cases around bearing, obsoleting #1558:

* `mbgl::util::wrap()` is now min-inclusive, max-exclusive. It is the responsibility of the caller to handle the case in which `min` is returned. Previously, `wrap(360, 0, 360)` would return 360 but `wrap(720, 0, 360)` would return 0. This is how mapbox-gl-js behaves, but I believe the max-exclusive behavior is more predictable.
* `-[MGLMapView direction]` now returns a value in the range [0, 360) instead of [0, 360].
* When pressing the compass to reset the direction to due north, the compass’ animation now begins at the current rotation. Previously, it began at due north and spun 360° every time, due to an overzealous response to change notifications. (ref #1431, #1624, 6532438fe47bca1af690779ffa7292d6f1080d0c)
* For consistency, during drift rotation, changes to the compass’ rotation are driven by mbgl animation rather than view-based animation.

/cc @mourner @friedbunny @kkaefer