### PR TITLE
[node, core] Revert #3994

### DIFF
--- a/platform/default/async_task.cpp
+++ b/platform/default/async_task.cpp
@@ -28,6 +28,7 @@ public:
         }
 
         handle()->data = this;
+        uv_unref(handle());
     }
 
     ~Impl() {

--- a/platform/default/run_loop.cpp
+++ b/platform/default/run_loop.cpp
@@ -13,6 +13,12 @@ namespace {
 using namespace mbgl::util;
 static ThreadLocal<RunLoop>& current = *new ThreadLocal<RunLoop>;
 
+#if UV_VERSION_MAJOR == 0 && UV_VERSION_MINOR <= 10
+void dummyCallback(uv_async_t*, int) {};
+#else
+void dummyCallback(uv_async_t*) {};
+#endif
+
 } // namespace
 
 namespace mbgl {
@@ -56,7 +62,18 @@ RunLoop* RunLoop::Get() {
 
 class RunLoop::Impl {
 public:
+    void closeHolder() {
+        uv_close(holderHandle(), [](uv_handle_t* h) {
+            delete reinterpret_cast<uv_async_t*>(h);
+        });
+    }
+
+    uv_handle_t* holderHandle() {
+        return reinterpret_cast<uv_handle_t*>(holder);
+    }
+
     uv_loop_t *loop = nullptr;
+    uv_async_t* holder = new uv_async_t;
 
     RunLoop::Type type;
     std::unique_ptr<AsyncTask> async;
@@ -82,6 +99,12 @@ RunLoop::RunLoop(Type type) : impl(std::make_unique<Impl>()) {
         break;
     }
 
+    // Just for holding a ref to the main loop and keep
+    // it alive as required by libuv.
+    if (uv_async_init(impl->loop, impl->holder, dummyCallback) != 0) {
+        throw std::runtime_error("Failed to initialize async.");
+    }
+
     impl->type = type;
 
     current.set(this);
@@ -90,6 +113,10 @@ RunLoop::RunLoop(Type type) : impl(std::make_unique<Impl>()) {
 
 RunLoop::~RunLoop() {
     current.set(nullptr);
+
+    // Close the dummy handle that we have
+    // just to keep the main loop alive.
+    impl->closeHolder();
 
     if (impl->type == Type::Default) {
         return;
@@ -134,7 +161,7 @@ void RunLoop::runOnce() {
 }
 
 void RunLoop::stop() {
-    invoke([&] { uv_stop(impl->loop); });
+    invoke([&] { uv_unref(impl->holderHandle()); });
 }
 
 void RunLoop::addWatch(int fd, Event event, std::function<void(int, Event)>&& callback) {

--- a/platform/default/timer.cpp
+++ b/platform/default/timer.cpp
@@ -22,6 +22,7 @@ public:
         }
 
         handle()->data = this;
+        uv_unref(handle());
     }
 
     ~Impl() {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -439,7 +439,6 @@ void NodeMap::release() {
     });
 
     map.reset(nullptr);
-    loop.reset();
 }
 
 NAN_METHOD(NodeMap::DumpDebugLogs) {
@@ -459,7 +458,6 @@ NodeMap::NodeMap(v8::Local<v8::Object> options) :
         Nan::HandleScope scope;
         return Nan::Has(options, Nan::New("ratio").ToLocalChecked()).FromJust() ? Nan::Get(options, Nan::New("ratio").ToLocalChecked()).ToLocalChecked()->NumberValue() : 1.0;
     }()),
-    loop(NodeRunLoop()),
     map(std::make_unique<mbgl::Map>(view, *this, mbgl::MapMode::Still)),
     async(new uv_async_t) {
 
@@ -486,7 +484,7 @@ std::unique_ptr<mbgl::FileRequest> NodeMap::request(const mbgl::Resource& resour
 
     // This function can be called from any thread. Make sure we're executing the
     // JS implementation in the node event loop.
-    req->workRequest = loop->invokeWithCallback([this] (mbgl::Resource res, Callback cb2) {
+    req->workRequest = NodeRunLoop().invokeWithCallback([this] (mbgl::Resource res, Callback cb2) {
         Nan::HandleScope scope;
 
         auto requestHandle = NodeRequest::Create(res, cb2)->ToObject();

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -3,7 +3,6 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/platform/default/headless_view.hpp>
-#include <mbgl/util/run_loop.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -46,7 +45,6 @@ public:
     std::unique_ptr<mbgl::FileRequest> request(const mbgl::Resource&, Callback);
 
     mbgl::HeadlessView view;
-    std::shared_ptr<mbgl::util::RunLoop> loop;
     std::unique_ptr<mbgl::Map> map;
 
     std::exception_ptr error;

--- a/platform/node/src/node_mapbox_gl_native.cpp
+++ b/platform/node/src/node_mapbox_gl_native.cpp
@@ -12,21 +12,19 @@
 
 namespace node_mbgl {
 
-std::shared_ptr<mbgl::util::RunLoop> NodeRunLoop() {
-    static std::weak_ptr<mbgl::util::RunLoop> nodeRunLoop;
-
-    auto loop = nodeRunLoop.lock();
-    if (!loop) {
-        loop = std::make_shared<mbgl::util::RunLoop>();
-        nodeRunLoop = loop;
-    }
-
-    return std::move(loop);
+mbgl::util::RunLoop& NodeRunLoop() {
+    static mbgl::util::RunLoop nodeRunLoop;
+    return nodeRunLoop;
 }
 
 }
 
 NAN_MODULE_INIT(RegisterModule) {
+    // This has the effect of:
+    //   a) Ensuring that the static local variable is initialized before any thread contention.
+    //   b) unreffing an async handle, which otherwise would keep the default loop running.
+    node_mbgl::NodeRunLoop().stop();
+
     node_mbgl::NodeMap::Init(target);
     node_mbgl::NodeRequest::Init(target);
 

--- a/platform/node/src/node_mapbox_gl_native.hpp
+++ b/platform/node/src/node_mapbox_gl_native.hpp
@@ -2,10 +2,8 @@
 
 #include <mbgl/util/run_loop.hpp>
 
-#include <memory>
-
 namespace node_mbgl {
 
-std::shared_ptr<mbgl::util::RunLoop> NodeRunLoop();
+mbgl::util::RunLoop& NodeRunLoop();
 
 }

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -323,5 +323,21 @@ test('Map', function(t) {
                 t.end();
             });
         });
+
+        t.test('not holding references', function(t) {
+            var options = {
+                request: function() {},
+                ratio: 1
+            };
+
+            // We explicitly don't call release. mbgl.Map should
+            // not hold any reference to the node's main loop and
+            // prevent the test from exit.
+            var map1 = new mbgl.Map(options);
+            var map2 = new mbgl.Map(options);
+            var map3 = new mbgl.Map(options);
+
+            t.end();
+        });
     });
 });


### PR DESCRIPTION
We cannot hold any references to the libuv's default main loop otherwise node won't exit. The prior implementation assumed that the gc() would be called frequently to collect the unused NodeMaps holding these references but this is simply not true.

/cc @jfirebaugh @mikemorris