### PR TITLE
more clearly indicate Foundation imports to avoid recursion

### DIFF
--- a/include/mbgl/ios/MGLAccountManager.h
+++ b/include/mbgl/ios/MGLAccountManager.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 #import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/include/mbgl/ios/MGLAnnotation.h
+++ b/include/mbgl/ios/MGLAnnotation.h
@@ -1,3 +1,4 @@
+#import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
 #import "MGLTypes.h"

--- a/include/mbgl/ios/MGLGeometry.h
+++ b/include/mbgl/ios/MGLGeometry.h
@@ -1,9 +1,8 @@
-#pragma once
-
-#import "MGLTypes.h"
-
+#import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 #import <CoreGraphics/CGBase.h>
+
+#import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/mbgl/ios/MGLMapCamera.h
+++ b/include/mbgl/ios/MGLMapCamera.h
@@ -1,6 +1,8 @@
-#import "Mapbox.h"
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <CoreLocation/CoreLocation.h>
 
-#pragma once
+#import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -1,5 +1,8 @@
-#import "MGLMapView.h"
+#import <Foundation/Foundation.h>
+
 #import "MGLTypes.h"
+
+@class MGLMapView;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -4,10 +4,11 @@
 #import <UIKit/UIKit.h>
 #import <CoreLocation/CoreLocation.h>
 
+#import "MGLTypes.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class MGLAnnotationImage;
-@class MGLMapCamera;
 @class MGLUserLocation;
 @class MGLPolyline;
 @class MGLPolygon;

--- a/include/mbgl/ios/MGLMultiPoint.h
+++ b/include/mbgl/ios/MGLMultiPoint.h
@@ -3,6 +3,8 @@
 
 #import "MGLShape.h"
 
+#import "MGLTypes.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** The `MGLMultiPoint` class is an abstract superclass used to define shapes composed of multiple points. You should not create instances of this class directly. Instead, you should create instances of the `MGLPolyline` or `MGLPolygon` classes. However, you can use the method and properties of this class to access information about the specific points associated with the line or polygon. */

--- a/include/mbgl/ios/MGLOverlay.h
+++ b/include/mbgl/ios/MGLOverlay.h
@@ -4,6 +4,8 @@
 #import "MGLAnnotation.h"
 #import "MGLGeometry.h"
 
+#import "MGLTypes.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** The `MGLOverlay` protocol defines a specific type of annotation that represents both a point and an area on a map. Overlay objects are essentially data objects that contain the geographic data needed to represent the map area. For example, overlays can take the form of common shapes such as rectangles and circles. They can also describe polygons and other complex shapes.

--- a/include/mbgl/ios/MGLPointAnnotation.h
+++ b/include/mbgl/ios/MGLPointAnnotation.h
@@ -3,6 +3,8 @@
 
 #import "MGLShape.h"
 
+#import "MGLTypes.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** The `MGLPointAnnotation` class defines a concrete annotation object located at a specified point. You can use this class, rather than define your own, in situations where all you want to do is associate a point on the map with a title. */

--- a/include/mbgl/ios/MGLPolygon.h
+++ b/include/mbgl/ios/MGLPolygon.h
@@ -4,6 +4,8 @@
 #import "MGLMultiPoint.h"
 #import "MGLOverlay.h"
 
+#import "MGLTypes.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** The `MGLPolygon` class represents a shape consisting of one or more points that define a closed polygon. The points are connected end-to-end in the order they are provided. The first and last points are connected to each other to create the closed shape. */

--- a/include/mbgl/ios/MGLPolyline.h
+++ b/include/mbgl/ios/MGLPolyline.h
@@ -4,6 +4,8 @@
 #import "MGLMultiPoint.h"
 #import "MGLOverlay.h"
 
+#import "MGLTypes.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** The `MGLPolyline` class represents a shape consisting of one or more points that define connecting line segments. The points are connected end-to-end in the order they are provided. The first and last points are not connected to each other. */

--- a/include/mbgl/ios/MGLShape.h
+++ b/include/mbgl/ios/MGLShape.h
@@ -2,6 +2,8 @@
 
 #import "MGLAnnotation.h"
 
+#import "MGLTypes.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** The `MGLShape` class is an abstract class that defines the basic properties for all shape-based annotation objects. This class must be subclassed and cannot be used as is. Subclasses are responsible for defining the geometry of the shape and providing an appropriate value for the coordinate property inherited from the `MGLAnnotation` protocol. */

--- a/include/mbgl/ios/MGLStyle.h
+++ b/include/mbgl/ios/MGLStyle.h
@@ -1,4 +1,6 @@
-#import "Mapbox.h"
+#import <Foundation/Foundation.h>
+
+#import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/mbgl/ios/MGLUserLocation.h
+++ b/include/mbgl/ios/MGLUserLocation.h
@@ -1,4 +1,9 @@
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
+
 #import "MGLAnnotation.h"
+
+#import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/platform/ios/MGLMapboxEvents.h
+++ b/platform/ios/MGLMapboxEvents.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 #import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platform/ios/MGLMultiPoint_Private.h
+++ b/platform/ios/MGLMultiPoint_Private.h
@@ -1,5 +1,7 @@
 #import "MGLMultiPoint.h"
 
+#import <CoreLocation/CoreLocation.h>
+
 @interface MGLMultiPoint (Private)
 
 - (instancetype)initWithCoordinates:(CLLocationCoordinate2D *)coords count:(NSUInteger)count;

--- a/platform/ios/MGLUserLocation_Private.h
+++ b/platform/ios/MGLUserLocation_Private.h
@@ -1,8 +1,10 @@
 #import "MGLUserLocation.h"
 
-NS_ASSUME_NONNULL_BEGIN
+#import <CoreLocation/CoreLocation.h>
 
 @class MGLMapView;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface MGLUserLocation (Private)
 

--- a/platform/ios/NSBundle+MGLAdditions.h
+++ b/platform/ios/NSBundle+MGLAdditions.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 #import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platform/ios/NSString+MGLAdditions.h
+++ b/platform/ios/NSString+MGLAdditions.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 #import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Due to https://github.com/mapbox/mapbox-gl-native/commit/0a8d9a3b6d686c1fce9dc48014d1b13fdd58cdb3, we recursively import `Mapbox.h` and we shouldn't do this. Instead, we should bring in any Apple Foundation imports directly, our own superclasses / category-extended classes if necessary, and forward-declare the rest. 

/cc @1ec5 