### PR TITLE
Transparent GLKView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Known issues:
 - The user dot’s callout view is now centered above the user dot. It was previously offset slightly to the left. ([#3261](https://github.com/mapbox/mapbox-gl-native/pull/3261))
 - Fixed an issue with small map views not properly fitting annotations within bounds. (#[3407](https://github.com/mapbox/mapbox-gl-native/pull/3407))
 - The map will now snap to north. ([#3403](https://github.com/mapbox/mapbox-gl-native/pull/3403))
+- The map view’s background can now be transparent or translucent, as long as the style’s background layer is transparent or translucent and `MGLMapView.opaque` is set to `NO`. ([#3096](https://github.com/mapbox/mapbox-gl-native/pull/3096))
 
 ## iOS 3.0.1
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -157,6 +157,8 @@ public:
     MBGLView *_mbglView;
     std::shared_ptr<mbgl::SQLiteCache> _mbglFileCache;
     mbgl::DefaultFileSource *_mbglFileSource;
+    
+    BOOL _opaque;
 
     NS_MUTABLE_ARRAY_OF(NSURL *) *_bundledStyleURLs;
     
@@ -257,6 +259,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 - (void)commonInit
 {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
+    _opaque = YES;
 
     BOOL background = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
     if (!background)
@@ -450,6 +453,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     _glView.drawableStencilFormat = GLKViewDrawableStencilFormat8;
     _glView.drawableDepthFormat = GLKViewDrawableDepthFormat16;
     _glView.contentScaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
+    _glView.layer.opaque = _opaque;
     _glView.delegate = self;
     [_glView bindDrawable];
     [self insertSubview:_glView atIndex:0];
@@ -712,6 +716,16 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     [constraintParentView addConstraints:self.attributionButtonConstraints];
 
     [super updateConstraints];
+}
+
+- (BOOL)isOpaque
+{
+    return _opaque;
+}
+
+- (void)setOpaque:(BOOL)opaque
+{
+    _glView.layer.opaque = _opaque = opaque;
 }
 
 // This is the delegate of the GLKView object's display call.


### PR DESCRIPTION
Set the GLKView’s layer to be non-opaque. In rudimentary testing, this appears to have no noticeable performance impact on styles that have opaque background layers (which should be the vast majority of styles). Any performance impact I’m seeing with a transparent background style layer appears to be due to content beneath the map view.

![transparent](https://cloud.githubusercontent.com/assets/1231218/11315058/0cf78bda-8fa1-11e5-87f9-f8c10768d6f7.png)

Fixes #3038.

/cc @incanus