### PR TITLE
Fixed incorrect notification

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -884,7 +884,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
         self.centerPoint = CGPointMake(self.centerPoint.x + delta.x, self.centerPoint.y + delta.y);
 
-        [self notifyMapChange:mbgl::MapChangeRegionDidChangeAnimated];
+        [self notifyMapChange:mbgl::MapChangeRegionIsChanging];
     }
     else if (pan.state == UIGestureRecognizerStateEnded || pan.state == UIGestureRecognizerStateCancelled)
     {

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -960,6 +960,8 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         if (log2(newScale) < _mbglMap->getMinZoom()) return;
 
         _mbglMap->setScale(newScale, [pinch locationInView:pinch.view].x, [pinch locationInView:pinch.view].y);
+        
+        [self notifyMapChange:mbgl::MapChangeRegionIsChanging];
     }
     else if (pinch.state == UIGestureRecognizerStateEnded || pinch.state == UIGestureRecognizerStateCancelled)
     {

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1335,6 +1335,8 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         if (newZoom < _mbglMap->getMinZoom()) return;
 
         _mbglMap->scaleBy(powf(2, newZoom) / _mbglMap->getScale(), self.bounds.size.width / 2, self.bounds.size.height / 2);
+        
+        [self notifyMapChange:mbgl::MapChangeRegionIsChanging];
     }
     else if (quickZoom.state == UIGestureRecognizerStateEnded || quickZoom.state == UIGestureRecognizerStateCancelled)
     {


### PR DESCRIPTION
This is incorrect, no?

`UIGestureRecognizerStateChanged` should yield `MapChangeRegionIsChanging` and not until `UIGestureRecognizerStateEnded` should you get `MapChangeRegionDidChangeAnimated`.