### PR TITLE
[node] bump version to 2.0.0-pre.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-native",
-  "version": "2.0.0-pre.7",
+  "version": "2.0.0-pre.8",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -9,11 +9,12 @@
 - Requires numerical `ratio` in `mbgl.Map` options argument.
   Map pixel ratio is now immutable and can no longer be set with
   render options. ([`a8d9b92`](https://github.com/mapbox/mapbox-gl-native/commit/a8d9b921d71a91d7f8eff82e5a584aaab8b7d1c6), [#1799](https://github.com/mapbox/mapbox-gl-native/pull/1799))
-- `map.render` now returns a raw image buffer instead of an object with 
+- `map.render` now returns a raw image buffer instead of an object with
   `width`, `height` and `pixels` properties. ([#2262](https://github.com/mapbox/mapbox-gl-native/pull/2262))
 - Adds support for rendering v8 styles.
 - No longer loads resources before a render request is made. ([`55d25a8`](https://github.com/mapbox/mapbox-gl-native/commit/55d25a80a77c06ef5e66acc0d8518867b03fe8a4))
 - Adds io.js v3.x support. ([#2261](https://github.com/mapbox/mapbox-gl-native/pull/2261))
+- Fixes a bug which prevented raster tiles that `404`'ed from rendering ([#2458](https://github.com/mapbox/mapbox-gl-native/pull/2458))
 
 # 1.1.3
 


### PR DESCRIPTION
* Fixes an issue which prevented tile rendering on tile that `404`'ed. https://github.com/mapbox/mapbox-gl-native/pull/2458