### PR TITLE
[core] Simplify revalidation (part 2)

### DIFF
--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -1,12 +1,15 @@
 #ifndef MBGL_STORAGE_RESOURCE
 #define MBGL_STORAGE_RESOURCE
 
+#include <mbgl/storage/response.hpp>
+#include <mbgl/util/optional.hpp>
+
 #include <string>
-#include <functional>
 
 namespace mbgl {
 
-struct Resource {
+class Resource {
+public:
     enum Kind : uint8_t {
         Unknown = 0,
         Style,
@@ -17,19 +20,17 @@ struct Resource {
         SpriteJSON
     };
 
+    Resource(Kind kind_, const std::string& url_)
+        : kind(kind_),
+          url(url_) {
+    }
+
     const Kind kind;
     const std::string url;
 
-    inline bool operator==(const Resource &res) const {
-        return kind == res.kind && url == res.url;
-    }
-
-    struct Hash {
-        std::size_t operator()(Resource const& r) const {
-            return std::hash<std::string>()(r.url) ^ (std::hash<uint8_t>()(r.kind) << 1);
-        }
-    };
-
+    optional<SystemTimePoint> priorModified;
+    optional<SystemTimePoint> priorExpires;
+    optional<std::string> priorEtag;
 };
 
 } // namespace mbgl

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -23,7 +23,7 @@ public:
     // This is set to true for 304 Not Modified responses.
     bool notModified = false;
 
-    // The actual data of the response. This is guaranteed to never be empty.
+    // The actual data of the response. This is null if notModified is true.
     std::shared_ptr<const std::string> data;
 
     optional<SystemTimePoint> modified;
@@ -34,7 +34,7 @@ public:
 class Response::Error {
 public:
     enum class Reason : uint8_t {
-        // Success = 1, // Reserve 1 for Success.
+        Success = 1,
         NotFound = 2,
         Server = 3,
         Connection = 4,

--- a/platform/android/src/http_request_android.cpp
+++ b/platform/android/src/http_request_android.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/storage/http_context_base.hpp>
 #include <mbgl/storage/http_request_base.hpp>
+#include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/platform/log.hpp>
 #include "jni.hpp"
@@ -22,9 +23,7 @@ public:
     explicit HTTPAndroidContext();
     ~HTTPAndroidContext();
 
-    HTTPRequestBase* createRequest(const std::string& url,
-                               HTTPRequestBase::Callback,
-                               std::shared_ptr<const Response>) final;
+    HTTPRequestBase* createRequest(const Resource&, HTTPRequestBase::Callback) final;
 
     JavaVM *vm = nullptr;
     jobject obj = nullptr;
@@ -32,10 +31,7 @@ public:
 
 class HTTPAndroidRequest : public HTTPRequestBase {
 public:
-    HTTPAndroidRequest(HTTPAndroidContext*,
-                const std::string& url,
-                Callback,
-                std::shared_ptr<const Response>);
+    HTTPAndroidRequest(HTTPAndroidContext*, const Resource&, Callback);
     ~HTTPAndroidRequest();
 
     void cancel() final;
@@ -107,32 +103,28 @@ HTTPAndroidContext::~HTTPAndroidContext() {
     vm = nullptr;
 }
 
-HTTPRequestBase* HTTPAndroidContext::createRequest(const std::string& url,
-                                            HTTPRequestBase::Callback callback,
-                                            std::shared_ptr<const Response> response) {
-    return new HTTPAndroidRequest(this, url, callback, response);
+HTTPRequestBase* HTTPAndroidContext::createRequest(const Resource& resource, HTTPRequestBase::Callback callback) {
+    return new HTTPAndroidRequest(this, resource, callback);
 }
 
-HTTPAndroidRequest::HTTPAndroidRequest(HTTPAndroidContext* context_, const std::string& url_, Callback callback_, std::shared_ptr<const Response> response_)
-    : HTTPRequestBase(url_, callback_),
+HTTPAndroidRequest::HTTPAndroidRequest(HTTPAndroidContext* context_, const Resource& resource_, Callback callback_)
+    : HTTPRequestBase(resource_, callback_),
       context(context_),
-      existingResponse(response_),
       async([this] { finish(); }) {
 
     std::string etagStr;
     std::string modifiedStr;
-    if (existingResponse) {
-        if (existingResponse->etag) {
-            etagStr = *existingResponse->etag;
-        } else if (existingResponse->modified) {
-            modifiedStr = util::rfc1123(*existingResponse->modified);
-        }
+
+    if (resource.priorEtag) {
+        etagStr = *resource.priorEtag;
+    } else if (resource.priorModified) {
+        modifiedStr = util::rfc1123(*resource.priorModified);
     }
 
     JNIEnv *env = nullptr;
     bool detach = mbgl::android::attach_jni_thread(context->vm, &env, "HTTPAndroidContext::HTTPAndroidRequest()");
 
-    jstring resourceUrl = mbgl::android::std_string_to_jstring(env, url);
+    jstring resourceUrl = mbgl::android::std_string_to_jstring(env, resource.url);
     jstring userAgent = mbgl::android::std_string_to_jstring(env, "MapboxGL/1.0");
     jstring etag = mbgl::android::std_string_to_jstring(env, etagStr);
     jstring modified = mbgl::android::std_string_to_jstring(env, modifiedStr);
@@ -180,7 +172,7 @@ void HTTPAndroidRequest::cancel() {
 
 void HTTPAndroidRequest::finish() {
     if (!cancelled) {
-        notify(std::move(response));
+        notify(*response);
     }
 
     delete this;
@@ -216,22 +208,7 @@ void HTTPAndroidRequest::onResponse(JNIEnv* env, int code, jstring /* message */
         // Nothing to do; this is what we want
     } else if (code == 304) {
         response->notModified = true;
-
-        if (existingResponse) {
-            response->data = existingResponse->data;
-
-            if (!response->expires) {
-                response->expires = existingResponse->expires;
-            }
-
-            if (!response->modified) {
-                response->modified = existingResponse->modified;
-            }
-
-            if (!response->etag) {
-                response->etag = existingResponse->etag;
-            }
-        }
+        response->data.reset();
     } else if (code == 404) {
         response->error = std::make_unique<Error>(Error::Reason::NotFound, "HTTP status code 404");
     } else if (code >= 500 && code < 600) {

--- a/platform/default/http_request_curl.cpp
+++ b/platform/default/http_request_curl.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/storage/http_context_base.hpp>
 #include <mbgl/storage/http_request_base.hpp>
+#include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/platform/log.hpp>
 
@@ -45,9 +46,7 @@ public:
     HTTPCURLContext();
     ~HTTPCURLContext();
 
-    HTTPRequestBase* createRequest(const std::string& url,
-                               HTTPRequestBase::Callback,
-                               std::shared_ptr<const Response>) final;
+    HTTPRequestBase* createRequest(const Resource&, HTTPRequestBase::Callback) final;
 
     static int handleSocket(CURL *handle, curl_socket_t s, int action, void *userp, void *socketp);
     static int startTimeout(CURLM *multi, long timeout_ms, void *userp);
@@ -77,10 +76,7 @@ class HTTPCURLRequest : public HTTPRequestBase {
     MBGL_STORE_THREAD(tid)
 
 public:
-    HTTPCURLRequest(HTTPCURLContext*,
-                const std::string& url,
-                Callback,
-                std::shared_ptr<const Response>);
+    HTTPCURLRequest(HTTPCURLContext*, const Resource&, Callback);
     ~HTTPCURLRequest();
 
     void cancel() final;
@@ -137,10 +133,8 @@ HTTPCURLContext::~HTTPCURLContext() {
     timeout.stop();
 }
 
-HTTPRequestBase* HTTPCURLContext::createRequest(const std::string& url,
-                                            HTTPRequestBase::Callback callback,
-                                            std::shared_ptr<const Response> response) {
-    return new HTTPCURLRequest(this, url, callback, response);
+HTTPRequestBase* HTTPCURLContext::createRequest(const Resource& resource, HTTPRequestBase::Callback callback) {
+    return new HTTPCURLRequest(this, resource, callback);
 }
 
 CURL *HTTPCURLContext::getHandle() {
@@ -351,25 +345,22 @@ static CURLcode sslctx_function(CURL * /* curl */, void *sslctx, void * /* parm 
 }
 #endif
 
-HTTPCURLRequest::HTTPCURLRequest(HTTPCURLContext* context_, const std::string& url_, Callback callback_, std::shared_ptr<const Response> response_)
-    : HTTPRequestBase(url_, callback_),
+HTTPCURLRequest::HTTPCURLRequest(HTTPCURLContext* context_, const Resource& resource_, Callback callback_)
+    : HTTPRequestBase(resource_, callback_),
       context(context_),
-      existingResponse(response_),
       handle(context->getHandle()) {
     // Zero out the error buffer.
     memset(error, 0, sizeof(error));
 
     // If there's already a response, set the correct etags/modified headers to make sure we are
     // getting a 304 response if possible. This avoids redownloading unchanged data.
-    if (existingResponse) {
-        if (existingResponse->etag) {
-            const std::string header = std::string("If-None-Match: ") + *existingResponse->etag;
-            headers = curl_slist_append(headers, header.c_str());
-        } else if (existingResponse->modified) {
-            const std::string time =
-                std::string("If-Modified-Since: ") + util::rfc1123(*existingResponse->modified);
-            headers = curl_slist_append(headers, time.c_str());
-        }
+    if (resource.priorEtag) {
+        const std::string header = std::string("If-None-Match: ") + *resource.priorEtag;
+        headers = curl_slist_append(headers, header.c_str());
+    } else if (resource.priorModified) {
+        const std::string time =
+            std::string("If-Modified-Since: ") + util::rfc1123(*resource.priorModified);
+        headers = curl_slist_append(headers, time.c_str());
     }
 
     if (headers) {
@@ -385,7 +376,7 @@ HTTPCURLRequest::HTTPCURLRequest(HTTPCURLContext* context_, const std::string& u
     handleError(curl_easy_setopt(handle, CURLOPT_CAINFO, "ca-bundle.crt"));
 #endif
     handleError(curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1));
-    handleError(curl_easy_setopt(handle, CURLOPT_URL, url.c_str()));
+    handleError(curl_easy_setopt(handle, CURLOPT_URL, resource.url.c_str()));
     handleError(curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, writeCallback));
     handleError(curl_easy_setopt(handle, CURLOPT_WRITEDATA, this));
     handleError(curl_easy_setopt(handle, CURLOPT_HEADERFUNCTION, headerCallback));
@@ -529,22 +520,7 @@ void HTTPCURLRequest::handleResult(CURLcode code) {
             // Nothing to do; this is what we want.
         } else if (responseCode == 304) {
             response->notModified = true;
-
-            if (existingResponse) {
-                response->data = existingResponse->data;
-
-                if (!response->expires) {
-                    response->expires = existingResponse->expires;
-                }
-
-                if (!response->modified) {
-                    response->modified = existingResponse->modified;
-                }
-
-                if (!response->etag) {
-                    response->etag = existingResponse->etag;
-                }
-            }
+            response->data.reset();
         } else if (responseCode == 404) {
             response->error =
                 std::make_unique<Error>(Error::Reason::NotFound, "HTTP status code 404");
@@ -560,7 +536,7 @@ void HTTPCURLRequest::handleResult(CURLcode code) {
     }
 
     // Actually return the response.
-    notify(std::move(response));
+    notify(*response);
     delete this;
 }
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -113,12 +113,14 @@ void MapContext::setStyleURL(const std::string& url) {
                 Log::Error(Event::Setup, "loading style failed: %s", res.error->message.c_str());
                 data.loading = false;
             }
-        } else {
-            // We got a new stylesheet; only update when it's different from the previous one.
-            if (styleJSON != *res.data) {
-                loadStyleJSON(*res.data, base);
-            }
+            return;
         }
+
+        if (res.notModified) {
+            return;
+        }
+
+        loadStyleJSON(*res.data, base);
     });
 }
 

--- a/src/mbgl/storage/http_context_base.hpp
+++ b/src/mbgl/storage/http_context_base.hpp
@@ -13,9 +13,7 @@ public:
     static std::unique_ptr<HTTPContextBase> createContext();
 
     virtual ~HTTPContextBase() = default;
-    virtual HTTPRequestBase* createRequest(const std::string& url,
-                                       HTTPRequestBase::Callback,
-                                       std::shared_ptr<const Response>) = 0;
+    virtual HTTPRequestBase* createRequest(const Resource&, HTTPRequestBase::Callback) = 0;
 };
 
 } // namespace mbgl

--- a/src/mbgl/storage/http_request_base.hpp
+++ b/src/mbgl/storage/http_request_base.hpp
@@ -1,14 +1,14 @@
 #ifndef MBGL_STORAGE_HTTP_REQUEST_BASE
 #define MBGL_STORAGE_HTTP_REQUEST_BASE
 
+#include <mbgl/storage/response.hpp>
+#include <mbgl/storage/resource.hpp>
+
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/optional.hpp>
 
-#include <memory>
 #include <functional>
-#include <utility>
-#include <string>
 
 namespace mbgl {
 
@@ -16,10 +16,10 @@ class Response;
 
 class HTTPRequestBase : private util::noncopyable {
 public:
-    using Callback = std::function<void (std::shared_ptr<const Response> response)>;
+    using Callback = std::function<void (Response)>;
 
-    HTTPRequestBase(const std::string& url_, Callback notify_)
-        : url(url_)
+    HTTPRequestBase(const Resource& resource_, Callback notify_)
+        : resource(resource_)
         , notify(std::move(notify_))
         , cancelled(false) {
     }
@@ -30,7 +30,7 @@ public:
 protected:
     static optional<SystemTimePoint> parseCacheControl(const char *value);
 
-    std::string url;
+    Resource resource;
     Callback notify;
     bool cancelled;
 };

--- a/src/mbgl/storage/sqlite_cache.hpp
+++ b/src/mbgl/storage/sqlite_cache.hpp
@@ -10,7 +10,7 @@
 
 namespace mbgl {
 
-struct Resource;
+class Resource;
 class Response;
 class WorkRequest;
 

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -28,13 +28,8 @@ public:
     }
 
 private:
-    void parse(GlyphStore*, const std::string& fontStack, const GlyphRange&);
-
-    std::shared_ptr<const std::string> data;
     std::atomic<bool> parsed;
-
     std::unique_ptr<FileRequest> req;
-
     GlyphStore::Observer* observer = nullptr;
 };
 

--- a/test/storage/cache_revalidate.cpp
+++ b/test/storage/cache_revalidate.cpp
@@ -40,8 +40,7 @@ TEST_F(Storage, CacheRevalidateSame) {
 
                 EXPECT_EQ(nullptr, res2.error);
                 EXPECT_TRUE(res2.notModified);
-                ASSERT_TRUE(res2.data.get());
-                EXPECT_EQ("Response", *res2.data);
+                ASSERT_FALSE(res2.data.get());
                 EXPECT_TRUE(bool(res2.expires));
                 EXPECT_FALSE(bool(res2.modified));
                 // We're not sending the ETag in the 304 reply, but it should still be there.
@@ -92,8 +91,7 @@ TEST_F(Storage, CacheRevalidateModified) {
 
                 EXPECT_EQ(nullptr, res2.error);
                 EXPECT_TRUE(res2.notModified);
-                ASSERT_TRUE(res2.data.get());
-                EXPECT_EQ("Response", *res2.data);
+                ASSERT_FALSE(res2.data.get());
                 EXPECT_TRUE(bool(res2.expires));
                 EXPECT_EQ(SystemClock::from_time_t(1420070400), *res2.modified);
                 EXPECT_FALSE(res2.etag);


### PR DESCRIPTION
This implements changes to consumers of `FileSource::request` as described in https://github.com/mapbox/mapbox-gl-native/commit/7c6ae71791bf5e7171d1ecda1670eb0cae068150#commitcomment-15482416, namely always using `response.notModified` to check for unchanged responses, rather than retaining and comparing the prior response body.

Then it adds members to `Resource` such that it's possible to implement a self-contained revalidating `FileSource` (i.e. you don't have to pass in the whole prior response, which isn't possible in the `FileSource` API). This is necessary for further progress on offline APIs.

:eyes: @kkaefer