### PR TITLE
[core] mbgl::util::noncopyable default dtor should be virtual

### DIFF
--- a/include/mbgl/util/noncopyable.hpp
+++ b/include/mbgl/util/noncopyable.hpp
@@ -1,24 +1,20 @@
 #ifndef MBGL_UTIL_NONCOPYABLE
 #define MBGL_UTIL_NONCOPYABLE
 
-namespace mbgl { namespace util {
+namespace mbgl {
+namespace util {
 
-namespace non_copyable_
-{
-
-class noncopyable
-{
+class noncopyable {
 protected:
     constexpr noncopyable() = default;
-    ~noncopyable() = default;
-    noncopyable( noncopyable const& ) = delete;
-    noncopyable& operator=(noncopyable const& ) = delete;
-};
-} // namespace non_copyable_
+    virtual ~noncopyable() = default;
 
-typedef non_copyable_::noncopyable noncopyable;
+    // Disable copy semantics.
+    noncopyable(noncopyable const&) = delete;
+    noncopyable& operator=(noncopyable const&) = delete;
+};
 
 } // namespace util
 } // namespace mbgl
 
-#endif
+#endif // MBGL_UTIL_NONCOPYABLE

--- a/include/mbgl/util/work_request.hpp
+++ b/include/mbgl/util/work_request.hpp
@@ -9,7 +9,7 @@ namespace mbgl {
 
 class WorkTask;
 
-class WorkRequest : public util::noncopyable {
+class WorkRequest : private util::noncopyable {
 public:
     using Task = std::shared_ptr<WorkTask>;
     WorkRequest(Task);

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -20,7 +20,7 @@
 
 namespace mbgl {
 
-class OnlineFileRequestImpl : public util::noncopyable {
+class OnlineFileRequestImpl : private util::noncopyable {
 public:
     using Callback = std::function<void (Response)>;
 

--- a/src/mbgl/geometry/elements_buffer.hpp
+++ b/src/mbgl/geometry/elements_buffer.hpp
@@ -11,7 +11,7 @@
 namespace mbgl {
 
 template <GLsizei count>
-struct ElementGroup : public util::noncopyable {
+struct ElementGroup : private util::noncopyable {
     std::array<VertexArrayObject, count> array;
     GLsizei vertex_length;
     GLsizei elements_length;

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -14,7 +14,7 @@
 
 namespace mbgl {
 
-class GlyphAtlas : public util::noncopyable {
+class GlyphAtlas : private util::noncopyable {
 public:
     GlyphAtlas(uint16_t width, uint16_t height);
     ~GlyphAtlas();

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -9,7 +9,7 @@
 
 namespace mbgl {
 
-class VertexArrayObject : public util::noncopyable {
+class VertexArrayObject : private util::noncopyable {
 public:
     static void Unbind();
     static void Delete(GLsizei n, const GLuint* arrays);

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -36,7 +36,7 @@ struct SpriteAtlasElement {
     float relativePixelRatio;
 };
 
-class SpriteAtlas : public util::noncopyable {
+class SpriteAtlas : private util::noncopyable {
 public:
     typedef uint16_t dimension;
 

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -52,7 +52,7 @@ struct RenderData {
 class Style : public GlyphStore::Observer,
               public SpriteStore::Observer,
               public Source::Observer,
-              public util::noncopyable {
+              private util::noncopyable {
 public:
     Style(MapData&);
     ~Style();

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -38,7 +38,7 @@ using TileParseResult = mapbox::util::variant<
     TileParseResultBuckets, // success
     std::exception_ptr>;    // error
 
-class TileWorker : public util::noncopyable {
+class TileWorker : private util::noncopyable {
 public:
     TileWorker(TileID,
                std::string sourceID,

--- a/src/mbgl/util/channel.hpp
+++ b/src/mbgl/util/channel.hpp
@@ -10,7 +10,7 @@
 namespace mbgl {
 
 template <class T>
-class Channel : public mbgl::util::noncopyable {
+class Channel : private util::noncopyable {
 public:
     void send(const T& t) {
         std::unique_lock<std::mutex> lock(mutex);

--- a/src/mbgl/util/thread_local.hpp
+++ b/src/mbgl/util/thread_local.hpp
@@ -11,7 +11,7 @@ namespace mbgl {
 namespace util {
 
 template <class T>
-class ThreadLocal : public noncopyable {
+class ThreadLocal : private noncopyable {
 public:
     inline ThreadLocal(T* val) {
         ThreadLocal();

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -18,7 +18,7 @@ using RasterTileParseResult = mapbox::util::variant<
     std::unique_ptr<Bucket>, // success
     std::exception_ptr>;     // error
 
-class Worker : public mbgl::util::noncopyable {
+class Worker : private util::noncopyable {
 public:
     explicit Worker(std::size_t count);
     ~Worker();


### PR DESCRIPTION
FWIW `noncopyable` is just a trait we use for disabling copy semantics. However, we are often using non-virtual dtors for its derived classes. This change allows all further derived classes to properly call their respective dtors. Plus for enforcing private inheritance for derived classes.

:eyes: @kkaefer @tmpsantos @jfirebaugh