### PR TITLE
Fix crash on launch when osxapp is run without a debugger attached

### DIFF
--- a/platform/osx/app/mapboxgl-app.gypi
+++ b/platform/osx/app/mapboxgl-app.gypi
@@ -60,7 +60,7 @@
       
       'copies': [
         {
-          'destination': '<(PRODUCT_DIR)/\${FRAMEWORKS_FOLDER_PATH}',
+          'destination': '<(PRODUCT_DIR)/${FRAMEWORKS_FOLDER_PATH}',
           'files': [
             '<(PRODUCT_DIR)/Mapbox.framework',
           ],


### PR DESCRIPTION
Xcode (or perhaps gyp’s Xcode adapter) doesn’t understand \$ inside a copy files run phase path.

/ref #3337
/cc @brunoabinader