### PR TITLE
[ios] fix CoreTelephony crash (by removing it)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Known issues:
 
 ## iOS master
 
+- Fixed CoreTelephony.framework crash. ([#3170](https://github.com/mapbox/mapbox-gl-native/pull/3170))
 - `MGLMapView` methods that alter the viewport now accept optional completion handlers. ([#3090](https://github.com/mapbox/mapbox-gl-native/pull/3090))
 - Fixed an issue preventing the compass from responding to taps after the compass is moved programmatically. ([#3117](https://github.com/mapbox/mapbox-gl-native/pull/3117))
 

--- a/docs/BUILD_IOS_OSX.md
+++ b/docs/BUILD_IOS_OSX.md
@@ -83,7 +83,6 @@ Currently, until [#1437](https://github.com/mapbox/mapbox-gl-native/issues/1437)
    - `libc++.dylib`
    - `libsqlite3.dylib`
    - `libz.dylib`
-   - `CoreTelephony.framework` (optional, telemetry-only)
 
 1. Add `-ObjC` to your target's "Other Linker Flags" build setting (`OTHER_LDFLAGS`).
 


### PR DESCRIPTION
For v3.0.1, we're removing the possibility of using CoreTelephony.framework entirely as the optional linking proved to be buggy. When build and packaging improvements land soonish, we'll revisit this.

Fix #3112, ref #2581

/cc @incanus, @1ec5 