### PR TITLE
patch Painter::renderSDF to fix missing labels

### DIFF
--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -67,11 +67,18 @@ void Painter::renderSDF(SymbolBucket &bucket,
 
     sdfShader.u_zoom = (state.getNormalizedZoom() - zoomAdjust) * 10; // current zoom level
 
-    FadeProperties f = frameHistory.getFadeProperties(data.getAnimationTime(), data.getDefaultFadeDuration());
-    sdfShader.u_fadedist = f.fadedist * 10;
-    sdfShader.u_minfadezoom = std::floor(f.minfadezoom * 10);
-    sdfShader.u_maxfadezoom = std::floor(f.maxfadezoom * 10);
-    sdfShader.u_fadezoom = (state.getNormalizedZoom() + f.bump) * 10;
+    if (data.mode == MapMode::Continuous) {
+        FadeProperties f = frameHistory.getFadeProperties(data.getAnimationTime(), data.getDefaultFadeDuration());
+        sdfShader.u_fadedist = f.fadedist * 10;
+        sdfShader.u_minfadezoom = std::floor(f.minfadezoom * 10);
+        sdfShader.u_maxfadezoom = std::floor(f.maxfadezoom * 10);
+        sdfShader.u_fadezoom = (state.getNormalizedZoom() + f.bump) * 10;
+    } else { // MapMode::Still
+        sdfShader.u_fadedist = 0;
+        sdfShader.u_minfadezoom = state.getNormalizedZoom() * 10;
+        sdfShader.u_maxfadezoom = state.getNormalizedZoom() * 10;
+        sdfShader.u_fadezoom = state.getNormalizedZoom() * 10;
+    }
 
     // The default gamma value has to be adjust for the current pixelratio so that we're not
     // drawing blurry font on retina screens.


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/pull/942, fixes https://github.com/mapbox/mapbox-gl-native/issues/2264.

Ignores animation and fade duration when rendering SDFs in `MapMode::Still`.

/cc @bsudekum @brunoabinader