### PR TITLE
Simplify non-animated transitions

### DIFF
--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -58,13 +58,17 @@ struct AnimationOptions {
     /** The easing timing curve of the transition. */
     optional<mbgl::util::UnitBezier> easing;
     
-    /** A function that is called on each frame of the transition, just before a
-        screen update, except on the last frame. The first parameter indicates
-        the elapsed time as a percentage of the duration. */
+    /** A function that is called from the Map thread on each frame of the
+        transition, just before a screen update, except on the last frame. The
+        first parameter indicates the elapsed time as a percentage of the
+        duration. */
     std::function<void(double)> transitionFrameFn;
     
-    /** A function that is called once on the last frame of the transition, just
-        before the corresponding screen update. */
+    /** A function that is called once from the Map thread on the last frame of
+        the transition, just before the corresponding screen update. The first
+        parameter indicates how much of the transition was completed, as a
+        percentage of the duration. In the event that the transition is
+        canceled, this parameter will have a value less than 1.0. */
     std::function<void()> transitionFinishFn;
     
     /** Creates an animation with no options specified. */

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -65,10 +65,7 @@ struct AnimationOptions {
     std::function<void(double)> transitionFrameFn;
     
     /** A function that is called once from the Map thread on the last frame of
-        the transition, just before the corresponding screen update. The first
-        parameter indicates how much of the transition was completed, as a
-        percentage of the duration. In the event that the transition is
-        canceled, this parameter will have a value less than 1.0. */
+        the transition, just before the corresponding screen update. */
     std::function<void()> transitionFinishFn;
     
     /** Creates an animation with no options specified. */

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -553,11 +553,11 @@ void Transform::startTransition(const CameraOptions& camera,
                                 const AnimationOptions& animation,
                                 std::function<Update(double)> frame,
                                 const Duration& duration) {
-    if (transitionFinishFn) {
+    bool isAnimated = duration != Duration::zero();
+    if (isAnimated && transitionFinishFn) {
         transitionFinishFn();
     }
     
-    bool isAnimated = duration != Duration::zero();
     view.notifyMapChange(isAnimated ? MapChangeRegionWillChangeAnimated : MapChangeRegionWillChange);
     
     // Associate the anchor, if given, with a coordinate.
@@ -567,12 +567,8 @@ void Transform::startTransition(const CameraOptions& camera,
         anchor.y = state.getHeight() - anchor.y;
         anchorLatLng = state.pointToLatLng(anchor);
     }
-
-    transitionStart = Clock::now();
-    transitionDuration = duration;
-
-    transitionFrameFn = [isAnimated, animation, frame, anchor, anchorLatLng, this](const TimePoint now) {
-        float t = isAnimated ? (std::chrono::duration<float>(now - transitionStart) / transitionDuration) : 1.0;
+    
+    auto frameFn = [animation, frame, anchor, anchorLatLng, this](double t) {
         Update result;
         if (t >= 1.0) {
             result = frame(1.0);
@@ -584,6 +580,24 @@ void Transform::startTransition(const CameraOptions& camera,
         if (_validPoint(anchor)) {
             state.moveLatLng(anchorLatLng, anchor);
         }
+        return result;
+    };
+    
+    if (!isAnimated) {
+        view.notifyMapChange(MapChangeRegionWillChange);
+        frameFn(1.0);
+        view.notifyMapChange(MapChangeRegionDidChange);
+        return;
+    }
+    
+    view.notifyMapChange(MapChangeRegionWillChangeAnimated);
+
+    transitionStart = Clock::now();
+    transitionDuration = duration;
+
+    transitionFrameFn = [isAnimated, animation, frame, anchor, anchorLatLng, frameFn, this](const TimePoint now) {
+        float t = isAnimated ? (std::chrono::duration<float>(now - transitionStart) / transitionDuration) : 1.0;
+        Update result = frameFn(t);
         
         // At t = 1.0, a DidChangeAnimated notification should be sent from finish().
         if (t < 1.0) {
@@ -611,10 +625,6 @@ void Transform::startTransition(const CameraOptions& camera,
         }
         view.notifyMapChange(isAnimated ? MapChangeRegionDidChangeAnimated : MapChangeRegionDidChange);
     };
-    
-    if (!isAnimated) {
-        transitionFrameFn(Clock::now());
-    }
 }
 
 bool Transform::inTransition() const {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -558,8 +558,6 @@ void Transform::startTransition(const CameraOptions& camera,
         transitionFinishFn();
     }
     
-    view.notifyMapChange(isAnimated ? MapChangeRegionWillChangeAnimated : MapChangeRegionWillChange);
-    
     // Associate the anchor, if given, with a coordinate.
     PrecisionPoint anchor = camera.anchor ? *camera.anchor : PrecisionPoint(NAN, NAN);
     LatLng anchorLatLng;


### PR DESCRIPTION
This PR short-circuits the complex machinery around animated transitions for transitions that occur instantaneously and synchronously. This is a speculative fix for #3607.

/cc @tmpsantos
