### PR TITLE
[core] libuv unref() not really needed

### DIFF
--- a/platform/default/async_task.cpp
+++ b/platform/default/async_task.cpp
@@ -28,7 +28,6 @@ public:
         }
 
         handle()->data = this;
-        uv_unref(handle());
     }
 
     ~Impl() {

--- a/platform/default/timer.cpp
+++ b/platform/default/timer.cpp
@@ -22,7 +22,6 @@ public:
         }
 
         handle()->data = this;
-        uv_unref(handle());
     }
 
     ~Impl() {

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/platform/default/headless_view.hpp>
+#include <mbgl/util/run_loop.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -45,6 +46,7 @@ public:
     std::unique_ptr<mbgl::FileRequest> request(const mbgl::Resource&, Callback);
 
     mbgl::HeadlessView view;
+    std::shared_ptr<mbgl::util::RunLoop> loop;
     std::unique_ptr<mbgl::Map> map;
 
     std::exception_ptr error;

--- a/platform/node/src/node_mapbox_gl_native.cpp
+++ b/platform/node/src/node_mapbox_gl_native.cpp
@@ -12,19 +12,21 @@
 
 namespace node_mbgl {
 
-mbgl::util::RunLoop& NodeRunLoop() {
-    static mbgl::util::RunLoop nodeRunLoop;
-    return nodeRunLoop;
+std::shared_ptr<mbgl::util::RunLoop> NodeRunLoop() {
+    static std::weak_ptr<mbgl::util::RunLoop> nodeRunLoop;
+
+    auto loop = nodeRunLoop.lock();
+    if (!loop) {
+        loop = std::make_shared<mbgl::util::RunLoop>();
+        nodeRunLoop = loop;
+    }
+
+    return std::move(loop);
 }
 
 }
 
 NAN_MODULE_INIT(RegisterModule) {
-    // This has the effect of:
-    //   a) Ensuring that the static local variable is initialized before any thread contention.
-    //   b) unreffing an async handle, which otherwise would keep the default loop running.
-    node_mbgl::NodeRunLoop().stop();
-
     node_mbgl::NodeMap::Init(target);
     node_mbgl::NodeRequest::Init(target);
 

--- a/platform/node/src/node_mapbox_gl_native.hpp
+++ b/platform/node/src/node_mapbox_gl_native.hpp
@@ -2,8 +2,10 @@
 
 #include <mbgl/util/run_loop.hpp>
 
+#include <memory>
+
 namespace node_mbgl {
 
-mbgl::util::RunLoop& NodeRunLoop();
+std::shared_ptr<mbgl::util::RunLoop> NodeRunLoop();
 
 }

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -41,7 +41,8 @@ test('Map', function(t) {
 
         options.request = function() {};
         t.doesNotThrow(function() {
-            new mbgl.Map(options);
+            var map = new mbgl.Map(options);
+            map.release();
         });
 
         t.end();
@@ -59,7 +60,8 @@ test('Map', function(t) {
 
         options.cancel = function() {};
         t.doesNotThrow(function() {
-            new mbgl.Map(options);
+            var map = new mbgl.Map(options);
+            map.release();
         });
 
         t.end();
@@ -78,7 +80,8 @@ test('Map', function(t) {
 
         options.ratio = 1.0;
         t.doesNotThrow(function() {
-            new mbgl.Map(options);
+            var map = new mbgl.Map(options);
+            map.release();
         });
 
         t.end();
@@ -300,6 +303,7 @@ test('Map', function(t) {
             });
             map.load(style);
             map.render({ zoom: 1 }, function(err, data) {
+                map.release();
                 t.ok(err, 'returns error');
                 t.equal(err.message, 'request error');
                 t.end();
@@ -314,6 +318,7 @@ test('Map', function(t) {
             });
             map.load(style);
             map.render({ zoom: 1 }, function(err, data) {
+                map.release();
                 t.ok(data, 'no error');
                 t.end();
             });


### PR DESCRIPTION
The run loop will be kept alive because it has an `AsyncTask`. We also can simple stop the loop with `uv_stop()`.

The `RunLoop` is still gonna be the last object to be destroyed because it is the first object to be created in the thread, so by design it won't outlive `Timer`s and `AsyncTask`s.

This patch won't change the current behavior, will just make the code simpler.