### PR TITLE
Enhance!

### DIFF
--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -316,7 +316,13 @@ double Source::getZoom(const TransformState& state) const {
 }
 
 int32_t Source::coveringZoomLevel(const TransformState& state) const {
-    return std::floor(getZoom(state));
+    double zoom = getZoom(state);
+    if (info.type == SourceType::Raster || info.type == SourceType::Video) {
+        zoom = std::round(zoom);
+    } else {
+        zoom = std::floor(zoom);
+    }
+    return zoom;
 }
 
 std::forward_list<TileID> Source::coveringTiles(const TransformState& state) const {
@@ -405,7 +411,12 @@ bool Source::update(MapData& data,
         return allTilesUpdated;
     }
 
-    int32_t zoom = std::floor(getZoom(transformState));
+    double zoom = getZoom(transformState);
+    if (info.type == SourceType::Raster || info.type == SourceType::Video) {
+        zoom = std::round(zoom);
+    } else {
+        zoom = std::floor(zoom);
+    }
     std::forward_list<TileID> required = coveringTiles(transformState);
 
     // Determine the overzooming/underzooming amounts.


### PR DESCRIPTION
For raster and video sources, fetch tiles from one zoom level higher when the map’s logical zoom level is halfway or greater. So z14.49 loads z14 tiles like before, but z14.5 loads z15 tiles. This behavior avoids blurriness in styles such as Satellite, given that the zoom level is rarely integral, especially after the user manually pinches to zoom. Leaflet apparently [does the same thing](https://github.com/Leaflet/Leaflet/blob/4101f017784f3c40ba744b4fd33bdc0401522983/src/layer/tile/GridLayer.js#L387).

Fixes #963.

/cc @incanus @peterqliu