### PR TITLE
fix redoPlacement blocking main thread, fix #3727

### DIFF
--- a/src/mbgl/map/vector_tile_data.cpp
+++ b/src/mbgl/map/vector_tile_data.cpp
@@ -144,16 +144,15 @@ void VectorTileData::redoPlacement(const PlacementConfig newConfig, const std::f
     if (newConfig != placedConfig) {
         targetConfig = newConfig;
 
-        if (!workRequest) {
-            // Don't start a new placement request when the current one hasn't completed yet, or when
-            // we are parsing buckets.
-            redoPlacement(callback);
-        }
+        redoPlacement(callback);
     }
 }
 
 void VectorTileData::redoPlacement(const std::function<void()>& callback) {
-    workRequest.reset();
+    // Don't start a new placement request when the current one hasn't completed yet, or when
+    // we are parsing buckets.
+    if (workRequest) return;
+
     workRequest = worker.redoPlacement(tileWorker, buckets, targetConfig, [this, callback, config = targetConfig] {
         workRequest.reset();
 


### PR DESCRIPTION
fix #3727

If a workRequest exists, don't cancel it and start an new request. It's ok to just do nothing if the request exists because a new call to redoPlacement will be triggered after the existing request finishes.

This fixes a regression in https://github.com/mapbox/mapbox-gl-native/pull/3543

@tmpsantos can you review?