### PR TITLE
use std::unique_ptr for NodeMap resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-native",
-  "version": "2.0.0-pre.13",
+  "version": "2.0.0-pre.16",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",
@@ -19,18 +19,18 @@
   ],
   "dependencies": {
     "nan": "^2.1.0",
-    "node-pre-gyp": "^0.6.12"
+    "node-pre-gyp": "^0.6.15"
   },
   "bundledDependencies": [
     "node-pre-gyp"
   ],
   "devDependencies": {
-    "aws-sdk": "^2.2.9",
+    "aws-sdk": "^2.2.17",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#744b63be01e36c75c6e629aec16a53048c0b7dbc",
-    "node-gyp": "^3.0.3",
+    "node-gyp": "^3.1.0",
     "read-package-json": "^2.0.2",
     "request": "^2.65.0",
-    "tape": "^4.2.1"
+    "tape": "^4.2.2"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build=false || make node",

--- a/platform/node/src/node_file_source.cpp
+++ b/platform/node/src/node_file_source.cpp
@@ -2,11 +2,11 @@
 #include "node_request.hpp"
 #include "node_mapbox_gl_native.hpp"
 
-namespace node_mbgl {
+namespace mbgl {
 
-class NodeFileSourceRequest : public mbgl::FileRequest {
+class NodeFileSourceRequest : public FileRequest {
 public:
-    std::unique_ptr<mbgl::WorkRequest> workRequest;
+    std::unique_ptr<WorkRequest> workRequest;
 };
 
 NodeFileSource::NodeFileSource(v8::Local<v8::Object> options_) {
@@ -17,12 +17,12 @@ NodeFileSource::~NodeFileSource() {
     options.Reset();
 }
 
-std::unique_ptr<mbgl::FileRequest> NodeFileSource::request(const mbgl::Resource& resource, Callback callback) {
+std::unique_ptr<FileRequest> NodeFileSource::request(const Resource& resource, Callback callback) {
     auto req = std::make_unique<NodeFileSourceRequest>();
 
     // This function can be called from any thread. Make sure we're executing the
     // JS implementation in the node event loop.
-    req->workRequest = NodeRunLoop().invokeWithCallback([this] (mbgl::Resource res, Callback cb) {
+    req->workRequest = util::NodeRunLoop().invokeWithCallback([this] (Resource res, Callback cb) {
         Nan::HandleScope scope;
 
         auto requestHandle = NodeRequest::Create(res, cb)->ToObject();

--- a/platform/node/src/node_file_source.hpp
+++ b/platform/node/src/node_file_source.hpp
@@ -9,14 +9,14 @@
 #include <nan.h>
 #pragma GCC diagnostic pop
 
-namespace node_mbgl {
+namespace mbgl {
 
-class NodeFileSource : public mbgl::FileSource {
+class NodeFileSource : public FileSource {
 public:
     NodeFileSource(v8::Local<v8::Object>);
-    ~NodeFileSource();
+    ~NodeFileSource() override;
 
-    std::unique_ptr<mbgl::FileRequest> request(const mbgl::Resource&, Callback);
+    std::unique_ptr<FileRequest> request(const Resource&, Callback) override;
 
 private:
     Nan::Persistent<v8::Object> options;

--- a/platform/node/src/node_file_source.hpp
+++ b/platform/node/src/node_file_source.hpp
@@ -13,13 +13,13 @@ namespace mbgl {
 
 class NodeFileSource : public FileSource {
 public:
-    NodeFileSource(v8::Local<v8::Object>);
+    NodeFileSource(Nan::Persistent<v8::Object>*);
     ~NodeFileSource() override;
 
     std::unique_ptr<FileRequest> request(const Resource&, Callback) override;
 
 private:
-    Nan::Persistent<v8::Object> options;
+    Nan::Persistent<v8::Object>* options;
 };
 
 }

--- a/platform/node/src/node_log.cpp
+++ b/platform/node/src/node_log.cpp
@@ -1,15 +1,15 @@
 #include "node_log.hpp"
 #include "util/async_queue.hpp"
 
-namespace node_mbgl {
+namespace mbgl {
 
 struct NodeLogObserver::LogMessage {
-    mbgl::EventSeverity severity;
-    mbgl::Event event;
+    EventSeverity severity;
+    Event event;
     int64_t code;
     std::string text;
 
-    LogMessage(mbgl::EventSeverity severity_, mbgl::Event event_, int64_t code_, std::string text_)
+    LogMessage(EventSeverity severity_, Event event_, int64_t code_, std::string text_)
         : severity(severity_),
         event(event_),
         code(code_),
@@ -23,10 +23,10 @@ NodeLogObserver::NodeLogObserver(v8::Local<v8::Object> target)
           auto msg = Nan::New<v8::Object>();
 
           Nan::Set(msg, Nan::New("class").ToLocalChecked(),
-              Nan::New(mbgl::EventClass(message.event).c_str()).ToLocalChecked());
+              Nan::New(EventClass(message.event).c_str()).ToLocalChecked());
 
           Nan::Set(msg, Nan::New("severity").ToLocalChecked(),
-              Nan::New(mbgl::EventSeverityClass(message.severity).c_str()).ToLocalChecked());
+              Nan::New(EventSeverityClass(message.severity).c_str()).ToLocalChecked());
 
           if (message.code != -1) {
               Nan::Set(msg, Nan::New("code").ToLocalChecked(),
@@ -55,7 +55,7 @@ NodeLogObserver::~NodeLogObserver() {
     module.Reset();
 }
 
-bool NodeLogObserver::onRecord(mbgl::EventSeverity severity, mbgl::Event event, int64_t code, const std::string &text) {
+bool NodeLogObserver::onRecord(EventSeverity severity, Event event, int64_t code, const std::string &text) {
     queue->send({ severity, event, code, text });
     return true;
 }

--- a/platform/node/src/node_log.hpp
+++ b/platform/node/src/node_log.hpp
@@ -9,17 +9,17 @@
 #include <nan.h>
 #pragma GCC diagnostic pop
 
-namespace node_mbgl {
+namespace mbgl {
 
 namespace util { template <typename T> class AsyncQueue; }
 
-class NodeLogObserver : public mbgl::Log::Observer {
+class NodeLogObserver : public Log::Observer {
 public:
     NodeLogObserver(v8::Local<v8::Object> target);
     ~NodeLogObserver();
 
     // Log::Observer implementation
-    virtual bool onRecord(mbgl::EventSeverity severity, mbgl::Event event, int64_t code, const std::string &msg) override;
+    virtual bool onRecord(EventSeverity severity, Event event, int64_t code, const std::string &msg) override;
 
 private:
     Nan::Persistent<v8::Object> module;

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/exception.hpp>
 
 #include <unistd.h>
+#include <iostream>
 
 #if UV_VERSION_MAJOR == 0 && UV_VERSION_MINOR <= 10
 #define UV_ASYNC_PARAMS(handle) uv_async_t *handle, int
@@ -196,58 +197,58 @@ NAN_METHOD(NodeMap::Load) {
 std::unique_ptr<NodeMap::RenderOptions> NodeMap::ParseOptions(v8::Local<v8::Object> obj) {
     Nan::HandleScope scope;
 
-    auto options = std::make_unique<RenderOptions>();
+    auto renderOptions = std::make_unique<RenderOptions>();
 
     if (Nan::Has(obj, Nan::New("zoom").ToLocalChecked()).FromJust()) {
-        options->zoom = Nan::Get(obj, Nan::New("zoom").ToLocalChecked()).ToLocalChecked()->NumberValue();
+        renderOptions->zoom = Nan::Get(obj, Nan::New("zoom").ToLocalChecked()).ToLocalChecked()->NumberValue();
     }
 
     if (Nan::Has(obj, Nan::New("bearing").ToLocalChecked()).FromJust()) {
-        options->bearing = Nan::Get(obj, Nan::New("bearing").ToLocalChecked()).ToLocalChecked()->NumberValue();
+        renderOptions->bearing = Nan::Get(obj, Nan::New("bearing").ToLocalChecked()).ToLocalChecked()->NumberValue();
     }
 
     if (Nan::Has(obj, Nan::New("pitch").ToLocalChecked()).FromJust()) {
-        options->pitch = Nan::Get(obj, Nan::New("pitch").ToLocalChecked()).ToLocalChecked()->NumberValue();
+        renderOptions->pitch = Nan::Get(obj, Nan::New("pitch").ToLocalChecked()).ToLocalChecked()->NumberValue();
     }
 
     if (Nan::Has(obj, Nan::New("center").ToLocalChecked()).FromJust()) {
         auto center = Nan::Get(obj, Nan::New("center").ToLocalChecked()).ToLocalChecked().As<v8::Array>();
-        if (center->Length() > 0) { options->longitude = Nan::Get(center, 0).ToLocalChecked()->NumberValue(); }
-        if (center->Length() > 1) { options->latitude = Nan::Get(center, 1).ToLocalChecked()->NumberValue(); }
+        if (center->Length() > 0) { renderOptions->longitude = Nan::Get(center, 0).ToLocalChecked()->NumberValue(); }
+        if (center->Length() > 1) { renderOptions->latitude = Nan::Get(center, 1).ToLocalChecked()->NumberValue(); }
     }
 
     if (Nan::Has(obj, Nan::New("width").ToLocalChecked()).FromJust()) {
-        options->width = Nan::Get(obj, Nan::New("width").ToLocalChecked()).ToLocalChecked()->IntegerValue();
+        renderOptions->width = Nan::Get(obj, Nan::New("width").ToLocalChecked()).ToLocalChecked()->IntegerValue();
     }
 
     if (Nan::Has(obj, Nan::New("height").ToLocalChecked()).FromJust()) {
-        options->height = Nan::Get(obj, Nan::New("height").ToLocalChecked()).ToLocalChecked()->IntegerValue();
+        renderOptions->height = Nan::Get(obj, Nan::New("height").ToLocalChecked()).ToLocalChecked()->IntegerValue();
     }
 
     if (Nan::Has(obj, Nan::New("classes").ToLocalChecked()).FromJust()) {
         auto classes = Nan::Get(obj, Nan::New("classes").ToLocalChecked()).ToLocalChecked()->ToObject().As<v8::Array>();
         const int length = classes->Length();
-        options->classes.reserve(length);
+        renderOptions->classes.reserve(length);
         for (int i = 0; i < length; i++) {
-            options->classes.push_back(std::string { *Nan::Utf8String(Nan::Get(classes, i).ToLocalChecked()->ToString()) });
+            renderOptions->classes.push_back(std::string { *Nan::Utf8String(Nan::Get(classes, i).ToLocalChecked()->ToString()) });
         }
     }
 
-    return options;
+    return renderOptions;
 }
 
 /**
  * Render an image from the currently-loaded style
  *
  * @name render
- * @param {Object} options
- * @param {number} [options.zoom=0]
- * @param {number} [options.width=512]
- * @param {number} [options.height=512]
- * @param {Array<number>} [options.center=[0,0]] longitude, latitude center
+ * @param {Object} renderOptions
+ * @param {number} [renderOptions.zoom=0]
+ * @param {number} [renderOptions.width=512]
+ * @param {number} [renderOptions.height=512]
+ * @param {Array<number>} [renderOptions.center=[0,0]] longitude, latitude center
  * of the map
- * @param {number} [options.bearing=0] rotation
- * @param {Array<string>} [options.classes=[]] GL Style Classes
+ * @param {number} [renderOptions.bearing=0] rotation
+ * @param {Array<string>} [renderOptions.classes=[]] GL Style Classes
  * @param {Function} callback
  * @returns {undefined} calls callback
  * @throws {Error} if stylesheet is not loaded or if map is already rendering
@@ -258,7 +259,7 @@ NAN_METHOD(NodeMap::Render) {
     if (!nodeMap->isValid()) return Nan::ThrowError(releasedMessage());
 
     if (info.Length() <= 0 || !info[0]->IsObject()) {
-        return Nan::ThrowTypeError("First argument must be an options object");
+        return Nan::ThrowTypeError("First argument must be a render options object");
     }
 
     if (info.Length() <= 1 || !info[1]->IsFunction()) {
@@ -273,14 +274,14 @@ NAN_METHOD(NodeMap::Render) {
         return Nan::ThrowError("Map is currently rendering an image");
     }
 
-    auto options = ParseOptions(info[0]->ToObject());
+    auto renderOptions = ParseOptions(info[0]->ToObject());
 
     assert(!nodeMap->callback);
     assert(!nodeMap->image);
     nodeMap->callback = std::make_unique<Nan::Callback>(info[1].As<v8::Function>());
 
     try {
-        nodeMap->startRender(std::move(options));
+        nodeMap->startRender(std::move(renderOptions));
     } catch (util::Exception &ex) {
         return Nan::ThrowError(ex.what());
     }
@@ -288,13 +289,13 @@ NAN_METHOD(NodeMap::Render) {
     info.GetReturnValue().SetUndefined();
 }
 
-void NodeMap::startRender(std::unique_ptr<NodeMap::RenderOptions> options) {
-    view->resize(options->width, options->height);
+void NodeMap::startRender(std::unique_ptr<NodeMap::RenderOptions> renderOptions) {
+    view->resize(renderOptions->width, renderOptions->height);
     map->update(Update::Dimensions);
-    map->setClasses(options->classes);
-    map->setLatLngZoom(LatLng(options->latitude, options->longitude), options->zoom);
-    map->setBearing(options->bearing);
-    map->setPitch(options->pitch);
+    map->setClasses(renderOptions->classes);
+    map->setLatLngZoom(LatLng(renderOptions->latitude, renderOptions->longitude), renderOptions->zoom);
+    map->setBearing(renderOptions->bearing);
+    map->setPitch(renderOptions->pitch);
 
     map->renderStill([this](const std::exception_ptr eptr, std::unique_ptr<const StillImage> result) {
         if (eptr) {
@@ -381,7 +382,7 @@ void NodeMap::renderFinished() {
 }
 
 /**
- * Clean up any resources used by a map instance.options
+ * Clean up any resources used by a map instance.
  * @name release
  * @returns {undefined}
  */
@@ -425,14 +426,20 @@ NAN_METHOD(NodeMap::DumpDebugLogs) {
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Instance
 
-NodeMap::NodeMap(v8::Local<v8::Object> options) :
+NodeMap::NodeMap(v8::Local<v8::Object> options_) :
+    options(options_),
     view(std::make_unique<HeadlessView>(sharedDisplay(), [&] {
         Nan::HandleScope scope;
-        return Nan::Has(options, Nan::New("ratio").ToLocalChecked()).FromJust() ? Nan::Get(options, Nan::New("ratio").ToLocalChecked()).ToLocalChecked()->NumberValue() : 1.0;
+        return Nan::Has(options_, Nan::New("ratio").ToLocalChecked()).FromJust() ? Nan::Get(options_, Nan::New("ratio").ToLocalChecked()).ToLocalChecked()->NumberValue() : 1.0;
     }())),
-    fs(std::make_unique<NodeFileSource>(options)),
+    fs(std::make_unique<NodeFileSource>(&options)),
     map(std::make_unique<Map>(*view, *fs, MapMode::Still)),
     async(new uv_async_t) {
+
+    options.SetWeak(&options, [](const Nan::WeakCallbackInfo<Nan::Persistent<v8::Object>>&) {
+        // The Nan::Persistent in GetParameter() will be destroyed by
+        // the garbage collector before this callback runs.
+    }, Nan::WeakCallbackType::kParameter);
 
     async->data = this;
     uv_async_init(uv_default_loop(), async, [](UV_ASYNC_PARAMS(handle)) {
@@ -444,7 +451,8 @@ NodeMap::NodeMap(v8::Local<v8::Object> options) :
 }
 
 NodeMap::~NodeMap() {
-    if (valid) release();
+    if (isValid()) release();
+    std::cout << "~NodeMap" << std::endl;
 }
 
 }

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -14,7 +14,7 @@
 
 #include <queue>
 
-namespace node_mbgl {
+namespace mbgl {
 
 class NodeMap : public Nan::ObjectWrap {
 public:
@@ -29,7 +29,7 @@ public:
     static NAN_METHOD(Release);
     static NAN_METHOD(DumpDebugLogs);
 
-    void startRender(std::unique_ptr<NodeMap::RenderOptions> options);
+    void startRender(std::unique_ptr<NodeMap::RenderOptions>);
     void renderFinished();
 
     void release();
@@ -43,12 +43,12 @@ public:
     NodeMap(v8::Local<v8::Object>);
     ~NodeMap();
 
-    mbgl::HeadlessView view;
+    HeadlessView view;
     NodeFileSource fs;
-    std::unique_ptr<mbgl::Map> map;
+    std::unique_ptr<Map> map;
 
     std::exception_ptr error;
-    std::unique_ptr<const mbgl::StillImage> image;
+    std::unique_ptr<const StillImage> image;
     std::unique_ptr<Nan::Callback> callback;
 
     // Async for delivering the notifications of render completion.

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -43,8 +43,8 @@ public:
     NodeMap(v8::Local<v8::Object>);
     ~NodeMap();
 
-    HeadlessView view;
-    NodeFileSource fs;
+    std::unique_ptr<HeadlessView> view;
+    std::unique_ptr<NodeFileSource> fs;
     std::unique_ptr<Map> map;
 
     std::exception_ptr error;

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -43,6 +43,8 @@ public:
     NodeMap(v8::Local<v8::Object>);
     ~NodeMap();
 
+    Nan::Persistent<v8::Object> options;
+
     std::unique_ptr<HeadlessView> view;
     std::unique_ptr<NodeFileSource> fs;
     std::unique_ptr<Map> map;

--- a/platform/node/src/node_mapbox_gl_native.cpp
+++ b/platform/node/src/node_mapbox_gl_native.cpp
@@ -11,10 +11,12 @@
 #include "node_log.hpp"
 #include "node_request.hpp"
 
-namespace node_mbgl {
+namespace mbgl {
 
-mbgl::util::RunLoop& NodeRunLoop() {
-    static mbgl::util::RunLoop nodeRunLoop(uv_default_loop());
+namespace util {
+
+RunLoop& NodeRunLoop() {
+    static RunLoop nodeRunLoop(uv_default_loop());
     return nodeRunLoop;
 }
 
@@ -24,41 +26,41 @@ NAN_MODULE_INIT(RegisterModule) {
     // This has the effect of:
     //   a) Ensuring that the static local variable is initialized before any thread contention.
     //   b) unreffing an async handle, which otherwise would keep the default loop running.
-    node_mbgl::NodeRunLoop().stop();
+    util::NodeRunLoop().stop();
 
-    node_mbgl::NodeMap::Init(target);
-    node_mbgl::NodeRequest::Init(target);
+    NodeMap::Init(target);
+    NodeRequest::Init(target);
 
     // Exports Resource constants.
     v8::Local<v8::Object> resource = Nan::New<v8::Object>();
 
     Nan::Set(resource,
         Nan::New("Unknown").ToLocalChecked(),
-        Nan::New(mbgl::Resource::Unknown));
+        Nan::New(Resource::Unknown));
 
     Nan::Set(resource,
         Nan::New("Style").ToLocalChecked(),
-        Nan::New(mbgl::Resource::Style));
+        Nan::New(Resource::Style));
 
     Nan::Set(resource,
         Nan::New("Source").ToLocalChecked(),
-        Nan::New(mbgl::Resource::Source));
+        Nan::New(Resource::Source));
 
     Nan::Set(resource,
         Nan::New("Tile").ToLocalChecked(),
-        Nan::New(mbgl::Resource::Tile));
+        Nan::New(Resource::Tile));
 
     Nan::Set(resource,
         Nan::New("Glyphs").ToLocalChecked(),
-        Nan::New(mbgl::Resource::Glyphs));
+        Nan::New(Resource::Glyphs));
 
     Nan::Set(resource,
         Nan::New("SpriteImage").ToLocalChecked(),
-        Nan::New(mbgl::Resource::SpriteImage));
+        Nan::New(Resource::SpriteImage));
 
     Nan::Set(resource,
         Nan::New("SpriteJSON").ToLocalChecked(),
-        Nan::New(mbgl::Resource::SpriteJSON));
+        Nan::New(Resource::SpriteJSON));
 
     Nan::Set(target,
         Nan::New("Resource").ToLocalChecked(),
@@ -75,7 +77,9 @@ NAN_MODULE_INIT(RegisterModule) {
     Nan::SetPrototype(target,
         Nan::Get(EventEmitter, Nan::New("prototype").ToLocalChecked()).ToLocalChecked());
 
-    mbgl::Log::setObserver(std::make_unique<node_mbgl::NodeLogObserver>(target->ToObject()));
+    Log::setObserver(std::make_unique<NodeLogObserver>(target->ToObject()));
 }
 
 NODE_MODULE(mapbox_gl_native, RegisterModule)
+
+}

--- a/platform/node/src/node_mapbox_gl_native.hpp
+++ b/platform/node/src/node_mapbox_gl_native.hpp
@@ -2,8 +2,12 @@
 
 #include <mbgl/util/run_loop.hpp>
 
-namespace node_mbgl {
+namespace mbgl {
 
-mbgl::util::RunLoop& NodeRunLoop();
+namespace util {
+
+RunLoop& NodeRunLoop();
+
+}
 
 }

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -3,12 +3,8 @@
 #include <mbgl/storage/response.hpp>
 
 #include <cmath>
-#include <iostream>
 
-namespace node_mbgl {
-
-////////////////////////////////////////////////////////////////////////////////////////////////
-// Static Node Methods
+namespace mbgl {
 
 Nan::Persistent<v8::Function> NodeRequest::constructor;
 
@@ -23,16 +19,16 @@ NAN_MODULE_INIT(NodeRequest::Init) {
 }
 
 NAN_METHOD(NodeRequest::New) {
-    auto req = new NodeRequest(*reinterpret_cast<mbgl::FileSource::Callback*>(info[0].As<v8::External>()->Value()));
+    auto req = new NodeRequest(*reinterpret_cast<FileSource::Callback*>(info[0].As<v8::External>()->Value()));
     req->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
 }
 
-v8::Handle<v8::Object> NodeRequest::Create(const mbgl::Resource& resource, mbgl::FileSource::Callback callback) {
+v8::Handle<v8::Object> NodeRequest::Create(const Resource& resource, FileSource::Callback callback) {
     Nan::EscapableHandleScope scope;
 
     v8::Local<v8::Value> argv[] = {
-        Nan::New<v8::External>(const_cast<mbgl::FileSource::Callback*>(&callback))
+        Nan::New<v8::External>(const_cast<FileSource::Callback*>(&callback))
     };
     auto instance = Nan::New(constructor)->NewInstance(1, argv);
 
@@ -43,21 +39,18 @@ v8::Handle<v8::Object> NodeRequest::Create(const mbgl::Resource& resource, mbgl:
 }
 
 NAN_METHOD(NodeRequest::Respond) {
-    using Error = mbgl::Response::Error;
-    mbgl::Response response;
+    using Error = Response::Error;
+    Response response;
 
     if (info.Length() < 1) {
         response.error = std::make_unique<Error>(Error::Reason::NotFound);
-
     } else if (info[0]->BooleanValue()) {
         // Store the error string.
         const Nan::Utf8String message { info[0]->ToString() };
         response.error = std::make_unique<Error>(
             Error::Reason::Other, std::string{ *message, size_t(message.length()) });
-
     } else if (info.Length() < 2 || !info[1]->IsObject()) {
         return Nan::ThrowTypeError("Second argument must be a response object");
-
     } else {
         auto res = info[1]->ToObject();
 
@@ -101,10 +94,6 @@ NAN_METHOD(NodeRequest::Respond) {
     info.GetReturnValue().SetUndefined();
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-// Instance
-
-NodeRequest::NodeRequest(mbgl::FileSource::Callback callback_)
+NodeRequest::NodeRequest(FileSource::Callback callback_)
     : callback(callback_) {}
-
 }

--- a/platform/node/src/node_request.hpp
+++ b/platform/node/src/node_request.hpp
@@ -10,7 +10,7 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/file_source.hpp>
 
-namespace node_mbgl {
+namespace mbgl {
 
 class NodeFileSource;
 
@@ -21,13 +21,13 @@ public:
     static NAN_METHOD(New);
     static NAN_METHOD(Respond);
 
-    static v8::Handle<v8::Object> Create(const mbgl::Resource&, mbgl::FileSource::Callback);
+    static v8::Handle<v8::Object> Create(const Resource&, FileSource::Callback);
     static Nan::Persistent<v8::Function> constructor;
 
-    NodeRequest(mbgl::FileSource::Callback);
+    NodeRequest(FileSource::Callback);
 
 private:
-    mbgl::FileSource::Callback callback;
+    FileSource::Callback callback;
 };
 
 }

--- a/platform/node/src/util/async_queue.hpp
+++ b/platform/node/src/util/async_queue.hpp
@@ -14,7 +14,7 @@
 #define UV_ASYNC_PARAMS(handle) uv_async_t *handle
 #endif
 
-namespace node_mbgl {
+namespace mbgl {
 namespace util {
 
 template <typename T>

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -181,11 +181,11 @@ test('Map', function(t) {
 
             t.throws(function() {
                 map.render();
-            }, /First argument must be an options object/);
+            }, /First argument must be a render options object/);
 
             t.throws(function() {
                 map.render('invalid');
-            }, /First argument must be an options object/);
+            }, /First argument must be a render options object/);
 
             map.release();
             t.end();

--- a/platform/node/test/render.test.js
+++ b/platform/node/test/render.test.js
@@ -33,7 +33,7 @@ suite.run('native', {tests: tests}, function (style, options, callback) {
 
     map.load(style);
     map.render(options, function (err, pixels) {
-        map.release();
+        // map.release();
         if (timedOut) return;
         clearTimeout(watchdog);
         callback(err, pixels);

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<FileRequest> DefaultFileSource::request(const Resource& resource
 
     switch (resource.kind) {
     case Resource::Kind::Style:
-        url = mbgl::util::mapbox::normalizeStyleURL(resource.url, accessToken);
+        url = util::mapbox::normalizeStyleURL(resource.url, accessToken);
         break;
 
     case Resource::Kind::Source:

--- a/src/mbgl/util/channel.hpp
+++ b/src/mbgl/util/channel.hpp
@@ -10,7 +10,7 @@
 namespace mbgl {
 
 template <class T>
-class Channel : public mbgl::util::noncopyable {
+class Channel : public util::noncopyable {
 public:
     void send(const T& t) {
         std::unique_lock<std::mutex> lock(mutex);

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -18,7 +18,7 @@ using RasterTileParseResult = mapbox::util::variant<
     std::unique_ptr<Bucket>, // success
     std::string>;            // error
 
-class Worker : public mbgl::util::noncopyable {
+class Worker : public util::noncopyable {
 public:
     explicit Worker(std::size_t count);
     ~Worker();


### PR DESCRIPTION
Properly clean up all resources in `NodeMap::release` to allow the `NodeMap`
object to be garbage collected.

Fixes a memory leak that likely started in https://github.com/mapbox/node-mapbox-gl-native/pull/143 when the `NodeFileSource` object was moved inside the `NodeMap` instead of being an external reference.

/cc @lucaswoj @jfirebaugh @miccolis