### PR TITLE
Invalidate CADisplayLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Known issues:
 
 ## iOS master
 
+- Fixed an issue causing the entire MGLMapView to leak. ([#3447](https://github.com/mapbox/mapbox-gl-native/pull/3447))
 - `MGLMapView` methods that alter the viewport now accept optional completion handlers. ([#3090](https://github.com/mapbox/mapbox-gl-native/pull/3090))
 - You can now modify an annotation’s image after adding the annotation to the map. ([#3146](https://github.com/mapbox/mapbox-gl-native/pull/3146))
 - Tapping now selects annotations more reliably. Tapping near the top of a large annotation image now selects that annotation. An annotation image’s alignment insets influence how far away the user can tap and still select the annotation. For example, if your annotation image has a large shadow, you can keep that shadow from being tappable by excluding it from the image’s alignment rect. ([#3261](https://github.com/mapbox/mapbox-gl-native/pull/3261))

--- a/ios/benchmark/MBXBenchViewController.mm
+++ b/ios/benchmark/MBXBenchViewController.mm
@@ -11,7 +11,7 @@
 #pragma mark - Debugging
 
 /** Triggers another render pass even when it is not necessary. */
-- (void)invalidate;
+- (void)setNeedsGLDisplay;
 
 /** Returns whether the map view is currently loading or processing any assets required to render the map */
 - (BOOL)isFullyLoaded;
@@ -119,7 +119,7 @@ static const int benchmarkDuration = 200; // frames
             idx++;
             [self startBenchmarkIteration];
         } else {
-            [mapView invalidate];
+            [mapView setNeedsGLDisplay];
         }
         return;
     }
@@ -134,7 +134,7 @@ static const int benchmarkDuration = 200; // frames
             started = Clock::now();
             NSLog(@"- Benchmarking for %d frames...", benchmarkDuration);
         }
-        [mapView invalidate];
+        [mapView setNeedsGLDisplay];
         return;
     }
 
@@ -146,7 +146,7 @@ static const int benchmarkDuration = 200; // frames
             state = State::WarmingUp;
             [self.mapView emptyMemoryCache];
             NSLog(@"- Warming up for %d frames...", warmupDuration);
-            [mapView invalidate];
+            [mapView setNeedsGLDisplay];
         }
         return;
     }


### PR DESCRIPTION
CADisplayLink holds a strong reference to its target, forming a cycle that must be broken with `-[CADisplayLink invalidate]` when the animation is complete. I don’t yet have enough faith that `MapChangeRegionWillChangeAnimated` and `MapChangeRegionDidChangeAnimated` notifications are always coming from mbgl in pairs, so this change limits CADisplayLink to when MGLMapView is in the view hierarchy. It also pauses the CADisplayLink when the application is in the background. Finally, `-[MGLMapView invalidate]` has been renamed because that term tends not to mean “redraw” in Cocoa but is rather tied to timers.

Fixes #3130, which is a regression introduced in #2922.

@adam-mapbox @tomtaylor, can you verify that the original fix has not regressed with this change?