### PR TITLE
[core] Introduce StyleLayer subclasses

### DIFF
--- a/android/cpp/jni.cpp
+++ b/android/cpp/jni.cpp
@@ -340,7 +340,7 @@ mbgl::AnnotationSegment annotation_segment_from_latlng_jlist(JNIEnv *env, jobjec
     return segment;
 }
 
-std::pair<mbgl::AnnotationSegment, mbgl::StyleProperties> annotation_std_pair_from_polygon_jobject(JNIEnv *env, jobject polygon) {
+std::pair<mbgl::AnnotationSegment, mbgl::ShapeAnnotation::Properties> annotation_std_pair_from_polygon_jobject(JNIEnv *env, jobject polygon) {
     jfloat alpha = env->GetFloatField(polygon, polygonAlphaId);
     jint fillColor = env->GetIntField(polygon, polygonFillColorId);
     jint strokeColor = env->GetIntField(polygon, polygonStrokeColorId);
@@ -355,7 +355,7 @@ std::pair<mbgl::AnnotationSegment, mbgl::StyleProperties> annotation_std_pair_fr
     int bS = (strokeColor) & 0xFF;
     int aS = (strokeColor >> 24) & 0xFF;
 
-    mbgl::StyleProperties shapeProperties;
+    mbgl::ShapeAnnotation::Properties shapeProperties;
     mbgl::FillPaintProperties fillProperties;
     fillProperties.opacity = alpha;
     fillProperties.stroke_color = {{ static_cast<float>(rS) / 255.0f, static_cast<float>(gS) / 255.0f, static_cast<float>(bS) / 255.0f, static_cast<float>(aS) / 255.0f }};
@@ -939,7 +939,7 @@ jlong JNICALL nativeAddPolyline(JNIEnv *env, jobject obj, jlong nativeMapViewPtr
         return -1;
     }
 
-    mbgl::StyleProperties shapeProperties;
+    mbgl::ShapeAnnotation::Properties shapeProperties;
     mbgl::LinePaintProperties lineProperties;
     lineProperties.opacity = alpha;
     lineProperties.color = {{ static_cast<float>(r) / 255.0f, static_cast<float>(g) / 255.0f, static_cast<float>(b) / 255.0f, static_cast<float>(a) / 255.0f }};
@@ -964,7 +964,7 @@ jlong JNICALL nativeAddPolygon(JNIEnv *env, jobject obj, jlong nativeMapViewPtr,
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
 
     std::vector<mbgl::ShapeAnnotation> shapes;
-    std::pair<mbgl::AnnotationSegment, mbgl::StyleProperties> segment = annotation_std_pair_from_polygon_jobject(env, polygon);
+    std::pair<mbgl::AnnotationSegment, mbgl::ShapeAnnotation::Properties> segment = annotation_std_pair_from_polygon_jobject(env, polygon);
 
     if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
@@ -1011,7 +1011,7 @@ jlongArray JNICALL nativeAddPolygons(JNIEnv *env, jobject obj, jlong nativeMapVi
     for (jsize i = 0; i < len; i++) {
         jobject polygon = reinterpret_cast<jobject>(env->GetObjectArrayElement(jarray, i));
 
-        std::pair<mbgl::AnnotationSegment, mbgl::StyleProperties> segment = annotation_std_pair_from_polygon_jobject(env, polygon);
+        std::pair<mbgl::AnnotationSegment, mbgl::ShapeAnnotation::Properties> segment = annotation_std_pair_from_polygon_jobject(env, polygon);
         if (env->ExceptionCheck()) {
             env->ExceptionDescribe();
             return nullptr;

--- a/include/mbgl/annotation/shape_annotation.hpp
+++ b/include/mbgl/annotation/shape_annotation.hpp
@@ -6,6 +6,8 @@
 
 #include <mbgl/util/geo.hpp>
 
+#include <mapbox/variant.hpp>
+
 namespace mbgl {
 
 using AnnotationSegment = std::vector<LatLng>;
@@ -13,12 +15,14 @@ using AnnotationSegments = std::vector<AnnotationSegment>;
 
 class ShapeAnnotation {
 public:
-    inline ShapeAnnotation(const AnnotationSegments& segments_, const StyleProperties& styleProperties_)
+    using Properties = mapbox::util::variant<FillPaintProperties, LinePaintProperties>;
+
+    inline ShapeAnnotation(const AnnotationSegments& segments_, const Properties& styleProperties_)
         : segments(segments_), styleProperties(styleProperties_) {
     }
 
     const AnnotationSegments segments;
-    const StyleProperties styleProperties;
+    const Properties styleProperties;
 };
 
 }

--- a/include/mbgl/style/style_properties.hpp
+++ b/include/mbgl/style/style_properties.hpp
@@ -1,14 +1,10 @@
 #ifndef MBGL_STYLE_STYLE_PROPERTIES
 #define MBGL_STYLE_STYLE_PROPERTIES
 
-#include <mapbox/variant.hpp>
-
 #include <mbgl/style/types.hpp>
 
 #include <array>
 #include <string>
-#include <type_traits>
-#include <memory>
 #include <vector>
 
 namespace mbgl {
@@ -169,21 +165,15 @@ public:
     float opacity = 1.0f;
     Color color = {{ 0, 0, 0, 1 }};
     Faded<std::string> image;
+
+    inline bool isVisible() const {
+        return opacity > 0;
+    }
 };
 
 class BackgroundLayoutProperties {
 public:
 };
-
-typedef mapbox::util::variant<
-    FillPaintProperties,
-    LinePaintProperties,
-    CirclePaintProperties,
-    SymbolPaintProperties,
-    RasterPaintProperties,
-    BackgroundPaintProperties,
-    std::false_type
-> StyleProperties;
 
 }
 

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -223,11 +223,8 @@ void GLFWView::addRandomPointAnnotations(int count) {
 void GLFWView::addRandomShapeAnnotations(int count) {
     std::vector<mbgl::ShapeAnnotation> shapes;
 
-    mbgl::FillPaintProperties fillProperties;
-    fillProperties.opacity = .1;
-
-    mbgl::StyleProperties properties;
-    properties.set<mbgl::FillPaintProperties>(fillProperties);
+    mbgl::FillPaintProperties properties;
+    properties.opacity = .1;
 
     for (int i = 0; i < count; i++) {
         mbgl::AnnotationSegment triangle;

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2167,7 +2167,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
             [strokeColor getRed:&r green:&g blue:&b alpha:&a];
             mbgl::Color strokeNativeColor({{ (float)r, (float)g, (float)b, (float)a }});
 
-            mbgl::StyleProperties shapeProperties;
+            mbgl::ShapeAnnotation::Properties shapeProperties;
 
             if ([annotation isKindOfClass:[MGLPolyline class]])
             {

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/annotation/annotation_tile.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_bucket.hpp>
-#include <mbgl/style/style_layer.hpp>
+#include <mbgl/layer/symbol_layer.hpp>
 
 #include <boost/function_output_iterator.hpp>
 
@@ -112,20 +112,19 @@ void AnnotationManager::updateStyle(Style& style) {
         source->enabled = true;
         style.addSource(std::move(source));
 
-        std::map<ClassID, ClassProperties> pointPaints;
-        pointPaints.emplace(ClassID::Default, ClassProperties());
-        std::unique_ptr<StyleLayer> pointLayer = std::make_unique<StyleLayer>(PointLayerID, std::move(pointPaints));
-        pointLayer->type = StyleLayerType::Symbol;
+        std::unique_ptr<SymbolLayer> layer = std::make_unique<SymbolLayer>();
+        layer->id = PointLayerID;
+        layer->type = StyleLayerType::Symbol;
+        layer->styles.emplace(ClassID::Default, ClassProperties());
 
-        util::ptr<StyleBucket> pointBucket = std::make_shared<StyleBucket>(pointLayer->type);
-        pointBucket->name = pointLayer->id;
-        pointBucket->source = SourceID;
-        pointBucket->source_layer = PointLayerID;
-        pointBucket->layout.set(PropertyKey::IconImage, ConstantFunction<std::string>("{sprite}"));
-        pointBucket->layout.set(PropertyKey::IconAllowOverlap, ConstantFunction<bool>(true));
+        layer->bucket = std::make_shared<StyleBucket>(layer->type);
+        layer->bucket->name = layer->id;
+        layer->bucket->source = SourceID;
+        layer->bucket->source_layer = PointLayerID;
+        layer->bucket->layout.set(PropertyKey::IconImage, ConstantFunction<std::string>("{sprite}"));
+        layer->bucket->layout.set(PropertyKey::IconAllowOverlap, ConstantFunction<bool>(true));
 
-        pointLayer->bucket = pointBucket;
-        style.addLayer(std::move(pointLayer));
+        style.addLayer(std::move(layer));
     }
 
     for (const auto& shape : shapeAnnotations) {

--- a/src/mbgl/annotation/shape_annotation_impl.hpp
+++ b/src/mbgl/annotation/shape_annotation_impl.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/geojsonvt/geojsonvt.hpp>
 
+#include <memory>
 #include <string>
 #include <map>
 

--- a/src/mbgl/layer/background_layer.cpp
+++ b/src/mbgl/layer/background_layer.cpp
@@ -1,0 +1,12 @@
+#include <mbgl/layer/background_layer.hpp>
+
+namespace mbgl {
+
+RenderPass BackgroundLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
+    applyTransitionedStyleProperty(PropertyKey::BackgroundOpacity, properties.opacity, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::BackgroundColor, properties.color, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::BackgroundImage, properties.image, z, now, zoomHistory);
+    return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
+}
+
+}

--- a/src/mbgl/layer/background_layer.hpp
+++ b/src/mbgl/layer/background_layer.hpp
@@ -1,0 +1,18 @@
+#ifndef MBGL_BACKGROUND_LAYER
+#define MBGL_BACKGROUND_LAYER
+
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/style/style_properties.hpp>
+
+namespace mbgl {
+
+class BackgroundLayer : public StyleLayer {
+public:
+    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+
+    BackgroundPaintProperties properties;
+};
+
+}
+
+#endif

--- a/src/mbgl/layer/circle_layer.cpp
+++ b/src/mbgl/layer/circle_layer.cpp
@@ -1,0 +1,15 @@
+#include <mbgl/layer/circle_layer.hpp>
+
+namespace mbgl {
+
+RenderPass CircleLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
+    applyTransitionedStyleProperty(PropertyKey::CircleRadius, properties.radius, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::CircleColor, properties.color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::CircleOpacity, properties.opacity, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::CircleTranslate, properties.translate, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::CircleTranslateAnchor, properties.translateAnchor, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::CircleBlur, properties.blur, z, now, zoomHistory);
+    return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
+}
+
+}

--- a/src/mbgl/layer/circle_layer.hpp
+++ b/src/mbgl/layer/circle_layer.hpp
@@ -1,0 +1,18 @@
+#ifndef MBGL_CIRCLE_LAYER
+#define MBGL_CIRCLE_LAYER
+
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/style/style_properties.hpp>
+
+namespace mbgl {
+
+class CircleLayer : public StyleLayer {
+public:
+    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+
+    CirclePaintProperties properties;
+};
+
+}
+
+#endif

--- a/src/mbgl/layer/fill_layer.cpp
+++ b/src/mbgl/layer/fill_layer.cpp
@@ -1,0 +1,29 @@
+#include <mbgl/layer/fill_layer.hpp>
+
+namespace mbgl {
+
+RenderPass FillLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
+    applyStyleProperty(PropertyKey::FillAntialias, properties.antialias, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::FillOpacity, properties.opacity, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::FillColor, properties.fill_color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::FillOutlineColor, properties.stroke_color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::FillTranslate, properties.translate, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::FillTranslateAnchor, properties.translateAnchor, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::FillImage, properties.image, z, now, zoomHistory);
+
+    RenderPass result = RenderPass::None;
+
+    if (properties.antialias) {
+        result |= RenderPass::Translucent;
+    }
+
+    if (!properties.image.from.empty() || (properties.fill_color[3] * properties.opacity) < 1.0f) {
+        result |= RenderPass::Translucent;
+    } else {
+        result |= RenderPass::Opaque;
+    }
+
+    return result;
+}
+
+}

--- a/src/mbgl/layer/fill_layer.hpp
+++ b/src/mbgl/layer/fill_layer.hpp
@@ -1,0 +1,18 @@
+#ifndef MBGL_FILL_LAYER
+#define MBGL_FILL_LAYER
+
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/style/style_properties.hpp>
+
+namespace mbgl {
+
+class FillLayer : public StyleLayer {
+public:
+    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+
+    FillPaintProperties properties;
+};
+
+}
+
+#endif

--- a/src/mbgl/layer/line_layer.cpp
+++ b/src/mbgl/layer/line_layer.cpp
@@ -1,0 +1,22 @@
+#include <mbgl/layer/line_layer.hpp>
+
+namespace mbgl {
+
+RenderPass LineLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
+    applyTransitionedStyleProperty(PropertyKey::LineOpacity, properties.opacity, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::LineColor, properties.color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::LineTranslate, properties.translate, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::LineTranslateAnchor, properties.translateAnchor, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::LineWidth, properties.width, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::LineGapWidth, properties.gap_width, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::LineBlur, properties.blur, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::LineDashArray, properties.dash_array, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::LineImage, properties.image, z, now, zoomHistory);
+
+    // for scaling dasharrays
+    applyStyleProperty(PropertyKey::LineWidth, properties.dash_line_width, std::floor(z), now, zoomHistory);
+
+    return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
+}
+
+}

--- a/src/mbgl/layer/line_layer.hpp
+++ b/src/mbgl/layer/line_layer.hpp
@@ -1,0 +1,18 @@
+#ifndef MBGL_LINE_LAYER
+#define MBGL_LINE_LAYER
+
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/style/style_properties.hpp>
+
+namespace mbgl {
+
+class LineLayer : public StyleLayer {
+public:
+    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+
+    LinePaintProperties properties;
+};
+
+}
+
+#endif

--- a/src/mbgl/layer/raster_layer.cpp
+++ b/src/mbgl/layer/raster_layer.cpp
@@ -1,0 +1,16 @@
+#include <mbgl/layer/raster_layer.hpp>
+
+namespace mbgl {
+
+RenderPass RasterLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
+    applyTransitionedStyleProperty(PropertyKey::RasterOpacity, properties.opacity, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::RasterHueRotate, properties.hue_rotate, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::RasterBrightnessLow, properties.brightness[0], z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::RasterBrightnessHigh, properties.brightness[1], z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::RasterSaturation, properties.saturation, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::RasterContrast, properties.contrast, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::RasterFade, properties.fade, z, now, zoomHistory);
+    return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
+}
+
+}

--- a/src/mbgl/layer/raster_layer.hpp
+++ b/src/mbgl/layer/raster_layer.hpp
@@ -1,0 +1,18 @@
+#ifndef MBGL_RASTER_LAYER
+#define MBGL_RASTER_LAYER
+
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/style/style_properties.hpp>
+
+namespace mbgl {
+
+class RasterLayer : public StyleLayer {
+public:
+    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+
+    RasterPaintProperties properties;
+};
+
+}
+
+#endif

--- a/src/mbgl/layer/symbol_layer.cpp
+++ b/src/mbgl/layer/symbol_layer.cpp
@@ -1,0 +1,39 @@
+#include <mbgl/layer/symbol_layer.hpp>
+#include <mbgl/style/style_bucket.hpp>
+#include <mbgl/style/property_evaluator.hpp>
+
+namespace mbgl {
+
+RenderPass SymbolLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
+    applyTransitionedStyleProperty(PropertyKey::IconOpacity, properties.icon.opacity, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::IconColor, properties.icon.color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::IconHaloColor, properties.icon.halo_color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::IconHaloWidth, properties.icon.halo_width, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::IconHaloBlur, properties.icon.halo_blur, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::IconTranslate, properties.icon.translate, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::IconTranslateAnchor, properties.icon.translate_anchor, z, now, zoomHistory);
+
+    applyTransitionedStyleProperty(PropertyKey::TextOpacity, properties.text.opacity, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::TextColor, properties.text.color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::TextHaloColor, properties.text.halo_color, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::TextHaloWidth, properties.text.halo_width, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::TextHaloBlur, properties.text.halo_blur, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::TextTranslate, properties.text.translate, z, now, zoomHistory);
+    applyStyleProperty(PropertyKey::TextTranslateAnchor, properties.text.translate_anchor, z, now, zoomHistory);
+
+    // text-size and icon-size are layout properties but they also need to be evaluated as paint properties:
+    auto it = bucket->layout.properties.find(PropertyKey::IconSize);
+    if (it != bucket->layout.properties.end()) {
+        const PropertyEvaluator<float> evaluator(z, zoomHistory);
+        properties.icon.size = mapbox::util::apply_visitor(evaluator, it->second);
+    }
+    it = bucket->layout.properties.find(PropertyKey::TextSize);
+    if (it != bucket->layout.properties.end()) {
+        const PropertyEvaluator<float> evaluator(z, zoomHistory);
+        properties.text.size = mapbox::util::apply_visitor(evaluator, it->second);
+    }
+
+    return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
+}
+
+}

--- a/src/mbgl/layer/symbol_layer.hpp
+++ b/src/mbgl/layer/symbol_layer.hpp
@@ -1,0 +1,18 @@
+#ifndef MBGL_SYMBOL_LAYER
+#define MBGL_SYMBOL_LAYER
+
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/style/style_properties.hpp>
+
+namespace mbgl {
+
+class SymbolLayer : public StyleLayer {
+public:
+    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+
+    SymbolPaintProperties properties;
+};
+
+}
+
+#endif

--- a/src/mbgl/map/tile_worker.cpp
+++ b/src/mbgl/map/tile_worker.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/map/tile_worker.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_layer.hpp>
+#include <mbgl/style/property_evaluator.hpp>
 #include <mbgl/geometry/glyph_atlas.hpp>
 #include <mbgl/renderer/fill_bucket.hpp>
 #include <mbgl/renderer/line_bucket.hpp>
@@ -62,29 +63,6 @@ void TileWorker::redoPlacement(float angle, float pitch, bool collisionDebug) {
         }
     }
 }
-
-template <typename T>
-struct PropertyEvaluator {
-    typedef T result_type;
-    explicit PropertyEvaluator(float z_) : z(z_) {}
-
-    template <typename P, typename std::enable_if<std::is_convertible<P, T>::value, int>::type = 0>
-    T operator()(const P &value) const {
-        return value;
-    }
-
-    T operator()(const Function<T> &value) const {
-        return mapbox::util::apply_visitor(FunctionEvaluator<T>(z), value);
-    }
-
-    template <typename P, typename std::enable_if<!std::is_convertible<P, T>::value, int>::type = 0>
-    T operator()(const P &) const {
-        return T();
-    }
-
-private:
-    const float z;
-};
 
 template <typename T>
 void applyLayoutProperty(PropertyKey key, const ClassProperties &classProperties, T &target, const float z) {

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/renderer/painter.hpp>
 
 #include <mbgl/shader/circle_shader.hpp>
+#include <mbgl/layer/circle_layer.hpp>
 
 using namespace mbgl;
 
@@ -19,10 +20,10 @@ void CircleBucket::upload() {
 }
 
 void CircleBucket::render(Painter& painter,
-                        const StyleLayer& layer_desc,
+                        const StyleLayer& layer,
                         const TileID& id,
                         const mat4& matrix) {
-    painter.renderCircle(*this, layer_desc, id, matrix);
+    painter.renderCircle(*this, dynamic_cast<const CircleLayer&>(layer), id, matrix);
 }
 
 bool CircleBucket::hasData() const {

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/renderer/fill_bucket.hpp>
 #include <mbgl/geometry/fill_buffer.hpp>
+#include <mbgl/layer/fill_layer.hpp>
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/style/style.hpp>
@@ -197,10 +198,10 @@ void FillBucket::upload() {
 }
 
 void FillBucket::render(Painter& painter,
-                        const StyleLayer& layer_desc,
+                        const StyleLayer& layer,
                         const TileID& id,
                         const mat4& matrix) {
-    painter.renderFill(*this, layer_desc, id, matrix);
+    painter.renderFill(*this, dynamic_cast<const FillLayer&>(layer), id, matrix);
 }
 
 bool FillBucket::hasData() const {

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -1,5 +1,5 @@
 #include <mbgl/renderer/line_bucket.hpp>
-
+#include <mbgl/layer/line_layer.hpp>
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/style/style.hpp>
@@ -388,10 +388,10 @@ void LineBucket::upload() {
 }
 
 void LineBucket::render(Painter& painter,
-                        const StyleLayer& layer_desc,
+                        const StyleLayer& layer,
                         const TileID& id,
                         const mat4& matrix) {
-    painter.renderLine(*this, layer_desc, id, matrix);
+    painter.renderLine(*this, dynamic_cast<const LineLayer&>(layer), id, matrix);
 }
 
 bool LineBucket::hasData() const {

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -37,10 +37,16 @@ struct FrameData;
 
 class DebugBucket;
 class FillBucket;
+class FillLayer;
 class LineBucket;
+class LineLayer;
 class CircleBucket;
+class CircleLayer;
 class SymbolBucket;
+class SymbolLayer;
 class RasterBucket;
+class RasterLayer;
+class BackgroundLayer;
 
 struct RasterProperties;
 
@@ -96,13 +102,13 @@ public:
     // Renders the red debug frame around a tile, visualizing its perimeter.
     void renderDebugFrame(const mat4 &matrix);
 
-    void renderDebugText(DebugBucket& bucket, const mat4 &matrix);
-    void renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
-    void renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
-    void renderCircle(CircleBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
-    void renderSymbol(SymbolBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
-    void renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix);
-    void renderBackground(const StyleLayer &layer_desc);
+    void renderDebugText(DebugBucket&, const mat4&);
+    void renderFill(FillBucket&, const FillLayer&, const TileID&, const mat4&);
+    void renderLine(LineBucket&, const LineLayer&, const TileID&, const mat4&);
+    void renderCircle(CircleBucket&, const CircleLayer&, const TileID&, const mat4&);
+    void renderSymbol(SymbolBucket&, const SymbolLayer&, const TileID&, const mat4&);
+    void renderRaster(RasterBucket&, const RasterLayer&, const TileID&, const mat4&);
+    void renderBackground(const BackgroundLayer&);
 
     float saturationFactor(float saturation);
     float contrastFactor(float contrast);

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -1,9 +1,7 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/circle_bucket.hpp>
 
-#include <mbgl/style/style.hpp>
-#include <mbgl/style/style_layer.hpp>
-#include <mbgl/style/style_properties.hpp>
+#include <mbgl/layer/circle_layer.hpp>
 
 #include <mbgl/map/sprite.hpp>
 #include <mbgl/map/tile_id.hpp>
@@ -14,7 +12,7 @@
 using namespace mbgl;
 
 void Painter::renderCircle(CircleBucket& bucket,
-                           const StyleLayer& layer_desc,
+                           const CircleLayer& layer,
                            const TileID& id,
                            const mat4& matrix) {
     // Abort early.
@@ -22,7 +20,7 @@ void Painter::renderCircle(CircleBucket& bucket,
 
     config.stencilTest = false;
 
-    const CirclePaintProperties& properties = layer_desc.getProperties<CirclePaintProperties>();
+    const CirclePaintProperties& properties = layer.properties;
     mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);
 
     Color color = properties.color;

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -1,8 +1,6 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/fill_bucket.hpp>
-#include <mbgl/style/style.hpp>
-#include <mbgl/style/style_layer.hpp>
-#include <mbgl/style/style_properties.hpp>
+#include <mbgl/layer/fill_layer.hpp>
 #include <mbgl/map/sprite.hpp>
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/geometry/sprite_atlas.hpp>
@@ -13,8 +11,8 @@
 
 using namespace mbgl;
 
-void Painter::renderFill(FillBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix) {
-    const FillPaintProperties& properties = layer_desc.getProperties<FillPaintProperties>();
+void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileID& id, const mat4& matrix) {
+    const FillPaintProperties& properties = layer.properties;
     mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);
 
     Color fill_color = properties.fill_color;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -1,8 +1,6 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/line_bucket.hpp>
-#include <mbgl/style/style.hpp>
-#include <mbgl/style/style_layer.hpp>
-#include <mbgl/style/style_properties.hpp>
+#include <mbgl/layer/line_layer.hpp>
 #include <mbgl/map/sprite.hpp>
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/map/map_data.hpp>
@@ -15,7 +13,7 @@
 
 using namespace mbgl;
 
-void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const TileID& id, const mat4 &matrix) {
+void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileID& id, const mat4& matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
@@ -23,7 +21,7 @@ void Painter::renderLine(LineBucket& bucket, const StyleLayer &layer_desc, const
     config.depthTest = true;
     config.depthMask = GL_FALSE;
 
-    const auto& properties = layer_desc.getProperties<LinePaintProperties>();
+    const auto& properties = layer.properties;
     const auto& layout = bucket.layout;
 
     // the distance over which the line edge fades out.

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -1,15 +1,15 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/renderer/raster_bucket.hpp>
-#include <mbgl/style/style_layer.hpp>
+#include <mbgl/layer/raster_layer.hpp>
 #include <mbgl/shader/raster_shader.hpp>
 
 using namespace mbgl;
 
-void Painter::renderRaster(RasterBucket& bucket, const StyleLayer &layer_desc, const TileID&, const mat4 &matrix) {
+void Painter::renderRaster(RasterBucket& bucket, const RasterLayer& layer, const TileID&, const mat4& matrix) {
     if (pass != RenderPass::Translucent) return;
 
-    const RasterPaintProperties& properties = layer_desc.getProperties<RasterPaintProperties>();
+    const RasterPaintProperties& properties = layer.properties;
 
     if (bucket.hasData()) {
         useProgram(rasterShader->program);

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -1,7 +1,6 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/symbol_bucket.hpp>
-#include <mbgl/style/style_layer.hpp>
-#include <mbgl/style/style_properties.hpp>
+#include <mbgl/layer/symbol_layer.hpp>
 #include <mbgl/geometry/glyph_atlas.hpp>
 #include <mbgl/geometry/sprite_atlas.hpp>
 #include <mbgl/shader/sdf_shader.hpp>
@@ -126,13 +125,13 @@ void Painter::renderSDF(SymbolBucket &bucket,
     }
 }
 
-void Painter::renderSymbol(SymbolBucket &bucket, const StyleLayer &layer_desc, const TileID &id, const mat4 &matrix) {
+void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const TileID& id, const mat4& matrix) {
     // Abort early.
     if (pass == RenderPass::Opaque) {
         return;
     }
 
-    const auto& properties = layer_desc.getProperties<SymbolPaintProperties>();
+    const auto& properties = layer.properties;
     const auto& layout = bucket.layout;
 
     config.depthMask = GL_FALSE;

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/renderer/raster_bucket.hpp>
+#include <mbgl/layer/raster_layer.hpp>
 #include <mbgl/shader/raster_shader.hpp>
 #include <mbgl/renderer/painter.hpp>
 
@@ -17,10 +18,10 @@ void RasterBucket::upload() {
 }
 
 void RasterBucket::render(Painter& painter,
-                          const StyleLayer& layer_desc,
+                          const StyleLayer& layer,
                           const TileID& id,
                           const mat4& matrix) {
-    painter.renderRaster(*this, layer_desc, id, matrix);
+    painter.renderRaster(*this, dynamic_cast<const RasterLayer&>(layer), id, matrix);
 }
 
 bool RasterBucket::setImage(std::unique_ptr<util::Image> image) {

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/renderer/symbol_bucket.hpp>
+#include <mbgl/layer/symbol_layer.hpp>
 #include <mbgl/map/geometry_tile.hpp>
 #include <mbgl/style/style_properties.hpp>
 #include <mbgl/annotation/sprite_image.hpp>
@@ -75,10 +76,10 @@ void SymbolBucket::upload() {
 }
 
 void SymbolBucket::render(Painter& painter,
-                          const StyleLayer& layer_desc,
+                          const StyleLayer& layer,
                           const TileID& id,
                           const mat4& matrix) {
-    painter.renderSymbol(*this, layer_desc, id, matrix);
+    painter.renderSymbol(*this, dynamic_cast<const SymbolLayer&>(layer), id, matrix);
 }
 
 bool SymbolBucket::hasData() const { return hasTextData() || hasIconData() || !symbolInstances.empty(); }

--- a/src/mbgl/style/property_evaluator.hpp
+++ b/src/mbgl/style/property_evaluator.hpp
@@ -1,0 +1,45 @@
+#ifndef MBGL_PROPERTY_EVALUATOR
+#define MBGL_PROPERTY_EVALUATOR
+
+#include <mbgl/style/zoom_history.hpp>
+#include <mbgl/style/function_properties.hpp>
+#include <mbgl/style/piecewisefunction_properties.hpp>
+
+namespace mbgl {
+
+struct ZoomHistory;
+
+template <typename T>
+class PropertyEvaluator {
+public:
+    typedef T result_type;
+
+    PropertyEvaluator(float z_) : z(z_), zoomHistory() {}
+    PropertyEvaluator(float z_, const ZoomHistory& zoomHistory_) : z(z_), zoomHistory(zoomHistory_) {}
+
+    template <typename P, typename std::enable_if<std::is_convertible<P, T>::value, int>::type = 0>
+    T operator()(const P &value) const {
+        return value;
+    }
+
+    T operator()(const Function<T>& value) const {
+        return mapbox::util::apply_visitor(FunctionEvaluator<T>(z), value);
+    }
+
+    T operator()(const PiecewiseConstantFunction<T>& value) const {
+        return value.evaluate(z, zoomHistory);
+    }
+
+    template <typename P, typename std::enable_if<!std::is_convertible<P, T>::value, int>::type = 0>
+    T operator()(const P &) const {
+        return T();
+    }
+
+private:
+    const float z;
+    ZoomHistory zoomHistory;
+};
+
+}
+
+#endif

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -54,11 +54,9 @@ public:
 private:
     void parseSources(JSVal value);
     void parseLayers(JSVal value);
-    void parseLayer(std::pair<JSVal, util::ptr<StyleLayer>> &pair);
+    void parseLayer(const std::string& id, JSVal value, util::ptr<StyleLayer>&);
     void parsePaints(JSVal value, std::map<ClassID, ClassProperties> &paints);
     void parsePaint(JSVal, ClassProperties &properties);
-    void parseReference(JSVal value, util::ptr<StyleLayer> &layer);
-    void parseBucket(JSVal value, util::ptr<StyleLayer> &layer);
     void parseLayout(JSVal value, util::ptr<StyleBucket> &bucket);
     void parseSprite(JSVal value);
     void parseGlyphURL(JSVal value);
@@ -106,8 +104,8 @@ private:
     std::unordered_map<std::string, const Source*> sourcesMap;
     std::unordered_map<std::string, std::pair<JSVal, util::ptr<StyleLayer>>> layersMap;
 
-    // Store a stack of layers we're parsing right now. This is to prevent reference cycles.
-    std::forward_list<StyleLayer *> stack;
+    // Store a stack of layer IDs we're parsing right now. This is to prevent reference cycles.
+    std::forward_list<std::string> stack;
 
     // Base URL of the sprite image.
     std::string sprite;

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -48,14 +48,11 @@ TEST(Annotations, LineAnnotation) {
 
     AnnotationSegments segments = {{ {{ { 0, 0 }, { 45, 45 } }} }};
 
-    LinePaintProperties lineProperties;
-    lineProperties.color = {{ 255, 0, 0, 1 }};
-    lineProperties.width = 5;
+    LinePaintProperties properties;
+    properties.color = {{ 255, 0, 0, 1 }};
+    properties.width = 5;
 
-    StyleProperties styleProperties;
-    styleProperties.set<LinePaintProperties>(lineProperties);
-
-    map.addShapeAnnotation(ShapeAnnotation(segments, styleProperties));
+    map.addShapeAnnotation(ShapeAnnotation(segments, properties));
 
     util::write_file("test/output/line_annotation.png", renderPNG(map));
 }
@@ -70,13 +67,10 @@ TEST(Annotations, FillAnnotation) {
 
     AnnotationSegments segments = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
 
-    FillPaintProperties fillProperties;
-    fillProperties.fill_color = {{ 255, 0, 0, 1 }};
+    FillPaintProperties properties;
+    properties.fill_color = {{ 255, 0, 0, 1 }};
 
-    StyleProperties styleProperties;
-    styleProperties.set<FillPaintProperties>(fillProperties);
-
-    map.addShapeAnnotation(ShapeAnnotation(segments, styleProperties));
+    map.addShapeAnnotation(ShapeAnnotation(segments, properties));
 
     util::write_file("test/output/fill_annotation.png", renderPNG(map));
 }
@@ -109,13 +103,10 @@ TEST(Annotations, NonImmediateAdd) {
 
     AnnotationSegments segments = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
 
-    FillPaintProperties fillProperties;
-    fillProperties.fill_color = {{ 255, 0, 0, 1 }};
+    FillPaintProperties properties;
+    properties.fill_color = {{ 255, 0, 0, 1 }};
 
-    StyleProperties styleProperties;
-    styleProperties.set<FillPaintProperties>(fillProperties);
-
-    map.addShapeAnnotation(ShapeAnnotation(segments, styleProperties));
+    map.addShapeAnnotation(ShapeAnnotation(segments, properties));
 
     util::write_file("test/output/non_immediate_add.png", renderPNG(map));
 }
@@ -143,16 +134,13 @@ TEST(Annotations, RemoveShape) {
 
     AnnotationSegments segments = {{ {{ { 0, 0 }, { 45, 45 } }} }};
 
-    LinePaintProperties lineProperties;
-    lineProperties.color = {{ 255, 0, 0, 1 }};
-    lineProperties.width = 5;
-
-    StyleProperties styleProperties;
-    styleProperties.set<LinePaintProperties>(lineProperties);
+    LinePaintProperties properties;
+    properties.color = {{ 255, 0, 0, 1 }};
+    properties.width = 5;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
-    uint32_t shape = map.addShapeAnnotation(ShapeAnnotation(segments, styleProperties));
+    uint32_t shape = map.addShapeAnnotation(ShapeAnnotation(segments, properties));
 
     renderPNG(map);
 

--- a/test/fixtures/style_parser/text-size.style.json
+++ b/test/fixtures/style_parser/text-size.style.json
@@ -9,7 +9,7 @@
   },
   "layers": [{
     "id": "country_label",
-    "type": "text",
+    "type": "symbol",
     "source": "mapbox",
     "source-layer": "country_label",
     "filter": ["==", "$type", "Point"],


### PR DESCRIPTION
Second in a series of PRs that builds towards a full-fledged [programmatic style API](https://github.com/mapbox/mapbox-gl-native/issues/837). This is a big chunk of work, but I'm trying to break it up step by step and not create a long-lived branch with a lot of changes.

This change introduces subclasses of `StyleLayer`, one for each layer type. Each subclass holds an instance of the appropriate `___PaintProperties` that we introduced in the [previous commit](https://github.com/mapbox/mapbox-gl-native/pull/2705). That means we can eliminate the `StyleProperties` variant. (Well, not completely: `ShapeAnnotation` still uses a version reduced to varying between `LinePaintProperties` and `FillPaintProperties`.)

We can also move the explicit instantiations of `StyleLayer::applyStyleProperties` (one for each layer type) into pure virtual `StyleLayer::applyStyleProperties` and subclass implementations. Future commits in this series will make similar changes, replacing `switch` or `template` polymorphism with good old type polymorphism.

:eyes: @kkaefer @brunoabinader 