### PR TITLE
Include app-info.plist in iOS demo app's project

### DIFF
--- a/ios/app/mapboxgl-app.gypi
+++ b/ios/app/mapboxgl-app.gypi
@@ -13,7 +13,8 @@
         './points.geojson',
         './polyline.geojson',
         './threestates.geojson',
-        './Settings.bundle/'
+        './Settings.bundle/',
+        './app-info.plist'
       ],
 
       'dependencies': [


### PR DESCRIPTION
`app-info.plist` controls essential settings and was being included in the build phase, but wasn't included in the visible list of files in Xcode. This PR adds it to the that list.

![screen shot 2015-07-27 at 7 05 37 pm](https://cloud.githubusercontent.com/assets/1198851/8920016/91bbc864-3492-11e5-8788-6883f29700b1.png)

/cc @incanus @1ec5