### PR TITLE
[android] #3238 inconsistent package name

### DIFF
--- a/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -39,7 +39,7 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        applicationId "com.mapbox.mapboxgl.testapp"
+        applicationId "com.mapbox.mapboxsdk.testapp"
         minSdkVersion 15
         targetSdkVersion 23
         versionCode 6


### PR DESCRIPTION
closes #3238 