### PR TITLE
[android] #3444 #3435 - Stop user tracking and permissions annotation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.views;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.Dialog;
@@ -28,6 +29,7 @@ import android.support.annotation.IntDef;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresPermission;
 import android.support.annotation.UiThread;
 import android.support.v4.view.GestureDetectorCompat;
 import android.support.v4.view.ScaleGestureDetectorCompat;
@@ -51,6 +53,7 @@ import android.widget.ArrayAdapter;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.ZoomButtonsController;
+
 import com.almeros.android.multitouch.gesturedetectors.RotateGestureDetector;
 import com.almeros.android.multitouch.gesturedetectors.ShoveGestureDetector;
 import com.almeros.android.multitouch.gesturedetectors.TwoFingerGestureDetector;
@@ -81,6 +84,7 @@ import com.mapbox.mapboxsdk.geometry.LatLngZoom;
 import com.mapbox.mapboxsdk.layers.CustomLayer;
 import com.mapbox.mapboxsdk.utils.ApiAccess;
 import com.mapbox.mapboxsdk.utils.MathUtils;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.nio.ByteBuffer;
@@ -250,6 +254,10 @@ public final class MapView extends FrameLayout {
     // Used to manage FPS change event listeners
     private OnFpsChangedListener mOnFpsChangedListener;
 
+    // Used to manage tracking mode changes
+    private OnMyLocationTrackingModeChangeListener mOnMyLocationTrackingModeChangeListener;
+    private OnMyBearingTrackingModeChangeListener mOnMyBearingTrackingModeChangeListener;
+
     //
     // Properties
     //
@@ -303,6 +311,7 @@ public final class MapView extends FrameLayout {
      * This event is followed by a series of {@link MapView#REGION_IS_CHANGING} and ends
      * with {@link MapView#REGION_DID_CHANGE}.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int REGION_WILL_CHANGE = 0;
@@ -316,6 +325,7 @@ public final class MapView extends FrameLayout {
      * This event is followed by a series of {@link MapView#REGION_IS_CHANGING} and ends
      * with {@link MapView#REGION_DID_CHANGE_ANIMATED}.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int REGION_WILL_CHANGE_ANIMATED = 1;
@@ -324,6 +334,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This {@link MapChange} is triggered whenever the currently displayed map region is changing.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int REGION_IS_CHANGING = 2;
@@ -333,6 +344,7 @@ public final class MapView extends FrameLayout {
      * This {@link MapChange} is triggered whenever the currently displayed map region finished changing
      * without an animation.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int REGION_DID_CHANGE = 3;
@@ -342,6 +354,7 @@ public final class MapView extends FrameLayout {
      * This {@link MapChange} is triggered whenever the currently displayed map region finished changing
      * with an animation.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int REGION_DID_CHANGE_ANIMATED = 4;
@@ -354,6 +367,7 @@ public final class MapView extends FrameLayout {
      * This event is followed by {@link MapView#DID_FINISH_LOADING_MAP} or
      * {@link MapView#DID_FAIL_LOADING_MAP}.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int WILL_START_LOADING_MAP = 5;
@@ -362,6 +376,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This {@link MapChange} is triggered when the map has successfully loaded a new map style.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int DID_FINISH_LOADING_MAP = 6;
@@ -373,6 +388,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This event is triggered when the map has failed to load a new map style.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int DID_FAIL_LOADING_MAP = 7;
@@ -381,6 +397,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This {@link MapChange} is currently not implemented.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int WILL_START_RENDERING_FRAME = 8;
@@ -389,6 +406,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This {@link MapChange} is currently not implemented.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int DID_FINISH_RENDERING_FRAME = 9;
@@ -397,6 +415,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This {@link MapChange} is currently not implemented.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int DID_FINISH_RENDERING_FRAME_FULLY_RENDERED = 10;
@@ -405,6 +424,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This {@link MapChange} is currently not implemented.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int WILL_START_RENDERING_MAP = 11;
@@ -413,6 +433,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This {@link MapChange} is currently not implemented.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int DID_FINISH_RENDERING_MAP = 12;
@@ -421,6 +442,7 @@ public final class MapView extends FrameLayout {
      * <p>
      * This {@link MapChange} is currently not implemented.
      * </p>
+     *
      * @see com.mapbox.mapboxsdk.views.MapView.OnMapChangedListener
      */
     public static final int DID_FINISH_RENDERING_MAP_FULLY_RENDERED = 13;
@@ -587,18 +609,48 @@ public final class MapView extends FrameLayout {
     }
 
     /**
+     * Interface definition for a callback to be invoked when the the My Location tracking mode changes.
+     *
+     * @see MapView#setMyLocationTrackingMode(int)
+     */
+    public interface OnMyLocationTrackingModeChangeListener {
+
+        /**
+         * Called when the tracking mode of My Location tracking has changed
+         *
+         * @param myLocationTrackingMode the current active location tracking mode
+         */
+        void onMyLocationTrackingModeChange(@MyLocationTracking.Mode int myLocationTrackingMode);
+    }
+
+    /**
+     * Interface definition for a callback to be invoked when the the My Location tracking mode changes.
+     *
+     * @see MapView#setMyLocationTrackingMode(int)
+     */
+    public interface OnMyBearingTrackingModeChangeListener {
+
+        /**
+         * Called when the tracking mode of My Bearing tracking has changed
+         *
+         * @param myBearingTrackingMode the current active bearing tracking mode
+         */
+        void onMyBearingTrackingModeChange(@MyBearingTracking.Mode int myBearingTrackingMode);
+    }
+
+    /**
      * A callback interface for reporting when a task is complete or cancelled.
      */
-    public static interface CancelableCallback {
+    public interface CancelableCallback {
         /**
          * Invoked when a task is cancelled.
          */
-        public abstract void onCancel();
+        void onCancel();
 
         /**
          * Invoked when a task is complete.
          */
-        public abstract void onFinish();
+        void onFinish();
     }
 
     //
@@ -1179,6 +1231,7 @@ public final class MapView extends FrameLayout {
 
     /**
      * Gets the current Tilt in degrees of the MapView
+     *
      * @return tilt in degrees
      */
     public double getTilt() {
@@ -1187,7 +1240,8 @@ public final class MapView extends FrameLayout {
 
     /**
      * Sets the Tilt in degrees of the MapView.
-     * @param pitch New tilt in degrees
+     *
+     * @param pitch    New tilt in degrees
      * @param duration Animation time in milliseconds.  If null then 0 is used, making the animation immediate.
      */
     @FloatRange(from = MINIMUM_TILT, to = MAXIMUM_TILT)
@@ -1487,21 +1541,23 @@ public final class MapView extends FrameLayout {
     /**
      * Gets the current position of the camera.
      * The CameraPosition returned is a snapshot of the current position, and will not automatically update when the camera moves.
+     *
      * @return The current position of the Camera.
      */
-    public final CameraPosition getCameraPosition () {
-        return new CameraPosition(getCenterCoordinate(), (float)getZoomLevel(), (float)getTilt(), (float)getBearing());
+    public final CameraPosition getCameraPosition() {
+        return new CameraPosition(getCenterCoordinate(), (float) getZoomLevel(), (float) getTilt(), (float) getBearing());
     }
 
     /**
      * Animates the movement of the camera from the current position to the position defined in the update.
      * During the animation, a call to getCameraPosition() returns an intermediate location of the camera.
-
+     * <p/>
      * See CameraUpdateFactory for a set of updates.
+     *
      * @param update The change that should be applied to the camera.
      */
     @UiThread
-    public final void animateCamera (CameraUpdate update) {
+    public final void animateCamera(CameraUpdate update) {
         animateCamera(update, 1, null);
     }
 
@@ -1510,23 +1566,25 @@ public final class MapView extends FrameLayout {
      * Animates the movement of the camera from the current position to the position defined in the update and calls an optional callback on completion.
      * See CameraUpdateFactory for a set of updates.
      * During the animation, a call to getCameraPosition() returns an intermediate location of the camera.
-     * @param update The change that should be applied to the camera.
+     *
+     * @param update   The change that should be applied to the camera.
      * @param callback The callback to invoke from the main thread when the animation stops. If the animation completes normally, onFinish() is called; otherwise, onCancel() is called. Do not update or animate the camera from within onCancel().
      */
     @UiThread
-    public final void animateCamera (CameraUpdate update, MapView.CancelableCallback callback) {
+    public final void animateCamera(CameraUpdate update, MapView.CancelableCallback callback) {
         animateCamera(update, 1, callback);
     }
 
     /**
      * Moves the map according to the update with an animation over a specified duration, and calls an optional callback on completion. See CameraUpdateFactory for a set of updates.
      * If getCameraPosition() is called during the animation, it will return the current location of the camera in flight.
-     * @param update The change that should be applied to the camera.
+     *
+     * @param update     The change that should be applied to the camera.
      * @param durationMs The duration of the animation in milliseconds. This must be strictly positive, otherwise an IllegalArgumentException will be thrown.
-     * @param callback An optional callback to be notified from the main thread when the animation stops. If the animation stops due to its natural completion, the callback will be notified with onFinish(). If the animation stops due to interruption by a later camera movement or a user gesture, onCancel() will be called. The callback should not attempt to move or animate the camera in its cancellation method. If a callback isn't required, leave it as null.
+     * @param callback   An optional callback to be notified from the main thread when the animation stops. If the animation stops due to its natural completion, the callback will be notified with onFinish(). If the animation stops due to interruption by a later camera movement or a user gesture, onCancel() will be called. The callback should not attempt to move or animate the camera in its cancellation method. If a callback isn't required, leave it as null.
      */
     @UiThread
-    public final void animateCamera (CameraUpdate update, int durationMs, final MapView.CancelableCallback callback) {
+    public final void animateCamera(CameraUpdate update, int durationMs, final MapView.CancelableCallback callback) {
 
         if (update.getTarget() == null) {
             Log.w(TAG, "animateCamera with null target coordinate passed in.  Will immediately return without animating camera.");
@@ -1577,9 +1635,10 @@ public final class MapView extends FrameLayout {
     /**
      * Ease the map according to the update with an animation over a specified duration, and calls an optional callback on completion. See CameraUpdateFactory for a set of updates.
      * If getCameraPosition() is called during the animation, it will return the current location of the camera in flight.
-     * @param update The change that should be applied to the camera.
+     *
+     * @param update     The change that should be applied to the camera.
      * @param durationMs The duration of the animation in milliseconds. This must be strictly positive, otherwise an IllegalArgumentException will be thrown.
-     * @param callback An optional callback to be notified from the main thread when the animation stops. If the animation stops due to its natural completion, the callback will be notified with onFinish(). If the animation stops due to interruption by a later camera movement or a user gesture, onCancel() will be called. The callback should not attempt to move or animate the camera in its cancellation method. If a callback isn't required, leave it as null.
+     * @param callback   An optional callback to be notified from the main thread when the animation stops. If the animation stops due to its natural completion, the callback will be notified with onFinish(). If the animation stops due to interruption by a later camera movement or a user gesture, onCancel() will be called. The callback should not attempt to move or animate the camera in its cancellation method. If a callback isn't required, leave it as null.
      */
     @UiThread
     public final void easeCamera(CameraUpdate update, int durationMs, final MapView.CancelableCallback callback) {
@@ -1633,10 +1692,11 @@ public final class MapView extends FrameLayout {
      * Repositions the camera according to the instructions defined in the update.
      * The move is instantaneous, and a subsequent getCameraPosition() will reflect the new position.
      * See CameraUpdateFactory for a set of updates.
+     *
      * @param update The change that should be applied to the camera.
      */
     @UiThread
-    public final void moveCamera (CameraUpdate update) {
+    public final void moveCamera(CameraUpdate update) {
         if (update.getTarget() == null) {
             Log.w(TAG, "moveCamera with null target coordinate passed in.  Will immediately return without moving camera.");
             return;
@@ -2493,10 +2553,11 @@ public final class MapView extends FrameLayout {
      * Change any combination of center, zoom, bearing, and pitch, without
      * a transition. The map will retain the current values for any options
      * not included in `options`.
+     *
      * @param bearing Bearing in Radians
-     * @param center Center Coordinate
-     * @param pitch Pitch in Radians
-     * @param zoom Zoom Level
+     * @param center  Center Coordinate
+     * @param pitch   Pitch in Radians
+     * @param zoom    Zoom Level
      */
     @UiThread
     private void jumpTo(double bearing, LatLng center, double pitch, double zoom) {
@@ -2507,24 +2568,26 @@ public final class MapView extends FrameLayout {
      * Change any combination of center, zoom, bearing, and pitch, with a smooth animation
      * between old and new values. The map will retain the current values for any options
      * not included in `options`.
-     * @param bearing Bearing in Radians
-     * @param center Center Coordinate
+     *
+     * @param bearing  Bearing in Radians
+     * @param center   Center Coordinate
      * @param duration Animation time in Nanoseconds
-     * @param pitch Pitch in Radians
-     * @param zoom Zoom Level
+     * @param pitch    Pitch in Radians
+     * @param zoom     Zoom Level
      */
     @UiThread
-    private void easeTo(double bearing, LatLng center, long duration,  double pitch, double zoom) {
+    private void easeTo(double bearing, LatLng center, long duration, double pitch, double zoom) {
         mNativeMapView.easeTo(bearing, center, duration, pitch, zoom);
     }
 
     /**
      * Flying animation to a specified location/zoom/bearing with automatic curve.
-     * @param bearing Bearing in Radians
-     * @param center Center Coordinate
+     *
+     * @param bearing  Bearing in Radians
+     * @param center   Center Coordinate
      * @param duration Animation time in Nanoseconds
-     * @param pitch Pitch in Radians
-     * @param zoom Zoom Level
+     * @param pitch    Pitch in Radians
+     * @param zoom     Zoom Level
      */
     @UiThread
     private void flyTo(double bearing, LatLng center, long duration, double pitch, double zoom) {
@@ -2718,6 +2781,7 @@ public final class MapView extends FrameLayout {
 
     /**
      * Get Bearing in degrees
+     *
      * @return Bearing in degrees
      */
     public double getBearing() {
@@ -2726,6 +2790,7 @@ public final class MapView extends FrameLayout {
 
     /**
      * Set Bearing in degrees
+     *
      * @param bearing Bearing in degrees
      */
     public void setBearing(float bearing) {
@@ -2734,10 +2799,10 @@ public final class MapView extends FrameLayout {
 
     /**
      * Sets Bearing in degrees
-     *
+     * <p/>
      * NOTE: Used by UserLocationView
      *
-     * @param bearing Bearing in degrees
+     * @param bearing  Bearing in degrees
      * @param duration Length of time to rotate
      */
     public void setBearing(float bearing, long duration) {
@@ -2870,6 +2935,8 @@ public final class MapView extends FrameLayout {
                 mZoomButtonsController.setVisible(true);
             }
 
+            setMyLocationTrackingMode(MyLocationTracking.TRACKING_NONE);
+            setMyBearingTrackingMode(MyBearingTracking.NONE);
             return true;
         }
 
@@ -2960,8 +3027,8 @@ public final class MapView extends FrameLayout {
 //                        long result = mMarkersNearLastTap.indexOf(mSelectedMarker);
 //                        newSelectedMarkerId = mMarkersNearLastTap.get((int) result + 1).getId();
 //                    } else {
-                        // no current selection; select the first one
-                        newSelectedMarkerId = mMarkersNearLastTap.get(0).getId();
+                    // no current selection; select the first one
+                    newSelectedMarkerId = mMarkersNearLastTap.get(0).getId();
 //                    }
                 } else {
                     // start tracking a new set of nearby markers
@@ -3796,8 +3863,13 @@ public final class MapView extends FrameLayout {
      * or @link android.Manifest.permission#ACCESS_FINE_LOCATION.
      *
      * @param enabled True to enable; false to disable.
+     *
+     * @throws SecurityException if no suitable permission is present
      */
     @UiThread
+    @RequiresPermission(anyOf = {
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION})
     public void setMyLocationEnabled(boolean enabled) {
         mUserLocationView.setEnabled(enabled);
     }
@@ -3828,33 +3900,32 @@ public final class MapView extends FrameLayout {
     /**
      * <p>
      * Set the current my location tracking mode.
-     * Tracking my location disables gestures and pans the viewport
+     * </p>
+     * <p>
+     * Will enable my location if not active.
      * </p>
      * See {@link MyLocationTracking} for different values.
      *
      * @param myLocationTrackingMode The location tracking mode to be used.
      * @see MyLocationTracking
+     *
+     * @throws SecurityException if no suitable permission is present
      */
     @UiThread
+    @RequiresPermission(anyOf = {
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION})
     public void setMyLocationTrackingMode(@MyLocationTracking.Mode int myLocationTrackingMode) {
+        if(!isMyLocationEnabled()){
+            setMyLocationEnabled(true);
+        }
+
         mUserLocationView.setMyLocationTrackingMode(myLocationTrackingMode);
-        validateGesturesForTrackingModes();
-    }
 
-    private void validateGesturesForTrackingModes() {
-        int myLocationTrackingMode = mUserLocationView.getMyLocationTrackingMode();
-        int myBearingTrackingMode = mUserLocationView.getMyBearingTrackingMode();
-
-        // Enable/disable gestures based on tracking mode
-        if (myLocationTrackingMode == MyLocationTracking.TRACKING_NONE) {
-            mScrollEnabled = true;
-            mRotateEnabled = true;
-        } else {
-            mScrollEnabled = false;
-            mRotateEnabled = (myBearingTrackingMode == MyBearingTracking.NONE);
+        if (mOnMyLocationTrackingModeChangeListener != null) {
+            mOnMyLocationTrackingModeChangeListener.onMyLocationTrackingModeChange(myLocationTrackingMode);
         }
     }
-
 
     /**
      * Returns the current user location tracking mode.
@@ -3870,12 +3941,21 @@ public final class MapView extends FrameLayout {
     }
 
     /**
+     * Sets a callback that's invoked when the location tracking mode changes.
+     *
+     * @param listener The callback that's invoked when the location tracking mode changes.
+     *                 To unset the callback, use null.
+     */
+    @UiThread
+    public void setOnMyLocationTrackingModeChangeListener(@Nullable OnMyLocationTrackingModeChangeListener listener) {
+        mOnMyLocationTrackingModeChangeListener = listener;
+    }
+
+    /**
      * <p>
      * Set the current my bearing tracking mode.
      * </p>
-     * <p>
-     * Tracking the users bearing will disable gestures and shows the direction the user is heading.
-     * </p>
+     * Shows the direction the user is heading.
      * <p>
      * When location tracking is disabled the direction of {@link UserLocationView}  is rotated
      * When location tracking is enabled the {@link MapView} is rotated based on bearing value.
@@ -3884,11 +3964,23 @@ public final class MapView extends FrameLayout {
      *
      * @param myBearingTrackingMode The bearing tracking mode to be used.
      * @see MyBearingTracking
+     *
+     * @throws SecurityException if no suitable permission is present
      */
     @UiThread
+    @RequiresPermission(anyOf = {
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION})
     public void setMyBearingTrackingMode(@MyBearingTracking.Mode int myBearingTrackingMode) {
+        if(!isMyLocationEnabled()){
+            setMyLocationEnabled(true);
+        }
+
         mUserLocationView.setMyBearingTrackingMode(myBearingTrackingMode);
-        validateGesturesForTrackingModes();
+
+        if (mOnMyBearingTrackingModeChangeListener != null) {
+            mOnMyBearingTrackingModeChangeListener.onMyBearingTrackingModeChange(myBearingTrackingMode);
+        }
     }
 
     /**
@@ -3903,6 +3995,17 @@ public final class MapView extends FrameLayout {
     public int getMyBearingTrackingMode() {
         //noinspection ResourceType
         return mUserLocationView.getMyBearingTrackingMode();
+    }
+
+    /**
+     * Sets a callback that's invoked when the bearing tracking mode changes.
+     *
+     * @param listener The callback that's invoked when the bearing tracking mode changes.
+     *                 To unset the callback, use null.
+     */
+    @UiThread
+    public void setOnMyBearingTrackingModeChangeListener(@Nullable OnMyBearingTrackingModeChangeListener listener) {
+        mOnMyBearingTrackingModeChangeListener = listener;
     }
 
     //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/UserLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/UserLocationView.java
@@ -245,6 +245,12 @@ final class UserLocationView extends View implements LocationListener {
             // center map directly if we have a location fix
             mMarkerCoordinate = new LatLng(mUserLocation.getLatitude(), mUserLocation.getLongitude());
             mMapView.setCenterCoordinate(new LatLng(mUserLocation));
+
+            // center view directly
+            mMarkerScreenMatrix.reset();
+            mMarkerScreenMatrix.setTranslate(
+                    getMeasuredWidth() / 2,
+                    getMeasuredHeight() / 2);
         }
     }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MainActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MainActivity.java
@@ -8,6 +8,7 @@ import android.location.Location;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresPermission;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.NavigationView;
@@ -295,7 +296,7 @@ public class MainActivity extends AppCompatActivity {
         switch (requestCode) {
             case PERMISSIONS_LOCATION:
                 if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    enableGps();
+                    toggleGps(true);
                 }
                 break;
 
@@ -473,29 +474,25 @@ public class MainActivity extends AppCompatActivity {
                         new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION},
                         PERMISSIONS_LOCATION);
             } else {
-                enableGps();
+                mMapView.setOnMyLocationChangeListener(new MapView.OnMyLocationChangeListener() {
+                    @Override
+                    public void onMyLocationChange(@Nullable Location location) {
+                        if (location != null) {
+                            mMapView.setZoomLevel(16);
+                            mMapView.setCenterCoordinate(new LatLng(location));
+                            mMapView.setOnMyLocationChangeListener(null);
+                        }
+                    }
+                });
+                mMapView.setMyLocationEnabled(true);
+                mMapView.setMyLocationTrackingMode(MyLocationTracking.TRACKING_NONE);
+                mMapView.setMyBearingTrackingMode(MyBearingTracking.GPS);
+                mLocationFAB.setColorFilter(ContextCompat.getColor(this, R.color.primary));
             }
         } else {
             mMapView.setMyLocationEnabled(false);
             mLocationFAB.setColorFilter(Color.TRANSPARENT);
         }
-    }
-
-    private void enableGps() {
-        mMapView.setOnMyLocationChangeListener(new MapView.OnMyLocationChangeListener() {
-            @Override
-            public void onMyLocationChange(@Nullable Location location) {
-                if (location != null) {
-                    mMapView.setZoomLevel(16);
-                    mMapView.setCenterCoordinate(new LatLng(location));
-                    mMapView.setOnMyLocationChangeListener(null);
-                }
-            }
-        });
-        mMapView.setMyLocationEnabled(true);
-        mMapView.setMyLocationTrackingMode(MyLocationTracking.TRACKING_NONE);
-        mMapView.setMyBearingTrackingMode(MyBearingTracking.GPS);
-        mLocationFAB.setColorFilter(ContextCompat.getColor(this, R.color.primary));
     }
 
     /**

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MyLocationTrackingModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MyLocationTrackingModeActivity.java
@@ -12,6 +12,7 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
+import android.widget.Toast;
 
 import com.mapbox.mapboxsdk.constants.MyBearingTracking;
 import com.mapbox.mapboxsdk.constants.MyLocationTracking;
@@ -45,20 +46,47 @@ public class MyLocationTrackingModeActivity extends AppCompatActivity implements
         mLocationSpinner = (Spinner) findViewById(R.id.spinner_location);
         mLocationSpinner.setAdapter(locationTrackingAdapter);
         mLocationSpinner.setOnItemSelectedListener(this);
-//        mLocationSpinner.setEnabled(false);
 
         ArrayAdapter<CharSequence> bearingTrackingAdapter = ArrayAdapter.createFromResource(actionBar.getThemedContext(), R.array.user_bearing_mode, android.R.layout.simple_spinner_item);
         bearingTrackingAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mBearingSpinner = (Spinner) findViewById(R.id.spinner_bearing);
         mBearingSpinner.setAdapter(bearingTrackingAdapter);
         mBearingSpinner.setOnItemSelectedListener(this);
-//        mBearingSpinner.setEnabled(false);
 
         mMapView = (MapView) findViewById(R.id.mapView);
         mMapView.setAccessToken(ApiAccess.getToken(this));
         mMapView.onCreate(savedInstanceState);
         mMapView.setOnMyLocationChangeListener(this);
-        mMapView.setMyLocationEnabled(true);
+
+        try {
+            mMapView.setMyLocationEnabled(true);
+        } catch (SecurityException e) {
+            //should not occur, permission was checked in MainActivity
+            Toast.makeText(this, "Location permission is not availlable", Toast.LENGTH_SHORT).show();
+            finish();
+        }
+
+        mMapView.setOnMyLocationTrackingModeChangeListener(new MapView.OnMyLocationTrackingModeChangeListener() {
+            @Override
+            public void onMyLocationTrackingModeChange(@MyLocationTracking.Mode int myLocationTrackingMode) {
+                if (MyLocationTracking.TRACKING_NONE == myLocationTrackingMode) {
+                    mLocationSpinner.setOnItemSelectedListener(null);
+                    mLocationSpinner.setSelection(0);
+                    mLocationSpinner.setOnItemSelectedListener(MyLocationTrackingModeActivity.this);
+                }
+            }
+        });
+        
+        mMapView.setOnMyBearingTrackingModeChangeListener(new MapView.OnMyBearingTrackingModeChangeListener() {
+            @Override
+            public void onMyBearingTrackingModeChange(@MyBearingTracking.Mode int myBearingTrackingMode) {
+                if (MyBearingTracking.NONE == myBearingTrackingMode) {
+                    mBearingSpinner.setOnItemSelectedListener(null);
+                    mBearingSpinner.setSelection(0);
+                    mBearingSpinner.setOnItemSelectedListener(MyLocationTrackingModeActivity.this);
+                }
+            }
+        });
     }
 
     @Override
@@ -93,7 +121,7 @@ public class MyLocationTrackingModeActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+    public void onItemSelected(AdapterView<?> parent, View view, int position, long id) throws SecurityException {
         if (parent.getId() == R.id.spinner_location) {
             switch (position) {
                 case 0:
@@ -117,10 +145,6 @@ public class MyLocationTrackingModeActivity extends AppCompatActivity implements
                 case 2:
                     mMapView.setMyBearingTrackingMode(MyBearingTracking.COMPASS);
                     break;
-
-//                case 3:
-//                    mMapView.setMyBearingTrackingMode(MyBearingTracking.COMBINED);
-//                    break;
             }
         }
     }


### PR DESCRIPTION
Closes #3444 and #3435.

Added change listeners to location tracking and bearing tracking, added requires permissions checks and handled them in the test app, update javadoc to reflect changes, formatting commit of MapView, Reposition UserLocationView when location tracking becomes active.