### PR TITLE
[core] Restore existing response body

### DIFF
--- a/platform/android/src/http_request_android.cpp
+++ b/platform/android/src/http_request_android.cpp
@@ -209,6 +209,8 @@ void HTTPAndroidRequest::onResponse(int code, std::string message, std::string e
         response->notModified = true;
 
         if (existingResponse) {
+            response->data = existingResponse->data;
+
             if (response->expires == Seconds::zero()) {
                 response->expires = existingResponse->expires;
             }

--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -229,6 +229,8 @@ void HTTPNSURLRequest::handleResult(NSData *data, NSURLResponse *res, NSError *e
             response->notModified = true;
 
             if (existingResponse) {
+                response->data = existingResponse->data;
+
                 if (response->expires == Seconds::zero()) {
                     response->expires = existingResponse->expires;
                 }

--- a/platform/default/http_request_curl.cpp
+++ b/platform/default/http_request_curl.cpp
@@ -532,6 +532,8 @@ void HTTPCURLRequest::handleResult(CURLcode code) {
             response->notModified = true;
 
             if (existingResponse) {
+                response->data = existingResponse->data;
+
                 if (response->expires == Seconds::zero()) {
                     response->expires = existingResponse->expires;
                 }

--- a/test/storage/cache_revalidate.cpp
+++ b/test/storage/cache_revalidate.cpp
@@ -49,6 +49,8 @@ TEST_F(Storage, CacheRevalidateSame) {
             EXPECT_EQ(nullptr, res2.error);
             EXPECT_EQ(false, res2.stale);
             EXPECT_TRUE(res2.notModified);
+            ASSERT_TRUE(res2.data.get());
+            EXPECT_EQ("Response", *res2.data);
             EXPECT_LT(Seconds::zero(), res2.expires);
             EXPECT_EQ(Seconds::zero(), res2.modified);
             // We're not sending the ETag in the 304 reply, but it should still be there.
@@ -107,6 +109,8 @@ TEST_F(Storage, CacheRevalidateModified) {
             EXPECT_EQ(nullptr, res2.error);
             EXPECT_EQ(false, res2.stale);
             EXPECT_TRUE(res2.notModified);
+            ASSERT_TRUE(res2.data.get());
+            EXPECT_EQ("Response", *res2.data);
             EXPECT_LT(Seconds::zero(), res2.expires);
             EXPECT_EQ(1420070400, res2.modified.count());
             EXPECT_EQ("", res2.etag);


### PR DESCRIPTION
Until #2721 lands we still need this.

Fixes #3560.