### PR TITLE
Request GlyphPBF on the MapThread

### DIFF
--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -240,14 +240,8 @@ bool Source::handlePartialTile(const TileID& id, Worker&) {
         return true;
     }
 
-    // The signal is only emitted if there was an actual change on the tile. The
-    // tile can be in a "partial" state waiting for resources and get reparsed on
-    // the arrival of new resources that were needed by another tile.
-    size_t bucketCount = data->countBuckets();
-    return data->reparse([this, data, bucketCount]() {
-        if (data->countBuckets() > bucketCount) {
-            emitTileLoaded(false);
-        }
+    return data->reparse([this, data]() {
+	emitTileLoaded(false);
     });
 }
 

--- a/src/mbgl/map/tile_worker.cpp
+++ b/src/mbgl/map/tile_worker.cpp
@@ -44,11 +44,6 @@ Bucket* TileWorker::getBucket(const StyleLayer& layer) const {
     return it->second.get();
 }
 
-size_t TileWorker::countBuckets() const {
-    std::lock_guard<std::mutex> lock(bucketsMutex);
-    return buckets.size();
-}
-
 TileParseResult TileWorker::parse(const GeometryTile& geometryTile) {
     partialParse = false;
 

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -41,7 +41,6 @@ public:
     ~TileWorker();
 
     Bucket* getBucket(const StyleLayer&) const;
-    size_t countBuckets() const;
 
     TileParseResult parse(const GeometryTile&);
     void redoPlacement(float angle, bool collisionDebug);

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -98,10 +98,6 @@ Bucket* VectorTileData::getBucket(const StyleLayer& layer) {
     return tileWorker.getBucket(layer);
 }
 
-size_t VectorTileData::countBuckets() const {
-    return tileWorker.countBuckets();
-}
-
 void VectorTileData::redoPlacement(float angle, bool collisionDebug) {
     if (angle == currentAngle && collisionDebug == currentCollisionDebug)
         return;

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -23,7 +23,6 @@ public:
     ~VectorTileData();
 
     Bucket* getBucket(const StyleLayer&) override;
-    size_t countBuckets() const;
 
     void request(float pixelRatio,
                  const std::function<void()>& callback);

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -160,7 +160,7 @@ bool SymbolBucket::needsDependencies(const GeometryTileLayer& layer,
         util::mergeLines(features);
     }
 
-    if (glyphStore.requestGlyphRangesIfNeeded(layout.text.font, ranges)) {
+    if (!glyphStore.hasGlyphRanges(layout.text.font, ranges)) {
         return true;
     }
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -22,9 +22,9 @@
 
 namespace mbgl {
 
-Style::Style(MapData& data_, uv_loop_t* loop)
+Style::Style(MapData& data_, uv_loop_t*)
     : data(data_),
-      glyphStore(std::make_unique<GlyphStore>(loop)),
+      glyphStore(std::make_unique<GlyphStore>()),
       glyphAtlas(std::make_unique<GlyphAtlas>(1024, 1024)),
       spriteStore(std::make_unique<SpriteStore>()),
       spriteAtlas(std::make_unique<SpriteAtlas>(512, 512, data.pixelRatio, *spriteStore)),

--- a/src/mbgl/util/run_loop.cpp
+++ b/src/mbgl/util/run_loop.cpp
@@ -15,7 +15,7 @@ RunLoop::~RunLoop() {
 }
 
 void RunLoop::withMutex(std::function<void()>&& fn) {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::lock_guard<std::recursive_mutex> lock(mutex);
     fn();
 }
 

--- a/src/mbgl/util/work_queue.cpp
+++ b/src/mbgl/util/work_queue.cpp
@@ -1,0 +1,37 @@
+#include <mbgl/util/work_queue.hpp>
+
+#include <mbgl/util/run_loop.hpp>
+
+namespace mbgl {
+namespace util {
+
+WorkQueue::WorkQueue() : runLoop(RunLoop::Get()) {
+}
+
+WorkQueue::~WorkQueue() {
+    assert(runLoop == RunLoop::Get());
+
+    // Cancel all pending WorkRequests.
+    while (!queue.empty()) {
+        queue.pop();
+    }
+}
+
+void WorkQueue::push(std::function<void()>&& fn) {
+    std::lock_guard<std::mutex> lock(queueMutex);
+
+    auto workRequest = runLoop->invokeCancellable(std::bind(&WorkQueue::pop, this, std::move(fn)));
+    queue.push(std::move(workRequest));
+}
+
+void WorkQueue::pop(const std::function<void()>& fn) {
+    assert(runLoop == RunLoop::Get());
+
+    fn();
+
+    std::lock_guard<std::mutex> lock(queueMutex);
+    queue.pop();
+}
+
+}
+}

--- a/src/mbgl/util/work_queue.hpp
+++ b/src/mbgl/util/work_queue.hpp
@@ -1,0 +1,36 @@
+#ifndef MBGL_UTIL_WORK_QUEUE
+#define MBGL_UTIL_WORK_QUEUE
+
+#include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/work_request.hpp>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <queue>
+
+namespace mbgl {
+namespace util {
+
+class RunLoop;
+
+class WorkQueue : private util::noncopyable {
+public:
+    WorkQueue();
+    virtual ~WorkQueue();
+
+    void push(std::function<void()>&&);
+
+private:
+    void pop(const std::function<void()>&);
+
+    std::queue<std::unique_ptr<WorkRequest>> queue;
+    std::mutex queueMutex;
+
+    RunLoop* runLoop;
+};
+
+}
+}
+
+#endif

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -14,11 +14,7 @@ namespace mbgl {
 
 class Worker::Impl {
 public:
-    explicit Impl(FileSource* fs) {
-        // FIXME: Workers should not access the FileSource but it
-        // is currently needed because of GlyphsPBF. See #1664.
-        util::ThreadContext::setFileSource(fs);
-    }
+    Impl() = default;
 
     void parseRasterTile(RasterBucket* bucket, std::string data, std::function<void (TileParseResult)> callback) {
         std::unique_ptr<util::Image> image(new util::Image(data));
@@ -59,7 +55,7 @@ public:
 Worker::Worker(std::size_t count) {
     util::ThreadContext context = {"Worker", util::ThreadType::Worker, util::ThreadPriority::Low};
     for (std::size_t i = 0; i < count; i++) {
-        threads.emplace_back(std::make_unique<util::Thread<Impl>>(context, util::ThreadContext::getFileSource()));
+        threads.emplace_back(std::make_unique<util::Thread<Impl>>(context));
     }
 }
 

--- a/test/miscellaneous/work_queue.cpp
+++ b/test/miscellaneous/work_queue.cpp
@@ -1,0 +1,63 @@
+#include "../fixtures/util.hpp"
+
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/thread.hpp>
+#include <mbgl/util/work_queue.hpp>
+
+#include <thread>
+
+using namespace mbgl::util;
+
+class TestThread {
+public:
+    TestThread(WorkQueue* queue_) : queue(queue_) {}
+
+    void send(std::function<void()>&& fn) {
+        EXPECT_TRUE(ThreadContext::currentlyOn(ThreadType::Map));
+
+        queue->push(std::move(fn));
+    }
+
+private:
+    WorkQueue* queue;
+};
+
+TEST(WorkQueue, push) {
+    RunLoop loop(uv_default_loop());
+
+    WorkQueue queue;
+    Thread<TestThread> thread({"Test", ThreadType::Map, ThreadPriority::Regular}, &queue);
+
+    uint8_t count = 0;
+
+    auto endTest = [&]() {
+        EXPECT_TRUE(ThreadContext::currentlyOn(ThreadType::Main));
+
+        if (++count == 4) {
+            loop.stop();
+        }
+    };
+
+    thread.invoke(&TestThread::send, endTest);
+    thread.invoke(&TestThread::send, endTest);
+    thread.invoke(&TestThread::send, endTest);
+    thread.invoke(&TestThread::send, endTest);
+
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+}
+
+TEST(WorkQueue, cancel) {
+    RunLoop loop(uv_default_loop());
+
+    WorkQueue queue;
+
+    auto work = [&]() {
+        FAIL() << "Should never be called";
+    };
+
+    queue.push(work);
+    queue.push(work);
+    queue.push(work);
+    queue.push(work);
+    queue.push(work);
+}

--- a/test/style/glyph_store.cpp
+++ b/test/style/glyph_store.cpp
@@ -1,0 +1,225 @@
+#include "../fixtures/fixture_log_observer.hpp"
+#include "../fixtures/mock_file_source.hpp"
+#include "../fixtures/util.hpp"
+
+#include <mbgl/text/font_stack.hpp>
+#include <mbgl/text/glyph_store.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/thread.hpp>
+
+using namespace mbgl;
+
+using GlyphStoreTestCallback = std::function<void(GlyphStore*, std::exception_ptr)>;
+
+struct GlyphStoreParams {
+    const std::string url;
+    const std::string stack;
+    const std::set<GlyphRange> ranges;
+};
+
+class GlyphStoreThread : public GlyphStore::Observer {
+public:
+    GlyphStoreThread(FileSource* fileSource, GlyphStoreTestCallback callback) : callback_(callback) {
+        util::ThreadContext::setFileSource(fileSource);
+    }
+
+    void loadGlyphStore(const GlyphStoreParams& params) {
+        glyphStore_.reset(new GlyphStore());
+
+        glyphStore_->setObserver(this);
+        glyphStore_->setURL(params.url);
+
+        ASSERT_FALSE(glyphStore_->hasGlyphRanges(params.stack, params.ranges));
+    }
+
+    void unloadGlyphStore() {
+        glyphStore_->setObserver(nullptr);
+        glyphStore_.reset();
+    }
+
+    void onGlyphRangeLoaded() override {
+        callback_(glyphStore_.get(), nullptr);
+    }
+
+    void onGlyphRangeLoadingFailed(std::exception_ptr error) override {
+        callback_(glyphStore_.get(), error);
+    }
+
+private:
+    std::unique_ptr<GlyphStore> glyphStore_;
+    GlyphStoreTestCallback callback_;
+};
+
+class GlyphStoreTest : public testing::Test {
+protected:
+    void runTest(const GlyphStoreParams& params, FileSource* fileSource, GlyphStoreTestCallback callback) {
+        util::RunLoop loop(uv_default_loop());
+
+        async_ = std::make_unique<uv::async>(loop.get(), [&]{ loop.stop(); });
+        async_->unref();
+
+        const util::ThreadContext context = {"Map", util::ThreadType::Map, util::ThreadPriority::Regular};
+
+        util::Thread<GlyphStoreThread> tester(context, fileSource, callback);
+        tester.invoke(&GlyphStoreThread::loadGlyphStore, params);
+
+        uv_run(loop.get(), UV_RUN_DEFAULT);
+
+        tester.invoke(&GlyphStoreThread::unloadGlyphStore);
+    }
+
+    void stopTest() {
+        testDone = true;
+        async_->send();
+    }
+
+    bool isDone() const {
+        return testDone;
+    }
+
+private:
+    bool testDone = false;
+
+    std::unique_ptr<uv::async> async_;
+};
+
+TEST_F(GlyphStoreTest, LoadingSuccess) {
+    GlyphStoreParams params = {
+        "test/fixtures/resources/glyphs.pbf",
+        "Test Stack",
+        {{0, 255}, {256, 511}}
+    };
+
+    auto callback = [this, &params](GlyphStore* store, std::exception_ptr error) {
+        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+        // We need to check if the test is over because checking
+        // if the GlyphStore has glyphs below will cause more requests
+        // to happen and we don't want this endless loop.
+        if (isDone()) {
+            return;
+        }
+
+        ASSERT_EQ(error, nullptr);
+
+        if (!store->hasGlyphRanges(params.stack, params.ranges)) {
+            return;
+        }
+
+        ASSERT_FALSE(store->hasGlyphRanges("Foobar", params.ranges));
+        ASSERT_FALSE(store->hasGlyphRanges("Foobar", {{512, 767}}));
+        ASSERT_FALSE(store->hasGlyphRanges("Test Stack",  {{512, 767}}));
+
+        auto fontStack = store->getFontStack(params.stack);
+        ASSERT_FALSE(fontStack->getMetrics().empty());
+        ASSERT_FALSE(fontStack->getSDFs().empty());
+
+        stopTest();
+    };
+
+    MockFileSource fileSource(MockFileSource::Success, "");
+    runTest(params, &fileSource, callback);
+}
+
+TEST_F(GlyphStoreTest, LoadingFail) {
+    GlyphStoreParams params = {
+        "test/fixtures/resources/glyphs.pbf",
+        "Test Stack",
+        {{0, 255}, {256, 511}}
+    };
+
+    auto callback = [this, &params](GlyphStore* store, std::exception_ptr error) {
+        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+        if (isDone()) {
+            return;
+        }
+
+        ASSERT_TRUE(error != nullptr);
+
+        auto fontStack = store->getFontStack(params.stack);
+        ASSERT_EQ(*fontStack, nullptr);
+
+        for (const auto& range : params.ranges) {
+            ASSERT_FALSE(store->hasGlyphRanges(params.stack, {range}));
+        }
+
+        ASSERT_FALSE(store->hasGlyphRanges(params.stack, params.ranges));
+        ASSERT_FALSE(store->hasGlyphRanges("Foobar", params.ranges));
+        ASSERT_FALSE(store->hasGlyphRanges("Foobar", {{512, 767}}));
+
+        stopTest();
+    };
+
+    MockFileSource fileSource(MockFileSource::RequestFail, "glyphs.pbf");
+    runTest(params, &fileSource, callback);
+}
+
+TEST_F(GlyphStoreTest, LoadingCorrupted) {
+    GlyphStoreParams params = {
+        "test/fixtures/resources/glyphs.pbf",
+        "Test Stack",
+        {{0, 255}, {256, 511}}
+    };
+
+    auto callback = [this, &params](GlyphStore* store, std::exception_ptr error) {
+        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+        if (isDone()) {
+            return;
+        }
+
+        ASSERT_TRUE(error != nullptr);
+
+        for (const auto& range : params.ranges) {
+            ASSERT_FALSE(store->hasGlyphRanges(params.stack, {range}));
+        }
+
+        ASSERT_FALSE(store->hasGlyphRanges(params.stack, params.ranges));
+        ASSERT_FALSE(store->hasGlyphRanges("Foobar", params.ranges));
+        ASSERT_FALSE(store->hasGlyphRanges("Foobar", {{512, 767}}));
+
+        stopTest();
+    };
+
+    MockFileSource fileSource(MockFileSource::RequestWithCorruptedData, "glyphs.pbf");
+    runTest(params, &fileSource, callback);
+}
+
+TEST_F(GlyphStoreTest, LoadingCancel) {
+    GlyphStoreParams params = {
+        "test/fixtures/resources/glyphs.pbf",
+        "Test Stack",
+        {{0, 255}, {256, 511}}
+    };
+
+    auto callback = [this](GlyphStore*, std::exception_ptr) {
+        FAIL() << "Should never be called";
+    };
+
+    MockFileSource fileSource(MockFileSource::SuccessWithDelay, "glyphs.pbf");
+    fileSource.setOnRequestDelayedCallback([this]{
+        stopTest();
+    });
+    runTest(params, &fileSource, callback);
+}
+
+TEST_F(GlyphStoreTest, InvalidURL) {
+    GlyphStoreParams params = {
+        "foo bar",
+        "Test Stack",
+        {{0, 255}, {256, 511}}
+    };
+
+    auto callback = [this, &params](GlyphStore* store, std::exception_ptr error) {
+        ASSERT_TRUE(error != nullptr);
+
+        auto fontStack = store->getFontStack(params.stack);
+        ASSERT_EQ(*fontStack, nullptr);
+
+        stopTest();
+    };
+
+    MockFileSource fileSource(MockFileSource::Success, "");
+    runTest(params, &fileSource, callback);
+}

--- a/test/style/pending_resources.cpp
+++ b/test/style/pending_resources.cpp
@@ -21,11 +21,6 @@ class PendingResources : public ::testing::TestWithParam<std::string> {
 // the Map object after that. The idea here is to test if these pending requests
 // are getting canceled correctly if on shutdown.
 TEST_P(PendingResources, DeleteMapObjectWithPendingRequest) {
-    // TODO: The glyphs test is blocked by the issue #1664.
-    if (GetParam() == "glyphs.pbf") {
-        return;
-    }
-
     util::RunLoop loop(uv_default_loop());
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -69,6 +69,7 @@
         'miscellaneous/thread.cpp',
         'miscellaneous/tile.cpp',
         'miscellaneous/transform.cpp',
+        'miscellaneous/work_queue.cpp',
         'miscellaneous/variant.cpp',
 
         'storage/storage.hpp',

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -88,6 +88,7 @@
         'storage/http_other_loop.cpp',
         'storage/http_reading.cpp',
 
+        'style/glyph_store.cpp',
         'style/pending_resources.cpp',
         'style/resource_loading.cpp',
         'style/sprite.cpp',


### PR DESCRIPTION
The GlyphStore is accessed by the MapThread and Workers (currently owned by the Style). When a new Glyph is needed, it is requested by the Worker and thus, the reply callback is also called at the Worker thread.

This has many unwanted consequences being the most notable not being able to destroy a Map object before all the Glyph requests are complete, because the GlyphStore is destroyed after the Style and the Workers are blocked by the pending requests.

We need to refactor this code and fire the Glyph requests from the MapThread.