### PR TITLE
[android] Use ViewCompat in CompassView for pre-Jelly Bean animation

### DIFF
--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/CompassView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/CompassView.java
@@ -1,14 +1,13 @@
 package com.mapbox.mapboxsdk.views;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.content.Context;
-import android.os.Build;
 import android.support.v4.content.ContextCompat;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.ViewPropertyAnimatorCompat;
+import android.support.v4.view.ViewPropertyAnimatorListenerAdapter;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewPropertyAnimator;
 import android.widget.ImageView;
 
 import com.mapbox.mapboxsdk.R;
@@ -21,7 +20,7 @@ final class CompassView extends ImageView {
 
     private Timer mNorthTimer;
     private double mDirection = 0.0f;
-    private ViewPropertyAnimator mFadeAnimator;
+    private ViewPropertyAnimatorCompat mFadeAnimator;
 
     public CompassView(Context context) {
         super(context);
@@ -107,13 +106,10 @@ final class CompassView extends ImageView {
                             @Override
                             public void run() {
                                 setAlpha(1.0f);
-                                mFadeAnimator = animate().alpha(0.0f).setDuration(1000);
-                                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                                    mFadeAnimator.withLayer();
-                                }
-                                mFadeAnimator.setListener(new AnimatorListenerAdapter() {
+                                mFadeAnimator = ViewCompat.animate(CompassView.this).alpha(0.0f).setDuration(1000).withLayer();
+                                mFadeAnimator.setListener(new ViewPropertyAnimatorListenerAdapter() {
                                     @Override
-                                    public void onAnimationEnd(Animator animation) {
+                                    public void onAnimationEnd(View view) {
                                         setVisibility(View.INVISIBLE);
                                         mNorthTimer = null;
                                     }

--- a/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/android/java/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -3082,7 +3082,7 @@ public final class MapView extends FrameLayout {
      * While enabled, the my-location layer continuously draws an indication of a user's current
      * location and bearing.
      * <p/>
-     * In order to use the my-location-layer feature you need to request permission for either
+     * In order to use the my-location layer feature you need to request permission for either
      * {@link android.Manifest.permission#ACCESS_COARSE_LOCATION}
      * or @link android.Manifest.permission#ACCESS_FINE_LOCATION.
      *


### PR DESCRIPTION
Fixes possible problem with using `withLayer()` on API < 16