### PR TITLE
Refactor telemetry keys

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1056,7 +1056,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
     if (pan.state == UIGestureRecognizerStateBegan)
     {
-        [self trackGestureEvent:MGLEventGesturePanStart forRecognizer:pan];
+        [self trackGestureEvent:MGLEventGesturePanStart];
 
         self.userTrackingMode = MGLUserTrackingModeNone;
         
@@ -1114,7 +1114,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
     if (pinch.state == UIGestureRecognizerStateBegan)
     {
-        [self trackGestureEvent:MGLEventGesturePinchStart forRecognizer:pinch];
+        [self trackGestureEvent:MGLEventGesturePinchStart];
 
         self.scale = _mbglMap->getScale();
         
@@ -1185,7 +1185,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
     if (rotate.state == UIGestureRecognizerStateBegan)
     {
-        [self trackGestureEvent:MGLEventGestureRotateStart forRecognizer:rotate];
+        [self trackGestureEvent:MGLEventGestureRotateStart];
 
         self.angle = MGLRadiansFromDegrees(_mbglMap->getBearing()) * -1;
 
@@ -1248,7 +1248,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     {
         return;
     }
-    [self trackGestureEvent:MGLEventGestureSingleTap forRecognizer:singleTap];
+    [self trackGestureEvent:MGLEventGestureSingleTap];
 
     CGPoint tapPoint = [singleTap locationInView:self];
 
@@ -1293,7 +1293,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
     if (doubleTap.state == UIGestureRecognizerStateBegan)
     {
-        [self trackGestureEvent:MGLEventGestureDoubleTap forRecognizer:doubleTap];
+        [self trackGestureEvent:MGLEventGestureDoubleTap];
     }
     else if (doubleTap.state == UIGestureRecognizerStateEnded)
     {
@@ -1325,7 +1325,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
     if (twoFingerTap.state == UIGestureRecognizerStateBegan)
     {
-        [self trackGestureEvent:MGLEventGestureTwoFingerSingleTap forRecognizer:twoFingerTap];
+        [self trackGestureEvent:MGLEventGestureTwoFingerSingleTap];
     }
     else if (twoFingerTap.state == UIGestureRecognizerStateEnded)
     {
@@ -1355,7 +1355,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
     if (quickZoom.state == UIGestureRecognizerStateBegan)
     {
-        [self trackGestureEvent:MGLEventGestureQuickZoom forRecognizer:quickZoom];
+        [self trackGestureEvent:MGLEventGestureQuickZoom];
 
         self.scale = _mbglMap->getScale();
 
@@ -1396,7 +1396,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
     if (twoFingerDrag.state == UIGestureRecognizerStateBegan)
     {
-        [self trackGestureEvent:MGLEventGesturePitchStart forRecognizer:twoFingerDrag];
+        [self trackGestureEvent:MGLEventGesturePitchStart];
         [self notifyGestureDidBegin];
     }
     else if (twoFingerDrag.state == UIGestureRecognizerStateBegan || twoFingerDrag.state == UIGestureRecognizerStateChanged)
@@ -1471,7 +1471,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     return ([validSimultaneousGestures containsObject:gestureRecognizer] && [validSimultaneousGestures containsObject:otherGestureRecognizer]);
 }
 
-- (void)trackGestureEvent:(NSString *)gestureID forRecognizer:(__unused UIGestureRecognizer *)recognizer
+- (void)trackGestureEvent:(NSString *)gestureID
 {
     int zoom = round([self zoomLevel]);
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -444,15 +444,11 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     _pendingLatitude = NAN;
     _pendingLongitude = NAN;
 
-    // metrics: map load event
-    mbgl::LatLng latLng = _mbglMap->getLatLng(padding);
+    // telemetry: map load event
     int zoom = round(_mbglMap->getZoom());
 
     [MGLMapboxEvents pushEvent:MGLEventTypeMapLoad withAttributes:@{
-        MGLEventKeyLatitude: @(latLng.latitude),
-        MGLEventKeyLongitude: @(latLng.longitude),
-        MGLEventKeyZoomLevel: @(zoom),
-        MGLEventKeyPushEnabled: @([MGLMapboxEvents checkPushEnabled])
+        MGLEventKeyZoomLevel: @(zoom)
     }];
 }
 
@@ -1093,14 +1089,10 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
         [self notifyGestureDidEndWithDrift:drift];
 
-        // metrics: pan end
-        CGPoint pointInView = CGPointMake([pan locationInView:pan.view].x, [pan locationInView:pan.view].y);
-        CLLocationCoordinate2D panCoordinate = [self convertPoint:pointInView toCoordinateFromView:pan.view];
+        // telemetry: pan/drag end
         int zoom = round([self zoomLevel]);
 
         [MGLMapboxEvents pushEvent:MGLEventTypeMapDragEnd withAttributes:@{
-            MGLEventKeyLatitude: @(panCoordinate.latitude),
-            MGLEventKeyLongitude: @(panCoordinate.longitude),
             MGLEventKeyZoomLevel: @(zoom)
         }];
     }
@@ -1479,15 +1471,11 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
     return ([validSimultaneousGestures containsObject:gestureRecognizer] && [validSimultaneousGestures containsObject:otherGestureRecognizer]);
 }
 
-- (void)trackGestureEvent:(NSString *)gestureID forRecognizer:(UIGestureRecognizer *)recognizer
+- (void)trackGestureEvent:(NSString *)gestureID forRecognizer:(__unused UIGestureRecognizer *)recognizer
 {
-    CGPoint pointInView = CGPointMake([recognizer locationInView:recognizer.view].x, [recognizer locationInView:recognizer.view].y);
-    CLLocationCoordinate2D gestureCoordinate = [self convertPoint:pointInView toCoordinateFromView:recognizer.view];
     int zoom = round([self zoomLevel]);
 
     [MGLMapboxEvents pushEvent:MGLEventTypeMapTap withAttributes:@{
-        MGLEventKeyLatitude: @(gestureCoordinate.latitude),
-        MGLEventKeyLongitude: @(gestureCoordinate.longitude),
         MGLEventKeyZoomLevel: @(zoom),
         MGLEventKeyGestureID: gestureID
     }];

--- a/platform/ios/src/MGLMapboxEvents.h
+++ b/platform/ios/src/MGLMapboxEvents.h
@@ -20,8 +20,6 @@ extern NSString *const MGLEventKeyCourse;
 extern NSString *const MGLEventKeyAltitude;
 extern NSString *const MGLEventKeyHorizontalAccuracy;
 extern NSString *const MGLEventKeyVerticalAccuracy;
-extern NSString *const MGLEventKeyPushEnabled;
-extern NSString *const MGLEventKeyEmailEnabled;
 extern NSString *const MGLEventKeyGestureID;
 extern NSString *const MGLEventKeyArrivalDate;
 extern NSString *const MGLEventKeyDepartureDate;
@@ -62,10 +60,6 @@ typedef NS_MUTABLE_DICTIONARY_OF(NSString *, id) MGLMutableMapboxEventAttributes
 + (void) pushDebugEvent:(NSString *)event withAttributes:(MGLMapboxEventAttributes *)attributeDictionary;
 
 + (BOOL) debugLoggingEnabled;
-
-// You can call these methods from any thread.
-//
-+ (BOOL) checkPushEnabled;
 
 // You can call this method from any thread.
 //

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -417,37 +417,33 @@ const NSTimeInterval MGLFlushInterval = 60;
 }
 
 - (void) pushTurnstileEvent {
-
     __weak MGLMapboxEvents *weakSelf = self;
 
     dispatch_async(_serialQueue, ^{
-
         MGLMapboxEvents *strongSelf = weakSelf;
 
         if ( ! strongSelf) return;
 
-            // Build only IDFV event
-            NSString *vid = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+        NSString *idfv = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
 
-            if (!vid) return;
+        if ( ! idfv) return;
 
-            NSDictionary *vevt = @{
-                @"event" : MGLEventTypeAppUserTurnstile,
-                @"created" : [strongSelf.rfc3339DateFormatter stringFromDate:[NSDate date]],
-                @"vendorId": vid,
-                @"version": @(version)
-            };
+        NSDictionary *vevt = @{
+            @"event" : MGLEventTypeAppUserTurnstile,
+            @"created" : [strongSelf.rfc3339DateFormatter stringFromDate:[NSDate date]],
+            @"vendorId": idfv,
+            @"version": @(version),
+            @"enabled.telemetry": @([[strongSelf class] isEnabled])
+        };
 
-            // Add to Queue
-            [_eventQueue addObject:vevt];
+        [_eventQueue addObject:vevt];
 
-            // Flush
-            [strongSelf flush];
+        // Flush
+        [strongSelf flush];
 
         if ([strongSelf debugLoggingEnabled]) {
             [strongSelf writeEventToLocalDebugLog:vevt];
         }
-
     });
 }
 
@@ -477,7 +473,7 @@ const NSTimeInterval MGLFlushInterval = 60;
             return;
         }
         
-        if (!event) return;
+        if ( ! event) return;
 
         MGLMutableMapboxEventAttributes *evt = [MGLMutableMapboxEventAttributes dictionaryWithDictionary:attributeDictionary];
         // Send these keys with every event

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -12,8 +12,8 @@
 
 #include <sys/sysctl.h>
 
-static const NSUInteger version = 1;
-static NSString *const MGLMapboxEventsUserAgent = @"MapboxEventsiOS/1.1";
+static const NSUInteger version = 2;
+static NSString *const MGLMapboxEventsUserAgent = @"MapboxEventsiOS/2.0";
 static NSString *MGLMapboxEventsAPIBase = @"https://api.tiles.mapbox.com";
 
 NSString *const MGLEventTypeAppUserTurnstile = @"appUserTurnstile";

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -32,8 +32,6 @@ NSString *const MGLEventKeyCourse = @"course";
 NSString *const MGLEventKeyAltitude = @"altitude";
 NSString *const MGLEventKeyHorizontalAccuracy = @"horizontalAccuracy";
 NSString *const MGLEventKeyVerticalAccuracy = @"verticalAccuracy";
-NSString *const MGLEventKeyPushEnabled = @"enabled.push";
-NSString *const MGLEventKeyEmailEnabled = @"enabled.email";
 NSString *const MGLEventKeyGestureID = @"gesture";
 NSString *const MGLEventKeyArrivalDate = @"arrivalDate";
 NSString *const MGLEventKeyDepartureDate = @"departureDate";
@@ -436,10 +434,8 @@ const NSTimeInterval MGLFlushInterval = 60;
             NSDictionary *vevt = @{
                 @"event" : MGLEventTypeAppUserTurnstile,
                 @"created" : [strongSelf.rfc3339DateFormatter stringFromDate:[NSDate date]],
-                @"appBundleId" : strongSelf.appBundleId,
                 @"vendorId": vid,
-                @"version": @(version),
-                @"instance": strongSelf.instanceID
+                @"version": @(version)
             };
 
             // Add to Queue
@@ -476,7 +472,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 
         if ( ! strongSelf) return;
 
-        // Metrics Collection Has Been Paused
+        // Telemetry collection has been paused
         if (_paused) {
             return;
         }
@@ -484,39 +480,49 @@ const NSTimeInterval MGLFlushInterval = 60;
         if (!event) return;
 
         MGLMutableMapboxEventAttributes *evt = [MGLMutableMapboxEventAttributes dictionaryWithDictionary:attributeDictionary];
-        // mapbox-events stock attributes
+        // Send these keys with every event
         [evt setObject:event forKey:@"event"];
         [evt setObject:@(version) forKey:@"version"];
         [evt setObject:[strongSelf.rfc3339DateFormatter stringFromDate:[NSDate date]] forKey:@"created"];
-        [evt setObject:strongSelf.instanceID forKey:@"instance"];
-        [evt setObject:strongSelf.data.vendorId forKey:@"vendorId"];
-        [evt setObject:strongSelf.appBundleId forKeyedSubscript:@"appBundleId"];
-
-        // mapbox-events-ios stock attributes
-        [evt setValue:strongSelf.data.model forKey:@"model"];
-        [evt setValue:strongSelf.data.iOSVersion forKey:@"operatingSystem"];
-        [evt setValue:[strongSelf deviceOrientation] forKey:@"orientation"];
-        [evt setValue:@((int)(100 * [UIDevice currentDevice].batteryLevel)) forKey:@"batteryLevel"];
-        [evt setValue:@(strongSelf.data.scale) forKey:@"resolution"];
-
-        MGLReachability *reachability = [MGLReachability reachabilityForLocalWiFi];
-        [evt setValue:([reachability isReachableViaWiFi] ? @YES : @NO) forKey:@"wifi"];
 
         [evt setValue:[strongSelf applicationState] forKey:@"applicationState"];
 
-        [evt setValue:@([strongSelf contentSizeScale]) forKey:@"accessibilityFontScale"];
+        // Send with every event, but exclude these keys from location & visit events.
+        if ( ! [event isEqualToString:MGLEventTypeLocation] && ! [event isEqualToString:MGLEventTypeVisit]) {
+            [evt setValue:[strongSelf deviceOrientation] forKey:@"orientation"];
 
-        // Make Immutable Version
+            [evt setValue:@((int)(100 * [UIDevice currentDevice].batteryLevel)) forKey:@"batteryLevel"];
+
+            MGLReachability *reachability = [MGLReachability reachabilityForLocalWiFi];
+            [evt setValue:([reachability isReachableViaWiFi] ? @YES : @NO) forKey:@"wifi"];
+        }
+
+        // Only add IDFV to location events
+        if ([event isEqualToString:MGLEventTypeLocation] || [event isEqualToString:MGLEventTypeVisit]) {
+            [evt setObject:strongSelf.data.vendorId forKey:@"vendorId"];
+        }
+
+        // Only send these (relatively static) keys with the map load event
+        if ([event isEqualToString:MGLEventTypeMapLoad]) {
+            [evt setObject:strongSelf.data.vendorId forKey:@"vendorId"];
+            [evt setValue:strongSelf.data.model forKey:@"model"];
+            [evt setValue:strongSelf.data.iOSVersion forKey:@"operatingSystem"];
+            [evt setValue:@(strongSelf.data.scale) forKey:@"resolution"];
+            [evt setValue:@([strongSelf contentSizeScale]) forKey:@"accessibilityFontScale"];
+            [evt setValue:@([strongSelf checkPushEnabled]) forKey:@"enabled.push"];
+        }
+
+        // Make immutable version
         NSDictionary *finalEvent = [NSDictionary dictionaryWithDictionary:evt];
         
-        // Put On The Queue
+        // Put on the queue
         [_eventQueue addObject:finalEvent];
         
-        // Has Flush Limit Been Reached?
+        // Has flush limit been reached?
         if (_eventQueue.count >= MGLMaximumEventsPerFlush) {
             [strongSelf flush];
         } else if (_eventQueue.count ==  1) {
-            // If this is first new event on queue start timer,
+            // If this is first new event on queue, start timer
             [strongSelf startTimer];
         }
 
@@ -775,7 +781,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 
 // Can be called from any thread.
 //
-+ (BOOL) checkPushEnabled {
+- (BOOL) checkPushEnabled {
     BOOL (^pushCheckBlock)(void) = ^{
         BOOL blockResult;
         if ([[UIApplication sharedApplication] respondsToSelector:@selector(isRegisteredForRemoteNotifications)]) {

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -1007,8 +1007,9 @@ const NSTimeInterval MGLFlushInterval = 60;
     }
 
     if ( ! _debugLogSerialQueue) {
+        NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
         NSString *uniqueID = [[NSProcessInfo processInfo] globallyUniqueString];
-        _debugLogSerialQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.%@.events.debugLog", _appBundleId, uniqueID] UTF8String], DISPATCH_QUEUE_SERIAL);
+        _debugLogSerialQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.%@.events.debugLog", bundleID, uniqueID] UTF8String], DISPATCH_QUEUE_SERIAL);
     }
 
     dispatch_sync(_debugLogSerialQueue, ^{

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -485,7 +485,8 @@ const NSTimeInterval MGLFlushInterval = 60;
         if ( ! [event isEqualToString:MGLEventTypeLocation] && ! [event isEqualToString:MGLEventTypeVisit]) {
             [evt setValue:[strongSelf deviceOrientation] forKey:@"orientation"];
 
-            [evt setValue:@((int)(100 * [UIDevice currentDevice].batteryLevel)) forKey:@"batteryLevel"];
+            int batteryLevel = roundf(100 * [UIDevice currentDevice].batteryLevel);
+            [evt setValue:@(batteryLevel) forKey:@"batteryLevel"];
 
             UIDeviceBatteryState batteryState = [[UIDevice currentDevice] batteryState];
             if (batteryState != UIDeviceBatteryStateUnknown) {

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -67,7 +67,6 @@ const NSTimeInterval MGLFlushInterval = 60;
 - (instancetype)init {
     if (self = [super init]) {
         _vendorId = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
-        
         _model = [self sysInfoByName:"hw.machine"];
         _iOSVersion = [NSString stringWithFormat:@"%@ %@", [UIDevice currentDevice].systemName, [UIDevice currentDevice].systemVersion];
         if ([UIScreen instancesRespondToSelector:@selector(nativeScale)]) {
@@ -119,11 +118,9 @@ const NSTimeInterval MGLFlushInterval = 60;
 // the main thread, but can be read on any thread.
 //
 @property (atomic) MGLMapboxEventsData *data;
-@property (atomic) NSString *appBundleId;
 @property (atomic) NSString *appName;
 @property (atomic) NSString *appVersion;
 @property (atomic) NSString *appBuildNumber;
-@property (atomic) NSString *instanceID;
 @property (atomic) NSDateFormatter *rfc3339DateFormatter;
 @property (atomic) NSURLSession *session;
 @property (atomic) NSData *digicertCert;
@@ -194,14 +191,13 @@ const NSTimeInterval MGLFlushInterval = 60;
 
     self = [super init];
     if (self) {
-        _appBundleId = [[NSBundle mainBundle] bundleIdentifier];
         _appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
         _appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
         _appBuildNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
-        _instanceID = [[NSUUID UUID] UUIDString];
 
+        NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
         NSString *uniqueID = [[NSProcessInfo processInfo] globallyUniqueString];
-        _serialQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.%@.events.serial", _appBundleId, uniqueID] UTF8String], DISPATCH_QUEUE_SERIAL);
+        _serialQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.%@.events.serial", bundleID, uniqueID] UTF8String], DISPATCH_QUEUE_SERIAL);
 
         // Configure Events Infrastructure
         // ===============================

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -121,6 +121,7 @@ const NSTimeInterval MGLFlushInterval = 60;
 @property (atomic) NSString *appName;
 @property (atomic) NSString *appVersion;
 @property (atomic) NSString *appBuildNumber;
+@property (atomic) NSString *instanceID;
 @property (atomic) NSDateFormatter *rfc3339DateFormatter;
 @property (atomic) NSURLSession *session;
 @property (atomic) NSData *digicertCert;
@@ -194,6 +195,7 @@ const NSTimeInterval MGLFlushInterval = 60;
         _appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
         _appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
         _appBuildNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+        _instanceID = [[NSUUID UUID] UUIDString];
 
         NSString *bundleID = [[NSBundle mainBundle] bundleIdentifier];
         NSString *uniqueID = [[NSProcessInfo processInfo] globallyUniqueString];
@@ -494,9 +496,10 @@ const NSTimeInterval MGLFlushInterval = 60;
             [evt setValue:([reachability isReachableViaWiFi] ? @YES : @NO) forKey:@"wifi"];
         }
 
-        // Only add IDFV to location events
+        // Only additionally add IDFV and app instance UUID to location events
         if ([event isEqualToString:MGLEventTypeLocation] || [event isEqualToString:MGLEventTypeVisit]) {
             [evt setObject:strongSelf.data.vendorId forKey:@"vendorId"];
+            [evt setObject:strongSelf.instanceID forKey:@"instance"];
         }
 
         // Only send these (relatively static) keys with the map load event

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -493,6 +493,11 @@ const NSTimeInterval MGLFlushInterval = 60;
 
             [evt setValue:@((int)(100 * [UIDevice currentDevice].batteryLevel)) forKey:@"batteryLevel"];
 
+            UIDeviceBatteryState batteryState = [[UIDevice currentDevice] batteryState];
+            if (batteryState != UIDeviceBatteryStateUnknown) {
+                [evt setValue:(batteryState == UIDeviceBatteryStateUnplugged ? @NO : @YES) forKey:@"pluggedIn"];
+            }
+
             MGLReachability *reachability = [MGLReachability reachabilityForLocalWiFi];
             [evt setValue:([reachability isReachableViaWiFi] ? @YES : @NO) forKey:@"wifi"];
         }


### PR DESCRIPTION
- Add `pluggedIn` key to non-location events
- Add `enabled.telemetry` key to turnstile (supercedes #3496)
- Remove `instance`
- Remove `bundleId`
- Remove `lat`,`lng` from interaction events
- Remove obsolete `enabled.email` key
- Make `pushEnabled` an instance method
- Move most static keys to `map.load`

/cc @1ec5 @mapbox/mobiledata @boundsj