### PR TITLE
Android annotations improvements

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -227,7 +227,9 @@ mbgl::AnnotationSegment annotation_segment_from_latlng_jlist(JNIEnv *env, jobjec
         }
 
         segment.push_back(mbgl::LatLng(latitude, longitude));
+        env->DeleteLocalRef(latLng);
     }
+    env->DeleteLocalRef(array);
     return segment;
 }
 
@@ -662,6 +664,7 @@ std::pair<mbgl::AnnotationSegment, mbgl::StyleProperties> readPolygon(JNIEnv *en
 
     jobject points = env->GetObjectField(polygon, polygonPointsId);
     mbgl::AnnotationSegment segment = annotation_segment_from_latlng_jlist(env, points);
+    env->DeleteLocalRef(points);
 
     return std::make_pair(segment, shapeProperties);
 }
@@ -727,6 +730,8 @@ jlongArray JNICALL nativeAddPolygons(JNIEnv *env, jobject obj, jlong nativeMapVi
         }
 
         shapes.emplace_back(mbgl::AnnotationSegments {{ segment.first }}, segment.second);
+
+        env->DeleteLocalRef(polygon);
     }
 
     std::vector<uint32_t> shapeAnnotationIDs = nativeMapView->getMap().addShapeAnnotations(shapes);

--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -746,6 +746,36 @@ void JNICALL nativeRemoveAnnotation(JNIEnv *env, jobject obj, jlong nativeMapVie
     nativeMapView->getMap().removeAnnotation((uint32_t)annotationId);
 }
 
+void JNICALL nativeRemoveAnnotations(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jlongArray array) {
+    mbgl::Log::Debug(mbgl::Event::JNI, "nativeRemoveAnnotations");
+    assert(nativeMapViewPtr != 0);
+    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
+
+    std::vector<uint32_t> ids;
+
+    if (env->ExceptionCheck() || (array == nullptr)) {
+        env->ExceptionDescribe();
+        return;
+    }
+
+    jsize len = env->GetArrayLength(array);
+    if (len < 0) {
+        env->ExceptionDescribe();
+        return;
+    }
+
+    ids.reserve(len);
+    jlong* jids = env->GetLongArrayElements(array, nullptr);
+
+    for (jsize i = 0; i < len; i++) {
+        if(jids[i] == -1L)
+            continue;
+        ids.push_back((uint32_t) jids[i]);
+    }
+
+    nativeMapView->getMap().removeAnnotations(ids);
+}
+
 jobject JNICALL nativeGetLatLng(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetLatLng");
     assert(nativeMapViewPtr != 0);
@@ -1418,6 +1448,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         {"nativeAddPolygons", "(JLjava/util/List;)[J",
          reinterpret_cast<void *>(&nativeAddPolygons)},
         {"nativeRemoveAnnotation", "(JJ)V", reinterpret_cast<void *>(&nativeRemoveAnnotation)},
+        {"nativeRemoveAnnotations", "(J[J)V", reinterpret_cast<void *>(&nativeRemoveAnnotations)},
         {"nativeGetLatLng", "(J)Lcom/mapbox/mapboxgl/geometry/LatLng;",
          reinterpret_cast<void *>(&nativeGetLatLng)},
         {"nativeResetPosition", "(J)V", reinterpret_cast<void *>(&nativeResetPosition)},

--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -607,7 +607,7 @@ jlong JNICALL nativeAddPolyline(JNIEnv *env, jobject obj, jlong nativeMapViewPtr
     mbgl::StyleProperties shapeProperties;
     mbgl::LineProperties lineProperties;
     lineProperties.opacity = alpha;
-    lineProperties.color = {{ (float)r, (float)g, (float)b, (float)a }};
+    lineProperties.color = {{ (float)r / 255.0f, (float)g / 255.0f, (float)b / 255.0f, (float)a / 255.0f }};
     lineProperties.width = width;
     shapeProperties.set<mbgl::LineProperties>(lineProperties);
 
@@ -658,8 +658,8 @@ std::pair<mbgl::AnnotationSegment, mbgl::StyleProperties> readPolygon(JNIEnv *en
     mbgl::StyleProperties shapeProperties;
     mbgl::FillProperties fillProperties;
     fillProperties.opacity = alpha;
-    fillProperties.stroke_color = {{ (float)rS, (float)gS, (float)bS, (float)aS }};
-    fillProperties.fill_color = {{ (float)rF, (float)gF, (float)bF, (float)aF }};
+    fillProperties.stroke_color = {{ (float)rS / 255.0f, (float)gS / 255.0f, (float)bS / 255.0f, (float)aS / 255.0f }};
+    fillProperties.fill_color = {{ (float)rF / 255.0f, (float)gF / 255.0f, (float)bF / 255.0f, (float)aF / 255.0f }};
     shapeProperties.set<mbgl::FillProperties>(fillProperties);
 
     jobject points = env->GetObjectField(polygon, polygonPointsId);

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/Annotation.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/Annotation.java
@@ -23,7 +23,7 @@ public abstract class Annotation {
         return alpha;
     }
 
-    public long getId() {
+    public Long getId() {
         return id;
     }
 

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/Marker.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/Marker.java
@@ -49,17 +49,6 @@ public class Marker extends Annotation {
         return anchorV;
     }
 
-    /**
-     * NOTE: Google Maps Android API uses String for IDs.
-     *
-     * Internal C++ id is stored as unsigned int.
-     *
-     * @return the annotation id
-     */
-    public long getId() {
-        return id;
-    }
-
     public LatLng getPosition() {
         return position;
     }

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -270,9 +270,16 @@ public class MapView extends SurfaceView {
     }
 
     public void removeAnnotations() {
-        for (Annotation annotation : annotations) {
-            annotation.remove();
+        long[] ids = new long[annotations.size()];
+        for(int i=0; i<annotations.size(); i++) {
+            Long id = annotations.get(i).getId();
+            if(id == null) {
+                ids[i] = -1;
+            } else {
+                ids[i] = id;
+            }
         }
+        mNativeMapView.removeAnnotations(ids);
     }
 
     //

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -243,6 +243,23 @@ public class MapView extends SurfaceView {
         return polygon;
     }
 
+    public List<Polygon> addPolygons(List<PolygonOptions> polygonOptions) {
+        List<Polygon> polygons = new ArrayList<>();
+        for(PolygonOptions popts : polygonOptions) {
+            polygons.add(popts.getPolygon());
+        }
+
+        long[] ids = mNativeMapView.addPolygons(polygons);
+
+        for(int i=0; i<polygons.size(); i++) {
+            polygons.get(i).setId(ids[i]);
+            polygons.get(i).setMapView(this);
+            annotations.add(polygons.get(i));
+        }
+
+        return polygons;
+    }
+
     public void removeAnnotation(Annotation annotation) {
         long id = annotation.getId();
         mNativeMapView.removeAnnotation(id);

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.res.TypedArray;
+import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -41,6 +42,8 @@ import com.mapbox.mapboxgl.geometry.LatLngZoom;
 
 import org.apache.commons.validator.routines.UrlValidator;
 
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -214,6 +217,16 @@ public class MapView extends SurfaceView {
             boolean isConnected = (activeNetwork != null) && activeNetwork.isConnectedOrConnecting();
             onConnectivityChanged(isConnected);
         }
+    }
+
+    public void setSprite(String symbol, float scale, Bitmap bitmap) {
+        if(bitmap.getConfig() != Bitmap.Config.ARGB_8888) {
+            bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, false);
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(bitmap.getByteCount());
+        bitmap.copyPixelsToBuffer(buffer);
+
+        mNativeMapView.setSprite(symbol, bitmap.getWidth(), bitmap.getHeight(), scale, buffer.array());
     }
 
     public Marker addMarker(MarkerOptions markerOptions) {

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -177,7 +177,7 @@ class NativeMapView {
     }
 
     public void setStyleJson(String newStyleJson) {
-        setStyleJson(newStyleJson,  "");
+        setStyleJson(newStyleJson, "");
     }
 
     public void setStyleJson(String newStyleJson, String base) {
@@ -214,6 +214,10 @@ class NativeMapView {
 
     public void setLatLng(LatLng latLng, long duration) {
         nativeSetLatLng(mNativeMapViewPtr, latLng, duration);
+    }
+
+    public void setSprite(String symbol, int width, int height, float scale, byte[] pixels) {
+        nativeSetSprite(mNativeMapViewPtr, symbol, width, height, scale, pixels);
     }
 
     public long addMarker(Marker marker) {
@@ -474,6 +478,9 @@ class NativeMapView {
 
     private native void nativeSetLatLng(long nativeMapViewPtr, LatLng latLng,
                                         long duration);
+
+    private native void nativeSetSprite(long nativeMapViewPtr, String symbol,
+                                        int width, int height, float scale, byte[] pixels);
 
     private native long nativeAddMarker(long nativeMapViewPtr, Marker marker);
 

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -239,6 +239,10 @@ class NativeMapView {
         nativeRemoveAnnotation(mNativeMapViewPtr, id);
     }
 
+    public void removeAnnotations(long[] ids) {
+        nativeRemoveAnnotations(mNativeMapViewPtr, ids);
+    }
+
     public LatLng getLatLng() {
         return nativeGetLatLng(mNativeMapViewPtr);
     }
@@ -480,6 +484,8 @@ class NativeMapView {
     private native long[] nativeAddPolygons(long mNativeMapViewPtr, List<Polygon> polygon);
 
     private native void nativeRemoveAnnotation(long nativeMapViewPtr, long id);
+
+    private native void nativeRemoveAnnotations(long nativeMapViewPtr, long[] id);
 
     private native LatLng nativeGetLatLng(long nativeMapViewPtr);
 

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -230,6 +230,11 @@ class NativeMapView {
         return nativeAddPolygon(mNativeMapViewPtr, polygon);
     }
 
+    public long[] addPolygons(List<Polygon> polygon) {
+        // NH TODO Throw exception if returns -1
+        return nativeAddPolygons(mNativeMapViewPtr, polygon);
+    }
+
     public void removeAnnotation(long id) {
         nativeRemoveAnnotation(mNativeMapViewPtr, id);
     }
@@ -471,6 +476,8 @@ class NativeMapView {
     private native long nativeAddPolyline(long nativeMapViewPtr, Polyline polyline);
 
     private native long nativeAddPolygon(long mNativeMapViewPtr, Polygon polygon);
+
+    private native long[] nativeAddPolygons(long mNativeMapViewPtr, List<Polygon> polygon);
 
     private native void nativeRemoveAnnotation(long nativeMapViewPtr, long id);
 

--- a/android/java/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxgl/testapp/MainActivity.java
+++ b/android/java/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxgl/testapp/MainActivity.java
@@ -327,10 +327,12 @@ public class MainActivity extends ActionBarActivity {
             geojsonStr = Util.loadStringFromAssets(this, "small_poly.geojson");
             LatLng[] latLngs = Util.parseGeoJSONCoordinates(geojsonStr);
             MapView map = mMapFragment.getMap();
-            Polygon polygon = map.addPolygon(new PolygonOptions()
-                    .add(latLngs)
-                    .strokeColor(Color.MAGENTA)
-                    .fillColor(Color.BLUE));
+            ArrayList<PolygonOptions> opts = new ArrayList<PolygonOptions>();
+            opts.add(new PolygonOptions()
+                        .add(latLngs)
+                        .strokeColor(Color.MAGENTA)
+                        .fillColor(Color.BLUE));
+            Polygon polygon = map.addPolygons(opts).get(0);
         } catch (IOException e) {
             e.printStackTrace();
         } catch (JSONException e) {


### PR DESCRIPTION
More work on #1716. This pull request contains improvements on #1899.

This lowers my loading times from more than 1 minute to about 2 seconds in adding and removing polygons.
There was also a bug with colors not being remapped to a correct range.
And exposed setSprite.

