### PR TITLE
[core] HTTP replies with expiration time already expired should be treated as errors

### DIFF
--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -1,6 +1,8 @@
 #ifndef MBGL_UTIL_CONSTANTS
 #define MBGL_UTIL_CONSTANTS
 
+#include <mbgl/util/chrono.hpp>
+
 #include <cmath>
 #include <string>
 #include <vector>
@@ -22,6 +24,8 @@ extern const double MIN_ZOOM;
 extern const double MAX_ZOOM;
 
 extern const uint64_t DEFAULT_MAX_CACHE_SIZE;
+
+extern const Duration CLOCK_SKEW_RETRY_TIMEOUT;
 
 } // namespace util
 

--- a/src/mbgl/util/constants.cpp
+++ b/src/mbgl/util/constants.cpp
@@ -31,6 +31,8 @@ const double MAX_ZOOM = 25.5;
 
 const uint64_t DEFAULT_MAX_CACHE_SIZE = 50 * 1024 * 1024;
 
+const Duration CLOCK_SKEW_RETRY_TIMEOUT = Seconds(30);
+
 } // namespace util
 
 namespace debug {

--- a/test/storage/http_expires.cpp
+++ b/test/storage/http_expires.cpp
@@ -1,0 +1,35 @@
+#include "storage.hpp"
+
+#include <mbgl/storage/online_file_source.hpp>
+#include <mbgl/util/chrono.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/timer.hpp>
+
+TEST_F(Storage, HTTPRetryDelayOnExpiredTile) {
+    SCOPED_TEST(HTTPRetryDelayOnExpiredTile)
+
+    using namespace mbgl;
+
+    util::RunLoop loop;
+    OnlineFileSource fs;
+
+    int counter = 0;
+
+    const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test?expires=10000" };
+    std::unique_ptr<FileRequest> req = fs.request(resource, [&](Response res) {
+        counter++;
+        EXPECT_EQ(nullptr, res.error);
+        EXPECT_GT(SystemClock::now(), res.expires);
+    });
+
+    util::Timer timer;
+    timer.start(Milliseconds(500), Duration::zero(), [&] () {
+        loop.stop();
+    });
+
+    loop.run();
+
+    EXPECT_EQ(1, counter);
+
+    HTTPRetryDelayOnExpiredTile.finish();
+}

--- a/test/storage/server.js
+++ b/test/storage/server.js
@@ -55,6 +55,11 @@ app.get('/revalidate-same', function(req, res) {
     }
 });
 
+var expiresCounter = 0;
+app.get('/clockskew', function (req, res) {
+    res.setHeader('Expires', (new Date(2010, 1, 1, 10, ++expiresCounter, 0)).toUTCString());
+    res.status(200).send('Response');
+});
 
 app.get('/revalidate-modified', function(req, res) {
     var jan1 = new Date('jan 1 2015 utc');

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -77,6 +77,7 @@
         'storage/headers.cpp',
         'storage/http_cancel.cpp',
         'storage/http_error.cpp',
+        'storage/http_expires.cpp',
         'storage/http_header_parsing.cpp',
         'storage/http_issue_1369.cpp',
         'storage/http_load.cpp',


### PR DESCRIPTION
The `OnlineFileSource` should treat a HTTP reply with expiration time already expired as an error and apply the same delay rules for retrying that we have in place for other errors, otherwise a faulty server can trigger an endless number of consecutive requests.

/cc @jfirebaugh 