### PR TITLE
initial implementation of Map::setView

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -64,7 +64,7 @@ public:
     void resume();
 
     // Attaches a View to the Map
-    void setView(View&);
+    void setView(View*);
 
     // Register a callback that will get called (on the render thread) when all resources have
     // been loaded and a complete render occurs.

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -175,7 +175,7 @@ public:
     bool isFullyLoaded() const;
 
 private:
-    View& view;
+    View* view;
     std::unique_ptr<Transform> transform;
     const std::unique_ptr<MapData> data;
     const std::unique_ptr<util::Thread<MapContext>> context;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -53,6 +53,8 @@ class Map : private util::noncopyable {
 public:
     explicit Map(View&, FileSource&,
                  MapMode mode = MapMode::Continuous);
+    explicit Map(float pixelRatio, FileSource&,
+                 MapMode mode = MapMode::Continuous);
     ~Map();
 
     // Pauses the render thread. The render thread will stop running but will not be terminated and will not lose state until resumed.
@@ -60,6 +62,9 @@ public:
 
     // Resumes a paused render thread
     void resume();
+
+    // Attaches a View to the Map
+    void setView(View&);
 
     // Register a callback that will get called (on the render thread) when all resources have
     // been loaded and a complete render occurs.
@@ -171,7 +176,7 @@ public:
 
 private:
     View& view;
-    const std::unique_ptr<Transform> transform;
+    std::unique_ptr<Transform> transform;
     const std::unique_ptr<MapData> data;
     const std::unique_ptr<util::Thread<MapContext>> context;
 

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -208,7 +208,7 @@ void HeadlessView::clearBuffers() {
 }
 
 HeadlessView::~HeadlessView() {
-    activate();
+    if (!isActive()) activate();
     clearBuffers();
     deactivate();
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -15,7 +15,7 @@ namespace mbgl {
 Map::Map(View& view_, FileSource& fileSource, MapMode mode)
     : data(std::make_unique<MapData>(mode, view_.getPixelRatio())),
     context(std::make_unique<util::Thread<MapContext>>(util::ThreadContext{"Map", util::ThreadType::Map, util::ThreadPriority::Regular}, fileSource, *data)) {
-    setView(view_);
+    setView(&view_);
 }
 
 Map::Map(float pixelRatio, FileSource& fileSource, MapMode mode)
@@ -43,10 +43,10 @@ void Map::resume() {
     paused = false;
 }
 
-void Map::setView(View& view_) {
-    view = &view_;
+void Map::setView(View* view_) {
+    view = view_;
     transform = std::make_unique<Transform>(*view);
-    context->invokeSync(&MapContext::setView, *view);
+    context->invokeSync(&MapContext::setView, view);
 
     view->initialize(this);
     update(Update::Dimensions);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -46,7 +46,7 @@ void Map::resume() {
 void Map::setView(View* view_) {
     view = view_;
     transform = std::make_unique<Transform>(*view);
-    context->invoke(&MapContext::setView, view);
+    context->invokeSync(&MapContext::setView, view);
 
     view->initialize(this);
     update(Update::Dimensions);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -46,7 +46,7 @@ void Map::resume() {
 void Map::setView(View* view_) {
     view = view_;
     transform = std::make_unique<Transform>(*view);
-    context->invokeSync(&MapContext::setView, view);
+    context->invoke(&MapContext::setView, view);
 
     view->initialize(this);
     update(Update::Dimensions);

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -48,7 +48,8 @@ MapContext::~MapContext() {
 }
 
 void MapContext::setView(View* view_) {
-    if (view) view->deactivate();
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
     view = view_;
     view->activate();
 }

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -48,6 +48,8 @@ MapContext::~MapContext() {
 }
 
 void MapContext::setView(View* view_) {
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
     view = view_;
     view->activate();
 }

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -47,9 +47,9 @@ MapContext::~MapContext() {
     assert(!style);
 }
 
-void MapContext::setView(const View& view_) {
-    view(view_);
-    view.activate();
+void MapContext::setView(View& view_) {
+    view = &view_;
+    view->activate();
 }
 
 void MapContext::cleanup() {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -48,8 +48,7 @@ MapContext::~MapContext() {
 }
 
 void MapContext::setView(View* view_) {
-    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
-
+    if (view) view->deactivate();
     view = view_;
     view->activate();
 }

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -29,9 +29,8 @@
 
 namespace mbgl {
 
-MapContext::MapContext(View& view_, FileSource& fileSource, MapData& data_)
-    : view(view_),
-      data(data_),
+MapContext::MapContext(FileSource& fileSource, MapData& data_)
+    : data(data_),
       updated(static_cast<UpdateType>(Update::Nothing)),
       asyncUpdate(std::make_unique<uv::async>(util::RunLoop::getLoop(), [this] { update(); })),
       texturePool(std::make_unique<TexturePool>()) {
@@ -41,13 +40,16 @@ MapContext::MapContext(View& view_, FileSource& fileSource, MapData& data_)
     util::ThreadContext::setGLObjectStore(&glObjectStore);
 
     asyncUpdate->unref();
-
-    view.activate();
 }
 
 MapContext::~MapContext() {
     // Make sure we call cleanup() before deleting this object.
     assert(!style);
+}
+
+void MapContext::setView(const View& view_) {
+    view(view_);
+    view.activate();
 }
 
 void MapContext::cleanup() {

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -42,7 +42,7 @@ public:
         bool needsRerender;
     };
 
-    void setView(const View&);
+    void setView(View&);
 
     void pause();
 
@@ -80,7 +80,7 @@ private:
     // Loads the actual JSON object an creates a new Style object.
     void loadStyleJSON(const std::string& json, const std::string& base);
 
-    View& view;
+    View* view;
     MapData& data;
 
     util::GLObjectStore glObjectStore;

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -42,7 +42,7 @@ public:
         bool needsRerender;
     };
 
-    void setView(View&);
+    void setView(View*);
 
     void pause();
 

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -34,13 +34,15 @@ struct FrameData {
 
 class MapContext : public Style::Observer {
 public:
-    MapContext(View&, FileSource&, MapData&);
+    MapContext(FileSource&, MapData&);
     ~MapContext();
 
     struct RenderResult {
         bool fullyLoaded;
         bool needsRerender;
     };
+
+    void setView(const View&);
 
     void pause();
 

--- a/test/miscellaneous/map_context.cpp
+++ b/test/miscellaneous/map_context.cpp
@@ -15,8 +15,9 @@ TEST(MapContext, DoubleStyleLoad) {
     DefaultFileSource fileSource(nullptr);
     MapData data(MapMode::Continuous, view.getPixelRatio());
 
-    util::Thread<MapContext> context({"Map", util::ThreadType::Map, util::ThreadPriority::Regular}, view, fileSource, data);
+    util::Thread<MapContext> context({"Map", util::ThreadType::Map, util::ThreadPriority::Regular}, fileSource, data);
 
+    context.invokeSync(&MapContext::setView, &view);
     context.invokeSync(&MapContext::setStyleJSON, "", "");
     context.invokeSync(&MapContext::setStyleJSON, "", "");
     context.invokeSync(&MapContext::cleanup);


### PR DESCRIPTION
I'm not sure if something needs to change in `MapContext` or if I'm just implementing wrong, but calling `context->invokeSync(&MapContext::setView, *view);` results in the error `field type 'mbgl::View' is an abstract class`. Would love a quick review here from @kkaefer or @tmpsantos to check if I'm going in the right direction.