### PR TITLE
Remove CoreTelephony dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a rendering issue with styles that use the `background-pattern` property. ([#2531](https://github.com/mapbox/mapbox-gl-native/pull/2531))
 - Labels can now line wrap on hyphens and other punctuation. ([#2598](https://github.com/mapbox/mapbox-gl-native/pull/2598))
 - A new delegate callback was added for observing taps to annotation callout views. ([#2596](https://github.com/mapbox/mapbox-gl-native/pull/2596))
+- Removed CoreTelephony.framework dependency. ([#2581](https://github.com/mapbox/mapbox-gl-native/pull/2581))
 
 ## iOS 2.1.2
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,7 +150,6 @@ Currently, until [#1437](https://github.com/mapbox/mapbox-gl-native/issues/1437)
 
 1. Add the following Cocoa framework dependencies to your target's *Link Binary With Libraries* build phase:
 
-   - `CoreTelephony.framework`
    - `GLKit.framework`
    - `ImageIO.framework`
    - `MobileCoreServices.framework`
@@ -159,6 +158,7 @@ Currently, until [#1437](https://github.com/mapbox/mapbox-gl-native/issues/1437)
    - `libc++.dylib`
    - `libsqlite3.dylib`
    - `libz.dylib`
+   - `CoreTelephony.framework` (optional, telemetry-only)
 
 1. Add `-ObjC` to your target's "Other Linker Flags" build setting (`OTHER_LDFLAGS`).
 
@@ -167,6 +167,10 @@ Currently, until [#1437](https://github.com/mapbox/mapbox-gl-native/issues/1437)
 Devices: iPhone 4S and above (5, 5c, 5s, 6, 6 Plus), iPad 2 and above (3, 4, Mini, Air, Mini 2, Air 2), iPod touch 5th gen and above
 
 iOS: 7.0+
+
+### Telemetry
+
+The iOS SDK collects [telemetry data](https://www.mapbox.com/telemetry/) during use and [requires additional setup](https://www.mapbox.com/ios-sdk/#metrics_opt_out).
 
 
 ## Linux

--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -75,7 +75,6 @@
         ],
         'ldflags': [
           '-framework CoreLocation',
-          '-framework CoreTelephony',
           '-framework GLKit',
           '-framework ImageIO',
           '-framework MobileCoreServices',

--- a/ios/Mapbox-iOS-SDK.podspec
+++ b/ios/Mapbox-iOS-SDK.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |m|
   m.vendored_library = 'libMapbox.a'
   m.module_name = 'Mapbox'
 
-  m.frameworks = 'CoreLocation', 'CoreTelephony', 'GLKit', 'ImageIO', 'MobileCoreServices', 'QuartzCore', 'SystemConfiguration'
+  m.frameworks = 'CoreLocation', 'GLKit', 'ImageIO', 'MobileCoreServices', 'QuartzCore', 'SystemConfiguration'
   m.libraries = 'c++', 'sqlite3', 'z'
   m.xcconfig = {
     'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++',

--- a/test/ios/ios-tests.xcodeproj/project.pbxproj
+++ b/test/ios/ios-tests.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		DD0E6F9B1B01B68E00DC035A /* OHHTTPStubsResponse+HTTPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = DD0E6F931B01B68E00DC035A /* OHHTTPStubsResponse+HTTPMessage.m */; };
 		DD0E6F9C1B01B68E00DC035A /* OHHTTPStubsResponse+JSON.m in Sources */ = {isa = PBXBuildFile; fileRef = DD0E6F951B01B68E00DC035A /* OHHTTPStubsResponse+JSON.m */; };
 		DD0E6F9D1B01B68E00DC035A /* OHPathHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = DD0E6F971B01B68E00DC035A /* OHPathHelpers.m */; };
-		DD41CE091ACB5DBC00FA7979 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD41CE081ACB5DBC00FA7979 /* CoreTelephony.framework */; };
 		DD41CE0B1ACB5DC400FA7979 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD41CE0A1ACB5DC400FA7979 /* SystemConfiguration.framework */; };
 		DD41CE0D1ACB5DCB00FA7979 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = DD41CE0C1ACB5DCB00FA7979 /* libc++.dylib */; };
 		DD41CE0F1ACB5DD000FA7979 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = DD41CE0E1ACB5DD000FA7979 /* libsqlite3.dylib */; };
@@ -145,7 +144,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD41CE091ACB5DBC00FA7979 /* CoreTelephony.framework in Frameworks */,
 				DD41CE171ACB5DE700FA7979 /* GLKit.framework in Frameworks */,
 				DD41CE151ACB5DE000FA7979 /* ImageIO.framework in Frameworks */,
 				DD41CE131ACB5DDA00FA7979 /* MobileCoreServices.framework in Frameworks */,


### PR DESCRIPTION
Removes the CoreTelephony framework dependency by conditionally using it if already linked.

If a developer chooses to link CoreTelephony in their app, telemetry data on their users' cellular carrier and connectivity will be collected.

Should also help the tvOS situation in #2340, which does not include CoreTelephony at the OS level.

/cc @incanus @1ec5 @twbell @camilleanne @mapbox/mobiledata