### PR TITLE
map.render return only pixels

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -258,9 +258,6 @@ void NodeMap::renderFinished() {
 
         cb->Call(1, argv);
     } else if (img) {
-        auto result = NanNew<v8::Object>();
-        result->Set(NanNew("width"), NanNew(img->width));
-        result->Set(NanNew("height"), NanNew(img->height));
 
         v8::Local<v8::Object> pixels = NanNewBufferHandle(
             reinterpret_cast<char *>(img->pixels.get()),
@@ -274,11 +271,9 @@ void NodeMap::renderFinished() {
         );
         img.release();
 
-        result->Set(NanNew("pixels"), pixels);
-
         v8::Local<v8::Value> argv[] = {
             NanNull(),
-            result,
+            pixels,
         };
         cb->Call(2, argv);
     } else {

--- a/platform/node/test/js/gzip.test.js
+++ b/platform/node/test/js/gzip.test.js
@@ -62,7 +62,7 @@ test('gzip', function(t) {
 
         setup(getOptions(true, t), function(map) {
             map.load(style);
-            map.render({}, function(err, data) {
+            map.render({}, function(err, pixels) {
                 mbgl.removeAllListeners('message');
                 map.release();
 
@@ -71,11 +71,11 @@ test('gzip', function(t) {
                 var filename = filePath('success.png');
 
                 var png = new PNG({
-                    width: data.width,
-                    height: data.height
+                    width: 512,
+                    height: 512
                 });
 
-                png.data = data.pixels;
+                png.data = pixels;
 
                 if (process.env.UPDATE) {
                     png.pack()

--- a/platform/node/test/js/gzip.test.js
+++ b/platform/node/test/js/gzip.test.js
@@ -61,8 +61,9 @@ test('gzip', function(t) {
         });
 
         setup(getOptions(true, t), function(map) {
+            var options = { height: 512, width: 512 };
             map.load(style);
-            map.render({}, function(err, pixels) {
+            map.render(options, function(err, pixels) {
                 mbgl.removeAllListeners('message');
                 map.release();
 
@@ -70,10 +71,7 @@ test('gzip', function(t) {
 
                 var filename = filePath('success.png');
 
-                var png = new PNG({
-                    width: 512,
-                    height: 512
-                });
+                var png = new PNG(options);
 
                 png.data = pixels;
 

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -244,8 +244,9 @@ test('Map', function(t) {
 
         t.test('returns an image', function(t) {
             var map = new mbgl.Map(options);
+            console.log(options);
             map.load(style);
-            map.render({}, function(err, data) {
+            map.render({}, function(err, pixels) {
                 t.error(err);
 
                 map.release();
@@ -253,11 +254,11 @@ test('Map', function(t) {
                 var filename = filePath('image.png');
 
                 var png = new PNG({
-                    width: data.width,
-                    height: data.height
+                    width: 512,
+                    height: 512
                 });
 
-                png.data = data.pixels;
+                png.data = pixels;
 
                 if (process.env.UPDATE) {
                     png.pack()

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -244,7 +244,6 @@ test('Map', function(t) {
 
         t.test('returns an image', function(t) {
             var map = new mbgl.Map(options);
-            console.log(options);
             map.load(style);
             map.render({}, function(err, pixels) {
                 t.error(err);


### PR DESCRIPTION
Currently we're returning an object from the `map.render` function:

```json
{
  "height": 60,
  "width": 60,
  "pixels": "<SlowBuffer 34 43 45 ...>"
}
```

This is overkill since the height and width are already know _because they are necessary to render an image in the first place_. Although this is a small change, the system needs to allocate memory to do these processes which can add up. This change would no longer return an object but rather just the raw image buffer. 

/cc @mikemorris @springmeyer @jfirebaugh 
