### PR TITLE
Drop node 0.10 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,6 @@ matrix:
       compiler: clang
       env: FLAVOR=node NODE_VERSION=4
 
-    # OS X/Node.js 0.10 - Xcode 7
-    - os: osx
-      osx_image: xcode7
-      compiler: clang
-      env: FLAVOR=node NODE_VERSION=0.10
-
 
     # Linux/Node.js 5 - Clang 3.5 - Release
     - os: linux
@@ -56,12 +50,6 @@ matrix:
     - os: linux
       compiler: ": node4-clang35-release"
       env: FLAVOR=node BUILDTYPE=Release NODE_VERSION=4 _CXX=clang++-3.5 _CC=clang-3.5 CCACHE=1
-      addons: *clang35
-
-    # Linux/Node.js 0.10 - Clang 3.5 - Release
-    - os: linux
-      compiler: ": node0.10-clang35-release"
-      env: FLAVOR=node BUILDTYPE=Release NODE_VERSION=0.10 _CXX=clang++-3.5 _CC=clang-3.5 CCACHE=1
       addons: *clang35
 
 

--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -10,7 +10,7 @@ Requires a modern C++ runtime that supports C++14.
 By default, installs binaries. On these platforms no additional dependencies are needed.
 
 - 64 bit OS X or 64 bit Linux
-- Node.js v0.10.x, Node.js v0.12.x, io.js v2.x
+- Node.js v4+
 
 Just run:
 


### PR DESCRIPTION
We're continually squeezed by Travis build queue, so any reduction of the build matrix size is good. Can we drop node 0.10 on OS X and linux (2 rows)?

cc @mikemorris 