### PR TITLE
Discourage code usage of styleURL__ property

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -234,6 +234,9 @@ IB_DESIGNABLE
 *   To display the default style, set this property to `nil`. */
 @property (nonatomic, null_resettable) NSURL *styleURL;
 
+/* Discourage programmatic usage of this IB-only property. Interface Builder skips over this declaration because it is unable to parse attributes. See the real declaration in MGLMapView+IBAdditions.h. */
+@property (nonatomic, nullable) IBInspectable NSString *styleURL__ __attribute__((unavailable("styleURL__ is for use within Interface Builder only. Use styleURL in code.")));
+
 /** Currently active style classes, represented as an array of string identifiers. */
 @property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses;
 


### PR DESCRIPTION
A hack atop the hack added in #2632. Pre-declare `styleURL__` with an attribute that prevents it from appearing in code completion suggestions, while leaving it available to Interface Builder, which is unable to parse attributes.

/cc @incanus @friedbunny