### PR TITLE
replaceTokens() tests

### DIFF
--- a/test/miscellaneous/token.cpp
+++ b/test/miscellaneous/token.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include "../fixtures/util.hpp"
+
+#include <mbgl/util/token.hpp>
+
+using namespace mbgl;
+
+TEST(Token, replaceTokens) {
+    EXPECT_EQ("literal", mbgl::util::replaceTokens("literal", [](const std::string &token) -> std::string {
+        if (token == "name") return "14th St NW";
+        return "";
+    }));
+    EXPECT_EQ("14th St NW", mbgl::util::replaceTokens("{name}", [](const std::string &token) -> std::string {
+        if (token == "name") return "14th St NW";
+        return "";
+    }));
+    EXPECT_EQ("", mbgl::util::replaceTokens("{name}", [](const std::string &token) -> std::string {
+        if (token == "text") return "14th St NW";
+        return "";
+    }));
+    EXPECT_EQ("1400", mbgl::util::replaceTokens("{num}", [](const std::string &token) -> std::string {
+        if (token == "num") return "1400";
+        return "";
+    }));
+    EXPECT_EQ("500 m", mbgl::util::replaceTokens("{num} m", [](const std::string &token) -> std::string {
+        if (token == "num") return "500";
+        return "";
+    }));
+    EXPECT_EQ("3 Fine Fields", mbgl::util::replaceTokens("{a} {b} {c}", [](const std::string &token) -> std::string {
+        if (token == "a") return "3";
+        if (token == "b") return "Fine";
+        if (token == "c") return "Fields";
+        return "";
+    }));
+    EXPECT_EQ(" but still", mbgl::util::replaceTokens("{notset} but still", [](__unused const std::string &token) -> std::string {
+        return "";
+    }));
+    EXPECT_EQ("dashed", mbgl::util::replaceTokens("{dashed-property}", [](const std::string &token) -> std::string {
+        if (token == "dashed-property") return "dashed";
+        return "";
+    }));
+    EXPECT_EQ("150 m", mbgl::util::replaceTokens("{HØYDE} m", [](const std::string &token) -> std::string {
+        if (token == "HØYDE") return "150";
+        return "";
+    }));
+    EXPECT_EQ("reserved {for:future} use", mbgl::util::replaceTokens("reserved {for:future} use", [](const std::string &token) -> std::string {
+        if (token == "for:future") return "unknown";
+        return "";
+    }));
+}

--- a/test/miscellaneous/token.cpp
+++ b/test/miscellaneous/token.cpp
@@ -6,44 +6,44 @@
 using namespace mbgl;
 
 TEST(Token, replaceTokens) {
-    EXPECT_EQ("literal", mbgl::util::replaceTokens("literal", [](const std::string &token) -> std::string {
+    EXPECT_EQ("literal", mbgl::util::replaceTokens("literal", [](const std::string& token) -> std::string {
         if (token == "name") return "14th St NW";
         return "";
     }));
-    EXPECT_EQ("14th St NW", mbgl::util::replaceTokens("{name}", [](const std::string &token) -> std::string {
+    EXPECT_EQ("14th St NW", mbgl::util::replaceTokens("{name}", [](const std::string& token) -> std::string {
         if (token == "name") return "14th St NW";
         return "";
     }));
-    EXPECT_EQ("", mbgl::util::replaceTokens("{name}", [](const std::string &token) -> std::string {
+    EXPECT_EQ("", mbgl::util::replaceTokens("{name}", [](const std::string& token) -> std::string {
         if (token == "text") return "14th St NW";
         return "";
     }));
-    EXPECT_EQ("1400", mbgl::util::replaceTokens("{num}", [](const std::string &token) -> std::string {
+    EXPECT_EQ("1400", mbgl::util::replaceTokens("{num}", [](const std::string& token) -> std::string {
         if (token == "num") return "1400";
         return "";
     }));
-    EXPECT_EQ("500 m", mbgl::util::replaceTokens("{num} m", [](const std::string &token) -> std::string {
+    EXPECT_EQ("500 m", mbgl::util::replaceTokens("{num} m", [](const std::string& token) -> std::string {
         if (token == "num") return "500";
         return "";
     }));
-    EXPECT_EQ("3 Fine Fields", mbgl::util::replaceTokens("{a} {b} {c}", [](const std::string &token) -> std::string {
+    EXPECT_EQ("3 Fine Fields", mbgl::util::replaceTokens("{a} {b} {c}", [](const std::string& token) -> std::string {
         if (token == "a") return "3";
         if (token == "b") return "Fine";
         if (token == "c") return "Fields";
         return "";
     }));
-    EXPECT_EQ(" but still", mbgl::util::replaceTokens("{notset} but still", [](__unused const std::string &token) -> std::string {
+    EXPECT_EQ(" but still", mbgl::util::replaceTokens("{notset} but still", [](const std::string&) -> std::string {
         return "";
     }));
-    EXPECT_EQ("dashed", mbgl::util::replaceTokens("{dashed-property}", [](const std::string &token) -> std::string {
+    EXPECT_EQ("dashed", mbgl::util::replaceTokens("{dashed-property}", [](const std::string& token) -> std::string {
         if (token == "dashed-property") return "dashed";
         return "";
     }));
-    EXPECT_EQ("150 m", mbgl::util::replaceTokens("{HØYDE} m", [](const std::string &token) -> std::string {
+    EXPECT_EQ("150 m", mbgl::util::replaceTokens("{HØYDE} m", [](const std::string& token) -> std::string {
         if (token == "HØYDE") return "150";
         return "";
     }));
-    EXPECT_EQ("reserved {for:future} use", mbgl::util::replaceTokens("reserved {for:future} use", [](const std::string &token) -> std::string {
+    EXPECT_EQ("reserved {for:future} use", mbgl::util::replaceTokens("reserved {for:future} use", [](const std::string& token) -> std::string {
         if (token == "for:future") return "unknown";
         return "";
     }));

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -60,6 +60,7 @@
         'miscellaneous/text_conversions.cpp',
         'miscellaneous/thread.cpp',
         'miscellaneous/tile.cpp',
+        'miscellaneous/token.cpp',
         'miscellaneous/transform.cpp',
         'miscellaneous/work_queue.cpp',
         'miscellaneous/variant.cpp',


### PR DESCRIPTION
Ported `replaceTokens()` tests [from GL JS](https://github.com/mapbox/mapbox-gl-js/blob/d37fc014635e1cc640c92f06b9993e1dd6b05899/test/js/util/token.test.js) in anticipation of a forthcoming PR implementing mapbox/mapbox-gl-style-spec#104.

/cc @jfirebaugh