### PR TITLE
Remove access token from ios test app

### DIFF
--- a/test/ios/App-Info.plist
+++ b/test/ios/App-Info.plist
@@ -25,7 +25,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MGLMapboxAccessToken</key>
-	<string>pk.eyJ1IjoianVzdGluIiwiYSI6Ik9RX3RRQzAifQ.dmOg_BAp1ywuDZMM7YsXRg</string>
+	<string></string>
 	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
 	<true/>
 	<key>NSLocationAlwaysUsageDescription</key>


### PR DESCRIPTION
Although this token will load maps loaded in the `Mapbox.bundle`, custom styles made in mapbox studo will not load glyphs and sprites. This is because these assets are access controlled and cannot be accessed by another user. This will required devs using the test app to bring their own access token.

/cc @1ec5 @jfirebaugh 