### PR TITLE
patch up iOS version-deducing scripts

### DIFF
--- a/ios/docs/install_docs.sh
+++ b/ios/docs/install_docs.sh
@@ -7,8 +7,8 @@ fi
 
 OUTPUT="/tmp/`uuidgen`"
 
-VERSION=$( git tag --sort -v:refname | grep -v '\-rc.' | sed -n '1p' | sed 's/^v//' )
-echo "Creating new docs for ${VERSION}..."
+DOCS_VERSION=$( git tag | grep ^ios | sed 's/^ios-//' | sort -r | grep -v '\-rc.' | grep -v '\-pre.' | sed -n '1p' | sed 's/^v//' )
+echo "Creating new docs for ${DOCS_VERSION}..."
 echo
 
 rm -rf /tmp/mbgl
@@ -26,7 +26,7 @@ perl \
     /tmp/mbgl/ios/*.h
 appledoc \
     --output ${OUTPUT} \
-    --project-name "Mapbox iOS SDK ${VERSION}" \
+    --project-name "Mapbox iOS SDK ${DOCS_VERSION}" \
     --project-company Mapbox \
     --create-docset \
     --company-id com.mapbox \

--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -111,7 +111,7 @@ if [ -z `which appledoc` ]; then
 fi
 DOCS_OUTPUT="${OUTPUT}/static/Docs"
 git fetch --tags
-DOCS_VERSION=$( git tag | sed 's/^ios-//' | sort -r | grep -v '\-rc.' | grep -v '\-pre.' | sed -n '1p' | sed 's/^v//' )
+DOCS_VERSION=$( git tag | grep ^ios | sed 's/^ios-//' | sort -r | grep -v '\-rc.' | grep -v '\-pre.' | sed -n '1p' | sed 's/^v//' )
 rm -rf /tmp/mbgl
 mkdir -p /tmp/mbgl/
 README=/tmp/mbgl/README.md


### PR DESCRIPTION
Fixes some issues based on our new `ios-vX.Y.Z` tagging scheme. 