### PR TITLE
static framework target for iOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ ipackage: Xcode/ios ; @JOBS=$(JOBS) ./scripts/ios/package.sh
 ipackage-strip: Xcode/ios ; @JOBS=$(JOBS) ./scripts/ios/package.sh strip
 ipackage-sim: Xcode/ios ; @JOBS=$(JOBS) ./scripts/ios/package.sh sim
 ipackage-no-bitcode: Xcode/ios ; @JOBS=$(JOBS) ./scripts/ios/package.sh no-bitcode
+iframework: Xcode/ios ; ipackage-strip ; ./scripts/ios/framework.sh
 itest: ipackage-sim ; ./scripts/ios/test.sh
 endif
 

--- a/ios/framework/Info.plist
+++ b/ios/framework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${PRODUCT_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>#####</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>%%%%%</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/ios/framework/modulemap
+++ b/ios/framework/modulemap
@@ -1,0 +1,5 @@
+framework module Mapbox {
+  umbrella header "Mapbox.h"
+  export *
+  module * { export * }
+}

--- a/ios/framework/umbrella
+++ b/ios/framework/umbrella
@@ -1,0 +1,3 @@
+
+FOUNDATION_EXPORT double MapboxVersionNumber;
+FOUNDATION_EXPORT const unsigned char MapboxVersionString[];

--- a/scripts/ios/framework.sh
+++ b/scripts/ios/framework.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+cd build/ios/pkg
+rm -rf framework
+mkdir framework
+cd framework
+
+mkdir Mapbox.framework
+
+# headers
+cp -rv ../static/Headers Mapbox.framework/Headers
+cat ../../../../ios/framework/umbrella >> Mapbox.framework/Headers/Mapbox.h
+
+# resources
+cp -rv ../static/Mapbox.bundle Mapbox.framework/Mapbox.bundle
+
+# binary
+cp -v ../static/libMapbox.a Mapbox.framework/Mapbox
+
+# module map
+mkdir Mapbox.framework/Modules
+cp -v ../../../../ios/framework/modulemap Mapbox.framework/Modules/module.modulemap
+
+# Info.plist
+VERSION=$( git tag | grep ^ios | sed 's/^ios-//' | sort -r | grep -v '\-rc.' | grep -v '\-pre.' | sed -n '1p' | sed 's/^v//' )
+cp -v ../../../../ios/framework/Info.plist Mapbox.framework
+perl -pi -e "s/#####/$VERSION/" Mapbox.framework/Info.plist
+perl -pi -e "s/%%%%%/$VERSION/" Mapbox.framework/Info.plist


### PR DESCRIPTION
The idea is to just leave this in the `Makefile` for now, but still only distribute static libraries directly (plus CocoaPods install), not framework bundles. 