### PR TITLE
Properly disable debug calls on non-debug builds

### DIFF
--- a/src/mbgl/gl/debugging.cpp
+++ b/src/mbgl/gl/debugging.cpp
@@ -169,7 +169,6 @@ void enable() {
     MBGL_CHECK_ERROR(DebugMessageCallback(debugCallback, nullptr));
 }
 
-#if defined(DEBUG)
 group::group(const std::string& str) {
     if (PushDebugGroup) {
         PushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, GLsizei(str.size()), str.c_str());
@@ -185,10 +184,6 @@ group::~group() {
         PopGroupMarkerEXT();
     }
 }
-#else
-group::group(const std::string&) {}
-group::~group() = default;
-#endif
 
 }
 }

--- a/src/mbgl/gl/debugging.cpp
+++ b/src/mbgl/gl/debugging.cpp
@@ -173,7 +173,7 @@ group::group(const std::string& str) {
     if (PushDebugGroup) {
         PushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, GLsizei(str.size()), str.c_str());
     } else if (PushGroupMarkerEXT) {
-        PushGroupMarkerEXT(GLsizei(str.size()), str.c_str());
+        PushGroupMarkerEXT(GLsizei(str.size() + 1), str.c_str());
     }
 }
 

--- a/src/mbgl/gl/debugging.hpp
+++ b/src/mbgl/gl/debugging.hpp
@@ -3,6 +3,14 @@
 
 #include <string>
 
+#if defined(DEBUG)
+#define __MBGL_DEBUG_GROUP_NAME2(counter) __MBGL_DEBUG_GROUP_##counter
+#define __MBGL_DEBUG_GROUP_NAME(counter) __MBGL_DEBUG_GROUP_NAME2(counter)
+#define MBGL_DEBUG_GROUP(string) ::mbgl::gl::debugging::group __MBGL_DEBUG_GROUP_NAME(__LINE__)(string);
+#else
+#define MBGL_DEBUG_GROUP(string)
+#endif
+
 namespace mbgl {
 namespace gl {
 namespace debugging {

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -186,7 +186,7 @@ void Source::updateMatrices(const mat4 &projMatrix, const TransformState &transf
 void Source::drawClippingMasks(Painter &painter) {
     for (const auto& pair : tiles) {
         Tile &tile = *pair.second;
-        gl::debugging::group group(std::string { "mask: " } + std::string(tile.id));
+        MBGL_DEBUG_GROUP(std::string { "mask: " } + std::string(tile.id));
         painter.drawClippingMask(tile.matrix, tile.clip);
     }
 }

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -147,7 +147,7 @@ void Painter::changeMatrix() {
 }
 
 void Painter::clear() {
-    gl::debugging::group group("clear");
+    MBGL_DEBUG_GROUP("clear");
     config.stencilTest = true;
     config.stencilMask = 0xFF;
     config.depthTest = false;
@@ -190,7 +190,7 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
     // - UPLOAD PASS -------------------------------------------------------------------------------
     // Uploads all required buffers and images before we do any actual rendering.
     {
-        const gl::debugging::group upload("upload");
+        MBGL_DEBUG_GROUP("upload");
 
         tileStencilBuffer.upload();
         tileBorderBuffer.upload();
@@ -209,7 +209,7 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
     // - CLIPPING MASKS ----------------------------------------------------------------------------
     // Draws the clipping masks to the stencil buffer.
     {
-        const gl::debugging::group clip("clip");
+        MBGL_DEBUG_GROUP("clip");
 
         // Update all clipping IDs.
         ClipIDGenerator generator;
@@ -248,7 +248,7 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
     // - DEBUG PASS --------------------------------------------------------------------------------
     // Renders debug overlays.
     {
-        const gl::debugging::group _("debug");
+        MBGL_DEBUG_GROUP("debug");
 
         // Finalize the rendering, e.g. by calling debug render calls per tile.
         // This guarantees that we have at least one function per tile called.
@@ -262,7 +262,7 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
     // TODO: Find a better way to unbind VAOs after we're done with them without introducing
     // unnecessary bind(0)/bind(N) sequences.
     {
-        const gl::debugging::group _("cleanup");
+        MBGL_DEBUG_GROUP("cleanup");
 
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, 0));
         MBGL_CHECK_ERROR(VertexArrayObject::Unbind());
@@ -276,11 +276,11 @@ void Painter::renderPass(RenderPass pass_,
                          const float strataThickness) {
     pass = pass_;
 
-    const char * passName = pass == RenderPass::Opaque ? "opaque" : "translucent";
-    const gl::debugging::group _(passName);
+    MBGL_DEBUG_GROUP(pass == RenderPass::Opaque ? "opaque" : "translucent");
 
     if (debug::renderTree) {
-        Log::Info(Event::Render, "%*s%s {", indent++ * 4, "", passName);
+        Log::Info(Event::Render, "%*s%s {", indent++ * 4, "",
+                  pass == RenderPass::Opaque ? "opaque" : "translucent");
     }
 
     config.blend = pass == RenderPass::Translucent;
@@ -289,13 +289,13 @@ void Painter::renderPass(RenderPass pass_,
         const auto& item = *it;
         if (item.bucket && item.tile) {
             if (item.hasRenderPass(pass)) {
-                const gl::debugging::group group(item.layer.id + " - " + std::string(item.tile->id));
+                MBGL_DEBUG_GROUP(item.layer.id + " - " + std::string(item.tile->id));
                 setStrata(i * strataThickness);
                 prepareTile(*item.tile);
                 item.bucket->render(*this, item.layer, item.tile->id, item.tile->matrix);
             }
         } else {
-            const gl::debugging::group group("background");
+            MBGL_DEBUG_GROUP("background");
             setStrata(i * strataThickness);
             renderBackground(item.layer);
         }

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -7,7 +7,7 @@
 using namespace mbgl;
 
 void Painter::drawClippingMasks(const std::set<Source*>& sources) {
-    gl::debugging::group group("clipping masks");
+    MBGL_DEBUG_GROUP("clipping masks");
 
     useProgram(plainShader->program);
     config.stencilTest = true;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -10,7 +10,7 @@
 using namespace mbgl;
 
 void Painter::renderTileDebug(const Tile& tile) {
-    gl::debugging::group group(std::string { "debug " } + std::string(tile.id));
+    MBGL_DEBUG_GROUP(std::string { "debug " } + std::string(tile.id));
     assert(tile.data);
     if (debug) {
         prepareTile(tile);
@@ -20,7 +20,7 @@ void Painter::renderTileDebug(const Tile& tile) {
 }
 
 void Painter::renderDebugText(DebugBucket& bucket, const mat4 &matrix) {
-    gl::debugging::group group("debug text");
+    MBGL_DEBUG_GROUP("debug text");
 
     config.depthTest = false;
 
@@ -47,7 +47,7 @@ void Painter::renderDebugText(DebugBucket& bucket, const mat4 &matrix) {
 }
 
 void Painter::renderDebugFrame(const mat4 &matrix) {
-    gl::debugging::group group("debug frame");
+    MBGL_DEBUG_GROUP("debug frame");
 
     // Disable depth test and don't count this towards the depth buffer,
     // but *don't* disable stencil test, as we want to clip the red tile border


### PR DESCRIPTION
In non-debug builds, our calls to `mbgl::gl::debugging::group` are technically no-ops, but the compiler fails to optimize them out, and generates the (sometimes very costly!) arguments to it.