### PR TITLE
Fix for style properties' transition updates

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -243,7 +243,12 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
 
     view.afterRender();
 
-    if (style->hasTransitions() || painter->needsAnimation()) {
+    if (style->hasTransitions()) {
+        updateFlags |= Update::Classes;
+        asyncUpdate->send();
+    }
+
+    if (painter->needsAnimation()) {
         updateFlags |= Update::Repaint;
         asyncUpdate->send();
     }

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -172,6 +172,7 @@ void StyleLayer::applyTransitionedStyleProperty(PropertyKey key, T &target, cons
                 // We overwrite the current property partially with the new value.
                 float progress = std::chrono::duration<float>(now - property.begin) / (property.end - property.begin);
                 target = util::interpolate(target, mapbox::util::apply_visitor(evaluator, property.value), progress);
+                hasPendingTransitions = true;
             } else {
                 // Do not apply this property because its transition hasn't begun yet.
             }
@@ -280,6 +281,9 @@ void StyleLayer::applyStyleProperties<BackgroundProperties>(const float z, const
 void StyleLayer::updateProperties(float z, const TimePoint& now, ZoomHistory &zoomHistory) {
     cleanupAppliedStyleProperties(now);
 
+    // Clear the pending transitions flag upon each update.
+    hasPendingTransitions = false;
+
     switch (type) {
         case StyleLayerType::Fill: applyStyleProperties<FillProperties>(z, now, zoomHistory); break;
         case StyleLayerType::Line: applyStyleProperties<LineProperties>(z, now, zoomHistory); break;
@@ -317,7 +321,7 @@ bool StyleLayer::hasTransitions() const {
             return true;
         }
     }
-    return false;
+    return hasPendingTransitions;
 }
 
 void StyleLayer::cleanupAppliedStyleProperties(const TimePoint& now) {

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -94,6 +94,10 @@ public:
     // Stores the evaluated, and cascaded styling information, specific to this
     // layer's type.
     StyleProperties properties;
+
+private:
+    // Stores whether there are pending transitions to be done on each update.
+    bool hasPendingTransitions = false;
 };
 
 }


### PR DESCRIPTION
There was no way of knowing whether a style property transition was finished or not. This was causing weird rendering artefacts when e.g. adding/removing the `night` class from the GLFW port. This issue was is also not easily perceived because we're currently setting the default animation/transition times to zero (see `src/mbgl/map/map_data.hpp`).

For each style recalculation, we're now storing the information whether there is still some update needed to complete the style properties transitions. This information is then used by `Style::hasTransitions()` so we can properly call for an asynchronous update in `MapContext::renderSync()` if there are pending style property transitions.

/cc @jfirebaugh @kkaefer @incanus @ljbade @tmpsantos