### PR TITLE
Fix flyTo trajectory; port to OS X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Known issues:
 
 - `MGLMapView` methods that alter the viewport now accept optional completion handlers. ([#3090](https://github.com/mapbox/mapbox-gl-native/pull/3090))
 - Tapping now selects annotations more reliably. Tapping near the top of a large annotation image now selects that annotation. An annotation image’s alignment insets influence how far away the user can tap and still select the annotation. For example, if your annotation image has a large shadow, you can keep that shadow from being tappable by excluding it from the image’s alignment rect. ([#3261](https://github.com/mapbox/mapbox-gl-native/pull/3261))
+- A new method on MGLMapView, `-flyToCamera:withDuration:completionHandler:`, lets you transition between viewpoints along an arc as if by aircraft. ([#3171](https://github.com/mapbox/mapbox-gl-native/pull/3171), [#3301](https://github.com/mapbox/mapbox-gl-native/pull/3301))
 - The user dot’s callout view is now centered above the user dot. It was previously offset slightly to the left. ([#3261](https://github.com/mapbox/mapbox-gl-native/pull/3261))
 
 ## iOS 3.0.1

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -218,10 +218,15 @@ IB_DESIGNABLE
 *   @param completion The block to execute after the animation finishes. */
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))completion;
 
+/** Uses a ballistic parabolic motion to "fly" the viewpoint to a different location with respect to the map with a default duration based on the length of the flight path.
+*   @param camera The new viewpoint.
+*   @param completion The block to execute after the animation finishes. */
+- (void)flyToCamera:(MGLMapCamera *)camera completionHandler:(nullable void (^)(void))completion;
+
 /** Uses a ballistic parabolic motion to "fly" the viewpoint to a different location with respect to the map with an optional transition duration.
- *   @param camera The new viewpoint.
- *   @param duration The amount of time, measured in seconds, that the transition animation should take. Specify `0` to jump to the new viewpoint instantaneously.
- *   @param completion The block to execute after the animation finishes. */
+*   @param camera The new viewpoint.
+*   @param duration The amount of time, measured in seconds, that the transition animation should take. Specify `0` to use the default duration, which is based on the length of the flight path.
+*   @param completion The block to execute after the animation finishes. */
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion;
 
 #pragma mark - Converting Map Coordinates

--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -218,8 +218,6 @@ IB_DESIGNABLE
 *   @param completion The block to execute after the animation finishes. */
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))completion;
 
-#pragma mark - flyTo
-
 /** Uses a ballistic parabolic motion to "fly" the viewpoint to a different location with respect to the map with an optional transition duration.
  *   @param camera The new viewpoint.
  *   @param duration The amount of time, measured in seconds, that the transition animation should take. Specify `0` to jump to the new viewpoint instantaneously.

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -17,6 +17,8 @@ struct CameraOptions {
     mapbox::util::optional<double> angle;
     mapbox::util::optional<double> pitch;
     mapbox::util::optional<Duration> duration;
+    mapbox::util::optional<double> speed;
+    mapbox::util::optional<double> curve;
     mapbox::util::optional<mbgl::util::UnitBezier> easing;
     std::function<void(double)> transitionFrameFn;
     std::function<void()> transitionFinishFn;

--- a/include/mbgl/osx/MGLMapView.h
+++ b/include/mbgl/osx/MGLMapView.h
@@ -249,6 +249,16 @@ IB_DESIGNABLE
     @param completion The block to execute after the animation finishes. */
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))completion;
 
+/** Uses a ballistic parabolic motion to “fly” the viewpoint to a different
+    location with respect to the map with an optional transition duration.
+    
+    @param camera The new viewpoint.
+    @param duration The amount of time, measured in seconds, that the transition
+        animation should take. Specify `0` to jump to the new viewpoint
+        instantaneously.
+    @param completion The block to execute after the animation finishes. */
+- (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion;
+
 /** The geographic coordinate bounds visible in the receiver’s viewport.
     
     Changing the value of this property updates the receiver immediately. If you

--- a/include/mbgl/osx/MGLMapView.h
+++ b/include/mbgl/osx/MGLMapView.h
@@ -250,12 +250,20 @@ IB_DESIGNABLE
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))completion;
 
 /** Uses a ballistic parabolic motion to “fly” the viewpoint to a different
+    location with respect to the map with a default duration based on the length
+    of the flight path.
+    
+    @param camera The new viewpoint.
+    @param completion The block to execute after the animation finishes. */
+- (void)flyToCamera:(MGLMapCamera *)camera completionHandler:(nullable void (^)(void))completion;
+
+/** Uses a ballistic parabolic motion to “fly” the viewpoint to a different
     location with respect to the map with an optional transition duration.
     
     @param camera The new viewpoint.
     @param duration The amount of time, measured in seconds, that the transition
-        animation should take. Specify `0` to jump to the new viewpoint
-        instantaneously.
+        animation should take. Specify `0` to use the default duration, which is
+        based on the length of the flight path.
     @param completion The block to execute after the animation finishes. */
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion;
 

--- a/ios/app/MBXViewController.mm
+++ b/ios/app/MBXViewController.mm
@@ -379,7 +379,7 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
                                                                    pitch:arc4random_uniform(60)
                                                                  heading:arc4random_uniform(360)];
     __weak MBXViewController *weakSelf = self;
-    [self.mapView flyToCamera:camera withDuration:0 completionHandler:^{
+    [self.mapView flyToCamera:camera completionHandler:^{
         MBXViewController *strongSelf = weakSelf;
         [strongSelf performSelector:@selector(continueWorldTourWithRemainingAnnotations:)
                          withObject:annotations

--- a/platform/ios/MGLMapView.mm
+++ b/platform/ios/MGLMapView.mm
@@ -1808,6 +1808,11 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     [self didChangeValueForKey:@"camera"];
 }
 
+- (void)flyToCamera:(MGLMapCamera *)camera completionHandler:(nullable void (^)(void))completion
+{
+    [self flyToCamera:camera withDuration:0 completionHandler:completion];
+}
+
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion
 {
     _mbglMap->cancelTransitions();

--- a/platform/osx/app/AppDelegate.m
+++ b/platform/osx/app/AppDelegate.m
@@ -319,7 +319,7 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
                                                                    pitch:arc4random_uniform(60)
                                                                  heading:arc4random_uniform(360)];
     __weak AppDelegate *weakSelf = self;
-    [self.mapView flyToCamera:camera withDuration:0 completionHandler:^{
+    [self.mapView flyToCamera:camera completionHandler:^{
         AppDelegate *strongSelf = weakSelf;
         [strongSelf performSelector:@selector(continueWorldTourWithRemainingAnnotations:)
                          withObject:annotations

--- a/platform/osx/app/MainMenu.xib
+++ b/platform/osx/app/MainMenu.xib
@@ -469,7 +469,7 @@
                                     <action selector="toggleRandomizesCursorsOnDroppedPins:" target="-1" id="Mpw-b8-oub"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" id="wQq-Mx-QY0"/>
+                            <menuItem isSeparatorItem="YES" id="Sl5-nE-kHd"/>
                             <menuItem title="Blanket Map With Pins" id="LMZ-oe-Ngh">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -480,6 +480,19 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="removeAllPins:" target="-1" id="NRM-y5-Wul"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="wQq-Mx-QY0"/>
+                            <menuItem title="Start World Tour" id="VFo-Jh-2sw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="startWorldTour:" target="-1" id="66Y-Gm-Yn1"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Stop World Tour" id="Pa8-qU-xfr">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="stopWorldTour:" target="-1" id="aq0-7t-AGi"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1008,6 +1008,10 @@ public:
     [self didChangeValueForKey:@"camera"];
 }
 
+- (void)flyToCamera:(MGLMapCamera *)camera completionHandler:(nullable void (^)(void))completion {
+    [self flyToCamera:camera withDuration:0 completionHandler:completion];
+}
+
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion {
     _mbglMap->cancelTransitions();
     

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -319,6 +319,7 @@ void Transform::flyTo(const CameraOptions &options) {
     LatLng startLatLng = getLatLng();
     double zoom = flyOptions.zoom ? *flyOptions.zoom : getZoom();
     double angle = flyOptions.angle ? *flyOptions.angle : getAngle();
+    double pitch = flyOptions.pitch ? *flyOptions.pitch : getPitch();
     if (std::isnan(latLng.latitude) || std::isnan(latLng.longitude) || std::isnan(zoom)) {
         return;
     }
@@ -337,13 +338,14 @@ void Transform::flyTo(const CameraOptions &options) {
     
     view.notifyMapChange(MapChangeRegionWillChangeAnimated);
     
-    const double startS = state.scale;
+    const double startZ = state.scaleZoom(state.scale);
     const double startA = state.angle;
+    const double startP = state.pitch;
     state.panning = true;
     state.scaling = true;
     state.rotating = true;
     
-    const double rho = 1.42;
+    double rho = flyOptions.curve ? *flyOptions.curve : 1.42;
     double w0 = std::max(state.width, state.height);
     double w1 = w0 / new_scale;
     double u1 = ::hypot(xn, yn);
@@ -371,47 +373,65 @@ void Transform::flyTo(const CameraOptions &options) {
     double S = (is_close ? (std::abs(std::log(w1 / w0)) / rho)
                 : ((r(1) - r0) / rho));
     
-    if (!flyOptions.duration) {
-        flyOptions.duration = Duration::zero();
+    Duration duration = flyOptions.duration ? *flyOptions.duration : Duration::zero();
+    if (flyOptions.duration) {
+        duration = *flyOptions.duration;
+    } else {
+        double speed = flyOptions.speed ? *flyOptions.speed : 1.2;
+        duration = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::duration<double, std::chrono::seconds::period>(S / speed));
     }
     startTransition(
-                    [=](double t) {
-                        util::UnitBezier ease = flyOptions.easing ? *flyOptions.easing : util::UnitBezier(0, 0, 0.25, 1);
-                        return ease.solve(t, 0.001);
-                    },
-                    [=](double k) {
-                        double s = k * S;
-                        double us = u(s);
-                        
-                        //First calculate the desired latlng
-                        double desiredLat = startLatLng.latitude + (latLng.latitude - startLatLng.latitude) * us;
-                        double desiredLng = startLatLng.longitude + (latLng.longitude - startLatLng.longitude) * us;
-                        
-                        //Now calculate desired zoom
-                        state.scale = startS - w(s);
-                        
-                        //Now set values
-                        const double new_scaled_tile_size = state.scale * util::tileSize;
-                        state.Bc = new_scaled_tile_size / 360;
-                        state.Cc = new_scaled_tile_size / util::M2PI;
-                        
-                        const double f2 = ::fmin(::fmax(std::sin(util::DEG2RAD * desiredLat), -m), m);
-                        state.x = -desiredLng * state.Bc;
-                        state.y = 0.5 * state.Cc * std::log((1 + f2) / (1 - f2));
-                        
-                        if (angle != startA) {
-                            state.angle = util::wrap(util::interpolate(startA, angle, k), -M_PI, M_PI);
-                        }
-                        
-                        view.notifyMapChange(MapChangeRegionIsChanging);
-                        return Update::Zoom;
-                    },
-                    [=] {
-                        state.panning = false;
-                        state.scaling = false;
-                        state.rotating = false;
-                        view.notifyMapChange(MapChangeRegionDidChangeAnimated);
-                    }, *flyOptions.duration);
+        [=](double t) {
+            util::UnitBezier ease = flyOptions.easing ? *flyOptions.easing : util::UnitBezier(0, 0, 0.25, 1);
+            return ease.solve(t, 0.001);
+        },
+        [=](double k) {
+            double s = k * S;
+            double us = u(s);
+            
+            //First calculate the desired latlng
+            double desiredLat = startLatLng.latitude + (latLng.latitude - startLatLng.latitude) * us;
+            double desiredLng = startLatLng.longitude + (latLng.longitude - startLatLng.longitude) * us;
+            
+            //Now calculate desired zoom
+            double desiredZoom = startZ + state.scaleZoom(1 / w(s));
+            double desiredScale = state.zoomScale(desiredZoom);
+            state.scale = ::fmax(::fmin(desiredScale, state.max_scale), state.min_scale);
+            
+            //Now set values
+            const double new_scaled_tile_size = state.scale * util::tileSize;
+            state.Bc = new_scaled_tile_size / 360;
+            state.Cc = new_scaled_tile_size / util::M2PI;
+            
+            const double f2 = ::fmin(::fmax(std::sin(util::DEG2RAD * desiredLat), -m), m);
+            state.x = -desiredLng * state.Bc;
+            state.y = 0.5 * state.Cc * std::log((1 + f2) / (1 - f2));
+            
+            if (angle != startA) {
+                state.angle = util::wrap(util::interpolate(startA, angle, k), -M_PI, M_PI);
+            }
+            if (pitch != startP) {
+                state.pitch = util::clamp(util::interpolate(startP, pitch, k), 0., 60.);
+            }
+            // At k = 1.0, a DidChangeAnimated notification should be sent from finish().
+            if (k < 1.0) {
+                if (options.transitionFrameFn) {
+                    options.transitionFrameFn(k);
+                }
+                view.notifyMapChange(MapChangeRegionIsChanging);
+            }
+            return Update::Zoom;
+        },
+        [=] {
+            state.panning = false;
+            state.scaling = false;
+            state.rotating = false;
+            if (options.transitionFinishFn) {
+                options.transitionFinishFn();
+            }
+            view.notifyMapChange(MapChangeRegionDidChangeAnimated);
+        }, duration);
 };
 
 #pragma mark - Angle

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -243,6 +243,10 @@ double TransformState::zoomScale(double zoom) const {
     return std::pow(2.0f, zoom);
 }
 
+double TransformState::scaleZoom(double s) const {
+    return std::log2(s);
+}
+
 float TransformState::worldSize() const {
     return util::tileSize * scale;
 }

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -95,6 +95,7 @@ private:
     double lngX(double lon) const;
     double latY(double lat) const;
     double zoomScale(double zoom) const;
+    double scaleZoom(double scale) const;
     float worldSize() const;
 
     mat4 coordinatePointMatrix(double z) const;


### PR DESCRIPTION
This PR fixes the trajectory of `mbgl::Map::flyTo()` to stay within the Earth’s atmosphere. When this function was originally ported from GL JS, there was apparently some confusion between zoom level and scale.

`flyTo()` now transitions the pitch in addition to the position and bearing; calls transition frame/finish callback functions, allowing client code to chain animations; and recognizes the same `speed` and `curve` parameters as GL JS. Unfortunately, these two parameters appear to be specific to the animation formulae and not expressed in physical units; I haven’t exposed them publicly because I don’t know of a good way to explain them other than “numbers that you fiddle with”. (They come from mapbox/mapbox-gl-js@983ae5efccb43c08d406bedbc21bff4e3593d66b.)

A `-flyToCamera:withDuration:completionHandler:` method has been added to the OS X version of MGLMapView. It works just like the iOS version, which I refactored to accommodate future variations that specify speed, easing, etc. In the osxapp demo application, the Debug menu now has a “World tour” command that takes you on a grand tour of the world by air, demonstrating `flyTo` functionality. The same demonstration is available in iosapp via the gear menu.

Fixes #3296, fixes #3297.

/cc @adam-mapbox @friedbunny @zugaldia @incanus @bleege