### PR TITLE
[core] Crash on the OnlineFileSource

### DIFF
--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -16,7 +16,7 @@
 #include <algorithm>
 #include <cassert>
 #include <list>
-#include <set>
+#include <unordered_set>
 #include <unordered_map>
 
 namespace mbgl {
@@ -135,7 +135,7 @@ private:
     std::unordered_map<FileRequest*, std::unique_ptr<OnlineFileRequestImpl>> allRequests;
     std::list<FileRequest*> pendingRequestsList;
     std::unordered_map<FileRequest*, std::list<FileRequest*>::iterator> pendingRequestsMap;
-    std::set<FileRequest*> activeRequests;
+    std::unordered_set<FileRequest*> activeRequests;
 
     const std::unique_ptr<HTTPContextBase> httpContext { HTTPContextBase::createContext() };
     util::AsyncTask reachability { std::bind(&Impl::networkIsReachableAgain, this) };

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <list>
 #include <set>
 #include <unordered_map>
 
@@ -62,6 +63,12 @@ public:
         allRequests.erase(key);
         if (activeRequests.erase(key)) {
             activatePendingRequest();
+        } else {
+            auto it = pendingRequestsMap.find(key);
+            if (it != pendingRequestsMap.end()) {
+                pendingRequestsList.erase(it->second);
+                pendingRequestsMap.erase(it);
+            }
         }
     }
 
@@ -78,7 +85,8 @@ public:
     }
 
     void queueRequest(OnlineFileRequestImpl* impl) {
-        pendingRequests.push(impl->key);
+        auto it = pendingRequestsList.insert(pendingRequestsList.end(), impl->key);
+        pendingRequestsMap.emplace(impl->key, std::move(it));
     }
 
     void activateRequest(OnlineFileRequestImpl* impl) {
@@ -92,19 +100,18 @@ public:
     }
 
     void activatePendingRequest() {
-        while (!pendingRequests.empty()) {
-            FileRequest* key = pendingRequests.front();
-            pendingRequests.pop();
-
-            auto it = allRequests.find(key);
-            if (it == allRequests.end()) {
-                // It must have been cancelled.
-                continue;
-            }
-
-            activateRequest(it->second.get());
+        if (pendingRequestsList.empty()) {
             return;
         }
+
+        FileRequest* key = pendingRequestsList.front();
+        pendingRequestsList.pop_front();
+
+        pendingRequestsMap.erase(key);
+
+        auto it = allRequests.find(key);
+        assert(it != allRequests.end());
+        activateRequest(it->second.get());
     }
 
 private:
@@ -126,7 +133,8 @@ private:
      * `pendingRequests`. Requests in the active state are in `activeRequests`.
      */
     std::unordered_map<FileRequest*, std::unique_ptr<OnlineFileRequestImpl>> allRequests;
-    std::queue<FileRequest*> pendingRequests;
+    std::list<FileRequest*> pendingRequestsList;
+    std::unordered_map<FileRequest*, std::list<FileRequest*>::iterator> pendingRequestsMap;
     std::set<FileRequest*> activeRequests;
 
     const std::unique_ptr<HTTPContextBase> httpContext { HTTPContextBase::createContext() };


### PR DESCRIPTION
Hit this one today testing  a3f8710574fe1a0c on Linux.

Can be reproduced by maximizing the window and full tilt (i.e. load as many tiles as possibles). After that, rotate the map as fast as possible.

```
#0  0x00007fd2daeac3f6 in std::string::assign(std::string const&) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x000000000054ec8b in std::string::operator= (__str=..., this=<optimized out>) at /usr/include/c++/5/bits/basic_string.h:2951
#2  std::experimental::fundamentals_v1::_Optional_base<std::string, true>::operator= (__other=..., this=0x7fd2c08e0388)
    at /usr/include/c++/5/experimental/optional:256
#3  std::experimental::fundamentals_v1::optional<std::string>::operator= (this=0x7fd2c08e0388)
    at /usr/include/c++/5/experimental/optional:477
#4  mbgl::OnlineFileRequestImpl::completed (this=0x7fd2c08e0330, impl=..., response=...)
    at ../../platform/default/online_file_source.cpp:267
#5  0x0000000000551ec4 in mbgl::OnlineFileSource::Impl::activateRequest(mbgl::OnlineFileRequestImpl*)::{lambda(mbgl::Response)#1}::operator()(mbgl::Response) const (response=..., __closure=0x7fd2c0bf0568) at ../../platform/default/online_file_source.cpp:90
#6  std::_Function_handler<void (mbgl::Response), mbgl::OnlineFileSource::Impl::activateRequest(mbgl::OnlineFileRequestImpl*)::{lambda(mbgl::Response)#1}>::_M_invoke(std::_Any_data const&, mbgl::Response&&) (__functor=..., __args#0=<optimized out>)
    at /usr/include/c++/5/functional:1871
#7  0x00000000005667d9 in std::function<void (mbgl::Response)>::operator()(mbgl::Response) const (__args#0=..., 
    this=0x7fd2c0bf0568) at /usr/include/c++/5/functional:2267
#8  mbgl::HTTPCURLRequest::handleResult (this=0x7fd2c0bf0500, code=<optimized out>)
    at ../../platform/default/http_request_curl.cpp:537
#9  0x0000000000567426 in mbgl::HTTPCURLContext::checkMultiInfo (this=this@entry=0x7fd2c0001440)
    at ../../platform/default/http_request_curl.cpp:167
#10 0x00000000005674ec in mbgl::HTTPCURLContext::perform (this=0x7fd2c0001440, s=<optimized out>, events=<optimized out>)
    at ../../platform/default/http_request_curl.cpp:192
#11 0x000000000053d1db in std::function<void (int, mbgl::util::RunLoop::Event)>::operator()(int, mbgl::util::RunLoop::Event) const
    (__args#1=mbgl::util::RunLoop::Event::Read, __args#0=48, this=<optimized out>) at /usr/include/c++/5/functional:2267
#12 mbgl::util::Watch::onEvent (poll=<optimized out>, event=<optimized out>) at ../../platform/default/run_loop.cpp:45
#13 0x00000000005f1f2e in uv__io_poll (loop=0x7fd2c0000c70, timeout=21) at src/unix/linux-core.c:345
#14 0x00000000005e9003 in uv_run (loop=0x7fd2c0000c70, mode=mode@entry=UV_RUN_DEFAULT) at src/unix/core.c:341
#15 0x000000000053b47f in mbgl::util::RunLoop::run (this=this@entry=0x7fd2ce2ccd70) at ../../platform/default/run_loop.cpp:157
#16 0x00000000005532b5 in mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::run<std::tuple<int>, 0ul>(mbgl::util::ThreadContext, std::tuple<int>&&, std::integer_sequence<unsigned long, 0ul>) (this=0x7fd2c8006520, context=..., 
    params=params@entry=<unknown type in /opt/tmpsantos/Projects/mapbox-gl-native/build/linux-x86_64/Release/mapbox-gl, CU 0x1a74ee3, DIE 0x1adf388>) at ../../src/mbgl/util/thread.hpp:124
#17 0x0000000000553768 in mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::Thread<int>(mbgl::util::ThreadContext const&, int&&)::{lambda()#1}::operator()() const (__closure=0x7fd2c80030d8) at ../../src/mbgl/util/thread.hpp:106
#18 std::_Bind_simple<mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::Thread<int>(mbgl::util::ThreadContext const&, int&&)::{lambda()#1} ()>::_M_invoke<>(std::_Index_tuple<>) (this=0x7fd2c80030d8) at /usr/include/c++/5/functional:1531
#19 std::_Bind_simple<mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::Thread<int>(mbgl::util::ThreadContext const&, int&&)::{lambda()#1} ()>::operator()() (this=0x7fd2c80030d8) at /usr/include/c++/5/functional:1520
#20 std::thread::_Impl<std::_Bind_simple<mbgl::util::Thread<mbgl::OnlineFileSource::Impl>::Thread<int>(mbgl::util::ThreadContext co---Type <return> to continue, or q <return> to quit---
nst&, int&&)::{lambda()#1} ()> >::_M_run() (this=0x7fd2c80030c0) at /usr/include/c++/5/thread:115
#21 0x00007fd2dae94c30 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#22 0x00007fd2dbb2e66a in start_thread (arg=0x7fd2ce2cd700) at pthread_create.c:333
#23 0x00007fd2da902e4d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```

/cc @jfirebaugh 