### PR TITLE
Remove constraints instead of deactivating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Known issues:
 - Fixed a rendering issue that caused one-way arrows along tile boundaries to point due east instead of in the direction of travel. ([#2530](https://github.com/mapbox/mapbox-gl-native/pull/2530))
 - Fixed an issue that prevented zoom level–dependent style properties from updating after zooming programmatically with animation. ([#2951](https://github.com/mapbox/mapbox-gl-native/pull/2951))
 - Fixed a rendering issue with styles that use the `background-pattern` property. ([#2531](https://github.com/mapbox/mapbox-gl-native/pull/2531))
+- Fixed a crash when reusing a single `MGLMapView` across multiple `UIViewController`s. ([#2969](https://github.com/mapbox/mapbox-gl-native/pull/2969))
 - Labels can now line wrap on hyphens and other punctuation. ([#2598](https://github.com/mapbox/mapbox-gl-native/pull/2598))
 - A new delegate callback was added for observing taps to annotation callout views. ([#2596](https://github.com/mapbox/mapbox-gl-native/pull/2596))
 - `-mapViewRegionIsChanging:` is now sent to the map view’s delegate during gestures. ([#2700](https://github.com/mapbox/mapbox-gl-native/pull/2700))

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -534,14 +534,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     // compass
     //
     UIView *compassContainer = self.compassView.superview;
-    if ([NSLayoutConstraint respondsToSelector:@selector(deactivateConstraints:)])
-    {
-        [NSLayoutConstraint deactivateConstraints:compassContainer.constraints];
-    }
-    else
-    {
-        [compassContainer removeConstraints:compassContainer.constraints];
-    }
+    [compassContainer removeConstraints:compassContainer.constraints];
 
     NSMutableArray *compassContainerConstraints = [NSMutableArray array];
     if (viewController)
@@ -573,7 +566,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
                                  multiplier:1
                                    constant:5]];
 
-    [compassContainer addConstraint:
+    [compassContainerConstraints addObject:
      [NSLayoutConstraint constraintWithItem:compassContainer
                                   attribute:NSLayoutAttributeWidth
                                   relatedBy:NSLayoutRelationEqual
@@ -582,7 +575,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
                                  multiplier:1
                                    constant:self.compassView.image.size.width]];
 
-    [compassContainer addConstraint:
+    [compassContainerConstraints addObject:
      [NSLayoutConstraint constraintWithItem:compassContainer
                                   attribute:NSLayoutAttributeHeight
                                   relatedBy:NSLayoutRelationEqual
@@ -590,25 +583,11 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
                                   attribute:NSLayoutAttributeNotAnAttribute
                                  multiplier:1
                                    constant:self.compassView.image.size.height]];
-    if ([NSLayoutConstraint respondsToSelector:@selector(activateConstraints:)])
-    {
-        [NSLayoutConstraint activateConstraints:compassContainerConstraints];
-    }
-    else
-    {
-        [constraintParentView addConstraints:compassContainerConstraints];
-    }
+    [constraintParentView addConstraints:compassContainerConstraints];
 
     // logo bug
     //
-    if ([NSLayoutConstraint respondsToSelector:@selector(deactivateConstraints:)])
-    {
-        [NSLayoutConstraint deactivateConstraints:self.logoViewConstraints];
-    }
-    else
-    {
-        [self.logoView removeConstraints:self.logoViewConstraints];
-    }
+    [self.logoView removeConstraints:self.logoViewConstraints];
     [self.logoViewConstraints removeAllObjects];
     if (viewController)
     {
@@ -638,25 +617,11 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
                                   attribute:NSLayoutAttributeLeading
                                  multiplier:1
                                    constant:8]];
-    if ([NSLayoutConstraint respondsToSelector:@selector(activateConstraints:)])
-    {
-        [NSLayoutConstraint activateConstraints:self.logoViewConstraints];
-    }
-    else
-    {
-        [constraintParentView addConstraints:self.logoViewConstraints];
-    }
+    [constraintParentView addConstraints:self.logoViewConstraints];
 
     // attribution button
     //
-    if ([NSLayoutConstraint respondsToSelector:@selector(deactivateConstraints:)])
-    {
-        [NSLayoutConstraint deactivateConstraints:self.attributionButtonConstraints];
-    }
-    else
-    {
-        [self.attributionButton removeConstraints:self.attributionButtonConstraints];
-    }
+    [self.attributionButton removeConstraints:self.attributionButtonConstraints];
     [self.attributionButtonConstraints removeAllObjects];
     if (viewController)
     {
@@ -686,14 +651,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
                                   attribute:NSLayoutAttributeTrailing
                                  multiplier:1
                                    constant:8]];
-    if ([NSLayoutConstraint respondsToSelector:@selector(activateConstraints:)])
-    {
-        [NSLayoutConstraint activateConstraints:self.attributionButtonConstraints];
-    }
-    else
-    {
-        [constraintParentView addConstraints:self.attributionButtonConstraints];
-    }
+    [constraintParentView addConstraints:self.attributionButtonConstraints];
 
     [super updateConstraints];
 }


### PR DESCRIPTION
Avoid piling up lots of deactivated constraints. Also avoid trying to deactivate constraints that have already been removed from the view hierarchy due to a change in view controllers.

Fixes #2020.

@incanus, would you mind testing on an iOS 7.x device, just in case? Thanks!