### PR TITLE
Custom edgeInsets for fitting in showAnnotations

### DIFF
--- a/include/mbgl/ios/MGLMapView.h
+++ b/include/mbgl/ios/MGLMapView.h
@@ -498,15 +498,33 @@ IB_DESIGNABLE
 
 /**
  Sets the visible region so that the map displays the specified annotations.
- 
+
  Calling this method updates the value in the visibleCoordinateBounds property
- and potentially other properties to reflect the new map region.
- 
+ and potentially other properties to reflect the new map region. Defaults to 
+ insetting the annotation bounds by 100,100,100,100, or if map is smaller than 
+ 200x200 in either dimension, sets the insets to 20% of that dimmension on
+ either side.
+
  @param annotations The annotations that you want to be visible in the map.
  @param animated `YES` if you want the map region change to be animated, or `NO`
     if you want the map to display the new region immediately without animations.
  */
 - (void)showAnnotations:(NS_ARRAY_OF(id <MGLAnnotation>) *)annotations animated:(BOOL)animated;
+
+/**
+ Sets the visible region so that the map displays the specified annotations with
+ custom insets.
+
+ Calling this method updates the value in the visibleCoordinateBounds property
+ and potentially other properties to reflect the new map region. It allows for
+ the customization of the UIEdgeInsets that determine the resultant viewport.
+
+ @param annotations The annotations that you want to be visible in the map.
+ @param edgeInsets Custom edge insets to contain the the annotations within.
+ @param animated `YES` if you want the map region change to be animated, or `NO`
+    if you want the map to display the new region immediately without animations.
+ */
+- (void)showAnnotations:(NS_ARRAY_OF(id <MGLAnnotation>) *)annotations withEdgeInsets:(UIEdgeInsets)edgeInsets animated:(BOOL)animated;
 
 /**
  A camera representing the current viewpoint of the map.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2842,6 +2842,20 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
 
 - (void)showAnnotations:(NS_ARRAY_OF(id <MGLAnnotation>) *)annotations animated:(BOOL)animated
 {
+    CGFloat defaultPadding = 100;
+    CGFloat yPadding = (self.frame.size.height / 2 <= defaultPadding) ? (self.frame.size.height / 5) : defaultPadding;
+    CGFloat xPadding = (self.frame.size.width / 2 <= defaultPadding) ? (self.frame.size.width / 5) : defaultPadding;
+
+    UIEdgeInsets edgeInsets = UIEdgeInsetsMake(yPadding, xPadding, yPadding, xPadding);
+
+    [self showAnnotations:annotations
+           withEdgeInsets:edgeInsets
+                 animated:animated];
+    ]
+}
+
+- (void)showAnnotations:(NS_ARRAY_OF(id <MGLAnnotation>) *)annotations withEdgeInsets:(UIEdgeInsets)edgeInsets animated:(BOOL)animated
+{
     if ( ! annotations || ! annotations.count) return;
 
     mbgl::LatLngBounds bounds = mbgl::LatLngBounds::getExtendable();
@@ -2858,12 +2872,8 @@ std::chrono::steady_clock::duration MGLDurationInSeconds(float duration)
         }
     }
 
-    CGFloat defaultPadding = 100;
-    CGFloat yPadding = (self.frame.size.height / 2 <= defaultPadding) ? (self.frame.size.height / 5) : defaultPadding;
-    CGFloat xPadding = (self.frame.size.width / 2 <= defaultPadding) ? (self.frame.size.width / 5) : defaultPadding;
-
     [self setVisibleCoordinateBounds:MGLCoordinateBoundsFromLatLngBounds(bounds)
-                         edgePadding:UIEdgeInsetsMake(yPadding, xPadding, yPadding, xPadding)
+                         edgePadding:edgeInsets
                             animated:animated];
 }
 


### PR DESCRIPTION
Keeps sensible defaults already in place, but allows callers to override.