### PR TITLE
iOS Customize Callout Content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Known issues:
 
 ## iOS master
 
+- Add the ability to customize callout views content via the mapView:calloutViewForAnnotation: callback of MGLMapViewDelegate.
 - If you install this SDK via CocoaPods, CocoaPods version 0.38.0 or above is required. ([#2132](https://github.com/mapbox/mapbox-gl-native/pull/2132))
 - The `styleID` property has been removed from MGLMapView. Instead, set the `styleURL` property to an NSURL in the form `mapbox://styles/STYLE_ID`. If you previously set the style ID in Interface Builder’s Attributes inspector, delete the `styleID` entry from the User Defined Runtime Attributes section of the Identity inspector, then set the new “Style URL” inspectable to a value in the form `mapbox://styles/STYLE_ID`. ([#2632](https://github.com/mapbox/mapbox-gl-native/pull/2632))
 - Default styles such as Streets are no longer bundled with the SDK; instead, they are loaded at runtime from the style API on mapbox.com. As always, you can use these default styles with any valid access token, and Streets continues to be `MGLMapView`’s initial style. The `bundledStyleURLs` property on `MGLMapView` has been deprecated in favor of several class methods on `MGLStyle` that provide direct access to the default styles. ([#2746](https://github.com/mapbox/mapbox-gl-native/pull/2746))

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -527,6 +527,18 @@ IB_DESIGNABLE
 *   @return A Boolean indicating whether the annotation should show a callout. */
 - (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id <MGLAnnotation>)annotation;
 
+/** Returns the view to display as the content view of the callout bubble.
+ *
+ *  The returned view is displayed inside the callout in the top-left corner without any margin. The callout adapts its bounds to fit the size of the returned view.
+ *  The callout will not display any other view except the ones returned by the left/rightCalloutAccessoryViewForAnnotation callbacks.
+ *
+ *  If this callback is not implemented or the returned value is `nil`, the callout displays the default content.
+ *
+ *  @param mapView The map view containing the annotation.
+ *  @param annotation The object representing the annotation with the callout.
+ *  @return The content view to display. */
+- (nullable UIView *)mapView:(MGLMapView *)mapView calloutViewForAnnotation:(id <MGLAnnotation>)annotation;
+
 /** Return the view to display on the left side of the standard callout bubble.
 *
 *   The default value is treated as if `nil`. The left callout view is typically used to display information about the annotation or to link to custom information provided by your application.

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2486,6 +2486,14 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 {
     SMCalloutView *calloutView = [SMCalloutView platformCalloutView];
 
+    UIView *customCalloutView = nil;
+    if ([self.delegate respondsToSelector: @selector(mapView:calloutViewForAnnotation:)]
+        && (customCalloutView = [self.delegate mapView: self calloutViewForAnnotation: annotation]))
+    {
+        calloutView.contentView = customCalloutView;
+        calloutView.contentViewInset = UIEdgeInsetsZero;
+    }
+
     if ([annotation respondsToSelector:@selector(title)]) calloutView.title = annotation.title;
     if ([annotation respondsToSelector:@selector(subtitle)]) calloutView.subtitle = annotation.subtitle;
 


### PR DESCRIPTION
Add the ability to customize callout views content via the mapView:calloutViewForAnnotation: callback of MGLMapViewDelegate.