### PR TITLE
[core] make sure icons fit before the ends of the line

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2b4ed672dc7e7e60f98115e3eb2dc55125b96e66",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#47f62a86a568bbf67dd5b2f4b42b46ef4769f356",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"


### PR DESCRIPTION
-js: https://github.com/mapbox/mapbox-gl-js/pull/2077/files

This skips anchors if there is not enough room before the end of the line for the icon to fit.

Previously it allowed icons that extended past the end of a line as long as the icon's anchor fit on the line. This changes it so that the icon itself has to fit on the line. With these changes there are no icons on really short lines and no icons right at the end of lines.

The test suite changes (mapbox/mapbox-gl-test-suite@6b6a03e) make it look like this is a huge change, but in actual maps it only drops a small number of icons that are right at the ends of lines or are on really short lines.

:eyes: @jfirebaugh 