### PR TITLE
[core] ::unref() is probably no longer needed

### DIFF
--- a/platform/default/async_task.cpp
+++ b/platform/default/async_task.cpp
@@ -28,6 +28,7 @@ public:
         }
 
         handle()->data = this;
+        uv_unref(handle());
     }
 
     ~Impl() {
@@ -41,10 +42,6 @@ public:
         if (uv_async_send(async) != 0) {
             throw std::runtime_error("Failed to async send.");
         }
-    }
-
-    void unref() {
-        uv_unref(handle());
     }
 
 private:
@@ -69,10 +66,6 @@ AsyncTask::~AsyncTask() = default;
 
 void AsyncTask::send() {
     impl->maySend();
-}
-
-void AsyncTask::unref() {
-    impl->unref();
 }
 
 } // namespace util

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -177,7 +177,6 @@ OnlineFileSource::Impl::Impl(FileCache* cache_, const std::string& root)
     // loop alive; otherwise our app wouldn't terminate. After all, we only need status change
     // notifications when our app is still running.
     NetworkStatus::Subscribe(&reachability);
-    reachability.unref();
 }
 
 OnlineFileSource::Impl::~Impl() {

--- a/platform/default/run_loop.cpp
+++ b/platform/default/run_loop.cpp
@@ -13,6 +13,12 @@ namespace {
 using namespace mbgl::util;
 static ThreadLocal<RunLoop>& current = *new ThreadLocal<RunLoop>;
 
+#if UV_VERSION_MAJOR == 0 && UV_VERSION_MINOR <= 10
+void dummyCallback(uv_async_t*, int) {};
+#else
+void dummyCallback(uv_async_t*) {};
+#endif
+
 } // namespace
 
 namespace mbgl {
@@ -56,7 +62,19 @@ RunLoop* RunLoop::Get() {
 
 class RunLoop::Impl {
 public:
+    void closeHolder() {
+        uv_close(holderHandle(), [](uv_handle_t* h) {
+            delete reinterpret_cast<uv_async_t*>(h);
+        });
+    }
+
+    uv_handle_t* holderHandle() {
+        return reinterpret_cast<uv_handle_t*>(holder);
+    }
+
     uv_loop_t *loop = nullptr;
+    uv_async_t* holder = new uv_async_t;
+
     RunLoop::Type type;
     std::unique_ptr<AsyncTask> async;
 
@@ -81,6 +99,12 @@ RunLoop::RunLoop(Type type) : impl(std::make_unique<Impl>()) {
         break;
     }
 
+    // Just for holding a ref to the main loop and keep
+    // it alive as required by libuv.
+    if (uv_async_init(impl->loop, impl->holder, dummyCallback) != 0) {
+        throw std::runtime_error("Failed to initialize async.");
+    }
+
     impl->type = type;
 
     current.set(this);
@@ -89,6 +113,10 @@ RunLoop::RunLoop(Type type) : impl(std::make_unique<Impl>()) {
 
 RunLoop::~RunLoop() {
     current.set(nullptr);
+
+    // Close the dummy handle that we have
+    // just to keep the main loop alive.
+    impl->closeHolder();
 
     if (impl->type == Type::Default) {
         return;
@@ -133,7 +161,7 @@ void RunLoop::runOnce() {
 }
 
 void RunLoop::stop() {
-    invoke([&] { impl->async->unref(); });
+    invoke([&] { uv_unref(impl->holderHandle()); });
 }
 
 void RunLoop::addWatch(int fd, Event event, std::function<void(int, Event)>&& callback) {

--- a/platform/default/timer.cpp
+++ b/platform/default/timer.cpp
@@ -22,6 +22,7 @@ public:
         }
 
         handle()->data = this;
+        uv_unref(handle());
     }
 
     ~Impl() {
@@ -42,10 +43,6 @@ public:
         if (uv_timer_stop(timer) != 0) {
             throw std::runtime_error("Failed to stop timer.");
         }
-    }
-
-    void unref() {
-        uv_unref(handle());
     }
 
 private:
@@ -76,10 +73,6 @@ void Timer::start(Duration timeout, Duration repeat, std::function<void()>&& cb)
 
 void Timer::stop() {
     impl->stop();
-}
-
-void Timer::unref() {
-    impl->unref();
 }
 
 } // namespace util

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -39,9 +39,6 @@ MapContext::MapContext(View& view_, FileSource& fileSource, MapMode mode_, GLCon
     util::ThreadContext::setFileSource(&fileSource);
     util::ThreadContext::setGLObjectStore(&glObjectStore);
 
-    asyncUpdate.unref();
-    asyncInvalidate.unref();
-
     view.activate();
 }
 

--- a/src/mbgl/util/async_task.hpp
+++ b/src/mbgl/util/async_task.hpp
@@ -15,7 +15,6 @@ public:
     ~AsyncTask();
 
     void send();
-    void unref();
 
 private:
     class Impl;

--- a/src/mbgl/util/timer.hpp
+++ b/src/mbgl/util/timer.hpp
@@ -17,7 +17,6 @@ public:
 
     void start(Duration timeout, Duration repeat, std::function<void()>&&);
     void stop();
-    void unref();
 
 private:
     class Impl;

--- a/test/fixtures/mock_file_source.cpp
+++ b/test/fixtures/mock_file_source.cpp
@@ -18,7 +18,6 @@ public:
 
 MockFileSource::MockFileSource(Type type_, const std::string& match_)
     : type(type_), match(match_) {
-    timer.unref();
     timer.start(std::chrono::milliseconds(10), std::chrono::milliseconds(10), [this] {
         // Explicit move to avoid iterator invalidation if ~MockFileRequest gets called within the loop.
         auto pending_ = std::move(pending);

--- a/test/miscellaneous/async_task.cpp
+++ b/test/miscellaneous/async_task.cpp
@@ -40,7 +40,6 @@ TEST(AsyncTask, RequestCoalescing) {
 
     unsigned count = 0;
     AsyncTask async([&count] { ++count; });
-    async.unref();
 
     async.send();
     async.send();
@@ -70,7 +69,6 @@ TEST(AsyncTask, RequestCoalescingMultithreaded) {
 
     unsigned count = 0;
     AsyncTask async([&count] { ++count; });
-    async.unref();
 
     std::vector<std::unique_ptr<Thread<TestWorker>>> threads;
     ThreadContext context = {"Test", ThreadType::Map, ThreadPriority::Regular};
@@ -97,7 +95,6 @@ TEST(AsyncTask, ThreadSafety) {
 
     unsigned count = 0;
     AsyncTask async([&count] { ++count; });
-    async.unref();
 
     unsigned numThreads = 25;
 

--- a/test/miscellaneous/timer.cpp
+++ b/test/miscellaneous/timer.cpp
@@ -12,7 +12,6 @@ TEST(Timer, Basic) {
     RunLoop loop;
 
     Timer timer;
-    timer.unref();
 
     auto callback = [&loop] { loop.stop(); };
 
@@ -38,7 +37,6 @@ TEST(Timer, Repeat) {
     RunLoop loop;
 
     Timer timer;
-    timer.unref();
 
     unsigned count = 10;
     auto callback = [&] {
@@ -66,10 +64,7 @@ TEST(Timer, Stop) {
     RunLoop loop;
 
     Timer timer1;
-    timer1.unref();
-
     Timer timer2;
-    timer2.unref();
 
     auto interval1 = std::chrono::milliseconds(50);
     auto interval2 = std::chrono::milliseconds(250);
@@ -106,10 +101,7 @@ TEST(Timer, DestroyShouldStop) {
     RunLoop loop;
 
     auto timer1 = std::make_unique<Timer>();
-    timer1->unref();
-
     Timer timer2;
-    timer2.unref();
 
     auto interval1 = std::chrono::milliseconds(50);
     auto interval2 = std::chrono::milliseconds(250);
@@ -146,7 +138,6 @@ TEST(Timer, StartOverrides) {
     RunLoop loop;
 
     Timer timer;
-    timer.unref();
 
     auto interval1 = std::chrono::milliseconds(50);
     auto interval2 = std::chrono::milliseconds(250);
@@ -182,6 +173,5 @@ TEST(Timer, CanStopNonStartedTimer) {
     RunLoop loop;
 
     Timer timer;
-    timer.unref();
     timer.stop();
 }

--- a/test/style/pending_resources.cpp
+++ b/test/style/pending_resources.cpp
@@ -33,7 +33,6 @@ TEST_P(PendingResources, DeleteMapObjectWithPendingRequest) {
         loop.stop();
     });
 
-    endTest.unref();
     fileSource.requestEnqueuedCallback = [&endTest] { endTest.send(); };
 
     const std::string style = util::read_file("test/fixtures/resources/style.json");


### PR DESCRIPTION
Classes like `Timer` and `AsyncTask` have a `::ref()` and `::unref()` method which is legacy from `libuv` for keeping the main loop alive. Now that we have a `util::RunLoop` abstraction we don't need this and it just causes confusion.

Removing these methods also opens a door for optimization as we can lazy instantiate the `Impl` part of these objects and thus save some memory.