### PR TITLE
Don't clip glyphs with the view frustum

### DIFF
--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -130,7 +130,7 @@ void Painter::lineWidth(float line_width) {
 
 void Painter::changeMatrix() {
     // Initialize projection matrix
-    matrix::ortho(projMatrix, 0, state.getWidth(), state.getHeight(), 0, 0, 1);
+    matrix::ortho(projMatrix, 0, state.getWidth(), state.getHeight(), 0, -1, 1);
 
     // The extrusion matrix.
     matrix::identity(extrudeMatrix);

--- a/src/mbgl/shader/sdf.vertex.glsl
+++ b/src/mbgl/shader/sdf.vertex.glsl
@@ -28,7 +28,7 @@ void main() {
     float a_maxzoom = a_zoom[1];
 
     // u_zoom is the current zoom level adjusted for the change in font size
-    float z = 2.0 - step(a_minzoom, u_zoom) - (1.0 - step(a_maxzoom, u_zoom));
+    float show = step(a_minzoom, u_zoom) * (1.0 - step(a_maxzoom, u_zoom));
 
     // fade out labels
     float alpha = clamp((u_fadezoom - a_labelminzoom) / u_fadedist, 0.0, 1.0);
@@ -46,8 +46,8 @@ void main() {
     }
 
     // if label has been faded out, clip it
-    z += step(v_alpha, 0.0);
+    show *= (1.0 - step(v_alpha, 0.0));
 
-    gl_Position = u_matrix * vec4(a_pos, 0, 1) + u_exmatrix * vec4(a_offset / 64.0, z, 0);
+    gl_Position = u_matrix * vec4(a_pos, 0, 1) + u_exmatrix * vec4(a_offset * show / 64.0, 0, 0);
     v_tex = a_tex / u_texsize;
 }


### PR DESCRIPTION
Instead, we should generate degenerate triangles. This will likely fix a few floating precision errors on various non-Apple GPUs.