### PR TITLE
Clean up transition durations & time points

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -79,8 +79,8 @@ public:
     void setClasses(const std::vector<std::string>&);
     std::vector<std::string> getClasses() const;
 
-    void setDefaultTransitionDuration(Duration = Duration::zero());
-    Duration getDefaultTransitionDuration();
+    void setDefaultTransitionDuration(const Duration& = Duration::zero());
+    Duration getDefaultTransitionDuration() const;
     void setStyleURL(const std::string& url);
     void setStyleJSON(const std::string& json, const std::string& base = "");
     std::string getStyleURL() const;
@@ -91,27 +91,27 @@ public:
     void setGestureInProgress(bool);
 
     // Position
-    void moveBy(double dx, double dy, Duration = Duration::zero());
-    void setLatLng(LatLng latLng, Duration = Duration::zero());
+    void moveBy(double dx, double dy, const Duration& = Duration::zero());
+    void setLatLng(LatLng latLng, const Duration& = Duration::zero());
     LatLng getLatLng() const;
     void resetPosition();
 
     // Scale
-    void scaleBy(double ds, double cx = -1, double cy = -1, Duration = Duration::zero());
-    void setScale(double scale, double cx = -1, double cy = -1, Duration = Duration::zero());
+    void scaleBy(double ds, double cx = -1, double cy = -1, const Duration& = Duration::zero());
+    void setScale(double scale, double cx = -1, double cy = -1, const Duration& = Duration::zero());
     double getScale() const;
-    void setZoom(double zoom, Duration = Duration::zero());
+    void setZoom(double zoom, const Duration& = Duration::zero());
     double getZoom() const;
-    void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
-    void fitBounds(LatLngBounds bounds, EdgeInsets padding, Duration duration = Duration::zero());
-    void fitBounds(AnnotationSegment segment, EdgeInsets padding, Duration duration = Duration::zero());
+    void setLatLngZoom(LatLng latLng, double zoom, const Duration& = Duration::zero());
+    void fitBounds(LatLngBounds bounds, EdgeInsets padding, const Duration& duration = Duration::zero());
+    void fitBounds(AnnotationSegment segment, EdgeInsets padding, const Duration& duration = Duration::zero());
     void resetZoom();
     double getMinZoom() const;
     double getMaxZoom() const;
 
     // Rotation
-    void rotateBy(double sx, double sy, double ex, double ey, Duration = Duration::zero());
-    void setBearing(double degrees, Duration = Duration::zero());
+    void rotateBy(double sx, double sy, double ex, double ey, const Duration& = Duration::zero());
+    void setBearing(double degrees, const Duration& = Duration::zero());
     void setBearing(double degrees, double cx, double cy);
     double getBearing() const;
     void resetNorth();

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -116,12 +116,12 @@ void Map::setGestureInProgress(bool inProgress) {
 
 #pragma mark - Position
 
-void Map::moveBy(double dx, double dy, Duration duration) {
+void Map::moveBy(double dx, double dy, const Duration& duration) {
     transform->moveBy(dx, dy, duration);
     update();
 }
 
-void Map::setLatLng(LatLng latLng, Duration duration) {
+void Map::setLatLng(LatLng latLng, const Duration& duration) {
     transform->setLatLng(latLng, duration);
     update();
 }
@@ -140,12 +140,12 @@ void Map::resetPosition() {
 
 #pragma mark - Scale
 
-void Map::scaleBy(double ds, double cx, double cy, Duration duration) {
+void Map::scaleBy(double ds, double cx, double cy, const Duration& duration) {
     transform->scaleBy(ds, cx, cy, duration);
     update(Update::Zoom);
 }
 
-void Map::setScale(double scale, double cx, double cy, Duration duration) {
+void Map::setScale(double scale, double cx, double cy, const Duration& duration) {
     transform->setScale(scale, cx, cy, duration);
     update(Update::Zoom);
 }
@@ -154,7 +154,7 @@ double Map::getScale() const {
     return transform->getScale();
 }
 
-void Map::setZoom(double zoom, Duration duration) {
+void Map::setZoom(double zoom, const Duration& duration) {
     transform->setZoom(zoom, duration);
     update(Update::Zoom);
 }
@@ -163,12 +163,12 @@ double Map::getZoom() const {
     return transform->getZoom();
 }
 
-void Map::setLatLngZoom(LatLng latLng, double zoom, Duration duration) {
+void Map::setLatLngZoom(LatLng latLng, double zoom, const Duration& duration) {
     transform->setLatLngZoom(latLng, zoom, duration);
     update(Update::Zoom);
 }
 
-void Map::fitBounds(LatLngBounds bounds, EdgeInsets padding, Duration duration) {
+void Map::fitBounds(LatLngBounds bounds, EdgeInsets padding, const Duration& duration) {
     AnnotationSegment segment = {
         {bounds.ne.latitude, bounds.sw.longitude},
         bounds.sw,
@@ -178,7 +178,7 @@ void Map::fitBounds(LatLngBounds bounds, EdgeInsets padding, Duration duration) 
     fitBounds(segment, padding, duration);
 }
 
-void Map::fitBounds(AnnotationSegment segment, EdgeInsets padding, Duration duration) {
+void Map::fitBounds(AnnotationSegment segment, EdgeInsets padding, const Duration& duration) {
     if (segment.empty()) {
         return;
     }
@@ -243,12 +243,12 @@ uint16_t Map::getHeight() const {
 
 #pragma mark - Rotation
 
-void Map::rotateBy(double sx, double sy, double ex, double ey, Duration duration) {
+void Map::rotateBy(double sx, double sy, double ex, double ey, const Duration& duration) {
     transform->rotateBy(sx, sy, ex, ey, duration);
     update();
 }
 
-void Map::setBearing(double degrees, Duration duration) {
+void Map::setBearing(double degrees, const Duration& duration) {
     transform->setAngle(-degrees * M_PI / 180, duration);
     update();
 }
@@ -416,12 +416,12 @@ std::vector<std::string> Map::getClasses() const {
     return data->getClasses();
 }
 
-void Map::setDefaultTransitionDuration(Duration duration) {
+void Map::setDefaultTransitionDuration(const Duration& duration) {
     data->setDefaultTransitionDuration(duration);
     update(Update::DefaultTransitionDuration);
 }
 
-Duration Map::getDefaultTransitionDuration() {
+Duration Map::getDefaultTransitionDuration() const {
     return data->getDefaultTransitionDuration();
 }
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -254,21 +254,15 @@ void MapContext::update() {
         return;
     }
 
-    const TimePoint now = Clock::now();
-
-    data.setAnimationTime(now);
-
-    if (updated & static_cast<UpdateType>(Update::DefaultTransitionDuration)) {
-        style->setDefaultTransitionDuration(data.getDefaultTransitionDuration());
-    }
+    data.setAnimationTime(Clock::now());
 
     if (updated & static_cast<UpdateType>(Update::Classes)) {
-        style->cascade(data.getClasses(), now);
+        style->cascade();
     }
 
     if (updated & static_cast<UpdateType>(Update::Classes) ||
             updated & static_cast<UpdateType>(Update::Zoom)) {
-        style->recalculate(transformState.getNormalizedZoom(), now);
+        style->recalculate(transformState.getNormalizedZoom());
     }
 
     style->update(transformState, *texturePool);
@@ -330,7 +324,7 @@ MapContext::RenderResult MapContext::renderSync(const TransformState& state, con
     glObjectStore.performCleanup();
 
     if (!painter) {
-        painter = std::make_unique<Painter>(data.pixelRatio);
+        painter = std::make_unique<Painter>(data);
         painter->setup();
     }
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -254,7 +254,7 @@ void MapContext::update() {
         return;
     }
 
-    TimePoint now = Clock::now();
+    const TimePoint now = Clock::now();
 
     data.setAnimationTime(now);
 

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -72,9 +72,6 @@ public:
     void onResourceLoadingFailed(std::exception_ptr error) override;
 
 private:
-    // Style-related updates.
-    void cascadeClasses();
-
     // Update the state indicated by the accumulated Update flags, then render.
     void update();
 

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -20,10 +20,14 @@ class MapData {
     using Lock = std::lock_guard<std::mutex>;
 
 public:
-    inline MapData(MapMode mode_, const float pixelRatio_) : mode(mode_), pixelRatio(pixelRatio_) {
+    inline MapData(MapMode mode_, const float pixelRatio_)
+        : mode(mode_)
+        , pixelRatio(pixelRatio_)
+        , animationTime(Duration::zero())
+        , defaultFadeDuration(std::chrono::milliseconds(300))
+        , defaultTransitionDuration(Duration::zero())
+        , defaultTransitionDelay(Duration::zero()) {
         assert(pixelRatio > 0);
-        setAnimationTime(TimePoint::min());
-        setDefaultTransitionDuration(Duration::zero());
     }
 
     // Adds the class if it's not yet set. Returns true when it added the class, and false when it
@@ -73,12 +77,28 @@ public:
         animationTime = timePoint.time_since_epoch();
     };
 
+    inline Duration getDefaultFadeDuration() const {
+        return defaultFadeDuration;
+    }
+
+    inline void setDefaultFadeDuration(const Duration& duration) {
+        defaultFadeDuration = duration;
+    }
+
     inline Duration getDefaultTransitionDuration() const {
         return defaultTransitionDuration;
     }
 
     inline void setDefaultTransitionDuration(const Duration& duration) {
         defaultTransitionDuration = duration;
+    }
+
+    inline Duration getDefaultTransitionDelay() const {
+        return defaultTransitionDelay;
+    }
+
+    inline void setDefaultTransitionDelay(const Duration& delay) {
+        defaultTransitionDelay = delay;
     }
 
     util::exclusive<AnnotationManager> getAnnotationManager() {
@@ -101,7 +121,9 @@ private:
     std::atomic<uint8_t> debug { false };
     std::atomic<uint8_t> collisionDebug { false };
     std::atomic<Duration> animationTime;
+    std::atomic<Duration> defaultFadeDuration;
     std::atomic<Duration> defaultTransitionDuration;
+    std::atomic<Duration> defaultTransitionDelay;
 
 // TODO: make private
 public:

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -69,14 +69,15 @@ public:
         // has a bug that doesn't allow TimePoints to be atomic.
         return TimePoint(animationTime);
     }
-    inline void setAnimationTime(TimePoint timePoint) {
+    inline void setAnimationTime(const TimePoint& timePoint) {
         animationTime = timePoint.time_since_epoch();
     };
 
     inline Duration getDefaultTransitionDuration() const {
         return defaultTransitionDuration;
     }
-    inline void setDefaultTransitionDuration(Duration duration) {
+
+    inline void setDefaultTransitionDuration(const Duration& duration) {
         defaultTransitionDuration = duration;
     }
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -53,7 +53,7 @@ bool Transform::resize(const std::array<uint16_t, 2> size) {
 
 #pragma mark - Position
 
-void Transform::moveBy(const double dx, const double dy, const Duration duration) {
+void Transform::moveBy(const double dx, const double dy, const Duration& duration) {
     if (std::isnan(dx) || std::isnan(dy)) {
         return;
     }
@@ -61,7 +61,7 @@ void Transform::moveBy(const double dx, const double dy, const Duration duration
     _moveBy(dx, dy, duration);
 }
 
-void Transform::_moveBy(const double dx, const double dy, const Duration duration) {
+void Transform::_moveBy(const double dx, const double dy, const Duration& duration) {
     double x = state.x + std::cos(state.angle) * dx + std::sin( state.angle) * dy;
     double y = state.y + std::cos(state.angle) * dy + std::sin(-state.angle) * dx;
 
@@ -95,7 +95,7 @@ void Transform::_moveBy(const double dx, const double dy, const Duration duratio
     }
 }
 
-void Transform::setLatLng(const LatLng latLng, const Duration duration) {
+void Transform::setLatLng(const LatLng latLng, const Duration& duration) {
     if (std::isnan(latLng.latitude) || std::isnan(latLng.longitude)) {
         return;
     }
@@ -109,7 +109,7 @@ void Transform::setLatLng(const LatLng latLng, const Duration duration) {
     _setScaleXY(state.scale, xn, yn, duration);
 }
 
-void Transform::setLatLngZoom(const LatLng latLng, const double zoom, const Duration duration) {
+void Transform::setLatLngZoom(const LatLng latLng, const double zoom, const Duration& duration) {
     if (std::isnan(latLng.latitude) || std::isnan(latLng.longitude) || std::isnan(zoom)) {
         return;
     }
@@ -132,7 +132,7 @@ void Transform::setLatLngZoom(const LatLng latLng, const double zoom, const Dura
 
 #pragma mark - Zoom
 
-void Transform::scaleBy(const double ds, const double cx, const double cy, const Duration duration) {
+void Transform::scaleBy(const double ds, const double cx, const double cy, const Duration& duration) {
     if (std::isnan(ds) || std::isnan(cx) || std::isnan(cy)) {
         return;
     }
@@ -149,7 +149,7 @@ void Transform::scaleBy(const double ds, const double cx, const double cy, const
 }
 
 void Transform::setScale(const double scale, const double cx, const double cy,
-                         const Duration duration) {
+                         const Duration& duration) {
     if (std::isnan(scale) || std::isnan(cx) || std::isnan(cy)) {
         return;
     }
@@ -157,7 +157,7 @@ void Transform::setScale(const double scale, const double cx, const double cy,
     _setScale(scale, cx, cy, duration);
 }
 
-void Transform::setZoom(const double zoom, const Duration duration) {
+void Transform::setZoom(const double zoom, const Duration& duration) {
     if (std::isnan(zoom)) {
         return;
     }
@@ -173,7 +173,7 @@ double Transform::getScale() const {
     return state.scale;
 }
 
-void Transform::_setScale(double new_scale, double cx, double cy, const Duration duration) {
+void Transform::_setScale(double new_scale, double cx, double cy, const Duration& duration) {
     // Ensure that we don't zoom in further than the maximum allowed.
     if (new_scale < state.min_scale) {
         new_scale = state.min_scale;
@@ -205,7 +205,7 @@ void Transform::_setScale(double new_scale, double cx, double cy, const Duration
 }
 
 void Transform::_setScaleXY(const double new_scale, const double xn, const double yn,
-                            const Duration duration) {
+                            const Duration& duration) {
     double scale = new_scale;
     double x = xn;
     double y = yn;
@@ -254,7 +254,7 @@ void Transform::_setScaleXY(const double new_scale, const double xn, const doubl
 #pragma mark - Angle
 
 void Transform::rotateBy(const double start_x, const double start_y, const double end_x,
-                         const double end_y, const Duration duration) {
+                         const double end_y, const Duration& duration) {
     if (std::isnan(start_x) || std::isnan(start_y) || std::isnan(end_x) || std::isnan(end_y)) {
         return;
     }
@@ -286,7 +286,7 @@ void Transform::rotateBy(const double start_x, const double start_y, const doubl
     _setAngle(ang, duration);
 }
 
-void Transform::setAngle(const double new_angle, const Duration duration) {
+void Transform::setAngle(const double new_angle, const Duration& duration) {
     if (std::isnan(new_angle)) {
         return;
     }
@@ -314,7 +314,7 @@ void Transform::setAngle(const double new_angle, const double cx, const double c
     }
 }
 
-void Transform::_setAngle(double new_angle, const Duration duration) {
+void Transform::_setAngle(double new_angle, const Duration& duration) {
     double angle = _normalizeAngle(new_angle, state.angle);
     state.angle = _normalizeAngle(state.angle, angle);
 
@@ -352,7 +352,7 @@ double Transform::getAngle() const {
 
 void Transform::startTransition(std::function<Update(double)> frame,
                                 std::function<void()> finish,
-                                Duration duration) {
+                                const Duration& duration) {
     if (transitionFinishFn) {
         transitionFinishFn();
     }
@@ -360,7 +360,7 @@ void Transform::startTransition(std::function<Update(double)> frame,
     transitionStart = Clock::now();
     transitionDuration = duration;
 
-    transitionFrameFn = [frame, this](TimePoint now) {
+    transitionFrameFn = [frame, this](const TimePoint now) {
         float t = std::chrono::duration<float>(now - transitionStart) / transitionDuration;
         if (t >= 1.0) {
             Update result = frame(1.0);
@@ -381,7 +381,7 @@ bool Transform::needsTransition() const {
     return !!transitionFrameFn;
 }
 
-UpdateType Transform::updateTransitions(const TimePoint now) {
+UpdateType Transform::updateTransitions(const TimePoint& now) {
     return static_cast<UpdateType>(transitionFrameFn ? transitionFrameFn(now) : Update::Nothing);
 }
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -23,27 +23,27 @@ public:
     bool resize(std::array<uint16_t, 2> size);
 
     // Position
-    void moveBy(double dx, double dy, Duration = Duration::zero());
-    void setLatLng(LatLng latLng, Duration = Duration::zero());
-    void setLatLngZoom(LatLng latLng, double zoom, Duration = Duration::zero());
+    void moveBy(double dx, double dy, const Duration& = Duration::zero());
+    void setLatLng(LatLng latLng, const Duration& = Duration::zero());
+    void setLatLngZoom(LatLng latLng, double zoom, const Duration& = Duration::zero());
     inline const LatLng getLatLng() const { return state.getLatLng(); }
 
     // Zoom
-    void scaleBy(double ds, double cx = -1, double cy = -1, Duration = Duration::zero());
-    void setScale(double scale, double cx = -1, double cy = -1, Duration = Duration::zero());
-    void setZoom(double zoom, Duration = Duration::zero());
+    void scaleBy(double ds, double cx = -1, double cy = -1, const Duration& = Duration::zero());
+    void setScale(double scale, double cx = -1, double cy = -1, const Duration& = Duration::zero());
+    void setZoom(double zoom, const Duration& = Duration::zero());
     double getZoom() const;
     double getScale() const;
 
     // Angle
-    void rotateBy(double sx, double sy, double ex, double ey, Duration = Duration::zero());
-    void setAngle(double angle, Duration = Duration::zero());
+    void rotateBy(double sx, double sy, double ex, double ey, const Duration& = Duration::zero());
+    void setAngle(double angle, const Duration& = Duration::zero());
     void setAngle(double angle, double cx, double cy);
     double getAngle() const;
 
     // Transitions
     bool needsTransition() const;
-    UpdateType updateTransitions(TimePoint now);
+    UpdateType updateTransitions(const TimePoint& now);
     void cancelTransitions();
 
     // Gesture
@@ -53,10 +53,10 @@ public:
     const TransformState getState() const { return state; }
 
 private:
-    void _moveBy(double dx, double dy, Duration = Duration::zero());
-    void _setScale(double scale, double cx, double cy, Duration = Duration::zero());
-    void _setScaleXY(double new_scale, double xn, double yn, Duration = Duration::zero());
-    void _setAngle(double angle, Duration = Duration::zero());
+    void _moveBy(double dx, double dy, const Duration& = Duration::zero());
+    void _setScale(double scale, double cx, double cy, const Duration& = Duration::zero());
+    void _setScaleXY(double new_scale, double xn, double yn, const Duration& = Duration::zero());
+    void _setAngle(double angle, const Duration& = Duration::zero());
 
     View &view;
 
@@ -64,11 +64,11 @@ private:
 
     void startTransition(std::function<Update(double)> frame,
                          std::function<void()> finish,
-                         Duration);
+                         const Duration& duration);
 
     TimePoint transitionStart;
     Duration transitionDuration;
-    std::function<Update(TimePoint)> transitionFrameFn;
+    std::function<Update(const TimePoint)> transitionFrameFn;
     std::function<void()> transitionFinishFn;
 };
 

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -3,7 +3,7 @@
 using namespace mbgl;
 
 // Record frame history that will be used to calculate fading params
-void FrameHistory::record(TimePoint now, float zoom) {
+void FrameHistory::record(const TimePoint& now, float zoom) {
     // first frame ever
     if (!history.size()) {
         history.emplace_back(FrameSnapshot{TimePoint::min(), zoom});
@@ -15,7 +15,7 @@ void FrameHistory::record(TimePoint now, float zoom) {
     }
 }
 
-bool FrameHistory::needsAnimation(const Duration duration) const {
+bool FrameHistory::needsAnimation(const Duration& duration) const {
     if (!history.size()) {
         return false;
     }
@@ -47,7 +47,7 @@ bool FrameHistory::needsAnimation(const Duration duration) const {
     return false;
 }
 
-FadeProperties FrameHistory::getFadeProperties(Duration duration) {
+FadeProperties FrameHistory::getFadeProperties(const Duration& duration) {
     const TimePoint currentTime = Clock::now();
 
     // Remove frames until only one is outside the duration, or until there are only three

--- a/src/mbgl/renderer/frame_history.hpp
+++ b/src/mbgl/renderer/frame_history.hpp
@@ -11,8 +11,8 @@
 namespace mbgl {
 
 struct FrameSnapshot {
-    explicit inline FrameSnapshot(TimePoint now_, float z_) : now(now_), z(z_) {}
-    TimePoint now;
+    explicit inline FrameSnapshot(const TimePoint& now_, float z_) : now(now_), z(z_) {}
+    const TimePoint now;
     float z;
 };
 
@@ -26,10 +26,10 @@ struct FadeProperties {
 class FrameHistory {
 public:
     // Record frame history that will be used to calculate fading params
-    void record(TimePoint now, float zoom);
+    void record(const TimePoint& now, float zoom);
 
-    bool needsAnimation(Duration) const;
-    FadeProperties getFadeProperties(Duration);
+    bool needsAnimation(const Duration& duration) const;
+    FadeProperties getFadeProperties(const Duration& duration);
 
 public:
     std::deque<FrameSnapshot> history;

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/map/source.hpp>
 #include <mbgl/map/tile.hpp>
 #include <mbgl/map/map_context.hpp>
+#include <mbgl/map/map_data.hpp>
 
 #include <mbgl/platform/log.hpp>
 #include <mbgl/gl/debugging.hpp>
@@ -41,14 +42,14 @@
 
 using namespace mbgl;
 
-Painter::Painter(const float pixelRatio_) : pixelRatio(pixelRatio_) {
+Painter::Painter(MapData& data_) : data(data_) {
 }
 
 Painter::~Painter() {
 }
 
 bool Painter::needsAnimation() const {
-    return frameHistory.needsAnimation(std::chrono::milliseconds(300));
+    return frameHistory.needsAnimation(data.getDefaultFadeDuration()) || state.isChanging();
 }
 
 void Painter::setup() {

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -165,7 +165,7 @@ void Painter::prepareTile(const Tile& tile) {
     config.stencilFunc = { GL_EQUAL, ref, mask };
 }
 
-void Painter::render(const Style& style, TransformState state_, const FrameData& frame_, TimePoint time) {
+void Painter::render(const Style& style, TransformState state_, const FrameData& frame_, const TimePoint& time) {
     state = state_;
     frame = frame_;
 

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -81,7 +81,7 @@ struct RenderItem {
 
 class Painter : private util::noncopyable {
 public:
-    Painter(float pixelRatio);
+    Painter(MapData& data);
     ~Painter();
 
     void setup();
@@ -191,7 +191,7 @@ public:
     }();
 
 private:
-    const float pixelRatio;
+    MapData& data;
 
     TransformState state;
     FrameData frame;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -96,7 +96,7 @@ public:
     void render(const Style& style,
                 TransformState state,
                 const FrameData& frame,
-                TimePoint time);
+                const TimePoint& time);
 
     // Renders debug information for a tile.
     void renderTileDebug(const Tile& tile);

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/renderer/debug_bucket.hpp>
 #include <mbgl/map/tile.hpp>
 #include <mbgl/map/tile_data.hpp>
+#include <mbgl/map/map_data.hpp>
 #include <mbgl/shader/plain_shader.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/gl/debugging.hpp>
@@ -28,7 +29,7 @@ void Painter::renderDebugText(DebugBucket& bucket, const mat4 &matrix) {
 
     // Draw white outline
     plainShader->u_color = {{ 1.0f, 1.0f, 1.0f, 1.0f }};
-    lineWidth(4.0f * pixelRatio);
+    lineWidth(4.0f * data.pixelRatio);
     bucket.drawLines(*plainShader);
 
 #ifndef GL_ES_VERSION_2_0
@@ -39,7 +40,7 @@ void Painter::renderDebugText(DebugBucket& bucket, const mat4 &matrix) {
 
     // Draw black text.
     plainShader->u_color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
-    lineWidth(2.0f * pixelRatio);
+    lineWidth(2.0f * data.pixelRatio);
     bucket.drawLines(*plainShader);
 
     config.depthTest = true;
@@ -60,6 +61,6 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     // draw tile outline
     tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET(0));
     plainShader->u_color = {{ 1.0f, 0.0f, 0.0f, 1.0f }};
-    lineWidth(4.0f * pixelRatio);
+    lineWidth(4.0f * data.pixelRatio);
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, (GLsizei)tileBorderBuffer.index()));
 }

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/style/style_layout.hpp>
 #include <mbgl/map/sprite.hpp>
 #include <mbgl/map/tile_id.hpp>
+#include <mbgl/map/map_data.hpp>
 #include <mbgl/shader/line_shader.hpp>
 #include <mbgl/shader/linesdf_shader.hpp>
 #include <mbgl/shader/linepattern_shader.hpp>
@@ -26,7 +27,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
 
     // the distance over which the line edge fades out.
     // Retina devices need a smaller distance to avoid aliasing.
-    float antialiasing = 1.0 / pixelRatio;
+    float antialiasing = 1.0 / data.pixelRatio;
 
     float blur = properties.blur + antialiasing;
     float edgeWidth = properties.width / 2.0;
@@ -61,7 +62,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         linesdfShader->u_matrix = vtxMatrix;
         linesdfShader->u_exmatrix = extrudeMatrix;
         linesdfShader->u_linewidth = {{ outset, inset }};
-        linesdfShader->u_ratio = pixelRatio;
+        linesdfShader->u_ratio = data.pixelRatio;
         linesdfShader->u_blur = blur;
         linesdfShader->u_color = color;
 
@@ -80,7 +81,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         linesdfShader->u_patternscale_b = {{ scaleXB, scaleYB }};
         linesdfShader->u_tex_y_b = posB.y;
         linesdfShader->u_image = 0;
-        linesdfShader->u_sdfgamma = lineAtlas->width / (properties.dash_line_width * std::min(posA.width, posB.width) * 256.0 * pixelRatio) / 2;
+        linesdfShader->u_sdfgamma = lineAtlas->width / (properties.dash_line_width * std::min(posA.width, posB.width) * 256.0 * data.pixelRatio) / 2;
         linesdfShader->u_mix = properties.dash_array.t;
 
         bucket.drawLineSDF(*linesdfShader);
@@ -96,7 +97,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         linepatternShader->u_matrix = vtxMatrix;
         linepatternShader->u_exmatrix = extrudeMatrix;
         linepatternShader->u_linewidth = {{ outset, inset }};
-        linepatternShader->u_ratio = pixelRatio;
+        linepatternShader->u_ratio = data.pixelRatio;
         linepatternShader->u_blur = blur;
 
         linepatternShader->u_pattern_size_a = {{imagePosA.size[0] * factor * properties.image.fromScale, imagePosA.size[1]}};
@@ -120,7 +121,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
         lineShader->u_matrix = vtxMatrix;
         lineShader->u_exmatrix = extrudeMatrix;
         lineShader->u_linewidth = {{ outset, inset }};
-        lineShader->u_ratio = pixelRatio;
+        lineShader->u_ratio = data.pixelRatio;
         lineShader->u_blur = blur;
 
         lineShader->u_color = color;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -8,6 +8,7 @@
 #include <mbgl/shader/icon_shader.hpp>
 #include <mbgl/shader/box_shader.hpp>
 #include <mbgl/map/tile_id.hpp>
+#include <mbgl/map/map_data.hpp>
 #include <mbgl/util/math.hpp>
 
 #include <cmath>
@@ -52,7 +53,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
 
     sdfShader.u_zoom = (state.getNormalizedZoom() - zoomAdjust) * 10; // current zoom level
 
-    FadeProperties f = frameHistory.getFadeProperties(std::chrono::milliseconds(300));
+    FadeProperties f = frameHistory.getFadeProperties(data.getDefaultFadeDuration());
     sdfShader.u_fadedist = f.fadedist * 10;
     sdfShader.u_minfadezoom = std::floor(f.minfadezoom * 10);
     sdfShader.u_maxfadezoom = std::floor(f.maxfadezoom * 10);
@@ -60,7 +61,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
 
     // The default gamma value has to be adjust for the current pixelratio so that we're not
     // drawing blurry font on retina screens.
-    const float gamma = 0.105 * sdfFontSize / fontSize / pixelRatio;
+    const float gamma = 0.105 * sdfFontSize / fontSize / data.pixelRatio;
 
     const float sdfPx = 8.0f;
     const float blurOffset = 1.19f;

--- a/src/mbgl/style/applied_class_properties.cpp
+++ b/src/mbgl/style/applied_class_properties.cpp
@@ -10,15 +10,15 @@ AppliedClassProperty::AppliedClassProperty(ClassID class_id, TimePoint begin_, T
 
 // Returns the ID of the most recent
 ClassID AppliedClassProperties::mostRecent() const {
-    return properties.size() ? properties.back().name : ClassID::Fallback;
+    return propertyValues.empty() ? ClassID::Fallback : propertyValues.back().name;
 }
 
 void AppliedClassProperties::add(ClassID class_id, TimePoint begin, TimePoint end, const PropertyValue &value) {
-    properties.emplace_back(class_id, begin, end, value);
+    propertyValues.emplace_back(class_id, begin, end, value);
 }
 
 bool AppliedClassProperties::hasTransitions() const {
-    return properties.size() > 1;
+    return propertyValues.size() > 1;
 }
 
 // Erase all items in the property list that are before a completed transition.
@@ -26,19 +26,19 @@ bool AppliedClassProperties::hasTransitions() const {
 void AppliedClassProperties::cleanup(TimePoint now) {
     // Iterate backwards, but without using the rbegin/rend interface since we need forward
     // iterators to use .erase().
-    for (auto it = properties.end(), begin = properties.begin(); it != begin;) {
+    for (auto it = propertyValues.end(), begin = propertyValues.begin(); it != begin;) {
         // If the property is finished, break iteration and delete all remaining items.
         if ((--it)->end <= now) {
             // Removes all items that precede the current iterator, but *not* the element currently
             // pointed to by the iterator. This preserves the last completed transition as the
             // first element in the property list.
-            properties.erase(begin, it);
+            propertyValues.erase(begin, it);
 
             // Also erase the pivot element if it's a fallback value. This means we can remove the
             // entire applied properties object as well, because we already have the fallback
             // value set as the default.
             if (it->name == ClassID::Fallback) {
-                properties.erase(it);
+                propertyValues.erase(it);
             }
             break;
         }
@@ -46,7 +46,7 @@ void AppliedClassProperties::cleanup(TimePoint now) {
 }
 
 bool AppliedClassProperties::empty() const {
-    return properties.empty();
+    return propertyValues.empty();
 }
 
 }

--- a/src/mbgl/style/applied_class_properties.cpp
+++ b/src/mbgl/style/applied_class_properties.cpp
@@ -2,7 +2,7 @@
 
 namespace mbgl {
 
-AppliedClassProperty::AppliedClassProperty(ClassID class_id, TimePoint begin_, TimePoint end_, const PropertyValue &value_)
+AppliedClassProperty::AppliedClassProperty(ClassID class_id, const TimePoint& begin_, const TimePoint& end_, const PropertyValue &value_)
     : name(class_id),
     begin(begin_),
     end(end_),
@@ -13,7 +13,7 @@ ClassID AppliedClassProperties::mostRecent() const {
     return propertyValues.empty() ? ClassID::Fallback : propertyValues.back().name;
 }
 
-void AppliedClassProperties::add(ClassID class_id, TimePoint begin, TimePoint end, const PropertyValue &value) {
+void AppliedClassProperties::add(ClassID class_id, const TimePoint& begin, const TimePoint& end, const PropertyValue &value) {
     propertyValues.emplace_back(class_id, begin, end, value);
 }
 
@@ -23,7 +23,7 @@ bool AppliedClassProperties::hasTransitions() const {
 
 // Erase all items in the property list that are before a completed transition.
 // Then, if the only remaining property is a Fallback value, remove it too.
-void AppliedClassProperties::cleanup(TimePoint now) {
+void AppliedClassProperties::cleanup(const TimePoint& now) {
     // Iterate backwards, but without using the rbegin/rend interface since we need forward
     // iterators to use .erase().
     for (auto it = propertyValues.end(), begin = propertyValues.begin(); it != begin;) {

--- a/src/mbgl/style/applied_class_properties.hpp
+++ b/src/mbgl/style/applied_class_properties.hpp
@@ -11,7 +11,7 @@ namespace mbgl {
 
 class AppliedClassProperty {
 public:
-    AppliedClassProperty(ClassID class_id, TimePoint begin, TimePoint end, const PropertyValue &value);
+    AppliedClassProperty(ClassID class_id, const TimePoint& begin, const TimePoint& end, const PropertyValue &value);
 
 public:
     const ClassID name;
@@ -28,8 +28,8 @@ public:
 public:
     // Returns the ID of the most recent
     ClassID mostRecent() const;
-    void add(ClassID class_id, TimePoint begin, TimePoint end, const PropertyValue &value);
-    void cleanup(TimePoint now);
+    void add(ClassID class_id, const TimePoint& begin, const TimePoint& end, const PropertyValue &value);
+    void cleanup(const TimePoint& now);
     bool hasTransitions() const;
     bool empty() const;
 };

--- a/src/mbgl/style/applied_class_properties.hpp
+++ b/src/mbgl/style/applied_class_properties.hpp
@@ -23,14 +23,14 @@ public:
 
 class AppliedClassProperties {
 public:
-    std::list<AppliedClassProperty> properties;
+    std::list<AppliedClassProperty> propertyValues;
 
 public:
     // Returns the ID of the most recent
     ClassID mostRecent() const;
     void add(ClassID class_id, TimePoint begin, TimePoint end, const PropertyValue &value);
-    bool hasTransitions() const;
     void cleanup(TimePoint now);
+    bool hasTransitions() const;
     bool empty() const;
 };
 

--- a/src/mbgl/style/piecewisefunction_properties.hpp
+++ b/src/mbgl/style/piecewisefunction_properties.hpp
@@ -11,7 +11,6 @@ template <typename T>
 struct PiecewiseConstantFunction {
     inline PiecewiseConstantFunction(const std::vector<std::pair<float, T>> &values_, std::chrono::duration<float> duration_) : values(values_), duration(duration_) {}
     inline PiecewiseConstantFunction(T &value, std::chrono::duration<float> duration_) : values({{ 0, value }}), duration(duration_) {}
-    inline PiecewiseConstantFunction() : values(), duration(std::chrono::milliseconds(300)) {}
     T evaluate(float z, const ZoomHistory &zoomHistory) const;
 
 private:

--- a/src/mbgl/style/property_transition.hpp
+++ b/src/mbgl/style/property_transition.hpp
@@ -8,6 +8,8 @@
 namespace mbgl {
 
 struct PropertyTransition {
+    explicit inline PropertyTransition(const Duration& duration_, const Duration& delay_)
+        : duration(duration_), delay(delay_) {}
     Duration duration = Duration::zero();
     Duration delay = Duration::zero();
 };

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -86,9 +86,7 @@ void Style::update(const TransformState& transform,
     }
 }
 
-void Style::cascade(const std::vector<std::string>& classes) {
-    TimePoint now = Clock::now();
-
+void Style::cascade(const std::vector<std::string>& classes, TimePoint now) {
     for (const auto& layer : layers) {
         layer->setClasses(classes, now, defaultTransition);
     }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -86,13 +86,13 @@ void Style::update(const TransformState& transform,
     }
 }
 
-void Style::cascade(const std::vector<std::string>& classes, TimePoint now) {
+void Style::cascade(const std::vector<std::string>& classes, const TimePoint& now) {
     for (const auto& layer : layers) {
         layer->setClasses(classes, now, defaultTransition);
     }
 }
 
-void Style::recalculate(float z, TimePoint now) {
+void Style::recalculate(float z, const TimePoint& now) {
     uv::writelock lock(mtx);
 
     for (const auto& source : sources) {

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -54,10 +54,9 @@ public:
     // a tile is ready so observers can render the tile.
     void update(const TransformState&, TexturePool&);
 
-    void cascade(const std::vector<std::string>&, const TimePoint& now);
-    void recalculate(float z, const TimePoint& now);
+    void cascade();
+    void recalculate(float z);
 
-    void setDefaultTransitionDuration(Duration);
     bool hasTransitions() const;
 
     std::exception_ptr getLastError() const {
@@ -101,7 +100,6 @@ private:
 
     std::exception_ptr lastError;
 
-    PropertyTransition defaultTransition;
     std::unique_ptr<uv::rwlock> mtx;
     ZoomHistory zoomHistory;
 

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -54,8 +54,8 @@ public:
     // a tile is ready so observers can render the tile.
     void update(const TransformState&, TexturePool&);
 
-    void cascade(const std::vector<std::string>&, TimePoint now);
-    void recalculate(float z, TimePoint now);
+    void cascade(const std::vector<std::string>&, const TimePoint& now);
+    void recalculate(float z, const TimePoint& now);
 
     void setDefaultTransitionDuration(Duration);
     bool hasTransitions() const;

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -54,7 +54,7 @@ public:
     // a tile is ready so observers can render the tile.
     void update(const TransformState&, TexturePool&);
 
-    void cascade(const std::vector<std::string>&);
+    void cascade(const std::vector<std::string>&, TimePoint now);
     void recalculate(float z, TimePoint now);
 
     void setDefaultTransitionDuration(Duration);

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -140,7 +140,7 @@ void StyleLayer::applyStyleProperty(PropertyKey key, T &target, const float z, c
         AppliedClassProperties &applied = it->second;
         // Iterate through all properties that we need to apply in order.
         const PropertyEvaluator<T> evaluator(z, zoomHistory);
-        for (auto& property : applied.properties) {
+        for (auto& property : applied.propertyValues) {
             if (now >= property.begin) {
                 // We overwrite the current property with the new value.
                 target = mapbox::util::apply_visitor(evaluator, property.value);
@@ -158,7 +158,7 @@ void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, cons
         AppliedClassProperties &applied = it->second;
         // Iterate through all properties that we need to apply in order.
         const PropertyEvaluator<T> evaluator(z, zoomHistory);
-        for (auto& property : applied.properties) {
+        for (auto& property : applied.propertyValues) {
             if (now >= property.end) {
                 // We overwrite the current property with the new value.
                 target = mapbox::util::apply_visitor(evaluator, property.value);
@@ -270,7 +270,6 @@ bool StyleLayer::hasTransitions() const {
     }
     return false;
 }
-
 
 void StyleLayer::cleanupAppliedStyleProperties(TimePoint now) {
     for (auto it = appliedStyle.begin(); it != appliedStyle.end();) {

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -273,18 +273,11 @@ bool StyleLayer::hasTransitions() const {
 
 
 void StyleLayer::cleanupAppliedStyleProperties(TimePoint now) {
-    auto it = appliedStyle.begin();
-    const auto end = appliedStyle.end();
-    while (it != end) {
-        AppliedClassProperties &applied_properties = it->second;
-        applied_properties.cleanup(now);
-
+    for (auto it = appliedStyle.begin(); it != appliedStyle.end();) {
+        AppliedClassProperties& appliedPropertyValues = it->second;
+        appliedPropertyValues.cleanup(now);
         // If the current properties object is empty, remove it from the map entirely.
-        if (applied_properties.empty()) {
-            appliedStyle.erase(it++);
-        } else {
-            ++it;
-        }
+        appliedPropertyValues.empty() ? appliedStyle.erase(it++) : ++it;
     }
 }
 

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -28,7 +28,7 @@ bool StyleLayer::isVisible() const {
     }
 }
 
-void StyleLayer::setClasses(const std::vector<std::string> &class_names, const TimePoint now,
+void StyleLayer::setClasses(const std::vector<std::string> &class_names, const TimePoint& now,
                             const PropertyTransition &defaultTransition) {
     // Stores all keys that we have already added transitions for.
     std::set<PropertyKey> already_applied;
@@ -69,7 +69,7 @@ void StyleLayer::setClasses(const std::vector<std::string> &class_names, const T
 
 // Helper function for applying all properties of a a single class that haven't been applied yet.
 void StyleLayer::applyClassProperties(const ClassID class_id,
-                                      std::set<PropertyKey> &already_applied, TimePoint now,
+                                      std::set<PropertyKey> &already_applied, const TimePoint& now,
                                       const PropertyTransition &defaultTransition) {
     auto style_it = styles.find(class_id);
     if (style_it == styles.end()) {
@@ -134,7 +134,7 @@ private:
 };
 
 template <typename T>
-void StyleLayer::applyStyleProperty(PropertyKey key, T &target, const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperty(PropertyKey key, T &target, const float z, const TimePoint& now, const ZoomHistory &zoomHistory) {
     auto it = appliedStyle.find(key);
     if (it != appliedStyle.end()) {
         AppliedClassProperties &applied = it->second;
@@ -152,7 +152,7 @@ void StyleLayer::applyStyleProperty(PropertyKey key, T &target, const float z, c
 }
 
 template <typename T>
-void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, const float z, const TimePoint& now, const ZoomHistory &zoomHistory) {
     auto it = appliedStyle.find(key);
     if (it != appliedStyle.end()) {
         AppliedClassProperties &applied = it->second;
@@ -174,7 +174,7 @@ void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, cons
 }
 
 template <>
-void StyleLayer::applyStyleProperties<FillProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<FillProperties>(const float z, const TimePoint& now, const ZoomHistory &zoomHistory) {
     properties.set<FillProperties>();
     FillProperties &fill = properties.get<FillProperties>();
     applyStyleProperty(PropertyKey::FillAntialias, fill.antialias, z, now, zoomHistory);
@@ -187,7 +187,7 @@ void StyleLayer::applyStyleProperties<FillProperties>(const float z, const TimeP
 }
 
 template <>
-void StyleLayer::applyStyleProperties<LineProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<LineProperties>(const float z, const TimePoint& now, const ZoomHistory &zoomHistory) {
     properties.set<LineProperties>();
     LineProperties &line = properties.get<LineProperties>();
     applyTransitionedStyleProperty(PropertyKey::LineOpacity, line.opacity, z, now, zoomHistory);
@@ -201,11 +201,11 @@ void StyleLayer::applyStyleProperties<LineProperties>(const float z, const TimeP
     applyStyleProperty(PropertyKey::LineImage, line.image, z, now, zoomHistory);
 
     // for scaling dasharrays
-    applyStyleProperty(PropertyKey::LineWidth, line.dash_line_width, std::floor(z), TimePoint::max(), zoomHistory);
+    applyStyleProperty(PropertyKey::LineWidth, line.dash_line_width, std::floor(z), now, zoomHistory);
 }
 
 template <>
-void StyleLayer::applyStyleProperties<SymbolProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<SymbolProperties>(const float z, const TimePoint& now, const ZoomHistory &zoomHistory) {
     properties.set<SymbolProperties>();
     SymbolProperties &symbol = properties.get<SymbolProperties>();
     applyTransitionedStyleProperty(PropertyKey::IconOpacity, symbol.icon.opacity, z, now, zoomHistory);
@@ -228,7 +228,7 @@ void StyleLayer::applyStyleProperties<SymbolProperties>(const float z, const Tim
 }
 
 template <>
-void StyleLayer::applyStyleProperties<RasterProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<RasterProperties>(const float z, const TimePoint& now, const ZoomHistory &zoomHistory) {
     properties.set<RasterProperties>();
     RasterProperties &raster = properties.get<RasterProperties>();
     applyTransitionedStyleProperty(PropertyKey::RasterOpacity, raster.opacity, z, now, zoomHistory);
@@ -241,7 +241,7 @@ void StyleLayer::applyStyleProperties<RasterProperties>(const float z, const Tim
 }
 
 template <>
-void StyleLayer::applyStyleProperties<BackgroundProperties>(const float z, const TimePoint now, const ZoomHistory &zoomHistory) {
+void StyleLayer::applyStyleProperties<BackgroundProperties>(const float z, const TimePoint& now, const ZoomHistory &zoomHistory) {
     properties.set<BackgroundProperties>();
     BackgroundProperties &background = properties.get<BackgroundProperties>();
     applyTransitionedStyleProperty(PropertyKey::BackgroundOpacity, background.opacity, z, now, zoomHistory);
@@ -249,7 +249,7 @@ void StyleLayer::applyStyleProperties<BackgroundProperties>(const float z, const
     applyStyleProperty(PropertyKey::BackgroundImage, background.image, z, now, zoomHistory);
 }
 
-void StyleLayer::updateProperties(float z, const TimePoint now, ZoomHistory &zoomHistory) {
+void StyleLayer::updateProperties(float z, const TimePoint& now, ZoomHistory &zoomHistory) {
     cleanupAppliedStyleProperties(now);
 
     switch (type) {
@@ -271,7 +271,7 @@ bool StyleLayer::hasTransitions() const {
     return false;
 }
 
-void StyleLayer::cleanupAppliedStyleProperties(TimePoint now) {
+void StyleLayer::cleanupAppliedStyleProperties(const TimePoint& now) {
     for (auto it = appliedStyle.begin(); it != appliedStyle.end();) {
         AppliedClassProperties& appliedPropertyValues = it->second;
         appliedPropertyValues.cleanup(now);

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -40,10 +40,10 @@ public:
 
     // Updates the StyleProperties information in this layer by evaluating all
     // pending transitions and applied classes in order.
-    void updateProperties(float z, TimePoint now, ZoomHistory &zoomHistory);
+    void updateProperties(float z, const TimePoint& now, ZoomHistory &zoomHistory);
 
     // Sets the list of classes and creates transitions to the currently applied values.
-    void setClasses(const std::vector<std::string> &class_names, TimePoint now,
+    void setClasses(const std::vector<std::string> &class_names, const TimePoint& now,
                     const PropertyTransition &defaultTransition);
 
     bool hasTransitions() const;
@@ -51,16 +51,16 @@ public:
 private:
     // Applies all properties from a class, if they haven't been applied already.
     void applyClassProperties(ClassID class_id, std::set<PropertyKey> &already_applied,
-                              TimePoint now, const PropertyTransition &defaultTransition);
+                              const TimePoint& now, const PropertyTransition &defaultTransition);
 
     // Sets the properties of this object by evaluating all pending transitions and
     // aplied classes in order.
-    template <typename T> void applyStyleProperties(float z, TimePoint now, const ZoomHistory &zoomHistory);
-    template <typename T> void applyStyleProperty(PropertyKey key, T &, float z, TimePoint now, const ZoomHistory &zoomHistory);
-    template <typename T> void applyTransitionedStyleProperty(PropertyKey key, T &, float z, TimePoint now, const ZoomHistory &zoomHistory);
+    template <typename T> void applyStyleProperties(float z, const TimePoint& now, const ZoomHistory &zoomHistory);
+    template <typename T> void applyStyleProperty(PropertyKey key, T &, float z, const TimePoint& now, const ZoomHistory &zoomHistory);
+    template <typename T> void applyTransitionedStyleProperty(PropertyKey key, T &, float z, const TimePoint& now, const ZoomHistory &zoomHistory);
 
     // Removes all expired style transitions.
-    void cleanupAppliedStyleProperties(TimePoint now);
+    void cleanupAppliedStyleProperties(const TimePoint& now);
 
 public:
     // The name of this layer.

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -31,7 +31,7 @@ public:
     template<typename T>
     using Result = std::pair<Status, T>;
 
-    StyleParser();
+    StyleParser(MapData& data);
 
     void parse(JSVal document);
 
@@ -117,6 +117,9 @@ private:
 
     // URL template for glyph PBFs.
     std::string glyph_url;
+
+    // Obtain default transition duration from map data.
+    MapData& data;
 };
 
 }

--- a/src/mbgl/style/zoom_history.hpp
+++ b/src/mbgl/style/zoom_history.hpp
@@ -13,12 +13,12 @@ struct ZoomHistory {
     TimePoint lastIntegerZoomTime;
     bool first = true;
 
-    void update(float z, TimePoint now) {
+    void update(float z, const TimePoint& now) {
         if (first) {
             first = false;
 
             lastIntegerZoom = std::floor(z);
-            lastIntegerZoomTime = TimePoint(Duration(0));
+            lastIntegerZoomTime = TimePoint(Duration::zero());
             lastZoom = z;
         }
 

--- a/src/mbgl/util/transition.cpp
+++ b/src/mbgl/util/transition.cpp
@@ -10,7 +10,7 @@ UnitBezier ease(0, 0, 0.25, 1);
 transition::~transition() {}
 
 template <typename T>
-transition::state ease_transition<T>::update(TimePoint now) const {
+transition::state ease_transition<T>::update(const TimePoint& now) const {
     float t = progress(now);
     if (t >= 1) {
         value = to;

--- a/src/mbgl/util/transition.hpp
+++ b/src/mbgl/util/transition.hpp
@@ -14,18 +14,18 @@ public:
         complete
     };
 
-    inline transition(TimePoint start_, Duration duration_)
+    inline transition(const TimePoint& start_, const Duration& duration_)
         : start(start_),
           duration(duration_) {}
 
-    inline float progress(TimePoint now) const {
+    inline float progress(const TimePoint& now) const {
         if (duration == Duration::zero()) return 1;
         if (start > now) return 0;
 
         return std::chrono::duration<float>(now - start) / duration;
     }
 
-    virtual state update(TimePoint now) const = 0;
+    virtual state update(const TimePoint& now) const = 0;
     virtual ~transition();
 
 protected:
@@ -36,13 +36,13 @@ protected:
 template <typename T>
 class ease_transition : public transition {
 public:
-    ease_transition(T from_, T to_, T& value_, TimePoint start_, Duration duration_)
+    ease_transition(T from_, T to_, T& value_, const TimePoint& start_, const Duration& duration_)
         : transition(start_, duration_),
           from(from_),
           to(to_),
           value(value_) {}
 
-    state update(TimePoint now) const;
+    state update(const TimePoint& now) const;
 
 private:
     const T from, to;
@@ -53,12 +53,12 @@ private:
 template <typename T>
 class timeout : public transition {
 public:
-    timeout(T final_value_, T& value_, TimePoint start_, Duration duration_)
+    timeout(T final_value_, T& value_, const TimePoint& start_, const Duration& duration_)
         : transition(start_, duration_),
           final_value(final_value_),
           value(value_) {}
 
-    state update(TimePoint now) const {
+    state update(const TimePoint& now) const {
         if (progress(now) >= 1) {
             value = final_value;
             return complete;

--- a/test/miscellaneous/style_parser.cpp
+++ b/test/miscellaneous/style_parser.cpp
@@ -3,6 +3,9 @@
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/util/io.hpp>
 
+#include <mbgl/map/mode.hpp>
+#include <mbgl/map/map_data.hpp>
+
 #include <rapidjson/document.h>
 
 #include "../fixtures/fixture_log_observer.hpp"
@@ -35,7 +38,11 @@ TEST_P(StyleParserTest, ParseStyle) {
     FixtureLogObserver* observer = new FixtureLogObserver();
     Log::setObserver(std::unique_ptr<Log::Observer>(observer));
 
-    StyleParser parser;
+    MapMode mapMode = MapMode::Continuous;
+    const float pixelRatio = 1.0f;
+
+    MapData data(mapMode, pixelRatio);
+    StyleParser parser(data);
     parser.parse(styleDoc);
 
     for (auto it = infoDoc.MemberBegin(), end = infoDoc.MemberEnd(); it != end; it++) {


### PR DESCRIPTION
Relevant changes:
- Unify default transition values in `MapData`:
   - Added `defaultFadeDuration` and `defaultTransitionDelay` to `MapData`;
   - `Painter` & `StyleParser` now receives a reference to `MapData`;
   - As previously seen on the code:
      - 300ms is the default fade duration;
      - 0ms is the default transition duration;
   - We no longer pass the current time point to `Style`, since it now uses `MapData.animationTime`, which gets updated in `MapContext::update()`.
   - Updated `StyleParser` check to use a mock `MapData`;
- Pass {`Duration`,`TimePoint`} by const ref whenever possible;
- Unify time point for Mapcontext::update:
    - Let style classes cascade use the same time point as the one used to
      recalculate style.
    - Cleaned up `MapContext::update()` to return early whenever possible.
    - Cleaned up `MapContext::loadStyleJSON()` to avoid redundant calls to style
      classes cascade.

Part of #1548.

/cc @jfirebaugh @kkaefer @tmpsantos @tmcw