### PR TITLE
Remove implicit conversion from double → float

### DIFF
--- a/include/mbgl/ios/MGLGeometry.h
+++ b/include/mbgl/ios/MGLGeometry.h
@@ -85,7 +85,7 @@ NS_INLINE NSString *MGLStringFromCoordinateBounds(MGLCoordinateBounds bounds) {
 
 NS_INLINE CGFloat MGLRadiansFromDegrees(CLLocationDegrees degrees)
 {
-    return degrees * M_PI / 180;
+    return (CGFloat)(degrees * M_PI) / 180;
 }
 
 NS_INLINE CLLocationDegrees MGLDegreesFromRadians(CGFloat radians)


### PR DESCRIPTION
Occurs when targeting a 32-bit architecture

Fixes #2367 