### PR TITLE
Disable fading when rendering still images

### DIFF
--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -24,7 +24,7 @@ public:
         : mode(mode_)
         , pixelRatio(pixelRatio_)
         , animationTime(Duration::zero())
-        , defaultFadeDuration(std::chrono::milliseconds(300))
+        , defaultFadeDuration(mode_ == MapMode::Continuous ? std::chrono::milliseconds(300) : Duration::zero())
         , defaultTransitionDuration(Duration::zero())
         , defaultTransitionDelay(Duration::zero()) {
         assert(pixelRatio > 0);
@@ -71,9 +71,13 @@ public:
     inline TimePoint getAnimationTime() const {
         // We're casting the TimePoint to and from a Duration because libstdc++
         // has a bug that doesn't allow TimePoints to be atomic.
-        return TimePoint(animationTime);
+        return mode == MapMode::Continuous ? TimePoint(animationTime) : Clock::now();
     }
     inline void setAnimationTime(const TimePoint& timePoint) {
+        if (mode == MapMode::Still) {
+            return;
+        }
+
         animationTime = timePoint.time_since_epoch();
     };
 
@@ -82,6 +86,10 @@ public:
     }
 
     inline void setDefaultFadeDuration(const Duration& duration) {
+        if (mode == MapMode::Still) {
+            return;
+        }
+
         defaultFadeDuration = duration;
     }
 
@@ -90,6 +98,10 @@ public:
     }
 
     inline void setDefaultTransitionDuration(const Duration& duration) {
+        if (mode == MapMode::Still) {
+            return;
+        }
+
         defaultTransitionDuration = duration;
     }
 
@@ -98,6 +110,10 @@ public:
     }
 
     inline void setDefaultTransitionDelay(const Duration& delay) {
+        if (mode == MapMode::Still) {
+            return;
+        }
+
         defaultTransitionDelay = delay;
     }
 

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -520,11 +520,11 @@ template<> StyleParser::Result<PropertyTransition> StyleParser::parseProperty(JS
     PropertyTransition transition { data.getDefaultTransitionDuration(), data.getDefaultTransitionDelay() };
     if (value.IsObject()) {
         bool parsed = false;
-        if (value.HasMember("duration") && value["duration"].IsNumber()) {
+        if (value.HasMember("duration") && value["duration"].IsNumber() && data.mode == MapMode::Continuous) {
             transition.duration = std::chrono::milliseconds(value["duration"].GetUint());
             parsed = true;
         }
-        if (value.HasMember("delay") && value["delay"].IsNumber()) {
+        if (value.HasMember("delay") && value["delay"].IsNumber() && data.mode == MapMode::Continuous) {
             transition.delay = std::chrono::milliseconds(value["delay"].GetUint());
             parsed = true;
         }
@@ -594,7 +594,7 @@ template<> StyleParser::Result<Function<Color>> StyleParser::parseProperty(JSVal
 
 template<> StyleParser::Result<PiecewiseConstantFunction<Faded<std::vector<float>>>> StyleParser::parseProperty(JSVal value, const char *property_name, JSVal transition) {
     Duration duration = data.getDefaultFadeDuration();
-    if (transition.HasMember("duration")) {
+    if (transition.HasMember("duration") && data.mode == MapMode::Continuous) {
         duration = std::chrono::milliseconds(transition["duration"].GetUint());
     }
 
@@ -613,7 +613,7 @@ template<> StyleParser::Result<PiecewiseConstantFunction<Faded<std::vector<float
 
 template<> StyleParser::Result<PiecewiseConstantFunction<Faded<std::string>>> StyleParser::parseProperty(JSVal value, const char *property_name, JSVal transition) {
     Duration duration = data.getDefaultFadeDuration();
-    if (transition.HasMember("duration")) {
+    if (transition.HasMember("duration") && data.mode == MapMode::Continuous) {
         duration = std::chrono::milliseconds(transition["duration"].GetUint());
     }
 


### PR DESCRIPTION
When using the static image rendering API, we have to disable fading.

![image](https://cloud.githubusercontent.com/assets/98601/9695275/ceff1c1c-5314-11e5-82f3-2dca9055b199.png)
