### PR TITLE
Test fail with "terminating with uncaught exception of type std::runtime_error: Failed to close loop."

### DIFF
--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -41,6 +41,9 @@ public:
     void runOnce();
     void stop();
 
+    void ref();
+    void unref();
+
     // So far only needed by the libcurl backend.
     void addWatch(int fd, Event, std::function<void(int, Event)>&& callback);
     void removeWatch(int fd);

--- a/test/miscellaneous/run_loop.cpp
+++ b/test/miscellaneous/run_loop.cpp
@@ -1,0 +1,75 @@
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/timer.hpp>
+
+#include "../fixtures/util.hpp"
+
+using namespace mbgl::util;
+
+TEST(RunLoop, Stop) {
+    RunLoop loop(RunLoop::Type::New);
+
+    Timer timer;
+    timer.start(mbgl::Duration::zero(), mbgl::Duration::zero(), [&] {
+        loop.stop();
+    });
+
+    loop.run();
+}
+
+TEST(RunLoop, MultipleStop) {
+    RunLoop loop(RunLoop::Type::New);
+
+    Timer timer;
+    timer.start(mbgl::Duration::zero(), mbgl::Duration::zero(), [&] {
+        loop.stop();
+        loop.stop();
+        loop.stop();
+        loop.stop();
+    });
+
+    loop.run();
+}
+
+TEST(RunLoop, UnrefShouldStop) {
+    RunLoop loop(RunLoop::Type::New);
+
+    Timer timer;
+    timer.start(mbgl::Duration::zero(), mbgl::Duration::zero(), [&] {
+        loop.unref();
+    });
+
+    loop.run();
+}
+
+TEST(RunLoop, RefUnref) {
+    RunLoop loop(RunLoop::Type::New);
+
+    Timer timer;
+    auto zero = mbgl::Duration::zero();
+
+    auto cb3 = [&] {
+        loop.stop();
+    };
+
+    auto cb2 = [&] {
+        loop.unref();
+        loop.unref();
+
+        loop.ref();
+
+        timer.start(zero, zero, cb3);
+    };
+
+    auto cb1 = [&] {
+        loop.ref();
+        loop.ref();
+
+        loop.unref();
+
+        timer.start(zero, zero, cb2);
+    };
+
+    timer.start(zero, zero, cb1);
+
+    loop.run();
+}

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -57,6 +57,7 @@
         'miscellaneous/mapbox.cpp',
         'miscellaneous/merge_lines.cpp',
         'miscellaneous/style_parser.cpp',
+        'miscellaneous/run_loop.cpp',
         'miscellaneous/text_conversions.cpp',
         'miscellaneous/thread.cpp',
         'miscellaneous/thread_local.cpp',


### PR DESCRIPTION
```
[ RUN      ] Storage.HTTPLoad
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: Failed to close loop.
./scripts/run_tests.sh: line 32: 96090 Abort trap: 6           (core dumped) ${CMD}
make[1]: *** [test-Storage.HTTPLoad] Error 134
make: *** [test-Storage.HTTPLoad] Error 2
```

Presumably related to d7fdcc73bfcab39f63e547ce2af8435a9859cb08.

cc @tmpsantos 