### PR TITLE
Abandon Cocoa bindings on iOS

### DIFF
--- a/ios/Mapbox-iOS-SDK.podspec
+++ b/ios/Mapbox-iOS-SDK.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |m|
   m.version = '3.0.0-symbols'
 
   m.summary          = 'Open source vector map solution for iOS with full styling capabilities.'
-  m.description      = 'Open source OpenGL-based vector map solution for iOS with full styling capabilities and Cocoa bindings.'
+  m.description      = 'Open source, OpenGL-based vector map solution for iOS with full styling capabilities and Cocoa Touch APIs.'
   m.homepage         = 'https://www.mapbox.com/ios-sdk/'
   m.license          = 'BSD'
   m.author           = { 'Mapbox' => 'mobile@mapbox.com' }

--- a/ios/docs/pod-README.md
+++ b/ios/docs/pod-README.md
@@ -1,6 +1,6 @@
 # Mapbox iOS SDK
 
-An open source OpenGL-based vector map solution for iOS with full styling capabilities and Cocoa bindings.
+An open source, OpenGL-based vector map solution for iOS with full styling capabilities and Cocoa Touch APIs.
 
 For more information, check out [our online overview](https://www.mapbox.com/ios-sdk/). 
 


### PR DESCRIPTION
Replaced the term “Cocoa bindings” in documentation because this library is for iOS, not OS X. Cocoa bindings are a [completely different technology](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/CocoaBindings/Concepts/WhatAreBindings.html) than what we’re developing, although the OS X port I’m making in #3135 does support Cocoa bindings.

![](https://s3.amazonaws.com/rapgenius/1302629365_trix.jpg)

/cc @incanus @friedbunny @mapbox/support