### PR TITLE
Fix error in Xcode 7.3 build

### DIFF
--- a/include/mbgl/osx/MGLMapView.h
+++ b/include/mbgl/osx/MGLMapView.h
@@ -69,7 +69,7 @@ IB_DESIGNABLE
     
     @param frame The frame for the view, measured in points.
     @return An initialized map view. */
-- (instancetype)initWithFrame:(CGRect)frame;
+- (instancetype)initWithFrame:(NSRect)frame;
 
 /** Initializes and returns a newly allocated map view with the specified frame
     and style URL.
@@ -80,7 +80,7 @@ IB_DESIGNABLE
         (`mapbox://styles/<user>/<style>`), or a path to a local file relative
         to the application’s resource path. Specify `nil` for the default style.
     @return An initialized map view. */
-- (instancetype)initWithFrame:(CGRect)frame styleURL:(nullable NSURL *)styleURL;
+- (instancetype)initWithFrame:(NSRect)frame styleURL:(nullable NSURL *)styleURL;
 
 #pragma mark Accessing the delegate
 /** @name Accessing the Delegate */

--- a/platform/darwin/MGLMapCamera.mm
+++ b/platform/darwin/MGLMapCamera.mm
@@ -95,7 +95,7 @@
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<%@ %p centerCoordinate:%f, %f altitude:%.0fm heading:%.0f° pitch:%.0f°>",
-            NSStringFromClass([self class]), self, _centerCoordinate.latitude, _centerCoordinate.longitude, _altitude, _heading, _pitch];
+            NSStringFromClass([self class]), (void *)self, _centerCoordinate.latitude, _centerCoordinate.longitude, _altitude, _heading, _pitch];
 }
 
 - (BOOL)isEqual:(id)other

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -200,7 +200,7 @@ public:
     return self;
 }
 
-- (instancetype)initWithFrame:(CGRect)frame styleURL:(nullable NSURL *)styleURL {
+- (instancetype)initWithFrame:(NSRect)frame styleURL:(nullable NSURL *)styleURL {
     if (self = [super initWithFrame:frame]) {
         [self commonInit];
         self.styleURL = styleURL;


### PR DESCRIPTION
Fixed a compiler error that’s new in Xcode 7.3. Also corrected a typo in MGLMapView on OS X.