### PR TITLE
Fix static analyzer warnings

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -124,7 +124,7 @@ public:
     void setBearing(double degrees, const Duration& = Duration::zero());
     void setBearing(double degrees, const PrecisionPoint&);
     double getBearing() const;
-    void resetNorth();
+    void resetNorth(const Duration& = std::chrono::milliseconds(500));
 
     // Pitch
     void setPitch(double pitch, const Duration& = Duration::zero());

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -9,17 +9,7 @@ namespace mbgl {
 
 class TileID;
 
-struct PrecisionPoint {
-    double x = 0;
-    double y = 0;
-
-    inline PrecisionPoint(double x_ = 0, double y_ = 0)
-        : x(x_), y(y_) {}
-
-    inline bool isValid() const {
-        return !(std::isnan(x) || std::isnan(y));
-    }
-};
+using PrecisionPoint = vec2<double>;
 
 struct LatLng {
     double latitude = 0;
@@ -28,7 +18,7 @@ struct LatLng {
     inline LatLng(double lat = 0, double lon = 0)
         : latitude(lat), longitude(lon) {}
 
-    inline bool isValid() const {
+    inline operator bool() const {
         return !(std::isnan(latitude) || std::isnan(longitude));
     }
 
@@ -45,7 +35,7 @@ struct ProjectedMeters {
     inline ProjectedMeters(double n = 0, double e = 0)
         : northing(n), easting(e) {}
 
-    inline bool isValid() const {
+    inline operator bool() const {
         return !(std::isnan(northing) || std::isnan(easting));
     }
 };
@@ -57,8 +47,8 @@ struct LatLngBounds {
     inline LatLngBounds(const LatLng& sw_ = {90, 180}, const LatLng& ne_ = {-90, -180})
         : sw(sw_), ne(ne_) {}
 
-    inline bool isValid() const {
-        return sw.isValid() && ne.isValid();
+    inline operator bool() const {
+        return sw && ne;
     }
 
     // Constructs a LatLngBounds object with the tile's exact boundaries.
@@ -98,8 +88,8 @@ struct MetersBounds {
     inline MetersBounds(const ProjectedMeters& sw_, const ProjectedMeters& ne_)
         : sw(sw_), ne(ne_) {}
 
-    inline bool isValid() const {
-        return sw.isValid() && ne.isValid();
+    inline operator bool() const {
+        return sw && ne;
     }
 };
 

--- a/include/mbgl/util/vec.hpp
+++ b/include/mbgl/util/vec.hpp
@@ -41,11 +41,20 @@ struct vec2 {
         return {x * o, y * o};
     }
 
-    template <typename O>
-    inline typename std::enable_if<std::is_arithmetic<O>::value, vec2>::type &
-    operator*=(O o) {
+    inline void operator*=(T o) {
         x *= o;
         y *= o;
+    }
+
+    template <typename O>
+    inline typename std::enable_if<std::is_arithmetic<O>::value, vec2>::type
+    operator/(O o) const {
+        return {x / o, y / o};
+    }
+
+    inline void operator/=(T o) {
+        x /= o;
+        y /= o;
     }
 
     inline vec2<T> operator *(const std::array<float, 16>& matrix) {
@@ -111,7 +120,7 @@ struct vec4 {
 };
 
 
-typedef vec2<int16_t> Coordinate;
+using Coordinate = vec2<int16_t>;
 
 }
 

--- a/platform/android/jni.cpp
+++ b/platform/android/jni.cpp
@@ -777,11 +777,12 @@ void JNICALL nativeRotateBy(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jd
 }
 
 void JNICALL nativeSetBearing(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdouble degrees,
-                              jlong duration) {
+                              jlong milliseconds) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeSetBearing");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().setBearing(degrees, std::chrono::milliseconds(duration));
+    mbgl::Duration duration((std::chrono::milliseconds(milliseconds)));
+    nativeMapView->getMap().setBearing(degrees, duration);
 }
 
 void JNICALL nativeSetBearing(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdouble degrees,

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1039,7 +1039,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
             CGFloat newRadians = radians + velocity * duration * 0.1;
             CGFloat newDegrees = MGLDegreesFromRadians(newRadians) * -1;
 
-            _mbglMap->setBearing(newDegrees, secondsAsDuration(duration));
+            _mbglMap->setBearing(newDegrees, mbgl::Duration(secondsAsDuration(duration)));
 
             _mbglMap->setGestureInProgress(false);
 
@@ -1555,9 +1555,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 - (void)resetNorthAnimated:(BOOL)animated
 {
-    CGFloat duration = (animated ? MGLAnimationDuration : 0);
-
-    _mbglMap->setBearing(0, secondsAsDuration(duration));
+    _mbglMap->setBearing(0, mbgl::Duration(secondsAsDuration(animated ? MGLAnimationDuration : 0)));
 }
 
 - (void)resetPosition
@@ -1789,10 +1787,10 @@ mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBounds coord
         self.userTrackingMode = MGLUserTrackingModeFollow;
     }
 
-    CGFloat duration = (animated ? MGLAnimationDuration : 0);
+    CGFloat duration = animated ? MGLAnimationDuration : 0;
 
-    _mbglMap->setBearing(direction, secondsAsDuration(duration));
-    
+    _mbglMap->setBearing(direction, mbgl::Duration(secondsAsDuration(duration)));
+
     if (animated)
     {
         __weak MGLMapView *weakSelf = self;
@@ -2820,7 +2818,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     if (headingDirection >= 0 && self.userTrackingMode == MGLUserTrackingModeFollowWithHeading)
     {
-        _mbglMap->setBearing(headingDirection, secondsAsDuration(MGLAnimationDuration));
+        _mbglMap->setBearing(headingDirection, mbgl::Duration(secondsAsDuration(MGLAnimationDuration)));
     }
 }
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -134,7 +134,7 @@ mbgl::util::UnitBezier MGLUnitBezierForMediaTimingFunction(CAMediaTimingFunction
 
 @dynamic debugActive;
 
-std::chrono::steady_clock::duration secondsAsDuration(float duration)
+std::chrono::steady_clock::duration durationInSeconds(float duration)
 {
     return std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<float, std::chrono::seconds::period>(duration));
 }
@@ -867,7 +867,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         if ( ! CGPointEqualToPoint(velocity, CGPointZero))
         {
             CGPoint offset = CGPointMake(velocity.x * duration / 4, velocity.y * duration / 4);
-            _mbglMap->moveBy({ offset.x, offset.y }, secondsAsDuration(duration));
+            _mbglMap->moveBy({ offset.x, offset.y }, durationInSeconds(duration));
         }
 
         _mbglMap->setGestureInProgress(false);
@@ -967,7 +967,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         {
             CGPoint pinchCenter = [pinch locationInView:pinch.view];
             mbgl::PrecisionPoint center(pinchCenter.x, pinchCenter.y);
-            _mbglMap->setScale(newScale, center, secondsAsDuration(duration));
+            _mbglMap->setScale(newScale, center, durationInSeconds(duration));
         }
 
         _mbglMap->setGestureInProgress(false);
@@ -1039,7 +1039,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
             CGFloat newRadians = radians + velocity * duration * 0.1;
             CGFloat newDegrees = MGLDegreesFromRadians(newRadians) * -1;
 
-            _mbglMap->setBearing(newDegrees, mbgl::Duration(secondsAsDuration(duration)));
+            _mbglMap->setBearing(newDegrees, durationInSeconds(duration));
 
             _mbglMap->setGestureInProgress(false);
 
@@ -1257,7 +1257,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         }
 
         mbgl::PrecisionPoint center(zoomInPoint.x, zoomInPoint.y);
-        _mbglMap->scaleBy(2, center, secondsAsDuration(MGLAnimationDuration));
+        _mbglMap->scaleBy(2, center, durationInSeconds(MGLAnimationDuration));
 
         self.animatingGesture = YES;
 
@@ -1302,7 +1302,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
         }
 
         mbgl::PrecisionPoint center(zoomOutPoint.x, zoomOutPoint.y);
-        _mbglMap->scaleBy(0.5, center, secondsAsDuration(MGLAnimationDuration));
+        _mbglMap->scaleBy(0.5, center, durationInSeconds(MGLAnimationDuration));
 
         self.animatingGesture = YES;
 
@@ -1555,7 +1555,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
 
 - (void)resetNorthAnimated:(BOOL)animated
 {
-    _mbglMap->setBearing(0, mbgl::Duration(secondsAsDuration(animated ? MGLAnimationDuration : 0)));
+    _mbglMap->setBearing(0, durationInSeconds(animated ? MGLAnimationDuration : 0));
 }
 
 - (void)resetPosition
@@ -1622,7 +1622,7 @@ std::chrono::steady_clock::duration secondsAsDuration(float duration)
     }
     if (animated)
     {
-        options.duration = secondsAsDuration(duration);
+        options.duration = durationInSeconds(duration);
         options.easing = MGLUnitBezierForMediaTimingFunction(nil);
     }
     _mbglMap->easeTo(options);
@@ -1746,7 +1746,7 @@ mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBounds coord
     }
     if (duration > 0)
     {
-        options.duration = secondsAsDuration(duration);
+        options.duration = durationInSeconds(duration);
         options.easing = MGLUnitBezierForMediaTimingFunction(function);
     }
     _mbglMap->easeTo(options);
@@ -1789,7 +1789,7 @@ mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBounds coord
 
     CGFloat duration = animated ? MGLAnimationDuration : 0;
 
-    _mbglMap->setBearing(direction, mbgl::Duration(secondsAsDuration(duration)));
+    _mbglMap->setBearing(direction, durationInSeconds(duration));
 
     if (animated)
     {
@@ -1939,7 +1939,7 @@ mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBounds coord
     }
     if (duration > 0)
     {
-        options.duration = secondsAsDuration(duration);
+        options.duration = durationInSeconds(duration);
         options.easing = MGLUnitBezierForMediaTimingFunction(function);
     }
     _mbglMap->easeTo(options);
@@ -2073,7 +2073,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
         newAppliedClasses.insert(newAppliedClasses.end(), [appliedClass UTF8String]);
     }
 
-    _mbglMap->setDefaultTransitionDuration(secondsAsDuration(transitionDuration));
+    _mbglMap->setDefaultTransitionDuration(durationInSeconds(transitionDuration));
     _mbglMap->setClasses(newAppliedClasses);
 }
 
@@ -2818,7 +2818,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     if (headingDirection >= 0 && self.userTrackingMode == MGLUserTrackingModeFollowWithHeading)
     {
-        _mbglMap->setBearing(headingDirection, mbgl::Duration(secondsAsDuration(MGLAnimationDuration)));
+        _mbglMap->setBearing(headingDirection, durationInSeconds(MGLAnimationDuration));
     }
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -315,8 +315,8 @@ double Map::getBearing() const {
     return -transform->getAngle() / M_PI * 180;
 }
 
-void Map::resetNorth() {
-    transform->setAngle(0, std::chrono::milliseconds(500));
+void Map::resetNorth(const Duration& duration) {
+    transform->setAngle(0, duration);
     update(Update::Repaint);
 }
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -310,29 +310,24 @@ void Transform::rotateBy(const PrecisionPoint& first, const PrecisionPoint& seco
         return;
     }
 
-    double center_x = static_cast<double>(state.width) / 2.0, center_y = static_cast<double>(state.height) / 2.0;
+    PrecisionPoint center(state.width, state.height);
+    center /= 2;
 
-    const double begin_center_x = first.x - center_x;
-    const double begin_center_y = first.y - center_y;
-
-    const double beginning_center_dist =
-        std::sqrt(begin_center_x * begin_center_x + begin_center_y * begin_center_y);
+    const PrecisionPoint offset = first - center;
+    const double distance = std::sqrt(std::pow(2, offset.x) + std::pow(2, offset.y));
 
     // If the first click was too close to the center, move the center of rotation by 200 pixels
     // in the direction of the click.
-    if (beginning_center_dist < 200) {
-        const double offset_x = -200, offset_y = 0;
-        const double rotate_angle = std::atan2(begin_center_y, begin_center_x);
-        const double rotate_angle_sin = std::sin(rotate_angle);
-        const double rotate_angle_cos = std::cos(rotate_angle);
-        center_x = first.x + rotate_angle_cos * offset_x - rotate_angle_sin * offset_y;
-        center_y = first.y + rotate_angle_sin * offset_x + rotate_angle_cos * offset_y;
+    if (distance < 200) {
+        const double heightOffset = -200;
+        const double rotateAngle = std::atan2(offset.y, offset.x);
+        center.x = first.x + std::cos(rotateAngle) * heightOffset;
+        center.y = first.y + std::sin(rotateAngle) * heightOffset;
     }
 
-    const double first_x = first.x - center_x, first_y = first.y - center_y;
-    const double second_x = second.x - center_x, second_y = second.y - center_y;
-
-    const double ang = state.angle + util::angle_between(first_x, first_y, second_x, second_y);
+    const PrecisionPoint newFirst = first - center;
+    const PrecisionPoint newSecond = second - center;
+    const double ang = state.angle + util::angle_between(newFirst.x, newFirst.y, newSecond.x, newSecond.y);
 
     _setAngle(ang, duration);
 }

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -71,7 +71,7 @@ void Transform::easeTo(const CameraOptions& options) {
     LatLng latLng = easeOptions.center ? *easeOptions.center : getLatLng();
     double zoom = easeOptions.zoom ? *easeOptions.zoom : getZoom();
     double angle = easeOptions.angle ? *easeOptions.angle : getAngle();
-    if (!latLng.isValid() || std::isnan(zoom) || std::isnan(angle)) {
+    if (!latLng || std::isnan(zoom) || std::isnan(angle)) {
         return;
     }
 
@@ -94,7 +94,7 @@ void Transform::easeTo(const CameraOptions& options) {
 }
 
 void Transform::moveBy(const PrecisionPoint& point, const Duration& duration) {
-    if (!point.isValid()) {
+    if (!point) {
         return;
     }
 
@@ -113,7 +113,7 @@ void Transform::_moveBy(const PrecisionPoint& point, const Duration& duration) {
 }
 
 void Transform::setLatLng(const LatLng& latLng, const Duration& duration) {
-    if (!latLng.isValid()) {
+    if (!latLng) {
         return;
     }
 
@@ -124,7 +124,7 @@ void Transform::setLatLng(const LatLng& latLng, const Duration& duration) {
 }
 
 void Transform::setLatLng(const LatLng& latLng, const PrecisionPoint& point, const Duration& duration) {
-    if (!latLng.isValid() || !point.isValid()) {
+    if (!latLng || !point) {
         return;
     }
 
@@ -145,7 +145,7 @@ void Transform::setLatLng(const LatLng& latLng, const PrecisionPoint& point, con
 }
 
 void Transform::setLatLngZoom(const LatLng& latLng, double zoom, const Duration& duration) {
-    if (!latLng.isValid() || std::isnan(zoom)) {
+    if (!latLng || std::isnan(zoom)) {
         return;
     }
 
@@ -160,7 +160,7 @@ void Transform::setLatLngZoom(const LatLng& latLng, double zoom, const Duration&
 #pragma mark - Zoom
 
 void Transform::scaleBy(const double ds, const PrecisionPoint& center, const Duration& duration) {
-    if (std::isnan(ds) || !center.isValid()) {
+    if (std::isnan(ds) || !center) {
         return;
     }
 
@@ -176,7 +176,7 @@ void Transform::scaleBy(const double ds, const PrecisionPoint& center, const Dur
 }
 
 void Transform::setScale(const double scale, const PrecisionPoint& center, const Duration& duration) {
-    if (std::isnan(scale) || !center.isValid()) {
+    if (std::isnan(scale) || !center) {
         return;
     }
 
@@ -306,7 +306,7 @@ void Transform::_easeTo(const CameraOptions& options, double new_scale, double n
 #pragma mark - Angle
 
 void Transform::rotateBy(const PrecisionPoint& first, const PrecisionPoint& second, const Duration& duration) {
-    if (!first.isValid() || !second.isValid()) {
+    if (!first || !second) {
         return;
     }
 
@@ -346,7 +346,7 @@ void Transform::setAngle(const double new_angle, const Duration& duration) {
 }
 
 void Transform::setAngle(const double new_angle, const PrecisionPoint& center) {
-    if (std::isnan(new_angle) || !center.isValid()) {
+    if (std::isnan(new_angle) || !center) {
         return;
     }
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -310,24 +310,27 @@ void Transform::rotateBy(const PrecisionPoint& first, const PrecisionPoint& seco
         return;
     }
 
-    double center_x = static_cast<double>(state.width) / 2.0;
-    double center_y = static_cast<double>(state.height) / 2.0;
-    const double first_x = first.x - center_x;
-    const double first_y = first.y - center_y;
-    const double second_x = second.x - center_x;
-    const double second_y = second.y - center_y;
-    const double beginning_center_dist = std::sqrt(first_x * first_x + first_y * first_y);
+    double center_x = static_cast<double>(state.width) / 2.0, center_y = static_cast<double>(state.height) / 2.0;
+
+    const double begin_center_x = first.x - center_x;
+    const double begin_center_y = first.y - center_y;
+
+    const double beginning_center_dist =
+        std::sqrt(begin_center_x * begin_center_x + begin_center_y * begin_center_y);
 
     // If the first click was too close to the center, move the center of rotation by 200 pixels
     // in the direction of the click.
     if (beginning_center_dist < 200) {
         const double offset_x = -200, offset_y = 0;
-        const double rotate_angle = std::atan2(first_y, first_x);
+        const double rotate_angle = std::atan2(begin_center_y, begin_center_x);
         const double rotate_angle_sin = std::sin(rotate_angle);
         const double rotate_angle_cos = std::cos(rotate_angle);
         center_x = first.x + rotate_angle_cos * offset_x - rotate_angle_sin * offset_y;
         center_y = first.y + rotate_angle_sin * offset_x + rotate_angle_cos * offset_y;
     }
+
+    const double first_x = first.x - center_x, first_y = first.y - center_y;
+    const double second_x = second.x - center_x, second_y = second.y - center_y;
 
     const double ang = state.angle + util::angle_between(first_x, first_y, second_x, second_y);
 

--- a/src/mbgl/storage/default_file_source.cpp
+++ b/src/mbgl/storage/default_file_source.cpp
@@ -325,12 +325,12 @@ int64_t DefaultFileRequest::getRetryTimeout() const {
             if (failedRequests <= graceRetries) {
                 timeout = 1;
             } else {
-                timeout = 1 << std::min(failedRequests - graceRetries, 32);
+                timeout = 1 << std::min(failedRequests - graceRetries, 31);
             }
         } break;
         case Response::Error::Reason::Connection: {
             // Exponential backoff
-            timeout = 1 << std::min(failedRequests - 1, 32);
+            timeout = 1 << std::min(failedRequests - 1, 31);
         } break;
         default:
             // Do not retry due to error.


### PR DESCRIPTION
This PR fixes the following static analyzer warnings introduced by 5a24ac6 for #2994 and 4d5c633 for #2727:

```
/path/to/mapbox-gl-native/src/mbgl/storage/default_file_source.cpp
/path/to/mapbox-gl-native/src/mbgl/storage/default_file_source.cpp:328:29: The result of the '<<' expression is undefined
/path/to/mapbox-gl-native/src/mbgl/storage/default_file_source.cpp:328:29: The result of the '<<' expression is undefined
/path/to/mapbox-gl-native/src/mbgl/storage/default_file_source.cpp:333:25: The result of the '<<' expression is undefined
/path/to/mapbox-gl-native/src/mbgl/storage/default_file_source.cpp:333:25: The result of the '<<' expression is undefined
/path/to/mapbox-gl-native/src/mbgl/map/transform.cpp
/path/to/mapbox-gl-native/src/mbgl/map/transform.cpp:328:9: Value stored to 'center_x' is never read
/path/to/mapbox-gl-native/src/mbgl/map/transform.cpp:328:9: Value stored to 'center_x' is never read
/path/to/mapbox-gl-native/src/mbgl/map/transform.cpp:329:9: Value stored to 'center_y' is never read
/path/to/mapbox-gl-native/src/mbgl/map/transform.cpp:329:9: Value stored to 'center_y' is never read
```

More details in the commit messages.

/cc @brunoabinader @kkaefer