### PR TITLE
[core] improve text-max-angle check

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#bc0272cdde41d027a5df1ca8fb3aa1bc49aa8149",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2f4d8ed044a3c962a43d62de0608b752eb68052c",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/src/mbgl/text/check_max_angle.cpp
+++ b/src/mbgl/text/check_max_angle.cpp
@@ -51,7 +51,7 @@ bool checkMaxAngle(const std::vector<Coordinate> &line, Anchor &anchor, const fl
 
         float angleDelta = util::angle_to(prev, current) - util::angle_to(current, next);
         // restrict angle to -pi..pi range
-        angleDelta = std::fmod(angleDelta + 3 * M_PI, M_PI * 2) - M_PI;
+        angleDelta = std::fabs(std::fmod(angleDelta + 3 * M_PI, M_PI * 2) - M_PI);
 
         recentCorners.emplace(anchorDistance, angleDelta);
         recentAngleDelta += angleDelta;
@@ -63,7 +63,7 @@ bool checkMaxAngle(const std::vector<Coordinate> &line, Anchor &anchor, const fl
         }
 
         // the sum of angles within the window area exceeds the maximum allowed value. check fails.
-        if (std::fabs(recentAngleDelta) > maxAngle) return false;
+        if (recentAngleDelta > maxAngle) return false;
 
         index++;
         anchorDistance += util::dist<float>(current, next);


### PR DESCRIPTION
Instead of using the absolute value of the sum of angles, use the sum of the absolute values of angles.

This helps avoid labels on lines with sharp zig zags.

for example, the "Central Campus Mall" label in issue #2998

-js pr: https://github.com/mapbox/mapbox-gl-js/pull/1959
test-suite update: test-suite update: https://github.com/mapbox/mapbox-gl-test-suite/tree/max-angle-fix