### PR TITLE
Support multiple paths in SharedSQLiteCache::get

### DIFF
--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -22,7 +22,7 @@ class DefaultFileSource::Impl {
 public:
     Impl(const std::string& cachePath, const std::string& assetRoot)
         : assetFileSource(assetRoot),
-          cache(SharedSQLiteCache::get(cachePath)),
+          cache(SQLiteCache::getShared(cachePath)),
           onlineFileSource(cache.get()) {
     }
 

--- a/platform/default/sqlite_cache.cpp
+++ b/platform/default/sqlite_cache.cpp
@@ -472,7 +472,7 @@ void SQLiteCache::Impl::refresh(const Resource& resource, Seconds expires) {
     }
 }
 
-std::shared_ptr<SQLiteCache> SharedSQLiteCache::get(const std::string &path) {
+std::shared_ptr<SQLiteCache> SQLiteCache::getShared(const std::string &path) {
     std::shared_ptr<SQLiteCache> temp = masterPtr.lock();
     if (!temp) {
         temp.reset(new SQLiteCache(path));
@@ -482,6 +482,6 @@ std::shared_ptr<SQLiteCache> SharedSQLiteCache::get(const std::string &path) {
     return temp;
 }
 
-std::weak_ptr<SQLiteCache> SharedSQLiteCache::masterPtr;
+std::weak_ptr<SQLiteCache> SQLiteCache::masterPtr;
 
 } // namespace mbgl

--- a/src/mbgl/storage/sqlite_cache.hpp
+++ b/src/mbgl/storage/sqlite_cache.hpp
@@ -20,6 +20,8 @@ template <typename T> class Thread;
 
 class SQLiteCache : private util::noncopyable {
 public:
+    static std::shared_ptr<SQLiteCache> getShared(const std::string &path = ":memory:");
+
     SQLiteCache(const std::string &path = ":memory:");
     ~SQLiteCache();
 
@@ -35,15 +37,6 @@ public:
 
 private:
     const std::unique_ptr<util::Thread<Impl>> thread;
-};
-
-class SharedSQLiteCache : util::noncopyable {
-public:
-    static std::shared_ptr<SQLiteCache> get(const std::string &path = ":memory:");
-
-private:
-    SharedSQLiteCache() {}
-
     static std::weak_ptr<SQLiteCache> masterPtr;
 };
 

--- a/src/mbgl/storage/sqlite_cache.hpp
+++ b/src/mbgl/storage/sqlite_cache.hpp
@@ -37,7 +37,6 @@ public:
 
 private:
     const std::unique_ptr<util::Thread<Impl>> thread;
-    static std::weak_ptr<SQLiteCache> masterPtr;
 };
 
 } // namespace mbgl

--- a/test/storage/cache_shared.cpp
+++ b/test/storage/cache_shared.cpp
@@ -1,0 +1,34 @@
+#include "storage.hpp"
+
+#include <mbgl/storage/sqlite_cache.hpp>
+#include <mbgl/storage/resource.hpp>
+#include <mbgl/util/run_loop.hpp>
+
+TEST_F(Storage, CacheShared) {
+    SCOPED_TEST(CacheShared)
+    using namespace mbgl;
+
+    util::RunLoop loop;
+
+    // Check that we're getting two different caches when we request different paths.
+    auto memory = SQLiteCache::getShared();
+    auto file = SQLiteCache::getShared("test/fixtures/database/cache.db");
+    EXPECT_NE(memory.get(), file.get());
+    EXPECT_EQ(memory.get(), SQLiteCache::getShared().get());
+
+    // Store a response into the memory file cache, then delete the last reference.
+    const Resource resource { Resource::Kind::Unknown, "http://example.com" };
+    memory->put(resource, Response());
+    memory.reset();
+
+    // Now check that the original memory file cache has been destructed and that it doesn't contain
+    // the information we put into it.
+    memory = SQLiteCache::getShared();
+    auto req = memory->get(resource, [&](std::unique_ptr<Response> res) {
+        EXPECT_FALSE(res.get());
+        CacheShared.finish();
+        loop.stop();
+    });
+
+    loop.run();
+}

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -70,6 +70,7 @@
         'storage/storage.cpp',
         'storage/cache_response.cpp',
         'storage/cache_revalidate.cpp',
+        'storage/cache_shared.cpp',
         'storage/cache_size.cpp',
         'storage/database.cpp',
         'storage/asset_file_source.cpp',


### PR DESCRIPTION
We're currently only supporting one path, and calling this function will always return the same cache, as long as it's held elsewhere. That means subsequent requests won't necessarily honor the path passed to `SharedSQLiteCache::get()`.