### PR TITLE
Crash when changing styles too fast

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -97,6 +97,9 @@ void MapContext::setStyleURL(const std::string& url) {
     styleJSON.clear();
 
     style = std::make_unique<Style>(data);
+    if (painter) {
+        painter->updateRenderOrder(*style);
+    }
 
     const size_t pos = styleURL.rfind('/');
     std::string base = "";
@@ -135,6 +138,9 @@ void MapContext::setStyleJSON(const std::string& json, const std::string& base) 
     styleJSON = json;
 
     style = std::make_unique<Style>(data);
+    if (painter) {
+        painter->updateRenderOrder(*style);
+    }
 
     loadStyleJSON(json, base);
 }


### PR DESCRIPTION
I could easily reproduce this on 179917ccb670d62125754a6b519aa3c89f16d25f by launching the Linux app and pressing `s` (change style) fast. Eventually it crashes. This has probably something to do with trying to render after cleaning up the style.

/cc @kkaefer 

```
#0  0x00000000004aee94 in mbgl::Painter::render (this=0x7f23600033c0, style=..., state_=..., frame_=...)
    at ../../src/mbgl/renderer/painter.cpp:158

158	                item.bucket->upload();

#1  0x0000000000462bb2 in mbgl::MapContext::renderSync (this=0x7f2369a18cc0, state=..., frame=...) at ../../src/mbgl/map/map_context.cpp:250
#2  0x000000000042871c in operator() (this=0x7f2360575438) at /usr/include/c++/4.9/functional:2439
#3  operator() (this=0x7f2360575430) at /usr/include/c++/4.9/future:1241
#4  std::_Function_handler<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> (), std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<bool>, std::__future_base::_Result_base::_Deleter>, bool> >::_M_invoke(std::_Any_data const&) (__functor=...) at /usr/include/c++/4.9/functional:2025
#5  0x0000000000426a52 in operator() (this=<optimized out>) at /usr/include/c++/4.9/functional:2439
#6  std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>&, bool&) (this=0x286a2e0, __f=..., __set=@0x7f2369a153af: false) at /usr/include/c++/4.9/future:485
#7  0x00007f237549236b in __pthread_once_slow (once_control=0x286a34c, init_routine=0x7f2374869e60 <__once_proxy>) at pthread_once.c:114
#8  0x0000000000422342 in __gthread_once (__func=<optimized out>, __once=0x286a34c)
    at /usr/include/x86_64-linux-gnu/c++/4.9/bits/gthr-default.h:699
#9  call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>()>&, bool&), std::__future_base::_State_baseV2*, std::reference_wrapper<std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>()> >, std::reference_wrapper<bool> > (__f=<optimized out>, __once=...)
    at /usr/include/c++/4.9/mutex:746
#10 std::__future_base::_State_baseV2::_M_set_result(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>, bool) (this=this@entry=0x286a2e0, __res=..., __ignore_failure=false) at /usr/include/c++/4.9/future:372
#11 0x000000000042da55 in std::__future_base::_Task_state<std::_Bind<std::_Mem_fn<bool (mbgl::MapContext::*)(mbgl::TransformState const&, mbgl::FrameData const&)> (mbgl::MapContext*, mbgl::TransformState, mbgl::FrameData)>, std::allocator<int>, bool ()>::_M_run() (this=0x286a2e0)
    at /usr/include/c++/4.9/future:1319
```