### PR TITLE
gcc-5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
     - os: linux
   include:
     - os: linux
-      env: FLAVOR=linux CXX=g++-4.9 BUILDTYPE=Release
+      env: FLAVOR=linux CXX=g++-5 BUILDTYPE=Release
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
+          packages: [ 'gdb', 'g++-5', 'gcc-5', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
     - os: linux
       env: FLAVOR=linux CXX=clang++-3.5 BUILDTYPE=Debug
       addons:

--- a/gyp/common.gypi
+++ b/gyp/common.gypi
@@ -12,7 +12,7 @@
           'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
           'GCC_ENABLE_CPP_RTTI': 'YES',
           'OTHER_CPLUSPLUSFLAGS': [
-            '-std=c++1y',
+            '-std=c++14',
             '-Werror',
             '-Wall',
             '-Wextra',
@@ -35,7 +35,6 @@
           '-Wshadow',
           '-Wno-variadic-macros',
           '-Wno-error=unused-parameter',
-          '-Wno-c++1y-extensions',
           '-frtti',
           '-fexceptions',
           '${CFLAGS}',

--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -11,6 +11,8 @@
 
 #include <mbgl/platform/default/image_reader.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 // Check png library version.
 const static bool png_version_check = []() {
     const png_uint_32 version = png_access_version_number();
@@ -22,6 +24,7 @@ const static bool png_version_check = []() {
     }
     return true;
 }();
+#pragma GCC diagnostic pop
 
 
 namespace mbgl {

--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -5,6 +5,8 @@
 #include <cstring>
 #include <cstdio>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 // Check sqlite3 library version.
 const static bool sqliteVersionCheck = []() {
     if (sqlite3_libversion_number() / 1000000 != SQLITE_VERSION_NUMBER / 1000000) {
@@ -17,6 +19,7 @@ const static bool sqliteVersionCheck = []() {
 
     return true;
 }();
+#pragma GCC diagnostic pop
 
 namespace mapbox {
 namespace sqlite {

--- a/src/mbgl/util/compression.cpp
+++ b/src/mbgl/util/compression.cpp
@@ -7,6 +7,8 @@
 #include <stdexcept>
 
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 // Check zlib library version.
 const static bool zlibVersionCheck = []() {
     const char *const version = zlibVersion();
@@ -19,6 +21,7 @@ const static bool zlibVersionCheck = []() {
 
     return true;
 }();
+#pragma GCC diagnostic pop
 
 
 namespace mbgl {

--- a/src/mbgl/util/uv.cpp
+++ b/src/mbgl/util/uv.cpp
@@ -4,6 +4,8 @@
 
 #include <uv.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 // Check libuv library version.
 const static bool uvVersionCheck = []() {
     const unsigned int version = uv_version();
@@ -23,6 +25,7 @@ const static bool uvVersionCheck = []() {
     }
     return true;
 }();
+#pragma GCC diagnostic pop
 
 #if UV_VERSION_MAJOR == 0 && UV_VERSION_MINOR <= 10
 


### PR DESCRIPTION
Fixes #2553, #2502

Keeps `libstdc++-4.9-dev` for `clang-3.5` builds because of
```
error: debug information for auto is not yet supported
```
https://stackoverflow.com/questions/24617679/workaround-for-debug-symbol-error-with-auto-member-function

/cc @jfirebaugh @springmeyer 