### PR TITLE
plumb map notifications through JNI to Android

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -1465,7 +1465,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         return JNI_ERR;
     }
 
-    onMapChangedId = env->GetMethodID(nativeMapViewClass, "onMapChanged", "()V");
+    onMapChangedId = env->GetMethodID(nativeMapViewClass, "onMapChanged", "(I)V");
     if (onMapChangedId == nullptr) {
         env->ExceptionDescribe();
         return JNI_ERR;

--- a/android/cpp/native_map_view.cpp
+++ b/android/cpp/native_map_view.cpp
@@ -637,7 +637,7 @@ void NativeMapView::resume() {
     }
 }
 
-void NativeMapView::notifyMapChange(mbgl::MapChange) {
+void NativeMapView::notifyMapChange(mbgl::MapChange change) {
     mbgl::Log::Debug(mbgl::Event::Android, "NativeMapView::notifyMapChange()");
 
     assert(vm != nullptr);
@@ -646,7 +646,7 @@ void NativeMapView::notifyMapChange(mbgl::MapChange) {
     JNIEnv *env = nullptr;
     bool detach = attach_jni_thread(vm, &env, "NativeMapView::notifyMapChange()");
 
-    env->CallVoidMethod(obj, onMapChangedId);
+    env->CallVoidMethod(obj, onMapChangedId, change);
     if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
     }

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -432,8 +432,8 @@ class NativeMapView {
         mMapView.onInvalidate();
     }
 
-    protected void onMapChanged() {
-        mMapView.onMapChanged();
+    protected void onMapChanged(int rawChange) {
+        mMapView.onMapChanged(rawChange);
     }
 
     protected void onFpsChanged(double fps) {


### PR DESCRIPTION
Passes through `mbgl::MapChange` notification types into native Java. 

Two review issues: 

1. I _think_ that I am using Java `enum` right here — backing with an `int value`, but since unable to instantiate in the style of classes, using a `switch` later on to deduce the raw `int` passed and map to the `enum` case. This seems verbose and redundant (i.e. specifying the raw values `-1` to `13` two times). 

1. Since we already made use of pure Java `updateMap()` in places, I added a Java-only case `MapChangeNullChange(-1)` for these cases. However I'm confused why/if we need to notify at all in these cases since we're only modifying map properties such as tracking state, compass visibility, and the like and not actually modifying fetch/parse/render properties. 

Unblocks https://github.com/mapbox/mapbox-gl-native/issues/894#issuecomment-137590751. 

/cc @bleege @ljbade 