### PR TITLE
Add missing coordinate conversion methods to iOS SDK

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -593,6 +593,28 @@ IB_DESIGNABLE
 - (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(nullable UIView *)view;
 
 /**
+ Converts a rectangle in the given view’s coordinate system to a geographic
+ bounding box.
+ 
+ @param rect The rectangle to convert.
+ @param view The view in whose coordinate system the rectangle is expressed.
+ @return The geographic bounding box coextensive with the given rectangle.
+ */
+- (MGLCoordinateBounds)convertRect:(CGRect)rect toCoordinateBoundsFromView:(nullable UIView *)view;
+
+/**
+ Converts a geographic bounding box to a rectangle in the given view’s
+ coordinate system.
+ 
+ @param bounds The geographic bounding box to convert.
+ @param view The view in whose coordinate system the returned rectangle should
+    be expressed. If this parameter is `nil`, the returned rectangle is
+    expressed in the window’s coordinate system. If `view` is not `nil`, it must
+    belong to the same window as the map view.
+ */
+- (CGRect)convertCoordinateBounds:(MGLCoordinateBounds)bounds toRectToView:(nullable UIView *)view;
+
+/**
  Returns the distance spanned by one point in the map view's coordinate system
  at the given latitude and current zoom level.
  

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1926,6 +1926,19 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     return MGLCoordinateBoundsFromLatLngBounds([self convertRect:rect toLatLngBoundsFromView:view]);
 }
 
+- (CGRect)convertCoordinateBounds:(MGLCoordinateBounds)bounds toRectToView:(nullable UIView *)view
+{
+    return [self convertLatLngBounds:MGLLatLngBoundsFromCoordinateBounds(bounds) toRectToView:view];
+}
+
+/// Converts a geographic bounding box to a rectangle in the view’s coordinate
+/// system.
+- (CGRect)convertLatLngBounds:(mbgl::LatLngBounds)bounds toRectToView:(nullable UIView *)view {
+    CGRect rect = { [self convertLatLng:bounds.sw toPointToView:view], CGSizeZero };
+    rect = MGLExtendRect(rect, [self convertLatLng:bounds.ne toPointToView:view]);
+    return rect;
+}
+
 /// Converts a rectangle in the given view’s coordinate system to a geographic
 /// bounding box.
 - (mbgl::LatLngBounds)convertRect:(CGRect)rect toLatLngBoundsFromView:(nullable UIView *)view


### PR DESCRIPTION
The coordinate bounds conversion methods on MGLMapView have been public in the OS X SDK all along. This change makes them public in the iOS SDK too.

/cc @friedbunny @jfirebaugh