### PR TITLE
Remove OS X SDK from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,6 @@ matrix:
     - os: linux
   include:
 
-    # OS X - Xcode 7 - Debug
-    - os: osx
-      osx_image: xcode7
-      compiler: clang
-      env: FLAVOR=osx BUILDTYPE=Debug
-
-
     # OS X/Node.js 5 - Xcode 7
     - os: osx
       osx_image: xcode7


### PR DESCRIPTION
This PR removes the OS X SDK (OS X + Xcode 7) from the Travis build matrix. OS X SDK builds on Bitrise have worked well for us since #3415. Meanwhile, the OS X build takes the longest in the Travis build matrix, even though it doesn’t even run or test anything. OS X–hosted Node.js builds will continue to run on Travis.

Obviates #3428.

/cc @jfirebaugh