### PR TITLE
Reattach user dot to map at low zoom levels

### DIFF
--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -175,7 +175,7 @@ double TransformState::yLat(double y_, double worldSize_) const {
     return 360.0f / M_PI * std::atan(std::exp(y2 * M_PI / 180.0f)) - 90.0f;
 }
 
-float TransformState::zoomScale(float zoom) const {
+double TransformState::zoomScale(double zoom) const {
     return std::pow(2.0f, zoom);
 }
 
@@ -192,8 +192,8 @@ LatLng TransformState::pointToLatLng(const vec2<double> point) const {
 }
 
 TileCoordinate TransformState::latLngToCoordinate(const LatLng& latLng) const {
-    const float tileZoom = getIntegerZoom();
-    const float k = zoomScale(tileZoom) / worldSize();
+    const double tileZoom = getZoom();
+    const double k = zoomScale(tileZoom) / worldSize();
     return {
         lngX(latLng.longitude) * k,
         latY(latLng.latitude) * k,
@@ -202,12 +202,12 @@ TileCoordinate TransformState::latLngToCoordinate(const LatLng& latLng) const {
 }
 
 LatLng TransformState::coordinateToLatLng(const TileCoordinate& coord) const {
-    const float worldSize_ = zoomScale(coord.zoom);
+    const double worldSize_ = zoomScale(coord.zoom);
     LatLng latLng = {
         yLat(coord.row, worldSize_),
         xLng(coord.column, worldSize_)
     };
-    while (latLng.longitude < 180.0f) latLng.longitude += 360.0f;
+    while (latLng.longitude < -180.0f) latLng.longitude += 360.0f;
     while (latLng.longitude > 180.0f) latLng.longitude -= 360.0f;
     return latLng;
 }
@@ -223,7 +223,7 @@ vec2<double> TransformState::coordinateToPoint(const TileCoordinate& coord) cons
 TileCoordinate TransformState::pointToCoordinate(const vec2<double> point) const {
 
     float targetZ = 0;
-    const float tileZoom = getIntegerZoom();
+    const double tileZoom = getZoom();
 
     mat4 mat = coordinatePointMatrix(tileZoom);
 
@@ -259,11 +259,11 @@ TileCoordinate TransformState::pointToCoordinate(const vec2<double> point) const
     return { util::interpolate(x0, x1, t), util::interpolate(y0, y1, t), tileZoom };
 }
 
-mat4 TransformState::coordinatePointMatrix(float z) const {
+mat4 TransformState::coordinatePointMatrix(double z) const {
     mat4 proj;
     getProjMatrix(proj);
     float s = util::tileSize * scale / std::pow(2, z);
-    matrix::scale(proj, proj, s , s, 1);
+    matrix::scale(proj, proj, s, s, 1);
     matrix::multiply(proj, getPixelMatrix(), proj);
     return proj;
 }

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -157,21 +157,21 @@ float TransformState::getPitch() const {
 
 #pragma mark - Projection
 
-float TransformState::lngX(float lng) const {
+double TransformState::lngX(double lng) const {
     return (180.0f + lng) * worldSize() / 360.0f;
 }
 
-float TransformState::latY(float lat) const {
-    float y_ = 180.0f / M_PI * std::log(std::tan(M_PI / 4 + lat * M_PI / 360.0f));
+double TransformState::latY(double lat) const {
+    double y_ = 180.0f / M_PI * std::log(std::tan(M_PI / 4 + lat * M_PI / 360.0f));
     return (180.0f - y_) * worldSize() / 360.0f;
 }
 
-float TransformState::xLng(float x_, float worldSize_) const {
+double TransformState::xLng(double x_, double worldSize_) const {
     return x_ * 360.0f / worldSize_ - 180.0f;
 }
 
-float TransformState::yLat(float y_, float worldSize_) const {
-    float y2 = 180.0f - y_ * 360.0f / worldSize_;
+double TransformState::yLat(double y_, double worldSize_) const {
+    double y2 = 180.0f - y_ * 360.0f / worldSize_;
     return 360.0f / M_PI * std::atan(std::exp(y2 * M_PI / 180.0f)) - 90.0f;
 }
 
@@ -245,17 +245,16 @@ TileCoordinate TransformState::pointToCoordinate(const vec2<double> point) const
     matrix::transformMat4(coord0, point0, inverted);
     matrix::transformMat4(coord1, point1, inverted);
 
-    float w0 = coord0[3];
-    float w1 = coord1[3];
-    float x0 = coord0[0] / w0;
-    float x1 = coord1[0] / w1;
-    float y0 = coord0[1] / w0;
-    float y1 = coord1[1] / w1;
-    float z0 = coord0[2] / w0;
-    float z1 = coord1[2] / w1;
+    double w0 = coord0[3];
+    double w1 = coord1[3];
+    double x0 = coord0[0] / w0;
+    double x1 = coord1[0] / w1;
+    double y0 = coord0[1] / w0;
+    double y1 = coord1[1] / w1;
+    double z0 = coord0[2] / w0;
+    double z1 = coord1[2] / w1;
 
-
-    float t = z0 == z1 ? 0 : (targetZ - z0) / (z1 - z0);
+    double t = z0 == z1 ? 0 : (targetZ - z0) / (z1 - z0);
   
     return { util::interpolate(x0, x1, t), util::interpolate(y0, y1, t), tileZoom };
 }

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -83,10 +83,10 @@ private:
     double yLat(double y, double worldSize) const;
     double lngX(double lon) const;
     double latY(double lat) const;
-    float zoomScale(float zoom) const;
+    double zoomScale(double zoom) const;
     float worldSize() const;
 
-    mat4 coordinatePointMatrix(float z) const;
+    mat4 coordinatePointMatrix(double z) const;
     mat4 getPixelMatrix() const;
 
 private:

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -79,10 +79,10 @@ private:
     // logical dimensions
     uint16_t width = 0, height = 0;
 
-    float xLng(float x, float worldSize) const;
-    float yLat(float y, float worldSize) const;
-    float lngX(float lon) const;
-    float latY(float lat) const;
+    double xLng(double x, double worldSize) const;
+    double yLat(double y, double worldSize) const;
+    double lngX(double lon) const;
+    double latY(double lat) const;
     float zoomScale(float zoom) const;
     float worldSize() const;
 

--- a/src/mbgl/util/mat4.cpp
+++ b/src/mbgl/util/mat4.cpp
@@ -46,7 +46,7 @@ void matrix::identity(mat4& out) {
 }
 
 bool matrix::invert(mat4& out, mat4& a) {
-    float a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3],
+    double a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3],
           a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7],
           a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11],
           a30 = a[12], a31 = a[13], a32 = a[14], a33 = a[15],

--- a/src/mbgl/util/tile_coordinate.hpp
+++ b/src/mbgl/util/tile_coordinate.hpp
@@ -6,15 +6,15 @@
 namespace mbgl {
 
 struct TileCoordinate {
-    float column;
-    float row;
-    float zoom;
+    double column;
+    double row;
+    double zoom;
 
-    TileCoordinate(float column_, float row_, float zoom_) :
+    TileCoordinate(double column_, double row_, double zoom_) :
         column(column_), row(row_), zoom(zoom_) {}
 
-    TileCoordinate zoomTo(float targetZoom) {
-        float scale = std::pow(2, targetZoom - zoom);
+    TileCoordinate zoomTo(double targetZoom) {
+        double scale = std::pow(2, targetZoom - zoom);
         return { column * scale, row * scale, targetZoom };
     }
 

--- a/src/mbgl/util/vec4.cpp
+++ b/src/mbgl/util/vec4.cpp
@@ -25,7 +25,7 @@
 using namespace mbgl;
 
 void matrix::transformMat4(vec4& out, vec4& a, mat4& m) {
-    float x = a[0], y = a[1], z = a[2], w = a[3];
+    double x = a[0], y = a[1], z = a[2], w = a[3];
     out[0] = m[0] * x + m[4] * y + m[8] * z + m[12] * w;
     out[1] = m[1] * x + m[5] * y + m[9] * z + m[13] * w;
     out[2] = m[2] * x + m[6] * y + m[10] * z + m[14] * w;


### PR DESCRIPTION
Fixes #2230 by increasing precision in a few key methods and folding in 214f997fbe881ab30a19756eedf34c7cda60aaad from @ansis’ `perspective-improved-gestures` branch. We may in all likelihood turn up additional places where `double` is needed, but this is safe for the release branch.

/cc @friedbunny @incanus