### PR TITLE
Reverse and quicken quickzoom gesture

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1339,7 +1339,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     {
         CGFloat distance = [quickZoom locationInView:quickZoom.view].y - self.quickZoomStart;
 
-        CGFloat newZoom = log2f(self.scale) + (distance / 100);
+        CGFloat newZoom = log2f(self.scale) + (distance / 75);
 
         if (newZoom < _mbglMap->getMinZoom()) return;
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -370,7 +370,8 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     {
         _quickZoom = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleQuickZoomGesture:)];
         _quickZoom.numberOfTapsRequired = 1;
-        _quickZoom.minimumPressDuration = 0.25;
+        _quickZoom.minimumPressDuration = 0;
+        [_quickZoom requireGestureRecognizerToFail:doubleTap];
         [self addGestureRecognizer:_quickZoom];
     }
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1336,7 +1336,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }
     else if (quickZoom.state == UIGestureRecognizerStateChanged)
     {
-        CGFloat distance = self.quickZoomStart - [quickZoom locationInView:quickZoom.view].y;
+        CGFloat distance = [quickZoom locationInView:quickZoom.view].y - self.quickZoomStart;
 
         CGFloat newZoom = log2f(self.scale) + (distance / 100);
 


### PR DESCRIPTION
This enhances the existing quickzoom gesture:

- Double-tap and hold now immediately engages quickzoom, presuming normal double-tap fails
- During the gesture, moving your finger up now zooms out, moving down zooms in (i.e., reversed)
- Zooming happens slightly more quickly/is more sensitive

/cc @incanus @1ec5 @bleege