### PR TITLE
Expose default fade duration

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -73,10 +73,13 @@ public:
     void setClasses(const std::vector<std::string>&);
     std::vector<std::string> getClasses() const;
 
-    void setDefaultTransitionDuration(const Duration& = Duration::zero());
+    void setDefaultFadeDuration(const Duration&);
+    Duration getDefaultFadeDuration() const;
+
+    void setDefaultTransitionDuration(const Duration&);
     Duration getDefaultTransitionDuration() const;
 
-    void setDefaultTransitionDelay(const Duration& = Duration::zero());
+    void setDefaultTransitionDelay(const Duration&);
     Duration getDefaultTransitionDelay() const;
 
     void setStyleURL(const std::string& url);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -474,6 +474,15 @@ std::vector<std::string> Map::getClasses() const {
     return data->getClasses();
 }
 
+void Map::setDefaultFadeDuration(const Duration& duration) {
+    data->setDefaultFadeDuration(duration);
+    update(Update::Classes);
+}
+
+Duration Map::getDefaultFadeDuration() const {
+    return data->getDefaultFadeDuration();
+}
+
 void Map::setDefaultTransitionDuration(const Duration& duration) {
     data->setDefaultTransitionDuration(duration);
     update(Update::DefaultTransition);


### PR DESCRIPTION
We should expose default fade duration to public Map API. This allows clients to e.g. disable label fade transitions by setting their duration to zero.

/cc @incanus @jfirebaugh @kkaefer @tmpsantos 