### PR TITLE
refs #3112: cleanups around Core Telephony runtime

### DIFF
--- a/platform/ios/MGLMapboxEvents.m
+++ b/platform/ios/MGLMapboxEvents.m
@@ -76,21 +76,22 @@ const NSTimeInterval MGLFlushInterval = 60;
             _scale = [UIScreen mainScreen].scale;
         }
 
+#if !TARGET_OS_SIMULATOR
         // Collect cellular carrier data if CoreTelephony is linked
-        Class CTTelephonyNetworkInfo = NSClassFromString(@"CTTelephonyNetworkInfo");
-        if (CTTelephonyNetworkInfo != NULL) {
-            id telephonyNetworkInfo = [[CTTelephonyNetworkInfo alloc] init];
-
+        Class MGLTelephony = NSClassFromString(@"CTTelephonyNetworkInfo");
+        if (MGLTelephony) {
+            id telephonyNetworkInfo = [[MGLTelephony alloc] init];
             SEL subscriberCellularProviderSelector = NSSelectorFromString(@"subscriberCellularProvider");
-            id carrierVendor = ((id (*)(id, SEL))[telephonyNetworkInfo methodForSelector:subscriberCellularProviderSelector])(telephonyNetworkInfo, subscriberCellularProviderSelector);
+            id carrierVendor = [telephonyNetworkInfo performSelector:subscriberCellularProviderSelector];
 
             // Guard against simulator, iPod Touch, etc.
             if (carrierVendor) {
                 SEL carrierNameSelector = NSSelectorFromString(@"carrierName");
-                NSString *carrierName = ((id (*)(id, SEL))[carrierVendor methodForSelector:carrierNameSelector])(carrierVendor, carrierNameSelector);
+                NSString *carrierName = [carrierVendor performSelector:carrierNameSelector];
                 _carrier = carrierName;
             }
         }
+#endif
     }
     return self;
 }


### PR DESCRIPTION
This doesn't solve our problems directly, but does make things clearer (I think) and avoid doing anything with CT on the simulator anyway, as I think that can be unpredictable. Basically I was seeing crashes from the root of #3112 on device, and I think on simulator because of weird behavior of CT there (so, not related directly).

/cc @friedbunny @1ec5 