### PR TITLE
Conform to SMCalloutViewDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Known issues:
 
 - Corrected the dynamic framework’s minimum deployment target to iOS 8.0. ([#3872](https://github.com/mapbox/mapbox-gl-native/pull/3872))
 - Fixed Fabric compatibility. ([#3847](https://github.com/mapbox/mapbox-gl-native/pull/3847))
+- Fixed an issue preventing `-[MGLMapViewDelegate mapView:tapOnCalloutForAnnotation:]` from being called when a non-custom callout view is tapped. ([#3875](https://github.com/mapbox/mapbox-gl-native/pull/3875))
 
 ## iOS 3.1.0
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -147,6 +147,7 @@ public:
                           GLKViewDelegate,
                           CLLocationManagerDelegate,
                           UIActionSheetDelegate,
+                          SMCalloutViewDelegate,
                           MGLCalloutViewDelegate,
                           UIAlertViewDelegate,
                           MGLMultiPointDelegate,
@@ -1480,6 +1481,14 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 - (BOOL)calloutViewShouldHighlight:(__unused MGLCompactCalloutView *)calloutView
 {
     return [self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)];
+}
+
+- (void)calloutViewClicked:(__unused SMCalloutView *)calloutView
+{
+    if ([self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)])
+    {
+        [self.delegate mapView:self tapOnCalloutForAnnotation:self.selectedAnnotation];
+    }
 }
 
 - (void)calloutViewTapped:(__unused MGLCompactCalloutView *)calloutView


### PR DESCRIPTION
#3322 #3456 replaced SMCalloutViewDelegate conformance with MGLCalloutViewDelegate conformance. Unfortunately, the two protocols differ in some symbols. This change restores SMCalloutViewDelegate methods alongside MGLCalloutViewDelegate methods.

Fixes #3871.

/cc @friedbunny @picciano