### PR TITLE
[core] Throttle state updates

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -39,6 +39,15 @@ MapContext::MapContext(View& view_, FileSource& fileSource, MapMode mode_, GLCon
     util::ThreadContext::setFileSource(&fileSource);
     util::ThreadContext::setGLObjectStore(&glObjectStore);
 
+    // Throttle ::update() to 60 Hz. The idea here is it is
+    // useless to try to update the map state more than
+    // 60 times a second because the user will never see the
+    // changes. Increasing the throttle value might increase
+    // performance at slow systems at the cost of rendering
+    // old tiles, labels colliding or upside down when
+    // rotated until the next ::update().
+    asyncUpdate.setThrottle(std::chrono::milliseconds(1000 / 60));
+
     view.activate();
 }
 

--- a/src/mbgl/util/async_task.hpp
+++ b/src/mbgl/util/async_task.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_UTIL_ASYNC_TASK
 #define MBGL_UTIL_ASYNC_TASK
 
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
 #include <memory>
@@ -15,6 +16,8 @@ public:
     ~AsyncTask();
 
     void send();
+
+    void setThrottle(Duration timeout);
 
 private:
     class Impl;


### PR DESCRIPTION
Throttle how often we update the tile state. Previously we were updating as fast as we could, but if we do it more often than the frame rate, it is just a waste of resources because you only see the last state before rendering a frame.

Note that we still send invalidate requests as much as we can. In my tests throttling the ::invalidate() rate to the same frequency as the ::update() didn't yield great results mostly because the clock tick is not so precise. Maybe it could be tunned so we don't spam the client with invalidate request and don't wake the main loop too much.

Finally, we should probably expose the update throttle as a public API because:

1. The client might want to reduce the update frequency due to performance reasons. I.e. wants to paint at 60FPS at the cost of not having a so up-to-date map in the frame.
2. The client might have a frame rate set to something lower than 60FPS so updating at 16ms is overkill.