### PR TITLE
[ios] Adds the ability to disable map deceleration

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -19,6 +19,10 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MGLOverlay;
 @protocol MGLCalloutView;
 
+extern const CGFloat MGLMapViewDecelerationRateNormal;
+extern const CGFloat MGLMapViewDecelerationRateFast;
+extern const CGFloat MGLMapViewDecelerationRateImmediate;
+
 /** The vertical alignment of an annotation within a map view. */
 typedef NS_ENUM(NSUInteger, MGLAnnotationVerticalAlignment) {
     /** Aligns the annotation vertically in the center of the map view. */
@@ -382,6 +386,14 @@ IB_DESIGNABLE
  The default value of this property is `YES`.
  */
 @property(nonatomic, getter=isPitchEnabled) BOOL pitchEnabled;
+
+/**
+ A floating-point value that determines the rate of deceleration after the user lifts their finger.
+
+ Your application can use the MGLMapViewDecelerationRateNormal and MGLMapViewDecelerationRateFast constants as reference points for reasonable deceleration rates.
+ MGLMapViewDecelerationRateImmediate can be used to disable deceleration entirely.
+ */
+@property(nonatomic) CGFloat decelerationRate;
 
 #pragma mark Manipulating the Viewpoint
 


### PR DESCRIPTION
This adds the ability to disable the deceleration animation that occurs when the user stops panning. This feature can be useful when trying to move a marker on the map.