### PR TITLE
Fix iosapp location ask

### DIFF
--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -49,7 +49,6 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
 
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.mapView.showsUserLocation = YES;
     self.mapView.delegate = self;
     [self.view addSubview:self.mapView];
 
@@ -76,6 +75,13 @@ mbgl::Settings_NSUserDefaults *settings = nullptr;
 
     settings = new mbgl::Settings_NSUserDefaults();
     [self restoreState:nil];
+
+    if ( ! settings->showsUserLocation)
+    {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            self.mapView.showsUserLocation = YES;
+        });
+    }
 }
 
 - (void)saveState:(__unused NSNotification *)notification

--- a/ios/app/app-info.plist
+++ b/ios/app/app-info.plist
@@ -40,7 +40,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>(c) 2014 Mapbox</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>The map will be centered on the user's location.</string>
+	<string>The map will display the user&apos;s location.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>Default</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
The iosapp demo app was asking for location permission via `showsUserLocation = YES` in `viewDidLoad`, then immediately having `restoreState:` set `showsUserLocation = NO` because that's what the default is.

This PR lets `restoreState:` do the setting of `showsUserLocation` and then only asks for permissions if the value is `NO` — after a delay to allow the map to load.

Fixes #1930.

/cc @1ec5 @incanus