### PR TITLE
Fix GCC5 complaining about -Wunused-variable.

### DIFF
--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -11,6 +11,8 @@
 
 #include <mbgl/platform/default/image_reader.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 // Check png library version.
 const static bool png_version_check = []() {
     const png_uint_32 version = png_access_version_number();
@@ -22,7 +24,7 @@ const static bool png_version_check = []() {
     }
     return true;
 }();
-
+#pragma GCC diagnostic pop
 
 namespace mbgl {
 namespace util {

--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -5,6 +5,8 @@
 #include <cstring>
 #include <cstdio>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 // Check sqlite3 library version.
 const static bool sqliteVersionCheck = []() {
     if (sqlite3_libversion_number() / 1000000 != SQLITE_VERSION_NUMBER / 1000000) {
@@ -17,6 +19,7 @@ const static bool sqliteVersionCheck = []() {
 
     return true;
 }();
+#pragma GCC diagnostic pop 
 
 namespace mapbox {
 namespace sqlite {

--- a/src/mbgl/util/compression.cpp
+++ b/src/mbgl/util/compression.cpp
@@ -6,6 +6,8 @@
 #include <cstring>
 #include <stdexcept>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 
 // Check zlib library version.
 const static bool zlibVersionCheck = []() {
@@ -20,6 +22,7 @@ const static bool zlibVersionCheck = []() {
     return true;
 }();
 
+#pragma GCC diagnostic pop
 
 namespace mbgl {
 namespace util {

--- a/src/mbgl/util/uv.cpp
+++ b/src/mbgl/util/uv.cpp
@@ -4,12 +4,15 @@
 
 #include <uv.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 // Check libuv library version.
 const static bool uvVersionCheck = []() {
     const unsigned int version = uv_version();
     const unsigned int major = (version >> 16) & 0xFF;
     const unsigned int minor = (version >> 8) & 0xFF;
     const unsigned int patch = version & 0xFF;
+#pragma GCC diagnostic pop
 
 #ifndef UV_VERSION_PATCH
     // 0.10 doesn't have UV_VERSION_PATCH defined, so we "fake" it by using the library patch level.


### PR DESCRIPTION
GCC5 and later complains about unused variables in the files altered by this PR. Selectively disabling the warning solves the issue and leaves the forcing function of the variables untouched.