### PR TITLE
[node] Do not throw if raster image does not load

### DIFF
--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -18,12 +18,8 @@ public:
 
     void parseRasterTile(RasterBucket* bucket, std::string data, std::function<void (TileParseResult)> callback) {
         std::unique_ptr<util::Image> image(new util::Image(data));
-        if (!(*image)) {
-            callback(TileParseResult("error parsing raster image"));
-        }
-
-        if (!bucket->setImage(std::move(image))) {
-            callback(TileParseResult("error setting raster image to bucket"));
+        if (*image) {
+            bucket->setImage(std::move(image));
         }
 
         callback(TileParseResult(TileData::State::parsed));

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -17,9 +17,18 @@ public:
     Impl() = default;
 
     void parseRasterTile(RasterBucket* bucket, std::string data, std::function<void (TileParseResult)> callback) {
+        if (data.empty()) {
+            return callback(TileParseResult(TileData::State::parsed));
+        }
+
         std::unique_ptr<util::Image> image(new util::Image(data));
-        if (*image) {
-            bucket->setImage(std::move(image));
+
+        if (!(*image)) {
+            callback(TileParseResult("error parsing raster image"));
+        }
+
+        if (!bucket->setImage(std::move(image))) {
+            callback(TileParseResult("error setting raster image to bucket"));
         }
 
         callback(TileParseResult(TileData::State::parsed));


### PR DESCRIPTION
Currently, if a vector tile does not load, we still render the map. This is not true for raster tiles; if a raster tile does not load, we throw an error.

For example, imagine a map that has imagery for a given city. When the user is zoomed in on the city and the tiles are in view, all is well. The moment they pan out side the imagery limits, tiles begin to `404` (as intended) but we should still render the given map.

This change allows raster tiles which `404` to pass by.

/cc @jfirebaugh @mikemorris 