### PR TITLE
Do not alter OpenGL viewport

### DIFF
--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -81,6 +81,8 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     glfwGetFramebufferSize(window, &fbWidth, &fbHeight);
     pixelRatio = static_cast<float>(fbWidth) / width;
 
+    glViewport(0, 0, fbWidth, fbHeight);
+
     glfwMakeContextCurrent(nullptr);
 
     printf("\n");
@@ -316,6 +318,8 @@ void GLFWView::onFramebufferResize(GLFWwindow *window, int width, int height) {
     GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     view->fbWidth = width;
     view->fbHeight = height;
+
+    glViewport(0, 0, width, height);
 
     view->map->update(mbgl::Update::Repaint);
 }

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -156,6 +156,8 @@ void HeadlessView::resizeFramebuffer() {
         throw std::runtime_error(error);
     }
 
+    MBGL_CHECK_ERROR(glViewport(0, 0, w, h));
+
     needsResize = false;
 }
 

--- a/src/mbgl/renderer/gl_config.cpp
+++ b/src/mbgl/renderer/gl_config.cpp
@@ -19,7 +19,6 @@ const ClearColor::Type ClearColor::Default = { 0, 0, 0, 0 };
 const ClearStencil::Type ClearStencil::Default = 0;
 const Program::Type Program::Default = 0;
 const LineWidth::Type LineWidth::Default = 1;
-const Viewport::Type Viewport::Default = { 0, 0, 0, 0 };
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/renderer/gl_config.hpp
+++ b/src/mbgl/renderer/gl_config.hpp
@@ -266,23 +266,6 @@ struct LineWidth {
     }
 };
 
-struct Viewport {
-    struct Type { GLint x, y; GLsizei width, height; };
-    static const Type Default;
-    inline static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glViewport(value.x, value.y, value.width, value.height));
-    }
-    inline static Type Get() {
-        GLint viewport[4];
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_VIEWPORT, viewport));
-        return { viewport[0], viewport[1], viewport[2], viewport[3] };
-    }
-};
-
-inline bool operator!=(const Viewport::Type& a, const Viewport::Type& b) {
-    return a.x != b.x || a.y != b.y || a.width != b.width || a.height != b.height;
-}
-
 class Config {
 public:
     void reset() {
@@ -302,7 +285,6 @@ public:
         clearStencil.reset();
         program.reset();
         lineWidth.reset();
-        viewport.reset();
     }
 
     void setDirty() {
@@ -322,7 +304,6 @@ public:
         clearStencil.setDirty();
         program.setDirty();
         lineWidth.setDirty();
-        viewport.setDirty();
     }
 
     Value<StencilFunc> stencilFunc;
@@ -341,7 +322,6 @@ public:
     Value<ClearStencil> clearStencil;
     Value<Program> program;
     Value<LineWidth> lineWidth;
-    Value<Viewport> viewport;
 };
 
 } // namespace gl

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -91,8 +91,6 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     const std::set<Source*>& sources = renderData.sources;
     const Color& background = renderData.backgroundColor;
 
-    config.viewport = { 0, 0, frame.framebufferSize[0], frame.framebufferSize[1] };
-
     // Update the default matrices to the current viewport dimensions.
     state.getProjMatrix(projMatrix);
 
@@ -235,7 +233,6 @@ void Painter::renderPass(RenderPass pass_,
 
         config.colorMask = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
         config.stencilMask = 0x0;
-        config.viewport = { 0, 0, frame.framebufferSize[0], frame.framebufferSize[1] };
 
         if (layer.is<BackgroundLayer>()) {
             MBGL_DEBUG_GROUP("background");


### PR DESCRIPTION
We're currently setting the OpenGL viewport for every frame. Instead, we should move this to the bindings since they know best when the viewport will change. This would also allow bindings to render the map into a specific area of the screen, rather than grabbing the full screen. In particular, there's no relation between the dimensions of the map (which must match the viewport dimensions or the map will be distorted) and the size of the OpenGL context/backbuffer.