### PR TITLE
fixes #1969: support for marker tapping in Android

### DIFF
--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -3,13 +3,16 @@ package com.mapbox.mapboxgl.views;
 import android.graphics.PointF;
 import android.view.Surface;
 
+import com.mapbox.mapboxgl.annotations.Annotation;
 import com.mapbox.mapboxgl.annotations.Marker;
 import com.mapbox.mapboxgl.annotations.Polygon;
 import com.mapbox.mapboxgl.annotations.Polyline;
+import com.mapbox.mapboxgl.geometry.BoundingBox;
 import com.mapbox.mapboxgl.geometry.LatLng;
 import com.mapbox.mapboxgl.geometry.LatLngZoom;
 import com.mapbox.mapboxgl.geometry.ProjectedMeters;
 
+import java.util.ArrayList;
 import java.util.List;
 
 // Class that wraps the native methods for convenience
@@ -353,6 +356,10 @@ class NativeMapView {
         nativeRemoveAnnotations(mNativeMapViewPtr, ids);
     }
 
+    public long[] getAnnotationsInBounds(BoundingBox bbox) {
+        return nativeGetAnnotationsInBounds(mNativeMapViewPtr, bbox);
+    }
+
     public void setSprite(String symbol, int width, int height, float scale, byte[] pixels) {
         nativeSetSprite(mNativeMapViewPtr, symbol, width, height, scale, pixels);
     }
@@ -562,6 +569,8 @@ class NativeMapView {
     private native void nativeRemoveAnnotation(long nativeMapViewPtr, long id);
 
     private native void nativeRemoveAnnotations(long nativeMapViewPtr, long[] id);
+
+    private native long[] nativeGetAnnotationsInBounds(long mNativeMapViewPtr, BoundingBox bbox);
 
     private native void nativeSetSprite(long nativeMapViewPtr, String symbol,
                                         int width, int height, float scale, byte[] pixels);

--- a/include/mbgl/android/jni.hpp
+++ b/include/mbgl/android/jni.hpp
@@ -43,6 +43,13 @@ extern jfieldID latLngZoomLatitudeId;
 extern jfieldID latLngZoomLongitudeId;
 extern jfieldID latLngZoomZoomId;
 
+extern jclass bboxClass;
+extern jmethodID bboxConstructorId;
+extern jfieldID bboxLatNorthId;
+extern jfieldID bboxLatSouthId;
+extern jfieldID bboxLonEastId;
+extern jfieldID bboxLonWestId;
+
 extern jclass markerClass;
 extern jmethodID markerConstructorId;
 extern jfieldID markerPositionId;


### PR DESCRIPTION
Just logs the marker ID to console right now. 

@bleege @ljbade give it a whirl and let me know how it could be better, in particular [this routine](https://github.com/mapbox/mapbox-gl-native/blob/0c58172020fb13e0596667f3fd2125df6fc33e1f/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java#L432-L449) feels a little wasteful, but I wasn't sure of the best way to make use of `ArrayList.contains()` otherwise given a `long[]`. 

We can tune this up possibly, then merge and pick up work in https://github.com/mapbox/mapbox-gl-native/issues/894 for popups connecting to this. 

Another weirdness is a `60x80` top two-thirds-weighted hit region felt best on Android as opposed to the `40x60` we use on iOS. I am making sure to take `MapView.mScreenDensity` into account. 