### PR TITLE
ignore -Wunused-variable around libtess2

### DIFF
--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -7,7 +7,11 @@
 #include <mbgl/geometry/fill_buffer.hpp>
 
 #include <clipper/clipper.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #include <libtess2/tesselator.h>
+#pragma GCC diagnostic pop
 
 #include <vector>
 #include <memory>


### PR DESCRIPTION
Fixes the annoying warning below.

```
../src/libtess2/sweep.c:1139:6: warning: unused variable 'fixedEdges' [-Wunused-variable]
        int fixedEdges = 0;
            ^
  CC(target) Release/obj.target/core/src/libtess2/tess.o
1 warning generated.
```