### PR TITLE
[node] Handle tiles which 404 better

### DIFF
--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class Response {
 public:
-    enum Status : bool { Error, Successful };
+    enum Status { Error, Successful, NotFound };
 
     Status status = Error;
     std::string message;

--- a/platform/android/http_request_android.cpp
+++ b/platform/android/http_request_android.cpp
@@ -292,6 +292,9 @@ void HTTPAndroidRequest::onResponse(int code, std::string message, std::string e
     } else if (code == 200) {
         response->status = Response::Successful;
         status = ResponseStatus::Successful;
+    } else if (responseCode == 404) {
+        response->status = Response::NotFound;
+        status = ResponseStatus::Successful;
     } else if (code >= 500 && code < 600) {
         response->status = Response::Error;
         response->message = "HTTP status code " + util::toString(code);

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -294,6 +294,9 @@ void HTTPNSURLRequest::handleResult(NSData *data, NSURLResponse *res, NSError *e
         } else if (responseCode == 200) {
             response->status = Response::Successful;
             status = ResponseStatus::Successful;
+        } else if (responseCode == 404) {
+            response->status = Response::NotFound;
+            status = ResponseStatus::Successful;
         } else if (responseCode >= 500 && responseCode < 600) {
             // Server errors may be temporary, so back off exponentially.
             response->status = Response::Error;

--- a/platform/default/http_request_curl.cpp
+++ b/platform/default/http_request_curl.cpp
@@ -703,6 +703,9 @@ void HTTPCURLRequest::handleResult(CURLcode code) {
         } else if (responseCode == 200) {
             response->status = Response::Successful;
             return finish(ResponseStatus::Successful);
+        } else if (responseCode == 404) {
+            response->status = Response::NotFound;
+            return finish(ResponseStatus::Successful);
         } else if (responseCode >= 500 && responseCode < 600) {
             // Server errors may be temporary, so back off exponentially.
             response->status = Response::Error;

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -64,7 +64,9 @@ NAN_METHOD(NodeRequest::Respond) {
     auto resource = std::move(nodeRequest->resource);
 
     if (info.Length() < 1) {
-        return Nan::ThrowTypeError("First argument must be an error object");
+        auto response = std::make_shared<mbgl::Response>();
+        response->status = mbgl::Response::NotFound;
+        source->notify(*resource, response);
     } else if (info[0]->BooleanValue()) {
         auto response = std::make_shared<mbgl::Response>();
 

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -33,6 +33,12 @@ void RasterTileData::request(float pixelRatio,
     req = fs->request({ Resource::Kind::Tile, url }, util::RunLoop::getLoop(), [url, callback, this](const Response &res) {
         req = nullptr;
 
+        if (res.status == Response::NotFound) {
+            state = State::parsed;
+            callback();
+            return;
+        }
+
         if (res.status != Response::Successful) {
             std::stringstream message;
             message <<  "Failed to load [" << url << "]: " << res.message;

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -44,6 +44,12 @@ void VectorTileData::request(float pixelRatio, const std::function<void()>& call
     req = fs->request({ Resource::Kind::Tile, url }, util::RunLoop::getLoop(), [url, callback, this](const Response &res) {
         req = nullptr;
 
+        if (res.status == Response::NotFound) {
+            state = State::parsed;
+            callback();
+            return;
+        }
+
         if (res.status != Response::Successful) {
             std::stringstream message;
             message <<  "Failed to load [" << url << "]: " << res.message;

--- a/test/storage/server.js
+++ b/test/storage/server.js
@@ -73,6 +73,9 @@ app.get('/revalidate-etag', function(req, res) {
     revalidateEtagCounter++;
 });
 
+app.get('/permanent-error', function(req, res) {
+    res.status(500).end();
+});
 
 var temporaryErrorCounter = 0;
 app.get('/temporary-error', function(req, res) {


### PR DESCRIPTION
Continuation of: https://github.com/mapbox/mapbox-gl-native/pull/2388

Currently, if a vector tile does not load, we still render the map. This is not true for raster tiles; if a raster tile does not load, we throw an error.

For example, imagine a map that has imagery for a given city. When the user is zoomed in on the city and the tiles are in view, all is well. The moment they pan out side the imagery limits, tiles begin to 404 (as intended) but we should still render the given map.

This change short circuits all tiles which 404 and does not attempt to parse/render these tiles. With this change, a (node) filesource which retrieves a tile that 404's should return the `callback()` with no arguments. It might look like:

```js
if (res.statusCode === 404 && req.kind === 3) { // tile 404's and is of type tile
  callback(); // just return an empty callback, no data
} 
```

/cc @mikemorris @jfirebaugh 