### PR TITLE
provide resource bundle search for premade frameworks

### DIFF
--- a/platform/ios/NSBundle+MGLAdditions.m
+++ b/platform/ios/NSBundle+MGLAdditions.m
@@ -8,8 +8,21 @@ void mgl_linkBundleCategory(){}
 
 + (NSString *)mgl_resourceBundlePath
 {
-    NSString *resourceBundlePath = [[NSBundle bundleForClass:[MGLMapView class]] pathForResource:@"Mapbox" ofType:@"bundle"];
+    NSString *resourceBundlePath = nil;
 
+    // check for resource bundle in framework bundle (Fabric, premade framework)
+    //
+    NSString *frameworkBundlePath = [NSString stringWithFormat:@"%@/Mapbox.framework/Mapbox.bundle",
+        [[NSBundle mainBundle] privateFrameworksPath]];
+    if ([NSBundle bundleWithPath:frameworkBundlePath]) resourceBundlePath = frameworkBundlePath;
+
+    // check for resource bundle in app bundle (static library)
+    //
+    if ( ! resourceBundlePath) resourceBundlePath = [[NSBundle bundleForClass:
+        [MGLMapView class]] pathForResource:@"Mapbox" ofType:@"bundle"];
+
+    // fall back to resources directly in app bundle (test app)
+    //
     if ( ! resourceBundlePath) resourceBundlePath = [[NSBundle mainBundle] bundlePath];
 
     return resourceBundlePath;


### PR DESCRIPTION
If you package the static library, the resource bundle, and the headers into a faux-framework `Mapbox.framework`, this is needed in order to actually locate the resource bundle, since frameworks are copied as a build phase into the app bundle, but `[NSBundle bundleWithClass:[MGLMapView class]]` returns that app bundle due to linking behavior. 