### PR TITLE
Update after final frame of transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Known issues:
 - The double-tap-drag gesture for zooming in and out is now consistent with the Google Maps SDK. ([#2153](https://github.com/mapbox/mapbox-gl-native/pull/2153))
 - A new `MGLAnnotationImage.enabled` property allows you to disable touch events on individual annotations. ([#2501](https://github.com/mapbox/mapbox-gl-native/pull/2501))
 - Fixed a rendering issue that caused one-way arrows along tile boundaries to point due east instead of in the direction of travel. ([#2530](https://github.com/mapbox/mapbox-gl-native/pull/2530))
+- Fixed an issue that prevented zoom level–dependent style properties from updating after zooming programmatically with animation. ([#2951](https://github.com/mapbox/mapbox-gl-native/pull/2951))
 - Fixed a rendering issue with styles that use the `background-pattern` property. ([#2531](https://github.com/mapbox/mapbox-gl-native/pull/2531))
 - Labels can now line wrap on hyphens and other punctuation. ([#2598](https://github.com/mapbox/mapbox-gl-native/pull/2598))
 - A new delegate callback was added for observing taps to annotation callout views. ([#2596](https://github.com/mapbox/mapbox-gl-native/pull/2596))

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -82,7 +82,7 @@ void Map::renderSync() {
 
     // Triggers an asynchronous update, that eventually triggers a view
     // invalidation, causing renderSync to be called again if in transition.
-    if (transform->inTransition()) {
+    if (flags != Update::Nothing) {
         update(flags);
     }
 }

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -275,7 +275,10 @@ void Transform::_easeTo(CameraOptions options, const double new_scale, const dou
                 state.Cc = s / util::M2PI;
                 state.angle = util::wrap(util::interpolate(startA, angle, t), -M_PI, M_PI);
                 state.pitch = util::interpolate(startP, pitch, t);
-                view.notifyMapChange(MapChangeRegionIsChanging);
+                // At t = 1.0, a DidChangeAnimated notification should be sent from finish().
+                if (t < 1.0) {
+                    view.notifyMapChange(MapChangeRegionIsChanging);
+                }
                 return update;
             },
             [=] {


### PR DESCRIPTION
The final frame is self-destructing – it destroys the frame and finish functions – so technically we’re no longer `inTransition()`. Yet there still needs to be an update after that final frame.

Also, this PR removes a redundant IsChanging notification that was being sent from the final frame of the transition. It would’ve come after the finish function’s DidChange notification.

Fixes #2946.

/cc @brunoabinader