### PR TITLE
Reduce async complexity

### DIFF
--- a/platform/ios/src/MGLMapboxEvents.h
+++ b/platform/ios/src/MGLMapboxEvents.h
@@ -45,37 +45,14 @@ typedef NS_MUTABLE_DICTIONARY_OF(NSString *, id) MGLMutableMapboxEventAttributes
 
 // You must call these methods from the main thread.
 //
-+ (void) pauseMetricsCollection;
-+ (void) resumeMetricsCollection;
-
-// You can call this method from any thread. Significant work will
-// be dispatched to a low-priority background queue and all
-// resulting calls are guaranteed threadsafe.
-//
-// Events or attributes passed could be accessed on non-main threads,
-// so you must not reference UI elements from within any arguments.
-// Copy any values needed first or create dedicated methods in this
-// class for threadsafe access to UIKit classes.
-//
-+ (void) pushEvent:(NSString *)event withAttributes:(MGLMapboxEventAttributes *)attributeDictionary;
-
-+ (void) pushDebugEvent:(NSString *)event withAttributes:(MGLMapboxEventAttributes *)attributeDictionary;
-
-+ (BOOL) debugLoggingEnabled;
-
-// You can call these methods from any thread.
-//
-+ (BOOL) checkPushEnabled;
-
-// You can call this method from any thread.
-//
-+ (void) flush;
-
-// Main thread only
-+ (void) validate;
-
-// Main thread only
-+ (void) ensureMetricsOptoutExists;
++ (void)pauseMetricsCollection;
++ (void)resumeMetricsCollection;
++ (void)pushEvent:(NSString *)event withAttributes:(MGLMapboxEventAttributes *)attributeDictionary;
++ (void)pushDebugEvent:(NSString *)event withAttributes:(MGLMapboxEventAttributes *)attributeDictionary;
++ (void)validate;
++ (void)ensureMetricsOptoutExists;
++ (void)flush;
++ (BOOL)checkPushEnabled;
 
 @end
 


### PR DESCRIPTION
Since MGLMapboxEvents is only accessed via the main thread the
complexity to ensure thread safety is not required. This removes
that extra code so that future work can benefit from being based
on a simpler foundation.

The main changes in this commit are:

- Untangle nested calls to GCD dispatch_async (i.e. `pushEvents` used to
dispatch onto a global (concurrent) background queue from a public
class method and then those blocks would be dispatched onto a custom
serial queue). Now, the only calls to dispatch_async that are left are
in `- postEvents:` and `- writeEventToLocalDebugLog:` and the
performance requirement to have even that dispatching done is still
unclear. I'm keeping it for now only because it allows for non-blocking
JSON serialization and pre-validation (network requests are already
non-blocking anyway)
- Since the async dispatches are pushed down to just wrap around
the JSON serialization / networking, this commit also removes the main
thread marshaling that was done in many places (i.e. guarding access
to UIKit methods that provide data for events that used to be
(synchronously) gathered via the main thread)
- Remove assertions that we are running on the main thread.
- Pushed some bools used for guards (i.e. `debugLoggingEnabled`) down
into the methods that really need to know about the bool value to
eliminate some repetitive boilerplate guarding all over the place
- Make progress towards a consistent code style

cc @1ec5 @friedbunny 