### PR TITLE
Include application and operating system name and version in user agent string

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.  If you’d like 
 - Applications linking against the SDK static framework no longer need to add `-ObjC` to the Other Linker Flags (`OTHER_LDFLAGS`) build setting. If you previously added this flag solely for this SDK, removing the flag may potentially reduce the overall size of your application. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Removed the `armv7s` slice from the SDK to reduce its size. iPhone 5 and iPhone 5c automatically use the `armv7` slice instead. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - User location heading updates now resume properly when an app becomes active again. ([#4674](https://github.com/mapbox/mapbox-gl-native/pull/4674))
+- A more specific user agent string is now sent with style and tile requests. ([#4012](https://github.com/mapbox/mapbox-gl-native/pull/4012))
 - Removed unused SVG files from the SDK’s resource bundle. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 
 ## 3.2.0


### PR DESCRIPTION
The user agent string for all non-telemetry requests in the iOS and OS X SDKs now conforms to the following format:

```
MyApp/0.1.2 Mapbox/3.4.5 MapboxGL/6.7.8 (deadfeed) iOS Simulator/9.0.1 (x86_64)
^ app       ^ sdk        ^ core                    ^ os                 ^ arch
```

This file only links against the cross-platform CoreFoundation and Foundation frameworks, not the platform-specific AppKit or UIKit frameworks, so the options for identifying the operating system and device are fairly limited. (I didn’t want to go through [such](https://github.com/WebKit/webkit/blob/67985c34ffc405f69995e8a35f9c38618625c403/Source/WebCore/page/mac/UserAgentMac.mm) [great](https://github.com/WebKit/webkit/blob/0d5a0900084c2babb65ff85dedcb1a42d854f54c/Source/WebCore/page/ios/UserAgentIOS.mm#L71) [lengths](http://stackoverflow.com/a/5462277/4585461) to include all those details.)

Fixes #3997.

@kkaefer for review. @boundsj, can you confirm that this beefed-up user agent string will be compatible with the style API and dashboard?