### PR TITLE
[core] Simplify OnlineFileSource

### DIFF
--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -22,6 +22,8 @@ public:
 
 private:
     friend class OnlineFileRequest;
+    friend class OnlineFileRequestImpl;
+
     void cancel(const Resource&, FileRequest*);
 
     class Impl;

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -104,7 +104,6 @@ public:
     void cancel(Resource, FileRequest*);
 
 private:
-    void update(OnlineFileRequestImpl&);
     void startCacheRequest(OnlineFileRequestImpl&);
     void startRealRequest(OnlineFileRequestImpl&);
     void reschedule(OnlineFileRequestImpl&);
@@ -199,15 +198,6 @@ void OnlineFileSource::Impl::add(Resource resource, FileRequest* req, Callback c
     auto& request = *pending.emplace(resource,
         std::make_unique<OnlineFileRequestImpl>(resource)).first->second;
 
-    // Trigger a potentially required refresh of this Request
-    update(request);
-
-    // Add this request as an observer so that it'll get notified when something about this
-    // request changes.
-    request.addObserver(req, callback);
-}
-
-void OnlineFileSource::Impl::update(OnlineFileRequestImpl& request) {
     if (request.getResponse()) {
         // We've at least obtained a cache value, potentially we also got a final response.
         // The observers have been notified already; send what we have to the new one as well.
@@ -237,6 +227,10 @@ void OnlineFileSource::Impl::update(OnlineFileRequestImpl& request) {
     } else {
         // There is a request in progress. We just have to wait.
     }
+
+    // Add this request as an observer so that it'll get notified when something about this
+    // request changes.
+    request.addObserver(req, callback);
 }
 
 void OnlineFileSource::Impl::startCacheRequest(OnlineFileRequestImpl& request) {

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -200,11 +200,10 @@ void OnlineFileSource::Impl::add(Resource resource, FileRequest* req, Callback c
 
     if (request.getResponse()) {
         // We've at least obtained a cache value, potentially we also got a final response.
-        // The observers have been notified already; send what we have to the new one as well.
-
         // Before returning the existing response, make sure that it is still fresh, or update the
         // `stale` flag.
         request.checkResponseFreshness();
+        callback(*request.getResponse());
 
         if (request.getResponse()->stale && !request.realRequest) {
             // We've returned a stale response; now make sure the requester also gets a fresh
@@ -334,11 +333,6 @@ OnlineFileRequestImpl::~OnlineFileRequestImpl() {
 
 void OnlineFileRequestImpl::addObserver(FileRequest* req, Callback callback) {
     observers.emplace(req, callback);
-
-    if (response) {
-        // We've got a response, so send the (potentially stale) response to the requester.
-        callback(*response);
-    }
 }
 
 void OnlineFileRequestImpl::removeObserver(FileRequest* req) {

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -320,9 +320,7 @@ void OnlineFileSource::Impl::reschedule(OnlineFileRequestImpl& request) {
 
     const Seconds timeout = request.getRetryTimeout();
 
-    if (timeout == Seconds::zero()) {
-        update(request);
-    } else if (timeout > Seconds::zero()) {
+    if (timeout >= Seconds::zero()) {
         request.realRequestTimer.start(timeout, Duration::zero(), [this, &request] {
             assert(!request.realRequest);
             startRealRequest(request);


### PR DESCRIPTION
Sorry for the large'ish PR -- I reached the end point of where I could do refactors in parallel rather than sequentially, and I wanted to queue up reviews for all of these commits. Each commit is self-contained, if you want to go step by step. Or skip the diff and read the end result of `online_file_source.cpp`.

The end result is that it's easier to see the big picture of an `OnlineFileRequestImpl`'s lifetime -- it starts with an optional cache request, then moves on to making periodic network requests, either for error retries or when the resource becomes stale.

From here, we can better judge if #2826 makes sense, embark on further refactors as suggested in https://github.com/mapbox/mapbox-gl-native/pull/3454#issuecomment-169739312 and https://github.com/mapbox/mapbox-gl-native/pull/3477#issuecomment-170066918, and begin to see how offline fits in.

cc @tmpsantos @kkaefer 