### PR TITLE
Return raw image buffer instead of an object

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -258,10 +258,6 @@ void NodeMap::renderFinished() {
 
         cb->Call(1, argv);
     } else if (img) {
-        auto result = NanNew<v8::Object>();
-        result->Set(NanNew("width"), NanNew(img->width));
-        result->Set(NanNew("height"), NanNew(img->height));
-
         v8::Local<v8::Object> pixels = NanNewBufferHandle(
             reinterpret_cast<char *>(img->pixels.get()),
             size_t(img->width) * size_t(img->height) * sizeof(mbgl::StillImage::Pixel),
@@ -274,11 +270,9 @@ void NodeMap::renderFinished() {
         );
         img.release();
 
-        result->Set(NanNew("pixels"), pixels);
-
         v8::Local<v8::Value> argv[] = {
             NanNull(),
-            result,
+            pixels,
         };
         cb->Call(2, argv);
     } else {

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -231,14 +231,12 @@ test('Map', function(t) {
         t.test('returns an image', function(t) {
             var map = new mbgl.Map(options);
             map.load(style);
-            map.render({}, function(err, data) {
+            map.render({}, function(err, pixels) {
                 t.error(err);
 
                 map.release();
 
-                t.ok(data.pixels);
-                t.equal(data.width, 512);
-                t.equal(data.height, 512);
+                t.ok(pixels);
                 t.end();
             });
         });

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -233,10 +233,10 @@ test('Map', function(t) {
             map.load(style);
             map.render({}, function(err, pixels) {
                 t.error(err);
-
                 map.release();
-
                 t.ok(pixels);
+                t.ok(pixels instanceof Buffer);
+                t.equal(pixels.length, 512 * 512 * 4)
                 t.end();
             });
         });

--- a/platform/node/test/render.test.js
+++ b/platform/node/test/render.test.js
@@ -21,8 +21,8 @@ suite.run('native', {tests: tests}, function (style, options, callback) {
     });
 
     map.load(style);
-    map.render(options, function (err, result) {
+    map.render(options, function (err, pixels) {
         map.release();
-        callback(err, result && result.pixels);
+        callback(err, pixels);
     });
 });


### PR DESCRIPTION
_continuation of https://github.com/mapbox/mapbox-gl-native/pull/2258_ 

Currently we're returning an object from the `map.render` function:

```json
{
  "height": 60,
  "width": 60,
  "pixels": "<SlowBuffer 34 43 45 ...>"
}
```

This is overkill since the height and width are already know _because they are necessary to render an image in the first place_. Although this is a small change, the system needs to allocate memory to do these processes which can add up. This change would no longer return an object but rather just the raw image buffer. 

/cc @mikemorris @springmeyer @jfirebaugh 
