### PR TITLE
Notify MGLMapView delegate about single and long taps on the map

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -601,6 +601,26 @@ IB_DESIGNABLE
 *  @param annotation The annotation that was deselected. */
 - (void)mapView:(MGLMapView *)mapView didDeselectAnnotation:(id <MGLAnnotation>)annotation;
 
+#pragma mark - Map Interaction
+
+/** @name Map Interaction */
+
+/* Tells the delegate that the map was tapped outside of any annotations.
+ *
+ *  You can use this method to cancel overlays, remove dropped pins etc.
+ *
+ *  @param mapView The map view that was tapped.
+ *  @param coordinate The coordinate that was tapped. */
+- (void)mapView:(MGLMapView *)mapView singleTapOnMapAtCoordinate:(CLLocationCoordinate2D)coordinate;
+
+/* Tells the delegate that the map was long pressed outside of any annotations.
+ *
+ *  You can use this method to drop a pin on the map.
+ *
+ *  @param mapView The map view that was long pressed.
+ *  @param coordinate The coordinate that was long pressed. */
+- (void)mapView:(MGLMapView *)mapView longPressOnMapAtCoordinate:(CLLocationCoordinate2D)coordinate;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Adds two delegate methods for notifying the delegate about single- and long taps on the map.

    - (void)mapView:(MGLMapView *)mapView singleTapOnMapAtCoordinate:(CLLocationCoordinate2D)coordinate;

    - (void)mapView:(MGLMapView *)mapView longPressOnMapAtCoordinate:(CLLocationCoordinate2D)coordinate;