### PR TITLE
[core] Avoid calling AnnotationManager::updateStyle until the style is loaded

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -169,7 +169,7 @@ void MapContext::update() {
 
     data.setAnimationTime(Clock::now());
 
-    if (updateFlags & Update::Annotations) {
+    if (style->isLoaded() && updateFlags & Update::Annotations) {
         data.getAnnotationManager()->updateStyle(*style);
         updateFlags |= Update::Classes;
     }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -57,6 +57,8 @@ void Style::setJSON(const std::string& json, const std::string&) {
 
     glyphStore->setURL(parser.getGlyphURL());
     spriteStore->setURL(parser.getSpriteURL());
+
+    loaded = true;
 }
 
 Style::~Style() {
@@ -175,6 +177,10 @@ bool Style::hasTransitions() const {
 }
 
 bool Style::isLoaded() const {
+    if (!loaded) {
+        return false;
+    }
+
     for (const auto& source : sources) {
         if (!source->isLoaded()) {
             return false;

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -100,6 +100,7 @@ private:
     void emitTileDataChanged();
     void emitResourceLoadingFailed(std::exception_ptr error);
 
+    bool loaded = false;
     bool shouldReparsePartialTiles = false;
 
     Observer* observer = nullptr;


### PR DESCRIPTION
Fixes #3037

cc @incanus -- I stuck this on the 3.0.0 milestone / branch. It should be fairly safe but I'd be fine with waiting too.