### PR TITLE
3627 android content insets

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -278,6 +278,10 @@ public final class MapView extends FrameLayout {
     private boolean mTiltEnabled = true;
     private boolean mAllowConcurrentMultipleOpenInfoWindows = false;
     private String mStyleUrl;
+    private int mContentPaddingLeft;
+    private int mContentPaddingTop;
+    private int mContentPaddingRight;
+    private int mContentPaddingBottom;
 
     //
     // Inner classes
@@ -4340,6 +4344,38 @@ public final class MapView extends FrameLayout {
     public void setAttributionMargins(int left, int top, int right, int bottom) {
         setWidgetMargins(mAttributionsView, left, top, right, bottom);
     }
+
+
+    /**
+     * Sets the distance from the edges of the map view’s frame to the edges of the map
+     * view’s logical viewport.
+     *
+     * When the value of this property is equal to {0,0,0,0}, viewport
+     * properties such as `centerCoordinate` assume a viewport that matches the map
+     * view’s frame. Otherwise, those properties are inset, excluding part of the
+     * frame from the viewport. For instance, if the only the top edge is inset, the
+     * map center is effectively shifted downward.
+     *
+     * @param left     The left margin in pixels.
+     * @param top      The top margin in pixels.
+     * @param right    The right margin in pixels.
+     * @param bottom   The bottom margin in pixels.
+     */
+    @UiThread
+    public void setContentPadding(int left, int top, int right, int bottom) {
+
+        if (left == mContentPaddingLeft && top == mContentPaddingTop && right == mContentPaddingRight && bottom == mContentPaddingBottom) {
+            return;
+        }
+
+        mContentPaddingLeft = left;
+        mContentPaddingTop = top;
+        mContentPaddingRight = right;
+        mContentPaddingBottom = bottom;
+
+        mNativeMapView.setContentPadding(top / mScreenDensity, left / mScreenDensity, bottom / mScreenDensity, right / mScreenDensity);
+    }
+
 
     /**
      * <p>

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -278,6 +278,7 @@ public final class MapView extends FrameLayout {
     private boolean mTiltEnabled = true;
     private boolean mAllowConcurrentMultipleOpenInfoWindows = false;
     private String mStyleUrl;
+
     private int mContentPaddingLeft;
     private int mContentPaddingTop;
     private int mContentPaddingRight;
@@ -1573,6 +1574,38 @@ public final class MapView extends FrameLayout {
     @Deprecated
     public double getZoomLevel() {
         return mNativeMapView.getZoom();
+    }
+
+    /**
+     * Return The current content padding left of the map view viewport.
+     * @return The current content padding left
+     */
+    public int getContentPaddingLeft() {
+        return mContentPaddingLeft;
+    }
+
+    /**
+     * Return The current content padding left of the map view viewport.
+     * @return The current content padding left
+     */
+    public int getContentPaddingTop() {
+        return mContentPaddingTop;
+    }
+
+    /**
+     * Return The current content padding left of the map view viewport.
+     * @return The current content padding left
+     */
+    public int getContentPaddingRight() {
+        return mContentPaddingRight;
+    }
+
+    /**
+     * Return The current content padding left of the map view viewport.
+     * @return The current content padding left
+     */
+    public int getContentPaddingBottom() {
+        return mContentPaddingBottom;
     }
 
     /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/MapView.java
@@ -4351,7 +4351,7 @@ public final class MapView extends FrameLayout {
      * view’s logical viewport.
      *
      * When the value of this property is equal to {0,0,0,0}, viewport
-     * properties such as `centerCoordinate` assume a viewport that matches the map
+     * properties such as `getLatLng` assume a viewport that matches the map
      * view’s frame. Otherwise, those properties are inset, excluding part of the
      * frame from the viewport. For instance, if the only the top edge is inset, the
      * map center is effectively shifted downward.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/NativeMapView.java
@@ -336,6 +336,10 @@ final class NativeMapView {
         nativeRotateBy(mNativeMapViewPtr, sx, sy, ex, ey, duration);
     }
 
+    public void setContentPadding(double top, double left, double bottom, double right) {
+        nativeSetContentPadding(mNativeMapViewPtr, top, left, bottom, right);
+    }
+
     public void setBearing(double degrees) {
         setBearing(degrees, 0);
     }
@@ -590,6 +594,8 @@ final class NativeMapView {
 
     private native void nativeRotateBy(long nativeMapViewPtr, double sx,
                                        double sy, double ex, double ey, long duration);
+
+    private native void nativeSetContentPadding(long nativeMapViewPtr, double top, double left, double bottom, double right);
 
     private native void nativeSetBearing(long nativeMapViewPtr, double degrees,
                                          long duration);

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -655,7 +655,7 @@ jobject JNICALL nativeGetLatLng(JNIEnv *env, jobject obj, jlong nativeMapViewPtr
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeGetLatLng");
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    mbgl::LatLng latLng = nativeMapView->getMap().getLatLng();
+    mbgl::LatLng latLng = nativeMapView->getMap().getLatLng(nativeMapView->getInsets());
 
     jobject ret = env->NewObject(latLngClass, latLngConstructorId, latLng.latitude, latLng.longitude);
     if (ret == nullptr) {

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -648,7 +648,7 @@ void JNICALL nativeSetLatLng(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, j
         return;
     }
 
-    nativeMapView->getMap().setLatLng(mbgl::LatLng(latitude, longitude), mbgl::Duration(duration));
+    nativeMapView->getMap().setLatLng(mbgl::LatLng(latitude, longitude), nativeMapView->getInsets(), mbgl::Duration(duration));
 }
 
 jobject JNICALL nativeGetLatLng(JNIEnv *env, jobject obj, jlong nativeMapViewPtr) {
@@ -1504,6 +1504,7 @@ void JNICALL nativeJumpTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdou
         options.angle = angle;
     }
     options.center = mbgl::LatLng(latitude, longitude);
+    options.padding = nativeMapView->getInsets();
     if (pitch != -1) {
         options.pitch = pitch;
     }
@@ -1536,6 +1537,7 @@ void JNICALL nativeEaseTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdou
         cameraOptions.angle = angle;
     }
     cameraOptions.center = mbgl::LatLng(latitude, longitude);
+    cameraOptions.padding = nativeMapView->getInsets();
     if (pitch != -1) {
         cameraOptions.pitch = pitch;
     }
@@ -1547,6 +1549,14 @@ void JNICALL nativeEaseTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdou
 
     nativeMapView->getMap().easeTo(cameraOptions, animationOptions);
 }
+
+void JNICALL nativeSetContentPadding(JNIEnv *env, jobject obj,long nativeMapViewPtr, double top, double left, double bottom, double right) {
+    mbgl::Log::Debug(mbgl::Event::JNI, "nativeSetContentPadding");
+    assert(nativeMapViewPtr != 0);
+    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
+    nativeMapView->setInsets({top, left, bottom, right});
+}
+
 
 void JNICALL nativeFlyTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdouble angle, jobject centerLatLng, jlong duration, jdouble pitch, jdouble zoom) {
     mbgl::Log::Debug(mbgl::Event::JNI, "nativeFlyTo");
@@ -1570,6 +1580,7 @@ void JNICALL nativeFlyTo(JNIEnv *env, jobject obj, jlong nativeMapViewPtr, jdoub
         cameraOptions.angle = angle;
     }
     cameraOptions.center = mbgl::LatLng(latitude, longitude);
+    cameraOptions.padding = nativeMapView->getInsets();
     if (pitch != -1) {
         cameraOptions.pitch = pitch;
     }
@@ -2135,6 +2146,8 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
          reinterpret_cast<void *>(&nativeAddCustomLayer)},
         {"nativeRemoveCustomLayer", "(JLjava/lang/String;)V",
          reinterpret_cast<void *>(&nativeRemoveCustomLayer)},
+        {"nativeSetContentPadding", "(JDDDD)V",
+         reinterpret_cast<void *>(&nativeSetContentPadding)}
     };
 
     if (env->RegisterNatives(nativeMapViewClass, methods.data(), methods.size()) < 0) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -752,5 +752,9 @@ void NativeMapView::resizeFramebuffer(int w, int h) {
     map->update(mbgl::Update::Repaint);
 }
 
+void NativeMapView::setInsets(mbgl::EdgeInsets insets_) {
+    insets = insets_;
+}
+
 }
 }

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -51,6 +51,8 @@ public:
 
     void resizeView(int width, int height);
     void resizeFramebuffer(int width, int height);
+    mbgl::EdgeInsets getInsets() { return insets;}
+    void setInsets(mbgl::EdgeInsets insets_);
 
 private:
     EGLConfig chooseConfig(const EGLConfig configs[], EGLint numConfigs);
@@ -92,6 +94,7 @@ private:
     // Ensure these are initialised last
     std::unique_ptr<mbgl::DefaultFileSource> fileSource;
     std::unique_ptr<mbgl::Map> map;
+    mbgl::EdgeInsets insets;
 };
 }
 }


### PR DESCRIPTION
This PR is meant to implement padding functionality on android platform described in this issue #3627.

* Add a `setPaddingContent` method on `MapView`
* Padding are stored in NativeMapView to be applied on any methods that can update current bounding box.