### PR TITLE
Turn the compass into a button

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -73,8 +73,8 @@ IB_DESIGNABLE
 *   The default value of this property is `YES`. */
 @property(nonatomic, getter=isRotateEnabled) BOOL rotateEnabled;
 
-/** The compass image view shown in the upper-right when the map is rotated. */
-@property (nonatomic, readonly) UIImageView *compassView;
+/** The compass button shown in the upper-right when the map is rotated. */
+@property (nonatomic, readonly) UIButton *compassButton;
 
 /** The Mapbox logo image view shown in the lower-left of the map. */
 @property (nonatomic, readonly) UIImageView *logoView;


### PR DESCRIPTION
Touching down on the compass but dragging outside it should cause the map to pan, not reset to north. (This is how Maps behaves, though I’m open to changing the event back to `UIControlEventTouchDown`.) This PR also renames the property to reflect its new type.

This change obsoletes part of 90af18e708b617591766950413e3691449cad2ce for #1496 but omits the accessibility-related changes contained therein.

/cc @incanus @friedbunny