### PR TITLE
Disable callout view dimming when tap is a no-op

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1453,6 +1453,11 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }
 }
 
+- (BOOL)calloutViewShouldHighlight:(__unused SMCalloutView *)calloutView
+{
+    return [self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)];
+}
+
 - (void)calloutViewClicked:(__unused SMCalloutView *)calloutView
 {
     if ([self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)])


### PR DESCRIPTION
Fixes #2634.

@incanus, I left the dimming on if it looks like the delegate is going to respond to the tap (thereby treating it like a button). If you disagree, I can turn off the dimming in that case too.