### PR TITLE
Allow for Mapbox logo to be placed on either side of the map.

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -77,8 +77,11 @@ IB_DESIGNABLE
 /** The compass image view shown in the upper-right when the map is rotated. */
 @property (nonatomic, readonly) UIImageView *compassView;
 
-/** The Mapbox logo image view shown in the lower-left of the map. */
+/** The Mapbox logo image view shown in the corner of the map. */
 @property (nonatomic, readonly) UIImageView *logoView;
+
+/** Which side of the map to show the Mapbox logo. Valid values are NSLayoutAttributeLeading (default) or NSLayoutAttributeTrailing. */
+@property (nonatomic, assign) NSLayoutAttribute logoSide;
 
 /** The button shown in the lower-right of the map which when pressed displays the map attribution information. */
 @property (nonatomic, readonly) UIButton *attributionButton;

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -263,6 +263,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     _logoView.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:_logoView];
     _logoViewConstraints = [NSMutableArray array];
+    _logoSide = NSLayoutAttributeLeading;
 
     // setup attribution
     //
@@ -512,6 +513,13 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     return nil;
 }
 
+- (void)setLogoSide:(NSLayoutAttribute)newValue {
+    if (_logoSide != newValue && (newValue == NSLayoutAttributeLeading || newValue == NSLayoutAttributeTrailing)) {
+        _logoSide = newValue;
+        [self updateConstraints];
+    }
+}
+
 - (void)updateConstraints
 {
     // If we have a view controller reference, use its layout guides for our various top & bottom
@@ -622,12 +630,12 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
     [self.logoViewConstraints addObject:
      [NSLayoutConstraint constraintWithItem:self.logoView
-                                  attribute:NSLayoutAttributeLeading
+                                  attribute:self.logoSide
                                   relatedBy:NSLayoutRelationEqual
                                      toItem:self
-                                  attribute:NSLayoutAttributeLeading
+                                  attribute:self.logoSide
                                  multiplier:1
-                                   constant:8]];
+                                   constant:(self.logoSide == NSLayoutAttributeTrailing) ? -8 : 8]];
     if ([NSLayoutConstraint respondsToSelector:@selector(activateConstraints:)])
     {
         [NSLayoutConstraint activateConstraints:self.logoViewConstraints];


### PR DESCRIPTION
Created a property to choose whether the Mapbox logo should be shown on the right or left bottom corner of the maps. Defaults to bottom left, the same as current behavior. Having a bottom right placement option is convenient for developers who already have other UI components in the bottom left corner.