### PR TITLE
[core] ResourceLoading.Success and Transform.InvalidScale crashing

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -539,8 +539,11 @@ void Transform::startTransition(const CameraOptions& camera,
             view.notifyMapChange(MapChangeRegionIsChanging);
         } else {
             transitionFinishFn();
-            transitionFrameFn = nullptr;
             transitionFinishFn = nullptr;
+
+            // This callback gets destroyed here,
+            // we can only return after this point.
+            transitionFrameFn = nullptr;
         }
         return result;
     };


### PR DESCRIPTION
Crashing at the same line. Seems to be a race of the callback firing with an invalid `this` on the lambda. /cc @1ec5 

```
Program received signal SIGSEGV, Segmentation fault.
mbgl::Transform::<lambda(mbgl::TimePoint)>::operator() (now=..., __closure=0xc5c7a0) at ../../src/mbgl/map/transform.cpp:543
543	            transitionFinishFn = nullptr;

Thread 257 (Thread 0x7fff577f6700 (LWP 23998)):
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x000000000086581a in uv__epoll_wait (epfd=<optimized out>, events=<optimized out>, nevents=<optimized out>, timeout=<optimized out>) at src/unix/linux-syscalls.c:321
#2  0x0000000000863f02 in uv__io_poll (loop=0x7fffa4000bd0, timeout=-1) at src/unix/linux-core.c:243
#3  0x000000000085b163 in uv_run (loop=0x7fffa4000bd0, mode=mode@entry=UV_RUN_DEFAULT) at src/unix/core.c:341
#4  0x0000000000689a4e in mbgl::util::RunLoop::run (this=this@entry=0x7fff577f5e00) at ../../platform/default/run_loop.cpp:154
#5  0x0000000000632e93 in mbgl::util::Thread<mbgl::Worker::Impl>::run<std::tuple<>>(mbgl::util::ThreadContext, std::tuple<>&&, std::integer_sequence<unsigned long>) (params=<optimized out>, context=<error reading variable: access outside bounds of object referenced via synthetic pointer>, this=0xc5c550) at ../../src/mbgl/util/thread.hpp:124
#6  mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::{lambda()#1}::operator()() const (__closure=<optimized out>) at ../../src/mbgl/util/thread.hpp:106
#7  std::_Bind_simple<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::{lambda()#1} ()>::_M_invoke<>(std::_Index_tuple<>) (this=<optimized out>) at /usr/include/c++/5/functional:1531
#8  std::_Bind_simple<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::{lambda()#1} ()>::operator()() (this=<optimized out>) at /usr/include/c++/5/functional:1520
#9  std::thread::_Impl<std::_Bind_simple<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::{lambda()#1} ()> >::_M_run() (this=<optimized out>) at /usr/include/c++/5/thread:115
#10 0x00007ffff6783d10 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#11 0x00007ffff7bc266a in start_thread (arg=0x7fff577f6700) at pthread_create.c:333
#12 0x00007ffff61f0e4d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```