### PR TITLE
Remove dynamic_casts

### DIFF
--- a/src/mbgl/layer/background_layer.hpp
+++ b/src/mbgl/layer/background_layer.hpp
@@ -15,6 +15,7 @@ public:
 
 class BackgroundLayer : public StyleLayer {
 public:
+    BackgroundLayer() : StyleLayer(Type::Background) {}
     std::unique_ptr<StyleLayer> clone() const override;
 
     void parseLayout(const JSValue&) override {};
@@ -27,6 +28,11 @@ public:
 
     BackgroundPaintProperties paint;
 };
+
+template <>
+inline bool StyleLayer::is<BackgroundLayer>() const {
+    return type == Type::Background;
+}
 
 } // namespace mbgl
 

--- a/src/mbgl/layer/circle_layer.hpp
+++ b/src/mbgl/layer/circle_layer.hpp
@@ -22,6 +22,7 @@ public:
 
 class CircleLayer : public StyleLayer {
 public:
+    CircleLayer() : StyleLayer(Type::Circle) {}
     std::unique_ptr<StyleLayer> clone() const override;
 
     void parseLayout(const JSValue&) override {};
@@ -34,6 +35,11 @@ public:
 
     CirclePaintProperties paint;
 };
+
+template <>
+inline bool StyleLayer::is<CircleLayer>() const {
+    return type == Type::Circle;
+}
 
 } // namespace mbgl
 

--- a/src/mbgl/layer/custom_layer.cpp
+++ b/src/mbgl/layer/custom_layer.cpp
@@ -8,7 +8,8 @@ CustomLayer::CustomLayer(const std::string& id_,
                          CustomLayerInitializeFunction initializeFn_,
                          CustomLayerRenderFunction renderFn_,
                          CustomLayerDeinitializeFunction deinitializeFn_,
-                         void * context_) {
+                         void* context_)
+    : StyleLayer(Type::Custom) {
     id = id_;
     initializeFn = initializeFn_;
     renderFn = renderFn_;

--- a/src/mbgl/layer/custom_layer.hpp
+++ b/src/mbgl/layer/custom_layer.hpp
@@ -38,6 +38,11 @@ private:
     void* context = nullptr;
 };
 
+template <>
+inline bool StyleLayer::is<CustomLayer>() const {
+    return type == Type::Custom;
+}
+
 } // namespace mbgl
 
 #endif

--- a/src/mbgl/layer/fill_layer.hpp
+++ b/src/mbgl/layer/fill_layer.hpp
@@ -19,6 +19,7 @@ public:
 
 class FillLayer : public StyleLayer {
 public:
+    FillLayer() : StyleLayer(Type::Fill) {}
     std::unique_ptr<StyleLayer> clone() const override;
 
     void parseLayout(const JSValue&) override {};
@@ -31,6 +32,11 @@ public:
 
     FillPaintProperties paint;
 };
+
+template <>
+inline bool StyleLayer::is<FillLayer>() const {
+    return type == Type::Fill;
+}
 
 } // namespace mbgl
 

--- a/src/mbgl/layer/line_layer.hpp
+++ b/src/mbgl/layer/line_layer.hpp
@@ -38,6 +38,7 @@ public:
 
 class LineLayer : public StyleLayer {
 public:
+    LineLayer() : StyleLayer(Type::Line) {}
     std::unique_ptr<StyleLayer> clone() const override;
 
     void parseLayout(const JSValue&) override;
@@ -51,6 +52,11 @@ public:
     LineLayoutProperties layout;
     LinePaintProperties paint;
 };
+
+template <>
+inline bool StyleLayer::is<LineLayer>() const {
+    return type == Type::Line;
+}
 
 } // namespace mbgl
 

--- a/src/mbgl/layer/raster_layer.hpp
+++ b/src/mbgl/layer/raster_layer.hpp
@@ -19,6 +19,7 @@ public:
 
 class RasterLayer : public StyleLayer {
 public:
+    RasterLayer() : StyleLayer(Type::Raster) {}
     std::unique_ptr<StyleLayer> clone() const override;
 
     void parseLayout(const JSValue&) override {};
@@ -31,6 +32,11 @@ public:
 
     RasterPaintProperties paint;
 };
+
+template <>
+inline bool StyleLayer::is<RasterLayer>() const {
+    return type == Type::Raster;
+}
 
 } // namespace mbgl
 

--- a/src/mbgl/layer/symbol_layer.hpp
+++ b/src/mbgl/layer/symbol_layer.hpp
@@ -84,6 +84,7 @@ public:
 
 class SymbolLayer : public StyleLayer {
 public:
+    SymbolLayer() : StyleLayer(Type::Symbol) {}
     std::unique_ptr<StyleLayer> clone() const override;
 
     void parseLayout(const JSValue&) override;
@@ -99,6 +100,11 @@ public:
 
     SpriteAtlas* spriteAtlas = nullptr;
 };
+
+template <>
+inline bool StyleLayer::is<SymbolLayer>() const {
+    return type == Type::Symbol;
+}
 
 } // namespace mbgl
 

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -23,11 +23,18 @@ public:
     virtual ~StyleLayer() = default;
 
     // Check whether this layer is of the given subtype.
-    template <class T> bool is() const { return dynamic_cast<const T*>(this); }
+    template <class T>
+    bool is() const;
 
     // Dynamically cast this layer to the given subtype.
-    template <class T>       T* as()       { return dynamic_cast<      T*>(this); }
-    template <class T> const T* as() const { return dynamic_cast<const T*>(this); }
+    template <class T>
+    T* as() {
+        return is<T>() ? reinterpret_cast<T*>(this) : nullptr;
+    }
+    template <class T>
+    const T* as() const {
+        return is<T>() ? reinterpret_cast<const T*>(this) : nullptr;
+    }
 
     // Create a copy of this layer.
     virtual std::unique_ptr<StyleLayer> clone() const = 0;
@@ -64,9 +71,21 @@ public:
     VisibilityType visibility = VisibilityType::Visible;
 
 protected:
-    StyleLayer() = default;
+    enum class Type {
+        Fill,
+        Line,
+        Circle,
+        Symbol,
+        Raster,
+        Background,
+        Custom,
+    };
+
+    StyleLayer(Type type_) : type(type_) {}
     StyleLayer(const StyleLayer&) = default;
     StyleLayer& operator=(const StyleLayer&) = delete;
+
+    const Type type;
 
     // Stores what render passes this layer is currently enabled for. This depends on the
     // evaluated StyleProperties object and is updated accordingly.


### PR DESCRIPTION
Since https://github.com/mapbox/mapbox-gl-native/commit/e04c5f650648d150e78da3602745b6190ec4aee3, we're using `dynamic_cast`s in a few areas, in particular the `SymbolLayer`. However, these are very slow, especially on iOS, eating up to 10% of our render time for Mapbox Streets. I think we should go back to storing an explicit enum.

/cc @jfirebaugh 