### PR TITLE
Mapbox GL and the GL state

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -44,7 +44,8 @@ class Map : private util::noncopyable {
 
 public:
     explicit Map(View&, FileSource&,
-                 MapMode mode = MapMode::Continuous);
+                 MapMode mapMode = MapMode::Continuous,
+                 GLContextMode contextMode = GLContextMode::Unique);
     ~Map();
 
     // Pauses the render thread. The render thread will stop running but will not be terminated and will not lose state until resumed.

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -10,6 +10,11 @@ enum class MapMode : uint8_t {
     Still, // a once-off still image
 };
 
-}
+enum class GLContextMode : uint8_t {
+    Unique,
+    Shared,
+};
 
-#endif
+} // namespace mbgl
+
+#endif // MBGL_MAP_MODE

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -10,6 +10,10 @@ enum class MapMode : uint8_t {
     Still, // a once-off still image
 };
 
+// We can avoid redundant GL calls when it is known that the GL context is not
+// being shared. In a shared GL context case, we need to make sure that the
+// correct GL configurations are in use - they might have changed between render
+// calls.
 enum class GLContextMode : uint8_t {
     Unique,
     Shared,

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -14,10 +14,10 @@
 
 namespace mbgl {
 
-Map::Map(View& view_, FileSource& fileSource, MapMode mode)
+Map::Map(View& view_, FileSource& fileSource, MapMode mapMode, GLContextMode contextMode)
     : view(view_),
       transform(std::make_unique<Transform>(view)),
-      data(std::make_unique<MapData>(mode, view.getPixelRatio())),
+      data(std::make_unique<MapData>(mapMode, contextMode, view.getPixelRatio())),
       context(std::make_unique<util::Thread<MapContext>>(util::ThreadContext{"Map", util::ThreadType::Map, util::ThreadPriority::Regular}, view, fileSource, *data))
 {
     view.initialize(this);

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -20,8 +20,9 @@ class MapData {
     using Lock = std::lock_guard<std::mutex>;
 
 public:
-    inline MapData(MapMode mode_, const float pixelRatio_)
+    inline MapData(MapMode mode_, GLContextMode contextMode_, const float pixelRatio_)
         : mode(mode_)
+        , contextMode(contextMode_)
         , pixelRatio(pixelRatio_)
         , animationTime(Duration::zero())
         , defaultFadeDuration(mode_ == MapMode::Continuous ? std::chrono::milliseconds(300) : Duration::zero())
@@ -125,6 +126,7 @@ public:
 
 public:
     const MapMode mode;
+    const GLContextMode contextMode;
     const float pixelRatio;
 
 private:

--- a/src/mbgl/renderer/gl_config.cpp
+++ b/src/mbgl/renderer/gl_config.cpp
@@ -3,17 +3,20 @@
 namespace mbgl {
 namespace gl {
 
-const ClearDepth::Type ClearDepth::Default = 0;
+const StencilFunc::Type StencilFunc::Default = { GL_ALWAYS, 0, ~0u };
+const StencilMask::Type StencilMask::Default = ~0u;
+const StencilTest::Type StencilTest::Default = GL_FALSE;
+const StencilOp::Type StencilOp::Default = { GL_KEEP, GL_KEEP, GL_REPLACE };
+const DepthRange::Type DepthRange::Default = { 0, 1 };
+const DepthMask::Type DepthMask::Default = GL_TRUE;
+const DepthTest::Type DepthTest::Default = GL_FALSE;
+const DepthFunc::Type DepthFunc::Default = GL_LEQUAL;
+const Blend::Type Blend::Default = GL_TRUE;
+const BlendFunc::Type BlendFunc::Default = { GL_ONE, GL_ONE_MINUS_SRC_ALPHA };
+const ColorMask::Type ColorMask::Default = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
+const ClearDepth::Type ClearDepth::Default = 1;
 const ClearColor::Type ClearColor::Default = { 0, 0, 0, 0 };
 const ClearStencil::Type ClearStencil::Default = 0;
-const StencilMask::Type StencilMask::Default = ~0u;
-const DepthMask::Type DepthMask::Default = GL_TRUE;
-const ColorMask::Type ColorMask::Default = { false, false, false, false };
-const StencilFunc::Type StencilFunc::Default = { GL_ALWAYS, 0, ~0u };
-const StencilTest::Type StencilTest::Default = false;
-const DepthRange::Type DepthRange::Default = { 0, 1 };
-const DepthTest::Type DepthTest::Default = false;
-const Blend::Type Blend::Default = false;
 
 }
 }

--- a/src/mbgl/renderer/gl_config.hpp
+++ b/src/mbgl/renderer/gl_config.hpp
@@ -25,6 +25,14 @@ public:
         T::Set(current);
     }
 
+    inline void save() {
+        current = T::Get();
+    }
+
+    inline void restore() {
+        T::Set(current);
+    }
+
 private:
     typename T::Type current = T::Default;
 };
@@ -35,13 +43,23 @@ struct ClearDepth {
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glClearDepth(value));
     }
+    inline static Type Get() {
+        Type clearDepth;
+        MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_CLEAR_VALUE, &clearDepth));
+        return clearDepth;
+    }
 };
 
 struct ClearColor {
-    struct Type { float r, g, b, a; };
+    struct Type { GLfloat r, g, b, a; };
     static const Type Default;
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glClearColor(value.r, value.g, value.b, value.a));
+    }
+    inline static Type Get() {
+        GLfloat floats[4];
+        MBGL_CHECK_ERROR(glGetFloatv(GL_COLOR_CLEAR_VALUE, floats));
+        return { floats[0], floats[1], floats[2], floats[3] };
     }
 };
 
@@ -55,6 +73,11 @@ struct ClearStencil {
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glClearStencil(value));
     }
+    inline static Type Get() {
+        Type clearStencil;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_CLEAR_VALUE, &clearStencil));
+        return clearStencil;
+    }
 };
 
 struct StencilMask {
@@ -62,6 +85,11 @@ struct StencilMask {
     static const Type Default;
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glStencilMask(value));
+    }
+    inline static Type Get() {
+        GLint stencilMask;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_WRITEMASK, &stencilMask));
+        return stencilMask;
     }
 };
 
@@ -71,6 +99,11 @@ struct DepthMask {
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glDepthMask(value));
     }
+    inline static Type Get() {
+        Type depthMask;
+        MBGL_CHECK_ERROR(glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask));
+        return depthMask;
+    }
 };
 
 struct ColorMask {
@@ -78,6 +111,11 @@ struct ColorMask {
     static const Type Default;
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glColorMask(value.r, value.g, value.b, value.a));
+    }
+    inline static Type Get() {
+        GLfloat floats[4];
+        MBGL_CHECK_ERROR(glGetFloatv(GL_COLOR_WRITEMASK, floats));
+        return { floats[0], floats[1], floats[2], floats[3] };
     }
 };
 
@@ -91,6 +129,13 @@ struct StencilFunc {
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glStencilFunc(value.func, value.ref, value.mask));
     }
+    inline static Type Get() {
+        GLint func, ref, mask;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FUNC, &func));
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_REF, &ref));
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_VALUE_MASK, &mask));
+        return { static_cast<GLenum>(func), ref, static_cast<GLuint>(mask) };
+    }
 };
 
 inline bool operator!=(const StencilFunc::Type& a, const StencilFunc::Type& b) {
@@ -103,6 +148,11 @@ struct StencilTest {
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(value ? glEnable(GL_STENCIL_TEST) : glDisable(GL_STENCIL_TEST));
     }
+    inline static Type Get() {
+        Type stencilTest;
+        MBGL_CHECK_ERROR(stencilTest = glIsEnabled(GL_STENCIL_TEST));
+        return stencilTest;
+    }
 };
 
 struct StencilOp {
@@ -111,6 +161,13 @@ struct StencilOp {
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glStencilOp(value.sfail, value.dpfail, value.dppass));
     }
+    inline static Type Get() {
+        GLint sfail, dpfail, dppass;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FAIL, &sfail));
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_FAIL, &dpfail));
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_PASS, &dppass));
+        return { static_cast<GLenum>(sfail), static_cast<GLenum>(dpfail), static_cast<GLuint>(dppass) };
+    }
 };
 
 struct DepthRange {
@@ -118,6 +175,11 @@ struct DepthRange {
     static const Type Default;
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glDepthRange(value.near, value.far));
+    }
+    inline static Type Get() {
+        GLfloat floats[2];
+        MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_RANGE, floats));
+        return { floats[0], floats[1] };
     }
 };
 
@@ -131,6 +193,11 @@ struct DepthTest {
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(value ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST));
     }
+    inline static Type Get() {
+        Type depthTest;
+        MBGL_CHECK_ERROR(depthTest = glIsEnabled(GL_DEPTH_TEST));
+        return depthTest;
+    }
 };
 
 struct DepthFunc {
@@ -138,6 +205,11 @@ struct DepthFunc {
     static const Type Default;
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glDepthFunc(value));
+    }
+    inline static Type Get() {
+        GLint depthFunc;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_DEPTH_FUNC, &depthFunc));
+        return depthFunc;
     }
 };
 
@@ -147,6 +219,11 @@ struct Blend {
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(value ? glEnable(GL_BLEND) : glDisable(GL_BLEND));
     }
+    inline static Type Get() {
+        Type blend;
+        MBGL_CHECK_ERROR(blend = glIsEnabled(GL_BLEND));
+        return blend;
+    }
 };
 
 struct BlendFunc {
@@ -154,6 +231,12 @@ struct BlendFunc {
     static const Type Default;
     inline static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glBlendFunc(value.sfactor, value.dfactor));
+    }
+    inline static Type Get() {
+        GLint sfactor, dfactor;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_SRC_ALPHA, &sfactor));
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_DST_ALPHA, &dfactor));
+        return { static_cast<GLenum>(sfactor), static_cast<GLenum>(dfactor) };
     }
 };
 
@@ -174,6 +257,40 @@ public:
         clearDepth.reset();
         clearColor.reset();
         clearStencil.reset();
+    }
+
+    void restore() {
+        stencilFunc.restore();
+        stencilMask.restore();
+        stencilTest.restore();
+        stencilOp.restore();
+        depthRange.restore();
+        depthMask.restore();
+        depthTest.restore();
+        depthFunc.restore();
+        blend.restore();
+        blendFunc.restore();
+        colorMask.restore();
+        clearDepth.restore();
+        clearColor.restore();
+        clearStencil.restore();
+    }
+
+    void save() {
+        stencilFunc.save();
+        stencilMask.save();
+        stencilTest.save();
+        stencilOp.save();
+        depthRange.save();
+        depthMask.save();
+        depthTest.save();
+        depthFunc.save();
+        blend.save();
+        blendFunc.save();
+        colorMask.save();
+        clearDepth.save();
+        clearColor.save();
+        clearStencil.save();
     }
 
     Value<StencilFunc> stencilFunc;

--- a/src/mbgl/renderer/gl_config.hpp
+++ b/src/mbgl/renderer/gl_config.hpp
@@ -16,8 +16,13 @@ public:
     inline void operator=(const typename T::Type& value) {
         if (current != value) {
             current = value;
-            MBGL_CHECK_ERROR(T::Set(current));
+            T::Set(current);
         }
+    }
+
+    inline void reset() {
+        current = T::Default;
+        T::Set(current);
     }
 
 private:
@@ -100,6 +105,14 @@ struct StencilTest {
     }
 };
 
+struct StencilOp {
+    struct Type { GLenum sfail, dpfail, dppass; };
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glStencilOp(value.sfail, value.dpfail, value.dppass));
+    }
+};
+
 struct DepthRange {
     struct Type { GLfloat near, far; };
     static const Type Default;
@@ -120,6 +133,14 @@ struct DepthTest {
     }
 };
 
+struct DepthFunc {
+    using Type = GLenum;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glDepthFunc(value));
+    }
+};
+
 struct Blend {
     using Type = bool;
     static const Type Default;
@@ -128,22 +149,50 @@ struct Blend {
     }
 };
 
+struct BlendFunc {
+    struct Type { GLenum sfactor, dfactor; };
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glBlendFunc(value.sfactor, value.dfactor));
+    }
+};
+
 class Config {
 public:
+    void reset() {
+        stencilFunc.reset();
+        stencilMask.reset();
+        stencilTest.reset();
+        stencilOp.reset();
+        depthRange.reset();
+        depthMask.reset();
+        depthTest.reset();
+        depthFunc.reset();
+        blend.reset();
+        blendFunc.reset();
+        colorMask.reset();
+        clearDepth.reset();
+        clearColor.reset();
+        clearStencil.reset();
+    }
+
     Value<StencilFunc> stencilFunc;
     Value<StencilMask> stencilMask;
     Value<StencilTest> stencilTest;
+    Value<StencilOp> stencilOp;
     Value<DepthRange> depthRange;
     Value<DepthMask> depthMask;
     Value<DepthTest> depthTest;
+    Value<DepthFunc> depthFunc;
     Value<Blend> blend;
+    Value<BlendFunc> blendFunc;
     Value<ColorMask> colorMask;
     Value<ClearDepth> clearDepth;
     Value<ClearColor> clearColor;
     Value<ClearStencil> clearStencil;
 };
 
-}
-}
+} // namespace gl
+} // namespace mbgl
 
-#endif
+#endif // MBGL_RENDERER_GL_CONFIG

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -72,24 +72,8 @@ void Painter::setup() {
     assert(dotShader);
     assert(circleShader);
 
-
-    // Blending
-    // We are blending new pixels on top of old pixels. Since we have depth testing
-    // and are drawing opaque fragments first front-to-back, then translucent
-    // fragments back-to-front, this shades the fewest fragments possible.
-    config.blend = true;
-    MBGL_CHECK_ERROR(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
-
-    // Set clear values
-    config.clearColor = { 0.0f, 0.0f, 0.0f, 0.0f };
-    config.clearDepth = 1.0f;
-    config.clearStencil = 0x0;
-
-    // Stencil test
-    MBGL_CHECK_ERROR(glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE));
-
-    // Depth test
-    glDepthFunc(GL_LEQUAL);
+    // Reset GL values
+    config.reset();
 }
 
 void Painter::setupShaders() {
@@ -145,9 +129,9 @@ void Painter::changeMatrix() {
 
 void Painter::clear() {
     MBGL_DEBUG_GROUP("clear");
-    config.stencilTest = true;
+    config.stencilTest = GL_TRUE;
     config.stencilMask = 0xFF;
-    config.depthTest = false;
+    config.depthTest = GL_FALSE;
     config.depthMask = GL_TRUE;
     config.clearColor = { background[0], background[1], background[2], background[3] };
     MBGL_CHECK_ERROR(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -147,6 +147,10 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
     state = state_;
     frame = frame_;
 
+    if (data.contextMode == GLContextMode::Shared) {
+        config.restore();
+    }
+
     glyphAtlas = style.glyphAtlas.get();
     spriteAtlas = style.spriteAtlas.get();
     lineAtlas = style.lineAtlas.get();
@@ -243,6 +247,10 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
 
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, 0));
         MBGL_CHECK_ERROR(VertexArrayObject::Unbind());
+    }
+
+    if (data.contextMode == GLContextMode::Shared) {
+        config.save();
     }
 }
 

--- a/test/miscellaneous/map_context.cpp
+++ b/test/miscellaneous/map_context.cpp
@@ -13,7 +13,7 @@ TEST(MapContext, DoubleStyleLoad) {
     std::shared_ptr<HeadlessDisplay> display = std::make_shared<HeadlessDisplay>();
     HeadlessView view(display, 1, 512, 512);
     DefaultFileSource fileSource(nullptr);
-    MapData data(MapMode::Continuous, view.getPixelRatio());
+    MapData data(MapMode::Continuous, GLContextMode::Unique, view.getPixelRatio());
 
     util::Thread<MapContext> context({"Map", util::ThreadType::Map, util::ThreadPriority::Regular}, view, fileSource, data);
 

--- a/test/miscellaneous/style_parser.cpp
+++ b/test/miscellaneous/style_parser.cpp
@@ -39,9 +39,10 @@ TEST_P(StyleParserTest, ParseStyle) {
     Log::setObserver(std::unique_ptr<Log::Observer>(observer));
 
     MapMode mapMode = MapMode::Continuous;
+    GLContextMode contextMode = GLContextMode::Unique;
     const float pixelRatio = 1.0f;
 
-    MapData data(mapMode, pixelRatio);
+    MapData data(mapMode, contextMode, pixelRatio);
     StyleParser parser(data);
     parser.parse(styleDoc);
 

--- a/test/style/resource_loading.cpp
+++ b/test/style/resource_loading.cpp
@@ -23,7 +23,7 @@ public:
     MockMapContext(View& view,
                    FileSource& fileSource,
                    const std::function<void(std::exception_ptr error)>& callback)
-        : data_(MapMode::Still, view.getPixelRatio()),
+        : data_(MapMode::Still, GLContextMode::Unique, view.getPixelRatio()),
           transform_(view),
           callback_(callback) {
         util::ThreadContext::setFileSource(&fileSource);


### PR DESCRIPTION
We should be able to integrate Mapbox GL with other applications drawing using GL in the same GL context. That said, in order to play nice with a shared GL state we should:

- Not make any assumptions of the current GL state and reset it to our expectations before painting.
- Save the current state (scoped to things we might change) before painting and restore after painting is done so the client application won't be affected by us.
- Our CPU side cache is sometimes incorrect because the cached state might be changed by the client application after we paint. So in the next paint call, we will use incorrect GL capabilities.
- We don't always clear the background, so if the client application for some reason clears, we might see funny results. Obviously we should always observe our fill rate.

/cc @kkaefer 