### PR TITLE
compensate for Android screen ratio in conversion routines

### DIFF
--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -490,11 +490,12 @@ public class MapView extends SurfaceView {
     }
 
     public LatLng fromScreenLocation(PointF point) {
-        return mNativeMapView.latLngForPixel(point);
+        return mNativeMapView.latLngForPixel(new PointF(point.x / mScreenDensity, point.y / mScreenDensity));
     }
 
     public PointF toScreenLocation(LatLng location) {
-        return mNativeMapView.pixelForLatLng(location);
+        PointF point = mNativeMapView.pixelForLatLng(location);
+        return new PointF(point.x * mScreenDensity, point.y * mScreenDensity);
     }
 
     //


### PR DESCRIPTION
Fixes bugs where these conversions are inaccurate because screen density isn't taken into account during viewport calculations. 