### PR TITLE
[wip] experiments with Android user dot accuracy & sync

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -94,10 +94,10 @@ jmethodID projectedMetersConstructorId = nullptr;
 jfieldID projectedMetersNorthingId = nullptr;
 jfieldID projectedMetersEastingId = nullptr;
 
-jclass pointFClass = nullptr;
-jmethodID pointFConstructorId = nullptr;
-jfieldID pointFXId = nullptr;
-jfieldID pointFYId = nullptr;
+jclass point2DClass = nullptr;
+jmethodID point2DConstructorId = nullptr;
+jfieldID point2DXId = nullptr;
+jfieldID point2DYId = nullptr;
 
 jclass httpContextClass = nullptr;
 jmethodID httpContextGetInstanceId = nullptr;
@@ -1190,7 +1190,7 @@ jobject JNICALL nativePixelForLatLng(JNIEnv *env, jobject obj, jlong nativeMapVi
 
     mbgl::vec2<double> pixel = nativeMapView->getMap().pixelForLatLng(mbgl::LatLng(latitude, longitude));
 
-    jobject ret = env->NewObject(pointFClass, pointFConstructorId, static_cast<jfloat>(pixel.x), static_cast<jfloat>(pixel.y));
+    jobject ret = env->NewObject(point2DClass, point2DConstructorId, static_cast<jdouble>(pixel.x), static_cast<jdouble>(pixel.y));
     if (ret == nullptr) {
         env->ExceptionDescribe();
         return nullptr;
@@ -1204,13 +1204,13 @@ jobject JNICALL nativeLatLngForPixel(JNIEnv *env, jobject obj, jlong nativeMapVi
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
 
-    jfloat x = env->GetFloatField(pixel, pointFXId);
+    jfloat x = env->GetDoubleField(pixel, point2DXId);
     if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
         return nullptr;
     }
 
-    jfloat y = env->GetFloatField(pixel, pointFYId);
+    jfloat y = env->GetDoubleField(pixel, point2DYId);
     if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
         return nullptr;
@@ -1551,26 +1551,26 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         return JNI_ERR;
     }
 
-    pointFClass = env->FindClass("android/graphics/PointF");
-    if (pointFClass == nullptr) {
+    point2DClass = env->FindClass("math/geom2d/Point2D");
+    if (point2DClass == nullptr) {
         env->ExceptionDescribe();
         return JNI_ERR;
     }
 
-    pointFConstructorId = env->GetMethodID(pointFClass, "<init>", "(FF)V");
-    if (pointFConstructorId == nullptr) {
+    point2DConstructorId = env->GetMethodID(point2DClass, "<init>", "(DD)V");
+    if (point2DConstructorId == nullptr) {
         env->ExceptionDescribe();
         return JNI_ERR;
     }
 
-    pointFXId = env->GetFieldID(pointFClass, "x", "F");
-    if (pointFXId == nullptr) {
+    point2DXId = env->GetFieldID(point2DClass, "x", "D");
+    if (point2DXId == nullptr) {
         env->ExceptionDescribe();
         return JNI_ERR;
     }
 
-    pointFYId = env->GetFieldID(pointFClass, "y", "F");
-    if (pointFYId == nullptr) {
+    point2DYId = env->GetFieldID(point2DClass, "y", "D");
+    if (point2DYId == nullptr) {
         env->ExceptionDescribe();
         return JNI_ERR;
     }
@@ -1712,9 +1712,9 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         {"nativeLatLngForProjectedMeters",
          "(JLcom/mapbox/mapboxgl/geometry/ProjectedMeters;)Lcom/mapbox/mapboxgl/geometry/LatLng;",
          reinterpret_cast<void *>(&nativeLatLngForProjectedMeters)},
-        {"nativePixelForLatLng", "(JLcom/mapbox/mapboxgl/geometry/LatLng;)Landroid/graphics/PointF;",
+        {"nativePixelForLatLng", "(JLcom/mapbox/mapboxgl/geometry/LatLng;)Lmath/geom2d/Point2D;",
          reinterpret_cast<void *>(&nativePixelForLatLng)},
-        {"nativeLatLngForPixel", "(JLandroid/graphics/PointF;)Lcom/mapbox/mapboxgl/geometry/LatLng;",
+        {"nativeLatLngForPixel", "(JLmath/geom2d/Point2D;)Lcom/mapbox/mapboxgl/geometry/LatLng;",
          reinterpret_cast<void *>(&nativeLatLngForPixel)},
         {"nativeGetTopOffsetPixelsForAnnotationSymbol", "(JLjava/lang/String;)D",
          reinterpret_cast<void *>(&nativeGetTopOffsetPixelsForAnnotationSymbol)},
@@ -1832,8 +1832,8 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         return JNI_ERR;
     }
 
-    pointFClass = reinterpret_cast<jclass>(env->NewGlobalRef(pointFClass));
-    if (pointFClass == nullptr) {
+    point2DClass = reinterpret_cast<jclass>(env->NewGlobalRef(point2DClass));
+    if (point2DClass == nullptr) {
         env->ExceptionDescribe();
         env->DeleteGlobalRef(latLngClass);
         env->DeleteGlobalRef(markerClass);
@@ -1861,7 +1861,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         env->DeleteGlobalRef(nullPointerExceptionClass);
         env->DeleteGlobalRef(arrayListClass);
         env->DeleteGlobalRef(projectedMetersClass);
-        env->DeleteGlobalRef(pointFClass);
+        env->DeleteGlobalRef(point2DClass);
     }
 
     httpRequestClass = reinterpret_cast<jclass>(env->NewGlobalRef(httpRequestClass));
@@ -1877,7 +1877,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         env->DeleteGlobalRef(nullPointerExceptionClass);
         env->DeleteGlobalRef(arrayListClass);
         env->DeleteGlobalRef(projectedMetersClass);
-        env->DeleteGlobalRef(pointFClass);
+        env->DeleteGlobalRef(point2DClass);
         env->DeleteGlobalRef(httpContextClass);
     }
 
@@ -1970,11 +1970,11 @@ extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved) {
     projectedMetersNorthingId = nullptr;
     projectedMetersEastingId = nullptr;
 
-    env->DeleteGlobalRef(pointFClass);
-    pointFClass = nullptr;
-    pointFConstructorId = nullptr;
-    pointFXId = nullptr;
-    pointFYId = nullptr;
+    env->DeleteGlobalRef(point2DClass);
+    point2DClass = nullptr;
+    point2DConstructorId = nullptr;
+    point2DXId = nullptr;
+    point2DYId = nullptr;
 
     env->DeleteGlobalRef(httpContextClass);
     httpContextGetInstanceId = nullptr;

--- a/android/java/MapboxGLAndroidSDK/build.gradle
+++ b/android/java/MapboxGLAndroidSDK/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compile 'com.android.support:design:23.0.1'
     compile 'com.squareup.okhttp:okhttp:2.4.0'
     compile 'com.mapzen.android:lost:1.0.1'
+    compile 'math.geom2d:javaGeom:0.11.1'
 }
 
 android {

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/InfoWindow.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/annotations/InfoWindow.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxgl.annotations;
 
 import android.content.Context;
-import android.graphics.PointF;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -9,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import com.mapbox.mapboxgl.geometry.LatLng;
 import com.mapbox.mapboxgl.views.MapView;
+import math.geom2d.Point2D;
 
 /**
  * A tooltip view
@@ -84,15 +84,15 @@ public class InfoWindow {
         MapView.LayoutParams lp = new MapView.LayoutParams(MapView.LayoutParams.WRAP_CONTENT, MapView.LayoutParams.WRAP_CONTENT);
         mView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
 
-        PointF coords = mMapView.toScreenLocation(position);
+        Point2D coords = mMapView.toScreenLocation(position);
         double y = mMapView.getTopOffsetPixelsForAnnotationSymbol(object.sprite);
         y = y * mMapView.getScreenDensity();
 
         // Flip y coordinate as Android view origin is upper left corner
-        coords.y = mMapView.getHeight() - coords.y;
-        lp.leftMargin = (int) coords.x - (mView.getMeasuredWidth() / 2);
+        coords = new Point2D(coords.x(), mMapView.getHeight() - coords.y());
+        lp.leftMargin = (int) coords.x() - (mView.getMeasuredWidth() / 2);
         // Add y because it's a negative value
-        lp.topMargin = (int) coords.y - mView.getMeasuredHeight() + (int) y;
+        lp.topMargin = (int) coords.y() - mView.getMeasuredHeight() + (int) y;
 
         close(); //if it was already opened
         mMapView.addView(mView, lp);

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -71,6 +71,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import math.geom2d.Point2D;
 
 // Custom view that shows a Map
 // Based on SurfaceView as we use OpenGL ES to render
@@ -813,13 +814,13 @@ public class MapView extends FrameLayout implements LocationListener {
         setStyleClasses(styleClasses);
     }
 
-    public LatLng fromScreenLocation(PointF point) {
-        return mNativeMapView.latLngForPixel(new PointF(point.x / mScreenDensity, point.y / mScreenDensity));
+    public LatLng fromScreenLocation(Point2D point) {
+        return mNativeMapView.latLngForPixel(new Point2D(point.x() / mScreenDensity, point.y() / mScreenDensity));
     }
 
-    public PointF toScreenLocation(LatLng location) {
-        PointF point = mNativeMapView.pixelForLatLng(location);
-        return new PointF(point.x * mScreenDensity, point.y * mScreenDensity);
+    public Point2D toScreenLocation(LatLng location) {
+        Point2D point = mNativeMapView.pixelForLatLng(location);
+        return new Point2D(point.x() * mScreenDensity, point.y() * mScreenDensity);
     }
 
     public double getTopOffsetPixelsForAnnotationSymbol(@NonNull String symbolName) {
@@ -1196,10 +1197,10 @@ public class MapView extends FrameLayout implements LocationListener {
                                       tapPoint.x + toleranceWidth / 2, tapPoint.y - 1 * toleranceHeight / 3);
 
             List<LatLng> corners = Arrays.asList(
-                fromScreenLocation(new PointF(tapRect.left, tapRect.bottom)),
-                fromScreenLocation(new PointF(tapRect.left, tapRect.top)),
-                fromScreenLocation(new PointF(tapRect.right, tapRect.top)),
-                fromScreenLocation(new PointF(tapRect.right, tapRect.bottom))
+                fromScreenLocation(new Point2D(tapRect.left, tapRect.bottom)),
+                fromScreenLocation(new Point2D(tapRect.left, tapRect.top)),
+                fromScreenLocation(new Point2D(tapRect.right, tapRect.top)),
+                fromScreenLocation(new Point2D(tapRect.right, tapRect.bottom))
             );
 
             BoundingBox tapBounds = BoundingBox.fromLatLngs(corners);
@@ -2137,17 +2138,20 @@ public class MapView extends FrameLayout implements LocationListener {
             }
 
             mGpsMarker.setVisibility(View.VISIBLE);
-            LatLng coordinate = new LatLng(mGpsLocation);
-            PointF screenLocation = toScreenLocation(coordinate);
 
-            float iconSize = 27.0f * mScreenDensity;
-            // Update Location
-            FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams((int) iconSize, (int) iconSize);
-            lp.leftMargin = (int) (screenLocation.x - iconSize / 2.0f);
-            lp.topMargin = getHeight() - (int) (screenLocation.y + iconSize / 2.0f);
-            mGpsMarker.setLayoutParams(lp);
-            rotateImageView(mGpsMarker, 0.0f);
-            mGpsMarker.requestLayout();
+            if (change.value >= MapChange.MapChangeWillStartRenderingFrame.value) { // any frame render activity
+                LatLng coordinate = new LatLng(mGpsLocation);
+                Point2D screenLocation = toScreenLocation(coordinate);
+
+                float iconSize = 27.0f * mScreenDensity;
+                // Update Location
+                FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams((int) iconSize, (int) iconSize);
+                lp.leftMargin = (int) (screenLocation.x() - iconSize / 2.0f);
+                lp.topMargin = getHeight() - (int) (screenLocation.y() + iconSize / 2.0f);
+                mGpsMarker.setLayoutParams(lp);
+                rotateImageView(mGpsMarker, 0.0f);
+                mGpsMarker.forceLayout();
+            }
 
             // Update direction if tracking mode
             if(mUserLocationTrackingMode == UserLocationTrackingMode.FOLLOW_BEARING && mCompassValid){

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxgl.views;
 
-import android.graphics.PointF;
 import android.view.Surface;
 
 import com.mapbox.mapboxgl.annotations.Marker;
@@ -11,6 +10,8 @@ import com.mapbox.mapboxgl.geometry.LatLng;
 import com.mapbox.mapboxgl.geometry.LatLngZoom;
 import com.mapbox.mapboxgl.geometry.ProjectedMeters;
 import java.util.List;
+
+import math.geom2d.Point2D;
 
 // Class that wraps the native methods for convenience
 class NativeMapView {
@@ -413,11 +414,11 @@ class NativeMapView {
         return nativeLatLngForProjectedMeters(mNativeMapViewPtr, projectedMeters);
     }
 
-    public PointF pixelForLatLng(LatLng latLng) {
+    public Point2D pixelForLatLng(LatLng latLng) {
         return nativePixelForLatLng(mNativeMapViewPtr, latLng);
     }
 
-    public LatLng latLngForPixel(PointF pixel) {
+    public LatLng latLngForPixel(Point2D pixel) {
         return nativeLatLngForPixel(mNativeMapViewPtr, pixel);
     }
 
@@ -604,9 +605,9 @@ class NativeMapView {
 
     private native LatLng nativeLatLngForProjectedMeters(long nativeMapViewPtr, ProjectedMeters projectedMeters);
 
-    private native PointF nativePixelForLatLng(long nativeMapViewPtr, LatLng latLng);
+    private native Point2D nativePixelForLatLng(long nativeMapViewPtr, LatLng latLng);
 
-    private native LatLng nativeLatLngForPixel(long nativeMapViewPtr, PointF pixel);
+    private native LatLng nativeLatLngForPixel(long nativeMapViewPtr, Point2D pixel);
 
     private native double nativeGetTopOffsetPixelsForAnnotationSymbol(long nativeMapViewPtr, String symbolName);
 }

--- a/android/java/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxgl/testapp/MainActivity.java
+++ b/android/java/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxgl/testapp/MainActivity.java
@@ -31,6 +31,8 @@ import com.mapbox.mapboxgl.annotations.PolylineOptions;
 import com.mapbox.mapboxgl.geometry.LatLng;
 import com.mapbox.mapboxgl.views.MapView;
 import io.fabric.sdk.android.Fabric;
+import math.geom2d.Point2D;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -119,7 +121,7 @@ public class MainActivity extends AppCompatActivity {
                 // flip y direction vertically to match core GL
                 y = mMapView.getHeight() - y;
 
-                LatLng position = mMapView.fromScreenLocation(new PointF(x, y));
+                LatLng position = mMapView.fromScreenLocation(new Point2D(x, y));
 
                 mMapView.addMarker(new MarkerOptions()
                         .position(position)


### PR DESCRIPTION
Building on our learning in https://github.com/mapbox/mapbox-gl-native/pull/2301, I attempted a few things (with no luck yet) to try to fix up #1676 Android user dot wiggle. 

- Using `math.geom2d.Point2D` for `double` accuracy in pixel/coordinate conversions instead of `PointF` with `float`. 
- Only re-laying out the user dot on frame render changes, not all viewport changes. 
- Specifically re-laying out the dot after `invalidate()` (not present here). 

These might help and are directions to explore, but I think the main problem is that we can only `requestLayout()` or `forceLayout()` on the user dot, but it's not guaranteed to be synchronous. 

So far, this helps pan activity but not zoom. 

/cc @ljbade @bleege @adam-mapbox 