### PR TITLE
Mark debug mask as restorable on OS X

### DIFF
--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -233,7 +233,7 @@ public:
 }
 
 + (NSArray *)restorableStateKeyPaths {
-    return @[@"camera"];
+    return @[@"camera", @"debugMask"];
 }
 
 - (void)commonInit {


### PR DESCRIPTION
Fixes #3287.

/cc @jfirebaugh