### PR TITLE
[core][ios][osx][android] fix icons with non-integer width/height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Android master
 
+* Fixed crash caused by annotation image with non-integer width or height ([#3031](https://github.com/mapbox/mapbox-gl-native/issues/3031))
+
 ## 3.0.0
 
 * Added Camera API ([#3244](https://github.com/mapbox/mapbox-gl-native/issues/3244))
@@ -53,6 +55,7 @@ Known issues:
 - New API to provide a custom callout view to the map for annotations. ([#3456](https://github.com/mapbox/mapbox-gl-native/pull/3456))
 - Made telemetry on/off setting available in-app. ([#3445](https://github.com/mapbox/mapbox-gl-native/pull/3445))
 - Fixed an issue with users not being counted by Mapbox if they had disabled telemetry. ([#3495](https://github.com/mapbox/mapbox-gl-native/pull/3495))
+- Fixed crash caused by MGLAnnotationImage with non-integer width or height ([#2198](https://github.com/mapbox/mapbox-gl-native/issues/2198))
 
 ## iOS 3.0.1
 

--- a/include/mbgl/sprite/sprite_image.hpp
+++ b/include/mbgl/sprite/sprite_image.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/image.hpp>
 
 #include <string>
 #include <memory>
@@ -12,27 +13,18 @@ namespace mbgl {
 
 class SpriteImage : private util::noncopyable {
 public:
-    SpriteImage(
-        uint16_t width, uint16_t height, float pixelRatio, std::string&& data, bool sdf = false);
+    SpriteImage(PremultipliedImage&&, float pixelRatio, bool sdf = false);
 
-    // Logical dimensions of the sprite image.
-    const uint16_t width;
-    const uint16_t height;
+    PremultipliedImage image;
 
     // Pixel ratio of the sprite image.
     const float pixelRatio;
 
-    // Physical dimensions of the sprite image.
-    const uint16_t pixelWidth;
-    const uint16_t pixelHeight;
-
-    // A string of an RGBA8 representation of the sprite. It must have exactly
-    // (width * ratio) * (height * ratio) * 4 (RGBA) bytes. The scan lines may
-    // not have gaps between them (i.e. stride == 0).
-    const std::string data;
-
     // Whether this image should be interpreted as a signed distance field icon.
     const bool sdf;
+
+    float getWidth() const { return image.width / pixelRatio; }
+    float getHeight() const { return image.height / pixelRatio; }
 };
 
 } // namespace mbgl

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -2314,8 +2314,8 @@ public final class MapView extends FrameLayout {
 
         mNativeMapView.addAnnotationIcon(
                 id,
-                (int) (bitmap.getWidth() / scale),
-                (int) (bitmap.getHeight() / scale),
+                bitmap.getWidth(),
+                bitmap.getHeight(),
                 scale, buffer.array());
     }
 

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -200,8 +200,8 @@ GLFWView::makeSpriteImage(int width, int height, float pixelRatio) {
     const int w = std::ceil(pixelRatio * width);
     const int h = std::ceil(pixelRatio * height);
 
-    std::string pixels(w * h * 4, '\x00');
-    auto data = reinterpret_cast<uint32_t*>(const_cast<char*>(pixels.data()));
+    mbgl::PremultipliedImage image(w, h);
+    auto data = reinterpret_cast<uint32_t*>(image.data.get());
     const int dist = (w / 2) * (w / 2);
     for (int y = 0; y < h; y++) {
         for (int x = 0; x < w; x++) {
@@ -217,7 +217,7 @@ GLFWView::makeSpriteImage(int width, int height, float pixelRatio) {
         }
     }
 
-    return std::make_shared<mbgl::SpriteImage>(width, height, pixelRatio, std::move(pixels));
+    return std::make_shared<mbgl::SpriteImage>(std::move(image), pixelRatio);
 }
 
 void GLFWView::nextOrientation() {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2346,8 +2346,8 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
     // add sprite
     auto cSpriteImage = std::make_shared<mbgl::SpriteImage>(
-        uint16_t(annotationImage.image.size.width),
-        uint16_t(annotationImage.image.size.height),
+        uint16_t(width),
+        uint16_t(height),
         float(annotationImage.image.scale),
         std::move(pixels));
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2334,22 +2334,19 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     size_t width = CGImageGetWidth(image);
     size_t height = CGImageGetHeight(image);
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    std::string pixels(width * height * 4, '\0');
+    mbgl::PremultipliedImage cPremultipliedImage(width, height);
     size_t bytesPerPixel = 4;
     size_t bytesPerRow = bytesPerPixel * width;
     size_t bitsPerComponent = 8;
-    char *pixelData = const_cast<char *>(pixels.data());
-    CGContextRef context = CGBitmapContextCreate(pixelData, width, height, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast);
+    CGContextRef context = CGBitmapContextCreate(cPremultipliedImage.data.get(), width, height, bitsPerComponent, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast);
     CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
     CGContextRelease(context);
     CGColorSpaceRelease(colorSpace);
 
     // add sprite
     auto cSpriteImage = std::make_shared<mbgl::SpriteImage>(
-        uint16_t(width),
-        uint16_t(height),
-        float(annotationImage.image.scale),
-        std::move(pixels));
+        std::move(cPremultipliedImage), 
+        float(annotationImage.image.scale));
 
     // sprite upload
     NSString *symbolName = [MGLAnnotationSpritePrefix stringByAppendingString:annotationImage.reuseIdentifier];

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1590,10 +1590,11 @@ public:
     
     // Get the image’s raw pixel data as an RGBA buffer.
     std::string pixelString((const char *)rep.bitmapData, rep.pixelsWide * rep.pixelsHigh * 4 /* RGBA */);
-    auto cSpriteImage = std::make_shared<mbgl::SpriteImage>((uint16_t)rep.pixelsWide,
-                                                            (uint16_t)rep.pixelsHigh,
-                                                            (float)(rep.pixelsWide / size.width),
-                                                            std::move(pixelString));
+
+    mbgl::PremultipliedImage cPremultipliedImage(rep.pixelsWide, rep.pixelsHigh);
+    std::copy(rep.bitmapData, rep.bitmapData + cPremultipliedImage.size(), cPremultipliedImage.data.get());
+    auto cSpriteImage = std::make_shared<mbgl::SpriteImage>(std::move(cPremultipliedImage),
+                                                            (float)(rep.pixelsWide / size.width));
     NSString *symbolName = [MGLAnnotationSpritePrefix stringByAppendingString:annotationImage.reuseIdentifier];
     _mbglMap->addAnnotationIcon(symbolName.UTF8String, cSpriteImage);
     

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1590,8 +1590,8 @@ public:
     
     // Get the image’s raw pixel data as an RGBA buffer.
     std::string pixelString((const char *)rep.bitmapData, rep.pixelsWide * rep.pixelsHigh * 4 /* RGBA */);
-    auto cSpriteImage = std::make_shared<mbgl::SpriteImage>((uint16_t)rep.size.width,
-                                                            (uint16_t)rep.size.height,
+    auto cSpriteImage = std::make_shared<mbgl::SpriteImage>((uint16_t)rep.pixelsWide,
+                                                            (uint16_t)rep.pixelsHigh,
                                                             (float)(rep.pixelsWide / size.width),
                                                             std::move(pixelString));
     NSString *symbolName = [MGLAnnotationSpritePrefix stringByAppendingString:annotationImage.reuseIdentifier];

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -165,7 +165,7 @@ void AnnotationManager::removeIcon(const std::string& name) {
 
 double AnnotationManager::getTopOffsetPixelsForIcon(const std::string& name) {
     auto sprite = spriteStore.getSprite(name);
-    return sprite ? -sprite->height / 2 : 0;
+    return sprite ? -(sprite->image.height / sprite->pixelRatio) / 2 : 0;
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -248,8 +248,8 @@ void SymbolBucket::addFeatures(uintptr_t tileUID,
             auto image = spriteAtlas.getImage(feature.sprite, false);
             if (image) {
                 shapedIcon = shapeIcon(*image, layout);
-                assert((*image).texture);
-                if ((*image).texture->sdf) {
+                assert((*image).spriteImage);
+                if ((*image).spriteImage->sdf) {
                     sdfIcons = true;
                 }
                 if ((*image).relativePixelRatio != 1.0f) {

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -32,7 +32,7 @@ struct SpriteAtlasPosition {
 
 struct SpriteAtlasElement {
     Rect<uint16_t> pos;
-    std::shared_ptr<const SpriteImage> texture;
+    std::shared_ptr<const SpriteImage> spriteImage;
     float relativePixelRatio;
 };
 
@@ -77,13 +77,13 @@ private:
     struct Holder : private util::noncopyable {
         inline Holder(const std::shared_ptr<const SpriteImage>&, const Rect<dimension>&);
         inline Holder(Holder&&);
-        std::shared_ptr<const SpriteImage> texture;
+        std::shared_ptr<const SpriteImage> spriteImage;
         const Rect<dimension> pos;
     };
 
     using Key = std::pair<std::string, bool>;
 
-    Rect<SpriteAtlas::dimension> allocateImage(float width, float height);
+    Rect<SpriteAtlas::dimension> allocateImage(const SpriteImage&);
     void copy(const Holder& holder, const bool wrap);
 
     std::recursive_mutex mtx;

--- a/src/mbgl/sprite/sprite_image.cpp
+++ b/src/mbgl/sprite/sprite_image.cpp
@@ -6,16 +6,16 @@
 
 namespace mbgl {
 
-SpriteImage::SpriteImage(const uint16_t width_,
-                         const uint16_t height_,
+SpriteImage::SpriteImage(const uint16_t pixelWidth_,
+                         const uint16_t pixelHeight_,
                          const float pixelRatio_,
                          std::string&& data_,
                          bool sdf_)
-    : width(width_),
-      height(height_),
+    : width(std::ceil(pixelWidth_ / pixelRatio_)),
+      height(std::ceil(pixelHeight_ / pixelRatio_)),
       pixelRatio(pixelRatio_),
-      pixelWidth(std::ceil(width * pixelRatio)),
-      pixelHeight(std::ceil(height * pixelRatio)),
+      pixelWidth(pixelWidth_),
+      pixelHeight(pixelHeight_),
       data(std::move(data_)),
       sdf(sdf_) {
     const size_t size = pixelWidth * pixelHeight * 4;

--- a/src/mbgl/sprite/sprite_image.cpp
+++ b/src/mbgl/sprite/sprite_image.cpp
@@ -6,23 +6,17 @@
 
 namespace mbgl {
 
-SpriteImage::SpriteImage(const uint16_t pixelWidth_,
-                         const uint16_t pixelHeight_,
+SpriteImage::SpriteImage(PremultipliedImage&& image_,
                          const float pixelRatio_,
-                         std::string&& data_,
                          bool sdf_)
-    : width(std::ceil(pixelWidth_ / pixelRatio_)),
-      height(std::ceil(pixelHeight_ / pixelRatio_)),
+    : image(std::move(image_)),
       pixelRatio(pixelRatio_),
-      pixelWidth(pixelWidth_),
-      pixelHeight(pixelHeight_),
-      data(std::move(data_)),
       sdf(sdf_) {
-    const size_t size = pixelWidth * pixelHeight * 4;
-    if (size == 0) {
+
+    if (image.size() == 0) {
         throw util::SpriteImageException("Sprite image dimensions may not be zero");
-    } else if (size != data.size()) {
-        throw util::SpriteImageException("Sprite image pixel count mismatch");
+    } else if (pixelRatio <= 0) {
+        throw util::SpriteImageException("Sprite pixelRatio may not be <= 0");
     }
 }
 

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -26,10 +26,10 @@ SpriteImagePtr createSpriteImage(const PremultipliedImage& image,
         return nullptr;
     }
 
-    std::string data(width * height * 4, '\0');
+    PremultipliedImage dstImage(width, height);
 
     auto srcData = reinterpret_cast<const uint32_t*>(image.data.get());
-    auto dstData = reinterpret_cast<uint32_t*>(const_cast<char*>(data.data()));
+    auto dstData = reinterpret_cast<uint32_t*>(dstImage.data.get());
 
     const int32_t maxX = std::min(uint32_t(image.width), uint32_t(width + srcX)) - srcX;
     assert(maxX <= int32_t(image.width));
@@ -45,7 +45,7 @@ SpriteImagePtr createSpriteImage(const PremultipliedImage& image,
         }
     }
 
-    return std::make_unique<const SpriteImage>(width, height, ratio, std::move(data), sdf);
+    return std::make_unique<const SpriteImage>(std::move(dstImage), ratio, sdf);
 }
 
 namespace {

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -15,37 +15,30 @@ namespace mbgl {
 SpriteImagePtr createSpriteImage(const PremultipliedImage& image,
                                  const uint16_t srcX,
                                  const uint16_t srcY,
-                                 const uint16_t srcWidth,
-                                 const uint16_t srcHeight,
+                                 const uint16_t width,
+                                 const uint16_t height,
                                  const double ratio,
                                  const bool sdf) {
     // Disallow invalid parameter configurations.
-    if (srcWidth == 0 || srcHeight == 0 || ratio <= 0 || ratio > 10 || srcWidth > 1024 ||
-        srcHeight > 1024) {
+    if (width == 0 || height == 0 || ratio <= 0 || ratio > 10 || width > 1024 ||
+        height > 1024) {
         Log::Warning(Event::Sprite, "Can't create sprite with invalid metrics");
         return nullptr;
     }
 
-    const uint16_t width = std::ceil(double(srcWidth) / ratio);
-    const uint16_t dstWidth = std::ceil(width * ratio);
-    assert(dstWidth >= srcWidth);
-    const uint16_t height = std::ceil(double(srcHeight) / ratio);
-    const uint16_t dstHeight = std::ceil(height * ratio);
-    assert(dstHeight >= srcHeight);
-
-    std::string data(dstWidth * dstHeight * 4, '\0');
+    std::string data(width * height * 4, '\0');
 
     auto srcData = reinterpret_cast<const uint32_t*>(image.data.get());
     auto dstData = reinterpret_cast<uint32_t*>(const_cast<char*>(data.data()));
 
-    const int32_t maxX = std::min(uint32_t(image.width), uint32_t(srcWidth + srcX)) - srcX;
+    const int32_t maxX = std::min(uint32_t(image.width), uint32_t(width + srcX)) - srcX;
     assert(maxX <= int32_t(image.width));
-    const int32_t maxY = std::min(uint32_t(image.height), uint32_t(srcHeight + srcY)) - srcY;
+    const int32_t maxY = std::min(uint32_t(image.height), uint32_t(height + srcY)) - srcY;
     assert(maxY <= int32_t(image.height));
 
     // Copy from the source image into our individual sprite image
     for (uint16_t y = 0; y < maxY; ++y) {
-        const auto dstRow = y * dstWidth;
+        const auto dstRow = y * width;
         const auto srcRow = (y + srcY) * image.width + srcX;
         for (uint16_t x = 0; x < maxX; ++x) {
             dstData[dstRow + x] = srcData[srcRow + x];

--- a/src/mbgl/sprite/sprite_store.cpp
+++ b/src/mbgl/sprite/sprite_store.cpp
@@ -113,7 +113,7 @@ void SpriteStore::_setSprite(const std::string& name,
         auto it = sprites.find(name);
         if (it != sprites.end()) {
             // There is already a sprite with that name in our store.
-            if ((it->second->width != sprite->width || it->second->height != sprite->height)) {
+            if ((it->second->image.width != sprite->image.width || it->second->image.height != sprite->image.height)) {
                 Log::Warning(Event::Sprite, "Can't change sprite dimensions for '%s'", name.c_str());
                 return;
             }

--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -6,10 +6,10 @@ namespace mbgl {
 PositionedIcon shapeIcon(const SpriteAtlasElement& image, const SymbolLayoutProperties& layout) {
     float dx = layout.icon.offset.value[0];
     float dy = layout.icon.offset.value[1];
-    float x1 = dx - image.texture->width / 2.0f;
-    float x2 = x1 + image.texture->width;
-    float y1 = dy - image.texture->height / 2.0f;
-    float y2 = y1 + image.texture->height;
+    float x1 = dx - image.spriteImage->getWidth() / 2.0f;
+    float x2 = x1 + image.spriteImage->getWidth();
+    float y1 = dy - image.spriteImage->getHeight() / 2.0f;
+    float y2 = y1 + image.spriteImage->getHeight();
 
     return PositionedIcon(image, y1, y2, x1, x2);
 }

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -16,7 +16,7 @@ using namespace mbgl;
 
 std::shared_ptr<SpriteImage> namedMarker(const std::string &name) {
     PremultipliedImage image = decodeImage(util::read_file("test/fixtures/sprites/" + name));
-    return std::make_shared<SpriteImage>(image.width, image.height, 1.0, std::string(reinterpret_cast<char*>(image.data.get()), image.size()));
+    return std::make_shared<SpriteImage>(std::move(image), 1.0);
 }
 
 namespace {

--- a/test/fixtures/util.cpp
+++ b/test/fixtures/util.cpp
@@ -89,6 +89,7 @@ Server::~Server() {
     }
 }
 
+
 // from https://gist.github.com/ArtemGr/997887
 uint64_t crc64(const char* data, size_t size) {
     boost::crc_optimal<64, 0x04C11DB7, 0, 0, false, false> crc;
@@ -98,6 +99,10 @@ uint64_t crc64(const char* data, size_t size) {
 
 uint64_t crc64(const std::string& str) {
     return crc64(str.data(), str.size());
+}
+
+uint64_t crc64(const PremultipliedImage &image) {
+    return crc64(reinterpret_cast<const char*>(image.data.get()), image.size());
 }
 
 PremultipliedImage render(Map& map, std::chrono::milliseconds timeout) {

--- a/test/fixtures/util.hpp
+++ b/test/fixtures/util.hpp
@@ -33,6 +33,7 @@ private:
 
 uint64_t crc64(const char*, size_t);
 uint64_t crc64(const std::string&);
+uint64_t crc64(const PremultipliedImage&);
 
 PremultipliedImage render(Map&,
                           std::chrono::milliseconds timeout = std::chrono::milliseconds(1000));

--- a/test/sprite/sprite_atlas.cpp
+++ b/test/sprite/sprite_atlas.cpp
@@ -34,11 +34,11 @@ TEST(Sprite, SpriteAtlas) {
     EXPECT_EQ(0, metro.pos.y);
     EXPECT_EQ(20, metro.pos.w);
     EXPECT_EQ(20, metro.pos.h);
-    EXPECT_EQ(18, metro.texture->width);
-    EXPECT_EQ(18, metro.texture->height);
-    EXPECT_EQ(18, metro.texture->pixelWidth);
-    EXPECT_EQ(18, metro.texture->pixelHeight);
-    EXPECT_EQ(1.0f, metro.texture->pixelRatio);
+    EXPECT_EQ(18, metro.spriteImage->getWidth());
+    EXPECT_EQ(18, metro.spriteImage->getHeight());
+    EXPECT_EQ(18, metro.spriteImage->image.width);
+    EXPECT_EQ(18, metro.spriteImage->image.height);
+    EXPECT_EQ(1.0f, metro.spriteImage->pixelRatio);
 
     EXPECT_TRUE(atlas.getData());
 
@@ -96,11 +96,11 @@ TEST(Sprite, SpriteAtlasSize) {
     EXPECT_EQ(0, metro.pos.y);
     EXPECT_EQ(16, metro.pos.w);
     EXPECT_EQ(16, metro.pos.h);
-    EXPECT_EQ(18, metro.texture->width);
-    EXPECT_EQ(18, metro.texture->height);
-    EXPECT_EQ(18, metro.texture->pixelWidth);
-    EXPECT_EQ(18, metro.texture->pixelHeight);
-    EXPECT_EQ(1.0f, metro.texture->pixelRatio);
+    EXPECT_EQ(18, metro.spriteImage->getWidth());
+    EXPECT_EQ(18, metro.spriteImage->getHeight());
+    EXPECT_EQ(18, metro.spriteImage->image.width);
+    EXPECT_EQ(18, metro.spriteImage->image.height);
+    EXPECT_EQ(1.0f, metro.spriteImage->pixelRatio);
 
     const size_t bytes = atlas.getTextureWidth() * atlas.getTextureHeight() * 4;
     const auto hash = test::crc64(reinterpret_cast<const char*>(atlas.getData()), bytes);
@@ -122,24 +122,28 @@ TEST(Sprite, SpriteAtlasUpdates) {
     EXPECT_EQ(32, atlas.getTextureWidth());
     EXPECT_EQ(32, atlas.getTextureHeight());
 
-    store.setSprite("one", std::make_shared<SpriteImage>(16, 12, 1, std::string(16 * 12 * 4, '\x00')));
+    store.setSprite("one", std::make_shared<SpriteImage>(PremultipliedImage(16, 12), 1));
     auto one = *atlas.getImage("one", false);
     EXPECT_EQ(0, one.pos.x);
     EXPECT_EQ(0, one.pos.y);
     EXPECT_EQ(20, one.pos.w);
     EXPECT_EQ(16, one.pos.h);
-    EXPECT_EQ(16, one.texture->width);
-    EXPECT_EQ(12, one.texture->height);
-    EXPECT_EQ(16, one.texture->pixelWidth);
-    EXPECT_EQ(12, one.texture->pixelHeight);
-    EXPECT_EQ(1.0f, one.texture->pixelRatio);
+    EXPECT_EQ(16, one.spriteImage->getWidth());
+    EXPECT_EQ(12, one.spriteImage->getHeight());
+    EXPECT_EQ(16, one.spriteImage->image.width);
+    EXPECT_EQ(12, one.spriteImage->image.height);
+    EXPECT_EQ(1.0f, one.spriteImage->pixelRatio);
 
     const size_t bytes = atlas.getTextureWidth() * atlas.getTextureHeight() * 4;
     const auto hash = test::crc64(reinterpret_cast<const char*>(atlas.getData()), bytes);
     EXPECT_EQ(0x0000000000000000u, hash) << std::hex << hash;
 
     // Update sprite
-    auto newSprite = std::make_shared<SpriteImage>(16, 12, 1, std::string(16 * 12 * 4, '\xFF'));
+    PremultipliedImage image2(16, 12);
+    for (size_t i = 0; i < image2.size(); i++) {
+        image2.data.get()[i] = 255;
+    }
+    auto newSprite = std::make_shared<SpriteImage>(std::move(image2), 1);
     store.setSprite("one", newSprite);
     ASSERT_EQ(newSprite, store.getSprite("one"));
 

--- a/test/sprite/sprite_image.cpp
+++ b/test/sprite/sprite_image.cpp
@@ -28,7 +28,7 @@ TEST(Sprite, SpriteImageZeroRatio) {
         SpriteImage(16, 16, 0, "");
         FAIL() << "Expected exception";
     } catch (util::SpriteImageException& ex) {
-        EXPECT_STREQ("Sprite image dimensions may not be zero", ex.what());
+        EXPECT_STREQ("Sprite image pixel count mismatch", ex.what());
     }
 }
 
@@ -43,7 +43,7 @@ TEST(Sprite, SpriteImageMismatchedData) {
 
 TEST(Sprite, SpriteImage) {
     std::string pixels(32 * 24 * 4, '\0');
-    SpriteImage sprite(16, 12, 2, std::move(pixels));
+    SpriteImage sprite(32, 24, 2, std::move(pixels));
     EXPECT_EQ(16, sprite.width);
     EXPECT_EQ(32, sprite.pixelWidth);
     EXPECT_EQ(12, sprite.height);
@@ -54,8 +54,8 @@ TEST(Sprite, SpriteImage) {
 
 TEST(Sprite, SpriteImageFractionalRatio) {
     std::string pixels(20 * 12 * 4, '\0');
-    SpriteImage sprite(13, 8, 1.5, std::move(pixels));
-    EXPECT_EQ(13, sprite.width);
+    SpriteImage sprite(20, 12, 1.5, std::move(pixels));
+    EXPECT_EQ(14, sprite.width);
     EXPECT_EQ(20, sprite.pixelWidth);
     EXPECT_EQ(8, sprite.height);
     EXPECT_EQ(12, sprite.pixelHeight);

--- a/test/sprite/sprite_image.cpp
+++ b/test/sprite/sprite_image.cpp
@@ -1,13 +1,15 @@
 #include "../fixtures/util.hpp"
 
 #include <mbgl/sprite/sprite_image.hpp>
+#include <mbgl/util/image.hpp>
 #include <mbgl/util/exception.hpp>
 
 using namespace mbgl;
 
 TEST(Sprite, SpriteImageZeroWidth) {
+    PremultipliedImage image(0, 16);
     try {
-        SpriteImage(0, 16, 2, "");
+        SpriteImage(std::move(image), 2.0);
         FAIL() << "Expected exception";
     } catch (util::SpriteImageException& ex) {
         EXPECT_STREQ("Sprite image dimensions may not be zero", ex.what());
@@ -15,8 +17,9 @@ TEST(Sprite, SpriteImageZeroWidth) {
 }
 
 TEST(Sprite, SpriteImageZeroHeight) {
+    PremultipliedImage image(16, 0);
     try {
-        SpriteImage(16, 0, 2, "");
+        SpriteImage(std::move(image), 2.0);
         FAIL() << "Expected exception";
     } catch (util::SpriteImageException& ex) {
         EXPECT_STREQ("Sprite image dimensions may not be zero", ex.what());
@@ -24,41 +27,31 @@ TEST(Sprite, SpriteImageZeroHeight) {
 }
 
 TEST(Sprite, SpriteImageZeroRatio) {
+    PremultipliedImage image(16, 16);
     try {
-        SpriteImage(16, 16, 0, "");
+        SpriteImage(std::move(image), 0.0);
         FAIL() << "Expected exception";
     } catch (util::SpriteImageException& ex) {
-        EXPECT_STREQ("Sprite image pixel count mismatch", ex.what());
-    }
-}
-
-TEST(Sprite, SpriteImageMismatchedData) {
-    try {
-        SpriteImage(16, 16, 2, "");
-        FAIL() << "Expected exception";
-    } catch (util::SpriteImageException& ex) {
-        EXPECT_STREQ("Sprite image pixel count mismatch", ex.what());
+        EXPECT_STREQ("Sprite pixelRatio may not be <= 0", ex.what());
     }
 }
 
 TEST(Sprite, SpriteImage) {
-    std::string pixels(32 * 24 * 4, '\0');
-    SpriteImage sprite(32, 24, 2, std::move(pixels));
-    EXPECT_EQ(16, sprite.width);
-    EXPECT_EQ(32, sprite.pixelWidth);
-    EXPECT_EQ(12, sprite.height);
-    EXPECT_EQ(24, sprite.pixelHeight);
+    PremultipliedImage image(32, 24);
+    SpriteImage sprite(std::move(image), 2.0);
+    EXPECT_EQ(16, sprite.getWidth());
+    EXPECT_EQ(32, sprite.image.width);
+    EXPECT_EQ(12, sprite.getHeight());
+    EXPECT_EQ(24, sprite.image.height);
     EXPECT_EQ(2, sprite.pixelRatio);
-    EXPECT_EQ(32u * 24 * 4, sprite.data.size());
 }
 
 TEST(Sprite, SpriteImageFractionalRatio) {
-    std::string pixels(20 * 12 * 4, '\0');
-    SpriteImage sprite(20, 12, 1.5, std::move(pixels));
-    EXPECT_EQ(14, sprite.width);
-    EXPECT_EQ(20, sprite.pixelWidth);
-    EXPECT_EQ(8, sprite.height);
-    EXPECT_EQ(12, sprite.pixelHeight);
+    PremultipliedImage image(20, 12);
+    SpriteImage sprite(std::move(image), 1.5);
+    EXPECT_EQ(float(20.0 / 1.5), sprite.getWidth());
+    EXPECT_EQ(20, sprite.image.width);
+    EXPECT_EQ(float(12.0 / 1.5), sprite.getHeight());
+    EXPECT_EQ(12, sprite.image.height);
     EXPECT_EQ(1.5, sprite.pixelRatio);
-    EXPECT_EQ(20u * 12 * 4, sprite.data.size());
 }

--- a/test/sprite/sprite_parser.cpp
+++ b/test/sprite/sprite_parser.cpp
@@ -43,34 +43,34 @@ TEST(Sprite, SpriteImageCreation1x) {
     { // "museum_icon":{"x":177,"y":187,"width":18,"height":18,"pixelRatio":1,"sdf":false}
         const auto sprite = createSpriteImage(image_1x, 177, 187, 18, 18, 1, false);
         ASSERT_TRUE(sprite.get());
-        EXPECT_EQ(18, sprite->width);
-        EXPECT_EQ(18, sprite->height);
-        EXPECT_EQ(18, sprite->pixelWidth);
-        EXPECT_EQ(18, sprite->pixelHeight);
+        EXPECT_EQ(18, sprite->getWidth());
+        EXPECT_EQ(18, sprite->getHeight());
+        EXPECT_EQ(18, sprite->image.width);
+        EXPECT_EQ(18, sprite->image.height);
         EXPECT_EQ(1, sprite->pixelRatio);
-        EXPECT_EQ(0x7FCC5F263D1FFE16u, test::crc64(sprite->data));
+        EXPECT_EQ(0x7FCC5F263D1FFE16u, test::crc64(sprite->image));
     }
 
     { // outside image == blank
         const auto sprite = createSpriteImage(image_1x, 200, 0, 16, 16, 1, false);
         ASSERT_TRUE(sprite.get());
-        EXPECT_EQ(16, sprite->width);
-        EXPECT_EQ(16, sprite->height);
-        EXPECT_EQ(16, sprite->pixelWidth);
-        EXPECT_EQ(16, sprite->pixelHeight);
+        EXPECT_EQ(16, sprite->getWidth());
+        EXPECT_EQ(16, sprite->getHeight());
+        EXPECT_EQ(16, sprite->image.width);
+        EXPECT_EQ(16, sprite->image.height);
         EXPECT_EQ(1, sprite->pixelRatio);
-        EXPECT_EQ(0x0000000000000000u, test::crc64(sprite->data)) << std::hex << test::crc64(sprite->data);
+        EXPECT_EQ(0x0000000000000000u, test::crc64(sprite->image)) << std::hex << test::crc64(sprite->image);
     }
 
     { // outside image == blank
         const auto sprite = createSpriteImage(image_1x, 0, 300, 16, 16, 1, false);
         ASSERT_TRUE(sprite.get());
-        EXPECT_EQ(16, sprite->width);
-        EXPECT_EQ(16, sprite->height);
-        EXPECT_EQ(16, sprite->pixelWidth);
-        EXPECT_EQ(16, sprite->pixelHeight);
+        EXPECT_EQ(16, sprite->getWidth());
+        EXPECT_EQ(16, sprite->getHeight());
+        EXPECT_EQ(16, sprite->image.width);
+        EXPECT_EQ(16, sprite->image.height);
         EXPECT_EQ(1, sprite->pixelRatio);
-        EXPECT_EQ(0x0000000000000000u, test::crc64(sprite->data)) << std::hex << test::crc64(sprite->data);
+        EXPECT_EQ(0x0000000000000000u, test::crc64(sprite->image)) << std::hex << test::crc64(sprite->image);
     }
 }
 
@@ -80,12 +80,12 @@ TEST(Sprite, SpriteImageCreation2x) {
     // "museum_icon":{"x":354,"y":374,"width":36,"height":36,"pixelRatio":2,"sdf":false}
     const auto sprite = createSpriteImage(image_2x, 354, 374, 36, 36, 2, false);
     ASSERT_TRUE(sprite.get());
-    EXPECT_EQ(18, sprite->width);
-    EXPECT_EQ(18, sprite->height);
-    EXPECT_EQ(36, sprite->pixelWidth);
-    EXPECT_EQ(36, sprite->pixelHeight);
+    EXPECT_EQ(18, sprite->getWidth());
+    EXPECT_EQ(18, sprite->getHeight());
+    EXPECT_EQ(36, sprite->image.width);
+    EXPECT_EQ(36, sprite->image.height);
     EXPECT_EQ(2, sprite->pixelRatio);
-    EXPECT_EQ(0x85F345098DD4F9E3u, test::crc64(sprite->data));
+    EXPECT_EQ(0x85F345098DD4F9E3u, test::crc64(sprite->image));
 }
 
 TEST(Sprite, SpriteImageCreation1_5x) {
@@ -94,22 +94,22 @@ TEST(Sprite, SpriteImageCreation1_5x) {
     // "museum_icon":{"x":354,"y":374,"width":36,"height":36,"pixelRatio":2,"sdf":false}
     const auto sprite = createSpriteImage(image_2x, 354, 374, 36, 36, 1.5, false);
     ASSERT_TRUE(sprite.get());
-    EXPECT_EQ(24, sprite->width);
-    EXPECT_EQ(24, sprite->height);
-    EXPECT_EQ(36, sprite->pixelWidth);
-    EXPECT_EQ(36, sprite->pixelHeight);
+    EXPECT_EQ(24, sprite->getWidth());
+    EXPECT_EQ(24, sprite->getHeight());
+    EXPECT_EQ(36, sprite->image.width);
+    EXPECT_EQ(36, sprite->image.height);
     EXPECT_EQ(1.5, sprite->pixelRatio);
-    EXPECT_EQ(0x85F345098DD4F9E3u, test::crc64(sprite->data));
+    EXPECT_EQ(0x85F345098DD4F9E3u, test::crc64(sprite->image));
 
     // "hospital_icon":{"x":314,"y":518,"width":36,"height":36,"pixelRatio":2,"sdf":false}
     const auto sprite2 = createSpriteImage(image_2x, 314, 518, 35, 35, 1.5, false);
     ASSERT_TRUE(sprite2.get());
-    EXPECT_EQ(24, sprite2->width);
-    EXPECT_EQ(24, sprite2->height);
-    EXPECT_EQ(35, sprite2->pixelWidth);
-    EXPECT_EQ(35, sprite2->pixelHeight);
+    EXPECT_EQ(float(35 / 1.5), sprite2->getWidth());
+    EXPECT_EQ(float(35 / 1.5), sprite2->getHeight());
+    EXPECT_EQ(35, sprite2->image.width);
+    EXPECT_EQ(35, sprite2->image.height);
     EXPECT_EQ(1.5, sprite2->pixelRatio);
-    EXPECT_EQ(14312995667113444493u, test::crc64(sprite2->data));
+    EXPECT_EQ(14312995667113444493u, test::crc64(sprite2->image));
 }
 
 TEST(Sprite, SpriteParsing) {
@@ -199,12 +199,12 @@ TEST(Sprite, SpriteParsing) {
 
     {
         auto sprite = images.find("generic-metro")->second;
-        EXPECT_EQ(18, sprite->width);
-        EXPECT_EQ(18, sprite->height);
-        EXPECT_EQ(18, sprite->pixelWidth);
-        EXPECT_EQ(18, sprite->pixelHeight);
+        EXPECT_EQ(18, sprite->getWidth());
+        EXPECT_EQ(18, sprite->getHeight());
+        EXPECT_EQ(18, sprite->image.width);
+        EXPECT_EQ(18, sprite->image.height);
         EXPECT_EQ(1, sprite->pixelRatio);
-        EXPECT_EQ(0xFF56F5F48F707147u, test::crc64(sprite->data));
+        EXPECT_EQ(0xFF56F5F48F707147u, test::crc64(sprite->image));
     }
 }
 

--- a/test/sprite/sprite_parser.cpp
+++ b/test/sprite/sprite_parser.cpp
@@ -106,10 +106,10 @@ TEST(Sprite, SpriteImageCreation1_5x) {
     ASSERT_TRUE(sprite2.get());
     EXPECT_EQ(24, sprite2->width);
     EXPECT_EQ(24, sprite2->height);
-    EXPECT_EQ(36, sprite2->pixelWidth);
-    EXPECT_EQ(36, sprite2->pixelHeight);
+    EXPECT_EQ(35, sprite2->pixelWidth);
+    EXPECT_EQ(35, sprite2->pixelHeight);
     EXPECT_EQ(1.5, sprite2->pixelRatio);
-    EXPECT_EQ(0x134A530C742DD141u, test::crc64(sprite2->data));
+    EXPECT_EQ(14312995667113444493u, test::crc64(sprite2->data));
 }
 
 TEST(Sprite, SpriteParsing) {

--- a/test/sprite/sprite_store.cpp
+++ b/test/sprite/sprite_store.cpp
@@ -13,9 +13,9 @@ using namespace mbgl;
 TEST(SpriteStore, SpriteStore) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite2 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite3 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
+    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
+    const auto sprite3 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);
@@ -79,7 +79,7 @@ TEST(SpriteStore, SpriteStore) {
 TEST(SpriteStore, OtherPixelRatio) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(8, 8, 1, std::string(8 * 8 * 4, '\0'));
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(8, 8), 1);
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);
@@ -90,8 +90,8 @@ TEST(SpriteStore, OtherPixelRatio) {
 }
 
 TEST(SpriteStore, Multiple) {
-    const auto sprite1 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite2 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
+    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);
@@ -109,8 +109,8 @@ TEST(SpriteStore, Multiple) {
 TEST(SpriteStore, Replace) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite2 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
+    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);
@@ -126,8 +126,10 @@ TEST(SpriteStore, Replace) {
 TEST(SpriteStore, ReplaceWithDifferentDimensions) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite2 = std::make_shared<SpriteImage>(18, 18, 2, std::string(18 * 18 * 4, '\0'));
+    PremultipliedImage image(16, 16);
+    PremultipliedImage image2(18, 18);
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
+    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage(18, 18), 2);
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);

--- a/test/sprite/sprite_store.cpp
+++ b/test/sprite/sprite_store.cpp
@@ -13,9 +13,9 @@ using namespace mbgl;
 TEST(SpriteStore, SpriteStore) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(8, 8, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite2 = std::make_shared<SpriteImage>(8, 8, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite3 = std::make_shared<SpriteImage>(8, 8, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite1 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite2 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite3 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);
@@ -90,8 +90,8 @@ TEST(SpriteStore, OtherPixelRatio) {
 }
 
 TEST(SpriteStore, Multiple) {
-    const auto sprite1 = std::make_shared<SpriteImage>(8, 8, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite2 = std::make_shared<SpriteImage>(8, 8, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite1 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite2 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);
@@ -109,8 +109,8 @@ TEST(SpriteStore, Multiple) {
 TEST(SpriteStore, Replace) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(8, 8, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite2 = std::make_shared<SpriteImage>(8, 8, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite1 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite2 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);
@@ -126,8 +126,8 @@ TEST(SpriteStore, Replace) {
 TEST(SpriteStore, ReplaceWithDifferentDimensions) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(8, 8, 2, std::string(16 * 16 * 4, '\0'));
-    const auto sprite2 = std::make_shared<SpriteImage>(9, 9, 2, std::string(18 * 18 * 4, '\0'));
+    const auto sprite1 = std::make_shared<SpriteImage>(16, 16, 2, std::string(16 * 16 * 4, '\0'));
+    const auto sprite2 = std::make_shared<SpriteImage>(18, 18, 2, std::string(18 * 18 * 4, '\0'));
 
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
     SpriteStore store(1);


### PR DESCRIPTION
ref #3031
ref #2198

For example, an icon that has:
- a pixel width of 10
- a pixel ratio of 3
- a scaled with of 3.333

is now supported.

SpriteImage is now constructed with the pixel width of the image instead of the width.

this works in android with @tobrun's https://github.com/mapbox/mapbox-gl-native/tree/3031-test-branch-android
@1ec5 I think this should fix #2198 - what's the best way to test that?