### PR TITLE
Fetch tags on install, not ipackage

### DIFF
--- a/ios/docs/install_docs.sh
+++ b/ios/docs/install_docs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -z `which appledoc` ]; then
-    echo "Unable to find appledoc. See https://github.com/mapbox/mapbox-gl-native/blob/master/INSTALL.md"
+    echo "Unable to find appledoc. See https://github.com/mapbox/mapbox-gl-native/blob/master/docs/BUILD_IOS_OSX.md"
     exit 1
 fi
 

--- a/scripts/ios/install.sh
+++ b/scripts/ios/install.sh
@@ -3,6 +3,8 @@
 set -e
 set -o pipefail
 
+git fetch --tags
+
 mapbox_time "checkout_mason" \
 git submodule update --init .mason
 

--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -115,7 +115,6 @@ if [ -z `which appledoc` ]; then
     exit 1
 fi
 DOCS_OUTPUT="${OUTPUT}/static/Docs"
-git fetch --tags
 DOCS_VERSION=$( git tag | grep ^ios | sed 's/^ios-//' | sort -r | grep -v '\-rc.' | grep -v '\-pre.' | sed -n '1p' | sed 's/^v//' )
 rm -rf /tmp/mbgl
 mkdir -p /tmp/mbgl/

--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -111,7 +111,7 @@ cp -pv platform/ios/resources/* "${OUTPUT}/static/${NAME}.bundle"
 
 step "Creating API Docs..."
 if [ -z `which appledoc` ]; then
-    echo "Unable to find appledoc. See https://github.com/mapbox/mapbox-gl-native/blob/master/INSTALL.md"
+    echo "Unable to find appledoc. See https://github.com/mapbox/mapbox-gl-native/blob/master/docs/BUILD_IOS_OSX.md"
     exit 1
 fi
 DOCS_OUTPUT="${OUTPUT}/static/Docs"


### PR DESCRIPTION
This change removes a git command that requires a network connection from the ipackage target. It was used to ensure that CI has a tag to version the appledoc documentation with, so the same command has been added to install.sh, where a network connection is otherwise expected.

Along for the ride, I’ve also updated some references to the old build documentation.

Fixes #2320; fixes #2871.

/cc @adam-mapbox @incanus