### PR TITLE
Rename `Map::setSprite`

### DIFF
--- a/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -1723,7 +1723,7 @@ public final class MapView extends FrameLayout {
         }
         float scale = density / DisplayMetrics.DENSITY_DEFAULT;
 
-        mNativeMapView.setSprite(
+        mNativeMapView.addAnnotationIcon(
                 id,
                 (int) (bitmap.getWidth() / scale),
                 (int) (bitmap.getHeight() / scale),

--- a/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
+++ b/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
@@ -385,8 +385,8 @@ final class NativeMapView {
         return nativeGetAnnotationsInBounds(mNativeMapViewPtr, bbox);
     }
 
-    public void setSprite(String symbol, int width, int height, float scale, byte[] pixels) {
-        nativeSetSprite(mNativeMapViewPtr, symbol, width, height, scale, pixels);
+    public void addAnnotationIcon(String symbol, int width, int height, float scale, byte[] pixels) {
+        nativeAddAnnotationIcon(mNativeMapViewPtr, symbol, width, height, scale, pixels);
     }
 
     public void setVisibleCoordinateBounds(LatLng[] coordinates, RectF padding, double direction, long duration) {
@@ -588,7 +588,7 @@ final class NativeMapView {
 
     private native long[] nativeGetAnnotationsInBounds(long mNativeMapViewPtr, BoundingBox bbox);
 
-    private native void nativeSetSprite(long nativeMapViewPtr, String symbol,
+    private native void nativeAddAnnotationIcon(long nativeMapViewPtr, String symbol,
                                         int width, int height, float scale, byte[] pixels);
 
     private native void nativeSetVisibleCoordinateBounds(long mNativeMapViewPtr, LatLng[] coordinates,

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -146,6 +146,10 @@ public:
     LatLng latLngForPixel(const PrecisionPoint&) const;
 
     // Annotations
+    void addAnnotationIcon(const std::string&, std::shared_ptr<const SpriteImage>);
+    void removeAnnotationIcon(const std::string&);
+    double getTopOffsetPixelsForAnnotationIcon(const std::string&);
+
     AnnotationID addPointAnnotation(const PointAnnotation&);
     AnnotationIDs addPointAnnotations(const std::vector<PointAnnotation>&);
 
@@ -157,11 +161,6 @@ public:
 
     AnnotationIDs getPointAnnotationsInBounds(const LatLngBounds&);
     LatLngBounds getBoundsForAnnotations(const AnnotationIDs&);
-    double getTopOffsetPixelsForAnnotationSymbol(const std::string&);
-
-    // Sprites
-    void setSprite(const std::string&, std::shared_ptr<const SpriteImage>);
-    void removeSprite(const std::string&);
 
     // Memory
     void setSourceTileCacheSize(size_t);

--- a/platform/android/jni.cpp
+++ b/platform/android/jni.cpp
@@ -1195,9 +1195,9 @@ jlongArray JNICALL nativeGetAnnotationsInBounds(JNIEnv *env, jobject obj, jlong 
     return std_vector_uint_to_jobject(env, annotations);
 }
 
-void JNICALL nativeSetSprite(JNIEnv *env, jobject obj, jlong nativeMapViewPtr,
+void JNICALL nativeAddAnnotationIcon(JNIEnv *env, jobject obj, jlong nativeMapViewPtr,
         jstring symbol, jint width, jint height, jfloat scale, jbyteArray jpixels) {
-    mbgl::Log::Debug(mbgl::Event::JNI, "nativeSetSprite");
+    mbgl::Log::Debug(mbgl::Event::JNI, "nativeAddAnnotationIcon");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
 
@@ -1214,7 +1214,7 @@ void JNICALL nativeSetSprite(JNIEnv *env, jobject obj, jlong nativeMapViewPtr,
         float(scale),
         std::move(pixels));
 
-    nativeMapView->getMap().setSprite(symbolName, spriteImage);
+    nativeMapView->getMap().addAnnotationIcon(symbolName, spriteImage);
 }
 
 void JNICALL nativeSetVisibleCoordinateBounds(JNIEnv *env, jobject obj, jlong nativeMapViewPtr,
@@ -1454,7 +1454,7 @@ jdouble JNICALL nativeGetTopOffsetPixelsForAnnotationSymbol(JNIEnv *env, jobject
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetTopOffsetPixelsForAnnotationSymbol");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    return nativeMapView->getMap().getTopOffsetPixelsForAnnotationSymbol(std_string_from_jstring(env, symbolName));
+    return nativeMapView->getMap().getTopOffsetPixelsForAnnotationIcon(std_string_from_jstring(env, symbolName));
 }
 
 
@@ -1927,7 +1927,7 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
         {"nativeRemoveAnnotations", "(J[J)V", reinterpret_cast<void *>(&nativeRemoveAnnotations)},
         {"nativeGetAnnotationsInBounds", "(JLcom/mapbox/mapboxsdk/geometry/BoundingBox;)[J",
          reinterpret_cast<void *>(&nativeGetAnnotationsInBounds)},
-        {"nativeSetSprite", "(JLjava/lang/String;IIF[B)V", reinterpret_cast<void *>(&nativeSetSprite)},
+        {"nativeAddAnnotationIcon", "(JLjava/lang/String;IIF[B)V", reinterpret_cast<void *>(&nativeAddAnnotationIcon)},
         {"nativeSetVisibleCoordinateBounds", "(J[Lcom/mapbox/mapboxsdk/geometry/LatLng;Landroid/graphics/RectF;DJ)V",
                 reinterpret_cast<void *>(&nativeSetVisibleCoordinateBounds)},
         {"nativeOnLowMemory", "(J)V", reinterpret_cast<void *>(&nativeOnLowMemory)},

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -115,7 +115,7 @@ GLFWView::~GLFWView() {
 
 void GLFWView::initialize(mbgl::Map *map_) {
     View::initialize(map_);
-    map->setSprite("default_marker", makeSpriteImage(22, 22, 1));
+    map->addAnnotationIcon("default_marker", makeSpriteImage(22, 22, 1));
 }
 
 void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, int mods) {
@@ -222,7 +222,7 @@ void GLFWView::addRandomCustomPointAnnotations(int count) {
     for (int i = 0; i < count; i++) {
         static int spriteID = 1;
         const auto name = std::string{ "marker-" } + mbgl::util::toString(spriteID++);
-        map->setSprite(name, makeSpriteImage(22, 22, 1));
+        map->addAnnotationIcon(name, makeSpriteImage(22, 22, 1));
         spriteIDs.push_back(name);
         points.emplace_back(makeRandomPoint(), name);
     }

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -2263,7 +2263,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
     // sprite upload
     NSString *symbolName = [MGLAnnotationSpritePrefix stringByAppendingString:annotationImage.reuseIdentifier];
-    _mbglMap->setSprite(symbolName.UTF8String, cSpriteImage);
+    _mbglMap->addAnnotationIcon(symbolName.UTF8String, cSpriteImage);
 }
 
 - (void)removeAnnotation:(id <MGLAnnotation>)annotation
@@ -2397,7 +2397,7 @@ CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng)
 
             // determine anchor point based on symbol
             CGPoint calloutAnchorPoint = [self convertCoordinate:annotation.coordinate toPointToView:self];
-            double y = _mbglMap->getTopOffsetPixelsForAnnotationSymbol(cSymbolName);
+            double y = _mbglMap->getTopOffsetPixelsForAnnotationIcon(cSymbolName);
             calloutBounds = CGRectMake(calloutAnchorPoint.x - 1, calloutAnchorPoint.y + y, 0, 0);
         }
 

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -157,12 +157,12 @@ void AnnotationManager::removeTileMonitor(AnnotationTileMonitor& monitor) {
     monitors.erase(&monitor);
 }
 
-void AnnotationManager::setSprite(const std::string& name, std::shared_ptr<const SpriteImage> sprite) {
+void AnnotationManager::addIcon(const std::string& name, std::shared_ptr<const SpriteImage> sprite) {
     spriteStore.setSprite(name, sprite);
     spriteAtlas.updateDirty();
 }
 
-double AnnotationManager::getTopOffsetPixelsForAnnotationSymbol(const std::string& name) {
+double AnnotationManager::getTopOffsetPixelsForIcon(const std::string& name) {
     auto sprite = spriteStore.getSprite(name);
     return sprite ? -sprite->height / 2 : 0;
 }

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -33,8 +33,8 @@ public:
     AnnotationIDs getPointAnnotationsInBounds(const LatLngBounds&) const;
     LatLngBounds getBoundsForAnnotations(const AnnotationIDs&) const;
 
-    void setSprite(const std::string& name, std::shared_ptr<const SpriteImage>);
-    double getTopOffsetPixelsForAnnotationSymbol(const std::string& name);
+    void addIcon(const std::string& name, std::shared_ptr<const SpriteImage>);
+    double getTopOffsetPixelsForIcon(const std::string& name);
     SpriteAtlas& getSpriteAtlas() { return spriteAtlas; }
 
     void updateStyle(Style&);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -367,8 +367,16 @@ LatLng Map::latLngForPixel(const PrecisionPoint& pixel) const {
 
 #pragma mark - Annotations
 
-double Map::getTopOffsetPixelsForAnnotationSymbol(const std::string& symbol) {
-    return context->invokeSync<double>(&MapContext::getTopOffsetPixelsForAnnotationSymbol, symbol);
+void Map::addAnnotationIcon(const std::string& name, std::shared_ptr<const SpriteImage> sprite) {
+    context->invoke(&MapContext::addAnnotationIcon, name, sprite);
+}
+
+void Map::removeAnnotationIcon(const std::string& name) {
+    addAnnotationIcon(name, nullptr);
+}
+
+double Map::getTopOffsetPixelsForAnnotationIcon(const std::string& symbol) {
+    return context->invokeSync<double>(&MapContext::getTopOffsetPixelsForAnnotationIcon, symbol);
 }
 
 AnnotationID Map::addPointAnnotation(const PointAnnotation& annotation) {
@@ -407,18 +415,6 @@ AnnotationIDs Map::getPointAnnotationsInBounds(const LatLngBounds& bounds) {
 LatLngBounds Map::getBoundsForAnnotations(const AnnotationIDs& annotations) {
     return data->getAnnotationManager()->getBoundsForAnnotations(annotations);
 }
-
-
-#pragma mark - Sprites
-
-void Map::setSprite(const std::string& name, std::shared_ptr<const SpriteImage> sprite) {
-    context->invoke(&MapContext::setSprite, name, sprite);
-}
-
-void Map::removeSprite(const std::string& name) {
-    setSprite(name, nullptr);
-}
-
 
 #pragma mark - Toggles
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -267,9 +267,14 @@ bool MapContext::isLoaded() const {
     return style->isLoaded();
 }
 
-double MapContext::getTopOffsetPixelsForAnnotationSymbol(const std::string& symbol) {
+void MapContext::addAnnotationIcon(const std::string& name, std::shared_ptr<const SpriteImage> sprite) {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
-    return data.getAnnotationManager()->getTopOffsetPixelsForAnnotationSymbol(symbol);
+    data.getAnnotationManager()->addIcon(name, sprite);
+}
+
+double MapContext::getTopOffsetPixelsForAnnotationIcon(const std::string& name) {
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+    return data.getAnnotationManager()->getTopOffsetPixelsForIcon(name);
 }
 
 void MapContext::setSourceTileCacheSize(size_t size) {
@@ -287,11 +292,6 @@ void MapContext::onLowMemory() {
     if (!style) return;
     style->onLowMemory();
     asyncInvalidate.send();
-}
-
-void MapContext::setSprite(const std::string& name, std::shared_ptr<const SpriteImage> sprite) {
-    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
-    data.getAnnotationManager()->setSprite(name, sprite);
 }
 
 void MapContext::onTileDataChanged() {

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -48,15 +48,14 @@ public:
 
     bool isLoaded() const;
 
-    double getTopOffsetPixelsForAnnotationSymbol(const std::string& symbol);
+    void addAnnotationIcon(const std::string&, std::shared_ptr<const SpriteImage>);
+    double getTopOffsetPixelsForAnnotationIcon(const std::string&);
     void updateAnnotations();
 
     void setSourceTileCacheSize(size_t size);
     void onLowMemory();
 
     void cleanup();
-
-    void setSprite(const std::string&, std::shared_ptr<const SpriteImage>);
 
     // Style::Observer implementation.
     void onTileDataChanged() override;

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -52,7 +52,7 @@ TEST(Annotations, PointAnnotation) {
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
-    map.setSprite("default_marker", defaultMarker());
+    map.addAnnotationIcon("default_marker", defaultMarker());
     map.addPointAnnotation(PointAnnotation({ 0, 0 }, "default_marker"));
 
     checkRendering(map, "point_annotation");
@@ -117,7 +117,7 @@ TEST(Annotations, AddMultiple) {
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
-    map.setSprite("default_marker", defaultMarker());
+    map.addAnnotationIcon("default_marker", defaultMarker());
     map.addPointAnnotation(PointAnnotation({ 0, -10 }, "default_marker"));
 
     render(map);
@@ -154,7 +154,7 @@ TEST(Annotations, RemovePoint) {
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
-    map.setSprite("default_marker", defaultMarker());
+    map.addAnnotationIcon("default_marker", defaultMarker());
     uint32_t point = map.addPointAnnotation(PointAnnotation({ 0, 0 }, "default_marker"));
 
     render(map);
@@ -205,7 +205,7 @@ TEST(Annotations, SwitchStyle) {
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
-    map.setSprite("default_marker", defaultMarker());
+    map.addAnnotationIcon("default_marker", defaultMarker());
     map.addPointAnnotation(PointAnnotation({ 0, 0 }, "default_marker"));
 
     render(map);


### PR DESCRIPTION
The correct name for this method is `Map::addPointAnnotationIcon`.