### PR TITLE
IB inspectable for allowing tilt

### DIFF
--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) IBInspectable BOOL allowsZooming;
 @property (nonatomic) IBInspectable BOOL allowsScrolling;
 @property (nonatomic) IBInspectable BOOL allowsRotating;
+@property (nonatomic) IBInspectable BOOL allowsTilting;
 @property (nonatomic) IBInspectable BOOL showsUserLocation;
 
 @end

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1535,7 +1535,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 + (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingPitchEnabled
 {
-    return [NSSet setWithObject:@"allowsPitching"];
+    return [NSSet setWithObject:@"allowsTilting"];
 }
 
 - (void)setDebugActive:(BOOL)debugActive
@@ -3410,19 +3410,19 @@ class MBGLView : public mbgl::View
     self.rotateEnabled = allowsRotating;
 }
 
-+ (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingAllowsPitching
++ (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingAllowsTilting
 {
     return [NSSet setWithObject:@"pitchEnabled"];
 }
 
-- (BOOL)allowsPitching
+- (BOOL)allowsTilting
 {
     return self.pitchEnabled;
 }
 
-- (void)setAllowsPitching:(BOOL)allowsPitching
+- (void)setAllowsTilting:(BOOL)allowsTilting
 {
-    self.pitchEnabled = allowsPitching;
+    self.pitchEnabled = allowsTilting;
 }
 
 - (void)didReceiveMemoryWarning


### PR DESCRIPTION
This PR adds an inspectable to Interface Builder for enabling or disabling tilt gesture recognition. 42dc5336db5179c50b8d1edeca0bef7a27c8cefd added some of the code required for this inspectable, but it didn’t declare the inspectable itself. Additionally, the property was called `allowsPitching` – I changed it to `allowsTilting`, because “to pitch” has [many senses](https://en.wiktionary.org/wiki/pitch#Verb_2) that are more common than the intended aviation sense of the word. (One adjusts the `centerCoordinate` by scrolling or panning the map. Similarly, adjusts the map view’s `pitch` by tilting the map.)

/cc @friedbunny