### PR TITLE
[android] Use -1px topMargin on InfoWindowTipView to avoid occasional gap

### DIFF
--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/InfoWindowView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/InfoWindowView.java
@@ -32,5 +32,8 @@ class InfoWindowView extends RelativeLayout{
     public void setTipViewMarginLeft(int marginLeft){
         RelativeLayout.LayoutParams layoutParams =  (RelativeLayout.LayoutParams) mTipView.getLayoutParams();
         layoutParams.leftMargin = marginLeft;
+        // This is a bit of a hack but prevents an occasional 1 pixel gap between the InfoWindow and
+        // the tip
+        layoutParams.topMargin = -1;
     }
 }


### PR DESCRIPTION
Fixes #2636