### PR TITLE
[node] Build OS X on Bitrise

### DIFF
--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -1,0 +1,64 @@
+format_version: 1.1.0
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+trigger_map:
+- pattern: "*"
+  is_pull_request_allowed: true
+  workflow: primary
+
+workflows:
+  primary:
+    steps:
+    - script:
+        title: Check for skipping CI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
+                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
+                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
+                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[ci skip\]/p')" ]]; then
+                envman add --key SKIPCI --value true
+            else
+                envman add --key SKIPCI --value false
+            fi
+    - select-xcode-version:
+        title: Select Xcode version
+        run_if: '{{enveq "SKIPCI" "false"}}'
+    - script:
+        title: Run build script
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -e
+            set -o pipefail
+            export TRAVIS_OS_NAME=osx
+            export TRAVIS_TAG=$BITRISE_GIT_TAG
+            export NODE_VERSION=4
+            export CXX=clang++
+            export CC=clang
+            source ./scripts/set_compiler.sh
+            ./platform/node/scripts/install.sh
+            if command -v ccache >/dev/null 2>&1; then ccache --zero-stats ; fi
+            ./platform/node/scripts/run.sh
+            if command -v ccache >/dev/null 2>&1; then ccache --show-stats ; fi
+            ./platform/node/scripts/after_script.sh
+    - slack:
+        title: Post to Slack
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - webhook_url: "$SLACK_HOOK_URL"
+        - channel: "#gl-bots"
+        - from_username: 'Bitrise Node OS X'
+        - from_username_on_error: 'Bitrise Node OS X'
+        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+            passed'
+        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+            failed'
+        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
+        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png

--- a/platform/node/scripts/after_script.sh
+++ b/platform/node/scripts/after_script.sh
@@ -10,10 +10,9 @@ else
     otool -L ./lib/mapbox-gl-native.node
 fi
 
-COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
 PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
 
-if [[ ${TRAVIS_TAG} == node-v${PACKAGE_JSON_VERSION} ]] || test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE"; then
+if [[ ${TRAVIS_TAG} == node-v${PACKAGE_JSON_VERSION} ]]; then
     source ~/.nvm/nvm.sh
     nvm use $NODE_VERSION
 

--- a/platform/node/scripts/install.sh
+++ b/platform/node/scripts/install.sh
@@ -3,13 +3,11 @@
 set -e
 set -o pipefail
 
-mapbox_time "checkout_mason" \
 git submodule update --init .mason
 
 export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
 
 if [ ${TRAVIS_OS_NAME} == "linux" ]; then
-    mapbox_time "install_mesa" \
     mason install mesa 10.4.3
 fi
 
@@ -19,9 +17,7 @@ fi
 
 source ~/.nvm/nvm.sh
 
-mapbox_time $NODE_VERSION \
 nvm install $NODE_VERSION
-
 nvm alias default $NODE_VERSION
 
 node --version

--- a/platform/node/scripts/run.sh
+++ b/platform/node/scripts/run.sh
@@ -13,19 +13,14 @@ BUILDTYPE=${BUILDTYPE:-Release}
 
 source ~/.nvm/nvm.sh
 nvm use $NODE_VERSION
-
-mapbox_time "compile_program" \
 npm install --build-from-source
 
 ################################################################################
 # Test
 ################################################################################
 
-# Travis OS X has no GPU
+# https://github.com/mapbox/mapbox-gl-native/issues/2150
 if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
-    mapbox_time "run_tests" \
     npm test
-
-    mapbox_time "run_render_tests" \
     npm run test-suite
 fi


### PR DESCRIPTION
The OS X node build is the last non-linux build on Travis. Moving it to Bitrise will reduce Travis queue pressure, and potentially allow us to move the linux builds to CircleCI. (The reason that's currently blocked is that CircleCI doesn't support build matrixes and the way to simulate them using parallelism does not support mixed OSs.)

@mikemorris @bsudekum @miccolis This would have the effect of building for node v4 only on OS X. How do you feel about that?