### PR TITLE
Set collision debug with -[MGLMapView setDebugActive:], too

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1387,7 +1387,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 - (BOOL)isDebugActive
 {
-    return _mbglMap->getDebug();
+    return (_mbglMap->getDebug() || _mbglMap->getCollisionDebug());
 }
 
 - (void)resetNorth

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1382,6 +1382,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 - (void)setDebugActive:(BOOL)debugActive
 {
     _mbglMap->setDebug(debugActive);
+    _mbglMap->setCollisionDebug(debugActive);
 }
 
 - (BOOL)isDebugActive


### PR DESCRIPTION
Forgot to enable collision debug in `setDebugActive:` when collision was added to `toggleDebug` in #1808.

`isDebugActive` now checks for both collision and plain debug, returning true if either is on. (Of course, both should always be on at the same time...)

/cc @1ec5 @incanus