### PR TITLE
Render solid background with glClear, rather than drawing quads

### DIFF
--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -207,6 +207,7 @@ private:
     float strata = 0;
     RenderPass pass = RenderPass::Opaque;
     const float strata_epsilon = 1.0f / (1 << 16);
+    Color background = {{ 0, 0, 0, 0 }};
 
 public:
     FrameHistory frameHistory;


### PR DESCRIPTION
This patch moves to setting the `glClear` color to the map's background color, if the background isn't textured. This allows us to skip drawing full screen quads for the background layer.