### PR TITLE
Replace size() with empty() whenever possible

### DIFF
--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -61,7 +61,7 @@ Rect<uint16_t> GlyphAtlas::addGlyph(uintptr_t tileUID,
     }
 
     // The glyph bitmap has zero width.
-    if (!glyph.bitmap.size()) {
+    if (glyph.bitmap.empty()) {
         return Rect<uint16_t>{ 0, 0, 0, 0 };
     }
 
@@ -114,7 +114,7 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
             GlyphValue& value = it->second;
             value.ids.erase(tileUID);
 
-            if (!value.ids.size()) {
+            if (value.ids.empty()) {
                 const Rect<uint16_t>& rect = value.rect;
 
                 // Clear out the bitmap.

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -175,7 +175,7 @@ AnnotationManager::addTileFeature(const uint32_t annotationID,
 
                         if (tile_it != featureTiles.end()) {
                             GeometryCollection& geometries = featureTiles.find(TileID(z, x, y, z))->second;
-                            if (geometries.size()) {
+                            if (!geometries.empty()) {
                                 geometries.back().push_back(coordinate);
                             } else {
                                 geometries.push_back({{ coordinate }});
@@ -495,14 +495,14 @@ const LiveTile* AnnotationManager::getTile(const TileID& id) {
     if (tile_lookup_it != tiles.end()) {
         // it exists and may have annotations already
         renderTile = tile_lookup_it->second.second.get();
-    } else if (orderedShapeAnnotations.size()) {
+    } else if (!orderedShapeAnnotations.empty()) {
         // it needs created, but only for on-demand shapes
         renderTile = tiles.emplace(id,
             std::make_pair(std::unordered_set<uint32_t>(), std::make_unique<LiveTile>())
         ).first->second.second.get();
     }
 
-    if (renderTile != nullptr && orderedShapeAnnotations.size()) {
+    if (renderTile != nullptr && !orderedShapeAnnotations.empty()) {
 
         // create shape tile layers from GeoJSONVT queries
         for (auto& tiler_it : shapeTilers) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -142,7 +142,7 @@ void MapContext::loadStyleJSON(const std::string& json, const std::string& base)
     asyncUpdate->send();
 
     auto staleTiles = data.getAnnotationManager()->resetStaleTiles();
-    if (staleTiles.size()) {
+    if (!staleTiles.empty()) {
         updateAnnotationTiles(staleTiles);
     }
 }

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -516,7 +516,7 @@ bool Source::update(MapData& data,
 
 void Source::invalidateTiles(const std::unordered_set<TileID, TileID::Hash>& ids) {
     cache.clear();
-    if (ids.size()) {
+    if (!ids.empty()) {
         for (auto& id : ids) {
             tiles.erase(id);
             tile_data.erase(id);

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -67,7 +67,7 @@ void FillBucket::addGeometry(const GeometryCollection& geometryCollection) {
         for (auto& v : line_) {
             line.emplace_back(v.x, v.y);
         }
-        if (line.size()) {
+        if (!line.empty()) {
             clipper.AddPath(line, ClipperLib::ptSubject, true);
             line.clear();
             hasVertices = true;
@@ -87,7 +87,7 @@ void FillBucket::tessellate() {
     clipper.Execute(ClipperLib::ctUnion, polygons, ClipperLib::pftEvenOdd, ClipperLib::pftEvenOdd);
     clipper.Clear();
 
-    if (polygons.size() == 0) {
+    if (polygons.empty()) {
         return;
     }
 
@@ -100,7 +100,7 @@ void FillBucket::tessellate() {
         throw geometry_too_long_exception();
     }
 
-    if (!lineGroups.size() || (lineGroups.back()->vertex_length + total_vertex_count > 65535)) {
+    if (lineGroups.empty() || (lineGroups.back()->vertex_length + total_vertex_count > 65535)) {
         // Move to a new group because the old one can't hold the geometry.
         lineGroups.emplace_back(std::make_unique<LineGroup>());
     }
@@ -147,7 +147,7 @@ void FillBucket::tessellate() {
             }
         }
 
-        if (!triangleGroups.size() || (triangleGroups.back()->vertex_length + total_vertex_count > 65535)) {
+        if (triangleGroups.empty() || (triangleGroups.back()->vertex_length + total_vertex_count > 65535)) {
             // Move to a new group because the old one can't hold the geometry.
             triangleGroups.emplace_back(std::make_unique<TriangleGroup>());
         }

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -5,18 +5,18 @@ using namespace mbgl;
 // Record frame history that will be used to calculate fading params
 void FrameHistory::record(const TimePoint& now, float zoom) {
     // first frame ever
-    if (!history.size()) {
+    if (history.empty()) {
         history.emplace_back(FrameSnapshot{TimePoint::min(), zoom});
         history.emplace_back(FrameSnapshot{TimePoint::min(), zoom});
     }
 
-    if (history.size() > 0 || history.back().z != zoom) {
+    if (!history.empty() || history.back().z != zoom) {
         history.emplace_back(FrameSnapshot{now, zoom});
     }
 }
 
 bool FrameHistory::needsAnimation(const Duration& duration) const {
-    if (!history.size()) {
+    if (history.empty()) {
         return false;
     }
 

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -308,8 +308,7 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
 
     // Store the triangle/line groups.
     {
-        if (!triangleGroups.size() ||
-            (triangleGroups.back()->vertex_length + vertexCount > 65535)) {
+        if (triangleGroups.empty() || (triangleGroups.back()->vertex_length + vertexCount > 65535)) {
             // Move to a new group because the old one can't hold the geometry.
             triangleGroups.emplace_back(std::make_unique<TriangleGroup>());
         }

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -374,7 +374,7 @@ RenderPass Painter::determineRenderPasses(const StyleLayer& layer) {
         if (properties.antialias) {
             passes |= RenderPass::Translucent;
         }
-        if (properties.image.from.size() || alpha < 1.0f) {
+        if (!properties.image.from.empty() || alpha < 1.0f) {
             passes |= RenderPass::Translucent;
         } else {
             passes |= RenderPass::Opaque;
@@ -389,7 +389,7 @@ RenderPass Painter::determineRenderPasses(const StyleLayer& layer) {
 void Painter::renderBackground(const StyleLayer &layer_desc) {
     const BackgroundProperties& properties = layer_desc.getProperties<BackgroundProperties>();
 
-    if (properties.image.to.size()) {
+    if (!properties.image.to.empty()) {
         if ((properties.opacity >= 1.0f) != (pass == RenderPass::Opaque))
             return;
 

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -33,7 +33,7 @@ void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const
         stroke_color[3] *= properties.opacity;
     }
 
-    const bool pattern = properties.image.from.size();
+    const bool pattern = !properties.image.from.empty();
 
     bool outline = properties.antialias && !pattern && stroke_color != fill_color;
     bool fringeline = properties.antialias && !pattern && stroke_color == fill_color;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -55,7 +55,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
 
     config.depthRange = { strata, 1.0f };
 
-    if (properties.dash_array.from.size()) {
+    if (!properties.dash_array.from.empty()) {
 
         useProgram(linesdfShader->program);
 
@@ -86,7 +86,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
 
         bucket.drawLineSDF(*linesdfShader);
 
-    } else if (properties.image.from.size()) {
+    } else if (!properties.image.from.empty()) {
         SpriteAtlasPosition imagePosA = spriteAtlas->getPosition(properties.image.from, true);
         SpriteAtlasPosition imagePosB = spriteAtlas->getPosition(properties.image.to, true);
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -81,7 +81,7 @@ void SymbolBucket::render(Painter& painter,
     painter.renderSymbol(*this, layer_desc, id, matrix);
 }
 
-bool SymbolBucket::hasData() const { return hasTextData() || hasIconData() || symbolInstances.size(); }
+bool SymbolBucket::hasData() const { return hasTextData() || hasIconData() || !symbolInstances.empty(); }
 
 bool SymbolBucket::hasTextData() const { return renderData && !renderData->text.groups.empty(); }
 
@@ -128,7 +128,7 @@ bool SymbolBucket::needsDependencies(const GeometryTileLayer& layer,
 
             ft.label = util::utf8_to_utf32::convert(u8string);
 
-            if (ft.label.size()) {
+            if (!ft.label.empty()) {
                 // Loop through all characters of this text and collect unique codepoints.
                 for (char32_t chr : ft.label) {
                     ranges.insert(getGlyphRange(chr));
@@ -219,7 +219,7 @@ void SymbolBucket::addFeatures(uintptr_t tileUID,
     auto fontStack = glyphStore.getFontStack(layout.text.font);
 
     for (const auto& feature : features) {
-        if (!feature.geometry.size()) continue;
+        if (feature.geometry.empty()) continue;
 
         Shaping shapedText;
         PositionedIcon shapedIcon;
@@ -298,7 +298,7 @@ void SymbolBucket::addFeature(const std::vector<std::vector<Coordinate>> &lines,
         lines;
 
     for (const auto& line : clippedLines) {
-        if (!line.size()) continue;
+        if (line.empty()) continue;
 
         // Calculate the anchor points around which you want to place labels
         Anchors anchors = isLine ?
@@ -478,8 +478,7 @@ void SymbolBucket::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float 
 
         const int glyph_vertex_length = 4;
 
-        if (!buffer.groups.size() ||
-            (buffer.groups.back()->vertex_length + glyph_vertex_length > 65535)) {
+        if (buffer.groups.empty() || (buffer.groups.back()->vertex_length + glyph_vertex_length > 65535)) {
             // Move to a new group because the old one can't hold the geometry.
             buffer.groups.emplace_back(std::make_unique<GroupType>());
         }
@@ -540,7 +539,7 @@ void SymbolBucket::addToDebugBuffers() {
                 const float placementZoom= util::max(0.0f, util::min(25.0f, static_cast<float>(zoom + log(box.placementScale) / log(2))));
 
                 auto& collisionBox = renderDataInProgress->collisionBox;
-                if (!collisionBox.groups.size()) {
+                if (collisionBox.groups.empty()) {
                     // Move to a new group because the old one can't hold the geometry.
                     collisionBox.groups.emplace_back(std::make_unique<CollisionBoxElementGroup>());
                 }

--- a/src/mbgl/text/font_stack.cpp
+++ b/src/mbgl/text/font_stack.cpp
@@ -39,7 +39,7 @@ const Shaping FontStack::getShaping(const std::u32string &string, const float ma
         }
     }
 
-    if (!shaping.positionedGlyphs.size())
+    if (shaping.positionedGlyphs.empty())
         return shaping;
 
     lineWrap(shaping, lineHeight, maxWidth, horizontalAlign, verticalAlign, justify);

--- a/src/mbgl/text/get_anchors.cpp
+++ b/src/mbgl/text/get_anchors.cpp
@@ -43,7 +43,7 @@ Anchors resample(const std::vector<Coordinate> &line, const float offset, const 
         distance += segmentDist;
     }
 
-    if (!placeAtMiddle && !anchors.size() && !continuedLine) {
+    if (!placeAtMiddle && anchors.empty() && !continuedLine) {
         // The first attempt at finding anchors at which labels can be placed failed.
         // Try again, but this time just try placing one anchor at the middle of the line.
         // This has the most effect for short lines in overscaled tiles, since the

--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -67,7 +67,7 @@ class Shaping {
     int32_t left;
     int32_t right;
 
-    operator bool() const { return positionedGlyphs.size(); }
+    operator bool() const { return !positionedGlyphs.empty(); }
 };
 
 class SDFGlyph {

--- a/src/mbgl/util/clip_id.cpp
+++ b/src/mbgl/util/clip_id.cpp
@@ -73,7 +73,7 @@ void ClipIDGenerator::update(std::forward_list<Tile *> tiles) {
         }
     }
 
-    if (pool.size()) {
+    if (!pool.empty()) {
         const uint32_t bit_count = util::ceil_log2(pool.size() + 1);
         const std::bitset<8> mask = uint64_t(((1ul << bit_count) - 1) << bit_offset);
 

--- a/src/mbgl/util/clip_lines.cpp
+++ b/src/mbgl/util/clip_lines.cpp
@@ -10,7 +10,7 @@ std::vector<std::vector<Coordinate>> clipLines(const std::vector<std::vector<Coo
 
     for (auto& line : lines) {
 
-        if (!line.size())
+        if (line.empty())
             continue;
 
         auto end = line.end() - 1;
@@ -50,7 +50,7 @@ std::vector<std::vector<Coordinate>> clipLines(const std::vector<std::vector<Coo
                 p1 = { static_cast<int16_t>(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y))), y2 };
             }
 
-            if (!clippedLines.size() || (clippedLines.back().size() && !(p0 == clippedLines.back().back()))) {
+            if (clippedLines.empty() || (!clippedLines.back().empty() && !(p0 == clippedLines.back().back()))) {
                 clippedLines.emplace_back();
                 clippedLines.back().push_back(p0);
             }

--- a/src/mbgl/util/stopwatch.cpp
+++ b/src/mbgl/util/stopwatch.cpp
@@ -28,7 +28,7 @@ void stopwatch::report(const std::string &name_) {
 }
 
 stopwatch::~stopwatch() {
-    if (name.size()) {
+    if (!name.empty()) {
         report(name);
     }
 }


### PR DESCRIPTION
This is good because `empty()` is O(1) while `size()` _might be - depends on platform and/or compiler version -_ O(n).