### PR TITLE
Simplify tests

### DIFF
--- a/test/fixtures/mock_file_source.cpp
+++ b/test/fixtures/mock_file_source.cpp
@@ -1,161 +1,69 @@
-#include "../fixtures/util.hpp"
 #include "mock_file_source.hpp"
-
 #include <mbgl/util/io.hpp>
-#include <mbgl/util/thread.hpp>
-#include <mbgl/util/timer.hpp>
-
-#include <algorithm>
-#include <unordered_map>
 
 namespace mbgl {
 
 class MockFileRequest : public FileRequest {
 public:
-    MockFileRequest(const Resource& resource_,
-                    MockFileSource& fileSource_)
-        : resource(resource_),
-          fileSource(fileSource_) {
+    MockFileRequest(MockFileSource& fileSource_)
+        : fileSource(fileSource_) {
     }
 
     ~MockFileRequest() {
-        fileSource.cancel(this);
+        fileSource.pending.erase(this);
     }
 
-    Resource resource;
     MockFileSource& fileSource;
-
-    std::unique_ptr<WorkRequest> workRequest;
 };
 
-class MockFileSource::Impl {
-public:
-    Impl(Type type, const std::string& match)
-        : type_(type), match_(match) {
-        timer_.start(std::chrono::milliseconds(1000), std::chrono::milliseconds(1000), [this] { dispatchPendingRequests(); });
-        timer_.unref();
-    }
-
-    ~Impl() {
-        timer_.stop();
-    }
-
-    void setOnRequestDelayedCallback(std::function<void(void)> callback) {
-        requestEnqueuedCallback_ = callback;
-    }
-
-    void handleRequest(FileRequest*, Resource, Callback);
-    void cancelRequest(FileRequest*);
-
-private:
-    void replyWithSuccess(Resource, Callback) const;
-    void replyWithSuccessWithDelay(FileRequest*, Resource, Callback);
-    void replyWithFailure(Resource, Callback) const;
-    void replyWithCorruptedData(Resource, Callback) const;
-
-    void dispatchPendingRequests();
-
-    Type type_;
-    std::string match_;
-    std::unordered_map<FileRequest*, std::pair<Resource, Callback>> pendingRequests_;
-    util::Timer timer_;
-
-    std::function<void(void)> requestEnqueuedCallback_;
-};
-
-void MockFileSource::Impl::replyWithSuccess(Resource resource, Callback callback) const {
-    Response res;
-
-    try {
-        res.data = std::make_shared<const std::string>(util::read_file(resource.url));
-    } catch (const std::exception& err) {
-        res.error = std::make_unique<Response::Error>(Response::Error::Reason::Other, err.what());
-    }
-
-    callback(res);
+MockFileSource::MockFileSource(Type type_, const std::string& match_)
+    : type(type_), match(match_) {
+    timer.unref();
+    timer.start(std::chrono::milliseconds(10), std::chrono::milliseconds(10), [this] {
+        // Explicit move to avoid iterator invalidation if ~MockFileRequest gets called within the loop.
+        auto pending_ = std::move(pending);
+        for (auto& pair : pending_) {
+            respond(pair.second.first, pair.second.second);
+        }
+    });
 }
 
-void MockFileSource::Impl::replyWithSuccessWithDelay(FileRequest* req, Resource resource, Callback callback) {
-    if (resource.url.find(match_) == std::string::npos) {
-        replyWithSuccess(resource, callback);
-        return;
-    }
-
-    pendingRequests_.emplace(req, std::make_pair(resource, callback));
-    requestEnqueuedCallback_();
+MockFileSource::~MockFileSource() {
+    timer.stop();
 }
 
-void MockFileSource::Impl::replyWithFailure(Resource resource, Callback callback) const {
-    if (resource.url.find(match_) == std::string::npos) {
-        replyWithSuccess(resource, callback);
-        return;
-    }
-
-    Response res;
-    res.error = std::make_unique<Response::Error>(Response::Error::Reason::Other, "Failed by the test case");
-    callback(res);
-}
-
-void MockFileSource::Impl::replyWithCorruptedData(Resource resource, Callback callback) const {
-    if (resource.url.find(match_) == std::string::npos) {
-        replyWithSuccess(resource, callback);
-        return;
-    }
-
-    Response res;
-    auto data = std::make_shared<std::string>(util::read_file(resource.url));
-    data->insert(0, "CORRUPTED");
-    res.data = std::move(data);
-    callback(res);
-}
-
-void MockFileSource::Impl::handleRequest(FileRequest* req, Resource resource, Callback callback) {
-    switch (type_) {
-    case Type::Success:
-        replyWithSuccess(resource, callback);
-        break;
-    case Type::SuccessWithDelay:
-        replyWithSuccessWithDelay(req, resource, callback);
-        break;
-    case Type::RequestFail:
-        replyWithFailure(resource, callback);
-        break;
-    case Type::RequestWithCorruptedData:
-        replyWithCorruptedData(resource, callback);
-        break;
-    default:
-        EXPECT_TRUE(false) << "Should never be reached.";
+void MockFileSource::respond(Resource resource, Callback callback) const {
+    if (type == Type::Success || resource.url.find(match) == std::string::npos) {
+        Response res;
+        try {
+            res.data = std::make_shared<const std::string>(util::read_file(resource.url));
+        } catch (const std::exception& err) {
+            res.error = std::make_unique<Response::Error>(Response::Error::Reason::Other, err.what());
+        }
+        callback(res);
+    } else if (type == Type::RequestFail) {
+        Response res;
+        res.error = std::make_unique<Response::Error>(Response::Error::Reason::Other, "Failed by the test case");
+        callback(res);
+    } else if (type == Type::RequestWithCorruptedData) {
+        Response res;
+        auto data = std::make_shared<std::string>(util::read_file(resource.url));
+        data->insert(0, "CORRUPTED");
+        res.data = std::move(data);
+        callback(res);
     }
 }
 
-void MockFileSource::Impl::cancelRequest(FileRequest* req) {
-    pendingRequests_.erase(req);
-}
+std::unique_ptr<FileRequest> MockFileSource::request(const Resource& resource, Callback callback) {
+    auto req = std::make_unique<MockFileRequest>(*this);
 
-void MockFileSource::Impl::dispatchPendingRequests() {
-    for (auto& pair : pendingRequests_) {
-        replyWithSuccess(pair.second.first, pair.second.second);
+    pending.emplace(req.get(), std::make_pair(resource, callback));
+
+    if (requestEnqueuedCallback && resource.url.find(match) != std::string::npos) {
+        requestEnqueuedCallback();
     }
 
-    pendingRequests_.clear();
-}
-
-MockFileSource::MockFileSource(Type type, const std::string& match)
-    : thread_(std::make_unique<util::Thread<Impl>>(util::ThreadContext{"FileSource", util::ThreadType::Unknown, util::ThreadPriority::Low}, type, match)) {
-}
-
-void MockFileSource::setOnRequestDelayedCallback(std::function<void(void)> callback) {
-    thread_->invokeSync(&Impl::setOnRequestDelayedCallback, callback);
-}
-
-std::unique_ptr<FileRequest> MockFileSource::request(const Resource& res, Callback callback) {
-    auto req = std::make_unique<MockFileRequest>(res, *this);
-    req->workRequest = thread_->invokeWithCallback(&Impl::handleRequest, callback, req.get(), res);
     return std::move(req);
-}
-
-void MockFileSource::cancel(FileRequest* req) {
-    thread_->invoke(&Impl::cancelRequest, req);
 }
 
 } // namespace mbgl

--- a/test/fixtures/stub_style_observer.hpp
+++ b/test/fixtures/stub_style_observer.hpp
@@ -1,0 +1,67 @@
+#ifndef MBGL_TEST_STUB_STYLE_OBSERVER
+#define MBGL_TEST_STUB_STYLE_OBSERVER
+
+#include <mbgl/style/style.hpp>
+
+namespace mbgl {
+
+/**
+ * An implementation of Style::Observer that forwards all methods to dynamically-settable lambas.
+ */
+class StubStyleObserver : public Style::Observer {
+public:
+    void onGlyphsLoaded(const std::string& fontStack, const GlyphRange& glyphRange) override {
+        if (glyphsLoaded) glyphsLoaded(fontStack, glyphRange);
+    }
+
+    void onGlyphsError(const std::string& fontStack, const GlyphRange& glyphRange, std::exception_ptr error) override {
+        if (glyphsError) glyphsError(fontStack, glyphRange, error);
+    }
+
+    void onSpriteLoaded() override {
+        if (spriteLoaded) spriteLoaded();
+    }
+
+    void onSpriteError(std::exception_ptr error) override {
+        if (spriteError) spriteError(error);
+    }
+
+    void onSourceLoaded(Source& source) override {
+        if (sourceLoaded) sourceLoaded(source);
+    }
+
+    void onSourceError(Source& source, std::exception_ptr error) override {
+        if (sourceError) sourceError(source, error);
+    }
+
+    void onTileLoaded(Source& source, const TileID& tileID, bool isNewTile) override {
+        if (tileLoaded) tileLoaded(source, tileID, isNewTile);
+    }
+
+    void onTileError(Source& source, const TileID& tileID, std::exception_ptr error) override {
+        if (tileError) tileError(source, tileID, error);
+    }
+
+    void onResourceLoaded() override {
+        if (resourceLoaded) resourceLoaded();
+    };
+
+    void onResourceError(std::exception_ptr error) override {
+        if (resourceError) resourceError(error);
+    };
+
+    std::function<void (const std::string& fontStack, const GlyphRange&)> glyphsLoaded;
+    std::function<void (const std::string& fontStack, const GlyphRange&, std::exception_ptr)> glyphsError;
+    std::function<void ()> spriteLoaded;
+    std::function<void (std::exception_ptr)> spriteError;
+    std::function<void (Source&)> sourceLoaded;
+    std::function<void (Source&, std::exception_ptr)> sourceError;
+    std::function<void (Source&, const TileID&, bool isNewTile)> tileLoaded;
+    std::function<void (Source&, const TileID&, std::exception_ptr)> tileError;
+    std::function<void ()> resourceLoaded;
+    std::function<void (std::exception_ptr)> resourceError;
+};
+
+} // namespace mbgl
+
+#endif

--- a/test/sprite/sprite_store.cpp
+++ b/test/sprite/sprite_store.cpp
@@ -220,15 +220,15 @@ TEST(SpriteStore, LoadingCorrupted) {
 }
 
 TEST(SpriteStore, LoadingCancel) {
-    SpriteStoreTest test(MockFileSource::SuccessWithDelay, "sprite.json");
+    SpriteStoreTest test(MockFileSource::Success, "sprite.json");
 
     test.observer.spriteLoaded = [&] () {
         FAIL() << "Should never be called";
     };
 
-    test.fileSource.setOnRequestDelayedCallback([&]{
+    test.fileSource.requestEnqueuedCallback = [&]{
         test.end();
-    });
+    };
 
     test.run("test/fixtures/resources/sprite");
 }

--- a/test/style/glyph_store.cpp
+++ b/test/style/glyph_store.cpp
@@ -109,15 +109,15 @@ TEST(GlyphStore, LoadingCorrupted) {
 }
 
 TEST(GlyphStore, LoadingCancel) {
-    GlyphStoreTest test(MockFileSource::SuccessWithDelay, "glyphs.pbf");
+    GlyphStoreTest test(MockFileSource::Success, "glyphs.pbf");
 
     test.observer.glyphsLoaded = [&] (const std::string&, const GlyphRange&) {
         FAIL() << "Should never be called";
     };
 
-    test.fileSource.setOnRequestDelayedCallback([&]{
+    test.fileSource.requestEnqueuedCallback = [&]{
         test.end();
-    });
+    };
 
     test.run(
         "test/fixtures/resources/glyphs.pbf",

--- a/test/style/glyph_store.cpp
+++ b/test/style/glyph_store.cpp
@@ -1,233 +1,145 @@
-#include "../fixtures/fixture_log_observer.hpp"
-#include "../fixtures/mock_file_source.hpp"
 #include "../fixtures/util.hpp"
+#include "../fixtures/mock_file_source.hpp"
+#include "../fixtures/stub_style_observer.hpp"
 
 #include <mbgl/text/font_stack.hpp>
 #include <mbgl/text/glyph_store.hpp>
-#include <mbgl/util/async_task.hpp>
 #include <mbgl/util/run_loop.hpp>
-#include <mbgl/util/thread.hpp>
-#include <utility>
+#include <mbgl/platform/log.hpp>
 
 using namespace mbgl;
 
-using GlyphStoreTestCallback = std::function<void(GlyphStore*, std::exception_ptr)>;
-
-struct GlyphStoreParams {
-    const std::string url;
-    const std::string stack;
-    const std::set<GlyphRange> ranges;
-};
-
-class GlyphStoreThread : public GlyphStore::Observer {
+class GlyphStoreTest {
 public:
-    GlyphStoreThread(FileSource* fileSource, GlyphStoreTestCallback callback) : callback_(std::move(callback)) {
-        util::ThreadContext::setFileSource(fileSource);
-    }
+    GlyphStoreTest(MockFileSource::Type type, const std::string& resource)
+        : fileSource(type, resource) {}
 
-    void loadGlyphStore(const GlyphStoreParams& params) {
-        glyphStore_.reset(new GlyphStore());
+    util::ThreadContext context { "Map", util::ThreadType::Map, util::ThreadPriority::Regular };
+    util::RunLoop loop;
+    MockFileSource fileSource;
+    StubStyleObserver observer;
+    GlyphStore glyphStore;
 
-        glyphStore_->setObserver(this);
-        glyphStore_->setURL(params.url);
+    void run(const std::string& url, const std::string& fontStack, const std::set<GlyphRange>& glyphRanges) {
+        // Squelch logging.
+        Log::setObserver(std::make_unique<Log::NullObserver>());
 
-        ASSERT_FALSE(glyphStore_->hasGlyphRanges(params.stack, params.ranges));
-    }
+        util::ThreadContext::Set(&context);
+        util::ThreadContext::setFileSource(&fileSource);
 
-    void unloadGlyphStore() {
-        glyphStore_->setObserver(nullptr);
-        glyphStore_.reset();
-    }
-
-    void onGlyphsLoaded(const std::string&, const GlyphRange&) override {
-        callback_(glyphStore_.get(), nullptr);
-    }
-
-    void onGlyphsError(const std::string&, const GlyphRange&, std::exception_ptr error) override {
-        callback_(glyphStore_.get(), error);
-    }
-
-private:
-    std::unique_ptr<GlyphStore> glyphStore_;
-    GlyphStoreTestCallback callback_;
-};
-
-class GlyphStoreTest : public testing::Test {
-protected:
-    void runTest(const GlyphStoreParams& params, FileSource* fileSource, GlyphStoreTestCallback callback) {
-        util::RunLoop loop;
-
-        async_ = std::make_unique<util::AsyncTask>([&]{ loop.stop(); });
-        async_->unref();
-
-        const util::ThreadContext context = {"Map", util::ThreadType::Map, util::ThreadPriority::Regular};
-
-        util::Thread<GlyphStoreThread> tester(context, fileSource, callback);
-        tester.invoke(&GlyphStoreThread::loadGlyphStore, params);
+        glyphStore.setObserver(&observer);
+        glyphStore.setURL(url);
+        glyphStore.hasGlyphRanges(fontStack, glyphRanges);
 
         loop.run();
-
-        tester.invoke(&GlyphStoreThread::unloadGlyphStore);
     }
 
-    void stopTest() {
-        testDone = true;
-        async_->send();
+    void end() {
+        loop.stop();
     }
-
-    bool isDone() const {
-        return testDone;
-    }
-
-private:
-    bool testDone = false;
-
-    std::unique_ptr<util::AsyncTask> async_;
 };
 
-TEST_F(GlyphStoreTest, LoadingSuccess) {
-    GlyphStoreParams params = {
-        "test/fixtures/resources/glyphs.pbf",
-        "Test Stack",
-        {{0, 255}, {256, 511}}
+TEST(GlyphStore, LoadingSuccess) {
+    GlyphStoreTest test(MockFileSource::Success, "");
+
+    test.observer.glyphsError = [&] (const std::string&, const GlyphRange&, std::exception_ptr) {
+        FAIL();
+        test.end();
     };
 
-    auto callback = [this, &params](GlyphStore* store, std::exception_ptr error) {
-        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
-
-        // We need to check if the test is over because checking
-        // if the GlyphStore has glyphs below will cause more requests
-        // to happen and we don't want this endless loop.
-        if (isDone()) {
+    test.observer.glyphsLoaded = [&] (const std::string&, const GlyphRange&) {
+        if (!test.glyphStore.hasGlyphRanges("Test Stack", {{0, 255}, {256, 511}}))
             return;
-        }
 
-        ASSERT_EQ(error, nullptr);
-
-        if (!store->hasGlyphRanges(params.stack, params.ranges)) {
-            return;
-        }
-
-        ASSERT_FALSE(store->hasGlyphRanges("Foobar", params.ranges));
-        ASSERT_FALSE(store->hasGlyphRanges("Foobar", {{512, 767}}));
-        ASSERT_FALSE(store->hasGlyphRanges("Test Stack",  {{512, 767}}));
-
-        auto fontStack = store->getFontStack(params.stack);
+        auto fontStack = test.glyphStore.getFontStack("Test Stack");
         ASSERT_FALSE(fontStack->getMetrics().empty());
         ASSERT_FALSE(fontStack->getSDFs().empty());
 
-        stopTest();
+        test.end();
     };
 
-    MockFileSource fileSource(MockFileSource::Success, "");
-    runTest(params, &fileSource, callback);
-}
-
-TEST_F(GlyphStoreTest, LoadingFail) {
-    GlyphStoreParams params = {
+    test.run(
         "test/fixtures/resources/glyphs.pbf",
         "Test Stack",
-        {{0, 255}, {256, 511}}
-    };
+        {{0, 255}, {256, 511}});
+}
 
-    auto callback = [this, &params](GlyphStore* store, std::exception_ptr error) {
-        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+TEST(GlyphStore, LoadingFail) {
+    GlyphStoreTest test(MockFileSource::RequestFail, "glyphs.pbf");
 
-        if (isDone()) {
-            return;
-        }
-
+    test.observer.glyphsError = [&] (const std::string& fontStack, const GlyphRange& glyphRange, std::exception_ptr error) {
         ASSERT_TRUE(error != nullptr);
+        ASSERT_EQ(fontStack, "Test Stack");
+        ASSERT_EQ(glyphRange, GlyphRange(0, 255));
 
-        auto fontStack = store->getFontStack(params.stack);
-        ASSERT_TRUE(fontStack->getMetrics().empty());
-        ASSERT_TRUE(fontStack->getSDFs().empty());
+        auto stack = test.glyphStore.getFontStack("Test Stack");
+        ASSERT_TRUE(stack->getMetrics().empty());
+        ASSERT_TRUE(stack->getSDFs().empty());
+        ASSERT_FALSE(test.glyphStore.hasGlyphRanges("Test Stack", {{0, 255}}));
 
-        for (const auto& range : params.ranges) {
-            ASSERT_FALSE(store->hasGlyphRanges(params.stack, {range}));
-        }
-
-        ASSERT_FALSE(store->hasGlyphRanges(params.stack, params.ranges));
-        ASSERT_FALSE(store->hasGlyphRanges("Foobar", params.ranges));
-        ASSERT_FALSE(store->hasGlyphRanges("Foobar", {{512, 767}}));
-
-        stopTest();
+        test.end();
     };
 
-    MockFileSource fileSource(MockFileSource::RequestFail, "glyphs.pbf");
-    runTest(params, &fileSource, callback);
-}
-
-TEST_F(GlyphStoreTest, LoadingCorrupted) {
-    GlyphStoreParams params = {
+    test.run(
         "test/fixtures/resources/glyphs.pbf",
         "Test Stack",
-        {{0, 255}, {256, 511}}
-    };
+        {{0, 255}});
+}
 
-    auto callback = [this, &params](GlyphStore* store, std::exception_ptr error) {
-        ASSERT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+TEST(GlyphStore, LoadingCorrupted) {
+    GlyphStoreTest test(MockFileSource::RequestWithCorruptedData, "glyphs.pbf");
 
-        if (isDone()) {
-            return;
-        }
-
+    test.observer.glyphsError = [&] (const std::string& fontStack, const GlyphRange& glyphRange, std::exception_ptr error) {
         ASSERT_TRUE(error != nullptr);
+        ASSERT_EQ(fontStack, "Test Stack");
+        ASSERT_EQ(glyphRange, GlyphRange(0, 255));
 
-        auto fontStack = store->getFontStack(params.stack);
-        ASSERT_TRUE(fontStack->getMetrics().empty());
-        ASSERT_TRUE(fontStack->getSDFs().empty());
+        auto stack = test.glyphStore.getFontStack("Test Stack");
+        ASSERT_TRUE(stack->getMetrics().empty());
+        ASSERT_TRUE(stack->getSDFs().empty());
+        ASSERT_FALSE(test.glyphStore.hasGlyphRanges("Test Stack", {{0, 255}}));
 
-        for (const auto& range : params.ranges) {
-            ASSERT_FALSE(store->hasGlyphRanges(params.stack, {range}));
-        }
-
-        ASSERT_FALSE(store->hasGlyphRanges(params.stack, params.ranges));
-        ASSERT_FALSE(store->hasGlyphRanges("Foobar", params.ranges));
-        ASSERT_FALSE(store->hasGlyphRanges("Foobar", {{512, 767}}));
-
-        stopTest();
+        test.end();
     };
 
-    MockFileSource fileSource(MockFileSource::RequestWithCorruptedData, "glyphs.pbf");
-    runTest(params, &fileSource, callback);
-}
-
-TEST_F(GlyphStoreTest, LoadingCancel) {
-    GlyphStoreParams params = {
+    test.run(
         "test/fixtures/resources/glyphs.pbf",
         "Test Stack",
-        {{0, 255}, {256, 511}}
-    };
+        {{0, 255}});
+}
 
-    auto callback = [this](GlyphStore*, std::exception_ptr) {
+TEST(GlyphStore, LoadingCancel) {
+    GlyphStoreTest test(MockFileSource::SuccessWithDelay, "glyphs.pbf");
+
+    test.observer.glyphsLoaded = [&] (const std::string&, const GlyphRange&) {
         FAIL() << "Should never be called";
     };
 
-    MockFileSource fileSource(MockFileSource::SuccessWithDelay, "glyphs.pbf");
-    fileSource.setOnRequestDelayedCallback([this]{
-        stopTest();
+    test.fileSource.setOnRequestDelayedCallback([&]{
+        test.end();
     });
-    runTest(params, &fileSource, callback);
+
+    test.run(
+        "test/fixtures/resources/glyphs.pbf",
+        "Test Stack",
+        {{0, 255}});
 }
 
-TEST_F(GlyphStoreTest, InvalidURL) {
-    GlyphStoreParams params = {
-        "foo bar",
-        "Test Stack",
-        {{0, 255}, {256, 511}}
-    };
+TEST(GlyphStore, InvalidURL) {
+    GlyphStoreTest test(MockFileSource::Success, "");
 
-    auto callback = [this, &params](GlyphStore* store, std::exception_ptr error) {
+    test.observer.glyphsError = [&] (const std::string&, const GlyphRange&, std::exception_ptr error) {
         ASSERT_TRUE(error != nullptr);
 
-        auto fontStack = store->getFontStack(params.stack);
-        ASSERT_TRUE(fontStack->getMetrics().empty());
-        ASSERT_TRUE(fontStack->getSDFs().empty());
+        auto stack = test.glyphStore.getFontStack("Test Stack");
+        ASSERT_TRUE(stack->getMetrics().empty());
+        ASSERT_TRUE(stack->getSDFs().empty());
 
-        stopTest();
+        test.end();
     };
 
-    MockFileSource fileSource(MockFileSource::Success, "");
-    runTest(params, &fileSource, callback);
+    test.run(
+        "foo bar",
+        "Test Stack",
+        {{0, 255}});
 }

--- a/test/style/pending_resources.cpp
+++ b/test/style/pending_resources.cpp
@@ -24,7 +24,7 @@ TEST_P(PendingResources, DeleteMapObjectWithPendingRequest) {
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1, 1000, 1000);
-    MockFileSource fileSource(MockFileSource::SuccessWithDelay, GetParam());
+    MockFileSource fileSource(MockFileSource::Success, GetParam());
 
     std::unique_ptr<Map> map = std::make_unique<Map>(view, fileSource, MapMode::Still);
 
@@ -34,7 +34,7 @@ TEST_P(PendingResources, DeleteMapObjectWithPendingRequest) {
     });
 
     endTest.unref();
-    fileSource.setOnRequestDelayedCallback([&endTest] { endTest.send(); });
+    fileSource.requestEnqueuedCallback = [&endTest] { endTest.send(); };
 
     const std::string style = util::read_file("test/fixtures/resources/style.json");
     map->setStyleJSON(style, ".");


### PR DESCRIPTION
* Rewrite {Sprite,Glyph}Store tests in the style of ResourceLoading
* Simplify MockFileSource

:eyes: @brunoabinader 