### PR TITLE
Map view gets black screen after changing style if default transition duration != 0

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -133,6 +133,9 @@ void MapContext::loadStyleJSON(const std::string& json, const std::string& base)
     style->setJSON(json, base);
     style->setObserver(this);
 
+    // force style cascade, causing all pending transitions to complete.
+    style->cascade();
+
     updated |= static_cast<UpdateType>(Update::DefaultTransitionDuration);
     updated |= static_cast<UpdateType>(Update::Classes);
     updated |= static_cast<UpdateType>(Update::Zoom);


### PR DESCRIPTION
I have found this while debugging for #1548. If the client manually sets a default transition duration [(example)](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/default/glfw_view.cpp#L109), after changing a style the screen goes black (with only symbols appearing) until you trigger another view update (like zooming in and out of screen).

Steps to reproduce:
1. Open Mapbox GL native test application
2. Press `R` key (which triggers a client-side update on the default transition duration)
3. Press `S` key
<img width="1136" alt="screen shot 2015-07-14 at 17 46 01" src="https://cloud.githubusercontent.com/assets/76133/8676138/3ed9cc6e-2a50-11e5-917e-02eb3e521c3e.png">
/cc @jfirebaugh @tmcw @kkaefer @tmpsantos