### PR TITLE
Fix Auto Layout crash on launch on iOS 7

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -539,7 +539,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
                                  multiplier:1
                                    constant:5]];
 
-    [compassContainerConstraints addObject:
+    [compassContainer addConstraint:
      [NSLayoutConstraint constraintWithItem:compassContainer
                                   attribute:NSLayoutAttributeWidth
                                   relatedBy:NSLayoutRelationEqual
@@ -548,7 +548,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
                                  multiplier:1
                                    constant:self.compassView.image.size.width]];
 
-    [compassContainerConstraints addObject:
+    [compassContainer addConstraint:
      [NSLayoutConstraint constraintWithItem:compassContainer
                                   attribute:NSLayoutAttributeHeight
                                   relatedBy:NSLayoutRelationEqual
@@ -562,7 +562,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }
     else
     {
-        [compassContainer addConstraints:compassContainerConstraints];
+        [constraintParentView addConstraints:compassContainerConstraints];
     }
 
     // logo bug


### PR DESCRIPTION
In #1793, I treated all the constraints on the compass container the same way: as constraints internal to the compass container. Unfortunately, most of the constraints are to the container’s superview, leading to a crash on launch on iOS 7 due to an older API we’re using on that OS.

Fixes #1818.