### PR TITLE
Bail if setting user dot to invalid location

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2309,7 +2309,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 {
     if ( ! _showsUserLocation || ! newLocation || ! CLLocationCoordinate2DIsValid(newLocation.coordinate)) return;
 
-    if ([newLocation distanceFromLocation:oldLocation] || ! oldLocation)
+    if (! oldLocation || ! CLLocationCoordinate2DIsValid(oldLocation.coordinate) || [newLocation distanceFromLocation:oldLocation])
     {
         self.userLocation.location = newLocation;
 

--- a/platform/ios/MGLUserLocation.m
+++ b/platform/ios/MGLUserLocation.m
@@ -37,13 +37,13 @@ NS_ASSUME_NONNULL_END
 
 - (void)setLocation:(CLLocation *)newLocation
 {
-    if ([newLocation distanceFromLocation:_location] && newLocation.coordinate.latitude != 0 &&
-            newLocation.coordinate.longitude != 0)
-    {
-        [self willChangeValueForKey:@"location"];
-        _location = newLocation;
-        [self didChangeValueForKey:@"location"];
-    }
+    if ( ! newLocation || ! CLLocationCoordinate2DIsValid(newLocation.coordinate)) return;
+    if ( _location && CLLocationCoordinate2DIsValid(_location.coordinate) && [newLocation distanceFromLocation:_location] == 0) return;
+    if (newLocation.coordinate.latitude == 0 && newLocation.coordinate.longitude == 0) return;
+
+    [self willChangeValueForKey:@"location"];
+    _location = newLocation;
+    [self didChangeValueForKey:@"location"];
 }
 
 - (BOOL)isUpdating


### PR DESCRIPTION
Just like `-[MGLMapView locationManager:didUpdateToLocation:fromLocation:]` does.

Fixes #1912.

/cc @incanus @bsudekum