### PR TITLE
[core] Blocking the Map Thread when destroying TileData objects

### DIFF
--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -1,8 +1,11 @@
 #ifndef MBGL_UTIL_RUN_LOOP
 #define MBGL_UTIL_RUN_LOOP
 
+#include <mbgl/platform/log.hpp>
+#include <mbgl/util/chrono.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/util.hpp>
+#include <mbgl/util/thread_context.hpp>
 #include <mbgl/util/work_task.hpp>
 #include <mbgl/util/work_request.hpp>
 
@@ -138,8 +141,33 @@ private:
         // If the task has completed and the after callback has executed, this will
         // do nothing.
         void cancel() override {
+#if defined(DEBUG)
+            auto now = Clock::now();
+
+            if (!tryCancel()) {
+                std::lock_guard<std::recursive_mutex> lock(mutex);
+                *canceled = true;
+
+                using std::chrono::duration_cast;
+                long elapsed = duration_cast<Milliseconds>(Clock::now() - now).count();
+
+                if (ThreadContext::currentlyOn(ThreadType::Map)) {
+                    Log::Warning(mbgl::Event::General, "Map thread blocked for %ld ms.", elapsed);
+                }
+            };
+#else
             std::lock_guard<std::recursive_mutex> lock(mutex);
             *canceled = true;
+#endif
+        }
+
+        bool tryCancel() override {
+            if (mutex.try_lock()) {
+                *canceled = true;
+                mutex.unlock();
+                return true;
+            }
+            return false;
         }
 
     private:

--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -61,7 +61,7 @@ public:
 
     // Post the cancellable work fn(args...) to this RunLoop.
     template <class Fn, class... Args>
-    std::unique_ptr<AsyncRequest>
+    std::unique_ptr<WorkRequest>
     invokeCancellable(Fn&& fn, Args&&... args) {
         auto flag = std::make_shared<std::atomic<bool>>();
         *flag = false;
@@ -79,7 +79,7 @@ public:
 
     // Invoke fn(args...) on this RunLoop, then invoke callback(results...) on the current RunLoop.
     template <class Fn, class Cb, class... Args>
-    std::unique_ptr<AsyncRequest>
+    std::unique_ptr<WorkRequest>
     invokeWithCallback(Fn&& fn, Cb&& callback, Args&&... args) {
         auto flag = std::make_shared<std::atomic<bool>>();
         *flag = false;

--- a/include/mbgl/util/work_request.hpp
+++ b/include/mbgl/util/work_request.hpp
@@ -15,6 +15,8 @@ public:
     WorkRequest(Task);
     ~WorkRequest() override;
 
+    bool tryCancel();
+
 private:
     std::shared_ptr<WorkTask> task;
 };

--- a/include/mbgl/util/work_task.hpp
+++ b/include/mbgl/util/work_task.hpp
@@ -14,6 +14,7 @@ public:
 
     virtual void operator()() = 0;
     virtual void cancel() = 0;
+    virtual bool tryCancel() = 0;
 };
 
 } // namespace mbgl

--- a/src/mbgl/source/source.cpp
+++ b/src/mbgl/source/source.cpp
@@ -254,7 +254,7 @@ TileData::State Source::addTile(const TileID& tileID, const StyleUpdateParameter
 
         // If we don't find working tile data, we're just going to load it.
         if (type == SourceType::Raster) {
-            newTile->data = std::make_shared<RasterTileData>(new RasterTileData{
+            newTile->data = std::shared_ptr<RasterTileData>(new RasterTileData(
                 normalizedID,
                 parameters.pixelRatio,
                 info->tiles.at(0),
@@ -262,7 +262,7 @@ TileData::State Source::addTile(const TileID& tileID, const StyleUpdateParameter
                 parameters.worker,
                 parameters.fileSource,
                 callback
-            }, [this](TileData* data) { tileDataDeleter.add(data); });
+            ), [this](TileData* data) { tileDataDeleter.add(data); });
         } else {
             std::unique_ptr<GeometryTileMonitor> monitor;
 

--- a/src/mbgl/source/source.cpp
+++ b/src/mbgl/source/source.cpp
@@ -443,7 +443,7 @@ bool Source::update(const StyleUpdateParameters& parameters) {
         bool obsolete = retain_data.find(tile->id) == retain_data.end();
         if (obsolete) {
             if (!tileCache.has(tile->id.normalized().to_uint64())) {
-                tile->cancel();
+                tile->tryCancel();
             }
             return true;
         } else {

--- a/src/mbgl/source/source.hpp
+++ b/src/mbgl/source/source.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/tile/tile_data.hpp>
 #include <mbgl/tile/tile_cache.hpp>
+#include <mbgl/tile/tile_data_deleter.hpp>
 #include <mbgl/source/source_info.hpp>
 
 #include <mbgl/util/mat4.hpp>
@@ -111,6 +112,8 @@ private:
 
     Observer nullObserver;
     Observer* observer = &nullObserver;
+
+    TileDataDeleter tileDataDeleter;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -45,7 +45,9 @@ RasterTileData::RasterTileData(const TileID& id_,
 
             workRequest.reset();
             workRequest = worker.parseRasterTile(std::make_unique<RasterBucket>(texturePool), res.data, [this, callback] (RasterTileParseResult result) {
+                WorkCompletedNotifier notifier(this);
                 workRequest.reset();
+
                 if (state != State::loaded) {
                     return;
                 }

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -67,19 +67,31 @@ RasterTileData::RasterTileData(const TileID& id_,
 }
 
 RasterTileData::~RasterTileData() {
-    cancel();
+    assert(tryCancel());
+    workRequest.reset();
 }
 
 Bucket* RasterTileData::getBucket(StyleLayer const&) {
     return bucket.get();
 }
 
-void RasterTileData::cancel() {
+bool RasterTileData::tryCancel(bool force) {
     if (state != State::obsolete) {
         state = State::obsolete;
     }
+
     req = nullptr;
     workRequest.reset();
+
+    if (force) {
+        workRequest.reset();
+    }
+
+    if (workRequest) {
+        return workRequest->tryCancel();
+    }
+
+    return true;
 }
 
 bool RasterTileData::hasData() const {

--- a/src/mbgl/tile/raster_tile_data.hpp
+++ b/src/mbgl/tile/raster_tile_data.hpp
@@ -8,6 +8,7 @@ namespace mbgl {
 
 class FileSource;
 class AsyncRequest;
+class WorkRequest;
 class StyleLayer;
 namespace gl { class TexturePool; }
 
@@ -31,7 +32,7 @@ private:
     Worker& worker;
     std::unique_ptr<AsyncRequest> req;
     std::unique_ptr<Bucket> bucket;
-    std::unique_ptr<AsyncRequest> workRequest;
+    std::unique_ptr<WorkRequest> workRequest;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/raster_tile_data.hpp
+++ b/src/mbgl/tile/raster_tile_data.hpp
@@ -22,7 +22,7 @@ public:
                    const std::function<void(std::exception_ptr)>& callback);
     ~RasterTileData();
 
-    void cancel() override;
+    bool tryCancel(bool force = false) override;
     Bucket* getBucket(StyleLayer const &layer_desc) override;
     bool hasData() const override;
 

--- a/src/mbgl/tile/tile_data.hpp
+++ b/src/mbgl/tile/tile_data.hpp
@@ -73,8 +73,11 @@ public:
     TileData(const TileID&);
     virtual ~TileData();
 
-    // Mark this tile as no longer needed and cancel any pending work.
-    virtual void cancel() = 0;
+    // Mark this tile as no longer needed and cancel any pending work. Returns
+    // true if the work was canceled, false otherwise. Canceling is not always
+    // possible because in some circumstances it might block. Force will force
+    // the cancellation and always return true, but it can potentially block.
+    virtual bool tryCancel(bool force = false) = 0;
 
     virtual Bucket* getBucket(const StyleLayer&) = 0;
 

--- a/src/mbgl/tile/tile_data_deleter.cpp
+++ b/src/mbgl/tile/tile_data_deleter.cpp
@@ -1,0 +1,34 @@
+#include <mbgl/tile/tile_data_deleter.hpp>
+
+#include <mbgl/tile/tile_data.hpp>
+
+namespace mbgl {
+
+TileDataDeleter::~TileDataDeleter() {
+    // Force the canceling of all pending TileData
+    // before destroying. We have assert()s on Debug
+    // mode on TileData to make sure it doesn't block
+    // at the destructor unless explicitly canceled.
+    for (auto& entry : tileDataMap) {
+        entry.first->tryCancel(true);
+    }
+}
+
+void TileDataDeleter::add(TileData* data) {
+    std::unique_ptr<TileData> tileData(data);
+
+    // This custom deleter will try to cancel the task if it is
+    // non-blocking, otherwise we keep it and subscribe to the
+    // event when the work is completed. When the event triggers
+    // we delete the TileData because this time it won't block.
+    if (!tileData->tryCancel()) {
+        data->setObserver(this);
+        tileDataMap.emplace(data, std::move(tileData));
+    }
+}
+
+void TileDataDeleter::onTileDataWorkCompleted(TileData* data) {
+    tileDataMap.erase(data);
+}
+
+} // namespace mbgl

--- a/src/mbgl/tile/tile_data_deleter.hpp
+++ b/src/mbgl/tile/tile_data_deleter.hpp
@@ -1,0 +1,29 @@
+#ifndef MBGL_MAP_TILE_DATA_DELETER
+#define MBGL_MAP_TILE_DATA_DELETER
+
+#include <mbgl/tile/tile_data.hpp>
+#include <mbgl/util/noncopyable.hpp>
+
+#include <memory>
+#include <unordered_map>
+
+namespace mbgl {
+
+class TileData;
+
+class TileDataDeleter : public TileData::Observer, private util::noncopyable {
+public:
+    virtual ~TileDataDeleter();
+
+    void add(TileData*);
+
+    // TileData::Observer implementation.
+    void onTileDataWorkCompleted(TileData*) override;
+
+private:
+    std::unordered_map<TileData*, std::unique_ptr<TileData>> tileDataMap;
+};
+
+} // namespace mbgl
+
+#endif

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -59,6 +59,7 @@ VectorTileData::VectorTileData(const TileID& id_,
         // request in case there is one.
         workRequest.reset();
         workRequest = worker.parseGeometryTile(tileWorker, style.getLayers(), std::move(tile), targetConfig, [callback, this, config = targetConfig] (TileParseResult result) {
+            WorkCompletedNotifier notifier(this);
             workRequest.reset();
             if (state == State::obsolete) {
                 return;
@@ -100,6 +101,7 @@ bool VectorTileData::parsePending(std::function<void(std::exception_ptr)> callba
 
     workRequest.reset();
     workRequest = worker.parsePendingGeometryTileLayers(tileWorker, targetConfig, [this, callback, config = targetConfig] (TileParseResult result) {
+        WorkCompletedNotifier notifier(this);
         workRequest.reset();
         if (state == State::obsolete) {
             return;
@@ -155,6 +157,7 @@ void VectorTileData::redoPlacement(const std::function<void()>& callback) {
     if (workRequest) return;
 
     workRequest = worker.redoPlacement(tileWorker, buckets, targetConfig, [this, callback, config = targetConfig] {
+        WorkCompletedNotifier notifier(this);
         workRequest.reset();
 
         // Persist the configuration we just placed so that we can later check whether we need to

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -88,7 +88,8 @@ VectorTileData::VectorTileData(const TileID& id_,
 }
 
 VectorTileData::~VectorTileData() {
-    cancel();
+    assert(tryCancel());
+    workRequest.reset();
 }
 
 bool VectorTileData::parsePending(std::function<void(std::exception_ptr)> callback) {
@@ -174,10 +175,19 @@ void VectorTileData::redoPlacement(const std::function<void()>& callback) {
     });
 }
 
-void VectorTileData::cancel() {
+bool VectorTileData::tryCancel(bool force) {
     state = State::obsolete;
     tileRequest.reset();
-    workRequest.reset();
+
+    if (force) {
+        workRequest.reset();
+    }
+
+    if (workRequest) {
+        return workRequest->tryCancel();
+    }
+
+    return true;
 }
 
 bool VectorTileData::hasData() const {

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -35,7 +35,7 @@ public:
 
     bool hasData() const override;
 
-    void cancel() override;
+    bool tryCancel(bool force = false) override;
 
 private:
     Style& style;

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -13,6 +13,7 @@ namespace mbgl {
 
 class Style;
 class AsyncRequest;
+class WorkRequest;
 class GeometryTileMonitor;
 
 class VectorTileData : public TileData {
@@ -44,7 +45,7 @@ private:
 
     std::unique_ptr<GeometryTileMonitor> monitor;
     std::unique_ptr<AsyncRequest> tileRequest;
-    std::unique_ptr<AsyncRequest> workRequest;
+    std::unique_ptr<WorkRequest> workRequest;
 
     // Contains all the Bucket objects for the tile. Buckets are render
     // objects and they get added by tile parsing operations.

--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -39,7 +39,7 @@ public:
 
     // Invoke object->fn(args...) in the runloop thread, then invoke callback(result) in the current thread.
     template <typename Fn, class Cb, class... Args>
-    std::unique_ptr<AsyncRequest>
+    std::unique_ptr<WorkRequest>
     invokeWithCallback(Fn fn, Cb&& callback, Args&&... args) {
         return loop->invokeWithCallback(bind(fn), callback, std::forward<Args>(args)...);
     }

--- a/src/mbgl/util/work_request.cpp
+++ b/src/mbgl/util/work_request.cpp
@@ -14,4 +14,8 @@ WorkRequest::~WorkRequest() {
     task->cancel();
 }
 
+bool WorkRequest::tryCancel() {
+    return task->tryCancel();
+}
+
 } // namespace mbgl

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -68,7 +68,7 @@ Worker::Worker(std::size_t count) {
 
 Worker::~Worker() = default;
 
-std::unique_ptr<AsyncRequest>
+std::unique_ptr<WorkRequest>
 Worker::parseRasterTile(std::unique_ptr<RasterBucket> bucket,
                         const std::shared_ptr<const std::string> data,
                         std::function<void(RasterTileParseResult)> callback) {
@@ -77,7 +77,7 @@ Worker::parseRasterTile(std::unique_ptr<RasterBucket> bucket,
                                                 data);
 }
 
-std::unique_ptr<AsyncRequest>
+std::unique_ptr<WorkRequest>
 Worker::parseGeometryTile(TileWorker& worker,
                           std::vector<std::unique_ptr<StyleLayer>> layers,
                           std::unique_ptr<GeometryTile> tile,
@@ -88,7 +88,7 @@ Worker::parseGeometryTile(TileWorker& worker,
                                                 std::move(layers), std::move(tile), config);
 }
 
-std::unique_ptr<AsyncRequest>
+std::unique_ptr<WorkRequest>
 Worker::parsePendingGeometryTileLayers(TileWorker& worker,
                                        PlacementConfig config,
                                        std::function<void(TileParseResult)> callback) {
@@ -97,7 +97,7 @@ Worker::parsePendingGeometryTileLayers(TileWorker& worker,
                                                 callback, &worker, config);
 }
 
-std::unique_ptr<AsyncRequest>
+std::unique_ptr<WorkRequest>
 Worker::redoPlacement(TileWorker& worker,
                       const std::unordered_map<std::string, std::unique_ptr<Bucket>>& buckets,
                       PlacementConfig config,

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -10,7 +10,7 @@
 
 namespace mbgl {
 
-class AsyncRequest;
+class WorkRequest;
 class RasterBucket;
 class GeometryTileLoader;
 
@@ -33,7 +33,7 @@ public:
     // bind references to itself, and if and when those lambdas execute, the references
     // will still be valid.
 
-    using Request = std::unique_ptr<AsyncRequest>;
+    using Request = std::unique_ptr<WorkRequest>;
 
     Request parseRasterTile(std::unique_ptr<RasterBucket> bucket,
                             std::shared_ptr<const std::string> data,


### PR DESCRIPTION
We create and destroy TileData objects constantly, specially when zooming in/out fast, and we might block and destroying them. This issue is noticeable on iOS (tested on a iPad Mini 2 Retina) and can be reproduced two ways:

- Pinch the map fast, zooming in and out and you will see the map hanging sometimes.
- Move the map to a place somewhat far from the current location and click on the top right button to trigger a "fly to" animation, that should hang a few times (can be made worse with the map on full tilt).

While the first scenario is hardly a real life use case, the second is. The root cause is that we cannot cancel worker tasks once they are started (see #2644).