### PR TITLE
Glyph markers

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -52,6 +52,7 @@ jclass markerClass = nullptr;
 jmethodID markerConstructorId = nullptr;
 jfieldID markerPositionId = nullptr;
 jfieldID markerSpriteId = nullptr;
+jfieldID markerTextId = nullptr;
 
 jclass polylineClass = nullptr;
 jmethodID polylineConstructorId = nullptr;
@@ -740,6 +741,9 @@ jlong JNICALL nativeAddMarker(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, 
     jstring jsprite = reinterpret_cast<jstring>(env->GetObjectField(marker, markerSpriteId));
     std::string sprite = std_string_from_jstring(env, jsprite);
 
+    jstring jtext = (jstring)env->GetObjectField(marker, markerTextId);
+    std::string text = std_string_from_jstring(env, jtext);
+
     jdouble latitude = env->GetDoubleField(position, latLngLatitudeId);
     if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
@@ -753,7 +757,8 @@ jlong JNICALL nativeAddMarker(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, 
     }
 
     // Because Java only has int, not unsigned int, we need to bump the annotation id up to a long.
-    return nativeMapView->getMap().addPointAnnotation(mbgl::PointAnnotation(mbgl::LatLng(latitude, longitude), sprite));
+    return nativeMapView->getMap().addPointAnnotation(
+            mbgl::PointAnnotation(mbgl::LatLng(latitude, longitude), sprite, text));
 }
 
 jlong JNICALL nativeAddPolyline(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jobject polyline) {
@@ -1212,6 +1217,12 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
 
     markerSpriteId = env->GetFieldID(markerClass, "sprite", "Ljava/lang/String;");
     if (markerSpriteId == nullptr) {
+        env->ExceptionDescribe();
+        return JNI_ERR;
+    }
+
+    markerTextId = env->GetFieldID(markerClass, "text", "Ljava/lang/String;");
+    if (markerTextId == nullptr) {
         env->ExceptionDescribe();
         return JNI_ERR;
     }
@@ -1676,6 +1687,7 @@ extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved) {
     markerConstructorId = nullptr;
     markerPositionId = nullptr;
     markerSpriteId = nullptr;
+    markerTextId = nullptr;
 
     env->DeleteGlobalRef(polylineClass);
     polylineClass = nullptr;

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/Marker.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/Marker.java
@@ -16,6 +16,7 @@ public class Marker extends Annotation {
     String snippet;
     String sprite = "default_marker";
     String title;
+    String text = "";
 
     private boolean infoWindowShown = false;
 

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/MarkerOptions.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/MarkerOptions.java
@@ -103,6 +103,11 @@ public class MarkerOptions extends AnnotationOptions {
         return this;
     }
 
+    public MarkerOptions text(String text) {
+        ((Marker)annotation).text = text;
+        return this;
+    }
+
     public MarkerOptions title(String title) {
         ((Marker)annotation).title = title;
         return this;
@@ -112,7 +117,6 @@ public class MarkerOptions extends AnnotationOptions {
         annotation.visible = visible;
         return this;
     }
-
 
     // TODO: Implement this method of Google Maps Android API
 //    public MarkerOptions icon(BitmapDescriptor icon) {

--- a/android/java/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxgl/testapp/MainActivity.java
+++ b/android/java/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxgl/testapp/MainActivity.java
@@ -309,7 +309,10 @@ public class MainActivity extends ActionBarActivity {
         marker = map.addMarker(new MarkerOptions()
             .position(backLot)
             .title("Back Lot")
-            .snippet("The back lot behind my house"));
+            .snippet("The back lot behind my house")
+            .text("Back Lot")
+            .sprite("")
+        );
 
         LatLng cheeseRoom = new LatLng(38.531577,-122.010646);
         map.addMarker(new MarkerOptions()

--- a/include/mbgl/annotation/point_annotation.hpp
+++ b/include/mbgl/annotation/point_annotation.hpp
@@ -9,12 +9,13 @@ namespace mbgl {
 
 class PointAnnotation {
 public:
-    inline PointAnnotation(const LatLng& position_, const std::string& icon_ = "")
-        : position(position_), icon(icon_) {
+    inline PointAnnotation(const LatLng& position_, const std::string& icon_ = "", const std::string& text_ = "")
+        : position(position_), icon(icon_), text(text_) {
     }
 
     const LatLng position;
     const std::string icon;
+    const std::string text;
 };
 
 }

--- a/include/mbgl/ios/MGLPointAnnotation.h
+++ b/include/mbgl/ios/MGLPointAnnotation.h
@@ -11,6 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** The coordinate point of the annotation, specified as a latitude and longitude. */
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 
+@property (nonatomic, readonly, copy, nullable) NSString *text;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/include/mbgl/ios/MGLPointAnnotation.h
+++ b/include/mbgl/ios/MGLPointAnnotation.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** The coordinate point of the annotation, specified as a latitude and longitude. */
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
 
-@property (nonatomic, readonly, copy, nullable) NSString *text;
+@property (nonatomic, copy, nullable) NSString *text;
 
 @end
 

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -262,7 +262,8 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
 
                 MGLPointAnnotation *annotation = [MGLPointAnnotation new];
                 annotation.coordinate = coordinate;
-                annotation.title = title;
+//                annotation.title = title;
+                annotation.text = title;
 
                 [annotations addObject:annotation];
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1897,6 +1897,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         {
             MGLAnnotationImage *annotationImage = nil;
             NSString *symbolName = nil;
+            NSString *text = [(MGLPointAnnotation *)annotation text];
 
             if (delegateImplementsImageForPoint)
             {
@@ -1940,7 +1941,9 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
                 }
             }
 
-            points.emplace_back(MGLLatLngFromLocationCoordinate2D(annotation.coordinate), symbolName ? [symbolName UTF8String] : "");
+            points.emplace_back(MGLLatLngFromLocationCoordinate2D(annotation.coordinate),
+                                symbolName ? [symbolName UTF8String] : "",
+                                text ? [text UTF8String] : "");
         }
     }
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1897,11 +1897,14 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         {
             MGLAnnotationImage *annotationImage = nil;
             NSString *symbolName = nil;
-            NSString *text = [(MGLPointAnnotation *)annotation text];
+            NSString *text = nil;
+            if ((MGLPointAnnotation *)annotation != nil) {
+                 text = [(MGLPointAnnotation *)annotation text];
+            }
 
             if (delegateImplementsImageForPoint)
             {
-                annotationImage = [self.delegate mapView:self imageForAnnotation:annotation];
+//                annotationImage = [self.delegate mapView:self imageForAnnotation:annotation];
 
                 if (annotationImage)
                 {

--- a/src/mbgl/map/annotation.cpp
+++ b/src/mbgl/map/annotation.cpp
@@ -277,6 +277,8 @@ AnnotationManager::addPointAnnotations(const std::vector<PointAnnotation>& point
         std::unordered_map<std::string, std::string> pointFeatureProperties;
         if (point.icon.length()) {
             pointFeatureProperties.emplace("sprite", point.icon);
+        } else if (point.text.length()) {
+            pointFeatureProperties.emplace("marker-text", point.text);
         } else {
             pointFeatureProperties.emplace("sprite", defaultPointAnnotationSymbol);
         }

--- a/src/mbgl/style/style_layout.hpp
+++ b/src/mbgl/style/style_layout.hpp
@@ -60,7 +60,7 @@ public:
 
     struct {
         RotationAlignmentType rotation_alignment = RotationAlignmentType::Viewport;
-        std::string field;
+        std::string field = "{marker-text}";
         std::string font = "Open Sans Regular, Arial Unicode MS Regular";
         float max_size = 16.0f;
         float max_width = 15.0f /* em */;


### PR DESCRIPTION
This fixes #1883

Instead of having a sprite for each marker, which causes sprite store overflow, use the glyphs to render text.

This utilizes the work done on glyph rendering and improves marker layout, marker rendering, and rendering speed.

It looks like this:
![](https://cloud.githubusercontent.com/assets/342441/8827527/8be24304-308d-11e5-9596-542de219d17a.gif)

Works on both Android and IOS.