### PR TITLE
Update geojson-vt options

### DIFF
--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -80,7 +80,7 @@ void ShapeAnnotationImpl::updateStyle(Style& style) {
 }
 
 void ShapeAnnotationImpl::updateTile(const TileID& tileID, AnnotationTile& tile) {
-    static const double baseTolerance = 3;
+    static const double baseTolerance = 10;
     static const uint16_t extent = 4096;
 
     if (!shapeTiler) {
@@ -108,9 +108,8 @@ void ShapeAnnotationImpl::updateTile(const TileID& tileID, AnnotationTile& tile)
 
         mapbox::geojsonvt::Options options;
         options.maxZoom = maxZoom;
-        options.indexMaxZoom = 4;
-        options.indexMaxPoints = 100;
-        options.tolerance = 10;
+        options.buffer = 128u;
+        options.tolerance = baseTolerance;
         shapeTiler = std::make_unique<mapbox::geojsonvt::GeoJSONVT>(features, options);
     }
 


### PR DESCRIPTION
- Fix the code to use the same simplification tolerance
- Remove outdated indexMaxZoom/Points values and rely on default
- Bump buffer 2x to fix bleeding linecaps on thick lines

cc @kkaefer 