### PR TITLE
[node] bump version to 2.0.0-pre.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-native",
-  "version": "2.0.0-pre.8",
+  "version": "2.0.0-pre.9",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
`2.0.0-pre.9` was published with the `node_modules` folder. This release looks to fix this issue and publish it without `node_modules`.

/cc @jfirebaugh 