### PR TITLE
[ios] fixes #2490: add annotation image enabled property

### DIFF
--- a/include/mbgl/ios/MGLAnnotationImage.h
+++ b/include/mbgl/ios/MGLAnnotationImage.h
@@ -27,6 +27,11 @@ NS_ASSUME_NONNULL_BEGIN
 *   If you define distinctly different types of annotations (with distinctly different annotation images to go with them), you can differentiate between the annotation types by specifying different reuse identifiers for each one. */
 @property (nonatomic, readonly) NSString *reuseIdentifier;
 
+/** A Boolean value indicating whether the annotation is enabled.
+*
+*   The default value of this property is `YES`. If the value of this property is `NO`, the annotation image ignores touch events and cannot be selected. */
+@property (nonatomic, getter=isEnabled) BOOL enabled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -357,6 +357,15 @@ static NSUInteger const kStyleVersion = 8;
     NSString *title = [(MGLPointAnnotation *)annotation title];
     NSString *lastTwoCharacters = [title substringFromIndex:title.length - 2];
 
+    UIColor *color;
+
+    // make every tenth annotation blue
+    if ([lastTwoCharacters hasSuffix:@"0"]) {
+        color = [UIColor blueColor];
+    } else {
+        color = [UIColor redColor];
+    }
+
     MGLAnnotationImage *image = [mapView dequeueReusableAnnotationImageWithIdentifier:lastTwoCharacters];
 
     if ( ! image)
@@ -367,7 +376,7 @@ static NSUInteger const kStyleVersion = 8;
 
         CGContextRef ctx = UIGraphicsGetCurrentContext();
 
-        CGContextSetFillColorWithColor(ctx, [[[UIColor redColor] colorWithAlphaComponent:0.75] CGColor]);
+        CGContextSetFillColorWithColor(ctx, [[color colorWithAlphaComponent:0.75] CGColor]);
         CGContextFillRect(ctx, rect);
 
         CGContextSetStrokeColorWithColor(ctx, [[UIColor blackColor] CGColor]);
@@ -384,6 +393,9 @@ static NSUInteger const kStyleVersion = 8;
         [drawString drawInRect:stringRect];
 
         image = [MGLAnnotationImage annotationImageWithImage:UIGraphicsGetImageFromCurrentImageContext() reuseIdentifier:lastTwoCharacters];
+
+        // don't allow touches on blue annotations
+        if ([color isEqual:[UIColor blueColor]]) image.enabled = NO;
 
         UIGraphicsEndImageContext();
     }

--- a/platform/ios/MGLAnnotationImage.m
+++ b/platform/ios/MGLAnnotationImage.m
@@ -22,6 +22,7 @@
     {
         _image = image;
         _reuseIdentifier = [reuseIdentifier copy];
+        _enabled = YES;
     }
 
     return self;


### PR DESCRIPTION
Still needs UI tests, but does the job. Not the most efficient thing in the world, but fortunately gesture events aren't much slower. Takes about 10ms for even 10,000 annotations to figure out enabled/disabled status. 

/cc @friedbunny 