### PR TITLE
refs #1125, 1813: update user dot tracking in one place

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -688,6 +688,8 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         _mbglMap->setSourceTileCacheSize(cacheSize);
 
         _mbglMap->renderSync();
+
+        [self updateUserLocationAnnotationView];
     }
 }
 
@@ -2351,8 +2353,6 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     self.userLocationAnnotationView.haloLayer.hidden = ! CLLocationCoordinate2DIsValid(self.userLocation.coordinate) ||
         newLocation.horizontalAccuracy > 10;
-
-    [self updateUserLocationAnnotationView];
 }
 
 - (BOOL)locationManagerShouldDisplayHeadingCalibration:(CLLocationManager *)manager
@@ -2509,8 +2509,6 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         case mbgl::MapChangeRegionWillChange:
         case mbgl::MapChangeRegionWillChangeAnimated:
         {
-            [self updateUserLocationAnnotationView];
-
             [self deselectAnnotation:self.selectedAnnotation animated:NO];
 
             BOOL animated = (change == mbgl::MapChangeRegionWillChangeAnimated);
@@ -2545,7 +2543,6 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         }
         case mbgl::MapChangeRegionIsChanging:
         {
-            [self updateUserLocationAnnotationView];
             [self updateCompass];
 
             if ([self.delegate respondsToSelector:@selector(mapViewRegionIsChanging:)])
@@ -2557,7 +2554,6 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         case mbgl::MapChangeRegionDidChange:
         case mbgl::MapChangeRegionDidChangeAnimated:
         {
-            [self updateUserLocationAnnotationView];
             [self updateCompass];
 
             if (self.pan.state       == UIGestureRecognizerStateChanged ||


### PR DESCRIPTION
Now that we have cleanup around the map viewport change notifications, this only needs to happen in one place: the GL frame draw loop.