### PR TITLE
Update title of attribution action sheet

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -280,7 +280,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     [self addSubview:_attributionButton];
     _attributionButtonConstraints = [NSMutableArray array];
     
-    _attributionSheet = [[UIActionSheet alloc] initWithTitle:@"Mapbox for iOS"
+    _attributionSheet = [[UIActionSheet alloc] initWithTitle:@"Mapbox iOS SDK"
                                                     delegate:self
                                            cancelButtonTitle:@"Cancel"
                                       destructiveButtonTitle:nil


### PR DESCRIPTION
This PR updates the title of the attribution action sheet from “Mapbox for iOS” to “Mapbox iOS SDK”, for consistency with the new branding.

ref #2175