### PR TITLE
Fix linker warnings about overridden styleURL__

### DIFF
--- a/include/mbgl/ios/MGLMapView+IBAdditions.h
+++ b/include/mbgl/ios/MGLMapView+IBAdditions.h
@@ -14,11 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 // inspectables declared in MGLMapView.h are always sorted before those in
 // MGLMapView+IBAdditions.h, due to ASCII sort order.
 
+#if TARGET_INTERFACE_BUILDER
+
 // HACK: We want this property to look like a URL bar in the Attributes
 // inspector, but just calling it styleURL would violate Cocoa naming
 // conventions and conflict with the existing NSURL property. Fortunately, IB
 // strips out the two underscores for display.
 @property (nonatomic, nullable) IBInspectable NSString *styleURL__;
+
+#endif // TARGET_INTERFACE_BUILDER
 
 // Convenience properties related to the initial viewport. These properties
 // are not meant to be used outside of Interface Builder. latitude and longitude

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -234,9 +234,6 @@ IB_DESIGNABLE
 *   To display the default style, set this property to `nil`. */
 @property (nonatomic, null_resettable) NSURL *styleURL;
 
-/* Discourage programmatic usage of this IB-only property. Interface Builder skips over this declaration because it is unable to parse attributes. See the real declaration in MGLMapView+IBAdditions.h. */
-@property (nonatomic, nullable) IBInspectable NSString *styleURL__ __attribute__((unavailable("styleURL__ is for use within Interface Builder only. Use styleURL in code.")));
-
 /** Currently active style classes, represented as an array of string identifiers. */
 @property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses;
 


### PR DESCRIPTION
Replaced #3088 with a better fix that relies on conditional compilation. It also happens to be semantically correct. The previous attempt produced these linker warnings:

```
ld: warning: instance method 'setStyleURL__:' in category from /Users/mxn/Library/Developer/Xcode/DerivedData/…/Build/Products/Debug-iphonesimulator/libmbgl-platform-ios.a(MGLMapView.o) overrides method from class in /Users/mxn/Library/Developer/Xcode/DerivedData/…/Build/Products/Debug-iphonesimulator/libmbgl-platform-ios.a(MGLMapView.o)
ld: warning: instance method 'styleURL__' in category from /Users/mxn/Library/Developer/Xcode/DerivedData/…/Build/Products/Debug-iphonesimulator/libmbgl-platform-ios.a(MGLMapView.o) overrides method from class in /Users/mxn/Library/Developer/Xcode/DerivedData/…/Build/Products/Debug-iphonesimulator/libmbgl-platform-ios.a(MGLMapView.o)
```

/cc @incanus @friedbunny