### PR TITLE
Don't use strings as IDs

### DIFF
--- a/include/mbgl/util/id.hpp
+++ b/include/mbgl/util/id.hpp
@@ -1,0 +1,84 @@
+#ifndef MBGL_UTIL_ID
+#define MBGL_UTIL_ID
+
+#include <cstdint>
+#include <string>
+#include <iosfwd>
+
+namespace mbgl {
+namespace util {
+
+class Dictionary {
+public:
+    using Type = uint32_t;
+
+public:
+    static Type Lookup(const std::string&);
+    static const std::string& Lookup(Type);
+};
+
+template <typename Tag>
+class ID {
+public:
+    static constexpr Dictionary::Type None = 0;
+
+    ID() : id(None) {
+    }
+    ID(const std::string& name) : id(Dictionary::Lookup(name)) {
+    }
+
+    ID& operator=(const ID& rhs) = default;
+    ID& operator=(const std::string& name) {
+        id = Dictionary::Lookup(name);
+        return *this;
+    }
+
+    bool valid() const {
+        return id != None;
+    }
+    bool operator==(const ID& rhs) const {
+        return valid() && id == rhs.id;
+    }
+    bool operator!=(const ID& rhs) const {
+        return !valid() || id != rhs.id;
+    }
+    bool operator<(const ID& rhs) const {
+        return id < rhs.id;
+    }
+
+    const std::string& str() const {
+        return Dictionary::Lookup(id);
+    }
+    const char* c_str() const {
+        return str().c_str();
+    }
+
+private:
+    Dictionary::Type id;
+
+    friend struct ::std::hash<ID>;
+};
+
+template <typename Tag>
+inline std::ostream& operator<<(std::ostream& os, ID<Tag> t) {
+    return os << t.str();
+}
+
+} // namespace util
+} // namespace mbgl
+
+namespace std {
+
+template <typename Tag>
+struct hash<mbgl::util::ID<Tag>> {
+    typedef mbgl::util::ID<Tag> argument_type;
+    typedef std::size_t result_type;
+
+    result_type operator()(mbgl::util::ID<Tag> id) const {
+        return static_cast<result_type>(id.id);
+    }
+};
+
+} // namespace std
+
+#endif

--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -39,7 +39,7 @@ void ShapeAnnotationImpl::updateStyle(Style& style) {
 
         layer->id = layerID;
         layer->source = AnnotationManager::SourceID;
-        layer->sourceLayer = layer->id;
+        layer->sourceLayer = layerID;
 
         style.addLayer(std::move(layer), AnnotationManager::PointLayerID);
 
@@ -55,7 +55,7 @@ void ShapeAnnotationImpl::updateStyle(Style& style) {
 
         layer->id = layerID;
         layer->source = AnnotationManager::SourceID;
-        layer->sourceLayer = layer->id;
+        layer->sourceLayer = layerID;
 
         style.addLayer(std::move(layer), AnnotationManager::PointLayerID);
 
@@ -70,9 +70,9 @@ void ShapeAnnotationImpl::updateStyle(Style& style) {
             : geojsonvt::ProjectedFeatureType::Polygon;
 
         layer->id = layerID;
-        layer->ref = "";
+        layer->ref = util::ID<StyleLayer>();
         layer->source = AnnotationManager::SourceID;
-        layer->sourceLayer = layer->id;
+        layer->sourceLayer = layerID;
         layer->visibility = VisibilityType::Visible;
 
         style.addLayer(std::move(layer), sourceLayer->id);

--- a/src/mbgl/layer/custom_layer.cpp
+++ b/src/mbgl/layer/custom_layer.cpp
@@ -4,7 +4,7 @@
 
 namespace mbgl {
 
-CustomLayer::CustomLayer(const std::string& id_,
+CustomLayer::CustomLayer(util::ID<StyleLayer> id_,
                          CustomLayerInitializeFunction initializeFn_,
                          CustomLayerRenderFunction renderFn_,
                          CustomLayerDeinitializeFunction deinitializeFn_,

--- a/src/mbgl/layer/custom_layer.hpp
+++ b/src/mbgl/layer/custom_layer.hpp
@@ -9,7 +9,7 @@ class TransformState;
 
 class CustomLayer : public StyleLayer {
 public:
-    CustomLayer(const std::string& id,
+    CustomLayer(util::ID<StyleLayer> id,
                 CustomLayerInitializeFunction,
                 CustomLayerRenderFunction,
                 CustomLayerDeinitializeFunction,

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -480,7 +480,7 @@ void Map::addCustomLayer(const std::string& id,
                          const char* before) {
     context->invoke(&MapContext::addLayer,
         std::make_unique<CustomLayer>(id, initialize, render, deinitialize, context_),
-        before ? std::string(before) : optional<std::string>());
+        before ? util::ID<StyleLayer>(before) : util::ID<StyleLayer>());
 }
 
 void Map::removeCustomLayer(const std::string& id) {

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -276,7 +276,7 @@ double MapContext::getTopOffsetPixelsForAnnotationIcon(const std::string& name) 
     return data.getAnnotationManager()->getTopOffsetPixelsForIcon(name);
 }
 
-void MapContext::addLayer(std::unique_ptr<StyleLayer> layer, optional<std::string> after) {
+void MapContext::addLayer(std::unique_ptr<StyleLayer> layer, util::ID<StyleLayer> after) {
     style->addLayer(std::move(layer), after);
     updateFlags |= Update::Classes;
     asyncUpdate.send();

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -57,8 +57,7 @@ public:
     void updateAnnotations();
     
     // Style API
-    void addLayer(std::unique_ptr<StyleLayer>,
-                  const optional<std::string> before);
+    void addLayer(std::unique_ptr<StyleLayer>, util::ID<StyleLayer> before);
     void removeLayer(const std::string& id);
 
     void setSourceTileCacheSize(size_t size);

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -242,12 +242,12 @@ void Painter::renderPass(RenderPass pass_,
             MBGL_DEBUG_GROUP("background");
             renderBackground(*layer.as<BackgroundLayer>());
         } else if (layer.is<CustomLayer>()) {
-            MBGL_DEBUG_GROUP(layer.id + " - custom");
+            MBGL_DEBUG_GROUP(layer.id.str() + " - custom");
             VertexArrayObject::Unbind();
             layer.as<CustomLayer>()->render(state);
             config.setDirty();
         } else {
-            MBGL_DEBUG_GROUP(layer.id + " - " + std::string(item.tile->id));
+            MBGL_DEBUG_GROUP(layer.id.str() + " - " + std::string(item.tile->id));
             prepareTile(*item.tile);
             item.bucket->render(*this, layer, item.tile->id, item.tile->matrix);
         }

--- a/src/mbgl/source/source.cpp
+++ b/src/mbgl/source/source.cpp
@@ -37,7 +37,7 @@
 namespace mbgl {
 
 Source::Source(SourceType type_,
-               const std::string& id_,
+               util::ID<Source> id_,
                const std::string& url_,
                uint16_t tileSize_,
                std::unique_ptr<SourceInfo>&& info_,

--- a/src/mbgl/source/source.hpp
+++ b/src/mbgl/source/source.hpp
@@ -7,6 +7,7 @@
 
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/rapidjson.hpp>
+#include <mbgl/util/id.hpp>
 
 #include <forward_list>
 #include <vector>
@@ -44,7 +45,7 @@ public:
     };
 
     Source(SourceType,
-           const std::string& id,
+           util::ID<Source> id,
            const std::string& url,
            uint16_t tileSize,
            std::unique_ptr<SourceInfo>&&,
@@ -77,7 +78,7 @@ public:
     void dumpDebugLogs() const;
 
     const SourceType type;
-    const std::string id;
+    const util::ID<Source> id;
     const std::string url;
     uint16_t tileSize = util::tileSize;
     bool enabled = false;

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -190,6 +190,10 @@ void Style::recalculate(float z) {
 }
 
 Source* Style::getSource(const std::string& id) const {
+    return getSource(util::ID<Source>(id));
+}
+
+Source* Style::getSource(util::ID<Source> id) const {
     const auto it = std::find_if(sources.begin(), sources.end(), [&](const auto& source) {
         return source->id == id;
     });

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -84,18 +84,18 @@ std::vector<std::unique_ptr<StyleLayer>> Style::getLayers() const {
     return result;
 }
 
-std::vector<std::unique_ptr<StyleLayer>>::const_iterator Style::findLayer(const std::string& id) const {
-    return std::find_if(layers.begin(), layers.end(), [&](const auto& layer) {
+std::vector<std::unique_ptr<StyleLayer>>::const_iterator Style::findLayer(const util::ID<StyleLayer> id) const {
+    return std::find_if(layers.begin(), layers.end(), [=](const auto& layer) {
         return layer->id == id;
     });
 }
 
-StyleLayer* Style::getLayer(const std::string& id) const {
+StyleLayer* Style::getLayer(const util::ID<StyleLayer> id) const {
     auto it = findLayer(id);
     return it != layers.end() ? it->get() : nullptr;
 }
 
-void Style::addLayer(std::unique_ptr<StyleLayer> layer, optional<std::string> before) {
+void Style::addLayer(std::unique_ptr<StyleLayer> layer, util::ID<StyleLayer> before) {
     if (SymbolLayer* symbolLayer = layer->as<SymbolLayer>()) {
         if (!symbolLayer->spriteAtlas) {
             symbolLayer->spriteAtlas = spriteAtlas.get();
@@ -106,10 +106,10 @@ void Style::addLayer(std::unique_ptr<StyleLayer> layer, optional<std::string> be
         customLayer->initialize();
     }
 
-    layers.emplace(before ? findLayer(*before) : layers.end(), std::move(layer));
+    layers.emplace(before.valid() ? findLayer(before) : layers.end(), std::move(layer));
 }
 
-void Style::removeLayer(const std::string& id) {
+void Style::removeLayer(const util::ID<StyleLayer> id) {
     auto it = findLayer(id);
     if (it == layers.end())
         throw std::runtime_error("no such layer");

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -92,6 +92,7 @@ public:
     }
 
     Source* getSource(const std::string& id) const;
+    Source* getSource(util::ID<Source> id) const;
     void addSource(std::unique_ptr<Source>);
 
     std::vector<std::unique_ptr<StyleLayer>> getLayers() const;

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -96,10 +96,10 @@ public:
     void addSource(std::unique_ptr<Source>);
 
     std::vector<std::unique_ptr<StyleLayer>> getLayers() const;
-    StyleLayer* getLayer(const std::string& id) const;
+    StyleLayer* getLayer(util::ID<StyleLayer> id) const;
     void addLayer(std::unique_ptr<StyleLayer>,
-                  optional<std::string> beforeLayerID = {});
-    void removeLayer(const std::string& layerID);
+                  util::ID<StyleLayer> beforeLayerID = {});
+    void removeLayer(const util::ID<StyleLayer> layerID);
 
     RenderData getRenderData() const;
 
@@ -120,7 +120,7 @@ private:
     std::vector<std::unique_ptr<Source>> sources;
     std::vector<std::unique_ptr<StyleLayer>> layers;
 
-    std::vector<std::unique_ptr<StyleLayer>>::const_iterator findLayer(const std::string& layerID) const;
+    std::vector<std::unique_ptr<StyleLayer>>::const_iterator findLayer(util::ID<StyleLayer> id) const;
 
     // GlyphStore::Observer implementation.
     void onGlyphsLoaded(const std::string& fontStack, const GlyphRange&) override;

--- a/src/mbgl/style/style_layer.cpp
+++ b/src/mbgl/style/style_layer.cpp
@@ -2,8 +2,8 @@
 
 namespace mbgl {
 
-const std::string& StyleLayer::bucketName() const {
-    return ref.empty() ? id : ref;
+const util::ID<StyleLayer> StyleLayer::bucketID() const {
+    return ref.valid() ? ref : id;
 }
 
 bool StyleLayer::hasRenderPass(RenderPass pass) const {

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -45,7 +45,7 @@ public:
     virtual void parsePaints(const JSValue& value) = 0;
 
     // If the layer has a ref, the ref. Otherwise, the id.
-    const std::string& bucketName() const;
+    const util::ID<StyleLayer> bucketID() const;
 
     // Partially evaluate paint properties based on a set of classes.
     virtual void cascade(const StyleCascadeParameters&) = 0;
@@ -63,8 +63,8 @@ public:
     bool needsRendering() const;
 
 public:
-    std::string id;
-    std::string ref;
+    util::ID<StyleLayer> id;
+    util::ID<StyleLayer> ref;
     util::ID<Source> source;
     std::string sourceLayer;
     FilterExpression filter;

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/renderer/render_pass.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/rapidjson.hpp>
+#include <mbgl/util/id.hpp>
 
 #include <memory>
 #include <string>
@@ -17,6 +18,7 @@ class StyleCascadeParameters;
 class StyleCalculationParameters;
 class StyleBucketParameters;
 class Bucket;
+class Source;
 
 class StyleLayer {
 public:
@@ -63,7 +65,7 @@ public:
 public:
     std::string id;
     std::string ref;
-    std::string source;
+    util::ID<Source> source;
     std::string sourceLayer;
     FilterExpression filter;
     float minZoom = -std::numeric_limits<float>::infinity();

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -343,7 +343,7 @@ void StyleParser::parseLayers(const JSValue& value) {
     }
 }
 
-void StyleParser::parseLayer(const std::string& id, const JSValue& value, std::unique_ptr<StyleLayer>& layer) {
+void StyleParser::parseLayer(const util::ID<StyleLayer> id, const JSValue& value, std::unique_ptr<StyleLayer>& layer) {
     if (layer) {
         // Skip parsing this again. We already have a valid layer definition.
         return;

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <map>
 #include <unordered_map>
 #include <forward_list>
 
@@ -42,7 +43,7 @@ private:
     void parseLayer(const std::string& id, const JSValue&, std::unique_ptr<StyleLayer>&);
     void parseVisibility(StyleLayer&, const JSValue& value);
 
-    std::unordered_map<std::string, const Source*> sourcesMap;
+    std::map<util::ID<Source>, const Source*> sourcesMap;
     std::unordered_map<std::string, std::pair<const JSValue&, std::unique_ptr<StyleLayer>>> layersMap;
 
     // Store a stack of layer IDs we're parsing right now. This is to prevent reference cycles.

--- a/src/mbgl/style/style_parser.hpp
+++ b/src/mbgl/style/style_parser.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <string>
 #include <map>
-#include <unordered_map>
 #include <forward_list>
 
 namespace mbgl {
@@ -40,14 +39,14 @@ public:
 private:
     void parseSources(const JSValue&);
     void parseLayers(const JSValue&);
-    void parseLayer(const std::string& id, const JSValue&, std::unique_ptr<StyleLayer>&);
+    void parseLayer(util::ID<StyleLayer> id, const JSValue&, std::unique_ptr<StyleLayer>&);
     void parseVisibility(StyleLayer&, const JSValue& value);
 
     std::map<util::ID<Source>, const Source*> sourcesMap;
-    std::unordered_map<std::string, std::pair<const JSValue&, std::unique_ptr<StyleLayer>>> layersMap;
+    std::map<util::ID<StyleLayer>, std::pair<const JSValue&, std::unique_ptr<StyleLayer>>> layersMap;
 
     // Store a stack of layer IDs we're parsing right now. This is to prevent reference cycles.
-    std::forward_list<std::string> stack;
+    std::forward_list<util::ID<StyleLayer>> stack;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile_worker.cpp
+++ b/src/mbgl/tile/tile_worker.cpp
@@ -49,12 +49,12 @@ TileParseResult TileWorker::parseAllLayers(std::vector<std::unique_ptr<StyleLaye
 
     // We're storing a set of bucket names we've parsed to avoid parsing a bucket twice that is
     // referenced from more than one layer
-    std::set<std::string> parsed;
+    std::set<util::ID<StyleLayer>> parsed;
 
     for (auto i = layers.rbegin(); i != layers.rend(); i++) {
         const StyleLayer* layer = i->get();
-        if (parsed.find(layer->bucketName()) == parsed.end()) {
-            parsed.emplace(layer->bucketName());
+        if (parsed.find(layer->bucketID()) == parsed.end()) {
+            parsed.emplace(layer->bucketID());
             parseLayer(layer, *geometryTile);
         }
     }
@@ -81,7 +81,7 @@ TileParseResult TileWorker::parsePendingLayers(const PlacementConfig config) {
                                 *layer.spriteAtlas,
                                 glyphAtlas,
                                 glyphStore);
-            placementPending.emplace(layer.bucketName(), std::move(it->second));
+            placementPending.emplace(layer.bucketID(), std::move(it->second));
             pending.erase(it++);
             continue;
         }
@@ -109,7 +109,7 @@ void TileWorker::placeLayers(const PlacementConfig config) {
 }
 
 void TileWorker::redoPlacement(
-    const std::unordered_map<std::string, std::unique_ptr<Bucket>>* buckets,
+    const std::map<util::ID<StyleLayer>, std::unique_ptr<Bucket>>* buckets,
     PlacementConfig config) {
 
     CollisionTile collisionTile(config);
@@ -166,14 +166,14 @@ void TileWorker::parseLayer(const StyleLayer* layer, const GeometryTile& geometr
             // We cannot parse this bucket yet. Instead, we're saving it for later.
             pending.emplace_back(layer->as<SymbolLayer>(), std::move(bucket));
         } else {
-            placementPending.emplace(layer->bucketName(), std::move(bucket));
+            placementPending.emplace(layer->bucketID(), std::move(bucket));
         }
     } else {
-        insertBucket(layer->bucketName(), std::move(bucket));
+        insertBucket(layer->bucketID(), std::move(bucket));
     }
 }
 
-void TileWorker::insertBucket(const std::string& name, std::unique_ptr<Bucket> bucket) {
+void TileWorker::insertBucket(const util::ID<StyleLayer> name, std::unique_ptr<Bucket> bucket) {
     if (bucket->hasData()) {
         result.buckets.emplace(name, std::move(bucket));
     }

--- a/src/mbgl/tile/tile_worker.cpp
+++ b/src/mbgl/tile/tile_worker.cpp
@@ -17,7 +17,7 @@
 using namespace mbgl;
 
 TileWorker::TileWorker(TileID id_,
-                       std::string sourceID_,
+                       util::ID<Source> sourceID_,
                        SpriteStore& spriteStore_,
                        GlyphAtlas& glyphAtlas_,
                        GlyphStore& glyphStore_,

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -14,7 +14,7 @@
 #include <memory>
 #include <mutex>
 #include <list>
-#include <unordered_map>
+#include <map>
 
 namespace mbgl {
 
@@ -33,7 +33,7 @@ class Source;
 class TileParseResultBuckets {
 public:
     TileData::State state = TileData::State::invalid;
-    std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
+    std::map<util::ID<StyleLayer>, std::unique_ptr<Bucket>> buckets;
 };
 
 using TileParseResult = mapbox::util::variant<
@@ -57,12 +57,12 @@ public:
 
     TileParseResult parsePendingLayers(PlacementConfig);
 
-    void redoPlacement(const std::unordered_map<std::string, std::unique_ptr<Bucket>>*,
+    void redoPlacement(const std::map<util::ID<StyleLayer>, std::unique_ptr<Bucket>>*,
                        PlacementConfig);
 
 private:
     void parseLayer(const StyleLayer*, const GeometryTile&);
-    void insertBucket(const std::string& name, std::unique_ptr<Bucket>);
+    void insertBucket(util::ID<StyleLayer> name, std::unique_ptr<Bucket>);
     void placeLayers(PlacementConfig);
 
     const TileID id;
@@ -84,7 +84,7 @@ private:
 
     // Contains buckets that have been parsed, but still need placement.
     // They will be placed when all buckets have been parsed.
-    std::unordered_map<std::string, std::unique_ptr<Bucket>> placementPending;
+    std::map<util::ID<StyleLayer>, std::unique_ptr<Bucket>> placementPending;
 
     // Temporary holder
     TileParseResultBuckets result;

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -7,6 +7,7 @@
 #include <mbgl/tile/tile_data.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/ptr.hpp>
+#include <mbgl/util/id.hpp>
 #include <mbgl/text/placement_config.hpp>
 
 #include <string>
@@ -25,6 +26,7 @@ class GlyphStore;
 class Bucket;
 class StyleLayer;
 class SymbolLayer;
+class Source;
 
 // We're using this class to shuttle the resulting buckets from the worker thread to the MapContext
 // thread. This class is movable-only because the vector contains movable-only value elements.
@@ -41,7 +43,7 @@ using TileParseResult = mapbox::util::variant<
 class TileWorker : public util::noncopyable {
 public:
     TileWorker(TileID,
-               std::string sourceID,
+               util::ID<Source> sourceID,
                SpriteStore&,
                GlyphAtlas&,
                GlyphStore&,
@@ -64,7 +66,7 @@ private:
     void placeLayers(PlacementConfig);
 
     const TileID id;
-    const std::string sourceID;
+    const util::ID<Source> sourceID;
 
     SpriteStore& spriteStore;
     GlyphAtlas& glyphAtlas;

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -10,7 +10,7 @@ namespace mbgl {
 
 VectorTileData::VectorTileData(const TileID& id_,
                                std::unique_ptr<GeometryTileMonitor> monitor_,
-                               std::string sourceID,
+                               util::ID<Source> sourceID,
                                Style& style_,
                                const MapMode mode_,
                                const std::function<void(std::exception_ptr)>& callback)

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -131,7 +131,7 @@ bool VectorTileData::parsePending(std::function<void(std::exception_ptr)> callba
 }
 
 Bucket* VectorTileData::getBucket(const StyleLayer& layer) {
-    const auto it = buckets.find(layer.bucketName());
+    const auto it = buckets.find(layer.bucketID());
     if (it == buckets.end()) {
         return nullptr;
     }

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/tile/tile_data.hpp>
 #include <mbgl/tile/tile_worker.hpp>
 #include <mbgl/text/placement_config.hpp>
+#include <mbgl/util/id.hpp>
 
 #include <atomic>
 #include <memory>
@@ -15,12 +16,13 @@ class Style;
 class WorkRequest;
 class FileRequest;
 class GeometryTileMonitor;
+class Source;
 
 class VectorTileData : public TileData {
 public:
     VectorTileData(const TileID&,
                    std::unique_ptr<GeometryTileMonitor> monitor,
-                   std::string sourceID,
+                   util::ID<Source> sourceID,
                    Style&,
                    const MapMode,
                    const std::function<void(std::exception_ptr)>& callback);

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -8,7 +8,7 @@
 
 #include <atomic>
 #include <memory>
-#include <unordered_map>
+#include <map>
 
 namespace mbgl {
 
@@ -49,7 +49,7 @@ private:
 
     // Contains all the Bucket objects for the tile. Buckets are render
     // objects and they get added by tile parsing operations.
-    std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
+    std::map<util::ID<StyleLayer>, std::unique_ptr<Bucket>> buckets;
 
     // Stores the placement configuration of the text that is currently placed on the screen.
     PlacementConfig placedConfig;

--- a/src/mbgl/util/id.cpp
+++ b/src/mbgl/util/id.cpp
@@ -1,0 +1,51 @@
+#include <mbgl/util/id.hpp>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wredeclared-class-member"
+#include <boost/bimap.hpp>
+#pragma clang diagnostic pop
+
+#include <mutex>
+
+namespace mbgl {
+namespace util {
+
+namespace {
+
+std::mutex mutex;
+boost::bimap<std::string, Dictionary::Type> store;
+Dictionary::Type counter = 1;
+const std::string empty = "";
+
+} // namespace
+
+Dictionary::Type Dictionary::Lookup(const std::string& name) {
+    if (name.empty()) {
+        return Type();
+    } else {
+        std::lock_guard<std::mutex> lock(mutex);
+        const auto it = store.left.find(name);
+        if (it == store.left.end()) {
+            return store.insert({ name, counter++ }).first->right;
+        } else {
+            return it->second;
+        }
+    }
+}
+
+const std::string& Dictionary::Lookup(Type id) {
+    if (!id) {
+        return empty;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex);
+    const auto it = store.right.find(id);
+    if (it == store.right.end()) {
+        return empty;
+    } else {
+        return it->second;
+    }
+}
+
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -51,7 +51,7 @@ public:
     }
 
     void redoPlacement(TileWorker* worker,
-                       const std::unordered_map<std::string, std::unique_ptr<Bucket>>* buckets,
+                       const std::map<util::ID<StyleLayer>, std::unique_ptr<Bucket>>* buckets,
                        PlacementConfig config,
                        std::function<void()> callback) {
         worker->redoPlacement(buckets, config);
@@ -99,7 +99,7 @@ Worker::parsePendingGeometryTileLayers(TileWorker& worker,
 
 std::unique_ptr<WorkRequest>
 Worker::redoPlacement(TileWorker& worker,
-                      const std::unordered_map<std::string, std::unique_ptr<Bucket>>& buckets,
+                      const std::map<util::ID<StyleLayer>, std::unique_ptr<Bucket>>& buckets,
                       PlacementConfig config,
                       std::function<void()> callback) {
     current = (current + 1) % threads.size();

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -50,7 +50,7 @@ public:
                                            std::function<void(TileParseResult)> callback);
 
     Request redoPlacement(TileWorker&,
-                          const std::unordered_map<std::string, std::unique_ptr<Bucket>>&,
+                          const std::map<util::ID<StyleLayer>, std::unique_ptr<Bucket>>&,
                           PlacementConfig config,
                           std::function<void()> callback);
 

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -86,7 +86,7 @@ TEST(Source, LoadingFail) {
         test.end();
     };
 
-    Source source(SourceType::Vector, "source", "url", 512, nullptr, nullptr);
+    Source source(SourceType::Vector, util::ID<Source>("source"), "url", 512, nullptr, nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
 
@@ -109,7 +109,7 @@ TEST(Source, LoadingCorrupt) {
         test.end();
     };
 
-    Source source(SourceType::Vector, "source", "url", 512, nullptr, nullptr);
+    Source source(SourceType::Vector, util::ID<Source>("source"), "url", 512, nullptr, nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
 
@@ -126,7 +126,7 @@ TEST(Source, RasterTileEmpty) {
     };
 
     test.observer.tileLoaded = [&] (Source& source, const TileID&, bool) {
-        EXPECT_EQ("source", source.id);
+        EXPECT_EQ(util::ID<Source>("source"), source.id);
         test.end();
     };
 
@@ -137,7 +137,8 @@ TEST(Source, RasterTileEmpty) {
     auto info = std::make_unique<SourceInfo>();
     info->tiles = { "tiles" };
 
-    Source source(SourceType::Raster, "source", "", 512, std::move(info), nullptr);
+    Source source(SourceType::Raster, util::ID<Source>("source"), "", 512, std::move(info),
+                  nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -155,7 +156,7 @@ TEST(Source, VectorTileEmpty) {
     };
 
     test.observer.tileLoaded = [&] (Source& source, const TileID&, bool) {
-        EXPECT_EQ("source", source.id);
+        EXPECT_EQ(util::ID<Source>("source"), source.id);
         test.end();
     };
 
@@ -166,7 +167,8 @@ TEST(Source, VectorTileEmpty) {
     auto info = std::make_unique<SourceInfo>();
     info->tiles = { "tiles" };
 
-    Source source(SourceType::Vector, "source", "", 512, std::move(info), nullptr);
+    Source source(SourceType::Vector, util::ID<Source>("source"), "", 512, std::move(info),
+                  nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -195,7 +197,8 @@ TEST(Source, RasterTileFail) {
     auto info = std::make_unique<SourceInfo>();
     info->tiles = { "tiles" };
 
-    Source source(SourceType::Raster, "source", "", 512, std::move(info), nullptr);
+    Source source(SourceType::Raster, util::ID<Source>("source"), "", 512, std::move(info),
+                  nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -224,7 +227,8 @@ TEST(Source, VectorTileFail) {
     auto info = std::make_unique<SourceInfo>();
     info->tiles = { "tiles" };
 
-    Source source(SourceType::Vector, "source", "", 512, std::move(info), nullptr);
+    Source source(SourceType::Vector, util::ID<Source>("source"), "", 512, std::move(info),
+                  nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -252,7 +256,8 @@ TEST(Source, RasterTileCorrupt) {
     auto info = std::make_unique<SourceInfo>();
     info->tiles = { "tiles" };
 
-    Source source(SourceType::Raster, "source", "", 512, std::move(info), nullptr);
+    Source source(SourceType::Raster, util::ID<Source>("source"), "", 512, std::move(info),
+                  nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -285,7 +290,8 @@ TEST(Source, VectorTileCorrupt) {
     auto info = std::make_unique<SourceInfo>();
     info->tiles = { "tiles" };
 
-    Source source(SourceType::Vector, "source", "", 512, std::move(info), nullptr);
+    Source source(SourceType::Vector, util::ID<Source>("source"), "", 512, std::move(info),
+                  nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -312,7 +318,8 @@ TEST(Source, RasterTileCancel) {
     auto info = std::make_unique<SourceInfo>();
     info->tiles = { "tiles" };
 
-    Source source(SourceType::Raster, "source", "", 512, std::move(info), nullptr);
+    Source source(SourceType::Raster, util::ID<Source>("source"), "", 512, std::move(info),
+                  nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -339,7 +346,8 @@ TEST(Source, VectorTileCancel) {
     auto info = std::make_unique<SourceInfo>();
     info->tiles = { "tiles" };
 
-    Source source(SourceType::Vector, "source", "", 512, std::move(info), nullptr);
+    Source source(SourceType::Vector, util::ID<Source>("source"), "", 512, std::move(info),
+                  nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);

--- a/test/style/style_layer.cpp
+++ b/test/style/style_layer.cpp
@@ -20,5 +20,5 @@ TEST(StyleLayer, Clone) {
 TEST(StyleLayer, CloneCopiesBaseProperties) {
     std::unique_ptr<BackgroundLayer> layer = std::make_unique<BackgroundLayer>();
     layer->id = "test";
-    EXPECT_EQ("test", layer->clone()->id);
+    EXPECT_EQ(util::ID<StyleLayer>("test"), layer->clone()->id);
 }

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -40,6 +40,7 @@
         'util/async_task.cpp',
         'util/clip_ids.cpp',
         'util/geo.cpp',
+        'util/id.cpp',
         'util/image.cpp',
         'util/mapbox.cpp',
         'util/merge_lines.cpp',

--- a/test/util/id.cpp
+++ b/test/util/id.cpp
@@ -1,0 +1,82 @@
+#include "../fixtures/util.hpp"
+
+#include <mbgl/util/id.hpp>
+
+#include <set>
+#include <sstream>
+#include <unordered_set>
+
+using namespace mbgl;
+
+class Foo;
+
+TEST(ID, Creation) {
+    const util::ID<Foo> foo("foo");
+    const util::ID<Foo> bar = { "bar" };
+    const util::ID<Foo> baz;
+    const util::ID<Foo> boo = { "" };
+
+    EXPECT_TRUE(foo.valid());
+    EXPECT_TRUE(bar.valid());
+    EXPECT_FALSE(baz.valid());
+    EXPECT_FALSE(boo.valid());
+}
+
+TEST(ID, Assignment) {
+    const util::ID<Foo> foo("foo");
+    util::ID<Foo> bar("bar");
+    util::ID<Foo> baz;
+    bar = "test";
+    bar = foo;
+    baz = "baz";
+
+    EXPECT_TRUE(foo.valid());
+    EXPECT_TRUE(bar.valid());
+    EXPECT_TRUE(baz.valid());
+}
+
+TEST(ID, Comparison) {
+    const util::ID<Foo> foo("foo");
+    const util::ID<Foo> baz;
+
+    EXPECT_EQ(foo, util::ID<Foo>("foo"));
+    EXPECT_NE(foo, util::ID<Foo>("bar"));
+
+    EXPECT_FALSE(baz == foo);
+    EXPECT_FALSE(foo == baz);
+    EXPECT_FALSE(baz == baz);
+
+    EXPECT_TRUE(baz != foo);
+    EXPECT_TRUE(foo != baz);
+    EXPECT_TRUE(baz != baz);
+
+    EXPECT_EQ("foo", foo.str());
+    EXPECT_STREQ("foo", foo.c_str());
+    EXPECT_EQ("", baz.str());
+}
+
+TEST(ID, Sorting) {
+    std::set<util::ID<Foo>> set;
+    set.emplace("foo");
+    set.emplace("bar");
+
+    const util::ID<Foo> a { "previously-unused-1" };
+    const util::ID<Foo> b { "previously-unused-2" };
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(a < a);
+    EXPECT_FALSE(b < a);
+}
+
+TEST(ID, Hashing) {
+    std::unordered_set<util::ID<Foo>> set;
+    set.emplace("foo");
+    set.emplace("bar");
+}
+
+TEST(ID, Stringstream) {
+    util::ID<Foo> foo("foo");
+
+    std::stringstream ss;
+    ss << "Source[" << foo << "]";
+    EXPECT_EQ("Source[foo]", ss.str());
+}


### PR DESCRIPTION
We're using strings as unique IDs in many places, but strings are dynamically allocated, take up unnecessary space and are costly to compare/sort. We should instead switch to numeric IDs.
