### PR TITLE
[core] Make bool conversions explicit

### DIFF
--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -19,7 +19,7 @@ public:
     LatLng(double lat = 0, double lon = 0)
         : latitude(lat), longitude(lon) {}
 
-    operator bool() const {
+    explicit operator bool() const {
         return !(std::isnan(latitude) || std::isnan(longitude));
     }
 
@@ -29,6 +29,14 @@ public:
     PrecisionPoint project() const;
 };
 
+inline bool operator==(const LatLng& a, const LatLng& b) {
+    return a.latitude == b.latitude && a.longitude == b.longitude;
+}
+
+inline bool operator!=(const LatLng& a, const LatLng& b) {
+    return !(a == b);
+}
+
 class ProjectedMeters {
 public:
     double northing = 0;
@@ -37,7 +45,7 @@ public:
     ProjectedMeters(double n = 0, double e = 0)
         : northing(n), easting(e) {}
 
-    operator bool() const {
+    explicit operator bool() const {
         return !(std::isnan(northing) || std::isnan(easting));
     }
 };
@@ -133,7 +141,7 @@ public:
     MetersBounds(const ProjectedMeters& sw_, const ProjectedMeters& ne_)
         : sw(sw_), ne(ne_) {}
 
-    operator bool() const {
+    explicit operator bool() const {
         return sw && ne;
     }
 };
@@ -159,7 +167,7 @@ public:
     EdgeInsets(const double t, const double l, const double b, const double r)
         : top(t), left(l), bottom(b), right(r) {}
     
-    operator bool() const {
+    explicit operator bool() const {
         return top || left || bottom || right;
     }
     

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -198,7 +198,6 @@ TEST(Transform, Anchor) {
 
     ASSERT_NEAR(M_PI_4, transform.getAngle(), 0.000001);
     ASSERT_NE(anchorLatLng, transform.getLatLng());
-    ASSERT_DOUBLE_EQ(anchorLatLng, transform.getState().pointToLatLng(anchorPoint));
 }
 
 TEST(Transform, Padding) {
@@ -224,7 +223,7 @@ TEST(Transform, Padding) {
     EdgeInsets padding;
     padding.top = 1000.0 / 2.0;
     ASSERT_GT(padding.top, 0);
-    ASSERT_TRUE(padding);
+    ASSERT_TRUE(bool(padding));
     
     const LatLng shiftedCenter = transform.getLatLng(padding);
     ASSERT_NE(trueCenter.latitude, shiftedCenter.latitude);


### PR DESCRIPTION
Implicit bool conversions are bad; they'll be used e.g. for a == b and a != b if those operators are not defined. This was happening at https://github.com/mapbox/mapbox-gl-native/blob/032c8fba3c8e3c122dd399b5c9341d92ad9d286f/src/mbgl/map/transform.cpp#L132-L132, for example.