### PR TITLE
Move FrameHistory::getFadeProperties to animation time

### DIFF
--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -3,7 +3,7 @@
 using namespace mbgl;
 
 // Record frame history that will be used to calculate fading params
-void FrameHistory::record(const TimePoint& now, float zoom) {
+void FrameHistory::record(const TimePoint now, float zoom) {
     // first frame ever
     if (history.empty()) {
         history.emplace_back(FrameSnapshot{TimePoint::min(), zoom});
@@ -47,15 +47,13 @@ bool FrameHistory::needsAnimation(const Duration& duration) const {
     return false;
 }
 
-FadeProperties FrameHistory::getFadeProperties(const Duration& duration) {
-    const TimePoint currentTime = Clock::now();
-
+FadeProperties FrameHistory::getFadeProperties(const TimePoint now, const Duration& duration) {
     // Remove frames until only one is outside the duration, or until there are only three
-    while (history.size() > 3 && history[1].now + duration < currentTime) {
+    while (history.size() > 3 && history[1].now + duration < now) {
         history.pop_front();
     }
 
-    if (history[1].now + duration < currentTime) {
+    if (history[1].now + duration < now) {
         history[0].z = history[1].z;
     }
 
@@ -74,7 +72,7 @@ FadeProperties FrameHistory::getFadeProperties(const Duration& duration) {
 
     // At end of a zoom when the zoom stops changing continue pretending to zoom at that speed
     // bump is how much farther it would have been if it had continued zooming at the same rate
-    float bump = std::chrono::duration<float>(currentTime - lastFrame.now) / duration * fadedist;
+    float bump = std::chrono::duration<float>(now - lastFrame.now) / duration * fadedist;
 
     return FadeProperties {
         fadedist,

--- a/src/mbgl/renderer/frame_history.hpp
+++ b/src/mbgl/renderer/frame_history.hpp
@@ -11,7 +11,7 @@
 namespace mbgl {
 
 struct FrameSnapshot {
-    explicit inline FrameSnapshot(const TimePoint& now_, float z_) : now(now_), z(z_) {}
+    explicit inline FrameSnapshot(TimePoint now_, float z_) : now(now_), z(z_) {}
     const TimePoint now;
     float z;
 };
@@ -26,10 +26,10 @@ struct FadeProperties {
 class FrameHistory {
 public:
     // Record frame history that will be used to calculate fading params
-    void record(const TimePoint& now, float zoom);
+    void record(TimePoint now, float zoom);
 
     bool needsAnimation(const Duration& duration) const;
-    FadeProperties getFadeProperties(const Duration& duration);
+    FadeProperties getFadeProperties(TimePoint now, const Duration& duration);
 
 public:
     std::deque<FrameSnapshot> history;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -53,7 +53,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
 
     sdfShader.u_zoom = (state.getNormalizedZoom() - zoomAdjust) * 10; // current zoom level
 
-    FadeProperties f = frameHistory.getFadeProperties(data.getDefaultFadeDuration());
+    FadeProperties f = frameHistory.getFadeProperties(data.getAnimationTime(), data.getDefaultFadeDuration());
     sdfShader.u_fadedist = f.fadedist * 10;
     sdfShader.u_minfadezoom = std::floor(f.minfadezoom * 10);
     sdfShader.u_maxfadezoom = std::floor(f.maxfadezoom * 10);


### PR DESCRIPTION
`FrameHistory::getFadeProperties` currently calls `chrono::steady_clock::now()` on every invocation. Instead, we should use the global animation time to prevent issues with different parts of the app using different clocks. Additionally, not querying the time will improve the speed.