### PR TITLE
Ignore tile URL sharding

### DIFF
--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -98,7 +98,7 @@ void SourceInfo::parseTileJSONProperties(const rapidjson::Value& value) {
 }
 
 std::string SourceInfo::tileURL(const TileID& id, float pixelRatio) const {
-    std::string result = tiles.at((id.x + id.y) % tiles.size());
+    std::string result = tiles.at(0);
     result = util::mapbox::normalizeTileURL(result, url, type);
     result = util::replaceTokens(result, [&](const std::string &token) -> std::string {
         if (token == "z") return util::toString(std::min(id.z, static_cast<int8_t>(max_zoom)));


### PR DESCRIPTION
The source returns sharded tile URLs, but sharding doesn’t buy us anything on native platforms, so always grab the first.

ref mapbox/mapbox-gl-native#2007

/cc @jfirebaugh @tmcw