### PR TITLE
Fix designable warning when showing user location

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2999,7 +2999,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
 - (void)setShowsUserLocation:(BOOL)showsUserLocation
 {
-    if (showsUserLocation == _showsUserLocation) return;
+    if (showsUserLocation == _showsUserLocation || _isTargetingInterfaceBuilder) return;
 
     _showsUserLocation = showsUserLocation;
 


### PR DESCRIPTION
Turn the Shows User Location inspectable into a no-op when running in the designables agent. Otherwise, we complain that the agent lacks Location Services permissions:

```
file:///path/to/TestApplication/TestApplication/Storyboard.storyboard: warning: IB Designables: Ignoring user defined runtime attribute for key path "showsUserLocation" on instance of "TestApplication.MapView". Hit an exception when attempting to set its value: In iOS 8 and above, this app must have a value for NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in its Info.plist.
```

/cc @friedbunny