### PR TITLE
SQLiteCache 'http_cache' table has no 'accessed' column

### DIFF
--- a/platform/default/sqlite_cache_impl.hpp
+++ b/platform/default/sqlite_cache_impl.hpp
@@ -42,6 +42,9 @@ private:
     void createDatabase();
     void createSchema();
 
+    int schemaVersion() const;
+    void ensureSchemaVersion();
+
     int pageSize = 0;
 
     uint64_t maximumCacheSize;


### PR DESCRIPTION
Launching iosapp on a recent master spews these:

```
[ERROR] {SQLiteCache}[Database](1): no such column: accessed
[ERROR] {SQLiteCache}[Database](1): table http_cache has no column named accessed
```

/cc @jfirebaugh @kkaefer