### PR TITLE
[android] #2880 - CoordinateBounds correction equals method

### DIFF
--- a/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/CoordinateBounds.java
+++ b/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/CoordinateBounds.java
@@ -46,7 +46,7 @@ public class CoordinateBounds {
         if (o instanceof CoordinateBounds) {
             CoordinateBounds other = (CoordinateBounds) o;
             return getNorthEast().equals(other.getNorthEast())
-                    && getSouthWest() == other.getSouthWest();
+                    && getSouthWest().equals(other.getSouthWest());
         }
         return false;
     }


### PR DESCRIPTION
closes #2880