### PR TITLE
remove Bright, Basic, and Outdoors from iOS testing

### DIFF
--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -13,9 +13,6 @@ static NSArray *const kStyleNames = @[
     @"Emerald",
     @"Light",
     @"Dark",
-    @"Bright",
-    @"Basic",
-    @"Outdoors",
     @"Satellite",
 ];
 


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/pull/2160 & https://github.com/mapbox/mapbox-gl-styles/issues/59. 