### PR TITLE
[android] Allow running without any permissions

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -2232,9 +2232,13 @@ public class MapView extends FrameLayout {
     // Called when MapView is being created
     private boolean isConnected() {
         Context appContext = getContext().getApplicationContext();
-        ConnectivityManager connectivityManager = (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
-        return (activeNetwork != null) && activeNetwork.isConnectedOrConnecting();
+        if (ContextCompat.checkSelfPermission(appContext, Manifest.permission.ACCESS_NETWORK_STATE)
+                == PackageManager.PERMISSION_GRANTED) {
+            ConnectivityManager connectivityManager = (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+            NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
+            return (activeNetwork != null) && activeNetwork.isConnectedOrConnecting();
+        }
+        return false;
     }
 
     // Called when our Internet connectivity has changed

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/telemetry/MapboxEventManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/telemetry/MapboxEventManager.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.telemetry;
 
+import android.Manifest;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
@@ -18,6 +19,7 @@ import android.os.AsyncTask;
 import android.os.BatteryManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
@@ -524,10 +526,15 @@ public class MapboxEventManager {
             }
 
             // Check for NetworkConnectivity
-            ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-            NetworkInfo networkInfo = cm.getActiveNetworkInfo();
-            if (networkInfo == null || !networkInfo.isConnected()) {
-                Log.w(TAG, "Not connected to network, so returning without attempting to send events");
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_NETWORK_STATE) == PackageManager.PERMISSION_GRANTED) {
+                ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+                NetworkInfo networkInfo = cm.getActiveNetworkInfo();
+                if (networkInfo == null || !networkInfo.isConnected()) {
+                    Log.w(TAG, "Not connected to network, so returning without attempting to send events");
+                    return null;
+                }
+            } else {
+                Log.w(TAG, "No network state permission, so returning without attempting to send events");
                 return null;
             }
 


### PR DESCRIPTION
Although a completely offline app can be created by placing the style and tiles in assets, the `ACCESS_NETWORK_STATE` permission is currently still required, and removing the `INTERNET` permission is currently risky (causes a crash if a request is attempted). This pull request makes both permissions optional.