### PR TITLE
Update CONTRIBUTING doc to ask for [platform] prefixed commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,6 @@ If you want to contribute code:
 1. Ensure that the [existing issues](https://github.com/mapbox/mapbox-gl-native/issues?utf8=✓&q=) don't already cover your question or contribution. 
 
 1. Pull requests gladly accepted. 
+
+1. Prefix your commit messages with the platform(s) your changes affect: `[core]`, `[ios]`, `[android]`, `[node]`, and so on.
+


### PR DESCRIPTION
We've discussed this internally, but let's indoctrinate the entire world. With the `mapbox-gl-native` repository now being home to actively developed node, iOS, and Android projects, it's important to be able to efficiently distinguish which commits belong to which project.

Here is what's been proposed by @tmpsantos, which many of us have been using:

>[node] Fixed this and that
>[iOS] Added feature x
>[Android] Fixed crash when blah
>[core] Improved tile rendering
>[tests] Added more tests

/cc @mapbox/gl @mapbox/mobile