### PR TITLE
[android] Remove autogenerated file from tree

### DIFF
--- a/android/MapboxGLAndroidSDKTestApp/src/main/res/values/developer-config.xml
+++ b/android/MapboxGLAndroidSDKTestApp/src/main/res/values/developer-config.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="access_token">null</string>
-</resources>


### PR DESCRIPTION
developer-config.xml gets generated on build time with the token set for the env var MAPBOX_ACCESS_TOKEN. Because the file was checked to the git repo, it was not being regenerated and thus, crashing the test app accusing no token set.