### PR TITLE
[core] Move parseCacheControl() up in the class hierarchy

### DIFF
--- a/platform/android/http_request_android.cpp
+++ b/platform/android/http_request_android.cpp
@@ -2,7 +2,6 @@
 #include <mbgl/storage/http_request_base.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
-#include <mbgl/util/chrono.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/android/jni.hpp>
 
@@ -246,21 +245,6 @@ void HTTPAndroidRequest::finish() {
     }
 
     delete this;
-}
-
-int64_t parseCacheControl(const char *value) {
-    if (value) {
-        unsigned long long seconds = 0;
-        // TODO: cache-control may contain other information as well:
-        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
-        if (std::sscanf(value, "max-age=%llu", &seconds) == 1) {
-            return std::chrono::duration_cast<std::chrono::seconds>(
-                       std::chrono::system_clock::now().time_since_epoch()).count() +
-                   seconds;
-        }
-    }
-
-    return 0;
 }
 
 void HTTPAndroidRequest::onResponse(int code, std::string message, std::string etag, std::string modified, std::string cacheControl, std::string expires, std::string body) {

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -198,21 +198,6 @@ void HTTPNSURLRequest::cancel() {
     }
 }
 
-int64_t parseCacheControl(const char *value) {
-    if (value) {
-        unsigned long long seconds = 0;
-        // TODO: cache-control may contain other information as well:
-        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
-        if (std::sscanf(value, "max-age=%llu", &seconds) == 1) {
-            return std::chrono::duration_cast<std::chrono::seconds>(
-                       std::chrono::system_clock::now().time_since_epoch()).count() +
-                   seconds;
-        }
-    }
-
-    return 0;
-}
-
 void HTTPNSURLRequest::handleResult(NSData *data, NSURLResponse *res, NSError *error) {
     if (error) {
         if ([error code] == NSURLErrorCancelled) {

--- a/platform/default/http_request_curl.cpp
+++ b/platform/default/http_request_curl.cpp
@@ -2,7 +2,6 @@
 #include <mbgl/storage/http_request_base.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
-#include <mbgl/util/chrono.hpp>
 #include <mbgl/platform/log.hpp>
 
 #include <mbgl/util/time.hpp>
@@ -539,21 +538,6 @@ size_t headerMatches(const char *const header, const char *const buffer, const s
         i++;
     }
     return i == headerLength ? i : std::string::npos;
-}
-
-int64_t parseCacheControl(const char *value) {
-    if (value) {
-        unsigned long long seconds = 0;
-        // TODO: cache-control may contain other information as well:
-        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
-        if (std::sscanf(value, "max-age=%llu", &seconds) == 1) {
-            return std::chrono::duration_cast<std::chrono::seconds>(
-                       SystemClock::now().time_since_epoch()).count() +
-                   seconds;
-        }
-    }
-
-    return 0;
 }
 
 size_t HTTPCURLRequest::headerCallback(char *const buffer, const size_t size, const size_t nmemb, void *userp) {

--- a/src/mbgl/storage/http_request_base.cpp
+++ b/src/mbgl/storage/http_request_base.cpp
@@ -1,0 +1,22 @@
+#include <mbgl/storage/http_request_base.hpp>
+
+#include <mbgl/util/chrono.hpp>
+
+namespace mbgl {
+
+int64_t HTTPRequestBase::parseCacheControl(const char *value) {
+    if (value) {
+        unsigned long long seconds = 0;
+        // TODO: cache-control may contain other information as well:
+        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9
+        if (std::sscanf(value, "max-age=%llu", &seconds) == 1) {
+            return std::chrono::duration_cast<std::chrono::seconds>(
+                       std::chrono::system_clock::now().time_since_epoch()).count() +
+                   seconds;
+        }
+    }
+
+    return 0;
+}
+
+}

--- a/src/mbgl/storage/http_request_base.hpp
+++ b/src/mbgl/storage/http_request_base.hpp
@@ -46,6 +46,8 @@ public:
     virtual void retry() = 0;
 
 protected:
+    static int64_t parseCacheControl(const char *value);
+
     bool cancelled;
 };
 


### PR DESCRIPTION
Avoid duplicating it on all the ports.