### PR TITLE
Test metrics on staging endpoint

### DIFF
--- a/test/ios/App-Info.plist
+++ b/test/ios/App-Info.plist
@@ -28,6 +28,8 @@
 	<string>pk.eyJ1IjoianVzdGluIiwiYSI6Ik9RX3RRQzAifQ.dmOg_BAp1ywuDZMM7YsXRg</string>
 	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
 	<true/>
+	<key>MGLMetricsTestServerURL</key>
+	<string>https://cloudfront-staging.tilestream.net</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Strictly for testing purposes, promise!</string>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
iOS metrics test metrics belong on the staging endpoint, not the production endpoint.

/cc @incanus @camilleanne