### PR TITLE
Make redoPlacement faster

### DIFF
--- a/src/mbgl/layer/background_layer.cpp
+++ b/src/mbgl/layer/background_layer.cpp
@@ -4,10 +4,7 @@
 namespace mbgl {
 
 std::unique_ptr<StyleLayer> BackgroundLayer::clone() const {
-    std::unique_ptr<BackgroundLayer> result = std::make_unique<BackgroundLayer>();
-    result->copy(*this);
-    result->paint = paint;
-    return std::move(result);
+    return std::make_unique<BackgroundLayer>(*this);
 }
 
 void BackgroundLayer::parsePaints(const JSVal& layer) {

--- a/src/mbgl/layer/background_layer.hpp
+++ b/src/mbgl/layer/background_layer.hpp
@@ -8,9 +8,9 @@ namespace mbgl {
 
 class BackgroundPaintProperties {
 public:
-    PaintProperty<float> opacity = 1.0f;
-    PaintProperty<Color> color = { {{ 0, 0, 0, 1 }} };
-    PaintProperty<std::string, Faded<std::string>> pattern = { "" };
+    PaintProperty<float> opacity { 1.0f };
+    PaintProperty<Color> color { {{ 0, 0, 0, 1 }} };
+    PaintProperty<std::string, Faded<std::string>> pattern { "" };
 };
 
 class BackgroundLayer : public StyleLayer {

--- a/src/mbgl/layer/circle_layer.cpp
+++ b/src/mbgl/layer/circle_layer.cpp
@@ -5,10 +5,7 @@
 namespace mbgl {
 
 std::unique_ptr<StyleLayer> CircleLayer::clone() const {
-    std::unique_ptr<CircleLayer> result = std::make_unique<CircleLayer>();
-    result->copy(*this);
-    result->paint = paint;
-    return std::move(result);
+    return std::make_unique<CircleLayer>(*this);
 }
 
 void CircleLayer::parsePaints(const JSVal& layer) {

--- a/src/mbgl/layer/circle_layer.hpp
+++ b/src/mbgl/layer/circle_layer.hpp
@@ -8,12 +8,12 @@ namespace mbgl {
 
 class CirclePaintProperties {
 public:
-    PaintProperty<float> radius = 5.0f;
-    PaintProperty<Color> color = { {{ 0, 0, 0, 1 }} };
-    PaintProperty<float> opacity = 1.0f;
-    PaintProperty<std::array<float, 2>> translate = { {{ 0, 0 }} };
-    PaintProperty<TranslateAnchorType> translateAnchor = TranslateAnchorType::Map;
-    PaintProperty<float> blur = 0;
+    PaintProperty<float> radius { 5.0f };
+    PaintProperty<Color> color { {{ 0, 0, 0, 1 }} };
+    PaintProperty<float> opacity { 1.0f };
+    PaintProperty<std::array<float, 2>> translate { {{ 0, 0 }} };
+    PaintProperty<TranslateAnchorType> translateAnchor { TranslateAnchorType::Map };
+    PaintProperty<float> blur { 0 };
 
     bool isVisible() const {
         return radius > 0 && color.value[3] > 0 && opacity > 0;

--- a/src/mbgl/layer/fill_layer.cpp
+++ b/src/mbgl/layer/fill_layer.cpp
@@ -5,10 +5,7 @@
 namespace mbgl {
 
 std::unique_ptr<StyleLayer> FillLayer::clone() const {
-    std::unique_ptr<FillLayer> result = std::make_unique<FillLayer>();
-    result->copy(*this);
-    result->paint = paint;
-    return std::move(result);
+    return std::make_unique<FillLayer>(*this);
 }
 
 void FillLayer::parsePaints(const JSVal& layer) {

--- a/src/mbgl/layer/fill_layer.hpp
+++ b/src/mbgl/layer/fill_layer.hpp
@@ -8,13 +8,13 @@ namespace mbgl {
 
 class FillPaintProperties {
 public:
-    PaintProperty<bool> antialias = true;
-    PaintProperty<float> opacity = 1.0f;
-    PaintProperty<Color> color = { {{ 0, 0, 0, 1 }} };
-    PaintProperty<Color> outlineColor = { {{ 0, 0, 0, -1 }} };
-    PaintProperty<std::array<float, 2>> translate = { {{ 0, 0 }} };
-    PaintProperty<TranslateAnchorType> translateAnchor = TranslateAnchorType::Map;
-    PaintProperty<std::string, Faded<std::string>> pattern = { "" };
+    PaintProperty<bool> antialias { true };
+    PaintProperty<float> opacity { 1.0f };
+    PaintProperty<Color> color { {{ 0, 0, 0, 1 }} };
+    PaintProperty<Color> outlineColor { {{ 0, 0, 0, -1 }} };
+    PaintProperty<std::array<float, 2>> translate { {{ 0, 0 }} };
+    PaintProperty<TranslateAnchorType> translateAnchor { TranslateAnchorType::Map };
+    PaintProperty<std::string, Faded<std::string>> pattern { "" };
 };
 
 class FillLayer : public StyleLayer {

--- a/src/mbgl/layer/line_layer.cpp
+++ b/src/mbgl/layer/line_layer.cpp
@@ -6,11 +6,7 @@
 namespace mbgl {
 
 std::unique_ptr<StyleLayer> LineLayer::clone() const {
-    std::unique_ptr<LineLayer> result = std::make_unique<LineLayer>();
-    result->copy(*this);
-    result->layout = layout;
-    result->paint = paint;
-    return std::move(result);
+    return std::make_unique<LineLayer>(*this);
 }
 
 void LineLayer::parseLayout(const JSVal& value) {

--- a/src/mbgl/layer/line_layer.hpp
+++ b/src/mbgl/layer/line_layer.hpp
@@ -9,24 +9,24 @@ namespace mbgl {
 
 class LineLayoutProperties {
 public:
-    LayoutProperty<CapType> cap = CapType::Butt;
-    LayoutProperty<JoinType> join = JoinType::Miter;
-    LayoutProperty<float> miterLimit = 2.0f;
-    LayoutProperty<float> roundLimit = 1.0f;
+    LayoutProperty<CapType> cap { CapType::Butt };
+    LayoutProperty<JoinType> join { JoinType::Miter };
+    LayoutProperty<float> miterLimit { 2.0f };
+    LayoutProperty<float> roundLimit { 1.0f };
 };
 
 class LinePaintProperties {
 public:
-    PaintProperty<float> opacity = 1.0f;
-    PaintProperty<Color> color = { {{ 0, 0, 0, 1 }} };
-    PaintProperty<std::array<float, 2>> translate = { {{ 0, 0 }} };
-    PaintProperty<TranslateAnchorType> translateAnchor = TranslateAnchorType::Map;
-    PaintProperty<float> width = 1;
-    PaintProperty<float> gapWidth = 0;
-    PaintProperty<float> blur = 0;
-    PaintProperty<float> offset = 0;
-    PaintProperty<std::vector<float>, Faded<std::vector<float>>> dasharray = { {} };
-    PaintProperty<std::string, Faded<std::string>> pattern = { "" };
+    PaintProperty<float> opacity { 1.0f };
+    PaintProperty<Color> color { {{ 0, 0, 0, 1 }} };
+    PaintProperty<std::array<float, 2>> translate { {{ 0, 0 }} };
+    PaintProperty<TranslateAnchorType> translateAnchor { TranslateAnchorType::Map };
+    PaintProperty<float> width { 1 };
+    PaintProperty<float> gapWidth { 0 };
+    PaintProperty<float> blur { 0 };
+    PaintProperty<float> offset { 0 };
+    PaintProperty<std::vector<float>, Faded<std::vector<float>>> dasharray { {} };
+    PaintProperty<std::string, Faded<std::string>> pattern { "" };
 
     // Special case
     float dashLineWidth = 1;

--- a/src/mbgl/layer/raster_layer.cpp
+++ b/src/mbgl/layer/raster_layer.cpp
@@ -4,10 +4,7 @@
 namespace mbgl {
 
 std::unique_ptr<StyleLayer> RasterLayer::clone() const {
-    std::unique_ptr<RasterLayer> result = std::make_unique<RasterLayer>();
-    result->copy(*this);
-    result->paint = paint;
-    return std::move(result);
+    return std::make_unique<RasterLayer>(*this);
 }
 
 void RasterLayer::parsePaints(const JSVal& layer) {

--- a/src/mbgl/layer/raster_layer.hpp
+++ b/src/mbgl/layer/raster_layer.hpp
@@ -8,13 +8,13 @@ namespace mbgl {
 
 class RasterPaintProperties {
 public:
-    PaintProperty<float> opacity = 1.0f;
-    PaintProperty<float> hueRotate = 0.0f;
-    PaintProperty<float> brightnessMin = 0.0f;
-    PaintProperty<float> brightnessMax = 1.0f;
-    PaintProperty<float> saturation = 0.0f;
-    PaintProperty<float> contrast = 0.0f;
-    PaintProperty<float> fadeDuration = 0.0f;
+    PaintProperty<float> opacity { 1.0f };
+    PaintProperty<float> hueRotate { 0.0f };
+    PaintProperty<float> brightnessMin { 0.0f };
+    PaintProperty<float> brightnessMax { 1.0f };
+    PaintProperty<float> saturation { 0.0f };
+    PaintProperty<float> contrast { 0.0f };
+    PaintProperty<float> fadeDuration { 0.0f };
 };
 
 class RasterLayer : public StyleLayer {

--- a/src/mbgl/layer/symbol_layer.cpp
+++ b/src/mbgl/layer/symbol_layer.cpp
@@ -6,12 +6,7 @@
 namespace mbgl {
 
 std::unique_ptr<StyleLayer> SymbolLayer::clone() const {
-    std::unique_ptr<SymbolLayer> result = std::make_unique<SymbolLayer>();
-    result->copy(*this);
-    result->layout = layout;
-    result->paint = paint;
-    result->spriteAtlas = spriteAtlas;
-    return std::move(result);
+    return std::make_unique<SymbolLayer>(*this);
 }
 
 void SymbolLayer::parseLayout(const JSVal& value) {

--- a/src/mbgl/layer/symbol_layer.hpp
+++ b/src/mbgl/layer/symbol_layer.hpp
@@ -11,44 +11,44 @@ class SpriteAtlas;
 
 class SymbolLayoutProperties {
 public:
-    LayoutProperty<PlacementType> placement = PlacementType::Point;
-    LayoutProperty<float> spacing = 250.0f;
-    LayoutProperty<bool> avoidEdges = false;
+    LayoutProperty<PlacementType> placement { PlacementType::Point };
+    LayoutProperty<float> spacing { 250.0f };
+    LayoutProperty<bool> avoidEdges { false };
 
     class IconProperties {
     public:
-        LayoutProperty<bool> allowOverlap = false;
-        LayoutProperty<bool> ignorePlacement = false;
-        LayoutProperty<bool> optional = false;
-        LayoutProperty<RotationAlignmentType> rotationAlignment = RotationAlignmentType::Viewport;
-        LayoutProperty<float> size = 1.0f;
-        LayoutProperty<std::string> image = { "" };
-        LayoutProperty<float> rotate = 0.0f;
-        LayoutProperty<float> padding = 2.0f;
-        LayoutProperty<bool> keepUpright = false;
-        LayoutProperty<std::array<float, 2>> offset = { {{ 0, 0 }} };
+        LayoutProperty<bool> allowOverlap { false };
+        LayoutProperty<bool> ignorePlacement { false };
+        LayoutProperty<bool> optional { false };
+        LayoutProperty<RotationAlignmentType> rotationAlignment { RotationAlignmentType::Viewport };
+        LayoutProperty<float> size { 1.0f };
+        LayoutProperty<std::string> image { "" };
+        LayoutProperty<float> rotate { 0.0f };
+        LayoutProperty<float> padding { 2.0f };
+        LayoutProperty<bool> keepUpright { false };
+        LayoutProperty<std::array<float, 2>> offset { {{ 0, 0 }} };
     } icon;
 
     class TextProperties {
     public:
-        LayoutProperty<RotationAlignmentType> rotationAlignment = RotationAlignmentType::Viewport;
-        LayoutProperty<std::string> field = { "" };
-        LayoutProperty<std::string> font = { "Open Sans Regular, Arial Unicode MS Regular" };
-        LayoutProperty<float> size = 16.0f;
-        LayoutProperty<float> maxWidth = 15.0f /* em */;
-        LayoutProperty<float> lineHeight = 1.2f /* em */;
-        LayoutProperty<float> letterSpacing = 0.0f /* em */;
-        LayoutProperty<TextJustifyType> justify = TextJustifyType::Center;
-        LayoutProperty<TextAnchorType> anchor = TextAnchorType::Center;
-        LayoutProperty<float> maxAngle = 45.0f /* degrees */;
-        LayoutProperty<float> rotate = 0.0f;
-        LayoutProperty<float> padding = 2.0f;
-        LayoutProperty<bool> keepUpright = true;
-        LayoutProperty<TextTransformType> transform = TextTransformType::None;
-        LayoutProperty<std::array<float, 2>> offset = { {{ 0, 0 }} };
-        LayoutProperty<bool> allowOverlap = false;
-        LayoutProperty<bool> ignorePlacement = false;
-        LayoutProperty<bool> optional = false;
+        LayoutProperty<RotationAlignmentType> rotationAlignment { RotationAlignmentType::Viewport };
+        LayoutProperty<std::string> field { "" };
+        LayoutProperty<std::string> font { "Open Sans Regular, Arial Unicode MS Regular" };
+        LayoutProperty<float> size { 16.0f };
+        LayoutProperty<float> maxWidth { 15.0f /* em */ };
+        LayoutProperty<float> lineHeight { 1.2f /* em */ };
+        LayoutProperty<float> letterSpacing { 0.0f /* em */ };
+        LayoutProperty<TextJustifyType> justify { TextJustifyType::Center };
+        LayoutProperty<TextAnchorType> anchor { TextAnchorType::Center };
+        LayoutProperty<float> maxAngle { 45.0f /* degrees */ };
+        LayoutProperty<float> rotate { 0.0f };
+        LayoutProperty<float> padding { 2.0f };
+        LayoutProperty<bool> keepUpright { true };
+        LayoutProperty<TextTransformType> transform { TextTransformType::None };
+        LayoutProperty<std::array<float, 2>> offset { {{ 0, 0 }} };
+        LayoutProperty<bool> allowOverlap { false };
+        LayoutProperty<bool> ignorePlacement { false };
+        LayoutProperty<bool> optional { false };
     } text;
 
     // Special case.
@@ -62,13 +62,13 @@ public:
     public:
         PaintProperties(float size_) : size(size_) {}
 
-        PaintProperty<float> opacity = 1.0f;
-        PaintProperty<Color> color = { {{ 0, 0, 0, 1 }} };
-        PaintProperty<Color> haloColor = { {{ 0, 0, 0, 0 }} };
-        PaintProperty<float> haloWidth = 0.0f;
-        PaintProperty<float> haloBlur = 0.0f;
-        PaintProperty<std::array<float, 2>> translate = { {{ 0, 0 }} };
-        PaintProperty<TranslateAnchorType> translateAnchor = TranslateAnchorType::Map;
+        PaintProperty<float> opacity { 1.0f };
+        PaintProperty<Color> color { {{ 0, 0, 0, 1 }} };
+        PaintProperty<Color> haloColor { {{ 0, 0, 0, 0 }} };
+        PaintProperty<float> haloWidth { 0.0f };
+        PaintProperty<float> haloBlur { 0.0f };
+        PaintProperty<std::array<float, 2>> translate { {{ 0, 0 }} };
+        PaintProperty<TranslateAnchorType> translateAnchor { TranslateAnchorType::Map };
 
         // Special case
         float size;

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -51,12 +51,11 @@ public:
 
     TileParseResult parsePendingLayers();
 
-    void redoPlacement(std::vector<std::unique_ptr<StyleLayer>>,
-                       const std::unordered_map<std::string, std::unique_ptr<Bucket>>*,
+    void redoPlacement(const std::unordered_map<std::string, std::unique_ptr<Bucket>>*,
                        PlacementConfig);
 
 private:
-    void parseLayer(std::unique_ptr<StyleLayer>, const GeometryTile&);
+    void parseLayer(const StyleLayer*, const GeometryTile&);
     void insertBucket(const std::string& name, std::unique_ptr<Bucket>);
 
     const TileID id;
@@ -69,11 +68,12 @@ private:
 
     bool partialParse = false;
 
+    std::vector<std::unique_ptr<StyleLayer>> layers;
     std::unique_ptr<CollisionTile> collisionTile;
 
     // Contains buckets that we couldn't parse so far due to missing resources.
     // They will be attempted on subsequent parses.
-    std::list<std::pair<std::unique_ptr<StyleLayer>, std::unique_ptr<Bucket>>> pending;
+    std::list<std::pair<const StyleLayer*, std::unique_ptr<Bucket>>> pending;
 
     // Temporary holder
     TileParseResultBuckets result;

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -166,7 +166,7 @@ void VectorTileData::redoPlacement(const PlacementConfig newConfig) {
 
 void VectorTileData::redoPlacement() {
     workRequest.reset();
-    workRequest = worker.redoPlacement(tileWorker, style.getLayers(), buckets, targetConfig, [this, config = targetConfig] {
+    workRequest = worker.redoPlacement(tileWorker, buckets, targetConfig, [this, config = targetConfig] {
         workRequest.reset();
 
         // Persist the configuration we just placed so that we can later check whether we need to

--- a/src/mbgl/style/layout_property.hpp
+++ b/src/mbgl/style/layout_property.hpp
@@ -14,7 +14,7 @@ using JSVal = rapidjson::Value;
 template <typename T>
 class LayoutProperty {
 public:
-    LayoutProperty(T v) : value(std::move(v)) {}
+    explicit LayoutProperty(T v) : value(std::move(v)) {}
 
     void parse(const char * name, const JSVal& layout) {
         if (layout.HasMember(name)) {
@@ -28,6 +28,7 @@ public:
         }
     }
 
+    void operator=(const T& v) { value = v; }
     operator T() const { return value; }
 
     mapbox::util::optional<Function<T>> parsedValue;

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -24,7 +24,7 @@ class PaintProperty {
 public:
     using Fn = Function<Result>;
 
-    PaintProperty(T fallbackValue)
+    explicit PaintProperty(T fallbackValue)
         : value(fallbackValue) {
         values.emplace(ClassID::Fallback, Fn(fallbackValue));
     }

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -35,16 +35,4 @@ bool StyleLayer::hasRenderPass(RenderPass pass) const {
     return bool(passes & pass);
 }
 
-void StyleLayer::copy(const StyleLayer& src) {
-    id = src.id;
-    ref = src.ref;
-    type = src.type;
-    source = src.source;
-    sourceLayer = src.sourceLayer;
-    filter = src.filter;
-    minZoom = src.minZoom;
-    maxZoom = src.maxZoom;
-    visibility = src.visibility;
-}
-
 } // namespace mbgl

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -21,7 +21,7 @@ class Bucket;
 
 using JSVal = rapidjson::Value;
 
-class StyleLayer : public util::noncopyable {
+class StyleLayer {
 public:
     static std::unique_ptr<StyleLayer> create(StyleLayerType);
     virtual std::unique_ptr<StyleLayer> clone() const = 0;
@@ -58,11 +58,13 @@ public:
     VisibilityType visibility = VisibilityType::Visible;
 
 protected:
+    StyleLayer() = default;
+    StyleLayer(const StyleLayer&) = default;
+    StyleLayer& operator=(const StyleLayer&) = delete;
+
     // Stores what render passes this layer is currently enabled for. This depends on the
     // evaluated StyleProperties object and is updated accordingly.
     RenderPass passes = RenderPass::None;
-
-    void copy(const StyleLayer& source);
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -55,11 +55,10 @@ public:
     }
 
     void redoPlacement(TileWorker* worker,
-                       std::vector<std::unique_ptr<StyleLayer>> layers,
                        const std::unordered_map<std::string, std::unique_ptr<Bucket>>* buckets,
                        PlacementConfig config,
                        std::function<void()> callback) {
-        worker->redoPlacement(std::move(layers), buckets, config);
+        worker->redoPlacement(buckets, config);
         callback();
     }
 };
@@ -103,13 +102,12 @@ Worker::parsePendingGeometryTileLayers(TileWorker& worker,
 
 std::unique_ptr<WorkRequest>
 Worker::redoPlacement(TileWorker& worker,
-                      std::vector<std::unique_ptr<StyleLayer>> layers,
                       const std::unordered_map<std::string, std::unique_ptr<Bucket>>& buckets,
                       PlacementConfig config,
                       std::function<void()> callback) {
     current = (current + 1) % threads.size();
     return threads[current]->invokeWithCallback(&Worker::Impl::redoPlacement, callback, &worker,
-                                                std::move(layers), &buckets, config);
+                                                &buckets, config);
 }
 
 } // end namespace mbgl

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -49,7 +49,6 @@ public:
                                            std::function<void(TileParseResult)> callback);
 
     Request redoPlacement(TileWorker&,
-                          std::vector<std::unique_ptr<StyleLayer>>,
                           const std::unordered_map<std::string, std::unique_ptr<Bucket>>&,
                           PlacementConfig config,
                           std::function<void()> callback);

--- a/test/style/style_layer.cpp
+++ b/test/style/style_layer.cpp
@@ -1,0 +1,24 @@
+#include "../fixtures/util.hpp"
+
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/layer/background_layer.hpp>
+
+using namespace mbgl;
+
+TEST(StyleLayer, Create) {
+    std::unique_ptr<StyleLayer> layer = StyleLayer::create(StyleLayerType::Background);
+    EXPECT_TRUE(reinterpret_cast<BackgroundLayer*>(layer.get()));
+}
+
+TEST(StyleLayer, Clone) {
+    std::unique_ptr<StyleLayer> layer = StyleLayer::create(StyleLayerType::Background);
+    std::unique_ptr<StyleLayer> clone = layer->clone();
+    EXPECT_NE(layer.get(), clone.get());
+    EXPECT_TRUE(reinterpret_cast<BackgroundLayer*>(layer.get()));
+}
+
+TEST(StyleLayer, CloneCopiesBaseProperties) {
+    std::unique_ptr<BackgroundLayer> layer = std::make_unique<BackgroundLayer>();
+    layer->id = "test";
+    EXPECT_EQ("test", layer->clone()->id);
+}

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -91,6 +91,7 @@
         'style/glyph_store.cpp',
         'style/pending_resources.cpp',
         'style/resource_loading.cpp',
+        'style/style_layer.cpp',
 
         'sprite/sprite_atlas.cpp',
         'sprite/sprite_image.cpp',


### PR DESCRIPTION
With https://github.com/mapbox/mapbox-gl-native/commit/bafbf6c04b1bfd5da84411f52a72e26783f3bcb7, label placement is very slow. Label placement occurs when the map is rotated or tilted (but not on zoom or pan). It's slow because we're creating a copy of the StyleLayer* objects on essentially every frame when rotating.

/cc @jfirebaugh 