### PR TITLE
Meters per point at latitude

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -261,13 +261,15 @@ IB_DESIGNABLE
 *   @return The point (in the appropriate view or window coordinate system) corresponding to the specified latitude and longitude value. */
 - (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(nullable UIView *)view;
 
-/** Returns the distance spanned by one pixel at the specified latitude and current zoom level.
+/** Returns the distance spanned by one point in the map view’s coordinate system at the given latitude and current zoom level.
 *
-*   The distance between pixels decreases as the latitude approaches the poles. This relationship parallels the relationship between longitudinal coordinates at different latitudes.
+*   The distance between points decreases as the latitude approaches the poles. This relationship parallels the relationship between longitudinal coordinates at different latitudes.
 *
-*   @param latitude The latitude for which to return the value.
-*   @return The distance (in meters) spanned by a single pixel. */
-- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude;
+*   @param latitude The latitude of the geographic coordinate represented by the point.
+*   @return The distance in meters spanned by a single point. */
+- (CLLocationDistance)metersPerPointAtLatitude:(CLLocationDegrees)latitude;
+
+- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude __attribute__((deprecated("Call -metersPerPointAtLatitude: instead.")));
 
 #pragma mark - Styling the Map
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1915,9 +1915,14 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     return bounds;
 }
 
-- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude
+- (CLLocationDistance)metersPerPointAtLatitude:(CLLocationDegrees)latitude
 {
     return _mbglMap->getMetersPerPixelAtLatitude(latitude, self.zoomLevel);
+}
+
+- (CLLocationDistance)metersPerPixelAtLatitude:(CLLocationDegrees)latitude
+{
+    return [self metersPerPointAtLatitude:latitude];
 }
 
 #pragma mark - Styling -

--- a/platform/ios/src/MGLUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLUserLocationAnnotationView.m
@@ -436,7 +436,7 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
 - (CGFloat)calculateAccuracyRingSize
 {
     CGFloat latRadians = self.annotation.coordinate.latitude * M_PI / 180.0f;
-    CGFloat pixelRadius = self.annotation.location.horizontalAccuracy / cos(latRadians) / [self.mapView metersPerPixelAtLatitude:self.annotation.coordinate.latitude];
+    CGFloat pixelRadius = self.annotation.location.horizontalAccuracy / cos(latRadians) / [self.mapView metersPerPointAtLatitude:self.annotation.coordinate.latitude];
 
     return pixelRadius * 2;
 }


### PR DESCRIPTION
Renamed `-metersPerPixelAtLatitude:` to `-metersPerPointAtLatitude:`, leaving the old name as a deprecated alias. In Cocoa Touch terminology, “point” is the visual unit backed by pixels.

(On OS X, I called the equivalent method `-metersPerPointAtLatitude:` from the start, so this makes the two SDKs more consistent.)

/cc @friedbunny