### PR TITLE
[ios] Avoid the blue background location status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Known issues:
 - Fixed an issue with users not being counted by Mapbox if they had disabled telemetry. ([#3495](https://github.com/mapbox/mapbox-gl-native/pull/3495))
 - Fixed crash caused by MGLAnnotationImage with non-integer width or height ([#2198](https://github.com/mapbox/mapbox-gl-native/issues/2198))
 - Fixed “include of non-modular header” errors in Swift projects managed by CocoaPods. ([#3679](https://github.com/mapbox/mapbox-gl-native/pull/3679)) 
+- Avoids triggering the blue background location status bar when user has granted "when in use" permission. ([#3671](https://github.com/mapbox/mapbox-gl-native/issues/3671))
 
 ## iOS 3.0.1
 

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -336,13 +336,24 @@ const NSTimeInterval MGLFlushInterval = 60;
     if (self.paused) {
         [self stopUpdatingLocation];
     } else {
-        CLAuthorizationStatus authStatus = [CLLocationManager authorizationStatus];
-        if (authStatus == kCLAuthorizationStatusDenied ||
-            authStatus == kCLAuthorizationStatusRestricted) {
-            [self stopUpdatingLocation];
-        } else if (authStatus == kCLAuthorizationStatusAuthorized ||
-                   authStatus == kCLAuthorizationStatusAuthorizedWhenInUse) {
-            [self startUpdatingLocation];
+        switch ([CLLocationManager authorizationStatus]) {
+            case kCLAuthorizationStatusNotDetermined:
+            case kCLAuthorizationStatusRestricted:
+            case kCLAuthorizationStatusDenied:
+                [self stopUpdatingLocation];
+                break;
+            case kCLAuthorizationStatusAuthorized:
+                // Also handles kCLAuthorizationStatusAuthorizedAlways
+                [self startUpdatingLocation];
+                break;
+            case kCLAuthorizationStatusAuthorizedWhenInUse:
+                if (UIApplication.sharedApplication.applicationState == UIApplicationStateBackground) {
+                    // Prevent blue status bar when app is not in foreground
+                    [self stopUpdatingLocation];
+                } else {
+                    [self startUpdatingLocation];
+                }
+                break;
         }
     }
 }


### PR DESCRIPTION
Apps with `whenInUse` location permission will show a blue status bar when they continue to use location services after leaving the foreground. This is worrying and to be avoided, so let's disable telemetry location services in this situation.

Fixes #2945, refs #3641.

/cc @boundsj @1ec5 @jfirebaugh @mikemorris