### PR TITLE
[iOS] Fix metrics wifi device console spew

### DIFF
--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -6,6 +6,8 @@
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreLocation/CoreLocation.h>
 
+#include <mbgl/platform/darwin/reachability.h>
+
 #import "MGLAccountManager.h"
 #import "NSProcessInfo+MGLAdditions.h"
 #import "NSBundle+MGLAdditions.h"
@@ -738,17 +740,21 @@ const NSTimeInterval MGLFlushInterval = 60;
 // Can be called from any thread.
 //
 - (NSString *) wifiNetworkName {
+    NSString *ssid = NULL;
     
-    NSString *ssid = nil;
-    CFArrayRef interfaces = CNCopySupportedInterfaces();
-    if (interfaces) {
-        NSDictionary *info = CFBridgingRelease(CNCopyCurrentNetworkInfo(CFArrayGetValueAtIndex(interfaces, 0)));
-        if (info) {
-            ssid = info[@"SSID"];
+    MGLReachability *reachability = [MGLReachability reachabilityForLocalWiFi];
+    if ([reachability isReachableViaWiFi])
+    {
+        CFArrayRef interfaces = CNCopySupportedInterfaces();
+        if (interfaces) {
+            NSDictionary *info = CFBridgingRelease(CNCopyCurrentNetworkInfo(CFArrayGetValueAtIndex(interfaces, 0)));
+            if (info) {
+                ssid = info[@"SSID"];
+            }
+            CFRelease(interfaces);
         }
-        CFRelease(interfaces);
     }
-    
+
     return ssid;
 }
 


### PR DESCRIPTION
- Fixes this device console warning (#2378):

```
9/22/15, 6:28:22 AM wifid[75]: WiFi:[464610502.447121]: Network NULL for client configd !
```

- Adds reachability check to `-wifiNetworkName`
- Defaults `ssid` to `NULL`, because that's what the metrics backend expects in the case of no network

/cc @1ec5 @incanus