### PR TITLE
refs #2039: add passthroughs for adding/removing overlays

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -341,7 +341,7 @@ IB_DESIGNABLE
 /** Removes a single overlay object from the map.
 *
 *   If the specified overlay is not currently associated with the map view, this method does nothing.
-*   @param The overlay object to remove. */
+*   @param overlay The overlay object to remove. */
 - (void)removeOverlay:(id <MGLOverlay>)overlay;
 
 /** Removes one or more overlay objects from the map.

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol MGLMapViewDelegate;
 @protocol MGLAnnotation;
+@protocol MGLOverlay;
 
 /** An MGLMapView object provides an embeddable map interface, similar to the one provided by Apple's MapKit. You use this class to display map information and to manipulate the map contents from your application. You can center the map on a given coordinate, specify the size of the area you want to display, and style the features of the map to fit your application's use case.
 *
@@ -316,6 +317,38 @@ IB_DESIGNABLE
 *   @param annotation The annotation object to deselect.
 *   @param animated If `YES`, the callout view is animated offscreen. */
 - (void)deselectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated;
+
+#pragma mark - Adding Overlays
+
+/** @name Adding Overlays */
+
+/** Adds a single overlay object to the map.
+*
+*   To remove an overlay from a map, use the removeOverlay: method.
+*   @param overlay The overlay object to add. This object must conform to the MGLOverlay protocol. */
+- (void)addOverlay:(id <MGLOverlay>)overlay;
+
+/** Adds an array of overlay objects to the map.
+*
+*   To remove multiple overlays from a map, use the removeOverlays: method.
+*   @param overlays An array of objects, each of which must conform to the MGLOverlay protocol. */
+- (void)addOverlays:(NS_ARRAY_OF(id <MGLOverlay>) *)overlays;
+
+#pragma mark - Removing Overlays
+
+/** @name Removing Overlays */
+
+/** Removes a single overlay object from the map.
+*
+*   If the specified overlay is not currently associated with the map view, this method does nothing.
+*   @param The overlay object to remove. */
+- (void)removeOverlay:(id <MGLOverlay>)overlay;
+
+/** Removes one or more overlay objects from the map.
+*
+*   If a given overlay object is not associated with the map view, it is ignored.
+*   @param overlays An array of objects, each of which conforms to the MGLOverlay protocol. */
+- (void)removeOverlays:(NS_ARRAY_OF(id <MGLOverlay>) *)overlays;
 
 #pragma mark - Displaying the User's Location
 

--- a/ios/docs/install_docs.sh
+++ b/ios/docs/install_docs.sh
@@ -14,7 +14,7 @@ echo
 rm -rf /tmp/mbgl
 mkdir -p /tmp/mbgl/
 README=/tmp/mbgl/GL-README.md
-cat ../README.md > ${README}
+cat ./pod-README.md > ${README}
 echo >> ${README}
 echo -n "#" >> ${README}
 cat ../../CHANGELOG.md >> ${README}

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1910,7 +1910,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     for (id <MGLAnnotation> annotation in annotations)
     {
-        assert([annotation conformsToProtocol:@protocol(MGLAnnotation)]);
+        NSAssert([annotation conformsToProtocol:@protocol(MGLAnnotation)], @"annotation should conform to MGLAnnotation");
 
         if ([annotation isKindOfClass:[MGLMultiPoint class]])
         {
@@ -2082,7 +2082,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     for (id <MGLAnnotation> annotation in annotations)
     {
-        assert([annotation conformsToProtocol:@protocol(MGLAnnotation)]);
+        NSAssert([annotation conformsToProtocol:@protocol(MGLAnnotation)], @"annotation should conform to MGLAnnotation");
 
         NSDictionary *infoDictionary = [self.annotationIDsByAnnotation objectForKey:annotation];
         annotationIDsToRemove.push_back([[infoDictionary objectForKey:MGLAnnotationIDKey] unsignedIntValue]);
@@ -2107,7 +2107,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 {
     for (id <MGLOverlay> overlay in overlays)
     {
-        assert([overlay conformsToProtocol:@protocol(MGLOverlay)]);
+        NSAssert([overlay conformsToProtocol:@protocol(MGLOverlay)], @"overlay should conform to MGLOverlay");
     }
 
     [self addAnnotations:overlays];
@@ -2122,7 +2122,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 {
     for (id <MGLOverlay> overlay in overlays)
     {
-        assert([overlay conformsToProtocol:@protocol(MGLOverlay)]);
+        NSAssert([overlay conformsToProtocol:@protocol(MGLOverlay)], @"overlay should conform to MGLOverlay");
     }
 
     [self removeAnnotations:overlays];
@@ -2144,7 +2144,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     id <MGLAnnotation> firstAnnotation = selectedAnnotations[0];
 
-    assert([firstAnnotation conformsToProtocol:@protocol(MGLAnnotation)]);
+    NSAssert([firstAnnotation conformsToProtocol:@protocol(MGLAnnotation)], @"annotation should conform to MGLAnnotation");
 
     if ([firstAnnotation isKindOfClass:[MGLMultiPoint class]]) return;
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2098,6 +2098,36 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
     _mbglMap->removeAnnotations(annotationIDsToRemove);
 }
 
+- (void)addOverlay:(id <MGLOverlay>)overlay
+{
+    [self addOverlays:@[ overlay ]];
+}
+
+- (void)addOverlays:(NS_ARRAY_OF(id <MGLOverlay>) *)overlays
+{
+    for (id <MGLOverlay> overlay in overlays)
+    {
+        assert([overlay conformsToProtocol:@protocol(MGLOverlay)]);
+    }
+
+    [self addAnnotations:overlays];
+}
+
+- (void)removeOverlay:(id <MGLOverlay>)overlay
+{
+    [self removeOverlays:@[ overlay ]];
+}
+
+- (void)removeOverlays:(NS_ARRAY_OF(id <MGLOverlay>) *)overlays
+{
+    for (id <MGLOverlay> overlay in overlays)
+    {
+        assert([overlay conformsToProtocol:@protocol(MGLOverlay)]);
+    }
+
+    [self removeAnnotations:overlays];
+}
+
 - (MGLAnnotationImage *)dequeueReusableAnnotationImageWithIdentifier:(NSString *)identifier
 {
     return [self.annotationImages objectForKey:identifier];


### PR DESCRIPTION
Per #2039, this just adds passthroughs on the methods people expect to pass `id <MGLOverlay>` objects to, passing them to the core annotation(s) add/remove routines. When we flesh out shape ordering in #1728, we can later add the insert/reorder Cocoa routines that are more than mere passthroughs. 

Keep in mind that I am still `assert()` type checking here for environments which don't support Objective-C generics (given that our macro there silently adds backwards compatibility). 

/cc @1ec5 @friedbunny 