### PR TITLE
[core] Remove ThreadContext::get{FileSource,GLObjectStore}

### DIFF
--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -24,9 +24,6 @@ class Buffer : private util::noncopyable {
 public:
     ~Buffer() {
         cleanup();
-        if (buffer) {
-            util::ThreadContext::getGLObjectStore()->abandon(std::move(buffer));
-        }
     }
 
     // Returns the number of elements in this buffer. This is not the number of
@@ -40,11 +37,11 @@ public:
     }
 
     // Transfers this buffer to the GPU and binds the buffer to the GL context.
-    void bind() {
+    void bind(gl::GLObjectStore& glObjectStore) {
         if (buffer) {
             MBGL_CHECK_ERROR(glBindBuffer(bufferType, getID()));
         } else {
-            buffer.create();
+            buffer.create(glObjectStore);
             MBGL_CHECK_ERROR(glBindBuffer(bufferType, getID()));
             if (array == nullptr) {
                 Log::Debug(Event::OpenGL, "Buffer doesn't contain elements");
@@ -69,9 +66,9 @@ public:
     }
 
     // Uploads the buffer to the GPU to be available when we need it.
-    inline void upload() {
+    inline void upload(gl::GLObjectStore& glObjectStore) {
         if (!buffer) {
-            bind();
+            bind(glObjectStore);
         }
     }
 

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -146,10 +146,10 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
     }
 }
 
-void GlyphAtlas::upload() {
+void GlyphAtlas::upload(gl::GLObjectStore& glObjectStore) {
     if (dirty) {
         const bool first = !texture;
-        bind();
+        bind(glObjectStore);
 
         std::lock_guard<std::mutex> lock(mtx);
 
@@ -187,9 +187,9 @@ void GlyphAtlas::upload() {
     }
 }
 
-void GlyphAtlas::bind() {
+void GlyphAtlas::bind(gl::GLObjectStore& glObjectStore) {
     if (!texture) {
-        texture.create();
+        texture.create(glObjectStore);
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture.getID()));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -28,11 +28,11 @@ public:
     void removeGlyphs(uintptr_t tileUID);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind();
+    void bind(gl::GLObjectStore&);
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload();
+    void upload(gl::GLObjectStore&);
 
     const GLsizei width;
     const GLsizei height;

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -21,14 +21,14 @@ public:
     ~LineAtlas();
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind();
+    void bind(gl::GLObjectStore&);
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload();
+    void upload(gl::GLObjectStore&);
 
-    LinePatternPos getDashPosition(const std::vector<float>&, bool);
-    LinePatternPos addDash(const std::vector<float> &dasharray, bool round);
+    LinePatternPos getDashPosition(const std::vector<float>&, bool, gl::GLObjectStore&);
+    LinePatternPos addDash(const std::vector<float> &dasharray, bool round, gl::GLObjectStore&);
 
     const GLsizei width;
     const GLsizei height;

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -2,7 +2,6 @@
 #include <mbgl/platform/log.hpp>
 #include <mbgl/gl/gl_object_store.hpp>
 #include <mbgl/util/string.hpp>
-#include <mbgl/util/thread_context.hpp>
 
 namespace mbgl {
 
@@ -15,10 +14,9 @@ VertexArrayObject::VertexArrayObject() {
 }
 
 VertexArrayObject::~VertexArrayObject() {
-    if (vao) util::ThreadContext::getGLObjectStore()->abandon(std::move(vao));
 }
 
-void VertexArrayObject::bindVertexArrayObject() {
+void VertexArrayObject::bindVertexArrayObject(gl::GLObjectStore& glObjectStore) {
     if (!gl::GenVertexArrays || !gl::BindVertexArray) {
         static bool reported = false;
         if (!reported) {
@@ -28,7 +26,7 @@ void VertexArrayObject::bindVertexArrayObject() {
         return;
     }
 
-    if (!vao) vao.create();
+    if (!vao) vao.create(glObjectStore);
     MBGL_CHECK_ERROR(gl::BindVertexArray(vao.getID()));
 }
 

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -20,10 +20,10 @@ public:
     ~VertexArrayObject();
 
     template <typename Shader, typename VertexBuffer>
-    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset) {
-        bindVertexArrayObject();
+    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset, gl::GLObjectStore& glObjectStore) {
+        bindVertexArrayObject(glObjectStore);
         if (bound_shader == 0) {
-            vertexBuffer.bind();
+            vertexBuffer.bind(glObjectStore);
             shader.bind(offset);
             if (vao) {
                 storeBinding(shader, vertexBuffer.getID(), 0, offset);
@@ -34,11 +34,11 @@ public:
     }
 
     template <typename Shader, typename VertexBuffer, typename ElementsBuffer>
-    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset) {
-        bindVertexArrayObject();
+    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset, gl::GLObjectStore& glObjectStore) {
+        bindVertexArrayObject(glObjectStore);
         if (bound_shader == 0) {
-            vertexBuffer.bind();
-            elementsBuffer.bind();
+            vertexBuffer.bind(glObjectStore);
+            elementsBuffer.bind(glObjectStore);
             shader.bind(offset);
             if (vao) {
                 storeBinding(shader, vertexBuffer.getID(), elementsBuffer.getID(), offset);
@@ -53,7 +53,7 @@ public:
     }
 
 private:
-    void bindVertexArrayObject();
+    void bindVertexArrayObject(gl::GLObjectStore&);
     void storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
     void verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
 

--- a/src/mbgl/gl/texture_pool.cpp
+++ b/src/mbgl/gl/texture_pool.cpp
@@ -1,15 +1,12 @@
 #include <mbgl/gl/texture_pool.hpp>
 #include <mbgl/gl/gl_object_store.hpp>
-#include <mbgl/util/thread_context.hpp>
 
 #include <vector>
 
 namespace mbgl {
 namespace gl {
 
-GLuint TexturePool::getTextureID() {
-    if (pools.empty()) pools.emplace_back();
-
+GLuint TexturePool::getTextureID(gl::GLObjectStore& glObjectStore) {
     for (auto& impl : pools) {
         if (impl.ids.empty()) continue;
         auto it = impl.ids.begin();
@@ -19,7 +16,7 @@ GLuint TexturePool::getTextureID() {
     }
 
     // All texture IDs are in use.
-    pools.emplace_back();
+    pools.emplace_back(Impl(glObjectStore));
     auto it = pools.back().ids.begin();
     GLuint id = *it;
     pools.back().ids.erase(it);
@@ -32,7 +29,6 @@ void TexturePool::releaseTextureID(GLuint id) {
             if (it->pool[i] == id) {
                 it->ids.push_back(id);
                 if (GLsizei(it->ids.size()) == gl::TexturePoolHolder::TextureMax) {
-                    util::ThreadContext::getGLObjectStore()->abandon(std::move(it->pool));
                     pools.erase(it);
                 }
                 return;

--- a/src/mbgl/gl/texture_pool.hpp
+++ b/src/mbgl/gl/texture_pool.hpp
@@ -14,14 +14,14 @@ namespace gl {
 
 class TexturePool : private util::noncopyable {
 public:
-    GLuint getTextureID();
+    GLuint getTextureID(gl::GLObjectStore&);
     void releaseTextureID(GLuint);
 
 private:
     class Impl : private util::noncopyable {
     public:
-        Impl() : ids(gl::TexturePoolHolder::TextureMax) {
-            pool.create();
+        Impl(gl::GLObjectStore& glObjectStore) : ids(gl::TexturePoolHolder::TextureMax) {
+            pool.create(glObjectStore);
             std::copy(pool.getIDs().begin(), pool.getIDs().end(), ids.begin());
         }
 

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -38,8 +38,6 @@ MapContext::MapContext(View& view_, FileSource& fileSource_, MapMode mode_, GLCo
       texturePool(std::make_unique<gl::TexturePool>()) {
     assert(util::ThreadContext::currentlyOn(util::ThreadType::Map));
 
-    util::ThreadContext::setGLObjectStore(&glObjectStore);
-
     view.activate();
 }
 
@@ -238,7 +236,7 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
     // Cleanup OpenGL objects that we abandoned since the last render call.
     glObjectStore.performCleanup();
 
-    if (!painter) painter = std::make_unique<Painter>(data, transformState);
+    if (!painter) painter = std::make_unique<Painter>(data, transformState, glObjectStore);
     painter->render(*style, frame, data.getAnnotationManager()->getSpriteAtlas());
 
     if (data.mode == MapMode::Still) {

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -78,6 +78,7 @@ private:
     void loadStyleJSON(const std::string& json, const std::string& base);
 
     View& view;
+    FileSource& fileSource;
     std::unique_ptr<MapData> dataPtr;
     MapData& data;
 

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -18,13 +18,17 @@ class StyleLayer;
 class TileID;
 class CollisionTile;
 
+namespace gl {
+class GLObjectStore;
+}
+
 class Bucket : private util::noncopyable {
 public:
     Bucket() : uploaded(false) {}
 
     // As long as this bucket has a Prepare render pass, this function is getting called. Typically,
     // this only happens once when the bucket is being rendered for the first time.
-    virtual void upload() = 0;
+    virtual void upload(gl::GLObjectStore&) = 0;
 
     // Every time this bucket is getting rendered, this function is called. This happens either
     // once or twice (for Opaque and Transparent render passes).

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -14,9 +14,9 @@ CircleBucket::~CircleBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void CircleBucket::upload() {
-    vertexBuffer_.upload();
-    elementsBuffer_.upload();
+void CircleBucket::upload(gl::GLObjectStore& glObjectStore) {
+    vertexBuffer_.upload(glObjectStore);
+    elementsBuffer_.upload(glObjectStore);
     uploaded = true;
 }
 
@@ -73,7 +73,7 @@ void CircleBucket::addGeometry(const GeometryCollection& geometryCollection) {
     }
 }
 
-void CircleBucket::drawCircles(CircleShader& shader) {
+void CircleBucket::drawCircles(CircleShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte* vertexIndex = BUFFER_OFFSET(0);
     GLbyte* elementsIndex = BUFFER_OFFSET(0);
 
@@ -82,7 +82,7 @@ void CircleBucket::drawCircles(CircleShader& shader) {
 
         if (!group->elements_length) continue;
 
-        group->array[0].bind(shader, vertexBuffer_, elementsBuffer_, vertexIndex);
+        group->array[0].bind(shader, vertexBuffer_, elementsBuffer_, vertexIndex, glObjectStore);
 
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elementsIndex));
 

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -20,13 +20,13 @@ public:
     CircleBucket();
     ~CircleBucket() override;
 
-    void upload() override;
+    void upload(gl::GLObjectStore&) override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
 
     bool hasData() const override;
     void addGeometry(const GeometryCollection&);
 
-    void drawCircles(CircleShader& shader);
+    void drawCircles(CircleShader&, gl::GLObjectStore&);
 
 private:
     CircleVertexBuffer vertexBuffer_;

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -30,12 +30,12 @@ DebugBucket::DebugBucket(const TileID id, const TileData::State state_, optional
     }
 }
 
-void DebugBucket::drawLines(PlainShader& shader) {
-    array.bind(shader, fontBuffer, BUFFER_OFFSET_0);
+void DebugBucket::drawLines(PlainShader& shader, gl::GLObjectStore& glObjectStore) {
+    array.bind(shader, fontBuffer, BUFFER_OFFSET_0, glObjectStore);
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, (GLsizei)(fontBuffer.index())));
 }
 
-void DebugBucket::drawPoints(PlainShader& shader) {
-    array.bind(shader, fontBuffer, BUFFER_OFFSET_0);
+void DebugBucket::drawPoints(PlainShader& shader, gl::GLObjectStore& glObjectStore) {
+    array.bind(shader, fontBuffer, BUFFER_OFFSET_0, glObjectStore);
     MBGL_CHECK_ERROR(glDrawArrays(GL_POINTS, 0, (GLsizei)(fontBuffer.index())));
 }

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -11,6 +11,10 @@ namespace mbgl {
 
 class PlainShader;
 
+namespace util {
+class GLObjectStore;
+}
+
 class DebugBucket : private util::noncopyable {
 public:
     DebugBucket(TileID id, TileData::State,
@@ -18,8 +22,8 @@ public:
                 optional<SystemTimePoint> expires,
                 MapDebugOptions);
 
-    void drawLines(PlainShader& shader);
-    void drawPoints(PlainShader& shader);
+    void drawLines(PlainShader&, gl::GLObjectStore&);
+    void drawPoints(PlainShader&, gl::GLObjectStore&);
 
     const TileData::State state;
     const optional<SystemTimePoint> modified;

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -186,10 +186,10 @@ void FillBucket::tessellate() {
     lineGroup.vertex_length += total_vertex_count;
 }
 
-void FillBucket::upload() {
-    vertexBuffer.upload();
-    triangleElementsBuffer.upload();
-    lineElementsBuffer.upload();
+void FillBucket::upload(gl::GLObjectStore& glObjectStore) {
+    vertexBuffer.upload(glObjectStore);
+    triangleElementsBuffer.upload(glObjectStore);
+    lineElementsBuffer.upload(glObjectStore);
 
     // From now on, we're going to render during the opaque and translucent pass.
     uploaded = true;
@@ -206,36 +206,36 @@ bool FillBucket::hasData() const {
     return !triangleGroups.empty() || !lineGroups.empty();
 }
 
-void FillBucket::drawElements(PlainShader& shader) {
+void FillBucket::drawElements(PlainShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
-        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
+        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * triangleElementsBuffer.itemSize;
     }
 }
 
-void FillBucket::drawElements(PatternShader& shader) {
+void FillBucket::drawElements(PatternShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
-        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
+        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * triangleElementsBuffer.itemSize;
     }
 }
 
-void FillBucket::drawVertices(OutlineShader& shader) {
+void FillBucket::drawVertices(OutlineShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : lineGroups) {
         assert(group);
-        group->array[0].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index);
+        group->array[0].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * lineElementsBuffer.itemSize;

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -32,16 +32,16 @@ public:
     FillBucket();
     ~FillBucket() override;
 
-    void upload() override;
+    void upload(gl::GLObjectStore&) override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const override;
 
     void addGeometry(const GeometryCollection&);
     void tessellate();
 
-    void drawElements(PlainShader& shader);
-    void drawElements(PatternShader& shader);
-    void drawVertices(OutlineShader& shader);
+    void drawElements(PlainShader&, gl::GLObjectStore&);
+    void drawElements(PatternShader&, gl::GLObjectStore&);
+    void drawVertices(OutlineShader&, gl::GLObjectStore&);
 
 private:
     TESSalloc *allocator;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -418,9 +418,9 @@ void LineBucket::addPieSliceVertex(const Coordinate& currentVertex,
     }
 }
 
-void LineBucket::upload() {
-    vertexBuffer.upload();
-    triangleElementsBuffer.upload();
+void LineBucket::upload(gl::GLObjectStore& glObjectStore) {
+    vertexBuffer.upload(glObjectStore);
+    triangleElementsBuffer.upload(glObjectStore);
 
     // From now on, we're only going to render during the translucent pass.
     uploaded = true;
@@ -437,7 +437,7 @@ bool LineBucket::hasData() const {
     return !triangleGroups.empty();
 }
 
-void LineBucket::drawLines(LineShader& shader) {
+void LineBucket::drawLines(LineShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -445,7 +445,7 @@ void LineBucket::drawLines(LineShader& shader) {
         if (!group->elements_length) {
             continue;
         }
-        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
+        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
@@ -453,7 +453,7 @@ void LineBucket::drawLines(LineShader& shader) {
     }
 }
 
-void LineBucket::drawLineSDF(LineSDFShader& shader) {
+void LineBucket::drawLineSDF(LineSDFShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -461,7 +461,7 @@ void LineBucket::drawLineSDF(LineSDFShader& shader) {
         if (!group->elements_length) {
             continue;
         }
-        group->array[2].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
+        group->array[2].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
@@ -469,7 +469,7 @@ void LineBucket::drawLineSDF(LineSDFShader& shader) {
     }
 }
 
-void LineBucket::drawLinePatterns(LinepatternShader& shader) {
+void LineBucket::drawLinePatterns(LinepatternShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -477,7 +477,7 @@ void LineBucket::drawLinePatterns(LinepatternShader& shader) {
         if (!group->elements_length) {
             continue;
         }
-        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
+        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -27,16 +27,16 @@ public:
     LineBucket(float overscaling);
     ~LineBucket() override;
 
-    void upload() override;
+    void upload(gl::GLObjectStore&) override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const override;
 
     void addGeometry(const GeometryCollection&);
     void addGeometry(const std::vector<Coordinate>& line);
 
-    void drawLines(LineShader& shader);
-    void drawLineSDF(LineSDFShader& shader);
-    void drawLinePatterns(LinepatternShader& shader);
+    void drawLines(LineShader&, gl::GLObjectStore&);
+    void drawLineSDF(LineSDFShader&, gl::GLObjectStore&);
+    void drawLinePatterns(LinepatternShader&, gl::GLObjectStore&);
 
 private:
     struct TriangleElement {

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -66,9 +66,13 @@ class CollisionBoxShader;
 
 struct ClipID;
 
+namespace util {
+class GLObjectStore;
+}
+
 class Painter : private util::noncopyable {
 public:
-    Painter(MapData&, TransformState&);
+    Painter(MapData&, TransformState&, gl::GLObjectStore&);
     ~Painter();
 
     void render(const Style& style,
@@ -118,7 +122,7 @@ private:
                    float scaleDivisor,
                    std::array<float, 2> texsize,
                    SDFShader& sdfShader,
-                   void (SymbolBucket::*drawSDF)(SDFShader&));
+                   void (SymbolBucket::*drawSDF)(SDFShader&, gl::GLObjectStore&));
 
     void setDepthSublayer(int n);
 
@@ -142,6 +146,8 @@ private:
 
     MapData& data;
     TransformState& state;
+    gl::GLObjectStore& glObjectStore;
+
     FrameData frame;
 
     int indent = 0;

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -46,5 +46,5 @@ void Painter::renderCircle(CircleBucket& bucket,
     circleShader->u_blur = std::max<float>(properties.blur, antialiasing);
     circleShader->u_size = properties.radius;
 
-    bucket.drawCircles(*circleShader);
+    bucket.drawCircles(*circleShader, glObjectStore);
 }

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -21,7 +21,7 @@ void Painter::drawClippingMasks(const std::map<TileID, ClipID>& stencils) {
     config.colorMask = { GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
     config.stencilMask = mask;
 
-    coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET_0);
+    coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET_0, glObjectStore);
 
     for (const auto& stencil : stencils) {
         const auto& id = stencil.first;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -39,18 +39,18 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
     // Draw white outline
     plainShader->u_color = {{ 1.0f, 1.0f, 1.0f, 1.0f }};
     config.lineWidth = 4.0f * data.pixelRatio;
-    tileData.debugBucket->drawLines(*plainShader);
+    tileData.debugBucket->drawLines(*plainShader, glObjectStore);
 
 #ifndef GL_ES_VERSION_2_0
     // Draw line "end caps"
     MBGL_CHECK_ERROR(glPointSize(2));
-    tileData.debugBucket->drawPoints(*plainShader);
+    tileData.debugBucket->drawPoints(*plainShader, glObjectStore);
 #endif
 
     // Draw black text.
     plainShader->u_color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
     config.lineWidth = 2.0f * data.pixelRatio;
-    tileData.debugBucket->drawLines(*plainShader);
+    tileData.debugBucket->drawLines(*plainShader, glObjectStore);
 
     config.depthFunc.reset();
     config.depthTest = GL_TRUE;
@@ -70,7 +70,7 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     plainShader->u_matrix = matrix;
 
     // draw tile outline
-    tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET_0);
+    tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET_0, glObjectStore);
     plainShader->u_color = {{ 1.0f, 0.0f, 0.0f, 1.0f }};
     config.lineWidth = 4.0f * data.pixelRatio;
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, (GLsizei)tileBorderBuffer.index()));

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -56,7 +56,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
             static_cast<float>(frame.framebufferSize[1])
         }};
         setDepthSublayer(0);
-        bucket.drawVertices(*outlineShader);
+        bucket.drawVertices(*outlineShader, glObjectStore);
     }
 
     if (pattern) {
@@ -111,11 +111,11 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
             patternShader->u_offset_b = std::array<float, 2>{{offsetBx, offsetBy}};
 
             MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0));
-            spriteAtlas->bind(true);
+            spriteAtlas->bind(true, glObjectStore);
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(0);
-            bucket.drawElements(*patternShader);
+            bucket.drawElements(*patternShader, glObjectStore);
         }
     }
     else {
@@ -131,7 +131,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(1);
-            bucket.drawElements(*plainShader);
+            bucket.drawElements(*plainShader, glObjectStore);
         }
     }
 
@@ -151,6 +151,6 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
         }};
 
         setDepthSublayer(2);
-        bucket.drawVertices(*outlineShader);
+        bucket.drawVertices(*outlineShader, glObjectStore);
     }
 }

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -79,9 +79,9 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         linesdfShader->u_blur = blur;
         linesdfShader->u_color = color;
 
-        LinePatternPos posA = lineAtlas->getDashPosition(properties.dasharray.value.from, layout.cap == CapType::Round);
-        LinePatternPos posB = lineAtlas->getDashPosition(properties.dasharray.value.to, layout.cap == CapType::Round);
-        lineAtlas->bind();
+        LinePatternPos posA = lineAtlas->getDashPosition(properties.dasharray.value.from, layout.cap == CapType::Round, glObjectStore);
+        LinePatternPos posB = lineAtlas->getDashPosition(properties.dasharray.value.to, layout.cap == CapType::Round, glObjectStore);
+        lineAtlas->bind(glObjectStore);
 
         const float widthA = posA.width * properties.dasharray.value.fromScale;
         const float widthB = posB.width * properties.dasharray.value.toScale;
@@ -102,7 +102,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         linesdfShader->u_offset = -properties.offset;
         linesdfShader->u_antialiasingmatrix = antialiasingMatrix;
 
-        bucket.drawLineSDF(*linesdfShader);
+        bucket.drawLineSDF(*linesdfShader, glObjectStore);
 
     } else if (!properties.pattern.value.from.empty()) {
         optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(properties.pattern.value.from, true);
@@ -134,9 +134,9 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         linepatternShader->u_antialiasingmatrix = antialiasingMatrix;
 
         MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0));
-        spriteAtlas->bind(true);
+        spriteAtlas->bind(true, glObjectStore);
 
-        bucket.drawLinePatterns(*linepatternShader);
+        bucket.drawLinePatterns(*linepatternShader, glObjectStore);
 
     } else {
         config.program = lineShader->getID();
@@ -152,6 +152,6 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
 
         lineShader->u_color = color;
 
-        bucket.drawLines(*lineShader);
+        bucket.drawLines(*lineShader, glObjectStore);
     }
 }

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -28,7 +28,7 @@ void Painter::renderRaster(RasterBucket& bucket, const RasterLayer& layer, const
         config.depthTest = GL_TRUE;
         config.depthMask = GL_FALSE;
         setDepthSublayer(0);
-        bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray);
+        bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray, glObjectStore);
     }
 }
 

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -23,7 +23,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
                         float sdfFontSize,
                         std::array<float, 2> texsize,
                         SDFShader& sdfShader,
-                        void (SymbolBucket::*drawSDF)(SDFShader&))
+                        void (SymbolBucket::*drawSDF)(SDFShader&, gl::GLObjectStore&))
 {
     mat4 vtxMatrix = translatedMatrix(matrix, styleProperties.translate, id, styleProperties.translateAnchor);
 
@@ -101,7 +101,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
         sdfShader.u_buffer = (haloOffset - styleProperties.haloWidth / fontScale) / sdfPx;
 
         setDepthSublayer(0);
-        (bucket.*drawSDF)(sdfShader);
+        (bucket.*drawSDF)(sdfShader, glObjectStore);
     }
 
     // Then, we draw the text/icon over the halo
@@ -122,7 +122,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
         sdfShader.u_buffer = (256.0f - 64.0f) / 256.0f;
 
         setDepthSublayer(1);
-        (bucket.*drawSDF)(sdfShader);
+        (bucket.*drawSDF)(sdfShader, glObjectStore);
     }
 }
 
@@ -174,7 +174,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
         SpriteAtlas* activeSpriteAtlas = layer.spriteAtlas;
         const bool iconScaled = fontScale != 1 || data.pixelRatio != activeSpriteAtlas->getPixelRatio() || bucket.iconsNeedLinear;
         const bool iconTransformed = layout.icon.rotationAlignment == RotationAlignmentType::Map || angleOffset != 0 || state.getPitch() != 0;
-        activeSpriteAtlas->bind(sdf || state.isChanging() || iconScaled || iconTransformed);
+        activeSpriteAtlas->bind(sdf || state.isChanging() || iconScaled || iconTransformed, glObjectStore);
 
         if (sdf) {
             renderSDF(bucket,
@@ -230,7 +230,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
             iconShader->u_opacity = properties.icon.opacity;
 
             setDepthSublayer(0);
-            bucket.drawIcons(*iconShader);
+            bucket.drawIcons(*iconShader, glObjectStore);
         }
     }
 
@@ -242,7 +242,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
             config.depthTest = GL_FALSE;
         }
 
-        glyphAtlas->bind();
+        glyphAtlas->bind(glObjectStore);
 
         renderSDF(bucket,
                   id,
@@ -267,7 +267,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
         config.lineWidth = 1.0f;
 
         setDepthSublayer(0);
-        bucket.drawCollisionBoxes(*collisionBoxShader);
+        bucket.drawCollisionBoxes(*collisionBoxShader, glObjectStore);
 
     }
 

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -9,9 +9,9 @@ RasterBucket::RasterBucket(gl::TexturePool& texturePool)
 : raster(texturePool) {
 }
 
-void RasterBucket::upload() {
+void RasterBucket::upload(gl::GLObjectStore& glObjectStore) {
     if (hasData()) {
-        raster.upload();
+        raster.upload(glObjectStore);
         uploaded = true;
     }
 }
@@ -27,10 +27,10 @@ void RasterBucket::setImage(PremultipliedImage image) {
     raster.load(std::move(image));
 }
 
-void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array) {
-    raster.bind(true);
+void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array, gl::GLObjectStore& glObjectStore) {
+    raster.bind(true, glObjectStore);
     shader.u_image = 0;
-    array.bind(shader, vertices, BUFFER_OFFSET_0);
+    array.bind(shader, vertices, BUFFER_OFFSET_0, glObjectStore);
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
 }
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -14,13 +14,13 @@ class RasterBucket : public Bucket {
 public:
     RasterBucket(gl::TexturePool&);
 
-    void upload() override;
+    void upload(gl::GLObjectStore&) override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const override;
 
     void setImage(PremultipliedImage);
 
-    void drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array);
+    void drawRaster(RasterShader&, StaticVertexBuffer&, VertexArrayObject&, gl::GLObjectStore&);
 
     Raster raster;
 };

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -64,14 +64,14 @@ SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void SymbolBucket::upload() {
+void SymbolBucket::upload(gl::GLObjectStore& glObjectStore) {
     if (hasTextData()) {
-        renderData->text.vertices.upload();
-        renderData->text.triangles.upload();
+        renderData->text.vertices.upload(glObjectStore);
+        renderData->text.triangles.upload(glObjectStore);
     }
     if (hasIconData()) {
-        renderData->icon.vertices.upload();
-        renderData->icon.triangles.upload();
+        renderData->icon.vertices.upload(glObjectStore);
+        renderData->icon.triangles.upload(glObjectStore);
     }
 
     uploaded = true;
@@ -572,50 +572,50 @@ void SymbolBucket::swapRenderData() {
     }
 }
 
-void SymbolBucket::drawGlyphs(SDFShader &shader) {
+void SymbolBucket::drawGlyphs(SDFShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& text = renderData->text;
     for (auto &group : text.groups) {
         assert(group);
-        group->array[0].bind(shader, text.vertices, text.triangles, vertex_index);
+        group->array[0].bind(shader, text.vertices, text.triangles, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * text.vertices.itemSize;
         elements_index += group->elements_length * text.triangles.itemSize;
     }
 }
 
-void SymbolBucket::drawIcons(SDFShader &shader) {
+void SymbolBucket::drawIcons(SDFShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& icon = renderData->icon;
     for (auto &group : icon.groups) {
         assert(group);
-        group->array[0].bind(shader, icon.vertices, icon.triangles, vertex_index);
+        group->array[0].bind(shader, icon.vertices, icon.triangles, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * icon.vertices.itemSize;
         elements_index += group->elements_length * icon.triangles.itemSize;
     }
 }
 
-void SymbolBucket::drawIcons(IconShader &shader) {
+void SymbolBucket::drawIcons(IconShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& icon = renderData->icon;
     for (auto &group : icon.groups) {
         assert(group);
-        group->array[1].bind(shader, icon.vertices, icon.triangles, vertex_index);
+        group->array[1].bind(shader, icon.vertices, icon.triangles, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * icon.vertices.itemSize;
         elements_index += group->elements_length * icon.triangles.itemSize;
     }
 }
 
-void SymbolBucket::drawCollisionBoxes(CollisionBoxShader &shader) {
+void SymbolBucket::drawCollisionBoxes(CollisionBoxShader& shader, gl::GLObjectStore& glObjectStore) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     auto& collisionBox = renderData->collisionBox;
     for (auto &group : collisionBox.groups) {
-        group->array[0].bind(shader, collisionBox.vertices, vertex_index);
+        group->array[0].bind(shader, collisionBox.vertices, vertex_index, glObjectStore);
         MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, group->vertex_length));
     }
 }

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -70,7 +70,7 @@ public:
     SymbolBucket(float overscaling, float zoom, const MapMode);
     ~SymbolBucket() override;
 
-    void upload() override;
+    void upload(gl::GLObjectStore&) override;
     void render(Painter&, const StyleLayer&, const TileID&, const mat4&) override;
     bool hasData() const override;
     bool hasTextData() const;
@@ -82,10 +82,10 @@ public:
                      GlyphAtlas&,
                      GlyphStore&);
 
-    void drawGlyphs(SDFShader& shader);
-    void drawIcons(SDFShader& shader);
-    void drawIcons(IconShader& shader);
-    void drawCollisionBoxes(CollisionBoxShader& shader);
+    void drawGlyphs(SDFShader&, gl::GLObjectStore&);
+    void drawIcons(SDFShader&, gl::GLObjectStore&);
+    void drawIcons(IconShader&, gl::GLObjectStore&);
+    void drawCollisionBoxes(CollisionBoxShader&, gl::GLObjectStore&);
 
     void parseFeatures(const GeometryTileLayer&,
                        const FilterExpression&);

--- a/src/mbgl/shader/box_shader.cpp
+++ b/src/mbgl/shader/box_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-CollisionBoxShader::CollisionBoxShader()
-    : Shader("collisionbox", shaders::box::vertex, shaders::box::fragment) {
+CollisionBoxShader::CollisionBoxShader(gl::GLObjectStore& glObjectStore)
+    : Shader("collisionbox", shaders::box::vertex, shaders::box::fragment, glObjectStore) {
     a_extrude = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_extrude"));
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
 }

--- a/src/mbgl/shader/box_shader.hpp
+++ b/src/mbgl/shader/box_shader.hpp
@@ -9,7 +9,7 @@ namespace mbgl {
 
 class CollisionBoxShader : public Shader {
 public:
-    CollisionBoxShader();
+    CollisionBoxShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-CircleShader::CircleShader()
-    : Shader("circle", shaders::circle::vertex, shaders::circle::fragment) {
+CircleShader::CircleShader(gl::GLObjectStore& glObjectStore)
+    : Shader("circle", shaders::circle::vertex, shaders::circle::fragment, glObjectStore) {
 }
 
 void CircleShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class CircleShader : public Shader {
 public:
-    CircleShader();
+    CircleShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/dot_shader.cpp
+++ b/src/mbgl/shader/dot_shader.cpp
@@ -7,7 +7,8 @@
 
 using namespace mbgl;
 
-DotShader::DotShader() : Shader("dot", shaders::dot::vertex, shaders::dot::fragment) {
+DotShader::DotShader(gl::GLObjectStore& glObjectStore)
+    : Shader("dot", shaders::dot::vertex, shaders::dot::fragment, glObjectStore) {
 }
 
 void DotShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/dot_shader.hpp
+++ b/src/mbgl/shader/dot_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class DotShader : public Shader {
 public:
-    DotShader();
+    DotShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -7,7 +7,8 @@
 
 using namespace mbgl;
 
-IconShader::IconShader() : Shader("icon", shaders::icon::vertex, shaders::icon::fragment) {
+IconShader::IconShader(gl::GLObjectStore& glObjectStore)
+    : Shader("icon", shaders::icon::vertex, shaders::icon::fragment, glObjectStore) {
     a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset"));
     a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1"));
     a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"));

--- a/src/mbgl/shader/icon_shader.hpp
+++ b/src/mbgl/shader/icon_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class IconShader : public Shader {
 public:
-    IconShader();
+    IconShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -7,7 +7,8 @@
 
 using namespace mbgl;
 
-LineShader::LineShader() : Shader("line", shaders::line::vertex, shaders::line::fragment) {
+LineShader::LineShader(gl::GLObjectStore& glObjectStore)
+    : Shader("line", shaders::line::vertex, shaders::line::fragment, glObjectStore) {
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
 }
 

--- a/src/mbgl/shader/line_shader.hpp
+++ b/src/mbgl/shader/line_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class LineShader : public Shader {
 public:
-    LineShader();
+    LineShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-LinepatternShader::LinepatternShader()
-    : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment) {
+LinepatternShader::LinepatternShader(gl::GLObjectStore& glObjectStore)
+    : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment, glObjectStore) {
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
 }
 

--- a/src/mbgl/shader/linepattern_shader.hpp
+++ b/src/mbgl/shader/linepattern_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class LinepatternShader : public Shader {
 public:
-    LinepatternShader();
+    LinepatternShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-LineSDFShader::LineSDFShader()
-    : Shader("line", shaders::linesdf::vertex, shaders::linesdf::fragment) {
+LineSDFShader::LineSDFShader(gl::GLObjectStore& glObjectStore)
+    : Shader("line", shaders::linesdf::vertex, shaders::linesdf::fragment, glObjectStore) {
     a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
 }
 

--- a/src/mbgl/shader/linesdf_shader.hpp
+++ b/src/mbgl/shader/linesdf_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class LineSDFShader : public Shader {
 public:
-    LineSDFShader();
+    LineSDFShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-OutlineShader::OutlineShader()
-    : Shader("outline", shaders::outline::vertex, shaders::outline::fragment) {
+OutlineShader::OutlineShader(gl::GLObjectStore& glObjectStore)
+    : Shader("outline", shaders::outline::vertex, shaders::outline::fragment, glObjectStore) {
 }
 
 void OutlineShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/outline_shader.hpp
+++ b/src/mbgl/shader/outline_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class OutlineShader : public Shader {
 public:
-    OutlineShader();
+    OutlineShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/pattern_shader.cpp
+++ b/src/mbgl/shader/pattern_shader.cpp
@@ -7,10 +7,11 @@
 
 using namespace mbgl;
 
-PatternShader::PatternShader()
+PatternShader::PatternShader(gl::GLObjectStore& glObjectStore)
     : Shader(
         "pattern",
-        shaders::pattern::vertex, shaders::pattern::fragment
+        shaders::pattern::vertex, shaders::pattern::fragment,
+        glObjectStore
     ) {
 }
 

--- a/src/mbgl/shader/pattern_shader.hpp
+++ b/src/mbgl/shader/pattern_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class PatternShader : public Shader {
 public:
-    PatternShader();
+    PatternShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -7,7 +7,8 @@
 
 using namespace mbgl;
 
-PlainShader::PlainShader() : Shader("plain", shaders::plain::vertex, shaders::plain::fragment) {
+PlainShader::PlainShader(gl::GLObjectStore& glObjectStore)
+    : Shader("plain", shaders::plain::vertex, shaders::plain::fragment, glObjectStore) {
 }
 
 void PlainShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/plain_shader.hpp
+++ b/src/mbgl/shader/plain_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class PlainShader : public Shader {
 public:
-    PlainShader();
+    PlainShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-RasterShader::RasterShader()
-    : Shader("raster", shaders::raster::vertex, shaders::raster::fragment) {
+RasterShader::RasterShader(gl::GLObjectStore& glObjectStore)
+    : Shader("raster", shaders::raster::vertex, shaders::raster::fragment, glObjectStore) {
 }
 
 void RasterShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/raster_shader.hpp
+++ b/src/mbgl/shader/raster_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class RasterShader : public Shader {
 public:
-    RasterShader();
+    RasterShader(gl::GLObjectStore&);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -7,7 +7,8 @@
 
 using namespace mbgl;
 
-SDFShader::SDFShader() : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment) {
+SDFShader::SDFShader(gl::GLObjectStore& glObjectStore)
+    : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment, glObjectStore) {
     a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset"));
     a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1"));
     a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"));

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class SDFShader : public Shader {
 public:
-    SDFShader();
+    SDFShader(gl::GLObjectStore&);
 
     UniformMatrix<4>                u_matrix      = {"u_matrix",      *this};
     UniformMatrix<4>                u_exmatrix    = {"u_exmatrix",    *this};
@@ -32,11 +32,13 @@ protected:
 
 class SDFGlyphShader : public SDFShader {
 public:
+    SDFGlyphShader(gl::GLObjectStore& glObjectStore) : SDFShader(glObjectStore) {}
     void bind(GLbyte *offset) final;
 };
 
 class SDFIconShader : public SDFShader {
 public:
+    SDFIconShader(gl::GLObjectStore& glObjectStore) : SDFShader(glObjectStore) {}
     void bind(GLbyte *offset) final;
 };
 

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -13,19 +13,19 @@
 
 namespace mbgl {
 
-Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSource)
+Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSource, gl::GLObjectStore& glObjectStore)
     : name(name_)
 {
     util::stopwatch stopwatch("shader compilation", Event::Shader);
 
-    program.create();
-    vertexShader.create();
+    program.create(glObjectStore);
+    vertexShader.create(glObjectStore);
     if (!compileShader(vertexShader, &vertSource)) {
         Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertSource);
         throw util::ShaderException(std::string { "Vertex shader " } + name + " failed to compile");
     }
 
-    fragmentShader.create();
+    fragmentShader.create(glObjectStore);
     if (!compileShader(fragmentShader, &fragSource)) {
         Log::Error(Event::Shader, "Fragment shader %s failed to compile: %s", name, fragSource);
         throw util::ShaderException(std::string { "Fragment shader " } + name + " failed to compile");

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -9,7 +9,7 @@ namespace mbgl {
 
 class Shader : private util::noncopyable {
 public:
-    Shader(const GLchar *name, const GLchar *vertex, const GLchar *fragment);
+    Shader(const GLchar *name, const GLchar *vertex, const GLchar *fragment, gl::GLObjectStore&);
 
     ~Shader();
     const GLchar *name;

--- a/src/mbgl/source/source.hpp
+++ b/src/mbgl/source/source.hpp
@@ -22,6 +22,7 @@ namespace mbgl {
 
 class StyleUpdateParameters;
 class Painter;
+class FileSource;
 class FileRequest;
 class TransformState;
 class Tile;
@@ -51,7 +52,7 @@ public:
     ~Source();
 
     bool loaded = false;
-    void load();
+    void load(FileSource&);
     bool isLoading() const;
     bool isLoaded() const;
 

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -143,9 +143,9 @@ void SpriteAtlas::copy(const Holder& holder, const bool wrap) {
     dirty = true;
 }
 
-void SpriteAtlas::upload() {
+void SpriteAtlas::upload(gl::GLObjectStore& glObjectStore) {
     if (dirty) {
-        bind();
+        bind(false, glObjectStore);
     }
 }
 
@@ -180,13 +180,13 @@ void SpriteAtlas::updateDirty() {
     }
 }
 
-void SpriteAtlas::bind(bool linear) {
+void SpriteAtlas::bind(bool linear, gl::GLObjectStore& glObjectStore) {
     if (!data) {
         return; // Empty atlas
     }
 
     if (!texture) {
-        texture.create();
+        texture.create(glObjectStore);
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture.getID()));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
@@ -246,12 +246,7 @@ void SpriteAtlas::bind(bool linear) {
     }
 };
 
-SpriteAtlas::~SpriteAtlas() {
-    std::lock_guard<std::recursive_mutex> lock(mtx);
-    if (texture) {
-        mbgl::util::ThreadContext::getGLObjectStore()->abandon(std::move(texture));
-    }
-}
+SpriteAtlas::~SpriteAtlas() = default;
 
 SpriteAtlas::Holder::Holder(const std::shared_ptr<const SpriteImage>& spriteImage_,
                             const Rect<dimension>& pos_)

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -52,14 +52,14 @@ public:
     optional<SpriteAtlasPosition> getPosition(const std::string& name, bool repeating = false);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind(bool linear = false);
+    void bind(bool linear, gl::GLObjectStore&);
 
     // Updates sprites in the atlas texture that may have changed in the source SpriteStore object.
     void updateDirty();
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload();
+    void upload(gl::GLObjectStore&);
 
     inline dimension getWidth() const { return width; }
     inline dimension getHeight() const { return height; }

--- a/src/mbgl/sprite/sprite_store.hpp
+++ b/src/mbgl/sprite/sprite_store.hpp
@@ -10,6 +10,8 @@
 
 namespace mbgl {
 
+class FileSource;
+
 class SpriteStore : private util::noncopyable {
 public:
     using Sprites = std::map<std::string, std::shared_ptr<const SpriteImage>>;
@@ -25,7 +27,7 @@ public:
     SpriteStore(float pixelRatio);
     ~SpriteStore();
 
-    void setURL(const std::string&);
+    void load(const std::string& url, FileSource&);
 
     bool isLoaded() const {
         return loaded;

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -19,6 +19,7 @@
 namespace mbgl {
 
 class MapData;
+class FileSource;
 class GlyphAtlas;
 class GlyphStore;
 class SpriteStore;
@@ -54,7 +55,7 @@ class Style : public GlyphStore::Observer,
               public Source::Observer,
               public util::noncopyable {
 public:
-    Style(MapData&);
+    Style(MapData&, FileSource&);
     ~Style();
 
     class Observer : public GlyphStore::Observer,
@@ -107,6 +108,7 @@ public:
     void dumpDebugLogs() const;
 
     MapData& data;
+    FileSource& fileSource;
     std::unique_ptr<GlyphStore> glyphStore;
     std::unique_ptr<GlyphAtlas> glyphAtlas;
     std::unique_ptr<SpriteStore> spriteStore;

--- a/src/mbgl/style/style_update_parameters.hpp
+++ b/src/mbgl/style/style_update_parameters.hpp
@@ -7,6 +7,7 @@ namespace mbgl {
 
 class TransformState;
 class Worker;
+class FileSource;
 class MapData;
 class Style;
 namespace gl { class TexturePool; }
@@ -18,6 +19,7 @@ public:
                           TimePoint animationTime_,
                           const TransformState& transformState_,
                           Worker& worker_,
+                          FileSource& fileSource_,
                           gl::TexturePool& texturePool_,
                           bool shouldReparsePartialTiles_,
                           const MapMode mode_,
@@ -28,6 +30,7 @@ public:
           animationTime(animationTime_),
           transformState(transformState_),
           worker(worker_),
+          fileSource(fileSource_),
           texturePool(texturePool_),
           shouldReparsePartialTiles(shouldReparsePartialTiles_),
           mode(mode_),
@@ -39,6 +42,7 @@ public:
     TimePoint animationTime;
     const TransformState& transformState;
     Worker& worker;
+    FileSource& fileSource;
     gl::TexturePool& texturePool;
     bool shouldReparsePartialTiles;
     const MapMode mode;

--- a/src/mbgl/text/glyph_pbf.cpp
+++ b/src/mbgl/text/glyph_pbf.cpp
@@ -8,7 +8,6 @@
 #include <mbgl/util/exception.hpp>
 #include <mbgl/util/pbf.hpp>
 #include <mbgl/util/string.hpp>
-#include <mbgl/util/thread_context.hpp>
 #include <mbgl/util/token.hpp>
 #include <mbgl/util/url.hpp>
 
@@ -64,11 +63,11 @@ namespace mbgl {
 GlyphPBF::GlyphPBF(GlyphStore* store,
                    const std::string& fontStack,
                    const GlyphRange& glyphRange,
-                   GlyphStore::Observer* observer_)
+                   GlyphStore::Observer* observer_,
+                   FileSource& fileSource)
     : parsed(false),
       observer(observer_) {
-    FileSource* fs = util::ThreadContext::getFileSource();
-    req = fs->request(Resource::glyphs(store->getURL(), fontStack, glyphRange), [this, store, fontStack, glyphRange](Response res) {
+    req = fileSource.request(Resource::glyphs(store->getURL(), fontStack, glyphRange), [this, store, fontStack, glyphRange](Response res) {
         if (res.error) {
             observer->onGlyphsError(fontStack, glyphRange, std::make_exception_ptr(std::runtime_error(res.error->message)));
         } else if (res.notModified) {

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -14,13 +14,15 @@ namespace mbgl {
 
 class FontStack;
 class FileRequest;
+class FileSource;
 
 class GlyphPBF : private util::noncopyable {
 public:
     GlyphPBF(GlyphStore* store,
              const std::string& fontStack,
              const GlyphRange&,
-             GlyphStore::Observer*);
+             GlyphStore::Observer*,
+             FileSource&);
     ~GlyphPBF();
 
     bool isParsed() const {

--- a/src/mbgl/text/glyph_store.cpp
+++ b/src/mbgl/text/glyph_store.cpp
@@ -7,7 +7,10 @@
 
 namespace mbgl {
 
-GlyphStore::GlyphStore() = default;
+GlyphStore::GlyphStore(FileSource& fileSource_)
+    : fileSource(fileSource_) {
+}
+
 GlyphStore::~GlyphStore() = default;
 
 void GlyphStore::requestGlyphRange(const std::string& fontStackName, const GlyphRange& range) {
@@ -22,7 +25,7 @@ void GlyphStore::requestGlyphRange(const std::string& fontStackName, const Glyph
     }
 
     rangeSets.emplace(range,
-        std::make_unique<GlyphPBF>(this, fontStackName, range, observer));
+        std::make_unique<GlyphPBF>(this, fontStackName, range, observer, fileSource));
 }
 
 

--- a/src/mbgl/text/glyph_store.hpp
+++ b/src/mbgl/text/glyph_store.hpp
@@ -14,6 +14,7 @@
 
 namespace mbgl {
 
+class FileSource;
 class GlyphPBF;
 
 // The GlyphStore manages the loading and storage of Glyphs
@@ -29,7 +30,7 @@ public:
         virtual void onGlyphsError(const std::string& /* fontStack */, const GlyphRange&, std::exception_ptr) {};
     };
 
-    GlyphStore();
+    GlyphStore(FileSource&);
     ~GlyphStore();
 
     util::exclusive<FontStack> getFontStack(const std::string& fontStack);
@@ -54,6 +55,7 @@ public:
 private:
     void requestGlyphRange(const std::string& fontStackName, const GlyphRange& range);
 
+    FileSource& fileSource;
     std::string glyphURL;
 
     std::unordered_map<std::string, std::map<GlyphRange, std::unique_ptr<GlyphPBF>>> ranges;

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -13,6 +13,7 @@ RasterTileData::RasterTileData(const TileID& id_,
                                const std::string& urlTemplate,
                                gl::TexturePool &texturePool_,
                                Worker& worker_,
+                               FileSource& fileSource,
                                const std::function<void(std::exception_ptr)>& callback)
     : TileData(id_),
       texturePool(texturePool_),
@@ -20,7 +21,7 @@ RasterTileData::RasterTileData(const TileID& id_,
     state = State::loading;
 
     const Resource resource = Resource::tile(urlTemplate, pixelRatio, id.x, id.y, id.sourceZ);
-    req = util::ThreadContext::getFileSource()->request(resource, [callback, this](Response res) {
+    req = fileSource.request(resource, [callback, this](Response res) {
         if (res.error) {
             callback(std::make_exception_ptr(std::runtime_error(res.error->message)));
         } else if (res.notModified) {

--- a/src/mbgl/tile/raster_tile_data.hpp
+++ b/src/mbgl/tile/raster_tile_data.hpp
@@ -6,6 +6,7 @@
 
 namespace mbgl {
 
+class FileSource;
 class FileRequest;
 class StyleLayer;
 class WorkRequest;
@@ -18,6 +19,7 @@ public:
                    const std::string& urlTemplate,
                    gl::TexturePool&,
                    Worker&,
+                   FileSource&,
                    const std::function<void(std::exception_ptr)>& callback);
     ~RasterTileData();
 

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -59,10 +59,11 @@ private:
 };
 
 class TileID;
+class FileSource;
 
 class VectorTileMonitor : public GeometryTileMonitor {
 public:
-    VectorTileMonitor(const TileID&, float pixelRatio, const std::string& urlTemplate);
+    VectorTileMonitor(const TileID&, float pixelRatio, const std::string& urlTemplate, FileSource&);
 
     std::unique_ptr<FileRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
 
@@ -70,6 +71,7 @@ private:
     TileID tileID;
     float pixelRatio;
     std::string urlTemplate;
+    FileSource& fileSource;
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -37,14 +37,14 @@ void Raster::load(PremultipliedImage image) {
 }
 
 
-void Raster::bind(bool linear) {
+void Raster::bind(bool linear, gl::GLObjectStore& glObjectStore) {
     if (!width || !height) {
         Log::Error(Event::OpenGL, "trying to bind texture without dimension");
         return;
     }
 
     if (img.data && !textured) {
-        upload();
+        upload(glObjectStore);
     } else if (textured) {
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, textureID));
     }
@@ -57,9 +57,9 @@ void Raster::bind(bool linear) {
     }
 }
 
-void Raster::upload() {
+void Raster::upload(gl::GLObjectStore& glObjectStore) {
     if (img.data && !textured) {
-        textureID = texturePool.getTextureID();
+        textureID = texturePool.getTextureID(glObjectStore);
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, textureID));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -21,10 +21,10 @@ public:
     void load(PremultipliedImage);
 
     // bind current texture
-    void bind(bool linear = false);
+    void bind(bool linear, gl::GLObjectStore&);
 
     // uploads the texture if it hasn't been uploaded yet.
-    void upload();
+    void upload(gl::GLObjectStore&);
 
     // loaded status
     bool isLoaded() const;

--- a/src/mbgl/util/thread_context.cpp
+++ b/src/mbgl/util/thread_context.cpp
@@ -44,22 +44,6 @@ ThreadPriority ThreadContext::getPriority() {
     }
 }
 
-FileSource* ThreadContext::getFileSource() {
-    if (current.get() != nullptr) {
-        return current.get()->fileSource;
-    } else {
-        return nullptr;
-    }
-}
-
-void ThreadContext::setFileSource(FileSource* fileSource) {
-    if (current.get() != nullptr) {
-        current.get()->fileSource = fileSource;
-    } else {
-        throw std::runtime_error("Current thread has no current ThreadContext.");
-    }
-}
-
 gl::GLObjectStore* ThreadContext::getGLObjectStore() {
     if (current.get() != nullptr) {
         return current.get()->glObjectStore;

--- a/src/mbgl/util/thread_context.cpp
+++ b/src/mbgl/util/thread_context.cpp
@@ -44,22 +44,6 @@ ThreadPriority ThreadContext::getPriority() {
     }
 }
 
-gl::GLObjectStore* ThreadContext::getGLObjectStore() {
-    if (current.get() != nullptr) {
-        return current.get()->glObjectStore;
-    } else {
-        return nullptr;
-    }
-}
-
-void ThreadContext::setGLObjectStore(gl::GLObjectStore* glObjectStore) {
-    if (current.get() != nullptr) {
-        current.get()->glObjectStore = glObjectStore;
-    } else {
-        throw std::runtime_error("Current thread has no current ThreadContext.");
-    }
-}
-
 class MainThreadContextRegistrar {
 public:
     MainThreadContextRegistrar() : context("Main", ThreadType::Main, ThreadPriority::Regular) {

--- a/src/mbgl/util/thread_context.hpp
+++ b/src/mbgl/util/thread_context.hpp
@@ -6,9 +6,6 @@
 #include <thread>
 
 namespace mbgl {
-
-namespace gl { class GLObjectStore; }
-
 namespace util {
 
 enum class ThreadPriority : bool {
@@ -33,14 +30,9 @@ public:
     static std::string getName();
     static ThreadPriority getPriority();
 
-    static gl::GLObjectStore* getGLObjectStore();
-    static void setGLObjectStore(gl::GLObjectStore* glObjectStore);
-
     std::string name;
     ThreadType type;
     ThreadPriority priority;
-
-    gl::GLObjectStore* glObjectStore = nullptr;
 };
 
 } // namespace util

--- a/src/mbgl/util/thread_context.hpp
+++ b/src/mbgl/util/thread_context.hpp
@@ -7,7 +7,6 @@
 
 namespace mbgl {
 
-class FileSource;
 namespace gl { class GLObjectStore; }
 
 namespace util {
@@ -34,8 +33,6 @@ public:
     static std::string getName();
     static ThreadPriority getPriority();
 
-    static FileSource* getFileSource();
-    static void setFileSource(FileSource* fileSource);
     static gl::GLObjectStore* getGLObjectStore();
     static void setGLObjectStore(gl::GLObjectStore* glObjectStore);
 
@@ -43,7 +40,6 @@ public:
     ThreadType type;
     ThreadPriority priority;
 
-    FileSource* fileSource = nullptr;
     gl::GLObjectStore* glObjectStore = nullptr;
 };
 

--- a/test/api/custom_layer.cpp
+++ b/test/api/custom_layer.cpp
@@ -7,46 +7,52 @@
 #include <mbgl/layer/custom_layer.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/mat4.hpp>
-#include <mbgl/gl/gl_object_store.hpp>
 
 using namespace mbgl;
 
 static const GLchar * vertexShaderSource = "attribute vec2 a_pos; void main() { gl_Position = vec4(a_pos, 0, 1); }";
 static const GLchar * fragmentShaderSource = "void main() { gl_FragColor = vec4(0, 1, 0, 1); }";
 
+// Not using any mbgl-specific stuff (other than a basic error-checking macro) in the
+// layer implementation because it is intended to reflect how someone using custom layers
+// might actually write their own implementation.
+
 class TestLayer {
 public:
     ~TestLayer() {
         if (program) {
-            MBGL_CHECK_ERROR(glDetachShader(program.getID(), vertexShader.getID()));
-            MBGL_CHECK_ERROR(glDetachShader(program.getID(), fragmentShader.getID()));
+            MBGL_CHECK_ERROR(glDeleteBuffers(1, &buffer));
+            MBGL_CHECK_ERROR(glDetachShader(program, vertexShader));
+            MBGL_CHECK_ERROR(glDetachShader(program, fragmentShader));
+            MBGL_CHECK_ERROR(glDeleteShader(vertexShader));
+            MBGL_CHECK_ERROR(glDeleteShader(fragmentShader));
+            MBGL_CHECK_ERROR(glDeleteProgram(program));
         }
     }
 
     void initialize() {
-        program.create();
-        vertexShader.create();
-        fragmentShader.create();
+        program = MBGL_CHECK_ERROR(glCreateProgram());
+        vertexShader = MBGL_CHECK_ERROR(glCreateShader(GL_VERTEX_SHADER));
+        fragmentShader = MBGL_CHECK_ERROR(glCreateShader(GL_FRAGMENT_SHADER));
 
-        MBGL_CHECK_ERROR(glShaderSource(vertexShader.getID(), 1, &vertexShaderSource, nullptr));
-        MBGL_CHECK_ERROR(glCompileShader(vertexShader.getID()));
-        MBGL_CHECK_ERROR(glAttachShader(program.getID(), vertexShader.getID()));
-        MBGL_CHECK_ERROR(glShaderSource(fragmentShader.getID(), 1, &fragmentShaderSource, nullptr));
-        MBGL_CHECK_ERROR(glCompileShader(fragmentShader.getID()));
-        MBGL_CHECK_ERROR(glAttachShader(program.getID(), fragmentShader.getID()));
-        MBGL_CHECK_ERROR(glLinkProgram(program.getID()));
-        a_pos = glGetAttribLocation(program.getID(), "a_pos");
+        MBGL_CHECK_ERROR(glShaderSource(vertexShader, 1, &vertexShaderSource, nullptr));
+        MBGL_CHECK_ERROR(glCompileShader(vertexShader));
+        MBGL_CHECK_ERROR(glAttachShader(program, vertexShader));
+        MBGL_CHECK_ERROR(glShaderSource(fragmentShader, 1, &fragmentShaderSource, nullptr));
+        MBGL_CHECK_ERROR(glCompileShader(fragmentShader));
+        MBGL_CHECK_ERROR(glAttachShader(program, fragmentShader));
+        MBGL_CHECK_ERROR(glLinkProgram(program));
+        a_pos = glGetAttribLocation(program, "a_pos");
 
-        buffer.create();
-        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer.getID()));
-
-        GLfloat background[] = { -1,-1, 1,-1,-1, 1, 1, 1 };
+        GLfloat background[] = { -1,-1, 1,-1, -1,1, 1,1 };
+        MBGL_CHECK_ERROR(glGenBuffers(1, &buffer));
+        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer));
         MBGL_CHECK_ERROR(glBufferData(GL_ARRAY_BUFFER, 8 * sizeof(GLfloat), background, GL_STATIC_DRAW));
     }
 
     void render() {
-        MBGL_CHECK_ERROR(glUseProgram(program.getID()));
-        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer.getID()));
+        MBGL_CHECK_ERROR(glUseProgram(program));
+        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer));
         MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
         MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_FLOAT, GL_FALSE, 0, NULL));
         MBGL_CHECK_ERROR(glDisable(GL_STENCIL_TEST));
@@ -54,10 +60,10 @@ public:
         MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
     }
 
-    gl::ProgramHolder program;
-    gl::ShaderHolder vertexShader = { GL_VERTEX_SHADER };
-    gl::ShaderHolder fragmentShader = { GL_FRAGMENT_SHADER };
-    gl::BufferHolder buffer;
+    GLuint program = 0;
+    GLuint vertexShader = 0;
+    GLuint fragmentShader = 0;
+    GLuint buffer = 0;
     GLuint a_pos = 0;
 };
 

--- a/test/sprite/sprite_store.cpp
+++ b/test/sprite/sprite_store.cpp
@@ -156,7 +156,6 @@ public:
     SpriteStoreTest()
         : spriteStore(1.0) {}
 
-    util::ThreadContext context { "Map", util::ThreadType::Map, util::ThreadPriority::Regular };
     util::RunLoop loop;
     StubFileSource fileSource;
     StubStyleObserver observer;
@@ -166,11 +165,8 @@ public:
         // Squelch logging.
         Log::setObserver(std::make_unique<Log::NullObserver>());
 
-        util::ThreadContext::Set(&context);
-        util::ThreadContext::setFileSource(&fileSource);
-
         spriteStore.setObserver(&observer);
-        spriteStore.setURL("test/fixtures/resources/sprite");
+        spriteStore.load("test/fixtures/resources/sprite", fileSource);
 
         loop.run();
     }

--- a/test/style/glyph_store.cpp
+++ b/test/style/glyph_store.cpp
@@ -17,14 +17,13 @@ public:
     util::RunLoop loop;
     StubFileSource fileSource;
     StubStyleObserver observer;
-    GlyphStore glyphStore;
+    GlyphStore glyphStore { fileSource };
 
     void run(const std::string& url, const std::string& fontStack, const std::set<GlyphRange>& glyphRanges) {
         // Squelch logging.
         Log::setObserver(std::make_unique<Log::NullObserver>());
 
         util::ThreadContext::Set(&context);
-        util::ThreadContext::setFileSource(&fileSource);
 
         glyphStore.setObserver(&observer);
         glyphStore.setURL(url);

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -31,7 +31,7 @@ public:
     Worker worker { 1 };
     gl::TexturePool texturePool;
     MapData mapData { MapMode::Still, GLContextMode::Unique, 1.0 };
-    Style style { mapData };
+    Style style { mapData, fileSource };
 
     StyleUpdateParameters updateParameters {
         1.0,
@@ -39,6 +39,7 @@ public:
         TimePoint(),
         transformState,
         worker,
+        fileSource,
         texturePool,
         true,
         MapMode::Continuous,
@@ -51,7 +52,6 @@ public:
         Log::setObserver(std::make_unique<Log::NullObserver>());
 
         util::ThreadContext::Set(&context);
-        util::ThreadContext::setFileSource(&fileSource);
 
         transform.resize({{ 512, 512 }});
         transform.setLatLngZoom({0, 0}, 0);
@@ -88,7 +88,7 @@ TEST(Source, LoadingFail) {
 
     Source source(SourceType::Vector, "source", "url", 512, nullptr, nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
 
     test.run();
 }
@@ -111,7 +111,7 @@ TEST(Source, LoadingCorrupt) {
 
     Source source(SourceType::Vector, "source", "url", 512, nullptr, nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
 
     test.run();
 }
@@ -139,7 +139,7 @@ TEST(Source, RasterTileEmpty) {
 
     Source source(SourceType::Raster, "source", "", 512, std::move(info), nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
     source.update(test.updateParameters);
 
     test.run();
@@ -168,7 +168,7 @@ TEST(Source, VectorTileEmpty) {
 
     Source source(SourceType::Vector, "source", "", 512, std::move(info), nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
     source.update(test.updateParameters);
 
     test.run();
@@ -197,7 +197,7 @@ TEST(Source, RasterTileFail) {
 
     Source source(SourceType::Raster, "source", "", 512, std::move(info), nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
     source.update(test.updateParameters);
 
     test.run();
@@ -226,7 +226,7 @@ TEST(Source, VectorTileFail) {
 
     Source source(SourceType::Vector, "source", "", 512, std::move(info), nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
     source.update(test.updateParameters);
 
     test.run();
@@ -254,7 +254,7 @@ TEST(Source, RasterTileCorrupt) {
 
     Source source(SourceType::Raster, "source", "", 512, std::move(info), nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
     source.update(test.updateParameters);
 
     test.run();
@@ -287,7 +287,7 @@ TEST(Source, VectorTileCorrupt) {
 
     Source source(SourceType::Vector, "source", "", 512, std::move(info), nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
     source.update(test.updateParameters);
 
     test.run();
@@ -314,7 +314,7 @@ TEST(Source, RasterTileCancel) {
 
     Source source(SourceType::Raster, "source", "", 512, std::move(info), nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
     source.update(test.updateParameters);
 
     test.run();
@@ -341,7 +341,7 @@ TEST(Source, VectorTileCancel) {
 
     Source source(SourceType::Vector, "source", "", 512, std::move(info), nullptr);
     source.setObserver(&test.observer);
-    source.load();
+    source.load(test.fileSource);
     source.update(test.updateParameters);
 
     test.run();

--- a/test/style/style.cpp
+++ b/test/style/style.cpp
@@ -1,4 +1,5 @@
 #include "../fixtures/util.hpp"
+#include "../fixtures/stub_file_source.hpp"
 
 #include <mbgl/map/map_data.hpp>
 #include <mbgl/style/style.hpp>
@@ -7,11 +8,13 @@
 using namespace mbgl;
 
 TEST(Style, UnusedSource) {
+    util::RunLoop loop;
     util::ThreadContext context { "Map", util::ThreadType::Map, util::ThreadPriority::Regular };
     util::ThreadContext::Set(&context);
 
     MapData data { MapMode::Still, GLContextMode::Unique, 1.0 };
-    Style style { data };
+    StubFileSource fileSource;
+    Style style { data, fileSource };
 
     style.setJSON(util::read_file("test/fixtures/resources/style-unused-sources.json"), "");
     style.cascade();
@@ -27,11 +30,13 @@ TEST(Style, UnusedSource) {
 }
 
 TEST(Style, UnusedSourceActiveViaClassUpdate) {
+    util::RunLoop loop;
     util::ThreadContext context { "Map", util::ThreadType::Map, util::ThreadPriority::Regular };
     util::ThreadContext::Set(&context);
 
     MapData data { MapMode::Still, GLContextMode::Unique, 1.0 };
-    Style style { data };
+    StubFileSource fileSource;
+    Style style { data, fileSource };
 
     data.addClass("visible");
 


### PR DESCRIPTION
Preparation for #2909.

This eliminates the reliance on ThreadContext to provide FileSource and GLObjectStore, and statically enforces that GL cleanup functions happen _only_ when GLObjectStore::performCleanup is called.

With the elimination of the Map thread, this becomes important because there may be multiple Maps per thread, and Map will need to ensure that the correct context is active when calling GLObjectStore::performCleanup.

:eyes: @tmpsantos @brunoabinader 