### PR TITLE
Set dynamic framework minimum deployment target to iOS 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Known issues:
 
 ## iOS 3.1.1
 
+- Corrected the dynamic framework’s minimum deployment target to iOS 8.0. ([#3872](https://github.com/mapbox/mapbox-gl-native/pull/3872))
 - Fixed Fabric compatibility. ([#3847](https://github.com/mapbox/mapbox-gl-native/pull/3847))
 
 ## iOS 3.1.0

--- a/ios/framework/framework-ios.gypi
+++ b/ios/framework/framework-ios.gypi
@@ -23,6 +23,7 @@
         'DEFINES_MODULE': 'YES',
         'DYLIB_INSTALL_NAME_BASE': '@rpath',
         'INFOPLIST_FILE': '../ios/framework/Info.plist',
+        'IPHONEOS_DEPLOYMENT_TARGET': '8.0',
         'LD_RUNPATH_SEARCH_PATHS': [
           '$(inherited)',
           '@executable_path/Frameworks',


### PR DESCRIPTION
Fixes #3870.

/cc @boundsj @friedbunny @parrots