### PR TITLE
Compile gtest with an OS X deployment target of 10.9

### DIFF
--- a/deps/gtest/gtest.gyp
+++ b/deps/gtest/gtest.gyp
@@ -12,6 +12,9 @@
         'sources': [
             'gtest-all.cc'
         ],
+        'xcode_settings': {
+            'MACOSX_DEPLOYMENT_TARGET': '10.9',
+        },
         'link_settings': {
             'xcode_settings': { 'OTHER_LDFLAGS': [ '-lpthread' ] },
             'ldflags': [ '-lpthread' ],


### PR DESCRIPTION
This will fix the

```
ld: warning: object file (./Release/libgtest.a(gtest-all.o)) was built for newer OSX version (10.11) than being linked (10.9)
```

error