### PR TITLE
Only build osxapp on Travis

### DIFF
--- a/scripts/osx/run.sh
+++ b/scripts/osx/run.sh
@@ -11,12 +11,6 @@ BUILDTYPE=${BUILDTYPE:-Release}
 # Build
 ################################################################################
 
-mapbox_time "package_osx_symbols" \
-make xpackage
-
-mapbox_time "package_osx_stripped" \
-make xpackage-strip
-
 mapbox_time "compile_program" \
 make xosx -j${JOBS} BUILDTYPE=${BUILDTYPE}
 


### PR DESCRIPTION
Building osxapp means building the SDK, so building the SDK independently is wasteful.

Fixes #3313.

/cc @jfirebaugh