### PR TITLE
[WIP] Throw/notify on map loading error

### DIFF
--- a/platform/darwin/log_nslog.mm
+++ b/platform/darwin/log_nslog.mm
@@ -5,9 +5,11 @@
 namespace mbgl {
 
 void Log::platformRecord(EventSeverity severity, const std::string &msg) {
-    NSString *message =
-        [[NSString alloc] initWithBytes:msg.data() length:msg.size() encoding:NSUTF8StringEncoding];
-    NSLog(@"[%s] %@", EventSeverityClass(severity).c_str(), message);
+    if (severity == EventSeverity::Error) {
+        [NSException raise:@"Mapbox GL Error" format:@"%s", msg.c_str()];
+    } else {
+        NSLog(@"[%s] %s", EventSeverityClass(severity).c_str(), msg.c_str());
+    }
 }
 
 }


### PR DESCRIPTION
Throw an Objective-C exception whenever mbgl encounters an error. (Developers are trained to break on Objective-C exceptions as opposed to C++ exceptions.) If mbgl is unable to set up the map and the delegate implements the map loading failure callback method, call that method instead of throwing the exception.

/ref #2762, #2775
/cc @friedbunny @incanus
