### PR TITLE
[core] Rationalize error handling for resource loading

### DIFF
--- a/include/mbgl/util/exception.hpp
+++ b/include/mbgl/util/exception.hpp
@@ -16,11 +16,6 @@ struct SpriteImageException : Exception {
     inline SpriteImageException(const std::string &msg) : Exception(msg) {}
 };
 
-struct GlyphRangeLoadingException : Exception {
-    inline GlyphRangeLoadingException(const char *msg) : Exception(msg) {}
-    inline GlyphRangeLoadingException(const std::string &msg) : Exception(msg) {}
-};
-
 struct MisuseException : Exception {
     inline MisuseException(const char *msg) : Exception(msg) {}
     inline MisuseException(const std::string &msg) : Exception(msg) {}
@@ -29,21 +24,6 @@ struct MisuseException : Exception {
 struct ShaderException : Exception {
     inline ShaderException(const char *msg) : Exception(msg) {}
     inline ShaderException(const std::string &msg) : Exception(msg) {}
-};
-
-struct SourceLoadingException : Exception {
-    inline SourceLoadingException(const char *msg) : Exception(msg) {}
-    inline SourceLoadingException(const std::string &msg) : Exception(msg) {}
-};
-
-struct SpriteLoadingException : Exception {
-    inline SpriteLoadingException(const char *msg) : Exception(msg) {}
-    inline SpriteLoadingException(const std::string &msg) : Exception(msg) {}
-};
-
-struct TileLoadingException : Exception {
-    inline TileLoadingException(const char *msg) : Exception(msg) {}
-    inline TileLoadingException(const std::string &msg) : Exception(msg) {}
 };
 
 } // namespace util

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -224,8 +224,6 @@ test('Map', function(t) {
                 map.release();
 
                 t.ok(err, 'returns error');
-                t.ok(err.message.match(/Failed to load/), 'error text matches');
-
                 t.end();
             });
         });

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -311,16 +311,13 @@ void MapContext::onLowMemory() {
     style->onLowMemory();
     asyncInvalidate.send();
 }
-    
-void MapContext::onTileDataChanged() {
-    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+
+void MapContext::onResourceLoaded() {
     updateFlags |= Update::Repaint;
     asyncUpdate.send();
 }
 
-void MapContext::onResourceLoadingFailed(std::exception_ptr error) {
-    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
-
+void MapContext::onResourceError(std::exception_ptr error) {
     if (data.mode == MapMode::Still && callback) {
         callback(error, {});
         callback = nullptr;

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -65,14 +65,12 @@ public:
     void onLowMemory();
 
     void cleanup();
-
-    // Style::Observer implementation.
-    void onTileDataChanged() override;
-    void onResourceLoadingFailed(std::exception_ptr error) override;
-
     void dumpDebugLogs() const;
 
 private:
+    void onResourceLoaded() override;
+    void onResourceError(std::exception_ptr) override;
+
     // Update the state indicated by the accumulated Update flags, then render.
     void update();
 

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -6,8 +6,6 @@
 #include <mbgl/util/worker.hpp>
 #include <mbgl/util/work_request.hpp>
 
-#include <sstream>
-
 using namespace mbgl;
 
 RasterTileData::RasterTileData(const TileID& id_,
@@ -41,9 +39,7 @@ void RasterTileData::request(float pixelRatio,
             if (res.error->reason == Response::Error::Reason::NotFound) {
                 state = State::parsed;
             } else {
-                std::stringstream message;
-                message <<  "Failed to load [" << url << "]: " << res.error->message;
-                error = message.str();
+                error = std::make_exception_ptr(std::runtime_error(res.error->message));
                 state = State::obsolete;
             }
             callback();
@@ -68,9 +64,7 @@ void RasterTileData::request(float pixelRatio,
                 state = State::parsed;
                 bucket = std::move(result.get<std::unique_ptr<Bucket>>());
             } else {
-                std::stringstream message;
-                message << "Failed to parse [" << std::string(id) << "]: " << result.get<std::string>();
-                error = message.str();
+                error = result.get<std::exception_ptr>();
                 state = State::obsolete;
             }
 

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -25,11 +25,11 @@ public:
     public:
         virtual ~Observer() = default;
 
-        virtual void onSourceLoaded() = 0;
-        virtual void onSourceLoadingFailed(std::exception_ptr error) = 0;
+        virtual void onSourceLoaded(Source&) {};
+        virtual void onSourceError(Source&, std::exception_ptr) {};
 
-        virtual void onTileLoaded(bool isNewTile) = 0;
-        virtual void onTileLoadingFailed(std::exception_ptr error) = 0;
+        virtual void onTileLoaded(Source&, const TileID&, bool /* isNewTile */) {};
+        virtual void onTileError(Source&, const TileID&, std::exception_ptr) {};
     };
 
     Source();
@@ -64,12 +64,6 @@ public:
 
 private:
     void tileLoadingCompleteCallback(const TileID&, const TransformState&, bool collisionDebug);
-
-    void emitSourceLoaded();
-    void emitSourceLoadingFailed(const std::string& message);
-    void emitTileLoaded(bool isNewTile);
-    void emitTileLoadingFailed(const std::string& message);
-
     bool handlePartialTile(const TileID &id, Worker &worker);
     bool findLoadedChildren(const TileID& id, int32_t maxCoveringZoom, std::forward_list<TileID>& retain);
     void findLoadedParent(const TileID& id, int32_t minCoveringZoom, std::forward_list<TileID>& retain);
@@ -82,7 +76,6 @@ private:
 
     double getZoom(const TransformState &state) const;
 
-
     // Stores the time when this source was most recently updated.
     TimePoint updated = TimePoint::min();
 
@@ -92,7 +85,9 @@ private:
     TileCache cache;
 
     std::unique_ptr<FileRequest> req;
-    Observer* observer_ = nullptr;
+
+    Observer nullObserver;
+    Observer* observer = &nullObserver;
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/tile_data.cpp
+++ b/src/mbgl/map/tile_data.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/map/tile_data.hpp>
 #include <mbgl/renderer/debug_bucket.hpp>
+#include <mbgl/util/string.hpp>
 
 namespace mbgl {
 
@@ -26,7 +27,10 @@ const char* TileData::StateToString(const State state) {
 void TileData::dumpDebugLogs() const {
     Log::Info(Event::General, "TileData::id: %s", std::string(id).c_str());
     Log::Info(Event::General, "TileData::state: %s", TileData::StateToString(state));
-    Log::Info(Event::General, "TileData::error: %s", error.c_str());
+
+    if (error) {
+        Log::Info(Event::General, "TileData::error: %s", util::toString(error).c_str());
+    }
 }
 
 } // namespace mbgl

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -88,7 +88,7 @@ public:
         return state;
     }
 
-    std::string getError() const {
+    std::exception_ptr getError() const {
         return error;
     }
 
@@ -103,7 +103,7 @@ public:
 
 protected:
     std::atomic<State> state;
-    std::string error;
+    std::exception_ptr error;
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -33,8 +33,9 @@ public:
     std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
 };
 
-using TileParseResult = mapbox::util::variant<TileParseResultBuckets, // success
-                                              std::string>;           // error
+using TileParseResult = mapbox::util::variant<
+    TileParseResultBuckets, // success
+    std::exception_ptr>;    // error
 
 class TileWorker : public util::noncopyable {
 public:

--- a/src/mbgl/map/vector_tile.cpp
+++ b/src/mbgl/map/vector_tile.cpp
@@ -5,7 +5,6 @@
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/util/thread_context.hpp>
 
-#include <sstream>
 #include <utility>
 
 namespace mbgl {
@@ -194,9 +193,7 @@ std::unique_ptr<FileRequest> VectorTileMonitor::monitorTile(const GeometryTileMo
                 callback(nullptr, nullptr, res.modified, res.expires);
                 return;
             } else {
-                std::stringstream message;
-                message << "Failed to load [" << url << "]: " << res.error->message;
-                callback(std::make_exception_ptr(std::runtime_error(message.str())), nullptr, res.modified, res.expires);
+                callback(std::make_exception_ptr(std::runtime_error(res.error->message)), nullptr, res.modified, res.expires);
                 return;
             }
         }

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -6,8 +6,6 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/storage/file_source.hpp>
 
-#include <sstream>
-
 namespace mbgl {
 
 VectorTileData::VectorTileData(const TileID& id_,
@@ -32,14 +30,10 @@ VectorTileData::VectorTileData(const TileID& id_,
                                                         Seconds modified_,
                                                         Seconds expires_) {
         if (err) {
-            try {
-                std::rethrow_exception(err);
-            } catch (const std::exception& e) {
-                error = e.what();
-                state = State::obsolete;
-                callback();
-                return;
-            }
+            error = err;
+            state = State::obsolete;
+            callback();
+            return;
         }
 
         if (!tile) {
@@ -86,9 +80,7 @@ VectorTileData::VectorTileData(const TileID& id_,
                     redoPlacement();
                 }
             } else {
-                std::stringstream message;
-                message << "Failed to parse [" << std::string(id) << "]: " << result.get<std::string>();
-                error = message.str();
+                error = result.get<std::exception_ptr>();
                 state = State::obsolete;
             }
 
@@ -130,9 +122,7 @@ bool VectorTileData::parsePending(std::function<void()> callback) {
                 redoPlacement();
             }
         } else {
-            std::stringstream message;
-            message << "Failed to parse [" << std::string(id) << "]: " << result.get<std::string>();
-            error = message.str();
+            error = result.get<std::exception_ptr>();
             state = State::obsolete;
         }
 

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -106,7 +106,7 @@ SpriteParseResult parseSprite(const std::string& image, const std::string& json)
     try {
         raster = decodeImage(image);
     } catch (...) {
-        return std::string("Could not parse sprite image");
+        return std::current_exception();
     }
 
     JSDocument doc;
@@ -115,9 +115,9 @@ SpriteParseResult parseSprite(const std::string& image, const std::string& json)
     if (doc.HasParseError()) {
         std::stringstream message;
         message << "Failed to parse JSON: " << rapidjson::GetParseError_En(doc.GetParseError()) << " at offset " << doc.GetErrorOffset();
-        return message.str();
+        return std::make_exception_ptr(std::runtime_error(message.str()));
     } else if (!doc.IsObject()) {
-        return std::string("Sprite JSON root must be an object");
+        return std::make_exception_ptr(std::runtime_error("Sprite JSON root must be an object"));
     } else {
         for (JSValue::ConstMemberIterator itr = doc.MemberBegin(); itr != doc.MemberEnd(); ++itr) {
             const std::string name = { itr->name.GetString(), itr->name.GetStringLength() };

--- a/src/mbgl/sprite/sprite_parser.hpp
+++ b/src/mbgl/sprite/sprite_parser.hpp
@@ -30,8 +30,8 @@ using Sprites = std::map<std::string, SpriteImagePtr>;
 
 
 using SpriteParseResult = mapbox::util::variant<
-    Sprites,      // success
-    std::string>; // error
+    Sprites,             // success
+    std::exception_ptr>; // error
 
 // Parses an image and an associated JSON file and returns the sprite objects.
 SpriteParseResult parseSprite(const std::string& image, const std::string& json);

--- a/src/mbgl/sprite/sprite_store.hpp
+++ b/src/mbgl/sprite/sprite_store.hpp
@@ -18,8 +18,8 @@ public:
     public:
         virtual ~Observer() = default;
 
-        virtual void onSpriteLoaded() = 0;
-        virtual void onSpriteLoadingFailed(std::exception_ptr) = 0;
+        virtual void onSpriteLoaded() {};
+        virtual void onSpriteError(std::exception_ptr) {};
     };
 
     SpriteStore(float pixelRatio);
@@ -54,16 +54,15 @@ public:
 
 private:
     void _setSprite(const std::string&, const std::shared_ptr<const SpriteImage>& = nullptr);
-
     void emitSpriteLoadedIfComplete();
-    void emitSpriteLoadingFailed(const std::string& message);
 
     struct Loader;
     std::unique_ptr<Loader> loader;
 
     bool loaded = false;
 
-    Observer* observer = nullptr;
+    Observer nullObserver;
+    Observer* observer = &nullObserver;
 
     // Lock for sprites and dirty maps.
     std::mutex mutex;

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -2,6 +2,7 @@
 #define MBGL_TEXT_GLYPH_PBF
 
 #include <mbgl/text/glyph.hpp>
+#include <mbgl/text/glyph_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
 #include <atomic>
@@ -11,43 +12,30 @@
 
 namespace mbgl {
 
-class GlyphStore;
 class FontStack;
 class FileRequest;
 
 class GlyphPBF : private util::noncopyable {
 public:
-    class Observer {
-    public:
-        virtual ~Observer() = default;
-
-        virtual void onGlyphPBFLoaded() = 0;
-        virtual void onGlyphPBFLoadingFailed(std::exception_ptr error) = 0;
-    };
-
     GlyphPBF(GlyphStore* store,
              const std::string& fontStack,
-             const GlyphRange& glyphRange);
-    virtual ~GlyphPBF();
+             const GlyphRange&,
+             GlyphStore::Observer*);
+    ~GlyphPBF();
 
     bool isParsed() const {
         return parsed;
-    };
-
-    void setObserver(Observer* observer);
+    }
 
 private:
-    void emitGlyphPBFLoaded();
-    void emitGlyphPBFLoadingFailed(const std::string& message);
-
-    void parse(GlyphStore* store, const std::string& fontStack, const std::string& url);
+    void parse(GlyphStore*, const std::string& fontStack, const GlyphRange&);
 
     std::shared_ptr<const std::string> data;
     std::atomic<bool> parsed;
 
     std::unique_ptr<FileRequest> req;
 
-    Observer* observer = nullptr;
+    GlyphStore::Observer* observer = nullptr;
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -18,18 +18,12 @@ public:
     void parseRasterTile(std::unique_ptr<RasterBucket> bucket,
                          const std::shared_ptr<const std::string> data,
                          std::function<void(RasterTileParseResult)> callback) {
-        PremultipliedImage image;
-
         try {
-            image = decodeImage(*data);
+            bucket->setImage(decodeImage(*data));
+            callback(RasterTileParseResult(std::move(bucket)));
         } catch (...) {
-            callback(RasterTileParseResult("error parsing raster image"));
-            return;
+            callback(std::current_exception());
         }
-
-        bucket->setImage(std::move(image));
-
-        callback(RasterTileParseResult(std::move(bucket)));
     }
 
     void parseGeometryTile(TileWorker* worker,
@@ -39,8 +33,8 @@ public:
                            std::function<void(TileParseResult)> callback) {
         try {
             callback(worker->parseAllLayers(std::move(layers), *tile, config));
-        } catch (const std::exception& ex) {
-            callback(TileParseResult(ex.what()));
+        } catch (...) {
+            callback(std::current_exception());
         }
     }
 
@@ -48,8 +42,8 @@ public:
                                         std::function<void(TileParseResult)> callback) {
         try {
             callback(worker->parsePendingLayers());
-        } catch (const std::exception& ex) {
-            callback(TileParseResult(ex.what()));
+        } catch (...) {
+            callback(std::current_exception());
         }
     }
 

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -16,7 +16,7 @@ class GeometryTileLoader;
 
 using RasterTileParseResult = mapbox::util::variant<
     std::unique_ptr<Bucket>, // success
-    std::string>;            // error
+    std::exception_ptr>;     // error
 
 class Worker : public mbgl::util::noncopyable {
 public:

--- a/test/sprite/sprite_parser.cpp
+++ b/test/sprite/sprite_parser.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/sprite/sprite_image.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/string.hpp>
 
 #include <algorithm>
 
@@ -211,9 +212,9 @@ TEST(Sprite, SpriteParsingInvalidJSON) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": " })JSON";
 
-    const auto error = parseSprite(image_1x, json_1x).get<std::string>();
+    const auto error = parseSprite(image_1x, json_1x).get<std::exception_ptr>();
 
-    EXPECT_EQ(error,
+    EXPECT_EQ(util::toString(error),
               std::string("Failed to parse JSON: Missing a closing quotation mark in string. at offset 13"));
 }
 

--- a/test/sprite/sprite_store.cpp
+++ b/test/sprite/sprite_store.cpp
@@ -176,7 +176,7 @@ public:
         callback_(spriteStore_.get(), nullptr);
     }
 
-    void onSpriteLoadingFailed(std::exception_ptr error) override {
+    void onSpriteError(std::exception_ptr error) override {
         callback_(spriteStore_.get(), error);
     }
 

--- a/test/style/glyph_store.cpp
+++ b/test/style/glyph_store.cpp
@@ -39,11 +39,11 @@ public:
         glyphStore_.reset();
     }
 
-    void onGlyphRangeLoaded() override {
+    void onGlyphsLoaded(const std::string&, const GlyphRange&) override {
         callback_(glyphStore_.get(), nullptr);
     }
 
-    void onGlyphRangeLoadingFailed(std::exception_ptr error) override {
+    void onGlyphsError(const std::string&, const GlyphRange&, std::exception_ptr error) override {
         callback_(glyphStore_.get(), error);
     }
 


### PR DESCRIPTION
* Standardize on std::exception_ptr as the error representation
  (fixes #2854).
* Don't format textual strings at the error source; pass on the
  constituent data via observer method parameters instead.
* Use the null object pattern to simplify observer notification code.
* Further refactoring for ResourceLoading tests.

:eyes: @brunoabinader 