### PR TITLE
FixtureLogObserver is not thread safe

### DIFF
--- a/test/fixtures/fixture_log_observer.cpp
+++ b/test/fixtures/fixture_log_observer.cpp
@@ -31,16 +31,22 @@ bool FixtureLog::Observer::onRecord(EventSeverity severity,
                                     Event event,
                                     int64_t code,
                                     const std::string& msg) {
+    std::lock_guard<std::mutex> lock(messagesMutex);
+
     messages.emplace_back(severity, event, code, msg);
 
     return true;
 }
 
 bool FixtureLog::Observer::empty() const {
+    std::lock_guard<std::mutex> lock(messagesMutex);
+
     return messages.empty();
 }
 
 size_t FixtureLog::Observer::count(const Message& message) const {
+    std::lock_guard<std::mutex> lock(messagesMutex);
+
     size_t message_count = 0;
     for (const auto& msg : messages) {
         if (msg == message) {
@@ -70,6 +76,8 @@ FixtureLog::~FixtureLog() {
 }
 
 std::vector<FixtureLog::Message> FixtureLogObserver::unchecked() const {
+    std::lock_guard<std::mutex> lock(messagesMutex);
+
     std::vector<Message> unchecked_messages;
     for (const auto& msg : messages) {
         if (!msg.checked) {

--- a/test/fixtures/fixture_log_observer.hpp
+++ b/test/fixtures/fixture_log_observer.hpp
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <cstdarg>
+#include <mutex>
 #include <iostream>
 
 namespace mbgl {
@@ -42,9 +43,10 @@ public:
         size_t count(const Message& message) const;
         std::vector<Message> unchecked() const;
 
-    public:
+    private:
         FixtureLog* log;
         std::vector<Message> messages;
+        mutable std::mutex messagesMutex;
     };
 
     FixtureLog();


### PR DESCRIPTION
On the tests, we log from different threads and the messages are captured by FixtureLogObserver and added to a list so we can later check if what we expected to be log was logged. We see random crashes on the tests that could be related with the fact that FixtureLogObserver is not thread-safe.