### PR TITLE
When network is unreachable, always read from cache (even if expired)…

### DIFF
--- a/include/mbgl/storage/network_status.hpp
+++ b/include/mbgl/storage/network_status.hpp
@@ -11,6 +11,8 @@ namespace mbgl {
 class NetworkStatus {
 public:
     static void Reachable();
+    static void Unreachable();
+    static bool IsReachable();
 
     static void Subscribe(uv_async_t *async);
     static void Unsubscribe(uv_async_t *async);
@@ -18,6 +20,7 @@ public:
 private:
     static std::mutex mtx;
     static std::set<uv_async_t *> observers;
+    static bool reachable;
 };
 
 }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -251,6 +251,9 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     {
         _isWaitingForRedundantReachableNotification = YES;
     }
+    else {
+        mbgl::NetworkStatus::Unreachable();
+    }
     [reachability startNotifier];
 
     // setup annotations
@@ -431,10 +434,15 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 - (void)reachabilityChanged:(NSNotification *)notification
 {
     MGLReachability *reachability = [notification object];
-    if ( ! _isWaitingForRedundantReachableNotification && [reachability isReachable])
-    {
-        mbgl::NetworkStatus::Reachable();
+    if ([reachability isReachable]) {
+        if ( ! _isWaitingForRedundantReachableNotification) {
+            mbgl::NetworkStatus::Reachable();
+        }
     }
+    else {
+        mbgl::NetworkStatus::Unreachable();
+    }
+    
     _isWaitingForRedundantReachableNotification = NO;
 }
 

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/storage/request.hpp>
 #include <mbgl/storage/asset_context_base.hpp>
 #include <mbgl/storage/http_context_base.hpp>
+#include <mbgl/storage/network_status.hpp>
 
 #include <mbgl/storage/response.hpp>
 #include <mbgl/platform/platform.hpp>
@@ -118,7 +119,7 @@ void DefaultFileSource::Impl::startCacheRequest(DefaultFileRequest* request) {
         auto expired = [&response] {
             const int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
                                     SystemClock::now().time_since_epoch()).count();
-            return response->expires <= now;
+            return (response->expires <= now) && NetworkStatus::IsReachable();
         };
 
         if (!response || expired()) {

--- a/src/mbgl/storage/network_status.cpp
+++ b/src/mbgl/storage/network_status.cpp
@@ -11,6 +11,7 @@ namespace mbgl {
 
 std::mutex NetworkStatus::mtx;
 std::set<uv_async_t *> NetworkStatus::observers;
+bool NetworkStatus::reachable = true;
 
 void NetworkStatus::Subscribe(uv_async_t *async) {
     std::lock_guard<std::mutex> lock(NetworkStatus::mtx);
@@ -24,9 +25,19 @@ void NetworkStatus::Unsubscribe(uv_async_t *async) {
 
 void NetworkStatus::Reachable() {
     std::lock_guard<std::mutex> lock(NetworkStatus::mtx);
+    reachable = true;
     for (auto async : observers) {
         uv_async_send(async);
     }
 }
 
+void NetworkStatus::Unreachable() {
+    std::lock_guard<std::mutex> lock(NetworkStatus::mtx);
+    reachable = false;
+}
+
+bool NetworkStatus::IsReachable() {
+    return reachable;
+}
+    
 }


### PR DESCRIPTION
When network is unreachable, always read from cache (even if expired) rather than attempting to fetch remote data. Improves reliability of map view when network is unavailable.