### PR TITLE
[core] Fix background-pattern origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#48d397ea31e551324f85f0eb2088a5017023cab5",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#d6e8968a784ac74bc2559177e72252911ef93d97",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -34,6 +34,7 @@
 
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/mat3.hpp>
+#include <mbgl/util/tile_coordinate.hpp>
 
 #if defined(DEBUG)
 #include <mbgl/util/stopwatch.hpp>
@@ -279,7 +280,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         patternShader->u_opacity = properties.opacity;
 
         LatLng latLng = state.getLatLng();
-        PrecisionPoint center = state.latLngToPoint(latLng);
+        TileCoordinate center = state.latLngToCoordinate(latLng);
         float scale = 1 / std::pow(2, zoomFraction);
 
         std::array<float, 2> sizeA = (*imagePosA).size;
@@ -289,8 +290,8 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
                       1.0f / (sizeA[0] * properties.pattern.value.fromScale),
                       1.0f / (sizeA[1] * properties.pattern.value.fromScale));
         matrix::translate(matrixA, matrixA,
-                          std::fmod(center.x * 512, sizeA[0] * properties.pattern.value.fromScale),
-                          std::fmod(center.y * 512, sizeA[1] * properties.pattern.value.fromScale));
+                          std::fmod(center.column * util::tileSize, sizeA[0] * properties.pattern.value.fromScale),
+                          std::fmod(center.row    * util::tileSize, sizeA[1] * properties.pattern.value.fromScale));
         matrix::rotate(matrixA, matrixA, -state.getAngle());
         matrix::scale(matrixA, matrixA,
                        scale * state.getWidth()  / 2,
@@ -303,8 +304,8 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
                       1.0f / (sizeB[0] * properties.pattern.value.toScale),
                       1.0f / (sizeB[1] * properties.pattern.value.toScale));
         matrix::translate(matrixB, matrixB,
-                          std::fmod(center.x * 512, sizeB[0] * properties.pattern.value.toScale),
-                          std::fmod(center.y * 512, sizeB[1] * properties.pattern.value.toScale));
+                          std::fmod(center.column * util::tileSize, sizeB[0] * properties.pattern.value.toScale),
+                          std::fmod(center.row    * util::tileSize, sizeB[1] * properties.pattern.value.toScale));
         matrix::rotate(matrixB, matrixB, -state.getAngle());
         matrix::scale(matrixB, matrixB,
                        scale * state.getWidth()  / 2,


### PR DESCRIPTION
Regressed in 6e41664cb033ee5edf6ae5ac66ed518d9f0d1f89. This restores it to the same behavior as gl-js, backed by test-suite tests.