### PR TITLE
add OS X / Android armv7 combo to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,14 @@ matrix:
     - os: osx
       osx_image: xcode7
       env: FLAVOR=ios BUILDTYPE=Release
+    - os: osx
+      osx_image: xcode6.4
+      env: FLAVOR=android ANDROID_ABI=arm-v7 BUILDTYPE=Release
+      android:
+        components: [ 'build-tools-23.0.1', 'android-23', 'extra-android-m2repository', 'extra-android-support', 'extra-google-m2repository' ]
+      addons:
+        apt:
+          packages: [ 'lib32stdc++6' ]
     - os: linux
       env: FLAVOR=android ANDROID_ABI=arm-v7 BUILDTYPE=Release
       android:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       osx_image: xcode7
       env: FLAVOR=ios BUILDTYPE=Release
     - os: osx
-      osx_image: xcode6.4
+      osx_image: xcode7
       env: FLAVOR=android ANDROID_ABI=arm-v7 BUILDTYPE=Release
       android:
         components: [ 'build-tools-23.0.1', 'android-23', 'extra-android-m2repository', 'extra-android-support', 'extra-google-m2repository' ]


### PR DESCRIPTION
The `geojsonvt`-related changes in https://github.com/mapbox/mapbox-gl-native/pull/2288 that landed yesterday turned up some problems in the Android build toolchain on an OS X host. Travis currently only tests Android on Linux hosts, so this adds _yet another_ matrix item to do a simple Android armv7 build on OS X (Xcode 6.4 currently; let's not get _too_ crazy). 

/cc @bleege @mikemorris @jfirebaugh @lucaswoj @ljbade 