### PR TITLE
patch memory leak in NodeMap::request

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -462,7 +462,7 @@ std::unique_ptr<mbgl::FileRequest> NodeMap::request(const mbgl::Resource& resour
         Nan::HandleScope scope;
 
         auto requestHandle = NodeRequest::Create(res, cb2)->ToObject();
-        auto callbackHandle = Nan::GetFunction(Nan::New<v8::FunctionTemplate>(NodeRequest::Respond, requestHandle)).ToLocalChecked();
+        auto callbackHandle = Nan::New<v8::Function>(NodeRequest::Respond, requestHandle);
 
         v8::Local<v8::Value> argv[] = { requestHandle, callbackHandle };
         Nan::MakeCallback(handle()->GetInternalField(1)->ToObject(), "request", 2, argv);


### PR DESCRIPTION
Creating a `v8::Function` with `Nan::GetFunction(Nan::New<v8::FunctionTemplate>)` can leak, use `Nan::New<v8::Function>` instead.

https://code.google.com/p/chromium/issues/detail?id=272579