### PR TITLE
[ios] snap to north if interaction ends within ±7°

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Known issues:
 - MGLMapCamera’s `altitude` values now match those of MKMapCamera. ([#3362](https://github.com/mapbox/mapbox-gl-native/pull/3362))
 - The user dot’s callout view is now centered above the user dot. It was previously offset slightly to the left. ([#3261](https://github.com/mapbox/mapbox-gl-native/pull/3261))
 - Fixed an issue with small map views not properly fitting annotations within bounds. (#[3407](https://github.com/mapbox/mapbox-gl-native/pull/3407))
+- The map will now snap to north. ([#3403](https://github.com/mapbox/mapbox-gl-native/pull/3403))
 
 ## iOS 3.0.1
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3027,6 +3027,8 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 //
 - (void)unrotateIfNeededAnimated:(BOOL)animated
 {
+    double snapTolerance = 7;
+
     // don't worry about it in the midst of pinch or rotate gestures
     //
     if (self.pinch.state  == UIGestureRecognizerStateChanged || self.rotate.state == UIGestureRecognizerStateChanged) return;
@@ -3056,6 +3058,10 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
         {
             [self resetNorthAnimated:NO];
         }
+    }
+    else if (self.direction < snapTolerance || self.direction > 360 - snapTolerance)
+    {
+        [self resetNorthAnimated:animated];
     }
 }
 


### PR DESCRIPTION
If a user pinch-rotates and the gesture ends within ±7° of north, reset to north (0°).

This behavior is the same as in MapKit.

First proposed in #938, implemented in #1059, reverted in #1064. (Closes #1064.)

/cc @1ec5