### PR TITLE
Request again when obtained data expires

### DIFF
--- a/include/mbgl/storage/request.hpp
+++ b/include/mbgl/storage/request.hpp
@@ -33,13 +33,13 @@ public:
 
 private:
     ~Request();
-    void invoke();
     void notifyCallback();
 
 private:
-    std::unique_ptr<uv::async> async;
-    struct Canceled;
-    std::unique_ptr<Canceled> canceled;
+    std::mutex mtx;
+    bool canceled = false;
+    bool confirmed = false;
+    const std::unique_ptr<uv::async> async;
     Callback callback;
     std::shared_ptr<const Response> response;
 

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -7,9 +7,13 @@ namespace mbgl {
 
 class Response {
 public:
+    bool isExpired() const;
+
+public:
     enum Status { Error, Successful, NotFound };
 
     Status status = Error;
+    bool stale = false;
     std::string message;
     int64_t modified = 0;
     int64_t expires = 0;

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -2,6 +2,7 @@
 #define MBGL_STORAGE_RESPONSE
 
 #include <string>
+#include <memory>
 
 namespace mbgl {
 

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -18,7 +18,7 @@ public:
     int64_t modified = 0;
     int64_t expires = 0;
     std::string etag;
-    std::string data;
+    std::shared_ptr<const std::string> data;
 };
 
 }

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -221,6 +221,9 @@ void HTTPNSURLRequest::handleResult(NSData *data, NSURLResponse *res, NSError *e
             // TODO: Use different codes for host not found, timeout, invalid URL etc.
             // These can be categorized in temporary and permanent errors.
             response = std::make_unique<Response>();
+            if (data) {
+                response->data = std::make_shared<std::string>((const char *)[data bytes], [data length]);
+            }
             response->status = Response::Error;
             response->message = [[error localizedDescription] UTF8String];
 
@@ -253,7 +256,7 @@ void HTTPNSURLRequest::handleResult(NSData *data, NSURLResponse *res, NSError *e
         const long responseCode = [(NSHTTPURLResponse *)res statusCode];
 
         response = std::make_unique<Response>();
-        response->data = {(const char *)[data bytes], [data length]};
+        response->data = std::make_shared<std::string>((const char *)[data bytes], [data length]);
 
         NSDictionary *headers = [(NSHTTPURLResponse *)res allHeaderFields];
         NSString *cache_control = [headers objectForKey:@"Cache-Control"];

--- a/platform/default/asset_request_fs.cpp
+++ b/platform/default/asset_request_fs.cpp
@@ -138,8 +138,10 @@ void AssetRequest::fileStated(uv_fs_t *req) {
 #endif
             self->response->etag = util::toString(stat->st_ino);
             const auto size = (unsigned int)(stat->st_size);
-            self->response->data.resize(size);
-            self->buffer = uv_buf_init(const_cast<char *>(self->response->data.data()), size);
+            auto data = std::make_shared<std::string>();
+            self->response->data = data;
+            data->resize(size);
+            self->buffer = uv_buf_init(const_cast<char *>(data->data()), size);
             uv_fs_req_cleanup(req);
 #if UV_VERSION_MAJOR == 0 && UV_VERSION_MINOR <= 10
             uv_fs_read(req->loop, req, self->fd, self->buffer.base, self->buffer.len, -1, fileRead);

--- a/platform/default/asset_request_zip.cpp
+++ b/platform/default/asset_request_zip.cpp
@@ -180,8 +180,10 @@ void AssetRequest::fileStated(uv_zip_t *zip) {
         response = std::make_unique<Response>();
 
         // Allocate the space for reading the data.
-        response->data.resize(zip->stat->size);
-        buffer = uv_buf_init(const_cast<char *>(response->data.data()), zip->stat->size);
+        auto data = std::make_shared<std::string>();
+        data->resize(zip->stat->size);
+        buffer = uv_buf_init(const_cast<char *>(data->data()), zip->stat->size);
+        response->data = data;
 
         // Get the modification time in case we have one.
         if (zip->stat->valid & ZIP_STAT_MTIME) {

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -213,7 +213,7 @@ void GLFWView::addRandomPointAnnotations(int count) {
     std::vector<mbgl::PointAnnotation> points;
 
     for (int i = 0; i < count; i++) {
-        points.emplace_back(makeRandomPoint(), "default_marker");
+        points.emplace_back(makeRandomPoint(), "marker-15");
     }
 
     auto newIDs = map->addPointAnnotations(points);

--- a/platform/node/src/node_file_source.cpp
+++ b/platform/node/src/node_file_source.cpp
@@ -133,7 +133,6 @@ void NodeFileSource::notify(const mbgl::Resource& resource, const std::shared_pt
     }
 
     observersIt->second->notify(response);
-    observers.erase(observersIt);
 }
 
 }

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -110,10 +110,10 @@ NAN_METHOD(NodeRequest::Respond) {
         if (Nan::Has(res, Nan::New("data").ToLocalChecked()).FromJust()) {
             auto dataHandle = Nan::Get(res, Nan::New("data").ToLocalChecked()).ToLocalChecked();
             if (node::Buffer::HasInstance(dataHandle)) {
-                response->data = std::string {
+                response->data = std::make_shared<std::string>(
                     node::Buffer::Data(dataHandle),
                     node::Buffer::Length(dataHandle)
-                };
+                );
             } else {
                 return Nan::ThrowTypeError("Response data must be a Buffer");
             }

--- a/src/mbgl/map/live_tile_data.cpp
+++ b/src/mbgl/map/live_tile_data.cpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/worker.hpp>
 #include <mbgl/util/work_request.hpp>
 #include <mbgl/style/style.hpp>
+#include <mbgl/style/style_bucket.hpp>
 
 #include <sstream>
 
@@ -32,21 +33,27 @@ LiveTileData::LiveTileData(const TileID& id_,
         return;
     }
 
-    reparse(callback);
+    parsePending(callback);
 }
 
-bool LiveTileData::reparse(std::function<void()> callback) {
-    if (parsing || (state != State::loaded && state != State::partial)) {
+bool LiveTileData::parsePending(std::function<void()> callback) {
+    if (workRequest || (state != State::loaded && state != State::partial)) {
         return false;
     }
 
-    parsing = true;
-
     workRequest = worker.parseLiveTile(tileWorker, *tile, [this, callback] (TileParseResult result) {
-        parsing = false;
+        workRequest.reset();
 
-        if (result.is<State>()) {
-            state = result.get<State>();
+        if (result.is<TileParseResultBuckets>()) {
+            auto& resultBuckets = result.get<TileParseResultBuckets>();
+            state = resultBuckets.state;
+
+            // Move over all buckets we received in this parse request, potentially overwriting
+            // existing buckets in case we got a refresh parse.
+            for (auto& bucket : resultBuckets.buckets) {
+                buckets[bucket.first] = std::move(bucket.second);
+            }
+
         } else {
             error = result.get<std::string>();
             state = State::obsolete;
@@ -67,7 +74,13 @@ Bucket* LiveTileData::getBucket(const StyleLayer& layer) {
         return nullptr;
     }
 
-    return tileWorker.getBucket(layer);
+    const auto it = buckets.find(layer.bucket->name);
+    if (it == buckets.end()) {
+        return nullptr;
+    }
+
+    assert(it->second);
+    return it->second.get();
 }
 
 void LiveTileData::cancel() {

--- a/src/mbgl/map/live_tile_data.hpp
+++ b/src/mbgl/map/live_tile_data.hpp
@@ -20,7 +20,7 @@ public:
                  std::function<void ()> callback);
     ~LiveTileData();
 
-    bool reparse(std::function<void ()> callback) override;
+    bool parsePending(std::function<void ()> callback) override;
 
     void cancel() override;
     Bucket* getBucket(const StyleLayer&) override;
@@ -29,8 +29,11 @@ private:
     Worker& worker;
     TileWorker tileWorker;
     std::unique_ptr<WorkRequest> workRequest;
-    bool parsing = false;
     std::unique_ptr<AnnotationTile> tile;
+
+    // Contains all the Bucket objects for the tile. Buckets are render
+    // objects and they get added by tile parsing operations.
+    std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
 };
 
 }

--- a/src/mbgl/map/live_tile_data.hpp
+++ b/src/mbgl/map/live_tile_data.hpp
@@ -22,6 +22,9 @@ public:
 
     bool parsePending(std::function<void ()> callback) override;
 
+    void redoPlacement(PlacementConfig config) override;
+    void redoPlacement();
+
     void cancel() override;
     Bucket* getBucket(const StyleLayer&) override;
 
@@ -34,6 +37,13 @@ private:
     // Contains all the Bucket objects for the tile. Buckets are render
     // objects and they get added by tile parsing operations.
     std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
+
+    // Stores the placement configuration of the text that is currently placed on the screen.
+    PlacementConfig placedConfig;
+
+    // Stores the placement configuration of how the text should be placed. This isn't necessarily
+    // the one that is being displayed.
+    PlacementConfig targetConfig;
 };
 
 }

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -53,8 +53,7 @@ void MapContext::cleanup() {
     view.notify();
 
     if (styleRequest) {
-        FileSource* fs = util::ThreadContext::getFileSource();
-        fs->cancel(styleRequest);
+        util::ThreadContext::getFileSource()->cancel(styleRequest);
         styleRequest = nullptr;
     }
 
@@ -100,6 +99,7 @@ void MapContext::setStyleURL(const std::string& url) {
 
     if (styleRequest) {
         fs->cancel(styleRequest);
+        styleRequest = nullptr;
     }
 
     styleURL = url;
@@ -114,6 +114,7 @@ void MapContext::setStyleURL(const std::string& url) {
     }
 
     styleRequest = fs->request({ Resource::Kind::Style, styleURL }, util::RunLoop::getLoop(), [this, base](const Response &res) {
+        util::ThreadContext::getFileSource()->cancel(styleRequest);
         styleRequest = nullptr;
 
         if (res.status == Response::Successful) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -113,7 +113,7 @@ void MapContext::setStyleURL(const std::string& url) {
         styleRequest = nullptr;
 
         if (res.status == Response::Successful) {
-            loadStyleJSON(res.data, base);
+            loadStyleJSON(*res.data, base);
         } else if (res.status == Response::NotFound && styleURL.find("mapbox://") == 0) {
             Log::Error(Event::Setup, "style %s could not be found or is an incompatible legacy map or style", styleURL.c_str());
         } else {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -106,6 +106,10 @@ void MapContext::setStyleURL(const std::string& url) {
 
     FileSource* fs = util::ThreadContext::getFileSource();
     styleRequest = fs->request({ Resource::Kind::Style, styleURL }, util::RunLoop::getLoop(), [this, base](const Response &res) {
+        if (res.stale) {
+            // Only handle fresh responses.
+            return;
+        }
         styleRequest = nullptr;
 
         if (res.status == Response::Successful) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -52,10 +52,7 @@ MapContext::~MapContext() {
 void MapContext::cleanup() {
     view.notify();
 
-    if (styleRequest) {
-        util::ThreadContext::getFileSource()->cancel(styleRequest);
-        styleRequest = nullptr;
-    }
+    styleRequest = nullptr;
 
     // Explicit resets currently necessary because these abandon resources that need to be
     // cleaned up by glObjectStore.performCleanup();
@@ -95,13 +92,7 @@ void MapContext::setStyleURL(const std::string& url) {
         return;
     }
 
-    FileSource* fs = util::ThreadContext::getFileSource();
-
-    if (styleRequest) {
-        fs->cancel(styleRequest);
-        styleRequest = nullptr;
-    }
-
+    styleRequest = nullptr;
     styleURL = url;
     styleJSON.clear();
 
@@ -113,8 +104,8 @@ void MapContext::setStyleURL(const std::string& url) {
         base = styleURL.substr(0, pos + 1);
     }
 
+    FileSource* fs = util::ThreadContext::getFileSource();
     styleRequest = fs->request({ Resource::Kind::Style, styleURL }, util::RunLoop::getLoop(), [this, base](const Response &res) {
-        util::ThreadContext::getFileSource()->cancel(styleRequest);
         styleRequest = nullptr;
 
         if (res.status == Response::Successful) {

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -90,7 +90,7 @@ private:
     std::string styleURL;
     std::string styleJSON;
 
-    Request* styleRequest = nullptr;
+    RequestHolder styleRequest;
 
     Map::StillImageCallback callback;
     size_t sourceCacheSize;

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -31,6 +31,10 @@ void RasterTileData::request(float pixelRatio,
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Tile, url }, util::RunLoop::getLoop(), [url, callback, this](const Response &res) {
+        if (res.stale) {
+            // Only handle fresh responses.
+            return;
+        }
         req = nullptr;
 
         if (res.status == Response::NotFound) {

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -31,6 +31,7 @@ void RasterTileData::request(float pixelRatio,
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Tile, url }, util::RunLoop::getLoop(), [url, callback, this](const Response &res) {
+        util::ThreadContext::getFileSource()->cancel(req);
         req = nullptr;
 
         if (res.status == Response::NotFound) {

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -31,7 +31,6 @@ void RasterTileData::request(float pixelRatio,
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Tile, url }, util::RunLoop::getLoop(), [url, callback, this](const Response &res) {
-        util::ThreadContext::getFileSource()->cancel(req);
         req = nullptr;
 
         if (res.status == Response::NotFound) {
@@ -78,9 +77,6 @@ void RasterTileData::cancel() {
     if (state != State::obsolete) {
         state = State::obsolete;
     }
-    if (req) {
-        util::ThreadContext::getFileSource()->cancel(req);
-        req = nullptr;
-    }
+    req = nullptr;
     workRequest.reset();
 }

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/tile_data.hpp>
 #include <mbgl/style/style_properties.hpp>
 #include <mbgl/renderer/raster_bucket.hpp>
+#include <mbgl/storage/request_holder.hpp>
 
 namespace mbgl {
 
@@ -28,7 +29,7 @@ public:
 private:
     const SourceInfo& source;
     Worker& worker;
-    Request* req = nullptr;
+    RequestHolder req;
 
     RasterLayoutProperties layout;
     RasterBucket bucket;

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -27,12 +27,13 @@ public:
     Bucket* getBucket(StyleLayer const &layer_desc) override;
 
 private:
+    TexturePool& texturePool;
     const SourceInfo& source;
     Worker& worker;
     RequestHolder req;
 
     RasterLayoutProperties layout;
-    RasterBucket bucket;
+    std::unique_ptr<Bucket> bucket;
 
     std::unique_ptr<WorkRequest> workRequest;
 };

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -163,7 +163,7 @@ void Source::load() {
         }
 
         rapidjson::Document d;
-        d.Parse<0>(res.data.c_str());
+        d.Parse<0>(res.data->c_str());
 
         if (d.HasParseError()) {
             std::stringstream message;

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -125,6 +125,7 @@ Source::Source() {}
 Source::~Source() {
     if (req) {
         util::ThreadContext::getFileSource()->cancel(req);
+        req = nullptr;
     }
 }
 
@@ -153,6 +154,7 @@ void Source::load() {
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Source, info.url }, util::RunLoop::getLoop(), [this](const Response &res) {
+        util::ThreadContext::getFileSource()->cancel(req);
         req = nullptr;
 
         if (res.status != Response::Successful) {

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -122,12 +122,7 @@ std::string SourceInfo::tileURL(const TileID& id, float pixelRatio) const {
 
 Source::Source() {}
 
-Source::~Source() {
-    if (req) {
-        util::ThreadContext::getFileSource()->cancel(req);
-        req = nullptr;
-    }
-}
+Source::~Source() = default;
 
 bool Source::isLoaded() const {
     if (!loaded) {
@@ -154,7 +149,6 @@ void Source::load() {
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Source, info.url }, util::RunLoop::getLoop(), [this](const Response &res) {
-        util::ThreadContext::getFileSource()->cancel(req);
         req = nullptr;
 
         if (res.status != Response::Successful) {

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -149,6 +149,10 @@ void Source::load() {
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Source, info.url }, util::RunLoop::getLoop(), [this](const Response &res) {
+        if (res.stale) {
+            // Only handle fresh responses.
+            return;
+        }
         req = nullptr;
 
         if (res.status != Response::Successful) {

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -286,8 +286,7 @@ TileData::State Source::addTile(MapData& data,
 
         // If we don't find working tile data, we're just going to load it.
         if (info.type == SourceType::Vector) {
-            auto tileData = std::make_shared<VectorTileData>(normalized_id, style, info, 
-                    transformState.getAngle(), transformState.getPitch(), data.getCollisionDebug());
+            auto tileData = std::make_shared<VectorTileData>(normalized_id, style, info);
             tileData->request(data.pixelRatio, callback);
             new_tile.data = tileData;
         } else if (info.type == SourceType::Raster) {
@@ -296,7 +295,7 @@ TileData::State Source::addTile(MapData& data,
             new_tile.data = tileData;
         } else if (info.type == SourceType::Annotations) {
             new_tile.data = std::make_shared<LiveTileData>(normalized_id,
-                	data.getAnnotationManager()->getTile(normalized_id), style, info, callback);
+                    data.getAnnotationManager()->getTile(normalized_id), style, info, callback);
         } else {
             throw std::runtime_error("source type not implemented");
         }
@@ -510,7 +509,8 @@ bool Source::update(MapData& data,
     updateTilePtrs();
 
     for (auto& tilePtr : tilePtrs) {
-        tilePtr->data->redoPlacement(transformState.getAngle(), transformState.getPitch(), data.getCollisionDebug());
+        tilePtr->data->redoPlacement(
+            { transformState.getAngle(), transformState.getPitch(), data.getCollisionDebug() });
     }
 
     updated = data.getAnimationTime();
@@ -560,7 +560,7 @@ void Source::tileLoadingCompleteCallback(const TileID& normalized_id, const Tran
         return;
     }
 
-    data->redoPlacement(transformState.getAngle(), transformState.getPitch(), collisionDebug);
+    data->redoPlacement({ transformState.getAngle(), transformState.getPitch(), collisionDebug });
     emitTileLoaded(true);
 }
 

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/map/tile_data.hpp>
 #include <mbgl/map/tile_cache.hpp>
 #include <mbgl/style/types.hpp>
+#include <mbgl/storage/request_holder.hpp>
 
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/mat4.hpp>
@@ -129,7 +130,7 @@ private:
     std::map<TileID, std::weak_ptr<TileData>> tile_data;
     TileCache cache;
 
-    Request* req = nullptr;
+    RequestHolder req;
     Observer* observer_ = nullptr;
 };
 

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -105,7 +105,7 @@ private:
 
     bool handlePartialTile(const TileID &id, Worker &worker);
     bool findLoadedChildren(const TileID& id, int32_t maxCoveringZoom, std::forward_list<TileID>& retain);
-    bool findLoadedParent(const TileID& id, int32_t minCoveringZoom, std::forward_list<TileID>& retain);
+    void findLoadedParent(const TileID& id, int32_t minCoveringZoom, std::forward_list<TileID>& retain);
     int32_t coveringZoomLevel(const TransformState&) const;
     std::forward_list<TileID> coveringTiles(const TransformState&) const;
 

--- a/src/mbgl/map/sprite.cpp
+++ b/src/mbgl/map/sprite.cpp
@@ -44,6 +44,10 @@ Sprite::Sprite(const std::string& baseUrl, float pixelRatio_)
     FileSource* fs = util::ThreadContext::getFileSource();
     loader->jsonRequest = fs->request({ Resource::Kind::SpriteJSON, jsonURL }, util::RunLoop::getLoop(),
                                       [this, jsonURL](const Response& res) {
+        if (res.stale) {
+            // Only handle fresh responses.
+            return;
+        }
         loader->jsonRequest = nullptr;
         if (res.status == Response::Successful) {
             loader->data->json = res.data;
@@ -60,6 +64,10 @@ Sprite::Sprite(const std::string& baseUrl, float pixelRatio_)
     loader->spriteRequest =
         fs->request({ Resource::Kind::SpriteImage, spriteURL }, util::RunLoop::getLoop(),
                     [this, spriteURL](const Response& res) {
+            if (res.stale) {
+                // Only handle fresh responses.
+                return;
+            }
             loader->spriteRequest = nullptr;
             if (res.status == Response::Successful) {
                 loader->data->image = res.data;

--- a/src/mbgl/map/sprite.cpp
+++ b/src/mbgl/map/sprite.cpp
@@ -29,9 +29,11 @@ struct Sprite::Loader {
     ~Loader() {
         if (jsonRequest) {
             util::ThreadContext::getFileSource()->cancel(jsonRequest);
+            jsonRequest = nullptr;
         }
         if (spriteRequest) {
             util::ThreadContext::getFileSource()->cancel(spriteRequest);
+            spriteRequest = nullptr;
         }
     }
 };
@@ -52,6 +54,7 @@ Sprite::Sprite(const std::string& baseUrl, float pixelRatio_)
     FileSource* fs = util::ThreadContext::getFileSource();
     loader->jsonRequest = fs->request({ Resource::Kind::SpriteJSON, jsonURL }, util::RunLoop::getLoop(),
                                       [this, jsonURL](const Response& res) {
+        util::ThreadContext::getFileSource()->cancel(loader->jsonRequest);
         loader->jsonRequest = nullptr;
         if (res.status == Response::Successful) {
             loader->data->json = res.data;
@@ -68,6 +71,7 @@ Sprite::Sprite(const std::string& baseUrl, float pixelRatio_)
     loader->spriteRequest =
         fs->request({ Resource::Kind::SpriteImage, spriteURL }, util::RunLoop::getLoop(),
                     [this, spriteURL](const Response& res) {
+            util::ThreadContext::getFileSource()->cancel(loader->spriteRequest);
             loader->spriteRequest = nullptr;
             if (res.status == Response::Successful) {
                 loader->data->image = res.data;

--- a/src/mbgl/map/sprite.hpp
+++ b/src/mbgl/map/sprite.hpp
@@ -19,11 +19,6 @@ class Request;
 
 class Sprite : private util::noncopyable {
 public:
-    struct Data {
-        std::string image;
-        std::string json;
-    };
-
     class Observer {
     public:
         virtual ~Observer() = default;

--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -1,11 +1,26 @@
 #include <mbgl/map/tile_data.hpp>
+#include <mbgl/renderer/debug_bucket.hpp>
 
-using namespace mbgl;
+namespace mbgl {
 
 TileData::TileData(const TileID& id_)
     : id(id_),
-      debugBucket(debugFontBuffer),
       state(State::initial) {
-    // Initialize tile debug coordinates
-    debugFontBuffer.addText(std::string(id).c_str(), 50, 200, 5);
 }
+
+TileData::~TileData() = default;
+
+const char* TileData::StateToString(const State state) {
+    switch (state) {
+        case TileData::State::initial: return "initial";
+        case TileData::State::invalid : return "invalid";
+        case TileData::State::loading : return "loading";
+        case TileData::State::loaded : return "loaded";
+        case TileData::State::obsolete : return "obsolete";
+        case TileData::State::parsed : return "parsed";
+        case TileData::State::partial : return "partial";
+        default: return "<unknown>";
+    }
+}
+
+} // namespace mbgl

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/renderer/bucket.hpp>
+#include <mbgl/text/placement_config.hpp>
 
 #include <atomic>
 #include <string>
@@ -76,7 +77,7 @@ public:
     virtual Bucket* getBucket(const StyleLayer&) = 0;
 
     virtual bool parsePending(std::function<void ()>) { return true; }
-    virtual void redoPlacement(float, float, bool) {}
+    virtual void redoPlacement(PlacementConfig) {}
 
     bool isReady() const {
         return isReadyState(state);

--- a/src/mbgl/map/tile_worker.cpp
+++ b/src/mbgl/map/tile_worker.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_layer.hpp>
 #include <mbgl/style/property_evaluator.hpp>
+#include <mbgl/geometry/sprite_atlas.hpp>
 #include <mbgl/geometry/glyph_atlas.hpp>
 #include <mbgl/renderer/fill_bucket.hpp>
 #include <mbgl/renderer/line_bucket.hpp>
@@ -10,6 +11,7 @@
 #include <mbgl/renderer/symbol_bucket.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/exception.hpp>
 
 using namespace mbgl;
 
@@ -33,34 +35,66 @@ TileWorker::~TileWorker() {
     style.glyphAtlas->removeGlyphs(reinterpret_cast<uintptr_t>(this));
 }
 
-Bucket* TileWorker::getBucket(const StyleLayer& layer) const {
-    std::lock_guard<std::mutex> lock(bucketsMutex);
+TileParseResult TileWorker::parseAllLayers(const GeometryTile& geometryTile) {
+    // We're doing a fresh parse of the tile, because the underlying data has changed.
+    pending.clear();
 
-    const auto it = buckets.find(layer.bucket->name);
-    if (it == buckets.end()) {
-        return nullptr;
-    }
-
-    assert(it->second);
-    return it->second.get();
-}
-
-TileParseResult TileWorker::parse(const GeometryTile& geometryTile) {
-    partialParse = false;
+    // We're storing a list of buckets we've parsed to avoid parsing a bucket twice that is
+    // referenced from more than one layer
+    std::set<StyleBucket*> parsed;
 
     for (auto i = layers.rbegin(); i != layers.rend(); i++) {
-        parseLayer(**i, geometryTile);
+        const StyleLayer& layer = **i;
+        if (layer.bucket && parsed.find(layer.bucket.get()) == parsed.end()) {
+            parsed.emplace(layer.bucket.get());
+            parseLayer(layer, geometryTile);
+        }
     }
 
-    return partialParse ? TileData::State::partial : TileData::State::parsed;
+    result.state = pending.empty() ? TileData::State::parsed : TileData::State::partial;
+    return std::move(result);
 }
 
-void TileWorker::redoPlacement(float angle, float pitch, bool collisionDebug) {
+TileParseResult TileWorker::parsePendingLayers() {
+    // Try parsing the remaining layers that we couldn't parse in the first step due to missing
+    // dependencies.
+    for (auto it = pending.begin(); it != pending.end();) {
+        auto& styleBucket = it->first;
+        auto& bucket = it->second;
+        assert(bucket);
+
+        if (styleBucket.type == StyleLayerType::Symbol) {
+            auto symbolBucket = dynamic_cast<SymbolBucket*>(bucket.get());
+            if (!symbolBucket->needsDependencies(*style.glyphStore, *style.sprite)) {
+                symbolBucket->addFeatures(reinterpret_cast<uintptr_t>(this), *style.spriteAtlas,
+                                          *style.glyphAtlas, *style.glyphStore, *collisionTile);
+                insertBucket(styleBucket.name, std::move(bucket));
+                pending.erase(it++);
+                continue;
+            }
+        }
+
+        // Advance the iterator here; we're skipping this when erasing an element from this list.
+        ++it;
+    }
+
+    result.state = pending.empty() ? TileData::State::parsed : TileData::State::partial;
+    return std::move(result);
+}
+
+void TileWorker::redoPlacement(
+    const std::unordered_map<std::string, std::unique_ptr<Bucket>>* buckets,
+    float angle,
+    float pitch,
+    bool collisionDebug) {
+
+    // Reset the collision tile so we have a clean slate; we're placing all features anyway.
     collisionTile = std::make_unique<CollisionTile>(angle, pitch, collisionDebug);
+
     for (auto i = layers.rbegin(); i != layers.rend(); i++) {
-        auto bucket = getBucket(**i);
-        if (bucket) {
-            bucket->placeFeatures(*collisionTile);
+        const auto it = buckets->find((*i)->id);
+        if (it != buckets->end()) {
+            it->second->placeFeatures(*collisionTile);
         }
     }
 }
@@ -88,21 +122,15 @@ void TileWorker::parseLayer(const StyleLayer& layer, const GeometryTile& geometr
         return;
     }
 
-    // This is a singular layer. Check if this bucket already exists.
-    if (getBucket(layer))
-        return;
-
     const StyleBucket& styleBucket = *layer.bucket;
 
     // Skip this bucket if we are to not render this
-    if (styleBucket.source != sourceID)
+    if ((styleBucket.source != sourceID) ||
+        (id.z < std::floor(styleBucket.min_zoom)) ||
+        (id.z >= std::ceil(styleBucket.max_zoom)) ||
+        (styleBucket.visibility == VisibilityType::None)) {
         return;
-    if (id.z < std::floor(styleBucket.min_zoom))
-        return;
-    if (id.z >= std::ceil(styleBucket.max_zoom))
-        return;
-    if (styleBucket.visibility == mbgl::VisibilityType::None)
-        return;
+    }
 
     auto geometryLayer = geometryTile.getLayer(styleBucket.source_layer);
     if (!geometryLayer) {
@@ -114,35 +142,25 @@ void TileWorker::parseLayer(const StyleLayer& layer, const GeometryTile& geometr
         return;
     }
 
-    std::unique_ptr<Bucket> bucket;
-
     switch (styleBucket.type) {
     case StyleLayerType::Fill:
-        bucket = createFillBucket(*geometryLayer, styleBucket);
+        createFillBucket(*geometryLayer, styleBucket);
         break;
     case StyleLayerType::Line:
-        bucket = createLineBucket(*geometryLayer, styleBucket);
+        createLineBucket(*geometryLayer, styleBucket);
         break;
     case StyleLayerType::Circle:
-        bucket = createCircleBucket(*geometryLayer, styleBucket);
+        createCircleBucket(*geometryLayer, styleBucket);
         break;
     case StyleLayerType::Symbol:
-        bucket = createSymbolBucket(*geometryLayer, styleBucket);
+        createSymbolBucket(*geometryLayer, styleBucket);
         break;
     case StyleLayerType::Raster:
-        return;
+        break;
     default:
         Log::Warning(Event::ParseTile, "unknown bucket render type for layer '%s' (source layer '%s')",
                 styleBucket.name.c_str(), styleBucket.source_layer.c_str());
     }
-
-    // Bucket creation might fail because the data tile may not
-    // contain any data that falls into this bucket.
-    if (!bucket)
-        return;
-
-    std::lock_guard<std::mutex> lock(bucketsMutex);
-    buckets[styleBucket.name] = std::move(bucket);
 }
 
 template <class Bucket>
@@ -161,101 +179,108 @@ void TileWorker::addBucketGeometries(Bucket& bucket, const GeometryTileLayer& la
     }
 }
 
-std::unique_ptr<Bucket> TileWorker::createFillBucket(const GeometryTileLayer& layer,
-                                                     const StyleBucket& bucket_desc) {
+void TileWorker::createFillBucket(const GeometryTileLayer& layer,
+                                  const StyleBucket& styleBucket) {
     auto bucket = std::make_unique<FillBucket>();
-    addBucketGeometries(bucket, layer, bucket_desc.filter);
-    return bucket->hasData() ? std::move(bucket) : nullptr;
+
+    // Fill does not have layout properties to apply.
+
+    addBucketGeometries(bucket, layer, styleBucket.filter);
+
+    insertBucket(styleBucket.name, std::move(bucket));
 }
 
-std::unique_ptr<Bucket> TileWorker::createLineBucket(const GeometryTileLayer& layer,
-                                                     const StyleBucket& bucket_desc) {
+void TileWorker::createLineBucket(const GeometryTileLayer& layer,
+                                  const StyleBucket& styleBucket) {
     auto bucket = std::make_unique<LineBucket>();
 
     const float z = id.z;
     auto& layout = bucket->layout;
 
-    applyLayoutProperty(PropertyKey::LineCap, bucket_desc.layout, layout.cap, z);
-    applyLayoutProperty(PropertyKey::LineJoin, bucket_desc.layout, layout.join, z);
-    applyLayoutProperty(PropertyKey::LineMiterLimit, bucket_desc.layout, layout.miter_limit, z);
-    applyLayoutProperty(PropertyKey::LineRoundLimit, bucket_desc.layout, layout.round_limit, z);
+    applyLayoutProperty(PropertyKey::LineCap, styleBucket.layout, layout.cap, z);
+    applyLayoutProperty(PropertyKey::LineJoin, styleBucket.layout, layout.join, z);
+    applyLayoutProperty(PropertyKey::LineMiterLimit, styleBucket.layout, layout.miter_limit, z);
+    applyLayoutProperty(PropertyKey::LineRoundLimit, styleBucket.layout, layout.round_limit, z);
 
-    addBucketGeometries(bucket, layer, bucket_desc.filter);
-    return bucket->hasData() ? std::move(bucket) : nullptr;
+    addBucketGeometries(bucket, layer, styleBucket.filter);
+
+    insertBucket(styleBucket.name, std::move(bucket));
 }
 
-std::unique_ptr<Bucket> TileWorker::createCircleBucket(const GeometryTileLayer& layer,
-                                                       const StyleBucket& bucket_desc) {
+void TileWorker::createCircleBucket(const GeometryTileLayer& layer,
+                                    const StyleBucket& styleBucket) {
     auto bucket = std::make_unique<CircleBucket>();
 
     // Circle does not have layout properties to apply.
 
-    addBucketGeometries(bucket, layer, bucket_desc.filter);
-    return bucket->hasData() ? std::move(bucket) : nullptr;
+    addBucketGeometries(bucket, layer, styleBucket.filter);
+
+    insertBucket(styleBucket.name, std::move(bucket));
 }
 
-std::unique_ptr<Bucket> TileWorker::createSymbolBucket(const GeometryTileLayer& layer,
-                                                       const StyleBucket& bucket_desc) {
+void TileWorker::createSymbolBucket(const GeometryTileLayer& layer,
+                                    const StyleBucket& styleBucket) {
     auto bucket = std::make_unique<SymbolBucket>(id.overscaling, id.z);
 
     const float z = id.z;
     auto& layout = bucket->layout;
 
-    applyLayoutProperty(PropertyKey::SymbolPlacement, bucket_desc.layout, layout.placement, z);
+    applyLayoutProperty(PropertyKey::SymbolPlacement, styleBucket.layout, layout.placement, z);
     if (layout.placement == PlacementType::Line) {
         layout.icon.rotation_alignment = RotationAlignmentType::Map;
         layout.text.rotation_alignment = RotationAlignmentType::Map;
     };
-    applyLayoutProperty(PropertyKey::SymbolSpacing, bucket_desc.layout, layout.spacing, z);
-    applyLayoutProperty(PropertyKey::SymbolAvoidEdges, bucket_desc.layout, layout.avoid_edges, z);
+    applyLayoutProperty(PropertyKey::SymbolSpacing, styleBucket.layout, layout.spacing, z);
+    applyLayoutProperty(PropertyKey::SymbolAvoidEdges, styleBucket.layout, layout.avoid_edges, z);
 
-    applyLayoutProperty(PropertyKey::IconAllowOverlap, bucket_desc.layout, layout.icon.allow_overlap, z);
-    applyLayoutProperty(PropertyKey::IconIgnorePlacement, bucket_desc.layout, layout.icon.ignore_placement, z);
-    applyLayoutProperty(PropertyKey::IconOptional, bucket_desc.layout, layout.icon.optional, z);
-    applyLayoutProperty(PropertyKey::IconRotationAlignment, bucket_desc.layout, layout.icon.rotation_alignment, z);
-    applyLayoutProperty(PropertyKey::IconImage, bucket_desc.layout, layout.icon.image, z);
-    applyLayoutProperty(PropertyKey::IconPadding, bucket_desc.layout, layout.icon.padding, z);
-    applyLayoutProperty(PropertyKey::IconRotate, bucket_desc.layout, layout.icon.rotate, z);
-    applyLayoutProperty(PropertyKey::IconKeepUpright, bucket_desc.layout, layout.icon.keep_upright, z);
-    applyLayoutProperty(PropertyKey::IconOffset, bucket_desc.layout, layout.icon.offset, z);
+    applyLayoutProperty(PropertyKey::IconAllowOverlap, styleBucket.layout, layout.icon.allow_overlap, z);
+    applyLayoutProperty(PropertyKey::IconIgnorePlacement, styleBucket.layout, layout.icon.ignore_placement, z);
+    applyLayoutProperty(PropertyKey::IconOptional, styleBucket.layout, layout.icon.optional, z);
+    applyLayoutProperty(PropertyKey::IconRotationAlignment, styleBucket.layout, layout.icon.rotation_alignment, z);
+    applyLayoutProperty(PropertyKey::IconImage, styleBucket.layout, layout.icon.image, z);
+    applyLayoutProperty(PropertyKey::IconPadding, styleBucket.layout, layout.icon.padding, z);
+    applyLayoutProperty(PropertyKey::IconRotate, styleBucket.layout, layout.icon.rotate, z);
+    applyLayoutProperty(PropertyKey::IconKeepUpright, styleBucket.layout, layout.icon.keep_upright, z);
+    applyLayoutProperty(PropertyKey::IconOffset, styleBucket.layout, layout.icon.offset, z);
 
-    applyLayoutProperty(PropertyKey::TextRotationAlignment, bucket_desc.layout, layout.text.rotation_alignment, z);
-    applyLayoutProperty(PropertyKey::TextField, bucket_desc.layout, layout.text.field, z);
-    applyLayoutProperty(PropertyKey::TextFont, bucket_desc.layout, layout.text.font, z);
-    applyLayoutProperty(PropertyKey::TextMaxWidth, bucket_desc.layout, layout.text.max_width, z);
-    applyLayoutProperty(PropertyKey::TextLineHeight, bucket_desc.layout, layout.text.line_height, z);
-    applyLayoutProperty(PropertyKey::TextLetterSpacing, bucket_desc.layout, layout.text.letter_spacing, z);
-    applyLayoutProperty(PropertyKey::TextMaxAngle, bucket_desc.layout, layout.text.max_angle, z);
-    applyLayoutProperty(PropertyKey::TextRotate, bucket_desc.layout, layout.text.rotate, z);
-    applyLayoutProperty(PropertyKey::TextPadding, bucket_desc.layout, layout.text.padding, z);
-    applyLayoutProperty(PropertyKey::TextIgnorePlacement, bucket_desc.layout, layout.text.ignore_placement, z);
-    applyLayoutProperty(PropertyKey::TextOptional, bucket_desc.layout, layout.text.optional, z);
-    applyLayoutProperty(PropertyKey::TextJustify, bucket_desc.layout, layout.text.justify, z);
-    applyLayoutProperty(PropertyKey::TextAnchor, bucket_desc.layout, layout.text.anchor, z);
-    applyLayoutProperty(PropertyKey::TextKeepUpright, bucket_desc.layout, layout.text.keep_upright, z);
-    applyLayoutProperty(PropertyKey::TextTransform, bucket_desc.layout, layout.text.transform, z);
-    applyLayoutProperty(PropertyKey::TextOffset, bucket_desc.layout, layout.text.offset, z);
-    applyLayoutProperty(PropertyKey::TextAllowOverlap, bucket_desc.layout, layout.text.allow_overlap, z);
+    applyLayoutProperty(PropertyKey::TextRotationAlignment, styleBucket.layout, layout.text.rotation_alignment, z);
+    applyLayoutProperty(PropertyKey::TextField, styleBucket.layout, layout.text.field, z);
+    applyLayoutProperty(PropertyKey::TextFont, styleBucket.layout, layout.text.font, z);
+    applyLayoutProperty(PropertyKey::TextMaxWidth, styleBucket.layout, layout.text.max_width, z);
+    applyLayoutProperty(PropertyKey::TextLineHeight, styleBucket.layout, layout.text.line_height, z);
+    applyLayoutProperty(PropertyKey::TextLetterSpacing, styleBucket.layout, layout.text.letter_spacing, z);
+    applyLayoutProperty(PropertyKey::TextMaxAngle, styleBucket.layout, layout.text.max_angle, z);
+    applyLayoutProperty(PropertyKey::TextRotate, styleBucket.layout, layout.text.rotate, z);
+    applyLayoutProperty(PropertyKey::TextPadding, styleBucket.layout, layout.text.padding, z);
+    applyLayoutProperty(PropertyKey::TextIgnorePlacement, styleBucket.layout, layout.text.ignore_placement, z);
+    applyLayoutProperty(PropertyKey::TextOptional, styleBucket.layout, layout.text.optional, z);
+    applyLayoutProperty(PropertyKey::TextJustify, styleBucket.layout, layout.text.justify, z);
+    applyLayoutProperty(PropertyKey::TextAnchor, styleBucket.layout, layout.text.anchor, z);
+    applyLayoutProperty(PropertyKey::TextKeepUpright, styleBucket.layout, layout.text.keep_upright, z);
+    applyLayoutProperty(PropertyKey::TextTransform, styleBucket.layout, layout.text.transform, z);
+    applyLayoutProperty(PropertyKey::TextOffset, styleBucket.layout, layout.text.offset, z);
+    applyLayoutProperty(PropertyKey::TextAllowOverlap, styleBucket.layout, layout.text.allow_overlap, z);
 
-    applyLayoutProperty(PropertyKey::IconSize, bucket_desc.layout, layout.icon.size, z + 1);
-    applyLayoutProperty(PropertyKey::IconSize, bucket_desc.layout, layout.icon.max_size, 18);
-    applyLayoutProperty(PropertyKey::TextSize, bucket_desc.layout, layout.text.size, z + 1);
-    applyLayoutProperty(PropertyKey::TextSize, bucket_desc.layout, layout.text.max_size, 18);
+    applyLayoutProperty(PropertyKey::IconSize, styleBucket.layout, layout.icon.size, z + 1);
+    applyLayoutProperty(PropertyKey::IconSize, styleBucket.layout, layout.icon.max_size, 18);
+    applyLayoutProperty(PropertyKey::TextSize, styleBucket.layout, layout.text.size, z + 1);
+    applyLayoutProperty(PropertyKey::TextSize, styleBucket.layout, layout.text.max_size, 18);
 
-    if (bucket->needsDependencies(layer, bucket_desc.filter, *style.glyphStore, *style.sprite)) {
-        partialParse = true;
+    bucket->parseFeatures(layer, styleBucket.filter);
+
+    const bool needsDependencies = bucket->needsDependencies(*style.glyphStore, *style.sprite);
+    if (needsDependencies) {
+        // We cannot parse this bucket yet. Instead, we're saving it for later.
+        pending.emplace_back(styleBucket, std::move(bucket));
+    } else {
+        bucket->addFeatures(reinterpret_cast<uintptr_t>(this), *style.spriteAtlas,
+                            *style.glyphAtlas, *style.glyphStore, *collisionTile);
+        insertBucket(styleBucket.name, std::move(bucket));
     }
+}
 
-    // We do not proceed if the parser is in a "partial" state because
-    // the layer ordering needs to be respected when calculating text
-    // collisions. Although, at this point, we requested all the resources
-    // needed by this tile.
-    if (partialParse) {
-        return nullptr;
+void TileWorker::insertBucket(const std::string& name, std::unique_ptr<Bucket> bucket) {
+    if (bucket->hasData()) {
+        result.buckets.emplace_back(name, std::move(bucket));
     }
-
-    bucket->addFeatures(reinterpret_cast<uintptr_t>(this), *style.spriteAtlas, *style.glyphAtlas,
-                        *style.glyphStore, *collisionTile);
-
-    return bucket->hasData() ? std::move(bucket) : nullptr;
 }

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -8,6 +8,7 @@
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/style/filter_expression.hpp>
 #include <mbgl/style/style_calculation_parameters.hpp>
+#include <mbgl/text/placement_config.hpp>
 
 #include <string>
 #include <memory>
@@ -42,16 +43,13 @@ public:
                std::string sourceID,
                Style&,
                std::vector<util::ptr<StyleLayer>>,
-               const std::atomic<TileData::State>&,
-               std::unique_ptr<CollisionTile>);
+               const std::atomic<TileData::State>&);
     ~TileWorker();
 
-    TileParseResult parseAllLayers(const GeometryTile&);
+    TileParseResult parseAllLayers(const GeometryTile&, PlacementConfig);
     TileParseResult parsePendingLayers();
     void redoPlacement(const std::unordered_map<std::string, std::unique_ptr<Bucket>>*,
-                       float angle,
-                       float pitch,
-                       bool collisionDebug);
+                       PlacementConfig);
 
     std::vector<util::ptr<StyleLayer>> layers;
 

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -43,6 +43,7 @@ void VectorTileData::request(float pixelRatio, const std::function<void()>& call
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Tile, url }, util::RunLoop::getLoop(), [url, callback, this](const Response &res) {
+        util::ThreadContext::getFileSource()->cancel(req);
         req = nullptr;
 
         if (res.status == Response::NotFound) {

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -43,6 +43,10 @@ void VectorTileData::request(float pixelRatio, const std::function<void()>& call
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Tile, url }, util::RunLoop::getLoop(), [url, callback, this](const Response &res) {
+        if (res.stale) {
+            // Only handle fresh responses.
+            return;
+        }
         req = nullptr;
 
         if (res.status == Response::NotFound) {

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -43,7 +43,6 @@ void VectorTileData::request(float pixelRatio, const std::function<void()>& call
 
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Tile, url }, util::RunLoop::getLoop(), [url, callback, this](const Response &res) {
-        util::ThreadContext::getFileSource()->cancel(req);
         req = nullptr;
 
         if (res.status == Response::NotFound) {
@@ -139,9 +138,6 @@ void VectorTileData::cancel() {
     if (state != State::obsolete) {
         state = State::obsolete;
     }
-    if (req) {
-        util::ThreadContext::getFileSource()->cancel(req);
-        req = nullptr;
-    }
+    req = nullptr;
     workRequest.reset();
 }

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -16,20 +16,16 @@ class Request;
 
 class VectorTileData : public TileData {
 public:
-    VectorTileData(const TileID&,
-                   Style&,
-                   const SourceInfo&,
-                   float angle_,
-                   float pitch_,
-                   bool collisionDebug_);
+    VectorTileData(
+        const TileID&, Style&, const SourceInfo&, float angle_, float pitch_, bool collisionDebug_);
     ~VectorTileData();
 
     Bucket* getBucket(const StyleLayer&) override;
 
-    void request(float pixelRatio,
-                 const std::function<void()>& callback);
+    void request(float pixelRatio, const std::function<void()>& callback);
 
-    bool reparse(std::function<void ()> callback) override;
+    void parse(std::function<void()> callback);
+    bool parsePending(std::function<void()> callback) override;
 
     void redoPlacement(float angle, float pitch, bool collisionDebug) override;
 
@@ -39,7 +35,11 @@ private:
     Worker& worker;
     TileWorker tileWorker;
     std::unique_ptr<WorkRequest> workRequest;
-    bool parsing = false;
+
+    // Contains all the Bucket objects for the tile. Buckets are render
+    // objects and they get added by tile parsing operations.
+    std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
+
     const SourceInfo& source;
     RequestHolder req;
     std::shared_ptr<const std::string> data;
@@ -49,9 +49,8 @@ private:
     float currentPitch;
     bool lastCollisionDebug = 0;
     bool currentCollisionDebug = 0;
-    bool redoingPlacement = false;
 };
 
-}
+} // namespace mbgl
 
 #endif

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -42,7 +42,7 @@ private:
     bool parsing = false;
     const SourceInfo& source;
     RequestHolder req;
-    std::string data;
+    std::shared_ptr<const std::string> data;
     float lastAngle = 0;
     float currentAngle;
     float lastPitch = 0;

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/tile_data.hpp>
 #include <mbgl/map/tile_worker.hpp>
 #include <mbgl/storage/request_holder.hpp>
+#include <mbgl/text/placement_config.hpp>
 
 #include <atomic>
 
@@ -17,7 +18,7 @@ class Request;
 class VectorTileData : public TileData {
 public:
     VectorTileData(
-        const TileID&, Style&, const SourceInfo&, float angle_, float pitch_, bool collisionDebug_);
+        const TileID&, Style&, const SourceInfo&);
     ~VectorTileData();
 
     Bucket* getBucket(const StyleLayer&) override;
@@ -27,7 +28,8 @@ public:
     void parse(std::function<void()> callback);
     bool parsePending(std::function<void()> callback) override;
 
-    void redoPlacement(float angle, float pitch, bool collisionDebug) override;
+    void redoPlacement(PlacementConfig config) override;
+    void redoPlacement();
 
     void cancel() override;
 
@@ -43,12 +45,13 @@ private:
     const SourceInfo& source;
     RequestHolder req;
     std::shared_ptr<const std::string> data;
-    float lastAngle = 0;
-    float currentAngle;
-    float lastPitch = 0;
-    float currentPitch;
-    bool lastCollisionDebug = 0;
-    bool currentCollisionDebug = 0;
+
+    // Stores the placement configuration of the text that is currently placed on the screen.
+    PlacementConfig placedConfig;
+
+    // Stores the placement configuration of how the text should be placed. This isn't necessarily
+    // the one that is being displayed.
+    PlacementConfig targetConfig;
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/map/tile_data.hpp>
 #include <mbgl/map/tile_worker.hpp>
+#include <mbgl/storage/request_holder.hpp>
 
 #include <atomic>
 
@@ -40,7 +41,7 @@ private:
     std::unique_ptr<WorkRequest> workRequest;
     bool parsing = false;
     const SourceInfo& source;
-    Request* req = nullptr;
+    RequestHolder req;
     std::string data;
     float lastAngle = 0;
     float currentAngle;

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -32,6 +32,8 @@ public:
 
     virtual ~Bucket() {}
 
+    virtual bool hasData() const = 0;
+
     inline bool needsUpload() const {
         return !uploaded;
     }

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -26,7 +26,7 @@ public:
     void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
 
-    bool hasData() const;
+    bool hasData() const override;
     void addGeometry(const GeometryCollection&);
 
     void drawCircles(CircleShader& shader);

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -5,21 +5,13 @@
 #include <mbgl/platform/gl.hpp>
 
 #include <cassert>
+#include <string>
 
 using namespace mbgl;
 
-DebugBucket::DebugBucket(DebugFontBuffer& fontBuffer_)
-    : fontBuffer(fontBuffer_) {
-}
-
-void DebugBucket::upload() {
-    fontBuffer.upload();
-
-    uploaded = true;
-}
-
-void DebugBucket::render(Painter& painter, const StyleLayer&, const TileID&, const mat4& matrix) {
-    painter.renderDebugText(*this, matrix);
+DebugBucket::DebugBucket(const TileID id, const TileData::State state_) : state(state_) {
+    const std::string text = std::string(id) + " - " + TileData::StateToString(state);
+    fontBuffer.addText(text.c_str(), 50, 200, 5);
 }
 
 void DebugBucket::drawLines(PlainShader& shader) {

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -1,28 +1,25 @@
 #ifndef MBGL_RENDERER_DEBUGBUCKET
 #define MBGL_RENDERER_DEBUGBUCKET
 
-#include <mbgl/renderer/bucket.hpp>
+#include <mbgl/map/tile_data.hpp>
 #include <mbgl/geometry/debug_font_buffer.hpp>
 #include <mbgl/geometry/vao.hpp>
-
-#include <vector>
 
 namespace mbgl {
 
 class PlainShader;
 
-class DebugBucket : public Bucket {
+class DebugBucket : private util::noncopyable {
 public:
-    DebugBucket(DebugFontBuffer& fontBuffer);
-
-    void upload() override;
-    void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
+    DebugBucket(TileID id, TileData::State);
 
     void drawLines(PlainShader& shader);
     void drawPoints(PlainShader& shader);
 
+    const TileData::State state;
+
 private:
-    DebugFontBuffer& fontBuffer;
+    DebugFontBuffer fontBuffer;
     VertexArrayObject array;
 };
 

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -34,7 +34,7 @@ public:
 
     void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
-    bool hasData() const;
+    bool hasData() const override;
 
     void addGeometry(const GeometryCollection&);
     void tessellate();

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -30,7 +30,7 @@ public:
 
     void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
-    bool hasData() const;
+    bool hasData() const override;
 
     void addGeometry(const GeometryCollection&);
     void addGeometry(const std::vector<Coordinate>& line);

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -102,7 +102,7 @@ public:
     // Renders the red debug frame around a tile, visualizing its perimeter.
     void renderDebugFrame(const mat4 &matrix);
 
-    void renderDebugText(DebugBucket&, const mat4&);
+    void renderDebugText(TileData&, const mat4&);
     void renderFill(FillBucket&, const FillLayer&, const TileID&, const mat4&);
     void renderLine(LineBucket&, const LineLayer&, const TileID&, const mat4&);
     void renderCircle(CircleBucket&, const CircleLayer&, const TileID&, const mat4&);

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -18,7 +18,7 @@ public:
 
     void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
-    bool hasData() const;
+    bool hasData() const override;
 
     bool setImage(std::unique_ptr<util::Image> image);
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -90,20 +90,16 @@ bool SymbolBucket::hasIconData() const { return renderData && !renderData->icon.
 
 bool SymbolBucket::hasCollisionBoxData() const { return renderData && !renderData->collisionBox.groups.empty(); }
 
-bool SymbolBucket::needsDependencies(const GeometryTileLayer& layer,
-                                     const FilterExpression& filter,
-                                     GlyphStore& glyphStore,
-                                     Sprite& sprite) {
+void SymbolBucket::parseFeatures(const GeometryTileLayer& layer,
+                                 const FilterExpression& filter) {
     const bool has_text = !layout.text.field.empty() && !layout.text.font.empty();
     const bool has_icon = !layout.icon.image.empty();
 
     if (!has_text && !has_icon) {
-        return false;
+        return;
     }
 
     // Determine and load glyph ranges
-    std::set<GlyphRange> ranges;
-
     const GLsizei featureCount = static_cast<GLsizei>(layer.featureCount());
     for (GLsizei i = 0; i < featureCount; i++) {
         auto feature = layer.getFeature(i);
@@ -161,12 +157,15 @@ bool SymbolBucket::needsDependencies(const GeometryTileLayer& layer,
     if (layout.placement == PlacementType::Line) {
         util::mergeLines(features);
     }
+}
 
-    if (!glyphStore.hasGlyphRanges(layout.text.font, ranges)) {
+bool SymbolBucket::needsDependencies(GlyphStore& glyphStore,
+                                     Sprite& sprite) {
+    if (!layout.text.field.empty() && !layout.text.font.empty() && !glyphStore.hasGlyphRanges(layout.text.font, ranges)) {
         return true;
     }
 
-    if (!sprite.isLoaded()) {
+    if (!layout.icon.image.empty() && !sprite.isLoaded()) {
         return true;
     }
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <map>
+#include <set>
 #include <vector>
 
 namespace mbgl {
@@ -69,7 +70,7 @@ public:
 
     void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
-    bool hasData() const;
+    bool hasData() const override;
     bool hasTextData() const;
     bool hasIconData() const;
     bool hasCollisionBoxData() const;
@@ -85,10 +86,10 @@ public:
     void drawIcons(IconShader& shader);
     void drawCollisionBoxes(CollisionBoxShader& shader);
 
-    bool needsDependencies(const GeometryTileLayer&,
-                           const FilterExpression&,
-                           GlyphStore&,
-                           Sprite&);
+    void parseFeatures(const GeometryTileLayer&,
+                       const FilterExpression&);
+    bool needsDependencies(GlyphStore& glyphStore,
+                           Sprite& sprite);
     void placeFeatures(CollisionTile&) override;
 
 private:
@@ -120,6 +121,7 @@ private:
     const float tileExtent = 4096.0f;
     const float tilePixelRatio;
 
+    std::set<GlyphRange> ranges;
     std::vector<SymbolInstance> symbolInstances;
     std::vector<SymbolFeature> features;
 

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -127,7 +127,6 @@ void DefaultFileSource::Impl::update(DefaultFileRequest* request) {
         if (!request->response->stale && request->response->isExpired()) {
             // Create a new Response object with `stale = true`, but the same data, and
             // replace the current request object we have.
-            // TODO: Make content shared_ptrs so we won't make copies of the content.
             auto response = std::make_shared<Response>(*request->response);
             response->stale = true;
             request->response = response;

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -11,6 +11,7 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/thread.hpp>
 #include <mbgl/util/mapbox.hpp>
+#include <mbgl/util/exception.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -39,6 +40,10 @@ Request* DefaultFileSource::request(const Resource& resource,
                                     uv_loop_t* l,
                                     Callback callback) {
     assert(l);
+
+    if (!callback) {
+        throw util::MisuseException("FileSource callback can't be empty");
+    }
 
     std::string url;
 
@@ -70,6 +75,7 @@ Request* DefaultFileSource::request(const Resource& resource,
 }
 
 void DefaultFileSource::cancel(Request *req) {
+    assert(req);
     req->cancel();
     thread->invoke(&Impl::cancel, req);
 }

--- a/src/mbgl/storage/default_file_source_impl.hpp
+++ b/src/mbgl/storage/default_file_source_impl.hpp
@@ -15,6 +15,7 @@ class RequestBase;
 struct DefaultFileRequest {
     const Resource resource;
     std::set<Request*> observers;
+    std::shared_ptr<const Response> response;
 
     std::unique_ptr<WorkRequest> cacheRequest;
     RequestBase* realRequest = nullptr;
@@ -39,6 +40,7 @@ public:
 private:
     DefaultFileRequest* find(const Resource&);
 
+    void update(DefaultFileRequest*);
     void startCacheRequest(DefaultFileRequest*);
     void startRealRequest(DefaultFileRequest*, std::shared_ptr<const Response> = nullptr);
     void notify(DefaultFileRequest*, std::shared_ptr<const Response>, FileCache::Hint);

--- a/src/mbgl/storage/default_file_source_impl.hpp
+++ b/src/mbgl/storage/default_file_source_impl.hpp
@@ -19,6 +19,7 @@ struct DefaultFileRequest {
 
     std::unique_ptr<WorkRequest> cacheRequest;
     RequestBase* realRequest = nullptr;
+    std::unique_ptr<uv::timer> timerRequest;
 
     inline DefaultFileRequest(const Resource& resource_)
         : resource(resource_) {}

--- a/src/mbgl/storage/request.cpp
+++ b/src/mbgl/storage/request.cpp
@@ -49,7 +49,6 @@ Request::~Request() = default;
 
 // Called in the FileSource thread.
 void Request::notify(const std::shared_ptr<const Response> &response_) {
-    assert(!std::atomic_load(&response));
     assert(response_);
     std::atomic_store(&response, response_);
     async->send();

--- a/src/mbgl/storage/request_holder.cpp
+++ b/src/mbgl/storage/request_holder.cpp
@@ -1,0 +1,12 @@
+#include <mbgl/storage/request_holder.hpp>
+#include <mbgl/storage/file_source.hpp>
+#include <mbgl/util/thread_context.hpp>
+
+namespace mbgl {
+
+void RequestHolder::Deleter::operator()(Request* req) const {
+    // This function is called by the unique_ptr's Deleter.
+    util::ThreadContext::getFileSource()->cancel(req);
+}
+
+}

--- a/src/mbgl/storage/request_holder.hpp
+++ b/src/mbgl/storage/request_holder.hpp
@@ -1,0 +1,26 @@
+#ifndef MBGL_STORAGE_REQUEST_HOLDER
+#define MBGL_STORAGE_REQUEST_HOLDER
+
+#include <memory>
+
+namespace mbgl {
+
+class Request;
+
+class RequestHolder {
+public:
+    inline RequestHolder& operator=(Request* req) {
+        ptr = std::unique_ptr<Request, Deleter>(req);
+        return *this;
+    }
+
+private:
+    struct Deleter {
+        void operator()(Request*) const;
+    };
+    std::unique_ptr<Request, Deleter> ptr;
+};
+
+}
+
+#endif

--- a/src/mbgl/storage/response.cpp
+++ b/src/mbgl/storage/response.cpp
@@ -1,0 +1,12 @@
+#include <mbgl/storage/response.hpp>
+#include <mbgl/util/chrono.hpp>
+
+namespace mbgl {
+
+bool Response::isExpired() const {
+    const int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
+                                    SystemClock::now().time_since_epoch()).count();
+    return expires <= now;
+}
+
+} // namespace mbgl

--- a/src/mbgl/text/collision_tile.cpp
+++ b/src/mbgl/text/collision_tile.cpp
@@ -3,17 +3,16 @@
 
 namespace mbgl {
 
-CollisionTile::CollisionTile(const float angle_, const float pitch, bool debug_) :
-    angle(angle_), debug(debug_) {
+CollisionTile::CollisionTile(PlacementConfig config_) : config(config_) {
     tree.clear();
 
-     // Compute the transformation matrix.
-    float angle_sin = std::sin(angle);
-    float angle_cos = std::cos(angle);
-    rotationMatrix = {{angle_cos, -angle_sin, angle_sin, angle_cos}};
+    // Compute the transformation matrix.
+    const float angle_sin = std::sin(config.angle);
+    const float angle_cos = std::cos(config.angle);
+    rotationMatrix = { { angle_cos, -angle_sin, angle_sin, angle_cos } };
 
     // Stretch boxes in y direction to account for the map tilt.
-    const float _yStretch = 1.0f / std::cos(pitch);
+    const float _yStretch = 1.0f / std::cos(config.pitch);
 
     // The amount the map is squished depends on the y position.
     // Sort of account for this by making all boxes a bit bigger.

--- a/src/mbgl/text/collision_tile.hpp
+++ b/src/mbgl/text/collision_tile.hpp
@@ -2,6 +2,7 @@
 #define MBGL_TEXT_COLLISION_TILE
 
 #include <mbgl/text/collision_feature.hpp>
+#include <mbgl/text/placement_config.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -24,39 +25,34 @@
 
 namespace mbgl {
 
-    namespace bg = boost::geometry;
-    namespace bgm = bg::model;
-    namespace bgi = bg::index;
-    typedef bgm::point<float, 2, bg::cs::cartesian> CollisionPoint;
-    typedef bgm::box<CollisionPoint> Box;
-    typedef std::pair<Box, CollisionBox> CollisionTreeBox;
-    typedef bgi::rtree<CollisionTreeBox, bgi::linear<16,4>> Tree;
+namespace bg = boost::geometry;
+namespace bgm = bg::model;
+namespace bgi = bg::index;
+typedef bgm::point<float, 2, bg::cs::cartesian> CollisionPoint;
+typedef bgm::box<CollisionPoint> Box;
+typedef std::pair<Box, CollisionBox> CollisionTreeBox;
+typedef bgi::rtree<CollisionTreeBox, bgi::linear<16, 4>> Tree;
 
 class CollisionTile {
+public:
+    explicit CollisionTile(PlacementConfig);
 
-    public:
-    explicit CollisionTile(float angle_, float pitch_, bool debug_);
+    float placeFeature(const CollisionFeature& feature);
+    void insertFeature(CollisionFeature& feature, const float minPlacementScale);
 
-    float placeFeature(const CollisionFeature &feature);
-    void insertFeature(CollisionFeature &feature, const float minPlacementScale);
-
-    bool getDebug() { return debug; }
-
-    const float angle = 0;
+    const PlacementConfig config;
 
     const float minScale = 0.5f;
     const float maxScale = 2.0f;
     float yStretch;
 
-    private:
-
-    Box getTreeBox(const vec2<float> &anchor, const CollisionBox &box);
+private:
+    Box getTreeBox(const vec2<float>& anchor, const CollisionBox& box);
 
     Tree tree;
     std::array<float, 4> rotationMatrix;
-    bool debug;
-
 };
-}
+
+} // namespace mbgl
 
 #endif

--- a/src/mbgl/text/glyph_pbf.cpp
+++ b/src/mbgl/text/glyph_pbf.cpp
@@ -75,7 +75,6 @@ GlyphPBF::GlyphPBF(GlyphStore* store,
     });
 
     auto requestCallback = [this, store, fontStack, url](const Response &res) {
-        util::ThreadContext::getFileSource()->cancel(req);
         req = nullptr;
 
         if (res.status != Response::Successful) {
@@ -92,12 +91,7 @@ GlyphPBF::GlyphPBF(GlyphStore* store,
     req = fs->request({ Resource::Kind::Glyphs, url }, util::RunLoop::getLoop(), requestCallback);
 }
 
-GlyphPBF::~GlyphPBF() {
-    if (req) {
-        util::ThreadContext::getFileSource()->cancel(req);
-        req = nullptr;
-    }
-}
+GlyphPBF::~GlyphPBF() = default;
 
 void GlyphPBF::parse(GlyphStore* store, const std::string& fontStack, const std::string& url) {
     if (data.empty()) {

--- a/src/mbgl/text/glyph_pbf.cpp
+++ b/src/mbgl/text/glyph_pbf.cpp
@@ -75,6 +75,7 @@ GlyphPBF::GlyphPBF(GlyphStore* store,
     });
 
     auto requestCallback = [this, store, fontStack, url](const Response &res) {
+        util::ThreadContext::getFileSource()->cancel(req);
         req = nullptr;
 
         if (res.status != Response::Successful) {
@@ -94,6 +95,7 @@ GlyphPBF::GlyphPBF(GlyphStore* store,
 GlyphPBF::~GlyphPBF() {
     if (req) {
         util::ThreadContext::getFileSource()->cancel(req);
+        req = nullptr;
     }
 }
 

--- a/src/mbgl/text/glyph_pbf.cpp
+++ b/src/mbgl/text/glyph_pbf.cpp
@@ -75,6 +75,10 @@ GlyphPBF::GlyphPBF(GlyphStore* store,
     });
 
     auto requestCallback = [this, store, fontStack, url](const Response &res) {
+        if (res.stale) {
+            // Only handle fresh responses.
+            return;
+        }
         req = nullptr;
 
         if (res.status != Response::Successful) {

--- a/src/mbgl/text/glyph_pbf.cpp
+++ b/src/mbgl/text/glyph_pbf.cpp
@@ -98,14 +98,15 @@ GlyphPBF::GlyphPBF(GlyphStore* store,
 GlyphPBF::~GlyphPBF() = default;
 
 void GlyphPBF::parse(GlyphStore* store, const std::string& fontStack, const std::string& url) {
-    if (data.empty()) {
+    assert(data);
+    if (data->empty()) {
         // If there is no data, this means we either haven't
         // received any data.
         return;
     }
 
     try {
-        parseGlyphPBF(**store->getFontStack(fontStack), std::move(data));
+        parseGlyphPBF(**store->getFontStack(fontStack), *data);
     } catch (const std::exception& ex) {
         std::stringstream message;
         message <<  "Failed to parse [" << url << "]: " << ex.what();

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -42,7 +42,7 @@ private:
 
     void parse(GlyphStore* store, const std::string& fontStack, const std::string& url);
 
-    std::string data;
+    std::shared_ptr<const std::string> data;
     std::atomic<bool> parsed;
 
     RequestHolder req;

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/text/glyph.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/storage/request_holder.hpp>
 
 #include <atomic>
 #include <functional>
@@ -44,7 +45,7 @@ private:
     std::string data;
     std::atomic<bool> parsed;
 
-    Request* req = nullptr;
+    RequestHolder req;
 
     Observer* observer = nullptr;
 };

--- a/src/mbgl/text/placement_config.hpp
+++ b/src/mbgl/text/placement_config.hpp
@@ -1,0 +1,28 @@
+#ifndef MBGL_TEXT_PLACEMENT_CONFIG
+#define MBGL_TEXT_PLACEMENT_CONFIG
+
+namespace mbgl {
+
+class PlacementConfig {
+public:
+    inline PlacementConfig(float angle_ = 0, float pitch_ = 0, bool debug_ = false)
+        : angle(angle_), pitch(pitch_), debug(debug_) {
+    }
+
+    inline bool operator==(const PlacementConfig& rhs) const {
+        return angle == rhs.angle && pitch == rhs.pitch && debug == rhs.debug;
+    }
+
+    inline bool operator!=(const PlacementConfig& rhs) const {
+        return !operator==(rhs);
+    }
+
+public:
+    float angle;
+    float pitch;
+    bool debug;
+};
+
+} // namespace mbgl
+
+#endif

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -37,6 +37,7 @@ public:
 
     Request parseVectorTile(TileWorker&,
                             std::shared_ptr<const std::string> data,
+                            PlacementConfig config,
                             std::function<void(TileParseResult)> callback);
 
     Request parsePendingVectorTileLayers(TileWorker&,
@@ -44,13 +45,12 @@ public:
 
     Request parseLiveTile(TileWorker&,
                           const AnnotationTile&,
+                          PlacementConfig config,
                           std::function<void(TileParseResult)> callback);
 
     Request redoPlacement(TileWorker&,
                           const std::unordered_map<std::string, std::unique_ptr<Bucket>>&,
-                          float angle,
-                          float pitch,
-                          bool collisionDebug,
+                          PlacementConfig config,
                           std::function<void()> callback);
 
 private:

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -33,12 +33,12 @@ public:
 
     Request parseRasterTile(
         RasterBucket&,
-        std::string data,
+        std::shared_ptr<const std::string> data,
         std::function<void (TileParseResult)> callback);
 
     Request parseVectorTile(
         TileWorker&,
-        std::string data,
+        std::shared_ptr<const std::string> data,
         std::function<void (TileParseResult)> callback);
 
     Request parseLiveTile(

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -31,34 +31,33 @@ public:
 
     using Request = std::unique_ptr<WorkRequest>;
 
-    Request parseRasterTile(
-        RasterBucket&,
-        std::shared_ptr<const std::string> data,
-        std::function<void (TileParseResult)> callback);
+    Request parseRasterTile(std::unique_ptr<RasterBucket> bucket,
+                            std::shared_ptr<const std::string> data,
+                            std::function<void(TileParseResult)> callback);
 
-    Request parseVectorTile(
-        TileWorker&,
-        std::shared_ptr<const std::string> data,
-        std::function<void (TileParseResult)> callback);
+    Request parseVectorTile(TileWorker&,
+                            std::shared_ptr<const std::string> data,
+                            std::function<void(TileParseResult)> callback);
 
-    Request parseLiveTile(
-        TileWorker&,
-        const AnnotationTile&,
-        std::function<void (TileParseResult)> callback);
+    Request parsePendingVectorTileLayers(TileWorker&,
+                                         std::function<void(TileParseResult)> callback);
 
-    Request redoPlacement(
-        TileWorker&,
-        float angle,
-        float pitch,
-        bool collisionDebug,
-        std::function<void ()> callback);
+    Request parseLiveTile(TileWorker&,
+                          const AnnotationTile&,
+                          std::function<void(TileParseResult)> callback);
+
+    Request redoPlacement(TileWorker&,
+                          const std::unordered_map<std::string, std::unique_ptr<Bucket>>&,
+                          float angle,
+                          float pitch,
+                          bool collisionDebug,
+                          std::function<void()> callback);
 
 private:
     class Impl;
     std::vector<std::unique_ptr<util::Thread<Impl>>> threads;
     std::size_t current = 0;
 };
-
 }
 
 #endif

--- a/test/fixtures/mock_file_source.cpp
+++ b/test/fixtures/mock_file_source.cpp
@@ -55,7 +55,7 @@ void MockFileSource::Impl::replyWithSuccess(Request* req) const {
     res->status = Response::Status::Successful;
 
     try {
-        res->data = util::read_file(req->resource.url);
+        res->data = std::make_shared<const std::string>(std::move(util::read_file(req->resource.url)));
     } catch (const std::exception& err) {
         res->status = Response::Status::Error;
         res->message = err.what();
@@ -95,8 +95,9 @@ void MockFileSource::Impl::replyWithCorruptedData(Request* req) const {
 
     std::shared_ptr<Response> res = std::make_shared<Response>();
     res->status = Response::Status::Successful;
-    res->data = util::read_file(req->resource.url);
-    res->data.insert(0, "CORRUPTED");
+    auto data = std::make_shared<std::string>(std::move(util::read_file(req->resource.url)));
+    data->insert(0, "CORRUPTED");
+    res->data = std::move(data);
 
     req->notify(res);
 }

--- a/test/storage/cache_response.cpp
+++ b/test/storage/cache_response.cpp
@@ -20,7 +20,8 @@ TEST_F(Storage, CacheResponse) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Response 1", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Response 1", *res.data);
         EXPECT_LT(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);
@@ -36,7 +37,8 @@ TEST_F(Storage, CacheResponse) {
         fs.cancel(req);
         EXPECT_EQ(response.status, res.status);
         EXPECT_EQ(response.stale, res.stale);
-        EXPECT_EQ(response.data, res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ(*response.data, *res.data);
         EXPECT_EQ(response.expires, res.expires);
         EXPECT_EQ(response.modified, res.modified);
         EXPECT_EQ(response.etag, res.etag);

--- a/test/storage/cache_response.cpp
+++ b/test/storage/cache_response.cpp
@@ -15,7 +15,8 @@ TEST_F(Storage, CacheResponse) {
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/cache" };
 
-    fs.request(resource, uv_default_loop(), [&](const Response &res) {
+    Request* req = fs.request(resource, uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Response 1", res.data);
         EXPECT_LT(0, res.expires);
@@ -23,7 +24,8 @@ TEST_F(Storage, CacheResponse) {
         EXPECT_EQ("", res.etag);
         EXPECT_EQ("", res.message);
 
-        fs.request(resource, uv_default_loop(), [&, res](const Response &res2) {
+        req = fs.request(resource, uv_default_loop(), [&, res](const Response &res2) {
+            fs.cancel(req);
             EXPECT_EQ(res.status, res2.status);
             EXPECT_EQ(res.data, res2.data);
             EXPECT_EQ(res.expires, res2.expires);

--- a/test/storage/cache_response.cpp
+++ b/test/storage/cache_response.cpp
@@ -14,27 +14,35 @@ TEST_F(Storage, CacheResponse) {
     DefaultFileSource fs(&cache);
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/cache" };
+    Response response;
 
     Request* req = fs.request(resource, uv_default_loop(), [&](const Response &res) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Response 1", res.data);
         EXPECT_LT(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);
         EXPECT_EQ("", res.message);
+        response = res;
+    });
 
-        req = fs.request(resource, uv_default_loop(), [&, res](const Response &res2) {
-            fs.cancel(req);
-            EXPECT_EQ(res.status, res2.status);
-            EXPECT_EQ(res.data, res2.data);
-            EXPECT_EQ(res.expires, res2.expires);
-            EXPECT_EQ(res.modified, res2.modified);
-            EXPECT_EQ(res.etag, res2.etag);
-            EXPECT_EQ(res.message, res2.message);
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 
-            CacheResponse.finish();
-        });
+    // Now test that we get the same values as in the previous request. If we'd go to the server
+    // again, we'd get different values.
+    req = fs.request(resource, uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req);
+        EXPECT_EQ(response.status, res.status);
+        EXPECT_EQ(response.stale, res.stale);
+        EXPECT_EQ(response.data, res.data);
+        EXPECT_EQ(response.expires, res.expires);
+        EXPECT_EQ(response.modified, res.modified);
+        EXPECT_EQ(response.etag, res.etag);
+        EXPECT_EQ(response.message, res.message);
+
+        CacheResponse.finish();
     });
 
     uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/storage/cache_revalidate.cpp
+++ b/test/storage/cache_revalidate.cpp
@@ -16,7 +16,8 @@ TEST_F(Storage, CacheRevalidate) {
     DefaultFileSource fs(&cache);
 
     const Resource revalidateSame { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
-    fs.request(revalidateSame, uv_default_loop(), [&](const Response &res) {
+    Request* req = fs.request(revalidateSame, uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Response", res.data);
         EXPECT_EQ(0, res.expires);
@@ -24,7 +25,8 @@ TEST_F(Storage, CacheRevalidate) {
         EXPECT_EQ("snowfall", res.etag);
         EXPECT_EQ("", res.message);
 
-        fs.request(revalidateSame, uv_default_loop(), [&, res](const Response &res2) {
+        req = fs.request(revalidateSame, uv_default_loop(), [&, res](const Response &res2) {
+            fs.cancel(req);
             EXPECT_EQ(Response::Successful, res2.status);
             EXPECT_EQ("Response", res2.data);
             // We use this to indicate that a 304 reply came back.
@@ -40,7 +42,8 @@ TEST_F(Storage, CacheRevalidate) {
 
     const Resource revalidateModified{ Resource::Unknown,
                                        "http://127.0.0.1:3000/revalidate-modified" };
-    fs.request(revalidateModified, uv_default_loop(), [&](const Response &res) {
+    Request* req2 = fs.request(revalidateModified, uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req2);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Response", res.data);
         EXPECT_EQ(0, res.expires);
@@ -48,7 +51,8 @@ TEST_F(Storage, CacheRevalidate) {
         EXPECT_EQ("", res.etag);
         EXPECT_EQ("", res.message);
 
-        fs.request(revalidateModified, uv_default_loop(), [&, res](const Response &res2) {
+        req2 = fs.request(revalidateModified, uv_default_loop(), [&, res](const Response &res2) {
+            fs.cancel(req2);
             EXPECT_EQ(Response::Successful, res2.status);
             EXPECT_EQ("Response", res2.data);
             // We use this to indicate that a 304 reply came back.
@@ -62,7 +66,8 @@ TEST_F(Storage, CacheRevalidate) {
     });
 
     const Resource revalidateEtag { Resource::Unknown, "http://127.0.0.1:3000/revalidate-etag" };
-    fs.request(revalidateEtag, uv_default_loop(), [&](const Response &res) {
+    Request* req3 = fs.request(revalidateEtag, uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req3);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Response 1", res.data);
         EXPECT_EQ(0, res.expires);
@@ -70,7 +75,8 @@ TEST_F(Storage, CacheRevalidate) {
         EXPECT_EQ("response-1", res.etag);
         EXPECT_EQ("", res.message);
 
-        fs.request(revalidateEtag, uv_default_loop(), [&, res](const Response &res2) {
+        req3 = fs.request(revalidateEtag, uv_default_loop(), [&, res](const Response &res2) {
+            fs.cancel(req3);
             EXPECT_EQ(Response::Successful, res2.status);
             EXPECT_EQ("Response 2", res2.data);
             EXPECT_EQ(0, res2.expires);

--- a/test/storage/cache_revalidate.cpp
+++ b/test/storage/cache_revalidate.cpp
@@ -5,29 +5,58 @@
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/sqlite_cache.hpp>
 
-TEST_F(Storage, CacheRevalidate) {
+TEST_F(Storage, CacheRevalidateSame) {
     SCOPED_TEST(CacheRevalidateSame)
-    SCOPED_TEST(CacheRevalidateModified)
-    SCOPED_TEST(CacheRevalidateEtag)
 
     using namespace mbgl;
 
     SQLiteCache cache(":memory:");
     DefaultFileSource fs(&cache);
 
+    const Response *reference = nullptr;
+
     const Resource revalidateSame { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
-    Request* req = fs.request(revalidateSame, uv_default_loop(), [&](const Response &res) {
-        fs.cancel(req);
+    Request* req1 = nullptr;
+    Request* req2 = nullptr;
+    req1 = fs.request(revalidateSame, uv_default_loop(), [&](const Response &res) {
+        // This callback can get triggered multiple times. We only care about the first invocation.
+        // It will get triggered again when refreshing the req2 (see below).
+        static bool first = true;
+        if (!first) {
+            return;
+        }
+        first = false;
+
+        EXPECT_EQ(nullptr, reference);
+        reference = &res;
+
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Response", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("snowfall", res.etag);
         EXPECT_EQ("", res.message);
 
-        req = fs.request(revalidateSame, uv_default_loop(), [&, res](const Response &res2) {
-            fs.cancel(req);
+        req2 = fs.request(revalidateSame, uv_default_loop(), [&, res](const Response &res2) {
+            // Make sure we get a different object than before, since this request should've been revalidated.
+            EXPECT_TRUE(reference != &res2);
+
+            if (res2.stale) {
+                // Discard stale responses, if any.
+                return;
+            }
+
+            ASSERT_TRUE(req1);
+            fs.cancel(req1);
+            req1 = nullptr;
+
+            ASSERT_TRUE(req2);
+            fs.cancel(req2);
+            req2 = nullptr;
+
             EXPECT_EQ(Response::Successful, res2.status);
+            EXPECT_EQ(false, res.stale);
             EXPECT_EQ("Response", res2.data);
             // We use this to indicate that a 304 reply came back.
             EXPECT_LT(0, res2.expires);
@@ -40,11 +69,37 @@ TEST_F(Storage, CacheRevalidate) {
         });
     });
 
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+}
+
+TEST_F(Storage, CacheRevalidateModified) {
+    SCOPED_TEST(CacheRevalidateModified)
+
+    using namespace mbgl;
+
+    SQLiteCache cache(":memory:");
+    DefaultFileSource fs(&cache);
+
+    const Response *reference = nullptr;
+
     const Resource revalidateModified{ Resource::Unknown,
                                        "http://127.0.0.1:3000/revalidate-modified" };
-    Request* req2 = fs.request(revalidateModified, uv_default_loop(), [&](const Response &res) {
-        fs.cancel(req2);
+    Request* req1 = nullptr;
+    Request* req2 = nullptr;
+    req1 = fs.request(revalidateModified, uv_default_loop(), [&](const Response& res) {
+        // This callback can get triggered multiple times. We only care about the first invocation.
+        // It will get triggered again when refreshing the req2 (see below).
+        static bool first = true;
+        if (!first) {
+            return;
+        }
+        first = false;
+
+        EXPECT_EQ(nullptr, reference);
+        reference = &res;
+
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Response", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(1420070400, res.modified);
@@ -52,8 +107,24 @@ TEST_F(Storage, CacheRevalidate) {
         EXPECT_EQ("", res.message);
 
         req2 = fs.request(revalidateModified, uv_default_loop(), [&, res](const Response &res2) {
+            // Make sure we get a different object than before, since this request should've been revalidated.
+            EXPECT_TRUE(reference != &res2);
+
+            if (res2.stale) {
+                // Discard stale responses, if any.
+                return;
+            }
+
+            ASSERT_TRUE(req1);
+            fs.cancel(req1);
+            req1 = nullptr;
+
+            ASSERT_TRUE(req2);
             fs.cancel(req2);
+            req2 = nullptr;
+
             EXPECT_EQ(Response::Successful, res2.status);
+            EXPECT_EQ(false, res.stale);
             EXPECT_EQ("Response", res2.data);
             // We use this to indicate that a 304 reply came back.
             EXPECT_LT(0, res2.expires);
@@ -65,19 +136,61 @@ TEST_F(Storage, CacheRevalidate) {
         });
     });
 
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+}
+
+TEST_F(Storage, CacheRevalidateEtag) {
+    SCOPED_TEST(CacheRevalidateEtag)
+
+    using namespace mbgl;
+
+    SQLiteCache cache(":memory:");
+    DefaultFileSource fs(&cache);
+
+    const Response *reference = nullptr;
+
     const Resource revalidateEtag { Resource::Unknown, "http://127.0.0.1:3000/revalidate-etag" };
-    Request* req3 = fs.request(revalidateEtag, uv_default_loop(), [&](const Response &res) {
-        fs.cancel(req3);
+    Request* req1 = nullptr;
+    Request* req2 = nullptr;
+    req1 = fs.request(revalidateEtag, uv_default_loop(), [&](const Response &res) {
+        // This callback can get triggered multiple times. We only care about the first invocation.
+        // It will get triggered again when refreshing the req2 (see below).
+        static bool first = true;
+        if (!first) {
+            return;
+        }
+        first = false;
+
+        EXPECT_EQ(nullptr, reference);
+        reference = &res;
+
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Response 1", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("response-1", res.etag);
         EXPECT_EQ("", res.message);
 
-        req3 = fs.request(revalidateEtag, uv_default_loop(), [&, res](const Response &res2) {
-            fs.cancel(req3);
+        req2 = fs.request(revalidateEtag, uv_default_loop(), [&, res](const Response &res2) {
+            // Make sure we get a different object than before, since this request should've been revalidated.
+            EXPECT_TRUE(reference != &res2);
+
+            if (res2.stale) {
+                // Discard stale responses, if any.
+                return;
+            }
+
+            ASSERT_TRUE(req1);
+            fs.cancel(req1);
+            req1 = nullptr;
+
+            ASSERT_TRUE(req2);
+            fs.cancel(req2);
+            req2 = nullptr;
+
             EXPECT_EQ(Response::Successful, res2.status);
+            EXPECT_EQ(false, res.stale);
             EXPECT_EQ("Response 2", res2.data);
             EXPECT_EQ(0, res2.expires);
             EXPECT_EQ(0, res2.modified);

--- a/test/storage/database.cpp
+++ b/test/storage/database.cpp
@@ -178,11 +178,12 @@ TEST_F(Storage, DatabaseLockedWrite) {
         Log::setObserver(std::make_unique<FixtureLogObserver>());
 
         auto response = std::make_shared<Response>();
-        response->data = "Demo";
+        response->data = std::make_shared<std::string>("Demo");
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
             ASSERT_NE(nullptr, res.get());
-            EXPECT_EQ("Demo", res->data);
+            ASSERT_TRUE(res->data.get());
+            EXPECT_EQ("Demo", *res->data);
         });
 
         // Make sure that we got a no errors
@@ -210,7 +211,7 @@ TEST_F(Storage, DatabaseLockedRefresh) {
         Log::setObserver(std::make_unique<FixtureLogObserver>());
 
         auto response = std::make_shared<Response>();
-        response->data = "Demo";
+        response->data = std::make_shared<std::string>("Demo");
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
             EXPECT_EQ(nullptr, res.get());
@@ -226,7 +227,7 @@ TEST_F(Storage, DatabaseLockedRefresh) {
         Log::setObserver(std::make_unique<FixtureLogObserver>());
 
         auto response = std::make_shared<Response>();
-        response->data = "Demo";
+        response->data = std::make_shared<std::string>("Demo");
         cache.refresh({ Resource::Unknown, "mapbox://test" }, response->expires);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
             EXPECT_EQ(nullptr, res.get());
@@ -255,11 +256,12 @@ TEST_F(Storage, DatabaseDeleted) {
         Log::setObserver(std::make_unique<FixtureLogObserver>());
 
         auto response = std::make_shared<Response>();
-        response->data = "Demo";
+        response->data = std::make_shared<std::string>("Demo");
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
             ASSERT_NE(nullptr, res.get());
-            EXPECT_EQ("Demo", res->data);
+            ASSERT_TRUE(res->data.get());
+            EXPECT_EQ("Demo", *res->data);
         });
 
         Log::removeObserver();
@@ -272,11 +274,12 @@ TEST_F(Storage, DatabaseDeleted) {
         Log::setObserver(std::make_unique<FixtureLogObserver>());
 
         auto response = std::make_shared<Response>();
-        response->data = "Demo";
+        response->data = std::make_shared<std::string>("Demo");
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
             ASSERT_NE(nullptr, res.get());
-            EXPECT_EQ("Demo", res->data);
+            ASSERT_TRUE(res->data.get());
+            EXPECT_EQ("Demo", *res->data);
         });
 
         auto observer = Log::removeObserver();
@@ -302,11 +305,12 @@ TEST_F(Storage, DatabaseInvalid) {
         Log::setObserver(std::make_unique<FixtureLogObserver>());
 
         auto response = std::make_shared<Response>();
-        response->data = "Demo";
+        response->data = std::make_shared<std::string>("Demo");
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
             ASSERT_NE(nullptr, res.get());
-            EXPECT_EQ("Demo", res->data);
+            ASSERT_TRUE(res->data.get());
+            EXPECT_EQ("Demo", *res->data);
         });
 
         auto observer = Log::removeObserver();

--- a/test/storage/database.cpp
+++ b/test/storage/database.cpp
@@ -181,7 +181,7 @@ TEST_F(Storage, DatabaseLockedWrite) {
         response->data = "Demo";
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
-            EXPECT_NE(nullptr, res.get());
+            ASSERT_NE(nullptr, res.get());
             EXPECT_EQ("Demo", res->data);
         });
 
@@ -258,7 +258,7 @@ TEST_F(Storage, DatabaseDeleted) {
         response->data = "Demo";
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
-            EXPECT_NE(nullptr, res.get());
+            ASSERT_NE(nullptr, res.get());
             EXPECT_EQ("Demo", res->data);
         });
 
@@ -275,7 +275,7 @@ TEST_F(Storage, DatabaseDeleted) {
         response->data = "Demo";
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
-            EXPECT_NE(nullptr, res.get());
+            ASSERT_NE(nullptr, res.get());
             EXPECT_EQ("Demo", res->data);
         });
 
@@ -305,7 +305,7 @@ TEST_F(Storage, DatabaseInvalid) {
         response->data = "Demo";
         cache.put({ Resource::Unknown, "mapbox://test" }, response);
         cache.get({ Resource::Unknown, "mapbox://test" }, [] (std::unique_ptr<Response> res) {
-            EXPECT_NE(nullptr, res.get());
+            ASSERT_NE(nullptr, res.get());
             EXPECT_EQ("Demo", res->data);
         });
 

--- a/test/storage/directory_reading.cpp
+++ b/test/storage/directory_reading.cpp
@@ -15,8 +15,9 @@ TEST_F(Storage, AssetReadDirectory) {
     DefaultFileSource fs(nullptr);
 #endif
 
-    fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage" }, uv_default_loop(),
+    Request* req = fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage" }, uv_default_loop(),
                [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);

--- a/test/storage/directory_reading.cpp
+++ b/test/storage/directory_reading.cpp
@@ -19,6 +19,7 @@ TEST_F(Storage, AssetReadDirectory) {
                [&](const Response &res) {
         fs.cancel(req);
         EXPECT_EQ(Response::Error, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);

--- a/test/storage/directory_reading.cpp
+++ b/test/storage/directory_reading.cpp
@@ -20,7 +20,7 @@ TEST_F(Storage, AssetReadDirectory) {
         fs.cancel(req);
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ(0ul, res.data.size());
+        ASSERT_FALSE(res.data.get());
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);

--- a/test/storage/file_reading.cpp
+++ b/test/storage/file_reading.cpp
@@ -16,8 +16,9 @@ TEST_F(Storage, AssetEmptyFile) {
     DefaultFileSource fs(nullptr);
 #endif
 
-    fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/empty" }, uv_default_loop(),
+    Request* req = fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/empty" }, uv_default_loop(),
                [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);
@@ -41,8 +42,9 @@ TEST_F(Storage, AssetNonEmptyFile) {
     DefaultFileSource fs(nullptr);
 #endif
 
-    fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/nonempty" },
+    Request* req = fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/nonempty" },
                uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(16ul, res.data.size());
         EXPECT_EQ(0, res.expires);
@@ -67,8 +69,9 @@ TEST_F(Storage, AssetNonExistentFile) {
     DefaultFileSource fs(nullptr);
 #endif
 
-    fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/does_not_exist" },
+    Request* req = fs.request({ Resource::Unknown, "asset://TEST_DATA/fixtures/storage/does_not_exist" },
                uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);

--- a/test/storage/file_reading.cpp
+++ b/test/storage/file_reading.cpp
@@ -21,7 +21,8 @@ TEST_F(Storage, AssetEmptyFile) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ(0ul, res.data.size());
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("", *res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_LT(1420000000, res.modified);
         EXPECT_NE("", res.etag);
@@ -48,12 +49,14 @@ TEST_F(Storage, AssetNonEmptyFile) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ(16ul, res.data.size());
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("content is here\n", *res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_LT(1420000000, res.modified);
         EXPECT_NE("", res.etag);
         EXPECT_EQ("", res.message);
-        EXPECT_EQ("content is here\n", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("content is here\n", *res.data);
         NonEmptyFile.finish();
     });
 
@@ -76,7 +79,7 @@ TEST_F(Storage, AssetNonExistentFile) {
         fs.cancel(req);
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ(0ul, res.data.size());
+        ASSERT_FALSE(res.data.get());
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);

--- a/test/storage/file_reading.cpp
+++ b/test/storage/file_reading.cpp
@@ -20,6 +20,7 @@ TEST_F(Storage, AssetEmptyFile) {
                [&](const Response &res) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);
         EXPECT_LT(1420000000, res.modified);
@@ -46,6 +47,7 @@ TEST_F(Storage, AssetNonEmptyFile) {
                uv_default_loop(), [&](const Response &res) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ(16ul, res.data.size());
         EXPECT_EQ(0, res.expires);
         EXPECT_LT(1420000000, res.modified);
@@ -73,6 +75,7 @@ TEST_F(Storage, AssetNonExistentFile) {
                uv_default_loop(), [&](const Response &res) {
         fs.cancel(req);
         EXPECT_EQ(Response::Error, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ(0ul, res.data.size());
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);

--- a/test/storage/http_cancel.cpp
+++ b/test/storage/http_cancel.cpp
@@ -40,7 +40,8 @@ TEST_F(Storage, HTTPCancelMultiple) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);

--- a/test/storage/http_cancel.cpp
+++ b/test/storage/http_cancel.cpp
@@ -36,7 +36,8 @@ TEST_F(Storage, HTTPCancelMultiple) {
     auto req2 = fs.request(resource, uv_default_loop(), [&](const Response &) {
         ADD_FAILURE() << "Callback should not be called";
     });
-    fs.request(resource, uv_default_loop(), [&](const Response &res) {
+    Request* req = fs.request(resource, uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);

--- a/test/storage/http_cancel.cpp
+++ b/test/storage/http_cancel.cpp
@@ -39,6 +39,7 @@ TEST_F(Storage, HTTPCancelMultiple) {
     Request* req = fs.request(resource, uv_default_loop(), [&](const Response &res) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);

--- a/test/storage/http_coalescing.cpp
+++ b/test/storage/http_coalescing.cpp
@@ -27,7 +27,8 @@ TEST_F(Storage, HTTPCoalescing) {
         }
 
         EXPECT_EQ(Response::Successful, res.status);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);
@@ -69,7 +70,8 @@ TEST_F(Storage, HTTPMultiple) {
 
         // Do not cancel the request right away.
         EXPECT_EQ(Response::Successful, res.status);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(2147483647, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);
@@ -85,7 +87,8 @@ TEST_F(Storage, HTTPMultiple) {
             fs.cancel(req2);
 
             EXPECT_EQ(Response::Successful, res2.status);
-            EXPECT_EQ("Hello World!", res2.data);
+            ASSERT_TRUE(res2.data.get());
+            EXPECT_EQ("Hello World!", *res2.data);
             EXPECT_EQ(2147483647, res2.expires);
             EXPECT_EQ(0, res2.modified);
             EXPECT_EQ("", res2.etag);
@@ -115,7 +118,8 @@ TEST_F(Storage, HTTPStale) {
     req1 = fs.request(resource, uv_default_loop(), [&] (const Response &res) {
         // Do not cancel the request right away.
         EXPECT_EQ(Response::Successful, res.status);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(false, res.stale);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
@@ -132,7 +136,8 @@ TEST_F(Storage, HTTPStale) {
         // Start a second request for the same resource after the first one has been completed.
         req2 = fs.request(resource, uv_default_loop(), [&] (const Response &res2) {
             EXPECT_EQ(Response::Successful, res2.status);
-            EXPECT_EQ("Hello World!", res2.data);
+            ASSERT_TRUE(res2.data.get());
+            EXPECT_EQ("Hello World!", *res2.data);
             EXPECT_EQ(0, res2.expires);
             EXPECT_EQ(0, res2.modified);
             EXPECT_EQ("", res2.etag);

--- a/test/storage/http_coalescing.cpp
+++ b/test/storage/http_coalescing.cpp
@@ -40,8 +40,12 @@ TEST_F(Storage, HTTPCoalescing) {
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 
+    Request* reqs[total];
     for (int i = 0; i < total; i++) {
-        fs.request(resource, uv_default_loop(), complete);
+        reqs[i] = fs.request(resource, uv_default_loop(), [&complete, &fs, &reqs, i] (const Response &res) {
+            fs.cancel(reqs[i]);
+            complete(res);
+        });
     }
 
     uv_run(uv_default_loop(), UV_RUN_DEFAULT);

--- a/test/storage/http_coalescing.cpp
+++ b/test/storage/http_coalescing.cpp
@@ -50,3 +50,108 @@ TEST_F(Storage, HTTPCoalescing) {
 
     uv_run(uv_default_loop(), UV_RUN_DEFAULT);
 }
+
+TEST_F(Storage, HTTPMultiple) {
+    SCOPED_TEST(HTTPMultiple)
+
+    using namespace mbgl;
+
+    DefaultFileSource fs(nullptr);
+
+    const Response *reference = nullptr;
+
+    const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test?expires=2147483647" };
+    Request* req1 = nullptr;
+    Request* req2 = nullptr;
+    req1 = fs.request(resource, uv_default_loop(), [&] (const Response &res) {
+        EXPECT_EQ(nullptr, reference);
+        reference = &res;
+
+        // Do not cancel the request right away.
+        EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ("Hello World!", res.data);
+        EXPECT_EQ(2147483647, res.expires);
+        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ("", res.etag);
+        EXPECT_EQ("", res.message);
+
+        // Start a second request for the same resource after the first one has been completed.
+        req2 = fs.request(resource, uv_default_loop(), [&] (const Response &res2) {
+            // Make sure we get the same object ID as before.
+            EXPECT_EQ(reference, &res2);
+
+            // Now cancel both requests after both have been notified.
+            fs.cancel(req1);
+            fs.cancel(req2);
+
+            EXPECT_EQ(Response::Successful, res2.status);
+            EXPECT_EQ("Hello World!", res2.data);
+            EXPECT_EQ(2147483647, res2.expires);
+            EXPECT_EQ(0, res2.modified);
+            EXPECT_EQ("", res2.etag);
+            EXPECT_EQ("", res2.message);
+
+            HTTPMultiple.finish();
+        });
+    });
+
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+}
+
+// Tests that we get stale responses from previous requests when requesting the same thing again.
+TEST_F(Storage, HTTPStale) {
+    SCOPED_TEST(HTTPStale)
+
+    using namespace mbgl;
+
+    DefaultFileSource fs(nullptr);
+
+    int updates = 0;
+    int stale = 0;
+
+    const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
+    Request* req1 = nullptr;
+    Request* req2 = nullptr;
+    req1 = fs.request(resource, uv_default_loop(), [&] (const Response &res) {
+        // Do not cancel the request right away.
+        EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ("Hello World!", res.data);
+        EXPECT_EQ(false, res.stale);
+        EXPECT_EQ(0, res.expires);
+        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ("", res.etag);
+        EXPECT_EQ("", res.message);
+
+        // Don't start the request twice in case this callback gets fired multiple times.
+        if (req2) {
+            return;
+        }
+
+        updates++;
+
+        // Start a second request for the same resource after the first one has been completed.
+        req2 = fs.request(resource, uv_default_loop(), [&] (const Response &res2) {
+            EXPECT_EQ(Response::Successful, res2.status);
+            EXPECT_EQ("Hello World!", res2.data);
+            EXPECT_EQ(0, res2.expires);
+            EXPECT_EQ(0, res2.modified);
+            EXPECT_EQ("", res2.etag);
+            EXPECT_EQ("", res2.message);
+
+            if (res2.stale) {
+                EXPECT_EQ(0, stale);
+                stale++;
+            } else {
+                // Now cancel both requests after both have been notified.
+                fs.cancel(req1);
+                fs.cancel(req2);
+                HTTPStale.finish();
+            }
+        });
+    });
+
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+    EXPECT_EQ(1, stale);
+    EXPECT_EQ(1, updates);
+}

--- a/test/storage/http_error.cpp
+++ b/test/storage/http_error.cpp
@@ -37,6 +37,7 @@ TEST_F(Storage, HTTPError) {
         EXPECT_LT(1, duration) << "Backoff timer didn't wait 1 second";
         EXPECT_GT(1.2, duration) << "Backoff timer fired too late";
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
@@ -54,6 +55,7 @@ TEST_F(Storage, HTTPError) {
         EXPECT_LT(1.5, duration) << "Resource wasn't retried the correct number of times";
         EXPECT_GT(1.7, duration) << "Resource wasn't retried the correct number of times";
         EXPECT_EQ(Response::Error, res.status);
+        EXPECT_EQ(false, res.stale);
 #ifdef MBGL_HTTP_NSURL
         EXPECT_TRUE(res.message ==
                         "The operation couldn’t be completed. (NSURLErrorDomain error -1004.)" ||

--- a/test/storage/http_error.cpp
+++ b/test/storage/http_error.cpp
@@ -38,7 +38,8 @@ TEST_F(Storage, HTTPError) {
         EXPECT_GT(1.2, duration) << "Backoff timer fired too late";
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);
@@ -67,7 +68,7 @@ TEST_F(Storage, HTTPError) {
 #else
         FAIL();
 #endif
-        EXPECT_EQ("", res.data);
+        ASSERT_FALSE(res.data.get());
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);

--- a/test/storage/http_header_parsing.cpp
+++ b/test/storage/http_header_parsing.cpp
@@ -15,9 +15,10 @@ TEST_F(Storage, HTTPHeaderParsing) {
 
     DefaultFileSource fs(nullptr);
 
-    fs.request({ Resource::Unknown,
+    Request* req1 = fs.request({ Resource::Unknown,
                  "http://127.0.0.1:3000/test?modified=1420794326&expires=1420797926&etag=foo" },
                uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req1);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(1420797926, res.expires);
@@ -30,8 +31,9 @@ TEST_F(Storage, HTTPHeaderParsing) {
     int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
                        SystemClock::now().time_since_epoch()).count();
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" },
+    Request* req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" },
                uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req2);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_GT(2, std::abs(res.expires - now - 120)) << "Expiration date isn't about 120 seconds in the future";

--- a/test/storage/http_header_parsing.cpp
+++ b/test/storage/http_header_parsing.cpp
@@ -20,6 +20,7 @@ TEST_F(Storage, HTTPHeaderParsing) {
                uv_default_loop(), [&](const Response &res) {
         fs.cancel(req1);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(1420797926, res.expires);
         EXPECT_EQ(1420794326, res.modified);
@@ -35,6 +36,7 @@ TEST_F(Storage, HTTPHeaderParsing) {
                uv_default_loop(), [&](const Response &res) {
         fs.cancel(req2);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_GT(2, std::abs(res.expires - now - 120)) << "Expiration date isn't about 120 seconds in the future";
         EXPECT_EQ(0, res.modified);

--- a/test/storage/http_header_parsing.cpp
+++ b/test/storage/http_header_parsing.cpp
@@ -21,7 +21,8 @@ TEST_F(Storage, HTTPHeaderParsing) {
         fs.cancel(req1);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(1420797926, res.expires);
         EXPECT_EQ(1420794326, res.modified);
         EXPECT_EQ("foo", res.etag);
@@ -37,7 +38,8 @@ TEST_F(Storage, HTTPHeaderParsing) {
         fs.cancel(req2);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_GT(2, std::abs(res.expires - now - 120)) << "Expiration date isn't about 120 seconds in the future";
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);

--- a/test/storage/http_issue_1369.cpp
+++ b/test/storage/http_issue_1369.cpp
@@ -33,6 +33,7 @@ TEST_F(Storage, HTTPIssue1369) {
     req = fs.request(resource, uv_default_loop(), [&](const Response &res) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);

--- a/test/storage/http_issue_1369.cpp
+++ b/test/storage/http_issue_1369.cpp
@@ -30,7 +30,8 @@ TEST_F(Storage, HTTPIssue1369) {
         ADD_FAILURE() << "Callback should not be called";
     });
     fs.cancel(req);
-    fs.request(resource, uv_default_loop(), [&](const Response &res) {
+    req = fs.request(resource, uv_default_loop(), [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);

--- a/test/storage/http_issue_1369.cpp
+++ b/test/storage/http_issue_1369.cpp
@@ -34,7 +34,8 @@ TEST_F(Storage, HTTPIssue1369) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);

--- a/test/storage/http_load.cpp
+++ b/test/storage/http_load.cpp
@@ -26,7 +26,8 @@ TEST_F(Storage, HTTPLoad) {
             reqs[i] = nullptr;
             EXPECT_EQ(Response::Successful, res.status);
             EXPECT_EQ(false, res.stale);
-            EXPECT_EQ(std::string("Request ") +  std::to_string(current), res.data);
+            ASSERT_TRUE(res.data.get());
+            EXPECT_EQ(std::string("Request ") +  std::to_string(current), *res.data);
             EXPECT_EQ(0, res.expires);
             EXPECT_EQ(0, res.modified);
             EXPECT_EQ("", res.etag);

--- a/test/storage/http_load.cpp
+++ b/test/storage/http_load.cpp
@@ -25,6 +25,7 @@ TEST_F(Storage, HTTPLoad) {
             fs.cancel(reqs[i]);
             reqs[i] = nullptr;
             EXPECT_EQ(Response::Successful, res.status);
+            EXPECT_EQ(false, res.stale);
             EXPECT_EQ(std::string("Request ") +  std::to_string(current), res.data);
             EXPECT_EQ(0, res.expires);
             EXPECT_EQ(0, res.modified);

--- a/test/storage/http_other_loop.cpp
+++ b/test/storage/http_other_loop.cpp
@@ -17,7 +17,8 @@ TEST_F(Storage, HTTPOtherLoop) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);

--- a/test/storage/http_other_loop.cpp
+++ b/test/storage/http_other_loop.cpp
@@ -16,6 +16,7 @@ TEST_F(Storage, HTTPOtherLoop) {
                [&](const Response &res) {
         fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);

--- a/test/storage/http_other_loop.cpp
+++ b/test/storage/http_other_loop.cpp
@@ -12,8 +12,9 @@ TEST_F(Storage, HTTPOtherLoop) {
     // This file source launches a separate thread to do the processing.
     DefaultFileSource fs(nullptr);
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(),
+    Request* req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(),
                [&](const Response &res) {
+        fs.cancel(req);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);

--- a/test/storage/http_reading.cpp
+++ b/test/storage/http_reading.cpp
@@ -23,6 +23,7 @@ TEST_F(Storage, HTTPReading) {
         fs.cancel(req1);
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("Hello World!", res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
@@ -36,6 +37,7 @@ TEST_F(Storage, HTTPReading) {
         fs.cancel(req2);
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::NotFound, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("", res.message);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
@@ -48,6 +50,7 @@ TEST_F(Storage, HTTPReading) {
         fs.cancel(req3);
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::Error, res.status);
+        EXPECT_EQ(false, res.stale);
         EXPECT_EQ("HTTP status code 500", res.message);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);

--- a/test/storage/http_reading.cpp
+++ b/test/storage/http_reading.cpp
@@ -24,7 +24,8 @@ TEST_F(Storage, HTTPReading) {
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);
@@ -38,6 +39,8 @@ TEST_F(Storage, HTTPReading) {
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::NotFound, res.status);
         EXPECT_EQ(false, res.stale);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Cannot GET /doesnotexist\n", *res.data);
         EXPECT_EQ("", res.message);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);
@@ -51,6 +54,8 @@ TEST_F(Storage, HTTPReading) {
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ(false, res.stale);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Server Error!", *res.data);
         EXPECT_EQ("HTTP status code 500", res.message);
         EXPECT_EQ(0, res.expires);
         EXPECT_EQ(0, res.modified);

--- a/test/storage/http_reading.cpp
+++ b/test/storage/http_reading.cpp
@@ -3,6 +3,7 @@
 #include <uv.h>
 
 #include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/util/exception.hpp>
 
 #include <future>
 
@@ -17,8 +18,9 @@ TEST_F(Storage, HTTPReading) {
 
     const auto mainThread = uv_thread_self();
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(),
+    Request* req1 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(),
                [&](const Response &res) {
+        fs.cancel(req1);
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ("Hello World!", res.data);
@@ -29,8 +31,9 @@ TEST_F(Storage, HTTPReading) {
         HTTPTest.finish();
     });
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/doesnotexist" }, uv_default_loop(),
+    Request* req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/doesnotexist" }, uv_default_loop(),
                [&](const Response &res) {
+        fs.cancel(req2);
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::NotFound, res.status);
         EXPECT_EQ("", res.message);
@@ -40,8 +43,9 @@ TEST_F(Storage, HTTPReading) {
         HTTP404.finish();
     });
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/permanent-error" }, uv_default_loop(),
+    Request* req3 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/permanent-error" }, uv_default_loop(),
                [&](const Response &res) {
+        fs.cancel(req3);
         EXPECT_EQ(uv_thread_self(), mainThread);
         EXPECT_EQ(Response::Error, res.status);
         EXPECT_EQ("HTTP status code 500", res.message);
@@ -61,10 +65,14 @@ TEST_F(Storage, HTTPNoCallback) {
 
     DefaultFileSource fs(nullptr);
 
-    fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(),
+    try {
+        fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" }, uv_default_loop(),
                nullptr);
-
-    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+    } catch (const util::MisuseException& ex) {
+        EXPECT_EQ(std::string(ex.what()), "FileSource callback can't be empty");
+    } catch (const std::exception&) {
+        EXPECT_TRUE(false) << "Unhandled exception.";
+    }
 
     HTTPTest.finish();
 }

--- a/test/storage/http_timeout.cpp
+++ b/test/storage/http_timeout.cpp
@@ -1,0 +1,37 @@
+#include "storage.hpp"
+
+#include <uv.h>
+
+#include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/storage/network_status.hpp>
+
+
+TEST_F(Storage, HTTPTimeout) {
+    SCOPED_TEST(HTTPTimeout)
+
+    using namespace mbgl;
+
+    DefaultFileSource fs(nullptr);
+
+    int counter = 0;
+
+    const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=1" };
+    Request* req = fs.request(resource, uv_default_loop(), [&](const Response &res) {
+        counter++;
+        EXPECT_EQ(Response::Successful, res.status);
+        EXPECT_EQ(false, res.stale);
+        EXPECT_EQ("Hello World!", res.data);
+        EXPECT_LT(0, res.expires);
+        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ("", res.etag);
+        EXPECT_EQ("", res.message);
+        if (counter == 4) {
+            fs.cancel(req);
+            HTTPTimeout.finish();
+        }
+    });
+
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+    EXPECT_EQ(4, counter);
+}

--- a/test/storage/http_timeout.cpp
+++ b/test/storage/http_timeout.cpp
@@ -20,7 +20,8 @@ TEST_F(Storage, HTTPTimeout) {
         counter++;
         EXPECT_EQ(Response::Successful, res.status);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ("Hello World!", res.data);
+        ASSERT_TRUE(res.data.get());
+        EXPECT_EQ("Hello World!", *res.data);
         EXPECT_LT(0, res.expires);
         EXPECT_EQ(0, res.modified);
         EXPECT_EQ("", res.etag);

--- a/test/storage/server.js
+++ b/test/storage/server.js
@@ -74,7 +74,7 @@ app.get('/revalidate-etag', function(req, res) {
 });
 
 app.get('/permanent-error', function(req, res) {
-    res.status(500).end();
+    res.status(500).send('Server Error!');
 });
 
 var temporaryErrorCounter = 0;

--- a/test/style/resource_loading.cpp
+++ b/test/style/resource_loading.cpp
@@ -38,6 +38,10 @@ public:
     }
 
     ~MockMapContext() {
+        cleanup();
+    }
+
+    void cleanup() {
         style_.reset();
     }
 
@@ -118,6 +122,7 @@ void runTestCase(MockFileSource::Type type,
 
     // Needed because it will make the Map thread
     // join and cease logging after this point.
+    context->invoke(&MockMapContext::cleanup);
     context.reset();
 
     uint32_t match = 0;

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -85,6 +85,7 @@
         'storage/http_load.cpp',
         'storage/http_other_loop.cpp',
         'storage/http_reading.cpp',
+        'storage/http_timeout.cpp',
 
         'style/glyph_store.cpp',
         'style/pending_resources.cpp',


### PR DESCRIPTION
We're currently treating a request as a one-time thing. We should change this to have "Request" mean "monitor this resource and send me updates about it". This means that the file source needs to keep track of when the resource expires, and issue a new request once it expires. This solves the following cases:

- Tiles with a very short TTL will display stale content, especially in situations where a map view is visible longer (e.g. an iPad in a kiosk mode)
- We obtain a file from cache just before it expires
- We can use the same infrastructure to implement #896