### PR TITLE
[iOS] disable perfectly good tests so they stop flapping on Travis

### DIFF
--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -66,7 +66,7 @@
 
     [tester.compass tap];
 
-    [tester waitForTimeInterval:1];
+    [tester waitForTimeInterval:2];
 
     XCTAssertEqual(tester.mapView.direction,
                    0,

--- a/test/ios/ios-tests.xcodeproj/xcshareddata/xcschemes/Mapbox GL Tests.xcscheme
+++ b/test/ios/ios-tests.xcodeproj/xcshareddata/xcschemes/Mapbox GL Tests.xcscheme
@@ -53,7 +53,22 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "MapViewTests/testCenterSet">
+               </Test>
+               <Test
+                  Identifier = "MapViewTests/testCompassTap">
+               </Test>
+               <Test
+                  Identifier = "MapViewTests/testDelegateRegionDidChange">
+               </Test>
+               <Test
                   Identifier = "MapViewTests/testDelegateRegionWillChange">
+               </Test>
+               <Test
+                  Identifier = "MapViewTests/testDirectionReset">
+               </Test>
+               <Test
+                  Identifier = "MapViewTests/testDirectionSet">
                </Test>
                <Test
                   Identifier = "MapViewTests/testUserTrackingModeFollowWithHeading">


### PR DESCRIPTION
Travis is inconsistently failing the following tests, so let's temporarily disable them.

- `testDirectionSet`
- `testCompassTap`
- `testDirectionReset`
- `testCenterSet`
- `testDelegateRegionDidChange`

It bears repeating that these tests _only_ fail on Travis, running them locally has always passed.

Fixes #2347

/cc @jfirebaugh @1ec5 @mapbox/gl