### PR TITLE
fix iOS view sync regression

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -67,7 +67,10 @@ public:
     void renderStill(StillImageCallback callback);
 
     // Triggers a synchronous or asynchronous render.
-    void renderSync();
+    bool renderSync();
+
+    // Nudges transitions one step, possibly notifying of the need for a rerender.
+    void nudgeTransitions(bool forceRerender);
 
     // Notifies the Map thread that the state has changed and an update might be necessary.
     void update(Update update = Update::Nothing);

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -335,7 +335,8 @@ void GLFWView::run() {
         glfwWaitEvents();
         const bool dirty = !clean.test_and_set();
         if (dirty) {
-            map->renderSync();
+            const bool needsRerender = map->renderSync();
+            map->nudgeTransitions(needsRerender);
         }
     }
 }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -703,9 +703,11 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
         _mbglMap->setSourceTileCacheSize(cacheSize);
 
-        _mbglMap->renderSync();
+        bool needsRerender = _mbglMap->renderSync();
 
         [self updateUserLocationAnnotationView];
+
+        _mbglMap->nudgeTransitions(needsRerender);
     }
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -48,7 +48,7 @@ void Map::renderStill(StillImageCallback callback) {
                     FrameData{ view.getFramebufferSize() }, callback);
 }
 
-void Map::renderSync() {
+bool Map::renderSync() {
     if (renderState == RenderState::never) {
         view.notifyMapChange(MapChangeWillStartRenderingMap);
     }
@@ -69,9 +69,13 @@ void Map::renderSync() {
         view.notifyMapChange(MapChangeDidFinishRenderingMapFullyRendered);
     }
 
+    return result.needsRerender;
+}
+
+void Map::nudgeTransitions(bool forceRerender) {
     if (transform->needsTransition()) {
         update(Update(transform->updateTransitions(Clock::now())));
-    } else if (result.needsRerender) {
+    } else if (forceRerender) {
         update();
     }
 }


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/pull/1903 introduced a regression in the improvements from #1125. The addition of `nudgeTransitions` was not related to https://github.com/mapbox/mapbox-gl-native/pull/1548, but rather happened in https://github.com/mapbox/mapbox-gl-native/commit/b8388168dd130c67c77254565cdb576df7905915 to allow iOS to insert position updates to native views _between_ the GL frame draw and any changes to the `Transform`, so that the views were in sync with the GL frame. 

@brunoabinader 