### PR TITLE
[core] Simplify OnlineFileSource::Impl::reschedule

### DIFF
--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -321,9 +321,7 @@ void OnlineFileSource::Impl::reschedule(OnlineFileRequestImpl& request) {
 
     const Seconds timeout = request.getRetryTimeout();
 
-    if (timeout == Seconds::zero()) {
-        update(request);
-    } else if (timeout > Seconds::zero()) {
+    if (timeout >= Seconds::zero()) {
         request.realRequestTimer.start(timeout, Duration::zero(), [this, &request] {
             assert(!request.realRequest);
             startRealRequest(request);


### PR DESCRIPTION
I assume `OnlineFileSource::Impl::reschedule` should only ever reschedule a realRequest, and that in the case that the real request should commence immediately, commencing it after a zero-second timeout is also acceptable. If so, this is a desirable refactor because it removes a conditional case and allows `OnlineFileSource::Impl::update` to be inlined as a followup.

cc @kkaefer 