### PR TITLE
switch to std::experimental::optional

### DIFF
--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -1,11 +1,10 @@
 #ifndef MBGL_MAP_CAMERA
 #define MBGL_MAP_CAMERA
 
-#include <mapbox/optional.hpp>
-
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/unitbezier.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <functional>
 
@@ -15,27 +14,27 @@ namespace mbgl {
     optional. */
 struct CameraOptions {
     /** Coordinate at the center of the map. */
-    mapbox::util::optional<LatLng> center;
+    optional<LatLng> center;
     
     /** Padding around the interior of the view that affects the frame of
         reference for `center`. */
-    mapbox::util::optional<EdgeInsets> padding;
+    optional<EdgeInsets> padding;
     
     /** Point of reference for `zoom` and `angle`, assuming an origin at the
         top-left corner of the view. */
-    mapbox::util::optional<PrecisionPoint> anchor;
+    optional<PrecisionPoint> anchor;
     
     /** Zero-based zoom level. Constrained to the minimum and maximum zoom
         levels. */
-    mapbox::util::optional<double> zoom;
+    optional<double> zoom;
     
     /** Bearing, measured in radians counterclockwise from true north. Wrapped
         to [−π rad, π rad). */
-    mapbox::util::optional<double> angle;
+    optional<double> angle;
     
     /** Pitch toward the horizon measured in radians, with 0 rad resulting in a
         two-dimensional map. */
-    mapbox::util::optional<double> pitch;
+    optional<double> pitch;
 };
 
 /** Various options for describing a transition between viewpoints with
@@ -43,21 +42,21 @@ struct CameraOptions {
     struct is used. */
 struct AnimationOptions {
     /** Time to animate to the viewpoint defined herein. */
-    mapbox::util::optional<Duration> duration;
+    optional<Duration> duration;
     
     /** Average velocity of a flyTo() transition, measured in screenfuls per
         second, assuming a linear timing curve.
         
         A <i>screenful</i> is the visible span in pixels. It does not correspond
         to a fixed physical distance but rather varies by zoom level. */
-    mapbox::util::optional<double> velocity;
+    optional<double> velocity;
     
     /** Zero-based zoom level at the peak of the flyTo() transition’s flight
         path. */
-    mapbox::util::optional<double> minZoom;
+    optional<double> minZoom;
     
     /** The easing timing curve of the transition. */
-    mapbox::util::optional<mbgl::util::UnitBezier> easing;
+    optional<mbgl::util::UnitBezier> easing;
     
     /** A function that is called on each frame of the transition, just before a
         screen update, except on the last frame. The first parameter indicates

--- a/include/mbgl/util/optional.hpp
+++ b/include/mbgl/util/optional.hpp
@@ -1,0 +1,13 @@
+#ifndef MBGL_UTIL_OPTIONAL
+#define MBGL_UTIL_OPTIONAL
+
+#include <experimental/optional>
+
+namespace mbgl {
+
+template <typename T>
+using optional = std::experimental::optional<T>;
+
+} // namespace mbgl
+
+#endif

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -1297,9 +1297,9 @@ void JNICALL nativeSetVisibleCoordinateBounds(JNIEnv *env, jobject obj, jlong na
     }
     mbgl::AnimationOptions animationOptions;
     if (duration > 0) {
-        animationOptions.duration = std::chrono::milliseconds(duration);
+        animationOptions.duration = mbgl::Duration(std::chrono::milliseconds(duration));
         // equivalent to kCAMediaTimingFunctionDefault in iOS
-        animationOptions.easing = {0.25, 0.1, 0.25, 0.1};
+        animationOptions.easing = mbgl::util::UnitBezier(0.25, 0.1, 0.25, 0.1);
     }
 
     nativeMapView->getMap().easeTo(cameraOptions, animationOptions);

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -12,12 +12,12 @@ AnnotationTileFeature::AnnotationTileFeature(FeatureType type_, GeometryCollecti
       properties(std::move(properties_)),
       geometries(geometries_) {}
 
-mapbox::util::optional<Value> AnnotationTileFeature::getValue(const std::string& key) const {
+optional<Value> AnnotationTileFeature::getValue(const std::string& key) const {
     auto it = properties.find(key);
     if (it != properties.end()) {
-        return mapbox::util::optional<Value>(it->second);
+        return optional<Value>(it->second);
     }
-    return mapbox::util::optional<Value>();
+    return optional<Value>();
 }
 
 util::ptr<GeometryTileLayer> AnnotationTile::getLayer(const std::string& name) const {

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -15,7 +15,7 @@ public:
                           std::unordered_map<std::string, std::string> properties = {{}});
 
     FeatureType getType() const override { return type; }
-    mapbox::util::optional<Value> getValue(const std::string&) const override;
+    optional<Value> getValue(const std::string&) const override;
     GeometryCollection getGeometries() const override { return geometries; }
 
     const FeatureType type;

--- a/src/mbgl/map/geometry_tile.cpp
+++ b/src/mbgl/map/geometry_tile.cpp
@@ -4,7 +4,7 @@
 
 namespace mbgl {
 
-mapbox::util::optional<Value> GeometryTileFeatureExtractor::getValue(const std::string& key) const {
+optional<Value> GeometryTileFeatureExtractor::getValue(const std::string& key) const {
     if (key == "$type") {
         return Value(uint64_t(feature.getType()));
     }

--- a/src/mbgl/map/geometry_tile.hpp
+++ b/src/mbgl/map/geometry_tile.hpp
@@ -2,13 +2,13 @@
 #define MBGL_MAP_GEOMETRY_TILE
 
 #include <mapbox/variant.hpp>
-#include <mapbox/optional.hpp>
 
 #include <mbgl/style/value.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/vec.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <cstdint>
 #include <string>
@@ -30,7 +30,7 @@ class GeometryTileFeature : private util::noncopyable {
 public:
     virtual ~GeometryTileFeature() = default;
     virtual FeatureType getType() const = 0;
-    virtual mapbox::util::optional<Value> getValue(const std::string& key) const = 0;
+    virtual optional<Value> getValue(const std::string& key) const = 0;
     virtual GeometryCollection getGeometries() const = 0;
 };
 
@@ -73,7 +73,7 @@ public:
     GeometryTileFeatureExtractor(const GeometryTileFeature& feature_)
         : feature(feature_) {}
 
-    mapbox::util::optional<Value> getValue(const std::string& key) const;
+    optional<Value> getValue(const std::string& key) const;
 
 private:
     const GeometryTileFeature& feature;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -469,7 +469,7 @@ void Map::addCustomLayer(const std::string& id,
                          const char* before) {
     context->invoke(&MapContext::addLayer,
         std::make_unique<CustomLayer>(id, initialize, render, deinitialize, context_),
-        before ? std::string(before) : mapbox::util::optional<std::string>());
+        before ? std::string(before) : optional<std::string>());
 }
 
 void Map::removeCustomLayer(const std::string& id) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -279,7 +279,7 @@ double MapContext::getTopOffsetPixelsForAnnotationIcon(const std::string& name) 
     return data.getAnnotationManager()->getTopOffsetPixelsForIcon(name);
 }
 
-void MapContext::addLayer(std::unique_ptr<StyleLayer> layer, mapbox::util::optional<std::string> after) {
+void MapContext::addLayer(std::unique_ptr<StyleLayer> layer, optional<std::string> after) {
     style->addLayer(std::move(layer), after);
     updateFlags |= Update::Classes;
     asyncUpdate.send();

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -10,8 +10,7 @@
 #include <mbgl/util/async_task.hpp>
 #include <mbgl/util/gl_object_store.hpp>
 #include <mbgl/util/ptr.hpp>
-
-#include <mapbox/optional.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <vector>
 
@@ -58,7 +57,7 @@ public:
     
     // Style API
     void addLayer(std::unique_ptr<StyleLayer>,
-                  const mapbox::util::optional<std::string> before);
+                  const optional<std::string> before);
     void removeLayer(const std::string& id);
 
     void setSourceTileCacheSize(size_t size);

--- a/src/mbgl/map/vector_tile.cpp
+++ b/src/mbgl/map/vector_tile.cpp
@@ -54,10 +54,10 @@ VectorTileFeature::VectorTileFeature(pbf feature_pbf, const VectorTileLayer& lay
     }
 }
 
-mapbox::util::optional<Value> VectorTileFeature::getValue(const std::string& key) const {
+optional<Value> VectorTileFeature::getValue(const std::string& key) const {
     auto keyIter = layer.keys.find(key);
     if (keyIter == layer.keys.end()) {
-        return mapbox::util::optional<Value>();
+        return optional<Value>();
     }
 
     pbf tags = tags_pbf;
@@ -82,7 +82,7 @@ mapbox::util::optional<Value> VectorTileFeature::getValue(const std::string& key
         }
     }
 
-    return mapbox::util::optional<Value>();
+    return optional<Value>();
 }
 
 GeometryCollection VectorTileFeature::getGeometries() const {

--- a/src/mbgl/map/vector_tile.hpp
+++ b/src/mbgl/map/vector_tile.hpp
@@ -16,7 +16,7 @@ public:
     VectorTileFeature(pbf, const VectorTileLayer&);
 
     FeatureType getType() const override { return type; }
-    mapbox::util::optional<Value> getValue(const std::string&) const override;
+    optional<Value> getValue(const std::string&) const override;
     GeometryCollection getGeometries() const override;
 
 private:

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -262,8 +262,8 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
     const BackgroundPaintProperties& properties = layer.paint;
 
     if (!properties.pattern.value.to.empty()) {
-        mapbox::util::optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(properties.pattern.value.from, true);
-        mapbox::util::optional<SpriteAtlasPosition> imagePosB = spriteAtlas->getPosition(properties.pattern.value.to, true);
+        optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(properties.pattern.value.from, true);
+        optional<SpriteAtlasPosition> imagePosB = spriteAtlas->getPosition(properties.pattern.value.to, true);
 
         if (!imagePosA || !imagePosB)
             return;

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -60,8 +60,8 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
     }
 
     if (pattern) {
-        mapbox::util::optional<SpriteAtlasPosition> posA = spriteAtlas->getPosition(properties.pattern.value.from, true);
-        mapbox::util::optional<SpriteAtlasPosition> posB = spriteAtlas->getPosition(properties.pattern.value.to, true);
+        optional<SpriteAtlasPosition> posA = spriteAtlas->getPosition(properties.pattern.value.from, true);
+        optional<SpriteAtlasPosition> posB = spriteAtlas->getPosition(properties.pattern.value.to, true);
 
         // Image fill.
         if (pass == RenderPass::Translucent && posA && posB) {

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -103,8 +103,8 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         bucket.drawLineSDF(*linesdfShader);
 
     } else if (!properties.pattern.value.from.empty()) {
-        mapbox::util::optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(properties.pattern.value.from, true);
-        mapbox::util::optional<SpriteAtlasPosition> imagePosB = spriteAtlas->getPosition(properties.pattern.value.to, true);
+        optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(properties.pattern.value.from, true);
+        optional<SpriteAtlasPosition> imagePosB = spriteAtlas->getPosition(properties.pattern.value.to, true);
         
         if (!imagePosA || !imagePosB)
             return;

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -47,7 +47,7 @@ Rect<SpriteAtlas::dimension> SpriteAtlas::allocateImage(float src_width, float s
     return rect;
 }
 
-mapbox::util::optional<SpriteAtlasElement> SpriteAtlas::getImage(const std::string& name, const bool wrap) {
+optional<SpriteAtlasElement> SpriteAtlas::getImage(const std::string& name, const bool wrap) {
     std::lock_guard<std::recursive_mutex> lock(mtx);
 
     auto rect_it = images.find({ name, wrap });
@@ -74,7 +74,7 @@ mapbox::util::optional<SpriteAtlasElement> SpriteAtlas::getImage(const std::stri
     return SpriteAtlasElement { rect, sprite, sprite->pixelRatio / pixelRatio };
 }
 
-mapbox::util::optional<SpriteAtlasPosition> SpriteAtlas::getPosition(const std::string& name, bool repeating) {
+optional<SpriteAtlasPosition> SpriteAtlas::getPosition(const std::string& name, bool repeating) {
     std::lock_guard<std::recursive_mutex> lock(mtx);
 
     auto img = getImage(name, repeating);

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -5,8 +5,7 @@
 #include <mbgl/platform/gl.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
-
-#include <mapbox/optional.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <string>
 #include <map>
@@ -32,9 +31,9 @@ struct SpriteAtlasPosition {
 };
 
 struct SpriteAtlasElement {
-    const Rect<uint16_t> pos;
-    const std::shared_ptr<const SpriteImage> texture;
-    const float relativePixelRatio;
+    Rect<uint16_t> pos;
+    std::shared_ptr<const SpriteImage> texture;
+    float relativePixelRatio;
 };
 
 class SpriteAtlas : public util::noncopyable {
@@ -46,10 +45,10 @@ public:
 
     // If the sprite is loaded, copies the requsted image from it into the atlas and returns
     // the resulting icon measurements. If not, returns an empty optional.
-    mapbox::util::optional<SpriteAtlasElement> getImage(const std::string& name, const bool wrap);
+    optional<SpriteAtlasElement> getImage(const std::string& name, const bool wrap);
 
     // This function is used for getting the position during render time.
-    mapbox::util::optional<SpriteAtlasPosition> getPosition(const std::string& name, bool repeating = false);
+    optional<SpriteAtlasPosition> getPosition(const std::string& name, bool repeating = false);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
     void bind(bool linear = false);

--- a/src/mbgl/style/filter_expression_private.hpp
+++ b/src/mbgl/style/filter_expression_private.hpp
@@ -1,4 +1,4 @@
-#include <mapbox/optional.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <mbgl/style/value_comparison.hpp>
 
@@ -23,43 +23,43 @@ bool evaluate(const FilterExpression& expression, const Extractor& extractor) {
 
 template <class Extractor>
 bool EqualsExpression::evaluate(const Extractor& extractor) const {
-    mapbox::util::optional<Value> actual = extractor.getValue(key);
+    optional<Value> actual = extractor.getValue(key);
     return actual && util::relaxed_equal(*actual, value);
 }
 
 template <class Extractor>
 bool NotEqualsExpression::evaluate(const Extractor& extractor) const {
-    mapbox::util::optional<Value> actual = extractor.getValue(key);
+    optional<Value> actual = extractor.getValue(key);
     return !actual || util::relaxed_not_equal(*actual, value);
 }
 
 template <class Extractor>
 bool LessThanExpression::evaluate(const Extractor& extractor) const {
-    mapbox::util::optional<Value> actual = extractor.getValue(key);
+    optional<Value> actual = extractor.getValue(key);
     return actual && util::relaxed_less(*actual, value);
 }
 
 template <class Extractor>
 bool LessThanEqualsExpression::evaluate(const Extractor& extractor) const {
-    mapbox::util::optional<Value> actual = extractor.getValue(key);
+    optional<Value> actual = extractor.getValue(key);
     return actual && util::relaxed_less_equal(*actual, value);
 }
 
 template <class Extractor>
 bool GreaterThanExpression::evaluate(const Extractor& extractor) const {
-    mapbox::util::optional<Value> actual = extractor.getValue(key);
+    optional<Value> actual = extractor.getValue(key);
     return actual && util::relaxed_greater(*actual, value);
 }
 
 template <class Extractor>
 bool GreaterThanEqualsExpression::evaluate(const Extractor& extractor) const {
-    mapbox::util::optional<Value> actual = extractor.getValue(key);
+    optional<Value> actual = extractor.getValue(key);
     return actual && util::relaxed_greater_equal(*actual, value);
 }
 
 template <class Extractor>
 bool InExpression::evaluate(const Extractor& extractor) const {
-    mapbox::util::optional<Value> actual = extractor.getValue(key);
+    optional<Value> actual = extractor.getValue(key);
     if (!actual)
         return false;
     for (const auto& v: values) {
@@ -72,7 +72,7 @@ bool InExpression::evaluate(const Extractor& extractor) const {
 
 template <class Extractor>
 bool NotInExpression::evaluate(const Extractor& extractor) const {
-    mapbox::util::optional<Value> actual = extractor.getValue(key);
+    optional<Value> actual = extractor.getValue(key);
     if (!actual)
         return true;
     for (const auto& v: values) {

--- a/src/mbgl/style/function.hpp
+++ b/src/mbgl/style/function.hpp
@@ -3,8 +3,7 @@
 
 #include <mbgl/style/types.hpp>
 #include <mbgl/util/chrono.hpp>
-
-#include <mapbox/optional.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <vector>
 #include <utility>

--- a/src/mbgl/style/layout_property.hpp
+++ b/src/mbgl/style/layout_property.hpp
@@ -29,7 +29,7 @@ public:
     void operator=(const T& v) { value = v; }
     operator T() const { return value; }
 
-    mapbox::util::optional<Function<T>> parsedValue;
+    optional<Function<T>> parsedValue;
     T value;
 };
 

--- a/src/mbgl/style/property_parsing.cpp
+++ b/src/mbgl/style/property_parsing.cpp
@@ -214,11 +214,11 @@ optional<PropertyTransition> parseProperty(const char *, const JSValue& value) {
     if (value.IsObject()) {
         bool parsed = false;
         if (value.HasMember("duration") && value["duration"].IsNumber()) {
-            transition.duration = std::chrono::milliseconds(value["duration"].GetUint());
+            transition.duration = Duration(std::chrono::milliseconds(value["duration"].GetUint()));
             parsed = true;
         }
         if (value.HasMember("delay") && value["delay"].IsNumber()) {
-            transition.delay = std::chrono::milliseconds(value["delay"].GetUint());
+            transition.delay = Duration(std::chrono::milliseconds(value["delay"].GetUint()));
             parsed = true;
         }
         if (!parsed) {

--- a/src/mbgl/style/property_parsing.hpp
+++ b/src/mbgl/style/property_parsing.hpp
@@ -4,15 +4,14 @@
 #include <mbgl/style/types.hpp>
 
 #include <mbgl/util/rapidjson.hpp>
-
-#include <mapbox/optional.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <functional>
 
 namespace mbgl {
 
 template <typename T>
-using optional = mapbox::util::optional<T>;
+using optional = optional<T>;
 
 template <typename T>
 optional<T> parseProperty(const char* name, const JSValue&);

--- a/src/mbgl/style/property_transition.hpp
+++ b/src/mbgl/style/property_transition.hpp
@@ -2,16 +2,16 @@
 #define MBGL_STYLE_PROPERTY_TRANSITION
 
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/optional.hpp>
 
-#include <mapbox/optional.hpp>
 #include <cstdint>
 
 namespace mbgl {
 
 class PropertyTransition {
 public:
-    mapbox::util::optional<Duration> duration;
-    mapbox::util::optional<Duration> delay;
+    optional<Duration> duration;
+    optional<Duration> delay;
 };
 
 } // namespace mbgl

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -104,7 +104,7 @@ StyleLayer* Style::getLayer(const std::string& id) const {
     return it != layers.end() ? it->get() : nullptr;
 }
 
-void Style::addLayer(std::unique_ptr<StyleLayer> layer, mapbox::util::optional<std::string> before) {
+void Style::addLayer(std::unique_ptr<StyleLayer> layer, optional<std::string> before) {
     if (SymbolLayer* symbolLayer = layer->as<SymbolLayer>()) {
         if (!symbolLayer->spriteAtlas) {
             symbolLayer->spriteAtlas = spriteAtlas.get();

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -10,8 +10,7 @@
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/worker.hpp>
-
-#include <mapbox/optional.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <cstdint>
 #include <string>
@@ -97,7 +96,7 @@ public:
     std::vector<std::unique_ptr<StyleLayer>> getLayers() const;
     StyleLayer* getLayer(const std::string& id) const;
     void addLayer(std::unique_ptr<StyleLayer>,
-                  mapbox::util::optional<std::string> beforeLayerID = {});
+                  optional<std::string> beforeLayerID = {});
     void removeLayer(const std::string& layerID);
 
     RenderData getRenderData() const;

--- a/src/mbgl/text/shaping.hpp
+++ b/src/mbgl/text/shaping.hpp
@@ -4,9 +4,9 @@
 #include <mbgl/text/glyph.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
 #include <mbgl/sprite/sprite_image.hpp>
-#include <mapbox/optional.hpp>
 
 #include <mbgl/util/vec.hpp>
+#include <mbgl/util/optional.hpp>
 
 namespace mbgl {
 
@@ -19,7 +19,7 @@ namespace mbgl {
                     float _top, float _bottom, float _left, float _right) :
                 image(_image), top(_top), bottom(_bottom), left(_left), right(_right) {}
 
-            mapbox::util::optional<SpriteAtlasElement> image;
+            optional<SpriteAtlasElement> image;
             float top = 0;
             float bottom = 0;
             float left = 0;

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -14,12 +14,12 @@ FeatureType GeoJSONTileFeature::getType() const {
     return type;
 }
 
-mapbox::util::optional<Value> GeoJSONTileFeature::getValue(const std::string& key) const {
+optional<Value> GeoJSONTileFeature::getValue(const std::string& key) const {
     auto it = tags.find(key);
     if (it != tags.end()) {
-        return mapbox::util::optional<Value>(it->second);
+        return optional<Value>(it->second);
     }
-    return mapbox::util::optional<Value>();
+    return optional<Value>();
 }
 
 GeometryCollection GeoJSONTileFeature::getGeometries() const {

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -23,7 +23,7 @@ public:
 
     GeoJSONTileFeature(FeatureType, GeometryCollection&&, Tags&& = Tags{});
     FeatureType getType() const override;
-    mapbox::util::optional<Value> getValue(const std::string&) const override;
+    optional<Value> getValue(const std::string&) const override;
     GeometryCollection getGeometries() const override;
 
 private:

--- a/src/mbgl/util/http_header.hpp
+++ b/src/mbgl/util/http_header.hpp
@@ -1,7 +1,7 @@
 #ifndef MBGL_UTIL_HTTP_HEADER
 #define MBGL_UTIL_HTTP_HEADER
 
-#include <mapbox/optional.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <string>
 
@@ -12,7 +12,7 @@ class CacheControl {
 public:
     static CacheControl parse(const std::string&);
 
-    mapbox::util::optional<uint64_t> maxAge;
+    optional<uint64_t> maxAge;
     bool mustRevalidate = false;
 };
 

--- a/test/miscellaneous/comparisons.cpp
+++ b/test/miscellaneous/comparisons.cpp
@@ -18,12 +18,12 @@ public:
         , type(type_)
     {}
 
-    mapbox::util::optional<Value> getValue(const std::string &key) const {
+    optional<Value> getValue(const std::string &key) const {
         if (key == "$type")
             return Value(uint64_t(type));
         auto it = properties.find(key);
         if (it == properties.end())
-            return mapbox::util::optional<Value>();
+            return optional<Value>();
         return it->second;
     }
 


### PR DESCRIPTION
`std::experimental::optional` is likely to become a non-experimental part of the standard library in the next revision, and is more complete than our `mapbox/variant`-based implementation. It's supported by gcc 4.9 and clang 3.5; need to check on iOS/OS X.

For brevity, I recommend we define `mbgl/util/optional.hpp`:

```
#include <experimental/optional>

namespace mbgl {
using optional = std::experimental::optional;
}
```

And then use unqualified `optional<T>` wherever needed in the `mbgl` namespace.