### PR TITLE
Floating-point logical sprite image dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Known issues:
 - Fixed an issue that prevented zoom level–dependent style properties from updating after zooming programmatically with animation. ([#2951](https://github.com/mapbox/mapbox-gl-native/pull/2951))
 - Fixed a rendering issue with styles that use the `background-pattern` property. ([#2531](https://github.com/mapbox/mapbox-gl-native/pull/2531))
 - Fixed a crash when reusing a single `MGLMapView` across multiple `UIViewController`s. ([#2969](https://github.com/mapbox/mapbox-gl-native/pull/2969))
+- Fixed a crash on Retina displays when displaying an annotation whose image has non-integral dimensions. ([#3008](https://github.com/mapbox/mapbox-gl-native/pull/3008))
 - Eliminated flickering when opening and closing an overlay, such as an alert or action sheet. ([#2309](https://github.com/mapbox/mapbox-gl-native/pull/2309))
 - Labels can now line wrap on hyphens and other punctuation. ([#2598](https://github.com/mapbox/mapbox-gl-native/pull/2598))
 - A new delegate callback was added for observing taps to annotation callout views. ([#2596](https://github.com/mapbox/mapbox-gl-native/pull/2596))

--- a/include/mbgl/annotation/sprite_image.hpp
+++ b/include/mbgl/annotation/sprite_image.hpp
@@ -13,11 +13,11 @@ namespace mbgl {
 class SpriteImage : private util::noncopyable {
 public:
     SpriteImage(
-        uint16_t width, uint16_t height, float pixelRatio, std::string&& data, bool sdf = false);
+        float width, float height, float pixelRatio, std::string&& data, bool sdf = false);
 
     // Logical dimensions of the sprite image.
-    const uint16_t width;
-    const uint16_t height;
+    const float width;
+    const float height;
 
     // Pixel ratio of the sprite image.
     const float pixelRatio;

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2289,9 +2289,9 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     // add sprite
     auto cSpriteImage = std::make_shared<mbgl::SpriteImage>(
-        uint16_t(annotationImage.image.size.width),
-        uint16_t(annotationImage.image.size.height),
-        float(annotationImage.image.scale),
+        annotationImage.image.size.width,
+        annotationImage.image.size.height,
+        annotationImage.image.scale,
         std::move(pixels));
 
     // sprite upload

--- a/src/mbgl/annotation/sprite_image.cpp
+++ b/src/mbgl/annotation/sprite_image.cpp
@@ -6,8 +6,8 @@
 
 namespace mbgl {
 
-SpriteImage::SpriteImage(const uint16_t width_,
-                         const uint16_t height_,
+SpriteImage::SpriteImage(const float width_,
+                         const float height_,
                          const float pixelRatio_,
                          std::string&& data_,
                          bool sdf_)


### PR DESCRIPTION
On HiDPI screens, the logical dimensions of a sprite image can be non-integral.

Fixes #2198.

/cc @incanus @friedbunny