### PR TITLE
[android] #2588 - Make getTopOffsetPixelsForAnnotationSymbol private.

### DIFF
--- a/android/java/.gitignore
+++ b/android/java/.gitignore
@@ -25,3 +25,6 @@ MapboxGLAndroidSDKTestApp/src/main/res/raw/token.txt
 
 # Twitter Fabric / Crashlytics
 fabric.properties
+
+# Capture files
+captures/

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/InfoWindow.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/InfoWindow.java
@@ -84,12 +84,10 @@ public final class InfoWindow {
         mView.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
 
         PointF coords = mMapView.toScreenLocation(position);
-        double y = mMapView.getTopOffsetPixelsForAnnotationSymbol(object.getSprite());
-        y = y * mMapView.getScreenDensity();
 
-        lp.leftMargin = (int) coords.x - (mView.getMeasuredWidth() / 2);
+        lp.leftMargin = (int) coords.x - (mView.getMeasuredWidth() / 2) + offsetX;
         // Add y because it's a negative value
-        lp.topMargin = (int) coords.y - mView.getMeasuredHeight() + (int) y;
+        lp.topMargin = (int) coords.y - mView.getMeasuredHeight() + offsetY;
 
         close(); //if it was already opened
         mMapView.addView(mView, lp);

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Marker.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Marker.java
@@ -15,14 +15,15 @@ public class Marker extends Annotation {
     private boolean flat;
     private float infoWindowAnchorU;
     private float infoWindowAnchorV;
-    LatLng position;
+    private LatLng position;
     private float rotation;
     private String snippet;
-    String sprite = "default_marker";
+    private String sprite = "default_marker";
     private String title;
     private InfoWindow infoWindow = null;
 
     private boolean infoWindowShown = false;
+    private int topOffsetPixels;
 
     /**
      * Constructor
@@ -124,7 +125,7 @@ public class Marker extends Annotation {
         infoWindowAnchorV = v;
     }
 
-    public void setPosition(LatLng latlng) {
+    public void setPosition(LatLng position) {
         this.position = position;
     }
 
@@ -161,26 +162,26 @@ public class Marker extends Annotation {
     }
 
     public void showInfoWindow() {
-
         if (!isVisible() || mapView == null) {
             return;
         }
 
         getInfoWindow().adaptDefaultMarker(this);
-        getInfoWindow().open(this, getPosition(), (int) anchorU, (int) anchorV);
-        getInfoWindow().setBoundMarker(this);
-        infoWindowShown = true;
+        showInfoWindow(getInfoWindow());
     }
 
     public void showInfoWindow(View view){
-
         if (!isVisible() || mapView == null) {
             return;
         }
 
         infoWindow = new InfoWindow(view, mapView);
-        infoWindow.open(this, getPosition(), (int) anchorU, (int) anchorV);
-        infoWindow.setBoundMarker(this);
+        showInfoWindow(infoWindow);
+    }
+
+    private void showInfoWindow(InfoWindow iw) {
+        iw.open(this, getPosition(), (int) anchorU, (int) anchorV + topOffsetPixels);
+        iw.setBoundMarker(this);
         infoWindowShown = true;
     }
 
@@ -222,4 +223,8 @@ public class Marker extends Annotation {
 //    void setIcon(BitmapDescriptor icon) {
 //
 //    }
+
+    void setTopOffsetPixels(int topOffsetPixels) {
+        this.topOffsetPixels = topOffsetPixels;
+    }
 }

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerOptions.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerOptions.java
@@ -46,7 +46,8 @@ public class MarkerOptions extends AnnotationOptions {
         return ((Marker)annotation).getInfoWindowAnchorV();
     }
 
-    public Marker getMarker() {
+    public Marker getMarker(int topOffsetPixels) {
+        ((Marker)annotation).setTopOffsetPixels(topOffsetPixels);
         return (Marker)annotation;
     }
 
@@ -64,6 +65,10 @@ public class MarkerOptions extends AnnotationOptions {
 
     public String getTitle() {
         return ((Marker)annotation).getTitle();
+    }
+
+    public String getSprite() {
+        return ((Marker)annotation).getSprite();
     }
 
     public MarkerOptions infoWindowAnchor(float u, float v) {
@@ -84,7 +89,7 @@ public class MarkerOptions extends AnnotationOptions {
     }
 
     public MarkerOptions position(LatLng position) {
-        ((Marker)annotation).position = position;
+        ((Marker)annotation).setPosition(position);
         return this;
     }
 
@@ -100,7 +105,7 @@ public class MarkerOptions extends AnnotationOptions {
 
     public MarkerOptions sprite(@Nullable String sprite) {
         if (!TextUtils.isEmpty(sprite)) {
-            ((Marker)annotation).sprite = sprite;
+            ((Marker)annotation).setSprite(sprite);
         }
         return this;
     }

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -1596,7 +1596,7 @@ public final class MapView extends FrameLayout {
             throw new NullPointerException("markerOptions is null");
         }
 
-        Marker marker = markerOptions.getMarker();
+        Marker marker = markerOptions.getMarker(getTopOffsetPixelsForAnnotationSymbol(markerOptions.getSprite()));
 
         // Load the default marker sprite
         if (marker.getSprite() == null) {
@@ -1634,7 +1634,7 @@ public final class MapView extends FrameLayout {
 
         List<Marker> markers = new ArrayList<>(markerOptionsList.size());
         for (MarkerOptions markerOptions : markerOptionsList) {
-            Marker marker = markerOptions.getMarker();
+            Marker marker = markerOptions.getMarker(getTopOffsetPixelsForAnnotationSymbol(markerOptions.getSprite()));
 
             // Load the default marker sprite
             if (marker.getSprite() == null) {
@@ -1646,7 +1646,7 @@ public final class MapView extends FrameLayout {
                 marker.setSprite("default_marker");
                 //marker.setSprite(DEFAULT_SPRITE);
             }
-            markers.add(markerOptions.getMarker());
+            markers.add(marker);
         }
 
         long[] ids = mNativeMapView.addMarkers(markers);
@@ -1857,8 +1857,8 @@ public final class MapView extends FrameLayout {
      * @param symbolName Annotation Symbol
      * @return Top Offset in pixels
      */
-    public double getTopOffsetPixelsForAnnotationSymbol(@NonNull String symbolName) {
-        return mNativeMapView.getTopOffsetPixelsForAnnotationSymbol(symbolName);
+    private int getTopOffsetPixelsForAnnotationSymbol(String symbolName) {
+        return (int) (mNativeMapView.getTopOffsetPixelsForAnnotationSymbol(symbolName) * mScreenDensity);
     }
 
     /**
@@ -1873,14 +1873,6 @@ public final class MapView extends FrameLayout {
     @UiThread
     public double getMetersPerPixelAtLatitude(@FloatRange(from = -180, to = 180) double latitude) {
         return mNativeMapView.getMetersPerPixelAtLatitude(latitude, getZoomLevel());
-    }
-
-    /**
-     * Get ScreenDensity of device
-     * @return Screen Density ratio
-     */
-    public float getScreenDensity() {
-        return mScreenDensity;
     }
 
     private void selectMarker(Marker marker) {


### PR DESCRIPTION
Make getTopOffsetPixelsForAnnotationSymbol private

Also:
- add `captures/` to .`gitignore`
- fix `setPosition`
- add missing `getSprite()`
- https://github.com/mapbox/mapbox-gl-native/issues/2551 make `sprite`/`position` `private` now that above bugs are fixed (JNI still can directly access the field) 