### PR TITLE
fix crashes after network connection was restored

### DIFF
--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -217,6 +217,7 @@ void HTTPNSURLRequest::handleResult(NSData *data, NSURLResponse *res, NSError *e
     if (error) {
         if ([error code] == NSURLErrorCancelled) {
             status = ResponseStatus::Canceled;
+            cancelled = true;
         } else {
             // TODO: Use different codes for host not found, timeout, invalid URL etc.
             // These can be categorized in temporary and permanent errors.
@@ -329,6 +330,11 @@ void HTTPNSURLRequest::retry() {
     if (strategy == PreemptImmediately) {
         // Triggers the timer upon the next event loop iteration.
         timer.stop();
+        if (task) {
+            [task cancel];
+            [task release];
+            task = nullptr;
+        }
         timer.start(0, 0, [this] { start(); });
     }
 }


### PR DESCRIPTION
Mapbox GL works well without a network connection, but I found and fixed two crashes that happened after the network connection was restored. To repro the issue on iOS:
1. Launch mapbox sample app
2. Turn on airplane mode
3. Scroll around or zoom out to areas of the map that have not been previously downloaded
4. After ~10 seconds, turn airplane mode off