### PR TITLE
fixes #2961: download payload over HTTPS

### DIFF
--- a/ios/Mapbox-iOS-SDK.podspec
+++ b/ios/Mapbox-iOS-SDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |m|
   m.documentation_url = 'https://www.mapbox.com/ios-sdk/'
 
   m.source = {
-    :http => "http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-#{m.version.to_s}.zip",
+    :http => "https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-#{m.version.to_s}.zip",
     :flatten => true
   }
 


### PR DESCRIPTION
This should be super simple, but let's CI it just to make sure it works everywhere. 