### PR TITLE
Fix update flags in mbgl::Transform::{_moveBy,_setAngle}

### DIFF
--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -5,9 +5,7 @@
 
 namespace mbgl {
 
-using UpdateType = uint32_t;
-
-enum class Update : UpdateType {
+enum class Update : uint32_t {
     Nothing                   = 0,
     Dimensions                = 1 << 1,
     DefaultTransition         = 1 << 2,
@@ -17,6 +15,19 @@ enum class Update : UpdateType {
     Repaint                   = 1 << 6,
 };
 
+inline Update operator| (const Update& lhs, const Update& rhs) {
+    return Update(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
 }
 
-#endif
+inline Update& operator|=(Update& lhs, const Update& rhs) {
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+inline bool operator& (const Update& lhs, const Update& rhs) {
+    return static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs);
+}
+
+} // namespace mbgl
+
+#endif // MBGL_MAP_UPDATE

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -71,19 +71,18 @@ void Map::renderSync() {
 }
 
 void Map::nudgeTransitions() {
-    UpdateType update_ = transform->updateTransitions(Clock::now());
+    Update flags = transform->updateTransitions(Clock::now());
     if (data->getNeedsRepaint()) {
-        update_ |= static_cast<UpdateType>(Update::Repaint);
+        flags |= Update::Repaint;
     }
-    update(Update(update_));
+    update(flags);
 }
 
-void Map::update(Update update_) {
-    if (update_ == Update::Dimensions) {
+void Map::update(Update flags) {
+    if (flags & Update::Dimensions) {
         transform->resize(view.getSize());
     }
-
-    context->invoke(&MapContext::triggerUpdate, transform->getState(), update_);
+    context->invoke(&MapContext::triggerUpdate, transform->getState(), flags);
 }
 
 #pragma mark - Style

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -81,7 +81,7 @@ private:
 
     util::GLObjectStore glObjectStore;
 
-    UpdateType updated { static_cast<UpdateType>(Update::Nothing) };
+    Update updateFlags = Update::Nothing;
     std::unique_ptr<uv::async> asyncUpdate;
 
     std::unique_ptr<TexturePool> texturePool;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -377,8 +377,8 @@ void Transform::startTransition(std::function<Update(double)> frame,
     transitionFinishFn = finish;
 }
 
-UpdateType Transform::updateTransitions(const TimePoint& now) {
-    return static_cast<UpdateType>(transitionFrameFn ? transitionFrameFn(now) : Update::Nothing);
+Update Transform::updateTransitions(const TimePoint& now) {
+    return transitionFrameFn ? transitionFrameFn(now) : Update::Nothing;
 }
 
 void Transform::cancelTransitions() {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -86,7 +86,7 @@ void Transform::_moveBy(const double dx, const double dy, const Duration& durati
                 state.x = util::interpolate(startX, x, t);
                 state.y = util::interpolate(startY, y, t);
                 view.notifyMapChange(MapChangeRegionIsChanging);
-                return Update::Nothing;
+                return Update::Repaint;
             },
             [=] {
                 state.panning = false;
@@ -334,7 +334,7 @@ void Transform::_setAngle(double new_angle, const Duration& duration) {
             [=](double t) {
                 state.angle = util::wrap(util::interpolate(startA, angle, t), -M_PI, M_PI);
                 view.notifyMapChange(MapChangeRegionIsChanging);
-                return Update::Nothing;
+                return Update::Repaint;
             },
             [=] {
                 state.rotating = false;

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -42,7 +42,7 @@ public:
     double getAngle() const;
 
     // Transitions
-    UpdateType updateTransitions(const TimePoint& now);
+    Update updateTransitions(const TimePoint& now);
     void cancelTransitions();
 
     // Gesture


### PR DESCRIPTION
This is needed to properly tell `Map::nudgeTransitions()` to trigger a repaint.

Fixes #2036.

/cc @friedbunny @ljbade @1ec5 @incanus @kkaefer @tmpsantos 