### PR TITLE
Token defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Android master
 
+- Tokens in style properties can now fall back on defaults: for example, `{name_en:{name:?}}` produces the value of `name_en`, falling back on `name` if `name_en` is undefined, and finally falling back on the string `?` if neither is defined. ([#3081](https://github.com/mapbox/mapbox-gl-native/pull/3081)
+
 ## 2.2.0
 
 - New User Dot location graphics ([#2732](https://github.com/mapbox/mapbox-gl-native/issues/2732)
@@ -22,6 +24,10 @@ Known issues:
   - Resolved in 2.2.0
 
 ## iOS master
+
+- Tokens in style properties can now fall back on defaults: for example, `{name_en:{name:?}}` produces the value of `name_en`, falling back on `name` if `name_en` is undefined, and finally falling back on the string `?` if neither is defined. ([#3081](https://github.com/mapbox/mapbox-gl-native/pull/3081)
+
+## iOS 3.0.0
 
 - If you install this SDK via CocoaPods, CocoaPods version 0.38.0 or above is required. ([#2132](https://github.com/mapbox/mapbox-gl-native/pull/2132))
 - The `styleID` property has been removed from MGLMapView. Instead, set the `styleURL` property to an NSURL in the form `mapbox://styles/STYLE_ID`. If you previously set the style ID in Interface Builder’s Attributes inspector, delete the `styleID` entry from the User Defined Runtime Attributes section of the Identity inspector, then set the new “Style URL” inspectable to a value in the form `mapbox://styles/STYLE_ID`. ([#2632](https://github.com/mapbox/mapbox-gl-native/pull/2632))

--- a/src/mbgl/util/token.hpp
+++ b/src/mbgl/util/token.hpp
@@ -28,6 +28,20 @@ std::string replaceTokens(const std::string &source, const Lookup &lookup) {
             if (brace != end && *brace == '}') {
                 result.append(lookup({ pos + 1, brace }));
                 pos = brace + 1;
+            } else if (brace != end && *brace == ':') {
+                std::string repl = lookup({ pos + 1, brace });
+                result.append(repl);
+                pos = brace + 1;
+                int depth = 1;
+                for (brace++; brace != end && depth > 0; brace++) {
+                    if (*brace == '{') depth++;
+                    else if (*brace == '}') depth--;
+                }
+                if (repl.empty()) {
+                    repl = replaceTokens({ pos, brace - 1 }, lookup);
+                    result.append(repl);
+                }
+                pos = brace;
             } else {
                 result.append(pos, brace);
                 pos = brace;

--- a/test/miscellaneous/token.cpp
+++ b/test/miscellaneous/token.cpp
@@ -43,8 +43,60 @@ TEST(Token, replaceTokens) {
         if (token == "HØYDE") return "150";
         return "";
     }));
-    EXPECT_EQ("reserved {for:future} use", mbgl::util::replaceTokens("reserved {for:future} use", [](const std::string& token) -> std::string {
-        if (token == "for:future") return "unknown";
+    EXPECT_EQ("reserved {for=future} use", mbgl::util::replaceTokens("reserved {for=future} use", [](const std::string& token) -> std::string {
+        if (token == "for=future") return "unknown";
+        return "";
+    }));
+    EXPECT_EQ("null", mbgl::util::replaceTokens("{}", [](const std::string& token) -> std::string {
+        if (token == "") return "null";
+        return "";
+    }));
+    EXPECT_EQ("", mbgl::util::replaceTokens("{}", [](const std::string&) -> std::string {
+        return "";
+    }));
+    EXPECT_EQ("?", mbgl::util::replaceTokens("{name:?}", [](const std::string&) -> std::string {
+        return "";
+    }));
+    EXPECT_EQ("Louisiana", mbgl::util::replaceTokens("{name_en:{name}}", [](const std::string& token) -> std::string {
+        if (token == "name") return "Louisiana";
+        return "";
+    }));
+    EXPECT_EQ("Louisiana", mbgl::util::replaceTokens("{name_en:{name}}", [](const std::string& token) -> std::string {
+        if (token == "name") return "Louisiana";
+        if (token == "name_fr") return "Louisiane";
+        return "";
+    }));
+    EXPECT_EQ("Louisiane", mbgl::util::replaceTokens("{name_fr:{name}}", [](const std::string& token) -> std::string {
+        if (token == "name") return "Louisiana";
+        if (token == "name_fr") return "Louisiane";
+        return "";
+    }));
+    EXPECT_EQ("Luisiana", mbgl::util::replaceTokens("{name_en:{name_es:{name:?}}}", [](const std::string& token) -> std::string {
+        if (token == "name") return "Lwizyàn";
+        if (token == "name_es") return "Luisiana";
+        return "";
+    }));
+    EXPECT_EQ("(Luisiana)", mbgl::util::replaceTokens("({name_en:{name_es:{name:?}}})", [](const std::string& token) -> std::string {
+        if (token == "name") return "Lwizyàn";
+        if (token == "name_es") return "Luisiana";
+        return "";
+    }));
+    EXPECT_EQ("Lwizyàn", mbgl::util::replaceTokens("{name_en:{name_es:{name:?}}}", [](const std::string& token) -> std::string {
+        if (token == "name") return "Lwizyàn";
+        return "";
+    }));
+    EXPECT_EQ("", mbgl::util::replaceTokens("{name_en:}", [](const std::string& token) -> std::string {
+        if (token == "name") return "Louisiana";
+        return "";
+    }));
+    EXPECT_EQ("Louisiana", mbgl::util::replaceTokens("{name:}", [](const std::string& token) -> std::string {
+        if (token == "name") return "Louisiana";
+        return "";
+    }));
+    EXPECT_EQ("name", mbgl::util::replaceTokens("{:name}", [](const std::string&) -> std::string {
+        return "";
+    }));
+    EXPECT_EQ("", mbgl::util::replaceTokens("{:}", [](const std::string&) -> std::string {
         return "";
     }));
 }


### PR DESCRIPTION
Tokens in style properties can now fall back on defaults: for example, `{name_en:{name:?}}` produces the value of `name_en`, falling back on `name` if `name_en` is undefined, and finally falling back on the string `?` if neither is defined.

/ref mapbox/mapbox-gl-style-spec#104
/cc @jfirebaugh @ajashton