### PR TITLE
Move mapbox/mapbox-gl-styles to mb-pages branch

### DIFF
--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -101,7 +101,8 @@ step "Copying Resources..."
 cp -pv LICENSE.md "${OUTPUT}/static"
 mkdir -p "${OUTPUT}/static/${NAME}.bundle"
 cp -pv platform/ios/resources/* "${OUTPUT}/static/${NAME}.bundle"
-cp -prv styles/styles "${OUTPUT}/static/${NAME}.bundle/styles"
+mkdir -p "${OUTPUT}/static/${NAME}.bundle/styles"
+cp -pv styles/styles/{dark,emerald,light,mapbox-streets,satellite}-v7.json "${OUTPUT}/static/${NAME}.bundle/styles"
 
 step "Creating API Docs..."
 if [ -z `which appledoc` ]; then


### PR DESCRIPTION
The ios-b1 branch of mapbox/mapbox-gl-styles is getting further and further behind mb-pages, as one would expect. The main reason we’re using a branch is so that we don’t end up bundling old versions of styles with Mapbox GL. This PR moves the submodule pin to mb-pages and causes the package script to filter to just the desired styles. It assumes that we’ll be on the lookout for any post-0.3.0 regressions in the stylesheets that have never shipped with Mapbox GL before.

(An alternative fix would be to restructure the mapbox/mapbox-gl-styles repository so that each -v* would be its own branch. That is, a v7 branch would contain mapbox-streets.json, emerald.json, etc. Then Mapbox GL could pull in just the v7 branch’s JSON files.)

/cc @incanus @bleege @nickidlugash @peterqliu @andreasviglakis @samanpwbb