### PR TITLE
[core] Introduce StyleUpdateParameters

### DIFF
--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/annotation/annotation_tile.hpp>
-#include <mbgl/map/map_data.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/layer/symbol_layer.hpp>
 
@@ -11,8 +10,7 @@ namespace mbgl {
 const std::string AnnotationManager::SourceID = "com.mapbox.annotations";
 const std::string AnnotationManager::PointLayerID = "com.mapbox.annotations.points";
 
-AnnotationManager::AnnotationManager(MapData& data_) : data(data_) {}
-
+AnnotationManager::AnnotationManager() = default;
 AnnotationManager::~AnnotationManager() = default;
 
 AnnotationIDs
@@ -110,7 +108,7 @@ std::unique_ptr<AnnotationTile> AnnotationManager::getTile(const TileID& tileID)
 void AnnotationManager::updateStyle(Style& style) {
     // Create annotation source, point layer, and point bucket
     if (!style.getSource(SourceID)) {
-        std::unique_ptr<Source> source = std::make_unique<Source>(data);
+        std::unique_ptr<Source> source = std::make_unique<Source>();
         source->info.type = SourceType::Annotations;
         source->info.source_id = SourceID;
         source->enabled = true;

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -13,7 +13,6 @@
 
 namespace mbgl {
 
-class MapData;
 class PointAnnotation;
 class ShapeAnnotation;
 class AnnotationTile;
@@ -22,7 +21,7 @@ class Style;
 
 class AnnotationManager : private util::noncopyable {
 public:
-    AnnotationManager(MapData&);
+    AnnotationManager();
     ~AnnotationManager();
 
     AnnotationIDs addPointAnnotations(const std::vector<PointAnnotation>&, const uint8_t maxZoom);
@@ -43,7 +42,6 @@ public:
 private:
     std::unique_ptr<AnnotationTile> getTile(const TileID&);
 
-    MapData& data;
     AnnotationID nextID = 0;
     PointAnnotationImpl::Tree pointTree;
     PointAnnotationImpl::Map pointAnnotations;

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -42,6 +42,7 @@ class MapData;
 
 class AnnotationTileMonitor : public GeometryTileMonitor {
 public:
+    // TODO: should just take AnnotationManager&, but we need to eliminate util::exclusive<AnnotationManager> from MapData first.
     AnnotationTileMonitor(const TileID&, MapData&);
     ~AnnotationTileMonitor();
 

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -24,7 +24,6 @@ public:
         : mode(mode_)
         , contextMode(contextMode_)
         , pixelRatio(pixelRatio_)
-        , annotationManager(*this)
         , animationTime(Duration::zero())
         , defaultFadeDuration(mode_ == MapMode::Continuous ? std::chrono::milliseconds(300) : Duration::zero())
         , defaultTransitionDuration(Duration::zero())

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -22,9 +22,7 @@
 
 namespace mbgl {
 
-class MapData;
-class TexturePool;
-class Style;
+class StyleUpdateParameters;
 class Painter;
 class FileRequest;
 class TransformState;
@@ -72,11 +70,7 @@ public:
     // will return true if all the tiles were scheduled for updating of false if
     // they were not. shouldReparsePartialTiles must be set to "true" if there is
     // new data available that a tile in the "partial" state might be interested at.
-    bool update(MapData&,
-                const TransformState&,
-                Style&,
-                TexturePool&,
-                bool shouldReparsePartialTiles);
+    bool update(const StyleUpdateParameters&);
 
     void updateMatrices(const mat4 &projMatrix, const TransformState &transform);
     void drawClippingMasks(Painter &painter);
@@ -108,13 +102,8 @@ private:
     int32_t coveringZoomLevel(const TransformState&) const;
     std::forward_list<TileID> coveringTiles(const TransformState&) const;
 
-    TileData::State addTile(MapData&,
-                            const TransformState&,
-                            Style&,
-                            TexturePool&,
-                            const TileID&);
-
-    TileData::State hasTile(const TileID& id);
+    TileData::State addTile(const TileID&, const StyleUpdateParameters&);
+    TileData::State hasTile(const TileID&);
     void updateTilePtrs();
 
     double getZoom(const TransformState &state) const;

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -62,7 +62,7 @@ public:
         virtual void onTileLoadingFailed(std::exception_ptr error) = 0;
     };
 
-    Source(MapData&);
+    Source();
     ~Source();
 
     void load();
@@ -72,7 +72,8 @@ public:
     // will return true if all the tiles were scheduled for updating of false if
     // they were not. shouldReparsePartialTiles must be set to "true" if there is
     // new data available that a tile in the "partial" state might be interested at.
-    bool update(const TransformState&,
+    bool update(MapData&,
+                const TransformState&,
                 Style&,
                 TexturePool&,
                 bool shouldReparsePartialTiles);
@@ -94,7 +95,7 @@ public:
     bool enabled;
 
 private:
-    void tileLoadingCompleteCallback(const TileID&, const TransformState&);
+    void tileLoadingCompleteCallback(const TileID&, const TransformState&, bool collisionDebug);
 
     void emitSourceLoaded();
     void emitSourceLoadingFailed(const std::string& message);
@@ -107,7 +108,8 @@ private:
     int32_t coveringZoomLevel(const TransformState&) const;
     std::forward_list<TileID> coveringTiles(const TransformState&) const;
 
-    TileData::State addTile(const TransformState&,
+    TileData::State addTile(MapData&,
+                            const TransformState&,
                             Style&,
                             TexturePool&,
                             const TileID&);
@@ -116,8 +118,6 @@ private:
     void updateTilePtrs();
 
     double getZoom(const TransformState &state) const;
-
-    MapData& data;
 
     bool loaded = false;
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -43,7 +43,7 @@ void Style::setJSON(const std::string& json, const std::string&) {
         return;
     }
 
-    StyleParser parser(data);
+    StyleParser parser;
     parser.parse(doc);
 
     for (auto& source : parser.getSources()) {
@@ -105,7 +105,7 @@ void Style::update(const TransformState& transform,
                    TexturePool& texturePool) {
     bool allTilesUpdated = true;
     for (const auto& source : sources) {
-        if (!source->update(transform, *this, texturePool, shouldReparsePartialTiles)) {
+        if (!source->update(data, transform, *this, texturePool, shouldReparsePartialTiles)) {
             allTilesUpdated = false;
         }
     }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -8,6 +8,7 @@
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/style/property_transition.hpp>
 #include <mbgl/style/class_dictionary.hpp>
+#include <mbgl/style/style_update_parameters.hpp>
 #include <mbgl/style/style_cascade_parameters.hpp>
 #include <mbgl/style/style_calculation_parameters.hpp>
 #include <mbgl/geometry/glyph_atlas.hpp>
@@ -104,8 +105,18 @@ void Style::removeLayer(const std::string& id) {
 void Style::update(const TransformState& transform,
                    TexturePool& texturePool) {
     bool allTilesUpdated = true;
+    StyleUpdateParameters parameters(data.pixelRatio,
+                                     data.getDebug(),
+                                     data.getAnimationTime(),
+                                     transform,
+                                     workers,
+                                     texturePool,
+                                     shouldReparsePartialTiles,
+                                     data,
+                                     *this);
+
     for (const auto& source : sources) {
-        if (!source->update(data, transform, *this, texturePool, shouldReparsePartialTiles)) {
+        if (!source->update(parameters)) {
             allTilesUpdated = false;
         }
     }

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -19,12 +19,15 @@
 
 namespace mbgl {
 
+class MapData;
 class GlyphAtlas;
 class GlyphStore;
 class SpriteStore;
 class SpriteAtlas;
 class LineAtlas;
 class StyleLayer;
+class TransformState;
+class TexturePool;
 
 class Style : public GlyphStore::Observer,
               public SpriteStore::Observer,

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -1,16 +1,11 @@
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/style/style_layer.hpp>
 
-#include <mbgl/map/map_data.hpp>
 #include <mbgl/platform/log.hpp>
 
 #include <algorithm>
 
 namespace mbgl {
-
-StyleParser::StyleParser(MapData& data_)
-    : data(data_) {
-}
 
 void StyleParser::parse(const JSVal& document) {
     if (document.HasMember("version")) {
@@ -54,7 +49,7 @@ void StyleParser::parseSources(const JSVal& value) {
         const JSVal& nameVal = itr->name;
         const JSVal& sourceVal = itr->value;
 
-        std::unique_ptr<Source> source = std::make_unique<Source>(data);
+        std::unique_ptr<Source> source = std::make_unique<Source>();
 
         source->info.source_id = { nameVal.GetString(), nameVal.GetStringLength() };
 

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -14,7 +14,6 @@
 
 namespace mbgl {
 
-class MapData;
 class StyleLayer;
 class Source;
 
@@ -22,8 +21,6 @@ using JSVal = rapidjson::Value;
 
 class StyleParser {
 public:
-    StyleParser(MapData&);
-
     void parse(const JSVal&);
 
     std::vector<std::unique_ptr<Source>>&& getSources() {
@@ -47,8 +44,6 @@ private:
     void parseLayers(const JSVal&);
     void parseLayer(const std::string& id, const JSVal&, util::ptr<StyleLayer>&);
     void parseVisibility(StyleLayer&, const JSVal& value);
-
-    MapData& data;
 
     std::uint8_t version;
 

--- a/src/mbgl/style/style_update_parameters.hpp
+++ b/src/mbgl/style/style_update_parameters.hpp
@@ -1,0 +1,50 @@
+#ifndef STYLE_UPDATE_PARAMETERS
+#define STYLE_UPDATE_PARAMETERS
+
+#include <mbgl/map/mode.hpp>
+
+namespace mbgl {
+
+class TransformState;
+class Worker;
+class TexturePool;
+class MapData;
+class Style;
+
+class StyleUpdateParameters {
+public:
+    StyleUpdateParameters(float pixelRatio_,
+                          MapDebugOptions debugOptions_,
+                          TimePoint animationTime_,
+                          const TransformState& transformState_,
+                          Worker& worker_,
+                          TexturePool& texturePool_,
+                          bool shouldReparsePartialTiles_,
+                          MapData& data_,
+                          Style& style_)
+        : pixelRatio(pixelRatio_),
+          debugOptions(debugOptions_),
+          animationTime(animationTime_),
+          transformState(transformState_),
+          worker(worker_),
+          texturePool(texturePool_),
+          shouldReparsePartialTiles(shouldReparsePartialTiles_),
+          data(data_),
+          style(style_) {}
+
+    float pixelRatio;
+    MapDebugOptions debugOptions;
+    TimePoint animationTime;
+    const TransformState& transformState;
+    Worker& worker;
+    TexturePool& texturePool;
+    bool shouldReparsePartialTiles;
+
+    // TODO: remove
+    MapData& data;
+    Style& style;
+};
+
+}
+
+#endif

--- a/test/miscellaneous/style_parser.cpp
+++ b/test/miscellaneous/style_parser.cpp
@@ -1,6 +1,5 @@
 #include "../fixtures/util.hpp"
 
-#include <mbgl/map/map_data.hpp>
 #include <mbgl/style/style_parser.hpp>
 #include <mbgl/util/io.hpp>
 
@@ -36,9 +35,7 @@ TEST_P(StyleParserTest, ParseStyle) {
     FixtureLogObserver* observer = new FixtureLogObserver();
     Log::setObserver(std::unique_ptr<Log::Observer>(observer));
 
-    double fakePixelRatio = 1.0;
-    MapData data(MapMode::Continuous, GLContextMode::Unique, fakePixelRatio);
-    StyleParser parser(data);
+    StyleParser parser;
     parser.parse(styleDoc);
 
     for (auto it = infoDoc.MemberBegin(), end = infoDoc.MemberEnd(); it != end; it++) {


### PR DESCRIPTION
The introduction of `StyleCascadeParameters` and `StyleCalculationParameters` proved to be very useful refactorings. This does the same for the parameters to `Source::update`. It also addresses the comment [here](https://github.com/mapbox/mapbox-gl-native/commit/d55aa7929cb10d40a58b6b7a8ed73bddd4f0a407#commitcomment-14692834).

:eyes: @brunoabinader 