### PR TITLE
Don't constantly repaint

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -345,12 +345,8 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
     }
 
     view.swap();
-
     viewInvalidated = false;
-
-    if (style->hasTransitions() || painter->needsAnimation()) {
-        data.setNeedsRepaint(true);
-    }
+    data.setNeedsRepaint(style->hasTransitions() || painter->needsAnimation());
 
     return isLoaded();
 }


### PR DESCRIPTION
Right now, we're constantly repainting, after you move the map once. This causes severe CPU usage and battery drain.