### PR TITLE
Ask contributors to update changelogs incrementally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## iOS master
+
+- The SDK now builds with Bitcode enabled. ([#2332](https://github.com/mapbox/mapbox-gl-native/issues/2332))
+- The double-tap-drag gesture for zooming in and out is now consistent with the Google Maps SDK. ([#2153](https://github.com/mapbox/mapbox-gl-native/pull/2153))
+- A new `MGLAnnotationImage.enabled` property allows you to disable touch events on individual annotations. ([#2501](https://github.com/mapbox/mapbox-gl-native/pull/2501))
+- Fixed a rendering issue with styles that use the `background-pattern` property. ([#2531](https://github.com/mapbox/mapbox-gl-native/pull/2531))
+
 ## iOS 2.1.2
 
 - Built with Xcode 6.4 to not yet trigger Bitcode compatibility until Xcode 7 stabilizes. ([#2332](https://github.com/mapbox/mapbox-gl-native/issues/2332))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,6 @@ If you want to contribute code:
 
 1. Ensure that the [existing issues](https://github.com/mapbox/mapbox-gl-native/issues?utf8=✓&q=) don't already cover your question or contribution. 
 
-1. Pull requests gladly accepted. 
+1. Pull requests gladly accepted. If there are any changes that developers using one of the GL SDKs should be aware of, please update the “master” section of the relevant changelog: [iOS](CHANGELOG.md) [Node.js](platform/node/CHANGELOG.md).
 
 1. Prefix your commit messages with the platform(s) your changes affect: `[core]`, `[ios]`, `[android]`, `[node]`, and so on.
-

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,5 @@
+# master
+
 # 2.0.0
 
 - Integrates Node.js bindings into core mapbox-gl-native project. ([#2179](https://github.com/mapbox/mapbox-gl-native/pull/2179))


### PR DESCRIPTION
Along the lines of #2470, we should ask contributors to update the iOS changelog as part of any pull request that significantly affects the iOS SDK. This way, we no longer have to root around for changes when it comes time to release, running the risk of missing a backwards-incompatible change.

For the past few iOS releases, we’ve been maintaining a running changelog in [the relevant milestone’s description](https://github.com/mapbox/mapbox-gl-native/milestones), but it’s easy to forget it’s there.

/cc @mapbox/gl