### PR TITLE
Add TMS tile scheme support

### DIFF
--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -184,6 +184,7 @@ void Source::load() {
 
 void Source::parseTileJSON(const JSValue& value) {
     parse(value, info.tiles, "tiles");
+    parse(value, info.scheme, "scheme");
     parse(value, info.min_zoom, "minzoom");
     parse(value, info.max_zoom, "maxzoom");
     parse(value, info.attribution, "attribution");

--- a/src/mbgl/map/source_info.cpp
+++ b/src/mbgl/map/source_info.cpp
@@ -15,7 +15,11 @@ std::string SourceInfo::tileURL(const TileID& id, float pixelRatio) const {
         } else if (token == "x") {
             return util::toString(id.x);
         } else if (token == "y") {
-            return util::toString(id.y);
+            if (scheme == "tms") {
+                return util::toString((1 << id.z) - id.y - 1);
+            } else {
+                return util::toString(id.y);
+            }
         } else if (token == "prefix") {
             std::string prefix{ 2 };
             prefix[0] = "0123456789abcdef"[id.x % 16];

--- a/src/mbgl/map/source_info.hpp
+++ b/src/mbgl/map/source_info.hpp
@@ -18,6 +18,7 @@ public:
     SourceType type = SourceType::Vector;
     std::string url;
     std::vector<std::string> tiles;
+    std::string scheme = "xyz";
     uint16_t tile_size = util::tileSize;
     uint16_t min_zoom = 0;
     uint16_t max_zoom = 22;


### PR DESCRIPTION
The TileJSON spec says TMS is supported, but the SDK ignores the scheme and uses XYZ.

After a day of testing this change, it seems to work as expected. I'm able to display TMS layers on top of XYZ layers.

fixes #2270