### PR TITLE
Compile node bindings with Nan 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         apt:
           packages: [ 'lib32stdc++6' ]
     - os: linux
-      env: FLAVOR=node CXX=clang++-3.5 BUILDTYPE=Release NODE_VERSION=iojs-v2
+      env: FLAVOR=node CXX=clang++-3.5 BUILDTYPE=Release NODE_VERSION=iojs-v3
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
@@ -79,7 +79,7 @@ matrix:
     - os: osx
       osx_image: xcode6.4
       compiler: clang
-      env: FLAVOR=node NODE_VERSION=iojs-v2
+      env: FLAVOR=node NODE_VERSION=iojs-v3
     - os: osx
       osx_image: xcode6.4
       compiler: clang

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": {
-    "nan": "^2.0.8",
+    "nan": "nodejs/nan#a71301e0f62877ca017c4ebec7fbac9f4359038e",
     "node-pre-gyp": "^0.6.9"
   },
   "bundledDependencies": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": {
-    "nan": "^1.9.0",
+    "nan": "^2.0.8",
     "node-pre-gyp": "^0.6.9"
   },
   "bundledDependencies": [

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -9,6 +9,7 @@
   render options.
 - Adds support for rendering v8 styles.
 - No longer load resources before a render request is made.
+- Adds io.js v3.x support.
 
 # 1.1.3
 

--- a/platform/node/src/node_file_source.cpp
+++ b/platform/node/src/node_file_source.cpp
@@ -75,7 +75,7 @@ void NodeFileSource::processAdd(const mbgl::Resource& resource) {
         queue->ref();
     }
 
-    auto requestHandle = Nan::New<v8::Object>(NodeRequest::Create(this, resource));
+    v8::Local<v8::Object> requestHandle = NodeRequest::Create(this, resource)->ToObject();
     pending.emplace(resource, requestHandle);
 
     v8::Local<v8::Value> argv[] = { requestHandle };

--- a/platform/node/src/node_file_source.cpp
+++ b/platform/node/src/node_file_source.cpp
@@ -11,7 +11,7 @@ struct NodeFileSource::Action {
     mbgl::Resource const resource;
 };
 
-NodeFileSource::NodeFileSource(v8::Handle<v8::Object> options_) :
+NodeFileSource::NodeFileSource(v8::Local<v8::Object> options_) :
     queue(new Queue(uv_default_loop(), [this](Action &action) {
         if (action.type == Action::Add) {
             processAdd(action.resource);
@@ -20,7 +20,7 @@ NodeFileSource::NodeFileSource(v8::Handle<v8::Object> options_) :
         }
     }))
 {
-    NanAssignPersistent(options, options_->ToObject());
+    options.Reset(options_);
 
     // Make sure that the queue doesn't block the loop from exiting.
     queue->unref();
@@ -30,7 +30,7 @@ NodeFileSource::~NodeFileSource() {
     queue->stop();
     queue = nullptr;
 
-    NanDisposePersistent(options);
+    options.Reset();
 }
 
 mbgl::Request* NodeFileSource::request(const mbgl::Resource& resource, uv_loop_t* loop, Callback callback) {
@@ -68,44 +68,30 @@ void NodeFileSource::cancel(mbgl::Request* req) {
 }
 
 void NodeFileSource::processAdd(const mbgl::Resource& resource) {
-    NanScope();
+    Nan::HandleScope scope;
 
     // Make sure the loop stays alive as long as request is pending.
     if (pending.empty()) {
         queue->ref();
     }
 
-    auto requestHandle = NanNew<v8::Object>(NodeRequest::Create(this, resource));
-
-    v8::Persistent<v8::Object> requestPersistent;
-    NanAssignPersistent(requestPersistent, requestHandle);
-    pending.emplace(resource, std::move(requestPersistent));
-
-#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-    auto requestFunction = v8::Local<v8::Object>::New(v8::Isolate::GetCurrent(), options)->Get(NanNew("request")).As<v8::Function>();
-#else
-    auto requestFunction = options->Get(NanNew("request")).As<v8::Function>();
-#endif
+    auto requestHandle = Nan::New<v8::Object>(NodeRequest::Create(this, resource));
+    pending.emplace(resource, requestHandle);
 
     v8::Local<v8::Value> argv[] = { requestHandle };
-    NanMakeCallback(NanGetCurrentContext()->Global(), requestFunction, 1, argv);
+    Nan::MakeCallback(Nan::New(options), "request", 1, argv);
 }
 
 void NodeFileSource::processCancel(const mbgl::Resource& resource) {
-    NanScope();
+    Nan::HandleScope scope;
 
     auto it = pending.find(resource);
     if (it == pending.end()) {
         // The response callback was already fired. There is no point in calling the cancelation
         // callback because the request is already completed.
     } else {
-#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-        auto requestHandle = v8::Local<v8::Object>::New(v8::Isolate::GetCurrent(), it->second);
+        v8::Local<v8::Object> requestHandle = Nan::New(it->second);
         it->second.Reset();
-#else
-        auto requestHandle = NanNew<v8::Object>(it->second);
-        NanDisposePersistent(it->second);
-#endif
         pending.erase(it);
 
         // Make sure the the loop can exit when there are no pending requests.
@@ -113,20 +99,13 @@ void NodeFileSource::processCancel(const mbgl::Resource& resource) {
             queue->unref();
         }
 
-#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-        auto optionsObject = v8::Local<v8::Object>::New(v8::Isolate::GetCurrent(), options);
-        if (optionsObject->Has(NanNew("cancel"))) {
-            auto cancelFunction = optionsObject->Get(NanNew("cancel")).As<v8::Function>();
-#else
-        if (options->Has(NanNew("cancel"))) {
-            auto cancelFunction = options->Get(NanNew("cancel")).As<v8::Function>();
-#endif
+        if (Nan::Has(Nan::New(options), Nan::New("cancel").ToLocalChecked()).FromJust()) {
             v8::Local<v8::Value> argv[] = { requestHandle };
-            NanMakeCallback(NanGetCurrentContext()->Global(), cancelFunction, 1, argv);
+            Nan::MakeCallback(Nan::New(options), "cancel", 1, argv);
         }
 
         // Set the request handle in the request wrapper handle to null
-        node::ObjectWrap::Unwrap<NodeRequest>(requestHandle)->cancel();
+        Nan::ObjectWrap::Unwrap<NodeRequest>(requestHandle)->cancel();
     }
 }
 
@@ -134,11 +113,7 @@ void NodeFileSource::notify(const mbgl::Resource& resource, const std::shared_pt
     // First, remove the request, since it might be destructed at any point now.
     auto it = pending.find(resource);
     if (it != pending.end()) {
-#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
         it->second.Reset();
-#else
-        NanDisposePersistent(it->second);
-#endif
         pending.erase(it);
 
         // Make sure the the loop can exit when there are no pending requests.

--- a/platform/node/src/node_file_source.hpp
+++ b/platform/node/src/node_file_source.hpp
@@ -5,8 +5,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
-#include <node.h>
-#include <node_version.h>
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -20,7 +18,7 @@ namespace util { template <typename T> class AsyncQueue; }
 
 class NodeFileSource : public mbgl::FileSource {
 public:
-    NodeFileSource(v8::Handle<v8::Object>);
+    NodeFileSource(v8::Local<v8::Object>);
     ~NodeFileSource();
 
     mbgl::Request* request(const mbgl::Resource&, uv_loop_t*, Callback);
@@ -36,14 +34,10 @@ private:
     void processAdd(const mbgl::Resource&);
     void processCancel(const mbgl::Resource&);
 
-    v8::Persistent<v8::Object> options;
+    Nan::Persistent<v8::Object> options;
 
 private:
-#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-    std::unordered_map<mbgl::Resource, v8::Persistent<v8::Object, v8::CopyablePersistentTraits<v8::Object>>, mbgl::Resource::Hash> pending;
-#else
-    std::unordered_map<mbgl::Resource, v8::Persistent<v8::Object>, mbgl::Resource::Hash> pending;
-#endif
+    std::unordered_map<mbgl::Resource, Nan::Persistent<v8::Object>, mbgl::Resource::Hash> pending;
 
     // The observers list will hold pointers to all the requests waiting
     // for a particular resource. The access must be guarded by a mutex

--- a/platform/node/src/node_log.hpp
+++ b/platform/node/src/node_log.hpp
@@ -5,7 +5,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
-#include <node.h>
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -15,14 +14,14 @@ namespace util { template <typename T> class AsyncQueue; }
 
 class NodeLogObserver : public mbgl::Log::Observer {
 public:
-    NodeLogObserver(v8::Handle<v8::Object> target);
+    NodeLogObserver(v8::Local<v8::Object> target);
     ~NodeLogObserver();
 
     // Log::Observer implementation
     virtual bool onRecord(mbgl::EventSeverity severity, mbgl::Event event, int64_t code, const std::string &msg) override;
 
 private:
-    v8::Persistent<v8::Object> module;
+    Nan::Persistent<v8::Object> module;
 
     struct LogMessage;
     using Queue = util::AsyncQueue<LogMessage>;

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -280,7 +280,7 @@ void NodeMap::renderFinished() {
 
         v8::Local<v8::Value> argv[] = {
             Nan::Null(),
-            pixels,
+            pixels
         };
         cb->Call(2, argv);
     } else {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -322,7 +322,10 @@ void NodeMap::release() {
 // Instance
 
 NodeMap::NodeMap(v8::Local<v8::Object> options) :
-    view(sharedDisplay(), Nan::Get(options, Nan::New("ratio").ToLocalChecked()).ToLocalChecked()->NumberValue()),
+    view(sharedDisplay(), [&] {
+        Nan::HandleScope scope;
+        return Nan::Get(options, Nan::New("ratio").ToLocalChecked()).ToLocalChecked()->NumberValue();
+    }()),
     fs(options),
     map(std::make_unique<mbgl::Map>(view, fs, mbgl::MapMode::Still)),
     async(new uv_async_t) {

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -8,7 +8,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
-#include <node.h>
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -16,14 +15,13 @@
 
 namespace node_mbgl {
 
-class NodeMap : public node::ObjectWrap {
+class NodeMap : public Nan::ObjectWrap {
+public:
     struct RenderOptions;
     class RenderWorker;
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // Static Node Methods
-public:
-    static void Init(v8::Handle<v8::Object> target);
+    static NAN_MODULE_INIT(Init);
+
     static NAN_METHOD(New);
     static NAN_METHOD(Load);
     static NAN_METHOD(Render);
@@ -37,24 +35,20 @@ public:
     inline bool isLoaded() { return loaded; }
     inline bool isValid() { return valid; }
 
-    static std::unique_ptr<NodeMap::RenderOptions> ParseOptions(v8::Local<v8::Object> obj);
+    static std::unique_ptr<NodeMap::RenderOptions> ParseOptions(v8::Local<v8::Object>);
+    static Nan::Persistent<v8::Function> constructor;
 
-    static v8::Persistent<v8::FunctionTemplate> constructorTemplate;
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // Instance
 private:
-    NodeMap(v8::Handle<v8::Object>);
+    NodeMap(v8::Local<v8::Object>);
     ~NodeMap();
 
-private:
     mbgl::HeadlessView view;
     NodeFileSource fs;
     std::unique_ptr<mbgl::Map> map;
 
     std::exception_ptr error;
     std::unique_ptr<const mbgl::StillImage> image;
-    std::unique_ptr<NanCallback> callback;
+    std::unique_ptr<Nan::Callback> callback;
 
     // Async for delivering the notifications of render completion.
     uv_async_t *async;

--- a/platform/node/src/node_mapbox_gl_native.cpp
+++ b/platform/node/src/node_mapbox_gl_native.cpp
@@ -59,7 +59,7 @@ NAN_MODULE_INIT(RegisterModule) {
     Nan::SetPrototype(target,
         Nan::Get(EventEmitter, Nan::New("prototype").ToLocalChecked()).ToLocalChecked());
 
-    mbgl::Log::setObserver(std::make_unique<node_mbgl::NodeLogObserver>(Nan::New(target)));
+    mbgl::Log::setObserver(std::make_unique<node_mbgl::NodeLogObserver>(target->ToObject()));
 }
 
 NODE_MODULE(mapbox_gl_native, RegisterModule)

--- a/platform/node/src/node_mapbox_gl_native.cpp
+++ b/platform/node/src/node_mapbox_gl_native.cpp
@@ -9,30 +9,57 @@
 #include "node_log.hpp"
 #include "node_request.hpp"
 
-void RegisterModule(v8::Handle<v8::Object> exports) {
-    NanScope();
-
-    node_mbgl::NodeMap::Init(exports);
-    node_mbgl::NodeRequest::Init(exports);
+NAN_MODULE_INIT(RegisterModule) {
+    node_mbgl::NodeMap::Init(target);
+    node_mbgl::NodeRequest::Init(target);
 
     // Exports Resource constants.
-    auto ConstantProperty = static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-    auto resource = NanNew<v8::Object>();
-    resource->ForceSet(NanNew("Unknown"), NanNew(mbgl::Resource::Unknown), ConstantProperty);
-    resource->ForceSet(NanNew("Style"), NanNew(mbgl::Resource::Style), ConstantProperty);
-    resource->ForceSet(NanNew("Source"), NanNew(mbgl::Resource::Source), ConstantProperty);
-    resource->ForceSet(NanNew("Tile"), NanNew(mbgl::Resource::Tile), ConstantProperty);
-    resource->ForceSet(NanNew("Glyphs"), NanNew(mbgl::Resource::Glyphs), ConstantProperty);
-    resource->ForceSet(NanNew("SpriteImage"), NanNew(mbgl::Resource::SpriteImage), ConstantProperty);
-    resource->ForceSet(NanNew("SpriteJSON"), NanNew(mbgl::Resource::SpriteJSON), ConstantProperty);
-    exports->ForceSet(NanNew("Resource"), resource, ConstantProperty);
+    v8::Local<v8::Object> resource = Nan::New<v8::Object>();
 
-    // Make the exported object inerhit from process.EventEmitter
-    auto process = NanGetCurrentContext()->Global()->Get(NanNew("process"))->ToObject();
-    auto EventEmitter = process->Get(NanNew("EventEmitter"))->ToObject();
-    exports->SetPrototype(EventEmitter->Get(NanNew("prototype")));
+    Nan::Set(resource,
+        Nan::New("Unknown").ToLocalChecked(),
+        Nan::New(mbgl::Resource::Unknown));
 
-    mbgl::Log::setObserver(std::make_unique<node_mbgl::NodeLogObserver>(exports));
+    Nan::Set(resource,
+        Nan::New("Style").ToLocalChecked(),
+        Nan::New(mbgl::Resource::Style));
+
+    Nan::Set(resource,
+        Nan::New("Source").ToLocalChecked(),
+        Nan::New(mbgl::Resource::Source));
+
+    Nan::Set(resource,
+        Nan::New("Tile").ToLocalChecked(),
+        Nan::New(mbgl::Resource::Tile));
+
+    Nan::Set(resource,
+        Nan::New("Glyphs").ToLocalChecked(),
+        Nan::New(mbgl::Resource::Glyphs));
+
+    Nan::Set(resource,
+        Nan::New("SpriteImage").ToLocalChecked(),
+        Nan::New(mbgl::Resource::SpriteImage));
+
+    Nan::Set(resource,
+        Nan::New("SpriteJSON").ToLocalChecked(),
+        Nan::New(mbgl::Resource::SpriteJSON));
+
+    Nan::Set(target,
+        Nan::New("Resource").ToLocalChecked(),
+        resource);
+
+    // Make the exported object inherit from process.EventEmitter
+    v8::Local<v8::Object> process = Nan::Get(
+        Nan::GetCurrentContext()->Global(),
+        Nan::New("process").ToLocalChecked()).ToLocalChecked()->ToObject();
+
+    v8::Local<v8::Object> EventEmitter = Nan::Get(process,
+        Nan::New("EventEmitter").ToLocalChecked()).ToLocalChecked()->ToObject();
+
+    Nan::SetPrototype(target,
+        Nan::Get(EventEmitter, Nan::New("prototype").ToLocalChecked()).ToLocalChecked());
+
+    mbgl::Log::setObserver(std::make_unique<node_mbgl::NodeLogObserver>(Nan::New(target)));
 }
 
 NODE_MODULE(mapbox_gl_native, RegisterModule)

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -11,112 +11,111 @@ namespace node_mbgl {
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Static Node Methods
 
-v8::Persistent<v8::FunctionTemplate> NodeRequest::constructorTemplate;
+Nan::Persistent<v8::Function> NodeRequest::constructor;
 
-void NodeRequest::Init(v8::Handle<v8::Object> target) {
-    NanScope();
+NAN_MODULE_INIT(NodeRequest::Init) {
+    v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
 
-    v8::Local<v8::FunctionTemplate> t = NanNew<v8::FunctionTemplate>(New);
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tpl->SetClassName(Nan::New("Request").ToLocalChecked());
 
-    t->InstanceTemplate()->SetInternalFieldCount(1);
-    t->SetClassName(NanNew("Request"));
+    Nan::SetPrototypeMethod(tpl, "respond", Respond);
 
-    NODE_SET_PROTOTYPE_METHOD(t, "respond", Respond);
-
-    NanAssignPersistent(constructorTemplate, t);
-
-    target->Set(NanNew("Request"), t->GetFunction());
+    constructor.Reset(tpl->GetFunction());
+    Nan::Set(target, Nan::New("Request").ToLocalChecked(), tpl->GetFunction());
 }
 
 NAN_METHOD(NodeRequest::New) {
-    NanScope();
-
     // Extract the pointer from the first argument
-    if (args.Length() < 2 || !args[0]->IsExternal() || !args[1]->IsExternal()) {
-        return NanThrowTypeError("Cannot create Request objects explicitly");
+    if (info.Length() < 2 || !info[0]->IsExternal() || !info[1]->IsExternal()) {
+        return Nan::ThrowTypeError("Cannot create Request objects explicitly");
     }
 
-    auto source = reinterpret_cast<NodeFileSource*>(args[0].As<v8::External>()->Value());
-    auto resource = reinterpret_cast<mbgl::Resource*>(args[1].As<v8::External>()->Value());
+    auto source = reinterpret_cast<NodeFileSource*>(info[0].As<v8::External>()->Value());
+    auto resource = reinterpret_cast<mbgl::Resource*>(info[1].As<v8::External>()->Value());
     auto req = new NodeRequest(source, *resource);
-    req->Wrap(args.This());
+    req->Wrap(info.This());
 
-    NanReturnValue(args.This());
+    info.GetReturnValue().Set(info.This());
 }
 
 v8::Handle<v8::Object> NodeRequest::Create(NodeFileSource* source, const mbgl::Resource& resource) {
-    NanEscapableScope();
+    Nan::EscapableHandleScope scope;
 
-    v8::Local<v8::Value> argv[] = { NanNew<v8::External>(const_cast<NodeFileSource*>(source)),
-        NanNew<v8::External>(const_cast<mbgl::Resource*>(&resource)) };
-    auto instance = NanNew<v8::FunctionTemplate>(constructorTemplate)->GetFunction()->NewInstance(2, argv);
+    v8::Local<v8::Value> argv[] = {
+        Nan::New<v8::External>(const_cast<NodeFileSource*>(source)),
+        Nan::New<v8::External>(const_cast<mbgl::Resource*>(&resource))
+    };
+    auto instance = Nan::New(constructor)->NewInstance(2, argv);
 
-    instance->ForceSet(NanNew("url"), NanNew(resource.url), v8::ReadOnly);
-    instance->ForceSet(NanNew("kind"), NanNew<v8::Integer>(int(resource.kind)), v8::ReadOnly);
+    Nan::Set(instance, Nan::New("url").ToLocalChecked(), Nan::New(resource.url).ToLocalChecked());
+    Nan::Set(instance, Nan::New("kind").ToLocalChecked(), Nan::New<v8::Integer>(int(resource.kind)));
 
-    return NanEscapeScope(instance);
+    return scope.Escape(instance);
 }
 
 NAN_METHOD(NodeRequest::Respond) {
-    auto nodeRequest = ObjectWrap::Unwrap<NodeRequest>(args.Holder());
+    auto nodeRequest = Nan::ObjectWrap::Unwrap<NodeRequest>(info.Holder());
 
     // Request has already been responded to, or was canceled, fail silently.
-    if (!nodeRequest->resource) NanReturnUndefined();
+    if (!nodeRequest->resource) {
+        return info.GetReturnValue().SetUndefined();
+    }
 
     auto source = nodeRequest->source;
     auto resource = std::move(nodeRequest->resource);
 
-    if (args.Length() < 1) {
-        return NanThrowTypeError("First argument must be an error object");
-    } else if (args[0]->BooleanValue()) {
+    if (info.Length() < 1) {
+        return Nan::ThrowTypeError("First argument must be an error object");
+    } else if (info[0]->BooleanValue()) {
         auto response = std::make_shared<mbgl::Response>();
 
         response->status = mbgl::Response::Error;
 
         // Store the error string.
-        const NanUtf8String message { args[0]->ToString() };
+        const Nan::Utf8String message { info[0]->ToString() };
         response->message = std::string { *message, size_t(message.length()) };
 
         source->notify(*resource, response);
-    } else if (args.Length() < 2 || !args[1]->IsObject()) {
-        return NanThrowTypeError("Second argument must be a response object");
+    } else if (info.Length() < 2 || !info[1]->IsObject()) {
+        return Nan::ThrowTypeError("Second argument must be a response object");
     } else {
         auto response = std::make_shared<mbgl::Response>();
-        auto res = args[1]->ToObject();
+        auto res = info[1]->ToObject();
 
         response->status = mbgl::Response::Successful;
 
-        if (res->Has(NanNew("modified"))) {
-            const double modified = res->Get(NanNew("modified"))->ToNumber()->Value();
+        if (Nan::Has(res, Nan::New("modified").ToLocalChecked()).FromJust()) {
+            const double modified = Nan::Get(res, Nan::New("modified").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value();
             if (!std::isnan(modified)) {
                 response->modified = modified / 1000; // JS timestamps are milliseconds
             }
         }
 
-        if (res->Has(NanNew("expires"))) {
-            const double expires = res->Get(NanNew("expires"))->ToNumber()->Value();
+        if (Nan::Has(res, Nan::New("expires").ToLocalChecked()).FromJust()) {
+            const double expires = Nan::Get(res, Nan::New("expires").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value();
             if (!std::isnan(expires)) {
                 response->expires = expires / 1000; // JS timestamps are milliseconds
             }
         }
 
-        if (res->Has(NanNew("etag"))) {
-            auto etagHandle = res->Get(NanNew("etag"));
+        if (Nan::Has(res, Nan::New("etag").ToLocalChecked()).FromJust()) {
+            auto etagHandle = Nan::Get(res, Nan::New("etag").ToLocalChecked()).ToLocalChecked();
             if (etagHandle->BooleanValue()) {
-                const NanUtf8String etag { etagHandle->ToString() };
+                const Nan::Utf8String etag { etagHandle->ToString() };
                 response->etag = std::string { *etag, size_t(etag.length()) };
             }
         }
 
-        if (res->Has(NanNew("data"))) {
-            auto dataHandle = res->Get(NanNew("data"));
+        if (Nan::Has(res, Nan::New("data").ToLocalChecked()).FromJust()) {
+            auto dataHandle = Nan::Get(res, Nan::New("data").ToLocalChecked()).ToLocalChecked();
             if (node::Buffer::HasInstance(dataHandle)) {
                 response->data = std::string {
                     node::Buffer::Data(dataHandle),
                     node::Buffer::Length(dataHandle)
                 };
             } else {
-                return NanThrowTypeError("Response data must be a Buffer");
+                return Nan::ThrowTypeError("Response data must be a Buffer");
             }
         }
 
@@ -124,7 +123,7 @@ NAN_METHOD(NodeRequest::Respond) {
         source->notify(*resource, response);
     }
 
-    NanReturnUndefined();
+    info.GetReturnValue().SetUndefined();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/platform/node/src/node_request.hpp
+++ b/platform/node/src/node_request.hpp
@@ -3,7 +3,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
-#include <node.h>
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -15,21 +14,16 @@ namespace node_mbgl {
 
 class NodeFileSource;
 
-class NodeRequest : public node::ObjectWrap {
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // Static Node Methods
+class NodeRequest : public Nan::ObjectWrap {
 public:
-    static void Init(v8::Handle<v8::Object> target);
+    static NAN_MODULE_INIT(Init);
+
     static NAN_METHOD(New);
     static NAN_METHOD(Respond);
 
     static v8::Handle<v8::Object> Create(NodeFileSource*, const mbgl::Resource&);
+    static Nan::Persistent<v8::Function> constructor;
 
-    static v8::Persistent<v8::FunctionTemplate> constructorTemplate;
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    // Instance
-public:
     NodeRequest(NodeFileSource* source, const mbgl::Resource& resource);
     ~NodeRequest();
 


### PR DESCRIPTION
This is failing on render tests because the callback is getting called with an object that has "pixels": "pixels" -- yes, the value is literally the string "pixels" rather than a Buffer containing pixel data. I don't know why that's happening. Presumably something about how I'm [using `Nan::NewBuffer`](https://github.com/mapbox/mapbox-gl-native/blob/fdda46dcf572e7e2f9da50898506e1c44cf98409/platform/node/src/node_map.cpp#L273-273) is incorrect but I don't see what.

:eyes: @mikemorris 