### PR TITLE
[ios] vary annotation bounds fit padding based on view size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Known issues:
 - A new method on MGLMapView, `-flyToCamera:withDuration:completionHandler:`, lets you transition between viewpoints along an arc as if by aircraft. ([#3171](https://github.com/mapbox/mapbox-gl-native/pull/3171), [#3301](https://github.com/mapbox/mapbox-gl-native/pull/3301))
 - MGLMapCamera’s `altitude` values now match those of MKMapCamera. ([#3362](https://github.com/mapbox/mapbox-gl-native/pull/3362))
 - The user dot’s callout view is now centered above the user dot. It was previously offset slightly to the left. ([#3261](https://github.com/mapbox/mapbox-gl-native/pull/3261))
+- Fixed an issue with small map views not properly fitting annotations within bounds. (#[3407](https://github.com/mapbox/mapbox-gl-native/pull/3407))
 
 ## iOS 3.0.1
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2653,8 +2653,12 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
         }
     }
 
+    CGFloat defaultPadding = 100;
+    CGFloat yPadding = (self.frame.size.height / 2 <= defaultPadding) ? (self.frame.size.height / 5) : defaultPadding;
+    CGFloat xPadding = (self.frame.size.width / 2 <= defaultPadding) ? (self.frame.size.width / 5) : defaultPadding;
+
     [self setVisibleCoordinateBounds:MGLCoordinateBoundsFromLatLngBounds(bounds)
-                         edgePadding:UIEdgeInsetsMake(100, 100, 100, 100)
+                         edgePadding:UIEdgeInsetsMake(yPadding, xPadding, yPadding, xPadding)
                             animated:animated];
 }
 


### PR DESCRIPTION
`-[MGLMapView showAnnotations:animated:]` hardcoded the edge inset to 100 points on all sides, which meant that views with height or width <=200 points would max-zoom into the center point of the bounds, not show the entire bounds.

This fix varies the edge padding based on the map view's frame size — if it's less than the default padding, use a fraction of the map view frame's height/width as inset padding.

Fix #3392, #3110.

/cc @1ec5