### PR TITLE
Fix build, only ask for location permission in iosapp on user's instigation

### DIFF
--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -83,13 +83,6 @@ static NSUInteger const kStyleVersion = 8;
                                                                              action:@selector(locateUser)];
 
     [self restoreState:nil];
-
-    if ( ! settings->showsUserLocation)
-    {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            self.mapView.showsUserLocation = YES;
-        });
-    }
 }
 
 - (void)saveState:(__unused NSNotification *)notification


### PR DESCRIPTION
Previously in #2265 we would ask for location permission at app startup if `!settings->showsUserLocation`. #2193 0a172a21fdc2a87473560fd7d45f4d495d95de91 changed the way we use `NSUserDefaults` and mostly removed the `settings` object, which broke #2265.

Rather than fix our pestering location permissions ask at iosapp startup, this commit now only asks for location permissions when the user hits the locate-me button.

Once a user grants permission, the user dot appears because a `userTrackingMode` is set, `showsUserLocation` is permanently set to `YES` in `NSUserDefaults` and is restored at launch.

/cc @incanus @1ec5