### PR TITLE
Use GL types for GL objects

### DIFF
--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -69,7 +69,7 @@ void VertexArrayObject::bindVertexArrayObject() {
 }
 
 void VertexArrayObject::verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer,
-                                      char *offset) {
+                                      GLbyte *offset) {
     if (bound_shader != shader.getID()) {
         throw std::runtime_error(std::string("trying to rebind VAO to another shader from " +
                                              util::toString(bound_shader) + "(" + bound_shader_name + ") to " +
@@ -84,7 +84,7 @@ void VertexArrayObject::verifyBinding(Shader &shader, GLuint vertexBuffer, GLuin
 }
 
 void VertexArrayObject::storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer,
-                                     char *offset) {
+                                     GLbyte *offset) {
     bound_shader = shader.getID();
     bound_shader_name = shader.name;
     bound_offset = offset;

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -18,7 +18,7 @@ public:
     ~VertexArrayObject();
 
     template <typename Shader, typename VertexBuffer>
-    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, char *offset) {
+    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset) {
         bindVertexArrayObject();
         if (bound_shader == 0) {
             vertexBuffer.bind();
@@ -32,7 +32,7 @@ public:
     }
 
     template <typename Shader, typename VertexBuffer, typename ElementsBuffer>
-    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, char *offset) {
+    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset) {
         bindVertexArrayObject();
         if (bound_shader == 0) {
             vertexBuffer.bind();
@@ -52,8 +52,8 @@ public:
 
 private:
     void bindVertexArrayObject();
-    void storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, char *offset);
-    void verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, char *offset);
+    void storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
+    void verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
 
     GLuint vao = 0;
 
@@ -63,7 +63,7 @@ private:
     const char *bound_shader_name = "";
     GLuint bound_vertex_buffer = 0;
     GLuint bound_elements_buffer = 0;
-    char *bound_offset = 0;
+    GLbyte *bound_offset = 0;
 };
 
 }

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -1,13 +1,15 @@
 #ifndef MBGL_RENDERER_BUCKET
 #define MBGL_RENDERER_BUCKET
 
+#include <mbgl/platform/gl.hpp>
 #include <mbgl/renderer/render_pass.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/mat4.hpp>
 
 #include <atomic>
 
-#define BUFFER_OFFSET(i) ((char*)nullptr + (i))
+#define BUFFER_OFFSET_0  ((GLbyte*)nullptr)
+#define BUFFER_OFFSET(i) ((BUFFER_OFFSET_0) + (i))
 
 namespace mbgl {
 

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -74,8 +74,8 @@ void CircleBucket::addGeometry(const GeometryCollection& geometryCollection) {
 }
 
 void CircleBucket::drawCircles(CircleShader& shader) {
-    char* vertexIndex = BUFFER_OFFSET(vertexStart_ * vertexBuffer_.itemSize);
-    char* elementsIndex = BUFFER_OFFSET(elementsStart_ * elementsBuffer_.itemSize);
+    GLbyte *vertexIndex = BUFFER_OFFSET(vertexStart_ * vertexBuffer_.itemSize);
+    GLbyte *elementsIndex = BUFFER_OFFSET(elementsStart_ * elementsBuffer_.itemSize);
 
     for (auto& group : triangleGroups_) {
         assert(group);

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -23,11 +23,11 @@ void DebugBucket::render(Painter& painter, const StyleLayer&, const TileID&, con
 }
 
 void DebugBucket::drawLines(PlainShader& shader) {
-    array.bind(shader, fontBuffer, BUFFER_OFFSET(0));
+    array.bind(shader, fontBuffer, BUFFER_OFFSET_0);
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, (GLsizei)(fontBuffer.index())));
 }
 
 void DebugBucket::drawPoints(PlainShader& shader) {
-    array.bind(shader, fontBuffer, BUFFER_OFFSET(0));
+    array.bind(shader, fontBuffer, BUFFER_OFFSET_0);
     MBGL_CHECK_ERROR(glDrawArrays(GL_POINTS, 0, (GLsizei)(fontBuffer.index())));
 }

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -216,8 +216,8 @@ bool FillBucket::hasData() const {
 }
 
 void FillBucket::drawElements(PlainShader& shader) {
-    char *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    char *elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
+    GLbyte *elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
     for (auto& group : triangleGroups) {
         assert(group);
         group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
@@ -228,8 +228,8 @@ void FillBucket::drawElements(PlainShader& shader) {
 }
 
 void FillBucket::drawElements(PatternShader& shader) {
-    char *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    char *elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
+    GLbyte *elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
     for (auto& group : triangleGroups) {
         assert(group);
         group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
@@ -240,8 +240,8 @@ void FillBucket::drawElements(PatternShader& shader) {
 }
 
 void FillBucket::drawVertices(OutlineShader& shader) {
-    char *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    char *elements_index = BUFFER_OFFSET(line_elements_start * lineElementsBuffer.itemSize);
+    GLbyte *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
+    GLbyte *elements_index = BUFFER_OFFSET(line_elements_start * lineElementsBuffer.itemSize);
     for (auto& group : lineGroups) {
         assert(group);
         group->array[0].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index);

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -405,8 +405,8 @@ bool LineBucket::hasData() const {
 }
 
 void LineBucket::drawLines(LineShader& shader) {
-    char* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    char* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
+    GLbyte* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
     for (auto& group : triangleGroups) {
         assert(group);
         if (!group->elements_length) {
@@ -421,8 +421,8 @@ void LineBucket::drawLines(LineShader& shader) {
 }
 
 void LineBucket::drawLineSDF(LineSDFShader& shader) {
-    char* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    char* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
+    GLbyte* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
     for (auto& group : triangleGroups) {
         assert(group);
         if (!group->elements_length) {
@@ -437,8 +437,8 @@ void LineBucket::drawLineSDF(LineSDFShader& shader) {
 }
 
 void LineBucket::drawLinePatterns(LinepatternShader& shader) {
-    char* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    char* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
+    GLbyte* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
     for (auto& group : triangleGroups) {
         assert(group);
         if (!group->elements_length) {

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -16,7 +16,7 @@ void Painter::drawClippingMasks(const std::set<Source*>& sources) {
     config.colorMask = { false, false, false, false };
     config.depthRange = { 1.0f, 1.0f };
 
-    coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET(0));
+    coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET_0);
 
     for (const auto& source : sources) {
         source->drawClippingMasks(*this);

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -59,7 +59,7 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     plainShader->u_matrix = matrix;
 
     // draw tile outline
-    tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET(0));
+    tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET_0);
     plainShader->u_color = {{ 1.0f, 0.0f, 0.0f, 1.0f }};
     lineWidth(4.0f * data.pixelRatio);
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, (GLsizei)tileBorderBuffer.index()));

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -30,7 +30,7 @@ bool RasterBucket::setImage(std::unique_ptr<util::Image> image) {
 void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array) {
     raster.bind(true);
     shader.u_image = 0;
-    array.bind(shader, vertices, BUFFER_OFFSET(0));
+    array.bind(shader, vertices, BUFFER_OFFSET_0);
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
 }
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -565,8 +565,8 @@ void SymbolBucket::swapRenderData() {
 }
 
 void SymbolBucket::drawGlyphs(SDFShader &shader) {
-    char *vertex_index = BUFFER_OFFSET(0);
-    char *elements_index = BUFFER_OFFSET(0);
+    GLbyte *vertex_index = BUFFER_OFFSET_0;
+    GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& text = renderData->text;
     for (auto &group : text.groups) {
         assert(group);
@@ -578,8 +578,8 @@ void SymbolBucket::drawGlyphs(SDFShader &shader) {
 }
 
 void SymbolBucket::drawIcons(SDFShader &shader) {
-    char *vertex_index = BUFFER_OFFSET(0);
-    char *elements_index = BUFFER_OFFSET(0);
+    GLbyte *vertex_index = BUFFER_OFFSET_0;
+    GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& icon = renderData->icon;
     for (auto &group : icon.groups) {
         assert(group);
@@ -591,8 +591,8 @@ void SymbolBucket::drawIcons(SDFShader &shader) {
 }
 
 void SymbolBucket::drawIcons(IconShader &shader) {
-    char *vertex_index = BUFFER_OFFSET(0);
-    char *elements_index = BUFFER_OFFSET(0);
+    GLbyte *vertex_index = BUFFER_OFFSET_0;
+    GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& icon = renderData->icon;
     for (auto &group : icon.groups) {
         assert(group);
@@ -604,7 +604,7 @@ void SymbolBucket::drawIcons(IconShader &shader) {
 }
 
 void SymbolBucket::drawCollisionBoxes(CollisionBoxShader &shader) {
-    char *vertex_index = BUFFER_OFFSET(0);
+    GLbyte *vertex_index = BUFFER_OFFSET_0;
     auto& collisionBox = renderData->collisionBox;
     for (auto &group : collisionBox.groups) {
         group->array[0].bind(shader, collisionBox.vertices, vertex_index);

--- a/src/mbgl/shader/box_shader.cpp
+++ b/src/mbgl/shader/box_shader.cpp
@@ -12,7 +12,6 @@ CollisionBoxShader::CollisionBoxShader()
         shaders[BOX_SHADER].vertex,
         shaders[BOX_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_extrude = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_extrude"));
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }

--- a/src/mbgl/shader/box_shader.cpp
+++ b/src/mbgl/shader/box_shader.cpp
@@ -16,7 +16,7 @@ CollisionBoxShader::CollisionBoxShader()
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }
 
-void CollisionBoxShader::bind(char *offset) {
+void CollisionBoxShader::bind(GLbyte *offset) {
     const int stride = 12;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));

--- a/src/mbgl/shader/box_shader.hpp
+++ b/src/mbgl/shader/box_shader.hpp
@@ -18,7 +18,6 @@ public:
     Uniform<float>                u_maxzoom        = {"u_maxzoom",        *this};
 
 protected:
-    int32_t a_pos = -1;
     int32_t a_extrude = -1;
     int32_t a_data = -1;
 };

--- a/src/mbgl/shader/box_shader.hpp
+++ b/src/mbgl/shader/box_shader.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/shader/shader.hpp>
 #include <mbgl/shader/uniform.hpp>
+#include <mbgl/platform/gl.hpp>
 
 namespace mbgl {
 
@@ -10,7 +11,7 @@ class CollisionBoxShader : public Shader {
 public:
     CollisionBoxShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix      = {"u_matrix",      *this};
     Uniform<float>                u_scale      = {"u_scale",      *this};

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -12,7 +12,6 @@ CircleShader::CircleShader()
         shaders[CIRCLE_SHADER].vertex,
         shaders[CIRCLE_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 
 void CircleShader::bind(char *offset) {

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -14,7 +14,7 @@ CircleShader::CircleShader()
     ) {
 }
 
-void CircleShader::bind(char *offset) {
+void CircleShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 4, offset));
 }

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -10,7 +10,7 @@ class CircleShader : public Shader {
 public:
     CircleShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>               u_matrix   = {"u_matrix",   *this};
     UniformMatrix<4>               u_exmatrix = {"u_exmatrix", *this};

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -17,9 +17,6 @@ public:
     Uniform<std::array<float, 4>>  u_color    = {"u_color",    *this};
     Uniform<float>                 u_size     = {"u_size",     *this};
     Uniform<float>                 u_blur     = {"u_blur",     *this};
-
-private:
-    int32_t a_pos = -1;
 };
 
 }

--- a/src/mbgl/shader/dot_shader.cpp
+++ b/src/mbgl/shader/dot_shader.cpp
@@ -12,7 +12,6 @@ DotShader::DotShader()
          shaders[DOT_SHADER].vertex,
          shaders[DOT_SHADER].fragment
          ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 
 void DotShader::bind(char *offset) {

--- a/src/mbgl/shader/dot_shader.cpp
+++ b/src/mbgl/shader/dot_shader.cpp
@@ -14,7 +14,7 @@ DotShader::DotShader()
          ) {
 }
 
-void DotShader::bind(char *offset) {
+void DotShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 8, offset));
 }

--- a/src/mbgl/shader/dot_shader.hpp
+++ b/src/mbgl/shader/dot_shader.hpp
@@ -10,7 +10,7 @@ class DotShader : public Shader {
 public:
     DotShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix = {"u_matrix", *this};
     Uniform<std::array<float, 4>> u_color  = {"u_color",  *this};

--- a/src/mbgl/shader/dot_shader.hpp
+++ b/src/mbgl/shader/dot_shader.hpp
@@ -16,9 +16,6 @@ public:
     Uniform<std::array<float, 4>> u_color  = {"u_color",  *this};
     Uniform<float>                u_size   = {"u_size",   *this};
     Uniform<float>                u_blur   = {"u_blur",   *this};
-
-private:
-    int32_t a_pos = -1;
 };
 
 }

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -12,7 +12,6 @@ IconShader::IconShader()
          shaders[ICON_SHADER].vertex,
          shaders[ICON_SHADER].fragment
          ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_offset"));
     a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data1"));
     a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data2"));

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -17,7 +17,7 @@ IconShader::IconShader()
     a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data2"));
 }
 
-void IconShader::bind(char *offset) {
+void IconShader::bind(GLbyte *offset) {
     const int stride = 16;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));

--- a/src/mbgl/shader/icon_shader.hpp
+++ b/src/mbgl/shader/icon_shader.hpp
@@ -25,7 +25,6 @@ public:
     Uniform<float>                u_extra       = {"u_extra",       *this};
 
 private:
-    int32_t a_pos = -1;
     int32_t a_offset = -1;
     int32_t a_data1 = -1;
     int32_t a_data2 = -1;

--- a/src/mbgl/shader/icon_shader.hpp
+++ b/src/mbgl/shader/icon_shader.hpp
@@ -10,7 +10,7 @@ class IconShader : public Shader {
 public:
     IconShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix      = {"u_matrix",      *this};
     UniformMatrix<4>              u_exmatrix    = {"u_exmatrix",    *this};

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -15,7 +15,7 @@ LineShader::LineShader()
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }
 
-void LineShader::bind(char *offset) {
+void LineShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 8, offset + 0));
 

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -12,7 +12,6 @@ LineShader::LineShader()
         shaders[LINE_SHADER].vertex,
         shaders[LINE_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }
 

--- a/src/mbgl/shader/line_shader.hpp
+++ b/src/mbgl/shader/line_shader.hpp
@@ -22,7 +22,6 @@ public:
     UniformMatrix<2>               u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
 
 private:
-    int32_t a_pos = -1;
     int32_t a_data = -1;
 };
 

--- a/src/mbgl/shader/line_shader.hpp
+++ b/src/mbgl/shader/line_shader.hpp
@@ -10,7 +10,7 @@ class LineShader : public Shader {
 public:
     LineShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>               u_matrix    = {"u_matrix",    *this};
     UniformMatrix<4>               u_exmatrix  = {"u_exmatrix",  *this};

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -12,7 +12,6 @@ LinepatternShader::LinepatternShader()
          shaders[LINEPATTERN_SHADER].vertex,
          shaders[LINEPATTERN_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }
 

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -15,7 +15,7 @@ LinepatternShader::LinepatternShader()
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }
 
-void LinepatternShader::bind(char *offset) {
+void LinepatternShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 8, offset + 0));
 

--- a/src/mbgl/shader/linepattern_shader.hpp
+++ b/src/mbgl/shader/linepattern_shader.hpp
@@ -30,7 +30,6 @@ public:
     UniformMatrix<2>               u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
 
 private:
-    int32_t a_pos = -1;
     int32_t a_data = -1;
 };
 }

--- a/src/mbgl/shader/linepattern_shader.hpp
+++ b/src/mbgl/shader/linepattern_shader.hpp
@@ -10,7 +10,7 @@ class LinepatternShader : public Shader {
 public:
     LinepatternShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix       = {"u_matrix",       *this};
     UniformMatrix<4>              u_exmatrix     = {"u_exmatrix",     *this};

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -15,7 +15,7 @@ LineSDFShader::LineSDFShader()
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }
 
-void LineSDFShader::bind(char *offset) {
+void LineSDFShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 8, offset + 0));
 

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -12,7 +12,6 @@ LineSDFShader::LineSDFShader()
         shaders[LINESDF_SHADER].vertex,
         shaders[LINESDF_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
 }
 

--- a/src/mbgl/shader/linesdf_shader.hpp
+++ b/src/mbgl/shader/linesdf_shader.hpp
@@ -10,7 +10,7 @@ class LineSDFShader : public Shader {
 public:
     LineSDFShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>               u_matrix    = {"u_matrix",    *this};
     UniformMatrix<4>               u_exmatrix  = {"u_exmatrix",  *this};

--- a/src/mbgl/shader/linesdf_shader.hpp
+++ b/src/mbgl/shader/linesdf_shader.hpp
@@ -29,7 +29,6 @@ public:
     UniformMatrix<2>               u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
 
 private:
-    int32_t a_pos = -1;
     int32_t a_data = -1;
 };
 

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -12,7 +12,6 @@ OutlineShader::OutlineShader()
         shaders[OUTLINE_SHADER].vertex,
         shaders[OUTLINE_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 
 void OutlineShader::bind(char *offset) {

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -14,7 +14,7 @@ OutlineShader::OutlineShader()
     ) {
 }
 
-void OutlineShader::bind(char *offset) {
+void OutlineShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 0, offset));
 }

--- a/src/mbgl/shader/outline_shader.hpp
+++ b/src/mbgl/shader/outline_shader.hpp
@@ -10,7 +10,7 @@ class OutlineShader : public Shader {
 public:
     OutlineShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix = {"u_matrix", *this};
     Uniform<std::array<float, 4>> u_color  = {"u_color",  *this};

--- a/src/mbgl/shader/outline_shader.hpp
+++ b/src/mbgl/shader/outline_shader.hpp
@@ -15,9 +15,6 @@ public:
     UniformMatrix<4>              u_matrix = {"u_matrix", *this};
     Uniform<std::array<float, 4>> u_color  = {"u_color",  *this};
     Uniform<std::array<float, 2>> u_world  = {"u_world",  *this};
-
-private:
-    int32_t a_pos = -1;
 };
 
 }

--- a/src/mbgl/shader/pattern_shader.cpp
+++ b/src/mbgl/shader/pattern_shader.cpp
@@ -14,7 +14,7 @@ PatternShader::PatternShader()
     ) {
 }
 
-void PatternShader::bind(char *offset) {
+void PatternShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 0, offset));
 }

--- a/src/mbgl/shader/pattern_shader.cpp
+++ b/src/mbgl/shader/pattern_shader.cpp
@@ -12,7 +12,6 @@ PatternShader::PatternShader()
         shaders[PATTERN_SHADER].vertex,
         shaders[PATTERN_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 
 void PatternShader::bind(char *offset) {

--- a/src/mbgl/shader/pattern_shader.hpp
+++ b/src/mbgl/shader/pattern_shader.hpp
@@ -22,9 +22,6 @@ public:
     Uniform<int32_t>              u_image         = {"u_image",         *this};
     UniformMatrix<3>              u_patternmatrix_a = {"u_patternmatrix_a", *this};
     UniformMatrix<3>              u_patternmatrix_b = {"u_patternmatrix_b", *this};
-
-private:
-    int32_t a_pos = -1;
 };
 
 }

--- a/src/mbgl/shader/pattern_shader.hpp
+++ b/src/mbgl/shader/pattern_shader.hpp
@@ -10,7 +10,7 @@ class PatternShader : public Shader {
 public:
     PatternShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix        = {"u_matrix",        *this};
     Uniform<std::array<float, 2>> u_pattern_tl_a    = {"u_pattern_tl_a",    *this};

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -12,7 +12,6 @@ PlainShader::PlainShader()
         shaders[PLAIN_SHADER].vertex,
         shaders[PLAIN_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 
 void PlainShader::bind(char *offset) {

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -14,7 +14,7 @@ PlainShader::PlainShader()
     ) {
 }
 
-void PlainShader::bind(char *offset) {
+void PlainShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 0, offset));
 }

--- a/src/mbgl/shader/plain_shader.hpp
+++ b/src/mbgl/shader/plain_shader.hpp
@@ -10,7 +10,7 @@ class PlainShader : public Shader {
 public:
     PlainShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix   = {"u_matrix", *this};
     Uniform<std::array<float, 4>> u_color    = {"u_color",  *this};

--- a/src/mbgl/shader/plain_shader.hpp
+++ b/src/mbgl/shader/plain_shader.hpp
@@ -14,9 +14,6 @@ public:
 
     UniformMatrix<4>              u_matrix   = {"u_matrix", *this};
     Uniform<std::array<float, 4>> u_color    = {"u_color",  *this};
-
-private:
-    int32_t a_pos = -1;
 };
 
 }

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -12,7 +12,6 @@ RasterShader::RasterShader()
          shaders[RASTER_SHADER].vertex,
          shaders[RASTER_SHADER].fragment
          ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 
 void RasterShader::bind(char *offset) {

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -14,7 +14,7 @@ RasterShader::RasterShader()
          ) {
 }
 
-void RasterShader::bind(char *offset) {
+void RasterShader::bind(GLbyte *offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 0, offset));
 }

--- a/src/mbgl/shader/raster_shader.hpp
+++ b/src/mbgl/shader/raster_shader.hpp
@@ -21,9 +21,6 @@ public:
     Uniform<float>                u_saturation_factor = {"u_saturation_factor", *this};
     Uniform<float>                u_contrast_factor   = {"u_contrast_factor",   *this};
     Uniform<std::array<float, 3>> u_spin_weights      = {"u_spin_weights",      *this};
-
-private:
-    int32_t a_pos = -1;
 };
 
 }

--- a/src/mbgl/shader/raster_shader.hpp
+++ b/src/mbgl/shader/raster_shader.hpp
@@ -10,7 +10,7 @@ class RasterShader : public Shader {
 public:
     RasterShader();
 
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix            = {"u_matrix",            *this};
     Uniform<int32_t>              u_image             = {"u_image",             *this};

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -17,7 +17,7 @@ SDFShader::SDFShader()
     a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data2"));
 }
 
-void SDFGlyphShader::bind(char *offset) {
+void SDFGlyphShader::bind(GLbyte *offset) {
     const int stride = 16;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
@@ -33,7 +33,7 @@ void SDFGlyphShader::bind(char *offset) {
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_data2, 4, GL_UNSIGNED_BYTE, false, stride, offset + 12));
 }
 
-void SDFIconShader::bind(char *offset) {
+void SDFIconShader::bind(GLbyte *offset) {
     const int stride = 16;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -12,7 +12,6 @@ SDFShader::SDFShader()
         shaders[SDF_SHADER].vertex,
         shaders[SDF_SHADER].fragment
     ) {
-    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
     a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_offset"));
     a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data1"));
     a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data2"));

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -27,7 +27,6 @@ public:
     Uniform<float>                u_extra       = {"u_extra",       *this};
 
 protected:
-    int32_t a_pos = -1;
     int32_t a_offset = -1;
     int32_t a_data1 = -1;
     int32_t a_data2 = -1;

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -10,8 +10,6 @@ class SDFShader : public Shader {
 public:
     SDFShader();
 
-    virtual void bind(char *offset) = 0;
-
     UniformMatrix<4>              u_matrix      = {"u_matrix",      *this};
     UniformMatrix<4>              u_exmatrix    = {"u_exmatrix",    *this};
     Uniform<std::array<float, 4>> u_color       = {"u_color",       *this};
@@ -34,12 +32,12 @@ protected:
 
 class SDFGlyphShader : public SDFShader {
 public:
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 };
 
 class SDFIconShader : public SDFShader {
 public:
-    void bind(char *offset);
+    void bind(GLbyte *offset) final;
 };
 
 }

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -97,6 +97,8 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
     MBGL_CHECK_ERROR(glDeleteShader(vertShader));
     MBGL_CHECK_ERROR(glDetachShader(program, fragShader));
     MBGL_CHECK_ERROR(glDeleteShader(fragShader));
+
+    a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_pos"));
 }
 
 

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -1,10 +1,12 @@
 #ifndef MBGL_RENDERER_SHADER
 #define MBGL_RENDERER_SHADER
 
+#include <mbgl/platform/gl.hpp>
+#include <mbgl/util/noncopyable.hpp>
+
 #include <cstdint>
 #include <array>
 #include <string>
-#include <mbgl/util/noncopyable.hpp>
 
 namespace mbgl {
 
@@ -18,6 +20,9 @@ public:
     inline uint32_t getID() const {
         return program;
     }
+
+protected:
+    GLint a_pos = -1;
 
 private:
     bool compileShader(uint32_t *shader, uint32_t type, const char *source);

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -21,6 +21,8 @@ public:
         return program;
     }
 
+    virtual void bind(GLbyte *offset) = 0;
+
 protected:
     GLint a_pos = -1;
 


### PR DESCRIPTION
Based on [a public discussion](http://stackoverflow.com/questions/8932912/whats-the-advantage-of-using-gluint-instead-of-unsigned-int) on this subject, I believe we have reasons to prefer using GL types for GL-related objects instead of stdlib types.

/cc @mapbox/gl