### PR TITLE
TestApp crashes when trying to pan out of bounds

### DIFF
--- a/src/mbgl/util/clip_id.cpp
+++ b/src/mbgl/util/clip_id.cpp
@@ -101,7 +101,7 @@ template <typename Container>
 bool coveredByChildren(const TileID& id, const Container& container) {
     for (const auto& child : id.children()) {
         const auto lower = container.lower_bound(child);
-        if (lower == container.end() ||
+        if (lower == container.end() || lower->first.w != child.w ||
             (lower->first != child && !coveredByChildren(child, container))) {
             return false;
         }


### PR DESCRIPTION
The TestApp's MainActivity has a worldview map. I'm observing the following crash when trying to pan out of bounds (this is is not limited to zoom 0):

```
           MainActivity  V  OnCameraChange : Target: LatLng [longitude=0.0, latitude=0.0, altitude=0.0], Zoom:0.23601419, Bearing:-0.0, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=5.880087093857298, latitude=0.0, altitude=0.0], Zoom:0.23601419, Bearing:-0.0, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=0.41373897776685453, latitude=-13.008171512779839, altitude=0.0], Zoom:0.7938645, Bearing:-1.877268, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=-3.581132412219887, latitude=-20.04411920307053, altitude=0.0], Zoom:1.4993753, Bearing:5.9545517, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=-5.488161476830584, latitude=-19.850166826320656, altitude=0.0], Zoom:1.578203, Bearing:6.210718, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=-2.591776894926312, latitude=-5.081216991071424, altitude=0.0], Zoom:0.77831167, Bearing:-0.74945086, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=-0.4579174221903486, latitude=0.0, altitude=0.0], Zoom:0.23601419, Bearing:-8.848209, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=-0.2581773818595252, latitude=0.0, altitude=0.0], Zoom:0.23601419, Bearing:-9.330876, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=-21.940622555082996, latitude=0.0, altitude=0.0], Zoom:0.23601419, Bearing:-9.330876, Tilt:0.0
                         V  OnCameraChange : Target: LatLng [longitude=-19.19468587495092, latitude=0.0, altitude=0.0], Zoom:0.23601419, Bearing:-9.330876, Tilt:0.0
                   libc  F  Fatal signal 8 (SIGFPE), code -6, fault addr 0x25f5 in tid 9740 (Map Thread)
                  DEBUG  F  #00 pc 00042374  /system/lib/libc.so (tgkill+12)
                         F  #01 pc 0003ff81  /system/lib/libc.so (pthread_kill+32)
                         F  #02 pc 0001c73f  /system/lib/libc.so (raise+10)
                         F  #03 pc 0041b2c8  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (__aeabi_idiv0+8)
                         F  #04 pc 0014f950  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (mbgl::TileID::children(signed char) const+260)
                         F  #05 pc 001c3cf0  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+48)
                         F  #06 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #07 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #08 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #09 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #10 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #11 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #12 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #13 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #14 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #15 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #16 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #17 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #18 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #19 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #20 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #21 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #22 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #23 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #24 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #25 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #26 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #27 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #28 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #29 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #30 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #31 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #32 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #33 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #34 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #35 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #36 pc 001c3e08  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (bool mbgl::coveredByChildren<std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>,
                             std::__1::allocator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > >(mbgl::TileID const&, std::__1::map<mbgl::TileID, mbgl::ClipID, std::__1::less<mbgl::TileID>, std::__1::allo
                            cator<std::__1::pair<mbgl::TileID const, mbgl::ClipID> > > const&)+328)
                         F  #37 pc 001c3a70  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (mbgl::ClipIDGenerator::getStencils() const+528)
                         F  #38 pc 0015eb50  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (mbgl::Painter::render(mbgl::Style const&, mbgl::FrameData const&, mbgl::SpriteAtlas&)+1144)
                         F  #39 pc 0014d5c8  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (mbgl::MapContext::renderSync(mbgl::TransformState const&, mbgl::FrameData const&)+224)
                         F  #40 pc 00146728  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (std::__1::packaged_task<bool ()>::operator()()+104)
                         F  #41 pc 00146668  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (mbgl::util::RunLoop::Invoker<std::__1::packaged_task<bool ()>, std::__1::tuple<> >::operator()()+52)
                         F  #42 pc 001e1500  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (mbgl::util::RunLoop::process()+352)
                         F  #43 pc 0035fdb4  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so
                         F  #44 pc 0035ffe0  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so
                         F  #45 pc 003695ac  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so
                         F  #46 pc 00360548  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (uv_run+428)
                         F  #47 pc 0014c08c  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (void mbgl::util::Thread<mbgl::MapContext>::run<std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl:
                            :MapMode&, mbgl::GLContextMode&, float>, 0u, 1u, 2u, 3u, 4u>(mbgl::util::ThreadContext, std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>&&,
                             std::__1::integer_sequence<unsigned int, 0u, 1u, 2u, 3u, 4u>)+120)
                         F  #48 pc 0014bfa0  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapMode&, mbgl::G
                            LContextMode&, float>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapMode&&&, mbgl::GLContextMode&&&, float&&)::'lambda'()::operator()() const+248)
                         F  #49 pc 0014be58  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so (std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, m
                            bgl::FileSource&, mbgl::MapMode&, mbgl::GLContextMode&, float>(mbgl::util::ThreadContext const&, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapMode&&&, mbgl::GLContextMode&&&, float&&)
                            ::'lambda'()> >(void*, void*)+88)
                         F  #50 pc 0003f883  /system/lib/libc.so (__pthread_start(void*)+30)
                         F  #51 pc 00019f75  /system/lib/libc.so (__start_thread+6)
```

/cc: @jfirebaugh @bleege @tobrun 