### PR TITLE
Fix build error in Xcode 7.3

### DIFF
--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -237,7 +237,7 @@ std::unique_ptr<SourceInfo> StyleParser::parseTileJSON(const JSValue& value) {
     parseTileJSONMember(value, info->attribution, "attribution");
     parseTileJSONMember(value, info->center, "center");
     parseTileJSONMember(value, info->bounds, "bounds");
-    return std::move(info);
+    return info;
 }
 
 void StyleParser::parseLayers(const JSValue& value) {


### PR DESCRIPTION
This PR removes a `std::move()` call, as suggested by Xcode’s fix-it feature. Xcode 7.3 beta 1 fails to compile this code with the following error:

```
/path/to/mapbox-gl-native/src/mbgl/style/style_parser.cpp
/path/to/mapbox-gl-native/src/mbgl/style/style_parser.cpp:240:12: Moving a local object in a return statement prevents copy elision
/path/to/mapbox-gl-native/src/mbgl/style/style_parser.cpp:240:12: Remove std::move call here
```

/ref #3480
/cc @kkaefer