### PR TITLE
Fix font rendering at the top of the viewport

### DIFF
--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -48,18 +48,11 @@ void Painter::renderSDF(SymbolBucket &bucket,
     float fontScale = fontSize / sdfFontSize;
     matrix::scale(exMatrix, exMatrix, fontScale, fontScale, 1.0f);
 
-    // calculate how much longer the real world distance is at the top of the screen
-    // than at the middle of the screen.
-    float topedgelength = std::sqrt(std::pow(state.getHeight(), 2) / 4.0f * (1.0f + std::pow(state.getAltitude(), 2)));
-    float x = state.getHeight() / 2.0f * std::tan(state.getPitch());
-    float extra = (topedgelength + x) / topedgelength - 1;
-
     config.program = sdfShader.program;
     sdfShader.u_matrix = vtxMatrix;
     sdfShader.u_exmatrix = exMatrix;
     sdfShader.u_texsize = texsize;
     sdfShader.u_skewed = skewed;
-    sdfShader.u_extra = extra;
 
     // adjust min/max zooms for variable font sies
     float zoomAdjust = std::log(fontSize / bucketProperties.size) / std::log(2);

--- a/src/mbgl/shader/sdf.vertex.glsl
+++ b/src/mbgl/shader/sdf.vertex.glsl
@@ -14,7 +14,6 @@ uniform float u_minfadezoom;
 uniform float u_maxfadezoom;
 uniform float u_fadezoom;
 uniform bool u_skewed;
-uniform float u_extra;
 
 uniform vec2 u_texsize;
 
@@ -59,11 +58,7 @@ void main() {
         gl_Position = u_matrix * vec4(a_pos, 0, 1) + extrude;
     }
 
-    // position of y on the screen
-    float y = gl_Position.y / gl_Position.w;
-    // how much features are squished in all directions by the perspectiveness
-    float perspective_scale = 1.0 / (1.0 - y * u_extra);
-    v_gamma_scale = perspective_scale;
+    v_gamma_scale = 0.5 * gl_Position.w;
 
     v_tex = a_tex / u_texsize;
 }

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -22,7 +22,6 @@ public:
     Uniform<GLfloat>                u_maxfadezoom = {"u_maxfadezoom", *this};
     Uniform<GLfloat>                u_fadezoom    = {"u_fadezoom",    *this};
     Uniform<GLint>                  u_skewed      = {"u_skewed",      *this};
-    Uniform<GLfloat>                u_extra       = {"u_extra",       *this};
 
 protected:
     GLint a_offset = -1;


### PR DESCRIPTION
When the map is tilted, glyphs at the top of the viewport are shaded incorrectly:

![screen shot 2015-11-17 at 19 32 41](https://cloud.githubusercontent.com/assets/52399/11220829/25905ec4-8d62-11e5-8aed-52a3c622972a.png)
