### PR TITLE
Adoption of GL types

### DIFF
--- a/scripts/build-shaders.py
+++ b/scripts/build-shaders.py
@@ -34,11 +34,13 @@ def write_header():
 #ifndef MBGL_SHADER_SHADERS
 #define MBGL_SHADER_SHADERS
 
+#include <mbgl/platform/gl.hpp>
+
 namespace mbgl {
 
 struct shader_source {
-    const char *vertex;
-    const char *fragment;
+    const GLchar *vertex;
+    const GLchar *fragment;
 };
 
 enum {

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -110,10 +110,10 @@ public:
 
 private:
     // CPU buffer
-    void *array = nullptr;
+    GLvoid *array = nullptr;
 
     // Byte position where we are writing.
-    size_t pos = 0;
+    GLsizeiptr pos = 0;
 
     // Number of bytes that are valid in this buffer.
     size_t length = 0;

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -14,9 +14,9 @@
 namespace mbgl {
 
 template <
-    size_t item_size,
-    int bufferType = GL_ARRAY_BUFFER,
-    size_t defaultLength = 8192,
+    GLsizei item_size,
+    GLenum bufferType = GL_ARRAY_BUFFER,
+    GLsizei defaultLength = 8192,
     bool retainAfterUpload = false
 >
 class Buffer : private util::noncopyable {
@@ -31,8 +31,8 @@ public:
 
     // Returns the number of elements in this buffer. This is not the number of
     // bytes, but rather the number of coordinates with associated information.
-    inline size_t index() const {
-        return pos / itemSize;
+    inline GLsizei index() const {
+        return static_cast<GLsizei>(pos / itemSize);
     }
 
     inline bool empty() const {

--- a/src/mbgl/geometry/elements_buffer.hpp
+++ b/src/mbgl/geometry/elements_buffer.hpp
@@ -10,16 +10,16 @@
 
 namespace mbgl {
 
-template <int count>
+template <GLsizei count>
 struct ElementGroup : public util::noncopyable {
     std::array<VertexArrayObject, count> array;
-    uint32_t vertex_length;
-    uint32_t elements_length;
+    GLsizei vertex_length;
+    GLsizei elements_length;
 
-    ElementGroup() : vertex_length(0), elements_length(0) {}
-    ElementGroup(uint32_t vertex_length_, uint32_t elements_length_)
-        : vertex_length(vertex_length_),
-          elements_length(elements_length_) {
+    ElementGroup(GLsizei vertex_length_ = 0, GLsizei elements_length_ = 0)
+        : vertex_length(vertex_length_)
+        , elements_length(elements_length_)
+    {
     }
 };
 

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/geometry/binpack.hpp>
 #include <mbgl/text/glyph_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/platform/gl.hpp>
 
 #include <string>
 #include <set>
@@ -51,7 +52,7 @@ private:
     std::map<std::string, std::map<uint32_t, GlyphValue>> index;
     const std::unique_ptr<uint8_t[]> data;
     std::atomic<bool> dirty;
-    uint32_t texture = 0;
+    GLuint texture = 0;
 };
 
 };

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -32,8 +32,8 @@ public:
     // the texture is only bound when the data is out of date (=dirty).
     void upload();
 
-    const uint16_t width = 0;
-    const uint16_t height = 0;
+    const GLsizei width;
+    const GLsizei height;
 
 private:
     struct GlyphValue {

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -12,10 +12,10 @@
 
 using namespace mbgl;
 
-LineAtlas::LineAtlas(uint16_t w, uint16_t h)
+LineAtlas::LineAtlas(GLsizei w, GLsizei h)
     : width(w),
       height(h),
-      data(std::make_unique<uint8_t[]>(w * h)),
+      data(std::make_unique<GLbyte[]>(w * h)),
       dirty(true) {
 }
 

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -1,6 +1,8 @@
 #ifndef MBGL_GEOMETRY_LINE_ATLAS
 #define MBGL_GEOMETRY_LINE_ATLAS
 
+#include <mbgl/platform/gl.hpp>
+
 #include <vector>
 #include <map>
 #include <memory>
@@ -15,7 +17,7 @@ typedef struct {
 
 class LineAtlas {
 public:
-    LineAtlas(uint16_t width, uint16_t height);
+    LineAtlas(GLsizei width, GLsizei height);
     ~LineAtlas();
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
@@ -28,13 +30,13 @@ public:
     LinePatternPos getDashPosition(const std::vector<float>&, bool);
     LinePatternPos addDash(const std::vector<float> &dasharray, bool round);
 
-    const int width;
-    const int height;
+    const GLsizei width;
+    const GLsizei height;
 
 private:
-    const std::unique_ptr<uint8_t[]> data;
+    const std::unique_ptr<GLbyte[]> data;
     bool dirty;
-    uint32_t texture = 0;
+    GLuint texture = 0;
     int nextRow = 0;
     std::map<size_t, LinePatternPos> positions;
 };

--- a/src/mbgl/geometry/line_buffer.cpp
+++ b/src/mbgl/geometry/line_buffer.cpp
@@ -5,8 +5,8 @@
 
 using namespace mbgl;
 
-size_t LineVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey, int8_t tx, int8_t ty, int32_t linesofar) {
-    size_t idx = index();
+GLsizei LineVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey, int8_t tx, int8_t ty, int32_t linesofar) {
+    GLsizei idx = index();
     void *data = addElement();
 
     int16_t *coords = static_cast<int16_t *>(data);

--- a/src/mbgl/geometry/line_buffer.hpp
+++ b/src/mbgl/geometry/line_buffer.hpp
@@ -30,7 +30,7 @@ public:
      * @param {number} tx texture normal
      * @param {number} ty texture normal
      */
-    size_t add(vertex_type x, vertex_type y, float ex, float ey, int8_t tx, int8_t ty, int32_t linesofar = 0);
+    GLsizei add(vertex_type x, vertex_type y, float ex, float ey, int8_t tx, int8_t ty, int32_t linesofar = 0);
 };
 
 

--- a/src/mbgl/geometry/sprite_atlas.hpp
+++ b/src/mbgl/geometry/sprite_atlas.hpp
@@ -69,7 +69,7 @@ public:
     inline const uint32_t* getData() const { return data.get(); }
 
 private:
-    const dimension width, height;
+    const GLsizei width, height;
     const dimension pixelWidth, pixelHeight;
     const float pixelRatio;
 

--- a/src/mbgl/geometry/sprite_atlas.hpp
+++ b/src/mbgl/geometry/sprite_atlas.hpp
@@ -2,7 +2,7 @@
 #define MBGL_GEOMETRY_SPRITE_ATLAS
 
 #include <mbgl/geometry/binpack.hpp>
-
+#include <mbgl/platform/gl.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
 
@@ -93,7 +93,7 @@ private:
     const std::unique_ptr<uint32_t[]> data;
     std::atomic<bool> dirty;
     bool fullUploadRequired = true;
-    uint32_t texture = 0;
+    GLuint texture = 0;
     uint32_t filter = 0;
     static const int buffer = 1;
 };

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -35,8 +35,8 @@ private:
     CircleVertexBuffer& vertexBuffer_;
     TriangleElementsBuffer& elementsBuffer_;
 
-    const size_t vertexStart_;
-    const size_t elementsStart_;
+    const GLsizei vertexStart_;
+    const GLsizei elementsStart_;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups_;
 };

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -107,7 +107,7 @@ void FillBucket::tessellate() {
 
     assert(lineGroups.back());
     LineGroup& lineGroup = *lineGroups.back();
-    uint32_t lineIndex = lineGroup.vertex_length;
+    GLsizei lineIndex = lineGroup.vertex_length;
 
     for (const auto& polygon : polygons) {
         const size_t group_count = polygon.size();
@@ -156,7 +156,7 @@ void FillBucket::tessellate() {
         // coordinate in this polygon.
         assert(triangleGroups.back());
         TriangleGroup& triangleGroup = *triangleGroups.back();
-        uint32_t triangleIndex = triangleGroup.vertex_length;
+        GLsizei triangleIndex = triangleGroup.vertex_length;
 
         for (int i = 0; i < triangle_count; ++i) {
             const TESSindex *element_group = &elements[i * vertices_per_group];

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -91,7 +91,7 @@ void FillBucket::tessellate() {
         return;
     }
 
-    size_t total_vertex_count = 0;
+    GLsizei total_vertex_count = 0;
     for (const auto& polygon : polygons) {
         total_vertex_count += polygon.size();
     }
@@ -110,7 +110,7 @@ void FillBucket::tessellate() {
     GLsizei lineIndex = lineGroup.vertex_length;
 
     for (const auto& polygon : polygons) {
-        const size_t group_count = polygon.size();
+        const GLsizei group_count = static_cast<GLsizei>(polygon.size());
         assert(group_count >= 3);
 
         std::vector<TESSreal> clipped_line;
@@ -120,8 +120,8 @@ void FillBucket::tessellate() {
             vertexBuffer.add(pt.X, pt.Y);
         }
 
-        for (size_t i = 0; i < group_count; i++) {
-            const size_t prev_i = (i == 0 ? group_count : i) - 1;
+        for (GLsizei i = 0; i < group_count; i++) {
+            const GLsizei prev_i = (i == 0 ? group_count : i) - 1;
             lineElementsBuffer.add(lineIndex + prev_i, lineIndex + i);
         }
 
@@ -134,12 +134,12 @@ void FillBucket::tessellate() {
 
     if (tessTesselate(tesselator, TESS_WINDING_ODD, TESS_POLYGONS, vertices_per_group, vertexSize, 0)) {
         const TESSreal *vertices = tessGetVertices(tesselator);
-        const size_t vertex_count = tessGetVertexCount(tesselator);
+        const GLsizei vertex_count = tessGetVertexCount(tesselator);
         TESSindex *vertex_indices = const_cast<TESSindex *>(tessGetVertexIndices(tesselator));
         const TESSindex *elements = tessGetElements(tesselator);
         const int triangle_count = tessGetElementCount(tesselator);
 
-        for (size_t i = 0; i < vertex_count; ++i) {
+        for (GLsizei i = 0; i < vertex_count; ++i) {
             if (vertex_indices[i] == TESS_UNDEF) {
                 vertexBuffer.add(::round(vertices[i * 2]), ::round(vertices[i * 2 + 1]));
                 vertex_indices[i] = (TESSindex)total_vertex_count;

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -54,9 +54,9 @@ private:
     LineElementsBuffer& lineElementsBuffer;
 
     // hold information on where the vertices are located in the FillBuffer
-    const size_t vertex_start;
-    const size_t triangle_elements_start;
-    const size_t line_elements_start;
+    const GLsizei vertex_start;
+    const GLsizei triangle_elements_start;
+    const GLsizei line_elements_start;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
     std::vector<std::unique_ptr<LineGroup>> lineGroups;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -75,7 +75,7 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
         nextNormal = util::perp(util::unit(vec2<double>(firstVertex - currentVertex)));
     }
 
-    const int32_t startVertex = (int32_t)vertexBuffer.index();
+    const GLint startVertex = vertexBuffer.index();
     std::vector<TriangleElement> triangleStore;
 
     for (size_t i = 0; i < len; ++i) {
@@ -333,16 +333,15 @@ void LineBucket::addCurrentVertex(const Coordinate& currentVertex,
                                   float endLeft,
                                   float endRight,
                                   bool round,
-                                  int32_t startVertex,
+                                  GLint startVertex,
                                   std::vector<TriangleElement>& triangleStore) {
     int8_t tx = round ? 1 : 0;
 
     vec2<double> extrude = normal * flip;
     if (endLeft)
         extrude = extrude - (util::perp(normal) * endLeft);
-    e3 = (int32_t)vertexBuffer.add(currentVertex.x, currentVertex.y, extrude.x, extrude.y, tx, 0,
-                                   distance) -
-         startVertex;
+    e3 = vertexBuffer.add(currentVertex.x, currentVertex.y, extrude.x, extrude.y, tx, 0, distance)
+         - startVertex;
     if (e1 >= 0 && e2 >= 0) {
         triangleStore.emplace_back(e1, e2, e3);
     }
@@ -352,9 +351,8 @@ void LineBucket::addCurrentVertex(const Coordinate& currentVertex,
     extrude = normal * (-flip);
     if (endRight)
         extrude = extrude - (util::perp(normal) * endRight);
-    e3 = (int32_t)vertexBuffer.add(currentVertex.x, currentVertex.y, extrude.x, extrude.y, tx, 1,
-                                   distance) -
-         startVertex;
+    e3 = vertexBuffer.add(currentVertex.x, currentVertex.y, extrude.x, extrude.y, tx, 1, distance)
+         - startVertex;
     if (e1 >= 0 && e2 >= 0) {
         triangleStore.emplace_back(e1, e2, e3);
     }
@@ -367,13 +365,13 @@ void LineBucket::addPieSliceVertex(const Coordinate& currentVertex,
                                    double distance,
                                    const vec2<double>& extrude,
                                    bool lineTurnsLeft,
-                                   int32_t startVertex,
+                                   GLint startVertex,
                                   std::vector<TriangleElement>& triangleStore) {
     int8_t ty = lineTurnsLeft;
 
     auto flippedExtrude = extrude * (flip * (lineTurnsLeft ? -1 : 1));
-    e3 = (int32_t)vertexBuffer.add(currentVertex.x, currentVertex.y, flippedExtrude.x, flippedExtrude.y, 0, ty,
-                                   distance) - startVertex;
+    e3 = vertexBuffer.add(currentVertex.x, currentVertex.y, flippedExtrude.x, flippedExtrude.y, 0, ty, distance)
+         - startVertex;
     if (e1 >= 0 && e2 >= 0) {
         triangleStore.emplace_back(e1, e2, e3);
     }

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -32,8 +32,8 @@ void LineBucket::addGeometry(const GeometryCollection& geometryCollection) {
 }
 
 void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
-    const auto len = [&vertices] {
-        auto l = vertices.size();
+    const GLsizei len = [&vertices] {
+        GLsizei l = static_cast<GLsizei>(vertices.size());
         // If the line has duplicate vertices at the end, adjust length to remove them.
         while (l > 2 && vertices[l - 1] == vertices[l - 2]) {
             l--;
@@ -78,7 +78,7 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
     const GLint startVertex = vertexBuffer.index();
     std::vector<TriangleElement> triangleStore;
 
-    for (size_t i = 0; i < len; ++i) {
+    for (GLsizei i = 0; i < len; ++i) {
         if (closed && i == len - 1) {
             // if the line is closed, we treat the last vertex like the first
             nextVertex = vertices[1];
@@ -303,8 +303,8 @@ void LineBucket::addGeometry(const std::vector<Coordinate>& vertices) {
         startOfLine = false;
     }
 
-    const size_t endVertex = vertexBuffer.index();
-    const size_t vertexCount = endVertex - startVertex;
+    const GLsizei endVertex = vertexBuffer.index();
+    const GLsizei vertexCount = endVertex - startVertex;
 
     // Store the triangle/line groups.
     {

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -58,8 +58,8 @@ private:
     LineVertexBuffer& vertexBuffer;
     TriangleElementsBuffer& triangleElementsBuffer;
 
-    const size_t vertex_start;
-    const size_t triangle_elements_start;
+    const GLsizei vertex_start;
+    const GLsizei triangle_elements_start;
 
     GLint e1;
     GLint e2;

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -46,9 +46,9 @@ private:
     };
     void addCurrentVertex(const Coordinate& currentVertex, float flip, double distance,
             const vec2<double>& normal, float endLeft, float endRight, bool round,
-            int32_t startVertex, std::vector<LineBucket::TriangleElement>& triangleStore);
+            GLint startVertex, std::vector<LineBucket::TriangleElement>& triangleStore);
     void addPieSliceVertex(const Coordinate& currentVertex, float flip, double distance,
-            const vec2<double>& extrude, bool lineTurnsLeft, int32_t startVertex,
+            const vec2<double>& extrude, bool lineTurnsLeft, GLint startVertex,
             std::vector<TriangleElement>& triangleStore);
 
 public:
@@ -61,9 +61,9 @@ private:
     const size_t vertex_start;
     const size_t triangle_elements_start;
 
-    int32_t e1;
-    int32_t e2;
-    int32_t e3;
+    GLint e1;
+    GLint e2;
+    GLint e3;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
 };

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -235,7 +235,7 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
     // Make a second pass, rendering translucent objects. This time, we render bottom-to-top.
     renderPass(RenderPass::Translucent,
                order.begin(), order.end(),
-               order.size() - 1, -1);
+               static_cast<GLsizei>(order.size()) - 1, -1);
 
     if (debug::renderTree) { Log::Info(Event::Render, "}"); indent--; }
 
@@ -266,7 +266,7 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
 template <class Iterator>
 void Painter::renderPass(RenderPass pass_,
                          Iterator it, Iterator end,
-                         std::size_t i, int8_t increment) {
+                         GLsizei i, int8_t increment) {
     pass = pass_;
 
     MBGL_DEBUG_GROUP(pass == RenderPass::Opaque ? "opaque" : "translucent");

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -117,14 +117,14 @@ void Painter::setDebug(bool enabled) {
     debug = enabled;
 }
 
-void Painter::useProgram(uint32_t program) {
+void Painter::useProgram(GLuint program) {
     if (gl_program != program) {
         MBGL_CHECK_ERROR(glUseProgram(program));
         gl_program = program;
     }
 }
 
-void Painter::lineWidth(float line_width) {
+void Painter::lineWidth(GLfloat line_width) {
     if (gl_lineWidth != line_width) {
         MBGL_CHECK_ERROR(glLineWidth(line_width));
         gl_lineWidth = line_width;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -161,8 +161,8 @@ private:
     void setDepthSublayer(int n);
 
 public:
-    void useProgram(uint32_t program);
-    void lineWidth(float lineWidth);
+    void useProgram(GLuint program);
+    void lineWidth(GLfloat lineWidth);
 
 public:
     mat4 projMatrix;
@@ -194,8 +194,8 @@ private:
 
     gl::Config config;
 
-    uint32_t gl_program = 0;
-    float gl_lineWidth = 0;
+    GLuint gl_program = 0;
+    GLfloat gl_lineWidth = 0;
     std::array<uint16_t, 2> gl_viewport = {{ 0, 0 }};
     RenderPass pass = RenderPass::Opaque;
     Color background = {{ 0, 0, 0, 0 }};

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -143,7 +143,7 @@ private:
     template <class Iterator>
     void renderPass(RenderPass,
                     Iterator it, Iterator end,
-                    std::size_t i, int8_t increment);
+                    GLsizei i, int8_t increment);
 
     void prepareTile(const Tile& tile);
 
@@ -201,7 +201,7 @@ private:
     Color background = {{ 0, 0, 0, 0 }};
 
     int numSublayers = 3;
-    size_t currentLayer;
+    GLsizei currentLayer;
     float depthRangeSize;
     const float depthEpsilon = 1.0f / (1 << 16);
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -488,7 +488,7 @@ void SymbolBucket::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float 
         // coordinate in this polygon.
         assert(buffer.groups.back());
         auto &triangleGroup = *buffer.groups.back();
-        uint32_t triangleIndex = triangleGroup.vertex_length;
+        GLsizei triangleIndex = triangleGroup.vertex_length;
 
         // coordinates (2 triangles)
         buffer.vertices.add(anchorPoint.x, anchorPoint.y, tl.x, tl.y, tex.x, tex.y, minZoom,

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -103,7 +103,8 @@ bool SymbolBucket::needsDependencies(const GeometryTileLayer& layer,
     // Determine and load glyph ranges
     std::set<GlyphRange> ranges;
 
-    for (std::size_t i = 0; i < layer.featureCount(); i++) {
+    const GLsizei featureCount = static_cast<GLsizei>(layer.featureCount());
+    for (GLsizei i = 0; i < featureCount; i++) {
         auto feature = layer.getFeature(i);
 
         GeometryTileFeatureExtractor extractor(*feature);

--- a/src/mbgl/shader/box_shader.cpp
+++ b/src/mbgl/shader/box_shader.cpp
@@ -17,7 +17,7 @@ CollisionBoxShader::CollisionBoxShader()
 }
 
 void CollisionBoxShader::bind(GLbyte *offset) {
-    const int stride = 12;
+    const GLint stride = 12;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, stride, offset + 0));

--- a/src/mbgl/shader/box_shader.hpp
+++ b/src/mbgl/shader/box_shader.hpp
@@ -14,15 +14,15 @@ public:
     void bind(GLbyte *offset) final;
 
     UniformMatrix<4>              u_matrix      = {"u_matrix",      *this};
-    Uniform<float>                u_scale      = {"u_scale",      *this};
-    Uniform<float>                u_zoom        = {"u_zoom",        *this};
-    Uniform<float>                u_maxzoom        = {"u_maxzoom",        *this};
+    Uniform<GLfloat>              u_scale       = {"u_scale",       *this};
+    Uniform<GLfloat>              u_zoom        = {"u_zoom",        *this};
+    Uniform<GLfloat>              u_maxzoom     = {"u_maxzoom",     *this};
 
 protected:
-    int32_t a_extrude = -1;
-    int32_t a_data = -1;
+    GLint a_extrude = -1;
+    GLint a_data = -1;
 };
 
-}
+} // namespace mbgl
 
-#endif
+#endif // MBGL_SHADER_BOX_SHADER

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -12,11 +12,11 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>               u_matrix   = {"u_matrix",   *this};
-    UniformMatrix<4>               u_exmatrix = {"u_exmatrix", *this};
-    Uniform<std::array<float, 4>>  u_color    = {"u_color",    *this};
-    Uniform<float>                 u_size     = {"u_size",     *this};
-    Uniform<float>                 u_blur     = {"u_blur",     *this};
+    UniformMatrix<4>                 u_matrix   = {"u_matrix",   *this};
+    UniformMatrix<4>                 u_exmatrix = {"u_exmatrix", *this};
+    Uniform<std::array<GLfloat, 4>>  u_color    = {"u_color",    *this};
+    Uniform<GLfloat>                 u_size     = {"u_size",     *this};
+    Uniform<GLfloat>                 u_blur     = {"u_blur",     *this};
 };
 
 }

--- a/src/mbgl/shader/dot_shader.hpp
+++ b/src/mbgl/shader/dot_shader.hpp
@@ -12,10 +12,10 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>              u_matrix = {"u_matrix", *this};
-    Uniform<std::array<float, 4>> u_color  = {"u_color",  *this};
-    Uniform<float>                u_size   = {"u_size",   *this};
-    Uniform<float>                u_blur   = {"u_blur",   *this};
+    UniformMatrix<4>                u_matrix = {"u_matrix", *this};
+    Uniform<std::array<GLfloat, 4>> u_color  = {"u_color",  *this};
+    Uniform<GLfloat>                u_size   = {"u_size",   *this};
+    Uniform<GLfloat>                u_blur   = {"u_blur",   *this};
 };
 
 }

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -18,7 +18,7 @@ IconShader::IconShader()
 }
 
 void IconShader::bind(GLbyte *offset) {
-    const int stride = 16;
+    const GLsizei stride = 16;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, stride, offset + 0));

--- a/src/mbgl/shader/icon_shader.hpp
+++ b/src/mbgl/shader/icon_shader.hpp
@@ -12,22 +12,22 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>              u_matrix      = {"u_matrix",      *this};
-    UniformMatrix<4>              u_exmatrix    = {"u_exmatrix",    *this};
-    Uniform<float>                u_zoom        = {"u_zoom",        *this};
-    Uniform<float>                u_fadedist    = {"u_fadedist",    *this};
-    Uniform<float>                u_minfadezoom = {"u_minfadezoom", *this};
-    Uniform<float>                u_maxfadezoom = {"u_maxfadezoom", *this};
-    Uniform<float>                u_fadezoom    = {"u_fadezoom",    *this};
-    Uniform<float>                u_opacity     = {"u_opacity",     *this};
-    Uniform<std::array<float, 2>> u_texsize     = {"u_texsize",     *this};
-    Uniform<int32_t>              u_skewed      = {"u_skewed",      *this};
-    Uniform<float>                u_extra       = {"u_extra",       *this};
+    UniformMatrix<4>                u_matrix      = {"u_matrix",      *this};
+    UniformMatrix<4>                u_exmatrix    = {"u_exmatrix",    *this};
+    Uniform<GLfloat>                u_zoom        = {"u_zoom",        *this};
+    Uniform<GLfloat>                u_fadedist    = {"u_fadedist",    *this};
+    Uniform<GLfloat>                u_minfadezoom = {"u_minfadezoom", *this};
+    Uniform<GLfloat>                u_maxfadezoom = {"u_maxfadezoom", *this};
+    Uniform<GLfloat>                u_fadezoom    = {"u_fadezoom",    *this};
+    Uniform<GLfloat>                u_opacity     = {"u_opacity",     *this};
+    Uniform<std::array<GLfloat, 2>> u_texsize     = {"u_texsize",     *this};
+    Uniform<GLint>                  u_skewed      = {"u_skewed",      *this};
+    Uniform<GLfloat>                u_extra       = {"u_extra",       *this};
 
-private:
-    int32_t a_offset = -1;
-    int32_t a_data1 = -1;
-    int32_t a_data2 = -1;
+protected:
+    GLint a_offset = -1;
+    GLint a_data1 = -1;
+    GLint a_data2 = -1;
 };
 
 }

--- a/src/mbgl/shader/line_shader.hpp
+++ b/src/mbgl/shader/line_shader.hpp
@@ -12,17 +12,17 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>               u_matrix    = {"u_matrix",    *this};
-    UniformMatrix<4>               u_exmatrix  = {"u_exmatrix",  *this};
-    Uniform<std::array<float, 4>>  u_color     = {"u_color",     *this};
-    Uniform<std::array<float, 2>>  u_linewidth = {"u_linewidth", *this};
-    Uniform<float>                 u_ratio     = {"u_ratio",     *this};
-    Uniform<float>                 u_blur      = {"u_blur",      *this};
-    Uniform<float>                 u_extra     = {"u_extra",     *this};
-    UniformMatrix<2>               u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
+    UniformMatrix<4>                 u_matrix    = {"u_matrix",    *this};
+    UniformMatrix<4>                 u_exmatrix  = {"u_exmatrix",  *this};
+    Uniform<std::array<GLfloat, 4>>  u_color     = {"u_color",     *this};
+    Uniform<std::array<GLfloat, 2>>  u_linewidth = {"u_linewidth", *this};
+    Uniform<GLfloat>                 u_ratio     = {"u_ratio",     *this};
+    Uniform<GLfloat>                 u_blur      = {"u_blur",      *this};
+    Uniform<GLfloat>                 u_extra     = {"u_extra",     *this};
+    UniformMatrix<2>                 u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
 
 private:
-    int32_t a_data = -1;
+    GLint a_data = -1;
 };
 
 

--- a/src/mbgl/shader/linepattern_shader.hpp
+++ b/src/mbgl/shader/linepattern_shader.hpp
@@ -12,25 +12,25 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>              u_matrix       = {"u_matrix",       *this};
-    UniformMatrix<4>              u_exmatrix     = {"u_exmatrix",     *this};
-    Uniform<std::array<float, 2>> u_linewidth    = {"u_linewidth",    *this};
-    Uniform<std::array<float, 2>> u_pattern_size_a = {"u_pattern_size_a", *this};
-    Uniform<std::array<float, 2>> u_pattern_tl_a   = {"u_pattern_tl_a",   *this};
-    Uniform<std::array<float, 2>> u_pattern_br_a   = {"u_pattern_br_a",   *this};
-    Uniform<std::array<float, 2>> u_pattern_size_b = {"u_pattern_size_b", *this};
-    Uniform<std::array<float, 2>> u_pattern_tl_b   = {"u_pattern_tl_b",   *this};
-    Uniform<std::array<float, 2>> u_pattern_br_b   = {"u_pattern_br_b",   *this};
-    Uniform<float>                u_ratio        = {"u_ratio",        *this};
-    Uniform<float>                u_point        = {"u_point",        *this};
-    Uniform<float>                u_blur         = {"u_blur",         *this};
-    Uniform<float>                u_fade         = {"u_fade",         *this};
-    Uniform<float>                u_opacity      = {"u_opacity",      *this};
-    Uniform<float>                 u_extra     = {"u_extra",     *this};
-    UniformMatrix<2>               u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
+    UniformMatrix<4>                u_matrix         = {"u_matrix",         *this};
+    UniformMatrix<4>                u_exmatrix       = {"u_exmatrix",       *this};
+    Uniform<std::array<GLfloat, 2>> u_linewidth      = {"u_linewidth",      *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_size_a = {"u_pattern_size_a", *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_tl_a   = {"u_pattern_tl_a",   *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_br_a   = {"u_pattern_br_a",   *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_size_b = {"u_pattern_size_b", *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_tl_b   = {"u_pattern_tl_b",   *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_br_b   = {"u_pattern_br_b",   *this};
+    Uniform<GLfloat>                u_ratio          = {"u_ratio",          *this};
+    Uniform<GLfloat>                u_point          = {"u_point",          *this};
+    Uniform<GLfloat>                u_blur           = {"u_blur",           *this};
+    Uniform<GLfloat>                u_fade           = {"u_fade",           *this};
+    Uniform<GLfloat>                u_opacity        = {"u_opacity",        *this};
+    Uniform<GLfloat>                u_extra          = {"u_extra",          *this};
+    UniformMatrix<2>                u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
 
 private:
-    int32_t a_data = -1;
+    GLint a_data = -1;
 };
 }
 

--- a/src/mbgl/shader/linesdf_shader.hpp
+++ b/src/mbgl/shader/linesdf_shader.hpp
@@ -12,24 +12,24 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>               u_matrix    = {"u_matrix",    *this};
-    UniformMatrix<4>               u_exmatrix  = {"u_exmatrix",  *this};
-    Uniform<std::array<float, 4>>  u_color     = {"u_color",     *this};
-    Uniform<std::array<float, 2>>  u_linewidth = {"u_linewidth", *this};
-    Uniform<float>                 u_ratio     = {"u_ratio",     *this};
-    Uniform<float>                 u_blur      = {"u_blur",      *this};
-    Uniform<std::array<float, 2>>  u_patternscale_a = { "u_patternscale_a", *this };
-    Uniform<float>                 u_tex_y_a   = {"u_tex_y_a",     *this};
-    Uniform<std::array<float, 2>>  u_patternscale_b = { "u_patternscale_b", *this };
-    Uniform<float>                 u_tex_y_b   = {"u_tex_y_b",     *this};
-    Uniform<int32_t>               u_image     = {"u_image",     *this};
-    Uniform<float>                 u_sdfgamma  = {"u_sdfgamma",  *this};
-    Uniform<float>                 u_mix       = {"u_mix",       *this};
-    Uniform<float>                 u_extra     = {"u_extra",     *this};
-    UniformMatrix<2>               u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
+    UniformMatrix<4>                 u_matrix    = {"u_matrix",    *this};
+    UniformMatrix<4>                 u_exmatrix  = {"u_exmatrix",  *this};
+    Uniform<std::array<GLfloat, 4>>  u_color     = {"u_color",     *this};
+    Uniform<std::array<GLfloat, 2>>  u_linewidth = {"u_linewidth", *this};
+    Uniform<GLfloat>                 u_ratio     = {"u_ratio",     *this};
+    Uniform<GLfloat>                 u_blur      = {"u_blur",      *this};
+    Uniform<std::array<GLfloat, 2>>  u_patternscale_a = { "u_patternscale_a", *this};
+    Uniform<GLfloat>                 u_tex_y_a   = {"u_tex_y_a",   *this};
+    Uniform<std::array<GLfloat, 2>>  u_patternscale_b = { "u_patternscale_b", *this};
+    Uniform<GLfloat>                 u_tex_y_b   = {"u_tex_y_b",   *this};
+    Uniform<GLint>                   u_image     = {"u_image",     *this};
+    Uniform<GLfloat>                 u_sdfgamma  = {"u_sdfgamma",  *this};
+    Uniform<GLfloat>                 u_mix       = {"u_mix",       *this};
+    Uniform<GLfloat>                 u_extra     = {"u_extra",     *this};
+    UniformMatrix<2>                 u_antialiasingmatrix = {"u_antialiasingmatrix", *this};
 
 private:
-    int32_t a_data = -1;
+    GLint a_data = -1;
 };
 
 

--- a/src/mbgl/shader/outline_shader.hpp
+++ b/src/mbgl/shader/outline_shader.hpp
@@ -12,9 +12,9 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>              u_matrix = {"u_matrix", *this};
-    Uniform<std::array<float, 4>> u_color  = {"u_color",  *this};
-    Uniform<std::array<float, 2>> u_world  = {"u_world",  *this};
+    UniformMatrix<4>                u_matrix = {"u_matrix", *this};
+    Uniform<std::array<GLfloat, 4>> u_color  = {"u_color",  *this};
+    Uniform<std::array<GLfloat, 2>> u_world  = {"u_world",  *this};
 };
 
 }

--- a/src/mbgl/shader/pattern_shader.hpp
+++ b/src/mbgl/shader/pattern_shader.hpp
@@ -12,16 +12,16 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>              u_matrix        = {"u_matrix",        *this};
-    Uniform<std::array<float, 2>> u_pattern_tl_a    = {"u_pattern_tl_a",    *this};
-    Uniform<std::array<float, 2>> u_pattern_br_a    = {"u_pattern_br_a",    *this};
-    Uniform<std::array<float, 2>> u_pattern_tl_b    = {"u_pattern_tl_b",    *this};
-    Uniform<std::array<float, 2>> u_pattern_br_b    = {"u_pattern_br_b",    *this};
-    Uniform<float>                u_opacity       = {"u_opacity",       *this};
-    Uniform<float>                u_mix           = {"u_mix",           *this};
-    Uniform<int32_t>              u_image         = {"u_image",         *this};
-    UniformMatrix<3>              u_patternmatrix_a = {"u_patternmatrix_a", *this};
-    UniformMatrix<3>              u_patternmatrix_b = {"u_patternmatrix_b", *this};
+    UniformMatrix<4>                u_matrix          = {"u_matrix",          *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_tl_a    = {"u_pattern_tl_a",    *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_br_a    = {"u_pattern_br_a",    *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_tl_b    = {"u_pattern_tl_b",    *this};
+    Uniform<std::array<GLfloat, 2>> u_pattern_br_b    = {"u_pattern_br_b",    *this};
+    Uniform<GLfloat>                u_opacity         = {"u_opacity",         *this};
+    Uniform<GLfloat>                u_mix             = {"u_mix",             *this};
+    Uniform<GLint>                  u_image           = {"u_image",           *this};
+    UniformMatrix<3>                u_patternmatrix_a = {"u_patternmatrix_a", *this};
+    UniformMatrix<3>                u_patternmatrix_b = {"u_patternmatrix_b", *this};
 };
 
 }

--- a/src/mbgl/shader/plain_shader.hpp
+++ b/src/mbgl/shader/plain_shader.hpp
@@ -12,8 +12,8 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>              u_matrix   = {"u_matrix", *this};
-    Uniform<std::array<float, 4>> u_color    = {"u_color",  *this};
+    UniformMatrix<4>                u_matrix   = {"u_matrix", *this};
+    Uniform<std::array<GLfloat, 4>> u_color    = {"u_color",  *this};
 };
 
 }

--- a/src/mbgl/shader/raster_shader.hpp
+++ b/src/mbgl/shader/raster_shader.hpp
@@ -12,15 +12,15 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>              u_matrix            = {"u_matrix",            *this};
-    Uniform<int32_t>              u_image             = {"u_image",             *this};
-    Uniform<float>                u_opacity           = {"u_opacity",           *this};
-    Uniform<float>                u_buffer            = {"u_buffer",            *this};
-    Uniform<float>                u_brightness_low    = {"u_brightness_low",    *this};
-    Uniform<float>                u_brightness_high   = {"u_brightness_high",   *this};
-    Uniform<float>                u_saturation_factor = {"u_saturation_factor", *this};
-    Uniform<float>                u_contrast_factor   = {"u_contrast_factor",   *this};
-    Uniform<std::array<float, 3>> u_spin_weights      = {"u_spin_weights",      *this};
+    UniformMatrix<4>                u_matrix            = {"u_matrix",            *this};
+    Uniform<GLint>                  u_image             = {"u_image",             *this};
+    Uniform<GLfloat>                u_opacity           = {"u_opacity",           *this};
+    Uniform<GLfloat>                u_buffer            = {"u_buffer",            *this};
+    Uniform<GLfloat>                u_brightness_low    = {"u_brightness_low",    *this};
+    Uniform<GLfloat>                u_brightness_high   = {"u_brightness_high",   *this};
+    Uniform<GLfloat>                u_saturation_factor = {"u_saturation_factor", *this};
+    Uniform<GLfloat>                u_contrast_factor   = {"u_contrast_factor",   *this};
+    Uniform<std::array<GLfloat, 3>> u_spin_weights      = {"u_spin_weights",      *this};
 };
 
 }

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -10,24 +10,24 @@ class SDFShader : public Shader {
 public:
     SDFShader();
 
-    UniformMatrix<4>              u_matrix      = {"u_matrix",      *this};
-    UniformMatrix<4>              u_exmatrix    = {"u_exmatrix",    *this};
-    Uniform<std::array<float, 4>> u_color       = {"u_color",       *this};
-    Uniform<std::array<float, 2>> u_texsize     = {"u_texsize",     *this};
-    Uniform<float>                u_buffer      = {"u_buffer",      *this};
-    Uniform<float>                u_gamma       = {"u_gamma",       *this};
-    Uniform<float>                u_zoom        = {"u_zoom",        *this};
-    Uniform<float>                u_fadedist    = {"u_fadedist",    *this};
-    Uniform<float>                u_minfadezoom = {"u_minfadezoom", *this};
-    Uniform<float>                u_maxfadezoom = {"u_maxfadezoom", *this};
-    Uniform<float>                u_fadezoom    = {"u_fadezoom",    *this};
-    Uniform<int32_t>              u_skewed      = {"u_skewed",      *this};
-    Uniform<float>                u_extra       = {"u_extra",       *this};
+    UniformMatrix<4>                u_matrix      = {"u_matrix",      *this};
+    UniformMatrix<4>                u_exmatrix    = {"u_exmatrix",    *this};
+    Uniform<std::array<GLfloat, 4>> u_color       = {"u_color",       *this};
+    Uniform<std::array<GLfloat, 2>> u_texsize     = {"u_texsize",     *this};
+    Uniform<GLfloat>                u_buffer      = {"u_buffer",      *this};
+    Uniform<GLfloat>                u_gamma       = {"u_gamma",       *this};
+    Uniform<GLfloat>                u_zoom        = {"u_zoom",        *this};
+    Uniform<GLfloat>                u_fadedist    = {"u_fadedist",    *this};
+    Uniform<GLfloat>                u_minfadezoom = {"u_minfadezoom", *this};
+    Uniform<GLfloat>                u_maxfadezoom = {"u_maxfadezoom", *this};
+    Uniform<GLfloat>                u_fadezoom    = {"u_fadezoom",    *this};
+    Uniform<GLint>                  u_skewed      = {"u_skewed",      *this};
+    Uniform<GLfloat>                u_extra       = {"u_extra",       *this};
 
 protected:
-    int32_t a_offset = -1;
-    int32_t a_data1 = -1;
-    int32_t a_data2 = -1;
+    GLint a_offset = -1;
+    GLint a_data1 = -1;
+    GLint a_data2 = -1;
 };
 
 class SDFGlyphShader : public SDFShader {

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -14,20 +14,21 @@
 using namespace mbgl;
 
 Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSource)
-    : name(name_),
-      program(0) {
+    : name(name_)
+    , program(0)
+{
     util::stopwatch stopwatch("shader compilation", Event::Shader);
 
     program = MBGL_CHECK_ERROR(glCreateProgram());
 
-    if (!compileShader(&vertShader, GL_VERTEX_SHADER, vertSource)) {
+    if (!compileShader(&vertShader, GL_VERTEX_SHADER, &vertSource)) {
         Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertSource);
         MBGL_CHECK_ERROR(glDeleteProgram(program));
         program = 0;
         throw util::ShaderException(std::string { "Vertex shader " } + name + " failed to compile");
     }
 
-    if (!compileShader(&fragShader, GL_FRAGMENT_SHADER, fragSource)) {
+    if (!compileShader(&fragShader, GL_FRAGMENT_SHADER, &fragSource)) {
         Log::Error(Event::Shader, "Fragment shader %s failed to compile: %s", name, fragSource);
         MBGL_CHECK_ERROR(glDeleteShader(vertShader));
         vertShader = 0;
@@ -69,13 +70,12 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
 }
 
 
-bool Shader::compileShader(GLuint *shader, GLenum type, const GLchar *source) {
+bool Shader::compileShader(GLuint *shader, GLenum type, const GLchar *source[]) {
     GLint status;
 
     *shader = MBGL_CHECK_ERROR(glCreateShader(type));
-    const GLchar *strings[] = { source };
-    const GLsizei lengths[] = { static_cast<GLsizei>(std::strlen(source)) };
-    MBGL_CHECK_ERROR(glShaderSource(*shader, 1, strings, lengths));
+    const GLsizei lengths = static_cast<GLsizei>(std::strlen(*source));
+    MBGL_CHECK_ERROR(glShaderSource(*shader, 1, source, &lengths));
 
     MBGL_CHECK_ERROR(glCompileShader(*shader));
 

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -12,9 +12,10 @@ namespace mbgl {
 
 class Shader : private util::noncopyable {
 public:
-    Shader(const char *name, const char *vertex, const char *fragment);
+    Shader(const GLchar *name, const GLchar *vertex, const GLchar *fragment);
+
     ~Shader();
-    const char *name;
+    const GLchar *name;
     uint32_t program;
 
     inline uint32_t getID() const {
@@ -27,10 +28,10 @@ protected:
     GLint a_pos = -1;
 
 private:
-    bool compileShader(uint32_t *shader, uint32_t type, const char *source);
+    bool compileShader(GLuint *shader, GLenum type, const GLchar *source[]);
 
-    uint32_t vertShader = 0;
-    uint32_t fragShader = 0;
+    GLuint vertShader = 0;
+    GLuint fragShader = 0;
 };
 
 }

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -16,9 +16,9 @@ public:
 
     ~Shader();
     const GLchar *name;
-    uint32_t program;
+    GLuint program;
 
-    inline uint32_t getID() const {
+    inline GLuint getID() const {
         return program;
     }
 

--- a/src/mbgl/shader/uniform.cpp
+++ b/src/mbgl/shader/uniform.cpp
@@ -3,42 +3,42 @@
 namespace mbgl {
 
 template <>
-void Uniform<float>::bind(const float& t) {
+void Uniform<GLfloat>::bind(const GLfloat& t) {
     MBGL_CHECK_ERROR(glUniform1f(location, t));
 }
 
 template <>
-void Uniform<int32_t>::bind(const int32_t& t) {
+void Uniform<GLint>::bind(const GLint& t) {
     MBGL_CHECK_ERROR(glUniform1i(location, t));
 }
 
 template <>
-void Uniform<std::array<float, 2>>::bind(const std::array<float, 2>& t) {
+void Uniform<std::array<GLfloat, 2>>::bind(const std::array<GLfloat, 2>& t) {
     MBGL_CHECK_ERROR(glUniform2fv(location, 1, t.data()));
 }
 
 template <>
-void Uniform<std::array<float, 3>>::bind(const std::array<float, 3>& t) {
+void Uniform<std::array<GLfloat, 3>>::bind(const std::array<GLfloat, 3>& t) {
     MBGL_CHECK_ERROR(glUniform3fv(location, 1, t.data()));
 }
 
 template <>
-void Uniform<std::array<float, 4>>::bind(const std::array<float, 4>& t) {
+void Uniform<std::array<GLfloat, 4>>::bind(const std::array<GLfloat, 4>& t) {
     MBGL_CHECK_ERROR(glUniform4fv(location, 1, t.data()));
 }
 
 template <>
-void UniformMatrix<2>::bind(const std::array<float, 4>& t) {
+void UniformMatrix<2>::bind(const std::array<GLfloat, 4>& t) {
     MBGL_CHECK_ERROR(glUniformMatrix2fv(location, 1, GL_FALSE, t.data()));
 }
 
 template <>
-void UniformMatrix<3>::bind(const std::array<float, 9>& t) {
+void UniformMatrix<3>::bind(const std::array<GLfloat, 9>& t) {
     MBGL_CHECK_ERROR(glUniformMatrix3fv(location, 1, GL_FALSE, t.data()));
 }
 
 template <>
-void UniformMatrix<4>::bind(const std::array<float, 16>& t) {
+void UniformMatrix<4>::bind(const std::array<GLfloat, 16>& t) {
     MBGL_CHECK_ERROR(glUniformMatrix4fv(location, 1, GL_FALSE, t.data()));
 }
 

--- a/src/mbgl/util/gl_object_store.cpp
+++ b/src/mbgl/util/gl_object_store.cpp
@@ -7,17 +7,17 @@
 namespace mbgl {
 namespace util {
 
-void GLObjectStore::abandonVAO(uint32_t vao) {
+void GLObjectStore::abandonVAO(GLuint vao) {
     assert(ThreadContext::currentlyOn(ThreadType::Map));
     abandonedVAOs.emplace_back(vao);
 }
 
-void GLObjectStore::abandonBuffer(uint32_t buffer) {
+void GLObjectStore::abandonBuffer(GLuint buffer) {
     assert(ThreadContext::currentlyOn(ThreadType::Map));
     abandonedBuffers.emplace_back(buffer);
 }
 
-void GLObjectStore::abandonTexture(uint32_t texture) {
+void GLObjectStore::abandonTexture(GLuint texture) {
     assert(ThreadContext::currentlyOn(ThreadType::Map));
     abandonedTextures.emplace_back(texture);
 }

--- a/src/mbgl/util/gl_object_store.hpp
+++ b/src/mbgl/util/gl_object_store.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_MAP_UTIL_GL_OBJECT_STORE
 #define MBGL_MAP_UTIL_GL_OBJECT_STORE
 
+#include <mbgl/platform/gl.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
 #include <cstdint>
@@ -14,18 +15,18 @@ public:
     GLObjectStore() = default;
 
     // Mark OpenGL objects for deletion
-    void abandonVAO(uint32_t vao);
-    void abandonBuffer(uint32_t buffer);
-    void abandonTexture(uint32_t texture);
+    void abandonVAO(GLuint vao);
+    void abandonBuffer(GLuint buffer);
+    void abandonTexture(GLuint texture);
 
     // Actually remove the objects we marked as abandoned with the above methods.
     // Only call this while the OpenGL context is exclusive to this thread.
     void performCleanup();
 
 private:
-    std::vector<uint32_t> abandonedVAOs;
-    std::vector<uint32_t> abandonedBuffers;
-    std::vector<uint32_t> abandonedTextures;
+    std::vector<GLuint> abandonedVAOs;
+    std::vector<GLuint> abandonedBuffers;
+    std::vector<GLuint> abandonedTextures;
 };
 
 }

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -50,7 +50,7 @@ void Raster::bind(bool linear) {
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
     }
 
-    GLuint new_filter = linear ? GL_LINEAR : GL_NEAREST;
+    GLint new_filter = linear ? GL_LINEAR : GL_NEAREST;
     if (new_filter != this->filter) {
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, new_filter));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, new_filter));

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_UTIL_RASTER
 #define MBGL_UTIL_RASTER
 
+#include <mbgl/platform/gl.hpp>
 #include <mbgl/util/texture_pool.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/ptr.hpp>
@@ -32,13 +33,14 @@ public:
 
 public:
     // loaded image dimensions
-    uint32_t width = 0, height = 0;
+    GLsizei width = 0;
+    GLsizei height = 0;
 
     // has been uploaded to texture
     bool textured = false;
 
     // the uploaded texture
-    uint32_t texture = 0;
+    GLuint texture = 0;
 
     // texture opacity
     double opacity = 0;
@@ -53,7 +55,7 @@ private:
     TexturePool& texturePool;
 
     // min/mag filter
-    uint32_t filter = 0;
+    GLint filter = 0;
 
     // the raw pixels
     std::unique_ptr<util::Image> img;

--- a/src/mbgl/util/texture_pool.cpp
+++ b/src/mbgl/util/texture_pool.cpp
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-const int TextureMax = 64;
+const GLsizei TextureMax = 64;
 
 using namespace mbgl;
 
@@ -13,7 +13,7 @@ GLuint TexturePool::getTextureID() {
     if (texture_ids.empty()) {
         GLuint new_texture_ids[TextureMax];
         MBGL_CHECK_ERROR(glGenTextures(TextureMax, new_texture_ids));
-        for (uint32_t id = 0; id < TextureMax; id++) {
+        for (GLuint id = 0; id < TextureMax; id++) {
             texture_ids.insert(new_texture_ids[id]);
         }
     }


### PR DESCRIPTION
We've been using `{u}int{8,16,32,64,ptr}_t` types in GL objects almost everywhere along the code, but we should really be using GL types for all things GL. [OpenGL type reference wiki](https://www.opengl.org/wiki/OpenGL_Type) mentions that these types shouldn't change their bit depths but we never really know what platforms do internally, specially when dealing with different architectures. 

I have found a [public discussion](http://stackoverflow.com/questions/8932912/whats-the-advantage-of-using-gluint-instead-of-unsigned-int) about the advantages of using GL instead of stdlib types, and this comment in particular sounds pretty convincing:

> Library-specific types are often created to be typedef'd according to platform-specific rules. This allows a generic application to use the right type without having to be aware of the platform it will be built for.

I have a suspicion that the `stencil buffer overflow` we randomly see on the console outputs is related to the fact that the incorrect type is in use somewhere.

/cc @mapbox/gl @mapbox/mobile