### PR TITLE
Improve style 404 error

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -112,7 +112,12 @@ void MapContext::setStyleURL(const std::string& url) {
         if (res.status == Response::Successful) {
             loadStyleJSON(res.data, base);
         } else {
-            Log::Error(Event::Setup, "loading style failed: %s", res.message.c_str());
+            if (res.message.substr(res.message.length() - 3) == "404" &&
+                (styleURL.find("mapbox://") != std::string::npos)) {
+                Log::Error(Event::Setup, "style %s could not be found or is not compatible", styleURL.c_str());
+            } else {
+                Log::Error(Event::Setup, "loading style failed: %s", res.message.c_str());
+            }
         }
     });
 }


### PR DESCRIPTION
When trying to load a remote `mapbox://userid.mapid` style that exists but isn't compatible with GL, we throw: `[ERROR] {Map}[Setup]: loading style failed: HTTP status code 404`, which is misleading and has led to numerous support enquires.

This PR checks if the style is Mapbox-hosted and 404'ing, then throws: `[ERROR] {Map}[Setup]: style mapbox://userid.mapid could not be found or is not compatible`

Ideally the server would respond differently, but this is a prudent stopgap for now.

/cc @mapbox/mobile @kkaefer @tmpsantos @brunoabinader