### PR TITLE
[osx] 'make compdb' is failing

### DIFF
--- a/platform/osx/app/mapboxgl-app.gypi
+++ b/platform/osx/app/mapboxgl-app.gypi
@@ -37,7 +37,7 @@
         'CLANG_ENABLE_OBJC_ARC': 'YES',
         'INFOPLIST_FILE': '../platform/osx/app/Info.plist',
         'LD_RUNPATH_SEARCH_PATHS': [
-          '$(inherited)',
+          '\${inherited}',
           '@executable_path/../Frameworks',
         ],
         'PRODUCT_BUNDLE_IDENTIFIER': 'com.mapbox.MapboxGL',
@@ -60,7 +60,7 @@
       
       'copies': [
         {
-          'destination': '<(PRODUCT_DIR)/$(FRAMEWORKS_FOLDER_PATH)',
+          'destination': '<(PRODUCT_DIR)/\${FRAMEWORKS_FOLDER_PATH}',
           'files': [
             '<(PRODUCT_DIR)/Mapbox.framework',
           ],

--- a/platform/osx/sdk/framework-osx.gypi
+++ b/platform/osx/sdk/framework-osx.gypi
@@ -24,7 +24,7 @@
         'DYLIB_INSTALL_NAME_BASE': '@rpath',
         'INFOPLIST_FILE': '../platform/osx/sdk/Info.plist',
         'LD_RUNPATH_SEARCH_PATHS': [
-          '$(inherited)',
+          '${inherited}',
           '@executable_path/../Frameworks',
           '@loader_path/Frameworks',
         ],


### PR DESCRIPTION
Error message:
```
ninja: error: obj/gyp/osxsdk.ninja:97: bad $-escape (literal $ must be written as $$)
    @rpath/Mapbox.framework/Versions/A/Mapbox -Wl,-rpath,$(inherited) $
                                                         ^ near here
```