### PR TITLE
Do not return a value on a "[]() -> void"

### DIFF
--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -57,7 +57,7 @@ public:
         std::packaged_task<void ()> task(std::bind(fn, object, args...));
         std::future<void> future = task.get_future();
         loop->invoke(std::move(task));
-        return future.get();
+        future.get();
     }
 
 private:


### PR DESCRIPTION
This is an undefined behavior, and it is a mystery why the
compiler was not complaining about it.