### PR TITLE
Sprites are not reporting parsing errors

### DIFF
--- a/src/mbgl/annotation/sprite_parser.cpp
+++ b/src/mbgl/annotation/sprite_parser.cpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <limits>
+#include <sstream>
 
 namespace mbgl {
 
@@ -99,7 +100,7 @@ inline bool getBoolean(const rapidjson::Value& value, const char* name, const bo
 
 } // namespace
 
-Sprites parseSprite(const std::string& image, const std::string& json) {
+SpriteParseResult parseSprite(const std::string& image, const std::string& json) {
     using namespace rapidjson;
 
     Sprites sprites;
@@ -107,20 +108,18 @@ Sprites parseSprite(const std::string& image, const std::string& json) {
     // Parse the sprite image.
     const util::Image raster(image);
     if (!raster) {
-        Log::Warning(Event::Sprite, "Could not parse sprite image");
-        return sprites;
+        return std::string("Could not parse sprite image");
     }
 
     Document doc;
     doc.Parse<0>(json.c_str());
 
     if (doc.HasParseError()) {
-        Log::Warning(Event::Sprite, std::string{ "Failed to parse JSON: " } + doc.GetParseError() +
-                                        " at offset " + std::to_string(doc.GetErrorOffset()));
-        return sprites;
+        std::stringstream message;
+        message << "Failed to parse JSON: " << doc.GetParseError() << " at offset " << doc.GetErrorOffset();
+        return message.str();
     } else if (!doc.IsObject()) {
-        Log::Warning(Event::Sprite, "Sprite JSON root must be an object");
-        return sprites;
+        return std::string("Sprite JSON root must be an object");
     } else {
         for (Value::ConstMemberIterator itr = doc.MemberBegin(); itr != doc.MemberEnd(); ++itr) {
             const std::string name = { itr->name.GetString(), itr->name.GetStringLength() };

--- a/src/mbgl/annotation/sprite_parser.hpp
+++ b/src/mbgl/annotation/sprite_parser.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/variant.hpp>
 
 #include <string>
 #include <memory>
@@ -31,8 +32,13 @@ SpriteImagePtr createSpriteImage(const util::Image& image,
 
 using Sprites = std::map<std::string, SpriteImagePtr>;
 
+
+using SpriteParseResult = mapbox::util::variant<
+    Sprites,      // success
+    std::string>; // error
+
 // Parses an image and an associated JSON file and returns the sprite objects.
-Sprites parseSprite(const std::string& image, const std::string& json);
+SpriteParseResult parseSprite(const std::string& image, const std::string& json);
 
 } // namespace mbgl
 

--- a/src/mbgl/map/sprite.cpp
+++ b/src/mbgl/map/sprite.cpp
@@ -86,9 +86,10 @@ Sprite::~Sprite() {
 void Sprite::emitSpriteLoadedIfComplete() {
     assert(loader);
     if (loader->loadedImage && loader->loadedJSON && observer) {
-        observer->onSpriteDataLoaded(std::move(loader->data));
+        std::unique_ptr<Data> data(std::move(loader->data));
         loader.reset();
-        observer->onSpriteLoaded();
+
+        observer->onSpriteLoaded(std::move(data));
     }
 }
 

--- a/src/mbgl/map/sprite.cpp
+++ b/src/mbgl/map/sprite.cpp
@@ -39,6 +39,7 @@ Sprite::Sprite(const std::string& baseUrl, float pixelRatio_)
     : pixelRatio(pixelRatio_ > 1 ? 2 : 1) {
     if (baseUrl.empty()) {
         // Treat a non-existent sprite as a successfully loaded empty sprite.
+        loaded = true;
         return;
     }
 
@@ -95,6 +96,7 @@ void Sprite::emitSpriteLoadedIfComplete() {
 
     auto result = parseSprite(data->image, data->json);
     if (result.is<Sprites>()) {
+        loaded = true;
         observer->onSpriteLoaded(result.get<Sprites>());
     } else {
         emitSpriteLoadingFailed(result.get<std::string>());

--- a/src/mbgl/map/sprite.cpp
+++ b/src/mbgl/map/sprite.cpp
@@ -85,11 +85,19 @@ Sprite::~Sprite() {
 
 void Sprite::emitSpriteLoadedIfComplete() {
     assert(loader);
-    if (loader->loadedImage && loader->loadedJSON && observer) {
-        std::unique_ptr<Data> data(std::move(loader->data));
-        loader.reset();
 
-        observer->onSpriteLoaded(std::move(data));
+    if (!loader->loadedImage || !loader->loadedJSON || !observer) {
+        return;
+    }
+
+    std::unique_ptr<Data> data(std::move(loader->data));
+    loader.reset();
+
+    auto result = parseSprite(data->image, data->json);
+    if (result.is<Sprites>()) {
+        observer->onSpriteLoaded(result.get<Sprites>());
+    } else {
+        emitSpriteLoadingFailed(result.get<std::string>());
     }
 }
 

--- a/src/mbgl/map/sprite.hpp
+++ b/src/mbgl/map/sprite.hpp
@@ -36,7 +36,7 @@ public:
     ~Sprite();
 
     inline bool isLoaded() const {
-        return loader == nullptr;
+        return loaded;
     }
 
     const float pixelRatio;
@@ -49,6 +49,8 @@ private:
 
     struct Loader;
     std::unique_ptr<Loader> loader;
+
+    bool loaded = false;
 
     Observer* observer = nullptr;
 };

--- a/src/mbgl/map/sprite.hpp
+++ b/src/mbgl/map/sprite.hpp
@@ -27,8 +27,7 @@ public:
     public:
         virtual ~Observer() = default;
 
-        virtual void onSpriteDataLoaded(std::unique_ptr<Data>) = 0;
-        virtual void onSpriteLoaded() = 0;
+        virtual void onSpriteLoaded(std::unique_ptr<Data>) = 0;
         virtual void onSpriteLoadingFailed(std::exception_ptr error) = 0;
     };
 

--- a/src/mbgl/map/sprite.hpp
+++ b/src/mbgl/map/sprite.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_STYLE_SPRITE
 #define MBGL_STYLE_SPRITE
 
+#include <mbgl/annotation/sprite_parser.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
@@ -27,7 +28,7 @@ public:
     public:
         virtual ~Observer() = default;
 
-        virtual void onSpriteLoaded(std::unique_ptr<Data>) = 0;
+        virtual void onSpriteLoaded(const Sprites& sprites) = 0;
         virtual void onSpriteLoadingFailed(std::exception_ptr error) = 0;
     };
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -4,7 +4,6 @@
 #include <mbgl/map/source.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/annotation/sprite_store.hpp>
-#include <mbgl/annotation/sprite_parser.hpp>
 #include <mbgl/style/style_layer.hpp>
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/style/style_bucket.hpp>
@@ -191,9 +190,9 @@ void Style::onTileLoadingFailed(std::exception_ptr error) {
     emitResourceLoadingFailed(error);
 }
 
-void Style::onSpriteLoaded(std::unique_ptr<Sprite::Data> spriteData) {
+void Style::onSpriteLoaded(const Sprites& sprites) {
     // Add all sprite images to the SpriteStore object
-    spriteStore->setSprites(parseSprite(spriteData->image, spriteData->json));
+    spriteStore->setSprites(sprites);
 
     shouldReparsePartialTiles = true;
     emitTileDataChanged();

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -191,14 +191,11 @@ void Style::onTileLoadingFailed(std::exception_ptr error) {
     emitResourceLoadingFailed(error);
 }
 
-void Style::onSpriteDataLoaded(std::unique_ptr<Sprite::Data> spriteData) {
+void Style::onSpriteLoaded(std::unique_ptr<Sprite::Data> spriteData) {
     // Add all sprite images to the SpriteStore object
     spriteStore->setSprites(parseSprite(spriteData->image, spriteData->json));
-}
 
-void Style::onSpriteLoaded() {
     shouldReparsePartialTiles = true;
-
     emitTileDataChanged();
 }
 

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -89,8 +89,7 @@ private:
     void onTileLoadingFailed(std::exception_ptr error) override;
 
     // Sprite::Observer implementation.
-    void onSpriteDataLoaded(std::unique_ptr<Sprite::Data>) override;
-    void onSpriteLoaded() override;
+    void onSpriteLoaded(std::unique_ptr<Sprite::Data>) override;
     void onSpriteLoadingFailed(std::exception_ptr error) override;
 
     void emitTileDataChanged();

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -89,7 +89,7 @@ private:
     void onTileLoadingFailed(std::exception_ptr error) override;
 
     // Sprite::Observer implementation.
-    void onSpriteLoaded(std::unique_ptr<Sprite::Data>) override;
+    void onSpriteLoaded(const Sprites& sprites) override;
     void onSpriteLoadingFailed(std::exception_ptr error) override;
 
     void emitTileDataChanged();

--- a/test/annotations/sprite_atlas.cpp
+++ b/test/annotations/sprite_atlas.cpp
@@ -12,9 +12,11 @@ using namespace mbgl;
 TEST(Annotations, SpriteAtlas) {
     FixtureLog log;
 
+    auto spriteParseResult = parseSprite(util::read_file("test/fixtures/annotations/emerald.png"),
+                                         util::read_file("test/fixtures/annotations/emerald.json"));
+
     SpriteStore store;
-    store.setSprites(parseSprite(util::read_file("test/fixtures/annotations/emerald.png"),
-                                 util::read_file("test/fixtures/annotations/emerald.json")));
+    store.setSprites(spriteParseResult.get<Sprites>());
 
     SpriteAtlas atlas(63, 112, 1, store);
 
@@ -85,9 +87,12 @@ TEST(Annotations, SpriteAtlas) {
 }
 
 TEST(Annotations, SpriteAtlasSize) {
+    auto spriteParseResult = parseSprite(util::read_file("test/fixtures/annotations/emerald.png"),
+                                         util::read_file("test/fixtures/annotations/emerald.json"));
+
     SpriteStore store;
-    store.setSprites(parseSprite(util::read_file("test/fixtures/annotations/emerald.png"),
-                                 util::read_file("test/fixtures/annotations/emerald.json")));
+    store.setSprites(spriteParseResult.get<Sprites>());
+
     SpriteAtlas atlas(63, 112, 1.4, store);
 
     EXPECT_DOUBLE_EQ(1.4f, atlas.getPixelRatio());

--- a/test/annotations/sprite_parser.cpp
+++ b/test/annotations/sprite_parser.cpp
@@ -117,7 +117,7 @@ TEST(Annotations, SpriteParsing) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = util::read_file("test/fixtures/annotations/emerald.json");
 
-    const auto images = parseSprite(image_1x, json_1x);
+    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
 
     std::set<std::string> names;
     std::transform(images.begin(), images.end(), std::inserter(names, names.begin()),
@@ -210,22 +210,13 @@ TEST(Annotations, SpriteParsing) {
 }
 
 TEST(Annotations, SpriteParsingInvalidJSON) {
-    FixtureLog log;
-
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": " })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x);
-    EXPECT_EQ(0u, images.size());
+    const auto error = parseSprite(image_1x, json_1x).get<std::string>();
 
-    EXPECT_EQ(
-        1u,
-        log.count({
-            EventSeverity::Warning,
-            Event::Sprite,
-            int64_t(-1),
-            "Failed to parse JSON: lacks ending quotation before the end of string at offset 10",
-        }));
+    EXPECT_EQ(error,
+              std::string("Failed to parse JSON: lacks ending quotation before the end of string at offset 10"));
 }
 
 TEST(Annotations, SpriteParsingEmptyImage) {
@@ -234,7 +225,7 @@ TEST(Annotations, SpriteParsingEmptyImage) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": {} })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x);
+    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
     EXPECT_EQ(0u, images.size());
 
     EXPECT_EQ(1u, log.count({
@@ -251,7 +242,7 @@ TEST(Annotations, SpriteParsingSimpleWidthHeight) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": { "width": 32, "height": 32 } })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x);
+    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
     EXPECT_EQ(1u, images.size());
 }
 
@@ -261,7 +252,7 @@ TEST(Annotations, SpriteParsingWidthTooBig) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": { "width": 65536, "height": 32 } })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x);
+    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
     EXPECT_EQ(0u, images.size());
 
     EXPECT_EQ(1u, log.count({
@@ -284,7 +275,7 @@ TEST(Annotations, SpriteParsingNegativeWidth) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": { "width": -1, "height": 32 } })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x);
+    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
     EXPECT_EQ(0u, images.size());
 
     EXPECT_EQ(1u, log.count({
@@ -307,7 +298,7 @@ TEST(Annotations, SpriteParsingNullRatio) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": { "width": 32, "height": 32, "pixelRatio": 0 } })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x);
+    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
     EXPECT_EQ(0u, images.size());
 
     EXPECT_EQ(1u, log.count({

--- a/test/style/mock_file_source.cpp
+++ b/test/style/mock_file_source.cpp
@@ -53,7 +53,13 @@ private:
 void MockFileSource::Impl::replyWithSuccess(Request* req) const {
     std::shared_ptr<Response> res = std::make_shared<Response>();
     res->status = Response::Status::Successful;
-    res->data = util::read_file(req->resource.url);
+
+    try {
+        res->data = util::read_file(req->resource.url);
+    } catch (const std::exception& err) {
+        res->status = Response::Status::Error;
+        res->message = err.what();
+    }
 
     req->notify(res);
 }

--- a/test/style/resource_loading.cpp
+++ b/test/style/resource_loading.cpp
@@ -138,45 +138,30 @@ void runTestCase(MockFileSource::Type type,
 
 }
 
-class ResourceLoading : public ::testing::TestWithParam<std::string> {
+class ResourceLoading : public ::testing::TestWithParam<std::pair<std::string, std::string>> {
 };
 
 TEST_P(ResourceLoading, Success) {
-    runTestCase(MockFileSource::Success, GetParam(), std::string());
+    runTestCase(MockFileSource::Success, GetParam().first, std::string());
 }
 
 TEST_P(ResourceLoading, RequestFail) {
     std::stringstream message;
-    message << "Failed to load \\[test\\/fixtures\\/resources\\/" << GetParam() << "\\]\\: Failed by the test case";
+    message << "Failed to load \\[test\\/fixtures\\/resources\\/" << GetParam().first << "\\]\\: Failed by the test case";
 
-    runTestCase(MockFileSource::RequestFail, GetParam(), message.str());
+    runTestCase(MockFileSource::RequestFail, GetParam().first, message.str());
 }
 
 TEST_P(ResourceLoading, RequestWithCorruptedData) {
-    const std::string param(GetParam());
-
-    std::stringstream message;
-    message << "Failed to parse ";
-
-    if (param == "vector.pbf") {
-        message << "\\[1(5|6)\\/1638(3|4)\\/1638(3|4)\\]\\: pbf unknown field type exception";
-    } else if (param == "raster.png") {
-        message << "\\[17\\/6553(4|5|6|7)\\/6553(4|5|6|7)\\]\\: error parsing raster image";
-    } else {
-        message << "\\[test\\/fixtures\\/resources\\/" << param << "\\]";
-    }
-
-    if (param.find("json") != std::string::npos) {
-        message << "\\: 0 - Expect either an object or array at root";
-    }
-
-    runTestCase(MockFileSource::RequestWithCorruptedData, GetParam(), message.str());
+    runTestCase(MockFileSource::RequestWithCorruptedData, GetParam().first, GetParam().second);
 }
 
 INSTANTIATE_TEST_CASE_P(Style, ResourceLoading,
     ::testing::Values(
-        "source_raster.json",
-        "source_vector.json",
-        "raster.png",
-        "vector.pbf",
-        "glyphs.pbf"));
+        std::make_pair("source_raster.json", "Failed to parse \\[test\\/fixtures\\/resources\\/source_raster.json\\]: 0 - Expect either an object or array at root"),
+        std::make_pair("source_vector.json", "Failed to parse \\[test\\/fixtures\\/resources\\/source_vector.json\\]: 0 - Expect either an object or array at root"),
+        std::make_pair("sprite.json", "Failed to parse JSON: Expect either an object or array at root at offset 0"),
+        std::make_pair("sprite.png", "Could not parse sprite image"),
+        std::make_pair("raster.png", "Failed to parse \\[17\\/6553(4|5|6|7)\\/6553(4|5|6|7)\\]\\: error parsing raster image"),
+        std::make_pair("vector.pbf", "Failed to parse \\[1(5|6)\\/1638(3|4)\\/1638(3|4)\\]\\: pbf unknown field type exception"),
+        std::make_pair("glyphs.pbf", "Failed to parse \\[test\\/fixtures\\/resources\\/glyphs.pbf\\]")));

--- a/test/style/sprite.cpp
+++ b/test/style/sprite.cpp
@@ -1,0 +1,173 @@
+#include "../fixtures/fixture_log_observer.hpp"
+#include "../fixtures/util.hpp"
+#include "mock_file_source.hpp"
+
+#include <mbgl/map/sprite.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/thread.hpp>
+
+using namespace mbgl;
+
+using SpriteTestCallback = std::function<void(Sprite*, const Sprites&, std::exception_ptr)>;
+
+struct SpriteParams {
+    const std::string baseUrl;
+    const float pixelRatio;
+};
+
+class SpriteThread : public Sprite::Observer {
+public:
+    SpriteThread(FileSource* fileSource, SpriteTestCallback callback) : callback_(callback) {
+        util::ThreadContext::setFileSource(fileSource);
+    }
+
+    void loadSprite(const SpriteParams& params) {
+        sprite_.reset(new Sprite(params.baseUrl, params.pixelRatio));
+        sprite_->setObserver(this);
+    }
+
+    void unloadSprite() {
+        sprite_->setObserver(nullptr);
+        sprite_.reset();
+    }
+
+    void onSpriteLoaded(const Sprites& sprites) override {
+        callback_(sprite_.get(), sprites, nullptr);
+    }
+
+    void onSpriteLoadingFailed(std::exception_ptr error) override {
+        callback_(sprite_.get(), Sprites(), error);
+    }
+
+private:
+    std::unique_ptr<Sprite> sprite_;
+    SpriteTestCallback callback_;
+};
+
+class SpriteTest : public testing::Test {
+protected:
+    void runTest(const SpriteParams& params, FileSource* fileSource, SpriteTestCallback callback) {
+        util::RunLoop loop(uv_default_loop());
+
+        async_ = std::make_unique<uv::async>(loop.get(), [&] { loop.stop(); });
+        async_->unref();
+
+        const util::ThreadContext context = {"Map", util::ThreadType::Map, util::ThreadPriority::Regular};
+
+        util::Thread<SpriteThread> tester(context, fileSource, callback);
+        tester.invoke(&SpriteThread::loadSprite, params);
+
+        uv_run(loop.get(), UV_RUN_DEFAULT);
+
+        tester.invoke(&SpriteThread::unloadSprite);
+    }
+
+    void stopTest() {
+        async_->send();
+    }
+
+private:
+    std::unique_ptr<uv::async> async_;
+};
+
+TEST_F(SpriteTest, LoadingSuccess) {
+    SpriteParams params = {
+        "test/fixtures/resources/sprite",
+        1.0,
+    };
+
+    auto callback = [this, &params](Sprite* sprite, const Sprites& sprites, std::exception_ptr error) {
+        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+        ASSERT_TRUE(error == nullptr);
+
+        ASSERT_TRUE(!sprites.empty());
+
+        ASSERT_EQ(sprite->pixelRatio, params.pixelRatio);
+        ASSERT_NE(sprite->pixelRatio, 1.5);
+        ASSERT_NE(sprite->pixelRatio, 2.0);
+
+        ASSERT_TRUE(sprite->isLoaded());
+
+        stopTest();
+    };
+
+    MockFileSource fileSource(MockFileSource::Success, "");
+    runTest(params, &fileSource, callback);
+}
+
+TEST_F(SpriteTest, LoadingFail) {
+    SpriteParams params = {
+        "test/fixtures/resources/sprite",
+        1.0,
+    };
+
+    auto callback = [this, &params](Sprite* sprite, const Sprites&, std::exception_ptr error) {
+        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+        ASSERT_TRUE(error != nullptr);
+
+        ASSERT_EQ(sprite->pixelRatio, params.pixelRatio);
+        ASSERT_NE(sprite->pixelRatio, 1.5);
+        ASSERT_NE(sprite->pixelRatio, 2.0);
+
+        ASSERT_FALSE(sprite->isLoaded());
+
+        stopTest();
+    };
+
+    MockFileSource fileSourceFailSpriteJSON(MockFileSource::RequestFail, "sprite.json");
+    runTest(params, &fileSourceFailSpriteJSON, callback);
+
+    MockFileSource fileSourceFailSpriteImage(MockFileSource::RequestFail, "sprite.png");
+    runTest(params, &fileSourceFailSpriteImage, callback);
+
+    MockFileSource fileSourceCorruptedSpriteJSON(MockFileSource::RequestWithCorruptedData, "sprite.json");
+    runTest(params, &fileSourceCorruptedSpriteJSON, callback);
+
+    MockFileSource fileSourceCorruptedSpriteImage(MockFileSource::RequestWithCorruptedData, "sprite.png");
+    runTest(params, &fileSourceCorruptedSpriteImage, callback);
+}
+
+TEST_F(SpriteTest, LoadingCancel) {
+    SpriteParams params = {
+        "test/fixtures/resources/sprite",
+        1.0,
+    };
+
+    auto callback = [this](Sprite*, const Sprites&, std::exception_ptr) {
+        FAIL() << "Should never be called";
+    };
+
+    MockFileSource fileSourceDelaySpriteJSON(MockFileSource::SuccessWithDelay, "sprite.json");
+    fileSourceDelaySpriteJSON.setOnRequestDelayedCallback([this]{
+        stopTest();
+    });
+    runTest(params, &fileSourceDelaySpriteJSON, callback);
+
+    MockFileSource fileSourceDelaySpriteImage(MockFileSource::SuccessWithDelay, "sprite.png");
+    fileSourceDelaySpriteImage.setOnRequestDelayedCallback([this]{
+        stopTest();
+    });
+    runTest(params, &fileSourceDelaySpriteImage, callback);
+}
+
+TEST_F(SpriteTest, InvalidURL) {
+    SpriteParams params = {
+        "foo bar",
+        1.0,
+    };
+
+    auto callback = [this](Sprite* sprite, const Sprites&, std::exception_ptr error) {
+        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+        ASSERT_TRUE(error != nullptr);
+
+        ASSERT_EQ(sprite->isLoaded(), false);
+
+        stopTest();
+    };
+
+    MockFileSource fileSource(MockFileSource::Success, "");
+    runTest(params, &fileSource, callback);
+}

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -88,6 +88,7 @@
         'style/mock_view.hpp',
         'style/pending_resources.cpp',
         'style/resource_loading.cpp',
+        'style/sprite.cpp',
       ],
       'libraries': [
         '<@(uv_static_libs)',


### PR DESCRIPTION
The map object will never know if the Sprite JSON or image is corrupted and will always fail silently. We want to know about these errors, but we can still only emit warnings for semantic errors.