### PR TITLE
[android] #3559 - don't show InfoWindow when marker is invalid

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -2704,8 +2704,9 @@ public final class MapView extends FrameLayout {
         }
 
         if (!handledDefaultClick) {
-            // default behaviour show InfoWindow
-            mInfoWindows.add(marker.showInfoWindow());
+            if (isInfoWindowValidForMarker(marker)) {
+                mInfoWindows.add(marker.showInfoWindow());
+            }
         }
 
         mSelectedMarkers.add(marker);
@@ -2744,6 +2745,10 @@ public final class MapView extends FrameLayout {
         }
 
         mSelectedMarkers.remove(marker);
+    }
+
+    private boolean isInfoWindowValidForMarker(@NonNull Marker marker) {
+        return !TextUtils.isEmpty(marker.getTitle()) || !TextUtils.isEmpty(marker.getSnippet());
     }
 
     //


### PR DESCRIPTION
closes #3559 