### PR TITLE
MapContext setStyle{URL,JSON} should ignore redundant calls

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -92,6 +92,10 @@ void MapContext::triggerUpdate(const TransformState& state, const Update flags) 
 }
 
 void MapContext::setStyleURL(const std::string& url) {
+    if (styleURL == url) {
+        return;
+    }
+
     FileSource* fs = util::ThreadContext::getFileSource();
 
     if (styleRequest) {
@@ -121,6 +125,10 @@ void MapContext::setStyleURL(const std::string& url) {
 }
 
 void MapContext::setStyleJSON(const std::string& json, const std::string& base) {
+    if (styleJSON == json) {
+        return;
+    }
+
     styleURL.clear();
     styleJSON = json;
 


### PR DESCRIPTION
Our engine should be robust enough to ignore redundant calls and avoid triggering a whole style update if the style URL and/or JSON are the same.

/cc @mapbox/mobile @mapbox/gl 