### PR TITLE
Fixed missing labels and icons

### DIFF
--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -2,6 +2,7 @@
 
 #include <stdexcept>
 #include <vector>
+#include <iostream>
 
 namespace mbgl {
 namespace util {
@@ -19,7 +20,12 @@ std::vector<std::string> getMapboxURLPathname(const std::string& url) {
     std::size_t startIndex = protocol.length();
     while (startIndex < url.length()) {
         std::size_t endIndex = url.find("/", startIndex);
-        if (endIndex == std::string::npos) endIndex = url.length();
+        if (endIndex == std::string::npos) {
+            endIndex = url.find_first_of("?#");
+        }
+        if (endIndex == std::string::npos) {
+            endIndex = url.length();
+        }
         pathname.push_back(url.substr(startIndex, endIndex - startIndex));
         startIndex = endIndex + 1;
     }
@@ -80,7 +86,10 @@ std::string normalizeGlyphsURL(const std::string& url, const std::string& access
 
     std::vector<std::string> pathname = getMapboxURLPathname(url);
     std::string user = pathname[1];
-    return baseURL + "fonts/v1/" + user + "/{fontstack}/{range}.pbf?access_token=" + accessToken;
+    std::string fontstack = pathname[2];
+    std::string range = pathname[3];
+
+    return baseURL + "fonts/v1/" + user + "/" + fontstack + "/" + range + "?access_token=" + accessToken;
 }
 
 std::string normalizeTileURL(const std::string& url, const std::string& sourceURL, SourceType sourceType) {

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -14,6 +14,7 @@ TEST(Mapbox, SourceURL) {
 }
 
 TEST(Mapbox, GlyphsURL) {
+    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/boxmap/Comic%20Sans/0-255.pbf", "key"), "https://api.mapbox.com/fonts/v1/boxmap/Comic%20Sans/0-255.pbf?access_token=key");
     EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/boxmap/{fontstack}/{range}.pbf", "key"), "https://api.mapbox.com/fonts/v1/boxmap/{fontstack}/{range}.pbf?access_token=key");
     EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("http://path", "key"), "http://path");
 }


### PR DESCRIPTION
Looks like I missed a case in `normalizeGlyphsURL` in #2141, now captured in a new test case.

fixes #2164 

cc @jfirebaugh 

