### PR TITLE
Fix crash reselecting annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Known issues:
 
 - Corrected the dynamic framework’s minimum deployment target to iOS 8.0. ([#3872](https://github.com/mapbox/mapbox-gl-native/pull/3872))
 - Fixed Fabric compatibility. ([#3847](https://github.com/mapbox/mapbox-gl-native/pull/3847))
+- Fixed a crash that can occur when reselecting an annotation. ([#3881](https://github.com/mapbox/mapbox-gl-native/pull/3881))
 - Fixed an issue preventing `-[MGLMapViewDelegate mapView:tapOnCalloutForAnnotation:]` from being called when a non-custom callout view is tapped. ([#3875](https://github.com/mapbox/mapbox-gl-native/pull/3875))
 
 ## iOS 3.1.0

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2698,19 +2698,28 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             if (_selectedAnnotationTag == MGLAnnotationTagNotFound
                 || _selectedAnnotationTag == _annotationsNearbyLastTap.back())
             {
-                // Either an annotation from this set hasn’t been selected
-                // before or the last annotation in the set was selected. Wrap
-                // around to the first annotation in the set.
+                // Either no annotation is selected or the last annotation in
+                // the set was selected. Wrap around to the first annotation in
+                // the set.
                 hitAnnotationTag = _annotationsNearbyLastTap.front();
             }
             else
             {
-                // Step to the next annotation in the set.
                 auto result = std::find(_annotationsNearbyLastTap.begin(),
                                         _annotationsNearbyLastTap.end(),
                                         _selectedAnnotationTag);
-                auto distance = std::distance(_annotationsNearbyLastTap.begin(), result);
-                hitAnnotationTag = _annotationsNearbyLastTap[distance + 1];
+                if (result == _annotationsNearbyLastTap.end())
+                {
+                    // An annotation from this set hasn’t been selected before.
+                    // Select the first (nearest) one.
+                    hitAnnotationTag = _annotationsNearbyLastTap.front();
+                }
+                else
+                {
+                    // Step to the next annotation in the set.
+                    auto distance = std::distance(_annotationsNearbyLastTap.begin(), result);
+                    hitAnnotationTag = _annotationsNearbyLastTap[distance + 1];
+                }
             }
         }
         else

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1757,17 +1757,23 @@ public:
             // set of annotations as we do now. Cycle through them.
             if (_lastSelectedAnnotationTag == MGLAnnotationTagNotFound
                 || _lastSelectedAnnotationTag == _annotationsNearbyLastClick.back()) {
-                // Either an annotation from this set hasn’t been selected
-                // before or the last annotation in the set was selected. Wrap
-                // around to the first annotation in the set.
+                // Either no annotation is selected or the last annotation in
+                // the set was selected. Wrap around to the first annotation in
+                // the set.
                 hitAnnotationTag = _annotationsNearbyLastClick.front();
             } else {
-                // Step to the next annotation in the set.
                 auto result = std::find(_annotationsNearbyLastClick.begin(),
                                         _annotationsNearbyLastClick.end(),
                                         _lastSelectedAnnotationTag);
-                auto distance = std::distance(_annotationsNearbyLastClick.begin(), result);
-                hitAnnotationTag = _annotationsNearbyLastClick[distance + 1];
+                if (result == _annotationsNearbyLastClick.end()) {
+                    // An annotation from this set hasn’t been selected before.
+                    // Select the first (nearest) one.
+                    hitAnnotationTag = _annotationsNearbyLastClick.front();
+                } else {
+                    // Step to the next annotation in the set.
+                    auto distance = std::distance(_annotationsNearbyLastClick.begin(), result);
+                    hitAnnotationTag = _annotationsNearbyLastClick[distance + 1];
+                }
             }
         } else {
             // Remember the nearby annotations for the next time this method is


### PR DESCRIPTION
Handle the case where the currently selected annotation isn’t one of the nearby annotations. This issue hasn’t come up before in the OS X SDK, from which this code was ported, because clicking an annotation while another annotation is selected only dismisses the callout popover.

Fixes #3284.

/cc @RomainQuidet @maciekish @Zakay