### PR TITLE
Don't validate/delete shaders

### DIFF
--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -67,31 +67,6 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
         }
     }
 
-    {
-        // Validate program
-        GLint status;
-        MBGL_CHECK_ERROR(glValidateProgram(program));
-
-        MBGL_CHECK_ERROR(glGetProgramiv(program, GL_VALIDATE_STATUS, &status));
-        if (status == 0) {
-            GLint logLength;
-            MBGL_CHECK_ERROR(glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength));
-            const auto log = std::make_unique<GLchar[]>(logLength);
-            if (logLength > 0) {
-                MBGL_CHECK_ERROR(glGetProgramInfoLog(program, logLength, &logLength, log.get()));
-                Log::Error(Event::Shader, "Program failed to validate: %s", log.get());
-            }
-
-            MBGL_CHECK_ERROR(glDeleteShader(vertShader));
-            vertShader = 0;
-            MBGL_CHECK_ERROR(glDeleteShader(fragShader));
-            fragShader = 0;
-            MBGL_CHECK_ERROR(glDeleteProgram(program));
-            program = 0;
-            throw util::ShaderException(std::string { "Program " } + name + " failed to link: " + log.get());
-        }
-    }
-
     // Remove the compiled shaders; they are now part of the program.
     MBGL_CHECK_ERROR(glDetachShader(program, vertShader));
     MBGL_CHECK_ERROR(glDeleteShader(vertShader));

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -20,8 +20,6 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
 
     program = MBGL_CHECK_ERROR(glCreateProgram());
 
-    GLuint vertShader = 0;
-    GLuint fragShader = 0;
     if (!compileShader(&vertShader, GL_VERTEX_SHADER, vertSource)) {
         Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertSource);
         MBGL_CHECK_ERROR(glDeleteProgram(program));
@@ -67,12 +65,6 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
         }
     }
 
-    // Remove the compiled shaders; they are now part of the program.
-    MBGL_CHECK_ERROR(glDetachShader(program, vertShader));
-    MBGL_CHECK_ERROR(glDeleteShader(vertShader));
-    MBGL_CHECK_ERROR(glDetachShader(program, fragShader));
-    MBGL_CHECK_ERROR(glDeleteShader(fragShader));
-
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 
@@ -115,7 +107,13 @@ bool Shader::compileShader(GLuint *shader, GLenum type, const GLchar *source) {
 
 Shader::~Shader() {
     if (program) {
+        MBGL_CHECK_ERROR(glDetachShader(program, vertShader));
+        MBGL_CHECK_ERROR(glDetachShader(program, fragShader));
         MBGL_CHECK_ERROR(glDeleteProgram(program));
         program = 0;
+        MBGL_CHECK_ERROR(glDeleteShader(vertShader));
+        vertShader = 0;
+        MBGL_CHECK_ERROR(glDeleteShader(fragShader));
+        fragShader = 0;
     }
 }

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -28,6 +28,9 @@ protected:
 
 private:
     bool compileShader(uint32_t *shader, uint32_t type, const char *source);
+
+    uint32_t vertShader = 0;
+    uint32_t fragShader = 0;
 };
 
 }


### PR DESCRIPTION
Some GPU drivers, such as the Tegra 3 (used in the Nexus 7) seem to have issues with our call to `glValidateProgram`. They are technically right about not validating since the time when we validate our shaders, we don't have the correct OpenGL state (e.g. textures) set yet.

Similarly, we're calling `glDeleteShader` in the shader object constructor, after the shader has been attached to the program. While this is technically correct according to the spec, this particular driver seems to crash when doing deleting the shader object. Instead, we can just hold off on deleting the shader object until the shader destructor.