### PR TITLE
WorkTasks: destruct data before invoking callback

### DIFF
--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -146,7 +146,7 @@ private:
     private:
         template <std::size_t... I>
         void invoke(std::index_sequence<I...>) {
-            func(std::get<I>(std::forward<P>(params))...);
+            func(std::move(std::get<I>(std::forward<P>(params)))...);
         }
 
         std::recursive_mutex mutex;

--- a/src/mbgl/map/tile_worker.cpp
+++ b/src/mbgl/map/tile_worker.cpp
@@ -37,7 +37,7 @@ TileWorker::~TileWorker() {
 }
 
 TileParseResult TileWorker::parseAllLayers(std::vector<std::unique_ptr<StyleLayer>> layers_,
-                                           const GeometryTile& geometryTile,
+                                           std::unique_ptr<const GeometryTile> geometryTile,
                                            PlacementConfig config) {
     // We're doing a fresh parse of the tile, because the underlying data has changed.
     pending.clear();
@@ -55,7 +55,7 @@ TileParseResult TileWorker::parseAllLayers(std::vector<std::unique_ptr<StyleLaye
         const StyleLayer* layer = i->get();
         if (parsed.find(layer->bucketName()) == parsed.end()) {
             parsed.emplace(layer->bucketName());
-            parseLayer(layer, geometryTile);
+            parseLayer(layer, *geometryTile);
         }
     }
 

--- a/src/mbgl/map/tile_worker.hpp
+++ b/src/mbgl/map/tile_worker.hpp
@@ -50,7 +50,7 @@ public:
     ~TileWorker();
 
     TileParseResult parseAllLayers(std::vector<std::unique_ptr<StyleLayer>>,
-                                   const GeometryTile&,
+                                   std::unique_ptr<const GeometryTile> geometryTile,
                                    PlacementConfig);
 
     TileParseResult parsePendingLayers(PlacementConfig);

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -16,10 +16,12 @@ public:
     Impl() = default;
 
     void parseRasterTile(std::unique_ptr<RasterBucket> bucket,
-                         const std::shared_ptr<const std::string> data,
+                         std::shared_ptr<const std::string> data,
                          std::function<void(RasterTileParseResult)> callback) {
         try {
             bucket->setImage(decodeImage(*data));
+            // Destruct the shared pointer before calling the callback.
+            data.reset();
             callback(RasterTileParseResult(std::move(bucket)));
         } catch (...) {
             callback(std::current_exception());
@@ -32,7 +34,7 @@ public:
                            PlacementConfig config,
                            std::function<void(TileParseResult)> callback) {
         try {
-            callback(worker->parseAllLayers(std::move(layers), *tile, config));
+            callback(worker->parseAllLayers(std::move(layers), std::move(tile), config));
         } catch (...) {
             callback(std::current_exception());
         }


### PR DESCRIPTION
This is a short term fix for #3636. The reason for the hangs we were seeing was because the following happened:

- Work task completes, calls `callback`, which schedules the after callback on the main thread
- After callback was invoked and tried to cancel the work task first thing, which blocks on the mutex
- On the worker thread, we were destructing the arguments (in particular the `VectorTile` object) *after* we've called the callback in the first step; on slow devices, this could take 20-100ms
- Worker thread releases mutex, then main thread can finally acquire it to mark the task as canceled

This patch fixes this with the following changes:

- Move work task arguments from the tuple into the actual function, so they can be destructed there before the callback gets fired
- Actually destruct the arguments by either resetting, or moving the data into the invocation where it will get destructed