### PR TITLE
[core] Style-sourced shape annotation properties

### DIFF
--- a/include/mbgl/annotation/shape_annotation.hpp
+++ b/include/mbgl/annotation/shape_annotation.hpp
@@ -15,14 +15,17 @@ using AnnotationSegments = std::vector<AnnotationSegment>;
 
 class ShapeAnnotation {
 public:
-    using Properties = mapbox::util::variant<FillPaintProperties, LinePaintProperties>;
+    using Properties = mapbox::util::variant<
+        FillPaintProperties, // creates a fill annotation
+        LinePaintProperties, // creates a line annotation
+        std::string>;        // creates an annotation whose type and properties are sourced from a style layer
 
-    inline ShapeAnnotation(const AnnotationSegments& segments_, const Properties& styleProperties_)
-        : segments(segments_), styleProperties(styleProperties_) {
+    ShapeAnnotation(const AnnotationSegments& segments_, const Properties& properties_)
+        : segments(segments_), properties(properties_) {
     }
 
     const AnnotationSegments segments;
-    const Properties styleProperties;
+    const Properties properties;
 };
 
 }

--- a/src/mbgl/annotation/shape_annotation_impl.hpp
+++ b/src/mbgl/annotation/shape_annotation_impl.hpp
@@ -13,6 +13,7 @@
 namespace mbgl {
 
 class Style;
+class StyleLayer;
 class AnnotationTile;
 
 class ShapeAnnotationImpl {
@@ -30,7 +31,12 @@ public:
     const ShapeAnnotation shape;
 
 private:
-    mapbox::util::geojsonvt::GeoJSONVT shapeTiler;
+    std::unique_ptr<StyleLayer> createLineLayer();
+    std::unique_ptr<StyleLayer> createFillLayer();
+
+    const uint8_t maxZoom;
+    mapbox::util::geojsonvt::ProjectedFeatureType type;
+    std::unique_ptr<mapbox::util::geojsonvt::GeoJSONVT> shapeTiler;
 };
 
 }

--- a/src/mbgl/style/class_properties.hpp
+++ b/src/mbgl/style/class_properties.hpp
@@ -11,10 +11,6 @@ namespace mbgl {
 
 class ClassProperties {
 public:
-    inline ClassProperties() {}
-    inline ClassProperties(ClassProperties &&properties_)
-        : properties(std::move(properties_.properties)) {}
-
     inline void set(PropertyKey key, const PropertyValue &value) {
         properties.emplace(key, value);
     }

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -75,6 +75,21 @@ TEST(Annotations, FillAnnotation) {
     util::write_file("test/output/fill_annotation.png", renderPNG(map));
 }
 
+TEST(Annotations, StyleSourcedShapeAnnotation) {
+    auto display = std::make_shared<mbgl::HeadlessDisplay>();
+    HeadlessView view(display, 1);
+    DefaultFileSource fileSource(nullptr);
+
+    Map map(view, fileSource, MapMode::Still);
+    map.setStyleJSON(util::read_file("test/fixtures/api/annotation.json"), "");
+
+    AnnotationSegments segments = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
+
+    map.addShapeAnnotation(ShapeAnnotation(segments, "annotation"));
+
+    util::write_file("test/output/style_sourced_shape_annotation.png", renderPNG(map));
+}
+
 TEST(Annotations, AddMultiple) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);

--- a/test/fixtures/api/annotation.json
+++ b/test/fixtures/api/annotation.json
@@ -1,0 +1,19 @@
+{
+  "version": 8,
+  "sources": {
+    "fake": {
+      "type": "vector",
+      "url": "asset://TEST_DATA/fixtures/tiles/streets.json"
+    }
+  },
+  "layers": [{
+    "id": "annotation",
+    "type": "fill",
+    "source": "fake",
+    "source-layer": "fake",
+    "paint": {
+      "fill-color": "rgba(255,0,0,1)"
+    }
+  }],
+  "sprite": "asset://TEST_DATA/fixtures/resources/sprite"
+}


### PR DESCRIPTION
This introduces the possibility to source the type and style properties of a shape annotation from a designated layer in the style.

:eyes: @brunoabinader 