### PR TITLE
[core] Do not make a copy of the TransformState all the time

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -71,7 +71,6 @@ public:
 
     Map::StillImageCallback callback;
     size_t sourceCacheSize;
-    TransformState transformState;
     TimePoint timePoint;
     bool loading = false;
 };
@@ -147,9 +146,7 @@ void Map::update(Update flags) {
         impl->transform.resize(impl->view.getSize());
     }
 
-    impl->transformState = impl->transform.getState();
     impl->updateFlags |= flags;
-
     impl->asyncUpdate.send();
 }
 
@@ -214,13 +211,13 @@ void Map::Impl::update() {
     }
 
     if (updateFlags & Update::Classes || updateFlags & Update::RecalculateStyle) {
-        style->recalculate(transformState.getZoom(), timePoint, mode);
+        style->recalculate(transform.getZoom(), timePoint, mode);
     }
 
     StyleUpdateParameters parameters(pixelRatio,
                                      debugOptions,
                                      timePoint,
-                                     transformState,
+                                     transform.getState(),
                                      style->workers,
                                      fileSource,
                                      *texturePool,
@@ -243,10 +240,8 @@ void Map::Impl::update() {
 }
 
 void Map::Impl::render() {
-    transformState = transform.getState();
-
     if (!painter) {
-        painter = std::make_unique<Painter>(transformState, glObjectStore);
+        painter = std::make_unique<Painter>(transform.getState(), glObjectStore);
     }
 
     FrameData frameData { view.getFramebufferSize(),

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -147,7 +147,7 @@ public:
     bool isGestureInProgress() const { return state.isGestureInProgress(); }
 
     // Transform state
-    TransformState getState() const { return state; }
+    const TransformState& getState() const { return state; }
     bool isRotating() const { return state.isRotating(); }
     bool isScaling() const { return state.isScaling(); }
     bool isPanning() const { return state.isPanning(); }

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -42,7 +42,7 @@
 
 using namespace mbgl;
 
-Painter::Painter(TransformState& state_, gl::GLObjectStore& glObjectStore_)
+Painter::Painter(const TransformState& state_, gl::GLObjectStore& glObjectStore_)
     : state(state_),
       glObjectStore(glObjectStore_) {
     gl::debugging::enable();

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -83,7 +83,7 @@ struct FrameData {
 
 class Painter : private util::noncopyable {
 public:
-    Painter(TransformState&, gl::GLObjectStore&);
+    Painter(const TransformState&, gl::GLObjectStore&);
     ~Painter();
 
     void render(const Style& style,
@@ -155,7 +155,7 @@ private:
         return identity;
     }();
 
-    TransformState& state;
+    const TransformState& state;
     gl::GLObjectStore& glObjectStore;
 
     FrameData frame;


### PR DESCRIPTION
Return a const ref instead. We use this mostly for:

```
return transform->getState().getMinZoom();
return transform->getState().getMaxZoom();
return transform->getState().getWidth();
return transform->getState().getHeight();
return transform->getState().latLngToPoint(latLng);
return transform->getState().pointToLatLng(pixel);
```

And when passing it on `::invoke()` it gets copied when packing the arguments.