### PR TITLE
[core] Add more tests to on-demand source load

### DIFF
--- a/test/fixtures/resources/style-unused-sources.json
+++ b/test/fixtures/resources/style-unused-sources.json
@@ -32,5 +32,17 @@
     "layout" : {
         "visibility" : "none"
     }
+  }, {
+    "id":  "classylayer",
+    "type": "symbol",
+    "source": "unusedsource",
+    "paint" : {
+        "icon-opacity" : 0,
+        "text-opacity" : 0
+    },
+    "paint.visible" : {
+        "icon-opacity" : 1,
+        "text-opacity" : 1
+    }
   }]
 }


### PR DESCRIPTION
This extra test checks whether a style, initially with two sources, but only one source used, triggers the second source loading after a class `visible` is added.

/cc @jfirebaugh @tmpsantos 