### PR TITLE
[ios] Update linked library extension to .tbd

### DIFF
--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -104,9 +104,9 @@ If your application targets iOS 7.x, you’ll need to install the static framewo
    - `MobileCoreServices.framework`
    - `QuartzCore.framework`
    - `SystemConfiguration.framework`
-   - `libc++.dylib`
-   - `libsqlite3.dylib`
-   - `libz.dylib`
+   - `libc++.tbd`
+   - `libsqlite3.tbd`
+   - `libz.tbd`
 
 1. In the Build Settings tab, add `-ObjC` to the “Other Linker Flags” (`OTHER_LDFLAGS`) build setting.
 

--- a/platform/ios/docs/pod-README.md
+++ b/platform/ios/docs/pod-README.md
@@ -42,9 +42,9 @@ If your application targets iOS 7.x, you’ll need to install the static framewo
    - `MobileCoreServices.framework`
    - `QuartzCore.framework`
    - `SystemConfiguration.framework`
-   - `libc++.dylib`
-   - `libsqlite3.dylib`
-   - `libz.dylib`
+   - `libc++.tbd`
+   - `libsqlite3.tbd`
+   - `libz.tbd`
 
 1. In the Build Settings tab, add `-ObjC` to the “Other Linker Flags” (`OTHER_LDFLAGS`) build setting.
 


### PR DESCRIPTION
Update some outdated docs that managed to escape my attention. Xcode 7 switched to `.tbd` wrappers around `.dylib`.