### PR TITLE
[core] Increment the schema version

### DIFF
--- a/platform/default/sqlite_cache.cpp
+++ b/platform/default/sqlite_cache.cpp
@@ -70,7 +70,7 @@ void SQLiteCache::Impl::createDatabase() {
 int SQLiteCache::Impl::schemaVersion() const {
     // WARNING: Bump the version when changing the cache
     // scheme to force the table to be recreated.
-    return 1;
+    return 2;
 }
 
 void SQLiteCache::Impl::createSchema() {


### PR DESCRIPTION
This is a followup to 1c21d0fd4cd30cbf6c5b863fd0179b227c28bc0b. Prior to that commit, resources without an expiration were stored with an expiration column value of 0. After it, they are stored with a null column value. Without a schema increment, existing resources in the cache with a 0 value would be treated as expiring at the epoch, causing endless revalidation.

cc @bleege 