### PR TITLE
Import required frameworks with static framework umbrella

### DIFF
--- a/ios/docs/pod-README.md
+++ b/ios/docs/pod-README.md
@@ -16,7 +16,7 @@ The Mapbox iOS SDK may be installed as either a dynamic framework or a static fr
 
 This is the recommended workflow for manually integrating the SDK into an application targeting iOS 8 and above:
 
-1. Open the project editor and select your application target. Drag `Mapbox.framework` from the `dynamic` folder into the “Embedded Binaries” section of the General tab. In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
+1. Open the project editor and select your application target. Drag `Mapbox.framework` from the `dynamic` folder into the “Embedded Binaries” section of the General tab. (Don’t drag it into the “Linked Frameworks and Libraries” section; Xcode will add it there automatically.) In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
 
 1. In the Build Phases tab, click the + button at the top and select “New Run Script Phase”. Enter the following code into the script text field:
 
@@ -33,18 +33,13 @@ bash "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework/strip-fra
 
 If your application targets iOS 7.x, you’ll need to install the static framework instead:
 
-1. Open the project editor and select your application target. Drag `Mapbox.framework` from the `static` folder into the “Embedded Binaries” section of the General tab. In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
+1. Open the project editor and select your application target. Drag `Mapbox.framework` from the `static` folder into the “Embedded Binaries” section of the General tab. (Don’t drag it into the “Linked Frameworks and Libraries” section; Xcode will add it there automatically.) In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
 
 1. Add the following Cocoa Touch frameworks and libraries to the “Linked Frameworks and Libraries” section:
 
    - `GLKit.framework`
    - `ImageIO.framework`
    - `MobileCoreServices.framework`
-   - `QuartzCore.framework`
-   - `SystemConfiguration.framework`
-   - `libc++.tbd`
-   - `libsqlite3.tbd`
-   - `libz.tbd`
 
 1. In the Build Settings tab, add `-ObjC` to the “Other Linker Flags” (`OTHER_LDFLAGS`) build setting.
 

--- a/ios/docs/pod-README.md
+++ b/ios/docs/pod-README.md
@@ -35,12 +35,6 @@ If your application targets iOS 7.x, you’ll need to install the static framewo
 
 1. Open the project editor and select your application target. Drag `Mapbox.framework` from the `static` folder into the “Embedded Binaries” section of the General tab. (Don’t drag it into the “Linked Frameworks and Libraries” section; Xcode will add it there automatically.) In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
 
-1. Add the following Cocoa Touch frameworks and libraries to the “Linked Frameworks and Libraries” section:
-
-   - `GLKit.framework`
-   - `ImageIO.framework`
-   - `MobileCoreServices.framework`
-
 1. In the Build Settings tab, add `-ObjC` to the “Other Linker Flags” (`OTHER_LDFLAGS`) build setting.
 
 {{/STATIC}}

--- a/ios/framework/Mapbox-static.h
+++ b/ios/framework/Mapbox-static.h
@@ -1,0 +1,3 @@
+#import <GLKit/GLKit.h>
+#import <ImageIO/ImageIO.h>
+#import <MobileCoreServices/MobileCoreServices.h>

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -97,12 +97,6 @@ If your application targets iOS 7.x, you’ll need to install the static framewo
 
 1. Open the project editor and select your application target. Drag `build/ios/pkg/static/Mapbox.framework` into the “Embedded Binaries” section of the General tab. (Don’t drag it into the “Linked Frameworks and Libraries” section; Xcode will add it there automatically.) In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
 
-1. Add the following Cocoa Touch frameworks and libraries to the “Linked Frameworks and Libraries” section:
-
-   - `GLKit.framework`
-   - `ImageIO.framework`
-   - `MobileCoreServices.framework`
-
 1. In the Build Settings tab, add `-ObjC` to the “Other Linker Flags” (`OTHER_LDFLAGS`) build setting.
 
 ### Use

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -79,7 +79,7 @@ This is the recommended workflow for manually integrating the SDK into an applic
 
 1. Build from source manually per above.
 
-1. Open the project editor and select your application target. Drag `build/ios/pkg/dynamic/Mapbox.framework` into the “Embedded Binaries” section of the General tab. In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
+1. Open the project editor and select your application target. Drag `build/ios/pkg/dynamic/Mapbox.framework` into the “Embedded Binaries” section of the General tab. (Don’t drag it into the “Linked Frameworks and Libraries” section; Xcode will add it there automatically.) In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
 
 1. In the Build Phases tab, click the + button at the top and select “New Run Script Phase”. Enter the following code into the script text field:
 
@@ -95,18 +95,13 @@ If your application targets iOS 7.x, you’ll need to install the static framewo
 
 1. Build from source manually per above.
 
-1. Open the project editor and select your application target. Drag `build/ios/pkg/static/Mapbox.framework` into the “Embedded Binaries” section of the General tab. In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
+1. Open the project editor and select your application target. Drag `build/ios/pkg/static/Mapbox.framework` into the “Embedded Binaries” section of the General tab. (Don’t drag it into the “Linked Frameworks and Libraries” section; Xcode will add it there automatically.) In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
 
 1. Add the following Cocoa Touch frameworks and libraries to the “Linked Frameworks and Libraries” section:
 
    - `GLKit.framework`
    - `ImageIO.framework`
    - `MobileCoreServices.framework`
-   - `QuartzCore.framework`
-   - `SystemConfiguration.framework`
-   - `libc++.tbd`
-   - `libsqlite3.tbd`
-   - `libz.tbd`
 
 1. In the Build Settings tab, add `-ObjC` to the “Other Linker Flags” (`OTHER_LDFLAGS`) build setting.
 

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -188,6 +188,8 @@ if [[ ${BUILD_STATIC} == true ]]; then
     step "Copying static library headers…"
     mkdir -p "${OUTPUT}/static/${NAME}.framework/Headers"
     cp -pv include/mbgl/{darwin,ios}/*.h "${OUTPUT}/static/${NAME}.framework/Headers"
+    cat ios/framework/Mapbox-static.h > "${OUTPUT}/static/${NAME}.framework/Headers/Mapbox.h"
+    cat ios/framework/Mapbox.h >> "${OUTPUT}/static/${NAME}.framework/Headers/Mapbox.h"
 fi
 
 step "Copying library resources…"


### PR DESCRIPTION
This change corrects a regression introduced in #3183, when the umbrella header used in version 3.0.1 was removed. The umbrella header inside the static framework now imports the required iOS SDK frameworks. With this change, it’s no longer necessary to manually link any frameworks other than Mapbox.framework.

/cc @friedbunny