### PR TITLE
Fix all Log::* usages

### DIFF
--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
         map.setStyleURL(newStyle.url);
         view->setWindowTitle(newStyle.name);
 
-        mbgl::Log::Info(mbgl::Event::Setup, std::string("Changed style to: ") + newStyle.name);
+        mbgl::Log::Info(mbgl::Event::Setup, "Changed style to: %s", newStyle.name);
     });
 
     // Load style

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -180,7 +180,7 @@ int main(int argc, char* argv[]) {
         map.setStyleURL(newStyle.url);
         view.setWindowTitle(newStyle.name);
 
-        mbgl::Log::Info(mbgl::Event::Setup, std::string("Changed style to: ") + newStyle.name);
+        mbgl::Log::Info(mbgl::Event::Setup, "Changed style to: %s", newStyle.name);
     });
 
 

--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -86,7 +86,7 @@ Image::Image(std::string const& data)
     }
     catch (ImageReaderException const& ex)
     {
-        Log::Error(Event::Image, ex.what());
+        Log::Error(Event::Image, "%s", ex.what());
         img.reset();
         width = 0;
         height = 0;

--- a/platform/default/sqlite_cache.cpp
+++ b/platform/default/sqlite_cache.cpp
@@ -134,7 +134,7 @@ void SQLiteCache::Impl::get(const Resource &resource, Callback callback) {
         Log::Error(Event::Database, ex.code, ex.what());
         callback(nullptr);
     } catch (std::runtime_error& ex) {
-        Log::Error(Event::Database, ex.what());
+        Log::Error(Event::Database, "%s", ex.what());
         callback(nullptr);
     }
 }
@@ -204,7 +204,7 @@ void SQLiteCache::Impl::put(const Resource& resource, std::shared_ptr<const Resp
     } catch (mapbox::sqlite::Exception& ex) {
         Log::Error(Event::Database, ex.code, ex.what());
     } catch (std::runtime_error& ex) {
-        Log::Error(Event::Database, ex.what());
+        Log::Error(Event::Database, "%s", ex.what());
     }
 }
 

--- a/src/mbgl/util/stopwatch.cpp
+++ b/src/mbgl/util/stopwatch.cpp
@@ -23,7 +23,7 @@ stopwatch::stopwatch(const std::string &name_, EventSeverity severity_, Event ev
 void stopwatch::report(const std::string &name_) {
     Duration duration = Clock::now() - start;
 
-    Log::Record(severity, event, name_ + ": " + util::toString(std::chrono::duration_cast<std::chrono::milliseconds>(duration).count()) + "ms");
+    Log::Record(severity, event, "%s: %fms", name_.c_str(), std::chrono::duration<float, std::chrono::milliseconds::period>(duration).count());
     start += duration;
 }
 


### PR DESCRIPTION
There are some usages of `Log::*` that don't pass a literal character string as the first argument, but we're feeding it into printf.