### PR TITLE
Override tileSize, tile API urls for mapbox raster sources

### DIFF
--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -406,6 +406,14 @@ bool Source::update(const StyleUpdateParameters& parameters) {
         return allTilesUpdated;
     }
 
+    // Mapbox+raster specific override: the requested image tiles are always
+    // of size 512x512 on the v4 tile API (see mapbox::normalizeRasterTileURL)
+    // so disregard the source tileSize and instead use a tileSize based on
+    // the device pixelRatio.
+    if (type == SourceType::Raster && util::mapbox::isMapboxURL(url)) {
+        tileSize = parameters.pixelRatio > 1.0 ? 256 : 512;
+    }
+
     double zoom = coveringZoomLevel(parameters.transformState);
     std::forward_list<TileID> required = coveringTiles(parameters.transformState);
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -121,8 +121,6 @@ void Source::load() {
 
             // TODO: Remove this hack by delivering proper URLs in the TileJSON to begin with.
             if (type == SourceType::Raster && util::mapbox::isMapboxURL(url)) {
-                // We need to insert {ratio} into raster source URLs that are loaded from mapbox://
-                // TileJSONs.
                 std::transform(newInfo->tiles.begin(), newInfo->tiles.end(), newInfo->tiles.begin(),
                                util::mapbox::normalizeRasterTileURL);
             }

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -404,14 +404,6 @@ bool Source::update(const StyleUpdateParameters& parameters) {
         return allTilesUpdated;
     }
 
-    // Mapbox+raster specific override: the requested image tiles are always
-    // of size 512x512 on the v4 tile API (see mapbox::normalizeRasterTileURL)
-    // so disregard the source tileSize and instead use a tileSize based on
-    // the device pixelRatio.
-    if (type == SourceType::Raster && util::mapbox::isMapboxURL(url)) {
-        tileSize = parameters.pixelRatio > 1.0 ? 256 : 512;
-    }
-
     double zoom = coveringZoomLevel(parameters.transformState);
     std::forward_list<TileID> required = coveringTiles(parameters.transformState);
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -54,7 +54,7 @@ void Style::setJSON(const std::string& json, const std::string&) {
     }
 
     StyleParser parser;
-    parser.parse(doc);
+    parser.parse(doc, data.pixelRatio);
 
     for (auto& source : parser.sources) {
         addSource(std::move(source));

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -20,7 +20,7 @@ class StyleParser {
 public:
     ~StyleParser();
 
-    void parse(const JSValue&);
+    void parse(const JSValue&, float pixelRatio = 1.0f);
 
     std::string spriteURL;
     std::string glyphURL;
@@ -32,7 +32,7 @@ public:
     static std::unique_ptr<SourceInfo> parseTileJSON(const JSValue&);
 
 private:
-    void parseSources(const JSValue&);
+    void parseSources(const JSValue&, float pixelRatio = 1.0f);
     void parseLayers(const JSValue&);
     void parseLayer(const std::string& id, const JSValue&, std::unique_ptr<StyleLayer>&);
     void parseVisibility(StyleLayer&, const JSValue& value);

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -135,10 +135,17 @@ std::string normalizeRasterTileURL(const std::string& url) {
         normalizedURL.replace(extensionIdx + 1, 3, "webp");
     }
 #endif // !defined(__ANDROID__) && !defined(__APPLE__)
+
     // Mapbox raster sources always use the @2x suffix on the v4 tile API
-    // to ensure a maximum 512 image size. Needs to be reevaluated when
-    // normalizeSourceURL() moves to a new API version.
-    normalizedURL.insert(extensionIdx, "@2x");
+    // to ensure a maximum 512 image size.
+    std::string::size_type versionIdx = url.rfind("/v4/");
+    if (versionIdx != std::string::npos &&
+        (normalizedURL.compare(extensionIdx + 1, 3, "png") == 0 ||
+        normalizedURL.compare(extensionIdx + 1, 3, "jpg") == 0 ||
+        normalizedURL.compare(extensionIdx + 1, 4, "webp") == 0)) {
+        normalizedURL.insert(extensionIdx, "@2x");
+    }
+
     return normalizedURL;
 }
 

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -135,10 +135,11 @@ std::string normalizeRasterTileURL(const std::string& url) {
         normalizedURL.replace(extensionIdx + 1, 3, "webp");
     }
 #endif // !defined(__ANDROID__) && !defined(__APPLE__)
-    normalizedURL.insert(extensionIdx, "{ratio}");
+    // Mapbox raster sources always use the @2x suffix on the v4 tile API
+    // to ensure a maximum 512 image size.
+    normalizedURL.insert(extensionIdx, "@2x");
     return normalizedURL;
 }
-
 
 std::string removeAccessTokenFromURL(const std::string &url) {
     const size_t token_start = url.find("access_token=");

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -136,10 +136,12 @@ std::string normalizeRasterTileURL(const std::string& url) {
     }
 #endif // !defined(__ANDROID__) && !defined(__APPLE__)
     // Mapbox raster sources always use the @2x suffix on the v4 tile API
-    // to ensure a maximum 512 image size.
+    // to ensure a maximum 512 image size. Needs to be reevaluated when
+    // normalizeSourceURL() moves to a new API version.
     normalizedURL.insert(extensionIdx, "@2x");
     return normalizedURL;
 }
+
 
 std::string removeAccessTokenFromURL(const std::string &url) {
     const size_t token_start = url.find("access_token=");

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -38,21 +38,21 @@ TEST(Mapbox, SpriteURL) {
 TEST(Mapbox, TileURL) {
     try {
 #if defined(__ANDROID__) || defined(__APPLE__)
-        EXPECT_EQ("http://path.png/tile{ratio}.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png"));
-        EXPECT_EQ("http://path.png/tile{ratio}.png32", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png32"));
-        EXPECT_EQ("http://path.png/tile{ratio}.png70", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png70"));
-        EXPECT_EQ("http://path.png/tile{ratio}.png?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png?access_token=foo"));
+        EXPECT_EQ("http://path.png/tile@2x.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png"));
+        EXPECT_EQ("http://path.png/tile@2x.png32", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png32"));
+        EXPECT_EQ("http://path.png/tile@2x.png70", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png70"));
+        EXPECT_EQ("http://path.png/tile@2x.png?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png?access_token=foo"));
 #else
-        EXPECT_EQ("http://path.png/tile{ratio}.webp", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png"));
-        EXPECT_EQ("http://path.png/tile{ratio}.webp32", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png32"));
-        EXPECT_EQ("http://path.png/tile{ratio}.webp70", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png70"));
-        EXPECT_EQ("http://path.png/tile{ratio}.webp?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png?access_token=foo"));
+        EXPECT_EQ("http://path.png/tile@2x.webp", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png"));
+        EXPECT_EQ("http://path.png/tile@2x.webp32", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png32"));
+        EXPECT_EQ("http://path.png/tile@2x.webp70", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png70"));
+        EXPECT_EQ("http://path.png/tile@2x.webp?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png?access_token=foo"));
 #endif // defined(__ANDROID__) || defined(__APPLE__)
-        EXPECT_EQ("http://path.png/tile{ratio}.pbf", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf"));
-        EXPECT_EQ("http://path.png/tile{ratio}.pbf?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo"));
-        EXPECT_EQ("http://path.png/tile{ratio}.pbf?access_token=foo.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png"));
-        EXPECT_EQ("http://path.png/tile{ratio}.pbf?access_token=foo.png/bar", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png/bar"));
-        EXPECT_EQ("http://path.png/tile{ratio}.pbf?access_token=foo.png/bar.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png/bar.png"));
+        EXPECT_EQ("http://path.png/tile@2x.pbf", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf"));
+        EXPECT_EQ("http://path.png/tile@2x.pbf?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo"));
+        EXPECT_EQ("http://path.png/tile@2x.pbf?access_token=foo.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png"));
+        EXPECT_EQ("http://path.png/tile@2x.pbf?access_token=foo.png/bar", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png/bar"));
+        EXPECT_EQ("http://path.png/tile@2x.pbf?access_token=foo.png/bar.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png/bar.png"));
     } catch (const std::regex_error& e) {
         const char *error = "unknown";
         switch (e.code()) {

--- a/test/miscellaneous/mapbox.cpp
+++ b/test/miscellaneous/mapbox.cpp
@@ -38,21 +38,30 @@ TEST(Mapbox, SpriteURL) {
 TEST(Mapbox, TileURL) {
     try {
 #if defined(__ANDROID__) || defined(__APPLE__)
-        EXPECT_EQ("http://path.png/tile@2x.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png"));
-        EXPECT_EQ("http://path.png/tile@2x.png32", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png32"));
-        EXPECT_EQ("http://path.png/tile@2x.png70", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png70"));
-        EXPECT_EQ("http://path.png/tile@2x.png?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png?access_token=foo"));
+        EXPECT_EQ("http://path.png/tile.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png"));
+        EXPECT_EQ("http://path.png/tile.png32", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png32"));
+        EXPECT_EQ("http://path.png/tile.png70", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png70"));
+        EXPECT_EQ("http://path.png/tile.png?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png?access_token=foo"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile@2x.png", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.png"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile@2x.png32", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.png32"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile@2x.jpg", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.jpg"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile@2x.jpg70", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.jpg70"));
 #else
-        EXPECT_EQ("http://path.png/tile@2x.webp", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png"));
-        EXPECT_EQ("http://path.png/tile@2x.webp32", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png32"));
-        EXPECT_EQ("http://path.png/tile@2x.webp70", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png70"));
-        EXPECT_EQ("http://path.png/tile@2x.webp?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png?access_token=foo"));
+        EXPECT_EQ("http://path.png/tile.webp", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png"));
+        EXPECT_EQ("http://path.png/tile.webp32", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png32"));
+        EXPECT_EQ("http://path.png/tile.webp70", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png70"));
+        EXPECT_EQ("http://path.png/tile.webp?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.png?access_token=foo"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile@2x.webp", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.webp"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile@2x.webp", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.webp"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile@2x.jpg", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.jpg"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile@2x.jpg70", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.jpg70"));
 #endif // defined(__ANDROID__) || defined(__APPLE__)
-        EXPECT_EQ("http://path.png/tile@2x.pbf", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf"));
-        EXPECT_EQ("http://path.png/tile@2x.pbf?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo"));
-        EXPECT_EQ("http://path.png/tile@2x.pbf?access_token=foo.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png"));
-        EXPECT_EQ("http://path.png/tile@2x.pbf?access_token=foo.png/bar", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png/bar"));
-        EXPECT_EQ("http://path.png/tile@2x.pbf?access_token=foo.png/bar.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png/bar.png"));
+        EXPECT_EQ("http://path.png/tile.pbf", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf"));
+        EXPECT_EQ("http://path.png/tile.pbf?access_token=foo", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo"));
+        EXPECT_EQ("http://path.png/tile.pbf?access_token=foo.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png"));
+        EXPECT_EQ("http://path.png/tile.pbf?access_token=foo.png/bar", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png/bar"));
+        EXPECT_EQ("http://path.png/tile.pbf?access_token=foo.png/bar.png", mbgl::util::mapbox::normalizeRasterTileURL("http://path.png/tile.pbf?access_token=foo.png/bar.png"));
+        EXPECT_EQ("http://api.mapbox.com/v4/mapbox.pnglike/tile.vector.pbf", mbgl::util::mapbox::normalizeRasterTileURL("http://api.mapbox.com/v4/mapbox.pnglike/tile.vector.pbf"));
     } catch (const std::regex_error& e) {
         const char *error = "unknown";
         switch (e.code()) {


### PR DESCRIPTION
Native port of PR: mapbox/mapbox-gl-js#1964. Would love your eyes, especially the best placement for `tileSize` override of Mapbox raster sources.

cc @kkaefer @jfirebaugh