### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /src/shader/shaders_gl.cpp
 /src/shader/shaders_gles2.cpp
 /bin/style.bin.js
+/node_modules
 *~
 
 /ios/benchmark/assets/tiles/mapbox.mapbox-streets-v6/


### PR DESCRIPTION
Now that `package.json` is in the root directory, we can end up with a `node_modules` folder that's not currently ignored by `.gitignore`

cc @jfirebaugh @adam-mapbox 