### PR TITLE
Fix crash when we get a HTTP 200 with no data

### DIFF
--- a/platform/android/src/http_request_android.cpp
+++ b/platform/android/src/http_request_android.cpp
@@ -204,6 +204,8 @@ void HTTPAndroidRequest::onResponse(JNIEnv* env, int code, jstring /* message */
             jbyte* bodyData = env->GetByteArrayElements(body, nullptr);
             response->data = std::make_shared<std::string>(reinterpret_cast<char*>(bodyData), env->GetArrayLength(body));
             env->ReleaseByteArrayElements(body, bodyData, JNI_ABORT);
+        } else {
+            response->data = std::make_shared<std::string>();
         }
     } else if (code == 204 || (code == 404 && resource.kind == Resource::Kind::Tile)) {
         response->noContent = true;

--- a/test/storage/http_reading.cpp
+++ b/test/storage/http_reading.cpp
@@ -84,6 +84,31 @@ TEST_F(Storage, HTTPTile404) {
     loop.run();
 }
 
+TEST_F(Storage, HTTP200EmptyData) {
+    SCOPED_TEST(HTTP200EmptyData)
+
+    using namespace mbgl;
+
+    util::RunLoop loop;
+    OnlineFileSource fs;
+
+    std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/empty-data" },
+               [&](Response res) {
+        req.reset();
+        EXPECT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Main));
+        EXPECT_FALSE(res.noContent);
+        EXPECT_FALSE(bool(res.error));
+        EXPECT_EQ(*res.data, std::string());
+        EXPECT_FALSE(bool(res.expires));
+        EXPECT_FALSE(bool(res.modified));
+        EXPECT_FALSE(bool(res.etag));
+        loop.stop();
+        HTTP200EmptyData.finish();
+    });
+
+    loop.run();
+}
+
 TEST_F(Storage, HTTP204) {
     SCOPED_TEST(HTTP204)
 

--- a/test/storage/server.js
+++ b/test/storage/server.js
@@ -84,6 +84,10 @@ app.get('/revalidate-etag', function(req, res) {
     revalidateEtagCounter++;
 });
 
+app.get('/empty-data', function(req, res) {
+    res.status(200).send();
+});
+
 app.get('/no-content', function(req, res) {
     res.status(204).send();
 });


### PR DESCRIPTION
We assume `response->data` an empty string instead of a null pointer.