### PR TITLE
Ask for 'always' location permissions, too

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2214,7 +2214,15 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
                 [NSException raise:@"Missing Location Services usage description" format:
                  @"In iOS 8 and above, this app must have a value for NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in its Info.plist."];
             }
-            [self.locationManager requestWhenInUseAuthorization];
+            // request location permissions, if both keys exist ask for less permissive
+            if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"])
+            {
+                [self.locationManager requestWhenInUseAuthorization];
+            }
+            else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"])
+            {
+                [self.locationManager requestAlwaysAuthorization];
+            }
         }
 #endif
 

--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -544,7 +544,7 @@
 - (void)testUserTrackingModeFollow {
     tester.mapView.userTrackingMode = MGLUserTrackingModeFollow;
 
-    [tester waitForTimeInterval:1];
+    [tester acknowledgeSystemAlert];
 
     XCTAssertEqual(tester.mapView.userLocationVisible,
                    YES,
@@ -570,7 +570,7 @@
 - (void)testUserTrackingModeFollowWithHeading {
     tester.mapView.userTrackingMode = MGLUserTrackingModeFollowWithHeading;
     
-    [tester waitForTimeInterval:1];
+    [tester acknowledgeSystemAlert];
     
     XCTAssertEqual(tester.mapView.userLocationVisible,
                    YES,

--- a/test/ios/MetricsTests.m
+++ b/test/ios/MetricsTests.m
@@ -119,7 +119,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 
     [[MGLMapboxEvents sharedManager] flush];
 
-    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
     XCTAssertNil([[MGLMapboxEvents sharedManager] timer]);
 }
@@ -143,7 +143,7 @@ const NSTimeInterval MGLFlushInterval = 60;
     id eventsMock = [OCMockObject partialMockForObject:[MGLMapboxEvents sharedManager]];
     [[[eventsMock expect] andForwardToRealObject] startTimer];
     [self pushFakeEvent];
-    [eventsMock verifyWithDelay:0.5];
+    [eventsMock verifyWithDelay:2.0];
 
     XCTAssertEqual([[[MGLMapboxEvents sharedManager] eventQueue] count], 1);
     XCTAssertNotNil([[MGLMapboxEvents sharedManager] timer]);
@@ -164,7 +164,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 
     [[MGLMapboxEvents sharedManager] flush];
 
-    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
     [self pushFakeEvent];
     id eventsMock = [OCMockObject partialMockForObject:[MGLMapboxEvents sharedManager]];
@@ -178,7 +178,7 @@ const NSTimeInterval MGLFlushInterval = 60;
     id eventsMock = [OCMockObject partialMockForObject:[MGLMapboxEvents sharedManager]];
     [[eventsMock expect] postEvents:events];
     [[MGLMapboxEvents sharedManager] flush];
-    [eventsMock verifyWithDelay:1.0];
+    [eventsMock verifyWithDelay:2.0];
 
     XCTAssertTrue([[[MGLMapboxEvents sharedManager] eventQueue] count] == 0);
 }
@@ -209,7 +209,7 @@ const NSTimeInterval MGLFlushInterval = 60;
     [self pushFakeEvent];
     [MGLMapboxEvents flush];
 
-    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
 - (void)testPushEventAddsToEventQueue {


### PR DESCRIPTION
If an iOS app only has the `NSLocationAlwaysUsageDescription` key, MBGL will never ask for location permission. This PR checks for both `always` and `inUse` permission keys, then asks the user (with a preference for the less permissive `inUse`).

/cc @1ec5 @incanus @bleege