### PR TITLE
Switching applications causes black screen, wildly colored snapshot

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -74,6 +74,8 @@ void MapContext::cleanup() {
 void MapContext::pause() {
     MBGL_CHECK_ERROR(glFinish());
 
+    viewInvalidated = false;
+
     view.deactivate();
 
     std::unique_lock<std::mutex> lockPause(data.mutexPause);
@@ -81,6 +83,8 @@ void MapContext::pause() {
     data.condResume.wait(lockPause);
 
     view.activate();
+
+    invalidateView();
 }
 
 void MapContext::triggerUpdate(const TransformState& state, const Update flags) {


### PR DESCRIPTION
Activating the application switcher when the user dot is visible causes the entire map view (other than ornaments and the user dot) to go black. The following screenshots are from the iOS 9 Simulator running as an iPhone 6:

![black-everything](https://cloud.githubusercontent.com/assets/1231218/9262421/a6e51f8a-41c9-11e5-8169-2096775a6920.png)

While the application is in the background, the snapshot we throw up on-screen has an artistic flair to it that suggests texture or [z-fighting](https://github.com/mapbox/mapbox-gl-native/issues/1702#issuecomment-127375809) issues. As soon as the entering-foreground animation completes, we take down the snapshot and the black screen returns.

![switching](https://cloud.githubusercontent.com/assets/1231218/9262494/1b870a06-41ca-11e5-9c0e-c580c7b09939.png)

![switched](https://cloud.githubusercontent.com/assets/1231218/9262497/2a68ebfc-41ca-11e5-8e36-b72848451f00.png)

If you enter the application switcher while the user dot is hidden, the snapshot is correct, although the black screen does come back as soon as you switch back to the application:

![switching-good](https://cloud.githubusercontent.com/assets/1231218/9262537/74d2fa52-41ca-11e5-96ee-0208defad798.png)

![switched-good](https://cloud.githubusercontent.com/assets/1231218/9262549/85d556f6-41ca-11e5-8d67-15eff3f9d8e9.png)

Notice how some features do appear in the corrupted snapshot, including a school grounds, part of a highway, and some terrain tinting.

The same thing happens on the iOS 8.4 Simulator running as an iPhone 6:

![switching-8 4](https://cloud.githubusercontent.com/assets/1231218/9262673/86629358-41cb-11e5-92da-9d78a24f21d3.png)

If you merely activate the application switcher but don’t switch away from iosapp, you’re left with a live, shrunken view of the application. In this state, you can sometimes see the colored splotches shifting around as the map redraws.

Unlike #2012, nothing is logged to the console.

/cc @kkaefer @incanus @friedbunny