### PR TITLE
Move OS X SDK builds from Travis to Bitrise

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -55,9 +55,10 @@ workflows:
         - channel: "#gl-bots"
         - from_username: Bitrise
         - from_username_on_error: Bitrise
-        - message: 'Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL}) for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME} passed'
-        - message_on_error: 'Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
+        - message: ':robot_face: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
+            for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+            passed'
+        - message_on_error: ':robot_face: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
             for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             failed'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png

--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -53,13 +53,15 @@ workflows:
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"
-        - from_username: Bitrise
-        - from_username_on_error: Bitrise
-        - message: ':robot_face: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
-            for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+        - from_username: 'Bitrise 🤖'
+        - from_username_on_error: 'Bitrise 🤖'
+        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             passed'
-        - message_on_error: ':robot_face: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
-            for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             failed'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -60,13 +60,15 @@ workflows:
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"
-        - from_username: Bitrise
-        - from_username_on_error: Bitrise
-        - message: ':iphone: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
-            for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+        - from_username: 'Bitrise 📱'
+        - from_username_on_error: 'Bitrise 📱'
+        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             passed'
-        - message_on_error: ':iphone: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
-            for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             failed'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png

--- a/platform/osx/bitrise.yml
+++ b/platform/osx/bitrise.yml
@@ -39,12 +39,12 @@ workflows:
             brew install pkgconfig
             brew install automake
     - script:
-        title: Build osxapp
+        title: Run SDK unit tests
         run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
-            make osx
+            make xctest BUILDTYPE=Debug
         - is_debug: 'yes'
     - slack:
         title: Post to Slack

--- a/platform/osx/bitrise.yml
+++ b/platform/osx/bitrise.yml
@@ -52,13 +52,15 @@ workflows:
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"
-        - from_username: Bitrise
-        - from_username_on_error: Bitrise
-        - message: ':desktop_computer: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
-            for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+        - from_username: 'Bitrise 🖥'
+        - from_username_on_error: 'Bitrise 🖥'
+        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             passed'
-        - message_on_error: ':desktop_computer: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
-            for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             failed'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png

--- a/platform/osx/bitrise.yml
+++ b/platform/osx/bitrise.yml
@@ -1,10 +1,16 @@
----
-format_version: 1.0.0
+format_version: 1.1.0
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+app:
+  envs:
+  - BITRISE_APP_TITLE: "Mapbox GL – OS X"
+  - BITRISE_DEV_BRANCH: "master"
+
 trigger_map:
 - pattern: "*"
   is_pull_request_allowed: true
   workflow: primary
+
 workflows:
   primary:
     steps:
@@ -13,7 +19,6 @@ workflows:
         inputs:
         - content: |-
             #!/bin/bash
-
             if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
                   -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
                   -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
@@ -31,29 +36,16 @@ workflows:
         inputs:
         - content: |-
             #!/bin/bash
-
             brew install pkgconfig
             brew install automake
-            brew install homebrew/versions/appledoc22
-            brew link --force appledoc22
     - script:
-        title: Run make ipackage-sim
+        title: Build osxapp
         run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
-
-            make ipackage-sim
+            make osx
         - is_debug: 'yes'
-    - xcode-test:
-        title: Run Xcode Tests
-        run_if: '{{enveq "SKIPCI" "false"}}'
-        inputs:
-        - project_path: "./test/ios/ios-tests.xcodeproj"
-        - scheme: Mapbox GL Tests
-        - simulator_device: iPhone 6
-          opts:
-            is_expand: false
     - slack:
         title: Post to Slack
         run_if: '{{enveq "SKIPCI" "false"}}'
@@ -62,13 +54,11 @@ workflows:
         - channel: "#gl-bots"
         - from_username: Bitrise
         - from_username_on_error: Bitrise
-        - message: ':iphone: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
+        - message: ':desktop_computer: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
             for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             passed'
-        - message_on_error: ':iphone: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
+        - message_on_error: ':desktop_computer: Build #${BITRISE_BUILD_NUMBER} (${BITRISE_BUILD_URL})
             for mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH} by ${GIT_CLONE_COMMIT_COMMITER_NAME}
             failed'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
-    before_run: 
-    after_run: 

--- a/platform/osx/scripts/run.sh
+++ b/platform/osx/scripts/run.sh
@@ -11,9 +11,6 @@ BUILDTYPE=${BUILDTYPE:-Release}
 # Build
 ################################################################################
 
-mapbox_time "run_sdk_tests" \
-make xctest -j${JOBS} BUILDTYPE=${BUILDTYPE}
-
 mapbox_time "compile_render_binary" \
 make xrender -j${JOBS} BUILDTYPE=${BUILDTYPE}
 


### PR DESCRIPTION
This PR moves building and testing of the OS X SDK from Travis to Bitrise, leaving Travis to build only the cross-platform rendering tests.

Since we now have three Bitrise hooks with identical output in our internal Slack room, I added pictograms to distinguish them from one another.

/cc @jfirebaugh @friedbunny @incanus