### PR TITLE
Force Bitcode in make ipackage

### DIFF
--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -53,6 +53,8 @@ if [[ "${BUILD_FOR_DEVICE}" == true ]]; then
         ARCHS="arm64 armv7 armv7s" \
         ONLY_ACTIVE_ARCH=NO \
         GCC_GENERATE_DEBUGGING_SYMBOLS=${GCC_GENERATE_DEBUGGING_SYMBOLS} \
+        ENABLE_BITCODE=YES \
+        DEPLOYMENT_POSTPROCESSING=YES \
         -project ./build/ios-all/mbgl.xcodeproj \
         -configuration ${BUILDTYPE} \
         -target everything \


### PR DESCRIPTION
`make ipackage` now performs a Bitcode-enabled archive build for devices, making it possible to archive a Bitcode-enabled application that links against the Mapbox iOS SDK.

@incanus, can you verify that the resulting static library contains all the expected symbols? I did notice some additional missing symbol warnings in the `CreateUniversalBinary` step, such as the one below, but I think those are the same things we try to suppress when calling `libtool` with the `-no_warning_for_no_symbols` flag:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: for architecture: x86_64 file: /Users/mxn/hub/mapbox-gl-native/build/mbgl.build/Release-iphonesimulator/core.build/Objects-normal/x86_64/libmbgl-core.a(camera.o) has no symbols
```

/ref #2332
/cc @mikemorris