### PR TITLE
#2076 expose getMetersPerPixel on Android

### DIFF
--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/MapView.java
@@ -813,6 +813,18 @@ public class MapView extends FrameLayout implements LocationListener {
         return new PointF(point.x * mScreenDensity, point.y * mScreenDensity);
     }
 
+    /**
+     * Returns the distance spanned by one pixel at the specified latitude and current zoom level.
+     * <p/>
+     * The distance between pixels decreases as the latitude approaches the poles. This relationship parallels the relationship between longitudinal coordinates at different latitudes.
+     *
+     * @param latitude The latitude for which to return the value.
+     * @return The distance (in meters) spanned by a single pixel.
+     */
+    public double getMetersPerPixel(double latitude) {
+        return mNativeMapView.getMetersPerPixelAtLatitude(latitude, getZoomLevel());
+    }
+
     public double getTopOffsetPixelsForAnnotationSymbol(@NonNull String symbolName) {
         return mNativeMapView.getTopOffsetPixelsForAnnotationSymbol(symbolName);
     }


### PR DESCRIPTION
In #2076 @ljbade indicated that only metersPerPixelAtLatitude was missing.

The [NativeMapview method](https://github.com/mapbox/mapbox-gl-native/blob/1d565a515953432ef9dc79fadaf62e3217c42920/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxgl/views/NativeMapView.java#L404) was already in place, I only needed to expose the method in MapView

To be validated: 
To be more Java compliant, I removed atLatitude part of the method signature because this is already indicated by the parameter. Do we want expose exact the same signature as iOS or go for more standard java compliant signatures? 






