### PR TITLE
Minor telemetry improvements

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -405,8 +405,8 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     _regionChangeDelegateQueue.maxConcurrentOperationCount = 1;
 
     // metrics: map load event
-    const mbgl::LatLng latLng = _mbglMap->getLatLng();
-    const double zoom = _mbglMap->getZoom();
+    mbgl::LatLng latLng = _mbglMap->getLatLng();
+    int zoom = round(_mbglMap->getZoom());
 
     [MGLMapboxEvents pushEvent:MGLEventTypeMapLoad withAttributes:@{
         MGLEventKeyLatitude: @(latLng.latitude),
@@ -942,7 +942,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         // metrics: pan end
         CGPoint pointInView = CGPointMake([pan locationInView:pan.view].x, [pan locationInView:pan.view].y);
         CLLocationCoordinate2D panCoordinate = [self convertPoint:pointInView toCoordinateFromView:pan.view];
-        double zoom = [self zoomLevel];
+        int zoom = round([self zoomLevel]);
 
         [MGLMapboxEvents pushEvent:MGLEventTypeMapDragEnd withAttributes:@{
             MGLEventKeyLatitude: @(panCoordinate.latitude),
@@ -1479,7 +1479,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 {
     CGPoint pointInView = CGPointMake([recognizer locationInView:recognizer.view].x, [recognizer locationInView:recognizer.view].y);
     CLLocationCoordinate2D gestureCoordinate = [self convertPoint:pointInView toCoordinateFromView:recognizer.view];
-    double zoom = [self zoomLevel];
+    int zoom = round([self zoomLevel]);
 
     [MGLMapboxEvents pushEvent:MGLEventTypeMapTap withAttributes:@{
         MGLEventKeyLatitude: @(gestureCoordinate.latitude),

--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -13,7 +13,7 @@
 #include <sys/sysctl.h>
 
 static const NSUInteger version = 1;
-static NSString *const MGLMapboxEventsUserAgent = @"MapboxEventsiOS/1.0";
+static NSString *const MGLMapboxEventsUserAgent = @"MapboxEventsiOS/1.1";
 static NSString *MGLMapboxEventsAPIBase = @"https://api.tiles.mapbox.com";
 
 NSString *const MGLEventTypeAppUserTurnstile = @"appUserTurnstile";
@@ -507,13 +507,13 @@ const NSTimeInterval MGLFlushInterval = 60;
         [evt setValue:[strongSelf deviceOrientation] forKey:@"orientation"];
         [evt setValue:@((int)(100 * [UIDevice currentDevice].batteryLevel)) forKey:@"batteryLevel"];
         [evt setValue:@(strongSelf.data.scale) forKey:@"resolution"];
-        [evt setValue:strongSelf.data.carrier forKey:@"carrier"];
 
-        NSString *cell;
         if (strongSelf.data.carrier) {
-            cell = [strongSelf currentCellularNetworkConnectionType];
+            [evt setValue:strongSelf.data.carrier forKey:@"carrier"];
+
+            NSString *cell = [strongSelf currentCellularNetworkConnectionType];
+            [evt setObject:(cell ? cell : [NSNull null]) forKey:@"cellularNetworkType"];
         }
-        [evt setObject:(cell ? cell : [NSNull null]) forKey:@"cellularNetworkType"];
 
         MGLReachability *reachability = [MGLReachability reachabilityForLocalWiFi];
         [evt setValue:([reachability isReachableViaWiFi] ? @YES : @NO) forKey:@"wifi"];
@@ -785,9 +785,9 @@ const NSTimeInterval MGLFlushInterval = 60;
             MGLEventKeyLongitude: @(loc.coordinate.longitude),
             MGLEventKeySpeed: @(loc.speed),
             MGLEventKeyCourse: @(loc.course),
-            MGLEventKeyAltitude: @(loc.altitude),
-            MGLEventKeyHorizontalAccuracy: @(loc.horizontalAccuracy),
-            MGLEventKeyVerticalAccuracy: @(loc.verticalAccuracy)
+            MGLEventKeyAltitude: @(round(loc.altitude)),
+            MGLEventKeyHorizontalAccuracy: @(round(loc.horizontalAccuracy)),
+            MGLEventKeyVerticalAccuracy: @(round(loc.verticalAccuracy))
         }];
     }
 }
@@ -796,7 +796,7 @@ const NSTimeInterval MGLFlushInterval = 60;
     [MGLMapboxEvents pushEvent:MGLEventTypeVisit withAttributes:@{
         MGLEventKeyLatitude: @(visit.coordinate.latitude),
         MGLEventKeyLongitude: @(visit.coordinate.longitude),
-        MGLEventKeyHorizontalAccuracy: @(visit.horizontalAccuracy),
+        MGLEventKeyHorizontalAccuracy: @(round(visit.horizontalAccuracy)),
         MGLEventKeyArrivalDate: [[NSDate distantPast] isEqualToDate:visit.arrivalDate] ? [NSNull null] : [_rfc3339DateFormatter stringFromDate:visit.arrivalDate],
         MGLEventKeyDepartureDate: [[NSDate distantFuture] isEqualToDate:visit.departureDate] ? [NSNull null] : [_rfc3339DateFormatter stringFromDate:visit.departureDate]
     }];


### PR DESCRIPTION
Made some minor changes to what we send as telemetry, mostly small improvements around how much actual data is sent.

- Bump telemetry user agent to 1.1
 - To help identify these and other recent changes
- Round zoom and horizontal/vertical accuracy to integer precision
 - These were floats with unnecessary padding added
- Only send cellular carrier/network type keys when there's something to send

/cc @mapbox/mobiledata 