### PR TITLE
Flip drag-rotate center point

### DIFF
--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1168,7 +1168,7 @@ public:
             _directionAtBeginningOfGesture = self.direction;
             _pitchAtBeginningOfGesture = _mbglMap->getPitch();
         } else if (gestureRecognizer.state == NSGestureRecognizerStateChanged) {
-            mbgl::PrecisionPoint center(startPoint.x, startPoint.y);
+            mbgl::PrecisionPoint center(startPoint.x, self.bounds.size.height - startPoint.y);
             if (self.rotateEnabled) {
                 CLLocationDirection newDirection = _directionAtBeginningOfGesture - delta.x / 10;
                 [self willChangeValueForKey:@"direction"];


### PR DESCRIPTION
Flip the origin when determining the center point of the drag-rotate gesture on OS X.