### PR TITLE
place symbol layers in correct order

### DIFF
--- a/src/mbgl/layer/symbol_layer.cpp
+++ b/src/mbgl/layer/symbol_layer.cpp
@@ -177,8 +177,7 @@ std::unique_ptr<Bucket> SymbolLayer::createBucket(StyleBucketParameters& paramet
         bucket->addFeatures(parameters.tileUID,
                             *spriteAtlas,
                             parameters.glyphAtlas,
-                            parameters.glyphStore,
-                            parameters.collisionTile);
+                            parameters.glyphStore);
     }
 
     return std::move(bucket);

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -53,7 +53,7 @@ public:
                                    const GeometryTile&,
                                    PlacementConfig);
 
-    TileParseResult parsePendingLayers();
+    TileParseResult parsePendingLayers(PlacementConfig);
 
     void redoPlacement(const std::unordered_map<std::string, std::unique_ptr<Bucket>>*,
                        PlacementConfig);
@@ -61,6 +61,7 @@ public:
 private:
     void parseLayer(const StyleLayer*, const GeometryTile&);
     void insertBucket(const std::string& name, std::unique_ptr<Bucket>);
+    void placeLayers(PlacementConfig);
 
     const TileID id;
     const std::string sourceID;
@@ -74,11 +75,14 @@ private:
     bool partialParse = false;
 
     std::vector<std::unique_ptr<StyleLayer>> layers;
-    std::unique_ptr<CollisionTile> collisionTile;
 
     // Contains buckets that we couldn't parse so far due to missing resources.
     // They will be attempted on subsequent parses.
     std::list<std::pair<const SymbolLayer*, std::unique_ptr<Bucket>>> pending;
+
+    // Contains buckets that have been parsed, but still need placement.
+    // They will be placed when all buckets have been parsed.
+    std::unordered_map<std::string, std::unique_ptr<Bucket>> placementPending;
 
     // Temporary holder
     TileParseResultBuckets result;

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -102,7 +102,7 @@ bool VectorTileData::parsePending(std::function<void()> callback) {
     }
 
     workRequest.reset();
-    workRequest = worker.parsePendingGeometryTileLayers(tileWorker, [this, callback] (TileParseResult result) {
+    workRequest = worker.parsePendingGeometryTileLayers(tileWorker, targetConfig, [this, callback, config = targetConfig] (TileParseResult result) {
         workRequest.reset();
         if (state == State::obsolete) {
             return;
@@ -117,6 +117,10 @@ bool VectorTileData::parsePending(std::function<void()> callback) {
             for (auto& bucket : resultBuckets.buckets) {
                 buckets[bucket.first] = std::move(bucket.second);
             }
+
+            // Persist the configuration we just placed so that we can later check whether we need to
+            // place again in case the configuration has changed.
+            placedConfig = config;
 
             // The target configuration could have changed since we started placement. In this case,
             // we're starting another placement run.

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -173,8 +173,7 @@ bool SymbolBucket::needsDependencies(GlyphStore& glyphStore, SpriteStore& sprite
 void SymbolBucket::addFeatures(uintptr_t tileUID,
                                SpriteAtlas& spriteAtlas,
                                GlyphAtlas& glyphAtlas,
-                               GlyphStore& glyphStore,
-                               CollisionTile& collisionTile) {
+                               GlyphStore& glyphStore) {
     float horizontalAlign = 0.5;
     float verticalAlign = 0.5;
 
@@ -266,8 +265,6 @@ void SymbolBucket::addFeatures(uintptr_t tileUID,
     }
 
     features.clear();
-
-    placeFeatures(collisionTile, true);
 }
 
 
@@ -358,10 +355,6 @@ bool SymbolBucket::anchorIsTooClose(const std::u32string &text, const float repe
 }
 
 void SymbolBucket::placeFeatures(CollisionTile& collisionTile) {
-    placeFeatures(collisionTile, false);
-}
-
-void SymbolBucket::placeFeatures(CollisionTile& collisionTile, bool swapImmediately) {
 
     renderDataInProgress = std::make_unique<SymbolRenderData>();
 
@@ -448,8 +441,6 @@ void SymbolBucket::placeFeatures(CollisionTile& collisionTile, bool swapImmediat
     if (collisionTile.config.debug) {
         addToDebugBuffers(collisionTile);
     }
-
-    if (swapImmediately) swapRenderData();
 }
 
 template <typename Buffer, typename GroupType>

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -79,8 +79,7 @@ public:
     void addFeatures(uintptr_t tileUID,
                      SpriteAtlas&,
                      GlyphAtlas&,
-                     GlyphStore&,
-                     CollisionTile&);
+                     GlyphStore&);
 
     void drawGlyphs(SDFShader& shader);
     void drawIcons(SDFShader& shader);
@@ -101,7 +100,6 @@ private:
     
     void addToDebugBuffers(CollisionTile &collisionTile);
 
-    void placeFeatures(CollisionTile& collisionTile, bool swapImmediately);
     void swapRenderData() override;
 
     // Adds placed items to the buffer.

--- a/src/mbgl/style/style_bucket_parameters.hpp
+++ b/src/mbgl/style/style_bucket_parameters.hpp
@@ -27,7 +27,6 @@ public:
                           SpriteStore& spriteStore_,
                           GlyphAtlas& glyphAtlas_,
                           GlyphStore& glyphStore_,
-                          CollisionTile& collisionTile_,
                           const MapMode mode_)
         : tileID(tileID_),
           layer(layer_),
@@ -37,7 +36,6 @@ public:
           spriteStore(spriteStore_),
           glyphAtlas(glyphAtlas_),
           glyphStore(glyphStore_),
-          collisionTile(collisionTile_),
           mode(mode_) {}
 
     bool cancelled() const {
@@ -54,7 +52,6 @@ public:
     SpriteStore& spriteStore;
     GlyphAtlas& glyphAtlas;
     GlyphStore& glyphStore;
-    CollisionTile& collisionTile;
     const MapMode mode;
 };
 

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -39,9 +39,10 @@ public:
     }
 
     void parsePendingGeometryTileLayers(TileWorker* worker,
+                                        PlacementConfig config,
                                         std::function<void(TileParseResult)> callback) {
         try {
-            callback(worker->parsePendingLayers());
+            callback(worker->parsePendingLayers(config));
         } catch (...) {
             callback(std::current_exception());
         }
@@ -87,10 +88,11 @@ Worker::parseGeometryTile(TileWorker& worker,
 
 std::unique_ptr<WorkRequest>
 Worker::parsePendingGeometryTileLayers(TileWorker& worker,
+                                       PlacementConfig config,
                                        std::function<void(TileParseResult)> callback) {
     current = (current + 1) % threads.size();
     return threads[current]->invokeWithCallback(&Worker::Impl::parsePendingGeometryTileLayers,
-                                                callback, &worker);
+                                                callback, &worker, config);
 }
 
 std::unique_ptr<WorkRequest>

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -46,6 +46,7 @@ public:
                               std::function<void(TileParseResult)> callback);
 
     Request parsePendingGeometryTileLayers(TileWorker&,
+                                           PlacementConfig config,
                                            std::function<void(TileParseResult)> callback);
 
     Request redoPlacement(TileWorker&,


### PR DESCRIPTION
Previously, the placement of symbol layers depended on the order in which the glyphs they need were loaded. The placement order should be based on the style.

To fix this, symbol layers are placed in `placementPending` after they are parsed. After all layers are parsed, symbol layers (stored in `placementPending`) are placed and returned.

@kkaefer can you review this?