### PR TITLE
Set default polyline and polygon color to match app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Known issues:
 
 ## iOS master
 
+- Polygons and polylines now default to using the map view's tint color. ([#4028](https://github.com/mapbox/mapbox-gl-native/pull/4028))
+
 ## iOS 3.1.0
 
 - The SDK is now distributed as a dynamic framework instead of a static library, resulting in a simpler installation workflow and significantly reduced download size. The framework contains both simulator and device content; due to [an Xcode bug](http://www.openradar.me/radar?id=6409498411401216), you’ll need to strip out the simulator content before submitting your application to the App Store. ([#3183](https://github.com/mapbox/mapbox-gl-native/pull/3183))

--- a/platform/ios/include/MGLMapView.h
+++ b/platform/ios/include/MGLMapView.h
@@ -1133,7 +1133,7 @@ IB_DESIGNABLE
 - (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation;
 
 /**
- Returns the stroke color to use when rendering a shape annotation. Defaults to black.
+ Returns the stroke color to use when rendering a shape annotation. Defaults to the map view’s tint color.
  
  @param mapView The map view rendering the shape annotation.
  @param annotation The annotation being rendered.
@@ -1142,7 +1142,7 @@ IB_DESIGNABLE
 - (UIColor *)mapView:(MGLMapView *)mapView strokeColorForShapeAnnotation:(MGLShape *)annotation;
 
 /**
- Returns the fill color to use when rendering a polygon annotation. Defaults to blue.
+ Returns the fill color to use when rendering a polygon annotation. Defaults to the map view’s tint color.
  
  @param mapView The map view rendering the polygon annotation.
  @param annotation The annotation being rendered.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2469,7 +2469,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 {
     UIColor *color = (_delegateHasStrokeColorsForShapeAnnotations
                       ? [self.delegate mapView:self strokeColorForShapeAnnotation:annotation]
-                      : [UIColor blackColor]);
+                      : self.tintColor);
     return MGLColorObjectFromUIColor(color);
 }
 
@@ -2477,7 +2477,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 {
     UIColor *color = (_delegateHasFillColorsForShapeAnnotations
                       ? [self.delegate mapView:self fillColorForPolygonAnnotation:annotation]
-                      : [UIColor blueColor]);
+                      : self.tintColor);
     return MGLColorObjectFromUIColor(color);
 }
 

--- a/platform/osx/app/MainMenu.xib
+++ b/platform/osx/app/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10109" systemVersion="15E39d" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10109"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -473,10 +473,16 @@
                                     <action selector="dropManyPins:" target="-1" id="Rtv-8N-3Z8"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Remove All Pins" id="6rC-68-vk0">
+                            <menuItem title="Add Polygon and Polyline" id="DVr-vT-lpe">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="removeAllPins:" target="-1" id="NRM-y5-Wul"/>
+                                    <action selector="drawPolygonAndPolyLineAnnotations:" target="-1" id="EhT-CB-gee"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Remove All Annotations" id="6rC-68-vk0">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="removeAllAnnotations:" target="-1" id="6v3-0E-LsR"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="wQq-Mx-QY0"/>
@@ -545,7 +551,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="109" y="131" width="350" height="62"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
             <view key="contentView" id="eA4-n3-qPe">
                 <rect key="frame" x="0.0" y="0.0" width="350" height="62"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/platform/osx/include/MGLMapViewDelegate.h
+++ b/platform/osx/include/MGLMapViewDelegate.h
@@ -104,8 +104,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Returns the color to use when rendering the outline of a shape annotation.
     
-    The default stroke color is black. If a pattern color is specified, the
-    result is undefined.
+    The default stroke color is the selected menu item color. If a pattern
+    color is specified, the result is undefined.
     
     @param mapView The map view rendering the shape annotation.
     @param annotation The annotation being rendered.
@@ -114,8 +114,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Returns the color to use when rendering the fill of a polygon annotation.
     
-    The default fill color is blue. If a pattern color is specified, the result
-    is undefined.
+    The default fill color is selected menu item color. If a pattern color
+    is specified, the result is undefined.
     
     @param mapView The map view rendering the polygon annotation.
     @param annotation The annotation being rendered.

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1987,14 +1987,14 @@ public:
 - (mbgl::Color)strokeColorForShapeAnnotation:(MGLShape *)annotation {
     NSColor *color = (_delegateHasStrokeColorsForShapeAnnotations
                       ? [self.delegate mapView:self strokeColorForShapeAnnotation:annotation]
-                      : [NSColor blackColor]);
+                      : [NSColor selectedMenuItemColor]);
     return MGLColorObjectFromNSColor(color);
 }
 
 - (mbgl::Color)fillColorForPolygonAnnotation:(MGLPolygon *)annotation {
     NSColor *color = (_delegateHasFillColorsForShapeAnnotations
                       ? [self.delegate mapView:self fillColorForPolygonAnnotation:annotation]
-                      : [NSColor blueColor]);
+                      : [NSColor selectedMenuItemColor]);
     return MGLColorObjectFromNSColor(color);
 }
 


### PR DESCRIPTION
**iOS**
- Set the poly annotation stroke and fill color to the map view's tint color

**OS X**
- Set the poly annotation stroke and fill color to the system menu item selection color
- Add polygon and polyline examples

Fixes #3927.

/cc @1ec5 