### PR TITLE
Split up buffers

### DIFF
--- a/src/mbgl/map/tile_worker.cpp
+++ b/src/mbgl/map/tile_worker.cpp
@@ -186,17 +186,14 @@ void TileWorker::addBucketGeometries(Bucket& bucket, const GeometryTileLayer& la
 
 std::unique_ptr<Bucket> TileWorker::createFillBucket(const GeometryTileLayer& layer,
                                                      const StyleBucket& bucket_desc) {
-    auto bucket = std::make_unique<FillBucket>(fillVertexBuffer,
-                                                triangleElementsBuffer,
-                                                lineElementsBuffer);
+    auto bucket = std::make_unique<FillBucket>();
     addBucketGeometries(bucket, layer, bucket_desc.filter);
     return bucket->hasData() ? std::move(bucket) : nullptr;
 }
 
 std::unique_ptr<Bucket> TileWorker::createLineBucket(const GeometryTileLayer& layer,
                                                      const StyleBucket& bucket_desc) {
-    auto bucket = std::make_unique<LineBucket>(lineVertexBuffer,
-                                                triangleElementsBuffer);
+    auto bucket = std::make_unique<LineBucket>();
 
     const float z = id.z;
     auto& layout = bucket->layout;
@@ -212,8 +209,7 @@ std::unique_ptr<Bucket> TileWorker::createLineBucket(const GeometryTileLayer& la
 
 std::unique_ptr<Bucket> TileWorker::createCircleBucket(const GeometryTileLayer& layer,
                                                        const StyleBucket& bucket_desc) {
-    auto bucket = std::make_unique<CircleBucket>(circleVertexBuffer,
-                                                 triangleElementsBuffer);
+    auto bucket = std::make_unique<CircleBucket>();
 
     // Circle does not have layout properties to apply.
 

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -4,10 +4,6 @@
 #include <mapbox/variant.hpp>
 
 #include <mbgl/map/tile_data.hpp>
-#include <mbgl/geometry/elements_buffer.hpp>
-#include <mbgl/geometry/fill_buffer.hpp>
-#include <mbgl/geometry/line_buffer.hpp>
-#include <mbgl/geometry/circle_buffer.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/style/filter_expression.hpp>
@@ -68,13 +64,6 @@ private:
     const std::atomic<TileData::State>& state;
 
     bool partialParse = false;
-
-    FillVertexBuffer fillVertexBuffer;
-    LineVertexBuffer lineVertexBuffer;
-    CircleVertexBuffer circleVertexBuffer;
-
-    TriangleElementsBuffer triangleElementsBuffer;
-    LineElementsBuffer lineElementsBuffer;
 
     std::unique_ptr<CollisionTile> collisionTile;
 

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -5,12 +5,7 @@
 
 using namespace mbgl;
 
-CircleBucket::CircleBucket(CircleVertexBuffer& vertexBuffer,
-                           TriangleElementsBuffer& elementsBuffer)
-    : vertexBuffer_(vertexBuffer)
-    , elementsBuffer_(elementsBuffer)
-    , vertexStart_(vertexBuffer_.index())
-    , elementsStart_(elementsBuffer_.index()) {
+CircleBucket::CircleBucket() {
 }
 
 CircleBucket::~CircleBucket() {
@@ -78,8 +73,8 @@ void CircleBucket::addGeometry(const GeometryCollection& geometryCollection) {
 }
 
 void CircleBucket::drawCircles(CircleShader& shader) {
-    GLbyte *vertexIndex = BUFFER_OFFSET(vertexStart_ * vertexBuffer_.itemSize);
-    GLbyte *elementsIndex = BUFFER_OFFSET(elementsStart_ * elementsBuffer_.itemSize);
+    GLbyte* vertexIndex = BUFFER_OFFSET(0);
+    GLbyte* elementsIndex = BUFFER_OFFSET(0);
 
     for (auto& group : triangleGroups_) {
         assert(group);

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -20,7 +20,7 @@ class CircleBucket : public Bucket {
     using TriangleGroup = ElementGroup<3>;
 
 public:
-    CircleBucket(CircleVertexBuffer &vertexBuffer, TriangleElementsBuffer &elementsBuffer);
+    CircleBucket();
     ~CircleBucket() override;
 
     void upload() override;
@@ -32,11 +32,8 @@ public:
     void drawCircles(CircleShader& shader);
 
 private:
-    CircleVertexBuffer& vertexBuffer_;
-    TriangleElementsBuffer& elementsBuffer_;
-
-    const GLsizei vertexStart_;
-    const GLsizei elementsStart_;
+    CircleVertexBuffer vertexBuffer_;
+    TriangleElementsBuffer elementsBuffer_;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups_;
 };

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -28,9 +28,7 @@ void FillBucket::free(void *, void *ptr) {
     ::free(ptr);
 }
 
-FillBucket::FillBucket(FillVertexBuffer &vertexBuffer_,
-                       TriangleElementsBuffer &triangleElementsBuffer_,
-                       LineElementsBuffer &lineElementsBuffer_)
+FillBucket::FillBucket()
     : allocator(new TESSalloc{
           &alloc,
           &realloc,
@@ -43,13 +41,7 @@ FillBucket::FillBucket(FillVertexBuffer &vertexBuffer_,
           8,       // regionBucketSize
           128,     // extraVertices allocated for the priority queue.
       }),
-      tesselator(tessNewTess(allocator)),
-      vertexBuffer(vertexBuffer_),
-      triangleElementsBuffer(triangleElementsBuffer_),
-      lineElementsBuffer(lineElementsBuffer_),
-      vertex_start(vertexBuffer_.index()),
-      triangle_elements_start(triangleElementsBuffer_.index()),
-      line_elements_start(lineElementsBuffer.index()) {
+      tesselator(tessNewTess(allocator)) {
     assert(tesselator);
 }
 
@@ -216,8 +208,8 @@ bool FillBucket::hasData() const {
 }
 
 void FillBucket::drawElements(PlainShader& shader) {
-    GLbyte *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    GLbyte *elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(0);
+    GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
         group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
@@ -228,8 +220,8 @@ void FillBucket::drawElements(PlainShader& shader) {
 }
 
 void FillBucket::drawElements(PatternShader& shader) {
-    GLbyte *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    GLbyte *elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(0);
+    GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
         group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
@@ -240,8 +232,8 @@ void FillBucket::drawElements(PatternShader& shader) {
 }
 
 void FillBucket::drawVertices(OutlineShader& shader) {
-    GLbyte *vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    GLbyte *elements_index = BUFFER_OFFSET(line_elements_start * lineElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(0);
+    GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : lineGroups) {
         assert(group);
         group->array[0].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index);

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/map/geometry_tile.hpp>
 #include <mbgl/geometry/elements_buffer.hpp>
+#include <mbgl/geometry/fill_buffer.hpp>
 
 #include <clipper/clipper.hpp>
 #include <libtess2/tesselator.h>
@@ -28,9 +29,7 @@ class FillBucket : public Bucket {
     typedef ElementGroup<1> LineGroup;
 
 public:
-    FillBucket(FillVertexBuffer &vertexBuffer,
-               TriangleElementsBuffer &triangleElementsBuffer,
-               LineElementsBuffer &lineElementsBuffer);
+    FillBucket();
     ~FillBucket() override;
 
     void upload() override;
@@ -49,14 +48,9 @@ private:
     TESStesselator *tesselator;
     ClipperLib::Clipper clipper;
 
-    FillVertexBuffer& vertexBuffer;
-    TriangleElementsBuffer& triangleElementsBuffer;
-    LineElementsBuffer& lineElementsBuffer;
-
-    // hold information on where the vertices are located in the FillBuffer
-    const GLsizei vertex_start;
-    const GLsizei triangle_elements_start;
-    const GLsizei line_elements_start;
+    FillVertexBuffer vertexBuffer;
+    TriangleElementsBuffer triangleElementsBuffer;
+    LineElementsBuffer lineElementsBuffer;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
     std::vector<std::unique_ptr<LineGroup>> lineGroups;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -14,12 +14,8 @@
 
 using namespace mbgl;
 
-LineBucket::LineBucket(LineVertexBuffer& vertexBuffer_,
-                       TriangleElementsBuffer& triangleElementsBuffer_)
-    : vertexBuffer(vertexBuffer_),
-      triangleElementsBuffer(triangleElementsBuffer_),
-      vertex_start(vertexBuffer_.index()),
-      triangle_elements_start(triangleElementsBuffer_.index()){};
+LineBucket::LineBucket() {
+}
 
 LineBucket::~LineBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
@@ -403,8 +399,8 @@ bool LineBucket::hasData() const {
 }
 
 void LineBucket::drawLines(LineShader& shader) {
-    GLbyte* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    GLbyte* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(0);
+    GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
         if (!group->elements_length) {
@@ -419,8 +415,8 @@ void LineBucket::drawLines(LineShader& shader) {
 }
 
 void LineBucket::drawLineSDF(LineSDFShader& shader) {
-    GLbyte* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    GLbyte* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(0);
+    GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
         if (!group->elements_length) {
@@ -435,8 +431,8 @@ void LineBucket::drawLineSDF(LineSDFShader& shader) {
 }
 
 void LineBucket::drawLinePatterns(LinepatternShader& shader) {
-    GLbyte* vertex_index = BUFFER_OFFSET(vertex_start * vertexBuffer.itemSize);
-    GLbyte* elements_index = BUFFER_OFFSET(triangle_elements_start * triangleElementsBuffer.itemSize);
+    GLbyte* vertex_index = BUFFER_OFFSET(0);
+    GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
         if (!group->elements_length) {

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -25,7 +25,7 @@ class LineBucket : public Bucket {
     using TriangleGroup = ElementGroup<3>;
 
 public:
-    LineBucket(LineVertexBuffer &vertexBuffer, TriangleElementsBuffer &triangleElementsBuffer);
+    LineBucket();
     ~LineBucket() override;
 
     void upload() override;
@@ -55,11 +55,8 @@ public:
     StyleLayoutLine layout;
 
 private:
-    LineVertexBuffer& vertexBuffer;
-    TriangleElementsBuffer& triangleElementsBuffer;
-
-    const GLsizei vertex_start;
-    const GLsizei triangle_elements_start;
+    LineVertexBuffer vertexBuffer;
+    TriangleElementsBuffer triangleElementsBuffer;
 
     GLint e1;
     GLint e2;


### PR DESCRIPTION
We're currently reusing buffers until they fill up to 65535 vertices. Instead, every logical buffer should have its own buffer rather than sharing them.