### PR TITLE
[WIP] cleanup podspec, packaging script

### DIFF
--- a/ios/Mapbox-iOS-SDK.podspec
+++ b/ios/Mapbox-iOS-SDK.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |m|
   m.requires_arc = true
 
   m.preserve_paths = '**'
-  m.source_files = 'Headers/*.h', 'MGLDummy.m'
+  m.source_files = 'Headers/*.h'
   m.resource_bundle = { 'Mapbox' => 'Mapbox.bundle/*' }
   m.vendored_library = 'libMapbox.a'
   m.module_name = 'Mapbox'
@@ -31,8 +31,7 @@ Pod::Spec.new do |m|
   m.frameworks = 'CoreLocation', 'GLKit', 'ImageIO', 'MobileCoreServices', 'QuartzCore', 'SystemConfiguration'
   m.libraries = 'c++', 'sqlite3', 'z'
   m.pod_target_xcconfig = {
-    'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++',
-    'OTHER_LDFLAGS' => '-ObjC',
+    'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++'
   }
 
 end

--- a/scripts/ios/package.sh
+++ b/scripts/ios/package.sh
@@ -103,9 +103,6 @@ for i in `ls -R include/mbgl/ios | grep -vi private`; do
     cp -pv include/mbgl/ios/$i "${OUTPUT}/static/Headers"
 done
 
-step "Setting up dummy source file for CocoaPods 0.37.0..."
-echo "// https://github.com/mapbox/mapbox-gl-native/issues/1426" > "${OUTPUT}/static/MGLDummy.m"
-
 
 # Manually create resource bundle. We don't use a GYP target here because of
 # complications between faked GYP bundles-as-executables, device build


### PR DESCRIPTION
- Remove MGLDummy.m (#1426)
- Remove `-ObjC` linker flag (#2966)

Hold for now, this PR currently causes existing projects to break — for some reason CocoaPods is failing to add the Mapbox module, which breaks `#import <Mapbox/Mapbox.h>`.

/cc @1ec5 @incanus