### PR TITLE
Hang on each tile load — VectorTileData, TileWorker::parseLayer

### DIFF
--- a/include/mbgl/util/work_request.hpp
+++ b/include/mbgl/util/work_request.hpp
@@ -15,6 +15,8 @@ public:
     WorkRequest(Task);
     ~WorkRequest();
 
+    bool tryCancel();
+
 private:
     std::shared_ptr<WorkTask> task;
 };

--- a/include/mbgl/util/work_task.hpp
+++ b/include/mbgl/util/work_task.hpp
@@ -14,6 +14,7 @@ public:
 
     virtual void operator()() = 0;
     virtual void cancel() = 0;
+    virtual bool tryCancel() = 0;
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -57,7 +57,9 @@ void RasterTileData::request(const std::string& url,
 
         workRequest.reset();
         workRequest = worker.parseRasterTile(std::make_unique<RasterBucket>(texturePool), res.data, [this, callback] (RasterTileParseResult result) {
+            WorkCompletedNotifier notifier(this);
             workRequest.reset();
+
             if (state != State::loaded) {
                 return;
             }

--- a/src/mbgl/map/raster_tile_data.cpp
+++ b/src/mbgl/map/raster_tile_data.cpp
@@ -17,7 +17,8 @@ RasterTileData::RasterTileData(const TileID& id_,
 }
 
 RasterTileData::~RasterTileData() {
-    cancel();
+    assert(tryCancel());
+    workRequest.reset();
 }
 
 void RasterTileData::request(const std::string& url,
@@ -80,10 +81,20 @@ Bucket* RasterTileData::getBucket(StyleLayer const&) {
     return bucket.get();
 }
 
-void RasterTileData::cancel() {
+bool RasterTileData::tryCancel(bool force) {
     if (state != State::obsolete) {
         state = State::obsolete;
     }
+
     req = nullptr;
-    workRequest.reset();
+
+    if (force) {
+        workRequest.reset();
+    }
+
+    if (workRequest) {
+        return workRequest->tryCancel();
+    }
+
+    return true;
 }

--- a/src/mbgl/map/raster_tile_data.hpp
+++ b/src/mbgl/map/raster_tile_data.hpp
@@ -21,7 +21,7 @@ public:
     void request(const std::string& url,
                  const Callback& callback);
 
-    void cancel() override;
+    bool tryCancel(bool force = false) override;
 
     Bucket* getBucket(StyleLayer const &layer_desc) override;
 

--- a/src/mbgl/map/source.cpp
+++ b/src/mbgl/map/source.cpp
@@ -485,7 +485,7 @@ bool Source::update(const StyleUpdateParameters& parameters) {
         bool obsolete = retain_data.find(tile->id) == retain_data.end();
         if (obsolete) {
             if (!tileCache.has(tile->id.normalized().to_uint64())) {
-                tile->cancel();
+                tile->tryCancel();
             }
             return true;
         } else {

--- a/src/mbgl/map/source.hpp
+++ b/src/mbgl/map/source.hpp
@@ -2,6 +2,7 @@
 #define MBGL_MAP_SOURCE
 
 #include <mbgl/map/tile_cache.hpp>
+#include <mbgl/map/tile_data_deleter.hpp>
 #include <mbgl/map/source_info.hpp>
 
 #include <mbgl/util/mat4.hpp>
@@ -111,6 +112,8 @@ private:
 
     Observer nullObserver;
     Observer* observer = &nullObserver;
+
+    TileDataDeleter tileDataDeleter;
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -73,8 +73,11 @@ public:
     TileData(const TileID&);
     virtual ~TileData();
 
-    // Mark this tile as no longer needed and cancel any pending work.
-    virtual void cancel() = 0;
+    // Mark this tile as no longer needed and cancel any pending work. Returns
+    // true if the work was canceled, false otherwise. Canceling is not always
+    // possible because in some circumstances it might block. Force will force
+    // the cancellation and always return true, but it can potentially block.
+    virtual bool tryCancel(bool force = false) = 0;
 
     virtual Bucket* getBucket(const StyleLayer&) = 0;
 

--- a/src/mbgl/map/tile_data.hpp
+++ b/src/mbgl/map/tile_data.hpp
@@ -21,6 +21,13 @@ class DebugBucket;
 
 class TileData : private util::noncopyable {
 public:
+    class Observer {
+    public:
+        virtual ~Observer() = default;
+
+        virtual void onTileDataWorkCompleted(TileData*) {};
+    };
+
     // initial:
     //   Initial state, only used when the TileData object is created.
     //
@@ -95,6 +102,10 @@ public:
 
     void dumpDebugLogs() const;
 
+    void setObserver(Observer* observer_) {
+        observer = observer_;
+    }
+
     const TileID id;
     optional<SystemTimePoint> modified;
     optional<SystemTimePoint> expires;
@@ -103,7 +114,21 @@ public:
     std::unique_ptr<DebugBucket> debugBucket;
 
 protected:
+    class WorkCompletedNotifier {
+    public:
+        WorkCompletedNotifier(TileData* data_) : data(data_) {}
+        ~WorkCompletedNotifier() {
+            data->observer->onTileDataWorkCompleted(data);
+        }
+
+    private:
+        TileData* data;
+    };
+
     std::atomic<State> state;
+
+    Observer nullObserver;
+    Observer* observer = &nullObserver;
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/tile_data_deleter.cpp
+++ b/src/mbgl/map/tile_data_deleter.cpp
@@ -1,0 +1,34 @@
+#include <mbgl/map/tile_data_deleter.hpp>
+
+#include <mbgl/map/tile_data.hpp>
+
+namespace mbgl {
+
+TileDataDeleter::~TileDataDeleter() {
+    // Force the canceling of all pending TileData
+    // before destroying. We have assert()s on Debug
+    // mode on TileData to make sure it doesn't block
+    // at the destructor unless explicitly canceled.
+    for (auto& entry : tileDataMap) {
+        entry.first->tryCancel(true);
+    }
+}
+
+void TileDataDeleter::add(TileData* data) {
+    std::unique_ptr<TileData> tileData(data);
+
+    // This custom deleter will try to cancel the task if it is
+    // non-blocking, otherwise we keep it and subscribe to the
+    // event when the work is completed. When the event triggers
+    // we delete the TileData because this time it won't block.
+    if (!tileData->tryCancel()) {
+        data->setObserver(this);
+        tileDataMap.emplace(data, std::move(tileData));
+    }
+}
+
+void TileDataDeleter::onTileDataWorkCompleted(TileData* data) {
+    tileDataMap.erase(data);
+}
+
+} // namespace mbgl

--- a/src/mbgl/map/tile_data_deleter.hpp
+++ b/src/mbgl/map/tile_data_deleter.hpp
@@ -1,0 +1,29 @@
+#ifndef MBGL_MAP_TILE_DATA_DELETER
+#define MBGL_MAP_TILE_DATA_DELETER
+
+#include <mbgl/map/tile_data.hpp>
+#include <mbgl/util/noncopyable.hpp>
+
+#include <memory>
+#include <unordered_map>
+
+namespace mbgl {
+
+class TileData;
+
+class TileDataDeleter : public TileData::Observer, private util::noncopyable {
+public:
+    virtual ~TileDataDeleter();
+
+    void add(TileData*);
+
+    // TileData::Observer implementation.
+    void onTileDataWorkCompleted(TileData*) override;
+
+private:
+    std::unordered_map<TileData*, std::unique_ptr<TileData>> tileDataMap;
+};
+
+} // namespace mbgl
+
+#endif

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -59,6 +59,7 @@ VectorTileData::VectorTileData(const TileID& id_,
         // request in case there is one.
         workRequest.reset();
         workRequest = worker.parseGeometryTile(tileWorker, style.getLayers(), std::move(tile), targetConfig, [callback, this, config = targetConfig] (TileParseResult result) {
+            WorkCompletedNotifier notifier(this);
             workRequest.reset();
             if (state == State::obsolete) {
                 return;
@@ -100,6 +101,7 @@ bool VectorTileData::parsePending(std::function<void(std::exception_ptr)> callba
 
     workRequest.reset();
     workRequest = worker.parsePendingGeometryTileLayers(tileWorker, targetConfig, [this, callback, config = targetConfig] (TileParseResult result) {
+        WorkCompletedNotifier notifier(this);
         workRequest.reset();
         if (state == State::obsolete) {
             return;
@@ -156,6 +158,7 @@ void VectorTileData::redoPlacement(const PlacementConfig newConfig, const std::f
 void VectorTileData::redoPlacement(const std::function<void()>& callback) {
     workRequest.reset();
     workRequest = worker.redoPlacement(tileWorker, buckets, targetConfig, [this, callback, config = targetConfig] {
+        WorkCompletedNotifier notifier(this);
         workRequest.reset();
 
         // Persist the configuration we just placed so that we can later check whether we need to

--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -88,7 +88,8 @@ VectorTileData::VectorTileData(const TileID& id_,
 }
 
 VectorTileData::~VectorTileData() {
-    cancel();
+    assert(tryCancel());
+    workRequest.reset();
 }
 
 bool VectorTileData::parsePending(std::function<void(std::exception_ptr)> callback) {
@@ -175,10 +176,19 @@ void VectorTileData::redoPlacement(const std::function<void()>& callback) {
     });
 }
 
-void VectorTileData::cancel() {
+bool VectorTileData::tryCancel(bool force) {
     state = State::obsolete;
     tileRequest.reset();
-    workRequest.reset();
+
+    if (force) {
+        workRequest.reset();
+    }
+
+    if (workRequest) {
+        return workRequest->tryCancel();
+    }
+
+    return true;
 }
 
 } // namespace mbgl

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -34,7 +34,7 @@ public:
     void redoPlacement(PlacementConfig config, const std::function<void()>&) override;
     void redoPlacement(const std::function<void()>&) override;
 
-    void cancel() override;
+    bool tryCancel(bool force = false) override;
 
 private:
     Style& style;

--- a/src/mbgl/map/vector_tile_data.hpp
+++ b/src/mbgl/map/vector_tile_data.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/tile_data.hpp>
 #include <mbgl/map/tile_worker.hpp>
 #include <mbgl/text/placement_config.hpp>
+#include <mbgl/util/async_task.hpp>
 
 #include <atomic>
 #include <memory>
@@ -44,6 +45,9 @@ private:
     std::unique_ptr<GeometryTileMonitor> monitor;
     std::unique_ptr<FileRequest> tileRequest;
     std::unique_ptr<WorkRequest> workRequest;
+
+    util::AsyncTask delayedRedoPlacement;
+    std::function<void(void)> delayedRedoPlacementFunction;
 
     // Contains all the Bucket objects for the tile. Buckets are render
     // objects and they get added by tile parsing operations.

--- a/src/mbgl/util/work_request.cpp
+++ b/src/mbgl/util/work_request.cpp
@@ -14,4 +14,8 @@ WorkRequest::~WorkRequest() {
     task->cancel();
 }
 
+bool WorkRequest::tryCancel() {
+    return task->tryCancel();
+}
+
 } // namespace mbgl


### PR DESCRIPTION
On iOS and to a lesser extent OS X, MGLMapView is unresponsive for a second or so every time a tile loads at mid zoom levels in the San Francisco Bay Area. This is a severe regression from probably late last week. These are the only threads that appear to be doing much of anything:

```
Map (13)#0	0x0000000183fc7f90 in __psynch_mutexwait ()
#1	0x000000018409239c in _pthread_mutex_lock_wait ()
#2	0x000000018409257c in _pthread_mutex_lock_slow ()
#3	0x0000000183a53a5c in std::__1::recursive_mutex::lock() ()
#4	0x00000001003cd3c0 in std::__1::lock_guard<std::__1::recursive_mutex>::lock_guard(std::__1::recursive_mutex&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__mutex_base:83
#5	0x00000001003cd3ac in std::__1::lock_guard<std::__1::recursive_mutex>::lock_guard(std::__1::recursive_mutex&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__mutex_base:83
#6	0x00000001003cd3a0 in _ZN4mbgl4util7RunLoop7InvokerIZNS0_6ThreadINS_6Worker4ImplEE4bindIMS5_FvPNS_10TileWorkerENSt3__16vectorINSA_10unique_ptrINS_10StyleLayerENSA_14default_deleteISD_EEEENSA_9allocatorISG_EEEENSC_INS_12GeometryTileENSE_ISK_EEEENS_15PlacementConfigENSA_8functionIFvN6mapbox4util7variantIJNS_22TileParseResultBucketsESt13exception_ptrEEEEEEEEEDaT_EUlDpOT_E_NSA_5tupleIJS9_SJ_SM_SN_ZNS1_18invokeWithCallbackIS14_RSW_JS9_SJ_SM_RSN_EEENSC_INS_11WorkRequestENSE_IS19_EEEEOS10_OT0_DpOT1_EUlS13_E_EEEE6cancelEv at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:142
#7	0x00000001003c1478 in mbgl::WorkRequest::~WorkRequest() at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/util/work_request.cpp:14
#8	0x00000001003c150c in mbgl::WorkRequest::~WorkRequest() at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/util/work_request.cpp:13
#9	0x0000000100245ce8 in std::__1::default_delete<mbgl::WorkRequest>::operator()(mbgl::WorkRequest*) const [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:2516
#10	0x0000000100245cd4 in std::__1::unique_ptr<mbgl::WorkRequest, std::__1::default_delete<mbgl::WorkRequest> >::reset(mbgl::WorkRequest*) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:2715
#11	0x0000000100245c74 in mbgl::VectorTileData::VectorTileData(mbgl::TileID const&, std::__1::unique_ptr<mbgl::GeometryTileMonitor, std::__1::default_delete<mbgl::GeometryTileMonitor> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, mbgl::Style&, mbgl::MapMode, std::__1::function<void (std::exception_ptr)> const&)::$_0::operator()(std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >) const at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/map/vector_tile_data.cpp:60
#12	0x000000010024564c in std::__1::__invoke<mbgl::VectorTileData::VectorTileData(mbgl::TileID const&, std::__1::unique_ptr<mbgl::GeometryTileMonitor, std::__1::default_delete<mbgl::GeometryTileMonitor> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, mbgl::Style&, mbgl::MapMode, std::__1::function<void (std::exception_ptr)> const&)::$_0&, std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> > >(decltype(std::__1::forward<mbgl::VectorTileData::VectorTileData(mbgl::TileID const&, std::__1::unique_ptr<mbgl::GeometryTileMonitor, std::__1::default_delete<mbgl::GeometryTileMonitor> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, mbgl::Style&, mbgl::MapMode, std::__1::function<void (std::exception_ptr)> const&)::$_0&>(fp)(std::__1::forward<std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> > >(fp0))), mbgl::VectorTileData::VectorTileData(mbgl::TileID const&, std::__1::unique_ptr<mbgl::GeometryTileMonitor, std::__1::default_delete<mbgl::GeometryTileMonitor> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, mbgl::Style&, mbgl::MapMode, std::__1::function<void (std::exception_ptr)> const&)::$_0&&&, std::exception_ptr&&, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >&&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >&&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#13	0x0000000100245528 in _ZNSt3__128__invoke_void_return_wrapperIvE6__callIJRZN4mbgl14VectorTileDataC1ERKNS3_6TileIDENS_10unique_ptrINS3_19GeometryTileMonitorENS_14default_deleteIS9_EEEENS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERNS3_5StyleENS3_7MapModeERKNS_8functionIFvSt13exception_ptrEEEE3$_0SN_NS8_INS3_12GeometryTileENSA_ISU_EEEENS_6chrono8durationIxNS_5ratioILl1ELl1EEEEES11_EEEvDpOT_ at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:468
#14	0x0000000100244f44 in std::__1::__function::__func<mbgl::VectorTileData::VectorTileData(mbgl::TileID const&, std::__1::unique_ptr<mbgl::GeometryTileMonitor, std::__1::default_delete<mbgl::GeometryTileMonitor> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, mbgl::Style&, mbgl::MapMode, std::__1::function<void (std::exception_ptr)> const&)::$_0, std::__1::allocator<mbgl::VectorTileData::VectorTileData(mbgl::TileID const&, std::__1::unique_ptr<mbgl::GeometryTileMonitor, std::__1::default_delete<mbgl::GeometryTileMonitor> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, mbgl::Style&, mbgl::MapMode, std::__1::function<void (std::exception_ptr)> const&)::$_0>, void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)>::operator()(std::exception_ptr&&, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >&&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >&&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >&&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1437
#15	0x000000010012acac in std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)>::operator()(std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >) const at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1817
#16	0x0000000100236fe0 in mbgl::VectorTileMonitor::monitorTile(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)> const&)::$_0::operator()(mbgl::Response) const at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/map/vector_tile.cpp:203
#17	0x000000010023674c in decltype(std::__1::forward<mbgl::VectorTileMonitor::monitorTile(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)> const&)::$_0&>(fp)(std::__1::forward<mbgl::Response>(fp0))) std::__1::__invoke<mbgl::VectorTileMonitor::monitorTile(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)> const&)::$_0&, mbgl::Response>(mbgl::VectorTileMonitor::monitorTile(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)> const&)::$_0&&&, mbgl::Response&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#18	0x000000010023670c in void std::__1::__invoke_void_return_wrapper<void>::__call<mbgl::VectorTileMonitor::monitorTile(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)> const&)::$_0&, mbgl::Response>(mbgl::VectorTileMonitor::monitorTile(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)> const&)::$_0&&&, mbgl::Response&&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:468
#19	0x000000010023615c in std::__1::__function::__func<mbgl::VectorTileMonitor::monitorTile(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)> const&)::$_0, std::__1::allocator<mbgl::VectorTileMonitor::monitorTile(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)> const&)::$_0>, void (mbgl::Response)>::operator()(mbgl::Response&&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1437
#20	0x00000001001f75d4 in std::__1::function<void (std::exception_ptr)>::operator()(std::exception_ptr) const at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1817
#21	0x0000000100408f20 in void void std::__1::unique_ptr<mbgl::WorkRequest, std::__1::default_delete<std::__1::default_delete> > mbgl::util::RunLoop::invokeWithCallback<auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)), std::__1::function<void (mbgl::Response)>&, mbgl::Resource&, mbgl::OnlineFileRequest*>(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>), std::__1::function<void (mbgl::Response)>&&&, mbgl::Resource&&&, mbgl::OnlineFileRequest*&&)::'lambda'(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)))::operator()<mbgl::Response>(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))) const::'lambda'(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)))::operator()<mbgl::Response>(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))) const at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:96
#22	0x0000000100408df8 in void mbgl::util::RunLoop::Invoker<void std::__1::unique_ptr<mbgl::WorkRequest, std::__1::default_delete<std::__1::default_delete> > mbgl::util::RunLoop::invokeWithCallback<auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)), std::__1::function<void (mbgl::Response)>&, mbgl::Resource&, mbgl::OnlineFileRequest*>(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>), std::__1::function<void (mbgl::Response)>&&&, mbgl::Resource&&&, mbgl::OnlineFileRequest*&&)::'lambda'(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)))::operator()<mbgl::Response>(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))) const::'lambda'(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))), std::__1::tuple<mbgl::Response> >::invoke<0ul>(std::__1::integer_sequence<unsigned long, 0ul>) at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:149
#23	0x0000000100408a60 in mbgl::util::RunLoop::Invoker<void std::__1::unique_ptr<mbgl::WorkRequest, std::__1::default_delete<std::__1::default_delete> > mbgl::util::RunLoop::invokeWithCallback<auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)), std::__1::function<void (mbgl::Response)>&, mbgl::Resource&, mbgl::OnlineFileRequest*>(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>), std::__1::function<void (mbgl::Response)>&&&, mbgl::Resource&&&, mbgl::OnlineFileRequest*&&)::'lambda'(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)))::operator()<mbgl::Response>(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))) const::'lambda'(auto mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::bind<void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>)>(void (mbgl::OnlineFileSource::Impl::*)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::OnlineFileSource::Impl::*&&)(mbgl::Resource, mbgl::FileRequest*, std::__1::function<void (mbgl::Response)>))), std::__1::tuple<mbgl::Response> >::operator()() at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:129
#24	0x00000001003ef0a8 in mbgl::util::RunLoop::process() at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:173
#25	0x00000001003f3c6c in decltype(*(std::__1::forward<mbgl::util::RunLoop*&>(fp0)).*fp(std::__1::forward<>(fp1))) std::__1::__invoke<void (mbgl::util::RunLoop::*&)(), mbgl::util::RunLoop*&, void>(void (mbgl::util::RunLoop::*&&&)(), mbgl::util::RunLoop*&&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:383
#26	0x00000001003f3c04 in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, __is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__apply_functor<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, 0ul, std::__1::tuple<> >(void (mbgl::util::RunLoop::*&)(), std::__1::tuple<mbgl::util::RunLoop*>&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2097
#27	0x00000001003f3bdc in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, __is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>::operator()<>() [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2160
#28	0x00000001003f3bc0 in decltype(std::__1::forward<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#29	0x00000001003f3bb8 in void std::__1::__invoke_void_return_wrapper<void>::__call<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:468
#30	0x00000001003f3954 in std::__1::__function::__func<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>, std::__1::allocator<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*> >, void ()>::operator()() at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1437
#31	0x00000001003f1bd0 in std::__1::function<void ()>::operator()() const at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1817
#32	0x00000001003e8ee8 in mbgl::util::AsyncTask::Impl::asyncCallback(uv_async_s*) at /Users/mxn/hub/mapbox-gl-native-3/platform/default/async_task.cpp:49
#33	0x00000001004b1c04 in uv__async_event at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/async.c:92
#34	0x00000001004b1e58 in uv__async_io at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/async.c:137
#35	0x00000001004bda2c in uv__io_poll at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/kqueue.c:247
#36	0x00000001004b236c in uv_run at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/core.c:341
#37	0x00000001003ea76c in mbgl::util::RunLoop::run() at /Users/mxn/hub/mapbox-gl-native-3/platform/default/run_loop.cpp:157
#38	0x00000001001c2690 in void mbgl::util::Thread<mbgl::MapContext>::run<std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>, 0ul, 1ul, 2ul, 3ul, 4ul>(mbgl::util::ThreadContext, std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>&&, std::__1::integer_sequence<unsigned long, 0ul, 1ul, 2ul, 3ul, 4ul>) at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/util/thread.hpp:124
#39	0x00000001001c2510 in mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapMode&&&, mbgl::GLContextMode&&&, float&&)::'lambda'()::operator()() const at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/util/thread.hpp:106
#40	0x00000001001c2178 in std::__1::__invoke<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapMode&&&, mbgl::GLContextMode&&&, float&&)::'lambda'()>(decltype(std::__1::forward<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapMode&&&, mbgl::GLContextMode&&&, float&&)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapMode&&&, mbgl::GLContextMode&&&, float&&)::'lambda'()&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#41	0x00000001001c216c in _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_10MapContextEEC1IJRNS1_4ViewERNS1_10FileSourceERNS1_7MapModeERNS1_13GLContextModeEfEEERKNS2_13ThreadContextEDpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:337
#42	0x00000001001c215c in std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapMode&&&, mbgl::GLContextMode&&&, float&&)::'lambda'()> >(void*, void*) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:347
#43	0x000000018408fb28 in _pthread_body ()
#44	0x000000018408fa8c in _pthread_start ()
```

```
Worker (14)#0	0x00000001001a327c in mapbox::util::detail::binary_dispatcher<mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::apply_const(mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>) at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/headers/variant/1.0/include/mapbox/variant.hpp:419
#1	0x00000001001a300c in mapbox::util::detail::binary_dispatcher<mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, bool, bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::apply_const(mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>) at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/headers/variant/1.0/include/mapbox/variant.hpp:435
#2	0x00000001001a2eec in decltype(detail::binary_dispatcher<mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, mapbox::util::detail::result_of_binary_visit<mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>, bool, void>::type, bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::apply_const(fpfp0fp1)) mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::binary_visit<mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >(mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>) at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/headers/variant/1.0/include/mapbox/variant.hpp:750
#3	0x00000001001a1f5c in decltype(mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::binary_visit(fp0fp1fp)) mapbox::util::apply_visitor<mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator> >(mbgl::util::detail::relaxed_operator_visitor<mbgl::util::detail::relaxed_equal_operator>, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&) at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/headers/variant/1.0/include/mapbox/variant.hpp:811
#4	0x00000001001a2e80 in mbgl::util::relaxed_equal(mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, mapbox::util::variant<bool, long long, unsigned long long, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&) at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/style/value_comparison.hpp:82
#5	0x00000001001a2d58 in bool mbgl::EqualsExpression::evaluate<mbgl::GeometryTileFeatureExtractor>(mbgl::GeometryTileFeatureExtractor const&) const at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/style/filter_expression_private.hpp:27
#6	0x00000001001a2a3c in bool mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>::operator()<mbgl::EqualsExpression>(mbgl::EqualsExpression const&) const at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/style/filter_expression_private.hpp:16
#7	0x00000001001a28f8 in mapbox::util::detail::dispatcher<mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>, mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>, bool, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>::apply_const(mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression> const&, mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>) at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/headers/variant/1.0/include/mapbox/variant.hpp:276
#8	0x00000001001a25fc in mapbox::util::detail::dispatcher<mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>, mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>, bool, mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>::apply_const(mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression> const&, mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>) at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/headers/variant/1.0/include/mapbox/variant.hpp:280
#9	0x00000001001a2504 in decltype(detail::dispatcher<mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>, mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>, mapbox::util::detail::result_of_unary_visit<mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>, mbgl::NullExpression, void>::type, mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>::apply_const(fpfp0)) mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>::visit<mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>, mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression> >(mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression> const&, mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>) at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/headers/variant/1.0/include/mapbox/variant.hpp:726
#10	0x00000001001a1d58 in decltype(mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>::visit(fp0fp)) mapbox::util::apply_visitor<mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression>, mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor> >(mbgl::Evaluator<mbgl::GeometryTileFeatureExtractor>, mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression> const&) at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/headers/variant/1.0/include/mapbox/variant.hpp:797
#11	0x00000001001a21f4 in bool mbgl::evaluate<mbgl::GeometryTileFeatureExtractor>(mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression> const&, mbgl::GeometryTileFeatureExtractor const&) at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/style/filter_expression_private.hpp:21
#12	0x00000001003267ac in mbgl::StyleBucketParameters::eachFilteredFeature(mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression> const&, std::__1::function<void (mbgl::GeometryTileFeature const&)>) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/style/style_bucket_parameters.cpp:12
#13	0x000000010016b41c in mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/layer/fill_layer.cpp:60
#14	0x0000000100218788 in mbgl::TileWorker::parseLayer(mbgl::StyleLayer const*, mbgl::GeometryTile const&) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/map/tile_worker.cpp:162
#15	0x0000000100217f7c in mbgl::TileWorker::parseAllLayers(std::__1::vector<std::__1::unique_ptr<mbgl::StyleLayer, std::__1::default_delete<mbgl::StyleLayer> >, std::__1::allocator<std::__1::unique_ptr<mbgl::StyleLayer, std::__1::default_delete<mbgl::StyleLayer> > > >, mbgl::GeometryTile const&, mbgl::PlacementConfig) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/map/tile_worker.cpp:58
#16	0x00000001003c279c in mbgl::Worker::Impl::parseGeometryTile(mbgl::TileWorker*, std::__1::vector<std::__1::unique_ptr<mbgl::StyleLayer, std::__1::default_delete<mbgl::StyleLayer> >, std::__1::allocator<std::__1::unique_ptr<mbgl::StyleLayer, std::__1::default_delete<mbgl::StyleLayer> > > >, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, mbgl::PlacementConfig, std::__1::function<void (mapbox::util::variant<mbgl::TileParseResultBuckets, std::exception_ptr>)>) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/util/worker.cpp:35
#17	0x00000001003cdfb4 in _ZZN4mbgl4util6ThreadINS_6Worker4ImplEE4bindIMS3_FvPNS_10TileWorkerENSt3__16vectorINS8_10unique_ptrINS_10StyleLayerENS8_14default_deleteISB_EEEENS8_9allocatorISE_EEEENSA_INS_12GeometryTileENSC_ISI_EEEENS_15PlacementConfigENS8_8functionIFvN6mapbox4util7variantIJNS_22TileParseResultBucketsESt13exception_ptrEEEEEEEEEDaT_ENKUlDpOT_E_clIJS7_SH_SK_SL_ZNS0_7RunLoop18invokeWithCallbackIS12_RSU_JS7_SH_SK_RSL_EEENSA_INS_11WorkRequestENSC_IS18_EEEEOSY_OT0_DpOT1_EUlS11_E_EEEDaS11_ at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/util/thread.hpp:72
#18	0x00000001003cdc94 in _ZN4mbgl4util7RunLoop7InvokerIZNS0_6ThreadINS_6Worker4ImplEE4bindIMS5_FvPNS_10TileWorkerENSt3__16vectorINSA_10unique_ptrINS_10StyleLayerENSA_14default_deleteISD_EEEENSA_9allocatorISG_EEEENSC_INS_12GeometryTileENSE_ISK_EEEENS_15PlacementConfigENSA_8functionIFvN6mapbox4util7variantIJNS_22TileParseResultBucketsESt13exception_ptrEEEEEEEEEDaT_EUlDpOT_E_NSA_5tupleIJS9_SJ_SM_SN_ZNS1_18invokeWithCallbackIS14_RSW_JS9_SJ_SM_RSN_EEENSC_INS_11WorkRequestENSE_IS19_EEEEOS10_OT0_DpOT1_EUlS13_E_EEEE6invokeIJLm0ELm1ELm2ELm3ELm4EEEEvNSA_16integer_sequenceImJXspT_EEEE at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:149
#19	0x00000001003cd2e4 in _ZN4mbgl4util7RunLoop7InvokerIZNS0_6ThreadINS_6Worker4ImplEE4bindIMS5_FvPNS_10TileWorkerENSt3__16vectorINSA_10unique_ptrINS_10StyleLayerENSA_14default_deleteISD_EEEENSA_9allocatorISG_EEEENSC_INS_12GeometryTileENSE_ISK_EEEENS_15PlacementConfigENSA_8functionIFvN6mapbox4util7variantIJNS_22TileParseResultBucketsESt13exception_ptrEEEEEEEEEDaT_EUlDpOT_E_NSA_5tupleIJS9_SJ_SM_SN_ZNS1_18invokeWithCallbackIS14_RSW_JS9_SJ_SM_RSN_EEENSC_INS_11WorkRequestENSE_IS19_EEEEOS10_OT0_DpOT1_EUlS13_E_EEEEclEv at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:129
#20	0x00000001003ef0a8 in mbgl::util::RunLoop::process() at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:173
#21	0x00000001003f3c6c in decltype(*(std::__1::forward<mbgl::util::RunLoop*&>(fp0)).*fp(std::__1::forward<>(fp1))) std::__1::__invoke<void (mbgl::util::RunLoop::*&)(), mbgl::util::RunLoop*&, void>(void (mbgl::util::RunLoop::*&&&)(), mbgl::util::RunLoop*&&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:383
#22	0x00000001003f3c04 in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, __is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__apply_functor<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, 0ul, std::__1::tuple<> >(void (mbgl::util::RunLoop::*&)(), std::__1::tuple<mbgl::util::RunLoop*>&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2097
#23	0x00000001003f3bdc in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, __is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>::operator()<>() [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2160
#24	0x00000001003f3bc0 in decltype(std::__1::forward<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#25	0x00000001003f3bb8 in void std::__1::__invoke_void_return_wrapper<void>::__call<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:468
#26	0x00000001003f3954 in std::__1::__function::__func<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>, std::__1::allocator<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*> >, void ()>::operator()() at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1437
#27	0x00000001003f1bd0 in std::__1::function<void ()>::operator()() const at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1817
#28	0x00000001003e8ee8 in mbgl::util::AsyncTask::Impl::asyncCallback(uv_async_s*) at /Users/mxn/hub/mapbox-gl-native-3/platform/default/async_task.cpp:49
#29	0x00000001004b1c04 in uv__async_event at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/async.c:92
#30	0x00000001004b1e58 in uv__async_io at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/async.c:137
#31	0x00000001004bda2c in uv__io_poll at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/kqueue.c:247
#32	0x00000001004b236c in uv_run at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/core.c:341
#33	0x00000001003ea76c in mbgl::util::RunLoop::run() at /Users/mxn/hub/mapbox-gl-native-3/platform/default/run_loop.cpp:157
#34	0x00000001003c3f54 in void mbgl::util::Thread<mbgl::Worker::Impl>::run<std::__1::tuple<> >(mbgl::util::ThreadContext, std::__1::tuple<>&&, std::__1::integer_sequence<unsigned long>) at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/util/thread.hpp:124
#35	0x00000001003c3e58 in mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()::operator()() const at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/util/thread.hpp:106
#36	0x00000001003c3b68 in std::__1::__invoke<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()>(decltype(std::__1::forward<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#37	0x00000001003c3b5c in _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_6Worker4ImplEEC1IJEEERKNS2_13ThreadContextEDpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:337
#38	0x00000001003c3b4c in std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()> >(void*, void*) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:347
#39	0x000000018408fb28 in _pthread_body ()
#40	0x000000018408fa8c in _pthread_start ()
```

```
Worker (17)#0	0x00000001840869d4 in _os_lock_handoff_lock ()
#1	0x0000000183ff4920 in szone_free_definite_size ()
#2	0x000000010014629c in std::__1::__deallocate(void*) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/new:176
#3	0x0000000100146294 in std::__1::allocator<mbgl::vec2<short> >::deallocate(mbgl::vec2<short>*, unsigned long) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:1722
#4	0x000000010014628c in std::__1::allocator_traits<std::__1::allocator<mbgl::vec2<short> > >::deallocate(std::__1::allocator<mbgl::vec2<short> >&, mbgl::vec2<short>*, unsigned long) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:1487
#5	0x0000000100146274 in std::__1::__split_buffer<mbgl::vec2<short>, std::__1::allocator<mbgl::vec2<short> >&>::~__split_buffer() at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__split_buffer:338
#6	0x0000000100145d90 in std::__1::__split_buffer<mbgl::vec2<short>, std::__1::allocator<mbgl::vec2<short> >&>::~__split_buffer() at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__split_buffer:335
#7	0x00000001002fa010 in void std::__1::vector<float, std::__1::allocator<float> >::__push_back_slow_path<float>(float&&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:1576
#8	0x000000010025d594 in std::__1::vector<float, std::__1::allocator<float> >::push_back(float&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/vector:1612
#9	0x000000010025d470 in mbgl::FillBucket::tessellate() at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/renderer/fill_bucket.cpp:109
#10	0x000000010025c7cc in mbgl::FillBucket::addGeometry(std::__1::vector<std::__1::vector<mbgl::vec2<short>, std::__1::allocator<mbgl::vec2<short> > >, std::__1::allocator<std::__1::vector<mbgl::vec2<short>, std::__1::allocator<mbgl::vec2<short> > > > > const&) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/renderer/fill_bucket.cpp:68
#11	0x000000010016c810 in mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const::void $_0::operator()<mbgl::GeometryTileFeature>(mbgl::GeometryTileFeature const&) const at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/layer/fill_layer.cpp:61
#12	0x000000010016c76c in decltype(std::__1::forward<mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const::$_0&>(fp)(std::__1::forward<mbgl::GeometryTileFeature const&>(fp0))) std::__1::__invoke<mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const::$_0&, mbgl::GeometryTileFeature const&>(mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const::$_0&&&, mbgl::GeometryTileFeature const&&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#13	0x000000010016c74c in void std::__1::__invoke_void_return_wrapper<void>::__call<mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const::$_0&, mbgl::GeometryTileFeature const&>(mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const::$_0&&&, mbgl::GeometryTileFeature const&&&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:468
#14	0x000000010016c4cc in std::__1::__function::__func<mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const::$_0, std::__1::allocator<mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const::$_0>, void (mbgl::GeometryTileFeature const&)>::operator()(mbgl::GeometryTileFeature const&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1437
#15	0x0000000100326a28 in std::__1::function<void (mbgl::GeometryTileFeature const&)>::operator()(mbgl::GeometryTileFeature const&) const at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1817
#16	0x0000000100326810 in mbgl::StyleBucketParameters::eachFilteredFeature(mapbox::util::variant<mbgl::NullExpression, mbgl::EqualsExpression, mbgl::NotEqualsExpression, mbgl::LessThanExpression, mbgl::LessThanEqualsExpression, mbgl::GreaterThanExpression, mbgl::GreaterThanEqualsExpression, mbgl::InExpression, mbgl::NotInExpression, mbgl::AnyExpression, mbgl::AllExpression, mbgl::NoneExpression> const&, std::__1::function<void (mbgl::GeometryTileFeature const&)>) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/style/style_bucket_parameters.cpp:15
#17	0x000000010016b41c in mbgl::FillLayer::createBucket(mbgl::StyleBucketParameters&) const at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/layer/fill_layer.cpp:60
#18	0x0000000100218788 in mbgl::TileWorker::parseLayer(mbgl::StyleLayer const*, mbgl::GeometryTile const&) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/map/tile_worker.cpp:162
#19	0x0000000100217f7c in mbgl::TileWorker::parseAllLayers(std::__1::vector<std::__1::unique_ptr<mbgl::StyleLayer, std::__1::default_delete<mbgl::StyleLayer> >, std::__1::allocator<std::__1::unique_ptr<mbgl::StyleLayer, std::__1::default_delete<mbgl::StyleLayer> > > >, mbgl::GeometryTile const&, mbgl::PlacementConfig) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/map/tile_worker.cpp:58
#20	0x00000001003c279c in mbgl::Worker::Impl::parseGeometryTile(mbgl::TileWorker*, std::__1::vector<std::__1::unique_ptr<mbgl::StyleLayer, std::__1::default_delete<mbgl::StyleLayer> >, std::__1::allocator<std::__1::unique_ptr<mbgl::StyleLayer, std::__1::default_delete<mbgl::StyleLayer> > > >, std::__1::unique_ptr<mbgl::GeometryTile, std::__1::default_delete<mbgl::GeometryTile> >, mbgl::PlacementConfig, std::__1::function<void (mapbox::util::variant<mbgl::TileParseResultBuckets, std::exception_ptr>)>) at /Users/mxn/hub/mapbox-gl-native-3/src/mbgl/util/worker.cpp:35
#21	0x00000001003cdfb4 in _ZZN4mbgl4util6ThreadINS_6Worker4ImplEE4bindIMS3_FvPNS_10TileWorkerENSt3__16vectorINS8_10unique_ptrINS_10StyleLayerENS8_14default_deleteISB_EEEENS8_9allocatorISE_EEEENSA_INS_12GeometryTileENSC_ISI_EEEENS_15PlacementConfigENS8_8functionIFvN6mapbox4util7variantIJNS_22TileParseResultBucketsESt13exception_ptrEEEEEEEEEDaT_ENKUlDpOT_E_clIJS7_SH_SK_SL_ZNS0_7RunLoop18invokeWithCallbackIS12_RSU_JS7_SH_SK_RSL_EEENSA_INS_11WorkRequestENSC_IS18_EEEEOSY_OT0_DpOT1_EUlS11_E_EEEDaS11_ at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/util/thread.hpp:72
#22	0x00000001003cdc94 in _ZN4mbgl4util7RunLoop7InvokerIZNS0_6ThreadINS_6Worker4ImplEE4bindIMS5_FvPNS_10TileWorkerENSt3__16vectorINSA_10unique_ptrINS_10StyleLayerENSA_14default_deleteISD_EEEENSA_9allocatorISG_EEEENSC_INS_12GeometryTileENSE_ISK_EEEENS_15PlacementConfigENSA_8functionIFvN6mapbox4util7variantIJNS_22TileParseResultBucketsESt13exception_ptrEEEEEEEEEDaT_EUlDpOT_E_NSA_5tupleIJS9_SJ_SM_SN_ZNS1_18invokeWithCallbackIS14_RSW_JS9_SJ_SM_RSN_EEENSC_INS_11WorkRequestENSE_IS19_EEEEOS10_OT0_DpOT1_EUlS13_E_EEEE6invokeIJLm0ELm1ELm2ELm3ELm4EEEEvNSA_16integer_sequenceImJXspT_EEEE at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:149
#23	0x00000001003cd2e4 in _ZN4mbgl4util7RunLoop7InvokerIZNS0_6ThreadINS_6Worker4ImplEE4bindIMS5_FvPNS_10TileWorkerENSt3__16vectorINSA_10unique_ptrINS_10StyleLayerENSA_14default_deleteISD_EEEENSA_9allocatorISG_EEEENSC_INS_12GeometryTileENSE_ISK_EEEENS_15PlacementConfigENSA_8functionIFvN6mapbox4util7variantIJNS_22TileParseResultBucketsESt13exception_ptrEEEEEEEEEDaT_EUlDpOT_E_NSA_5tupleIJS9_SJ_SM_SN_ZNS1_18invokeWithCallbackIS14_RSW_JS9_SJ_SM_RSN_EEENSC_INS_11WorkRequestENSE_IS19_EEEEOS10_OT0_DpOT1_EUlS13_E_EEEEclEv at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:129
#24	0x00000001003ef0a8 in mbgl::util::RunLoop::process() at /Users/mxn/hub/mapbox-gl-native-3/gyp/../include/mbgl/util/run_loop.hpp:173
#25	0x00000001003f3c6c in decltype(*(std::__1::forward<mbgl::util::RunLoop*&>(fp0)).*fp(std::__1::forward<>(fp1))) std::__1::__invoke<void (mbgl::util::RunLoop::*&)(), mbgl::util::RunLoop*&, void>(void (mbgl::util::RunLoop::*&&&)(), mbgl::util::RunLoop*&&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:383
#26	0x00000001003f3c04 in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, __is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__apply_functor<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, 0ul, std::__1::tuple<> >(void (mbgl::util::RunLoop::*&)(), std::__1::tuple<mbgl::util::RunLoop*>&, std::__1::__tuple_indices<0ul>, std::__1::tuple<>&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2097
#27	0x00000001003f3bdc in std::__1::__bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<>, __is_valid_bind_return<void (mbgl::util::RunLoop::*)(), std::__1::tuple<mbgl::util::RunLoop*>, std::__1::tuple<> >::value>::type std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>::operator()<>() [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:2160
#28	0x00000001003f3bc0 in decltype(std::__1::forward<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(fp)(std::__1::forward<>(fp0))) std::__1::__invoke<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#29	0x00000001003f3bb8 in void std::__1::__invoke_void_return_wrapper<void>::__call<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&>(std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>&&&) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:468
#30	0x00000001003f3954 in std::__1::__function::__func<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*>, std::__1::allocator<std::__1::__bind<void (mbgl::util::RunLoop::*)(), mbgl::util::RunLoop*> >, void ()>::operator()() at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1437
#31	0x00000001003f1bd0 in std::__1::function<void ()>::operator()() const at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/functional:1817
#32	0x00000001003e8ee8 in mbgl::util::AsyncTask::Impl::asyncCallback(uv_async_s*) at /Users/mxn/hub/mapbox-gl-native-3/platform/default/async_task.cpp:49
#33	0x00000001004b1c04 in uv__async_event at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/async.c:92
#34	0x00000001004b1e58 in uv__async_io at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/async.c:137
#35	0x00000001004bda2c in uv__io_poll at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/kqueue.c:247
#36	0x00000001004b236c in uv_run at /Users/mxn/hub/mapbox-gl-native-3/mason_packages/.build/libuv-1.7.5/src/unix/core.c:341
#37	0x00000001003ea76c in mbgl::util::RunLoop::run() at /Users/mxn/hub/mapbox-gl-native-3/platform/default/run_loop.cpp:157
#38	0x00000001003c3f54 in void mbgl::util::Thread<mbgl::Worker::Impl>::run<std::__1::tuple<> >(mbgl::util::ThreadContext, std::__1::tuple<>&&, std::__1::integer_sequence<unsigned long>) at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/util/thread.hpp:124
#39	0x00000001003c3e58 in mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()::operator()() const at /Users/mxn/hub/mapbox-gl-native-3/gyp/../src/mbgl/util/thread.hpp:106
#40	0x00000001003c3b68 in std::__1::__invoke<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()>(decltype(std::__1::forward<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()&&) [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__functional_base:416
#41	0x00000001003c3b5c in _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_6Worker4ImplEEC1IJEEERKNS2_13ThreadContextEDpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE [inlined] at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:337
#42	0x00000001003c3b4c in std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::Worker::Impl>::Thread<>(mbgl::util::ThreadContext const&)::'lambda'()> >(void*, void*) at /Applications/Xcode+1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/thread:347
#43	0x000000018408fb28 in _pthread_body ()
#44	0x000000018408fa8c in _pthread_start ()
```

/cc @tmpsantos