### PR TITLE
Replace styleID property with styleURL__ inspectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## iOS master
 
+- The `styleID` property has been removed from MGLMapView. Instead, set the `styleURL` property to an NSURL in the form `mapbox://styles/STYLE_ID`. If you previously set the style ID in Interface Builder’s Attributes inspector, delete the `styleID` entry from the User Defined Runtime Attributes section of the Identity inspector, then set the new “Style URL” inspectable to a value in the form `mapbox://styles/STYLE_ID`. ([#2632](https://github.com/mapbox/mapbox-gl-native/pull/2632)
 - The SDK now builds with Bitcode enabled. ([#2332](https://github.com/mapbox/mapbox-gl-native/issues/2332))
 - The double-tap-drag gesture for zooming in and out is now consistent with the Google Maps SDK. ([#2153](https://github.com/mapbox/mapbox-gl-native/pull/2153))
 - A new `MGLAnnotationImage.enabled` property allows you to disable touch events on individual annotations. ([#2501](https://github.com/mapbox/mapbox-gl-native/pull/2501))

--- a/include/mbgl/ios/MGLAccountManager.h
+++ b/include/mbgl/ios/MGLAccountManager.h
@@ -21,8 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** @name Providing User Metrics Opt-Out */
 
-+ (void)setMapboxMetricsEnabledSettingShownInApp:(BOOL)showsOptOut __attribute__((unavailable("Set MGLMapboxMetricsEnabledSettingShownInApp in Info.plist.")));
-
 /** Whether in-app user metrics opt-out is configured. If set to the default value of `NO`, a user opt-out preference is expected in a `Settings.bundle` that shows in the application's section within the system Settings app. */
 + (BOOL)mapboxMetricsEnabledSettingShownInApp;
 

--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -11,7 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
 // inspectables declared in MGLMapView.h are always sorted before those in
 // MGLMapView+IBAdditions.h, due to ASCII sort order.
 
-@property (nonatomic, nullable) IBInspectable NSString *styleID;
+// HACK: We want this property to look like a URL bar in the Attributes
+// inspector, but just calling it styleURL would violate Cocoa naming
+// conventions and conflict with the existing NSURL property. Fortunately, IB
+// strips out the two underscores for display.
+@property (nonatomic, nullable) IBInspectable NSString *styleURL__;
 
 // Convenience properties related to the initial viewport. These properties
 // are not meant to be used outside of Interface Builder. latitude and longitude

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -227,13 +227,7 @@ IB_DESIGNABLE
 
 /** @name Styling the Map */
 
-/** Mapbox ID of the style currently displayed in the receiver, or `nil` if the style does not have an ID.
-*
-*   The style may lack an ID if it is located at an HTTP, HTTPS, or local file URL. Use `styleURL` to get the URL in these cases.
-*
-*   To display the default style, set this property to `nil`. */
-@property (nonatomic, nullable) NSString *styleID;
-@property (nonatomic, nullable) NSString *mapID __attribute__((unavailable("Use styleID.")));
+@property (nonatomic, nullable) NSString *styleID __attribute__((unavailable("Set styleURL to an NSURL of the form <mapbox://styles/STYLE_ID>, where STYLE_ID would have been the value of this property.")));
 
 /** URLs of the styles bundled with the library. */
 @property (nonatomic, readonly) NS_ARRAY_OF(NSURL *) *bundledStyleURLs;

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -33,24 +33,12 @@ IB_DESIGNABLE
 *   @param frame The frame for the view, measured in points.
 *   @return An initialized map view. */
 - (instancetype)initWithFrame:(CGRect)frame;
-- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken __attribute__((unavailable("Use -initWithFrame:. Set MGLMapboxAccessToken in the Info.plist or call +[MGLAccountManager setAccessToken:].")));
 
 /** Initializes and returns a newly allocated map view with the specified frame and style URL.
 *   @param frame The frame for the view, measured in points.
 *   @param styleURL The map style URL to use. Can be either an HTTP/HTTPS URL or a Mapbox map ID style URL (`mapbox://styles/<user>/<style>`). Specify `nil` for the default style.
 *   @return An initialized map view. */
 - (instancetype)initWithFrame:(CGRect)frame styleURL:(nullable NSURL *)styleURL;
-- (instancetype)initWithFrame:(CGRect)frame accessToken:(NSString *)accessToken styleURL:(nullable NSURL *)styleURL __attribute__((unavailable("Use -initWithFrame:styleURL:. Set MGLMapboxAccessToken in the Info.plist or call +[MGLAccountManager setAccessToken:].")));
-
-#pragma mark - Authorizing Access
-
-/** @name Authorizing Access */
-
-@property (nonatomic, nullable) NSString *accessToken __attribute__((unavailable("Use +[MGLAccountManager accessToken] and +[MGLAccountManager setAccessToken:].")));
-
-#pragma mark - Managing Constraints
-
-/** @name Managing Constraints */
 
 #pragma mark - Accessing Map Properties
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -192,7 +192,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 + (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingStyleURL
 {
-    return [NSSet setWithObject:@"styleID"];
+    return [NSSet setWithObjects:@"styleURL__", nil];
 }
 
 - (nonnull NSURL *)styleURL
@@ -2012,37 +2012,21 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
     return [NSArray arrayWithArray:_bundledStyleURLs];
 }
 
-+ (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingStyleID
-{
-    return [NSSet setWithObject:@"styleURL"];
-}
-
 - (nullable NSString *)styleID
 {
-    NSURL *styleURL = self.styleURL;
-    return [styleURL.scheme isEqualToString:@"mapbox"] ? styleURL.host.mgl_stringOrNilIfEmpty : nil;
-}
-
-- (void)setStyleID:(nullable NSString *)styleID
-{
-    self.styleURL = styleID ? [NSURL URLWithString:[NSString stringWithFormat:@"mapbox://%@", styleID]] : nil;
-}
-
-- (nullable NSString *)mapID
-{
     [NSException raise:@"Method unavailable" format:
-     @"%s has been renamed -[MGLMapView styleID].",
+     @"%s has been replaced by -[MGLMapView styleURL].",
      __PRETTY_FUNCTION__];
     return nil;
 }
 
-- (void)setMapID:(nullable NSString *)mapID
+- (void)setStyleID:(nullable NSString *)styleID
 {
     [NSException raise:@"Method unavailable" format:
-     @"%s has been renamed -[MGLMapView setStyleID:].\n\n"
-     @"If you previously set this map ID in a storyboard inspectable, select the MGLMapView in Interface Builder and delete the “mapID” entry from the User Defined Runtime Attributes section of the Identity inspector. "
-     @"Then go to the Attributes inspector and enter “%@” into the “Style ID” field.",
-     __PRETTY_FUNCTION__, mapID];
+     @"%s has been replaced by -[MGLMapView setStyleURL:].\n\n"
+     @"If you previously set this style ID in a storyboard inspectable, select the MGLMapView in Interface Builder and delete the “styleID” entry from the User Defined Runtime Attributes section of the Identity inspector. "
+     @"Then go to the Attributes inspector and enter “mapbox://styles/%@” into the “Style URL” field.",
+     __PRETTY_FUNCTION__, styleID];
 }
 
 - (NS_ARRAY_OF(NSString *) *)styleClasses
@@ -3325,6 +3309,27 @@ class MBGLView : public mbgl::View
 @end
 
 @implementation MGLMapView (IBAdditions)
+
++ (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingStyleURL__
+{
+    return [NSSet setWithObject:@"styleURL"];
+}
+
+- (nullable NSString *)styleURL__
+{
+    return self.styleURL.absoluteString;
+}
+
+- (void)setStyleURL__:(nullable NSString *)URLString
+{
+    NSURL *url = URLString.length ? [NSURL URLWithString:URLString] : nil;
+    if (URLString.length && !url)
+    {
+        [NSException raise:@"Invalid style URL" format:
+         @"“%@” is not a valid style URL.", URLString];
+    }
+    self.styleURL = url;
+}
 
 + (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingLatitude
 {

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -172,24 +172,6 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     return self;
 }
 
-- (nullable NSString *)accessToken
-{
-    [NSException raise:@"Method unavailable" format:
-     @"%s has been removed. "
-     @"Use +[MGLAccountManager accessToken] or get MGLMapboxAccessToken from the Info.plist.",
-     __PRETTY_FUNCTION__];
-    return nil;
-}
-
-- (void)setAccessToken:(nullable NSString *)accessToken
-{
-    [NSException raise:@"Method unavailable" format:
-     @"%s has been replaced by +[MGLAccountManager setAccessToken:].\n\n"
-     @"If you previously set this access token in a storyboard inspectable, select the MGLMapView in Interface Builder and delete the “accessToken” entry from the User Defined Runtime Attributes section of the Identity inspector. "
-     @"Then go to the Info.plist file and set MGLMapboxAccessToken to “%@”.",
-     __PRETTY_FUNCTION__, accessToken];
-}
-
 + (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingStyleURL
 {
     return [NSSet setWithObjects:@"styleURL__", nil];


### PR DESCRIPTION
This PR replaces the `styleID` convenience property with an Interface Builder inspectable (normally inaccessible from code) that imitates a URL field. `styleID` is inconsistent with other GL-based APIs, and we never implemented a convenience initializer that took a `styleID` anyways, so it had limited usefulness as a separate property.

The new inspectable’s name is a horrible hack and is marked as such. I’ve filed <[rdar://problem/23134321](http://openradar.appspot.com/radar?id=6123837150199808)> against Interface Builder to request support for NSURL-typed inspectables.

I considered merely deprecating `styleID` but wound up cutting over in a manner similar to #1561. `styleID` is primarily used as an inspectable. Deprecating an inspectable leads to a horrible user experience, because the inspectable’s value continues to work even though it silently disappears from the Attributes inspector. (You’d have to know to go to the User Defined Runtime Attributes section of the Identity inspector.) If you ever tried to re-set the style, this time via the new “Style URL” inspectable, you might run into weirdness like #2626. **This backwards-incompatible change requires bumping the version up to 3.0.0.**

This PR also removes some APIs that have been marked unavailable for a few releases, since back before the iOS SDK left the 0.x series.

Fixes #2628.

/cc @jfirebaugh @incanus @bsudekum @friedbunny