### PR TITLE
Speed up time to first render call

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -334,6 +334,7 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
     if (!painter) {
         painter = std::make_unique<Painter>(data);
         painter->setup();
+        painter->updateRenderOrder(*style);
     }
 
     painter->setDebug(data.getDebug());
@@ -399,6 +400,10 @@ void MapContext::setSprite(const std::string& name, std::shared_ptr<const Sprite
 
 void MapContext::onTileDataChanged() {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+    if (painter) {
+        painter->updateRenderOrder(*style);
+    }
 
     updateFlags |= Update::Repaint;
     asyncUpdate->send();

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -529,9 +529,14 @@ void Source::invalidateTiles(const std::unordered_set<TileID, TileID::Hash>& ids
 }
 
 void Source::updateTilePtrs() {
-    tilePtrs.clear();
+    std::vector<Tile*> newPtrs;
     for (const auto& pair : tiles) {
-        tilePtrs.push_back(pair.second.get());
+        newPtrs.push_back(pair.second.get());
+    }
+
+    if (tilePtrs != newPtrs) {
+        tilePtrs = newPtrs;
+        emitTileLoaded(true);
     }
 }
 

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -134,11 +134,11 @@ public:
 
     bool needsAnimation() const;
 
+    void updateRenderOrder(const Style& style);
+
 private:
     void setupShaders();
     mat4 translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const TileID &id, TranslateAnchorType anchor);
-
-    std::vector<RenderItem> determineRenderOrder(const Style& style);
 
     template <class Iterator>
     void renderPass(RenderPass,
@@ -200,6 +200,8 @@ private:
     RenderPass pass = RenderPass::Opaque;
     const float strata_epsilon = 1.0f / (1 << 16);
     Color background = {{ 0, 0, 0, 0 }};
+
+    std::vector<RenderItem> order;
 
 public:
     FrameHistory frameHistory;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -63,19 +63,13 @@ struct ClipID;
 struct RenderItem {
     inline RenderItem(const StyleLayer& layer_,
                       const Tile* tile_ = nullptr,
-                      Bucket* bucket_ = nullptr,
-                      RenderPass passes_ = RenderPass::Opaque)
-        : tile(tile_), bucket(bucket_), layer(layer_), passes(passes_) {
+                      Bucket* bucket_ = nullptr)
+        : tile(tile_), bucket(bucket_), layer(layer_) {
     }
 
     const Tile* const tile;
     Bucket* const bucket;
     const StyleLayer& layer;
-    const RenderPass passes;
-
-    inline bool hasRenderPass(RenderPass pass) const {
-        return bool(passes & pass);
-    }
 };
 
 class Painter : private util::noncopyable {
@@ -145,7 +139,6 @@ private:
     mat4 translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const TileID &id, TranslateAnchorType anchor);
 
     std::vector<RenderItem> determineRenderOrder(const Style& style);
-    static RenderPass determineRenderPasses(const StyleLayer&);
 
     template <class Iterator>
     void renderPass(RenderPass,

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -7,6 +7,8 @@
 #include <mbgl/style/applied_class_properties.hpp>
 #include <mbgl/style/zoom_history.hpp>
 
+#include <mbgl/renderer/render_pass.hpp>
+
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/chrono.hpp>
@@ -35,8 +37,9 @@ public:
     // Determines whether this layer is the background layer.
     bool isBackground() const;
 
-    // Checks whether the layer is currently visible at all.
-    bool isVisible() const;
+public:
+    // Checks whether this layer needs to be rendered in the given render pass.
+    bool hasRenderPass(RenderPass) const;
 
     // Updates the StyleProperties information in this layer by evaluating all
     // pending transitions and applied classes in order.
@@ -62,6 +65,9 @@ private:
     // Removes all expired style transitions.
     void cleanupAppliedStyleProperties(const TimePoint& now);
 
+    // Checks whether the layer is currently visible at all.
+    bool isVisible() const;
+
 public:
     // The name of this layer.
     const std::string id;
@@ -79,6 +85,10 @@ private:
     // For every property, stores a list of applied property values, with
     // optional transition times.
     std::map<PropertyKey, AppliedClassPropertyValues> appliedStyle;
+
+    // Stores what render passes this layer is currently enabled for. This depends on the
+    // evaluated StyleProperties object and is updated accordingly.
+    RenderPass passes = RenderPass::None;
 
 public:
     // Stores the evaluated, and cascaded styling information, specific to this


### PR DESCRIPTION
I measured the time from the main thread calling `renderSync()` to us actually issuing our first render call (`glClear`). On an iPad 2, this is ~1.7ms, which is >10% of the total frame time. Most of this time is spent in `Painter::determineRenderOrder`, in particular the lookup of buckets by name in a tile object is very slow (and takes ~80% of the time).

Instead of building a list of all buckets we have to render on every frame, this list should be updated whenever we add/remove buckets/tiles, so we don't first have to build a list of things on every frame. Most frames don't actually see any changes to this list, in particular when panning.