### PR TITLE
consider supporting transition delays without duration

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -84,6 +84,10 @@ public:
 
     void setDefaultTransitionDuration(const Duration& = Duration::zero());
     Duration getDefaultTransitionDuration() const;
+
+    void setDefaultTransitionDelay(const Duration& = Duration::zero());
+    Duration getDefaultTransitionDelay() const;
+
     void setStyleURL(const std::string& url);
     void setStyleJSON(const std::string& json, const std::string& base = "");
     std::string getStyleURL() const;

--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -10,7 +10,7 @@ using UpdateType = uint32_t;
 enum class Update : UpdateType {
     Nothing                   = 0,
     Dimensions                = 1 << 1,
-    DefaultTransitionDuration = 1 << 2,
+    DefaultTransition         = 1 << 2,
     Classes                   = 1 << 3,
     Zoom                      = 1 << 4,
     RenderStill               = 1 << 5,

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -422,11 +422,20 @@ std::vector<std::string> Map::getClasses() const {
 
 void Map::setDefaultTransitionDuration(const Duration& duration) {
     data->setDefaultTransitionDuration(duration);
-    update(Update::DefaultTransitionDuration);
+    update(Update::DefaultTransition);
 }
 
 Duration Map::getDefaultTransitionDuration() const {
     return data->getDefaultTransitionDuration();
+}
+
+void Map::setDefaultTransitionDelay(const Duration& delay) {
+    data->setDefaultTransitionDelay(delay);
+    update(Update::DefaultTransition);
+}
+
+Duration Map::getDefaultTransitionDelay() const {
+    return data->getDefaultTransitionDelay();
 }
 
 void Map::setSourceTileCacheSize(size_t size) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -136,7 +136,7 @@ void MapContext::loadStyleJSON(const std::string& json, const std::string& base)
     // force style cascade, causing all pending transitions to complete.
     style->cascade();
 
-    updated |= static_cast<UpdateType>(Update::DefaultTransitionDuration);
+    updated |= static_cast<UpdateType>(Update::DefaultTransition);
     updated |= static_cast<UpdateType>(Update::Classes);
     updated |= static_cast<UpdateType>(Update::Zoom);
     asyncUpdate->send();


### PR DESCRIPTION
If the default transition duration is specified in the caller's code, it might sometimes be useful to support only `delay` specified in the class. Currently we [only transition properties which explicit durations](https://github.com/mapbox/mapbox-gl-native/blob/d15fb9ca97e737997f93c69cbebfa54fd9305d8f/src/style/style.cpp#L37). 