### PR TITLE
Set refresh interval to 60fps

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -53,7 +53,7 @@ const CGFloat MGLMinimumPitch = 0;
 const CGFloat MGLMaximumPitch = 60;
 const CLLocationDegrees MGLAngularFieldOfView = M_PI / 6.;
 const std::string spritePrefix = "com.mapbox.sprites.";
-const NSUInteger MGLTargetFrameInterval = 2;  //Target FPS will be 60 divided by this value
+const NSUInteger MGLTargetFrameInterval = 1;  //Target FPS will be 60 divided by this value
 
 NSString *const MGLAnnotationIDKey = @"MGLAnnotationIDKey";
 NSString *const MGLAnnotationSymbolKey = @"MGLAnnotationSymbolKey";


### PR DESCRIPTION
Set the refresh interval to 60 frames per second, which performs well on a 64 GB iPhone 6. We can blacklist specific hardware models that fail to keep up as we come across them in testing, but I think this is a good starting point.

Fixes #3005.

/cc @adam-mapbox @incanus @friedbunny