### PR TITLE
reduce framework binary size with more stripping

### DIFF
--- a/scripts/ios/framework.sh
+++ b/scripts/ios/framework.sh
@@ -23,6 +23,7 @@ cp -rv ../../../../ios/framework/Settings.bundle Mapbox.framework/Settings.bundl
 
 # binary
 cp -v ../static/libMapbox.a Mapbox.framework/Mapbox
+strip -Sx Mapbox.framework/Mapbox
 
 # module map
 mkdir Mapbox.framework/Modules


### PR DESCRIPTION
This needs some more testing, but this shaves off ~20MB on the "stripped" static binary we're producing already with `make ipackage-strip`. We should make sure it doesn't bust anything, but also work on this and other ways to reduce our footprint, especially for folks who don't care about debugging symbols anyway and want to use our framework as if it were closed source. 

Refs https://github.com/mapbox/mapbox-gl-native/issues/898

Also, from @1ec5: 

> There’s a `SEPARATE_STRIP` build setting in Xcode that invokes `strip`.
> 
> It’s off by default.
> 
> Instead, `COPY_PHASE_STRIP` and `STRIP_INSTALLED_PRODUCT` default to on.
> 
> `STRIP_INSTALLED_PRODUCT` only strips the product when you build for archive, something that we should already be doing via `DEPLOYMENT_POSTPROCESSING`.
> 
> Are you producing the framework using package.sh? Is `DEPLOYMENT_POSTPROCESSING` getting set?
> 
> package.sh only sets `DEPLOYMENT_POSTPROCESSING` when building for the device, since that’s where Bitcode bit us.
> 
> Maybe we should set `DEPLOYMENT_POSTPROCESSING` in all cases.

/cc @1ec5 @mikemorris @springmeyer 