### PR TITLE
Make server tests more robust

### DIFF
--- a/test/fixtures/util.hpp
+++ b/test/fixtures/util.hpp
@@ -16,19 +16,25 @@
     } name;
 
 namespace mbgl {
-    
+
 class Map;
-    
+
 namespace test {
-    
+
 std::string getFileSourceRoot();
 
-pid_t startServer(const char *executable);
-void stopServer(pid_t pid);
+class Server {
+public:
+    Server(const char* executable);
+    ~Server();
+
+private:
+    int fd = -1;
+};
 
 uint64_t crc64(const char*, size_t);
 uint64_t crc64(const std::string&);
-    
+
 PremultipliedImage render(Map&);
 
 void checkImage(const std::string& base,

--- a/test/storage/server.js
+++ b/test/storage/server.js
@@ -2,6 +2,13 @@
 /* jshint node: true */
 'use strict';
 
+// This needs to be here to make sure the pipe stays open.
+// We're waiting until the stdin pipe gets closed (e.g. because the parent
+// process dies)
+process.stdin.on('readable', function() {});
+process.stdin.on('end', function() { process.exit(0); });
+
+
 var fs = require('fs');
 var express = require('express');
 var app = express();
@@ -101,13 +108,6 @@ app.get('/load/:number(\\d+)', function(req, res) {
 });
 
 var server = app.listen(3000, function () {
-    var host = server.address().address;
-    var port = server.address().port;
-    console.warn('Storage test server listening at http://%s:%s', host, port);
-
-    if (process.argv[2]) {
-        // Allow the test to continue running.
-        fs.write(+process.argv[2], 'OK');
-        fs.close(+process.argv[2]);
-    }
+    // Tell parent that we're now listening.
+    process.stdout.write("OK");
 });

--- a/test/storage/storage.cpp
+++ b/test/storage/storage.cpp
@@ -2,13 +2,13 @@
 
 #include <mbgl/platform/platform.hpp>
 
-pid_t Storage::pid = 0;
+std::unique_ptr<mbgl::test::Server> Storage::server;
 
 void Storage::SetUpTestCase() {
-    const auto server = mbgl::platform::applicationRoot() + "/TEST_DATA/storage/server.js";
-    pid = mbgl::test::startServer(server.c_str());
+    const auto program = mbgl::platform::applicationRoot() + "/TEST_DATA/storage/server.js";
+    server = std::make_unique<mbgl::test::Server>(program.c_str());
 }
 
 void Storage::TearDownTestCase() {
-    mbgl::test::stopServer(pid);
+    server.reset();
 }

--- a/test/storage/storage.hpp
+++ b/test/storage/storage.hpp
@@ -4,6 +4,7 @@
 #include "../fixtures/util.hpp"
 #include <mbgl/storage/response.hpp>
 #include <iostream>
+#include <memory>
 
 class Storage : public testing::Test {
 public:
@@ -11,7 +12,7 @@ public:
     static void TearDownTestCase();
 
 protected:
-    static pid_t pid;
+    static std::unique_ptr<mbgl::test::Server> server;
 };
 
 namespace mbgl {


### PR DESCRIPTION
After 3a86321aeecbf4acb2c0b6040d1f332b616a823a, our test server is sometimes lingering around in case the main application crashed and failed to terminate the server. To prevent this from happening, we're going to use a second pipe that we're `dup`ing onto `stdin` in the server, and automatically terminate in case that pipe gets closed.