### PR TITLE
Force -ObjC in Mapbox GL pod

### DIFF
--- a/ios/MapboxGL.podspec
+++ b/ios/MapboxGL.podspec
@@ -29,6 +29,9 @@ Pod::Spec.new do |m|
 
   m.frameworks = 'CoreLocation', 'CoreTelephony', 'GLKit', 'ImageIO', 'MobileCoreServices', 'QuartzCore', 'SystemConfiguration'
   m.libraries = 'c++', 'sqlite3', 'z'
-  m.xcconfig = { 'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++' }
+  m.xcconfig = {
+    'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++',
+    'OTHER_LDFLAGS' => '-ObjC',
+  }
 
 end


### PR DESCRIPTION
Force `-ObjC` in Mapbox GL pod due to CocoaPods/CocoaPods#3537.

Fixes #1849.

/cc @incanus @friedbunny