### PR TITLE
Fix Memory leak caused by duplicated add in LocationListener list

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationServices.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationServices.java
@@ -117,7 +117,9 @@ public class LocationServices implements com.mapzen.android.lost.api.LocationLis
      * @param locationListener LocationListener
      */
     public void addLocationListener(@NonNull LocationListener locationListener) {
-        this.locationListeners.add(locationListener);
+		if(!this.locationListeners.contains(locationListener)){
+			this.locationListeners.add(locationListener);
+		}
     }
 
     /**


### PR DESCRIPTION
The addLocationListener method didn't check if the LocationListener was
already in the list.

From MapView, if we call setMyLocationEnabled(true), it adds a
LocationListener and onResume adds the same LocationListener again, but
is just removed by onPause.

So LocationListener is added twice but removed just once, so
LocationServices singleton keeps an instance of the the LocationListener
that is never released.