### PR TITLE
Upgrade Travis to Xcode 7 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
       osx_image: xcode6.4
       env: FLAVOR=osx BUILDTYPE=Debug
     - os: osx
-      osx_image: xcode6.4
+      osx_image: xcode7
       env: FLAVOR=ios BUILDTYPE=Release
     - os: linux
       env: FLAVOR=android ANDROID_ABI=arm-v7 BUILDTYPE=Release

--- a/scripts/ios/test.sh
+++ b/scripts/ios/test.sh
@@ -4,8 +4,11 @@ set -e
 set -o pipefail
 set -u
 
-xctool \
+xcodebuild \
     -project ./test/ios/ios-tests.xcodeproj \
     -scheme 'Mapbox GL Tests' \
-    -sdk iphonesimulator8.4 \
-    test
+    -sdk iphonesimulator \
+    -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
+    -destination 'platform=iOS Simulator,name=iPad 2,OS=latest' \
+    test \
+    | xcpretty

--- a/test/ios/App-Info.plist
+++ b/test/ios/App-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mapbox.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -28,6 +28,8 @@
 	<string>pk.eyJ1IjoianVzdGluIiwiYSI6Ik9RX3RRQzAifQ.dmOg_BAp1ywuDZMM7YsXRg</string>
 	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
 	<true/>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Strictly for testing purposes, promise!</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -40,8 +42,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Strictly for testing purposes, promise!</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/test/ios/Bundle-Info.plist
+++ b/test/ios/Bundle-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.mapbox.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -46,7 +46,7 @@
                    270,
                    @"setting direction should take effect");
 
-    [tester waitForTimeInterval:1];
+    [tester waitForTimeInterval:2];
 
     XCTAssertEqual(tester.compass.alpha,
                    1,
@@ -89,7 +89,7 @@
 
     [tester.mapView resetNorth];
 
-    [tester waitForTimeInterval:1];
+    [tester waitForTimeInterval:2];
 
     XCTAssertEqual(tester.mapView.direction,
                    0,

--- a/test/ios/ios-tests.xcodeproj/project.pbxproj
+++ b/test/ios/ios-tests.xcodeproj/project.pbxproj
@@ -41,19 +41,19 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		DA3BDF011BA2326400553BD2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDBD013A196DC3AE0033959E /* KIF.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9CC9673B1AD4B1B600576D13;
+			remoteInfo = KIFFramework;
+		};
 		DDBD0143196DC3AE0033959E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DDBD013A196DC3AE0033959E /* KIF.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = EABD46AA1857A0C700A5F081;
 			remoteInfo = KIF;
-		};
-		DDBD0145196DC3AE0033959E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DDBD013A196DC3AE0033959E /* KIF.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EB72047C1680DDAD00278DA2;
-			remoteInfo = "KIF-OCUnit";
 		};
 		DDBD0147196DC3AE0033959E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -68,13 +68,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = EABD46CD1857A0F300A5F081;
 			remoteInfo = "KIF Tests";
-		};
-		DDBD014B196DC3AE0033959E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DDBD013A196DC3AE0033959E /* KIF.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EB60ECEB177F8DB3005A041A;
-			remoteInfo = "KIF Tests-OCUnit";
 		};
 		DDBD0160196DC3D70033959E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -327,10 +320,9 @@
 			isa = PBXGroup;
 			children = (
 				DDBD0144196DC3AE0033959E /* libKIF.a */,
-				DDBD0146196DC3AE0033959E /* libKIF-OCUnit.a */,
 				DDBD0148196DC3AE0033959E /* Test Host.app */,
 				DDBD014A196DC3AE0033959E /* KIF Tests - XCTest.xctest */,
-				DDBD014C196DC3AE0033959E /* KIF Tests-OCUnit.octest */,
+				DA3BDF021BA2326400553BD2 /* KIF.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -396,7 +388,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = MGLT;
-				LastUpgradeCheck = 0620;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
 					DDBD0151196DC3D70033959E = {
@@ -430,18 +422,18 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		DA3BDF021BA2326400553BD2 /* KIF.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = KIF.framework;
+			remoteRef = DA3BDF011BA2326400553BD2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		DDBD0144196DC3AE0033959E /* libKIF.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libKIF.a;
 			remoteRef = DDBD0143196DC3AE0033959E /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DDBD0146196DC3AE0033959E /* libKIF-OCUnit.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libKIF-OCUnit.a";
-			remoteRef = DDBD0145196DC3AE0033959E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		DDBD0148196DC3AE0033959E /* Test Host.app */ = {
@@ -456,13 +448,6 @@
 			fileType = wrapper.cfbundle;
 			path = "KIF Tests - XCTest.xctest";
 			remoteRef = DDBD0149196DC3AE0033959E /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DDBD014C196DC3AE0033959E /* KIF Tests-OCUnit.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "KIF Tests-OCUnit.octest";
-			remoteRef = DDBD014B196DC3AE0033959E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -547,6 +532,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -618,6 +604,7 @@
 					../../build/ios/pkg/static,
 				);
 				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
@@ -641,6 +628,7 @@
 					../../build/ios/pkg/static,
 				);
 				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
@@ -651,12 +639,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Mapbox GL Tests.app/Mapbox GL Tests";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -680,6 +663,7 @@
 					XCTest,
 					"-ObjC",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
@@ -690,12 +674,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Mapbox GL Tests.app/Mapbox GL Tests";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_PREPROCESSOR_DEFINITIONS = "KIF_XCTEST=1";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -715,6 +694,7 @@
 					XCTest,
 					"-ObjC",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;

--- a/test/ios/ios-tests.xcodeproj/xcshareddata/xcschemes/Mapbox GL Tests.xcscheme
+++ b/test/ios/ios-tests.xcodeproj/xcshareddata/xcschemes/Mapbox GL Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR upgrades our Travis builds to use an [Xcode 7 image](http://blog.travis-ci.com/2015-08-27-xcode-70-beta-for-oss/). The same image includes new versions of other packages too, so we should be on the lookout for any fallout from that:

> * OS X: 10.10.4 (was: 10.10.3)
> * RubyMotion: 3.14 (was: 3.13)
> * xctool: 0.25
> * Git 2.5.0 (was: 2.4.4)
> * OpenSSL: 1.0.2d_1 (was: 1.0.2c)

Fixes #2205 via #1957 and mapbox/mason#106.

/cc @incanus @kkaefer @friedbunny @bsudekum