### PR TITLE
[core] Remove the ability to change cross-fade durations via transition

### DIFF
--- a/src/mbgl/layer/background_layer.cpp
+++ b/src/mbgl/layer/background_layer.cpp
@@ -7,7 +7,7 @@ void BackgroundLayer::parsePaints(const JSVal& layer) {
     paints.parseEach(layer, [&] (ClassProperties& paint, const JSVal& value) {
         parseProperty<Function<float>>("background-opacity", PropertyKey::BackgroundOpacity, paint, value);
         parseProperty<Function<Color>>("background-color", PropertyKey::BackgroundColor, paint, value);
-        parseProperty<Function<Faded<std::string>>>("background-pattern", PropertyKey::BackgroundImage, paint, value, "background-pattern-transition");
+        parseProperty<Function<Faded<std::string>>>("background-pattern", PropertyKey::BackgroundImage, paint, value);
     });
 }
 

--- a/src/mbgl/layer/fill_layer.cpp
+++ b/src/mbgl/layer/fill_layer.cpp
@@ -17,7 +17,7 @@ void FillLayer::parsePaints(const JSVal& layer) {
         parseProperty<Function<std::array<float, 2>>>("fill-translate", PropertyKey::FillTranslate, paint, value);
         parseProperty<PropertyTransition>("fill-translate-transition", PropertyKey::FillTranslate, paint, value);
         parseProperty<Function<TranslateAnchorType>>("fill-translate-anchor", PropertyKey::FillTranslateAnchor, paint, value);
-        parseProperty<Function<Faded<std::string>>>("fill-pattern", PropertyKey::FillImage, paint, value, "fill-pattern-transition");
+        parseProperty<Function<Faded<std::string>>>("fill-pattern", PropertyKey::FillImage, paint, value);
     });
 }
 

--- a/src/mbgl/layer/line_layer.cpp
+++ b/src/mbgl/layer/line_layer.cpp
@@ -28,8 +28,8 @@ void LineLayer::parsePaints(const JSVal& layer) {
         parseProperty<PropertyTransition>("line-gap-width-transition", PropertyKey::LineGapWidth, paint, value);
         parseProperty<Function<float>>("line-blur", PropertyKey::LineBlur, paint, value);
         parseProperty<PropertyTransition>("line-blur-transition", PropertyKey::LineBlur, paint, value);
-        parseProperty<Function<Faded<std::vector<float>>>>("line-dasharray", PropertyKey::LineDashArray, paint, value, "line-dasharray-transition");
-        parseProperty<Function<Faded<std::string>>>("line-pattern", PropertyKey::LineImage, paint, value, "line-pattern-transition");
+        parseProperty<Function<Faded<std::vector<float>>>>("line-dasharray", PropertyKey::LineDashArray, paint, value);
+        parseProperty<Function<Faded<std::string>>>("line-pattern", PropertyKey::LineImage, paint, value);
     });
 }
 

--- a/src/mbgl/style/function.cpp
+++ b/src/mbgl/style/function.cpp
@@ -107,7 +107,7 @@ Faded<T> Function<Faded<T>>::evaluate(const StyleCalculationParameters& paramete
 
     float z = parameters.z;
     float fraction = std::fmod(z, 1.0f);
-    std::chrono::duration<float> d = duration ? *duration : parameters.defaultFadeDuration;
+    std::chrono::duration<float> d = parameters.defaultFadeDuration;
     float t = std::min((parameters.now - parameters.zoomHistory.lastIntegerZoomTime) / d, 1.0f);
     float fromScale = 1.0f;
     float toScale = 1.0f;

--- a/src/mbgl/style/function.hpp
+++ b/src/mbgl/style/function.hpp
@@ -44,15 +44,13 @@ public:
     /* explicit */ Function(const T& constant)
         : stops({{ 0, constant }}) {}
 
-    explicit Function(const Stops& stops_,
-                      mapbox::util::optional<Duration> duration_)
-        : stops(stops_), duration(duration_) {}
+    explicit Function(const Stops& stops_)
+        : stops(stops_) {}
 
     Faded<T> evaluate(const StyleCalculationParameters&) const;
 
 private:
     const std::vector<std::pair<float, T>> stops;
-    const mapbox::util::optional<Duration> duration = {};
 };
 
 }

--- a/src/mbgl/style/property_parsing.cpp
+++ b/src/mbgl/style/property_parsing.cpp
@@ -360,12 +360,7 @@ template<> optional<Function<Color>> parseProperty(const char* name, const JSVal
 }
 
 template <typename T>
-optional<Function<Faded<T>>> parseFadedFunction(const JSVal& value, const JSVal& transition) {
-    mapbox::util::optional<Duration> duration;
-    if (transition.HasMember("duration")) {
-        duration = std::chrono::milliseconds(transition["duration"].GetUint());
-    }
-
+optional<Function<Faded<T>>> parseFadedFunction(const JSVal& value) {
     if (!value.HasMember("stops")) {
         Log::Warning(Event::ParseStyle, "function must specify a function type");
         return {};
@@ -377,13 +372,13 @@ optional<Function<Faded<T>>> parseFadedFunction(const JSVal& value, const JSVal&
         return {};
     }
 
-    return Function<Faded<T>>(*stops, duration);
+    return Function<Faded<T>>(*stops);
 }
 
 template <>
-optional<Function<Faded<std::vector<float>>>> parseProperty(const char* name, const JSVal& value, const JSVal& transition) {
+optional<Function<Faded<std::vector<float>>>> parseProperty(const char* name, const JSVal& value) {
     if (value.IsObject()) {
-        return parseFadedFunction<std::vector<float>>(value, transition);
+        return parseFadedFunction<std::vector<float>>(value);
     }
 
     auto constant = parseProperty<std::vector<float>>(name, value);
@@ -394,9 +389,9 @@ optional<Function<Faded<std::vector<float>>>> parseProperty(const char* name, co
 }
 
 template <>
-optional<Function<Faded<std::string>>> parseProperty(const char* name, const JSVal& value, const JSVal& transition) {
+optional<Function<Faded<std::string>>> parseProperty(const char* name, const JSVal& value) {
     if (value.IsObject()) {
-        return parseFadedFunction<std::string>(value, transition);
+        return parseFadedFunction<std::string>(value);
     }
 
     auto constant = parseProperty<std::string>(name, value);

--- a/src/mbgl/style/property_parsing.hpp
+++ b/src/mbgl/style/property_parsing.hpp
@@ -18,9 +18,6 @@ namespace detail {
 template <typename T>
 optional<T> parseProperty(const char* name, const JSVal&);
 
-template <typename T>
-optional<T> parseProperty(const char* name, const JSVal&, const JSVal& transition);
-
 }
 
 template <typename T>
@@ -29,23 +26,6 @@ void parseProperty(const char* name, PropertyKey key, ClassProperties& propertie
         return;
 
     const optional<T> res = detail::parseProperty<T>(name, value[name]);
-
-    if (res) {
-        properties.set(key, *res);
-    }
-}
-
-template <typename T>
-void parseProperty(const char* name, PropertyKey key, ClassProperties& properties, const JSVal& value, const char* transitionName) {
-    if (!value.HasMember(name))
-        return;
-
-    const JSVal& noTransition = JSVal { rapidjson::kObjectType };
-
-    const optional<T> res = detail::parseProperty<T>(name, value[name],
-        value.HasMember(transitionName)
-            ? value[transitionName]
-            : noTransition);
 
     if (res) {
         properties.set(key, *res);


### PR DESCRIPTION
We shouldn't overload transition duration to mean the duration of the cross-fade when moving between stops. If we want to allow styles to override the default 300ms fade duration, it should be a dedicated property like `raster-fade-duration`.

I don't think any styles use this functionality -- if they did, they were broken for `MapMode::Still` rendering.

:eyes: @kkaefer @ansis 