### PR TITLE
fixes #2611: iOS test app long press drops debug marker

### DIFF
--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -82,6 +82,8 @@ static NSUInteger const kStyleVersion = 8;
                                                                              target:self
                                                                              action:@selector(locateUser)];
 
+    [self.mapView addGestureRecognizer:[[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)]];
+
     [self restoreState:nil];
 }
 
@@ -296,6 +298,20 @@ static NSUInteger const kStyleVersion = 8;
     });
 }
 
+- (void)handleLongPress:(UILongPressGestureRecognizer *)longPress
+{
+    if (longPress.state == UIGestureRecognizerStateBegan)
+    {
+        MGLPointAnnotation *point = [MGLPointAnnotation new];
+        point.coordinate = [self.mapView convertPoint:[longPress locationInView:longPress.view]
+                                 toCoordinateFromView:self.mapView];
+        point.title = @"Dropped Marker";
+        point.subtitle = [NSString stringWithFormat:@"lat: %.3f, lon: %.3f", point.coordinate.latitude, point.coordinate.longitude];
+        [self.mapView addAnnotation:point];
+        [self.mapView selectAnnotation:point animated:YES];
+    }
+}
+
 - (void)cycleStyles
 {
     UIButton *titleButton = (UIButton *)self.navigationItem.titleView;
@@ -354,6 +370,8 @@ static NSUInteger const kStyleVersion = 8;
 
 - (MGLAnnotationImage *)mapView:(MGLMapView * __nonnull)mapView imageForAnnotation:(id <MGLAnnotation> __nonnull)annotation
 {
+    if ([annotation.title isEqualToString:@"Dropped Marker"]) return nil; // use default marker
+
     NSString *title = [(MGLPointAnnotation *)annotation title];
     NSString *lastTwoCharacters = [title substringFromIndex:title.length - 2];
 

--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -33,6 +33,8 @@
     tester.mapView.scrollEnabled = YES;
     tester.mapView.rotateEnabled = YES;
 
+    [tester.mapView removeAnnotations:tester.mapView.annotations];
+
     tester.viewController.navigationController.navigationBarHidden = YES;
     tester.viewController.navigationController.toolbarHidden = YES;
 
@@ -329,6 +331,44 @@
                                newZoom,
                                0.01,
                                @"setting zoom should take effect");
+}
+
+- (void)testMarkerSelection {
+    CGPoint point = CGPointMake(100, 100);
+    MGLPointAnnotation *marker = [MGLPointAnnotation new];
+    marker.coordinate = [tester.mapView convertPoint:point toCoordinateFromView:tester.mapView];
+    marker.title = @"test"; // title required for callout
+    [tester.mapView addAnnotation:marker];
+
+    XCTAssertEqual(tester.mapView.selectedAnnotations.count, 0);
+
+    [tester.mapView selectAnnotation:marker animated:NO];
+    XCTAssertEqualObjects(tester.mapView.selectedAnnotations.firstObject, marker);
+
+    [tester.mapView deselectAnnotation:marker animated:NO];
+    XCTAssertEqual(tester.mapView.selectedAnnotations.count, 0);
+}
+
+- (void)testMarkerAddWithoutDelegate {
+    XCTAssertFalse([tester.viewController respondsToSelector:@selector(mapView:imageForAnnotation:)]);
+
+    MGLPointAnnotation *marker = [MGLPointAnnotation new];
+    marker.coordinate = tester.mapView.centerCoordinate;
+    [tester.mapView addAnnotation:marker];
+
+    [tester.mapView selectAnnotation:marker animated:NO];
+    XCTAssertEqualObjects(tester.mapView.selectedAnnotations.firstObject, marker);
+    XCTAssertEqual([[tester.mapView subviewsWithClassNamePrefix:@"SM"] count], 0); // no callout for no title
+
+    [tester.mapView deselectAnnotation:marker animated:NO];
+    marker.title = @"test";
+    [tester.mapView selectAnnotation:marker animated:NO];
+    XCTAssertEqualObjects(tester.mapView.selectedAnnotations.firstObject, marker);
+    XCTAssertGreaterThan([[tester.mapView subviewsWithClassNamePrefix:@"SM"] count], 0);
+}
+
+- (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
+    return YES;
 }
 
 - (void)testTopLayoutGuide {


### PR DESCRIPTION
Note that this uses our already-present delegate method to just return `nil` for these markers. We still need to hit https://github.com/mapbox/mapbox-gl-native/issues/2610 (with tests) for the case of not implementing the delegate method. 