### PR TITLE
AsyncTask.RequestCoalescingMultithreaded test fails on OS X with default ulimits

### DIFF
--- a/test/miscellaneous/async_task.cpp
+++ b/test/miscellaneous/async_task.cpp
@@ -75,7 +75,7 @@ TEST(AsyncTask, RequestCoalescingMultithreaded) {
     std::vector<std::unique_ptr<Thread<TestWorker>>> threads;
     ThreadContext context = {"Test", ThreadType::Map, ThreadPriority::Regular};
 
-    unsigned numThreads = 50;
+    unsigned numThreads = 25;
     for (unsigned i = 0; i < numThreads; ++i) {
         std::unique_ptr<Thread<TestWorker>> thread =
             std::make_unique<Thread<TestWorker>>(context, &async);
@@ -99,7 +99,7 @@ TEST(AsyncTask, ThreadSafety) {
     AsyncTask async([&count] { ++count; });
     async.unref();
 
-    unsigned numThreads = 50;
+    unsigned numThreads = 25;
 
     auto callback = [&] {
         if (!--numThreads) {


### PR DESCRIPTION
```
[ RUN      ] AsyncTask.RequestCoalescingMultithreaded
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: Failed to initialize loop.
./scripts/run_tests.sh: line 32: 80042 Abort trap: 6           (core dumped) ${CMD}
```

Default value of `ulimit -n` on OS X is 256. Raising it to 1024 allows the test to pass. Can we rewrite the test so that it doesn't try to open more than 256 files?