### PR TITLE
Don't disable user tracking on `setDirection:` or quick zoom gesture

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1371,8 +1371,6 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         self.scale = _mbglMap->getScale();
 
         self.quickZoomStart = [quickZoom locationInView:quickZoom.view].y;
-
-        self.userTrackingMode = MGLUserTrackingModeNone;
     }
     else if (quickZoom.state == UIGestureRecognizerStateChanged)
     {
@@ -1772,7 +1770,10 @@ mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBounds coord
 {
     if ( ! animated && ! self.rotationAllowed) return;
 
-    self.userTrackingMode = MGLUserTrackingModeNone;
+    if (self.userTrackingMode == MGLUserTrackingModeFollowWithHeading)
+    {
+        self.userTrackingMode = MGLUserTrackingModeFollow;
+    }
 
     CGFloat duration = (animated ? MGLAnimationDuration : 0);
 


### PR DESCRIPTION
The user location tracking mode would be reset on `setDirection:`/`setDirection:animated:` — this is undesirable and has been changed to retain tracking.

The tracking mode would also be reset unnecessarily during the double-tap-hold-move-up-and-down quick-zoom gesture. This gesture now keeps tracking the user, though not while they're actively performing the gesture (it catches up when the zoom is over, even if the gesture is still being held).

Fixes #1644.

/cc @1ec5 @incanus