### PR TITLE
[core] Remove MapData dependency from StyleParser

### DIFF
--- a/src/mbgl/layer/background_layer.cpp
+++ b/src/mbgl/layer/background_layer.cpp
@@ -2,10 +2,10 @@
 
 namespace mbgl {
 
-RenderPass BackgroundLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
-    applyTransitionedStyleProperty(PropertyKey::BackgroundOpacity, properties.opacity, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::BackgroundColor, properties.color, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::BackgroundImage, properties.image, z, now, zoomHistory);
+RenderPass BackgroundLayer::applyStyleProperties(const StyleCalculationParameters& parameters) {
+    applyTransitionedStyleProperty(PropertyKey::BackgroundOpacity, properties.opacity, parameters);
+    applyTransitionedStyleProperty(PropertyKey::BackgroundColor, properties.color, parameters);
+    applyStyleProperty(PropertyKey::BackgroundImage, properties.image, parameters);
     return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
 }
 

--- a/src/mbgl/layer/background_layer.hpp
+++ b/src/mbgl/layer/background_layer.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class BackgroundLayer : public StyleLayer {
 public:
-    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+    RenderPass applyStyleProperties(const StyleCalculationParameters&) override;
 
     BackgroundPaintProperties properties;
 };

--- a/src/mbgl/layer/circle_layer.cpp
+++ b/src/mbgl/layer/circle_layer.cpp
@@ -2,13 +2,13 @@
 
 namespace mbgl {
 
-RenderPass CircleLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
-    applyTransitionedStyleProperty(PropertyKey::CircleRadius, properties.radius, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::CircleColor, properties.color, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::CircleOpacity, properties.opacity, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::CircleTranslate, properties.translate, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::CircleTranslateAnchor, properties.translateAnchor, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::CircleBlur, properties.blur, z, now, zoomHistory);
+RenderPass CircleLayer::applyStyleProperties(const StyleCalculationParameters& parameters) {
+    applyTransitionedStyleProperty(PropertyKey::CircleRadius, properties.radius, parameters);
+    applyTransitionedStyleProperty(PropertyKey::CircleColor, properties.color, parameters);
+    applyTransitionedStyleProperty(PropertyKey::CircleOpacity, properties.opacity, parameters);
+    applyTransitionedStyleProperty(PropertyKey::CircleTranslate, properties.translate, parameters);
+    applyStyleProperty(PropertyKey::CircleTranslateAnchor, properties.translateAnchor, parameters);
+    applyTransitionedStyleProperty(PropertyKey::CircleBlur, properties.blur, parameters);
     return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
 }
 

--- a/src/mbgl/layer/circle_layer.hpp
+++ b/src/mbgl/layer/circle_layer.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class CircleLayer : public StyleLayer {
 public:
-    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+    RenderPass applyStyleProperties(const StyleCalculationParameters&) override;
 
     CirclePaintProperties properties;
 };

--- a/src/mbgl/layer/fill_layer.cpp
+++ b/src/mbgl/layer/fill_layer.cpp
@@ -2,14 +2,14 @@
 
 namespace mbgl {
 
-RenderPass FillLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
-    applyStyleProperty(PropertyKey::FillAntialias, properties.antialias, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::FillOpacity, properties.opacity, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::FillColor, properties.fill_color, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::FillOutlineColor, properties.stroke_color, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::FillTranslate, properties.translate, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::FillTranslateAnchor, properties.translateAnchor, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::FillImage, properties.image, z, now, zoomHistory);
+RenderPass FillLayer::applyStyleProperties(const StyleCalculationParameters& parameters) {
+    applyStyleProperty(PropertyKey::FillAntialias, properties.antialias, parameters);
+    applyTransitionedStyleProperty(PropertyKey::FillOpacity, properties.opacity, parameters);
+    applyTransitionedStyleProperty(PropertyKey::FillColor, properties.fill_color, parameters);
+    applyTransitionedStyleProperty(PropertyKey::FillOutlineColor, properties.stroke_color, parameters);
+    applyTransitionedStyleProperty(PropertyKey::FillTranslate, properties.translate, parameters);
+    applyStyleProperty(PropertyKey::FillTranslateAnchor, properties.translateAnchor, parameters);
+    applyStyleProperty(PropertyKey::FillImage, properties.image, parameters);
 
     RenderPass result = RenderPass::None;
 

--- a/src/mbgl/layer/fill_layer.hpp
+++ b/src/mbgl/layer/fill_layer.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class FillLayer : public StyleLayer {
 public:
-    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+    RenderPass applyStyleProperties(const StyleCalculationParameters&) override;
 
     FillPaintProperties properties;
 };

--- a/src/mbgl/layer/line_layer.cpp
+++ b/src/mbgl/layer/line_layer.cpp
@@ -2,19 +2,21 @@
 
 namespace mbgl {
 
-RenderPass LineLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
-    applyTransitionedStyleProperty(PropertyKey::LineOpacity, properties.opacity, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::LineColor, properties.color, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::LineTranslate, properties.translate, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::LineTranslateAnchor, properties.translateAnchor, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::LineWidth, properties.width, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::LineGapWidth, properties.gap_width, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::LineBlur, properties.blur, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::LineDashArray, properties.dash_array, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::LineImage, properties.image, z, now, zoomHistory);
+RenderPass LineLayer::applyStyleProperties(const StyleCalculationParameters& parameters) {
+    applyTransitionedStyleProperty(PropertyKey::LineOpacity, properties.opacity, parameters);
+    applyTransitionedStyleProperty(PropertyKey::LineColor, properties.color, parameters);
+    applyTransitionedStyleProperty(PropertyKey::LineTranslate, properties.translate, parameters);
+    applyStyleProperty(PropertyKey::LineTranslateAnchor, properties.translateAnchor, parameters);
+    applyTransitionedStyleProperty(PropertyKey::LineWidth, properties.width, parameters);
+    applyTransitionedStyleProperty(PropertyKey::LineGapWidth, properties.gap_width, parameters);
+    applyTransitionedStyleProperty(PropertyKey::LineBlur, properties.blur, parameters);
+    applyStyleProperty(PropertyKey::LineDashArray, properties.dash_array, parameters);
+    applyStyleProperty(PropertyKey::LineImage, properties.image, parameters);
 
     // for scaling dasharrays
-    applyStyleProperty(PropertyKey::LineWidth, properties.dash_line_width, std::floor(z), now, zoomHistory);
+    StyleCalculationParameters dashArrayParams = parameters;
+    dashArrayParams.z = std::floor(dashArrayParams.z);
+    applyStyleProperty(PropertyKey::LineWidth, properties.dash_line_width, dashArrayParams);
 
     return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
 }

--- a/src/mbgl/layer/line_layer.hpp
+++ b/src/mbgl/layer/line_layer.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class LineLayer : public StyleLayer {
 public:
-    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+    RenderPass applyStyleProperties(const StyleCalculationParameters&) override;
 
     LinePaintProperties properties;
 };

--- a/src/mbgl/layer/raster_layer.cpp
+++ b/src/mbgl/layer/raster_layer.cpp
@@ -2,14 +2,14 @@
 
 namespace mbgl {
 
-RenderPass RasterLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
-    applyTransitionedStyleProperty(PropertyKey::RasterOpacity, properties.opacity, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::RasterHueRotate, properties.hue_rotate, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::RasterBrightnessLow, properties.brightness[0], z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::RasterBrightnessHigh, properties.brightness[1], z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::RasterSaturation, properties.saturation, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::RasterContrast, properties.contrast, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::RasterFade, properties.fade, z, now, zoomHistory);
+RenderPass RasterLayer::applyStyleProperties(const StyleCalculationParameters& parameters) {
+    applyTransitionedStyleProperty(PropertyKey::RasterOpacity, properties.opacity, parameters);
+    applyTransitionedStyleProperty(PropertyKey::RasterHueRotate, properties.hue_rotate, parameters);
+    applyTransitionedStyleProperty(PropertyKey::RasterBrightnessLow, properties.brightness[0], parameters);
+    applyTransitionedStyleProperty(PropertyKey::RasterBrightnessHigh, properties.brightness[1], parameters);
+    applyTransitionedStyleProperty(PropertyKey::RasterSaturation, properties.saturation, parameters);
+    applyTransitionedStyleProperty(PropertyKey::RasterContrast, properties.contrast, parameters);
+    applyTransitionedStyleProperty(PropertyKey::RasterFade, properties.fade, parameters);
     return properties.isVisible() ? RenderPass::Translucent : RenderPass::None;
 }
 

--- a/src/mbgl/layer/raster_layer.hpp
+++ b/src/mbgl/layer/raster_layer.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class RasterLayer : public StyleLayer {
 public:
-    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+    RenderPass applyStyleProperties(const StyleCalculationParameters&) override;
 
     RasterPaintProperties properties;
 };

--- a/src/mbgl/layer/symbol_layer.cpp
+++ b/src/mbgl/layer/symbol_layer.cpp
@@ -4,32 +4,32 @@
 
 namespace mbgl {
 
-RenderPass SymbolLayer::applyStyleProperties(const float z, const TimePoint& now, const ZoomHistory& zoomHistory) {
-    applyTransitionedStyleProperty(PropertyKey::IconOpacity, properties.icon.opacity, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::IconColor, properties.icon.color, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::IconHaloColor, properties.icon.halo_color, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::IconHaloWidth, properties.icon.halo_width, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::IconHaloBlur, properties.icon.halo_blur, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::IconTranslate, properties.icon.translate, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::IconTranslateAnchor, properties.icon.translate_anchor, z, now, zoomHistory);
+RenderPass SymbolLayer::applyStyleProperties(const StyleCalculationParameters& parameters) {
+    applyTransitionedStyleProperty(PropertyKey::IconOpacity, properties.icon.opacity, parameters);
+    applyTransitionedStyleProperty(PropertyKey::IconColor, properties.icon.color, parameters);
+    applyTransitionedStyleProperty(PropertyKey::IconHaloColor, properties.icon.halo_color, parameters);
+    applyTransitionedStyleProperty(PropertyKey::IconHaloWidth, properties.icon.halo_width, parameters);
+    applyTransitionedStyleProperty(PropertyKey::IconHaloBlur, properties.icon.halo_blur, parameters);
+    applyTransitionedStyleProperty(PropertyKey::IconTranslate, properties.icon.translate, parameters);
+    applyStyleProperty(PropertyKey::IconTranslateAnchor, properties.icon.translate_anchor, parameters);
 
-    applyTransitionedStyleProperty(PropertyKey::TextOpacity, properties.text.opacity, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::TextColor, properties.text.color, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::TextHaloColor, properties.text.halo_color, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::TextHaloWidth, properties.text.halo_width, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::TextHaloBlur, properties.text.halo_blur, z, now, zoomHistory);
-    applyTransitionedStyleProperty(PropertyKey::TextTranslate, properties.text.translate, z, now, zoomHistory);
-    applyStyleProperty(PropertyKey::TextTranslateAnchor, properties.text.translate_anchor, z, now, zoomHistory);
+    applyTransitionedStyleProperty(PropertyKey::TextOpacity, properties.text.opacity, parameters);
+    applyTransitionedStyleProperty(PropertyKey::TextColor, properties.text.color, parameters);
+    applyTransitionedStyleProperty(PropertyKey::TextHaloColor, properties.text.halo_color, parameters);
+    applyTransitionedStyleProperty(PropertyKey::TextHaloWidth, properties.text.halo_width, parameters);
+    applyTransitionedStyleProperty(PropertyKey::TextHaloBlur, properties.text.halo_blur, parameters);
+    applyTransitionedStyleProperty(PropertyKey::TextTranslate, properties.text.translate, parameters);
+    applyStyleProperty(PropertyKey::TextTranslateAnchor, properties.text.translate_anchor, parameters);
 
     // text-size and icon-size are layout properties but they also need to be evaluated as paint properties:
     auto it = bucket->layout.properties.find(PropertyKey::IconSize);
     if (it != bucket->layout.properties.end()) {
-        const PropertyEvaluator<float> evaluator(z, zoomHistory);
+        const PropertyEvaluator<float> evaluator(parameters);
         properties.icon.size = mapbox::util::apply_visitor(evaluator, it->second);
     }
     it = bucket->layout.properties.find(PropertyKey::TextSize);
     if (it != bucket->layout.properties.end()) {
-        const PropertyEvaluator<float> evaluator(z, zoomHistory);
+        const PropertyEvaluator<float> evaluator(parameters);
         properties.text.size = mapbox::util::apply_visitor(evaluator, it->second);
     }
 

--- a/src/mbgl/layer/symbol_layer.hpp
+++ b/src/mbgl/layer/symbol_layer.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class SymbolLayer : public StyleLayer {
 public:
-    RenderPass applyStyleProperties(float z, const TimePoint& now, const ZoomHistory&) override;
+    RenderPass applyStyleProperties(const StyleCalculationParameters&) override;
 
     SymbolPaintProperties properties;
 };

--- a/src/mbgl/map/tile_worker.cpp
+++ b/src/mbgl/map/tile_worker.cpp
@@ -22,6 +22,7 @@ TileWorker::TileWorker(TileID id_,
     : layers(std::move(layers_)),
       id(id_),
       sourceID(sourceID_),
+      parameters(id.z),
       style(style_),
       state(state_),
       collisionTile(std::move(collision_)) {
@@ -65,10 +66,10 @@ void TileWorker::redoPlacement(float angle, float pitch, bool collisionDebug) {
 }
 
 template <typename T>
-void applyLayoutProperty(PropertyKey key, const ClassProperties &classProperties, T &target, const float z) {
+void applyLayoutProperty(PropertyKey key, const ClassProperties &classProperties, T &target, const StyleCalculationParameters& parameters) {
     auto it = classProperties.properties.find(key);
     if (it != classProperties.properties.end()) {
-        const PropertyEvaluator<T> evaluator(z);
+        const PropertyEvaluator<T> evaluator(parameters);
         target = mapbox::util::apply_visitor(evaluator, it->second);
     }
 }

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -7,6 +7,7 @@
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/style/filter_expression.hpp>
+#include <mbgl/style/style_calculation_parameters.hpp>
 
 #include <string>
 #include <memory>
@@ -57,6 +58,7 @@ private:
 
     const TileID id;
     const std::string sourceID;
+    const StyleCalculationParameters parameters;
 
     Style& style;
     const std::atomic<TileData::State>& state;

--- a/src/mbgl/style/class_properties.cpp
+++ b/src/mbgl/style/class_properties.cpp
@@ -2,10 +2,10 @@
 
 namespace mbgl {
 
-const PropertyTransition &ClassProperties::getTransition(PropertyKey key, const PropertyTransition &defaultTransition) const {
+PropertyTransition ClassProperties::getTransition(PropertyKey key) const {
     auto it = transitions.find(key);
     if (it == transitions.end()) {
-        return defaultTransition;
+        return PropertyTransition();
     } else {
         return it->second;
     }

--- a/src/mbgl/style/class_properties.hpp
+++ b/src/mbgl/style/class_properties.hpp
@@ -19,7 +19,7 @@ public:
         transitions.emplace(key, transition);
     }
 
-    const PropertyTransition &getTransition(PropertyKey key, const PropertyTransition &defaultTransition) const;
+    PropertyTransition getTransition(PropertyKey key) const;
 
     // Route-through iterable interface so that you can iterate on the object as is.
     inline std::map<PropertyKey, PropertyValue>::const_iterator begin() const {

--- a/src/mbgl/style/piecewisefunction_properties.cpp
+++ b/src/mbgl/style/piecewisefunction_properties.cpp
@@ -16,16 +16,17 @@ size_t getBiggestStopLessThan(std::vector<std::pair<float, T>> stops, float z) {
 }
 
 template <typename T>
-T PiecewiseConstantFunction<T>::evaluate(float z, const ZoomHistory &zh) const {
+T PiecewiseConstantFunction<T>::evaluate(const StyleCalculationParameters& parameters) const {
     T result;
 
+    float z = parameters.z;
     float fraction = std::fmod(z, 1.0f);
-    float t = std::min((Clock::now() - zh.lastIntegerZoomTime) / duration, 1.0f);
+    float t = std::min((Clock::now() - parameters.zoomHistory.lastIntegerZoomTime) / duration, 1.0f);
     float fromScale = 1.0f;
     float toScale = 1.0f;
     size_t from, to;
 
-    if (z > zh.lastIntegerZoom) {
+    if (z > parameters.zoomHistory.lastIntegerZoom) {
         result.t = fraction + (1.0f - fraction) * t;
         from = getBiggestStopLessThan(values, z - 1.0f);
         to = getBiggestStopLessThan(values, z);
@@ -46,7 +47,7 @@ T PiecewiseConstantFunction<T>::evaluate(float z, const ZoomHistory &zh) const {
     return result;
 }
 
-template Faded<std::string> PiecewiseConstantFunction<Faded<std::string>>::evaluate(float z, const ZoomHistory &zoomHistory) const;
-template Faded<std::vector<float>> PiecewiseConstantFunction<Faded<std::vector<float>>>::evaluate(float z, const ZoomHistory &zoomHistory) const;
+template Faded<std::string> PiecewiseConstantFunction<Faded<std::string>>::evaluate(const StyleCalculationParameters&) const;
+template Faded<std::vector<float>> PiecewiseConstantFunction<Faded<std::vector<float>>>::evaluate(const StyleCalculationParameters&) const;
 
 }

--- a/src/mbgl/style/piecewisefunction_properties.cpp
+++ b/src/mbgl/style/piecewisefunction_properties.cpp
@@ -21,7 +21,8 @@ T PiecewiseConstantFunction<T>::evaluate(const StyleCalculationParameters& param
 
     float z = parameters.z;
     float fraction = std::fmod(z, 1.0f);
-    float t = std::min((Clock::now() - parameters.zoomHistory.lastIntegerZoomTime) / duration, 1.0f);
+    std::chrono::duration<float> d = duration ? *duration : parameters.defaultFadeDuration;
+    float t = std::min((Clock::now() - parameters.zoomHistory.lastIntegerZoomTime) / d, 1.0f);
     float fromScale = 1.0f;
     float toScale = 1.0f;
     size_t from, to;

--- a/src/mbgl/style/piecewisefunction_properties.hpp
+++ b/src/mbgl/style/piecewisefunction_properties.hpp
@@ -2,6 +2,9 @@
 #define MBGL_STYLE_FADEDFUNCTION_PROPERTIES
 
 #include <mbgl/style/style_calculation_parameters.hpp>
+#include <mbgl/util/chrono.hpp>
+
+#include <mapbox/optional.hpp>
 
 #include <vector>
 
@@ -9,14 +12,22 @@ namespace mbgl {
 
 template <typename T>
 struct PiecewiseConstantFunction {
-    inline PiecewiseConstantFunction(const std::vector<std::pair<float, T>> &values_, std::chrono::duration<float> duration_) : values(values_), duration(duration_) {}
-    inline PiecewiseConstantFunction(T &value, std::chrono::duration<float> duration_) : values({{ 0, value }}), duration(duration_) {}
+    PiecewiseConstantFunction(const std::vector<std::pair<float, T>>& values_,
+                              mapbox::util::optional<Duration> duration_)
+        : values(values_),
+          duration(duration_) {
+    }
+
+    PiecewiseConstantFunction(T& value, mapbox::util::optional<Duration> duration_)
+        : values({{ 0, value }}),
+          duration(duration_) {
+    }
 
     T evaluate(const StyleCalculationParameters&) const;
 
 private:
     const std::vector<std::pair<float, T>> values;
-    const std::chrono::duration<float> duration;
+    const mapbox::util::optional<Duration> duration;
 };
 
 }

--- a/src/mbgl/style/piecewisefunction_properties.hpp
+++ b/src/mbgl/style/piecewisefunction_properties.hpp
@@ -1,7 +1,7 @@
 #ifndef MBGL_STYLE_FADEDFUNCTION_PROPERTIES
 #define MBGL_STYLE_FADEDFUNCTION_PROPERTIES
 
-#include <mbgl/style/zoom_history.hpp>
+#include <mbgl/style/style_calculation_parameters.hpp>
 
 #include <vector>
 
@@ -11,7 +11,8 @@ template <typename T>
 struct PiecewiseConstantFunction {
     inline PiecewiseConstantFunction(const std::vector<std::pair<float, T>> &values_, std::chrono::duration<float> duration_) : values(values_), duration(duration_) {}
     inline PiecewiseConstantFunction(T &value, std::chrono::duration<float> duration_) : values({{ 0, value }}), duration(duration_) {}
-    T evaluate(float z, const ZoomHistory &zoomHistory) const;
+
+    T evaluate(const StyleCalculationParameters&) const;
 
 private:
     const std::vector<std::pair<float, T>> values;

--- a/src/mbgl/style/property_evaluator.hpp
+++ b/src/mbgl/style/property_evaluator.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/style/zoom_history.hpp>
 #include <mbgl/style/function_properties.hpp>
 #include <mbgl/style/piecewisefunction_properties.hpp>
+#include <mbgl/style/style_calculation_parameters.hpp>
 
 namespace mbgl {
 
@@ -14,8 +15,8 @@ class PropertyEvaluator {
 public:
     typedef T result_type;
 
-    PropertyEvaluator(float z_) : z(z_), zoomHistory() {}
-    PropertyEvaluator(float z_, const ZoomHistory& zoomHistory_) : z(z_), zoomHistory(zoomHistory_) {}
+    PropertyEvaluator(const StyleCalculationParameters& parameters_)
+        : parameters(parameters_) {}
 
     template <typename P, typename std::enable_if<std::is_convertible<P, T>::value, int>::type = 0>
     T operator()(const P &value) const {
@@ -23,11 +24,11 @@ public:
     }
 
     T operator()(const Function<T>& value) const {
-        return mapbox::util::apply_visitor(FunctionEvaluator<T>(z), value);
+        return mapbox::util::apply_visitor(FunctionEvaluator<T>(parameters.z), value);
     }
 
     T operator()(const PiecewiseConstantFunction<T>& value) const {
-        return value.evaluate(z, zoomHistory);
+        return value.evaluate(parameters);
     }
 
     template <typename P, typename std::enable_if<!std::is_convertible<P, T>::value, int>::type = 0>
@@ -36,8 +37,7 @@ public:
     }
 
 private:
-    const float z;
-    ZoomHistory zoomHistory;
+    StyleCalculationParameters parameters;
 };
 
 }

--- a/src/mbgl/style/property_transition.hpp
+++ b/src/mbgl/style/property_transition.hpp
@@ -3,15 +3,15 @@
 
 #include <mbgl/util/chrono.hpp>
 
+#include <mapbox/optional.hpp>
 #include <cstdint>
 
 namespace mbgl {
 
-struct PropertyTransition {
-    explicit inline PropertyTransition(const Duration& duration_, const Duration& delay_)
-        : duration(duration_), delay(delay_) {}
-    Duration duration = Duration::zero();
-    Duration delay = Duration::zero();
+class PropertyTransition {
+public:
+    mapbox::util::optional<Duration> duration;
+    mapbox::util::optional<Duration> delay;
 };
 
 }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -136,8 +136,10 @@ void Style::recalculate(float z) {
 
     zoomHistory.update(z, data.getAnimationTime());
 
+    StyleCalculationParameters parameters(z, data.getAnimationTime(), zoomHistory);
+
     for (const auto& layer : layers) {
-        layer->updateProperties(z, data.getAnimationTime(), zoomHistory);
+        layer->updateProperties(parameters);
         if (!layer->bucket) {
             continue;
         }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -42,7 +42,7 @@ void Style::setJSON(const std::string& json, const std::string&) {
         return;
     }
 
-    StyleParser parser(data);
+    StyleParser parser;
     parser.parse(doc);
 
     for (auto& source : parser.getSources()) {
@@ -136,7 +136,10 @@ void Style::recalculate(float z) {
 
     zoomHistory.update(z, data.getAnimationTime());
 
-    StyleCalculationParameters parameters(z, data.getAnimationTime(), zoomHistory);
+    StyleCalculationParameters parameters(z,
+                                          data.getAnimationTime(),
+                                          zoomHistory,
+                                          data.getDefaultFadeDuration());
 
     for (const auto& layer : layers) {
         layer->updateProperties(parameters);

--- a/src/mbgl/style/style_calculation_parameters.hpp
+++ b/src/mbgl/style/style_calculation_parameters.hpp
@@ -11,14 +11,19 @@ public:
     StyleCalculationParameters(float z_)
         : z(z_) {}
 
-    StyleCalculationParameters(float z_, const TimePoint& now_, const ZoomHistory& zoomHistory_)
+    StyleCalculationParameters(float z_,
+                               const TimePoint& now_,
+                               const ZoomHistory& zoomHistory_,
+                               const Duration& defaultFadeDuration_)
         : z(z_),
           now(now_),
-          zoomHistory(zoomHistory_) {}
+          zoomHistory(zoomHistory_),
+          defaultFadeDuration(defaultFadeDuration_) {}
 
     float z;
     TimePoint now;
     ZoomHistory zoomHistory;
+    Duration defaultFadeDuration;
 };
 
 }

--- a/src/mbgl/style/style_calculation_parameters.hpp
+++ b/src/mbgl/style/style_calculation_parameters.hpp
@@ -1,0 +1,26 @@
+#ifndef STYLE_CALCULATION_PARAMETERS
+#define STYLE_CALCULATION_PARAMETERS
+
+#include <mbgl/style/zoom_history.hpp>
+#include <mbgl/util/chrono.hpp>
+
+namespace mbgl {
+
+class StyleCalculationParameters {
+public:
+    StyleCalculationParameters(float z_)
+        : z(z_) {}
+
+    StyleCalculationParameters(float z_, const TimePoint& now_, const ZoomHistory& zoomHistory_)
+        : z(z_),
+          now(now_),
+          zoomHistory(zoomHistory_) {}
+
+    float z;
+    TimePoint now;
+    ZoomHistory zoomHistory;
+};
+
+}
+
+#endif

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -118,14 +118,14 @@ void StyleLayer::applyClassProperties(const ClassID class_id,
     }
 }
 
-void StyleLayer::updateProperties(float z, const TimePoint& now, ZoomHistory &zoomHistory) {
-    cleanupAppliedStyleProperties(now);
+void StyleLayer::updateProperties(const StyleCalculationParameters& parameters) {
+    cleanupAppliedStyleProperties(parameters.now);
 
     // Clear the pending transitions flag upon each update.
     hasPendingTransitions = false;
 
     // Update the render passes when this layer is visible.
-    passes = applyStyleProperties(z, now, zoomHistory);
+    passes = applyStyleProperties(parameters);
 }
 
 bool StyleLayer::hasTransitions() const {

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -73,8 +73,8 @@ void StyleLayer::setClasses(const std::vector<std::string> &class_names, const T
 
         // This property key hasn't been set by a previous class, so we need to add a transition
         // to the fallback value for that key.
-        const TimePoint begin = now + defaultTransition.delay;
-        const TimePoint end = begin + defaultTransition.duration;
+        const TimePoint begin = now + *defaultTransition.delay;
+        const TimePoint end = begin + *defaultTransition.duration;
         const PropertyValue &value = PropertyFallbackValue::Get(key);
         appliedProperties.add(ClassID::Fallback, begin, end, value);
     }
@@ -108,10 +108,11 @@ void StyleLayer::applyClassProperties(const ClassID class_id,
         // a transition.
         AppliedClassPropertyValues &appliedProperties = appliedStyle[key];
         if (appliedProperties.mostRecent() != class_id) {
-            const PropertyTransition &transition =
-                class_properties.getTransition(key, defaultTransition);
-            const TimePoint begin = now + transition.delay;
-            const TimePoint end = begin + transition.duration;
+            PropertyTransition transition = class_properties.getTransition(key);
+            Duration delay = transition.delay ? *transition.delay : *defaultTransition.delay;
+            Duration duration = transition.duration ? *transition.duration : *defaultTransition.duration;
+            const TimePoint begin = now + delay;
+            const TimePoint end = begin + duration;
             const PropertyValue &value = property_pair.second;
             appliedProperties.add(class_id, begin, end, value);
         }

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -31,8 +31,6 @@ public:
     template<typename T>
     using Result = std::pair<Status, T>;
 
-    StyleParser(MapData& data);
-
     void parse(JSVal document);
 
     std::vector<std::unique_ptr<Source>>&& getSources() {
@@ -87,7 +85,7 @@ private:
     template <typename T>
     Result<Function<T>> parseFunction(JSVal value, const char *);
     template <typename T>
-    Result<PiecewiseConstantFunction<T>> parsePiecewiseConstantFunction(JSVal value, Duration duration);
+    Result<PiecewiseConstantFunction<T>> parsePiecewiseConstantFunction(JSVal value, JSVal transition);
     template <typename T>
     Result<std::vector<std::pair<float, T>>> parseStops(JSVal value, const char *property_name);
 
@@ -112,9 +110,6 @@ private:
 
     // URL template for glyph PBFs.
     std::string glyph_url;
-
-    // Obtain default transition duration from map data.
-    MapData& data;
 };
 
 }

--- a/test/miscellaneous/style_parser.cpp
+++ b/test/miscellaneous/style_parser.cpp
@@ -3,9 +3,6 @@
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/util/io.hpp>
 
-#include <mbgl/map/mode.hpp>
-#include <mbgl/map/map_data.hpp>
-
 #include <rapidjson/document.h>
 
 #include "../fixtures/fixture_log_observer.hpp"
@@ -38,12 +35,7 @@ TEST_P(StyleParserTest, ParseStyle) {
     FixtureLogObserver* observer = new FixtureLogObserver();
     Log::setObserver(std::unique_ptr<Log::Observer>(observer));
 
-    MapMode mapMode = MapMode::Continuous;
-    GLContextMode contextMode = GLContextMode::Unique;
-    const float pixelRatio = 1.0f;
-
-    MapData data(mapMode, contextMode, pixelRatio);
-    StyleParser parser(data);
+    StyleParser parser;
     parser.parse(styleDoc);
 
     for (auto it = infoDoc.MemberBegin(), end = infoDoc.MemberEnd(); it != end; it++) {


### PR DESCRIPTION
Third in a series of PRs that builds towards a full-fledged [programmatic style API](https://github.com/mapbox/mapbox-gl-native/issues/837). This is a big chunk of work, but I'm trying to break it up step by step and not create a long-lived branch with a lot of changes.

When working on other changes in this series, I found that having a `MapData` dependency in the style parsing code was problematic for other necessary refactoring. The parsing code is low level code that should not have a dependency on high-level objects such as `MapData`.

MapData was needed for two things: getting the default transition and fade durations, and detecting still rendering vs. continuous. This avoids the first by making transition durations optional, and supplying the default fallback value at evaluation time. The second did not fix the still rendering issue, and will be followed up with a different approach in a later commit.

:eyes: @kkaefer @brunoabinader 