### PR TITLE
Various zoom level corrections

### DIFF
--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -865,6 +865,12 @@ public:
     _mbglMap->setZoom(zoomLevel, MGLDurationInSeconds(animated ? MGLAnimationDuration : 0));
 }
 
+- (void)zoomBy:(double)zoomDelta animated:(BOOL)animated {
+    [self willChangeValueForKey:@"zoomLevel"];
+    _mbglMap->setZoom(self.zoomLevel + zoomDelta, MGLDurationInSeconds(animated ? MGLAnimationDuration : 0));
+    [self didChangeValueForKey:@"zoomLevel"];
+}
+
 - (void)scaleBy:(double)scaleFactor atPoint:(NSPoint)point animated:(BOOL)animated {
     [self willChangeValueForKey:@"zoomLevel"];
     mbgl::PrecisionPoint center(point.x, point.y);
@@ -1299,13 +1305,13 @@ public:
 
 - (IBAction)moveToBeginningOfParagraph:(__unused id)sender {
     if (self.zoomEnabled) {
-        [self scaleBy:2 atPoint:NSZeroPoint animated:YES];
+        [self zoomBy:1 animated:YES];
     }
 }
 
 - (IBAction)moveToEndOfParagraph:(__unused id)sender {
     if (self.zoomEnabled) {
-        [self scaleBy:0.5 atPoint:NSZeroPoint animated:YES];
+        [self zoomBy:-1 animated:YES];
     }
 }
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -353,7 +353,7 @@ int32_t Source::coveringZoomLevel(const TransformState& state) const {
     } else {
         zoom = std::floor(zoom);
     }
-    return zoom;
+    return util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
 }
 
 std::forward_list<TileID> Source::coveringTiles(const TransformState& state) const {
@@ -440,12 +440,7 @@ bool Source::update(const StyleUpdateParameters& parameters) {
         return allTilesUpdated;
     }
 
-    double zoom = getZoom(parameters.transformState);
-    if (info.type == SourceType::Raster || info.type == SourceType::Video) {
-        zoom = ::round(zoom);
-    } else {
-        zoom = std::floor(zoom);
-    }
+    double zoom = coveringZoomLevel(parameters.transformState);
     std::forward_list<TileID> required = coveringTiles(parameters.transformState);
 
     // Determine the overzooming/underzooming amounts.

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -212,13 +212,6 @@ double Transform::getScale() const {
 }
 
 void Transform::_setScale(double new_scale, const PrecisionPoint& center, const Duration& duration) {
-    // Ensure that we don't zoom in further than the maximum allowed.
-    if (new_scale < state.min_scale) {
-        new_scale = state.min_scale;
-    } else if (new_scale > state.max_scale) {
-        new_scale = state.max_scale;
-    }
-
     const double factor = new_scale / state.scale;
     double dx = 0;
     double dy = 0;

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -169,16 +169,16 @@ double TransformState::getScale() const {
 }
 
 double TransformState::getMinZoom() const {
-    double test_scale = scale;
+    double test_scale = min_scale;
     double unused_x = x;
     double unused_y = y;
     constrain(test_scale, unused_x, unused_y);
 
-    return ::log2(::fmin(min_scale, test_scale));
+    return scaleZoom(test_scale);
 }
 
 double TransformState::getMaxZoom() const {
-    return ::log2(max_scale);
+    return scaleZoom(max_scale);
 }
 
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -355,11 +355,9 @@ bool TransformState::rotatedNorth() const {
 
 void TransformState::constrain(double& scale_, double& x_, double& y_) const {
     // Constrain minimum scale to avoid zooming out far enough to show off-world areas.
-    if (constrainMode == ConstrainMode::WidthAndHeight) {
-        scale_ = std::max(scale_, static_cast<double>((rotatedNorth() ? height : width) / util::tileSize));
-    }
-
-    scale_ = std::max(scale_, static_cast<double>((rotatedNorth() ? width : height) / util::tileSize));
+    scale_ = util::max(scale_,
+                       static_cast<double>((rotatedNorth() ? height : width) / util::tileSize),
+                       static_cast<double>((rotatedNorth() ? width : height) / util::tileSize));
 
     // Constrain min/max pan to avoid showing off-world areas.
     if (constrainMode == ConstrainMode::WidthAndHeight) {


### PR DESCRIPTION
I started out trying to fix the OS X SDK’s Zoom Out button, which refused to disable even as you reach the effective minimum zoom level. I wound up fixing a few related issues:

* Two active sources can have different minimum and maximum zoom levels. Always use the nearest available zoom level for the source. `TransformState` has the final say over whether a zoom level is allowed.
* Even if `TransformState::constrainMode` is `HeightOnly`, there isn’t usually a reason to _show_ more than one full revolution of the world at a time. Before this change, osxapp effectively constrained the zoom level based on whether the window was shorter or taller than 512 points. (Maps.app constrains the zoom level even further in standard view, but that’s because its satellite view is projected onto a globe, so it’s more appropriate at low zoom levels.)
* Fixed `Transform::getMinZoom()` to account for the constrained zoom level.

These changes have the side effect of fixing an issue in the iOS SDK, in which the minimum zoom level in portrait can be circumvented by zooming out in landscape then rotating the device. Now the two orientations have consistent minimum zoom levels, which fully fixes #1755.

/cc @brunoabinader @friedbunny @zugaldia