### PR TITLE
Correctly update cache for responses that sent a modified/expires time of 0

### DIFF
--- a/platform/darwin/http_request_nsurl.mm
+++ b/platform/darwin/http_request_nsurl.mm
@@ -231,15 +231,12 @@ void HTTPNSURLRequest::handleResult(NSData *data, NSURLResponse *res, NSError *e
             if (existingResponse) {
                 response->data = existingResponse->data;
 
-                if (response->expires == Seconds::zero()) {
-                    response->expires = existingResponse->expires;
-                }
-
-                if (response->modified == Seconds::zero()) {
+                // Only copy the existing headers if we didn't get one during this response.
+                if (!last_modified) {
                     response->modified = existingResponse->modified;
                 }
 
-                if (response->etag.empty()) {
+                if (!etag) {
                     response->etag = existingResponse->etag;
                 }
             }


### PR DESCRIPTION
We're currently treating `0` as a special value meaning "not set" when we get 304 Not Modified response, but `0` is also a valid response value.