### PR TITLE
Fix Xcode 7.3 error

### DIFF
--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -31,7 +31,7 @@ public:
     Resource(Kind kind_, const std::string& url_, optional<TileData> tileData_ = {})
         : kind(kind_),
           url(url_),
-          tileData(tileData_) {
+          tileData(std::move(tileData_)) {
     }
 
     static Resource style(const std::string& url);

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -344,7 +344,7 @@ std::vector<OfflineRegion> OfflineDatabase::listRegions() {
             stmt->get<std::vector<uint8_t>>(2)));
     }
 
-    return std::move(result);
+    return result;
 }
 
 OfflineRegion OfflineDatabase::createRegion(const OfflineRegionDefinition& definition,

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -190,7 +190,7 @@ std::unique_ptr<FileRequest> OnlineFileSource::request(const Resource& resource,
 OnlineFileRequestImpl::OnlineFileRequestImpl(FileRequest* key_, const Resource& resource_, Callback callback_, OnlineFileSource::Impl& impl)
     : key(key_),
       resource(resource_),
-      callback(callback_) {
+      callback(std::move(callback_)) {
     // Force an immediate first request if we don't have an expiration time.
     schedule(impl, !resource.priorExpires);
 }

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -10,7 +10,7 @@ AnnotationTileFeature::AnnotationTileFeature(FeatureType type_, GeometryCollecti
                                  std::unordered_map<std::string, std::string> properties_)
     : type(type_),
       properties(std::move(properties_)),
-      geometries(geometries_) {}
+      geometries(std::move(geometries_)) {}
 
 optional<Value> AnnotationTileFeature::getValue(const std::string& key) const {
     auto it = properties.find(key);

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -11,8 +11,8 @@ using namespace mbgl;
 
 DebugBucket::DebugBucket(const TileID id, const TileData::State state_, optional<SystemTimePoint> modified_, optional<SystemTimePoint> expires_, MapDebugOptions debugMode_)
     : state(state_),
-      modified(modified_),
-      expires(expires_),
+      modified(std::move(modified_)),
+      expires(std::move(expires_)),
       debugMode(debugMode_) {
     double baseline = 200;
     if (debugMode & MapDebugOptions::ParseStatus) {


### PR DESCRIPTION
Xcode 7.3 errors hard on C++ misuse, in particular when using `std::move()` prevents copy elision.