### PR TITLE
[ios] fix simulator crash on optional CoreTelephony code

### DIFF
--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -76,9 +76,10 @@ const NSTimeInterval MGLFlushInterval = 60;
             _scale = [UIScreen mainScreen].scale;
         }
 
+#if (!TARGET_IPHONE_SIMULATOR)
         // Collect cellular carrier data if CoreTelephony is linked
         Class CTTelephonyNetworkInfo = NSClassFromString(@"CTTelephonyNetworkInfo");
-        if (CTTelephonyNetworkInfo) {
+        if (CTTelephonyNetworkInfo != NULL) {
             id telephonyNetworkInfo = [[CTTelephonyNetworkInfo alloc] init];
 
             SEL subscriberCellularProviderSelector = NSSelectorFromString(@"subscriberCellularProvider");
@@ -88,6 +89,7 @@ const NSTimeInterval MGLFlushInterval = 60;
             NSString *carrierName = ((id (*)(id, SEL))[carrierVendor methodForSelector:carrierNameSelector])(carrierVendor, carrierNameSelector);
             _carrier = carrierName;
         }
+#endif
     }
     return self;
 }


### PR DESCRIPTION
With the optionalization of CoreTelephony in #2581, the simulator started throwing fits on launch and running the new code anyway, despite CoreTelephony not really existing.

Testing on devices without cellular hardware showed no issues. The new Apple TV may be an issue, but we're not there yet.

Fix #2687