### PR TITLE
Fix static analyzer warnings in Xcode 7.3

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -734,7 +734,7 @@ IB_DESIGNABLE
  @param annotation The annotation object to deselect.
  @param animated If `YES`, the callout view is animated offscreen.
  */
-- (void)deselectAnnotation:(id <MGLAnnotation>)annotation animated:(BOOL)animated;
+- (void)deselectAnnotation:(nullable id <MGLAnnotation>)annotation animated:(BOOL)animated;
 
 #pragma mark Overlaying the Map
 

--- a/include/mbgl/osx/MGLMapView.h
+++ b/include/mbgl/osx/MGLMapView.h
@@ -442,7 +442,7 @@ IB_DESIGNABLE
 /** Deselects an annotation and hides its callout popover.
     
     @param annotation The annotation object to deselect. */
-- (void)deselectAnnotation:(id <MGLAnnotation>)annotation;
+- (void)deselectAnnotation:(nullable id <MGLAnnotation>)annotation;
 
 /** A common view controller for managing a callout popover’s content view.
     

--- a/platform/ios/src/MGLCategoryLoader.m
+++ b/platform/ios/src/MGLCategoryLoader.m
@@ -18,7 +18,7 @@
 
     // https://github.com/mapbox/mapbox-gl-native/issues/3113
     //
-    NSString *description = [MGLMapView description];
+    [MGLMapView description];
 }
 
 @end

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1929,7 +1929,7 @@ public:
 
 - (void)popoverDidShow:(__unused NSNotification *)notification {
     id <MGLAnnotation> annotation = self.selectedAnnotation;
-    if ([self.delegate respondsToSelector:@selector(mapView:didSelectAnnotation:)]) {
+    if (annotation && [self.delegate respondsToSelector:@selector(mapView:didSelectAnnotation:)]) {
         [self.delegate mapView:self didSelectAnnotation:annotation];
     }
 }


### PR DESCRIPTION
This PR fixes the following static analyzer warnings reported by Xcode 7.3 beta 1 when building iosapp:

```
/path/to/mapbox-gl-native/platform/ios/src/MGLCategoryLoader.m
/path/to/mapbox-gl-native/platform/ios/src/MGLCategoryLoader.m:21:15: Value stored to 'description' during its initialization is never read
/path/to/mapbox-gl-native/platform/ios/src/MGLCategoryLoader.m:21:15: Value stored to 'description' during its initialization is never read
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:1197:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:1197:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:1375:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:1375:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:1389:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:1389:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:2562:39: Array element cannot be nil
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:2562:39: Array element cannot be nil
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:2592:5: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:2584:10: Assuming 'annotation' is non-nil
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:2592:5: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:3196:13: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:1326:9: Calling 'notifyGestureDidBegin'
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:931:1: Entered call from 'handleTwoFingerDragGesture:'
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:932:5: Calling 'notifyMapChange:'
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:3184:1: Entered call from 'notifyGestureDidBegin'
/path/to/mapbox-gl-native/platform/ios/src/MGLMapView.mm:3196:13: Null passed to a callee that requires a non-null argument
```

and osxapp:

```
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:544:5: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:544:5: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1206:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1206:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1767:5: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1199:9: Assuming 'hitAnnotationTag' is not equal to MGLAnnotationTagNotFound
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1202:13: Assuming 'annotation' is non-nil
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1203:13: Calling 'selectAnnotation:'
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1754:1: Entered call from 'handleClickGesture:'
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1761:5: 'selectedAnnotation' initialized to nil
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1767:5: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1933:9: Null passed to a callee that requires a non-null argument
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1931:5: 'annotation' initialized to nil
/path/to/mapbox-gl-native/platform/osx/src/MGLMapView.mm:1933:9: Null passed to a callee that requires a non-null argument
```