### PR TITLE
Reverse line-offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.19",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2e4c2b0e4903410d043ddeb2f5c88adc1dc90b7b",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#117067ee1789203c46d7648eef8dd49659e62090",
     "node-gyp": "^3.2.0",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -97,7 +97,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         linesdfShader->u_sdfgamma = lineAtlas->width / (properties.dashLineWidth * std::min(posA.width, posB.width) * 256.0 * data.pixelRatio) / 2;
         linesdfShader->u_mix = properties.dasharray.value.t;
         linesdfShader->u_extra = extra;
-        linesdfShader->u_offset = properties.offset;
+        linesdfShader->u_offset = -properties.offset;
         linesdfShader->u_antialiasingmatrix = antialiasingMatrix;
 
         bucket.drawLineSDF(*linesdfShader);
@@ -128,7 +128,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         linepatternShader->u_fade = properties.pattern.value.t;
         linepatternShader->u_opacity = properties.opacity;
         linepatternShader->u_extra = extra;
-        linepatternShader->u_offset = properties.offset;
+        linepatternShader->u_offset = -properties.offset;
         linepatternShader->u_antialiasingmatrix = antialiasingMatrix;
 
         MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0));
@@ -145,7 +145,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         lineShader->u_ratio = ratio;
         lineShader->u_blur = blur;
         lineShader->u_extra = extra;
-        lineShader->u_offset = properties.offset;
+        lineShader->u_offset = -properties.offset;
         lineShader->u_antialiasingmatrix = antialiasingMatrix;
 
         lineShader->u_color = color;


### PR DESCRIPTION
As per https://github.com/mapbox/mapbox-gl-style-spec/issues/386, we're reversing the direction of line-offset.

Master ticket: https://github.com/mapbox/mapbox-gl/issues/3#issuecomment-162607343