### PR TITLE
fixes #2966: remove -ObjC linker flag & bring in categories via other means

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -54,6 +54,8 @@
         '../platform/ios/MGLAnnotationImage.m',
         '../include/mbgl/ios/MGLStyle.h',
         '../platform/ios/MGLStyle.mm',
+        '../platform/ios/MGLCategoryLoader.h',
+        '../platform/ios/MGLCategoryLoader.m',
         '../platform/ios/NSBundle+MGLAdditions.h',
         '../platform/ios/NSBundle+MGLAdditions.m',
         '../platform/ios/NSException+MGLAdditions.h',
@@ -82,7 +84,6 @@
           '-framework MobileCoreServices',
           '-framework QuartzCore',
           '-framework SystemConfiguration',
-          '-ObjC',
         ],
       },
 

--- a/platform/ios/MGLAccountManager.m
+++ b/platform/ios/MGLAccountManager.m
@@ -1,5 +1,6 @@
 #import "MGLAccountManager_Private.h"
 #import "MGLMapboxEvents.h"
+#import "MGLCategoryLoader.h"
 #import "NSProcessInfo+MGLAdditions.h"
 
 #import <Fabric/FABKitProtocol.h>
@@ -34,6 +35,8 @@
 // Can be called from any thread.
 //
 + (instancetype) sharedManager {
+    [MGLCategoryLoader loadCategories];
+
     if (NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent) {
         return nil;
     }

--- a/platform/ios/MGLCategoryLoader.h
+++ b/platform/ios/MGLCategoryLoader.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface MGLCategoryLoader : NSObject
+
++ (void)loadCategories;
+
+@end

--- a/platform/ios/MGLCategoryLoader.m
+++ b/platform/ios/MGLCategoryLoader.m
@@ -1,0 +1,18 @@
+#import "MGLCategoryLoader.h"
+
+#import "NSBundle+MGLAdditions.h"
+#import "NSProcessInfo+MGLAdditions.h"
+#import "NSString+MGLAdditions.h"
+
+// https://github.com/mapbox/mapbox-gl-native/issues/2966
+
+@implementation MGLCategoryLoader
+
++ (void)loadCategories
+{
+    mgl_linkBundleCategory();
+    mgl_linkProcessCategory();
+    mgl_linkStringCategory();
+}
+
+@end

--- a/platform/ios/NSBundle+MGLAdditions.h
+++ b/platform/ios/NSBundle+MGLAdditions.h
@@ -2,6 +2,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+void mgl_linkBundleCategory();
+
 @interface NSBundle (MGLAdditions)
 
 + (NSString *)mgl_resourceBundlePath;

--- a/platform/ios/NSBundle+MGLAdditions.m
+++ b/platform/ios/NSBundle+MGLAdditions.m
@@ -4,6 +4,8 @@
 
 @implementation NSBundle (MGLAdditions)
 
+void mgl_linkBundleCategory(){}
+
 + (NSString *)mgl_resourceBundlePath
 {
     NSString *resourceBundlePath = [[NSBundle bundleForClass:[MGLMapView class]] pathForResource:@"Mapbox" ofType:@"bundle"];

--- a/platform/ios/NSProcessInfo+MGLAdditions.h
+++ b/platform/ios/NSProcessInfo+MGLAdditions.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+void mgl_linkProcessCategory();
+
 @interface NSProcessInfo (MGLAdditions)
 
 - (BOOL)mgl_isInterfaceBuilderDesignablesAgent;

--- a/platform/ios/NSProcessInfo+MGLAdditions.m
+++ b/platform/ios/NSProcessInfo+MGLAdditions.m
@@ -2,6 +2,8 @@
 
 @implementation NSProcessInfo (MGLAdditions)
 
+void mgl_linkProcessCategory(){}
+
 - (BOOL)mgl_isInterfaceBuilderDesignablesAgent
 {
     return [self.processName isEqualToString:@"IBDesignablesAgentCocoaTouch"];

--- a/platform/ios/NSString+MGLAdditions.h
+++ b/platform/ios/NSString+MGLAdditions.h
@@ -2,6 +2,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+void mgl_linkStringCategory();
+
 @interface NSString (MGLAdditions)
 
 /** Returns the receiver if non-empty or nil if empty. */

--- a/platform/ios/NSString+MGLAdditions.m
+++ b/platform/ios/NSString+MGLAdditions.m
@@ -2,6 +2,8 @@
 
 @implementation NSString (MGLAdditions)
 
+void mgl_linkStringCategory(){}
+
 - (nullable NSString *)mgl_stringOrNilIfEmpty
 {
     return self.length ? self : nil;


### PR DESCRIPTION
This should reduce our binary size as well as obviate the need for the `-ObjC` linker flag. 