### PR TITLE
Updates to Map::{renderSync,nudgeTransitions}

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -412,11 +412,11 @@ void JNICALL nativeUpdate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     nativeMapView->getMap().update(mbgl::Update::Repaint);
 }
 
-void JNICALL nativeOnInvalidate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jboolean inProgress) {
+void JNICALL nativeOnInvalidate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeOnInvalidate");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->onInvalidate(inProgress);
+    nativeMapView->onInvalidate();
 }
 
 void JNICALL nativeViewResize(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jint width, jint height) {
@@ -1440,7 +1440,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         {"nativePause", "(J)V", reinterpret_cast<void *>(&nativePause)},
         {"nativeResume", "(J)V", reinterpret_cast<void *>(&nativeResume)},
         {"nativeUpdate", "(J)V", reinterpret_cast<void *>(&nativeUpdate)},
-        {"nativeOnInvalidate", "(JZ)V", reinterpret_cast<void *>(&nativeOnInvalidate)},
+        {"nativeOnInvalidate", "(J)V", reinterpret_cast<void *>(&nativeOnInvalidate)},
         {"nativeViewResize", "(JII)V",
          reinterpret_cast<void *>(static_cast<void JNICALL (
              *)(JNIEnv *, jobject, jlong, jint, jint)>(&nativeViewResize))},

--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -409,7 +409,7 @@ void JNICALL nativeUpdate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeUpdate");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().update();
+    nativeMapView->getMap().update(mbgl::Update::Repaint);
 }
 
 void JNICALL nativeOnInvalidate(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jboolean inProgress) {

--- a/android/cpp/native_map_view.cpp
+++ b/android/cpp/native_map_view.cpp
@@ -761,7 +761,7 @@ void NativeMapView::updateFps() {
     env = nullptr;
 }
 
-void NativeMapView::onInvalidate(bool inProgress) {
+void NativeMapView::onInvalidate() {
     mbgl::Log::Debug(mbgl::Event::Android, "NativeMapView::onInvalidate()");
 
     const bool dirty = !clean.test_and_set();
@@ -776,10 +776,8 @@ void NativeMapView::onInvalidate(bool inProgress) {
 
         map.setSourceTileCacheSize(cacheSize);
 
-        const bool needsRerender = map.renderSync();
-        if (!inProgress) {
-            map.nudgeTransitions(needsRerender);
-        }
+        map.renderSync();
+        map.nudgeTransitions();
     }
 }
 

--- a/android/cpp/native_map_view.cpp
+++ b/android/cpp/native_map_view.cpp
@@ -792,6 +792,7 @@ void NativeMapView::resizeView(int w, int h) {
 void NativeMapView::resizeFramebuffer(int w, int h) {
     fbWidth = w;
     fbHeight = h;
+    map.update(mbgl::Update::Repaint);
 }
 
 }

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -1285,8 +1285,7 @@ public class MapView extends SurfaceView {
         post(new Runnable() {
             @Override
             public void run() {
-                boolean inProgress = mRotateGestureDetector.isInProgress() || mScaleGestureDetector.isInProgress();
-                mNativeMapView.invalidate(inProgress);
+                mNativeMapView.invalidate();
             }
         });
     }

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -96,8 +96,8 @@ class NativeMapView {
         nativeUpdate(mNativeMapViewPtr);
     }
 
-    public void invalidate(boolean inProgress) {
-        nativeOnInvalidate(mNativeMapViewPtr, inProgress);
+    public void invalidate() {
+        nativeOnInvalidate(mNativeMapViewPtr);
     }
 
     public void resizeView(int width, int height) {
@@ -463,7 +463,7 @@ class NativeMapView {
 
     private native void nativeUpdate(long nativeMapViewPtr);
 
-    private native void nativeOnInvalidate(long nativeMapViewPtr, boolean inProgress);
+    private native void nativeOnInvalidate(long nativeMapViewPtr);
 
     private native void nativeViewResize(long nativeMapViewPtr, int width, int height);
 

--- a/include/mbgl/android/native_map_view.hpp
+++ b/include/mbgl/android/native_map_view.hpp
@@ -49,7 +49,7 @@ public:
     void enableFps(bool enable);
     void updateFps();
 
-    void onInvalidate(bool inProgress);
+    void onInvalidate();
 
     void resizeView(int width, int height);
     void resizeFramebuffer(int width, int height);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -73,7 +73,7 @@ public:
     void nudgeTransitions(bool forceRerender);
 
     // Notifies the Map thread that the state has changed and an update might be necessary.
-    void update(Update update = Update::Nothing);
+    void update(Update update);
 
     // Styling
     void addClass(const std::string&);

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -66,11 +66,11 @@ public:
     using StillImageCallback = std::function<void(std::exception_ptr, std::unique_ptr<const StillImage>)>;
     void renderStill(StillImageCallback callback);
 
-    // Triggers a synchronous or asynchronous render.
-    bool renderSync();
+    // Triggers a synchronous render.
+    void renderSync();
 
-    // Nudges transitions one step, possibly notifying of the need for a rerender.
-    void nudgeTransitions(bool forceRerender);
+    // Nudges transitions one step, possibly notifying of the need for a rerender, if any.
+    void nudgeTransitions();
 
     // Notifies the Map thread that the state has changed and an update might be necessary.
     void update(Update update);

--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -14,6 +14,7 @@ enum class Update : UpdateType {
     Classes                   = 1 << 3,
     Zoom                      = 1 << 4,
     RenderStill               = 1 << 5,
+    Repaint                   = 1 << 6,
 };
 
 }

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -288,7 +288,7 @@ void GLFWView::onFramebufferResize(GLFWwindow *window, int width, int height) {
     view->fbWidth = width;
     view->fbHeight = height;
 
-    view->map->update();
+    view->map->update(mbgl::Update::Repaint);
 }
 
 void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modifiers) {

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -336,11 +336,8 @@ void GLFWView::run() {
         glfwWaitEvents();
         const bool dirty = !clean.test_and_set();
         if (dirty) {
-            const bool needsRerender = map->renderSync();
-            GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
-            if (!view->tracking || !view->rotating) {
-                map->nudgeTransitions(needsRerender);
-            }
+            map->renderSync();
+            map->nudgeTransitions();
         }
     }
 }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -710,17 +710,11 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
         _mbglMap->setSourceTileCacheSize(cacheSize);
 
-        bool needsRerender = _mbglMap->renderSync();
+        _mbglMap->renderSync();
 
         [self updateUserLocationAnnotationView];
 
-        // don't nudge transitions if in the midst of a gesture.
-        if (self.pan.state       == UIGestureRecognizerStateChanged ||
-            self.pinch.state     == UIGestureRecognizerStateChanged ||
-            self.rotate.state    == UIGestureRecognizerStateChanged ||
-            self.quickZoom.state == UIGestureRecognizerStateChanged) return;
-
-        _mbglMap->nudgeTransitions(needsRerender);
+        _mbglMap->nudgeTransitions();
     }
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -73,11 +73,11 @@ bool Map::renderSync() {
 }
 
 void Map::nudgeTransitions(bool forceRerender) {
-    if (transform->needsTransition()) {
-        update(Update(transform->updateTransitions(Clock::now())));
-    } else if (forceRerender) {
-        update();
+    UpdateType update_ = transform->updateTransitions(Clock::now());
+    if (forceRerender) {
+        update_ |= static_cast<UpdateType>(Update::Repaint);
     }
+    update(Update(update_));
 }
 
 void Map::update(Update update_) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -110,24 +110,24 @@ std::string Map::getStyleJSON() const {
 
 void Map::cancelTransitions() {
     transform->cancelTransitions();
-    update();
+    update(Update::Repaint);
 }
 
 void Map::setGestureInProgress(bool inProgress) {
     transform->setGestureInProgress(inProgress);
-    update();
+    update(Update::Repaint);
 }
 
 #pragma mark - Position
 
 void Map::moveBy(double dx, double dy, const Duration& duration) {
     transform->moveBy(dx, dy, duration);
-    update();
+    update(Update::Repaint);
 }
 
 void Map::setLatLng(LatLng latLng, const Duration& duration) {
     transform->setLatLng(latLng, duration);
-    update();
+    update(Update::Repaint);
 }
 
 LatLng Map::getLatLng() const {
@@ -249,17 +249,17 @@ uint16_t Map::getHeight() const {
 
 void Map::rotateBy(double sx, double sy, double ex, double ey, const Duration& duration) {
     transform->rotateBy(sx, sy, ex, ey, duration);
-    update();
+    update(Update::Repaint);
 }
 
 void Map::setBearing(double degrees, const Duration& duration) {
     transform->setAngle(-degrees * M_PI / 180, duration);
-    update();
+    update(Update::Repaint);
 }
 
 void Map::setBearing(double degrees, double cx, double cy) {
     transform->setAngle(-degrees * M_PI / 180, cx, cy);
-    update();
+    update(Update::Repaint);
 }
 
 double Map::getBearing() const {
@@ -268,7 +268,7 @@ double Map::getBearing() const {
 
 void Map::resetNorth() {
     transform->setAngle(0, std::chrono::milliseconds(500));
-    update();
+    update(Update::Repaint);
 }
 
 
@@ -365,12 +365,12 @@ void Map::removeSprite(const std::string& name) {
 
 void Map::setDebug(bool value) {
     data->setDebug(value);
-    update();
+    update(Update::Repaint);
 }
 
 void Map::toggleDebug() {
     data->toggleDebug();
-    update();
+    update(Update::Repaint);
 }
 
 bool Map::getDebug() const {
@@ -379,12 +379,12 @@ bool Map::getDebug() const {
 
 void Map::setCollisionDebug(bool value) {
     data->setCollisionDebug(value);
-    update();
+    update(Update::Repaint);
 }
 
 void Map::toggleCollisionDebug() {
     data->toggleCollisionDebug();
-    update();
+    update(Update::Repaint);
 }
 
 bool Map::getCollisionDebug() const {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -396,6 +396,8 @@ void MapContext::setSprite(const std::string& name, std::shared_ptr<const Sprite
 
 void MapContext::onTileDataChanged() {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+    updated |= static_cast<UpdateType>(Update::Repaint);
     asyncUpdate->send();
 }
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -35,7 +35,8 @@ MapContext::MapContext(View& view_, FileSource& fileSource, MapData& data_)
       data(data_),
       updated(static_cast<UpdateType>(Update::Nothing)),
       asyncUpdate(std::make_unique<uv::async>(util::RunLoop::getLoop(), [this] { update(); })),
-      texturePool(std::make_unique<TexturePool>()) {
+      texturePool(std::make_unique<TexturePool>()),
+      viewInvalidated(false) {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
 
     util::ThreadContext::setFileSource(&fileSource);
@@ -272,8 +273,8 @@ void MapContext::update() {
     style->update(transformState, *texturePool);
 
     if (data.mode == MapMode::Continuous) {
-        view.invalidate();
-    } else if (callback && style->isLoaded()) {
+        invalidateView();
+    } else if (callback && isLoaded()) {
         renderSync(transformState, frameData);
     }
 
@@ -342,8 +343,10 @@ MapContext::RenderResult MapContext::renderSync(const TransformState& state, con
 
     view.swap();
 
+    viewInvalidated = false;
+
     return RenderResult {
-        style->isLoaded(),
+        isLoaded(),
         style->hasTransitions() || painter->needsAnimation()
     };
 }
@@ -370,7 +373,7 @@ void MapContext::setSourceTileCacheSize(size_t size) {
         for (const auto &source : style->sources) {
             source->setCacheSize(sourceCacheSize);
         }
-        view.invalidate();
+        invalidateView();
     }
 }
 
@@ -380,7 +383,7 @@ void MapContext::onLowMemory() {
     for (const auto &source : style->sources) {
         source->onLowMemory();
     }
-    view.invalidate();
+    invalidateView();
 }
 
 void MapContext::setSprite(const std::string& name, std::shared_ptr<const SpriteImage> sprite) {
@@ -407,6 +410,13 @@ void MapContext::onResourceLoadingFailed(std::exception_ptr error) {
     if (data.mode == MapMode::Still && callback) {
         callback(error, nullptr);
         callback = nullptr;
+    }
+}
+
+void MapContext::invalidateView() {
+    if (!viewInvalidated) {
+        viewInvalidated = true;
+        view.invalidate();
     }
 }
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -280,7 +280,7 @@ void MapContext::update() {
     updated = static_cast<UpdateType>(Update::Nothing);
 }
 
-void MapContext::renderStill(const TransformState& state, const FrameData& frame, StillImageCallback fn) {
+void MapContext::renderStill(const TransformState& state, const FrameData& frame, Map::StillImageCallback fn) {
     if (!fn) {
         Log::Error(Event::General, "StillImageCallback not set");
         return;

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -256,6 +256,9 @@ void MapContext::update() {
 
     if (!style) {
         updated = static_cast<UpdateType>(Update::Nothing);
+    }
+
+    if (updated == static_cast<UpdateType>(Update::Nothing)) {
         return;
     }
 
@@ -315,12 +318,12 @@ void MapContext::renderStill(const TransformState& state, const FrameData& frame
     asyncUpdate->send();
 }
 
-MapContext::RenderResult MapContext::renderSync(const TransformState& state, const FrameData& frame) {
+bool MapContext::renderSync(const TransformState& state, const FrameData& frame) {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
 
     // Style was not loaded yet.
     if (!style) {
-        return { false, false };
+        return false;
     }
 
     transformState = state;
@@ -345,10 +348,11 @@ MapContext::RenderResult MapContext::renderSync(const TransformState& state, con
 
     viewInvalidated = false;
 
-    return RenderResult {
-        isLoaded(),
-        style->hasTransitions() || painter->needsAnimation()
-    };
+    if (style->hasTransitions() || painter->needsAnimation()) {
+        data.setNeedsRepaint(true);
+    }
+
+    return isLoaded();
 }
 
 bool MapContext::isLoaded() const {

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -38,16 +38,13 @@ public:
     MapContext(View&, FileSource&, MapData&);
     ~MapContext();
 
-    struct RenderResult {
-        bool fullyLoaded;
-        bool needsRerender;
-    };
-
     void pause();
 
     void triggerUpdate(const TransformState&, Update = Update::Nothing);
     void renderStill(const TransformState&, const FrameData&, Map::StillImageCallback callback);
-    RenderResult renderSync(const TransformState&, const FrameData&);
+
+    // Triggers a synchronous render. Returns true if style has been fully loaded.
+    bool renderSync(const TransformState&, const FrameData&);
 
     void setStyleURL(const std::string&);
     void setStyleJSON(const std::string& json, const std::string& base);

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/map/update.hpp>
 #include <mbgl/map/transform_state.hpp>
+#include <mbgl/map/map.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/gl_object_store.hpp>
 #include <mbgl/util/ptr.hpp>
@@ -44,10 +45,8 @@ public:
 
     void pause();
 
-    using StillImageCallback = std::function<void(std::exception_ptr, std::unique_ptr<const StillImage>)>;
-
     void triggerUpdate(const TransformState&, Update = Update::Nothing);
-    void renderStill(const TransformState&, const FrameData&, StillImageCallback callback);
+    void renderStill(const TransformState&, const FrameData&, Map::StillImageCallback callback);
     RenderResult renderSync(const TransformState&, const FrameData&);
 
     void setStyleURL(const std::string&);
@@ -95,7 +94,7 @@ private:
 
     Request* styleRequest = nullptr;
 
-    StillImageCallback callback;
+    Map::StillImageCallback callback;
     size_t sourceCacheSize;
     TransformState transformState;
     FrameData frameData;

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -77,6 +77,8 @@ private:
     // Loads the actual JSON object an creates a new Style object.
     void loadStyleJSON(const std::string& json, const std::string& base);
 
+    void invalidateView();
+
     View& view;
     MapData& data;
 
@@ -98,6 +100,7 @@ private:
     size_t sourceCacheSize;
     TransformState transformState;
     FrameData frameData;
+    bool viewInvalidated;
 };
 
 }

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -101,6 +101,14 @@ public:
         defaultTransitionDelay = delay;
     }
 
+    inline bool getNeedsRepaint() const {
+        return needsRepaint;
+    }
+
+    inline void setNeedsRepaint(const bool needsRepaint_) {
+        needsRepaint = needsRepaint_;
+    }
+
     util::exclusive<AnnotationManager> getAnnotationManager() {
         return util::exclusive<AnnotationManager>(
             &annotationManager,
@@ -124,6 +132,7 @@ private:
     std::atomic<Duration> defaultFadeDuration;
     std::atomic<Duration> defaultTransitionDuration;
     std::atomic<Duration> defaultTransitionDelay;
+    std::atomic<bool> needsRepaint;
 
 // TODO: make private
 public:

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -377,10 +377,6 @@ void Transform::startTransition(std::function<Update(double)> frame,
     transitionFinishFn = finish;
 }
 
-bool Transform::needsTransition() const {
-    return !!transitionFrameFn;
-}
-
 UpdateType Transform::updateTransitions(const TimePoint& now) {
     return static_cast<UpdateType>(transitionFrameFn ? transitionFrameFn(now) : Update::Nothing);
 }

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -42,7 +42,6 @@ public:
     double getAngle() const;
 
     // Transitions
-    bool needsTransition() const;
     UpdateType updateTransitions(const TimePoint& now);
     void cancelTransitions();
 


### PR DESCRIPTION
Given the example in #1975 where a custom animation (not triggered by an input event) triggers a `Map` repaint, `Map` should be self-sufficient in terms of data to avoid triggering `View` invalidations in a burst.

Important changes:
- `Map::renderSync()` no longer provides a return parameter.
- `Map::nudgeTransitions()` no longer requires a `forceRerender` parameter.
- `MapContext::renderSync()` should be ideally returning void, however for performance reasons we no w only return the value of `MapContext::isLoaded()` to avoid a second `invokeSync()` from `Map` to `MapContext`.
- Removed `Transform::needsTransition()` - `Transform::updateTransitions()` already checks for the transition callback.
- Moved `StillImageCallback` to its own header to avoid duplicated definitions in `Map` and `MapContext` headers.
- Added `Update::Repaint` enum to notify `MapContext` that all we require is a style update, followed by a view invalidation.
- Coalesce view invalidations in `MapContext::invalidateView()` to avoid flooding the client with redundant invalidation calls.
- Updated public API changes in the ports code accordingly.

/cc @incanus @kkaefer @jfirebaugh @tmpsantos @tmcw

Fixes #1975.