### PR TITLE
GL values should be reset upon need

### DIFF
--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -242,7 +242,11 @@ void Painter::renderPass(RenderPass pass_,
                   pass == RenderPass::Opaque ? "opaque" : "translucent");
     }
 
-    config.blend = pass == RenderPass::Translucent;
+    if (pass == RenderPass::Translucent) {
+        config.blend = GL_TRUE;
+    } else {
+        config.blend = GL_FALSE;
+    }
 
     for (; it != end; ++it, i += increment) {
         currentLayer = i;
@@ -398,8 +402,8 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         spriteAtlas->bind(true);
     }
 
-    config.stencilTest = false;
-    config.depthTest = true;
+    config.stencilTest = GL_FALSE;
+    config.depthTest = GL_TRUE;
     config.depthRange = { 1.0f, 1.0f };
 
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -110,11 +110,14 @@ void Painter::changeMatrix() {
 
 void Painter::clear() {
     MBGL_DEBUG_GROUP("clear");
+    config.stencilFunc.reset();
     config.stencilTest = GL_TRUE;
     config.stencilMask = 0xFF;
     config.depthTest = GL_FALSE;
     config.depthMask = GL_TRUE;
     config.clearColor = { background[0], background[1], background[2], background[3] };
+    config.clearStencil = 0;
+    config.clearDepth = 1;
     MBGL_CHECK_ERROR(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 }
 
@@ -243,6 +246,7 @@ void Painter::renderPass(RenderPass pass_,
     }
 
     if (pass == RenderPass::Translucent) {
+        config.blendFunc.reset();
         config.blend = GL_TRUE;
     } else {
         config.blend = GL_FALSE;
@@ -403,6 +407,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
     }
 
     config.stencilTest = GL_FALSE;
+    config.depthFunc.reset();
     config.depthTest = GL_TRUE;
     config.depthRange = { 1.0f, 1.0f };
 

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -18,7 +18,7 @@ void Painter::renderCircle(CircleBucket& bucket,
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
-    config.stencilTest = false;
+    config.stencilTest = GL_FALSE;
 
     const CirclePaintProperties& properties = layer.properties;
     mat4 vtxMatrix = translatedMatrix(matrix, properties.translate, id, properties.translateAnchor);

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -10,7 +10,9 @@ void Painter::drawClippingMasks(const std::set<Source*>& sources) {
     MBGL_DEBUG_GROUP("clipping masks");
 
     config.program = plainShader->program;
+    config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
+    config.depthFunc.reset();
     config.depthTest = GL_TRUE;
     config.depthMask = GL_FALSE;
     config.colorMask = { GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -10,10 +10,10 @@ void Painter::drawClippingMasks(const std::set<Source*>& sources) {
     MBGL_DEBUG_GROUP("clipping masks");
 
     config.program = plainShader->program;
-    config.stencilTest = true;
-    config.depthTest = true;
+    config.stencilTest = GL_TRUE;
+    config.depthTest = GL_TRUE;
     config.depthMask = GL_FALSE;
-    config.colorMask = { false, false, false, false };
+    config.colorMask = { GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
     config.depthRange = { 1.0f, 1.0f };
 
     coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET_0);
@@ -22,8 +22,7 @@ void Painter::drawClippingMasks(const std::set<Source*>& sources) {
         source->drawClippingMasks(*this);
     }
 
-    config.depthTest = true;
-    config.colorMask = { true, true, true, true };
+    config.colorMask = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
     config.depthMask = GL_TRUE;
     config.stencilMask = 0x0;
 }

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -47,6 +47,7 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
     config.lineWidth = 2.0f * data.pixelRatio;
     tileData.debugBucket->drawLines(*plainShader);
 
+    config.depthFunc.reset();
     config.depthTest = GL_TRUE;
 }
 
@@ -57,6 +58,7 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     // but *don't* disable stencil test, as we want to clip the red tile border
     // to the tile viewport.
     config.depthTest = GL_FALSE;
+    config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
 
     config.program = plainShader->program;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -22,7 +22,7 @@ void Painter::renderTileDebug(const Tile& tile) {
 void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
     MBGL_DEBUG_GROUP("debug text");
 
-    config.depthTest = false;
+    config.depthTest = GL_FALSE;
 
     if (!tileData.debugBucket || tileData.debugBucket->state != tileData.getState()) {
         tileData.debugBucket = std::make_unique<DebugBucket>(tileData.id, tileData.getState());
@@ -47,7 +47,7 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
     config.lineWidth = 2.0f * data.pixelRatio;
     tileData.debugBucket->drawLines(*plainShader);
 
-    config.depthTest = true;
+    config.depthTest = GL_TRUE;
 }
 
 void Painter::renderDebugFrame(const mat4 &matrix) {
@@ -56,8 +56,8 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     // Disable depth test and don't count this towards the depth buffer,
     // but *don't* disable stencil test, as we want to clip the red tile border
     // to the tile viewport.
-    config.depthTest = false;
-    config.stencilTest = true;
+    config.depthTest = GL_FALSE;
+    config.stencilTest = GL_TRUE;
 
     config.program = plainShader->program;
     plainShader->u_matrix = matrix;

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -36,7 +36,9 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
     bool outline = properties.antialias && !pattern && stroke_color != fill_color;
     bool fringeline = properties.antialias && !pattern && stroke_color == fill_color;
 
+    config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
+    config.depthFunc.reset();
     config.depthTest = GL_TRUE;
 
     // Because we're drawing top-to-bottom, and we update the stencil mask

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -36,8 +36,8 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
     bool outline = properties.antialias && !pattern && stroke_color != fill_color;
     bool fringeline = properties.antialias && !pattern && stroke_color == fill_color;
 
-    config.stencilTest = true;
-    config.depthTest = true;
+    config.stencilTest = GL_TRUE;
+    config.depthTest = GL_TRUE;
 
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // befrom, we have to draw the outline first (!)

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -17,7 +17,9 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
+    config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
+    config.depthFunc.reset();
     config.depthTest = GL_TRUE;
     config.depthMask = GL_FALSE;
 

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -17,8 +17,8 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
-    config.stencilTest = true;
-    config.depthTest = true;
+    config.stencilTest = GL_TRUE;
+    config.depthTest = GL_TRUE;
     config.depthMask = GL_FALSE;
 
     const auto& properties = layer.properties;

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -22,8 +22,8 @@ void Painter::renderRaster(RasterBucket& bucket, const RasterLayer& layer, const
         rasterShader->u_contrast_factor = contrastFactor(properties.contrast);
         rasterShader->u_spin_weights = spinWeights(properties.hue_rotate);
 
-        config.stencilTest = true;
-        config.depthTest = true;
+        config.stencilTest = GL_TRUE;
+        config.depthTest = GL_TRUE;
         setDepthSublayer(0);
         bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray);
     }

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -22,7 +22,9 @@ void Painter::renderRaster(RasterBucket& bucket, const RasterLayer& layer, const
         rasterShader->u_contrast_factor = contrastFactor(properties.contrast);
         rasterShader->u_spin_weights = spinWeights(properties.hue_rotate);
 
+        config.stencilOp.reset();
         config.stencilTest = GL_TRUE;
+        config.depthFunc.reset();
         config.depthTest = GL_TRUE;
         setDepthSublayer(0);
         bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray);

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -144,7 +144,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
     config.depthMask = GL_FALSE;
 
     if (bucket.hasCollisionBoxData()) {
-        config.stencilTest = true;
+        config.stencilTest = GL_TRUE;
 
         config.program = collisionBoxShader->program;
         collisionBoxShader->u_matrix = matrix;
@@ -158,16 +158,20 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
 
     }
 
-    // TODO remove the `|| true` when #1673 is implemented
-    const bool drawAcrossEdges = !(layout.text.allow_overlap || layout.icon.allow_overlap ||
-          layout.text.ignore_placement || layout.icon.ignore_placement) || true;
+    // TODO remove the `true ||` when #1673 is implemented
+    const bool drawAcrossEdges = true || !(layout.text.allow_overlap || layout.icon.allow_overlap ||
+          layout.text.ignore_placement || layout.icon.ignore_placement);
 
     // Disable the stencil test so that labels aren't clipped to tile boundaries.
     //
     // Layers with features that may be drawn overlapping aren't clipped. These
     // layers are sorted in the y direction, and to draw the correct ordering near
     // tile edges the icons are included in both tiles and clipped when drawing.
-    config.stencilTest = drawAcrossEdges ? false : true;
+    if (drawAcrossEdges) {
+        config.stencilTest = GL_FALSE;
+    } else {
+        config.stencilTest = GL_TRUE;
+    }
 
     if (bucket.hasIconData()) {
         config.depthTest = layout.icon.rotation_alignment == RotationAlignmentType::Map;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -144,6 +144,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
     config.depthMask = GL_FALSE;
 
     if (bucket.hasCollisionBoxData()) {
+        config.stencilOp.reset();
         config.stencilTest = GL_TRUE;
 
         config.program = collisionBoxShader->program;
@@ -170,11 +171,17 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
     if (drawAcrossEdges) {
         config.stencilTest = GL_FALSE;
     } else {
+        config.stencilOp.reset();
         config.stencilTest = GL_TRUE;
     }
 
     if (bucket.hasIconData()) {
-        config.depthTest = layout.icon.rotation_alignment == RotationAlignmentType::Map;
+        if (layout.icon.rotation_alignment == RotationAlignmentType::Map) {
+            config.depthFunc.reset();
+            config.depthTest = GL_TRUE;
+        } else {
+            config.depthTest = GL_FALSE;
+        }
 
         bool sdf = bucket.sdfIcons;
 
@@ -246,7 +253,12 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
     }
 
     if (bucket.hasTextData()) {
-        config.depthTest = layout.text.rotation_alignment == RotationAlignmentType::Map;
+        if (layout.text.rotation_alignment == RotationAlignmentType::Map) {
+            config.depthFunc.reset();
+            config.depthTest = GL_TRUE;
+        } else {
+            config.depthTest = GL_FALSE;
+        }
 
         glyphAtlas->bind();
 


### PR DESCRIPTION
While debugging shared GL context, we found out that some GL values were not being properly reset when needed (eg. when _depth_ or _stencil_ tests were enabled, or blend was enabled).

/cc @kkaefer