### PR TITLE
Implement GL object wrappers

### DIFF
--- a/include/mbgl/gl/gl.hpp
+++ b/include/mbgl/gl/gl.hpp
@@ -110,6 +110,32 @@ public:
 using glProc = void (*)();
 void InitializeExtensions(glProc (*getProcAddress)(const char *));
 
+static gl::ExtensionFunction<
+    void (GLuint array)>
+    BindVertexArray({
+        {"GL_ARB_vertex_array_object", "glBindVertexArray"},
+        {"GL_OES_vertex_array_object", "glBindVertexArrayOES"},
+        {"GL_APPLE_vertex_array_object", "glBindVertexArrayAPPLE"}
+    });
+
+static gl::ExtensionFunction<
+    void (GLsizei n,
+          const GLuint* arrays)>
+    DeleteVertexArrays({
+        {"GL_ARB_vertex_array_object", "glDeleteVertexArrays"},
+        {"GL_OES_vertex_array_object", "glDeleteVertexArraysOES"},
+        {"GL_APPLE_vertex_array_object", "glDeleteVertexArraysAPPLE"}
+    });
+
+static gl::ExtensionFunction<
+    void (GLsizei n,
+          GLuint* arrays)>
+    GenVertexArrays({
+        {"GL_ARB_vertex_array_object", "glGenVertexArrays"},
+        {"GL_OES_vertex_array_object", "glGenVertexArraysOES"},
+        {"GL_APPLE_vertex_array_object", "glGenVertexArraysAPPLE"}
+    });
+
 } // namespace gl
 } // namespace mbgl
 

--- a/platform/default/jpeg_reader.cpp
+++ b/platform/default/jpeg_reader.cpp
@@ -153,7 +153,7 @@ PremultipliedImage decodeJPEG(const uint8_t* data, size_t size) {
 
     jpeg_finish_decompress(&cinfo);
 
-    return std::move(image);
+    return image;
 }
 
 }

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -3,7 +3,7 @@
 
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/platform/log.hpp>
-#include <mbgl/util/gl_object_store.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/thread_context.hpp>
 

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -42,10 +42,10 @@ public:
     // Transfers this buffer to the GPU and binds the buffer to the GL context.
     void bind() {
         if (buffer) {
-            MBGL_CHECK_ERROR(glBindBuffer(bufferType, buffer));
+            MBGL_CHECK_ERROR(glBindBuffer(bufferType, getID()));
         } else {
             MBGL_CHECK_ERROR(glGenBuffers(1, &buffer));
-            MBGL_CHECK_ERROR(glBindBuffer(bufferType, buffer));
+            MBGL_CHECK_ERROR(glBindBuffer(bufferType, getID()));
             if (array == nullptr) {
                 Log::Debug(Event::OpenGL, "Buffer doesn't contain elements");
                 pos = 0;

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -5,7 +5,7 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
-#include <mbgl/util/gl_object_store.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/thread_context.hpp>
 
 #include <cassert>

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -3,9 +3,9 @@
 #include <mbgl/text/font_stack.hpp>
 
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
-#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/thread_context.hpp>
 
 #include <cassert>
@@ -24,11 +24,6 @@ GlyphAtlas::GlyphAtlas(uint16_t width_, uint16_t height_)
 
 GlyphAtlas::~GlyphAtlas() {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
-
-    if (texture) {
-        mbgl::util::ThreadContext::getGLObjectStore()->abandonTexture(texture);
-        texture = 0;
-    }
 }
 
 void GlyphAtlas::addGlyphs(uintptr_t tileUID,
@@ -194,8 +189,8 @@ void GlyphAtlas::upload() {
 
 void GlyphAtlas::bind() {
     if (!texture) {
-        MBGL_CHECK_ERROR(glGenTextures(1, &texture));
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
+        texture.create();
+        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture.getID()));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
 #endif
@@ -204,6 +199,6 @@ void GlyphAtlas::bind() {
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     } else {
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
+        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture.getID()));
     }
 };

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/text/glyph_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 
 #include <string>
 #include <set>
@@ -53,7 +54,7 @@ private:
     std::map<std::string, std::map<uint32_t, GlyphValue>> index;
     const std::unique_ptr<uint8_t[]> data;
     std::atomic<bool> dirty;
-    GLuint texture = 0;
+    gl::TextureHolder texture;
 };
 
 } // namespace mbgl

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
-#include <mbgl/util/gl_object_store.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/thread_context.hpp>
 
 #include <boost/functional/hash.hpp>

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -2,10 +2,10 @@
 #define MBGL_GEOMETRY_LINE_ATLAS
 
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 
 #include <vector>
 #include <map>
-#include <memory>
 
 namespace mbgl {
 
@@ -36,7 +36,7 @@ public:
 private:
     const std::unique_ptr<GLbyte[]> data;
     bool dirty;
-    GLuint texture = 0;
+    gl::TextureHolder texture;
     int nextRow = 0;
     std::map<size_t, LinePatternPos> positions;
 };

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -1,6 +1,6 @@
 #include <mbgl/geometry/vao.hpp>
 #include <mbgl/platform/log.hpp>
-#include <mbgl/util/gl_object_store.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/thread_context.hpp>
 

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -11,19 +11,11 @@ void VertexArrayObject::Unbind() {
     MBGL_CHECK_ERROR(gl::BindVertexArray(0));
 }
 
-void VertexArrayObject::Delete(GLsizei n, const GLuint* arrays) {
-    if (!gl::DeleteVertexArrays) return;
-    MBGL_CHECK_ERROR(gl::DeleteVertexArrays(n, arrays));
-}
-
 VertexArrayObject::VertexArrayObject() {
 }
 
 VertexArrayObject::~VertexArrayObject() {
-    if (!gl::DeleteVertexArrays) return;
-    if (vao) {
-        util::ThreadContext::getGLObjectStore()->abandonVAO(vao);
-    }
+    if (vao) util::ThreadContext::getGLObjectStore()->abandon(std::move(vao));
 }
 
 void VertexArrayObject::bindVertexArrayObject() {
@@ -36,10 +28,8 @@ void VertexArrayObject::bindVertexArrayObject() {
         return;
     }
 
-    if (!vao) {
-        MBGL_CHECK_ERROR(gl::GenVertexArrays(1, &vao));
-    }
-    MBGL_CHECK_ERROR(gl::BindVertexArray(vao));
+    if (!vao) vao.create();
+    MBGL_CHECK_ERROR(gl::BindVertexArray(vao.getID()));
 }
 
 void VertexArrayObject::verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer,

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -6,54 +6,28 @@
 
 namespace mbgl {
 
-static gl::ExtensionFunction<
-    void (GLuint array)>
-    BindVertexArray({
-        {"GL_ARB_vertex_array_object", "glBindVertexArray"},
-        {"GL_OES_vertex_array_object", "glBindVertexArrayOES"},
-        {"GL_APPLE_vertex_array_object", "glBindVertexArrayAPPLE"}
-    });
-
-static gl::ExtensionFunction<
-    void (GLsizei n,
-          const GLuint* arrays)>
-    DeleteVertexArrays({
-        {"GL_ARB_vertex_array_object", "glDeleteVertexArrays"},
-        {"GL_OES_vertex_array_object", "glDeleteVertexArraysOES"},
-        {"GL_APPLE_vertex_array_object", "glDeleteVertexArraysAPPLE"}
-    });
-
-static gl::ExtensionFunction<
-    void (GLsizei n,
-          GLuint* arrays)>
-    GenVertexArrays({
-        {"GL_ARB_vertex_array_object", "glGenVertexArrays"},
-        {"GL_OES_vertex_array_object", "glGenVertexArraysOES"},
-        {"GL_APPLE_vertex_array_object", "glGenVertexArraysAPPLE"}
-    });
-
 void VertexArrayObject::Unbind() {
-    if (!BindVertexArray) return;
-    MBGL_CHECK_ERROR(BindVertexArray(0));
+    if (!gl::BindVertexArray) return;
+    MBGL_CHECK_ERROR(gl::BindVertexArray(0));
 }
 
 void VertexArrayObject::Delete(GLsizei n, const GLuint* arrays) {
-    MBGL_CHECK_ERROR(DeleteVertexArrays(n, arrays));
+    if (!gl::DeleteVertexArrays) return;
+    MBGL_CHECK_ERROR(gl::DeleteVertexArrays(n, arrays));
 }
 
 VertexArrayObject::VertexArrayObject() {
 }
 
 VertexArrayObject::~VertexArrayObject() {
-    if (!DeleteVertexArrays) return;
-
+    if (!gl::DeleteVertexArrays) return;
     if (vao) {
         util::ThreadContext::getGLObjectStore()->abandonVAO(vao);
     }
 }
 
 void VertexArrayObject::bindVertexArrayObject() {
-    if (!GenVertexArrays || !BindVertexArray) {
+    if (!gl::GenVertexArrays || !gl::BindVertexArray) {
         static bool reported = false;
         if (!reported) {
             Log::Warning(Event::OpenGL, "Not using Vertex Array Objects");
@@ -63,9 +37,9 @@ void VertexArrayObject::bindVertexArrayObject() {
     }
 
     if (!vao) {
-        MBGL_CHECK_ERROR(GenVertexArrays(1, &vao));
+        MBGL_CHECK_ERROR(gl::GenVertexArrays(1, &vao));
     }
-    MBGL_CHECK_ERROR(BindVertexArray(vao));
+    MBGL_CHECK_ERROR(gl::BindVertexArray(vao));
 }
 
 void VertexArrayObject::verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer,

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -3,16 +3,18 @@
 
 #include <mbgl/shader/shader.hpp>
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
 #include <stdexcept>
 
 namespace mbgl {
 
+class Shader;
+
 class VertexArrayObject : public util::noncopyable {
 public:
     static void Unbind();
-    static void Delete(GLsizei n, const GLuint* arrays);
 
     VertexArrayObject();
     ~VertexArrayObject();
@@ -46,8 +48,8 @@ public:
         }
     }
 
-    inline GLuint getID() const {
-        return vao;
+    GLuint getID() const {
+        return vao.getID();
     }
 
 private:
@@ -55,7 +57,7 @@ private:
     void storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
     void verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
 
-    GLuint vao = 0;
+    gl::VAOHolder vao;
 
     // For debug reasons, we're storing the bind information so that we can
     // detect errors and report

--- a/src/mbgl/gl/gl_object_store.cpp
+++ b/src/mbgl/gl/gl_object_store.cpp
@@ -1,5 +1,5 @@
 #include <mbgl/gl/gl_object_store.hpp>
-
+#include <mbgl/util/thread_context.hpp>
 #include <mbgl/util/thread.hpp>
 #include <mbgl/geometry/vao.hpp>
 #include <mbgl/gl/gl.hpp>
@@ -8,6 +8,19 @@
 
 namespace mbgl {
 namespace gl {
+
+void ProgramHolder::create() {
+    if (id) return;
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+    id = MBGL_CHECK_ERROR(glCreateProgram());
+}
+
+void ProgramHolder::reset() {
+    if (!id) return;
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+    MBGL_CHECK_ERROR(glDeleteProgram(id));
+    id = 0;
+}
 
 void GLObjectStore::abandonVAO(GLuint vao) {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));

--- a/src/mbgl/gl/gl_object_store.cpp
+++ b/src/mbgl/gl/gl_object_store.cpp
@@ -22,6 +22,20 @@ void ProgramHolder::reset() {
     id = 0;
 }
 
+void ShaderHolder::create() {
+    if (id) return;
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+    id = MBGL_CHECK_ERROR(glCreateShader(type));
+}
+
+void ShaderHolder::reset() {
+    if (!id) return;
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
+    MBGL_CHECK_ERROR(glDeleteShader(id));
+    id = 0;
+}
+
+
 void GLObjectStore::abandonVAO(GLuint vao) {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
     abandonedVAOs.emplace_back(vao);

--- a/src/mbgl/gl/gl_object_store.cpp
+++ b/src/mbgl/gl/gl_object_store.cpp
@@ -1,4 +1,4 @@
-#include <mbgl/util/gl_object_store.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 
 #include <mbgl/util/thread.hpp>
 #include <mbgl/geometry/vao.hpp>
@@ -7,25 +7,25 @@
 #include <cassert>
 
 namespace mbgl {
-namespace util {
+namespace gl {
 
 void GLObjectStore::abandonVAO(GLuint vao) {
-    assert(ThreadContext::currentlyOn(ThreadType::Map));
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
     abandonedVAOs.emplace_back(vao);
 }
 
 void GLObjectStore::abandonBuffer(GLuint buffer) {
-    assert(ThreadContext::currentlyOn(ThreadType::Map));
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
     abandonedBuffers.emplace_back(buffer);
 }
 
 void GLObjectStore::abandonTexture(GLuint texture) {
-    assert(ThreadContext::currentlyOn(ThreadType::Map));
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
     abandonedTextures.emplace_back(texture);
 }
 
 void GLObjectStore::performCleanup() {
-    assert(ThreadContext::currentlyOn(ThreadType::Map));
+    assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
 
     if (!abandonedVAOs.empty()) {
         MBGL_CHECK_ERROR(VertexArrayObject::Delete(static_cast<GLsizei>(abandonedVAOs.size()),
@@ -46,5 +46,5 @@ void GLObjectStore::performCleanup() {
     }
 }
 
-} // namespace util
+} // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/gl_object_store.hpp
+++ b/src/mbgl/gl/gl_object_store.hpp
@@ -4,11 +4,10 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
-#include <cstdint>
 #include <vector>
 
 namespace mbgl {
-namespace util {
+namespace gl {
 
 class GLObjectStore : private util::noncopyable {
 public:
@@ -29,7 +28,7 @@ private:
     std::vector<GLuint> abandonedTextures;
 };
 
-} // namespace util
+} // namespace gl
 } // namespace mbgl
 
 #endif

--- a/src/mbgl/gl/gl_object_store.hpp
+++ b/src/mbgl/gl/gl_object_store.hpp
@@ -36,6 +36,21 @@ public:
     void reset();
 };
 
+class ShaderHolder : public GLHolder {
+public:
+    ShaderHolder(GLenum type_) : type(type_) {}
+    ~ShaderHolder() { reset(); }
+
+    ShaderHolder(ShaderHolder&& o) noexcept : GLHolder(std::move(o)), type(o.type) {}
+    ShaderHolder& operator=(ShaderHolder&& o) noexcept { GLHolder::operator=(std::move(o)); type = o.type; return *this; }
+
+    void create();
+    void reset();
+
+private:
+    GLenum type = 0;
+};
+
 class GLObjectStore : private util::noncopyable {
 public:
     // Mark OpenGL objects for deletion

--- a/src/mbgl/gl/gl_object_store.hpp
+++ b/src/mbgl/gl/gl_object_store.hpp
@@ -4,15 +4,40 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
+#include <memory>
 #include <vector>
 
 namespace mbgl {
 namespace gl {
 
+class GLHolder : private util::noncopyable {
+public:
+    GLHolder() {}
+
+    GLHolder(GLHolder&& o) noexcept : id(o.id) { o.id = 0; }
+    GLHolder& operator=(GLHolder&& o) noexcept { id = o.id; o.id = 0; return *this; }
+
+    explicit operator bool() const { return id; }
+    GLuint getID() const { return id; }
+
+protected:
+    GLuint id = 0;
+};
+
+class ProgramHolder : public GLHolder {
+public:
+    ProgramHolder() = default;
+    ~ProgramHolder() { reset(); }
+
+    ProgramHolder(ProgramHolder&& o) noexcept : GLHolder(std::move(o)) {}
+    ProgramHolder& operator=(ProgramHolder&& o) noexcept { GLHolder::operator=(std::move(o)); return *this; }
+
+    void create();
+    void reset();
+};
+
 class GLObjectStore : private util::noncopyable {
 public:
-    GLObjectStore() = default;
-
     // Mark OpenGL objects for deletion
     void abandonVAO(GLuint vao);
     void abandonBuffer(GLuint buffer);

--- a/src/mbgl/gl/gl_object_store.hpp
+++ b/src/mbgl/gl/gl_object_store.hpp
@@ -51,11 +51,23 @@ private:
     GLenum type = 0;
 };
 
+class BufferHolder : public GLHolder {
+public:
+    BufferHolder() = default;
+    ~BufferHolder() { reset(); }
+
+    BufferHolder(BufferHolder&& o) noexcept : GLHolder(std::move(o)) {}
+    BufferHolder& operator=(BufferHolder&& o) noexcept { GLHolder::operator=(std::move(o)); return *this; }
+
+    void create();
+    void reset();
+};
+
 class GLObjectStore : private util::noncopyable {
 public:
     // Mark OpenGL objects for deletion
     void abandonVAO(GLuint vao);
-    void abandonBuffer(GLuint buffer);
+    void abandon(BufferHolder&&);
     void abandonTexture(GLuint texture);
 
     // Actually remove the objects we marked as abandoned with the above methods.
@@ -63,8 +75,10 @@ public:
     void performCleanup();
 
 private:
+    // We split the holder objects in separate containers because each
+    // GLHolder-derived object can vary in size.
     std::vector<GLuint> abandonedVAOs;
-    std::vector<GLuint> abandonedBuffers;
+    std::vector<BufferHolder> abandonedBuffers;
     std::vector<GLuint> abandonedTextures;
 };
 

--- a/src/mbgl/gl/gl_object_store.hpp
+++ b/src/mbgl/gl/gl_object_store.hpp
@@ -98,10 +98,22 @@ private:
     std::array<GLuint, TextureMax> ids;
 };
 
+class VAOHolder : public GLHolder {
+public:
+    VAOHolder() = default;
+    ~VAOHolder() { reset(); }
+
+    VAOHolder(VAOHolder&& o) noexcept : GLHolder(std::move(o)) {}
+    VAOHolder& operator=(VAOHolder&& o) noexcept { GLHolder::operator=(std::move(o)); return *this; }
+
+    void create();
+    void reset();
+};
+
 class GLObjectStore : private util::noncopyable {
 public:
     // Mark OpenGL objects for deletion
-    void abandonVAO(GLuint vao);
+    void abandon(VAOHolder&&);
     void abandon(BufferHolder&&);
     void abandon(TextureHolder&&);
     void abandon(TexturePoolHolder&&);
@@ -113,7 +125,7 @@ public:
 private:
     // We split the holder objects in separate containers because each
     // GLHolder-derived object can vary in size.
-    std::vector<GLuint> abandonedVAOs;
+    std::vector<VAOHolder> abandonedVAOs;
     std::vector<BufferHolder> abandonedBuffers;
     std::vector<TextureHolder> abandonedTextures;
     std::vector<TexturePoolHolder> abandonedTexturePools;

--- a/src/mbgl/gl/texture_pool.cpp
+++ b/src/mbgl/gl/texture_pool.cpp
@@ -1,4 +1,4 @@
-#include <mbgl/util/texture_pool.hpp>
+#include <mbgl/gl/texture_pool.hpp>
 
 #include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/thread_context.hpp>
@@ -7,7 +7,8 @@
 
 const GLsizei TextureMax = 64;
 
-using namespace mbgl;
+namespace mbgl {
+namespace gl {
 
 GLuint TexturePool::getTextureID() {
     if (texture_ids.empty()) {
@@ -51,3 +52,6 @@ void TexturePool::clearTextureIDs() {
     }
     texture_ids.clear();
 }
+
+} // namespace gl
+} // namespace mbgl

--- a/src/mbgl/gl/texture_pool.cpp
+++ b/src/mbgl/gl/texture_pool.cpp
@@ -31,26 +31,8 @@ GLuint TexturePool::getTextureID() {
 }
 
 void TexturePool::removeTextureID(GLuint texture_id) {
-    bool needs_clear = false;
-
     texture_ids.insert(texture_id);
-
-    if (texture_ids.size() > TextureMax) {
-        needs_clear = true;
-    }
-
-    if (needs_clear) {
     // TODO: We need to find a better way to deal with texture pool cleanup
-//        clearTextureIDs();
-    }
-}
-
-void TexturePool::clearTextureIDs() {
-    auto getGLObjectStore = util::ThreadContext::getGLObjectStore();
-    for (auto texture : texture_ids) {
-        getGLObjectStore->abandonTexture(texture);
-    }
-    texture_ids.clear();
 }
 
 } // namespace gl

--- a/src/mbgl/gl/texture_pool.hpp
+++ b/src/mbgl/gl/texture_pool.hpp
@@ -5,9 +5,9 @@
 #include <mbgl/gl/gl.hpp>
 
 #include <set>
-#include <mutex>
 
 namespace mbgl {
+namespace gl {
 
 class TexturePool : private util::noncopyable {
 
@@ -20,6 +20,7 @@ private:
     std::set<GLuint> texture_ids;
 };
 
+} // namespace gl
 } // namespace mbgl
 
 #endif

--- a/src/mbgl/gl/texture_pool.hpp
+++ b/src/mbgl/gl/texture_pool.hpp
@@ -3,20 +3,36 @@
 
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 
-#include <set>
+#include <algorithm>
+#include <memory>
+#include <vector>
 
 namespace mbgl {
 namespace gl {
 
 class TexturePool : private util::noncopyable {
-
 public:
     GLuint getTextureID();
-    void removeTextureID(GLuint texture_id);
+    void releaseTextureID(GLuint);
 
 private:
-    std::set<GLuint> texture_ids;
+    class Impl : private util::noncopyable {
+    public:
+        Impl() : ids(gl::TexturePoolHolder::TextureMax) {
+            pool.create();
+            std::copy(pool.getIDs().begin(), pool.getIDs().end(), ids.begin());
+        }
+
+        Impl(Impl&& o) : pool(std::move(o.pool)), ids(std::move(o.ids)) {}
+        Impl& operator=(Impl&& o) { pool = std::move(o.pool); ids = std::move(o.ids); return *this; }
+
+        gl::TexturePoolHolder pool;
+        std::vector<GLuint> ids;
+    };
+
+    std::vector<Impl> pools;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/texture_pool.hpp
+++ b/src/mbgl/gl/texture_pool.hpp
@@ -14,7 +14,6 @@ class TexturePool : private util::noncopyable {
 public:
     GLuint getTextureID();
     void removeTextureID(GLuint texture_id);
-    void clearTextureIDs();
 
 private:
     std::set<GLuint> texture_ids;

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -16,7 +16,7 @@
 #include <mbgl/sprite/sprite_atlas.hpp>
 #include <mbgl/sprite/sprite_store.hpp>
 
-#include <mbgl/util/gl_object_store.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/worker.hpp>
 #include <mbgl/util/texture_pool.hpp>
 #include <mbgl/util/exception.hpp>

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -17,8 +17,9 @@
 #include <mbgl/sprite/sprite_store.hpp>
 
 #include <mbgl/gl/gl_object_store.hpp>
+#include <mbgl/gl/texture_pool.hpp>
+
 #include <mbgl/util/worker.hpp>
-#include <mbgl/util/texture_pool.hpp>
 #include <mbgl/util/exception.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/mapbox.hpp>
@@ -33,7 +34,7 @@ MapContext::MapContext(View& view_, FileSource& fileSource, MapMode mode_, GLCon
       data(*dataPtr),
       asyncUpdate([this] { update(); }),
       asyncInvalidate([&view_] { view_.invalidate(); }),
-      texturePool(std::make_unique<TexturePool>()) {
+      texturePool(std::make_unique<gl::TexturePool>()) {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
 
     util::ThreadContext::setFileSource(&fileSource);

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -18,10 +18,11 @@ namespace mbgl {
 
 class View;
 class MapData;
-class TexturePool;
 class Painter;
 class SpriteImage;
 class FileRequest;
+
+namespace gl { class TexturePool; }
 
 struct FrameData {
     std::array<uint16_t, 2> framebufferSize;
@@ -86,7 +87,7 @@ private:
     util::AsyncTask asyncUpdate;
     util::AsyncTask asyncInvalidate;
 
-    std::unique_ptr<TexturePool> texturePool;
+    std::unique_ptr<gl::TexturePool> texturePool;
     std::unique_ptr<Painter> painter;
     std::unique_ptr<Style> style;
 

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -8,9 +8,9 @@
 #include <mbgl/map/map_data.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/util/async_task.hpp>
-#include <mbgl/util/gl_object_store.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/optional.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 
 #include <vector>
 
@@ -80,7 +80,7 @@ private:
     std::unique_ptr<MapData> dataPtr;
     MapData& data;
 
-    util::GLObjectStore glObjectStore;
+    gl::GLObjectStore glObjectStore;
 
     Update updateFlags = Update::Nothing;
     util::AsyncTask asyncUpdate;

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -270,7 +270,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
 
         float zoomFraction = state.getZoomFraction();
 
-        config.program = patternShader->program;
+        config.program = patternShader->getID();
         patternShader->u_matrix = identityMatrix;
         patternShader->u_pattern_tl_a = (*imagePosA).tl;
         patternShader->u_pattern_br_a = (*imagePosA).br;
@@ -325,7 +325,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         color[2] *= properties.opacity;
         color[3] *= properties.opacity;
 
-        config.program = plainShader->program;
+        config.program = plainShader->getID();
         plainShader->u_matrix = identityMatrix;
         plainShader->u_color = color;
         backgroundArray.bind(*plainShader, backgroundBuffer, BUFFER_OFFSET(0));

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -38,7 +38,7 @@ void Painter::renderCircle(CircleBucket& bucket,
     // are inversely related.
     float antialiasing = 1 / data.pixelRatio / properties.radius;
 
-    config.program = circleShader->program;
+    config.program = circleShader->getID();
 
     circleShader->u_matrix = vtxMatrix;
     circleShader->u_exmatrix = extrudeMatrix;

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -13,7 +13,7 @@ void Painter::drawClippingMasks(const std::map<TileID, ClipID>& stencils) {
     mat4 matrix;
     const GLuint mask = 0b11111111;
 
-    config.program = plainShader->program;
+    config.program = plainShader->getID();
     config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
     config.depthTest = GL_FALSE;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -33,7 +33,7 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
         tileData.debugBucket = std::make_unique<DebugBucket>(tileData.id, tileData.getState(), tileData.modified, tileData.expires, data.getDebug());
     }
 
-    config.program = plainShader->program;
+    config.program = plainShader->getID();
     plainShader->u_matrix = matrix;
 
     // Draw white outline
@@ -66,7 +66,7 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
 
-    config.program = plainShader->program;
+    config.program = plainShader->getID();
     plainShader->u_matrix = matrix;
 
     // draw tile outline

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -44,7 +44,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // befrom, we have to draw the outline first (!)
     if (outline && pass == RenderPass::Translucent) {
-        config.program = outlineShader->program;
+        config.program = outlineShader->getID();
         outlineShader->u_matrix = vtxMatrix;
         config.lineWidth = 2.0f; // This is always fixed and does not depend on the pixelRatio!
 
@@ -78,7 +78,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
                     1.0f / ((*posB).size[0] * factor * properties.pattern.value.toScale),
                     1.0f / ((*posB).size[1] * factor * properties.pattern.value.toScale));
 
-            config.program = patternShader->program;
+            config.program = patternShader->getID();
             patternShader->u_matrix = vtxMatrix;
             patternShader->u_pattern_tl_a = (*posA).tl;
             patternShader->u_pattern_br_a = (*posA).br;
@@ -125,7 +125,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
             // fragments or when it's translucent and we're drawing translucent
             // fragments
             // Draw filling rectangle.
-            config.program = plainShader->program;
+            config.program = plainShader->getID();
             plainShader->u_matrix = vtxMatrix;
             plainShader->u_color = fill_color;
 
@@ -138,7 +138,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // below, we have to draw the outline first (!)
     if (fringeline && pass == RenderPass::Translucent) {
-        config.program = outlineShader->program;
+        config.program = outlineShader->getID();
         outlineShader->u_matrix = vtxMatrix;
         config.lineWidth = 2.0f; // This is always fixed and does not depend on the pixelRatio!
 

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -70,7 +70,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
 
     if (!properties.dasharray.value.from.empty()) {
 
-        config.program = linesdfShader->program;
+        config.program = linesdfShader->getID();
 
         linesdfShader->u_matrix = vtxMatrix;
         linesdfShader->u_exmatrix = extrudeMatrix;
@@ -113,7 +113,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
 
         float factor = util::EXTENT / (512 * id.overscaling) / std::pow(2, state.getIntegerZoom() - id.z);
 
-        config.program = linepatternShader->program;
+        config.program = linepatternShader->getID();
 
         linepatternShader->u_matrix = vtxMatrix;
         linepatternShader->u_exmatrix = extrudeMatrix;
@@ -139,7 +139,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         bucket.drawLinePatterns(*linepatternShader);
 
     } else {
-        config.program = lineShader->program;
+        config.program = lineShader->getID();
 
         lineShader->u_matrix = vtxMatrix;
         lineShader->u_exmatrix = extrudeMatrix;

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -12,7 +12,7 @@ void Painter::renderRaster(RasterBucket& bucket, const RasterLayer& layer, const
     const RasterPaintProperties& properties = layer.paint;
 
     if (bucket.hasData()) {
-        config.program = rasterShader->program;
+        config.program = rasterShader->getID();
         rasterShader->u_matrix = matrix;
         rasterShader->u_buffer = 0;
         rasterShader->u_opacity = properties.opacity;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -49,7 +49,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
     float fontScale = fontSize / sdfFontSize;
     matrix::scale(exMatrix, exMatrix, fontScale, fontScale, 1.0f);
 
-    config.program = sdfShader.program;
+    config.program = sdfShader.getID();
     sdfShader.u_matrix = vtxMatrix;
     sdfShader.u_exmatrix = exMatrix;
     sdfShader.u_texsize = texsize;
@@ -211,7 +211,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
             float x = state.getHeight() / 2.0f * std::tan(state.getPitch());
             float extra = (topedgelength + x) / topedgelength - 1;
 
-            config.program = iconShader->program;
+            config.program = iconShader->getID();
             iconShader->u_matrix = vtxMatrix;
             iconShader->u_exmatrix = exMatrix;
             iconShader->u_texsize = {{ float(activeSpriteAtlas->getWidth()) / 4.0f, float(activeSpriteAtlas->getHeight()) / 4.0f }};
@@ -259,7 +259,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
         config.stencilOp.reset();
         config.stencilTest = GL_TRUE;
 
-        config.program = collisionBoxShader->program;
+        config.program = collisionBoxShader->getID();
         collisionBoxShader->u_matrix = matrix;
         collisionBoxShader->u_scale = std::pow(2, state.getZoom() - id.z);
         collisionBoxShader->u_zoom = state.getZoom() * 10;

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -5,7 +5,7 @@
 
 using namespace mbgl;
 
-RasterBucket::RasterBucket(TexturePool& texturePool)
+RasterBucket::RasterBucket(gl::TexturePool& texturePool)
 : raster(texturePool) {
 }
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -12,7 +12,7 @@ class VertexArrayObject;
 
 class RasterBucket : public Bucket {
 public:
-    RasterBucket(TexturePool&);
+    RasterBucket(gl::TexturePool&);
 
     void upload() override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;

--- a/src/mbgl/shader/box_shader.cpp
+++ b/src/mbgl/shader/box_shader.cpp
@@ -9,8 +9,8 @@ using namespace mbgl;
 
 CollisionBoxShader::CollisionBoxShader()
     : Shader("collisionbox", shaders::box::vertex, shaders::box::fragment) {
-    a_extrude = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_extrude"));
-    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
+    a_extrude = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_extrude"));
+    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
 }
 
 void CollisionBoxShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -8,9 +8,9 @@
 using namespace mbgl;
 
 IconShader::IconShader() : Shader("icon", shaders::icon::vertex, shaders::icon::fragment) {
-    a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_offset"));
-    a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data1"));
-    a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data2"));
+    a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset"));
+    a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1"));
+    a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"));
 }
 
 void IconShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -8,7 +8,7 @@
 using namespace mbgl;
 
 LineShader::LineShader() : Shader("line", shaders::line::vertex, shaders::line::fragment) {
-    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
+    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
 }
 
 void LineShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -9,7 +9,7 @@ using namespace mbgl;
 
 LinepatternShader::LinepatternShader()
     : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment) {
-    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
+    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
 }
 
 void LinepatternShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -9,7 +9,7 @@ using namespace mbgl;
 
 LineSDFShader::LineSDFShader()
     : Shader("line", shaders::linesdf::vertex, shaders::linesdf::fragment) {
-    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data"));
+    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
 }
 
 void LineSDFShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -8,9 +8,9 @@
 using namespace mbgl;
 
 SDFShader::SDFShader() : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment) {
-    a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_offset"));
-    a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data1"));
-    a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(program, "a_data2"));
+    a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset"));
+    a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1"));
+    a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"));
 }
 
 void SDFGlyphShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -2,11 +2,8 @@
 #define MBGL_RENDERER_SHADER
 
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
-
-#include <cstdint>
-#include <array>
-#include <string>
 
 namespace mbgl {
 
@@ -16,10 +13,9 @@ public:
 
     ~Shader();
     const GLchar *name;
-    GLuint program;
 
-    inline GLuint getID() const {
-        return program;
+    inline const GLuint& getID() const {
+        return program.getID();
     }
 
     virtual void bind(GLbyte *offset) = 0;
@@ -30,6 +26,7 @@ protected:
 private:
     bool compileShader(GLuint *shader, GLenum type, const GLchar *source[]);
 
+    gl::ProgramHolder program;
     GLuint vertShader = 0;
     GLuint fragShader = 0;
 };

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -14,7 +14,7 @@ public:
     ~Shader();
     const GLchar *name;
 
-    inline const GLuint& getID() const {
+    GLuint getID() const {
         return program.getID();
     }
 
@@ -24,11 +24,11 @@ protected:
     GLint a_pos = -1;
 
 private:
-    bool compileShader(GLuint *shader, GLenum type, const GLchar *source[]);
+    bool compileShader(gl::ShaderHolder&, const GLchar *source[]);
 
     gl::ProgramHolder program;
-    GLuint vertShader = 0;
-    GLuint fragShader = 0;
+    gl::ShaderHolder vertexShader = { GL_VERTEX_SHADER };
+    gl::ShaderHolder fragmentShader = { GL_FRAGMENT_SHADER };
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/uniform.hpp
+++ b/src/mbgl/shader/uniform.hpp
@@ -4,13 +4,15 @@
 #include <mbgl/shader/shader.hpp>
 #include <mbgl/gl/gl.hpp>
 
+#include <array>
+
 namespace mbgl {
 
 template <typename T>
 class Uniform {
 public:
     Uniform(const GLchar* name, const Shader& shader) : current() {
-         location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.program, name));
+         location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.getID(), name));
     }
 
     void operator=(const T& t) {
@@ -33,7 +35,7 @@ public:
     typedef std::array<float, C*R> T;
 
     UniformMatrix(const GLchar* name, const Shader& shader) : current() {
-        location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.program, name));
+        location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.getID(), name));
     }
 
     void operator=(const std::array<double, C*R>& t) {

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -3,7 +3,7 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
-#include <mbgl/util/gl_object_store.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/constants.hpp>

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/geometry/binpack.hpp>
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/optional.hpp>
@@ -94,7 +95,7 @@ private:
     std::unique_ptr<uint32_t[]> data;
     std::atomic<bool> dirty;
     bool fullUploadRequired = true;
-    GLuint texture = 0;
+    gl::TextureHolder texture;
     uint32_t filter = 0;
     static const int buffer = 1;
 };

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -116,7 +116,7 @@ void Style::removeLayer(const std::string& id) {
 }
 
 void Style::update(const TransformState& transform,
-                   TexturePool& texturePool) {
+                   gl::TexturePool& texturePool) {
     bool allTilesUpdated = true;
     StyleUpdateParameters parameters(data.pixelRatio,
                                      data.getDebug(),

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -26,10 +26,10 @@ class SpriteAtlas;
 class LineAtlas;
 class StyleLayer;
 class TransformState;
-class TexturePool;
-
 class Tile;
 class Bucket;
+
+namespace gl { class TexturePool; }
 
 struct RenderItem {
     inline RenderItem(const StyleLayer& layer_,
@@ -79,7 +79,7 @@ public:
 
     // Fetch the tiles needed by the current viewport and emit a signal when
     // a tile is ready so observers can render the tile.
-    void update(const TransformState&, TexturePool&);
+    void update(const TransformState&, gl::TexturePool&);
 
     void cascade();
     void recalculate(float z);

--- a/src/mbgl/style/style_update_parameters.hpp
+++ b/src/mbgl/style/style_update_parameters.hpp
@@ -7,9 +7,9 @@ namespace mbgl {
 
 class TransformState;
 class Worker;
-class TexturePool;
 class MapData;
 class Style;
+namespace gl { class TexturePool; }
 
 class StyleUpdateParameters {
 public:
@@ -18,7 +18,7 @@ public:
                           TimePoint animationTime_,
                           const TransformState& transformState_,
                           Worker& worker_,
-                          TexturePool& texturePool_,
+                          gl::TexturePool& texturePool_,
                           bool shouldReparsePartialTiles_,
                           const MapMode mode_,
                           MapData& data_,
@@ -39,7 +39,7 @@ public:
     TimePoint animationTime;
     const TransformState& transformState;
     Worker& worker;
-    TexturePool& texturePool;
+    gl::TexturePool& texturePool;
     bool shouldReparsePartialTiles;
     const MapMode mode;
 

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -11,7 +11,7 @@ using namespace mbgl;
 RasterTileData::RasterTileData(const TileID& id_,
                                float pixelRatio,
                                const std::string& urlTemplate,
-                               TexturePool &texturePool_,
+                               gl::TexturePool &texturePool_,
                                Worker& worker_,
                                const std::function<void(std::exception_ptr)>& callback)
     : TileData(id_),

--- a/src/mbgl/tile/raster_tile_data.hpp
+++ b/src/mbgl/tile/raster_tile_data.hpp
@@ -8,15 +8,15 @@ namespace mbgl {
 
 class FileRequest;
 class StyleLayer;
-class TexturePool;
 class WorkRequest;
+namespace gl { class TexturePool; }
 
 class RasterTileData : public TileData {
 public:
     RasterTileData(const TileID&,
                    float pixelRatio,
                    const std::string& urlTemplate,
-                   TexturePool&,
+                   gl::TexturePool&,
                    Worker&,
                    const std::function<void(std::exception_ptr)>& callback);
     ~RasterTileData();
@@ -25,7 +25,7 @@ public:
     Bucket* getBucket(StyleLayer const &layer_desc) override;
 
 private:
-    TexturePool& texturePool;
+    gl::TexturePool& texturePool;
     Worker& worker;
     std::unique_ptr<FileRequest> req;
     std::unique_ptr<Bucket> bucket;

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -15,7 +15,7 @@ Raster::Raster(gl::TexturePool& texturePool_)
 
 Raster::~Raster() {
     if (textured) {
-        texturePool.removeTextureID(textureID);
+        texturePool.releaseTextureID(textureID);
         textureID = 0;
     }
 }

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -9,7 +9,7 @@
 
 using namespace mbgl;
 
-Raster::Raster(TexturePool& texturePool_)
+Raster::Raster(gl::TexturePool& texturePool_)
     : texturePool(texturePool_)
 {}
 

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -15,7 +15,8 @@ Raster::Raster(gl::TexturePool& texturePool_)
 
 Raster::~Raster() {
     if (textured) {
-        texturePool.removeTextureID(texture);
+        texturePool.removeTextureID(textureID);
+        textureID = 0;
     }
 }
 
@@ -45,7 +46,7 @@ void Raster::bind(bool linear) {
     if (img.data && !textured) {
         upload();
     } else if (textured) {
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
+        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, textureID));
     }
 
     GLint new_filter = linear ? GL_LINEAR : GL_NEAREST;
@@ -58,8 +59,8 @@ void Raster::bind(bool linear) {
 
 void Raster::upload() {
     if (img.data && !textured) {
-        texture = texturePool.getTextureID();
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture));
+        textureID = texturePool.getTextureID();
+        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, textureID));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
 #endif

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -38,7 +38,7 @@ public:
     bool textured = false;
 
     // the uploaded texture
-    GLuint texture = 0;
+    GLuint textureID = 0;
 
     // texture opacity
     double opacity = 0;

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -2,7 +2,7 @@
 #define MBGL_UTIL_RASTER
 
 #include <mbgl/gl/gl.hpp>
-#include <mbgl/util/texture_pool.hpp>
+#include <mbgl/gl/texture_pool.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/chrono.hpp>
@@ -14,7 +14,7 @@ namespace mbgl {
 class Raster : public std::enable_shared_from_this<Raster> {
 
 public:
-    Raster(TexturePool&);
+    Raster(gl::TexturePool&);
     ~Raster();
 
     // load image data
@@ -50,7 +50,7 @@ private:
     bool loaded = false;
 
     // shared texture pool
-    TexturePool& texturePool;
+    gl::TexturePool& texturePool;
 
     // min/mag filter
     GLint filter = 0;

--- a/src/mbgl/util/texture_pool.cpp
+++ b/src/mbgl/util/texture_pool.cpp
@@ -1,6 +1,6 @@
 #include <mbgl/util/texture_pool.hpp>
 
-#include <mbgl/util/gl_object_store.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/thread_context.hpp>
 
 #include <vector>

--- a/src/mbgl/util/thread_context.cpp
+++ b/src/mbgl/util/thread_context.cpp
@@ -60,7 +60,7 @@ void ThreadContext::setFileSource(FileSource* fileSource) {
     }
 }
 
-GLObjectStore* ThreadContext::getGLObjectStore() {
+gl::GLObjectStore* ThreadContext::getGLObjectStore() {
     if (current.get() != nullptr) {
         return current.get()->glObjectStore;
     } else {
@@ -68,7 +68,7 @@ GLObjectStore* ThreadContext::getGLObjectStore() {
     }
 }
 
-void ThreadContext::setGLObjectStore(GLObjectStore* glObjectStore) {
+void ThreadContext::setGLObjectStore(gl::GLObjectStore* glObjectStore) {
     if (current.get() != nullptr) {
         current.get()->glObjectStore = glObjectStore;
     } else {

--- a/src/mbgl/util/thread_context.hpp
+++ b/src/mbgl/util/thread_context.hpp
@@ -8,10 +8,9 @@
 namespace mbgl {
 
 class FileSource;
+namespace gl { class GLObjectStore; }
 
 namespace util {
-
-class GLObjectStore;
 
 enum class ThreadPriority : bool {
     Regular,
@@ -37,15 +36,15 @@ public:
 
     static FileSource* getFileSource();
     static void setFileSource(FileSource* fileSource);
-    static GLObjectStore* getGLObjectStore();
-    static void setGLObjectStore(GLObjectStore* glObjectStore);
+    static gl::GLObjectStore* getGLObjectStore();
+    static void setGLObjectStore(gl::GLObjectStore* glObjectStore);
 
     std::string name;
     ThreadType type;
     ThreadPriority priority;
 
     FileSource* fileSource = nullptr;
-    GLObjectStore* glObjectStore = nullptr;
+    gl::GLObjectStore* glObjectStore = nullptr;
 };
 
 } // namespace util

--- a/test/api/custom_layer.cpp
+++ b/test/api/custom_layer.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/layer/custom_layer.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/mat4.hpp>
+#include <mbgl/gl/gl_object_store.hpp>
 
 using namespace mbgl;
 
@@ -17,38 +18,35 @@ class TestLayer {
 public:
     ~TestLayer() {
         if (program) {
-            MBGL_CHECK_ERROR(glDeleteBuffers(1, &buffer));
-            MBGL_CHECK_ERROR(glDetachShader(program, vertexShader));
-            MBGL_CHECK_ERROR(glDetachShader(program, fragmentShader));
-            MBGL_CHECK_ERROR(glDeleteShader(vertexShader));
-            MBGL_CHECK_ERROR(glDeleteShader(fragmentShader));
-            MBGL_CHECK_ERROR(glDeleteProgram(program));
+            MBGL_CHECK_ERROR(glDetachShader(program.getID(), vertexShader.getID()));
+            MBGL_CHECK_ERROR(glDetachShader(program.getID(), fragmentShader.getID()));
         }
     }
 
     void initialize() {
-        program = MBGL_CHECK_ERROR(glCreateProgram());
-        vertexShader = MBGL_CHECK_ERROR(glCreateShader(GL_VERTEX_SHADER));
-        fragmentShader = MBGL_CHECK_ERROR(glCreateShader(GL_FRAGMENT_SHADER));
+        program.create();
+        vertexShader.create();
+        fragmentShader.create();
 
-        MBGL_CHECK_ERROR(glShaderSource(vertexShader, 1, &vertexShaderSource, nullptr));
-        MBGL_CHECK_ERROR(glCompileShader(vertexShader));
-        MBGL_CHECK_ERROR(glAttachShader(program, vertexShader));
-        MBGL_CHECK_ERROR(glShaderSource(fragmentShader, 1, &fragmentShaderSource, nullptr));
-        MBGL_CHECK_ERROR(glCompileShader(fragmentShader));
-        MBGL_CHECK_ERROR(glAttachShader(program, fragmentShader));
-        MBGL_CHECK_ERROR(glLinkProgram(program));
-        a_pos = glGetAttribLocation(program, "a_pos");
+        MBGL_CHECK_ERROR(glShaderSource(vertexShader.getID(), 1, &vertexShaderSource, nullptr));
+        MBGL_CHECK_ERROR(glCompileShader(vertexShader.getID()));
+        MBGL_CHECK_ERROR(glAttachShader(program.getID(), vertexShader.getID()));
+        MBGL_CHECK_ERROR(glShaderSource(fragmentShader.getID(), 1, &fragmentShaderSource, nullptr));
+        MBGL_CHECK_ERROR(glCompileShader(fragmentShader.getID()));
+        MBGL_CHECK_ERROR(glAttachShader(program.getID(), fragmentShader.getID()));
+        MBGL_CHECK_ERROR(glLinkProgram(program.getID()));
+        a_pos = glGetAttribLocation(program.getID(), "a_pos");
 
-        GLfloat background[] = { -1,-1, 1,-1, -1,1, 1,1 };
-        MBGL_CHECK_ERROR(glGenBuffers(1, &buffer));
-        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer));
+        buffer.create();
+        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer.getID()));
+
+        GLfloat background[] = { -1,-1, 1,-1,-1, 1, 1, 1 };
         MBGL_CHECK_ERROR(glBufferData(GL_ARRAY_BUFFER, 8 * sizeof(GLfloat), background, GL_STATIC_DRAW));
     }
 
     void render() {
-        MBGL_CHECK_ERROR(glUseProgram(program));
-        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer));
+        MBGL_CHECK_ERROR(glUseProgram(program.getID()));
+        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer.getID()));
         MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
         MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_FLOAT, GL_FALSE, 0, NULL));
         MBGL_CHECK_ERROR(glDisable(GL_STENCIL_TEST));
@@ -56,10 +54,10 @@ public:
         MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
     }
 
-    GLuint program = 0;
-    GLuint vertexShader = 0;
-    GLuint fragmentShader = 0;
-    GLuint buffer = 0;
+    gl::ProgramHolder program;
+    gl::ShaderHolder vertexShader = { GL_VERTEX_SHADER };
+    gl::ShaderHolder fragmentShader = { GL_FRAGMENT_SHADER };
+    gl::BufferHolder buffer;
     GLuint a_pos = 0;
 };
 

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -12,7 +12,7 @@
 #include <mbgl/map/transform.hpp>
 #include <mbgl/map/map_data.hpp>
 #include <mbgl/util/worker.hpp>
-#include <mbgl/util/texture_pool.hpp>
+#include <mbgl/gl/texture_pool.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/style_update_parameters.hpp>
 #include <mbgl/layer/line_layer.hpp>
@@ -29,7 +29,7 @@ public:
     Transform transform { view, ConstrainMode::HeightOnly };
     TransformState transformState;
     Worker worker { 1 };
-    TexturePool texturePool;
+    gl::TexturePool texturePool;
     MapData mapData { MapMode::Still, GLContextMode::Unique, 1.0 };
     Style style { mapData };
 


### PR DESCRIPTION
Main changes:
- Implement the following wrappers: `ProgramObject`, `ShaderObject`, `BufferObject`, `TextureObject` and `VAOObject`. These wrappers are used inside `std::unique_ptr` to provide RAII.
- Rewrite `TexturePool` to provide proper texture object cleanup.
- Simplify `GLObjectStore` code.
- Rewrite `CustomLayer` tests to verify GL object wrappers implementation.

/cc @jfirebaugh @kkaefer @tmpsantos