### PR TITLE
Cleanup std::chrono usage

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -125,8 +125,8 @@ public:
     void setBearing(double degrees, const PrecisionPoint&, const Duration& = Duration::zero());
     void setBearing(double degrees, const EdgeInsets&, const Duration& = Duration::zero());
     double getBearing() const;
-    void resetNorth(const Duration& = std::chrono::milliseconds(500));
-    void resetNorth(const EdgeInsets&, const Duration& = std::chrono::milliseconds(500));
+    void resetNorth(const Duration& = Milliseconds(500));
+    void resetNorth(const EdgeInsets&, const Duration& = Milliseconds(500));
 
     // Pitch
     void setPitch(double pitch, const Duration& = Duration::zero());

--- a/ios/benchmark/MBXBenchViewController.mm
+++ b/ios/benchmark/MBXBenchViewController.mm
@@ -60,13 +60,6 @@
 
 }
 
-using Clock = std::chrono::steady_clock;
-using TimePoint = Clock::time_point;
-template <typename Duration>
-inline int64_t Microseconds(Duration d) {
-    return std::chrono::duration_cast<std::chrono::microseconds>(d).count();
-}
-
 size_t idx = 0;
 enum class State { None, WaitingForAssets, WarmingUp, Benchmarking } state = State::None;
 int frames = 0;

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -560,14 +560,14 @@ void JNICALL nativeSetDefaultTransitionDuration(JNIEnv *env, jobject obj, jlong 
     assert(nativeMapViewPtr != 0);
     assert(duration >= 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().setDefaultTransitionDuration(std::chrono::milliseconds(duration));
+    nativeMapView->getMap().setDefaultTransitionDuration(mbgl::Milliseconds(duration));
 }
 
 jlong JNICALL nativeGetDefaultTransitionDuration(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetDefaultTransitionDuration");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    return std::chrono::duration_cast<std::chrono::milliseconds>(nativeMapView->getMap().getDefaultTransitionDuration()).count();
+    return std::chrono::duration_cast<mbgl::Milliseconds>(nativeMapView->getMap().getDefaultTransitionDuration()).count();
 }
 
 void JNICALL nativeSetStyleURL(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jstring url) {
@@ -627,7 +627,7 @@ void JNICALL nativeMoveBy(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdou
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
     mbgl::PrecisionPoint center(dx, dy);
-    nativeMapView->getMap().moveBy(center, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().moveBy(center, mbgl::Milliseconds(duration));
 }
 
 void JNICALL nativeSetLatLng(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jobject latLng,
@@ -684,7 +684,7 @@ void JNICALL nativeSetPitch(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jd
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetPitch");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().setPitch(pitch, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().setPitch(pitch, mbgl::Milliseconds(duration));
 }
 
 void JNICALL nativeScaleBy(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdouble ds, jdouble cx,
@@ -693,7 +693,7 @@ void JNICALL nativeScaleBy(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdo
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
     mbgl::PrecisionPoint center(cx, cy);
-    nativeMapView->getMap().scaleBy(ds, center, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().scaleBy(ds, center, mbgl::Milliseconds(duration));
 }
 
 void JNICALL nativeSetScale(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdouble scale,
@@ -702,7 +702,7 @@ void JNICALL nativeSetScale(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jd
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
     mbgl::PrecisionPoint center(cx, cy);
-    nativeMapView->getMap().setScale(scale, center, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().setScale(scale, center, mbgl::Milliseconds(duration));
 }
 
 jdouble JNICALL nativeGetScale(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
@@ -716,7 +716,7 @@ void JNICALL nativeSetZoom(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdo
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeSetZoom");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().setZoom(zoom, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().setZoom(zoom, mbgl::Milliseconds(duration));
 }
 
 jdouble JNICALL nativeGetZoom(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
@@ -750,7 +750,7 @@ void JNICALL nativeSetLatLngZoom(JNIEnv *env, jobject obj, jlong nativeMapViewPt
         return;
     }
 
-    nativeMapView->getMap().setLatLngZoom(mbgl::LatLng(latitude, longitude), zoom, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().setLatLngZoom(mbgl::LatLng(latitude, longitude), zoom, mbgl::Milliseconds(duration));
 }
 
 jobject JNICALL nativeGetLatLngZoom(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
@@ -797,7 +797,7 @@ void JNICALL nativeRotateBy(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jd
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
     mbgl::PrecisionPoint first(sx, sy);
     mbgl::PrecisionPoint second(ex, ey);
-    nativeMapView->getMap().rotateBy(first, second, std::chrono::milliseconds(duration));
+    nativeMapView->getMap().rotateBy(first, second, mbgl::Milliseconds(duration));
 }
 
 void JNICALL nativeSetBearing(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdouble degrees,
@@ -805,7 +805,7 @@ void JNICALL nativeSetBearing(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, 
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeSetBearing");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    mbgl::Duration duration((std::chrono::milliseconds(milliseconds)));
+    mbgl::Duration duration((mbgl::Milliseconds(milliseconds)));
     nativeMapView->getMap().setBearing(degrees, duration);
 }
 
@@ -1300,7 +1300,7 @@ void JNICALL nativeSetVisibleCoordinateBounds(JNIEnv *env, jobject obj, jlong na
     }
     mbgl::AnimationOptions animationOptions;
     if (duration > 0) {
-        animationOptions.duration = mbgl::Duration(std::chrono::milliseconds(duration));
+        animationOptions.duration.emplace(mbgl::Milliseconds(duration));
         // equivalent to kCAMediaTimingFunctionDefault in iOS
         animationOptions.easing = mbgl::util::UnitBezier(0.25, 0.1, 0.25, 0.1);
     }
@@ -1543,7 +1543,7 @@ void JNICALL nativeEaseTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdou
         cameraOptions.zoom = zoom;
     }
     mbgl::AnimationOptions animationOptions;
-    animationOptions.duration = mbgl::Duration(duration);
+    animationOptions.duration.emplace(mbgl::Duration(duration));
 
     nativeMapView->getMap().easeTo(cameraOptions, animationOptions);
 }
@@ -1577,7 +1577,7 @@ void JNICALL nativeFlyTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdoub
         cameraOptions.zoom = zoom;
     }
     mbgl::AnimationOptions animationOptions;
-    animationOptions.duration = mbgl::Duration(duration);
+    animationOptions.duration.emplace(mbgl::Duration(duration));
 
     nativeMapView->getMap().flyTo(cameraOptions, animationOptions);
 }

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -6,6 +6,7 @@
 #include <mbgl/platform/log.hpp>
 #include <mbgl/util/gl_helper.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <cassert>
 #include <cstdlib>
@@ -140,7 +141,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             break;
         case GLFW_KEY_R:
             if (!mods) {
-                view->map->setDefaultTransitionDuration(std::chrono::milliseconds(300));
+                view->map->setDefaultTransitionDuration(mbgl::Milliseconds(300));
                 if (view->map->hasClass("night")) {
                     view->map->removeClass("night");
                 } else {
@@ -352,9 +353,9 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
             double now = glfwGetTime();
             if (now - view->lastClick < 0.4 /* ms */) {
                 if (modifiers & GLFW_MOD_SHIFT) {
-                    view->map->scaleBy(0.5, { view->lastX, view->lastY }, std::chrono::milliseconds(500));
+                    view->map->scaleBy(0.5, { view->lastX, view->lastY }, mbgl::Milliseconds(500));
                 } else {
-                    view->map->scaleBy(2.0, { view->lastX, view->lastY }, std::chrono::milliseconds(500));
+                    view->map->scaleBy(2.0, { view->lastX, view->lastY }, mbgl::Milliseconds(500));
                 }
             }
             view->lastClick = now;

--- a/platform/default/http_request_curl.cpp
+++ b/platform/default/http_request_curl.cpp
@@ -8,6 +8,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/timer.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <curl/curl.h>
 
@@ -239,7 +240,7 @@ int HTTPCURLContext::startTimeout(CURLM * /* multi */, long timeout_ms, void *us
         timeout_ms = 0;
     }
     context->timeout.stop();
-    context->timeout.start(std::chrono::milliseconds(timeout_ms), Duration::zero(),
+    context->timeout.start(mbgl::Milliseconds(timeout_ms), Duration::zero(),
         std::bind(&HTTPCURLContext::onTimeout, context));
 
     return 0;

--- a/platform/default/timer.cpp
+++ b/platform/default/timer.cpp
@@ -66,8 +66,8 @@ Timer::Timer()
 Timer::~Timer() = default;
 
 void Timer::start(Duration timeout, Duration repeat, std::function<void()>&& cb) {
-    impl->start(std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count(),
-                std::chrono::duration_cast<std::chrono::milliseconds>(repeat).count(),
+    impl->start(std::chrono::duration_cast<Milliseconds>(timeout).count(),
+                std::chrono::duration_cast<Milliseconds>(repeat).count(),
                 std::move(cb));
 }
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -24,6 +24,7 @@
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/default_styles.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #import "Mapbox.h"
 #import "../../darwin/MGLGeometry_Private.h"
@@ -214,10 +215,9 @@ public:
 #pragma mark - Setup & Teardown -
 
 @dynamic debugActive;
-
-std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
+mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 {
-    return std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<float, std::chrono::seconds::period>(duration));
+    return std::chrono::duration_cast<mbgl::Duration>(std::chrono::duration<NSTimeInterval>(duration));
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -1083,7 +1083,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
             velocity = CGPointZero;
         }
 
-        CGFloat duration = UIScrollViewDecelerationRateNormal;
+        NSTimeInterval duration = UIScrollViewDecelerationRateNormal;
         BOOL drift = ! CGPointEqualToPoint(velocity, CGPointZero);
         if (drift)
         {
@@ -1150,7 +1150,8 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
         {
             velocity = 0;
         }
-        CGFloat duration = velocity > 0 ? 1 : 0.25;
+
+        NSTimeInterval duration = velocity > 0 ? 1 : 0.25;
 
         CGFloat scale = self.scale * pinch.scale;
         CGFloat newScale = scale;
@@ -1227,7 +1228,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
         if (fabs(velocity) > 3)
         {
             CGFloat radians = self.angle + rotate.rotation;
-            CGFloat duration = UIScrollViewDecelerationRateNormal;
+            NSTimeInterval duration = UIScrollViewDecelerationRateNormal;
             CGFloat newRadians = radians + velocity * duration * 0.1;
             CGFloat newDegrees = MGLDegreesFromRadians(newRadians) * -1;
 

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -25,6 +25,7 @@
 #import <mbgl/util/constants.hpp>
 #import <mbgl/util/math.hpp>
 #import <mbgl/util/std.hpp>
+#import <mbgl/util/chrono.hpp>
 
 #import <map>
 #import <unordered_set>
@@ -96,9 +97,8 @@ NSImage *MGLDefaultMarkerImage() {
 }
 
 /// Converts from a duration in seconds to a duration object usable in mbgl.
-std::chrono::steady_clock::duration MGLDurationInSeconds(NSTimeInterval duration) {
-    return std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-        std::chrono::duration<NSTimeInterval, std::chrono::seconds::period>(duration));
+mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration) {
+    return std::chrono::duration_cast<mbgl::Duration>(std::chrono::duration<NSTimeInterval>(duration));
 }
 
 /// Converts a media timing function into a unit bezier object usable in mbgl.

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -26,7 +26,7 @@ public:
         , pixelRatio(pixelRatio_)
         , annotationManager(pixelRatio)
         , animationTime(Duration::zero())
-        , defaultFadeDuration(mode_ == MapMode::Continuous ? std::chrono::milliseconds(300) : Duration::zero())
+        , defaultFadeDuration(mode_ == MapMode::Continuous ? Milliseconds(300) : Duration::zero())
         , defaultTransitionDuration(Duration::zero())
         , defaultTransitionDelay(Duration::zero()) {
         assert(pixelRatio > 0);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <cstdio>
 #include <cmath>
@@ -281,8 +282,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
         if (animation.velocity) {
             velocity = *animation.velocity / rho;
         }
-        duration = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-            std::chrono::duration<double, std::chrono::seconds::period>(S / velocity));
+        duration = std::chrono::duration_cast<Duration>(std::chrono::duration<double>(S / velocity));
     }
     if (duration == Duration::zero()) {
         // Perform an instantaneous transition.

--- a/src/mbgl/style/function.cpp
+++ b/src/mbgl/style/function.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/style/function.hpp>
 #include <mbgl/style/style_calculation_parameters.hpp>
 #include <mbgl/util/interpolate.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <cmath>
 

--- a/src/mbgl/style/property_parsing.cpp
+++ b/src/mbgl/style/property_parsing.cpp
@@ -214,11 +214,11 @@ optional<PropertyTransition> parseProperty(const char *, const JSValue& value) {
     if (value.IsObject()) {
         bool parsed = false;
         if (value.HasMember("duration") && value["duration"].IsNumber()) {
-            transition.duration = Duration(std::chrono::milliseconds(value["duration"].GetUint()));
+            transition.duration.emplace(Milliseconds(value["duration"].GetUint()));
             parsed = true;
         }
         if (value.HasMember("delay") && value["delay"].IsNumber()) {
-            transition.delay = Duration(std::chrono::milliseconds(value["delay"].GetUint()));
+            transition.delay.emplace(Milliseconds(value["delay"].GetUint()));
             parsed = true;
         }
         if (!parsed) {

--- a/src/mbgl/util/stopwatch.cpp
+++ b/src/mbgl/util/stopwatch.cpp
@@ -1,6 +1,7 @@
 #ifndef DISABLE_STOPWATCH
 #include <mbgl/util/stopwatch.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/platform/log.hpp>
 
 #include <iostream>

--- a/test/fixtures/mock_file_source.cpp
+++ b/test/fixtures/mock_file_source.cpp
@@ -1,5 +1,6 @@
 #include "mock_file_source.hpp"
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/chrono.hpp>
 
 namespace mbgl {
 
@@ -18,7 +19,7 @@ public:
 
 MockFileSource::MockFileSource(Type type_, const std::string& match_)
     : type(type_), match(match_) {
-    timer.start(std::chrono::milliseconds(10), std::chrono::milliseconds(10), [this] {
+    timer.start(Milliseconds(10), Milliseconds(10), [this] {
         // Explicit move to avoid iterator invalidation if ~MockFileRequest gets called within the loop.
         auto pending_ = std::move(pending);
         for (auto& pair : pending_) {

--- a/test/fixtures/util.cpp
+++ b/test/fixtures/util.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/platform/log.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <mapbox/pixelmatch.hpp>
 
@@ -105,7 +106,7 @@ uint64_t crc64(const PremultipliedImage &image) {
     return crc64(reinterpret_cast<const char*>(image.data.get()), image.size());
 }
 
-PremultipliedImage render(Map& map, std::chrono::milliseconds timeout) {
+PremultipliedImage render(Map& map, Milliseconds timeout) {
     std::promise<PremultipliedImage> promise;
     map.renderStill([&](std::exception_ptr, PremultipliedImage&& image) {
         promise.set_value(std::move(image));

--- a/test/fixtures/util.hpp
+++ b/test/fixtures/util.hpp
@@ -2,6 +2,7 @@
 #define MBGL_TEST_UTIL
 
 #include <mbgl/util/image.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <chrono>
 #include <cstdint>
@@ -35,8 +36,7 @@ uint64_t crc64(const char*, size_t);
 uint64_t crc64(const std::string&);
 uint64_t crc64(const PremultipliedImage&);
 
-PremultipliedImage render(Map&,
-                          std::chrono::milliseconds timeout = std::chrono::milliseconds(1000));
+PremultipliedImage render(Map&, Milliseconds timeout = Milliseconds(1000));
 
 void checkImage(const std::string& base,
                 const PremultipliedImage& actual,

--- a/test/miscellaneous/timer.cpp
+++ b/test/miscellaneous/timer.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/timer.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <memory>
 
@@ -15,7 +16,7 @@ TEST(Timer, Basic) {
 
     auto callback = [&loop] { loop.stop(); };
 
-    auto interval = std::chrono::milliseconds(300);
+    auto interval = mbgl::Milliseconds(300);
     auto expectedTotalTime = interval;
 
     auto first = mbgl::Clock::now();
@@ -23,8 +24,7 @@ TEST(Timer, Basic) {
 
     loop.run();
 
-    using namespace std::chrono;
-    auto totalTime = duration_cast<milliseconds>(mbgl::Clock::now() - first);
+    auto totalTime = std::chrono::duration_cast<mbgl::Milliseconds>(mbgl::Clock::now() - first);
 
     // These are not high precision timers. Especially libuv uses
     // cached time from the beginning of of the main loop iteration
@@ -45,7 +45,7 @@ TEST(Timer, Repeat) {
         }
     };
 
-    auto interval = std::chrono::milliseconds(50);
+    auto interval = mbgl::Milliseconds(50);
     auto expectedTotalTime = interval * count;
 
     auto first = mbgl::Clock::now();
@@ -53,8 +53,7 @@ TEST(Timer, Repeat) {
 
     loop.run();
 
-    using namespace std::chrono;
-    auto totalTime = duration_cast<milliseconds>(mbgl::Clock::now() - first);
+    auto totalTime = std::chrono::duration_cast<mbgl::Milliseconds>(mbgl::Clock::now() - first);
 
     EXPECT_GE(totalTime, expectedTotalTime * 0.8);
     EXPECT_LE(totalTime, expectedTotalTime * 1.2);
@@ -66,8 +65,8 @@ TEST(Timer, Stop) {
     Timer timer1;
     Timer timer2;
 
-    auto interval1 = std::chrono::milliseconds(50);
-    auto interval2 = std::chrono::milliseconds(250);
+    auto interval1 = mbgl::Milliseconds(50);
+    auto interval2 = mbgl::Milliseconds(250);
     auto expectedTotalTime = interval2;
 
     int count = 0;
@@ -88,8 +87,7 @@ TEST(Timer, Stop) {
 
     loop.run();
 
-    using namespace std::chrono;
-    auto totalTime = duration_cast<milliseconds>(mbgl::Clock::now() - first);
+    auto totalTime = std::chrono::duration_cast<mbgl::Milliseconds>(mbgl::Clock::now() - first);
 
     EXPECT_EQ(count, 2);
 
@@ -103,8 +101,8 @@ TEST(Timer, DestroyShouldStop) {
     auto timer1 = std::make_unique<Timer>();
     Timer timer2;
 
-    auto interval1 = std::chrono::milliseconds(50);
-    auto interval2 = std::chrono::milliseconds(250);
+    auto interval1 = mbgl::Milliseconds(50);
+    auto interval2 = mbgl::Milliseconds(250);
     auto expectedTotalTime = interval2;
 
     int count = 0;
@@ -125,8 +123,7 @@ TEST(Timer, DestroyShouldStop) {
 
     loop.run();
 
-    using namespace std::chrono;
-    auto totalTime = duration_cast<milliseconds>(mbgl::Clock::now() - first);
+    auto totalTime = std::chrono::duration_cast<mbgl::Milliseconds>(mbgl::Clock::now() - first);
 
     EXPECT_EQ(count, 2);
 
@@ -139,8 +136,8 @@ TEST(Timer, StartOverrides) {
 
     Timer timer;
 
-    auto interval1 = std::chrono::milliseconds(50);
-    auto interval2 = std::chrono::milliseconds(250);
+    auto interval1 = mbgl::Milliseconds(50);
+    auto interval2 = mbgl::Milliseconds(250);
     auto expectedTotalTime = interval1  + interval2;
 
     int count = 0;
@@ -160,8 +157,7 @@ TEST(Timer, StartOverrides) {
 
     loop.run();
 
-    using namespace std::chrono;
-    auto totalTime = duration_cast<milliseconds>(mbgl::Clock::now() - first);
+    auto totalTime = std::chrono::duration_cast<mbgl::Milliseconds>(mbgl::Clock::now() - first);
 
     EXPECT_EQ(count, 2);
 

--- a/test/storage/cache_size.cpp
+++ b/test/storage/cache_size.cpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/timer.hpp>
+#include <mbgl/util/chrono.hpp>
 
 #include <memory>
 #include <random>
@@ -186,7 +187,7 @@ TEST_F(Storage, CacheSizePruneLeastAccessed) {
             bool done = false;
 
             util::Timer timer;
-            timer.start(std::chrono::milliseconds(1300),
+            timer.start(Milliseconds(1300),
                         Duration::zero(),
                         [&done] { done = true; });
 

--- a/test/storage/http_retry_network_status.cpp
+++ b/test/storage/http_retry_network_status.cpp
@@ -37,14 +37,14 @@ TEST_F(Storage, HTTPNetworkStatusChange) {
 
     // After 50 milliseconds, we're going to trigger a NetworkStatus change.
     util::Timer reachableTimer;
-    reachableTimer.start(std::chrono::milliseconds(50), Duration::zero(), [] () {
+    reachableTimer.start(Milliseconds(50), Duration::zero(), [] () {
         mbgl::NetworkStatus::Reachable();
     });
 
     // This timer will keep the loop alive to make sure we would be getting a response in caes the
     // network status change triggered another change (which it shouldn't).
     util::Timer delayTimer;
-    delayTimer.start(std::chrono::milliseconds(300), Duration::zero(), [] () {});
+    delayTimer.start(Milliseconds(300), Duration::zero(), [] () {});
 
     loop.run();
 }
@@ -100,7 +100,7 @@ TEST_F(Storage, HTTPNetworkStatusChangePreempt) {
 
     // After 400 milliseconds, we're going to trigger a NetworkStatus change.
     util::Timer reachableTimer;
-    reachableTimer.start(std::chrono::milliseconds(400), Duration::zero(), [] () {
+    reachableTimer.start(Milliseconds(400), Duration::zero(), [] () {
         mbgl::NetworkStatus::Reachable();
     });
 


### PR DESCRIPTION
We have abstractions for `std::chrono` in `mbgl/util/chrono.hpp` for most common usages. This patch series reduces `std::chrono` cast complexity and usage to `include/mbgl/util/chrono.hpp`.

:eyes: @kkaefer @jfirebaugh @tmpsantos