### PR TITLE
[core] Do not use std:: namespace for log2()

### DIFF
--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -244,7 +244,7 @@ double TransformState::zoomScale(double zoom) const {
 }
 
 double TransformState::scaleZoom(double s) const {
-    return std::log2(s);
+    return ::log2(s);
 }
 
 float TransformState::worldSize() const {


### PR DESCRIPTION
As some versions of libstdc++ don't have it.