### PR TITLE
Only print Sprites not found messages after the sprites are loaded and parsed

### DIFF
--- a/src/mbgl/annotation/sprite_store.cpp
+++ b/src/mbgl/annotation/sprite_store.cpp
@@ -54,7 +54,9 @@ std::shared_ptr<const SpriteImage> SpriteStore::getSprite(const std::string& nam
     if (it != sprites.end()) {
         return it->second;
     } else {
-         Log::Info(Event::Sprite, "Can't find sprite named '%s'", name.c_str());
+        if (!sprites.empty()) {
+            Log::Info(Event::Sprite, "Can't find sprite named '%s'", name.c_str());
+        }
         return nullptr;
     }
 }


### PR DESCRIPTION
Sprites are loaded asynchronously and if we get the tiles before the sprites, we are going to see a lot of "Sprites not found" messages, which can be misleading. We should only print these messages after the sprite define on the Style is loaded.