### PR TITLE
[core] Final preparations for OfflineFileSource

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -5,6 +5,8 @@
 
 namespace mbgl {
 
+class SQLiteCache;
+
 class DefaultFileSource : public FileSource {
 public:
     DefaultFileSource(const std::string& cachePath, const std::string& assetRoot);
@@ -18,8 +20,13 @@ public:
 
     std::unique_ptr<FileRequest> request(const Resource&, Callback) override;
 
+    // For testing purposes only.
+    SQLiteCache& getCache();
+
 private:
     class Impl;
+    friend class DefaultFileRequest;
+
     const std::unique_ptr<Impl> impl;
 };
 

--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -5,15 +5,13 @@
 
 namespace mbgl {
 
-class SQLiteCache;
-
 namespace util {
 template <typename T> class Thread;
 } // namespace util
 
 class OnlineFileSource : public FileSource {
 public:
-    OnlineFileSource(SQLiteCache*);
+    OnlineFileSource();
     ~OnlineFileSource() override;
 
     void setAccessToken(const std::string& t) { accessToken = t; }

--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -25,8 +25,8 @@ public:
           url(url_) {
     }
 
-    const Kind kind;
-    const std::string url;
+    Kind kind;
+    std::string url;
 
     optional<SystemTimePoint> priorModified;
     optional<SystemTimePoint> priorExpires;

--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -31,6 +31,17 @@ public:
     optional<SystemTimePoint> priorModified;
     optional<SystemTimePoint> priorExpires;
     optional<std::string> priorEtag;
+
+    // Includes auxiliary data if this is a tile request.
+
+    struct TileData {
+        int32_t x;
+        int32_t y;
+        int8_t z;
+        float pixelRatio;
+    };
+
+    optional<TileData> tileData;
 };
 
 } // namespace mbgl

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -1,7 +1,6 @@
 #include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/storage/http_context_base.hpp>
 #include <mbgl/storage/network_status.hpp>
-#include <mbgl/storage/sqlite_cache.hpp>
 
 #include <mbgl/storage/response.hpp>
 #include <mbgl/platform/log.hpp>
@@ -45,13 +44,11 @@ public:
     void networkIsReachableAgain(OnlineFileSource::Impl&);
 
 private:
-    void scheduleCacheRequest(OnlineFileSource::Impl&);
-    void scheduleRealRequest(OnlineFileSource::Impl&, bool forceImmediate = false);
+    void schedule(OnlineFileSource::Impl&, bool forceImmediate = false);
 
     Resource resource;
-    std::unique_ptr<WorkRequest> cacheRequest;
-    HTTPRequestBase* realRequest = nullptr;
-    util::Timer realRequestTimer;
+    HTTPRequestBase* request = nullptr;
+    util::Timer timer;
     Callback callback;
 
     // Counts the number of subsequent failed requests. We're using this value for exponential
@@ -64,7 +61,7 @@ class OnlineFileSource::Impl {
 public:
     using Callback = std::function<void (Response)>;
 
-    Impl(SQLiteCache*);
+    Impl();
     ~Impl();
 
     void networkIsReachableAgain();
@@ -76,15 +73,13 @@ private:
     friend OnlineFileRequestImpl;
 
     std::unordered_map<FileRequest*, std::unique_ptr<OnlineFileRequestImpl>> pending;
-    SQLiteCache* const cache;
     const std::unique_ptr<HTTPContextBase> httpContext;
     util::AsyncTask reachability;
 };
 
-OnlineFileSource::OnlineFileSource(SQLiteCache* cache)
+OnlineFileSource::OnlineFileSource()
     : thread(std::make_unique<util::Thread<Impl>>(
-          util::ThreadContext{ "OnlineFileSource", util::ThreadType::Unknown, util::ThreadPriority::Low },
-          cache)) {
+          util::ThreadContext{ "OnlineFileSource", util::ThreadType::Unknown, util::ThreadPriority::Low })) {
 }
 
 OnlineFileSource::~OnlineFileSource() = default;
@@ -94,31 +89,30 @@ std::unique_ptr<FileRequest> OnlineFileSource::request(const Resource& resource,
         throw util::MisuseException("FileSource callback can't be empty");
     }
 
-    std::string url;
+    Resource res = resource;
 
     switch (resource.kind) {
     case Resource::Kind::Style:
-        url = mbgl::util::mapbox::normalizeStyleURL(resource.url, accessToken);
+        res.url = mbgl::util::mapbox::normalizeStyleURL(resource.url, accessToken);
         break;
 
     case Resource::Kind::Source:
-        url = util::mapbox::normalizeSourceURL(resource.url, accessToken);
+        res.url = util::mapbox::normalizeSourceURL(resource.url, accessToken);
         break;
 
     case Resource::Kind::Glyphs:
-        url = util::mapbox::normalizeGlyphsURL(resource.url, accessToken);
+        res.url = util::mapbox::normalizeGlyphsURL(resource.url, accessToken);
         break;
 
     case Resource::Kind::SpriteImage:
     case Resource::Kind::SpriteJSON:
-        url = util::mapbox::normalizeSpriteURL(resource.url, accessToken);
+        res.url = util::mapbox::normalizeSpriteURL(resource.url, accessToken);
         break;
 
     default:
-        url = resource.url;
+        break;
     }
 
-    Resource res { resource.kind, url };
     auto req = std::make_unique<OnlineFileRequest>(*this);
     req->workRequest = thread->invokeWithCallback(&Impl::add, callback, res, req.get());
     return std::move(req);
@@ -130,13 +124,9 @@ void OnlineFileSource::cancel(FileRequest* req) {
 
 // ----- Impl -----
 
-OnlineFileSource::Impl::Impl(SQLiteCache* cache_)
-    : cache(cache_),
-      httpContext(HTTPContextBase::createContext()),
+OnlineFileSource::Impl::Impl()
+    : httpContext(HTTPContextBase::createContext()),
       reachability(std::bind(&Impl::networkIsReachableAgain, this)) {
-    // Subscribe to network status changes, but make sure that this async handle doesn't keep the
-    // loop alive; otherwise our app wouldn't terminate. After all, we only need status change
-    // notifications when our app is still running.
     NetworkStatus::Subscribe(&reachability);
 }
 
@@ -163,39 +153,16 @@ void OnlineFileSource::Impl::cancel(FileRequest* req) {
 OnlineFileRequestImpl::OnlineFileRequestImpl(const Resource& resource_, Callback callback_, OnlineFileSource::Impl& impl)
     : resource(resource_),
       callback(callback_) {
-    if (impl.cache) {
-        scheduleCacheRequest(impl);
-    } else {
-        scheduleRealRequest(impl, true);
-    }
+    // Force an immediate first request if we don't have an expiration time.
+    schedule(impl, !resource.priorExpires);
 }
 
 OnlineFileRequestImpl::~OnlineFileRequestImpl() {
-    if (realRequest) {
-        realRequest->cancel();
-        realRequest = nullptr;
+    if (request) {
+        request->cancel();
+        request = nullptr;
     }
-    // realRequestTimer and cacheRequest are automatically canceled upon destruction.
-}
-
-void OnlineFileRequestImpl::scheduleCacheRequest(OnlineFileSource::Impl& impl) {
-    // Check the cache for existing data so that we can potentially
-    // revalidate the information without having to redownload everything.
-    cacheRequest = impl.cache->get(resource, [this, &impl](std::shared_ptr<Response> response) {
-        cacheRequest = nullptr;
-
-        if (response) {
-            resource.priorModified = response->modified;
-            resource.priorExpires = response->expires;
-            resource.priorEtag = response->etag;
-            callback(*response);
-        }
-
-        // Force immediate revalidation if we don't have a cached response, or the cached
-        // response does not have an expiration time. Otherwise revalidation will happen in
-        // the normal scheduling flow.
-        scheduleRealRequest(impl, !response || !response->expires);
-    });
+    // timer is automatically canceled upon destruction.
 }
 
 static Duration errorRetryTimeout(Response::Error::Reason failedRequestReason, uint32_t failedRequests) {
@@ -220,8 +187,8 @@ static Duration expirationTimeout(optional<SystemTimePoint> expires) {
     }
 }
 
-void OnlineFileRequestImpl::scheduleRealRequest(OnlineFileSource::Impl& impl, bool forceImmediate) {
-    if (realRequest) {
+void OnlineFileRequestImpl::schedule(OnlineFileSource::Impl& impl, bool forceImmediate) {
+    if (request) {
         // There's already a request in progress; don't start another one.
         return;
     }
@@ -237,10 +204,10 @@ void OnlineFileRequestImpl::scheduleRealRequest(OnlineFileSource::Impl& impl, bo
         return;
     }
 
-    realRequestTimer.start(timeout, Duration::zero(), [this, &impl] {
-        assert(!realRequest);
-        realRequest = impl.httpContext->createRequest(resource, [this, &impl](Response response) {
-            realRequest = nullptr;
+    timer.start(timeout, Duration::zero(), [this, &impl] {
+        assert(!request);
+        request = impl.httpContext->createRequest(resource, [this, &impl](Response response) {
+            request = nullptr;
 
             // If we didn't get various caching headers in the response, continue using the
             // previous values. Otherwise, update the previous values to the new values.
@@ -263,10 +230,6 @@ void OnlineFileRequestImpl::scheduleRealRequest(OnlineFileSource::Impl& impl, bo
                 resource.priorEtag = response.etag;
             }
 
-            if (impl.cache) {
-                impl.cache->put(resource, response);
-            }
-
             if (response.error) {
                 failedRequests++;
                 failedRequestReason = response.error->reason;
@@ -276,7 +239,7 @@ void OnlineFileRequestImpl::scheduleRealRequest(OnlineFileSource::Impl& impl, bo
             }
 
             callback(response);
-            scheduleRealRequest(impl);
+            schedule(impl);
         });
     });
 }
@@ -285,7 +248,7 @@ void OnlineFileRequestImpl::networkIsReachableAgain(OnlineFileSource::Impl& impl
     // We need all requests to fail at least once before we are going to start retrying
     // them, and we only immediately restart request that failed due to connection issues.
     if (failedRequestReason == Response::Error::Reason::Connection) {
-        scheduleRealRequest(impl, true);
+        schedule(impl, true);
     }
 }
 

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -61,7 +61,7 @@ class OnlineFileSource::Impl {
 public:
     using Callback = std::function<void (Response)>;
 
-    Impl();
+    Impl(int);
     ~Impl();
 
     void networkIsReachableAgain();
@@ -79,7 +79,7 @@ private:
 
 OnlineFileSource::OnlineFileSource()
     : thread(std::make_unique<util::Thread<Impl>>(
-          util::ThreadContext{ "OnlineFileSource", util::ThreadType::Unknown, util::ThreadPriority::Low })) {
+          util::ThreadContext{ "OnlineFileSource", util::ThreadType::Unknown, util::ThreadPriority::Low }, 0)) {
 }
 
 OnlineFileSource::~OnlineFileSource() = default;
@@ -124,7 +124,8 @@ void OnlineFileSource::cancel(FileRequest* req) {
 
 // ----- Impl -----
 
-OnlineFileSource::Impl::Impl()
+// Dummy parameter is a workaround for a gcc 4.9 bug.
+OnlineFileSource::Impl::Impl(int)
     : httpContext(HTTPContextBase::createContext()),
       reachability(std::bind(&Impl::networkIsReachableAgain, this)) {
     NetworkStatus::Subscribe(&reachability);

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -5,27 +5,34 @@
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/util/worker.hpp>
 #include <mbgl/util/work_request.hpp>
+#include <mbgl/util/url.hpp>
 
 using namespace mbgl;
 
 RasterTileData::RasterTileData(const TileID& id_,
+                               float pixelRatio,
+                               const std::string& urlTemplate,
                                TexturePool &texturePool_,
-                               Worker& worker_)
+                               Worker& worker_,
+                               const std::function<void(std::exception_ptr)>& callback)
     : TileData(id_),
       texturePool(texturePool_),
       worker(worker_) {
-}
-
-RasterTileData::~RasterTileData() {
-    cancel();
-}
-
-void RasterTileData::request(const std::string& url,
-                             const RasterTileData::Callback& callback) {
     state = State::loading;
 
-    FileSource* fs = util::ThreadContext::getFileSource();
-    req = fs->request({ Resource::Kind::Tile, url }, [url, callback, this](Response res) {
+    Resource resource {
+        Resource::Kind::Tile,
+        util::templateTileURL(urlTemplate, id, pixelRatio)
+    };
+
+    resource.tileData = Resource::TileData {
+        id.x,
+        id.y,
+        id.z,
+        pixelRatio
+    };
+
+    req = util::ThreadContext::getFileSource()->request(resource, [callback, this](Response res) {
         if (res.error) {
             std::exception_ptr error;
             if (res.error->reason == Response::Error::Reason::NotFound) {
@@ -74,6 +81,10 @@ void RasterTileData::request(const std::string& url,
             callback(error);
         });
     });
+}
+
+RasterTileData::~RasterTileData() {
+    cancel();
 }
 
 Bucket* RasterTileData::getBucket(StyleLayer const&) {

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -13,25 +13,22 @@ class WorkRequest;
 
 class RasterTileData : public TileData {
 public:
-    RasterTileData(const TileID&, TexturePool&, Worker&);
+    RasterTileData(const TileID&,
+                   float pixelRatio,
+                   const std::string& urlTemplate,
+                   TexturePool&,
+                   Worker&,
+                   const std::function<void(std::exception_ptr)>& callback);
     ~RasterTileData();
 
-    using Callback = std::function<void(std::exception_ptr)>;
-
-    void request(const std::string& url,
-                 const Callback& callback);
-
     void cancel() override;
-
     Bucket* getBucket(StyleLayer const &layer_desc) override;
 
 private:
     TexturePool& texturePool;
     Worker& worker;
     std::unique_ptr<FileRequest> req;
-
     std::unique_ptr<Bucket> bucket;
-
     std::unique_ptr<WorkRequest> workRequest;
 };
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -267,16 +267,17 @@ TileData::State Source::addTile(const TileID& tileID, const StyleUpdateParameter
 
         // If we don't find working tile data, we're just going to load it.
         if (type == SourceType::Raster) {
-            auto tileData = std::make_shared<RasterTileData>(normalizedID,
+            newTile->data = std::make_shared<RasterTileData>(normalizedID,
+                                                             parameters.pixelRatio,
+                                                             info->tiles.at(0),
                                                              parameters.texturePool,
-                                                             parameters.worker);
-            tileData->request(util::templateTileURL(info->tiles.at(0), normalizedID, parameters.pixelRatio), callback);
-            newTile->data = tileData;
+                                                             parameters.worker,
+                                                             callback);
         } else {
             std::unique_ptr<GeometryTileMonitor> monitor;
 
             if (type == SourceType::Vector) {
-                monitor = std::make_unique<VectorTileMonitor>(normalizedID, info->tiles.at(0));
+                monitor = std::make_unique<VectorTileMonitor>(normalizedID, parameters.pixelRatio, info->tiles.at(0));
             } else if (type == SourceType::Annotations) {
                 monitor = std::make_unique<AnnotationTileMonitor>(normalizedID, parameters.data);
             } else if (type == SourceType::GeoJSON) {

--- a/src/mbgl/map/vector_tile.cpp
+++ b/src/mbgl/map/vector_tile.cpp
@@ -178,13 +178,26 @@ util::ptr<const GeometryTileFeature> VectorTileLayer::getFeature(std::size_t i) 
     return std::make_shared<VectorTileFeature>(features.at(i), *this);
 }
 
-VectorTileMonitor::VectorTileMonitor(const TileID& tileID_, const std::string& urlTemplate_)
-    : tileID(tileID_), urlTemplate(urlTemplate_) {
+VectorTileMonitor::VectorTileMonitor(const TileID& tileID_, float pixelRatio_, const std::string& urlTemplate_)
+    : tileID(tileID_),
+      pixelRatio(pixelRatio_),
+      urlTemplate(urlTemplate_) {
 }
 
 std::unique_ptr<FileRequest> VectorTileMonitor::monitorTile(const GeometryTileMonitor::Callback& callback) {
-    const std::string url = util::templateTileURL(urlTemplate, tileID);
-    return util::ThreadContext::getFileSource()->request({ Resource::Kind::Tile, url }, [callback, this](Response res) {
+    Resource resource {
+        Resource::Kind::Tile,
+        util::templateTileURL(urlTemplate, tileID, pixelRatio)
+    };
+
+    resource.tileData = Resource::TileData {
+        tileID.x,
+        tileID.y,
+        tileID.z,
+        pixelRatio
+    };
+
+    return util::ThreadContext::getFileSource()->request(resource, [callback, this](Response res) {
         if (res.notModified) {
             // We got the same data again. Abort early.
             return;

--- a/src/mbgl/map/vector_tile.hpp
+++ b/src/mbgl/map/vector_tile.hpp
@@ -61,12 +61,13 @@ class TileID;
 
 class VectorTileMonitor : public GeometryTileMonitor {
 public:
-    VectorTileMonitor(const TileID&, const std::string& urlTemplate);
+    VectorTileMonitor(const TileID&, float pixelRatio, const std::string& urlTemplate);
 
     std::unique_ptr<FileRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
 
 private:
     TileID tileID;
+    float pixelRatio;
     std::string urlTemplate;
 };
 

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -31,7 +31,7 @@ void checkRendering(Map& map, const char * name) {
 TEST(Annotations, PointAnnotation) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
@@ -44,7 +44,7 @@ TEST(Annotations, PointAnnotation) {
 TEST(Annotations, LineAnnotation) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
@@ -63,7 +63,7 @@ TEST(Annotations, LineAnnotation) {
 TEST(Annotations, FillAnnotation) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
@@ -81,7 +81,7 @@ TEST(Annotations, FillAnnotation) {
 TEST(Annotations, StyleSourcedShapeAnnotation) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/annotation.json"), "");
@@ -96,7 +96,7 @@ TEST(Annotations, StyleSourcedShapeAnnotation) {
 TEST(Annotations, AddMultiple) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
@@ -113,7 +113,7 @@ TEST(Annotations, AddMultiple) {
 TEST(Annotations, NonImmediateAdd) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
@@ -133,7 +133,7 @@ TEST(Annotations, NonImmediateAdd) {
 TEST(Annotations, UpdatePoint) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
@@ -152,7 +152,7 @@ TEST(Annotations, UpdatePoint) {
 TEST(Annotations, RemovePoint) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
@@ -169,7 +169,7 @@ TEST(Annotations, RemovePoint) {
 TEST(Annotations, RemoveShape) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     AnnotationSegments segments = {{ {{ { 0, 0 }, { 45, 45 } }} }};
 
@@ -191,7 +191,7 @@ TEST(Annotations, RemoveShape) {
 TEST(Annotations, ImmediateRemoveShape) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
     Map map(view, fileSource, MapMode::Still);
 
     map.removeAnnotation(map.addShapeAnnotation(ShapeAnnotation({}, {})));
@@ -203,7 +203,7 @@ TEST(Annotations, ImmediateRemoveShape) {
 TEST(Annotations, SwitchStyle) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");

--- a/test/api/api_misuse.cpp
+++ b/test/api/api_misuse.cpp
@@ -18,7 +18,7 @@ TEST(API, RenderWithoutCallback) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     view.resize(128, 512);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     std::unique_ptr<Map> map = std::make_unique<Map>(view, fileSource, MapMode::Still);
     map->renderStill(nullptr);
@@ -40,7 +40,7 @@ TEST(API, RenderWithoutStyle) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
     view.resize(128, 512);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
 

--- a/test/api/custom_layer.cpp
+++ b/test/api/custom_layer.cpp
@@ -66,7 +66,7 @@ public:
 TEST(CustomLayer, Basic) {
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");

--- a/test/api/set_style.cpp
+++ b/test/api/set_style.cpp
@@ -12,7 +12,7 @@ TEST(API, SetStyle) {
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 

--- a/test/miscellaneous/map.cpp
+++ b/test/miscellaneous/map.cpp
@@ -12,7 +12,7 @@ TEST(Map, PauseResume) {
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Continuous);
 
@@ -25,7 +25,7 @@ TEST(Map, DoublePause) {
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Continuous);
 
@@ -39,7 +39,7 @@ TEST(Map, ResumeWithoutPause) {
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Continuous);
 
@@ -51,7 +51,7 @@ TEST(Map, DestroyPaused) {
 
     auto display = std::make_shared<mbgl::HeadlessDisplay>();
     HeadlessView view(display, 1);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     Map map(view, fileSource, MapMode::Continuous);
 

--- a/test/miscellaneous/map_context.cpp
+++ b/test/miscellaneous/map_context.cpp
@@ -12,7 +12,7 @@ using namespace mbgl;
 TEST(MapContext, DoubleStyleLoad) {
     std::shared_ptr<HeadlessDisplay> display = std::make_shared<HeadlessDisplay>();
     HeadlessView view(display, 1, 512, 512);
-    OnlineFileSource fileSource(nullptr);
+    OnlineFileSource fileSource;
 
     util::Thread<MapContext> context({"Map", util::ThreadType::Map, util::ThreadPriority::Regular},
         view, fileSource, MapMode::Continuous, GLContextMode::Unique, view.getPixelRatio());

--- a/test/storage/cache_revalidate.cpp
+++ b/test/storage/cache_revalidate.cpp
@@ -1,7 +1,6 @@
 #include "storage.hpp"
 
-#include <mbgl/storage/online_file_source.hpp>
-#include <mbgl/storage/sqlite_cache.hpp>
+#include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
 
@@ -11,8 +10,7 @@ TEST_F(Storage, CacheRevalidateSame) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    SQLiteCache cache(":memory:");
-    OnlineFileSource fs(&cache);
+    DefaultFileSource fs(":memory:", ".");
 
     const Resource revalidateSame { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
     std::unique_ptr<FileRequest> req1;
@@ -61,8 +59,7 @@ TEST_F(Storage, CacheRevalidateModified) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    SQLiteCache cache(":memory:");
-    OnlineFileSource fs(&cache);
+    DefaultFileSource fs(":memory:", ".");
 
     const Resource revalidateModified{ Resource::Unknown,
                                        "http://127.0.0.1:3000/revalidate-modified" };
@@ -111,8 +108,7 @@ TEST_F(Storage, CacheRevalidateEtag) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    SQLiteCache cache(":memory:");
-    OnlineFileSource fs(&cache);
+    DefaultFileSource fs(":memory:", ".");
 
     const Resource revalidateEtag { Resource::Unknown, "http://127.0.0.1:3000/revalidate-etag" };
     std::unique_ptr<FileRequest> req1;

--- a/test/storage/http_cancel.cpp
+++ b/test/storage/http_cancel.cpp
@@ -13,7 +13,7 @@ TEST_F(Storage, HTTPCancel) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     auto req =
         fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" },
@@ -31,7 +31,7 @@ TEST_F(Storage, HTTPCancelMultiple) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 

--- a/test/storage/http_error.cpp
+++ b/test/storage/http_error.cpp
@@ -13,7 +13,7 @@ TEST_F(Storage, HTTPTemporaryError) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     const auto start = Clock::now();
 
@@ -58,7 +58,7 @@ TEST_F(Storage, HTTPConnectionError) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     const auto start = Clock::now();
 

--- a/test/storage/http_header_parsing.cpp
+++ b/test/storage/http_header_parsing.cpp
@@ -12,7 +12,7 @@ TEST_F(Storage, HTTPExpiresParsing) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     std::unique_ptr<FileRequest> req1 = fs.request({ Resource::Unknown,
                  "http://127.0.0.1:3000/test?modified=1420794326&expires=1420797926&etag=foo" },
@@ -37,7 +37,7 @@ TEST_F(Storage, HTTPCacheControlParsing) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     std::unique_ptr<FileRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" },
                [&](Response res) {

--- a/test/storage/http_issue_1369.cpp
+++ b/test/storage/http_issue_1369.cpp
@@ -1,8 +1,6 @@
 #include "storage.hpp"
 
-#include <mbgl/storage/online_file_source.hpp>
-#include <mbgl/storage/sqlite_cache.hpp>
-#include <mbgl/util/chrono.hpp>
+#include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 // Test for https://github.com/mapbox/mapbox-gl-native/issue/1369
@@ -22,8 +20,7 @@ TEST_F(Storage, HTTPIssue1369) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    SQLiteCache cache;
-    OnlineFileSource fs(&cache);
+    DefaultFileSource fs(":memory:", ".");
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 

--- a/test/storage/http_load.cpp
+++ b/test/storage/http_load.cpp
@@ -10,7 +10,7 @@ TEST_F(Storage, HTTPLoad) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     const int concurrency = 50;
     const int max = 10000;

--- a/test/storage/http_other_loop.cpp
+++ b/test/storage/http_other_loop.cpp
@@ -11,7 +11,7 @@ TEST_F(Storage, HTTPOtherLoop) {
 
     // This file source launches a separate thread to do the processing.
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" },
                [&](Response res) {

--- a/test/storage/http_reading.cpp
+++ b/test/storage/http_reading.cpp
@@ -14,7 +14,7 @@ TEST_F(Storage, HTTPTest) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     std::unique_ptr<FileRequest> req1 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" },
                [&](Response res) {
@@ -39,7 +39,7 @@ TEST_F(Storage, HTTP404) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     std::unique_ptr<FileRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/doesnotexist" },
                [&](Response res) {
@@ -66,7 +66,7 @@ TEST_F(Storage, HTTP500) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     std::unique_ptr<FileRequest> req3 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/permanent-error" },
                [&](Response res) {
@@ -93,7 +93,7 @@ TEST_F(Storage, HTTPNoCallback) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     try {
         fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" },

--- a/test/storage/http_retry_network_status.cpp
+++ b/test/storage/http_retry_network_status.cpp
@@ -18,7 +18,7 @@ TEST_F(Storage, HTTPNetworkStatusChange) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/delayed" };
 
@@ -57,7 +57,7 @@ TEST_F(Storage, HTTPNetworkStatusChangePreempt) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     const auto start = Clock::now();
 

--- a/test/storage/http_timeout.cpp
+++ b/test/storage/http_timeout.cpp
@@ -11,7 +11,7 @@ TEST_F(Storage, HTTPTimeout) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    OnlineFileSource fs(nullptr);
+    OnlineFileSource fs;
 
     int counter = 0;
 


### PR DESCRIPTION
This results in `OnlineFileSource` containing precisely the logic we want for reuse by `OfflineFileSource` (which needs access to a `FileSource` from which to download), and no more.

:eyes: @kkaefer 