### PR TITLE
Exclude misses from nearby annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Known issues:
 - Fixed Fabric compatibility. ([#3847](https://github.com/mapbox/mapbox-gl-native/pull/3847))
 - Fixed a crash that can occur when reselecting an annotation. ([#3881](https://github.com/mapbox/mapbox-gl-native/pull/3881))
 - Fixed an issue preventing the Latitude inspectable from working when it is set before setting the Zoom Level inspectable in Interface Builder. ([#3886](https://github.com/mapbox/mapbox-gl-native/pull/3886))
+- Fixed an issue that incorrectly expanded the tappable area of an annotation and prevented the annotation’s alignment rect insets from having any effect on the tappable area. ([#3898](https://github.com/mapbox/mapbox-gl-native/pull/3898))
 - Fixed an issue preventing `-[MGLMapViewDelegate mapView:tapOnCalloutForAnnotation:]` from being called when a non-custom callout view is tapped. ([#3875](https://github.com/mapbox/mapbox-gl-native/pull/3875))
 
 ## iOS 3.1.0

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2657,7 +2657,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         
         // Filter out any annotation whose image is unselectable or for which
         // hit testing fails.
-        std::remove_if(nearbyAnnotations.begin(), nearbyAnnotations.end(), [&](const MGLAnnotationTag annotationTag)
+        auto end = std::remove_if(nearbyAnnotations.begin(), nearbyAnnotations.end(),
+                                  [&](const MGLAnnotationTag annotationTag)
         {
             id <MGLAnnotation> annotation = [self annotationWithTag:annotationTag];
             NSAssert(annotation, @"Unknown annotation found nearby tap");
@@ -2674,6 +2675,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
                                   centeredAtCoordinate:annotation.coordinate];
             return !!!CGRectIntersectsRect(annotationRect, hitRect);
         });
+        nearbyAnnotations.resize(std::distance(nearbyAnnotations.begin(), end));
     }
     
     MGLAnnotationTag hitAnnotationTag = MGLAnnotationTagNotFound;

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1717,7 +1717,7 @@ public:
         
         // Filter out any annotation whose image is unselectable or for which
         // hit testing fails.
-        std::remove_if(nearbyAnnotations.begin(), nearbyAnnotations.end(), [&](const MGLAnnotationTag annotationTag) {
+        auto end = std::remove_if(nearbyAnnotations.begin(), nearbyAnnotations.end(), [&](const MGLAnnotationTag annotationTag) {
             NSAssert(_annotationContextsByAnnotationTag.count(annotationTag) != 0, @"Unknown annotation found nearby click");
             id <MGLAnnotation> annotation = [self annotationWithTag:annotationTag];
             if (!annotation) {
@@ -1736,6 +1736,7 @@ public:
             return !!![annotationImage.image hitTestRect:hitRect withImageDestinationRect:annotationRect
                                                  context:nil hints:nil flipped:NO];
         });
+        nearbyAnnotations.resize(std::distance(nearbyAnnotations.begin(), end));
     }
     
     MGLAnnotationTag hitAnnotationTag = MGLAnnotationTagNotFound;


### PR DESCRIPTION
After filtering out elements of a vector using `std::remove_if()`, it’s apparently necessary to resize the vector. Otherwise, removing only has the effect of shifting the non-matching items to the end of the vector. This change reduces the annotation tap target back to almost what it was before #3261, except that these days the target is centered around the annotation image rather than the center point. There remains a much smaller slop area around the annotation, but nothing close to the effective padding before this change.

Fixes #3880.

/cc @jfirebaugh @BFTE