### PR TITLE
Update the user dot when the user moves

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2379,6 +2379,8 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     self.userLocationAnnotationView.haloLayer.hidden = ! CLLocationCoordinate2DIsValid(self.userLocation.coordinate) ||
         newLocation.horizontalAccuracy > 10;
+
+    [self updateUserLocationAnnotationView];
 }
 
 - (BOOL)locationManagerShouldDisplayHeadingCalibration:(CLLocationManager *)manager


### PR DESCRIPTION
Rolled back part of ed04e6d9f712437bc29502e134250cd979c74b64 for #1852. The user dot should move on its own even if the map has no other reason to rerender.

Fixes #1933.

/cc @incanus