### PR TITLE
Allow users to notify us when they are driving our maps via their own…

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -304,6 +304,10 @@ IB_DESIGNABLE
 *   @param animated If `YES`, the callout view is animated offscreen. */
 - (void)deselectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated;
 
+#pragma mark - User Animations
+
+- (void)setUserAnimating:(BOOL)userAnimating;
+
 #pragma mark - Adding Overlays
 
 /** @name Adding Overlays */

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -91,6 +91,10 @@ public:
     bool isRotating() const;
     bool isScaling() const;
     bool isPanning() const;
+    
+    // User Animating
+    void setUserAnimating(bool);
+    bool isUserAnimating() const;
 
     // Camera
     void jumpTo(CameraOptions options);

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1646,6 +1646,11 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     return [NSSet setWithObject:@"camera"];
 }
 
+- (void)setUserAnimating:(BOOL)userAnimating
+{
+    _mbglMap->setUserAnimating(userAnimating);
+}
+
 - (double)zoomLevel
 {
     return _mbglMap->getZoom();

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -130,6 +130,14 @@ bool Map::isGestureInProgress() const {
     return transform->isGestureInProgress();
 }
 
+void Map::setUserAnimating(bool userAnimating) {
+    context->invokeSync<void>(&MapContext::setUpdateHint, userAnimating ? UpdateHint::UserAnimating : UpdateHint::Nothing);
+}
+
+bool Map::isUserAnimating() const {
+    return context->invokeSync<UpdateHint>(&MapContext::getUpdateHint) == UpdateHint::UserAnimating;
+}
+    
 bool Map::isRotating() const {
     return transform->isRotating();
 }

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -33,6 +33,11 @@ struct FrameData {
     std::array<uint16_t, 2> framebufferSize;
 };
 
+enum class UpdateHint : uint32_t {
+    Nothing                   = 0,
+    UserAnimating             = 1 << 1,
+};
+    
 class MapContext : public Style::Observer {
 public:
     MapContext(View&, FileSource&, MapData&);
@@ -66,6 +71,9 @@ public:
     // Style::Observer implementation.
     void onTileDataChanged() override;
     void onResourceLoadingFailed(std::exception_ptr error) override;
+    
+    void setUpdateHint(UpdateHint updateHint);
+    UpdateHint getUpdateHint() const;
 
     void dumpDebugLogs() const;
 
@@ -98,6 +106,9 @@ private:
     size_t sourceCacheSize;
     TransformState transformState;
     FrameData frameData;
+    
+    UpdateHint currentUpdateHint;
+    
 };
 
 }


### PR DESCRIPTION
… animation.

#1975 

@brunoabinader @kkaefer @incanus @tomtaylor

This is our best idea for how to support multiple use cases.  Basically the idea is this: it would be difficult and brittle for us to detect when we're being driven by an external animation source (e.g. CADisplayLink).  So we allow the user to set this hint, which improves their performance while animating.  Basically we can skip certain operations because we know that we're going to be forced to render every frame.  Then they clear it when done.  The only failure mode is that if they set this, and never clear it, we could end up in situations where fades don't fully perform because we're no longer being driven, and so we don't continue to render.  If they never set it and ignore it completely, the only behavior regression(s) are related to performance, not correctness.

Auto-detecting external animation would require us to detect that we're being modified every frame, and then force us to include an auto-canceling dispatch_async that detected when we were no longer being modified every frame.  It would be fragile and error-prone and neither I nor @incanus  were in favor of that option.