### PR TITLE
FileSource HTTPNSURLRequest::start() crash

### DIFF
--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -125,7 +125,6 @@ void HTTPNSURLRequest::start() {
     attempts++;
 
     @autoreleasepool {
-        
         NSURL *url = [NSURL URLWithString:@(resource.url.c_str())];
         if (context->accountType == 0 &&
             ([url.host isEqualToString:@"mapbox.com"] || [url.host hasSuffix:@".mapbox.com"])) {
@@ -317,7 +316,7 @@ void HTTPNSURLRequest::retry(uint64_t timeout) {
 void HTTPNSURLRequest::retry() {
     // All batons get notified when the network status changed, but some of them
     // might not actually wait for the network to become available again.
-    if (strategy == PreemptImmediately) {
+    if (strategy == PreemptImmediately && !task) {
         // Triggers the timer upon the next event loop iteration.
         timer.stop();
         timer.start(0, 0, [this] { start(); });

--- a/test/storage/http_retry_network_status.cpp
+++ b/test/storage/http_retry_network_status.cpp
@@ -1,0 +1,52 @@
+#include "storage.hpp"
+
+#include <uv.h>
+
+#include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/storage/network_status.hpp>
+
+
+// Test for https://github.com/mapbox/mapbox-gl-native/issues/2123
+//
+// A request is made. While the request is in progress, the network status changes. This should
+// trigger an immediate retry of all requests that are not in progress. This test makes sure that
+// we don't accidentally double-trigger the request.
+
+TEST_F(Storage, HTTPNetworkStatusChange) {
+    SCOPED_TEST(HTTPNetworkStatusChange)
+
+    using namespace mbgl;
+
+    DefaultFileSource fs(nullptr);
+
+    const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/delayed" };
+
+    // This request takes 200 milliseconds to answer.
+    Request* req = fs.request(resource, uv_default_loop(), [&](const Response& res) {
+         fs.cancel(req);
+         EXPECT_EQ(Response::Successful, res.status);
+         EXPECT_EQ(false, res.stale);
+         ASSERT_TRUE(res.data.get());
+         EXPECT_EQ("Response", *res.data);
+         EXPECT_EQ(0, res.expires);
+         EXPECT_EQ(0, res.modified);
+         EXPECT_EQ("", res.etag);
+         EXPECT_EQ("", res.message);
+         HTTPNetworkStatusChange.finish();
+    });
+
+    // After 50 milliseconds, we're going to trigger a NetworkStatus change.
+    uv_timer_t reachableTimer;
+    uv_timer_init(uv_default_loop(), &reachableTimer);
+    uv_timer_start(&reachableTimer, [] (uv_timer_t*) {
+        mbgl::NetworkStatus::Reachable();
+    }, 50, 0);
+
+    // This timer will keep the loop alive to make sure we would be getting a response in caes the
+    // network status change triggered another change (which it shouldn't).
+    uv_timer_t delayTimer;
+    uv_timer_init(uv_default_loop(), &delayTimer);
+    uv_timer_start(&delayTimer, [] (uv_timer_t*) {}, 300, 0);
+
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+}

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -84,6 +84,7 @@
         'storage/http_issue_1369.cpp',
         'storage/http_load.cpp',
         'storage/http_other_loop.cpp',
+        'storage/http_retry_network_status.cpp',
         'storage/http_reading.cpp',
         'storage/http_timeout.cpp',
 


### PR DESCRIPTION
Networking crash while panning around on `iosapp`.

iPhone 5, **iOS 9b4**, testing the `perspective` branch (#2116) @ f34e037.

[Full crash log here](https://gist.github.com/friedbunny/cf44837091691785d54f).

```
Hardware Model:      iPhone5,1
Identifier:          com.mapbox.MapboxGL

Date/Time:           2015-08-18 17:38:57.57 -0400
Launch Time:         2015-08-18 17:19:26.26 -0400
OS Version:          iOS 9.0 (13A4325c)
Report Version:      105

Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000
Exception Note:  EXC_CORPSE_NOTIFY
Triggered by Thread:  4

Global Trace Buffer (reverse chronological seconds):
25.492606    CFNetwork                 	0x0000000022c2a6a9 NSURLSessionTask finished with error - code: -999
25.509530    CFNetwork                 	0x0000000022bd0c33 TCP Conn 0x16e0ac90 starting SSL negotiation
25.510032    CFNetwork                 	0x0000000022c50715 TCP Conn 0x16e0ac90 complete. fd: 46, err: 0
25.511438    CFNetwork                 	0x0000000022c51817 TCP Conn 0x16e0ac90 event 1. err: 0
25.567740    CFNetwork                 	0x0000000022c51895 TCP Conn 0x16e0ac90 started
25.590485    CFNetwork                 	0x0000000022c2a6a9 NSURLSessionTask finished with error - code: -999
27.339450    CFNetwork                 	0x0000000022bd0cf9 TCP Conn 0x18fdead0 SSL Handshake DONE
27.579481    CFNetwork                 	0x0000000022bd0c33 TCP Conn 0x18fdead0 starting SSL negotiation
27.580077    CFNetwork                 	0x0000000022c50715 TCP Conn 0x18fdead0 complete. fd: 46, err: 0
27.580647    CFNetwork                 	0x0000000022c51817 TCP Conn 0x18fdead0 event 1. err: 0
27.666185    CFNetwork                 	0x0000000022c51895 TCP Conn 0x18fdead0 started
27.809069    CFNetwork                 	0x0000000022c2a6a9 NSURLSessionTask finished with error - code: -999
27.811091    CFNetwork                 	0x0000000022c2a6a9 NSURLSessionTask finished with error - code: -999
27.878498    CFNetwork                 	0x0000000022c2a6a9 NSURLSessionTask finished with error - code: -999
27.885424    CFNetwork                 	0x0000000022c2a6a9 NSURLSessionTask finished with error - code: -999
27.888641    CFNetwork                 	0x0000000022c2a6a9 NSURLSessionTask finished with error - code: -999
27.893229    CFNetwork                 	0x0000000022bd0cf9 TCP Conn 0x1c0767c0 SSL Handshake DONE
28.124076    CFNetwork                 	0x0000000022bd0cf9 TCP Conn 0x1c0e9c20 SSL Handshake DONE
28.204113    CFNetwork                 	0x0000000022bd0c33 TCP Conn 0x18fa0120 starting SSL negotiation
28.205444    CFNetwork                 	0x0000000022bd0c33 TCP Conn 0x1c0767c0 starting SSL negotiation
28.205726    CFNetwork                 	0x0000000022c50715 TCP Conn 0x18fa0120 complete. fd: 51, err: 0
28.206028    CFNetwork                 	0x0000000022bd0cf9 TCP Conn 0x16d209c0 SSL Handshake DONE
28.206133    CFNetwork                 	0x0000000022c50715 TCP Conn 0x1c0767c0 complete. fd: 46, err: 0
28.206941    CFNetwork                 	0x0000000022c51817 TCP Conn 0x18fa0120 event 1. err: 0
28.206941    CFNetwork                 	0x0000000022c51817 TCP Conn 0x1c0767c0 event 1. err: 0
28.213566    CFNetwork                 	0x0000000022bd0cf9 TCP Conn 0x1c088870 SSL Handshake DONE
28.297061    CFNetwork                 	0x0000000022c51895 TCP Conn 0x18fa0120 started
28.297061    CFNetwork                 	0x0000000022c51895 TCP Conn 0x1c0767c0 started
28.455525    CFNetwork                 	0x0000000022c2a6a9 NSURLSessionTask finished with error - code: -999
28.457548    CFNetwork                 	0x0000000022bd0c33 TCP Conn 0x1c0e9c20 starting SSL negotiation
28.458989    CFNetwork                 	0x0000000022c50715 TCP Conn 0x1c0e9c20 complete. fd: 59, err: 0
28.493677    CFNetwork                 	0x0000000022c51817 TCP Conn 0x1c0e9c20 event 1. err: 0
28.585237    CFNetwork                 	0x0000000022c51895 TCP Conn 0x1c0e9c20 started
28.609777    CFNetwork                 	0x0000000022bd0c33 TCP Conn 0x16d209c0 starting SSL negotiation
28.611284    CFNetwork                 	0x0000000022c50715 TCP Conn 0x16d209c0 complete. fd: 54, err: 0
28.619713    CFNetwork                 	0x0000000022c51817 TCP Conn 0x16d209c0 event 1. err: 0



Thread 0 name:  Dispatch queue: com.apple.main-thread
Thread 0:
0   libsystem_kernel.dylib        	0x35138130 mach_msg_trap + 20
1   libsystem_kernel.dylib        	0x35137f30 mach_msg + 40
2   CoreFoundation                	0x2335a0cc __CFRunLoopServiceMachPort + 136
3   CoreFoundation                	0x23358452 __CFRunLoopRun + 1050
4   CoreFoundation                	0x232aad88 CFRunLoopRunSpecific + 516
5   CoreFoundation                	0x232aab7c CFRunLoopRunInMode + 108
6   GraphicsServices              	0x2c47daf8 GSEventRunModal + 160
7   UIKit                         	0x274d399c UIApplicationMain + 144
8   Mapbox GL                     	0x000fd984 main (main.m:8)
9   libdyld.dylib                 	0x3507c872 start + 2

Thread 4 name:  FileSource
Thread 4 Crashed:
0   libsystem_kernel.dylib        	0x3514bd24 __pthread_kill + 8
1   libsystem_pthread.dylib       	0x351ebb5a pthread_kill + 62
2   libsystem_c.dylib             	0x350e3f50 abort + 108
3   libsystem_c.dylib             	0x350c36de __assert_rtn + 302
4   Mapbox GL                     	0x003e4738 mbgl::HTTPNSURLRequest::start() (http_request_nsurl.mm:123)
5   Mapbox GL                     	0x003e8db4 mbgl::HTTPNSURLRequest::retry()::$_2::operator()() const (http_request_nsurl.mm:332)
6   Mapbox GL                     	0x003e8d76 void std::__1::__invoke_void_return_wrapper<void>::__call<mbgl::HTTPNSURLRequest::retry()::$_2&>(mbgl::HTTPNSURLRequest::retry()::$_2&&&) (__functional_base:440)
7   Mapbox GL                     	0x003e8c40 std::__1::__function::__func<mbgl::HTTPNSURLRequest::retry()::$_2, std::__1::allocator<mbgl::HTTPNSURLRequest::retry()::$_2>, void ()>::operator()() (functional:1407)
8   Mapbox GL                     	0x001cc36c std::__1::function<void ()>::operator()() const (functional:1793)
9   Mapbox GL                     	0x003e9c78 uv::timer::timer_cb(uv_timer_s*, int) (uv_detail.hpp:161)
10  Mapbox GL                     	0x0040c43c uv__run_timers (timer.c:140)
11  Mapbox GL                     	0x00401102 uv_run (core.c:309)
12  Mapbox GL                     	0x003f225e uv::loop::run() (uv_detail.hpp:62)
13  Mapbox GL                     	0x0029426e void mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::run<std::__1::tuple<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>, 0ul, 1ul>(mbgl::util::ThreadContext, std::__1::tuple<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>&&, std::__1::integer_sequence<unsigned long, 0ul, 1ul>) (thread.hpp:125)
14  Mapbox GL                     	0x00294104 mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(mbgl::util::ThreadContext const&, mbgl::FileCache*&&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&)::'lambda'()::operator()() const (thread.hpp:104)
15  Mapbox GL                     	0x00293e86 std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<mbgl::FileCache*&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&>(mbgl::util::ThreadContext const&, mbgl::FileCache*&&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&)::'lambda'()> >(void*, void*) (thread:347)
16  libsystem_pthread.dylib       	0x351eac92 _pthread_body + 138
17  libsystem_pthread.dylib       	0x351eac06 _pthread_start + 110
18  libsystem_pthread.dylib       	0x351e8a24 thread_start + 8

Thread 6 name:  Map
Thread 6:
0   libsystem_pthread.dylib       	0x351e8fcc pthread_mutex_unlock + 48
1   libc++.1.dylib                	0x340edd4e std::__1::mutex::unlock() + 82
2   Mapbox GL                     	0x001fe6ac mbgl::TileWorker::getBucket(mbgl::StyleLayer const&) const (tile_worker.cpp:45)
3   Mapbox GL                     	0x0022f864 mbgl::VectorTileData::getBucket(mbgl::StyleLayer const&) (vector_tile_data.cpp:99)
4   Mapbox GL                     	0x0023374c mbgl::VectorTileData::redoPlacement(float, float, bool)::$_2::operator()() const (vector_tile_data.cpp:122)
5   Mapbox GL                     	0x0023365a void std::__1::__invoke_void_return_wrapper<void>::__call<mbgl::VectorTileData::redoPlacement(float, float, bool)::$_2&>(mbgl::VectorTileData::redoPlacement(float, float, bool)::$_2&&&) (__functional_base:440)
6   Mapbox GL                     	0x00233524 std::__1::__function::__func<mbgl::VectorTileData::redoPlacement(float, float, bool)::$_2, std::__1::allocator<mbgl::VectorTileData::redoPlacement(float, float, bool)::$_2>, void ()>::operator()() (functional:1407)
7   Mapbox GL                     	0x001cc36c std::__1::function<void ()>::operator()() const (functional:1793)
8   Mapbox GL                     	0x00394406 _ZZN4mbgl4util7RunLoop18invokeWithCallbackIZNS0_6ThreadINS_6Worker4ImplEE4bindIMS5_FvPNS_10TileWorkerEffbNSt3__18functionIFvvEEEEEEDaT_EUlDpOT_E_RSD_JS9_RfSN_RbEEENSA_10unique_ptrINS_11WorkRequestENSA_14default_deleteISQ_EEEEOSH_OT0_DpOT1_ENKUlSK_E_clIJEEEDaSK_ (run_loop.hpp:72)
9   Mapbox GL                     	0x003943b8 _ZN4mbgl4util7RunLoop7InvokerIKZNS1_18invokeWithCallbackIZNS0_6ThreadINS_6Worker4ImplEE4bindIMS6_FvPNS_10TileWorkerEffbNSt3__18functionIFvvEEEEEEDaT_EUlDpOT_E_RSE_JSA_RfSO_RbEEENSB_10unique_ptrINS_11WorkRequestENSB_14default_deleteISR_EEEEOSI_OT0_DpOT1_EUlSL_E_NSB_5tupleIJEEEE6invokeIJEEEvNSB_16integer_sequenceImJXspT_EEEE (run_loop.hpp:133)
10  Mapbox GL                     	0x0039421a _ZN4mbgl4util7RunLoop7InvokerIKZNS1_18invokeWithCallbackIZNS0_6ThreadINS_6Worker4ImplEE4bindIMS6_FvPNS_10TileWorkerEffbNSt3__18functionIFvvEEEEEEDaT_EUlDpOT_E_RSE_JSA_RfSO_RbEEENSB_10unique_ptrINS_11WorkRequestENSB_14default_deleteISR_EEEEOSI_OT0_DpOT1_EUlSL_E_NSB_5tupleIJEEEEclEv (run_loop.hpp:113)
11  Mapbox GL                     	0x0036c316 mbgl::util::RunLoop::process() (run_loop.cpp:27)
12  Mapbox GL                     	0x0036fca0 void std::__1::__invoke_void_return_wrapper<void>::__call<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) (__functional_base:440)
13  Mapbox GL                     	0x0036fb08 std::__1::__function::__func<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>, std::__1::allocator<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*> >, void ()>::operator()() (functional:1407)
14  Mapbox GL                     	0x001cc36c std::__1::function<void ()>::operator()() const (functional:1793)
15  Mapbox GL                     	0x001cc130 uv::async::async_cb(uv_async_s*, int) (uv_detail.hpp:127)
16  Mapbox GL                     	0x00400a6a uv__async_event (async.c:76)
17  Mapbox GL                     	0x00400cd4 uv__async_io (async.c:156)
18  Mapbox GL                     	0x00411f3e uv__io_poll (kqueue.c:234)
19  Mapbox GL                     	0x00401132 uv_run (core.c:318)
20  Mapbox GL                     	0x003f225e uv::loop::run() (uv_detail.hpp:62)
21  Mapbox GL                     	0x0019b08c void mbgl::util::Thread<mbgl::MapContext>::run<std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>, 0ul, 1ul, 2ul>(mbgl::util::ThreadContext, std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>&&, std::__1::integer_sequence<unsigned long, 0ul, 1ul, 2ul>) (thread.hpp:125)
22  Mapbox GL                     	0x0019af14 mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()::operator()() const (thread.hpp:104)
23  Mapbox GL                     	0x0019ac96 std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()> >(void*, void*) (thread:347)
24  libsystem_pthread.dylib       	0x351eac92 _pthread_body + 138
25  libsystem_pthread.dylib       	0x351eac06 _pthread_start + 110
26  libsystem_pthread.dylib       	0x351e8a24 thread_start + 8

...
```

/cc @tmpsantos @kkaefer