### PR TITLE
Catch compression errors

### DIFF
--- a/platform/default/sqlite_cache.cpp
+++ b/platform/default/sqlite_cache.cpp
@@ -133,6 +133,9 @@ void SQLiteCache::Impl::get(const Resource &resource, Callback callback) {
     } catch (mapbox::sqlite::Exception& ex) {
         Log::Error(Event::Database, ex.code, ex.what());
         callback(nullptr);
+    } catch (std::runtime_error& ex) {
+        Log::Error(Event::Database, ex.what());
+        callback(nullptr);
     }
 }
 
@@ -200,6 +203,8 @@ void SQLiteCache::Impl::put(const Resource& resource, std::shared_ptr<const Resp
         putStmt->run();
     } catch (mapbox::sqlite::Exception& ex) {
         Log::Error(Event::Database, ex.code, ex.what());
+    } catch (std::runtime_error& ex) {
+        Log::Error(Event::Database, ex.what());
     }
 }
 


### PR DESCRIPTION
When a database file gets corrupted, or compression fails, we're currently throwing an error, which doesn't get caught.