### PR TITLE
[android] #3503 - remove serialisable interface

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/BoundingBox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/BoundingBox.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * A rectangular geographical area defined in latitude and longitude units.
  */
-public final class BoundingBox implements Parcelable, Serializable {
+public final class BoundingBox implements Parcelable {
 
     private final double mLatNorth;
     private final double mLatSouth;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/CoordinateBounds.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/CoordinateBounds.java
@@ -1,41 +1,52 @@
 package com.mapbox.mapboxsdk.geometry;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
 /**
  * A rectangular geograpical region defined by a south west {@link LatLng} and a north east {@link LatLng}.
  */
-public class CoordinateBounds {
+public class CoordinateBounds implements Parcelable {
 
-    private LatLng southWest;
-    private LatLng northEast;
+    private LatLng mSouthWest;
+    private LatLng mNorthEast;
 
-    public CoordinateBounds(LatLng southWest, LatLng northEast) {
-        this.southWest = southWest;
-        this.northEast = northEast;
+    public CoordinateBounds(@NonNull Parcel in) {
+        mSouthWest = in.readParcelable(LatLng.class.getClassLoader());
+        mNorthEast = in.readParcelable(LatLng.class.getClassLoader());
     }
 
+    public CoordinateBounds(@NonNull LatLng southWest, @NonNull LatLng northEast) {
+        mSouthWest = southWest;
+        mNorthEast = northEast;
+    }
+
+    @NonNull
     public LatLng getSouthWest() {
-        return southWest;
+        return mSouthWest;
     }
 
-    public void setSouthWest(LatLng southWest) {
-        this.southWest = southWest;
+    public void setSouthWest(@NonNull LatLng mSouthWest) {
+        this.mSouthWest = mSouthWest;
     }
 
+    @NonNull
     public LatLng getNorthEast() {
-        return northEast;
+        return mNorthEast;
     }
 
-    public void setNorthEast(LatLng northEast) {
-        this.northEast = northEast;
+    public void setNorthEast(@NonNull LatLng mNorthEast) {
+        this.mNorthEast = mNorthEast;
     }
 
     @Override
     public int hashCode() {
         int result;
         long temp;
-        temp = southWest.hashCode();
+        temp = mSouthWest.hashCode();
         result = (int) (temp ^ (temp >>> 32));
-        temp = northEast.hashCode();
+        temp = mNorthEast.hashCode();
         result = 31 * result + (int) (temp ^ (temp >>> 32));
         return result;
     }
@@ -53,6 +64,30 @@ public class CoordinateBounds {
 
     @Override
     public String toString() {
-        return "CoordinateBounds [northEast[" + getNorthEast() + "], southWest[]" + getSouthWest() + "]";
+        return "CoordinateBounds [mNorthEast[" + getNorthEast() + "], mSouthWest[]" + getSouthWest() + "]";
+    }
+
+    public static final Parcelable.Creator<CoordinateBounds> CREATOR =
+            new Parcelable.Creator<CoordinateBounds>() {
+                @Override
+                public CoordinateBounds createFromParcel(Parcel in) {
+                    return new CoordinateBounds(in);
+                }
+
+                @Override
+                public CoordinateBounds[] newArray(int size) {
+                    return new CoordinateBounds[size];
+                }
+            };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel out, int arg1) {
+        out.writeParcelable(mSouthWest, arg1);
+        out.writeParcelable(mNorthEast, arg1);
     }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/CoordinateRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/CoordinateRegion.java
@@ -1,30 +1,64 @@
 package com.mapbox.mapboxsdk.geometry;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
 /**
  * A geographical region defined by a {@link LatLng} and a {@link CoordinateSpan}.
  */
-public class CoordinateRegion {
-    private LatLng center;
-    private CoordinateSpan span;
+public class CoordinateRegion implements Parcelable{
 
-    public CoordinateRegion(final LatLng center, final CoordinateSpan span) {
-        this.center = center;
-        this.span = span;
+    private LatLng mCenter;
+    private CoordinateSpan mSpan;
+
+    public CoordinateRegion(@NonNull Parcel in){
+        mCenter = in.readParcelable(LatLng.class.getClassLoader());
+        mSpan = in.readParcelable(CoordinateSpan.class.getClassLoader());
+    }
+
+    public CoordinateRegion(@NonNull LatLng center, @NonNull CoordinateSpan span) {
+        mCenter = center;
+        mSpan = span;
     }
 
     public LatLng getCenter() {
-        return center;
+        return mCenter;
     }
 
-    public void setCenter(final LatLng center) {
-        this.center = center;
+    public void setCenter(@NonNull LatLng center) {
+        mCenter = center;
     }
 
     public CoordinateSpan getSpan() {
-        return span;
+        return mSpan;
     }
 
-    public void setSpan(final CoordinateSpan span) {
-        this.span = span;
+    public void setSpan(@NonNull CoordinateSpan span) {
+        this.mSpan = span;
+    }
+
+    public static final Parcelable.Creator<CoordinateRegion> CREATOR =
+            new Parcelable.Creator<CoordinateRegion>() {
+                @Override
+                public CoordinateRegion createFromParcel(Parcel in) {
+                    return new CoordinateRegion(in);
+                }
+
+                @Override
+                public CoordinateRegion[] newArray(int size) {
+                    return new CoordinateRegion[size];
+                }
+            };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel out, int arg1) {
+        out.writeParcelable(mCenter, arg1);
+        out.writeParcelable(mSpan, arg1);
     }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/CoordinateSpan.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/CoordinateSpan.java
@@ -1,32 +1,41 @@
 package com.mapbox.mapboxsdk.geometry;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
 /**
  * A geographical span defined by its latitude and longitude span.
  */
-public class CoordinateSpan {
+public class CoordinateSpan implements Parcelable {
 
-    private double latitudeSpan;
-    private double longitudeSpan;
+    private double mLatitudeSpan;
+    private double mLongitudeSpan;
 
-    public CoordinateSpan(final double latitudeSpan, final double longitudeSpan) {
-        this.latitudeSpan = latitudeSpan;
-        this.longitudeSpan = longitudeSpan;
+    public CoordinateSpan(@NonNull Parcel in){
+        mLatitudeSpan = in.readDouble();
+        mLongitudeSpan = in.readDouble();
+    }
+
+    public CoordinateSpan(double latitudeSpan, double longitudeSpan) {
+        mLatitudeSpan = latitudeSpan;
+        mLongitudeSpan = longitudeSpan;
     }
 
     public double getLatitudeSpan() {
-        return latitudeSpan;
+        return mLatitudeSpan;
     }
 
-    public void setLatitudeSpan(final double latitudeSpan) {
-        this.latitudeSpan = latitudeSpan;
+    public void setLatitudeSpan(double latitudeSpan) {
+        mLatitudeSpan = latitudeSpan;
     }
 
     public double getLongitudeSpan() {
-        return longitudeSpan;
+        return mLongitudeSpan;
     }
 
-    public void setLongitudeSpan(final double longitudeSpan) {
-        this.longitudeSpan = longitudeSpan;
+    public void setLongitudeSpan(double longitudeSpan) {
+        mLongitudeSpan = longitudeSpan;
     }
 
     @Override
@@ -34,10 +43,33 @@ public class CoordinateSpan {
         if (this == o) return true;
         if (o instanceof CoordinateSpan) {
             CoordinateSpan other = (CoordinateSpan) o;
-            return longitudeSpan == other.getLongitudeSpan()
-                    && latitudeSpan == other.getLatitudeSpan();
+            return mLongitudeSpan == other.getLongitudeSpan()
+                    && mLatitudeSpan == other.getLatitudeSpan();
         }
         return false;
     }
 
+    public static final Parcelable.Creator<CoordinateSpan> CREATOR =
+            new Parcelable.Creator<CoordinateSpan>() {
+                @Override
+                public CoordinateSpan createFromParcel(Parcel in) {
+                    return new CoordinateSpan(in);
+                }
+
+                @Override
+                public CoordinateSpan[] newArray(int size) {
+                    return new CoordinateSpan[size];
+                }
+            };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel out, int arg1) {
+        out.writeDouble(mLatitudeSpan);
+        out.writeDouble(mLongitudeSpan);
+    }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLng.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLng.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
  * data automatically, so all data enters in the WGS84 datum.
  * </p>
  */
-public class LatLng implements ILatLng, Parcelable, Serializable {
+public class LatLng implements ILatLng, Parcelable {
 
     public static final Parcelable.Creator<LatLng> CREATOR = new Parcelable.Creator<LatLng>() {
         public LatLng createFromParcel(Parcel in) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngZoom.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLngZoom.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 /**
  * A geographical location which contains a {@link LatLng}, zoom pair.
  */
-public class LatLngZoom extends LatLng implements Parcelable, Serializable {
+public class LatLngZoom extends LatLng implements Parcelable {
 
     public static final Parcelable.Creator<LatLngZoom> CREATOR = new Parcelable.Creator<LatLngZoom>() {
         public LatLngZoom createFromParcel(Parcel in) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/ProjectedMeters.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/ProjectedMeters.java
@@ -13,7 +13,7 @@ import java.io.Serializable;
  * except at the equator.
  * </p>
  */
-public class ProjectedMeters implements IProjectedMeters, Parcelable, Serializable {
+public class ProjectedMeters implements IProjectedMeters, Parcelable {
 
     public static final Creator<ProjectedMeters> CREATOR = new Creator<ProjectedMeters>() {
         public ProjectedMeters createFromParcel(Parcel in) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/CoordinateBoundsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/CoordinateBoundsTest.java
@@ -44,7 +44,7 @@ public class CoordinateBoundsTest {
         CoordinateBounds coordinateBounds = new CoordinateBounds(northEast, southWest);
         assertEquals("string should match",
                 coordinateBounds.toString(),
-                "CoordinateBounds [northEast[" + coordinateBounds.getNorthEast() + "], southWest[]" + coordinateBounds.getSouthWest() + "]");
+                "CoordinateBounds [mNorthEast[" + coordinateBounds.getNorthEast() + "], mSouthWest[]" + coordinateBounds.getSouthWest() + "]");
     }
 
     @Test


### PR DESCRIPTION
Remove serialisable interface from classes in geometry package, implemented parceable on CoordinateBounds, CoordinateRegion and CoordinateSpan. Enforced Android code conventions on those classes.

Closes #3503 