### PR TITLE
Move remaining GL state into GLConfig object

### DIFF
--- a/src/mbgl/renderer/gl_config.cpp
+++ b/src/mbgl/renderer/gl_config.cpp
@@ -17,6 +17,9 @@ const ColorMask::Type ColorMask::Default = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE 
 const ClearDepth::Type ClearDepth::Default = 1;
 const ClearColor::Type ClearColor::Default = { 0, 0, 0, 0 };
 const ClearStencil::Type ClearStencil::Default = 0;
+const Program::Type Program::Default = 0;
+const LineWidth::Type LineWidth::Default = 1;
+const Viewport::Type Viewport::Default = { 0, 0, 0, 0 };
 
 }
 }

--- a/src/mbgl/renderer/gl_config.hpp
+++ b/src/mbgl/renderer/gl_config.hpp
@@ -240,6 +240,49 @@ struct BlendFunc {
     }
 };
 
+struct Program {
+    using Type = GLuint;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glUseProgram(value));
+    }
+    inline static Type Get() {
+        GLint program;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_CURRENT_PROGRAM, &program));
+        return program;
+    }
+};
+
+struct LineWidth {
+    using Type = GLfloat;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glLineWidth(value));
+    }
+    inline static Type Get() {
+        Type lineWidth;
+        MBGL_CHECK_ERROR(glGetFloatv(GL_LINE_WIDTH, &lineWidth));
+        return lineWidth;
+    }
+};
+
+struct Viewport {
+    struct Type { GLint x, y; GLsizei width, height; };
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glViewport(value.x, value.y, value.width, value.height));
+    }
+    inline static Type Get() {
+        GLint viewport[4];
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_VIEWPORT, viewport));
+        return { viewport[0], viewport[1], viewport[2], viewport[3] };
+    }
+};
+
+inline bool operator!=(const Viewport::Type& a, const Viewport::Type& b) {
+    return a.x != b.x || a.y != b.y || a.width != b.width || a.height != b.height;
+}
+
 class Config {
 public:
     void reset() {
@@ -257,6 +300,9 @@ public:
         clearDepth.reset();
         clearColor.reset();
         clearStencil.reset();
+        program.reset();
+        lineWidth.reset();
+        viewport.reset();
     }
 
     void restore() {
@@ -274,6 +320,9 @@ public:
         clearDepth.restore();
         clearColor.restore();
         clearStencil.restore();
+        program.restore();
+        lineWidth.restore();
+        viewport.restore();
     }
 
     void save() {
@@ -291,6 +340,9 @@ public:
         clearDepth.save();
         clearColor.save();
         clearStencil.save();
+        program.save();
+        lineWidth.save();
+        viewport.save();
     }
 
     Value<StencilFunc> stencilFunc;
@@ -307,6 +359,9 @@ public:
     Value<ClearDepth> clearDepth;
     Value<ClearColor> clearColor;
     Value<ClearStencil> clearStencil;
+    Value<Program> program;
+    Value<LineWidth> lineWidth;
+    Value<Viewport> viewport;
 };
 
 } // namespace gl

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -92,25 +92,7 @@ void Painter::setupShaders() {
 }
 
 void Painter::resize() {
-    if (gl_viewport != frame.framebufferSize) {
-        gl_viewport = frame.framebufferSize;
-        assert(gl_viewport[0] > 0 && gl_viewport[1] > 0);
-        MBGL_CHECK_ERROR(glViewport(0, 0, gl_viewport[0], gl_viewport[1]));
-    }
-}
-
-void Painter::useProgram(GLuint program) {
-    if (gl_program != program) {
-        MBGL_CHECK_ERROR(glUseProgram(program));
-        gl_program = program;
-    }
-}
-
-void Painter::lineWidth(GLfloat line_width) {
-    if (gl_lineWidth != line_width) {
-        MBGL_CHECK_ERROR(glLineWidth(line_width));
-        gl_lineWidth = line_width;
-    }
+    config.viewport = { 0, 0, frame.framebufferSize[0], frame.framebufferSize[1] };
 }
 
 void Painter::changeMatrix() {
@@ -376,7 +358,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         SpriteAtlasPosition imagePosB = spriteAtlas->getPosition(properties.image.to, true);
         float zoomFraction = state.getZoomFraction();
 
-        useProgram(patternShader->program);
+        config.program = patternShader->program;
         patternShader->u_matrix = identityMatrix;
         patternShader->u_pattern_tl_a = imagePosA.tl;
         patternShader->u_pattern_br_a = imagePosA.br;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -162,10 +162,6 @@ private:
     void setDepthSublayer(int n);
 
 public:
-    void useProgram(GLuint program);
-    void lineWidth(GLfloat lineWidth);
-
-public:
     mat4 projMatrix;
     mat4 nativeMatrix;
     mat4 extrudeMatrix;
@@ -194,9 +190,6 @@ private:
 
     gl::Config config;
 
-    GLuint gl_program = 0;
-    GLfloat gl_lineWidth = 0;
-    std::array<uint16_t, 2> gl_viewport = {{ 0, 0 }};
     RenderPass pass = RenderPass::Opaque;
     Color background = {{ 0, 0, 0, 0 }};
 
@@ -259,14 +252,6 @@ public:
     };
 
     VertexArrayObject tileBorderArray;
-
-    // Framebuffer management
-    std::vector<GLuint> fbos;
-    std::vector<GLuint> fbos_color;
-    GLuint fbo_depth_stencil;
-    int fbo_level = -1;
-    bool fbo_depth_stencil_valid = false;
-
 };
 
 }

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -35,7 +35,7 @@ void Painter::renderCircle(CircleBucket& bucket,
     // are inversely related.
     float antialiasing = 1 / data.pixelRatio / properties.radius;
 
-    useProgram(circleShader->program);
+    config.program = circleShader->program;
 
     circleShader->u_matrix = vtxMatrix;
     circleShader->u_exmatrix = extrudeMatrix;

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -9,7 +9,7 @@ using namespace mbgl;
 void Painter::drawClippingMasks(const std::set<Source*>& sources) {
     MBGL_DEBUG_GROUP("clipping masks");
 
-    useProgram(plainShader->program);
+    config.program = plainShader->program;
     config.stencilTest = true;
     config.depthTest = true;
     config.depthMask = GL_FALSE;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -28,12 +28,12 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
         tileData.debugBucket = std::make_unique<DebugBucket>(tileData.id, tileData.getState());
     }
 
-    useProgram(plainShader->program);
+    config.program = plainShader->program;
     plainShader->u_matrix = matrix;
 
     // Draw white outline
     plainShader->u_color = {{ 1.0f, 1.0f, 1.0f, 1.0f }};
-    lineWidth(4.0f * data.pixelRatio);
+    config.lineWidth = 4.0f * data.pixelRatio;
     tileData.debugBucket->drawLines(*plainShader);
 
 #ifndef GL_ES_VERSION_2_0
@@ -44,7 +44,7 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
 
     // Draw black text.
     plainShader->u_color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
-    lineWidth(2.0f * data.pixelRatio);
+    config.lineWidth = 2.0f * data.pixelRatio;
     tileData.debugBucket->drawLines(*plainShader);
 
     config.depthTest = true;
@@ -59,12 +59,12 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     config.depthTest = false;
     config.stencilTest = true;
 
-    useProgram(plainShader->program);
+    config.program = plainShader->program;
     plainShader->u_matrix = matrix;
 
     // draw tile outline
     tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET_0);
     plainShader->u_color = {{ 1.0f, 0.0f, 0.0f, 1.0f }};
-    lineWidth(4.0f * data.pixelRatio);
+    config.lineWidth = 4.0f * data.pixelRatio;
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, (GLsizei)tileBorderBuffer.index()));
 }

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -42,9 +42,9 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // befrom, we have to draw the outline first (!)
     if (outline && pass == RenderPass::Translucent) {
-        useProgram(outlineShader->program);
+        config.program = outlineShader->program;
         outlineShader->u_matrix = vtxMatrix;
-        lineWidth(2.0f); // This is always fixed and does not depend on the pixelRatio!
+        config.lineWidth = 2.0f; // This is always fixed and does not depend on the pixelRatio!
 
         outlineShader->u_color = stroke_color;
 
@@ -76,7 +76,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
                     1.0f / (posB.size[0] * factor * properties.image.toScale),
                     1.0f / (posB.size[1] * factor * properties.image.toScale));
 
-            useProgram(patternShader->program);
+            config.program = patternShader->program;
             patternShader->u_matrix = vtxMatrix;
             patternShader->u_pattern_tl_a = posA.tl;
             patternShader->u_pattern_br_a = posA.br;
@@ -104,7 +104,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
             // fragments or when it's translucent and we're drawing translucent
             // fragments
             // Draw filling rectangle.
-            useProgram(plainShader->program);
+            config.program = plainShader->program;
             plainShader->u_matrix = vtxMatrix;
             plainShader->u_color = fill_color;
 
@@ -118,9 +118,9 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // below, we have to draw the outline first (!)
     if (fringeline && pass == RenderPass::Translucent) {
-        useProgram(outlineShader->program);
+        config.program = outlineShader->program;
         outlineShader->u_matrix = vtxMatrix;
-        lineWidth(2.0f); // This is always fixed and does not depend on the pixelRatio!
+        config.lineWidth = 2.0f; // This is always fixed and does not depend on the pixelRatio!
 
         outlineShader->u_color = fill_color;
 

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -69,7 +69,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
 
     if (!properties.dash_array.from.empty()) {
 
-        useProgram(linesdfShader->program);
+        config.program = linesdfShader->program;
 
         linesdfShader->u_matrix = vtxMatrix;
         linesdfShader->u_exmatrix = extrudeMatrix;
@@ -106,7 +106,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
 
         float factor = 8.0 / std::pow(2, state.getIntegerZoom() - id.z) * id.overscaling;
 
-        useProgram(linepatternShader->program);
+        config.program = linepatternShader->program;
 
         linepatternShader->u_matrix = vtxMatrix;
         linepatternShader->u_exmatrix = extrudeMatrix;
@@ -131,7 +131,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         bucket.drawLinePatterns(*linepatternShader);
 
     } else {
-        useProgram(lineShader->program);
+        config.program = lineShader->program;
 
         lineShader->u_matrix = vtxMatrix;
         lineShader->u_exmatrix = extrudeMatrix;

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -12,7 +12,7 @@ void Painter::renderRaster(RasterBucket& bucket, const RasterLayer& layer, const
     const RasterPaintProperties& properties = layer.properties;
 
     if (bucket.hasData()) {
-        useProgram(rasterShader->program);
+        config.program = rasterShader->program;
         rasterShader->u_matrix = matrix;
         rasterShader->u_buffer = 0;
         rasterShader->u_opacity = properties.opacity;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -55,7 +55,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
     float x = state.getHeight() / 2.0f * std::tan(state.getPitch());
     float extra = (topedgelength + x) / topedgelength - 1;
 
-    useProgram(sdfShader.program);
+    config.program = sdfShader.program;
     sdfShader.u_matrix = vtxMatrix;
     sdfShader.u_exmatrix = exMatrix;
     sdfShader.u_texsize = texsize;
@@ -146,12 +146,12 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
     if (bucket.hasCollisionBoxData()) {
         config.stencilTest = true;
 
-        useProgram(collisionBoxShader->program);
+        config.program = collisionBoxShader->program;
         collisionBoxShader->u_matrix = matrix;
         collisionBoxShader->u_scale = std::pow(2, state.getNormalizedZoom() - id.z);
         collisionBoxShader->u_zoom = state.getNormalizedZoom() * 10;
         collisionBoxShader->u_maxzoom = (id.z + 1) * 10;
-        lineWidth(1.0f);
+        config.lineWidth = 1.0f;
 
         setDepthSublayer(0);
         bucket.drawCollisionBoxes(*collisionBoxShader);
@@ -219,7 +219,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
             float x = state.getHeight() / 2.0f * std::tan(state.getPitch());
             float extra = (topedgelength + x) / topedgelength - 1;
 
-            useProgram(iconShader->program);
+            config.program = iconShader->program;
             iconShader->u_matrix = vtxMatrix;
             iconShader->u_exmatrix = exMatrix;
             iconShader->u_texsize = {{ float(spriteAtlas->getWidth()) / 4.0f, float(spriteAtlas->getHeight()) / 4.0f }};


### PR DESCRIPTION
There's still some GL state that we're managing directly in the painter object; in particular the program, line width and viewport. We should move those to the GLConfig object.