### PR TITLE
Disable user tracking in -setVisibleCoordinates:

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1196,6 +1196,11 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
         [self trackGestureEvent:MGLEventGestureRotateStart forRecognizer:rotate];
 
         self.angle = MGLRadiansFromDegrees(_mbglMap->getBearing()) * -1;
+
+        if (self.userTrackingMode != MGLUserTrackingModeNone)
+        {
+            self.userTrackingMode = MGLUserTrackingModeFollow;
+        }
         
         [self notifyGestureDidBegin];
     }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1813,6 +1813,7 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
 - (void)setVisibleCoordinates:(CLLocationCoordinate2D *)coordinates count:(NSUInteger)count edgePadding:(UIEdgeInsets)insets direction:(CLLocationDirection)direction duration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))completion
 {
+    self.userTrackingMode = MGLUserTrackingModeNone;
     _mbglMap->cancelTransitions();
     
     // NOTE: does not disrupt tracking mode


### PR DESCRIPTION
Programmatic modification of the viewport should kick the user out of user tracking mode. Also, fixed a regression from #3589 in which rotating the map with two fingers failed to kick the user out of heading or course tracking mode. (It now goes into location tracking mode, per MapKit.)