### PR TITLE
OS X SDK unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,10 @@ ipackage-no-bitcode: Xcode/ios ; @JOBS=$(JOBS) ./platform/ios/scripts/package.sh
 iframework: ipackage-strip ; ./platform/ios/scripts/framework.sh
 itest: ipackage-sim ; ./platform/ios/scripts/test.sh
 
-.PHONY: xpackage xpackage-strip
+.PHONY: xpackage xpackage-strip xctest
 xpackage: Xcode/osx ; @JOBS=$(JOBS) ./platform/osx/scripts/package.sh
 xpackage-strip: Xcode/osx ; @JOBS=$(JOBS) ./platform/osx/scripts/package.sh strip
+xctest: Xcode/osx ; @JOBS=$(JOBS) ./platform/osx/scripts/test.sh
 endif
 
 #### All platforms targets #####################################################

--- a/gyp/osx.gyp
+++ b/gyp/osx.gyp
@@ -2,6 +2,7 @@
   'includes': [
     '../platform/osx/app/mapboxgl-app.gypi',
     '../platform/osx/sdk/framework-osx.gypi',
+    '../platform/osx/test/osxtest.gypi',
     '../platform/linux/mapboxgl-app.gypi',
     '../test/test.gypi',
     '../bin/render.gypi',

--- a/platform/osx/scripts/run.sh
+++ b/platform/osx/scripts/run.sh
@@ -11,8 +11,8 @@ BUILDTYPE=${BUILDTYPE:-Release}
 # Build
 ################################################################################
 
-mapbox_time "compile_program" \
-make xosx -j${JOBS} BUILDTYPE=${BUILDTYPE}
+mapbox_time "run_sdk_tests" \
+make xctest -j${JOBS} BUILDTYPE=${BUILDTYPE}
 
 mapbox_time "compile_render_binary" \
 make xrender -j${JOBS} BUILDTYPE=${BUILDTYPE}

--- a/platform/osx/scripts/test.sh
+++ b/platform/osx/scripts/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+OSX_SDK_VERSION=`xcrun --sdk macosx --show-sdk-version`
+OSX_PROJ_PATH=./build/osx-x86_64/gyp/osx.xcodeproj
+
+export BUILDTYPE=${BUILDTYPE:-Release}
+
+if [[ ! -e "${OSX_PROJ_PATH}/xcshareddata/xcschemes/osxsdk.xcscheme" ]]; then
+    # Generate schemes
+    open -g "${OSX_PROJ_PATH}"
+    sleep 20
+    
+    # Share osxsdk scheme
+    mkdir -pv "${OSX_PROJ_PATH}/xcshareddata/xcschemes/"
+    mv -v \
+        "${OSX_PROJ_PATH}/xcuserdata/${USER}.xcuserdatad/xcschemes/osxsdk.xcscheme" \
+        "${OSX_PROJ_PATH}/xcshareddata/xcschemes/"
+fi
+
+xcodebuild -verbose \
+    -sdk macosx${OSX_SDK_VERSION} \
+    -project "${OSX_PROJ_PATH}" \
+    -scheme osxsdk \
+    test

--- a/platform/osx/test/Info.plist
+++ b/platform/osx/test/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/platform/osx/test/MGLGeometryTests.mm
+++ b/platform/osx/test/MGLGeometryTests.mm
@@ -1,0 +1,58 @@
+#import "../../darwin/MGLGeometry_Private.h"
+
+#pragma clang diagnostic ignored "-Wgnu-statement-expression"
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
+#import <XCTest/XCTest.h>
+
+@interface MGLGeometryTests : XCTestCase
+@end
+
+@implementation MGLGeometryTests
+
+- (void)testCoordinateBoundsIsEmpty {
+    MGLCoordinateBounds emptyBounds = MGLCoordinateBoundsMake(CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 0));
+    XCTAssertTrue(MGLCoordinateBoundsIsEmpty(emptyBounds));
+    XCTAssertFalse(MGLCoordinateSpanEqualToCoordinateSpan(MGLCoordinateSpanZero, MGLCoordinateBoundsGetCoordinateSpan(emptyBounds)));
+}
+
+- (void)testAngleConversions {
+    XCTAssertEqual(-180, MGLDegreesFromRadians(-M_PI));
+    XCTAssertEqual(0, MGLDegreesFromRadians(0));
+    XCTAssertEqual(45, MGLDegreesFromRadians(M_PI_4));
+    XCTAssertEqual(90, MGLDegreesFromRadians(M_PI_2));
+    XCTAssertEqual(180, MGLDegreesFromRadians(M_PI));
+    XCTAssertEqual(360, MGLDegreesFromRadians(2 * M_PI));
+    XCTAssertEqual(720, MGLDegreesFromRadians(4 * M_PI));
+    
+    XCTAssertEqual(-360, MGLDegreesFromRadians(MGLRadiansFromDegrees(-360)));
+    XCTAssertEqual(-180, MGLDegreesFromRadians(MGLRadiansFromDegrees(-180)));
+    XCTAssertEqual(-90, MGLDegreesFromRadians(MGLRadiansFromDegrees(-90)));
+    XCTAssertEqual(-45, MGLDegreesFromRadians(MGLRadiansFromDegrees(-45)));
+    XCTAssertEqual(0, MGLDegreesFromRadians(MGLRadiansFromDegrees(0)));
+    XCTAssertEqual(45, MGLDegreesFromRadians(MGLRadiansFromDegrees(45)));
+    XCTAssertEqual(90, MGLDegreesFromRadians(MGLRadiansFromDegrees(90)));
+    XCTAssertEqual(180, MGLDegreesFromRadians(MGLRadiansFromDegrees(180)));
+    XCTAssertEqual(360, MGLDegreesFromRadians(MGLRadiansFromDegrees(360)));
+}
+
+- (void)testAltitudeConversions {
+    CGSize tallSize = CGSizeMake(600, 1200);
+    CGSize midSize = CGSizeMake(600, 800);
+    CGSize shortSize = CGSizeMake(600, 400);
+    
+    XCTAssertEqualWithAccuracy(1800, MGLAltitudeForZoomLevel(MGLZoomLevelForAltitude(1800, 0, 0, midSize), 0, 0, midSize), 1);
+    XCTAssertLessThan(MGLZoomLevelForAltitude(1800, 0, 0, midSize), MGLZoomLevelForAltitude(1800, 0, 0, tallSize));
+    XCTAssertGreaterThan(MGLZoomLevelForAltitude(1800, 0, 0, midSize), MGLZoomLevelForAltitude(1800, 0, 0, shortSize));
+    
+    XCTAssertEqualWithAccuracy(0, MGLZoomLevelForAltitude(MGLAltitudeForZoomLevel(0, 0, 0, midSize), 0, 0, midSize), 3);
+    XCTAssertEqualWithAccuracy(18, MGLZoomLevelForAltitude(MGLAltitudeForZoomLevel(18, 0, 0, midSize), 0, 0, midSize), 3);
+    
+    XCTAssertEqualWithAccuracy(0, MGLZoomLevelForAltitude(MGLAltitudeForZoomLevel(0, 0, 40, midSize), 0, 40, midSize), 3);
+    XCTAssertEqualWithAccuracy(18, MGLZoomLevelForAltitude(MGLAltitudeForZoomLevel(18, 0, 40, midSize), 0, 40, midSize), 3);
+    
+    XCTAssertEqualWithAccuracy(0, MGLZoomLevelForAltitude(MGLAltitudeForZoomLevel(0, 60, 40, midSize), 60, 40, midSize), 3);
+    XCTAssertEqualWithAccuracy(18, MGLZoomLevelForAltitude(MGLAltitudeForZoomLevel(18, 60, 40, midSize), 60, 40, midSize), 3);
+}
+
+@end

--- a/platform/osx/test/MGLStyleTests.mm
+++ b/platform/osx/test/MGLStyleTests.mm
@@ -1,0 +1,29 @@
+#import "MGLStyle.h"
+
+#import <mbgl/util/default_styles.hpp>
+
+#pragma clang diagnostic ignored "-Wgnu-statement-expression"
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
+#import <XCTest/XCTest.h>
+
+@interface MGLStyleTests : XCTestCase
+@end
+
+@implementation MGLStyleTests
+
+- (void)testStyleURLs {
+    // Test that all the default styles have publicly-declared MGLStyle class
+    // methods and that the URLs are all well-formed.
+    XCTAssertEqualObjects([MGLStyle streetsStyleURL].absoluteString, @(mbgl::util::default_styles::streets.url));
+    XCTAssertEqualObjects([MGLStyle emeraldStyleURL].absoluteString, @(mbgl::util::default_styles::emerald.url));
+    XCTAssertEqualObjects([MGLStyle lightStyleURL].absoluteString, @(mbgl::util::default_styles::light.url));
+    XCTAssertEqualObjects([MGLStyle darkStyleURL].absoluteString, @(mbgl::util::default_styles::dark.url));
+    XCTAssertEqualObjects([MGLStyle satelliteStyleURL].absoluteString, @(mbgl::util::default_styles::satellite.url));
+    XCTAssertEqualObjects([MGLStyle hybridStyleURL].absoluteString, @(mbgl::util::default_styles::hybrid.url));
+    
+    static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
+                  "MGLStyleTests isn’t testing all the styles in mbgl::util::default_styles.");
+}
+
+@end

--- a/platform/osx/test/osxtest.gypi
+++ b/platform/osx/test/osxtest.gypi
@@ -1,0 +1,81 @@
+{
+  'includes': [
+    '../../../gyp/common.gypi',
+  ],
+  'targets': [
+    {
+      'target_name': 'osxtest',
+      'product_name': 'osxtest',
+      'type': 'loadable_module',
+      'mac_xctest_bundle': 1,
+      
+      'dependencies': [
+        'osxsdk',
+      ],
+
+      'variables': {
+        'cflags_cc': [
+        ],
+        'ldflags': [
+          '-stdlib=libc++',
+          '-lstdc++',
+        ],
+      },
+
+      'xcode_settings': {
+        'CLANG_ENABLE_MODULES': 'YES',
+        'CLANG_ENABLE_OBJC_ARC': 'YES',
+        'ENABLE_STRICT_OBJC_MSGSEND': 'YES',
+        'GCC_DYNAMIC_NO_PIC': 'NO',
+        'GCC_NO_COMMON_BLOCKS': 'YES',
+        'INFOPLIST_FILE': '../platform/osx/test/Info.plist',
+        'LD_RUNPATH_SEARCH_PATHS': [
+          '${inherited}',
+          '@executable_path/../Frameworks',
+          '@loader_path/../Frameworks',
+        ],
+        'PRODUCT_BUNDLE_IDENTIFIER': 'com.mapbox.osxtest',
+        'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
+        'OTHER_LDFLAGS': [ '<@(ldflags)' ],
+        'SDKROOT': 'macosx',
+        'SKIP_INSTALL': 'YES',
+        'SUPPORTED_PLATFORMS':'macosx',
+      },
+      
+      'sources': [
+        './MGLGeometryTests.mm',
+        './MGLStyleTests.mm',
+      ],
+
+      'include_dirs': [
+        '../../../include/mbgl/osx',
+        '../../../include/mbgl/darwin',
+        '../../../include',
+        '../../../src',
+      ],
+      
+      'configurations': {
+        'Debug': {
+          'xcode_settings': {
+            'COPY_PHASE_STRIP': 'NO',
+            'DEBUG_INFORMATION_FORMAT': 'dwarf',
+            'ENABLE_TESTABILITY': 'YES',
+            'GCC_OPTIMIZATION_LEVEL': '0',
+            'GCC_PREPROCESSOR_DEFINITIONS': [
+              'DEBUG=1',
+              '${inherited}',
+            ],
+            'ONLY_ACTIVE_ARCH': 'YES',
+          },
+        },
+        'Release': {
+          'xcode_settings': {
+            'COPY_PHASE_STRIP': 'YES',
+            'DEBUG_INFORMATION_FORMAT': 'dwarf-with-dsym',
+            'ENABLE_NS_ASSERTIONS': 'NO',
+          },
+        },
+      },
+    },
+  ]
+}


### PR DESCRIPTION
Added an XCTest bundle to the osxsdk scheme. For now, it contains some basic tests of shared iOS/OS X code. It can easily be extended to cover more of the SDK, including UI tests via XCTUI.

Unlike what we did on iOS for #830, I’ve integrated the test bundle directly into the project that contains the SDK code, allowing us to write unit tests as opposed to just integration tests.

This PR works toward replacing KIF with XCTUI on iOS, which would eliminate the unreliability in #2734 and allow us to add better tests around user interaction and performance. I started with OS X because everything’s simpler on OS X. :smile:

/cc @incanus @friedbunny @jfirebaugh