### PR TITLE
Missing parameters while issuing gdb via `make test-foo*`

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 if [ `uname -s` = 'Darwin' ]; then HOST=${HOST:-osx} ; else HOST=${HOST:-linux} ; fi
 
-CMD=$1
+CMD=$@
 shift
 
 # allow writing core files
@@ -24,5 +24,9 @@ if [ ! -d "test/node_modules/express" ]; then
     (cd test; npm install express@4.11.1)
 fi
 
-gdb -batch -return-child-result -ex 'set print thread-events off' \
-    -ex 'run' -ex 'thread apply all bt' ${CMD}
+if which -s 'gdb'; then
+    gdb -batch -return-child-result -ex 'set print thread-events off' \
+        -ex 'run' -ex 'thread apply all bt' --args ${CMD} ;
+else
+    ${CMD} ;
+fi


### PR DESCRIPTION
Two things were preventing me from running the tests on OSX:

- We cannot assume that `gdb` is installed in all environments;
- We were not passing all arguments to make test (eg. using `$1` instead of `$@` in `scripts/run_tests.sh`)