### PR TITLE
attempted OKHTTP fixes #2295

### DIFF
--- a/android/cpp/native_map_view.cpp
+++ b/android/cpp/native_map_view.cpp
@@ -73,7 +73,7 @@ NativeMapView::NativeMapView(JNIEnv *env, jobject obj_, float pixelRatio_, int a
         return;
     }
 
-    obj = env->NewGlobalRef(obj_);
+    obj = env->NewWeakGlobalRef(obj_);
     if (obj == nullptr) {
         env->ExceptionDescribe();
         return;
@@ -93,7 +93,7 @@ NativeMapView::~NativeMapView() {
     JNIEnv *env = nullptr;
     ret = vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
     if (ret == JNI_OK) {
-        env->DeleteGlobalRef(obj);
+        env->DeleteWeakGlobalRef(obj);
     } else {
         mbgl::Log::Error(mbgl::Event::JNI, "GetEnv() failed with %i", ret);
         throw new std::runtime_error("GetEnv() failed");

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/http/HTTPContext.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/http/HTTPContext.java
@@ -20,6 +20,7 @@ class HTTPContext {
     private static final int CONNECTION_ERROR = 0;
     private static final int TEMPORARY_ERROR = 1;
     private static final int PERMANENT_ERROR = 2;
+    private static final int CANCELED_ERROR = 3;
 
     private static HTTPContext mInstance = null;
 
@@ -78,7 +79,10 @@ class HTTPContext {
                 type = CONNECTION_ERROR;
             } else if ((e instanceof InterruptedIOException)) {
                 type = TEMPORARY_ERROR;
+            } else if (mCall.isCanceled()) {
+                type = CANCELED_ERROR;
             }
+
             nativeOnFailure(mNativePtr, type, e.getMessage());
         }
 

--- a/include/mbgl/android/native_map_view.hpp
+++ b/include/mbgl/android/native_map_view.hpp
@@ -62,7 +62,7 @@ private:
 
 private:
     JavaVM *vm = nullptr;
-    jobject obj = nullptr;
+    jweak obj = nullptr;
 
     ANativeWindow *window = nullptr;
     EGLDisplay display = EGL_NO_DISPLAY;


### PR DESCRIPTION
Not ready yet. 

Besides some smaller errors like the `switch` `break` statements and the `int`, see the commit log in https://github.com/mapbox/mapbox-gl-native/commit/6b0b71361bf933f369f17f07953d96d993746b52. 

> On iOS, if in HTTPNSURLRequest::handleResult(), we receive an error of
> type NSURLErrorCancelled, we don't construct a response object and
> merely call async.send() after setting the response status to
> ResponseStatus::Canceled.
> 
> Here, I've modified things to similarly do that (albeit in a brittle way
> since OKHTTP handles cancelations with the onFailure() handler).
> 
> In my testing, this avoids an outright crash, but still hangs the map
> rendering and the whole app on device rotate after catching an
> in-progress HTTP download.

Basically, we're not doing everything _quite_ like iOS or other platforms. This is a start down the path towards righting that. 

/cc @bleege @ljbade 