### PR TITLE
Don't store asset:// requests in the cache

### DIFF
--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -232,7 +232,7 @@ void OnlineFileSource::Impl::update(OnlineFileRequestImpl& request) {
     } else if (!request.cacheRequest && !request.realRequest) {
         // There is no request in progress, and we don't have a response yet. This means we'll have
         // to start the request ourselves.
-        if (cache) {
+        if (cache && !util::isAssetURL(request.resource.url)) {
             startCacheRequest(request);
         } else {
             startRealRequest(request);
@@ -276,7 +276,7 @@ void OnlineFileSource::Impl::startRealRequest(OnlineFileRequestImpl& request) {
     auto callback = [this, &request](std::shared_ptr<const Response> response) {
         request.realRequest = nullptr;
 
-        if (cache) {
+        if (cache && !util::isAssetURL(request.resource.url)) {
             // Store response in database. Make sure we only refresh the expires column if the data
             // didn't change.
             FileCache::Hint hint = FileCache::Hint::Full;

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -14,20 +14,12 @@
 #include <mbgl/util/async_task.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/timer.hpp>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#include <boost/algorithm/string.hpp>
-#pragma GCC diagnostic pop
+#include <mbgl/util/url.hpp>
 
 #include <algorithm>
 #include <cassert>
 #include <set>
 #include <unordered_map>
-
-namespace algo = boost::algorithm;
 
 namespace mbgl {
 
@@ -299,7 +291,7 @@ void OnlineFileSource::Impl::startRealRequest(OnlineFileRequestImpl& request) {
         reschedule(request);
     };
 
-    if (algo::starts_with(request.resource.url, "asset://")) {
+    if (util::isAssetURL(request.resource.url)) {
         request.realRequest =
             assetContext->createRequest(request.resource.url, callback, assetRoot);
     } else {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -21,6 +21,7 @@
 #include <mbgl/util/texture_pool.hpp>
 #include <mbgl/util/exception.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/mapbox.hpp>
 
 #include <algorithm>
 
@@ -114,7 +115,8 @@ void MapContext::setStyleURL(const std::string& url) {
         styleRequest = nullptr;
 
         if (res.error) {
-            if (res.error->reason == Response::Error::Reason::NotFound && styleURL.find("mapbox://") == 0) {
+            if (res.error->reason == Response::Error::Reason::NotFound &&
+                util::mapbox::isMapboxURL(styleURL)) {
                 Log::Error(Event::Setup, "style %s could not be found or is an incompatible legacy map or style", styleURL.c_str());
             } else {
                 Log::Error(Event::Setup, "loading style failed: %s", res.error->message.c_str());

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -13,7 +13,7 @@ const std::string protocol = "mapbox://";
 const std::string baseURL = "https://api.mapbox.com/";
 
 bool isMapboxURL(const std::string& url) {
-    return url.compare(0, protocol.length(), protocol) == 0;
+    return std::equal(protocol.begin(), protocol.end(), url.begin());
 }
 
 std::vector<std::string> getMapboxURLPathname(const std::string& url) {

--- a/src/mbgl/util/mapbox.hpp
+++ b/src/mbgl/util/mapbox.hpp
@@ -8,6 +8,8 @@ namespace mbgl {
 namespace util {
 namespace mapbox {
 
+bool isMapboxURL(const std::string& url);
+
 std::string normalizeSourceURL(const std::string& url, const std::string& accessToken);
 std::string normalizeStyleURL(const std::string& url, const std::string& accessToken);
 std::string normalizeSpriteURL(const std::string& url, const std::string& accessToken);

--- a/src/mbgl/util/url.cpp
+++ b/src/mbgl/util/url.cpp
@@ -47,5 +47,13 @@ std::string percentDecode(const std::string& input) {
     return decoded;
 }
 
+namespace {
+const std::string assetProtocol = "asset://";
+}
+
+bool isAssetURL(const std::string& url) {
+    return std::equal(assetProtocol.begin(), assetProtocol.end(), url.begin());
+}
+
 } // namespace util
 } // namespace mbgl

--- a/src/mbgl/util/url.hpp
+++ b/src/mbgl/util/url.hpp
@@ -9,6 +9,8 @@ namespace util {
 std::string percentEncode(const std::string&);
 std::string percentDecode(const std::string&);
 
+bool isAssetURL(const std::string&);
+
 } // namespace util
 } // namespace mbgl
 


### PR DESCRIPTION
We're currently storing `asset://` requests in the cache, but given that they're on the local file system anyway, we should never do that.