### PR TITLE
tidy up Android packaging & remove 64-bit ABI's

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -315,6 +315,10 @@ When you plug your device in and then run or debug the Android project you will 
 
 If your device does not show up,  you have not set it up properly. Double check the [Google documentation](http://developer.android.com/tools/device.html).
 
+### Distribution
+
+Use the `Makefile` target `make apackage` in order to build JNI libraries for all supported ABI's for eventual distribution of the whole package. 
+
 ### Target
 
 Devices running Android 4.0+ (API level 14+).

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,9 @@ android: android-lib
 	cd android/java && ./gradlew --parallel --max-workers=$(JOBS) assemble$(BUILDTYPE)
 
 # Builds all android architectures for distribution.
-apackage: android-lib-arm-v5 android-lib-arm-v7 android-lib-arm-v8
-apackage: android-lib-x86 android-lib-x86-64
-apackage: android-lib-mips android-lib-mips-64
+apackage: android-lib-arm-v5 android-lib-arm-v7
+apackage: android-lib-x86
+apackage: android-lib-mips
 	cd android/java && ./gradlew --parallel-threads=$(JOBS) assemble$(BUILDTYPE)
 
 # Builds the Node.js library

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ android-lib: ; $(RUN) HOST=android Makefile/androidapp
 android: android-lib
 	cd android/java && ./gradlew --parallel --max-workers=$(JOBS) assemble$(BUILDTYPE)
 
-# Builds all android architectures.
-android-all: android-lib-arm-v5 android-lib-arm-v7 android-lib-arm-v8
-android-all: android-lib-x86 android-lib-x86-64
-android-all: android-lib-mips android-lib-mips-64
+# Builds all android architectures for distribution.
+apackage: android-lib-arm-v5 android-lib-arm-v7 android-lib-arm-v8
+apackage: android-lib-x86 android-lib-x86-64
+apackage: android-lib-mips android-lib-mips-64
 	cd android/java && ./gradlew --parallel-threads=$(JOBS) assemble$(BUILDTYPE)
 
 # Builds the Node.js library


### PR DESCRIPTION
Refs #1956. We should ship `0.1.0` with just 32-bit ABI's until we get a better handle on: 

1. Benefits of the 64-bit hassle on Android, particularly with NDK. 
1. How to solve #1956. 
1. How to best test all shipping ABI's (refs #1683). 

/cc @bleege @ljbade 