### PR TITLE
Pause metrics-collection when app is suspended

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -763,6 +763,10 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     {
         self.dormant = YES;
 
+        if (self.locationManager) {
+            [self.locationManager stopUpdatingLocation];
+        }
+        [MGLMapboxEvents pauseMetricsCollection];
         [MGLMapboxEvents flush];
 
         if ( ! self.glSnapshotView)
@@ -797,6 +801,10 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     {
         self.dormant = NO;
         
+        if (_showsUserLocation && self.locationManager) {
+            [self.locationManager startUpdatingLocation];
+        }
+
         [self createGLView];
         [MGLMapboxEvents validate];
 
@@ -2198,8 +2206,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         self.userLocationAnnotationView = [[MGLUserLocationAnnotationView alloc] initInMapView:self];
         self.userLocationAnnotationView.autoresizingMask = (UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin |
                                                             UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin);
-
-        self.locationManager = [CLLocationManager new];
+        self.locationManager = [[CLLocationManager alloc] init];
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         // enable iOS 8+ location authorization API


### PR DESCRIPTION
Pause metrics-collection when app is suspended otherwise `MGLMapboxEvents` continues to run its locationManager.  Since `Mapbox` only requests `NSLocationWhenInUse` authorization, if another module (like [mine](https://github.com/transistorsoft/react-native-background-geolocation), for instance) requests `NSLocationAlwaysUsageDescription` authorization, and enables the `location` in **Background Modes**:

![](https://www.dropbox.com/s/539uq1vik40yz0e/Screenshot%202015-08-18%2014.29.44.png?dl=1)

`MGLMapboxEvents`' `locationManager` will continue updating-location, even when the app is suspended **preventing iOS from suspending the app**.  

This puts a huge drain on the battery, of course, not only since the location-manager is running but because **the app is prevented from suspending**.
