### PR TITLE
[ios] Improve heading tracking smoothness by filtering updates less

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2930,7 +2930,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         }
 #endif
 
-        self.locationManager.headingFilter = 5.0;
+        self.locationManager.headingFilter = 1.0;
         self.locationManager.delegate = self;
         [self.locationManager startUpdatingLocation];
     }


### PR DESCRIPTION
Heading tracking was only delivering updates every 5°, which seems kind of infrequent. This changes the filter to 1°.

To-do:
- [ ] Investigate and profile performance to see if this puts additional strain on our map, especially on older devices.
- [ ] Confirm that `headingFilter` is the bottleneck I think it is, rather than the animation.

/cc @1ec5