### PR TITLE
Eliminate separate "MapContext" thread

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -32,10 +32,6 @@ class ShapeAnnotation;
 struct CameraOptions;
 struct AnimationOptions;
 
-namespace util {
-template <class T> class Thread;
-} // namespace util
-
 class Map : private util::noncopyable {
     friend class View;
 
@@ -46,22 +42,15 @@ public:
                  ConstrainMode constrainMode = ConstrainMode::HeightOnly);
     ~Map();
 
-    // Pauses the render thread. The render thread will stop running but will not be terminated and will not lose state until resumed.
-    void pause();
-    bool isPaused();
-
-    // Resumes a paused render thread
-    void resume();
-
     // Register a callback that will get called (on the render thread) when all resources have
     // been loaded and a complete render occurs.
     using StillImageCallback = std::function<void (std::exception_ptr, PremultipliedImage&&)>;
     void renderStill(StillImageCallback callback);
 
-    // Triggers a synchronous render.
-    void renderSync();
+    // Main render function.
+    void render();
 
-    // Notifies the Map thread that the state has changed and an update might be necessary.
+    // Notifies the Map that the state has changed and an update might be necessary.
     void update(Update update);
 
     // Styling
@@ -189,7 +178,7 @@ public:
 private:
     View& view;
     const std::unique_ptr<Transform> transform;
-    const std::unique_ptr<util::Thread<MapContext>> context;
+    const std::unique_ptr<MapContext> context;
     MapData* data;
 
     enum class RenderState {

--- a/include/mbgl/map/view.hpp
+++ b/include/mbgl/map/view.hpp
@@ -30,43 +30,41 @@ enum MapChange : uint8_t {
 
 class View {
 public:
-    // Called from the main thread directly after initialization. Must always return the same value,
-    // i.e. it may not change over time.
+    virtual ~View() = default;
+
+    // Called directly after initialization. Must always return the same value, i.e. it may
+    // not change over time.
     virtual float getPixelRatio() const = 0;
 
-    // Called from the main thread when the View signaled a dimension change. Must return the
-    // logical dimension of this map in pixels.
+    // Called when the View signaled a dimension change. Must return the logical dimension
+    // of this map in pixels.
     virtual std::array<uint16_t, 2> getSize() const = 0;
 
-    // Called from the main thread for every frame that is being rendered. Must return the absolute
-    // dimensions of the current framebuffer. Typically, this is the logical width scaled by the
-    // pixel ratio, but in case the view was moved to display with a different pixel ratio, it can
-    // also be different from that rule.
+    // Called for every frame that is being rendered. Must return the absolute dimensions of
+    // the current framebuffer. Typically, this is the logical width scaled by the pixel ratio,
+    // but in case the view was moved to display with a different pixel ratio, it can also be
+    // different from that rule.
     virtual std::array<uint16_t, 2> getFramebufferSize() const = 0;
 
-    // Called from the main thread when this View is associated with a Map object.
-    virtual void initialize(Map *map_);
+    // Called when this View is associated with a Map object.
+    virtual void initialize(Map*);
 
-    // Called from the render thread. Makes the GL context active in the current
-    // thread. This is typically just called once at the beginning of the
-    // renderer setup since the render thread doesn't switch the contexts.
+    // Called when the view's GL context needs to be made active or inactive. These are called,
+    // as a matched pair, in four situations:
+    //
+    //   1. When releasing GL resources during Map destruction
+    //   2. When calling a CustomLayerInitializeFunction, during Map::addCustomLayer
+    //   3. When calling a CustomLayerDeinitializeFunction, during Map::removeCustomLayer
+    //   4. When rendering for Map::renderStill
+    //
+    // They are *not* called for Map::render; it is assumed that the correct context is already
+    // activated prior to calling Map::render.
     virtual void activate() = 0;
-
-    // Called from the render thread. Makes the GL context inactive in the current
-    // thread. This is called once just before the rendering thread terminates.
     virtual void deactivate() = 0;
 
-    virtual void notify() = 0;
-
-    // Called from the render thread. The implementation must trigger a rerender.
-    // (map->renderSync() from the main thread must be called as a result of this)
+    // Called when the map needs to be rendered; the view should call Map::render() at some point
+    // in the near future. (Not called for Map::renderStill() mode.)
     virtual void invalidate() = 0;
-
-    // Called from the render thread before the render begins.
-    virtual void beforeRender() = 0;
-
-    // Called from the render thread after the render is complete.
-    virtual void afterRender() = 0;
 
     // Reads the pixel data from the current framebuffer. If your View implementation
     // doesn't support reading from the framebuffer, return a null pointer.

--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -22,13 +22,10 @@ public:
     std::array<uint16_t, 2> getSize() const override;
     std::array<uint16_t, 2> getFramebufferSize() const override;
 
-    void initialize(mbgl::Map *map) override;
+    void initialize(mbgl::Map*) override;
     void activate() override;
     void deactivate() override;
-    void notify() override;
     void invalidate() override;
-    void beforeRender() override;
-    void afterRender() override;
 
     static void onKey(GLFWwindow *window, int key, int scancode, int action, int mods);
     static void onScroll(GLFWwindow *window, double xoffset, double yoffset);

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -38,34 +38,31 @@ public:
     std::array<uint16_t, 2> getSize() const override;
     std::array<uint16_t, 2> getFramebufferSize() const override;
 
+    void invalidate() override;
     void activate() override;
     void deactivate() override;
-    void notify() override;
-    void invalidate() override;
-    void beforeRender() override;
-    void afterRender() override;
+
     PremultipliedImage readStillImage() override;
 
-    void resizeFramebuffer();
     void resize(uint16_t width, uint16_t height);
 
 private:
-    void loadExtensions();
-    bool isActive() const;
-
     // Implementation specific functions
     static gl::glProc initializeExtension(const char*);
     void createContext();
     void destroyContext();
     void clearBuffers();
+    void resizeFramebuffer();
     void activateContext();
     void deactivateContext();
 
-private:
     std::shared_ptr<HeadlessDisplay> display;
     const float pixelRatio;
     std::array<uint16_t, 2> dimensions;
+
     bool needsResize = false;
+    bool extensionsLoaded = false;
+    bool active = false;
 
 #if MBGL_USE_CGL
     CGLContextObj glContext = nullptr;
@@ -82,13 +79,9 @@ private:
     GLXPbuffer glxPbuffer = 0;
 #endif
 
-    bool extensionsLoaded = false;
-
     GLuint fbo = 0;
     GLuint fboDepthStencil = 0;
     GLuint fboColor = 0;
-
-    std::thread::id thread;
 };
 
 } // namespace mbgl

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -521,7 +521,6 @@ public class MapView extends FrameLayout {
         mConnectivityReceiver = null;
 
         mUserLocationView.onPause();
-        mNativeMapView.pause();
     }
 
     /**
@@ -533,7 +532,6 @@ public class MapView extends FrameLayout {
         mConnectivityReceiver = new ConnectivityReceiver();
         getContext().registerReceiver(mConnectivityReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
 
-        mNativeMapView.resume();
         mNativeMapView.update();
         mUserLocationView.onResume();
 
@@ -1094,9 +1092,7 @@ public class MapView extends FrameLayout {
     }
 
     int getTopOffsetPixelsForIcon(Icon icon) {
-        // This method will dead lock if map paused. Causes a freeze if you add a marker in an
-        // activity's onCreate()
-        if (mDestroyed || mNativeMapView.isPaused()) {
+        if (mDestroyed) {
             return 0;
         }
 
@@ -1243,11 +1239,11 @@ public class MapView extends FrameLayout {
             return;
         }
 
-        if (mDestroyed || mNativeMapView.isPaused()) {
+        if (mDestroyed) {
             return;
         }
 
-        mNativeMapView.renderSync();
+        mNativeMapView.render();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -2297,7 +2297,6 @@ public class MapView extends FrameLayout {
      * @param listener The callback that's invoked on every frame rendered to the map view.
      * @see MapView#removeOnMapChangedListener(OnMapChangedListener)
      */
-    @UiThread
     public void addOnMapChangedListener(@Nullable OnMapChangedListener listener) {
         if (listener != null) {
             mOnMapChangedListener.add(listener);
@@ -2310,7 +2309,6 @@ public class MapView extends FrameLayout {
      * @param listener The previously added callback to remove.
      * @see MapView#addOnMapChangedListener(OnMapChangedListener)
      */
-    @UiThread
     public void removeOnMapChangedListener(@Nullable OnMapChangedListener listener) {
         if (listener != null) {
             mOnMapChangedListener.remove(listener);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -118,6 +118,8 @@ public class MapView extends FrameLayout {
     private int mAverageIconWidth;
 
     private NativeMapView mNativeMapView;
+    private boolean mHasSurface = false;
+
     private CompassView mCompassView;
     private ImageView mLogoView;
     private ImageView mAttributionsView;
@@ -1243,6 +1245,10 @@ public class MapView extends FrameLayout {
             return;
         }
 
+        if (!mHasSurface) {
+            return;
+        }
+
         mNativeMapView.render();
     }
 
@@ -1276,12 +1282,16 @@ public class MapView extends FrameLayout {
         public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
             mNativeMapView.createSurface(mSurface = new Surface(surface));
             mNativeMapView.resizeFramebuffer(width, height);
+
+            mHasSurface = true;
         }
 
         // Called when the native surface texture has been destroyed
         // Must do all EGL/GL ES destruction here
         @Override
         public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
+            mHasSurface = false;
+
             if (mNativeMapView != null) {
                 mNativeMapView.destroySurface();
             }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -119,24 +119,12 @@ final class NativeMapView {
         nativeDestroySurface(mNativeMapViewPtr);
     }
 
-    public void pause() {
-        nativePause(mNativeMapViewPtr);
-    }
-
-    public boolean isPaused() {
-        return nativeIsPaused(mNativeMapViewPtr);
-    }
-
-    public void resume() {
-        nativeResume(mNativeMapViewPtr);
-    }
-
     public void update() {
         nativeUpdate(mNativeMapViewPtr);
     }
 
-    public void renderSync() {
-        nativeRenderSync(mNativeMapViewPtr);
+    public void render() {
+        nativeRender(mNativeMapViewPtr);
     }
 
     public void resizeView(int width, int height) {
@@ -515,15 +503,9 @@ final class NativeMapView {
 
     private native void nativeDestroySurface(long nativeMapViewPtr);
 
-    private native void nativePause(long nativeMapViewPtr);
-
-    private native boolean nativeIsPaused(long nativeMapViewPtr);
-
-    private native void nativeResume(long nativeMapViewPtr);
-
     private native void nativeUpdate(long nativeMapViewPtr);
 
-    private native void nativeRenderSync(long nativeMapViewPtr);
+    private native void nativeRender(long nativeMapViewPtr);
 
     private native void nativeViewResize(long nativeMapViewPtr, int width, int height);
 

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -21,6 +21,7 @@
 #include <mbgl/storage/network_status.hpp>
 #include <mbgl/util/exception.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 #include <jni/jni.hpp>
 
@@ -1700,6 +1701,8 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     theJVM = vm;
 
     jni::JNIEnv& env = jni::GetEnv(*vm, jni::jni_version_1_6);
+
+    static mbgl::util::RunLoop mainRunLoop;
 
     mbgl::android::RegisterNativeHTTPRequest(env);
 

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -404,27 +404,6 @@ void nativeDestroySurface(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr
     nativeMapView->destroySurface();
 }
 
-void nativePause(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativePause");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->pause();
-}
-
-jboolean nativeIsPaused(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeIsPaused");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    return nativeMapView->getMap().isPaused();
-}
-
-void nativeResume(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeResume");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->resume();
-}
-
 void nativeUpdate(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeUpdate");
     assert(nativeMapViewPtr != 0);
@@ -432,11 +411,11 @@ void nativeUpdate(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
     nativeMapView->getMap().update(mbgl::Update::Repaint);
 }
 
-void nativeRenderSync(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeRenderSync");
+void nativeRender(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
+    mbgl::Log::Debug(mbgl::Event::JNI, "nativeRender");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().renderSync();
+    nativeMapView->render();
 }
 
 void nativeViewResize(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jint width, jint height) {
@@ -1815,11 +1794,8 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
         MAKE_NATIVE_METHOD(nativeTerminateContext, "(J)V"),
         MAKE_NATIVE_METHOD(nativeCreateSurface, "(JLandroid/view/Surface;)V"),
         MAKE_NATIVE_METHOD(nativeDestroySurface, "(J)V"),
-        MAKE_NATIVE_METHOD(nativePause, "(J)V"),
-        MAKE_NATIVE_METHOD(nativeIsPaused, "(J)Z"),
-        MAKE_NATIVE_METHOD(nativeResume, "(J)V"),
         MAKE_NATIVE_METHOD(nativeUpdate, "(J)V"),
-        MAKE_NATIVE_METHOD(nativeRenderSync, "(J)V"),
+        MAKE_NATIVE_METHOD(nativeRender, "(J)V"),
         MAKE_NATIVE_METHOD(nativeViewResize, "(JII)V"),
         MAKE_NATIVE_METHOD(nativeFramebufferResize, "(JII)V"),
         MAKE_NATIVE_METHOD(nativeAddClass, "(JLjava/lang/String;)V"),

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -380,11 +380,6 @@ void NativeMapView::createSurface(ANativeWindow *window_) {
     if (!firstTime) {
         firstTime = true;
 
-        EGLDisplay oldDisplay = eglGetCurrentDisplay();
-        EGLSurface oldReadSurface = eglGetCurrentSurface(EGL_READ);
-        EGLSurface oldDrawSurface = eglGetCurrentSurface(EGL_DRAW);
-        EGLContext oldContext = eglGetCurrentContext();
-
         if (!eglMakeCurrent(display, surface, surface, context)) {
             mbgl::Log::Error(mbgl::Event::OpenGL, "eglMakeCurrent() returned error %d",
                              eglGetError());
@@ -404,21 +399,6 @@ void NativeMapView::createSurface(ANativeWindow *window_) {
         mbgl::gl::InitializeExtensions([] (const char * name) {
              return reinterpret_cast<mbgl::gl::glProc>(eglGetProcAddress(name));
         });
-
-        if (oldDisplay == EGL_NO_DISPLAY) {
-            oldDisplay = display;
-        }
-
-        if (!eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
-            mbgl::Log::Error(mbgl::Event::OpenGL,"eglMakeCurrent(EGL_NO_CONTEXT) returned error %d", eglGetError());
-            throw std::runtime_error("eglMakeCurrent() failed");
-        }
-
-        if (!eglMakeCurrent(oldDisplay, oldDrawSurface, oldReadSurface, oldContext)) {
-            mbgl::Log::Error(mbgl::Event::OpenGL,
-                             "eglMakeCurrent(EGL_NO_CONTEXT) returned error %d", eglGetError());
-            throw std::runtime_error("eglMakeCurrent() failed");
-        }
     }
 }
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -24,10 +24,7 @@ public:
     std::array<uint16_t, 2> getFramebufferSize() const override;
     void activate() override;
     void deactivate() override;
-    void notify() override;
     void invalidate() override;
-    void beforeRender() override;
-    void afterRender() override;
 
     void notifyMapChange(mbgl::MapChange) override;
 
@@ -43,8 +40,7 @@ public:
     void createSurface(ANativeWindow *window);
     void destroySurface();
 
-    void resume();
-    void pause();
+    void render();
 
     void enableFps(bool enable);
     void updateFps();

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -57,6 +57,7 @@ private:
 
 private:
     JavaVM *vm = nullptr;
+    JNIEnv *env = nullptr;
     jweak obj = nullptr;
 
     ANativeWindow *window = nullptr;
@@ -83,9 +84,6 @@ private:
 
     int availableProcessors = 0;
     size_t totalMemory = 0;
-
-    jboolean renderDetach = false;
-    JNIEnv *renderEnv = nullptr;
 
     // Ensure these are initialised last
     std::unique_ptr<mbgl::DefaultFileSource> fileSource;

--- a/platform/android/src/run_loop_impl.hpp
+++ b/platform/android/src/run_loop_impl.hpp
@@ -27,6 +27,11 @@ public:
         std::list<Runnable*>::iterator iter;
     };
 
+    Impl(RunLoop*, RunLoop::Type);
+    ~Impl();
+
+    void wake();
+
     void addRunnable(Runnable*);
     void removeRunnable(Runnable*);
     void initRunnable(Runnable*);
@@ -35,6 +40,8 @@ public:
 
 private:
     friend RunLoop;
+
+    int fds[2];
 
     JNIEnv *env = nullptr;
     bool detach = false;

--- a/platform/darwin/src/headless_view_cgl.cpp
+++ b/platform/darwin/src/headless_view_cgl.cpp
@@ -76,7 +76,7 @@ void HeadlessView::resizeFramebuffer() {
 }
 
 void HeadlessView::clearBuffers() {
-    assert(isActive());
+    assert(active);
 
     MBGL_CHECK_ERROR(glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0));
 

--- a/platform/darwin/src/headless_view_eagl.mm
+++ b/platform/darwin/src/headless_view_eagl.mm
@@ -72,7 +72,7 @@ void HeadlessView::resizeFramebuffer() {
 }
 
 void HeadlessView::clearBuffers() {
-    assert(isActive());
+    assert(active);
 
     MBGL_CHECK_ERROR(glBindFramebuffer(GL_FRAMEBUFFER, 0));
 

--- a/platform/default/headless_view_glx.cpp
+++ b/platform/default/headless_view_glx.cpp
@@ -93,7 +93,7 @@ void HeadlessView::resizeFramebuffer() {
 }
 
 void HeadlessView::clearBuffers() {
-    assert(isActive());
+    assert(active);
 
     MBGL_CHECK_ERROR(glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0));
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -1,10 +1,8 @@
 #include "node_map.hpp"
 #include "node_request.hpp"
-#include "node_mapbox_gl_native.hpp"
 
 #include <mbgl/platform/default/headless_display.hpp>
 #include <mbgl/util/exception.hpp>
-#include <mbgl/util/work_request.hpp>
 
 #include <unistd.h>
 
@@ -474,18 +472,16 @@ NodeMap::~NodeMap() {
     if (valid) release();
 }
 
-std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resource, Callback cb1) {
-    // This function can be called from any thread. Make sure we're executing the
-    // JS implementation in the node event loop.
-    return NodeRunLoop().invokeWithCallback([this] (mbgl::Resource res, Callback cb2) {
-        Nan::HandleScope scope;
+std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resource, Callback callback_) {
+    Nan::HandleScope scope;
 
-        auto requestHandle = NodeRequest::Create(res, cb2)->ToObject();
-        auto callbackHandle = Nan::New<v8::Function>(NodeRequest::Respond, requestHandle);
+    auto requestHandle = NodeRequest::Create(resource, callback_)->ToObject();
+    auto callbackHandle = Nan::New<v8::Function>(NodeRequest::Respond, requestHandle);
 
-        v8::Local<v8::Value> argv[] = { requestHandle, callbackHandle };
-        Nan::MakeCallback(handle()->GetInternalField(1)->ToObject(), "request", 2, argv);
-    }, cb1, resource);
+    v8::Local<v8::Value> argv[] = { requestHandle, callbackHandle };
+    Nan::MakeCallback(handle()->GetInternalField(1)->ToObject(), "request", 2, argv);
+
+    return std::make_unique<mbgl::AsyncRequest>();
 }
 
 }

--- a/platform/node/src/node_mapbox_gl_native.cpp
+++ b/platform/node/src/node_mapbox_gl_native.cpp
@@ -5,25 +5,18 @@
 #include <nan.h>
 #pragma GCC diagnostic pop
 
-#include "node_mapbox_gl_native.hpp"
+#include <mbgl/util/run_loop.hpp>
+
 #include "node_map.hpp"
 #include "node_log.hpp"
 #include "node_request.hpp"
-
-namespace node_mbgl {
-
-mbgl::util::RunLoop& NodeRunLoop() {
-    static mbgl::util::RunLoop nodeRunLoop;
-    return nodeRunLoop;
-}
-
-}
 
 void RegisterModule(v8::Local<v8::Object> target, v8::Local<v8::Object> module) {
     // This has the effect of:
     //   a) Ensuring that the static local variable is initialized before any thread contention.
     //   b) unreffing an async handle, which otherwise would keep the default loop running.
-    node_mbgl::NodeRunLoop().stop();
+    static mbgl::util::RunLoop nodeRunLoop;
+    nodeRunLoop.stop();
 
     node_mbgl::NodeMap::Init(target);
     node_mbgl::NodeRequest::Init(target);

--- a/platform/node/src/node_mapbox_gl_native.hpp
+++ b/platform/node/src/node_mapbox_gl_native.hpp
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <mbgl/util/run_loop.hpp>
-
-namespace node_mbgl {
-
-mbgl::util::RunLoop& NodeRunLoop();
-
-}

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -298,7 +298,9 @@ test('Map', function(t) {
         t.test('returning an error', function(t) {
             var map = new mbgl.Map({
                 request: function(req, callback) {
-                    callback(new Error('request error'));
+                    setImmediate(function () {
+                        callback(new Error('request error'));
+                    });
                 },
             });
             map.load(style);

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -37,8 +37,6 @@ public:
 
     MapData& getData() { return data; }
 
-    void pause();
-
     void triggerUpdate(const TransformState&, Update = Update::Nothing);
     void renderStill(const TransformState&, const FrameData&, Map::StillImageCallback callback);
 
@@ -97,7 +95,6 @@ private:
 
     Update updateFlags = Update::Nothing;
     util::AsyncTask asyncUpdate;
-    util::AsyncTask asyncInvalidate;
 
     std::unique_ptr<gl::TexturePool> texturePool;
     std::unique_ptr<Painter> painter;

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -1,11 +1,8 @@
 #ifndef MBGL_MAP_MAP_DATA
 #define MBGL_MAP_MAP_DATA
 
-#include <mutex>
-#include <atomic>
 #include <vector>
 #include <cassert>
-#include <condition_variable>
 
 #include <mbgl/map/mode.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
@@ -14,8 +11,6 @@
 namespace mbgl {
 
 class MapData {
-    using Lock = std::lock_guard<std::mutex>;
-
 public:
     inline MapData(MapMode mode_, GLContextMode contextMode_, const float pixelRatio_)
         : mode(mode_)
@@ -46,10 +41,8 @@ public:
         debugOptions = debugOptions_;
     }
 
-    util::exclusive<AnnotationManager> getAnnotationManager() {
-        return util::exclusive<AnnotationManager>(
-            &annotationManager,
-            std::make_unique<std::lock_guard<std::mutex>>(annotationManagerMutex));
+    AnnotationManager* getAnnotationManager() {
+        return &annotationManager;
     }
 
 public:
@@ -58,16 +51,12 @@ public:
     const float pixelRatio;
 
 private:
-    mutable std::mutex annotationManagerMutex;
     AnnotationManager annotationManager;
 
-    std::atomic<MapDebugOptions> debugOptions { MapDebugOptions::NoDebug };
+    MapDebugOptions debugOptions { MapDebugOptions::NoDebug };
 
 // TODO: make private
 public:
-    bool paused = false;
-    std::mutex mutexPause;
-    std::condition_variable condPause;
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/thread_context.hpp
+++ b/src/mbgl/util/thread_context.hpp
@@ -15,7 +15,7 @@ enum class ThreadPriority : bool {
 
 enum class ThreadType : uint8_t {
     Main,
-    Map,
+    Map = Main,
     Worker,
     Unknown,
 };

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -8,6 +8,7 @@
 #include <mbgl/platform/default/headless_view.hpp>
 #include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 #include <future>
 #include <vector>
@@ -29,6 +30,8 @@ void checkRendering(Map& map, const char * name) {
 } // end namespace
 
 TEST(Annotations, PointAnnotation) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -42,6 +45,8 @@ TEST(Annotations, PointAnnotation) {
 }
 
 TEST(Annotations, LineAnnotation) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -61,6 +66,8 @@ TEST(Annotations, LineAnnotation) {
 }
 
 TEST(Annotations, FillAnnotation) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -79,6 +86,8 @@ TEST(Annotations, FillAnnotation) {
 }
 
 TEST(Annotations, StyleSourcedShapeAnnotation) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -94,6 +103,8 @@ TEST(Annotations, StyleSourcedShapeAnnotation) {
 }
 
 TEST(Annotations, AddMultiple) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -111,6 +122,8 @@ TEST(Annotations, AddMultiple) {
 }
 
 TEST(Annotations, NonImmediateAdd) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -131,6 +144,8 @@ TEST(Annotations, NonImmediateAdd) {
 }
 
 TEST(Annotations, UpdateIcon) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -150,6 +165,8 @@ TEST(Annotations, UpdateIcon) {
 }
 
 TEST(Annotations, UpdatePoint) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -168,6 +185,8 @@ TEST(Annotations, UpdatePoint) {
 }
 
 TEST(Annotations, RemovePoint) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -185,6 +204,8 @@ TEST(Annotations, RemovePoint) {
 }
 
 TEST(Annotations, RemoveShape) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -207,6 +228,8 @@ TEST(Annotations, RemoveShape) {
 }
 
 TEST(Annotations, ImmediateRemoveShape) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;
@@ -219,6 +242,8 @@ TEST(Annotations, ImmediateRemoveShape) {
 }
 
 TEST(Annotations, SwitchStyle) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;

--- a/test/api/api_misuse.cpp
+++ b/test/api/api_misuse.cpp
@@ -6,6 +6,7 @@
 #include <mbgl/platform/default/headless_view.hpp>
 #include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/util/exception.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 #include <future>
 
@@ -14,6 +15,8 @@ using namespace mbgl;
 TEST(API, RenderWithoutCallback) {
     FixtureLogObserver* log = new FixtureLogObserver();
     Log::setObserver(std::unique_ptr<Log::Observer>(log));
+
+    util::RunLoop loop;
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
@@ -37,6 +40,8 @@ TEST(API, RenderWithoutCallback) {
 }
 
 TEST(API, RenderWithoutStyle) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     view.resize(128, 512);
@@ -44,13 +49,16 @@ TEST(API, RenderWithoutStyle) {
 
     Map map(view, fileSource, MapMode::Still);
 
-    std::promise<std::exception_ptr> promise;
-    map.renderStill([&promise](std::exception_ptr error, PremultipliedImage&&) {
-        promise.set_value(error);
+    std::exception_ptr error;
+    map.renderStill([&](std::exception_ptr error_, PremultipliedImage&&) {
+        error = error_;
+        loop.stop();
     });
 
+    loop.run();
+
     try {
-        std::rethrow_exception(promise.get_future().get());
+        std::rethrow_exception(error);
     } catch (const util::MisuseException& ex) {
         EXPECT_EQ(std::string(ex.what()), "Map doesn't have a style");
     } catch (const std::exception&) {

--- a/test/api/custom_layer.cpp
+++ b/test/api/custom_layer.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/layer/custom_layer.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/mat4.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 using namespace mbgl;
 
@@ -68,6 +69,8 @@ public:
 };
 
 TEST(CustomLayer, Basic) {
+    util::RunLoop loop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     OnlineFileSource fileSource;

--- a/test/api/repeated_render.cpp
+++ b/test/api/repeated_render.cpp
@@ -7,11 +7,14 @@
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 #include <future>
 
 TEST(API, RepeatedRender) {
     using namespace mbgl;
+
+    util::RunLoop loop;
 
     const auto style = util::read_file("test/fixtures/api/water.json");
 
@@ -30,11 +33,15 @@ TEST(API, RepeatedRender) {
 
     {
         map.setStyleJSON(style, "");
-        std::promise<PremultipliedImage> promise;
-        map.renderStill([&promise](std::exception_ptr, PremultipliedImage&& image) {
-            promise.set_value(std::move(image));
+        PremultipliedImage result;
+        map.renderStill([&result](std::exception_ptr, PremultipliedImage&& image) {
+            result = std::move(image);
         });
-        auto result = promise.get_future().get();
+
+        while (!result.size()) {
+            loop.runOnce();
+        }
+
         ASSERT_EQ(256, result.width);
         ASSERT_EQ(512, result.height);
 #if !TEST_READ_ONLY
@@ -44,11 +51,15 @@ TEST(API, RepeatedRender) {
 
     {
         map.setStyleJSON(style, "");
-        std::promise<PremultipliedImage> promise;
-        map.renderStill([&promise](std::exception_ptr, PremultipliedImage&& image) {
-            promise.set_value(std::move(image));
+        PremultipliedImage result;
+        map.renderStill([&result](std::exception_ptr, PremultipliedImage&& image) {
+            result = std::move(image);
         });
-        auto result = promise.get_future().get();
+
+        while (!result.size()) {
+            loop.runOnce();
+        }
+
         ASSERT_EQ(256, result.width);
         ASSERT_EQ(512, result.height);
 #if !TEST_READ_ONLY

--- a/test/api/set_style.cpp
+++ b/test/api/set_style.cpp
@@ -5,10 +5,13 @@
 #include <mbgl/platform/default/headless_view.hpp>
 #include <mbgl/platform/default/headless_display.hpp>
 #include <mbgl/storage/online_file_source.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 
 TEST(API, SetStyle) {
     using namespace mbgl;
+
+    util::RunLoop loop;
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);

--- a/test/map/map.cpp
+++ b/test/map/map.cpp
@@ -3,59 +3,17 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/platform/default/headless_view.hpp>
 #include <mbgl/platform/default/headless_display.hpp>
-#include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/storage/network_status.hpp>
-#include <mbgl/storage/offline_database.hpp>
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 using namespace mbgl;
 using namespace std::literals::string_literals;
 
-TEST(Map, PauseResume) {
-    auto display = std::make_shared<mbgl::HeadlessDisplay>();
-    HeadlessView view(display, 1);
-    OnlineFileSource fileSource;
-
-    Map map(view, fileSource, MapMode::Continuous);
-
-    map.pause();
-    map.resume();
-}
-
-TEST(Map, DoublePause) {
-    auto display = std::make_shared<mbgl::HeadlessDisplay>();
-    HeadlessView view(display, 1);
-    OnlineFileSource fileSource;
-
-    Map map(view, fileSource, MapMode::Continuous);
-
-    map.pause();
-    map.pause();
-    map.resume();
-}
-
-TEST(Map, ResumeWithoutPause) {
-    auto display = std::make_shared<mbgl::HeadlessDisplay>();
-    HeadlessView view(display, 1);
-    OnlineFileSource fileSource;
-
-    Map map(view, fileSource, MapMode::Continuous);
-
-    map.resume();
-}
-
-TEST(Map, DestroyPaused) {
-    auto display = std::make_shared<mbgl::HeadlessDisplay>();
-    HeadlessView view(display, 1);
-    OnlineFileSource fileSource;
-
-    Map map(view, fileSource, MapMode::Continuous);
-
-    map.pause();
-}
-
 TEST(Map, Offline) {
+    util::RunLoop runLoop;
+
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     DefaultFileSource fileSource(":memory:", ".");

--- a/test/src/mbgl/test/mock_view.hpp
+++ b/test/src/mbgl/test/mock_view.hpp
@@ -18,10 +18,7 @@ public:
 
     void activate() override {};
     void deactivate() override {};
-    void notify() override {};
     void invalidate() override {}
-    void beforeRender() override {}
-    void afterRender() override {}
 };
 
 }

--- a/test/src/mbgl/test/util.cpp
+++ b/test/src/mbgl/test/util.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 #include <mapbox/pixelmatch.hpp>
 
@@ -86,11 +87,16 @@ Server::~Server() {
 }
 
 PremultipliedImage render(Map& map) {
-    std::promise<PremultipliedImage> promise;
-    map.renderStill([&](std::exception_ptr, PremultipliedImage&& image) {
-        promise.set_value(std::move(image));
+    PremultipliedImage result;
+    map.renderStill([&result](std::exception_ptr, PremultipliedImage&& image) {
+        result = std::move(image);
     });
-    return promise.get_future().get();
+
+    while (!result.size()) {
+        util::RunLoop::Get()->runOnce();
+    }
+
+    return result;
 }
 
 void checkImage(const std::string& base,

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -41,7 +41,6 @@
 
         'geometry/binpack.cpp',
 
-        'map/map.cpp',
         'map/map_context.cpp',
         'map/tile.cpp',
         'map/transform.cpp',


### PR DESCRIPTION
We're currently rendering on the MapContext thread. However, when triggering a render call from the main thread, we're also blocking the main thread, so there's no advantage from parallelization here, but we have the overhead of managing the OpenGL context on the MapContext thread. Instead, we should split up Mapbox GL into two parts: the MapContext thread manages the state of the objects, coordinates tile loading and style updates, the Painter thread (which can run either on the MapContext thread, the main thread, or an entirely different thread) that just takes the state the MapContext thread produces, and renders a frame.

-----

TODO list:

* [x] Eliminate use of `ThreadContext` for obtaining FileSource / GLObjectStore
  * [x] Restore GLObjectStore, but pass it in wherever needed
* [x] iOS / OSX
 * [x] Find the right place to call `mbgl::gl::InitializeExtensions` (fixes "Not using Vertex Array Objects" warning)
 * [x] Convert RunLoop implementation to pure C++
 * [x] Figure out why glfw app exits immediately
* [x] Android
 * [x] Update `View` implementation
 * [x] Write native `RunLoop` / `Timer` / `AsyncTask` implementation
 * [x] Fix https://github.com/mapbox/mapbox-gl-native/issues/4682
* [x] Node
