### PR TITLE
changing style on v8 iOS/OS X consistently crashes

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -334,7 +334,6 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
     if (!painter) {
         painter = std::make_unique<Painter>(data);
         painter->setup();
-        painter->updateRenderOrder(*style);
     }
 
     painter->setDebug(data.getDebug());
@@ -400,10 +399,6 @@ void MapContext::setSprite(const std::string& name, std::shared_ptr<const Sprite
 
 void MapContext::onTileDataChanged() {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
-
-    if (painter) {
-        painter->updateRenderOrder(*style);
-    }
 
     updateFlags |= Update::Repaint;
     asyncUpdate->send();

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -529,14 +529,9 @@ void Source::invalidateTiles(const std::unordered_set<TileID, TileID::Hash>& ids
 }
 
 void Source::updateTilePtrs() {
-    std::vector<Tile*> newPtrs;
+    tilePtrs.clear();
     for (const auto& pair : tiles) {
-        newPtrs.push_back(pair.second.get());
-    }
-
-    if (tilePtrs != newPtrs) {
-        tilePtrs = newPtrs;
-        emitTileLoaded(true);
+        tilePtrs.push_back(pair.second.get());
     }
 }
 

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -5,6 +5,8 @@
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/mat4.hpp>
 
+#include <atomic>
+
 #define BUFFER_OFFSET(i) ((char*)nullptr + (i))
 
 namespace mbgl {
@@ -15,6 +17,8 @@ class TileID;
 
 class Bucket : private util::noncopyable {
 public:
+    Bucket() : uploaded(false) {}
+    
     // As long as this bucket has a Prepare render pass, this function is getting called. Typically,
     // this only happens once when the bucket is being rendered for the first time.
     virtual void upload() = 0;
@@ -33,7 +37,7 @@ public:
     virtual void swapRenderData() {}
 
 protected:
-    bool uploaded = false;
+    std::atomic<bool> uploaded;
 
 };
 

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -184,6 +184,9 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
     resize();
     changeMatrix();
 
+    // Figure out what buckets we have to draw and what order we have to draw them in.
+    const auto order = determineRenderOrder(style);
+
     // - UPLOAD PASS -------------------------------------------------------------------------------
     // Uploads all required buffers and images before we do any actual rendering.
     {
@@ -201,6 +204,7 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
             }
         }
     }
+
 
     // - CLIPPING MASKS ----------------------------------------------------------------------------
     // Draws the clipping masks to the stencil buffer.
@@ -272,8 +276,6 @@ void Painter::renderPass(RenderPass pass_,
                          const float strataThickness) {
     pass = pass_;
 
-    const double zoom = state.getZoom();
-
     MBGL_DEBUG_GROUP(pass == RenderPass::Opaque ? "opaque" : "translucent");
 
     if (debug::renderTree) {
@@ -286,13 +288,6 @@ void Painter::renderPass(RenderPass pass_,
     for (; it != end; ++it, i += increment) {
         const auto& item = *it;
         if (item.bucket && item.tile) {
-            // Skip this layer if it's outside the range of min/maxzoom.
-            // This may occur when there /is/ a bucket created for this layer, but the min/max-zoom
-            // is set to a fractional value, or value that is larger than the source maxzoom.
-            if (item.layer.bucket->min_zoom > zoom ||
-                item.layer.bucket->max_zoom <= zoom) {
-                continue;
-            }
             if (item.layer.hasRenderPass(pass)) {
                 MBGL_DEBUG_GROUP(item.layer.id + " - " + std::string(item.tile->id));
                 setStrata(i * strataThickness);
@@ -311,8 +306,8 @@ void Painter::renderPass(RenderPass pass_,
     }
 }
 
-void Painter::updateRenderOrder(const Style& style) {
-    order.clear();
+std::vector<RenderItem> Painter::determineRenderOrder(const Style& style) {
+    std::vector<RenderItem> order;
 
     for (const auto& layerPtr : style.layers) {
         const auto& layer = *layerPtr;
@@ -349,6 +344,15 @@ void Painter::updateRenderOrder(const Style& style) {
             continue;
         }
 
+        // Skip this layer if it's outside the range of min/maxzoom.
+        // This may occur when there /is/ a bucket created for this layer, but the min/max-zoom
+        // is set to a fractional value, or value that is larger than the source maxzoom.
+        const double zoom = state.getZoom();
+        if (layer.bucket->min_zoom > zoom ||
+            layer.bucket->max_zoom <= zoom) {
+            continue;
+        }
+
         const auto& tiles = source->getTiles();
         for (auto tile : tiles) {
             assert(tile);
@@ -362,6 +366,8 @@ void Painter::updateRenderOrder(const Style& style) {
             }
         }
     }
+
+    return order;
 }
 
 void Painter::renderBackground(const StyleLayer &layer_desc) {

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -137,11 +137,11 @@ public:
 
     bool needsAnimation() const;
 
-    void updateRenderOrder(const Style& style);
-
 private:
     void setupShaders();
     mat4 translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const TileID &id, TranslateAnchorType anchor);
+
+    std::vector<RenderItem> determineRenderOrder(const Style& style);
 
     template <class Iterator>
     void renderPass(RenderPass,
@@ -203,8 +203,6 @@ private:
     RenderPass pass = RenderPass::Opaque;
     const float strata_epsilon = 1.0f / (1 << 16);
     Color background = {{ 0, 0, 0, 0 }};
-
-    std::vector<RenderItem> order;
 
 public:
     FrameHistory frameHistory;


### PR DESCRIPTION
Repro: 

- iOS: Run test app, tap style name to switch from Streets to Emerald, crash
- OS X: Run test app, type `S` to switch from Streets to Emerald, crash

OS X: 

Crash in `item.bucket->upload();`: 

```
#0	0x0000000100227fd4 in mbgl::Painter::render(mbgl::Style const&, mbgl::TransformState, mbgl::FrameData const&, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/renderer/painter.cpp:200
#1	0x0000000100145837 in mbgl::MapContext::renderSync(mbgl::TransformState const&, mbgl::FrameData const&) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/map/map_context.cpp:341
#2	0x0000000100136bc0 in decltype(*(std::__1::forward<mbgl::MapContext*&>(fp0)).*fp(std::__1::forward<mbgl::TransformState&, mbgl::FrameData&>(fp1))) std::__1::__invoke<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState&, mbgl::FrameData&, void>(bool (mbgl::MapContext::*&&&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&&&, mbgl::TransformState&&&, mbgl::FrameData&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:380
#3	0x0000000100136b19 in std::__1::__bind_return<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, std::__1::tuple<>, _is_valid_bind_return<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, std::__1::tuple<> >::value>::type std::__1::__apply_functor<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, 0ul, 1ul, 2ul, std::__1::tuple<> >(bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>&, std::__1::__tuple_indices<0ul, 1ul, 2ul>, std::__1::tuple<>&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2023
#4	0x0000000100136a85 in std::__1::__bind_return<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, std::__1::tuple<>, _is_valid_bind_return<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, std::__1::tuple<> >::value>::type std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>::operator()<>() [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2086
#5	0x0000000100136a5a in decltype(std::__1::forward<std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>&>(std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#6	0x0000000100136a4c in std::__1::__packaged_task_func<std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>, std::__1::allocator<std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&> >, bool ()>::operator()() at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:1817
#7	0x0000000100118a3b in std::__1::__packaged_task_function<bool ()>::operator()() const [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:1999
#8	0x0000000100118a24 in std::__1::packaged_task<bool ()>::operator()() at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:2090
#9	0x00000001001186cc in void mbgl::util::RunLoop::Invoker<std::__1::packaged_task<bool ()>, std::__1::tuple<> >::invoke<>(std::__1::integer_sequence<unsigned long>) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/run_loop.hpp:133
#10	0x0000000100118568 in mbgl::util::RunLoop::Invoker<std::__1::packaged_task<bool ()>, std::__1::tuple<> >::operator()() at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/run_loop.hpp:113
#11	0x00000001003d337b in mbgl::util::RunLoop::process() at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/run_loop.cpp:27
#12	0x00000001003d93a1 in decltype(*(std::__1::forward<mbgl::util::RunLoop*&>(fp0)).*fp(std::__1::forward<>(fp1))) std::__1::__invoke<void (mbgl::util::RunLoop::*&)(), mbgl::util::RunLoop*&, void>(void (mbgl::util::RunLoop::*&&&)(), mbgl::util::RunLoop*&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:380
#13	0x00000001003d931b in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, _is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__apply_functor<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, 0ul, std::__1::tuple<> >(void (mbgl::util::RunLoop::*&)(), std::__1::tuple<mbgl::util::RunLoop*>&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2023
#14	0x00000001003d92f3 in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, _is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>::operator()<>() [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2086
#15	0x00000001003d92d7 in decltype(std::__1::forward<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#16	0x00000001003d92cc in std::__1::__function::__func<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>, std::__1::allocator<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*> >, void ()>::operator()() at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1370
#17	0x000000010001f03f in std::__1::function<void ()>::operator()() const at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1756
#18	0x0000000100160453 in uv::async::async_cb(uv_async_s*, int) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/uv_detail.hpp:127
#19	0x000000010047cc0f in uv__async_event at /Users/travis/build/mapbox/mason/mason_packages/.build/libuv-0.10.28/src/unix/async.c:80
#20	0x000000010047d00a in uv__async_io at /Users/travis/build/mapbox/mason/mason_packages/.build/libuv-0.10.28/src/unix/async.c:156
#21	0x0000000100498c99 in uv__io_poll at /Users/travis/build/mapbox/mason/mason_packages/.build/libuv-0.10.28/src/unix/kqueue.c:233
#22	0x000000010047d711 in uv_run at /Users/travis/build/mapbox/mason/mason_packages/.build/libuv-0.10.28/src/unix/core.c:317
#23	0x0000000100453d88 in uv::loop::run() at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/uv_detail.hpp:62
#24	0x000000010013de9b in void mbgl::util::Thread<mbgl::MapContext>::run<std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>, 0ul, 1ul, 2ul>(mbgl::util::ThreadContext, std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>&&, std::__1::integer_sequence<unsigned long, 0ul, 1ul, 2ul>) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/thread.hpp:125
#25	0x000000010013dcfb in mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()::operator()() const at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/thread.hpp:104
#26	0x000000010013d904 in std::__1::__invoke<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()>(decltype(std::__1::forward<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#27	0x000000010013d8f5 in _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_10MapContextEEC1IJRNS1_4ViewERNS1_10FileSourceERNS1_7MapDataEEEERKNS2_13ThreadContextEDpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:332
#28	0x000000010013d8d9 in std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()> >(void*, void*) at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:342
#29	0x00007fff89c6b05a in _pthread_body ()
#30	0x00007fff89c6afd7 in _pthread_start ()
#31	0x00007fff89c683ed in thread_start ()
```

iOS : 

Crash in `item.bucket->upload();`: 

```
#0	0x000000010eea6354 in mbgl::Painter::render(mbgl::Style const&, mbgl::TransformState, mbgl::FrameData const&, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/renderer/painter.cpp:200
#1	0x000000010edbebf7 in mbgl::MapContext::renderSync(mbgl::TransformState const&, mbgl::FrameData const&) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/map/map_context.cpp:341
#2	0x000000010edb0310 in decltype(*(std::__1::forward<mbgl::MapContext*&>(fp0)).*fp(std::__1::forward<mbgl::TransformState&, mbgl::FrameData&>(fp1))) std::__1::__invoke<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState&, mbgl::FrameData&, void>(bool (mbgl::MapContext::*&&&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&&&, mbgl::TransformState&&&, mbgl::FrameData&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:380
#3	0x000000010edb0269 in std::__1::__bind_return<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, std::__1::tuple<>, _is_valid_bind_return<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, std::__1::tuple<> >::value>::type std::__1::__apply_functor<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, 0ul, 1ul, 2ul, std::__1::tuple<> >(bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>&, std::__1::__tuple_indices<0ul, 1ul, 2ul>, std::__1::tuple<>&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2023
#4	0x000000010edb01d5 in std::__1::__bind_return<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, std::__1::tuple<>, _is_valid_bind_return<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&), std::__1::tuple<mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData>, std::__1::tuple<> >::value>::type std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>::operator()<>() [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2086
#5	0x000000010edb01aa in decltype(std::__1::forward<std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>&>(std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#6	0x000000010edb019c in std::__1::__packaged_task_func<std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&>, std::__1::allocator<std::__1::__bind<bool (mbgl::MapContext::*&)(mbgl::TransformState const&, mbgl::FrameData const&), mbgl::MapContext*&, mbgl::TransformState const&, mbgl::FrameData&> >, bool ()>::operator()() at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:1817
#7	0x000000010ed922ab in std::__1::__packaged_task_function<bool ()>::operator()() const [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:1999
#8	0x000000010ed92294 in std::__1::packaged_task<bool ()>::operator()() at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/future:2090
#9	0x000000010ed91f3c in void mbgl::util::RunLoop::Invoker<std::__1::packaged_task<bool ()>, std::__1::tuple<> >::invoke<>(std::__1::integer_sequence<unsigned long>) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/run_loop.hpp:133
#10	0x000000010ed91dd8 in mbgl::util::RunLoop::Invoker<std::__1::packaged_task<bool ()>, std::__1::tuple<> >::operator()() at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/run_loop.hpp:113
#11	0x000000010f05633b in mbgl::util::RunLoop::process() at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/run_loop.cpp:27
#12	0x000000010f05c361 in decltype(*(std::__1::forward<mbgl::util::RunLoop*&>(fp0)).*fp(std::__1::forward<>(fp1))) std::__1::__invoke<void (mbgl::util::RunLoop::*&)(), mbgl::util::RunLoop*&, void>(void (mbgl::util::RunLoop::*&&&)(), mbgl::util::RunLoop*&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:380
#13	0x000000010f05c2db in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, _is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__apply_functor<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, 0ul, std::__1::tuple<> >(void (mbgl::util::RunLoop::*&)(), std::__1::tuple<mbgl::util::RunLoop*>&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2023
#14	0x000000010f05c2b3 in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, _is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>::operator()<>() [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2086
#15	0x000000010f05c297 in decltype(std::__1::forward<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#16	0x000000010f05c28c in std::__1::__function::__func<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>, std::__1::allocator<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*> >, void ()>::operator()() at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1370
#17	0x000000010edd9d4f in std::__1::function<void ()>::operator()() const at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1756
#18	0x000000010edd9c93 in uv::async::async_cb(uv_async_s*, int) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/uv_detail.hpp:127
#19	0x000000010f12ed3e in uv__async_event at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/async.c:80
#20	0x000000010f12f128 in uv__async_io at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/async.c:156
#21	0x000000010f14ab3e in uv__io_poll at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/kqueue.c:233
#22	0x000000010f12f833 in uv_run at /Users/kkaefer/Code/mason/libuv-0.10.28/mason_packages/.build/libuv-0.10.28/src/unix/core.c:317
#23	0x000000010f12c3b8 in uv::loop::run() at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/uv_detail.hpp:62
#24	0x000000010edb75eb in void mbgl::util::Thread<mbgl::MapContext>::run<std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>, 0ul, 1ul, 2ul>(mbgl::util::ThreadContext, std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>&&, std::__1::integer_sequence<unsigned long, 0ul, 1ul, 2ul>) at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/thread.hpp:125
#25	0x000000010edb744b in mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()::operator()() const at /Users/incanus/Documents/Projects/Mapbox/gl-native/src/mbgl/util/thread.hpp:104
#26	0x000000010edb7054 in std::__1::__invoke<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()>(decltype(std::__1::forward<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()&&) [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:413
#27	0x000000010edb7045 in _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_10MapContextEEC1IJRNS1_4ViewERNS1_10FileSourceERNS1_7MapDataEEEERKNS2_13ThreadContextEDpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE [inlined] at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:332
#28	0x000000010edb7029 in std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()> >(void*, void*) at /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:342
#29	0x0000000112a9605a in _pthread_body ()
#30	0x0000000112a95fd7 in _pthread_start ()
#31	0x0000000112a933ed in thread_start ()
```

@jfirebaugh