### PR TITLE
[core] reset line distance when it is near max

### DIFF
--- a/include/mbgl/util/math.hpp
+++ b/include/mbgl/util/math.hpp
@@ -88,6 +88,11 @@ inline T dist(const S1& a, const S2& b) {
 }
 
 template <typename T>
+inline T round(const T& a) {
+    return T(::round(a.x), ::round(a.y));
+}
+
+template <typename T>
 inline T length(T a, T b) {
     return std::sqrt(a * a + b * b);
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#47f62a86a568bbf67dd5b2f4b42b46ef4769f356",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#8859b504ef241bca49d4c2f9a79ff4d0bfdf81a1",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#8859b504ef241bca49d4c2f9a79ff4d0bfdf81a1",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2841bd69fe7ef9411aaca49737b8759d16f18997",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/src/mbgl/geometry/line_buffer.cpp
+++ b/src/mbgl/geometry/line_buffer.cpp
@@ -22,7 +22,7 @@ GLsizei LineVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey, 
     // The z component's first bit, as well as the sign bit is reserved for the direction,
     // so we need to shift the linesofar.
     extrude[6] = ((dir < 0) ? -1 : 1) * ((dir ? 1 : 0) | static_cast<int8_t>((linesofar << 1) & 0x7F));
-    extrude[7] = (linesofar >> 6) & 0x7F;
+    extrude[7] = ((linesofar >> 6) & 0xFF) - 128;
 
     return idx;
 }

--- a/src/mbgl/layer/line_layer.cpp
+++ b/src/mbgl/layer/line_layer.cpp
@@ -69,7 +69,7 @@ bool LineLayer::recalculate(const StyleCalculationParameters& parameters) {
 }
 
 std::unique_ptr<Bucket> LineLayer::createBucket(StyleBucketParameters& parameters) const {
-    auto bucket = std::make_unique<LineBucket>();
+    auto bucket = std::make_unique<LineBucket>(parameters.tileID.overscaling);
 
     bucket->layout = layout;
 

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -24,7 +24,7 @@ class LineBucket : public Bucket {
     using TriangleGroup = ElementGroup<3>;
 
 public:
-    LineBucket();
+    LineBucket(float overscaling);
     ~LineBucket() override;
 
     void upload() override;
@@ -62,6 +62,8 @@ private:
     GLint e3;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
+
+    const float overscaling;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -43,7 +43,7 @@ private:
         TriangleElement(uint16_t a_, uint16_t b_, uint16_t c_) : a(a_), b(b_), c(c_) {}
         uint16_t a, b, c;
     };
-    void addCurrentVertex(const Coordinate& currentVertex, float flip, double distance,
+    void addCurrentVertex(const Coordinate& currentVertex, float flip, double& distance,
             const vec2<double>& normal, float endLeft, float endRight, bool round,
             GLint startVertex, std::vector<LineBucket::TriangleElement>& triangleStore);
     void addPieSliceVertex(const Coordinate& currentVertex, float flip, double distance,

--- a/src/mbgl/shader/linepattern.vertex.glsl
+++ b/src/mbgl/shader/linepattern.vertex.glsl
@@ -6,6 +6,10 @@
 // #define scale 63.0
 #define scale 0.015873016
 
+// We scale the distance before adding it to the buffers so that we can store
+// long distances for long segments. Use this value to unscale the distance.
+#define LINE_DISTANCE_SCALE 2.0
+
 attribute vec2 a_pos;
 attribute vec4 a_data;
 
@@ -30,7 +34,7 @@ varying float v_gamma_scale;
 void main() {
     vec2 a_extrude = a_data.xy;
     float a_direction = sign(a_data.z) * mod(a_data.z, 2.0);
-    float a_linesofar = abs(floor(a_data.z / 2.0)) + a_data.w * 64.0;
+    float a_linesofar = (abs(floor(a_data.z / 2.0)) + (a_data.w + 128.0) * 64.0) * LINE_DISTANCE_SCALE;
 
     // We store the texture normals in the most insignificant bit
     // transform y so that 0 => -1 and 1 => 1

--- a/src/mbgl/shader/linesdf.vertex.glsl
+++ b/src/mbgl/shader/linesdf.vertex.glsl
@@ -6,6 +6,10 @@
 // #define scale 63.0
 #define scale 0.015873016
 
+// We scale the distance before adding it to the buffers so that we can store
+// long distances for long segments. Use this value to unscale the distance.
+#define LINE_DISTANCE_SCALE 2.0
+
 attribute vec2 a_pos;
 attribute vec4 a_data;
 
@@ -34,7 +38,7 @@ varying float v_gamma_scale;
 void main() {
     vec2 a_extrude = a_data.xy;
     float a_direction = sign(a_data.z) * mod(a_data.z, 2.0);
-    float a_linesofar = abs(floor(a_data.z / 2.0)) + a_data.w * 64.0;
+    float a_linesofar = (abs(floor(a_data.z / 2.0)) + (a_data.w + 128.0) * 64.0) * LINE_DISTANCE_SCALE;
 
     // We store the texture normals in the most insignificant bit
     // transform y so that 0 => -1 and 1 => 1

--- a/src/mbgl/util/clip_lines.cpp
+++ b/src/mbgl/util/clip_lines.cpp
@@ -21,33 +21,33 @@ std::vector<std::vector<Coordinate>> clipLines(const std::vector<std::vector<Coo
             if (p0.x < x1 && p1.x < x1) {
                 continue;
             } else if (p0.x < x1) {
-                p0 = { x1, static_cast<int16_t>(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x))) };
+                p0 = { x1, static_cast<int16_t>(::round(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x)))) };
             } else if (p1.x < x1) {
-                p1 = { x1, static_cast<int16_t>(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x))) };
+                p1 = { x1, static_cast<int16_t>(::round(p0.y + (p1.y - p0.y) * ((float)(x1 - p0.x) / (p1.x - p0.x)))) };
             }
 
             if (p0.y < y1 && p1.y < y1) {
                 continue;
             } else if (p0.y < y1) {
-                p0 = { static_cast<int16_t>(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y))), y1 };
+                p0 = { static_cast<int16_t>(::round(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y)))), y1 };
             } else if (p1.y < y1) {
-                p1 = { static_cast<int16_t>(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y))), y1 };
+                p1 = { static_cast<int16_t>(::round(p0.x + (p1.x - p0.x) * ((float)(y1 - p0.y) / (p1.y - p0.y)))), y1 };
             }
 
             if (p0.x >= x2 && p1.x >= x2) {
                 continue;
             } else if (p0.x >= x2) {
-                p0 = { x2, static_cast<int16_t>(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x))) };
+                p0 = { x2, static_cast<int16_t>(::round(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x)))) };
             } else if (p1.x >= x2) {
-                p1 = { x2, static_cast<int16_t>(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x))) };
+                p1 = { x2, static_cast<int16_t>(::round(p0.y + (p1.y - p0.y) * ((float)(x2 - p0.x) / (p1.x - p0.x)))) };
             }
 
             if (p0.y >= y2 && p1.y >= y2) {
                 continue;
             } else if (p0.y >= y2) {
-                p0 = { static_cast<int16_t>(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y))), y2 };
+                p0 = { static_cast<int16_t>(::round(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y)))), y2 };
             } else if (p1.y >= y2) {
-                p1 = { static_cast<int16_t>(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y))), y2 };
+                p1 = { static_cast<int16_t>(::round(p0.x + (p1.x - p0.x) * ((float)(y2 - p0.y) / (p1.y - p0.y)))), y2 };
             }
 
             if (clippedLines.empty() || (!clippedLines.back().empty() && !(p0 == clippedLines.back().back()))) {


### PR DESCRIPTION
port https://github.com/mapbox/mapbox-gl-js/pull/2114

ref https://github.com/mapbox/mapbox-gl-js/issues/2099

When the distance of the current vertex is > half the maximum distance that can be represented, reset the distance. This fixes the original problem where a line with many segments is longer than the maximum distance.

We still need to make sure we can represent the distance of the longest possible segment so we need to make two more changes:

- improve how linesofar is packed into the buffer so that we have two more bits
- scale the distance down before adding it to the buffer to increase the maximum distance that can be represented

I don't like how var distance changed to this.distance but addCurrentVertex needs to be able to reset the distance and I'm not seeing a better way to do this.