### PR TITLE
Generate unit tests coverage report via lcov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.actual.png
 *.diff.png
 *.pyc
+*.gcno
+*.gcda
 offline.db
 /platform/android/debug
 /platform/android/sdk

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ ifeq ($(BUILD),osx)
 xtest: ; $(RUN) HOST=osx HOST_VERSION=x86_64 Xcode/test
 endif
 
+.PHONY: check
+check: ; $(RUN) BUILDTYPE=Debug check
+
 .PHONY: render
 render: ; $(RUN) Makefile/mbgl-render
 

--- a/gyp/common.gypi
+++ b/gyp/common.gypi
@@ -88,7 +88,18 @@
     ],
     'configurations': {
       'Debug': {
-        'cflags_cc': [ '-g', '-O0', '-fno-omit-frame-pointer','-fwrapv', '-fstack-protector-all', '-fno-common' ],
+        'cflags_cc': [
+          '-g',
+          '-O0',
+          '-fno-omit-frame-pointer',
+          '-fwrapv',
+          '-fstack-protector-all',
+          '-fno-common',
+          '--coverage',
+        ],
+        'ldflags': [
+          '--coverage',
+        ],
         'defines': [ 'DEBUG' ],
         'xcode_settings': {
           'GCC_OPTIMIZATION_LEVEL': '0',

--- a/gyp/common.gypi
+++ b/gyp/common.gypi
@@ -106,7 +106,9 @@
           'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES',
           'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
           'DEAD_CODE_STRIPPING': 'NO',
-          'OTHER_CPLUSPLUSFLAGS': [ '-fno-omit-frame-pointer','-fwrapv', '-fstack-protector-all', '-fno-common']
+          'GCC_INSTRUMENT_PROGRAM_FLOW_ARCS': 'YES',
+          'GCC_GENERATE_TEST_COVERAGE_FILES': 'YES',
+          'OTHER_CPLUSPLUSFLAGS': [ '-fno-omit-frame-pointer','-fwrapv', '-fstack-protector-all', '-fno-common', '-fprofile-arcs', '-ftest-coverage' ],
         }
       },
       'Release': {

--- a/platform/linux/mapboxgl-app.gypi
+++ b/platform/linux/mapboxgl-app.gypi
@@ -47,7 +47,14 @@
             'OTHER_LDFLAGS': [ '<@(ldflags)' ],
             'SDKROOT': 'macosx',
             'MACOSX_DEPLOYMENT_TARGET': '10.10',
-          }
+          },
+          'configurations': {
+            'Debug': {
+              'xcode_settings': {
+                'OTHER_LDFLAGS': [ '-lgcov' ],
+              },
+            },
+          },
         }, {
           'cflags_cc': [ '<@(cflags_cc)' ],
           'libraries': [ '<@(libraries)', '<@(ldflags)' ],

--- a/scripts/collect-coverage.sh
+++ b/scripts/collect-coverage.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+function usage() {
+    echo "Error: LCOV and genhtml are required for generating coverage reports."
+    if [ `uname -s` = 'Linux' ]; then
+        echo "On Debian-based distros, you can install them via 'apt-get install lcov'"
+    elif [ `uname -s` = 'Darwin' ]; then
+        echo "On OS X, you can install them via 'brew install lcov'"
+    fi
+    exit 1
+}
+
+command -v lcov >/dev/null 2>&1 || usage
+command -v genhtml >/dev/null 2>&1 || usage
+
+# Zero coverage counters
+lcov \
+    --quiet \
+    --zerocounters \
+    --directory "build/${HOST_SLUG}/${BUILDTYPE}" \
+    --output-file "build/${HOST_SLUG}/${BUILDTYPE}/coverage.info" \
+    >/dev/null 2>&1
+
+# Run all unit tests
+./scripts/run_tests.sh "build/${HOST_SLUG}/${BUILDTYPE}/test"
+
+# Collect coverage data and save it into coverage.info
+echo "Collecting coverage data..."
+lcov \
+    --quiet \
+    --capture \
+    --no-external \
+    --directory "src/mbgl" \
+    --directory "platform" \
+    --directory "include/mbgl" \
+    --directory "build/${HOST_SLUG}/${BUILDTYPE}" \
+    --base-directory "build/${HOST_SLUG}/${BUILDTYPE}" \
+    --output-file "build/${HOST_SLUG}/${BUILDTYPE}/coverage.info" \
+    >/dev/null 2>&1
+
+# Generate HTML report based on coverage.info
+echo "Generating HTML report..."
+genhtml \
+    --quiet \
+    --show-details \
+    --keep-descriptions \
+    --function-coverage \
+    --no-branch-coverage \
+    --title "Mapbox GL Native" \
+    --num-spaces 4 \
+    --sort \
+    --demangle-cpp \
+    --prefix $(pwd -P) \
+    --output-directory "build/${HOST_SLUG}/${BUILDTYPE}/coverage" \
+    "build/${HOST_SLUG}/${BUILDTYPE}/coverage.info" \
+    >/dev/null 2>&1
+
+echo "Coverage report is now available in build/${HOST_SLUG}/${BUILDTYPE}/coverage/index.html"

--- a/scripts/main.mk
+++ b/scripts/main.mk
@@ -166,6 +166,9 @@ tidy: Ninja/compdb
 test-%: Makefile/test
 	./scripts/run_tests.sh "build/$(HOST_SLUG)/$(BUILDTYPE)/test" --gtest_filter=$*
 
+check: Makefile/test
+	./scripts/collect-coverage.sh
+
 #### Helper targets ############################################################
 
 .PHONY: print-env

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -126,6 +126,13 @@
             'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
             'OTHER_LDFLAGS': [ '<@(ldflags)' ],
           },
+          'configurations': {
+            'Debug': {
+              'xcode_settings': {
+                'OTHER_LDFLAGS': [ '--coverage' ],
+              },
+            },
+          },
         }, {
          'cflags_cc': [ '<@(cflags_cc)' ],
          'libraries': [ '<@(ldflags)' ],


### PR DESCRIPTION
This PR:
- Instruments `Debug` target with coverage data (supported by GCC and clang)
- Adds a new build target `check` that collects unit tests coverage data and reports it in HTML

Fixes #3973.

/cc @tmpsantos @zugaldia @1ec5 @jfirebaugh @kkaefer 