### PR TITLE
[ios] Remove incorrect tab whitespace in method

### DIFF
--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -439,25 +439,23 @@ const NSTimeInterval MGLFlushInterval = 60;
 
         if ( ! strongSelf) return;
 
-            // Build only IDFV event
-            NSString *vid = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
-
-            if (!vid) return;
-
-            NSDictionary *vevt = @{
-                @"event" : MGLEventTypeAppUserTurnstile,
-                @"created" : [strongSelf.rfc3339DateFormatter stringFromDate:[NSDate date]],
-                @"appBundleId" : strongSelf.appBundleId,
-                @"vendorId": vid,
-                @"version": @(version),
-                @"instance": strongSelf.instanceID
-            };
-
-            // Add to Queue
-            [_eventQueue addObject:vevt];
-
-            // Flush
-            [strongSelf flush];
+        // Build only IDFV event
+        NSString *vid = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
+        
+        if (!vid) return;
+        
+        NSDictionary *vevt = @{@"event" : MGLEventTypeAppUserTurnstile,
+                               @"created" : [strongSelf.rfc3339DateFormatter stringFromDate:[NSDate date]],
+                               @"appBundleId" : strongSelf.appBundleId,
+                               @"vendorId": vid,
+                               @"version": @(version),
+                               @"instance": strongSelf.instanceID};
+        
+        // Add to Queue
+        [_eventQueue addObject:vevt];
+        
+        // Flush
+        [strongSelf flush];
 
         if ([strongSelf debugLoggingEnabled]) {
             [strongSelf writeEventToLocalDebugLog:vevt];


### PR DESCRIPTION
This just removes some whitespace that made the implementation of
`pushTurnstileEvent` in `MGLMapboxEvents` look a little strange.

The indentation was right below an early return conditional
(with no braces) so it felt like the right thing to do (for
readability) to clean it up. Choosing and enforcing a consistent style
for conditionals with one line might be a good idea, too, but this
small change does not go there.

cc @1ec5 @friedbunny 