### PR TITLE
[core] Simplify OnlineFileSource's Timer use

### DIFF
--- a/test/miscellaneous/timer.cpp
+++ b/test/miscellaneous/timer.cpp
@@ -177,3 +177,11 @@ TEST(Timer, StartOverrides) {
     EXPECT_GE(totalTime, expectedTotalTime * 0.8);
     EXPECT_LE(totalTime, expectedTotalTime * 1.2);
 }
+
+TEST(Timer, CanStopNonStartedTimer) {
+    RunLoop loop;
+
+    Timer timer;
+    timer.unref();
+    timer.stop();
+}


### PR DESCRIPTION
There is no need for the timer to be created only under certain conditions. Stopping a non-started timer is a no-op (I added a test for this). Therefore it can simply be a direct member.

While here, rename the variable. It's a timer, not a request.

cc @kkaefer 