### PR TITLE
fixes #1675: fix initial annotation markers

### DIFF
--- a/src/mbgl/map/annotation.hpp
+++ b/src/mbgl/map/annotation.hpp
@@ -52,6 +52,7 @@ public:
     ~AnnotationManager();
 
     void markStaleTiles(std::unordered_set<TileID, TileID::Hash>);
+    size_t getStaleTileCount() const { return staleTiles.size(); }
     std::unordered_set<TileID, TileID::Hash> resetStaleTiles();
 
     void setDefaultPointAnnotationSymbol(const std::string& symbol);

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -142,9 +142,11 @@ void MapContext::loadStyleJSON(const std::string& json, const std::string& base)
 
     updateFlags |= Update::DefaultTransition | Update::Classes | Update::Zoom;
     asyncUpdate->send();
+}
 
-    auto staleTiles = data.getAnnotationManager()->resetStaleTiles();
-    if (!staleTiles.empty()) {
+void MapContext::updateAnnotationTilesIfNeeded() {
+    if (data.getAnnotationManager()->getStaleTileCount()) {
+        auto staleTiles = data.getAnnotationManager()->resetStaleTiles();
         updateAnnotationTiles(staleTiles);
     }
 }
@@ -415,6 +417,10 @@ void MapContext::onResourceLoadingFailed(std::exception_ptr error) {
         callback(error, nullptr);
         callback = nullptr;
     }
+}
+
+void MapContext::onSpriteStoreLoaded() {
+    updateAnnotationTilesIfNeeded();
 }
 
 }

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -54,6 +54,7 @@ public:
     bool isLoaded() const;
 
     double getTopOffsetPixelsForAnnotationSymbol(const std::string& symbol);
+    void updateAnnotationTilesIfNeeded();
     void updateAnnotationTiles(const std::unordered_set<TileID, TileID::Hash>&);
 
     void setSourceTileCacheSize(size_t size);
@@ -66,6 +67,7 @@ public:
     // Style::Observer implementation.
     void onTileDataChanged() override;
     void onResourceLoadingFailed(std::exception_ptr error) override;
+    void onSpriteStoreLoaded() override;
 
 private:
     // Update the state indicated by the accumulated Update flags, then render.

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -190,6 +190,10 @@ void Style::onSpriteLoaded(const Sprites& sprites) {
     // Add all sprite images to the SpriteStore object
     spriteStore->setSprites(sprites);
 
+    if (observer) {
+        observer->onSpriteStoreLoaded();
+    }
+
     shouldReparsePartialTiles = true;
     emitTileDataChanged();
 }

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -39,6 +39,7 @@ public:
         virtual ~Observer() = default;
 
         virtual void onTileDataChanged() = 0;
+        virtual void onSpriteStoreLoaded() = 0;
         virtual void onResourceLoadingFailed(std::exception_ptr error) = 0;
     };
 

--- a/test/style/resource_loading.cpp
+++ b/test/style/resource_loading.cpp
@@ -63,6 +63,10 @@ public:
         callback_(error);
     }
 
+    void onSpriteStoreLoaded() override {
+        // no-op
+    }
+
 private:
     MapData data_;
     Transform transform_;


### PR DESCRIPTION
This does two things: 

1. It abstracts the pattern of checking if there are any stale annotation tiles (moving them to the caller in the process), then passing those back to the update routine to invalidate said annotation tiles. 

1. It uses that routine additionally in response to the sprite store loading, which necessarily loads after the sprite, which is after the style, which is the only way that either runtime-provided marker imagery or the default style sprite marker imagery will work. It extends the `Observer` pattern already used in the style and the map context for decoupled communications. 