### PR TITLE
Constrain map on both axis

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -45,7 +45,8 @@ class Map : private util::noncopyable {
 public:
     explicit Map(View&, FileSource&,
                  MapMode mapMode = MapMode::Continuous,
-                 GLContextMode contextMode = GLContextMode::Unique);
+                 GLContextMode contextMode = GLContextMode::Unique,
+                 ConstrainMode constrainMode = ConstrainMode::HeightOnly);
     ~Map();
 
     // Pauses the render thread. The render thread will stop running but will not be terminated and will not lose state until resumed.

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -19,6 +19,13 @@ enum class GLContextMode : uint8_t {
     Shared,
 };
 
+// We can choose to constrain the map both horizontally or vertically, or only
+// vertically e.g. while panning.
+enum class ConstrainMode : uint8_t {
+    HeightOnly,
+    WidthAndHeight,
+};
+
 } // namespace mbgl
 
 #endif // MBGL_MAP_MODE

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -41,11 +41,18 @@ struct ProjectedMeters {
 };
 
 struct LatLngBounds {
-    LatLng sw = {90, 180};
-    LatLng ne = {-90, -180};
+    LatLng sw = {-90, -180};
+    LatLng ne = {90, 180};
 
-    inline LatLngBounds(const LatLng& sw_ = {90, 180}, const LatLng& ne_ = {-90, -180})
+    inline LatLngBounds() {}
+
+    inline LatLngBounds(const LatLng& sw_, const LatLng& ne_)
         : sw(sw_), ne(ne_) {}
+
+    static inline LatLngBounds getExtendable() {
+        LatLngBounds bounds;
+        return { bounds.ne, bounds.sw };
+    }
 
     inline operator bool() const {
         return sw && ne;

--- a/platform/android/jni.cpp
+++ b/platform/android/jni.cpp
@@ -1186,9 +1186,7 @@ jlongArray JNICALL nativeGetAnnotationsInBounds(JNIEnv *env, jobject obj, jlong 
         return nullptr;
     }
 
-    mbgl::LatLngBounds bounds;
-    bounds.sw = { swLat, swLon };
-    bounds.ne = { neLat, neLon };
+    mbgl::LatLngBounds bounds({ swLat, swLon }, { neLat, neLon });
 
     // assume only points for now
     std::vector<uint32_t> annotations = nativeMapView->getMap().getPointAnnotationsInBounds(bounds);

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1099,7 +1099,7 @@ std::chrono::steady_clock::duration durationInSeconds(float duration)
 
         // figure out what that means in coordinate space
         CLLocationCoordinate2D coordinate;
-        mbgl::LatLngBounds tapBounds;
+        mbgl::LatLngBounds tapBounds = mbgl::LatLngBounds::getExtendable();
 
         coordinate = [self convertPoint:tapRectLowerLeft  toCoordinateFromView:self];
         tapBounds.extend(MGLLatLngFromLocationCoordinate2D(coordinate));
@@ -1997,7 +1997,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
 - (mbgl::LatLngBounds)viewportBounds
 {
-    mbgl::LatLngBounds bounds;
+    mbgl::LatLngBounds bounds = mbgl::LatLngBounds::getExtendable();
 
     bounds.extend(MGLLatLngFromLocationCoordinate2D(
         [self convertPoint:CGPointMake(0, 0) toCoordinateFromView:self]));
@@ -2517,7 +2517,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 {
     if ( ! annotations || ! annotations.count) return;
 
-    mbgl::LatLngBounds bounds;
+    mbgl::LatLngBounds bounds = mbgl::LatLngBounds::getExtendable();
 
     for (id <MGLAnnotation> annotation in annotations)
     {

--- a/platform/ios/MGLMultiPoint.mm
+++ b/platform/ios/MGLMultiPoint.mm
@@ -19,6 +19,7 @@
     {
         _count = count;
         _coords = (CLLocationCoordinate2D *)malloc(_count * sizeof(CLLocationCoordinate2D));
+        _bounds = mbgl::LatLngBounds::getExtendable();
 
         for (NSUInteger i = 0; i < _count; i++)
         {

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -68,7 +68,7 @@ AnnotationIDs AnnotationManager::getPointAnnotationsInBounds(const LatLngBounds&
 }
 
 LatLngBounds AnnotationManager::getBoundsForAnnotations(const AnnotationIDs& ids) const {
-    LatLngBounds result;
+    LatLngBounds result = LatLngBounds::getExtendable();
 
     for (const auto& id : ids) {
         if (pointAnnotations.find(id) != pointAnnotations.end()) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -14,9 +14,9 @@
 
 namespace mbgl {
 
-Map::Map(View& view_, FileSource& fileSource, MapMode mapMode, GLContextMode contextMode)
+Map::Map(View& view_, FileSource& fileSource, MapMode mapMode, GLContextMode contextMode, ConstrainMode constrainMode)
     : view(view_),
-      transform(std::make_unique<Transform>(view)),
+      transform(std::make_unique<Transform>(view, constrainMode)),
       data(std::make_unique<MapData>(mapMode, contextMode, view.getPixelRatio())),
       context(std::make_unique<util::Thread<MapContext>>(util::ThreadContext{"Map", util::ThreadType::Map, util::ThreadPriority::Regular}, view, fileSource, *data))
 {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -242,8 +242,8 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
     // Cleanup OpenGL objects that we abandoned since the last render call.
     glObjectStore.performCleanup();
 
-    if (!painter) painter = std::make_unique<Painter>(data);
-    painter->render(*style, transformState, frame);
+    if (!painter) painter = std::make_unique<Painter>(data, transformState);
+    painter->render(*style, frame);
 
     if (data.mode == MapMode::Still) {
         callback(nullptr, view.readStillImage());

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -21,13 +21,8 @@ class View;
 class MapData;
 class TexturePool;
 class Painter;
-class Sprite;
-class Worker;
-class StillImage;
 class SpriteImage;
 class FileRequest;
-struct LatLng;
-struct LatLngBounds;
 
 struct FrameData {
     std::array<uint16_t, 2> framebufferSize;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -34,8 +34,9 @@ static double _normalizeAngle(double angle, double anchorAngle)
     return angle;
 }
 
-Transform::Transform(View &view_)
+Transform::Transform(View &view_, ConstrainMode constrainMode)
     : view(view_)
+    , state(constrainMode)
 {
 }
 
@@ -48,7 +49,7 @@ bool Transform::resize(const std::array<uint16_t, 2> size) {
 
         state.width = size[0];
         state.height = size[1];
-        state.constrain(state.scale, state.y);
+        state.constrain(state.scale, state.x, state.y);
 
         view.notifyMapChange(MapChangeRegionDidChange);
 
@@ -105,7 +106,7 @@ void Transform::_moveBy(const PrecisionPoint& point, const Duration& duration) {
     double x = state.x + std::cos(state.angle) * point.x + std::sin( state.angle) * point.y;
     double y = state.y + std::cos(state.angle) * point.y + std::sin(-state.angle) * point.x;
 
-    state.constrain(state.scale, y);
+    state.constrain(state.scale, x, y);
 
     CameraOptions options;
     options.duration = duration;
@@ -239,7 +240,7 @@ void Transform::_easeTo(const CameraOptions& options, double new_scale, double n
     double x = xn;
     double y = yn;
 
-    state.constrain(scale, y);
+    state.constrain(scale, x, y);
     
     double angle = _normalizeAngle(new_angle, state.angle);
     state.angle = _normalizeAngle(state.angle, angle);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -159,7 +159,7 @@ void Transform::setLatLngZoom(const LatLng& latLng, double zoom, const Duration&
 
 #pragma mark - Zoom
 
-void Transform::scaleBy(const double ds, const PrecisionPoint& center, const Duration& duration) {
+void Transform::scaleBy(double ds, const PrecisionPoint& center, const Duration& duration) {
     if (std::isnan(ds) || !center) {
         return;
     }
@@ -175,7 +175,7 @@ void Transform::scaleBy(const double ds, const PrecisionPoint& center, const Dur
     _setScale(new_scale, center, duration);
 }
 
-void Transform::setScale(const double scale, const PrecisionPoint& center, const Duration& duration) {
+void Transform::setScale(double scale, const PrecisionPoint& center, const Duration& duration) {
     if (std::isnan(scale) || !center) {
         return;
     }
@@ -183,7 +183,7 @@ void Transform::setScale(const double scale, const PrecisionPoint& center, const
     _setScale(scale, center, duration);
 }
 
-void Transform::setZoom(const double zoom, const Duration& duration) {
+void Transform::setZoom(double zoom, const Duration& duration) {
     if (std::isnan(zoom)) {
         return;
     }
@@ -225,7 +225,7 @@ void Transform::_setScale(double new_scale, const PrecisionPoint& center, const 
     _setScaleXY(new_scale, xn, yn, duration);
 }
 
-void Transform::_setScaleXY(const double new_scale, const double xn, const double yn,
+void Transform::_setScaleXY(double new_scale, double xn, double yn,
                             const Duration& duration) {
     CameraOptions options;
     options.duration = duration;
@@ -332,7 +332,7 @@ void Transform::rotateBy(const PrecisionPoint& first, const PrecisionPoint& seco
     _setAngle(ang, duration);
 }
 
-void Transform::setAngle(const double new_angle, const Duration& duration) {
+void Transform::setAngle(double new_angle, const Duration& duration) {
     if (std::isnan(new_angle)) {
         return;
     }
@@ -340,7 +340,7 @@ void Transform::setAngle(const double new_angle, const Duration& duration) {
     _setAngle(new_angle, duration);
 }
 
-void Transform::setAngle(const double new_angle, const PrecisionPoint& center) {
+void Transform::setAngle(double new_angle, const PrecisionPoint& center) {
     if (std::isnan(new_angle) || !center) {
         return;
     }

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -60,7 +60,7 @@ public:
     bool isGestureInProgress() const { return state.isGestureInProgress(); }
 
     // Transform state
-    const TransformState getState() const { return state; }
+    TransformState getState() const { return state; }
     bool isRotating() const { return state.isRotating(); }
     bool isScaling() const { return state.isScaling(); }
     bool isPanning() const { return state.isPanning(); }

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -1,10 +1,11 @@
 #ifndef MBGL_MAP_TRANSFORM
 #define MBGL_MAP_TRANSFORM
 
-#include <mbgl/map/transform_state.hpp>
 #include <mbgl/map/camera.hpp>
-#include <mbgl/util/chrono.hpp>
+#include <mbgl/map/mode.hpp>
+#include <mbgl/map/transform_state.hpp>
 #include <mbgl/map/update.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
@@ -18,7 +19,7 @@ class View;
 
 class Transform : private util::noncopyable {
 public:
-    Transform(View&);
+    Transform(View&, ConstrainMode);
 
     // Map view
     bool resize(std::array<uint16_t, 2> size);

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -7,6 +7,10 @@
 
 using namespace mbgl;
 
+TransformState::TransformState()
+{
+}
+
 #pragma mark - Matrix
 
 void TransformState::matrixFor(mat4& matrix, const TileID& id, const int8_t z) const {

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -21,6 +21,8 @@ class TransformState {
     friend class Transform;
 
 public:
+    TransformState();
+
     // Matrix
     void matrixFor(mat4& matrix, const TileID& id, const int8_t z) const;
     void getProjMatrix(mat4& matrix) const;

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_MAP_TRANSFORM_STATE
 #define MBGL_MAP_TRANSFORM_STATE
 
+#include <mbgl/map/mode.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/vec.hpp>
@@ -21,7 +22,7 @@ class TransformState {
     friend class Transform;
 
 public:
-    TransformState();
+    TransformState(ConstrainMode = ConstrainMode::HeightOnly);
 
     // Matrix
     void matrixFor(mat4& matrix, const TileID& id, const int8_t z) const;
@@ -73,7 +74,7 @@ public:
     TileCoordinate pointToCoordinate(const PrecisionPoint&) const;
 
 private:
-    void constrain(double& scale, double& y) const;
+    void constrain(double& scale, double& x, double& y) const;
 
     // Limit the amount of zooming possible on the map.
     double min_scale = std::pow(2, 0);
@@ -93,6 +94,8 @@ private:
     mat4 getPixelMatrix() const;
 
 private:
+    ConstrainMode constrainMode;
+
     // animation state
     bool rotating = false;
     bool scaling = false;

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -43,7 +43,8 @@
 
 using namespace mbgl;
 
-Painter::Painter(MapData& data_) : data(data_) {
+Painter::Painter(MapData& data_, TransformState& state_)
+    : data(data_), state(state_) {
     setup();
 }
 
@@ -127,8 +128,7 @@ void Painter::prepareTile(const Tile& tile) {
     config.stencilFunc = { GL_EQUAL, ref, mask };
 }
 
-void Painter::render(const Style& style, TransformState state_, const FrameData& frame_) {
-    state = state_;
+void Painter::render(const Style& style, const FrameData& frame_) {
     frame = frame_;
 
     glyphAtlas = style.glyphAtlas.get();

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -82,7 +82,7 @@ struct RenderItem {
 
 class Painter : private util::noncopyable {
 public:
-    Painter(MapData& data);
+    Painter(MapData&, TransformState&);
     ~Painter();
 
     // Renders the backdrop of the OpenGL view. This also paints in areas where we don't have any
@@ -93,7 +93,6 @@ public:
     void changeMatrix();
 
     void render(const Style& style,
-                TransformState state,
                 const FrameData& frame);
 
     // Renders debug information for a tile.
@@ -182,8 +181,7 @@ public:
 
 private:
     MapData& data;
-
-    TransformState state;
+    TransformState& state;
     FrameData frame;
 
     int indent = 0;

--- a/test/ios/MapViewTests.m
+++ b/test/ios/MapViewTests.m
@@ -317,12 +317,14 @@ const NSTimeInterval MGLAnimationDurationOverDefault = MGLAnimationDurationDefau
 
     tester.mapView.centerCoordinate = newCenterCoordinate;
 
-    XCTAssertEqual(tester.mapView.centerCoordinate.latitude,
+    XCTAssertEqualWithAccuracy(tester.mapView.centerCoordinate.latitude,
                    newCenterCoordinate.latitude,
+                   0.001,
                    @"setting center should change latitude");
 
-    XCTAssertEqual(tester.mapView.centerCoordinate.longitude,
+    XCTAssertEqualWithAccuracy(tester.mapView.centerCoordinate.longitude,
                    newCenterCoordinate.longitude,
+                   0.001,
                    @"setting center should change longitude");
 }
 

--- a/test/style/resource_loading.cpp
+++ b/test/style/resource_loading.cpp
@@ -24,7 +24,7 @@ public:
                    FileSource& fileSource,
                    const std::function<void(std::exception_ptr error)>& callback)
         : data_(MapMode::Still, GLContextMode::Unique, view.getPixelRatio()),
-          transform_(view),
+          transform_(view, ConstrainMode::HeightOnly),
           callback_(callback) {
         util::ThreadContext::setFileSource(&fileSource);
 


### PR DESCRIPTION
Currently we constrain the map boundaries only in the vertical axis. We should have the option to constrain also in horizontal axis, which would disable the possibility to infinitely pan the map horizontally, but also fixes an issue where annotations start disappearing once we reach the map horizontal boundaries.

/cc @mapbox/gl @mapbox/mobile