### PR TITLE
Look the other way when placing icon at start of line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The SDK now builds with Bitcode enabled. ([#2332](https://github.com/mapbox/mapbox-gl-native/issues/2332))
 - The double-tap-drag gesture for zooming in and out is now consistent with the Google Maps SDK. ([#2153](https://github.com/mapbox/mapbox-gl-native/pull/2153))
 - A new `MGLAnnotationImage.enabled` property allows you to disable touch events on individual annotations. ([#2501](https://github.com/mapbox/mapbox-gl-native/pull/2501))
+- Fixed a rendering issue that caused one-way arrows along tile boundaries to point due east instead of in the direction of travel. ([#2530](https://github.com/mapbox/mapbox-gl-native/pull/2530))
 - Fixed a rendering issue with styles that use the `background-pattern` property. ([#2531](https://github.com/mapbox/mapbox-gl-native/pull/2531))
 
 ## iOS 2.1.2

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -28,7 +28,13 @@ SymbolQuads getIconQuads(Anchor &anchor, const PositionedIcon &shapedIcon,
     if (alongLine) {
         assert(static_cast<unsigned int>(anchor.segment) < line.size());
         const Coordinate &prev= line[anchor.segment];
-        angle += std::atan2(anchor.y - prev.y, anchor.x - prev.x);
+        if (anchor.y == prev.y && anchor.x == prev.x &&
+            static_cast<unsigned int>(anchor.segment + 1) < line.size()) {
+            const Coordinate &next= line[anchor.segment + 1];
+            angle += std::atan2(anchor.y - next.y, anchor.x - next.x) + M_PI;
+        } else {
+            angle += std::atan2(anchor.y - prev.y, anchor.x - prev.x);
+        }
     }
 
 


### PR DESCRIPTION
This PR fixes a bug exposed by #1840. When an anchor is at the beginning of a line, it is coincident with its segment, resulting in an angle of 0°. In that case, consider the next segment instead.

This change also fixes a rarer bug: for some reason, `clipLines()` inserts a duplicate point at the beginning of the line for [this way](https://www.openstreetmap.org/way/157751098), so we must check whether the anchor is coincident with its segment; we can’t simply check whether `segment` is 0.

![before & after](https://cloud.githubusercontent.com/assets/1231218/10294829/82e64420-6b71-11e5-80b7-5052bebbca70.PNG)

This before and after shows that all the one-way arrows are pointing the right way again. However, collision boxes aren’t being generated for the icons being placed along tile boundaries, so they tend to run right up against icons in adjacent tiles.

Fixes #2474.

/cc @nickidlugash @ansis

[![Wrong way (CC BY-SA 3.0 by Wikipedia user Coolcaesar)](https://upload.wikimedia.org/wikipedia/commons/thumb/2/21/Californiaofframpwrongwaysignage.jpg/602px-Californiaofframpwrongwaysignage.jpg)](https://commons.wikimedia.org/wiki/File:Californiaofframpwrongwaysignage.jpg)