### PR TITLE
don't use glClear optimization for layers that aren't the bottommost

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#78bde0077848b4af0efd490d124bde3ea9f56ec9",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#48d397ea31e551324f85f0eb2088a5017023cab5",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -236,7 +236,7 @@ RenderData Style::getRenderData() const {
             continue;
 
         if (const BackgroundLayer* background = layer->as<BackgroundLayer>()) {
-            if (background->paint.pattern.value.from.empty()) {
+            if (layer.get() == layers[0].get() && background->paint.pattern.value.from.empty()) {
                 // This is a solid background. We can use glClear().
                 result.backgroundColor = background->paint.color;
                 result.backgroundColor[0] *= background->paint.opacity;
@@ -244,7 +244,7 @@ RenderData Style::getRenderData() const {
                 result.backgroundColor[2] *= background->paint.opacity;
                 result.backgroundColor[3] *= background->paint.opacity;
             } else {
-                // This is a textured background. We need to render it with a quad.
+                // This is a textured background, or not the bottommost layer. We need to render it with a quad.
                 result.order.emplace_back(*layer);
             }
             continue;


### PR DESCRIPTION
#2024 results in mis-rendered styles where a background layer is used to implement a semi-transparent overlay on top of other layers.