### PR TITLE
Disable implicit location updating in background

### DIFF
--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -351,7 +351,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 
 - (void)validateUpdatingLocation {
     MGLAssertIsMainThread();
-    if (self.paused) {
+    if (self.paused || UIApplication.sharedApplication.applicationState == UIApplicationStateBackground) {
         [self stopUpdatingLocation];
     } else {
         CLAuthorizationStatus authStatus = [CLLocationManager authorizationStatus];


### PR DESCRIPTION
If the `location` mode is added to `UIBackgroundModes` in an apps `Info.plist` the blue "Appname is using your location" bar never goes away after pressing the home button on iOS 8.1. This happens even if you set `showsUserLocation = NO` because it's not the `MGLMapView` that causes it, but `MGLMapBoxEvents`.

This fixes it by checking if the app is backgrounded in `MGLMapboxEvents.m`