### PR TITLE
Improve map debug options

### DIFF
--- a/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -1306,7 +1306,7 @@ public final class MapView extends FrameLayout {
      */
     @UiThread
     public boolean isDebugActive() {
-        return mNativeMapView.getDebug() || mNativeMapView.getCollisionDebug();
+        return mNativeMapView.getDebug();
     }
 
     /**
@@ -1319,20 +1319,19 @@ public final class MapView extends FrameLayout {
     @UiThread
     public void setDebugActive(boolean debugActive) {
         mNativeMapView.setDebug(debugActive);
-        mNativeMapView.setCollisionDebug(debugActive);
     }
 
     /**
-     * Toggles whether the map debug information is shown.
+     * Cycles through the map debug options.
      * <p/>
-     * The value of {@link MapView#isDebugActive()} is toggled.
+     * The value of {@link MapView#isDebugActive()} reflects whether there are
+     * any map debug options enabled or disabled.
      *
      * @see MapView#isDebugActive()
      */
     @UiThread
     public void cycleDebugOptions() {
         mNativeMapView.cycleDebugOptions();
-        mNativeMapView.toggleCollisionDebug();
     }
 
     // True if map has finished loading the view

--- a/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -1330,8 +1330,8 @@ public final class MapView extends FrameLayout {
      * @see MapView#isDebugActive()
      */
     @UiThread
-    public void toggleDebug() {
-        mNativeMapView.toggleDebug();
+    public void cycleDebugOptions() {
+        mNativeMapView.cycleDebugOptions();
         mNativeMapView.toggleCollisionDebug();
     }
 

--- a/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
+++ b/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
@@ -401,7 +401,7 @@ final class NativeMapView {
         nativeSetDebug(mNativeMapViewPtr, debug);
     }
 
-    public void toggleDebug() {
+    public void cycleDebugOptions() {
         nativeToggleDebug(mNativeMapViewPtr);
     }
 

--- a/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
+++ b/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
@@ -409,18 +409,6 @@ final class NativeMapView {
         return nativeGetDebug(mNativeMapViewPtr);
     }
 
-    public void setCollisionDebug(boolean debug) {
-        nativeSetCollisionDebug(mNativeMapViewPtr, debug);
-    }
-
-    public void toggleCollisionDebug() {
-        nativeToggleCollisionDebug(mNativeMapViewPtr);
-    }
-
-    public boolean getCollisionDebug() {
-        return nativeGetCollisionDebug(mNativeMapViewPtr);
-    }
-
     public boolean isFullyLoaded() {
         return nativeIsFullyLoaded(mNativeMapViewPtr);
     }
@@ -613,12 +601,6 @@ final class NativeMapView {
     private native void nativeToggleDebug(long nativeMapViewPtr);
 
     private native boolean nativeGetDebug(long nativeMapViewPtr);
-
-    private native void nativeSetCollisionDebug(long nativeMapViewPtr, boolean debug);
-
-    private native void nativeToggleCollisionDebug(long nativeMapViewPtr);
-
-    private native boolean nativeGetCollisionDebug(long nativeMapViewPtr);
 
     private native boolean nativeIsFullyLoaded(long nativeMapViewPtr);
 

--- a/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MainActivity.java
+++ b/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MainActivity.java
@@ -322,8 +322,8 @@ public class MainActivity extends AppCompatActivity {
                         switch (menuItem.getItemId()) {
 
                             case R.id.action_debug:
-                                // Toggle debug mode
-                                mMapView.toggleDebug();
+                                // Cycle map debug options
+                                mMapView.cycleDebugOptions();
                                 toggleFpsCounter(mMapView.isDebugActive());
                                 return true;
 

--- a/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="action_gps">Toggle GPS location</string>
     <string name="action_user_location_tracking">User location tracking</string>
     <string name="action_compass">Toggle compass</string>
-    <string name="action_debug">Toggle debug mode</string>
+    <string name="action_debug">Cycle map debug options</string>
     <string name="action_point_annotations">Toggle point annotations</string>
     <string name="action_info_window_adapter">InfoWindow Adapter</string>
     <string name="action_map_fragment">MapFragment</string>

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
     map.setBearing(bearing);
 
     if (debug) {
-        map.setDebug(debug);
+        map.setDebug(debug ? mbgl::MapDebugOptions::TileBorders | mbgl::MapDebugOptions::ParseStatus : mbgl::MapDebugOptions::NoDebug);
     }
 
     uv_async_t *async = new uv_async_t;

--- a/docs/DEVELOP_IOS_OSX.md
+++ b/docs/DEVELOP_IOS_OSX.md
@@ -46,4 +46,4 @@ If you want to run the tests in Xcode instead, first `make ipackage` to create a
 - Double-tap to zoom in one level
 - Two-finger single-tap to zoom out one level
 - Double-tap, long-pressing the second, then pan up and down to "quick zoom" (iPhone only, meant for one-handed use)
-- Use the debug menu to add test annotations, reset position, and toggle debug info.
+- Use the debug menu to add test annotations, reset position, and cycle through the debug options.

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -405,8 +405,8 @@ IB_DESIGNABLE
 *   The default value of this property is `NO`. */
 @property (nonatomic, getter=isDebugActive) BOOL debugActive;
 
-/** Toggle the current value of debugActive. */
-- (void)toggleDebug;
+/** Cycle map debug options. */
+- (void)cycleDebugOptions;
 
 /** Empties the in-memory tile cache. */
 - (void)emptyMemoryCache;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -171,9 +171,6 @@ public:
     void setDebug(MapDebugOptions);
     void cycleDebugOptions();
     MapDebugOptions getDebug() const;
-    void setCollisionDebug(bool value);
-    void toggleCollisionDebug();
-    bool getCollisionDebug() const;
 
     bool isFullyLoaded() const;
     void dumpDebugLogs() const;

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -168,12 +168,13 @@ public:
     void onLowMemory();
 
     // Debug
-    void setDebug(bool value);
-    void toggleDebug();
-    bool getDebug() const;
+    void setDebug(MapDebugOptions);
+    void cycleDebugOptions();
+    MapDebugOptions getDebug() const;
     void setCollisionDebug(bool value);
     void toggleCollisionDebug();
     bool getCollisionDebug() const;
+
     bool isFullyLoaded() const;
     void dumpDebugLogs() const;
 

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -5,7 +5,9 @@
 
 namespace mbgl {
 
-enum class MapMode : uint8_t {
+using EnumType = uint32_t;
+
+enum class MapMode : EnumType {
     Continuous, // continually updating map
     Still, // a once-off still image
 };
@@ -14,17 +16,37 @@ enum class MapMode : uint8_t {
 // being shared. In a shared GL context case, we need to make sure that the
 // correct GL configurations are in use - they might have changed between render
 // calls.
-enum class GLContextMode : uint8_t {
+enum class GLContextMode : EnumType {
     Unique,
     Shared,
 };
 
 // We can choose to constrain the map both horizontally or vertically, or only
 // vertically e.g. while panning.
-enum class ConstrainMode : uint8_t {
+enum class ConstrainMode : EnumType {
     HeightOnly,
     WidthAndHeight,
 };
+
+enum class MapDebugOptions : EnumType {
+    NoDebug     = 0,
+    TileBorders = 1 << 1,
+    ParseStatus = 1 << 2,
+    Timestamps  = 1 << 3,
+};
+
+inline MapDebugOptions operator| (const MapDebugOptions& lhs, const MapDebugOptions& rhs) {
+    return MapDebugOptions(static_cast<EnumType>(lhs) | static_cast<EnumType>(rhs));
+}
+
+inline MapDebugOptions& operator|=(MapDebugOptions& lhs, const MapDebugOptions& rhs) {
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+inline bool operator& (const MapDebugOptions& lhs, const MapDebugOptions& rhs) {
+    return static_cast<EnumType>(lhs) & static_cast<EnumType>(rhs);
+}
 
 } // namespace mbgl
 

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -33,6 +33,7 @@ enum class MapDebugOptions : EnumType {
     TileBorders = 1 << 1,
     ParseStatus = 1 << 2,
     Timestamps  = 1 << 3,
+    Collision   = 1 << 4,
 };
 
 inline MapDebugOptions operator| (const MapDebugOptions& lhs, const MapDebugOptions& rhs) {

--- a/include/mbgl/platform/darwin/settings_nsuserdefaults.hpp
+++ b/include/mbgl/platform/darwin/settings_nsuserdefaults.hpp
@@ -22,7 +22,7 @@ public:
     MGLUserTrackingMode userTrackingMode = MGLUserTrackingModeNone;
     bool showsUserLocation = false;
 
-    bool debug = false;
+    uint32_t debug = 0;
 };
 
 }

--- a/include/mbgl/platform/default/settings_json.hpp
+++ b/include/mbgl/platform/default/settings_json.hpp
@@ -1,6 +1,8 @@
 #ifndef MBGL_JSON_SETTINGS
 #define MBGL_JSON_SETTINGS
 
+#include <mbgl/map/mode.hpp>
+
 namespace mbgl {
 
 class Settings_JSON {
@@ -17,7 +19,7 @@ public:
     double bearing = 0;
     double pitch = 0;
 
-    bool debug = false;
+    EnumType debug = 0;
 };
 
 }

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -1,6 +1,8 @@
 #ifndef MBGL_STORAGE_RESPONSE
 #define MBGL_STORAGE_RESPONSE
 
+#include <mbgl/util/chrono.hpp>
+
 #include <string>
 #include <memory>
 
@@ -25,8 +27,8 @@ public:
     // The actual data of the response. This is guaranteed to never be empty.
     std::shared_ptr<const std::string> data;
 
-    int64_t modified = 0;
-    int64_t expires = 0;
+    Seconds modified = Seconds::zero();
+    Seconds expires = Seconds::zero();
     std::string etag;
 };
 

--- a/include/mbgl/util/chrono.hpp
+++ b/include/mbgl/util/chrono.hpp
@@ -8,8 +8,39 @@ namespace mbgl {
 using Clock = std::chrono::steady_clock;
 using SystemClock = std::chrono::system_clock;
 
+using Seconds = std::chrono::seconds;
+using Milliseconds = std::chrono::milliseconds;
+
 using TimePoint = Clock::time_point;
 using Duration  = Clock::duration;
+
+using SystemTimePoint = SystemClock::time_point;
+using SystemDuration = SystemClock::duration;
+
+template <class _Clock, class _Duration>
+_Duration toDuration(std::chrono::time_point<_Clock, _Duration> time_point) {
+    return time_point.time_since_epoch();
+}
+
+template <class _Duration>
+Seconds asSeconds(_Duration duration) {
+    return std::chrono::duration_cast<Seconds>(duration);
+}
+
+template <class _Clock, class _Duration>
+Seconds toSeconds(std::chrono::time_point<_Clock, _Duration> time_point) {
+    return asSeconds(toDuration<_Clock, _Duration>(time_point));
+}
+
+template <class _Duration>
+Milliseconds asMilliseconds(_Duration duration) {
+    return std::chrono::duration_cast<Milliseconds>(duration);
+}
+
+template <class _Clock, class _Duration>
+Milliseconds toMilliseconds(std::chrono::time_point<_Clock, _Duration> time_point) {
+    return asMilliseconds(toDuration<_Clock, _Duration>(time_point));
+}
 
 }
 

--- a/include/mbgl/util/time.hpp
+++ b/include/mbgl/util/time.hpp
@@ -1,6 +1,8 @@
 #ifndef MBGL_UTIL_TIME
 #define MBGL_UTIL_TIME
 
+#include <mbgl/util/chrono.hpp>
+
 #include <string>
 #include <cstdint>
 #include <ctime>
@@ -11,6 +13,9 @@ namespace util {
 
 // Returns the RFC1123 formatted date. E.g. "Tue, 04 Nov 2014 02:13:24 GMT"
 std::string rfc1123(std::time_t time);
+
+// YYYY-mm-dd HH:MM:SS e.g. "2015-11-26 16:11:23"
+std::string iso8601(std::time_t time);
 
 }
 

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -132,7 +132,7 @@ static UIColor *const kTintColor = [UIColor colorWithRed:0.120 green:0.550 blue:
                                          destructiveButtonTitle:nil
                                               otherButtonTitles:@"Reset North",
                                                                 @"Reset Position",
-                                                                @"Toggle Debug",
+                                                                @"Cycle debug options",
                                                                 @"Empty Memory",
                                                                 @"Add 100 Points",
                                                                 @"Add 1,000 Points",
@@ -156,7 +156,7 @@ static UIColor *const kTintColor = [UIColor colorWithRed:0.120 green:0.550 blue:
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 2)
     {
-        [self.mapView toggleDebug];
+        [self.mapView cycleDebugOptions];
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 3)
     {

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
         map.setLatLngZoom(mbgl::LatLng(settings.latitude, settings.longitude), settings.zoom);
         map.setBearing(settings.bearing);
         map.setPitch(settings.pitch);
-        map.setDebug(settings.debug);
+        map.setDebug(mbgl::MapDebugOptions(settings.debug));
     }
 
     view->setChangeStyleCallback([&map] () {
@@ -167,7 +167,7 @@ int main(int argc, char *argv[]) {
     settings.zoom = map.getZoom();
     settings.bearing = map.getBearing();
     settings.pitch = map.getPitch();
-    settings.debug = map.getDebug();
+    settings.debug = mbgl::EnumType(map.getDebug());
     if (!skipConfig) {
         settings.save();
     }

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -168,7 +168,7 @@ int main(int argc, char* argv[]) {
     map.setLatLngZoom(mbgl::LatLng(settings.latitude, settings.longitude), settings.zoom);
     map.setBearing(settings.bearing);
     map.setPitch(settings.pitch);
-    map.setDebug(settings.debug);
+    map.setDebug(mbgl::MapDebugOptions(settings.debug));
 
     view.setChangeStyleCallback([&map, &view] () {
         static uint8_t currentStyleIndex;
@@ -205,7 +205,7 @@ int main(int argc, char* argv[]) {
     settings.zoom = map.getZoom();
     settings.bearing = map.getBearing();
     settings.pitch = map.getPitch();
-    settings.debug = map.getDebug();
+    settings.debug = uint32_t(map.getDebug());
     settings.save();
 
     return 0;

--- a/platform/android/http_request_android.cpp
+++ b/platform/android/http_request_android.cpp
@@ -129,8 +129,8 @@ HTTPAndroidRequest::HTTPAndroidRequest(HTTPAndroidContext* context_, const Resou
     if (existingResponse) {
         if (!existingResponse->etag.empty()) {
             etagStr = existingResponse->etag;
-        } else if (existingResponse->modified) {
-            modifiedStr = util::rfc1123(existingResponse->modified);
+        } else if (existingResponse->modified != Seconds::zero()) {
+            modifiedStr = util::rfc1123(existingResponse->modified.count());
         }
     }
 
@@ -195,11 +195,11 @@ void HTTPAndroidRequest::onResponse(int code, std::string message, std::string e
     response = std::make_unique<Response>();
     using Error = Response::Error;
 
-    response->modified = parse_date(modified.c_str());
+    response->modified = Seconds(parse_date(modified.c_str()));
     response->etag = etag;
     response->expires = parseCacheControl(cacheControl.c_str());
     if (!expires.empty()) {
-        response->expires = parse_date(expires.c_str());
+        response->expires = Seconds(parse_date(expires.c_str()));
     }
     response->data = std::make_shared<std::string>(body);
 

--- a/platform/android/jni.cpp
+++ b/platform/android/jni.cpp
@@ -1295,7 +1295,7 @@ void JNICALL nativeSetDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jb
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
 
-    DebugOptions debugOptions = debug ? DebugOptions::TileBorders | DebugOptions::ParseStatus
+    DebugOptions debugOptions = debug ? DebugOptions::TileBorders | DebugOptions::ParseStatus | DebugOptions::Collision
                                       : DebugOptions::NoDebug;
     nativeMapView->getMap().setDebug(debugOptions);
     nativeMapView->enableFps(debug);
@@ -1314,27 +1314,6 @@ jboolean JNICALL nativeGetDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
     return nativeMapView->getMap().getDebug() != DebugOptions::NoDebug;
-}
-
-void JNICALL nativeSetCollisionDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jboolean debug) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeSetCollisionDebug");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().setCollisionDebug(debug);
-}
-
-void JNICALL nativeToggleCollisionDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeToggleCollisionDebug");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().toggleCollisionDebug();
-}
-
-jboolean JNICALL nativeGetCollisionDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetCollisionDebug");
-    assert(nativeMapViewPtr != 0);
-    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    return nativeMapView->getMap().getCollisionDebug();
 }
 
 jboolean JNICALL nativeIsFullyLoaded(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
@@ -1955,9 +1934,6 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         {"nativeSetDebug", "(JZ)V", reinterpret_cast<void *>(&nativeSetDebug)},
         {"nativeToggleDebug", "(J)V", reinterpret_cast<void *>(&nativeToggleDebug)},
         {"nativeGetDebug", "(J)Z", reinterpret_cast<void *>(&nativeGetDebug)},
-        {"nativeSetCollisionDebug", "(JZ)V", reinterpret_cast<void *>(&nativeSetCollisionDebug)},
-        {"nativeToggleCollisionDebug", "(J)V", reinterpret_cast<void *>(&nativeToggleCollisionDebug)},
-        {"nativeGetCollisionDebug", "(J)Z", reinterpret_cast<void *>(&nativeGetCollisionDebug)},
         {"nativeIsFullyLoaded", "(J)Z", reinterpret_cast<void *>(&nativeIsFullyLoaded)},
         {"nativeSetReachability", "(JZ)V", reinterpret_cast<void *>(&nativeSetReachability)},
         {"nativeGetMetersPerPixelAtLatitude", "(JDD)D", reinterpret_cast<void *>(&nativeGetMetersPerPixelAtLatitude)},

--- a/platform/android/jni.cpp
+++ b/platform/android/jni.cpp
@@ -375,6 +375,7 @@ std::pair<mbgl::AnnotationSegment, mbgl::ShapeAnnotation::Properties> annotation
 namespace {
 
 using namespace mbgl::android;
+using DebugOptions = mbgl::MapDebugOptions;
 
 jlong JNICALL nativeCreate(JNIEnv *env, jobject obj, jstring cachePath_, jstring dataPath_, jstring apkPath_, jfloat pixelRatio, jint availableProcessors, jlong totalMemory) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeCreate");
@@ -1293,7 +1294,10 @@ void JNICALL nativeSetDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jb
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeSetDebug");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().setDebug(debug);
+
+    DebugOptions debugOptions = debug ? DebugOptions::TileBorders | DebugOptions::ParseStatus
+                                      : DebugOptions::NoDebug;
+    nativeMapView->getMap().setDebug(debugOptions);
     nativeMapView->enableFps(debug);
 }
 
@@ -1301,15 +1305,15 @@ void JNICALL nativeToggleDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr)
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeToggleDebug");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().toggleDebug();
-    nativeMapView->enableFps(nativeMapView->getMap().getDebug());
+    nativeMapView->getMap().cycleDebugOptions();
+    nativeMapView->enableFps(nativeMapView->getMap().getDebug() != DebugOptions::NoDebug);
 }
 
 jboolean JNICALL nativeGetDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetDebug");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    return nativeMapView->getMap().getDebug();
+    return nativeMapView->getMap().getDebug() != DebugOptions::NoDebug;
 }
 
 void JNICALL nativeSetCollisionDebug(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jboolean debug) {

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -114,8 +114,8 @@ HTTPNSURLRequest::HTTPNSURLRequest(HTTPNSURLContext* context_,
             if (!existingResponse->etag.empty()) {
                 [req addValue:@(existingResponse->etag.c_str())
                     forHTTPHeaderField:@"If-None-Match"];
-            } else if (existingResponse->modified) {
-                const std::string time = util::rfc1123(existingResponse->modified);
+            } else if (existingResponse->modified != Seconds::zero()) {
+                const std::string time = util::rfc1123(existingResponse->modified.count());
                 [req addValue:@(time.c_str()) forHTTPHeaderField:@"If-Modified-Since"];
             }
         }
@@ -214,12 +214,12 @@ void HTTPNSURLRequest::handleResult(NSData *data, NSURLResponse *res, NSError *e
 
         NSString *expires = [headers objectForKey:@"Expires"];
         if (expires) {
-            response->expires = parse_date([expires UTF8String]);
+            response->expires = Seconds(parse_date([expires UTF8String]));
         }
 
         NSString *last_modified = [headers objectForKey:@"Last-Modified"];
         if (last_modified) {
-            response->modified = parse_date([last_modified UTF8String]);
+            response->modified = Seconds(parse_date([last_modified UTF8String]));
         }
 
         NSString *etag = [headers objectForKey:@"ETag"];

--- a/platform/default/asset_request_fs.cpp
+++ b/platform/default/asset_request_fs.cpp
@@ -130,12 +130,12 @@ void AssetRequest::fileStated(uv_fs_t *req) {
             self->response = std::make_unique<Response>();
 #if UV_VERSION_MAJOR == 0 && UV_VERSION_MINOR <= 10
 #ifdef __APPLE__
-            self->response->modified = stat->st_mtimespec.tv_sec;
+            self->response->modified = Seconds(stat->st_mtimespec.tv_sec);
 #else
-            self->response->modified = stat->st_mtime;
+            self->response->modified = Seconds(stat->st_mtime);
 #endif
 #else
-            self->response->modified = stat->st_mtim.tv_sec;
+            self->response->modified = Seconds(stat->st_mtim.tv_sec);
 #endif
             self->response->etag = util::toString(stat->st_ino);
             const auto size = (unsigned int)(stat->st_size);

--- a/platform/default/asset_request_zip.cpp
+++ b/platform/default/asset_request_zip.cpp
@@ -3,6 +3,7 @@
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/platform/log.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/util.hpp>
 #include <mbgl/util/uv.hpp>
 
@@ -187,7 +188,7 @@ void AssetRequest::fileStated(uv_zip_t *zip) {
 
         // Get the modification time in case we have one.
         if (zip->stat->valid & ZIP_STAT_MTIME) {
-            response->modified = zip->stat->mtime;
+            response->modified = Seconds(zip->stat->mtime);
         }
 
         if (zip->stat->valid & ZIP_STAT_INDEX) {

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -89,7 +89,6 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     printf("- Press `S` to cycle through bundled styles\n");
     printf("- Press `X` to reset the transform\n");
     printf("- Press `N` to reset north\n");
-    printf("- Press `C` to toggle symbol collision debug boxes\n");
     printf("- Press `R` to toggle any available `night` style class\n");
     printf("\n");
     printf("- Press `1` through `6` to add increasing numbers of point annotations for testing\n");
@@ -128,9 +127,6 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             break;
         case GLFW_KEY_TAB:
             view->map->cycleDebugOptions();
-            break;
-        case GLFW_KEY_C:
-            view->map->toggleCollisionDebug();
             break;
         case GLFW_KEY_X:
             if (!mods)

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -102,7 +102,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     printf("- `Control` + mouse drag to rotate\n");
     printf("- `Shift` + mouse drag to tilt\n");
     printf("\n");
-    printf("- Press `Tab` to toggle debug information\n");
+    printf("- Press `Tab` to cycle through the map debug options\n");
     printf("- Press `Esc` to quit\n");
     printf("\n");
     printf("================================================================================\n");
@@ -127,7 +127,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             glfwSetWindowShouldClose(window, true);
             break;
         case GLFW_KEY_TAB:
-            view->map->toggleDebug();
+            view->map->cycleDebugOptions();
             break;
         case GLFW_KEY_C:
             view->map->toggleCollisionDebug();

--- a/platform/default/settings_json.cpp
+++ b/platform/default/settings_json.cpp
@@ -35,5 +35,5 @@ void Settings_JSON::clear() {
     zoom = 0;
     bearing = 0;
     pitch = 0;
-    debug = false;
+    debug = 0;
 }

--- a/platform/default/sqlite_cache.cpp
+++ b/platform/default/sqlite_cache.cpp
@@ -118,9 +118,9 @@ void SQLiteCache::Impl::get(const Resource &resource, Callback callback) {
                 // Status codes > 1 indicate an error
                 response->error = std::make_unique<Response::Error>(Response::Error::Reason(status));
             }
-            response->modified = getStmt->get<int64_t>(1);
+            response->modified = Seconds(getStmt->get<Seconds::rep>(1));
             response->etag = getStmt->get<std::string>(2);
-            response->expires = getStmt->get<int64_t>(3);
+            response->expires = Seconds(getStmt->get<Seconds::rep>(3));
             response->data = std::make_shared<std::string>(std::move(getStmt->get<std::string>(4)));
             if (getStmt->get<int>(5)) { // == compressed
                 response->data = std::make_shared<std::string>(std::move(util::decompress(*response->data)));
@@ -177,9 +177,9 @@ void SQLiteCache::Impl::put(const Resource& resource, std::shared_ptr<const Resp
             putStmt->bind(2 /* status */, 1 /* success */);
         }
         putStmt->bind(3 /* kind */, int(resource.kind));
-        putStmt->bind(4 /* modified */, response->modified);
+        putStmt->bind(4 /* modified */, response->modified.count());
         putStmt->bind(5 /* etag */, response->etag.c_str());
-        putStmt->bind(6 /* expires */, response->expires);
+        putStmt->bind(6 /* expires */, response->expires.count());
 
         std::string data;
         if (resource.kind != Resource::SpriteImage && response->data) {
@@ -208,7 +208,7 @@ void SQLiteCache::Impl::put(const Resource& resource, std::shared_ptr<const Resp
     }
 }
 
-void SQLiteCache::Impl::refresh(const Resource& resource, int64_t expires) {
+void SQLiteCache::Impl::refresh(const Resource& resource, Seconds expires) {
     try {
         if (!db) {
             createDatabase();
@@ -226,7 +226,7 @@ void SQLiteCache::Impl::refresh(const Resource& resource, int64_t expires) {
         }
 
         const auto canonicalURL = util::mapbox::canonicalURL(resource.url);
-        refreshStmt->bind(1, int64_t(expires));
+        refreshStmt->bind(1, expires.count());
         refreshStmt->bind(2, canonicalURL.c_str());
         refreshStmt->run();
     } catch (mapbox::sqlite::Exception& ex) {

--- a/platform/default/sqlite_cache_impl.hpp
+++ b/platform/default/sqlite_cache_impl.hpp
@@ -2,6 +2,7 @@
 #define MBGL_STORAGE_DEFAULT_SQLITE_CACHE_IMPL
 
 #include <mbgl/storage/sqlite_cache.hpp>
+#include <mbgl/util/chrono.hpp>
 
 namespace mapbox {
 namespace sqlite {
@@ -19,7 +20,7 @@ public:
 
     void get(const Resource&, Callback);
     void put(const Resource& resource, std::shared_ptr<const Response> response);
-    void refresh(const Resource& resource, int64_t expires);
+    void refresh(const Resource& resource, Seconds expires);
 
 private:
     void createDatabase();

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -747,7 +747,7 @@ std::chrono::steady_clock::duration durationInSeconds(float duration)
         self.glSnapshotView.image = self.glView.snapshot;
         self.glSnapshotView.hidden = NO;
 
-        if (_mbglMap->getDebug() && [self.glSnapshotView.subviews count] == 0)
+        if (_mbglMap->getDebug() != mbgl::MapDebugOptions::NoDebug && [self.glSnapshotView.subviews count] == 0)
         {
             UIView *snapshotTint = [[UIView alloc] initWithFrame:self.glSnapshotView.bounds];
             snapshotTint.autoresizingMask = self.glSnapshotView.autoresizingMask;
@@ -1502,13 +1502,14 @@ std::chrono::steady_clock::duration durationInSeconds(float duration)
 
 - (void)setDebugActive:(BOOL)debugActive
 {
-    _mbglMap->setDebug(debugActive);
+    _mbglMap->setDebug(debugActive ? mbgl::MapDebugOptions::TileBorders | mbgl::MapDebugOptions::ParseStatus
+                                   : mbgl::MapDebugOptions::NoDebug);
     _mbglMap->setCollisionDebug(debugActive);
 }
 
 - (BOOL)isDebugActive
 {
-    return (_mbglMap->getDebug() || _mbglMap->getCollisionDebug());
+    return (_mbglMap->getDebug() != mbgl::MapDebugOptions::NoDebug || _mbglMap->getCollisionDebug());
 }
 
 - (void)resetNorth
@@ -1527,9 +1528,9 @@ std::chrono::steady_clock::duration durationInSeconds(float duration)
     _mbglMap->resetPosition();
 }
 
-- (void)toggleDebug
+- (void)cycleDebugOptions
 {
-    _mbglMap->toggleDebug();
+    _mbglMap->cycleDebugOptions();
     _mbglMap->toggleCollisionDebug();
 }
 

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -12,6 +12,7 @@
 #include <mbgl/annotation/shape_annotation.hpp>
 #include <mbgl/sprite/sprite_image.hpp>
 #include <mbgl/map/camera.hpp>
+#include <mbgl/map/mode.hpp>
 #include <mbgl/platform/platform.hpp>
 #include <mbgl/platform/darwin/reachability.h>
 #include <mbgl/storage/sqlite_cache.hpp>
@@ -1502,14 +1503,15 @@ std::chrono::steady_clock::duration durationInSeconds(float duration)
 
 - (void)setDebugActive:(BOOL)debugActive
 {
-    _mbglMap->setDebug(debugActive ? mbgl::MapDebugOptions::TileBorders | mbgl::MapDebugOptions::ParseStatus
+    _mbglMap->setDebug(debugActive ? mbgl::MapDebugOptions::TileBorders
+                                   | mbgl::MapDebugOptions::ParseStatus
+                                   | mbgl::MapDebugOptions::Collision
                                    : mbgl::MapDebugOptions::NoDebug);
-    _mbglMap->setCollisionDebug(debugActive);
 }
 
 - (BOOL)isDebugActive
 {
-    return (_mbglMap->getDebug() != mbgl::MapDebugOptions::NoDebug || _mbglMap->getCollisionDebug());
+    return (_mbglMap->getDebug() != mbgl::MapDebugOptions::NoDebug);
 }
 
 - (void)resetNorth
@@ -1531,7 +1533,6 @@ std::chrono::steady_clock::duration durationInSeconds(float duration)
 - (void)cycleDebugOptions
 {
     _mbglMap->cycleDebugOptions();
-    _mbglMap->toggleCollisionDebug();
 }
 
 - (void)emptyMemoryCache

--- a/platform/node/src/node_request.cpp
+++ b/platform/node/src/node_request.cpp
@@ -1,5 +1,6 @@
 #include "node_request.hpp"
 #include <mbgl/storage/response.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <cmath>
 #include <iostream>
@@ -43,6 +44,8 @@ v8::Handle<v8::Object> NodeRequest::Create(const mbgl::Resource& resource, mbgl:
 
 NAN_METHOD(NodeRequest::Respond) {
     using Error = mbgl::Response::Error;
+    using Milliseconds = mbgl::Milliseconds;
+
     mbgl::Response response;
 
     if (info.Length() < 1) {
@@ -63,14 +66,14 @@ NAN_METHOD(NodeRequest::Respond) {
         if (Nan::Has(res, Nan::New("modified").ToLocalChecked()).FromJust()) {
             const double modified = Nan::Get(res, Nan::New("modified").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value();
             if (!std::isnan(modified)) {
-                response.modified = modified / 1000; // JS timestamps are milliseconds
+                response.modified = mbgl::asSeconds(Milliseconds(Milliseconds::rep(modified)));
             }
         }
 
         if (Nan::Has(res, Nan::New("expires").ToLocalChecked()).FromJust()) {
             const double expires = Nan::Get(res, Nan::New("expires").ToLocalChecked()).ToLocalChecked()->ToNumber()->Value();
             if (!std::isnan(expires)) {
-                response.expires = expires / 1000; // JS timestamps are milliseconds
+                response.expires = mbgl::asSeconds(Milliseconds(Milliseconds::rep(expires)));
             }
         }
 

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/annotation/annotation_tile.hpp>
+#include <mbgl/map/map_data.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/layer/symbol_layer.hpp>
 
@@ -10,7 +11,8 @@ namespace mbgl {
 const std::string AnnotationManager::SourceID = "com.mapbox.annotations";
 const std::string AnnotationManager::PointLayerID = "com.mapbox.annotations.points";
 
-AnnotationManager::AnnotationManager() = default;
+AnnotationManager::AnnotationManager(MapData& data_) : data(data_) {}
+
 AnnotationManager::~AnnotationManager() = default;
 
 AnnotationIDs
@@ -108,7 +110,7 @@ std::unique_ptr<AnnotationTile> AnnotationManager::getTile(const TileID& tileID)
 void AnnotationManager::updateStyle(Style& style) {
     // Create annotation source, point layer, and point bucket
     if (!style.getSource(SourceID)) {
-        std::unique_ptr<Source> source = std::make_unique<Source>();
+        std::unique_ptr<Source> source = std::make_unique<Source>(data);
         source->info.type = SourceType::Annotations;
         source->info.source_id = SourceID;
         source->enabled = true;

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -13,6 +13,7 @@
 
 namespace mbgl {
 
+class MapData;
 class PointAnnotation;
 class ShapeAnnotation;
 class AnnotationTile;
@@ -21,7 +22,7 @@ class Style;
 
 class AnnotationManager : private util::noncopyable {
 public:
-    AnnotationManager();
+    AnnotationManager(MapData&);
     ~AnnotationManager();
 
     AnnotationIDs addPointAnnotations(const std::vector<PointAnnotation>&, const uint8_t maxZoom);
@@ -42,6 +43,7 @@ public:
 private:
     std::unique_ptr<AnnotationTile> getTile(const TileID&);
 
+    MapData& data;
     AnnotationID nextID = 0;
     PointAnnotationImpl::Tree pointTree;
     PointAnnotationImpl::Map pointAnnotations;

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -36,14 +36,14 @@ AnnotationTileMonitor::~AnnotationTileMonitor() {
     data.getAnnotationManager()->removeTileMonitor(*this);
 }
 
-std::unique_ptr<FileRequest> AnnotationTileMonitor::monitorTile(std::function<void (std::exception_ptr, std::unique_ptr<GeometryTile>)> callback_) {
+std::unique_ptr<FileRequest> AnnotationTileMonitor::monitorTile(const GeometryTileMonitor::Callback& callback_) {
     callback = callback_;
     data.getAnnotationManager()->addTileMonitor(*this);
     return nullptr;
 }
 
 void AnnotationTileMonitor::update(std::unique_ptr<GeometryTile> tile) {
-    callback(nullptr, std::move(tile));
+    callback(nullptr, std::move(tile), Seconds::zero(), Seconds::zero());
 }
 
 }

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -46,13 +46,13 @@ public:
     ~AnnotationTileMonitor();
 
     void update(std::unique_ptr<GeometryTile>);
-    std::unique_ptr<FileRequest> monitorTile(std::function<void (std::exception_ptr, std::unique_ptr<GeometryTile>)>) override;
+    std::unique_ptr<FileRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
 
     TileID tileID;
 
 private:
     MapData& data;
-    std::function<void (std::exception_ptr, std::unique_ptr<GeometryTile>)> callback;
+    GeometryTileMonitor::Callback callback;
 };
 
 }

--- a/src/mbgl/map/geometry_tile.hpp
+++ b/src/mbgl/map/geometry_tile.hpp
@@ -5,6 +5,7 @@
 #include <mapbox/optional.hpp>
 
 #include <mbgl/style/value.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/vec.hpp>
 #include <mbgl/util/noncopyable.hpp>
@@ -52,6 +53,10 @@ class GeometryTileMonitor : private util::noncopyable {
 public:
     virtual ~GeometryTileMonitor() = default;
 
+    using Callback = std::function<void (std::exception_ptr,
+                                         std::unique_ptr<GeometryTile>,
+                                         Seconds modified,
+                                         Seconds expires)>;
     /*
      * Monitor the tile held by this object for changes. When the tile is loaded for the first time,
      * or updates, the callback is executed. If an error occurs, the first parameter will be set.
@@ -60,7 +65,7 @@ public:
      *
      * To cease monitoring, release the returned Request.
      */
-    virtual std::unique_ptr<FileRequest> monitorTile(std::function<void (std::exception_ptr, std::unique_ptr<GeometryTile>)>) = 0;
+    virtual std::unique_ptr<FileRequest> monitorTile(const Callback&) = 0;
 };
 
 class GeometryTileFeatureExtractor {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -434,20 +434,6 @@ MapDebugOptions Map::getDebug() const {
     return data->getDebug();
 }
 
-void Map::setCollisionDebug(bool value) {
-    data->setCollisionDebug(value);
-    update(Update::Repaint);
-}
-
-void Map::toggleCollisionDebug() {
-    data->toggleCollisionDebug();
-    update(Update::Repaint);
-}
-
-bool Map::getCollisionDebug() const {
-    return data->getCollisionDebug();
-}
-
 bool Map::isFullyLoaded() const {
     return context->invokeSync<bool>(&MapContext::isLoaded);
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -420,17 +420,17 @@ void Map::removeSprite(const std::string& name) {
 
 #pragma mark - Toggles
 
-void Map::setDebug(bool value) {
-    data->setDebug(value);
+void Map::setDebug(MapDebugOptions mode) {
+    data->setDebug(mode);
     update(Update::Repaint);
 }
 
-void Map::toggleDebug() {
-    data->toggleDebug();
+void Map::cycleDebugOptions() {
+    data->cycleDebugOptions();
     update(Update::Repaint);
 }
 
-bool Map::getDebug() const {
+MapDebugOptions Map::getDebug() const {
     return data->getDebug();
 }
 

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -49,14 +49,23 @@ public:
     std::vector<std::string> getClasses() const;
 
 
-    inline bool getDebug() const {
-        return debug;
+    inline MapDebugOptions getDebug() const {
+        return debugOptions;
     }
-    inline bool toggleDebug() {
-        return debug ^= 1u;
+
+    inline void cycleDebugOptions() {
+        if (debugOptions & MapDebugOptions::Timestamps)
+            debugOptions = MapDebugOptions::NoDebug;
+        else if (debugOptions & MapDebugOptions::ParseStatus)
+            debugOptions = debugOptions | MapDebugOptions::Timestamps;
+        else if (debugOptions & MapDebugOptions::TileBorders)
+            debugOptions = debugOptions | MapDebugOptions::ParseStatus;
+        else
+            debugOptions = MapDebugOptions::TileBorders;
     }
-    inline void setDebug(bool value) {
-        debug = value;
+
+    inline void setDebug(MapDebugOptions debugOptions_) {
+        debugOptions = debugOptions_;
     }
 
     inline bool getCollisionDebug() const {
@@ -136,7 +145,7 @@ private:
     mutable std::mutex mtx;
 
     std::vector<std::string> classes;
-    std::atomic<uint8_t> debug { false };
+    std::atomic<MapDebugOptions> debugOptions { MapDebugOptions::NoDebug };
     std::atomic<uint8_t> collisionDebug { false };
     std::atomic<Duration> animationTime;
     std::atomic<Duration> defaultFadeDuration;

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -24,6 +24,7 @@ public:
         : mode(mode_)
         , contextMode(contextMode_)
         , pixelRatio(pixelRatio_)
+        , annotationManager(*this)
         , animationTime(Duration::zero())
         , defaultFadeDuration(mode_ == MapMode::Continuous ? std::chrono::milliseconds(300) : Duration::zero())
         , defaultTransitionDuration(Duration::zero())

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -55,8 +55,10 @@ public:
     }
 
     inline void cycleDebugOptions() {
-        if (debugOptions & MapDebugOptions::Timestamps)
+        if (debugOptions & MapDebugOptions::Collision)
             debugOptions = MapDebugOptions::NoDebug;
+        else if (debugOptions & MapDebugOptions::Timestamps)
+            debugOptions = debugOptions | MapDebugOptions::Collision;
         else if (debugOptions & MapDebugOptions::ParseStatus)
             debugOptions = debugOptions | MapDebugOptions::Timestamps;
         else if (debugOptions & MapDebugOptions::TileBorders)
@@ -67,16 +69,6 @@ public:
 
     inline void setDebug(MapDebugOptions debugOptions_) {
         debugOptions = debugOptions_;
-    }
-
-    inline bool getCollisionDebug() const {
-        return collisionDebug;
-    }
-    inline bool toggleCollisionDebug() {
-        return collisionDebug ^= 1u;
-    }
-    inline void setCollisionDebug(bool value) {
-        collisionDebug = value;
     }
 
     inline TimePoint getAnimationTime() const {
@@ -147,7 +139,6 @@ private:
 
     std::vector<std::string> classes;
     std::atomic<MapDebugOptions> debugOptions { MapDebugOptions::NoDebug };
-    std::atomic<uint8_t> collisionDebug { false };
     std::atomic<Duration> animationTime;
     std::atomic<Duration> defaultFadeDuration;
     std::atomic<Duration> defaultTransitionDuration;

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -25,7 +25,7 @@ RasterTileData::~RasterTileData() {
 }
 
 void RasterTileData::request(float pixelRatio,
-                             const std::function<void()>& callback) {
+                             const RasterTileData::Callback& callback) {
     std::string url = source.tileURL(id, pixelRatio);
     state = State::loading;
 
@@ -54,6 +54,9 @@ void RasterTileData::request(float pixelRatio,
             // Only overwrite the state when we didn't have a previous tile.
             state = State::loaded;
         }
+
+        modified = res.modified;
+        expires = res.expires;
 
         workRequest = worker.parseRasterTile(std::make_unique<RasterBucket>(texturePool), res.data, [this, callback] (RasterTileParseResult result) {
             workRequest.reset();

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -17,8 +17,10 @@ public:
     RasterTileData(const TileID&, TexturePool&, const SourceInfo&, Worker&);
     ~RasterTileData();
 
+    using Callback = std::function<void()>;
+
     void request(float pixelRatio,
-                 const std::function<void()>& callback);
+                 const Callback& callback);
 
     void cancel() override;
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -519,7 +519,7 @@ bool Source::update(const TransformState& transformState,
 
     for (auto& tilePtr : tilePtrs) {
         tilePtr->data->redoPlacement(
-            { transformState.getAngle(), transformState.getPitch(), data.getCollisionDebug() });
+            { transformState.getAngle(), transformState.getPitch(), data.getDebug() & MapDebugOptions::Collision });
     }
 
     updated = data.getAnimationTime();
@@ -562,7 +562,7 @@ void Source::tileLoadingCompleteCallback(const TileID& normalized_id, const Tran
         return;
     }
 
-    tileData->redoPlacement({ transformState.getAngle(), transformState.getPitch(), data.getCollisionDebug() });
+    tileData->redoPlacement({ transformState.getAngle(), transformState.getPitch(), data.getDebug() & MapDebugOptions::Collision});
     emitTileLoaded(true);
 }
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -285,7 +285,11 @@ TileData::State Source::addTile(MapData& data,
 
         // If we don't find working tile data, we're just going to load it.
         if (info.type == SourceType::Raster) {
-            auto tileData = std::make_shared<RasterTileData>(normalized_id, texturePool, info, style.workers);
+            auto tileData = std::make_shared<RasterTileData>(normalized_id,
+                                                             texturePool,
+                                                             info,
+                                                             style.workers);
+
             tileData->request(data.pixelRatio, callback);
             new_tile.data = tileData;
         } else {

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -62,7 +62,7 @@ public:
         virtual void onTileLoadingFailed(std::exception_ptr error) = 0;
     };
 
-    Source();
+    Source(MapData&);
     ~Source();
 
     void load();
@@ -72,8 +72,7 @@ public:
     // will return true if all the tiles were scheduled for updating of false if
     // they were not. shouldReparsePartialTiles must be set to "true" if there is
     // new data available that a tile in the "partial" state might be interested at.
-    bool update(MapData&,
-                const TransformState&,
+    bool update(const TransformState&,
                 Style&,
                 TexturePool&,
                 bool shouldReparsePartialTiles);
@@ -95,7 +94,7 @@ public:
     bool enabled;
 
 private:
-    void tileLoadingCompleteCallback(const TileID& normalized_id, const TransformState& transformState, bool collisionDebug);
+    void tileLoadingCompleteCallback(const TileID&, const TransformState&);
 
     void emitSourceLoaded();
     void emitSourceLoadingFailed(const std::string& message);
@@ -108,8 +107,7 @@ private:
     int32_t coveringZoomLevel(const TransformState&) const;
     std::forward_list<TileID> coveringTiles(const TransformState&) const;
 
-    TileData::State addTile(MapData&,
-                            const TransformState&,
+    TileData::State addTile(const TransformState&,
                             Style&,
                             TexturePool&,
                             const TileID&);
@@ -119,6 +117,8 @@ private:
 
     double getZoom(const TransformState &state) const;
 
+    MapData& data;
+
     bool loaded = false;
 
     // Stores the time when this source was most recently updated.
@@ -126,7 +126,7 @@ private:
 
     std::map<TileID, std::unique_ptr<Tile>> tiles;
     std::vector<Tile*> tilePtrs;
-    std::map<TileID, std::weak_ptr<TileData>> tile_data;
+    std::map<TileID, std::weak_ptr<TileData>> tileDataMap;
     TileCache cache;
 
     std::unique_ptr<FileRequest> req;

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -2,6 +2,7 @@
 #define MBGL_MAP_TILE_DATA
 
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/text/placement_config.hpp>
@@ -94,6 +95,8 @@ public:
     void dumpDebugLogs() const;
 
     const TileID id;
+    Seconds modified = Seconds::zero();
+    Seconds expires = Seconds::zero();
 
     // Contains the tile ID string for painting debug information.
     std::unique_ptr<DebugBucket> debugBucket;

--- a/src/mbgl/map/vector_tile.hpp
+++ b/src/mbgl/map/vector_tile.hpp
@@ -63,7 +63,7 @@ class VectorTileMonitor : public GeometryTileMonitor {
 public:
     VectorTileMonitor(const SourceInfo&, const TileID&, float pixelRatio);
 
-    std::unique_ptr<FileRequest> monitorTile(std::function<void (std::exception_ptr, std::unique_ptr<GeometryTile>)>) override;
+    std::unique_ptr<FileRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
 
 private:
     std::string url;

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -25,7 +25,10 @@ VectorTileData::VectorTileData(const TileID& id_,
       monitor(std::move(monitor_))
 {
     state = State::loading;
-    tileRequest = monitor->monitorTile([callback, this](std::exception_ptr err, std::unique_ptr<GeometryTile> tile) {
+    tileRequest = monitor->monitorTile([callback, this](std::exception_ptr err,
+                                                        std::unique_ptr<GeometryTile> tile,
+                                                        Seconds modified_,
+                                                        Seconds expires_) {
         if (err) {
             try {
                 std::rethrow_exception(err);
@@ -49,6 +52,9 @@ VectorTileData::VectorTileData(const TileID& id_,
         } else if (isReady()) {
             state = State::partial;
         }
+
+        modified = modified_;
+        expires = expires_;
 
         // Kick off a fresh parse of this tile. This happens when the tile is new, or
         // when tile data changed. Replacing the workdRequest will cancel a pending work

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -10,19 +10,24 @@
 
 using namespace mbgl;
 
-DebugBucket::DebugBucket(const TileID id, const TileData::State state_, Seconds modified_, Seconds expires_)
+DebugBucket::DebugBucket(const TileID id, const TileData::State state_, Seconds modified_, Seconds expires_, MapDebugOptions debugMode_)
     : state(state_),
       modified(modified_),
-      expires(expires_) {
-    const std::string text = std::string(id) + " - " + TileData::StateToString(state);
-    fontBuffer.addText(text.c_str(), 50, 200, 5);
+      expires(expires_),
+      debugMode(debugMode_) {
+    double baseline = 200;
+    if (debugMode & MapDebugOptions::ParseStatus) {
+        const std::string text = std::string(id) + " - " + TileData::StateToString(state);
+        fontBuffer.addText(text.c_str(), 50, baseline, 5);
+        baseline += 200;
+    }
 
-    if (modified > Seconds::zero() && expires > Seconds::zero()) {
+    if (debugMode & MapDebugOptions::Timestamps && modified > Seconds::zero() && expires > Seconds::zero()) {
         const std::string modifiedText = "modified: " + util::iso8601(modified.count());
-        fontBuffer.addText(modifiedText.c_str(), 50, 400, 5);
+        fontBuffer.addText(modifiedText.c_str(), 50, baseline, 5);
 
         const std::string expiresText = "expires: " + util::iso8601(expires.count());
-        fontBuffer.addText(expiresText.c_str(), 50, 600, 5);
+        fontBuffer.addText(expiresText.c_str(), 50, baseline + 200, 5);
     }
 }
 

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/renderer/debug_bucket.hpp>
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/shader/plain_shader.hpp>
+#include <mbgl/util/time.hpp>
 
 #include <mbgl/platform/gl.hpp>
 
@@ -9,9 +10,20 @@
 
 using namespace mbgl;
 
-DebugBucket::DebugBucket(const TileID id, const TileData::State state_) : state(state_) {
+DebugBucket::DebugBucket(const TileID id, const TileData::State state_, Seconds modified_, Seconds expires_)
+    : state(state_),
+      modified(modified_),
+      expires(expires_) {
     const std::string text = std::string(id) + " - " + TileData::StateToString(state);
     fontBuffer.addText(text.c_str(), 50, 200, 5);
+
+    if (modified > Seconds::zero() && expires > Seconds::zero()) {
+        const std::string modifiedText = "modified: " + util::iso8601(modified.count());
+        fontBuffer.addText(modifiedText.c_str(), 50, 400, 5);
+
+        const std::string expiresText = "expires: " + util::iso8601(expires.count());
+        fontBuffer.addText(expiresText.c_str(), 50, 600, 5);
+    }
 }
 
 void DebugBucket::drawLines(PlainShader& shader) {

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/tile_data.hpp>
 #include <mbgl/geometry/debug_font_buffer.hpp>
 #include <mbgl/geometry/vao.hpp>
+#include <mbgl/util/chrono.hpp>
 
 namespace mbgl {
 
@@ -11,12 +12,14 @@ class PlainShader;
 
 class DebugBucket : private util::noncopyable {
 public:
-    DebugBucket(TileID id, TileData::State);
+    DebugBucket(TileID id, TileData::State, Seconds modified, Seconds expires);
 
     void drawLines(PlainShader& shader);
     void drawPoints(PlainShader& shader);
 
     const TileData::State state;
+    const Seconds modified;
+    const Seconds expires;
 
 private:
     DebugFontBuffer fontBuffer;

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -2,6 +2,7 @@
 #define MBGL_RENDERER_DEBUGBUCKET
 
 #include <mbgl/map/tile_data.hpp>
+#include <mbgl/map/mode.hpp>
 #include <mbgl/geometry/debug_font_buffer.hpp>
 #include <mbgl/geometry/vao.hpp>
 #include <mbgl/util/chrono.hpp>
@@ -12,7 +13,7 @@ class PlainShader;
 
 class DebugBucket : private util::noncopyable {
 public:
-    DebugBucket(TileID id, TileData::State, Seconds modified, Seconds expires);
+    DebugBucket(TileID id, TileData::State, Seconds modified, Seconds expires, MapDebugOptions);
 
     void drawLines(PlainShader& shader);
     void drawPoints(PlainShader& shader);
@@ -20,6 +21,7 @@ public:
     const TileData::State state;
     const Seconds modified;
     const Seconds expires;
+    const MapDebugOptions debugMode;
 
 private:
     DebugFontBuffer fontBuffer;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -12,7 +12,7 @@ using namespace mbgl;
 void Painter::renderTileDebug(const Tile& tile) {
     MBGL_DEBUG_GROUP(std::string { "debug " } + std::string(tile.id));
     assert(tile.data);
-    if (data.getDebug()) {
+    if (data.getDebug() != MapDebugOptions::NoDebug) {
         prepareTile(tile);
         renderDebugText(*tile.data, tile.matrix);
         renderDebugFrame(tile.matrix);
@@ -26,8 +26,9 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
 
     if (!tileData.debugBucket || tileData.debugBucket->state != tileData.getState()
                               || tileData.debugBucket->modified != tileData.modified
-                              || tileData.debugBucket->expires != tileData.expires) {
-        tileData.debugBucket = std::make_unique<DebugBucket>(tileData.id, tileData.getState(), tileData.modified, tileData.expires);
+                              || tileData.debugBucket->expires != tileData.expires
+                              || tileData.debugBucket->debugMode != data.getDebug()) {
+        tileData.debugBucket = std::make_unique<DebugBucket>(tileData.id, tileData.getState(), tileData.modified, tileData.expires, data.getDebug());
     }
 
     config.program = plainShader->program;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -24,8 +24,10 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
 
     config.depthTest = GL_FALSE;
 
-    if (!tileData.debugBucket || tileData.debugBucket->state != tileData.getState()) {
-        tileData.debugBucket = std::make_unique<DebugBucket>(tileData.id, tileData.getState());
+    if (!tileData.debugBucket || tileData.debugBucket->state != tileData.getState()
+                              || tileData.debugBucket->modified != tileData.modified
+                              || tileData.debugBucket->expires != tileData.expires) {
+        tileData.debugBucket = std::make_unique<DebugBucket>(tileData.id, tileData.getState(), tileData.modified, tileData.expires);
     }
 
     config.program = plainShader->program;

--- a/src/mbgl/storage/default_file_source_impl.hpp
+++ b/src/mbgl/storage/default_file_source_impl.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/storage/asset_context_base.hpp>
 #include <mbgl/storage/http_context_base.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <set>
 #include <unordered_map>
@@ -57,7 +58,7 @@ public:
     // Returns the seconds we have to wait until we need to redo this request. A value of 0
     // means that we need to redo it immediately, and a negative value means that we're not setting
     // a timeout at all.
-    int64_t getRetryTimeout() const;
+    Seconds getRetryTimeout() const;
 
     // Checks the currently stored response and replaces it with an idential one, except with the
     // stale flag set, if the response is expired.

--- a/src/mbgl/storage/http_request_base.cpp
+++ b/src/mbgl/storage/http_request_base.cpp
@@ -5,18 +5,15 @@
 
 namespace mbgl {
 
-int64_t HTTPRequestBase::parseCacheControl(const char *value) {
+Seconds HTTPRequestBase::parseCacheControl(const char *value) {
     if (value) {
         const auto cacheControl = http::CacheControl::parse(value);
-
         if (cacheControl.maxAge) {
-            return std::chrono::duration_cast<std::chrono::seconds>(
-                       std::chrono::system_clock::now().time_since_epoch()).count() +
-                   *cacheControl.maxAge;
+            return toSeconds(SystemClock::now()) + Seconds(*cacheControl.maxAge);
         }
     }
 
-    return 0;
+    return Seconds::zero();
 }
 
 }

--- a/src/mbgl/storage/http_request_base.hpp
+++ b/src/mbgl/storage/http_request_base.hpp
@@ -2,6 +2,7 @@
 #define MBGL_STORAGE_HTTP_REQUEST_BASE
 
 #include <mbgl/storage/request_base.hpp>
+#include <mbgl/util/chrono.hpp>
 
 namespace mbgl {
 
@@ -16,7 +17,7 @@ public:
     virtual void cancel() override { cancelled = true; };
 
 protected:
-    static int64_t parseCacheControl(const char *value);
+    static Seconds parseCacheControl(const char *value);
 
     bool cancelled;
 };

--- a/src/mbgl/storage/response.cpp
+++ b/src/mbgl/storage/response.cpp
@@ -18,11 +18,8 @@ Response& Response::operator=(const Response& res) {
 }
 
 bool Response::isExpired() const {
-    const int64_t now =
-        std::chrono::duration_cast<std::chrono::seconds>(SystemClock::now().time_since_epoch())
-            .count();
     // Note: expires == 0 also counts as expired!
-    return expires <= now;
+    return SystemTimePoint(expires) <= SystemClock::now();
 }
 
 Response::Error::Error(Reason reason_, const std::string& message_)

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -44,7 +44,7 @@ void Style::setJSON(const std::string& json, const std::string&) {
         return;
     }
 
-    StyleParser parser;
+    StyleParser parser(data);
     parser.parse(doc);
 
     for (auto& source : parser.getSources()) {
@@ -106,7 +106,7 @@ void Style::update(const TransformState& transform,
                    TexturePool& texturePool) {
     bool allTilesUpdated = true;
     for (const auto& source : sources) {
-        if (!source->update(data, transform, *this, texturePool, shouldReparsePartialTiles)) {
+        if (!source->update(transform, *this, texturePool, shouldReparsePartialTiles)) {
             allTilesUpdated = false;
         }
     }

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -1,11 +1,16 @@
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/style/style_layer.hpp>
 
+#include <mbgl/map/map_data.hpp>
 #include <mbgl/platform/log.hpp>
 
 #include <algorithm>
 
 namespace mbgl {
+
+StyleParser::StyleParser(MapData& data_)
+    : data(data_) {
+}
 
 void StyleParser::parse(const JSVal& document) {
     if (document.HasMember("version")) {
@@ -49,7 +54,7 @@ void StyleParser::parseSources(const JSVal& value) {
         const JSVal& nameVal = itr->name;
         const JSVal& sourceVal = itr->value;
 
-        std::unique_ptr<Source> source = std::make_unique<Source>();
+        std::unique_ptr<Source> source = std::make_unique<Source>(data);
 
         source->info.source_id = { nameVal.GetString(), nameVal.GetStringLength() };
 

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -14,6 +14,7 @@
 
 namespace mbgl {
 
+class MapData;
 class StyleLayer;
 class Source;
 
@@ -21,6 +22,8 @@ using JSVal = rapidjson::Value;
 
 class StyleParser {
 public:
+    StyleParser(MapData&);
+
     void parse(const JSVal&);
 
     std::vector<std::unique_ptr<Source>>&& getSources() {
@@ -44,6 +47,8 @@ private:
     void parseLayers(const JSVal&);
     void parseLayer(const std::string& id, const JSVal&, util::ptr<StyleLayer>&);
     void parseVisibility(StyleLayer&, const JSVal& value);
+
+    MapData& data;
 
     std::uint8_t version;
 

--- a/src/mbgl/util/chrono.cpp
+++ b/src/mbgl/util/chrono.cpp
@@ -1,0 +1,20 @@
+#include <mbgl/util/chrono.hpp>
+
+namespace mbgl {
+
+template Duration toDuration<Clock, Duration>(TimePoint);
+template SystemDuration toDuration<SystemClock, SystemDuration>(SystemTimePoint);
+
+template Seconds asSeconds<Duration>(Duration);
+template Seconds asSeconds<Milliseconds>(Milliseconds);
+
+template Seconds toSeconds<Clock, Duration>(TimePoint);
+template Seconds toSeconds<SystemClock, SystemDuration>(SystemTimePoint);
+
+template Milliseconds asMilliseconds<Duration>(Duration);
+template Milliseconds asMilliseconds<Seconds>(Seconds);
+
+template Milliseconds toMilliseconds<Clock, Duration>(TimePoint);
+template Milliseconds toMilliseconds<SystemClock, SystemDuration>(SystemTimePoint);
+
+}

--- a/src/mbgl/util/time.cpp
+++ b/src/mbgl/util/time.cpp
@@ -19,5 +19,13 @@ std::string rfc1123(std::time_t time) {
     return buffer;
 }
 
+std::string iso8601(std::time_t time) {
+    std::tm info;
+    gmtime_r(&time, &info);
+    char buffer[30];
+    std::strftime(buffer, sizeof(buffer), "%F %T", &info);
+    return buffer;
+}
+
 }
 }

--- a/test/miscellaneous/style_parser.cpp
+++ b/test/miscellaneous/style_parser.cpp
@@ -1,5 +1,6 @@
 #include "../fixtures/util.hpp"
 
+#include <mbgl/map/map_data.hpp>
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/util/io.hpp>
 
@@ -35,7 +36,9 @@ TEST_P(StyleParserTest, ParseStyle) {
     FixtureLogObserver* observer = new FixtureLogObserver();
     Log::setObserver(std::unique_ptr<Log::Observer>(observer));
 
-    StyleParser parser;
+    double fakePixelRatio = 1.0;
+    MapData data(MapMode::Continuous, GLContextMode::Unique, fakePixelRatio);
+    StyleParser parser(data);
     parser.parse(styleDoc);
 
     for (auto it = infoDoc.MemberBegin(), end = infoDoc.MemberEnd(); it != end; it++) {

--- a/test/storage/cache_response.cpp
+++ b/test/storage/cache_response.cpp
@@ -4,6 +4,7 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/sqlite_cache.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 TEST_F(Storage, CacheResponse) {
@@ -27,8 +28,8 @@ TEST_F(Storage, CacheResponse) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Response 1", *res.data);
-        EXPECT_LT(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_LT(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         response = res;
 

--- a/test/storage/cache_revalidate.cpp
+++ b/test/storage/cache_revalidate.cpp
@@ -4,6 +4,7 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/sqlite_cache.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 TEST_F(Storage, CacheRevalidateSame) {
@@ -31,8 +32,8 @@ TEST_F(Storage, CacheRevalidateSame) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Response", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("snowfall", res.etag);
 
         req2 = fs.request(revalidateSame, [&, res](Response res2) {
@@ -53,8 +54,8 @@ TEST_F(Storage, CacheRevalidateSame) {
             EXPECT_EQ(res.data, res2.data);
             EXPECT_EQ("Response", *res2.data);
             // We use this to indicate that a 304 reply came back.
-            EXPECT_LT(0, res2.expires);
-            EXPECT_EQ(0, res2.modified);
+            EXPECT_LT(Seconds::zero(), res2.expires);
+            EXPECT_EQ(Seconds::zero(), res2.modified);
             // We're not sending the ETag in the 304 reply, but it should still be there.
             EXPECT_EQ("snowfall", res2.etag);
 
@@ -92,8 +93,8 @@ TEST_F(Storage, CacheRevalidateModified) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Response", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(1420070400, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(1420070400, res.modified.count());
         EXPECT_EQ("", res.etag);
 
         req2 = fs.request(revalidateModified, [&, res](Response res2) {
@@ -114,8 +115,8 @@ TEST_F(Storage, CacheRevalidateModified) {
             EXPECT_EQ("Response", *res2.data);
             EXPECT_EQ(res.data, res2.data);
             // We use this to indicate that a 304 reply came back.
-            EXPECT_LT(0, res2.expires);
-            EXPECT_EQ(1420070400, res2.modified);
+            EXPECT_LT(Seconds::zero(), res2.expires);
+            EXPECT_EQ(1420070400, res2.modified.count());
             EXPECT_EQ("", res2.etag);
 
             loop.stop();
@@ -151,8 +152,8 @@ TEST_F(Storage, CacheRevalidateEtag) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Response 1", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("response-1", res.etag);
 
         req2 = fs.request(revalidateEtag, [&, res](Response res2) {
@@ -172,8 +173,8 @@ TEST_F(Storage, CacheRevalidateEtag) {
             ASSERT_TRUE(res2.data.get());
             EXPECT_NE(res.data, res2.data);
             EXPECT_EQ("Response 2", *res2.data);
-            EXPECT_EQ(0, res2.expires);
-            EXPECT_EQ(0, res2.modified);
+            EXPECT_EQ(Seconds::zero(), res2.expires);
+            EXPECT_EQ(Seconds::zero(), res2.modified);
             EXPECT_EQ("response-2", res2.etag);
 
             loop.stop();

--- a/test/storage/directory_reading.cpp
+++ b/test/storage/directory_reading.cpp
@@ -3,6 +3,7 @@
 #include <uv.h>
 
 #include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 TEST_F(Storage, AssetReadDirectory) {
@@ -24,8 +25,8 @@ TEST_F(Storage, AssetReadDirectory) {
         EXPECT_EQ(Response::Error::Reason::NotFound, res.error->reason);
         EXPECT_EQ(false, res.stale);
         ASSERT_FALSE(res.data.get());
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
 #ifdef MBGL_ASSET_ZIP
         EXPECT_EQ("No such file", res.error->message);

--- a/test/storage/file_reading.cpp
+++ b/test/storage/file_reading.cpp
@@ -4,6 +4,7 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/platform/platform.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 TEST_F(Storage, AssetEmptyFile) {
@@ -25,8 +26,8 @@ TEST_F(Storage, AssetEmptyFile) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_LT(1420000000, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_LT(1420000000, res.modified.count());
         EXPECT_NE("", res.etag);
         loop.stop();
         EmptyFile.finish();
@@ -54,8 +55,8 @@ TEST_F(Storage, AssetNonEmptyFile) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("content is here\n", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_LT(1420000000, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_LT(1420000000, res.modified.count());
         EXPECT_NE("", res.etag);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("content is here\n", *res.data);
@@ -85,8 +86,8 @@ TEST_F(Storage, AssetNonExistentFile) {
         EXPECT_EQ(Response::Error::Reason::NotFound, res.error->reason);
         EXPECT_EQ(false, res.stale);
         ASSERT_FALSE(res.data.get());
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
 #ifdef MBGL_ASSET_ZIP
         EXPECT_EQ("No such file", res.error->message);

--- a/test/storage/http_cancel.cpp
+++ b/test/storage/http_cancel.cpp
@@ -4,6 +4,7 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/network_status.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 #include <cmath>
@@ -45,8 +46,8 @@ TEST_F(Storage, HTTPCancelMultiple) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         loop.stop();
         HTTPCancelMultiple.finish();

--- a/test/storage/http_coalescing.cpp
+++ b/test/storage/http_coalescing.cpp
@@ -3,6 +3,7 @@
 #include <uv.h>
 
 #include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 TEST_F(Storage, HTTPCoalescing) {
@@ -31,8 +32,8 @@ TEST_F(Storage, HTTPCoalescing) {
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
 
         if (counter >= total) {
@@ -70,8 +71,8 @@ TEST_F(Storage, HTTPMultiple) {
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_EQ(2147483647, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(2147483647, res.expires.count());
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
 
         // Start a second request for the same resource after the first one has been completed.
@@ -86,8 +87,8 @@ TEST_F(Storage, HTTPMultiple) {
             EXPECT_EQ(nullptr, res2.error);
             ASSERT_TRUE(res2.data.get());
             EXPECT_EQ("Hello World!", *res2.data);
-            EXPECT_EQ(2147483647, res2.expires);
-            EXPECT_EQ(0, res2.modified);
+            EXPECT_EQ(2147483647, res2.expires.count());
+            EXPECT_EQ(Seconds::zero(), res2.modified);
             EXPECT_EQ("", res2.etag);
 
             loop.stop();
@@ -119,8 +120,8 @@ TEST_F(Storage, HTTPStale) {
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
         EXPECT_EQ(false, res.stale);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
 
         // Don't start the request twice in case this callback gets fired multiple times.
@@ -135,8 +136,8 @@ TEST_F(Storage, HTTPStale) {
             EXPECT_EQ(nullptr, res2.error);
             ASSERT_TRUE(res2.data.get());
             EXPECT_EQ("Hello World!", *res2.data);
-            EXPECT_EQ(0, res2.expires);
-            EXPECT_EQ(0, res2.modified);
+            EXPECT_EQ(Seconds::zero(), res2.expires);
+            EXPECT_EQ(Seconds::zero(), res2.modified);
             EXPECT_EQ("", res2.etag);
 
             if (res2.stale) {

--- a/test/storage/http_error.cpp
+++ b/test/storage/http_error.cpp
@@ -4,6 +4,7 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/network_status.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 #include <cmath>
@@ -30,8 +31,8 @@ TEST_F(Storage, HTTPTemporaryError) {
             EXPECT_EQ(false, res.stale);
             ASSERT_TRUE(res.data.get());
             EXPECT_EQ("", *res.data);
-            EXPECT_EQ(0, res.expires);
-            EXPECT_EQ(0, res.modified);
+            EXPECT_EQ(Seconds::zero(), res.expires);
+            EXPECT_EQ(Seconds::zero(), res.modified);
             EXPECT_EQ("", res.etag);
         } break;
         case 1: {
@@ -43,8 +44,8 @@ TEST_F(Storage, HTTPTemporaryError) {
             EXPECT_EQ(false, res.stale);
             ASSERT_TRUE(res.data.get());
             EXPECT_EQ("Hello World!", *res.data);
-            EXPECT_EQ(0, res.expires);
-            EXPECT_EQ(0, res.modified);
+            EXPECT_EQ(Seconds::zero(), res.expires);
+            EXPECT_EQ(Seconds::zero(), res.modified);
             EXPECT_EQ("", res.etag);
             loop.stop();
             HTTPTemporaryError.finish();
@@ -86,8 +87,8 @@ TEST_F(Storage, HTTPConnectionError) {
 #endif
         EXPECT_EQ(false, res.stale);
         ASSERT_FALSE(res.data.get());
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
 
         if (counter == 2) {

--- a/test/storage/http_header_parsing.cpp
+++ b/test/storage/http_header_parsing.cpp
@@ -24,8 +24,8 @@ TEST_F(Storage, HTTPExpiresParsing) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_EQ(1420797926, res.expires);
-        EXPECT_EQ(1420794326, res.modified);
+        EXPECT_EQ(1420797926, res.expires.count());
+        EXPECT_EQ(1420794326, res.modified.count());
         EXPECT_EQ("foo", res.etag);
         loop.stop();
         HTTPExpiresTest.finish();
@@ -42,8 +42,7 @@ TEST_F(Storage, HTTPCacheControlParsing) {
     DefaultFileSource fs(nullptr);
     util::RunLoop loop(uv_default_loop());
 
-    int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
-                       SystemClock::now().time_since_epoch()).count();
+    const Seconds now = toSeconds(SystemClock::now());
 
     std::unique_ptr<FileRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" },
                [&](Response res) {
@@ -52,8 +51,8 @@ TEST_F(Storage, HTTPCacheControlParsing) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_GT(2, std::abs(res.expires - now - 120)) << "Expiration date isn't about 120 seconds in the future";
-        EXPECT_EQ(0, res.modified);
+        EXPECT_GT(2, std::abs(res.expires.count() - now.count() - 120)) << "Expiration date isn't about 120 seconds in the future";
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         loop.stop();
         HTTPCacheControlTest.finish();

--- a/test/storage/http_issue_1369.cpp
+++ b/test/storage/http_issue_1369.cpp
@@ -4,6 +4,7 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/sqlite_cache.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 // Test for https://github.com/mapbox/mapbox-gl-native/issue/1369
@@ -38,8 +39,8 @@ TEST_F(Storage, HTTPIssue1369) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         loop.stop();
         HTTPIssue1369.finish();

--- a/test/storage/http_load.cpp
+++ b/test/storage/http_load.cpp
@@ -3,6 +3,7 @@
 #include <uv.h>
 
 #include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 TEST_F(Storage, HTTPLoad) {
@@ -29,8 +30,8 @@ TEST_F(Storage, HTTPLoad) {
             EXPECT_EQ(false, res.stale);
             ASSERT_TRUE(res.data.get());
             EXPECT_EQ(std::string("Request ") +  std::to_string(current), *res.data);
-            EXPECT_EQ(0, res.expires);
-            EXPECT_EQ(0, res.modified);
+            EXPECT_EQ(Seconds::zero(), res.expires);
+            EXPECT_EQ(Seconds::zero(), res.modified);
             EXPECT_EQ("", res.etag);
 
             if (number <= max) {

--- a/test/storage/http_other_loop.cpp
+++ b/test/storage/http_other_loop.cpp
@@ -3,6 +3,7 @@
 #include <uv.h>
 
 #include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 TEST_F(Storage, HTTPOtherLoop) {
@@ -21,8 +22,8 @@ TEST_F(Storage, HTTPOtherLoop) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         loop.stop();
         HTTPOtherLoop.finish();

--- a/test/storage/http_reading.cpp
+++ b/test/storage/http_reading.cpp
@@ -4,6 +4,7 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/exception.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 #include <future>
@@ -26,8 +27,8 @@ TEST_F(Storage, HTTPTest) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         loop.stop();
         HTTPTest.finish();
@@ -56,8 +57,8 @@ TEST_F(Storage, HTTP404) {
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Cannot GET /doesnotexist\n", *res.data);
         EXPECT_EQ("HTTP status code 404", res.error->message);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         loop.stop();
         HTTP404.finish();
@@ -86,8 +87,8 @@ TEST_F(Storage, HTTP500) {
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Server Error!", *res.data);
         EXPECT_EQ("HTTP status code 500", res.error->message);
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         loop.stop();
         HTTP500.finish();

--- a/test/storage/http_retry_network_status.cpp
+++ b/test/storage/http_retry_network_status.cpp
@@ -4,8 +4,8 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/network_status.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
-
 
 // Test for https://github.com/mapbox/mapbox-gl-native/issues/2123
 //
@@ -30,8 +30,8 @@ TEST_F(Storage, HTTPNetworkStatusChange) {
          EXPECT_EQ(false, res.stale);
          ASSERT_TRUE(res.data.get());
          EXPECT_EQ("Response", *res.data);
-         EXPECT_EQ(0, res.expires);
-         EXPECT_EQ(0, res.modified);
+         EXPECT_EQ(Seconds::zero(), res.expires);
+         EXPECT_EQ(Seconds::zero(), res.modified);
          EXPECT_EQ("", res.etag);
          loop.stop();
          HTTPNetworkStatusChange.finish();
@@ -90,8 +90,8 @@ TEST_F(Storage, HTTPNetworkStatusChangePreempt) {
 #endif
         EXPECT_EQ(false, res.stale);
         ASSERT_FALSE(res.data.get());
-        EXPECT_EQ(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_EQ(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
 
         if (counter++ == 1) {

--- a/test/storage/http_timeout.cpp
+++ b/test/storage/http_timeout.cpp
@@ -4,8 +4,8 @@
 
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/network_status.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
-
 
 TEST_F(Storage, HTTPTimeout) {
     SCOPED_TEST(HTTPTimeout)
@@ -24,8 +24,8 @@ TEST_F(Storage, HTTPTimeout) {
         EXPECT_EQ(false, res.stale);
         ASSERT_TRUE(res.data.get());
         EXPECT_EQ("Hello World!", *res.data);
-        EXPECT_LT(0, res.expires);
-        EXPECT_EQ(0, res.modified);
+        EXPECT_LT(Seconds::zero(), res.expires);
+        EXPECT_EQ(Seconds::zero(), res.modified);
         EXPECT_EQ("", res.etag);
         if (counter == 4) {
             req.reset();


### PR DESCRIPTION
Besides tile identification and status, I believe it would be a nice feat to have the associated tile _timestamp_ information.

By _timestamp_ I refer to the time point used together with expiry date to calculate if the cached tile data is still valid.

/cc @mapbox/gl