### PR TITLE
[ios] Updates configure to work when project is a submodule

### DIFF
--- a/configure
+++ b/configure
@@ -15,7 +15,7 @@ function abort { >&2 echo -e "\033[1m\033[31m$1\033[0m"; exit 1; }
 function info { >&2 echo -e "\033[1m\033[33m$1\033[0m"; }
 function warn { >&2 echo -e "\033[1m\033[33m$1\033[0m"; }
 
-if [ -d "`pwd`/.git" ]; then
+if [ -e "`pwd`/.git" ]; then
     info "This build is within a git repository"
     export MASON_DIR="`pwd`/.mason"
     export PATH="${MASON_DIR}:${PATH}"


### PR DESCRIPTION
The configure bash script is currently checking for the existence of the .git directory to see if it should install mason dependencies within the current directory. We use mapbox-gl-native as a submodule which breaks this check.