### PR TITLE
Adjusting /fonts/ urls to normalize with /fonts/v1

### DIFF
--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -46,6 +46,14 @@ std::string normalizeGlyphsURL(const std::string& url, const std::string& access
         return url;
     }
 
+    const std::string fonts = "mapbox://fonts/";
+    const std::string fontsv1 = "mapbox://fonts/v1/";
+
+    if (url.compare(0, fonts.length(), fonts) == 0 && url.compare(0, fontsv1.length(), fontsv1) != 0) {
+        const std::string newURL = fontsv1 + url.substr(fonts.length());
+        return normalizeURL(newURL, "/", accessToken);
+    }
+
     const std::string fontstack = "mapbox://fontstack/";
 
     if (url.compare(0, fontstack.length(), fontstack) == 0) {

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -16,6 +16,7 @@ TEST(Mapbox, SourceURL) {
 TEST(Mapbox, GlyphsURL) {
     EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fontstack/{fontstack}/{range}.pbf", "key"), "https://api.tiles.mapbox.com/v4/fontstack/{fontstack}/{range}.pbf?access_token=key");
     EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/v1/user/{fontstack}/{range}.pbf", "key"), "https://api.tiles.mapbox.com/fonts/v1/user/{fontstack}/{range}.pbf?access_token=key");
+    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/user/{fontstack}/{range}.pbf", "key"), "https://api.tiles.mapbox.com/fonts/v1/user/{fontstack}/{range}.pbf?access_token=key");
     EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("http://path", "key"), "http://path");
 }
 


### PR DESCRIPTION
This change will probably need to be a part of the v8 style spec, as per discussion at https://github.com/mapbox/gl-internal/issues/253#issuecomment-127437196. 

@jfirebaugh and @kkaefer what are the procedures for making this a part of V8?

refs #1918 