### PR TITLE
Persist user tracking mode in iosapp

### DIFF
--- a/platform/darwin/settings_nsuserdefaults.mm
+++ b/platform/darwin/settings_nsuserdefaults.mm
@@ -30,7 +30,7 @@ void Settings_NSUserDefaults::load()
     pitch     = [settings[@"pitch"]     doubleValue];
     debug     = [settings[@"debug"]     boolValue];
     
-    unsigned uncheckedTrackingMode = [settings[@"trackingMode"] unsignedIntValue];
+    unsigned uncheckedTrackingMode = [settings[@"userTrackingMode"] unsignedIntValue];
     if (uncheckedTrackingMode > MGLUserTrackingModeNone &&
         uncheckedTrackingMode <= MGLUserTrackingModeFollowWithCourse)
     {


### PR DESCRIPTION
This typo prevented the tracking mode from being restored when relaunching iosapp.

/cc @incanus