### PR TITLE
Fix 'make xnode' to configure HOST_SLUG.gypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ node: ; $(RUN) HTTP=none ASSET=none CACHE=none Makefile/node
 
 
 .PHONY: Xcode/node
-Xcode/node: ; $(RUN) HTTP=none ASSET=none CACHE=none node/xproj
+Xcode/node: ; $(RUN) HTTP=none ASSET=none CACHE=none Xcode/node
 
 .PHONY: xnode
 xnode: Xcode/node ; @open ./build/binding.xcodeproj

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "aws-sdk": "^2.2.9",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#744b63be01e36c75c6e629aec16a53048c0b7dbc",
+    "node-gyp": "^3.0.3",
     "read-package-json": "^2.0.2",
     "request": "^2.65.0",
     "tape": "^4.2.1"

--- a/platform/node/src/node_file_source.hpp
+++ b/platform/node/src/node_file_source.hpp
@@ -5,6 +5,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wnested-anon-types"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/platform/node/src/node_log.hpp
+++ b/platform/node/src/node_log.hpp
@@ -5,6 +5,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wnested-anon-types"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -8,6 +8,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wnested-anon-types"
 #include <nan.h>
 #pragma GCC diagnostic pop
 

--- a/platform/node/src/node_mapbox_gl_native.cpp
+++ b/platform/node/src/node_mapbox_gl_native.cpp
@@ -1,6 +1,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wnested-anon-types"
 #include <node.h>
 #include <nan.h>
 #pragma GCC diagnostic pop

--- a/platform/node/src/node_request.hpp
+++ b/platform/node/src/node_request.hpp
@@ -3,6 +3,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wnested-anon-types"
 #include <nan.h>
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
Fixes #2938

Adds `node-gyp` to dev-dependencies to support `make xnode` on Node v0.10.x
Ignores `-Wnested-anon-types` around `v8.h` includes.