### PR TITLE
[Core] Load adjacent tiles for better label placement

### DIFF
--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -54,10 +54,10 @@ void TransformState::getProjMatrix(mat4& projMatrix) const {
 }
 
 box TransformState::cornersToBox(uint32_t z) const {
-    double w = width;
-    double h = height;
+    double w = width + util::tileSize * 2;
+    double h = height + util::tileSize * 2;
     box b(
-    pointToCoordinate({ 0, 0 }).zoomTo(z),
+    pointToCoordinate({ -util::tileSize, -util::tileSize }).zoomTo(z),
     pointToCoordinate({ w, 0 }).zoomTo(z),
     pointToCoordinate({ w, h }).zoomTo(z),
     pointToCoordinate({ 0, h }).zoomTo(z));


### PR DESCRIPTION
For a given view, tiles at the view boundary do not have knowledge of labels beyond the viewport. We can see this in action in a couple different situations:

1 - In iOS/android if a label is at the edge the adjacent tile, it will abruptly render to the map when the new tile is loaded

![2](https://cloud.githubusercontent.com/assets/1058624/11909657/bc4c00c6-a59e-11e5-81dc-5c9d920d2562.gif)

> Subtle, but notice howe `Colorado Springs` comes into view. With this change, the label would already be rendered. 

2 - When rendering tiles in node, a given tile has no concept of surrounding tiles. Because of this, labels are clipped at the tile boundary edge.

![](https://cldup.com/wAzm3RmObv.png)
> Notice how the label `City of London` is clipped between tiles

With this PR, we would download more tiles than necessary to account for labels on adjacent tiles. 

![](https://cldup.com/edo5AgKpLR.png)
> With the fix, `City of London` renders on both tiles

This however, is a hack. I propose we :

- [ ] Add flag to allow for this feature to be turned on and off. By default it should be `false`
- [ ] Don't actually render the tile. It should be loaded, parsed and used in label collision math only

_Let's not think about the cost of fetching more tiles, yet_

/cc @kkaefer @jfirebaugh @tmpsantos @ansis 