### PR TITLE
Update telemetry location manager to allow background location updates when required.

### DIFF
--- a/ios/app/app-info.plist
+++ b/ios/app/app-info.plist
@@ -43,6 +43,10 @@
 	<string>The map will ALWAYS display the user's location.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>The map will display the user's location.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>Default</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -977,6 +977,9 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         _mbglMap->pause();
 
         [self.glView deleteDrawable];
+        
+        [self.locationManager stopUpdatingLocation];
+        [self.locationManager stopUpdatingHeading];
     }
 }
 
@@ -1000,6 +1003,14 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         _mbglMap->resume();
         
         _displayLink.paused = NO;
+      
+        if (self.showsUserLocation) {
+            [self.locationManager startUpdatingLocation];
+            if (self.userTrackingMode == MGLUserTrackingModeFollowWithHeading) {
+                [self.locationManager startUpdatingHeading];
+            }
+        }
+        
     }
 }
 

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -862,6 +862,9 @@ const NSTimeInterval MGLFlushInterval = 60;
 }
 
 - (void)boostLocationManagerAccuracy {
+    if ([self debugLoggingEnabled]) {
+        [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"dormancy.boost_accuracy"}];
+    }
     self.locationManager.desiredAccuracy = kCLLocationAccuracyKilometer;
     self.locationManager.distanceFilter = 10;
 }
@@ -874,7 +877,12 @@ const NSTimeInterval MGLFlushInterval = 60;
         if (self.isDormant) {
             // if device is moving, start capturing data again
             if (loc.speed > 0.0) {
+                
                 self.dormant = NO;
+                if ([self debugLoggingEnabled]) {
+                    [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"dormancy.ended"}];
+                }
+                
                 [self.dormancyTimer invalidate];
                 [MGLMapboxEvents pushEvent:MGLEventTypeLocation withAttributes:@{MGLEventKeyLatitude: @(loc.coordinate.latitude),
                                                                                  MGLEventKeyLongitude: @(loc.coordinate.longitude),
@@ -884,6 +892,10 @@ const NSTimeInterval MGLFlushInterval = 60;
                                                                                  MGLEventKeyHorizontalAccuracy: @(round(loc.horizontalAccuracy)),
                                                                                  MGLEventKeyVerticalAccuracy: @(round(loc.verticalAccuracy))}];
             } else { // otherwise ignore
+                
+                if ([self debugLoggingEnabled]) {
+                    [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"dormancy.reduce_accuracy"}];
+                }
                 
                 // power down as much as possible
                 manager.desiredAccuracy = kCLLocationAccuracyThreeKilometers;
@@ -904,7 +916,16 @@ const NSTimeInterval MGLFlushInterval = 60;
                 // if the device has been stationary for 20 readings then go dormant
                 if (self.stationaryLocationReadingsCount > 20) {
                     self.stationaryLocationReadingsCount = 0;
+                    
+                    
                     self.dormant = YES;
+                    if ([self debugLoggingEnabled]) {
+                        [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"dormancy.started"}];
+                    }
+                    
+                    if ([self debugLoggingEnabled]) {
+                        [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"dormancy.reduce_accuracy"}];
+                    }
                     
                     // power down as much as possible
                     manager.desiredAccuracy = kCLLocationAccuracyThreeKilometers;


### PR DESCRIPTION
In iOS 9, it is now required to set the value of `allowsBackgroundLocationUpdates` on CLLocationManager to YES (in addition to previous requirements) to achieve location updates in the background. 

The Mapbox gl native telemetry location manager runs in the background to gather data for telemetry events for improving open map data. This PR updates that location manager to be compatible with iOS 9 for the applicable use cases. Bugs related to gaps in telemetry event data from devices running iOS 9 can probably be closed after we test this change.

cc @1ec5 @friedbunny 