### PR TITLE
[ios] fix user annotation view refresh when switched from course to n…

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2656,6 +2656,9 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         case MGLUserTrackingModeNone:
         {
             [self.locationManager stopUpdatingHeading];
+            // Only update the annotation view for this case, other cases update the view inside
+            // the did update location method.
+            [self updateUserLocationAnnotationView];
 
             break;
         }

--- a/platform/ios/MGLUserLocationAnnotationView.m
+++ b/platform/ios/MGLUserLocationAnnotationView.m
@@ -266,6 +266,8 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
     }
     else
     {
+        [_headingIndicatorLayer removeFromSuperlayer];
+        [_headingIndicatorMaskLayer removeFromSuperlayer];
         _headingIndicatorLayer = nil;
         _headingIndicatorMaskLayer = nil;
     }


### PR DESCRIPTION
Fixes a issue where the User Annotation was not updated to correctly reflect the non-tracking mode when switching from "course". The view would remain looking like the course puck until the next location update. There was also a issue in that the heading layer was incorrectly added.