### PR TITLE
[android] Avoid nudging transitions if a gesture is in progress

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -378,11 +378,11 @@ void JNICALL nativeUpdate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     nativeMapView->getMap().update();
 }
 
-void JNICALL nativeOnInvalidate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
+void JNICALL nativeOnInvalidate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jboolean inProgress) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeOnInvalidate");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->onInvalidate();
+    nativeMapView->onInvalidate(inProgress);
 }
 
 void JNICALL nativeViewResize(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jint width, jint height) {
@@ -1428,7 +1428,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         {"nativePause", "(J)V", reinterpret_cast<void *>(&nativePause)},
         {"nativeResume", "(J)V", reinterpret_cast<void *>(&nativeResume)},
         {"nativeUpdate", "(J)V", reinterpret_cast<void *>(&nativeUpdate)},
-        {"nativeOnInvalidate", "(J)V", reinterpret_cast<void *>(&nativeOnInvalidate)},
+        {"nativeOnInvalidate", "(JZ)V", reinterpret_cast<void *>(&nativeOnInvalidate)},
         {"nativeViewResize", "(JII)V",
          reinterpret_cast<void *>(static_cast<void JNICALL (
              *)(JNIEnv *, jobject, jlong, jint, jint)>(&nativeViewResize))},

--- a/android/cpp/native_map_view.cpp
+++ b/android/cpp/native_map_view.cpp
@@ -758,12 +758,15 @@ void NativeMapView::updateFps() {
     env = nullptr;
 }
 
-void NativeMapView::onInvalidate() {
+void NativeMapView::onInvalidate(bool inProgress) {
     mbgl::Log::Debug(mbgl::Event::Android, "NativeMapView::onInvalidate()");
 
     const bool dirty = !clean.test_and_set();
     if (dirty) {
-        map.renderSync();
+        const bool needsRerender = map.renderSync();
+        if (!inProgress) {
+            map.nudgeTransitions(needsRerender);
+        }
     }
 }
 

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -1268,7 +1268,8 @@ public class MapView extends SurfaceView {
         post(new Runnable() {
             @Override
             public void run() {
-                mNativeMapView.invalidate();
+                boolean inProgress = mRotateGestureDetector.isInProgress() || mScaleGestureDetector.isInProgress();
+                mNativeMapView.invalidate(inProgress);
             }
         });
     }

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -88,8 +88,8 @@ class NativeMapView {
         nativeUpdate(mNativeMapViewPtr);
     }
 
-    public void invalidate() {
-        nativeOnInvalidate(mNativeMapViewPtr);
+    public void invalidate(boolean inProgress) {
+        nativeOnInvalidate(mNativeMapViewPtr, inProgress);
     }
 
     public void resizeView(int width, int height) {
@@ -438,7 +438,7 @@ class NativeMapView {
 
     private native void nativeUpdate(long nativeMapViewPtr);
 
-    private native void nativeOnInvalidate(long nativeMapViewPtr);
+    private native void nativeOnInvalidate(long nativeMapViewPtr, boolean inProgress);
 
     private native void nativeViewResize(long nativeMapViewPtr, int width, int height);
 

--- a/include/mbgl/android/native_map_view.hpp
+++ b/include/mbgl/android/native_map_view.hpp
@@ -49,7 +49,7 @@ public:
     void enableFps(bool enable);
     void updateFps();
 
-    void onInvalidate();
+    void onInvalidate(bool inProgress);
 
     void resizeView(int width, int height);
     void resizeFramebuffer(int width, int height);


### PR DESCRIPTION
We're now using `nudgeTransitions()` to tell the Map view that we want to update it. However, if we're on a gesture movement, `update()` gets called too fast and causes general slowdown. This check ensures we only call for `nudgeTransitions()` after all gesture events are finished. Fixes the issue pointed out by #1548 on Android.

/cc @incanus @kkaefer @tmpsantos