### PR TITLE
Break lines on com­mon­ly un­spaced punc­tu­a­tion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - A new `MGLAnnotationImage.enabled` property allows you to disable touch events on individual annotations. ([#2501](https://github.com/mapbox/mapbox-gl-native/pull/2501))
 - Fixed a rendering issue that caused one-way arrows along tile boundaries to point due east instead of in the direction of travel. ([#2530](https://github.com/mapbox/mapbox-gl-native/pull/2530))
 - Fixed a rendering issue with styles that use the `background-pattern` property. ([#2531](https://github.com/mapbox/mapbox-gl-native/pull/2531))
+- Labels can now line wrap on hyphens and other punctuation. ([#2598](https://github.com/mapbox/mapbox-gl-native/pull/2598))
 - A new delegate callback was added for observing taps to annotation callout views. ([#2596](https://github.com/mapbox/mapbox-gl-native/pull/2596))
 
 ## iOS 2.1.2

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,4 +1,5 @@
 # master
+- Labels can now line wrap on hyphens and other punctuation. ([#2598](https://github.com/mapbox/mapbox-gl-native/pull/2598))
 
 # 2.0.0
 

--- a/src/mbgl/text/font_stack.cpp
+++ b/src/mbgl/text/font_stack.cpp
@@ -104,7 +104,15 @@ void FontStack::lineWrap(Shaping &shaping, const float lineHeight, const float m
                 }
 
                 if (justify) {
-                    justifyLine(positionedGlyphs, metrics, lineStartIndex, lastSafeBreak - 1, justify);
+                    // Collapse invisible characters.
+                    uint32_t breakGlyph = positionedGlyphs[lastSafeBreak].glyph;
+                    uint32_t lineEnd = lastSafeBreak;
+                    if (breakGlyph == 0x20 /* space */
+                        || breakGlyph == 0x200b /* zero-width space */) {
+                        lineEnd--;
+                    }
+
+                    justifyLine(positionedGlyphs, metrics, lineStartIndex, lineEnd, justify);
                 }
 
                 lineStartIndex = lastSafeBreak + 1;
@@ -113,7 +121,17 @@ void FontStack::lineWrap(Shaping &shaping, const float lineHeight, const float m
                 line++;
             }
 
-            if (shape.glyph == 32) {
+            // Spaces, plus word-breaking punctuation that often appears without surrounding spaces.
+            if (shape.glyph == 0x20 /* space */
+                || shape.glyph == 0x26 /* ampersand */
+                || shape.glyph == 0x2b /* plus sign */
+                || shape.glyph == 0x2d /* hyphen-minus */
+                || shape.glyph == 0x2f /* solidus */
+                || shape.glyph == 0xad /* soft hyphen */
+                || shape.glyph == 0xb7 /* middle dot */
+                || shape.glyph == 0x200b /* zero-width space */
+                || shape.glyph == 0x2010 /* hyphen */
+                || shape.glyph == 0x2013 /* en dash */) {
                 lastSafeBreak = i;
             }
         }


### PR DESCRIPTION
This PR breaks lines in labels on commonly unspaced punctuation, par­ti­cu­lar­ly hy­phens (important in French-speaking regions) and soft hy­phens (important in Welsh, Thai, and Māori-speaking regions).

_Before:_  
![montreal-before](https://cloud.githubusercontent.com/assets/1231218/10438345/f660b02c-70e7-11e5-9902-33f28e57f054.png)

_After:_  
![montreal-after](https://cloud.githubusercontent.com/assets/1231218/10438347/f9fe1b66-70e7-11e5-8db7-cd2bb8648157.png)

_Stress test:_

[![taumata­whakatangi­hanga­koauau­o­tamatea­turi­pukaka­piki­maunga­horo­nuku­pokai­when­ua­ki­tana­tahu](https://upload.wikimedia.org/wikipedia/commons/thumb/5/5b/New_Zealand_0577.jpg/640px-New_Zealand_0577.jpg)](https://en.wikipedia.org/wiki/Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu)

Fixes #2595.

/cc @ansis @nickidlugash @mikemorris @peterqliu