### PR TITLE
Make Xcode run the test-suite directly to enable debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ Xcode/node: ; $(RUN) HTTP=none ASSET=none CACHE=none Xcode/node
 
 .PHONY: xnode
 xnode: Xcode/node ; @open ./build/binding.xcodeproj
+nproj:
+	$(RUN) HTTP=none ASSET=none CACHE=none node/xproj
+	@open ./build/binding.xcodeproj
 
 .PHONY: test
 test: ; $(RUN) Makefile/test

--- a/scripts/main.mk
+++ b/scripts/main.mk
@@ -112,8 +112,8 @@ node/configure:
 node/xproj:
 	$(QUIET)$(ENV) $(NODE_PRE_GYP) configure --clang -- \
 	$(GYP_FLAGS) -f xcode -Dlibuv_cflags= -Dlibuv_ldflags= -Dlibuv_static_libs=
-	$(QUIET)$(ENV) ./scripts/node/create_npm_scheme.sh test
-	$(QUIET)$(ENV) ./scripts/node/create_npm_scheme.sh run test-suite
+	$(QUIET)$(ENV) ./scripts/node/create_node_scheme.sh "node test" "`npm bin tape`/tape platform/node/test/js/**/*.test.js"
+	$(QUIET)$(ENV) ./scripts/node/create_node_scheme.sh "npm run test-suite" "platform/node/test/render.test.js"
 
 Makefile/node: Makefile/__project__ node/configure
 	@printf "$(TEXT_BOLD)$(COLOR_GREEN)* Building target node...$(FORMAT_END)\n"

--- a/scripts/node/create_node_scheme.sh
+++ b/scripts/node/create_node_scheme.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+NAME=$1
+shift
+CMD=$@
+DIR="build/binding.xcodeproj/xcshareddata/xcschemes"
+mkdir -p "${DIR}"
+
+sed "s#{{NODE_PATH}}#$(dirname `which node`)#;s#{{BLUEPRINT_IDENTIFIER}}#$(hexdump -n 12 -v -e '/1 "%02X"' /dev/urandom)#;s#{{WORKING_DIRECTORY}}#$(pwd)#;s#{{NODE_ARGUMENT}}#${CMD}#" scripts/node/node.xcscheme > "${DIR}/${NAME}.xcscheme"

--- a/scripts/node/create_npm_scheme.sh
+++ b/scripts/node/create_npm_scheme.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-CMD=$@
-DIR="build/binding.xcodeproj/xcshareddata/xcschemes"
-FILE="${DIR}/npm ${CMD}.xcscheme"
-mkdir -p "${DIR}"
-
-sed "s#{{NODE_PATH}}#$(dirname `which node`)#;s#{{BLUEPRINT_IDENTIFIER}}#$(hexdump -n 12 -v -e '/1 "%02X"' /dev/urandom)#;s#{{WORKING_DIRECTORY}}#$(pwd)#;s#{{NPM_COMMAND}}#${CMD}#" scripts/node/npm.xcscheme > "${FILE}"

--- a/scripts/node/node.xcscheme
+++ b/scripts/node/node.xcscheme
@@ -58,11 +58,7 @@
       </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "{{NODE_PATH}}/npm"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "{{NPM_COMMAND}}"
+            argument = "{{NODE_ARGUMENT}}"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
Our Xcode scheme currently uses `npm` to invoke the test suite, but that breaks debugging because npm runs as a subcommand (and seemingly doesn't `execv`). Instead, we should execute the script directly to enable breakpoints in Xcode.