### PR TITLE
[core] trigger repaint after placement is redone

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2f4d8ed044a3c962a43d62de0608b752eb68052c",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#1b9035a02f8f23bf72a197c2a8d8f910d935346f",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -37,6 +37,7 @@ public:
 
         virtual void onTileLoaded(Source&, const TileID&, bool /* isNewTile */) {};
         virtual void onTileError(Source&, const TileID&, std::exception_ptr) {};
+        virtual void onPlacementRedone() {};
     };
 
     Source(SourceType,
@@ -78,11 +79,10 @@ public:
     bool enabled = false;
 
 private:
-    void tileLoadingCompleteCallback(const TileID&,
-                                     std::exception_ptr,
-                                     const TransformState&,
-                                     bool collisionDebug);
-    bool handlePartialTile(const TileID&, Worker& worker);
+    void tileLoadingCallback(const TileID&,
+                             std::exception_ptr,
+                             bool isNewTile);
+    bool handlePartialTile(const TileID&);
     bool findLoadedChildren(const TileID&, int32_t maxCoveringZoom, std::forward_list<TileID>& retain);
     void findLoadedParent(const TileID&, int32_t minCoveringZoom, std::forward_list<TileID>& retain);
     int32_t coveringZoomLevel(const TransformState&) const;

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -79,7 +79,8 @@ public:
     virtual Bucket* getBucket(const StyleLayer&) = 0;
 
     virtual bool parsePending(std::function<void (std::exception_ptr)>) { return true; }
-    virtual void redoPlacement(PlacementConfig) {}
+    virtual void redoPlacement(PlacementConfig, const std::function<void()>&) {}
+    virtual void redoPlacement(const std::function<void()>&) {}
 
     bool isReady() const {
         return isReadyState(state);

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -31,8 +31,8 @@ public:
 
     bool parsePending(std::function<void(std::exception_ptr)> callback) override;
 
-    void redoPlacement(PlacementConfig config) override;
-    void redoPlacement();
+    void redoPlacement(PlacementConfig config, const std::function<void()>&) override;
+    void redoPlacement(const std::function<void()>&) override;
 
     void cancel() override;
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -356,6 +356,10 @@ void Style::onTileError(Source& source, const TileID& tileID, std::exception_ptr
     observer->onResourceError(error);
 }
 
+void Style::onPlacementRedone() {
+    observer->onResourceLoaded();
+}
+
 void Style::onSpriteLoaded() {
     shouldReparsePartialTiles = true;
     observer->onSpriteLoaded();

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -132,6 +132,7 @@ private:
     void onSourceError(Source&, std::exception_ptr) override;
     void onTileLoaded(Source&, const TileID&, bool isNewTile) override;
     void onTileError(Source&, const TileID&, std::exception_ptr) override;
+    void onPlacementRedone() override;
 
     bool shouldReparsePartialTiles = false;
 


### PR DESCRIPTION
This adds `onPlacementRedone` to `Source::Observer` which is called when a tile is updated with new symbol placement. Style uses this to trigger a repaint.

fixes #3140

This also fixes a bug where placement could be redone with a stale PlacementConfig after the tile first finishes loading.

@jfirebaugh can you review?