### PR TITLE
Further refine flyTo() flight path

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -218,14 +218,20 @@ IB_DESIGNABLE
 *   @param completion The block to execute after the animation finishes. */
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))completion;
 
-/** Uses a ballistic parabolic motion to "fly" the viewpoint to a different location with respect to the map with a default duration based on the length of the flight path.
+/** Moves the viewpoint to a different location using a transition animation that evokes powered flight and a default duration based on the length of the flight path.
+*
+*   The transition animation seamlessly incorporates zooming and panning to help the user find his or her bearings even after traversing a great distance.
+*
 *   @param camera The new viewpoint.
 *   @param completion The block to execute after the animation finishes. */
 - (void)flyToCamera:(MGLMapCamera *)camera completionHandler:(nullable void (^)(void))completion;
 
-/** Uses a ballistic parabolic motion to "fly" the viewpoint to a different location with respect to the map with an optional transition duration.
+/** Moves the viewpoint to a different location using a transition animation that evokes powered flight and an optional transition duration.
+*
+*   The transition animation seamlessly incorporates zooming and panning to help the user find his or her bearings even after traversing a great distance.
+*
 *   @param camera The new viewpoint.
-*   @param duration The amount of time, measured in seconds, that the transition animation should take. Specify `0` to use the default duration, which is based on the length of the flight path.
+*   @param duration The amount of time, measured in seconds, that the transition animation should take. Specify `0` to jump to the new viewpoint instantaneously. Specify a negative value to use the default duration, which is based on the length of the flight path.
 *   @param completion The block to execute after the animation finishes. */
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion;
 

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -38,15 +38,16 @@ struct CameraOptions {
     /** Time to animate to the viewpoint defined herein. */
     mapbox::util::optional<Duration> duration;
     
-    /** Average velocity of a flyTo() transition, measured in distance units per
-        second. */
-    mapbox::util::optional<double> speed;
+    /** Average velocity of a flyTo() transition, measured in screenfuls per
+        second, assuming a linear timing curve.
+        
+        A <i>screenful</i> is the visible span in pixels. It does not correspond
+        to a fixed physical distance but rather varies by zoom level. */
+    mapbox::util::optional<double> velocity;
     
-    /** The relative amount of zooming that takes place along the flight path of
-        a flyTo() transition. A high value maximizes zooming for an exaggerated
-        animation, while a low value minimizes zooming for something closer to
-        easeTo(). */
-    mapbox::util::optional<double> curve;
+    /** Zero-based zoom level at the peak of the flyTo() transition’s flight
+        path. */
+    mapbox::util::optional<double> minZoom;
     
     /** The easing timing curve of the transition. */
     mapbox::util::optional<mbgl::util::UnitBezier> easing;

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -11,16 +11,53 @@
 
 namespace mbgl {
 
+/** Various options for describing the viewpoint of a map, along with parameters
+    for transitioning to the viewpoint with animation. All fields are optional;
+    the default values of transition options depend on how this struct is used.
+ */
 struct CameraOptions {
-    mapbox::util::optional<LatLng> center;      // Map center (Degrees)
-    mapbox::util::optional<double> zoom;        // Map zoom level Positive Numbers > 0 and < 18
-    mapbox::util::optional<double> angle;       // Map rotation bearing in Radians counter-clockwise from north. The value is wrapped to [−π rad, π rad]
-    mapbox::util::optional<double> pitch;       // Map angle in degrees at which the camera is looking to ground (Radians)
-    mapbox::util::optional<Duration> duration;  // Animation time length (Nanoseconds)
+    // Viewpoint options
+    
+    /** Coordinate at the center of the map. */
+    mapbox::util::optional<LatLng> center;
+    
+    /** Zero-based zoom level. Constrained to the minimum and maximum zoom
+        levels. */
+    mapbox::util::optional<double> zoom;
+    
+    /** Bearing, measured in radians counterclockwise from true north. Wrapped
+        to [−π rad, π rad). */
+    mapbox::util::optional<double> angle;
+    
+    /** Pitch toward the horizon measured in radians, with 0 rad resulting in a
+        two-dimensional map. */
+    mapbox::util::optional<double> pitch;
+    
+    // Transition options
+    
+    /** Time to animate to the viewpoint defined herein. */
+    mapbox::util::optional<Duration> duration;
+    
+    /** Average velocity of a flyTo() transition, measured in distance units per
+        second. */
     mapbox::util::optional<double> speed;
+    
+    /** The relative amount of zooming that takes place along the flight path of
+        a flyTo() transition. A high value maximizes zooming for an exaggerated
+        animation, while a low value minimizes zooming for something closer to
+        easeTo(). */
     mapbox::util::optional<double> curve;
+    
+    /** The easing timing curve of the transition. */
     mapbox::util::optional<mbgl::util::UnitBezier> easing;
+    
+    /** A function that is called on each frame of the transition, just before a
+        screen update, except on the last frame. The first parameter indicates
+        the elapsed time as a percentage of the duration. */
     std::function<void(double)> transitionFrameFn;
+    
+    /** A function that is called once on the last frame of the transition, just
+        before the corresponding screen update. */
     std::function<void()> transitionFinishFn;
 };
 

--- a/include/mbgl/osx/MGLMapView.h
+++ b/include/mbgl/osx/MGLMapView.h
@@ -249,21 +249,28 @@ IB_DESIGNABLE
     @param completion The block to execute after the animation finishes. */
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))completion;
 
-/** Uses a ballistic parabolic motion to “fly” the viewpoint to a different
-    location with respect to the map with a default duration based on the length
-    of the flight path.
+/** Moves the viewpoint to a different location using a transition animation
+    that evokes powered flight and a default duration based on the length of the
+    flight path.
+    
+    The transition animation seamlessly incorporates zooming and panning to help
+    the user find his or her bearings even after traversing a great distance.
     
     @param camera The new viewpoint.
     @param completion The block to execute after the animation finishes. */
 - (void)flyToCamera:(MGLMapCamera *)camera completionHandler:(nullable void (^)(void))completion;
 
-/** Uses a ballistic parabolic motion to “fly” the viewpoint to a different
-    location with respect to the map with an optional transition duration.
+/** Moves the viewpoint to a different location using a transition animation
+    that evokes powered flight and an optional transition duration.
+    
+    The transition animation seamlessly incorporates zooming and panning to help
+    the user find his or her bearings even after traversing a great distance.
     
     @param camera The new viewpoint.
     @param duration The amount of time, measured in seconds, that the transition
-        animation should take. Specify `0` to use the default duration, which is
-        based on the length of the flight path.
+        animation should take. Specify `0` to jump to the new viewpoint
+        instantaneously. Specify a negative value to use the default duration,
+        which is based on the length of the flight path.
     @param completion The block to execute after the animation finishes. */
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion;
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1813,14 +1813,14 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
 - (void)flyToCamera:(MGLMapCamera *)camera completionHandler:(nullable void (^)(void))completion
 {
-    [self flyToCamera:camera withDuration:0 completionHandler:completion];
+    [self flyToCamera:camera withDuration:-1 completionHandler:completion];
 }
 
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion
 {
     _mbglMap->cancelTransitions();
     mbgl::CameraOptions options = [self cameraOptionsObjectForAnimatingToCamera:camera];
-    if (duration > 0)
+    if (duration >= 0)
     {
         options.duration = MGLDurationInSeconds(duration);
     }

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1009,14 +1009,14 @@ public:
 }
 
 - (void)flyToCamera:(MGLMapCamera *)camera completionHandler:(nullable void (^)(void))completion {
-    [self flyToCamera:camera withDuration:0 completionHandler:completion];
+    [self flyToCamera:camera withDuration:-1 completionHandler:completion];
 }
 
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration completionHandler:(nullable void (^)(void))completion {
     _mbglMap->cancelTransitions();
     
     mbgl::CameraOptions options = [self cameraOptionsObjectForAnimatingToCamera:camera];
-    if (duration > 0) {
+    if (duration >= 0) {
         options.duration = MGLDurationInSeconds(duration);
     }
     if (completion) {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -344,6 +344,16 @@ void Transform::flyTo(const CameraOptions &options) {
         return;
     }
     
+    // If a path crossing the antemeridian would be shorter, extend the final
+    // coordinate so that interpolating between the two endpoints will cross it.
+    if (std::abs(startLatLng.longitude) + std::abs(latLng.longitude) > 180) {
+        if (startLatLng.longitude > 0 && latLng.longitude < 0) {
+            latLng.longitude += 360;
+        } else if (startLatLng.longitude < 0 && latLng.longitude > 0) {
+            latLng.longitude -= 360;
+        }
+    }
+    
     const PrecisionPoint startPoint = {
         state.lngX(startLatLng.longitude),
         state.latY(startLatLng.latitude),

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -26,6 +26,8 @@ public:
 
     void jumpTo(const CameraOptions&);
     void easeTo(const CameraOptions&);
+    /** Smoothly zoom out, pan, and zoom back into the given camera along a
+        great circle, as though the viewer is aboard a supersonic jetcopter. */
     void flyTo(const CameraOptions&);
 
     // Position

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -100,6 +100,9 @@ private:
 
     mat4 coordinatePointMatrix(double z) const;
     mat4 getPixelMatrix() const;
+    
+    void setLatLngZoom(const LatLng &latLng, double zoom);
+    void setScalePoint(const double scale, const PrecisionPoint &point);
 
 private:
     ConstrainMode constrainMode;


### PR DESCRIPTION
This is a followup to #3301 that further refines the flight path used by `Transform::flyTo()` to match GL JS exactly, even as the pitch varies between the endpoints. It fixes #3296 and ensures that the ending zoom level is respected regardless of the starting zoom level. Finally, I began documenting and renaming variables to reflect a better understanding of this algorithm, now that [this paper](https://www.win.tue.nl/%7Evanwijk/zoompan.pdf) has been rediscovered.

Other noteworthy changes:
* Began pushing mutators into `TransformState`, which will allow us to begin factoring redundant code out of `Transform`.
* Addresses mapbox/mapbox-gl-js#1853 by crossing the antimeridian if that would be a shorter path.
* Replaces the opaque `speed` and `curve` options with more intuitive options that are expressed in screen units.

/cc @bleege @zugaldia @mourner @lucaswoj