### PR TITLE
Revert "split renderSync and transition nudging to allow client view …

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -67,10 +67,7 @@ public:
     void renderStill(StillImageCallback callback);
 
     // Triggers a synchronous or asynchronous render.
-    bool renderSync();
-
-    // Nudges transitions one step, possibly notifying of the need for a rerender.
-    void nudgeTransitions(bool forceRerender);
+    void renderSync();
 
     // Notifies the Map thread that the state has changed and an update might be necessary.
     void update(Update update = Update::Nothing);

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -703,11 +703,9 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
         _mbglMap->setSourceTileCacheSize(cacheSize);
 
-        bool needsRerender = _mbglMap->renderSync();
+        _mbglMap->renderSync();
 
         [self updateUserLocationAnnotationView];
-
-        _mbglMap->nudgeTransitions(needsRerender);
     }
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -48,7 +48,7 @@ void Map::renderStill(StillImageCallback callback) {
                     FrameData{ view.getFramebufferSize() }, callback);
 }
 
-bool Map::renderSync() {
+void Map::renderSync() {
     if (renderState == RenderState::never) {
         view.notifyMapChange(MapChangeWillStartRenderingMap);
     }
@@ -69,13 +69,9 @@ bool Map::renderSync() {
         view.notifyMapChange(MapChangeDidFinishRenderingMapFullyRendered);
     }
 
-    return result.needsRerender;
-}
-
-void Map::nudgeTransitions(bool forceRerender) {
     if (transform->needsTransition()) {
         update(Update(transform->updateTransitions(Clock::now())));
-    } else if (forceRerender) {
+    } else if (result.needsRerender) {
         update();
     }
 }


### PR DESCRIPTION
This reverts commit b8388168dd130c67c77254565cdb576df7905915.

As per comment in https://github.com/mapbox/mapbox-gl-native/commit/1f78d285160785c8c8fff3806b38f3ae9d0e312d#commitcomment-12161646 it seems `nudgeTransitions()` is no longer necessary as #1548 has fixed the update issues. I found it while debugging for OSX, which uses GLFW port and have not been updated to use `nudgeTransitions()`.

FWIW, I have tested this revert on both OSX and iOS via emulation and the transitions all seem to be working fine.

/cc @incanus @kkaefer