### PR TITLE
This fixes latLngForPixel on Android

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -969,13 +969,13 @@ jobject JNICALL nativeLatLngForPixel(JNIEnv *env, jobject obj, jlong nativeMapVi
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
 
-    jfloat x = env->GetDoubleField(pixel, pointFXId);
+    jfloat x = env->GetFloatField(pixel, pointFXId);
     if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
         return nullptr;
     }
 
-    jfloat y = env->GetDoubleField(pixel, pointFYId);
+    jfloat y = env->GetFloatField(pixel, pointFYId);
     if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
         return nullptr;


### PR DESCRIPTION
It used GetDoubleField where it should have used GetFloatField.
This fixes it for me.

Thanks to the hint from @kkaefer on the meetup in Berlin!