### PR TITLE
Tidy up iOS resources

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -61,6 +61,7 @@
         '../platform/ios/NSString+MGLAdditions.m',
         '../platform/ios/vendor/SMCalloutView/SMCalloutView.h',
         '../platform/ios/vendor/SMCalloutView/SMCalloutView.m',
+        '../platform/ios/resources/',
       ],
 
       'variables': {
@@ -105,7 +106,7 @@
           '../include',
         ],
         'mac_bundle_resources': [
-          '<!@(find ./platform/ios/resources -type f)',
+          '<!@(find ./platform/ios/resources -type f \! -name "README")',
         ],
       },
     },

--- a/platform/ios/resources/README
+++ b/platform/ios/resources/README
@@ -1,0 +1,5 @@
+When adding new image resources, make sure that you've reduced the file size as much as possible using a tool such as:
+
+ImageOptim — https://imageoptim.com
+
+See also: https://github.com/mapbox/mapbox-gl-native/pull/2227


### PR DESCRIPTION
Follows on from the monumentally insignificant image size reductions in #2227.

- Adds `README` to `platform/ios/resources/` reminding future-us to use ImageOptim
- Includes the `platform/ios/resources/` folder in the iOS Xcode project
- Excludes `README` from the final `.bundle` compilation

/cc @incanus @1ec5 