### PR TITLE
Update links to access token manager

### DIFF
--- a/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -90,7 +90,7 @@ import java.util.List;
  * and style the features of the map to fit your application's use case.
  * <p/>
  * Use of {@code MapView} requires a Mapbox API access token.
- * Obtain an access token on the <a href="https://www.mapbox.com/account/apps/">Mapbox account page</a>.
+ * Obtain an access token on the <a href="https://www.mapbox.com/studio/account/tokens/">Mapbox account page</a>.
  * <p/>
  * <strong>Warning:</strong> Please note that you are responsible for getting permission to use the map data,
  * and for ensuring your use adheres to the relevant terms of use.

--- a/docs/BUILD_IOS_OSX.md
+++ b/docs/BUILD_IOS_OSX.md
@@ -17,7 +17,7 @@ This section is for people contributing to Mapbox GL directly in the context of 
 
 ### Access Tokens
 
-_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/account/apps/)._
+_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/)._
 
 Set up the access token by editing the scheme for the application target, then adding an environment variable with the name `MAPBOX_ACCESS_TOKEN`.
 

--- a/docs/DEVELOP_ANDROID_LINUX.md
+++ b/docs/DEVELOP_ANDROID_LINUX.md
@@ -19,7 +19,7 @@ In the Android SDK Manager also select and install "Android Support Repository" 
 
 ## Setting Mapbox Access Token
 
-_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/account/apps/)._
+_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/)._
 
 gradle will take the value of the `MAPBOX_ACCESS_TOKEN` environ variable and save it to `"MapboxGLAndroidSDKTestApp/src/main/res/values/developer-config.xml` where the app will read it from.
 

--- a/docs/DEVELOP_ANDROID_OSX.md
+++ b/docs/DEVELOP_ANDROID_OSX.md
@@ -17,7 +17,7 @@ By default, the Android SDK will be installed to `/Users/<user>/Library/Android/
 
 ## Setting Mapbox Access Token
 
-_The test application (used for development purposes) uses Mapbox vector tiles, which require a Mapbox account and API access token. Obtain a free access token on the [Mapbox account page](https://www.mapbox.com/account/apps/)._
+_The test application (used for development purposes) uses Mapbox vector tiles, which require a Mapbox account and API access token. Obtain a free access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/)._
 
 gradle will take the value of the `MAPBOX_ACCESS_TOKEN` environ variable and save it to `MapboxGLAndroidSDKTestApp/src/main/res/values/developer-config.xml` where the app will read it from.
 

--- a/docs/DEVELOP_IOS_OSX.md
+++ b/docs/DEVELOP_IOS_OSX.md
@@ -20,7 +20,7 @@ If you don't have an Apple Developer account, change the destination from "My Ma
 
 ### Access Tokens
 
-_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/account/apps/)._
+_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/)._
 
 Set up the access token by editing the scheme for the application target, then adding an environment variable with the name `MAPBOX_ACCESS_TOKEN`.
 

--- a/docs/DEVELOP_OSX.md
+++ b/docs/DEVELOP_OSX.md
@@ -10,7 +10,7 @@ Note that you can't have more than one project in Xcode open at a time because t
 
 ### Access Tokens
 
-_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/account/apps/)._
+_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/)._
 
 Set up the access token by editing the scheme for the application target, then adding an environment variable with the name `MAPBOX_ACCESS_TOKEN`.
 

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** An MGLMapView object provides an embeddable map interface, similar to the one provided by Apple's MapKit. You use this class to display map information and to manipulate the map contents from your application. You can center the map on a given coordinate, specify the size of the area you want to display, and style the features of the map to fit your application's use case.
 *
-*   Use of MGLMapView requires a Mapbox API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/account/apps/). If you instantiate an MGLMapView from Interface Builder, rendering of the map won't begin until the accessToken property has been set.
+*   Use of MGLMapView requires a Mapbox API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/). If you instantiate an MGLMapView from Interface Builder, rendering of the map won't begin until the accessToken property has been set.
 *
 *   @warning Please note that you are responsible for getting permission to use the map data, and for ensuring your use adheres to the relevant terms of use. */
 IB_DESIGNABLE


### PR DESCRIPTION
Replaced https://www.mapbox.com/account/apps/ with https://www.mapbox.com/studio/account/tokens/. The old URL redirects to a Mapbox Studio page not specifically about access tokens.

/cc @friedbunny @danswick