### PR TITLE
Fix tileSize in style sources specification

### DIFF
--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<AnnotationTile> AnnotationManager::getTile(const TileID& tileID)
 void AnnotationManager::updateStyle(Style& style) {
     // Create annotation source, point layer, and point bucket
     if (!style.getSource(SourceID)) {
-        std::unique_ptr<Source> source = std::make_unique<Source>(SourceType::Annotations, SourceID, "", std::make_unique<SourceInfo>(), nullptr);
+        std::unique_ptr<Source> source = std::make_unique<Source>(SourceType::Annotations, SourceID, "", util::tileSize, std::make_unique<SourceInfo>(), nullptr);
         source->enabled = true;
         style.addSource(std::move(source));
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -43,11 +43,13 @@ namespace mbgl {
 Source::Source(SourceType type_,
                const std::string& id_,
                const std::string& url_,
+               uint16_t tileSize_,
                std::unique_ptr<SourceInfo>&& info_,
                std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
     : type(type_),
       id(id_),
       url(url_),
+      tileSize(tileSize_),
       info(std::move(info_)),
       geojsonvt(std::move(geojsonvt_)) {
 }
@@ -306,7 +308,7 @@ TileData::State Source::addTile(const TileID& tileID, const StyleUpdateParameter
 }
 
 double Source::getZoom(const TransformState& state) const {
-    double offset = std::log(util::tileSize / info->tile_size) / std::log(2);
+    double offset = std::log(util::tileSize / tileSize) / std::log(2);
     return state.getZoom() + offset;
 }
 

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -42,6 +42,7 @@ public:
     Source(SourceType,
            const std::string& id,
            const std::string& url,
+           uint16_t tileSize,
            std::unique_ptr<SourceInfo>&&,
            std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
     ~Source();
@@ -73,6 +74,7 @@ public:
     const SourceType type;
     const std::string id;
     const std::string url;
+    uint16_t tileSize = util::tileSize;
     bool enabled = false;
 
 private:

--- a/src/mbgl/map/source_info.hpp
+++ b/src/mbgl/map/source_info.hpp
@@ -16,7 +16,6 @@ class TileID;
 class SourceInfo {
 public:
     std::vector<std::string> tiles;
-    uint16_t tile_size = util::tileSize;
     uint16_t min_zoom = 0;
     uint16_t max_zoom = 22;
     std::string attribution;

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -156,12 +156,25 @@ void StyleParser::parseSources(const JSValue& value) {
         // parameters are specified inline.
         std::string url;
 
+        uint16_t tileSize = util::tileSize;
+
         std::unique_ptr<SourceInfo> info;
         std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
 
         switch (type) {
-        case SourceType::Vector:
         case SourceType::Raster:
+            if (sourceVal.HasMember("tileSize")) {
+                const JSValue& tileSizeVal = sourceVal["tileSize"];
+                if (tileSizeVal.IsNumber() && tileSizeVal.GetUint64() <= std::numeric_limits<uint16_t>::max()) {
+                    tileSize = tileSizeVal.GetUint64();
+                } else {
+                    Log::Error(Event::ParseStyle, "invalid tileSize");
+                    continue;
+                }
+            }
+            // Fall through. Vector sources are forbidden from having a tileSize.
+
+        case SourceType::Vector:
             if (sourceVal.HasMember("url")) {
                 const JSValue& urlVal = sourceVal["url"];
                 if (urlVal.IsString()) {
@@ -208,7 +221,7 @@ void StyleParser::parseSources(const JSValue& value) {
         }
 
         const std::string id { nameVal.GetString(), nameVal.GetStringLength() };
-        std::unique_ptr<Source> source = std::make_unique<Source>(type, id, url, std::move(info), std::move(geojsonvt));
+        std::unique_ptr<Source> source = std::make_unique<Source>(type, id, url, tileSize, std::move(info), std::move(geojsonvt));
 
         sourcesMap.emplace(id, source.get());
         sources.emplace_back(std::move(source));
@@ -231,7 +244,6 @@ std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> StyleParser::parseGeoJSON(const JS
 std::unique_ptr<SourceInfo> StyleParser::parseTileJSON(const JSValue& value) {
     auto info = std::make_unique<SourceInfo>();
     parseTileJSONMember(value, info->tiles, "tiles");
-    parseTileJSONMember(value, info->tile_size, "tileSize");
     parseTileJSONMember(value, info->min_zoom, "minzoom");
     parseTileJSONMember(value, info->max_zoom, "maxzoom");
     parseTileJSONMember(value, info->attribution, "attribution");


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/commit/e8705d535d56415ff8f97db1ad6b5a77ed3fcd4a#commitcomment-15454766 accidentally moved `tileSize` from the style to the TileJSON file.