### PR TITLE
Refactor Transform

### DIFF
--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -17,6 +17,10 @@ struct CameraOptions {
     /** Coordinate at the center of the map. */
     mapbox::util::optional<LatLng> center;
     
+    /** Point of reference for `zoom` and `angle`, assuming an origin at the
+        top-left corner of the view. */
+    mapbox::util::optional<PrecisionPoint> anchor;
+    
     /** Zero-based zoom level. Constrained to the minimum and maximum zoom
         levels. */
     mapbox::util::optional<double> zoom;

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -11,13 +11,9 @@
 
 namespace mbgl {
 
-/** Various options for describing the viewpoint of a map, along with parameters
-    for transitioning to the viewpoint with animation. All fields are optional;
-    the default values of transition options depend on how this struct is used.
- */
+/** Various options for describing the viewpoint of a map. All fields are
+    optional. */
 struct CameraOptions {
-    // Viewpoint options
-    
     /** Coordinate at the center of the map. */
     mapbox::util::optional<LatLng> center;
     
@@ -32,9 +28,12 @@ struct CameraOptions {
     /** Pitch toward the horizon measured in radians, with 0 rad resulting in a
         two-dimensional map. */
     mapbox::util::optional<double> pitch;
-    
-    // Transition options
-    
+};
+
+/** Various options for describing a transition between viewpoints with
+    animation. All fields are optional; the default values depend on how this
+    struct is used. */
+struct AnimationOptions {
     /** Time to animate to the viewpoint defined herein. */
     mapbox::util::optional<Duration> duration;
     

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -59,6 +59,13 @@ struct AnimationOptions {
     /** A function that is called once on the last frame of the transition, just
         before the corresponding screen update. */
     std::function<void()> transitionFinishFn;
+    
+    /** Creates an animation with no options specified. */
+    inline AnimationOptions() {}
+    
+    /** Creates an animation with the specified duration. */
+    inline AnimationOptions(Duration d)
+        : duration(d) {}
 };
 
 } // namespace mbgl

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -28,6 +28,7 @@ class Transform;
 class PointAnnotation;
 class ShapeAnnotation;
 struct CameraOptions;
+struct AnimationOptions;
 
 namespace util {
 template <class T> class Thread;
@@ -99,8 +100,8 @@ public:
 
     // Camera
     void jumpTo(const CameraOptions&);
-    void easeTo(const CameraOptions&);
-    void flyTo(const CameraOptions&);
+    void easeTo(const CameraOptions&, const AnimationOptions&);
+    void flyTo(const CameraOptions&, const AnimationOptions&);
 
     // Position
     void moveBy(const PrecisionPoint&, const Duration& = Duration::zero());

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -111,8 +111,8 @@ public:
     void resetPosition();
 
     // Scale
-    void scaleBy(double ds, const PrecisionPoint& = { 0, 0 }, const Duration& = Duration::zero());
-    void setScale(double scale, const PrecisionPoint& = { 0, 0 }, const Duration& = Duration::zero());
+    void scaleBy(double ds, const PrecisionPoint& = { NAN, NAN }, const Duration& = Duration::zero());
+    void setScale(double scale, const PrecisionPoint& = { NAN, NAN }, const Duration& = Duration::zero());
     double getScale() const;
     void setZoom(double zoom, const Duration& = Duration::zero());
     double getZoom() const;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -3471,7 +3471,7 @@ public final class MapView extends FrameLayout {
                 // around gesture
                 mNativeMapView.setBearing(bearing,
                         detector.getFocusX() / mScreenDensity,
-                        (getHeight() - detector.getFocusY()) / mScreenDensity);
+                        detector.getFocusY() / mScreenDensity);
             } else {
                 // around center map
                 mNativeMapView.setBearing(bearing,

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
@@ -264,7 +264,7 @@ final class NativeMapView {
     }
 
     public void scaleBy(double ds) {
-        scaleBy(ds, -1.0, -1.0);
+        scaleBy(ds, Double.NaN, Double.NaN);
     }
 
     public void scaleBy(double ds, double cx, double cy) {
@@ -276,7 +276,7 @@ final class NativeMapView {
     }
 
     public void setScale(double scale) {
-        setScale(scale, -1.0, -1.0);
+        setScale(scale, Double.NaN, Double.NaN);
     }
 
     public void setScale(double scale, double cx, double cy) {

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -1290,19 +1290,19 @@ void JNICALL nativeSetVisibleCoordinateBounds(JNIEnv *env, jobject obj, jlong na
         segment.push_back(mbgl::LatLng(latitude, longitude));
     }
 
-    mbgl::CameraOptions options = nativeMapView->getMap().cameraForLatLngs(segment, mbglInsets);
-
+    mbgl::CameraOptions cameraOptions = nativeMapView->getMap().cameraForLatLngs(segment, mbglInsets);
     if (direction >= 0) {
         // convert from degrees to radians
-        options.angle = (-direction * M_PI) / 180;
+        cameraOptions.angle = (-direction * M_PI) / 180;
     }
+    mbgl::AnimationOptions animationOptions;
     if (duration > 0) {
-        options.duration = std::chrono::milliseconds(duration);
+        animationOptions.duration = std::chrono::milliseconds(duration);
         // equivalent to kCAMediaTimingFunctionDefault in iOS
-        options.easing = {0.25, 0.1, 0.25, 0.1};
+        animationOptions.easing = {0.25, 0.1, 0.25, 0.1};
     }
 
-    nativeMapView->getMap().easeTo(options);
+    nativeMapView->getMap().easeTo(cameraOptions, animationOptions);
 }
 
 void JNICALL nativeOnLowMemory(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
@@ -1528,20 +1528,21 @@ void JNICALL nativeEaseTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdou
         return;
     }
 
-    mbgl::CameraOptions options;
+    mbgl::CameraOptions cameraOptions;
     if (angle != -1) {
-        options.angle = angle;
+        cameraOptions.angle = angle;
     }
-    options.center = mbgl::LatLng(latitude, longitude);
-    options.duration = mbgl::Duration(duration);
+    cameraOptions.center = mbgl::LatLng(latitude, longitude);
     if (pitch != -1) {
-        options.pitch = pitch;
+        cameraOptions.pitch = pitch;
     }
     if (zoom != -1) {
-        options.zoom = zoom;
+        cameraOptions.zoom = zoom;
     }
+    mbgl::AnimationOptions animationOptions;
+    animationOptions.duration = mbgl::Duration(duration);
 
-    nativeMapView->getMap().easeTo(options);
+    nativeMapView->getMap().easeTo(cameraOptions, animationOptions);
 }
 
 void JNICALL nativeFlyTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdouble angle, jobject centerLatLng, jlong duration, jdouble pitch, jdouble zoom) {
@@ -1561,20 +1562,21 @@ void JNICALL nativeFlyTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdoub
         return;
     }
 
-    mbgl::CameraOptions options;
+    mbgl::CameraOptions cameraOptions;
     if (angle != -1) {
-        options.angle = angle;
+        cameraOptions.angle = angle;
     }
-    options.center = mbgl::LatLng(latitude, longitude);
-    options.duration = mbgl::Duration(duration);
+    cameraOptions.center = mbgl::LatLng(latitude, longitude);
     if (pitch != -1) {
-        options.pitch = pitch;
+        cameraOptions.pitch = pitch;
     }
     if (zoom != -1) {
-        options.zoom = zoom;
+        cameraOptions.zoom = zoom;
     }
+    mbgl::AnimationOptions animationOptions;
+    animationOptions.duration = mbgl::Duration(duration);
 
-    nativeMapView->getMap().flyTo(options);
+    nativeMapView->getMap().flyTo(cameraOptions, animationOptions);
 }
 
 void JNICALL nativeAddCustomLayer(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jobject customLayer, jstring before) {

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -125,7 +125,7 @@ if [ -z `which jazzy` ]; then
     step "Installing jazzy..."
     gem install jazzy
     if [ -z `which jazzy` ]; then
-        echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native/blob/master/docs/BUILD_IOS_OSX.md"
+        echo "Unable to install jazzy. See https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/INSTALL.md"
         exit 1
     fi
 fi

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1119,7 +1119,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
         }
 
         mbgl::PrecisionPoint center([rotate locationInView:rotate.view].x,
-                                    self.bounds.size.height - [rotate locationInView:rotate.view].y);
+                                    [rotate locationInView:rotate.view].y);
         _mbglMap->setBearing(newDegrees, center);
 
         [self notifyMapChange:mbgl::MapChangeRegionIsChanging];

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1239,7 +1239,7 @@ public:
         _directionAtBeginningOfGesture = self.direction;
     } else if (gestureRecognizer.state == NSGestureRecognizerStateChanged) {
         NSPoint rotationPoint = [gestureRecognizer locationInView:self];
-        mbgl::PrecisionPoint center(rotationPoint.x, rotationPoint.y);
+        mbgl::PrecisionPoint center(rotationPoint.x, self.bounds.size.height - rotationPoint.y);
         _mbglMap->setBearing(_directionAtBeginningOfGesture + gestureRecognizer.rotationInDegrees, center);
     } else if (gestureRecognizer.state == NSGestureRecognizerStateEnded
                || gestureRecognizer.state == NSGestureRecognizerStateCancelled) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -148,20 +148,20 @@ bool Map::isPanning() const {
 
 #pragma mark -
 
-void Map::jumpTo(const CameraOptions& options) {
-    transform->jumpTo(options);
-    update(options.zoom ? Update::Zoom : Update::Repaint);
+void Map::jumpTo(const CameraOptions& camera) {
+    transform->jumpTo(camera);
+    update(camera.zoom ? Update::Zoom : Update::Repaint);
 }
 
-void Map::easeTo(const CameraOptions& options) {
-    transform->easeTo(options);
-    update(options.zoom ? Update::Zoom : Update::Repaint);
+void Map::easeTo(const CameraOptions& camera, const AnimationOptions& animation) {
+    transform->easeTo(camera, animation);
+    update(camera.zoom ? Update::Zoom : Update::Repaint);
 }
     
     
-void Map::flyTo(const CameraOptions& options) {
-    transform->flyTo(options);
-    update(options.zoom ? Update::Zoom : Update::Repaint);
+void Map::flyTo(const CameraOptions& camera, const AnimationOptions& animation) {
+    transform->flyTo(camera, animation);
+    update(Update::Zoom);
 }
 
 #pragma mark - Position

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -64,7 +64,7 @@ bool Transform::resize(const std::array<uint16_t, 2> size) {
     }
 }
 
-#pragma mark - Position
+#pragma mark - Camera
 
 /**
  * Change any combination of center, zoom, bearing, and pitch, without
@@ -73,99 +73,6 @@ bool Transform::resize(const std::array<uint16_t, 2> size) {
  */
 void Transform::jumpTo(const CameraOptions& camera) {
     easeTo(camera);
-}
-
-void Transform::moveBy(const PrecisionPoint& offset, const Duration& duration) {
-    if (!_validPoint(offset)) {
-        return;
-    }
-
-    PrecisionPoint centerOffset = {
-        offset.x,
-        -offset.y,
-    };
-    PrecisionPoint centerPoint = state.latLngToPoint(state.getLatLng()) - centerOffset;
-
-    CameraOptions camera;
-    camera.center = state.pointToLatLng(centerPoint);
-    easeTo(camera, duration);
-}
-
-void Transform::setLatLng(const LatLng& latLng, const Duration& duration) {
-    if (!latLng) {
-        return;
-    }
-
-    CameraOptions camera;
-    camera.center = latLng;
-    easeTo(camera, duration);
-}
-
-void Transform::setLatLng(const LatLng& latLng, const PrecisionPoint& point, const Duration& duration) {
-    if (!latLng || !point) {
-        return;
-    }
-
-    auto coord = state.latLngToCoordinate(latLng);
-    auto coordAtPoint = state.pointToCoordinate(point);
-    auto coordCenter = state.pointToCoordinate({ state.width / 2.0f, state.height / 2.0f });
-
-    float columnDiff = coordAtPoint.column - coord.column;
-    float rowDiff = coordAtPoint.row - coord.row;
-
-    auto newLatLng = state.coordinateToLatLng({
-        coordCenter.column - columnDiff,
-        coordCenter.row - rowDiff,
-        coordCenter.zoom
-    });
-
-    setLatLng(newLatLng, duration);
-}
-
-void Transform::setLatLngZoom(const LatLng& latLng, double zoom, const Duration& duration) {
-    if (!latLng || std::isnan(zoom)) {
-        return;
-    }
-
-    CameraOptions camera;
-    camera.center = latLng;
-    camera.zoom = zoom;
-    easeTo(camera, duration);
-}
-
-
-#pragma mark - Zoom
-
-void Transform::scaleBy(double ds, const PrecisionPoint& center, const Duration& duration) {
-    if (std::isnan(ds)) {
-        return;
-    }
-
-    double scale = util::clamp(state.scale * ds, state.min_scale, state.max_scale);
-    setScale(scale, center, duration);
-}
-
-void Transform::setZoom(double zoom, const Duration& duration) {
-    setScale(state.zoomScale(zoom), {NAN, NAN}, duration);
-}
-
-double Transform::getZoom() const {
-    return state.getZoom();
-}
-
-double Transform::getScale() const {
-    return state.scale;
-}
-
-void Transform::setScale(double scale, const PrecisionPoint& anchor, const Duration& duration) {
-    if (std::isnan(scale)) {
-        return;
-    }
-    
-    CameraOptions camera;
-    camera.zoom = state.scaleZoom(scale);
-    camera.anchor = anchor;
-    easeTo(camera, duration);
 }
 
 /**
@@ -488,6 +395,101 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
             view.notifyMapChange(MapChangeRegionDidChangeAnimated);
         }, duration);
 };
+
+#pragma mark - Position
+
+void Transform::moveBy(const PrecisionPoint& offset, const Duration& duration) {
+    if (!_validPoint(offset)) {
+        return;
+    }
+
+    PrecisionPoint centerOffset = {
+        offset.x,
+        -offset.y,
+    };
+    PrecisionPoint centerPoint = state.latLngToPoint(state.getLatLng()) - centerOffset;
+
+    CameraOptions camera;
+    camera.center = state.pointToLatLng(centerPoint);
+    easeTo(camera, duration);
+}
+
+void Transform::setLatLng(const LatLng& latLng, const Duration& duration) {
+    if (!latLng) {
+        return;
+    }
+
+    CameraOptions camera;
+    camera.center = latLng;
+    easeTo(camera, duration);
+}
+
+void Transform::setLatLng(const LatLng& latLng, const PrecisionPoint& point, const Duration& duration) {
+    if (!latLng || !point) {
+        return;
+    }
+
+    auto coord = state.latLngToCoordinate(latLng);
+    auto coordAtPoint = state.pointToCoordinate(point);
+    auto coordCenter = state.pointToCoordinate({ state.width / 2.0f, state.height / 2.0f });
+
+    float columnDiff = coordAtPoint.column - coord.column;
+    float rowDiff = coordAtPoint.row - coord.row;
+
+    auto newLatLng = state.coordinateToLatLng({
+        coordCenter.column - columnDiff,
+        coordCenter.row - rowDiff,
+        coordCenter.zoom
+    });
+
+    setLatLng(newLatLng, duration);
+}
+
+void Transform::setLatLngZoom(const LatLng& latLng, double zoom, const Duration& duration) {
+    if (!latLng || std::isnan(zoom)) {
+        return;
+    }
+
+    CameraOptions camera;
+    camera.center = latLng;
+    camera.zoom = zoom;
+    easeTo(camera, duration);
+}
+
+
+#pragma mark - Zoom
+
+void Transform::scaleBy(double ds, const PrecisionPoint& center, const Duration& duration) {
+    if (std::isnan(ds)) {
+        return;
+    }
+
+    double scale = util::clamp(state.scale * ds, state.min_scale, state.max_scale);
+    setScale(scale, center, duration);
+}
+
+void Transform::setZoom(double zoom, const Duration& duration) {
+    setScale(state.zoomScale(zoom), {NAN, NAN}, duration);
+}
+
+double Transform::getZoom() const {
+    return state.getZoom();
+}
+
+double Transform::getScale() const {
+    return state.scale;
+}
+
+void Transform::setScale(double scale, const PrecisionPoint& anchor, const Duration& duration) {
+    if (std::isnan(scale)) {
+        return;
+    }
+    
+    CameraOptions camera;
+    camera.zoom = state.scaleZoom(scale);
+    camera.anchor = anchor;
+    easeTo(camera, duration);
+}
 
 #pragma mark - Angle
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -35,6 +35,10 @@ static double _normalizeAngle(double angle, double anchorAngle)
     return angle;
 }
 
+inline bool _validPoint(const PrecisionPoint& point) {
+    return !std::isnan(point.x) && !std::isnan(point.y);
+}
+
 Transform::Transform(View &view_, ConstrainMode constrainMode)
     : view(view_)
     , state(constrainMode)
@@ -72,7 +76,7 @@ void Transform::jumpTo(const CameraOptions& camera) {
 }
 
 void Transform::moveBy(const PrecisionPoint& offset, const Duration& duration) {
-    if (!offset) {
+    if (!_validPoint(offset)) {
         return;
     }
 
@@ -153,26 +157,14 @@ double Transform::getScale() const {
     return state.scale;
 }
 
-void Transform::setScale(double scale, const PrecisionPoint& flippedAnchor, const Duration& duration) {
+void Transform::setScale(double scale, const PrecisionPoint& anchor, const Duration& duration) {
     if (std::isnan(scale)) {
         return;
     }
     
     CameraOptions camera;
-    if (flippedAnchor) {
-        const double factor = scale / state.scale;
-        PrecisionPoint center = {
-            state.width / 2.0,
-            state.height / 2.0,
-        };
-        PrecisionPoint anchor = {
-            flippedAnchor.x,
-            state.height - flippedAnchor.y,
-        };
-        PrecisionPoint offset = anchor - center;
-        camera.center = state.pointToLatLng(anchor - offset / factor);
-    }
     camera.zoom = state.scaleZoom(scale);
+    camera.anchor = anchor;
     easeTo(camera, duration);
 }
 
@@ -202,10 +194,27 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
         }
     }
     
+    PrecisionPoint anchor = camera.anchor ? *camera.anchor : PrecisionPoint(NAN, NAN);
+    LatLng anchorLatLng;
+    if (_validPoint(anchor)) {
+        anchor.y = state.getHeight() - anchor.y;
+        anchorLatLng = state.pointToLatLng(anchor);
+    }
+    
+    const PrecisionPoint startPoint = {
+        state.lngX(startLatLng.longitude),
+        state.latY(startLatLng.latitude),
+    };
+    const PrecisionPoint endPoint = {
+        state.lngX(latLng.longitude),
+        state.latY(latLng.latitude),
+    };
+    
     Update update = state.getZoom() == zoom ? Update::Repaint : Update::Zoom;
     
     // Constrain camera options.
     zoom = util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
+    const double scale = state.zoomScale(zoom);
     pitch = util::clamp(pitch, 0., util::PITCH_MAX);
     
     // Minimize rotation by taking the shorter path around the circle.
@@ -219,6 +228,9 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
         state.setLatLngZoom(latLng, zoom);
         state.angle = angle;
         state.pitch = pitch;
+        if (_validPoint(anchor)) {
+            state.moveLatLng(anchorLatLng, anchor);
+        }
 
         if (animation.transitionFinishFn) {
             animation.transitionFinishFn();
@@ -231,7 +243,6 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
         state.Bc = startWorldSize / 360;
         state.Cc = startWorldSize / util::M2PI;
         
-        const double scale = state.zoomScale(zoom);
         const double startScale = state.scale;
         const double startAngle = state.angle;
         const double startPitch = state.pitch;
@@ -245,9 +256,10 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
                 return ease.solve(t, 0.001);
             },
             [=](double t) {
+                PrecisionPoint framePoint = util::interpolate(startPoint, endPoint, t);
                 LatLng frameLatLng = {
-                    util::interpolate(startLatLng.latitude, latLng.latitude, t),
-                    util::interpolate(startLatLng.longitude, latLng.longitude, t),
+                    state.yLat(framePoint.y, startWorldSize),
+                    state.xLng(framePoint.x, startWorldSize),
                 };
                 double frameScale = util::interpolate(startScale, scale, t);
                 state.setLatLngZoom(frameLatLng, state.scaleZoom(frameScale));
@@ -257,6 +269,9 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
                 }
                 if (pitch != startPitch) {
                     state.pitch = util::interpolate(startPitch, pitch, t);
+                }
+                if (_validPoint(anchor)) {
+                    state.moveLatLng(anchorLatLng, anchor);
                 }
                 
                 // At t = 1.0, a DidChangeAnimated notification should be sent from finish().
@@ -509,29 +524,15 @@ void Transform::setAngle(double angle, const Duration& duration) {
     setAngle(angle, {NAN, NAN}, duration);
 }
 
-void Transform::setAngle(double angle, const PrecisionPoint& flippedAnchor, const Duration& duration) {
+void Transform::setAngle(double angle, const PrecisionPoint& anchor, const Duration& duration) {
     if (std::isnan(angle)) {
         return;
-    }
-
-    PrecisionPoint anchor = {
-        flippedAnchor.x,
-        state.height - flippedAnchor.y,
-    };
-    LatLng anchorLatLng;
-
-    if (flippedAnchor) {
-        anchorLatLng = state.pointToLatLng(anchor);
-        setLatLng(anchorLatLng);
     }
     
     CameraOptions camera;
     camera.angle = angle;
+    camera.anchor = anchor;
     easeTo(camera, duration);
-
-    if (flippedAnchor) {
-        setLatLng(anchorLatLng, anchor);
-    }
 }
 
 double Transform::getAngle() const {

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -25,10 +25,10 @@ public:
     bool resize(std::array<uint16_t, 2> size);
 
     void jumpTo(const CameraOptions&);
-    void easeTo(const CameraOptions&);
+    void easeTo(const CameraOptions&, const AnimationOptions&);
     /** Smoothly zoom out, pan, and zoom back into the given camera along a
         great circle, as though the viewer is aboard a supersonic jetcopter. */
-    void flyTo(const CameraOptions&);
+    void flyTo(const CameraOptions&, const AnimationOptions&);
 
     // Position
     void moveBy(const PrecisionPoint&, const Duration& = Duration::zero());
@@ -76,8 +76,7 @@ public:
 private:
     void _moveBy(const PrecisionPoint&, const Duration& = Duration::zero());
     void _setScale(double scale, const PrecisionPoint& center, const Duration& = Duration::zero());
-    void _setScaleXY(double new_scale, double xn, double yn, const Duration& = Duration::zero());
-    void _easeTo(const CameraOptions&, double new_scale, double new_angle, double xn, double yn);
+    void _easeTo(const CameraOptions&, const AnimationOptions&, double new_scale, double new_angle, double xn, double yn);
     void _setAngle(double angle, const Duration& = Duration::zero());
 
     View &view;

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -26,28 +26,54 @@ public:
 
     void jumpTo(const CameraOptions&);
     void easeTo(const CameraOptions&, const AnimationOptions& = {});
-    /** Smoothly zoom out, pan, and zoom back into the given camera along a
+    /** Smoothly zooms out, pan, and zoom back into the given camera along a
         great circle, as though the viewer is aboard a supersonic jetcopter. */
     void flyTo(const CameraOptions&, const AnimationOptions& = {});
 
     // Position
-    void moveBy(const PrecisionPoint&, const Duration& = Duration::zero());
+    
+    /** Pans the map by the given amount.
+        @param offset The distance to pan the map by, measured in pixels from
+            top to bottom and from left to right. */
+    void moveBy(const PrecisionPoint& offset, const Duration& = Duration::zero());
     void setLatLng(const LatLng&, const Duration& = Duration::zero());
     void setLatLng(const LatLng&, const PrecisionPoint&, const Duration& = Duration::zero());
     void setLatLngZoom(const LatLng&, double zoom, const Duration& = Duration::zero());
     LatLng getLatLng() const { return state.getLatLng(); }
 
     // Zoom
-    void scaleBy(double ds, const PrecisionPoint& center = {NAN, NAN}, const Duration& = Duration::zero());
-    void setScale(double scale, const PrecisionPoint& center = {NAN, NAN}, const Duration& = Duration::zero());
+
+    /** Scales the map, keeping the given point fixed within the view.
+        @param ds The difference in scale factors to scale the map by.
+        @param anchor A point relative to the top-left corner of the view. */
+    void scaleBy(double ds, const PrecisionPoint& anchor = {NAN, NAN}, const Duration& = Duration::zero());
+    /** Sets the scale factor, keeping the given point fixed within the view.
+        @param scale The new scale factor.
+        @param anchor A point relative to the top-left corner of the view. */
+    void setScale(double scale, const PrecisionPoint& anchor = {NAN, NAN}, const Duration& = Duration::zero());
+    /** Sets the zoom level.
+        @param zoom The new zoom level. */
     void setZoom(double zoom, const Duration& = Duration::zero());
+    /** Returns the zoom level. */
     double getZoom() const;
+    /** Returns the scale factor. */
     double getScale() const;
 
     // Angle
+
     void rotateBy(const PrecisionPoint& first, const PrecisionPoint& second, const Duration& = Duration::zero());
+    /** Sets the angle of rotation.
+        @param angle The new angle of rotation, measured in radians
+            counterclockwise from true north. */
     void setAngle(double angle, const Duration& = Duration::zero());
-    void setAngle(double angle, const PrecisionPoint& center, const Duration& = Duration::zero());
+    /** Sets the angle of rotation, keeping the given point fixed within the view.
+        @param angle The new angle of rotation, measured in radians
+            counterclockwise from true north.
+        @param anchor A point relative to the top-left corner of the view. */
+    void setAngle(double angle, const PrecisionPoint& anchor, const Duration& = Duration::zero());
+    /** Returns the angle of rotation.
+        @return The angle of rotation, measured in radians counterclockwise from
+            true north. */
     double getAngle() const;
 
     // Pitch

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -24,10 +24,16 @@ public:
     // Map view
     bool resize(std::array<uint16_t, 2> size);
 
+    // Camera
+    
+    /** Instantaneously, synchronously applies the given camera options. */
     void jumpTo(const CameraOptions&);
+    /** Asynchronously transitions all specified camera options linearly along
+        an optional time curve. */
     void easeTo(const CameraOptions&, const AnimationOptions& = {});
-    /** Smoothly zooms out, pan, and zoom back into the given camera along a
-        great circle, as though the viewer is aboard a supersonic jetcopter. */
+    /** Asynchronously zooms out, pans, and zooms back into the given camera
+        along a great circle, as though the viewer is riding a supersonic
+        jetcopter. */
     void flyTo(const CameraOptions&, const AnimationOptions& = {});
 
     // Position

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -100,6 +100,8 @@ public:
     bool isPanning() const { return state.isPanning(); }
 
 private:
+    void moveLatLng(const LatLng&, const PrecisionPoint&);
+    
     View &view;
 
     TransformState state;

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -25,10 +25,10 @@ public:
     bool resize(std::array<uint16_t, 2> size);
 
     void jumpTo(const CameraOptions&);
-    void easeTo(const CameraOptions&, const AnimationOptions&);
+    void easeTo(const CameraOptions&, const AnimationOptions& = {});
     /** Smoothly zoom out, pan, and zoom back into the given camera along a
         great circle, as though the viewer is aboard a supersonic jetcopter. */
-    void flyTo(const CameraOptions&, const AnimationOptions&);
+    void flyTo(const CameraOptions&, const AnimationOptions& = {});
 
     // Position
     void moveBy(const PrecisionPoint&, const Duration& = Duration::zero());
@@ -38,8 +38,8 @@ public:
     LatLng getLatLng() const { return state.getLatLng(); }
 
     // Zoom
-    void scaleBy(double ds, const PrecisionPoint& center = { 0, 0 }, const Duration& = Duration::zero());
-    void setScale(double scale, const PrecisionPoint& center = { 0, 0 }, const Duration& = Duration::zero());
+    void scaleBy(double ds, const PrecisionPoint& center = {NAN, NAN}, const Duration& = Duration::zero());
+    void setScale(double scale, const PrecisionPoint& center = {NAN, NAN}, const Duration& = Duration::zero());
     void setZoom(double zoom, const Duration& = Duration::zero());
     double getZoom() const;
     double getScale() const;
@@ -47,7 +47,7 @@ public:
     // Angle
     void rotateBy(const PrecisionPoint& first, const PrecisionPoint& second, const Duration& = Duration::zero());
     void setAngle(double angle, const Duration& = Duration::zero());
-    void setAngle(double angle, const PrecisionPoint& center);
+    void setAngle(double angle, const PrecisionPoint& center, const Duration& = Duration::zero());
     double getAngle() const;
 
     // Pitch
@@ -74,11 +74,6 @@ public:
     bool isPanning() const { return state.isPanning(); }
 
 private:
-    void _moveBy(const PrecisionPoint&, const Duration& = Duration::zero());
-    void _setScale(double scale, const PrecisionPoint& center, const Duration& = Duration::zero());
-    void _easeTo(const CameraOptions&, const AnimationOptions&, double new_scale, double new_angle, double xn, double yn);
-    void _setAngle(double angle, const Duration& = Duration::zero());
-
     View &view;
 
     TransformState state;

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -106,16 +106,16 @@ public:
     bool isPanning() const { return state.isPanning(); }
 
 private:
-    void moveLatLng(const LatLng&, const PrecisionPoint&);
+    void unwrapLatLng(LatLng&);
     
     View &view;
 
     TransformState state;
 
-    void startTransition(std::function<double(double)> easing,
-                         std::function<Update(double)> frame,
-                         std::function<void()> finish,
-                         const Duration& duration);
+    void startTransition(const CameraOptions&,
+                         const AnimationOptions&,
+                         std::function<Update(double)>,
+                         const Duration&);
 
     TimePoint transitionStart;
     Duration transitionDuration;

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -396,5 +396,3 @@ void TransformState::setScalePoint(const double newScale, const PrecisionPoint &
     Bc = worldSize() / 360;
     Cc = worldSize() / util::M2PI;
 }
-
-

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -369,6 +369,26 @@ void TransformState::constrain(double& scale_, double& x_, double& y_) const {
     y_ = std::max(-max_y, std::min(y_, max_y));
 }
 
+void TransformState::moveLatLng(const LatLng& latLng, const PrecisionPoint& anchor) {
+    if (!latLng || !anchor) {
+        return;
+    }
+    
+    auto coord = latLngToCoordinate(latLng);
+    auto coordAtPoint = pointToCoordinate(anchor);
+    auto coordCenter = pointToCoordinate({ width / 2.0f, height / 2.0f });
+    
+    float columnDiff = coordAtPoint.column - coord.column;
+    float rowDiff = coordAtPoint.row - coord.row;
+    
+    auto newLatLng = coordinateToLatLng({
+        coordCenter.column - columnDiff,
+        coordCenter.row - rowDiff,
+        coordCenter.zoom
+    });
+    setLatLngZoom(newLatLng, coordCenter.zoom);
+}
+
 void TransformState::setLatLngZoom(const LatLng &latLng, double zoom) {
     double newScale = zoomScale(zoom);
     const double newWorldSize = newScale * util::tileSize;

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -248,8 +248,8 @@ double TransformState::scaleZoom(double s) const {
     return ::log2(s);
 }
 
-float TransformState::worldSize() const {
-    return util::tileSize * scale;
+double TransformState::worldSize() const {
+    return scale * util::tileSize;
 }
 
 PrecisionPoint TransformState::latLngToPoint(const LatLng& latLng) const {

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -101,8 +101,11 @@ private:
     mat4 coordinatePointMatrix(double z) const;
     mat4 getPixelMatrix() const;
     
+    /** Recenter the map so that the given coordinate is located at the given
+        point on screen. */
+    void moveLatLng(const LatLng&, const PrecisionPoint&);
     void setLatLngZoom(const LatLng &latLng, double zoom);
-    void setScalePoint(const double scale, const PrecisionPoint &point);
+    void setScalePoint(const double scale, const PrecisionPoint& point);
 
 private:
     ConstrainMode constrainMode;

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -96,7 +96,7 @@ private:
     double latY(double lat) const;
     double zoomScale(double zoom) const;
     double scaleZoom(double scale) const;
-    float worldSize() const;
+    double worldSize() const;
 
     mat4 coordinatePointMatrix(double z) const;
     mat4 getPixelMatrix() const;

--- a/test/miscellaneous/transform.cpp
+++ b/test/miscellaneous/transform.cpp
@@ -177,3 +177,28 @@ TEST(Transform, ConstrainWidthAndHeight) {
     ASSERT_NEAR(85.021422866378742, loc.latitude, 0.0001);
     ASSERT_NEAR(179.65667724609358, std::abs(loc.longitude), 0.0001);
 }
+
+TEST(Transform, Anchor) {
+    MockView view;
+    Transform transform(view, ConstrainMode::HeightOnly);
+
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(1, transform.getScale());
+
+    transform.setLatLngZoom({ 10, -100 }, 10);
+
+    ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(-100, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(10, transform.getZoom());
+    ASSERT_DOUBLE_EQ(0, transform.getAngle());
+
+    const auto size = view.getSize();
+    const PrecisionPoint anchorPoint = { size[0] * 0.8, size[1] * 0.3 };
+    const LatLng anchorLatLng = transform.getState().pointToLatLng(anchorPoint);
+    transform.setAngle(M_PI_4, anchorPoint);
+
+    ASSERT_NEAR(M_PI_4, transform.getAngle(), 0.000001);
+    ASSERT_NE(anchorLatLng, transform.getLatLng());
+    ASSERT_DOUBLE_EQ(anchorLatLng, transform.getState().pointToLatLng(anchorPoint));
+}


### PR DESCRIPTION
This PR cleans up `Transform` considerably, making it easier to implement #2600 at this low level:

* `CameraOptions` only describes the destination viewpoint now. `AnimationOptions` describes the transition to that destination viewpoint.
* Eliminated many redundant methods on `Transform`.
* Minimized usage of `TransformState::x` and `TransformState::y`.
* Added convenience constructors for `AnimationOptions`. When scaling, passing in view’s origin as the anchor no longer anchors the scaling operation at the view’s center. To specify no anchor, use `NaN` instead of 0.
* Corrected `setBearing()` to assume an origin at the upper-left corner of the view rather than the lower-left corner.
* Added an `anchor` option to `CameraOptions` that pins a coordinate to a point within the view throughout a zoom, rotation, or tilt. This option is useful for ensuring that a pinch or rotation gesture is revolves around the gesture rather than the view’s center point. However, all the platform frontends currently use convenience methods for this purpose anyways.
* Easing across the antimeridian now travels the short way around the globe (see #3355).

/cc @tmpsantos @zugaldia