### PR TITLE
node code review cleanup

### DIFF
--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -48,7 +48,7 @@ private:
     void createContext();
     void loadExtensions();
     void clearBuffers();
-    bool isActive();
+    bool isActive() const;
 
 private:
     std::shared_ptr<HeadlessDisplay> display;

--- a/platform/default/headless_display.cpp
+++ b/platform/default/headless_display.cpp
@@ -24,11 +24,9 @@ HeadlessDisplay::HeadlessDisplay() {
     CGLError error = CGLChoosePixelFormat(attributes, &pixelFormat, &num);
     if (error != kCGLNoError) {
         throw std::runtime_error(std::string("Error choosing pixel format:") + CGLErrorString(error) + "\n");
-        return;
     }
     if (num <= 0) {
         throw std::runtime_error("No pixel formats found.");
-        return;
     }
 #endif
 

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -1,4 +1,3 @@
-
 #include <mbgl/platform/default/headless_view.hpp>
 #include <mbgl/platform/default/headless_display.hpp>
 #include <mbgl/platform/log.hpp>
@@ -108,7 +107,7 @@ void HeadlessView::createContext() {
 #endif
 }
 
-bool HeadlessView::isActive() {
+bool HeadlessView::isActive() const {
     return std::this_thread::get_id() == thread;
 }
 

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -28,7 +28,7 @@ public:
     static NAN_METHOD(Release);
     static NAN_METHOD(DumpDebugLogs);
 
-    void startRender(std::unique_ptr<NodeMap::RenderOptions> options);
+    void startRender(RenderOptions options);
     void renderFinished();
 
     void release();
@@ -36,7 +36,7 @@ public:
     inline bool isLoaded() { return loaded; }
     inline bool isValid() { return valid; }
 
-    static std::unique_ptr<NodeMap::RenderOptions> ParseOptions(v8::Local<v8::Object>);
+    static RenderOptions ParseOptions(v8::Local<v8::Object>);
     static Nan::Persistent<v8::Function> constructor;
 
     NodeMap(v8::Local<v8::Object>);


### PR DESCRIPTION
Refs #3179

- In platform/node/src/util/async_queue.hpp:
  - Punting on this per https://github.com/mapbox/mapbox-gl-native/issues/3179#issuecomment-162964129

- In platform/node/src/node_log.cpp:
  - [x] NodeLogOserver's constructor: std::move arguments into their sink, e.g. the std::string to avoic a potential copy (probably everywhere in codebase)

- In platform/node/src/node_map.cpp:
  - [x] return by const value does not make sense, probably in the whole code base --- there should be compiler warnings for that
  - [x] NodeMap::ParseOptions returns a std::unique_ptr<RenderOptions>: this does not make sense, better: just return a RenderOptions type by value

- In platform/default/headless_display.cpp
  - [x] return after throw is dead code

- In platform/default/headless_view.cpp
  - [x] empty line at top, argh my ocd is killing me
  - [x] move the shared_ptrs into their sink in the constructors, otherwise you have an additional refcount increment and decrement
  - [x] isActive can be const

    ```
    error: 'const' type qualifier on return type has no effect
    ```
  - [ ] functions in the HeadlessView destructor can throw, throwing from destructor is bad: wrap in try-catch, log or exit on exception; I would check the whole codebase for that. I think if you mark them noexcept, the standard guarentees for std::terminate to be called; at least it's not UB.
    - Not quite sure what can throw or how to best implement this...

/cc @daniel-j-h