### PR TITLE
swap array order to [lng, lat] for render option center

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.9",
-    "mapbox-gl-test-suite": "git+https://github.com/mapbox/mapbox-gl-test-suite.git#bbf55fb517eb2d55ba34dd0dced80af425e6db0d",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#744b63be01e36c75c6e629aec16a53048c0b7dbc",
     "request": "^2.65.0",
     "tape": "^4.2.1"
   },

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -4,6 +4,7 @@
 # 2.0.0
 
 - Integrates Node.js bindings into core mapbox-gl-native project. ([#2179](https://github.com/mapbox/mapbox-gl-native/pull/2179))
+- Adds Node.js v4.x and io.js v3.x support. ([#2261](https://github.com/mapbox/mapbox-gl-native/pull/2261))
 - Requires an options object argument to `new mbgl.Map()`
   (with required `request` and optional `cancel` methods),
   drops `mbgl.FileSource`. ([mapbox/node-mapbox-gl-native#143](https://github.com/mapbox/node-mapbox-gl-native/pull/143))
@@ -12,14 +13,14 @@
 - Requires numerical `ratio` in `mbgl.Map` options argument.
   Map pixel ratio is now immutable and can no longer be set with
   render options. ([`a8d9b92`](https://github.com/mapbox/mapbox-gl-native/commit/a8d9b921d71a91d7f8eff82e5a584aaab8b7d1c6), [#1799](https://github.com/mapbox/mapbox-gl-native/pull/1799))
+- Swaps array order in render options `center` argument to `[lng, lat]` for consistency with GeoJSON and mapbox-gl-js.
+- Adds render option `pitch` ([#2702](https://github.com/mapbox/mapbox-gl-native/pull/2702))
 - `map.render` now returns a raw image buffer instead of an object with
   `width`, `height` and `pixels` properties. ([#2262](https://github.com/mapbox/mapbox-gl-native/pull/2262))
 - Adds support for rendering [mapbox-gl-style-spec](https://github.com/mapbox/mapbox-gl-style-spec) v8 styles.
 - No longer loads resources before a render request is made. ([`55d25a8`](https://github.com/mapbox/mapbox-gl-native/commit/55d25a80a77c06ef5e66acc0d8518867b03fe8a4))
-- Adds Node.js v4.x and io.js v3.x support. ([#2261](https://github.com/mapbox/mapbox-gl-native/pull/2261))
 - Fixes a bug which prevented raster tiles that `404`'ed from rendering ([#2458](https://github.com/mapbox/mapbox-gl-native/pull/2458))
 - Fade transitions are now ignored to prevent half faded labels. ([#942](https://github.com/mapbox/mapbox-gl-native/pull/942))
-- Adds option `pitch` ([#2702](https://github.com/mapbox/mapbox-gl-native/pull/2702))
 
 # 1.1.3
 

--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -37,7 +37,7 @@ The first argument passed to `map.render` is an options object, all keys are opt
     zoom: {zoom}, // number, defaults to 0
     width: {width}, // number (px), defaults to 512
     height: {height}, // number (px), defaults to 512
-    center: [{latitude}, {longitude}], // array of numbers (coordinates), defaults to [0,0]
+    center: [{longitude}, {latitude}], // array of numbers (coordinates), defaults to [0,0]
     bearing: {bearing}, // number (in degrees, counter-clockwise from north), defaults to 0
     classes: {classes} // array of strings
 }

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -211,8 +211,8 @@ std::unique_ptr<NodeMap::RenderOptions> NodeMap::ParseOptions(v8::Local<v8::Obje
 
     if (Nan::Has(obj, Nan::New("center").ToLocalChecked()).FromJust()) {
         auto center = Nan::Get(obj, Nan::New("center").ToLocalChecked()).ToLocalChecked().As<v8::Array>();
-        if (center->Length() > 0) { options->latitude = Nan::Get(center, 0).ToLocalChecked()->NumberValue(); }
-        if (center->Length() > 1) { options->longitude = Nan::Get(center, 1).ToLocalChecked()->NumberValue(); }
+        if (center->Length() > 0) { options->longitude = Nan::Get(center, 0).ToLocalChecked()->NumberValue(); }
+        if (center->Length() > 1) { options->latitude = Nan::Get(center, 1).ToLocalChecked()->NumberValue(); }
     }
 
     if (Nan::Has(obj, Nan::New("width").ToLocalChecked()).FromJust()) {
@@ -243,7 +243,7 @@ std::unique_ptr<NodeMap::RenderOptions> NodeMap::ParseOptions(v8::Local<v8::Obje
  * @param {number} [options.zoom=0]
  * @param {number} [options.width=512]
  * @param {number} [options.height=512]
- * @param {Array<number>} [options.center=[0,0]] latitude, longitude center
+ * @param {Array<number>} [options.center=[0,0]] longitude, latitude center
  * of the map
  * @param {number} [options.bearing=0] rotation
  * @param {Array<string>} [options.classes=[]] GL Style Classes


### PR DESCRIPTION
Fixes #2846

For consistency with GeoJSON and mapbox-gl-js