### PR TITLE
Fix coordinate bounds documentation.

### DIFF
--- a/platform/darwin/include/MGLGeometry.h
+++ b/platform/darwin/include/MGLGeometry.h
@@ -72,8 +72,7 @@ NS_INLINE MGLCoordinateBounds MGLCoordinateBoundsOffset(MGLCoordinateBounds boun
 }
 
 /** Returns `YES` if the coordinate bounds covers no area.
-
-    Note that a bounds may be empty but have a non-zero coordinate span (e.g., when its northeast point lies due north of its southwest point). */
+  Note that a bounds may be empty but have a non-zero coordinate span (e.g., when its northeast point lies due north of its southwest point). */
 NS_INLINE BOOL MGLCoordinateBoundsIsEmpty(MGLCoordinateBounds bounds) {
     MGLCoordinateSpan span = MGLCoordinateBoundsGetCoordinateSpan(bounds);
     return span.latitudeDelta == 0 || span.longitudeDelta == 0;


### PR DESCRIPTION
<img width="695" alt="2016-02-15 at 12 43 pm" src="https://cloud.githubusercontent.com/assets/32314/13056184/b83fcc76-d3e1-11e5-9641-f23a44554a61.png">

4-space indentation was being intepreted as a Markdown code block