### PR TITLE
Cleanup Painter usage in MapContext

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -248,7 +248,6 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
         painter->setup();
     }
 
-    painter->setDebug(data.getDebug());
     painter->render(*style, transformState, frame, data.getAnimationTime());
 
     if (data.mode == MapMode::Still) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -243,11 +243,7 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
     // Cleanup OpenGL objects that we abandoned since the last render call.
     glObjectStore.performCleanup();
 
-    if (!painter) {
-        painter = std::make_unique<Painter>(data);
-        painter->setup();
-    }
-
+    if (!painter) painter = std::make_unique<Painter>(data);
     painter->render(*style, transformState, frame, data.getAnimationTime());
 
     if (data.mode == MapMode::Still) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -244,7 +244,7 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
     glObjectStore.performCleanup();
 
     if (!painter) painter = std::make_unique<Painter>(data);
-    painter->render(*style, transformState, frame, data.getAnimationTime());
+    painter->render(*style, transformState, frame);
 
     if (data.mode == MapMode::Still) {
         callback(nullptr, view.readStillImage());

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -43,6 +43,7 @@
 using namespace mbgl;
 
 Painter::Painter(MapData& data_) : data(data_) {
+    setup();
 }
 
 Painter::~Painter() {

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -113,10 +113,6 @@ void Painter::resize() {
     }
 }
 
-void Painter::setDebug(bool enabled) {
-    debug = enabled;
-}
-
 void Painter::useProgram(GLuint program) {
     if (gl_program != program) {
         MBGL_CHECK_ERROR(glUseProgram(program));

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -157,7 +157,7 @@ void Painter::prepareTile(const Tile& tile) {
     config.stencilFunc = { GL_EQUAL, ref, mask };
 }
 
-void Painter::render(const Style& style, TransformState state_, const FrameData& frame_, const TimePoint& time) {
+void Painter::render(const Style& style, TransformState state_, const FrameData& frame_) {
     state = state_;
     frame = frame_;
 
@@ -214,7 +214,7 @@ void Painter::render(const Style& style, TransformState state_, const FrameData&
         drawClippingMasks(sources);
     }
 
-    frameHistory.record(time, state.getNormalizedZoom());
+    frameHistory.record(data.getAnimationTime(), state.getNormalizedZoom());
 
     // Actually render the layers
     if (debug::renderTree) { Log::Info(Event::Render, "{"); indent++; }

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -120,9 +120,6 @@ public:
     // Adjusts the dimensions of the OpenGL viewport
     void resize();
 
-    // Changes whether debug information is drawn onto the map
-    void setDebug(bool enabled);
-
     void drawClippingMasks(const std::set<Source*>&);
     void drawClippingMask(const mat4& matrix, const ClipID& clip);
 
@@ -189,7 +186,6 @@ private:
     TransformState state;
     FrameData frame;
 
-    bool debug = false;
     int indent = 0;
 
     gl::Config config;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -79,8 +79,6 @@ public:
     Painter(MapData& data);
     ~Painter();
 
-    void setup();
-
     // Renders the backdrop of the OpenGL view. This also paints in areas where we don't have any
     // tiles whatsoever.
     void clear();
@@ -132,6 +130,7 @@ public:
     bool needsAnimation() const;
 
 private:
+    void setup();
     void setupShaders();
     mat4 translatedMatrix(const mat4& matrix, const std::array<float, 2> &translation, const TileID &id, TranslateAnchorType anchor);
 

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -88,8 +88,7 @@ public:
 
     void render(const Style& style,
                 TransformState state,
-                const FrameData& frame,
-                const TimePoint& time);
+                const FrameData& frame);
 
     // Renders debug information for a tile.
     void renderTileDebug(const Tile& tile);

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -12,7 +12,7 @@ using namespace mbgl;
 void Painter::renderTileDebug(const Tile& tile) {
     MBGL_DEBUG_GROUP(std::string { "debug " } + std::string(tile.id));
     assert(tile.data);
-    if (debug) {
+    if (data.getDebug()) {
         prepareTile(tile);
         renderDebugText(tile.data->debugBucket, tile.matrix);
         renderDebugFrame(tile.matrix);


### PR DESCRIPTION
Both debug and animation time data can be obtained directly through `MapData` (which `Painter` also has access to), so no need to provide that to `Painter`. Also, `Painter::setup()` can be called within `Painter` ctor.

/cc @tmpsantos @kkaefer @jfirebaugh 