### PR TITLE
Normalize api.mapbox.com

### DIFF
--- a/src/mbgl/util/mapbox.hpp
+++ b/src/mbgl/util/mapbox.hpp
@@ -14,6 +14,12 @@ std::string normalizeSpriteURL(const std::string& url, const std::string& access
 std::string normalizeGlyphsURL(const std::string& url, const std::string& accessToken);
 std::string normalizeTileURL(const std::string& url, const std::string& sourceURL, SourceType sourceType);
 
+// Canonicalizes Mapbox URLs by removing [a-d] subdomain prefixes, access tokens, and protocol.
+// Note that this is close, but not exactly the reverse operation as above, as this retains certain
+// information, such as the API version. It is used to cache resources retrieved from the URL, that
+// sometimes have multiple valid URLs.
+std::string canonicalURL(const std::string &url);
+
 }
 }
 }

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -81,3 +81,59 @@ TEST(Mapbox, TileURL) {
         throw e;
     }
 }
+
+TEST(Mapbox, CanonicalURL) {
+    using mbgl::util::mapbox::canonicalURL;
+    EXPECT_EQ(
+        canonicalURL("https://a.tiles.mapbox.com/v4/"
+                     "mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/"
+                     "10744.vector.pbf?access_token=pk.kAeslEm93Sjf3mXk."
+                     "vbiF02XnvkPkzlFhGSn2iIm6De3Cxsk5tmips2tvkG8sF"),
+        "mapbox://v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/10744.vector.pbf");
+
+    EXPECT_EQ(
+        canonicalURL("http://a.tiles.mapbox.com/v4/"
+                     "mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/"
+                     "10744.vector.pbf?access_token=pk.kAeslEm93Sjf3mXk."
+                     "vbiF02XnvkPkzlFhGSn2iIm6De3Cxsk5tmips2tvkG8sF"),
+        "mapbox://v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/10744.vector.pbf");
+
+    EXPECT_EQ(
+        canonicalURL("https://b.tiles.mapbox.com/v4/"
+                     "mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/"
+                     "10744.vector.pbf?access_token=pk.kAeslEm93Sjf3mXk."
+                     "vbiF02XnvkPkzlFhGSn2iIm6De3Cxsk5tmips2tvkG8sF"),
+        "mapbox://v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/10744.vector.pbf");
+
+    EXPECT_EQ(
+        canonicalURL("http://c.tiles.mapbox.com/v4/"
+                     "mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/"
+                     "10744.vector.pbf?access_token=pk.kAeslEm93Sjf3mXk."
+                     "vbiF02XnvkPkzlFhGSn2iIm6De3Cxsk5tmips2tvkG8sF"),
+        "mapbox://v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/10744.vector.pbf");
+
+    EXPECT_EQ(
+        canonicalURL("https://api.mapbox.com/v4/"
+                     "mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/"
+                     "10744.vector.pbf?access_token=pk.kAeslEm93Sjf3mXk."
+                     "vbiF02XnvkPkzlFhGSn2iIm6De3Cxsk5tmips2tvkG8sF"),
+        "mapbox://v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/10744.vector.pbf");
+
+    EXPECT_EQ(
+        canonicalURL("http://api.mapbox.com/v4/"
+                     "mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/"
+                     "10744.vector.pbf"),
+        "mapbox://v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6/15/17599/10744.vector.pbf");
+
+    EXPECT_EQ(canonicalURL("https://api.mapbox.com/fonts/v1/mapbox/"
+                           "DIN%20Offc%20Pro%20Italic%2cArial%20Unicode%20MS%20Regular/"
+                           "0-255.pbf?access_token=pk.kAeslEm93Sjf3mXk."
+                           "vbiF02XnvkPkzlFhGSn2iIm6De3Cxsk5tmips2tvkG8sF"),
+              "mapbox://fonts/v1/mapbox/DIN%20Offc%20Pro%20Italic%2cArial%20Unicode%20MS%20Regular/"
+              "0-255.pbf");
+
+    EXPECT_EQ(canonicalURL("https://api.mapbox.com/styles/v1/mapbox/streets-v8/"
+                           "sprite.json?access_token=pk.kAeslEm93Sjf3mXk."
+                           "vbiF02XnvkPkzlFhGSn2iIm6De3Cxsk5tmips2tvkG8sF"),
+              "mapbox://styles/v1/mapbox/streets-v8/sprite.json");
+}


### PR DESCRIPTION
We're currently [normalizing](https://github.com/mapbox/mapbox-gl-native/blob/81fde4261f2430a428f7dea98cdc524e4a3e31f5/platform/default/sqlite_cache.cpp#L50) the old `*.tiles.mapbox.com` to `mapbox://`, but we don't yet include the equivalent `api.mapbox.com`.

We should also move `unifyMapboxURLs()` to a more location that isn't dependent on the SQLiteCache class so that we can use it even if we don't use the cache.