### PR TITLE
[iOS] Give iosapp the option to use `always` location permissions

### DIFF
--- a/ios/app/app-info.plist
+++ b/ios/app/app-info.plist
@@ -60,5 +60,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>The map will ALWAYS display the user&apos;s location.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Useful in testing metrics and background location. Default is still `whenInUse`, user must switch in `Settings.app`.

/cc @1ec5 @incanus