### PR TITLE
Fix off-by-one zoom level for map feedback tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Known issues:
 ## iOS master
 
 - Polygons and polylines now default to using the map view's tint color. ([#4028](https://github.com/mapbox/mapbox-gl-native/pull/4028))
+- The Improve This Map tool now uses the same zoom level that is currently being shown in the map view. ([#4068](https://github.com/mapbox/mapbox-gl-native/pull/4068))
 
 ## iOS 3.1.0
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1548,7 +1548,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 2)
     {
         NSString *feedbackURL = [NSString stringWithFormat:@"https://www.mapbox.com/map-feedback/#/%.5f/%.5f/%i",
-                                 self.longitude, self.latitude, (int)round(self.zoomLevel)];
+                                 self.longitude, self.latitude, (int)round(self.zoomLevel + 1)];
         [[UIApplication sharedApplication] openURL:
          [NSURL URLWithString:feedbackURL]];
     }


### PR DESCRIPTION
The map feedback tool uses mapbox.js, so its zoom levels are one off the zoom levels used by Mapbox GL.

/ref #3427
/cc @friedbunny