### PR TITLE
Include iOS README in binary pod

### DIFF
--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -113,7 +113,7 @@ git fetch --tags
 DOCS_VERSION=$( git tag --sort -v:refname | grep -v '\-rc.' | sed -n '1p' | sed 's/^v//' )
 rm -rf /tmp/mbgl
 mkdir -p /tmp/mbgl/
-README=/tmp/mbgl/GL-README.md
+README=/tmp/mbgl/README.md
 cat ios/README.md > ${README}
 echo >> ${README}
 echo -n "#" >> ${README}
@@ -134,3 +134,4 @@ appledoc \
     --company-id com.mapbox \
     --index-desc ${README} \
     /tmp/mbgl/Headers
+cp ${README} "${OUTPUT}/static"


### PR DESCRIPTION
This PR adds the iOS-specific README to the build folder that gets zipped up and distributed as a CocoaPods binary pod. Without this README, CocoaPods [dings](https://cocoapods.org/pods/MapboxGL/quality) the MapboxGL pod big time in its quality metrics for lacking a README. We’ve been compiling this README to serve as the index page of the API documentation that gets generated, but a README also needs to set right alongside the library and resource bundle.

/cc @incanus @friedbunny