### PR TITLE
legacy raster mapID API

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -211,6 +211,10 @@ IB_DESIGNABLE
 *   To display the default style, set this property to `nil`. */
 @property (nonatomic, null_resettable) NSURL *styleURL;
 
+/** Compatibility API to use legacy raster-only tile sources. Expected format is e.g. `examples.map-pgygbwdm`.
+*   @param mapID A legacy Mapbox raster-only map ID. */
+- (void)setRasterMapID:(NSString *)mapID;
+
 /** Currently active style classes, represented as an array of string identifiers. */
 @property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses;
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -198,6 +198,29 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     _mbglMap->setStyleURL([[styleURL absoluteString] UTF8String]);
 }
 
+- (void)setRasterMapID:(NSString *)mapID
+{
+    NSMutableString *templateJSON = [[[NSString alloc] initWithContentsOfFile:
+                                         [MGLMapView pathForBundleResourceNamed:@"raster-v7"
+                                                                         ofType:@"json"
+                                                                    inDirectory:nil]
+                                                              encoding:NSUTF8StringEncoding
+                                                                 error:nil] mutableCopy];
+
+    [templateJSON replaceOccurrencesOfString:@"mapbox://xxxxxx"
+                                  withString:[NSString stringWithFormat:@"mapbox://%@", mapID]
+                                     options:0
+                                       range:NSMakeRange(0, templateJSON.length)];
+
+    NSString *tempFile = [[NSTemporaryDirectory()
+                             stringByAppendingString:@"/"]
+                             stringByAppendingString:[[NSUUID UUID] UUIDString]];
+
+    [templateJSON writeToFile:tempFile atomically:YES encoding:NSUTF8StringEncoding error:nil];
+
+    _mbglMap->setStyleURL([[@"asset://" stringByAppendingString:tempFile] UTF8String]);
+}
+
 - (void)commonInit
 {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;

--- a/platform/ios/resources/raster-v7.json
+++ b/platform/ios/resources/raster-v7.json
@@ -1,0 +1,25 @@
+{
+  "version": 7,
+  "name": "Raster",
+  "sources": {
+    "raster": {
+      "type": "raster",
+      "url": "mapbox://xxxxxx",
+      "tileSize": 256
+    }
+  },
+  "layers": [{
+    "id": "background",
+    "type": "background",
+    "paint": {
+      "background-color": "#666"
+    }
+  }, {
+    "id": "raster",
+    "type": "raster",
+    "source": "raster",
+    "paint": {
+      "raster-fade-duration": 100
+    }
+  }]
+}

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -204,7 +204,7 @@ void MapContext::updateAnnotationTiles(const std::unordered_set<TileID, TileID::
             shapeLayer->type = (shapeStyle.is<LineProperties>() ? StyleLayerType::Line : StyleLayerType::Fill);
 
             // add to end of other shape layers just before (last) point layer
-            style->layers.emplace((style->layers.end() - 2), shapeLayer);
+            style->layers.emplace((style->layers.end() - 1), shapeLayer);
 
             // create shape bucket & connect to source
             util::ptr<StyleBucket> shapeBucket = std::make_shared<StyleBucket>(shapeLayer->type);


### PR DESCRIPTION
For your perusal and consideration. When #963 lands, this will be trivially doable. 

```objc
[self.mapView setRasterMapID:@"examples.map-pgygbwdm"];
```

Only concerns are around interference with `styleID`, such as in IB. I don't want to overthink this, and would punt at the earliest sign of complication, but if this can stand like this, it's an easy win. 

/cc @1ec5 @friedbunny 