### PR TITLE
Revert Node.js 4.1 pin and update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         apt:
           packages: [ 'lib32stdc++6' ]
     - os: linux
-      env: FLAVOR=node CXX=clang++-3.5 BUILDTYPE=Release NODE_VERSION=4.1
+      env: FLAVOR=node CXX=clang++-3.5 BUILDTYPE=Release NODE_VERSION=4
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
@@ -79,7 +79,7 @@ matrix:
     - os: osx
       osx_image: xcode7
       compiler: clang
-      env: FLAVOR=node NODE_VERSION=4.1
+      env: FLAVOR=node NODE_VERSION=4
     - os: osx
       osx_image: xcode7
       compiler: clang

--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
     }
   ],
   "dependencies": {
-    "nan": "^2.0.9",
-    "node-pre-gyp": "^0.6.11"
+    "nan": "^2.1.0",
+    "node-pre-gyp": "^0.6.12"
   },
   "bundledDependencies": [
     "node-pre-gyp"
   ],
   "devDependencies": {
-    "aws-sdk": "^2.1.47",
+    "aws-sdk": "^2.2.9",
     "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#9b3df7ea2751d076abf31015e20d5f3137cd10f6",
-    "request": "^2.61.0",
-    "tape": "^4.2.0"
+    "request": "^2.65.0",
+    "tape": "^4.2.1"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build=false || make node",


### PR DESCRIPTION
Node.js tagged v4.2.1 just before I pushed the `NODE_VERSION=4.1` commit, this closes #2597

/cc @jfirebaugh @bleege @tobrun 