### PR TITLE
Ensure proper delegate callbacks for resetNorth

### DIFF
--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1555,7 +1555,7 @@ std::chrono::steady_clock::duration durationInSeconds(float duration)
 
 - (void)resetNorthAnimated:(BOOL)animated
 {
-    _mbglMap->setBearing(0, durationInSeconds(animated ? MGLAnimationDuration : 0));
+    [self setDirection:0 animated:animated];
 }
 
 - (void)resetPosition
@@ -1782,10 +1782,18 @@ mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBounds coord
 {
     if ( ! animated && ! self.rotationAllowed) return;
 
-    if (self.userTrackingMode == MGLUserTrackingModeFollowWithHeading)
+    if (self.userTrackingMode == MGLUserTrackingModeFollowWithHeading ||
+        self.userTrackingMode == MGLUserTrackingModeFollowWithCourse)
     {
         self.userTrackingMode = MGLUserTrackingModeFollow;
     }
+    
+    [self _setDirection:direction animated:animated];
+}
+
+- (void)_setDirection:(CLLocationDirection)direction animated:(BOOL)animated
+{
+    if (direction == self.direction) return;
 
     CGFloat duration = animated ? MGLAnimationDuration : 0;
 
@@ -2818,7 +2826,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     if (headingDirection >= 0 && self.userTrackingMode == MGLUserTrackingModeFollowWithHeading)
     {
-        _mbglMap->setBearing(headingDirection, durationInSeconds(MGLAnimationDuration));
+        [self _setDirection:headingDirection animated:YES];
     }
 }
 


### PR DESCRIPTION
Any MGLMapView method that can programmatically move the map’s viewport, with or without animation, needs to explicitly send a didChange notification. Otherwise, mbgl will trigger notifications, but not necessarily in the right order. This includes the programmatic rotation that occurs due to tracked heading changes.

This PR also fixes a bug in which setting the direction programmatically would fail to boot the user out of course-tracking mode.

/ref #2948
/cc @friedbunny @incanus