### PR TITLE
[android] #3692 - catch NullPointerException assign a generic message in that case

### DIFF
--- a/platform/android/src/http_request_android.cpp
+++ b/platform/android/src/http_request_android.cpp
@@ -221,7 +221,10 @@ void HTTPAndroidRequest::onResponse(JNIEnv* env, int code, jstring /* message */
 }
 
 void HTTPAndroidRequest::onFailure(JNIEnv* env, int type, jstring message) {
-    std::string messageStr = mbgl::android::std_string_from_jstring(env, message);
+    std::string messageStr = "Error processing the request";
+    if(message) {
+        messageStr = mbgl::android::std_string_from_jstring(env, message);
+    }
 
     response = std::make_unique<Response>();
     using Error = Response::Error;


### PR DESCRIPTION
Closes #3692.

Initially I wanted to optimise `:std_string_from_jstring`, but I was not able to remove the throw of the NullPointerException since it's being used by other methods. I decided to check for a null value and replace that value with a generic message "Error processing the request". This should stop crashing the application if there is a bad internet connection. Not really sure if this is the correct way of handling this..

:eyes: @jfirebaugh 