### PR TITLE
Strip whitespace and newlines from access token and style URL

### DIFF
--- a/platform/ios/MGLAccountManager.m
+++ b/platform/ios/MGLAccountManager.m
@@ -60,6 +60,8 @@
 }
 
 + (void) setAccessToken:(NSString *) accessToken {
+    accessToken = [accessToken stringByTrimmingCharactersInSet:
+                   [NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if ( ! [accessToken length]) return;
     
     [MGLAccountManager sharedManager].accessToken = accessToken;

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -3303,6 +3303,8 @@ class MBGLView : public mbgl::View
 
 - (void)setStyleURL__:(nullable NSString *)URLString
 {
+    URLString = [URLString stringByTrimmingCharactersInSet:
+                 [NSCharacterSet whitespaceAndNewlineCharacterSet]];
     NSURL *url = URLString.length ? [NSURL URLWithString:URLString] : nil;
     if (URLString.length && !url)
     {


### PR DESCRIPTION
Just in case browser weirdness or a tendency to triple-click-select is causing some cases of #2012.

Ordinarily we’d want this kind of logic down in mbgl, but I think it belongs up here too because:

* The access token is stored as an instance variable of MGLAccountManager, and I think that ivar should have the correct value too.
* The inspectable style URL string gets transformed into an NSURL in `-[MGLMapView setStyleURL__:]`. NSURL demands RFC 1738/2732 well-formedness, so if the string has leading whitespace, the transformation will fail and you’ll wind up w/ no URL (and the default style).

/cc @friedbunny