### PR TITLE
Call cancelTransitions when setting map position, zoom level, or direction

### DIFF
--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -628,6 +628,7 @@ public class MapView extends FrameLayout implements LocationListener {
 
     public void setCenterCoordinate(LatLng centerCoordinate, boolean animated) {
         long duration = animated ? ANIMATION_DURATION : 0;
+        mNativeMapView.cancelTransitions();
         mNativeMapView.setLatLng(centerCoordinate, duration);
     }
 
@@ -638,6 +639,7 @@ public class MapView extends FrameLayout implements LocationListener {
     public void setCenterCoordinate(LatLngZoom centerCoordinate,
                                     boolean animated) {
         long duration = animated ? ANIMATION_DURATION : 0;
+        mNativeMapView.cancelTransitions();
         mNativeMapView.setLatLngZoom(centerCoordinate, duration);
     }
 
@@ -660,14 +662,17 @@ public class MapView extends FrameLayout implements LocationListener {
 
     public void setDirection(double direction, boolean animated) {
         long duration = animated ? ANIMATION_DURATION : 0;
+        mNativeMapView.cancelTransitions();
         mNativeMapView.setBearing(-direction, duration);
     }
 
     public void resetPosition() {
+        mNativeMapView.cancelTransitions();
         mNativeMapView.resetPosition();
     }
 
     public void resetNorth() {
+        mNativeMapView.cancelTransitions();
         mNativeMapView.resetNorth();
     }
 
@@ -681,6 +686,7 @@ public class MapView extends FrameLayout implements LocationListener {
 
     public void setZoomLevel(double zoomLevel, boolean animated) {
         long duration = animated ? ANIMATION_DURATION : 0;
+        mNativeMapView.cancelTransitions();
         mNativeMapView.setZoom(zoomLevel, duration);
     }
 


### PR DESCRIPTION
Fixes # 2296

Should be cherry-picked into `release-android-v0.1.0` branch.

@bleege @incanus Eyeball this then cherry-pick if all clear.