### PR TITLE
Avoid loading style source if its layer(s) are not shown

### DIFF
--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -61,6 +61,8 @@ void Source::load() {
         return;
     }
 
+    if (req) return;
+
     // URL may either be a TileJSON file, or a GeoJSON file.
     FileSource* fs = util::ThreadContext::getFileSource();
     req = fs->request({ Resource::Kind::Source, info.url }, [this](Response res) {

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -39,9 +39,7 @@ Source::Source() {}
 Source::~Source() = default;
 
 bool Source::isLoaded() const {
-    if (!loaded) {
-        return false;
-    }
+    if (!loaded) return false;
 
     for (const auto& tile : tiles) {
         if (tile.second->data->getState() != TileData::State::parsed) {
@@ -50,6 +48,10 @@ bool Source::isLoaded() const {
     }
 
     return true;
+}
+
+bool Source::isLoading() const {
+    return !loaded && req.operator bool();
 }
 
 // Note: This is a separate function that must be called exactly once after creation

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -35,7 +35,9 @@ public:
     Source();
     ~Source();
 
+    bool loaded = false;
     void load();
+    bool isLoading() const;
     bool isLoaded() const;
 
     // Request or parse all the tiles relevant for the "TransformState". This method
@@ -58,7 +60,7 @@ public:
     void dumpDebugLogs() const;
 
     SourceInfo info;
-    bool enabled;
+    bool enabled = false;
 
 private:
     void tileLoadingCompleteCallback(const TileID&, const TransformState&, bool collisionDebug);
@@ -80,7 +82,6 @@ private:
 
     double getZoom(const TransformState &state) const;
 
-    bool loaded = false;
 
     // Stores the time when this source was most recently updated.
     TimePoint updated = TimePoint::min();

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -10,4 +10,8 @@ bool StyleLayer::hasRenderPass(RenderPass pass) const {
     return bool(passes & pass);
 }
 
+bool StyleLayer::needsRendering() const {
+    return passes != RenderPass::None && visibility != VisibilityType::None;
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -50,6 +50,9 @@ public:
     // Checks whether this layer needs to be rendered in the given render pass.
     bool hasRenderPass(RenderPass) const;
 
+    // Checks whether this layer can be rendered.
+    bool needsRendering() const;
+
 public:
     std::string id;
     std::string ref;

--- a/test/fixtures/resources/style-unused-sources.json
+++ b/test/fixtures/resources/style-unused-sources.json
@@ -1,0 +1,36 @@
+{
+  "version": 8,
+  "name": "Test",
+  "sources": {
+    "usedsource": {
+      "url": "test/fixtures/resources/source_vector.json",
+      "type": "vector"
+    },
+    "unusedsource": {
+      "url": "test/fixtures/resources/source_vector.json",
+      "type": "vector"
+    }
+  },
+  "sprite": "test/fixtures/resources/sprite",
+  "glyphs": "test/fixtures/resources/glyphs.pbf",
+  "layers": [{
+    "id": "usedlayer",
+    "type": "symbol",
+    "source": "usedsource"
+  }, {
+    "id":  "unusedlayeropacity",
+    "type": "symbol",
+    "source": "unusedsource",
+    "paint" : {
+        "icon-opacity" : 0,
+        "text-opacity" : 0
+    }
+  }, {
+    "id":  "unusedlayervisibility",
+    "type": "symbol",
+    "source": "unusedsource",
+    "layout" : {
+        "visibility" : "none"
+    }
+  }]
+}

--- a/test/fixtures/resources/style.json
+++ b/test/fixtures/resources/style.json
@@ -32,5 +32,9 @@
       "text-font": ["Open Sans Regular", "Arial Unicode MS Regular"],
       "icon-image": "{maki}_icon"
     }
+  }, {
+    "id":  "rasterlayer",
+    "type": "fill",
+    "source": "rastersource"
   }]
 }

--- a/test/style/pending_resources.cpp
+++ b/test/style/pending_resources.cpp
@@ -39,7 +39,7 @@ TEST_P(PendingResources, DeleteMapObjectWithPendingRequest) {
     const std::string style = util::read_file("test/fixtures/resources/style.json");
     map->setStyleJSON(style, ".");
 
-    map->renderStill([&endTest](std::exception_ptr, PremultipliedImage&&) {
+    map->renderStill([](std::exception_ptr, PremultipliedImage&&) {
         EXPECT_TRUE(false) << "Should never happen.";
     });
 

--- a/test/style/resource_loading.cpp
+++ b/test/style/resource_loading.cpp
@@ -51,6 +51,8 @@ public:
         data_.setAnimationTime(now);
         transform_.updateTransitions(now);
 
+        style_->cascade();
+        style_->recalculate(16);
         style_->update(transform_.getState(), texturePool_);
     }
 

--- a/test/style/unused_sources.cpp
+++ b/test/style/unused_sources.cpp
@@ -1,0 +1,111 @@
+#include "../fixtures/util.hpp"
+#include "../fixtures/mock_file_source.hpp"
+#include "../fixtures/mock_view.hpp"
+
+#include <mbgl/style/style.hpp>
+#include <mbgl/map/view.hpp>
+#include <mbgl/storage/file_source.hpp>
+#include <mbgl/map/map_data.hpp>
+#include <mbgl/map/transform.hpp>
+#include <mbgl/util/exception.hpp>
+#include <mbgl/util/io.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/texture_pool.hpp>
+#include <mbgl/util/thread.hpp>
+
+namespace mbgl {
+
+class MockStyleObserver: public Style::Observer {
+public:
+    using MockStyleObserverCallback = std::function<void(std::exception_ptr, Style*)>;
+
+    MockStyleObserver(View& view_,
+                      FileSource& fileSource_,
+                      const MockStyleObserverCallback& callback_)
+        : data(MapMode::Still, GLContextMode::Unique, view_.getPixelRatio()),
+          style(std::make_unique<Style>(data)),
+          transform(view_, ConstrainMode::HeightOnly),
+          callback(callback_) {
+        util::ThreadContext::setFileSource(&fileSource_);
+
+        transform.resize({{ 1000, 1000 }});
+        transform.setLatLngZoom({0, 0}, 16);
+
+        const std::string style_ = util::read_file("test/fixtures/resources/style-unused-sources.json");
+        style->setJSON(style_, "");
+        style->setObserver(this);
+    }
+
+    ~MockStyleObserver() {
+        cleanup();
+    }
+
+    void cleanup() {
+        style.reset();
+    }
+
+    void update() {
+        const auto now = Clock::now();
+
+        data.setAnimationTime(now);
+        transform.updateTransitions(now);
+
+        style->cascade();
+        style->recalculate(16);
+        style->update(transform.getState(), texturePool);
+    }
+
+    // Style::Observer implementation.
+    void onTileDataChanged() override {
+        update();
+
+        if (style->isLoaded()) {
+            callback(nullptr, style.get());
+        }
+    }
+
+    void onResourceLoadingFailed(std::exception_ptr error) override {
+        callback(error, style.get());
+    }
+
+private:
+    MapData data;
+    std::unique_ptr<Style> style;
+    Transform transform;
+    TexturePool texturePool;
+
+    MockStyleObserverCallback callback;
+};
+
+TEST(Style, UnusedSources) {
+    util::RunLoop loop;
+
+    MockView view;
+    MockFileSource fileSource(MockFileSource::Success, "");
+
+    auto callback = [&loop](std::exception_ptr error, Style* style) {
+        EXPECT_TRUE(error == nullptr);
+        loop.stop();
+
+        Source *usedSource = style->getSource("usedsource");
+        EXPECT_TRUE(usedSource);
+        EXPECT_TRUE(usedSource->isLoaded());
+
+        Source *unusedSource = style->getSource("unusedsource");
+        EXPECT_TRUE(unusedSource);
+        EXPECT_FALSE(unusedSource->isLoaded());
+    };
+
+    std::unique_ptr<util::Thread<MockStyleObserver>> observer(
+        std::make_unique<util::Thread<MockStyleObserver>>(
+            util::ThreadContext{"Map", util::ThreadType::Map, util::ThreadPriority::Regular}, view, fileSource, callback));
+
+    loop.run();
+
+    // Needed because it will make the Map thread
+    // join and cease logging after this point.
+    observer->invoke(&MockStyleObserver::cleanup);
+    observer.reset();
+}
+
+} // namespace mbgl

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -91,6 +91,7 @@
         'style/pending_resources.cpp',
         'style/resource_loading.cpp',
         'style/style_layer.cpp',
+        'style/unused_sources.cpp',
 
         'sprite/sprite_atlas.cpp',
         'sprite/sprite_image.cpp',


### PR DESCRIPTION
Given https://github.com/mapbox/mapbox-gl-styles/blob/master/styles/satellite-hybrid-v8.json as example of a style containing 2+ sources, if all layers related to a specific source are either disabled (e.g. due to class selections) or invisible, we should avoid _loading_ the style source entirely. This saves processing time and network bandwidth.

When the layers related to a specific style source are re-enabled, the burden of loading the style source could be reduced by using a cache file source.

/cc @mapbox/gl @mapbox/mobile