### PR TITLE
Test and document `willStartLoading` & `didFinishLoading` delegate methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Known issues:
 - A new delegate callback was added for observing taps to annotation callout views. ([#2596](https://github.com/mapbox/mapbox-gl-native/pull/2596))
 - `-mapViewRegionIsChanging:` is now sent to the map view’s delegate during gestures. ([#2700](https://github.com/mapbox/mapbox-gl-native/pull/2700))
 - Improved gesture recognition while the map is tilted. ([#2770](https://github.com/mapbox/mapbox-gl-native/pull/2770))
+- `-mapViewWillStartLoadingMap:` and `-mapViewDidFinishLoadingMap:` delegate methods now work. ([#2706](https://github.com/mapbox/mapbox-gl-native/pull/2706))
 - Removed CoreTelephony.framework dependency. ([#2581](https://github.com/mapbox/mapbox-gl-native/pull/2581))
 - Improved user location annotation responsiveness. ([#2643](https://github.com/mapbox/mapbox-gl-native/pull/2643))
 

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -414,14 +414,20 @@ IB_DESIGNABLE
  *   @param animated Whether the change caused an animated effect on the map. */
 - (void)mapView:(MGLMapView *)mapView regionDidChangeAnimated:(BOOL)animated;
 
-#pragma mark - Loading the Map Data
+#pragma mark - Loading the Map
 
-/** @name Loading the Map Data */
+/** @name Loading the Map */
 
-// TODO
+/** Tells the delegate that the map view will begin to load.
+ *
+ *   This method is called whenever the map view starts loading, including when a new style has been set and the map must reload.
+ *   @param mapView The map view that is starting to load. */
 - (void)mapViewWillStartLoadingMap:(MGLMapView *)mapView;
 
-// TODO
+/** Tells the delegate that the map view has finished loading.
+ *
+ *   This method is called whenever the map view finishes loading, either after the initial load or after a style change has forced a reload.
+ *   @param mapView The map view that has finished loading. */
 - (void)mapViewDidFinishLoadingMap:(MGLMapView *)mapView;
 
 // TODO


### PR DESCRIPTION
With #630 and #2627, the map loading notifications should be being sent from core MBGL, which means that the `mapViewWillStartLoadingMap:` & `mapViewDidFinishLoadingMap:` delegate methods that already exist in `MGLMapViewDelegate` should be ready for use.

- [x] Make sure the current delegate methods [are actually hooked up](https://github.com/mapbox/mapbox-gl-native/blob/17121563ac807fbc68a203ac08c64de5711d8b92/platform/ios/MGLMapView.mm#L3001-L3016)
- [x] Update [core changelog](https://github.com/mapbox/mapbox-gl-native/blob/master/CHANGELOG.md)
- [x] Update [iOS docs](https://github.com/mapbox/mapbox-gl-native/blob/17121563ac807fbc68a203ac08c64de5711d8b92/include/mbgl/ios/MGLMapView.h#L437-L441)
- [ ] Is this testable? If so, write tests.

/cc @incanus @1ec5