### PR TITLE
Disable non-null warning

### DIFF
--- a/test/ios/LocationMocker/CLLocationManager+MockLocation.m
+++ b/test/ios/LocationMocker/CLLocationManager+MockLocation.m
@@ -32,6 +32,7 @@
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                 #pragma clang diagnostic push
                 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                #pragma clang diagnostic ignored "-Wnonnull"
                 [self.delegate locationManager:self didUpdateToLocation:self.location fromLocation:nil];
                 #pragma clang diagnostic pop
             });


### PR DESCRIPTION
Silence non-null warning in deprecated `CLLocationManager` method. Cluttered up Travis, [as in here](https://travis-ci.org/mapbox/mapbox-gl-native/jobs/83786613#L939-L941).

```objc
LocationMocker/CLLocationManager+MockLocation.m:35:32: null passed to a callee that requires a non-null argument [-Wnonnull]
  [self.delegate locationManager:self didUpdateToLocation:self.location fromLocation:nil];
```

/cc @1ec5 @mikemorris