### PR TITLE
Introduce API Client

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -46,6 +46,8 @@
         '../platform/darwin/src/MGLMapCamera.mm',
         '../platform/ios/src/MGLMapboxEvents.h',
         '../platform/ios/src/MGLMapboxEvents.m',
+        '../platform/ios/src/MGLAPIClient.h',
+        '../platform/ios/src/MGLAPIClient.m',
         '../platform/ios/src/MGLMapView.mm',
         '../platform/ios/src/MGLAccountManager_Private.h',
         '../platform/ios/src/MGLAccountManager.m',

--- a/platform/ios/src/MGLAPIClient.h
+++ b/platform/ios/src/MGLAPIClient.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+#import "MGLMapboxEvents.h"
+#import "MGLTypes.h"
+
+@interface MGLAPIClient : NSObject <NSURLSessionDelegate>
+
+- (void)postEvents:(nonnull NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
+- (void)postEvent:(nonnull MGLMapboxEventAttributes *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
+- (void)cancelAll;
+
+@end

--- a/platform/ios/src/MGLAPIClient.m
+++ b/platform/ios/src/MGLAPIClient.m
@@ -1,0 +1,191 @@
+#import "MGLAPIClient.h"
+#import "NSBundle+MGLAdditions.h"
+#import "MGLAccountManager.h"
+
+static NSString * const MGLAPIClientUserAgent = @"MapboxEventsiOS/1.1";
+static NSString * const MGLAPIClientBaseURL = @"https://api.tiles.mapbox.com";
+
+static NSString * const MGLAPIClientHeaderFieldUserAgentKey = @"User-Agent";
+static NSString * const MGLAPIClientHeaderFieldContentTypeKey = @"Content-Type";
+static NSString * const MGLAPIClientHeaderFieldContentTypeValue = @"application/json";
+static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
+
+@interface MGLAPIClient ()
+
+@property (nonatomic, copy) NSURLSession *session;
+@property (nonatomic, copy) NSString *baseURL;
+@property (nonatomic, copy) NSData *digicertCert;
+@property (nonatomic, copy) NSData *geoTrustCert;
+@property (nonatomic, copy) NSData *testServerCert;
+@property (nonatomic, copy) NSString *userAgent;
+@property (nonatomic) NSMutableArray *dataTasks;
+@property (nonatomic) BOOL usesTestServer;
+
+@end
+
+@implementation MGLAPIClient
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
+                                                 delegate:self delegateQueue:nil];
+        _dataTasks = [NSMutableArray array];
+        [self loadCertificates];
+        [self setupBaseURL];
+        [self setupUserAgent];
+    }
+    return self;
+}
+
+
+#pragma mark Public API
+
+- (void)postEvents:(nonnull NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler {
+    NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:[self requestForEvents:events]
+                                                     completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                                                         [self.dataTasks removeObject:dataTask];
+                                                         if (completionHandler) {
+                                                             completionHandler(error);
+                                                         }
+    }];
+    [dataTask resume];
+    [self.dataTasks addObject:dataTask];
+}
+
+- (void)postEvent:(nonnull MGLMapboxEventAttributes *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler {
+    [self postEvents:@[event] completionHandler:completionHandler];
+}
+
+- (void)cancelAll {
+    [self.dataTasks makeObjectsPerformSelector:@selector(cancel)];
+    [self.dataTasks removeAllObjects];
+}
+
+#pragma mark Utilities
+
+- (NSURLRequest *)requestForEvents:(NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events {
+    NSString *url = [NSString stringWithFormat:@"%@/events/v1?access_token=%@", self.baseURL, [MGLAccountManager accessToken]];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    [request setValue:self.userAgent forHTTPHeaderField:MGLAPIClientHeaderFieldUserAgentKey];
+    [request setValue:MGLAPIClientHeaderFieldContentTypeValue forHTTPHeaderField:MGLAPIClientHeaderFieldContentTypeKey];
+    [request setHTTPMethod:MGLAPIClientHTTPMethodPost];
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:events options:NSJSONWritingPrettyPrinted error:nil];
+    [request setHTTPBody:jsonData];
+    return [request copy];
+}
+
+- (void)setupBaseURL {
+    NSString *testServerURL = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLMetricsTestServerURL"];
+    if (testServerURL) {
+        _baseURL = testServerURL;
+        _usesTestServer = YES;
+    } else {
+        _baseURL = MGLAPIClientBaseURL;
+    }
+}
+
+- (void)loadCertificates {
+    NSData *certificate;
+    [self loadCertificate:&certificate withResource:@"api_mapbox_com-geotrust"];
+    self.geoTrustCert = certificate;
+    [self loadCertificate:&certificate withResource:@"api_mapbox_com-digicert"];
+    self.digicertCert = certificate;
+    [self loadCertificate:&certificate withResource:@"star_tilestream_net"];
+    self.testServerCert = certificate;
+}
+
+- (void)loadCertificate:(NSData **)certificate withResource:(NSString *)resource {
+    NSBundle *resourceBundle = [NSBundle mgl_frameworkBundle];
+    NSString *cerPath = [resourceBundle pathForResource:resource ofType:@"der"];
+    if (cerPath != nil) {
+        *certificate = [NSData dataWithContentsOfFile:cerPath];
+    }
+}
+
+- (void)setupUserAgent {
+    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+    NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString *appBuildNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
+    _userAgent = [NSString stringWithFormat:@"%@/%@/%@ %@", appName, appVersion, appBuildNumber, MGLAPIClientUserAgent];
+}
+
+#pragma mark NSURLSessionDelegate
+
+- (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^) (NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler {
+    
+    if([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        
+        SecTrustRef serverTrust = [[challenge protectionSpace] serverTrust];
+        SecTrustResultType trustResult;
+        
+        // Validate the certificate chain with the device's trust store anyway
+        // This *might* give use revocation checking
+        SecTrustEvaluate(serverTrust, &trustResult);
+        if (trustResult == kSecTrustResultUnspecified)
+        {
+            // Look for a pinned certificate in the server's certificate chain
+            long numKeys = SecTrustGetCertificateCount(serverTrust);
+            
+            BOOL found = NO;
+            // Try GeoTrust Cert First
+            for (int lc = 0; lc < numKeys; lc++) {
+                SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, lc);
+                NSData *remoteCertificateData = CFBridgingRelease(SecCertificateCopyData(certificate));
+                
+                // Compare Remote Key With Local Version
+                if ([remoteCertificateData isEqualToData:_geoTrustCert]) {
+                    // Found the certificate; continue connecting
+                    completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+                    found = YES;
+                    break;
+                }
+            }
+            
+            if (!found) {
+                // Fallback to Digicert Cert
+                for (int lc = 0; lc < numKeys; lc++) {
+                    SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, lc);
+                    NSData *remoteCertificateData = CFBridgingRelease(SecCertificateCopyData(certificate));
+                    
+                    // Compare Remote Key With Local Version
+                    if ([remoteCertificateData isEqualToData:_digicertCert]) {
+                        // Found the certificate; continue connecting
+                        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+                        found = YES;
+                        break;
+                    }
+                }
+                
+                if (!found && _usesTestServer) {
+                    // See if this is test server
+                    for (int lc = 0; lc < numKeys; lc++) {
+                        SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, lc);
+                        NSData *remoteCertificateData = CFBridgingRelease(SecCertificateCopyData(certificate));
+                        
+                        // Compare Remote Key With Local Version
+                        if ([remoteCertificateData isEqualToData:_testServerCert]) {
+                            // Found the certificate; continue connecting
+                            completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+                            found = YES;
+                            break;
+                        }
+                    }
+                }
+                
+                if (!found) {
+                    // The certificate wasn't found in GeoTrust nor Digicert. Cancel the connection.
+                    completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+                }
+            }
+        }
+        else
+        {
+            // Certificate chain validation failed; cancel the connection
+            completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+        }
+    }
+    
+}
+
+@end

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -5,13 +5,12 @@
 #import "NSProcessInfo+MGLAdditions.h"
 #import "NSBundle+MGLAdditions.h"
 #import "NSException+MGLAdditions.h"
+#import "MGLAPIClient.h"
 
 #include <mbgl/platform/darwin/reachability.h>
 #include <sys/sysctl.h>
 
 static const NSUInteger version = 1;
-static NSString *const MGLMapboxEventsUserAgent = @"MapboxEventsiOS/1.1";
-static NSString *MGLMapboxEventsAPIBase = @"https://api.tiles.mapbox.com";
 
 NSString *const MGLEventTypeAppUserTurnstile = @"appUserTurnstile";
 NSString *const MGLEventTypeMapLoad = @"map.load";
@@ -94,17 +93,10 @@ const NSTimeInterval MGLFlushInterval = 60;
 
 @property (nonatomic) MGLMapboxEventsData *data;
 @property (nonatomic, copy) NSString *appBundleId;
-@property (nonatomic, copy) NSString *appName;
-@property (nonatomic, copy) NSString *appVersion;
-@property (nonatomic, copy) NSString *appBuildNumber;
 @property (nonatomic, copy) NSString *instanceID;
 @property (nonatomic, copy) NSString *dateForDebugLogFile;
-@property (nonatomic, copy) NSData *digicertCert;
-@property (nonatomic, copy) NSData *geoTrustCert;
-@property (nonatomic, copy) NSData *testServerCert;
 @property (nonatomic) NSDateFormatter *rfc3339DateFormatter;
-@property (nonatomic) NSURLSession *session;
-@property (nonatomic) BOOL usesTestServer;
+@property (nonatomic) MGLAPIClient *apiClient;
 @property (nonatomic) BOOL canEnableDebugLogging;
 @property (nonatomic, getter=isPaused) BOOL paused;
 @property (nonatomic) NS_MUTABLE_ARRAY_OF(MGLMapboxEventAttributes *) *eventQueue;
@@ -145,46 +137,15 @@ const NSTimeInterval MGLFlushInterval = 60;
     self = [super init];
     if (self) {
         _appBundleId = [[NSBundle mainBundle] bundleIdentifier];
-        _appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
-        _appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-        _appBuildNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
         _instanceID = [[NSUUID UUID] UUIDString];
+        _apiClient = [[MGLAPIClient alloc] init];
 
         NSString *uniqueID = [[NSProcessInfo processInfo] globallyUniqueString];
         _serialQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.%@.events.serial", _appBundleId, uniqueID] UTF8String], DISPATCH_QUEUE_SERIAL);
 
-        // Configure Events Infrastructure
-        // ===============================
-
-        // Check for TEST Metrics URL
-        NSString *testURL = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLMetricsTestServerURL"];
-        if (testURL != nil) {
-            MGLMapboxEventsAPIBase = testURL;
-            _usesTestServer = YES;
-        } else {
-            // Explicitly Set For Clarity
-            _usesTestServer = NO;
-        }
-
         _paused = YES;
         [self resumeMetricsCollection];
         NSBundle *resourceBundle = [NSBundle mgl_frameworkBundle];
-
-        // Load Local Copy of Server's Public Key
-        NSString *cerPath = nil;
-        cerPath = [resourceBundle pathForResource:@"api_mapbox_com-geotrust" ofType:@"der"];
-        if (cerPath != nil) {
-            _geoTrustCert = [NSData dataWithContentsOfFile:cerPath];
-        }
-
-        cerPath = [resourceBundle pathForResource:@"api_mapbox_com-digicert" ofType:@"der"];
-        if (cerPath != nil) {
-            _digicertCert = [NSData dataWithContentsOfFile:cerPath];
-        }
-        cerPath = [resourceBundle pathForResource:@"star_tilestream_net" ofType:@"der"];
-        if (cerPath != nil) {
-            _testServerCert = [NSData dataWithContentsOfFile:cerPath];
-        }
 
         // Events Control
         _eventQueue = [[NSMutableArray alloc] init];
@@ -313,8 +274,6 @@ const NSTimeInterval MGLFlushInterval = 60;
     self.timer = nil;
     [self.eventQueue removeAllObjects];
     self.data = nil;
-    [self.session invalidateAndCancel];
-    self.session = nil;
     
     [self validateUpdatingLocation];
 }
@@ -341,7 +300,6 @@ const NSTimeInterval MGLFlushInterval = 60;
     
     self.paused = NO;
     self.data = [[MGLMapboxEventsData alloc] init];
-    self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
     
     [self validateUpdatingLocation];
 }
@@ -429,16 +387,24 @@ const NSTimeInterval MGLFlushInterval = 60;
             return;
         }
         
-        NSDictionary *vevt = @{@"event" : MGLEventTypeAppUserTurnstile,
-                               @"created" : [strongSelf.rfc3339DateFormatter stringFromDate:[NSDate date]],
-                               @"appBundleId" : strongSelf.appBundleId,
-                               @"vendorId": vendorID,
-                               @"version": @(version),
-                               @"instance": strongSelf.instanceID};
-        
-        [strongSelf.eventQueue addObject:vevt];
-        [strongSelf flush];
-        [strongSelf writeEventToLocalDebugLog:vevt];
+        NSDictionary *turnstileEventAttributes = @{@"event" : MGLEventTypeAppUserTurnstile,
+                                                   @"created" : [strongSelf.rfc3339DateFormatter stringFromDate:[NSDate date]],
+                                                   @"appBundleId" : strongSelf.appBundleId,
+                                                   @"vendorId": vendorID,
+                                                   @"version": @(version),
+                                                   @"instance": strongSelf.instanceID};
+      
+        if ([MGLAccountManager accessToken] == nil) {
+            return;
+        }
+        [strongSelf.apiClient postEvent:turnstileEventAttributes completionHandler:^(NSError * _Nullable error) {
+            if (error) {
+                [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"Network error",
+                                                                                        @"error": error}];
+                return;
+            }
+            [strongSelf writeEventToLocalDebugLog:turnstileEventAttributes];
+        }];
     });
 }
 
@@ -471,43 +437,18 @@ const NSTimeInterval MGLFlushInterval = 60;
 // Called implicitly from public use of +flush.
 //
 - (void)postEvents:(NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events {
-    __weak MGLMapboxEvents *weakSelf = self;
-
-    dispatch_async(self.serialQueue, ^{
-        MGLMapboxEvents *strongSelf = weakSelf;
-        
-        if (!strongSelf) {
+    if ([self isPaused]) {
+        return;
+    }
+    [self.apiClient postEvents:events completionHandler:^(NSError * _Nullable error) {
+        if (error) {
+            [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"Network error",
+                                                                                    @"error": error}];
             return;
         }
-
-        NSString *url = [NSString stringWithFormat:@"%@/events/v1?access_token=%@", MGLMapboxEventsAPIBase, [MGLAccountManager accessToken]];
-        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
-        [request setValue:strongSelf.userAgent forHTTPHeaderField:@"User-Agent"];
-        [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-        [request setHTTPMethod:@"POST"];
-        
-        if ([NSJSONSerialization isValidJSONObject:events]) {
-            NSData *jsonData = [NSJSONSerialization dataWithJSONObject:events options:NSJSONWritingPrettyPrinted error:nil];
-            [request setHTTPBody:jsonData];
-
-            if (!strongSelf.paused) {
-                [[strongSelf.session dataTaskWithRequest:request] resume];
-            } else {
-                for (MGLMapboxEventAttributes *event in events) {
-                    if ([event[@"event"] isEqualToString:MGLEventTypeAppUserTurnstile]) {
-                        NSURLSession *temporarySession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
-                                                                                       delegate:strongSelf
-                                                                                  delegateQueue:nil];
-                        [[temporarySession dataTaskWithRequest:request] resume];
-                        [temporarySession finishTasksAndInvalidate];
-                    }
-                }
-            }
-
-            [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"post",
-                                                                                    @"debug.eventsCount": @(events.count)}];
-        }
-    });
+        [MGLMapboxEvents pushDebugEvent:MGLEventTypeLocalDebug withAttributes:@{MGLEventKeyLocalDebugDescription: @"post",
+                                                                                @"debug.eventsCount": @(events.count)}];
+    }];
 }
 
 - (void)startTimer {
@@ -517,10 +458,6 @@ const NSTimeInterval MGLFlushInterval = 60;
                                                 selector:@selector(flush)
                                                 userInfo:nil
                                                  repeats:YES];
-}
-
-- (NSString *)userAgent {
-    return [NSString stringWithFormat:@"%@/%@/%@ %@", self.appName, self.appVersion, self.appBuildNumber, MGLMapboxEventsUserAgent];
 }
 
 - (NSInteger)batteryLevel {
@@ -692,84 +629,6 @@ const NSTimeInterval MGLFlushInterval = 60;
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
     [self validateUpdatingLocation];
-}
-
-#pragma mark NSURLSessionDelegate
-
-- (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^) (NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler {
-
-    if([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
-
-        SecTrustRef serverTrust = [[challenge protectionSpace] serverTrust];
-        SecTrustResultType trustResult;
-
-        // Validate the certificate chain with the device's trust store anyway
-        // This *might* give use revocation checking
-        SecTrustEvaluate(serverTrust, &trustResult);
-        if (trustResult == kSecTrustResultUnspecified)
-        {
-            // Look for a pinned certificate in the server's certificate chain
-            long numKeys = SecTrustGetCertificateCount(serverTrust);
-
-            BOOL found = NO;
-            // Try GeoTrust Cert First
-            for (int lc = 0; lc < numKeys; lc++) {
-                SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, lc);
-                NSData *remoteCertificateData = CFBridgingRelease(SecCertificateCopyData(certificate));
-
-                // Compare Remote Key With Local Version
-                if ([remoteCertificateData isEqualToData:_geoTrustCert]) {
-                    // Found the certificate; continue connecting
-                    completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-                    found = YES;
-                    break;
-                }
-            }
-
-            if (!found) {
-                // Fallback to Digicert Cert
-                for (int lc = 0; lc < numKeys; lc++) {
-                    SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, lc);
-                    NSData *remoteCertificateData = CFBridgingRelease(SecCertificateCopyData(certificate));
-
-                    // Compare Remote Key With Local Version
-                    if ([remoteCertificateData isEqualToData:_digicertCert]) {
-                        // Found the certificate; continue connecting
-                        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-                        found = YES;
-                        break;
-                    }
-                }
-
-                if (!found && _usesTestServer) {
-                    // See if this is test server
-                    for (int lc = 0; lc < numKeys; lc++) {
-                        SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, lc);
-                        NSData *remoteCertificateData = CFBridgingRelease(SecCertificateCopyData(certificate));
-
-                        // Compare Remote Key With Local Version
-                        if ([remoteCertificateData isEqualToData:_testServerCert]) {
-                            // Found the certificate; continue connecting
-                            completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-                            found = YES;
-                            break;
-                        }
-                    }
-                }
-
-                if (!found) {
-                    // The certificate wasn't found in GeoTrust nor Digicert. Cancel the connection.
-                    completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-                }
-            }
-        }
-        else
-        {
-            // Certificate chain validation failed; cancel the connection
-            completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-        }
-    }
-
 }
 
 #pragma mark MGLMapboxEvents Debug


### PR DESCRIPTION
This introduces a new utility class that wraps networking via NSURLSession. All related code that used to live inside the telemetry MGLMapboxEvents class has been pulled into the new MGLAPIClient. An API client instance is used as a service by telemetry and can be reused in the future when and if our networking needs grow or become more complex.

There are some nice side effects as a result of this refactor such as:

- The turnstile event can now be guaranteed to have a send attempt without having to be special cased and searched for inside a queue of other events
- We can react to failures (for now I've just added debug logging but in the future it would be nice to have a back off strategy when the network just doesn't work)
- Future work to make the MGLMapboxEvents class more testable will be easier since the networking client can be mocked and injected under test so tests are more controllable and determinate
- In flight requests can be cancelled

The main benefit of the api client is the API it presents to its clients. The public interface is:

```
- (void)postEvents:(nonnull NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
- (void)postEvent:(nonnull MGLMapboxEventAttributes *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
- (void)cancelAll;
```

An example usage of this for sending the turnstile event specifically is:

```
[self.apiClient postEvent:eventAttributes completionHandler:^(NSError * _Nullable error) {
    if (error) { /* log error and return */ }
    [strongSelf writeEventToLocalDebugLog:turnstileEventAttributes];
}];
```

Addresses https://github.com/mapbox/mapbox-gl-native/issues/3704