### PR TITLE
Adding special case for non-fontstack "glyph" resource URLs

### DIFF
--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -42,12 +42,15 @@ std::string normalizeStyleURL(const std::string& url, const std::string& accessT
 }
 
 std::string normalizeGlyphsURL(const std::string& url, const std::string& accessToken) {
-    if (url.compare(0, mapbox.length(), mapbox) != 0)
+    if (url.compare(0, mapbox.length(), mapbox) != 0) {
         return url;
+    }
 
     const std::string fontstack = "mapbox://fontstack/";
-    if (url.compare(0, fontstack.length(), fontstack) == 0) 
+
+    if (url.compare(0, fontstack.length(), fontstack) == 0) {
         return normalizeURL(url, "/v4/", accessToken);
+    }
 
     return normalizeURL(url, "/", accessToken);
 }

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -45,7 +45,11 @@ std::string normalizeGlyphsURL(const std::string& url, const std::string& access
     if (url.compare(0, mapbox.length(), mapbox) != 0)
         return url;
 
-    return normalizeURL(url, "/v4/", accessToken);
+    const std::string fontstack = "mapbox://fontstack/";
+    if (url.compare(0, fontstack.length(), fontstack) == 0) 
+        return normalizeURL(url, "/v4/", accessToken);
+
+    return normalizeURL(url, "/", accessToken);
 }
 
 std::string normalizeTileURL(const std::string& url, const std::string& sourceURL, SourceType sourceType) {

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -15,6 +15,7 @@ TEST(Mapbox, SourceURL) {
 
 TEST(Mapbox, GlyphsURL) {
     EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fontstack/{fontstack}/{range}.pbf", "key"), "https://api.tiles.mapbox.com/v4/fontstack/{fontstack}/{range}.pbf?access_token=key");
+    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/v1/user/{fontstack}/{range}.pbf", "key"), "https://api.tiles.mapbox.com/fonts/v1/user/{fontstack}/{range}.pbf?access_token=key");
     EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("http://path", "key"), "http://path");
 }
 


### PR DESCRIPTION
- does not prepend /v4/ to api endpoints like /fonts/v1/
- only prepends it to things starting with /fontstack
- solves the problem in #1918
- refs mapbox/mapbox-gl-style-spec#309

cc/ @incanus @bleege @samanpwbb @mikemorris 