### PR TITLE
[core] Added more transform state getters

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -86,6 +86,10 @@ public:
     // Transition
     void cancelTransitions();
     void setGestureInProgress(bool);
+    bool isGestureInProgress() const;
+    bool isRotating() const;
+    bool isScaling() const;
+    bool isPanning() const;
 
     // Camera
     void jumpTo(CameraOptions options);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -126,6 +126,22 @@ void Map::setGestureInProgress(bool inProgress) {
     update(Update::Repaint);
 }
 
+bool Map::isGestureInProgress() const {
+    return transform->isGestureInProgress();
+}
+
+bool Map::isRotating() const {
+    return transform->isRotating();
+}
+
+bool Map::isScaling() const {
+    return transform->isScaling();
+}
+
+bool Map::isPanning() const {
+    return transform->isPanning();
+}
+
 #pragma mark -
 
 void Map::jumpTo(CameraOptions options) {

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -56,9 +56,13 @@ public:
 
     // Gesture
     void setGestureInProgress(bool);
+    bool isGestureInProgress() const { return state.isGestureInProgress(); }
 
     // Transform state
     const TransformState getState() const { return state; }
+    bool isRotating() const { return state.isRotating(); }
+    bool isScaling() const { return state.isScaling(); }
+    bool isPanning() const { return state.isPanning(); }
 
 private:
     void _moveBy(double dx, double dy, const Duration& = Duration::zero());

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -105,6 +105,15 @@ const LatLng TransformState::getLatLng() const {
     return ll;
 }
 
+double TransformState::pixel_x() const {
+    const double center = (width - scale * util::tileSize) / 2;
+    return center + x;
+}
+
+double TransformState::pixel_y() const {
+    const double center = (height - scale * util::tileSize) / 2;
+    return center + y;
+}
 
 #pragma mark - Zoom
 
@@ -154,6 +163,30 @@ float TransformState::getAltitude() const {
 float TransformState::getPitch() const {
     return pitch;
 }
+
+
+#pragma mark - State
+
+bool TransformState::isChanging() const {
+    return rotating || scaling || panning || gestureInProgress;
+}
+
+bool TransformState::isRotating() const {
+    return rotating;
+}
+
+bool TransformState::isScaling() const {
+    return scaling;
+}
+
+bool TransformState::isPanning() const {
+    return panning;
+}
+
+bool TransformState::isGestureInProgress() const {
+    return gestureInProgress;
+}
+
 
 #pragma mark - Projection
 
@@ -277,13 +310,6 @@ mat4 TransformState::getPixelMatrix() const {
 }
 
 
-#pragma mark - Changing
-
-bool TransformState::isChanging() const {
-    return rotating || scaling || panning || gestureInProgress;
-}
-
-
 #pragma mark - (private helper functions)
 
 void TransformState::constrain(double& scale_, double& y_) const {
@@ -299,12 +325,4 @@ void TransformState::constrain(double& scale_, double& y_) const {
     if (y_ < -max_y) y_ = -max_y;
 }
 
-double TransformState::pixel_x() const {
-    const double center = (width - scale * util::tileSize) / 2;
-    return center + x;
-}
 
-double TransformState::pixel_y() const {
-    const double center = (height - scale * util::tileSize) / 2;
-    return center + y;
-}

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -36,6 +36,8 @@ public:
 
     // Position
     const LatLng getLatLng() const;
+    double pixel_x() const;
+    double pixel_y() const;
 
     // Zoom
     float getNormalizedZoom() const;
@@ -48,18 +50,17 @@ public:
 
     // Rotation
     float getAngle() const;
-
     float getAltitude() const;
     float getPitch() const;
 
-    // Changing
+    // State
     bool isChanging() const;
-
-    double pixel_x() const;
-    double pixel_y() const;
+    bool isRotating() const;
+    bool isScaling() const;
+    bool isPanning() const;
+    bool isGestureInProgress() const;
 
     // Conversion and projection
-
     vec2<double> latLngToPoint(const LatLng& latLng) const;
     LatLng pointToLatLng(const vec2<double> point) const;
 
@@ -108,6 +109,6 @@ private:
     double Cc = (scale * util::tileSize) / util::M2PI;
 };
 
-}
+} // namespace mbgl
 
-#endif
+#endif // MBGL_MAP_TRANSFORM_STATE


### PR DESCRIPTION
Some platforms requires specific information that was previously not available in public API, but stored internally in `TransformState` object.

/cc @tmpsantos @kkaefer @jfirebaugh 