### PR TITLE
Introduce Location Manager Utility and Optimize Background Telemetry

### DIFF
--- a/gyp/platform-ios.gypi
+++ b/gyp/platform-ios.gypi
@@ -48,6 +48,8 @@
         '../platform/ios/src/MGLMapboxEvents.m',
         '../platform/ios/src/MGLAPIClient.h',
         '../platform/ios/src/MGLAPIClient.m',
+        '../platform/ios/src/MGLLocationManager.h',
+        '../platform/ios/src/MGLLocationManager.m',
         '../platform/ios/src/MGLMapView.mm',
         '../platform/ios/src/MGLAccountManager_Private.h',
         '../platform/ios/src/MGLAccountManager.m',

--- a/platform/ios/src/MGLLocationManager.h
+++ b/platform/ios/src/MGLLocationManager.h
@@ -1,0 +1,25 @@
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
+
+@protocol MGLLocationManagerDelegate;
+
+@interface MGLLocationManager : NSObject <CLLocationManagerDelegate>
+
+@property (nonatomic, weak) id<MGLLocationManagerDelegate> delegate;
+
+- (void)startUpdatingLocation;
+- (void)stopUpdatingLocation;
+
+@end
+
+@protocol MGLLocationManagerDelegate <NSObject>
+
+@optional
+
+- (void)locationManager:(MGLLocationManager *)locationManager didUpdateLocations:(NSArray *)locations;
+- (void)locationManagerDidStartLocationUpdates:(MGLLocationManager *)locationManager;
+- (void)locationManagerBackgroundLocationUpdatesDidTimeout:(MGLLocationManager *)locationManager;
+- (void)locationManagerBackgroundLocationUpdatesDidAutomaticallyPause:(MGLLocationManager *)locationManager;
+- (void)locationManagerDidStopLocationUpdates:(MGLLocationManager *)locationManager;
+
+@end

--- a/platform/ios/src/MGLLocationManager.m
+++ b/platform/ios/src/MGLLocationManager.m
@@ -1,0 +1,159 @@
+#import "MGLLocationManager.h"
+#import <UIKit/UIKit.h>
+
+static const NSTimeInterval fiveMinuteTimeInterval = 300.0;
+static const NSTimeInterval fiveSecondTimeInterval = 5.0;
+static const CLLocationDistance regionRadiusLocationDistance = 300.0;
+static NSString * const MGLLocationManagerRegionIdentifier = @"MGLLocationManagerRegionIdentifier.fence.center";
+
+@interface MGLLocationManager ()
+
+@property (nonatomic) CLLocationManager *standardLocationManager;
+@property (nonatomic) BOOL hostAppHasBackgroundCapability;
+@property (nonatomic, getter=isUpdatingLocation) BOOL updatingLocation;
+@property (nonatomic) NSDate *backgroundLocationServiceTimeoutAllowedDate;
+@property (nonatomic) NSTimer *backgroundLocationServiceTimeoutTimer;
+
+@end
+
+@implementation MGLLocationManager
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
+       _hostAppHasBackgroundCapability = [backgroundModes containsObject:@"location"];
+    }
+    return self;
+}
+
+- (void)startUpdatingLocation {
+    if ([self isUpdatingLocation]) {
+        return;
+    }
+    
+    [self configurePassiveStandardLocationManager];
+    [self startLocationServices];
+}
+
+- (void)stopUpdatingLocation {
+    if ([self isUpdatingLocation]) {
+        [self.standardLocationManager stopUpdatingLocation];
+        [self.standardLocationManager stopMonitoringSignificantLocationChanges];
+        self.updatingLocation = NO;
+        if ([self.delegate respondsToSelector:@selector(locationManagerDidStopLocationUpdates:)]) {
+            [self.delegate locationManagerDidStopLocationUpdates:self];
+        }
+    }
+}
+
+#pragma mark - Utilities
+
+- (void)configurePassiveStandardLocationManager {
+    if (!self.standardLocationManager) {
+        CLLocationManager *standardLocationManager = [[CLLocationManager alloc] init];
+        standardLocationManager.delegate = self;
+        standardLocationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers;
+        standardLocationManager.distanceFilter = 1;
+        self.standardLocationManager = standardLocationManager;
+    }
+}
+
+- (void)startLocationServices {
+    if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorized ||
+        [CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedWhenInUse) {
+       
+        // If the host app can run in the background with `always` location permissions then allow background
+        // updates and start the significant location change service and background timeout timer
+        if (self.hostAppHasBackgroundCapability && [CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorized) {
+            [self.standardLocationManager startMonitoringSignificantLocationChanges];
+            [self startBackgroundTimeoutTimer];
+            // On iOS 9 and above also allow background location updates
+            if ([self.standardLocationManager respondsToSelector:@selector(allowsBackgroundLocationUpdates)]) {
+                self.standardLocationManager.allowsBackgroundLocationUpdates = YES;
+            }
+        }
+        
+        [self.standardLocationManager startUpdatingLocation];
+        self.updatingLocation = YES;
+        if ([self.delegate respondsToSelector:@selector(locationManagerDidStartLocationUpdates:)]) {
+            [self.delegate locationManagerDidStartLocationUpdates:self];
+        }
+    }
+}
+
+- (void)timeoutAllowedCheck {
+    if (self.backgroundLocationServiceTimeoutAllowedDate == nil) {
+        return;
+    }
+  
+    if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive ||
+        [UIApplication sharedApplication].applicationState == UIApplicationStateInactive ) {
+        [self startBackgroundTimeoutTimer];
+        return;
+    }
+    
+    NSTimeInterval timeIntervalSinceTimeoutAllowed = [[NSDate date] timeIntervalSinceDate:self.backgroundLocationServiceTimeoutAllowedDate];
+    if (timeIntervalSinceTimeoutAllowed > 0) {
+        [self.standardLocationManager stopUpdatingLocation];
+        self.backgroundLocationServiceTimeoutAllowedDate = nil;
+        if ([self.delegate respondsToSelector:@selector(locationManagerBackgroundLocationUpdatesDidTimeout:)]) {
+            [self.delegate locationManagerBackgroundLocationUpdatesDidTimeout:self];
+        }
+    }
+}
+
+- (void)startBackgroundTimeoutTimer {
+    [self.backgroundLocationServiceTimeoutTimer invalidate];
+    self.backgroundLocationServiceTimeoutAllowedDate = [[NSDate date] dateByAddingTimeInterval:fiveMinuteTimeInterval];
+    self.backgroundLocationServiceTimeoutTimer = [NSTimer scheduledTimerWithTimeInterval:fiveSecondTimeInterval target:self selector:@selector(timeoutAllowedCheck) userInfo:nil repeats:YES];
+}
+
+- (void)establishRegionMonitoringForLocation:(CLLocation *)location {
+    CLCircularRegion *region = [[CLCircularRegion alloc] initWithCenter:location.coordinate radius:regionRadiusLocationDistance identifier:MGLLocationManagerRegionIdentifier];
+    region.notifyOnEntry = NO;
+    region.notifyOnExit = YES;
+    [self.standardLocationManager startMonitoringForRegion:region];
+}
+
+#pragma mark - CLLocationManagerDelegate
+
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    switch (status) {
+        case kCLAuthorizationStatusAuthorized: // Also handles kCLAuthorizationStatusAuthorizedAlways
+        case kCLAuthorizationStatusAuthorizedWhenInUse:
+            [self startUpdatingLocation];
+            break;
+        default:
+            [self stopUpdatingLocation];
+            break;
+    }
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
+    CLLocation *location = locations.lastObject;
+    if (location.speed > 0.0) {
+        [self startBackgroundTimeoutTimer];
+    }
+    if (self.standardLocationManager.monitoredRegions.count == 0 || location.horizontalAccuracy < regionRadiusLocationDistance) {
+        [self establishRegionMonitoringForLocation:location];
+    }
+    if ([self.delegate respondsToSelector:@selector(locationManager:didUpdateLocations:)]) {
+        [self.delegate locationManager:self didUpdateLocations:locations];
+    }
+}
+
+- (void)locationManager:(CLLocationManager *)manager didExitRegion:(CLRegion *)region {
+    [self startBackgroundTimeoutTimer];
+    [self.standardLocationManager startUpdatingLocation];
+}
+
+- (void)locationManagerDidPauseLocationUpdates:(CLLocationManager *)manager {
+    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
+        if ([self.delegate respondsToSelector:@selector(locationManagerBackgroundLocationUpdatesDidAutomaticallyPause:)]) {
+            [self.delegate locationManagerBackgroundLocationUpdatesDidAutomaticallyPause:self];
+        }
+    }
+}
+
+@end

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -997,7 +997,6 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         self.dormant = NO;
 
         [self createGLView];
-        [MGLMapboxEvents validate];
 
         self.glSnapshotView.hidden = YES;
 

--- a/platform/ios/src/MGLMapboxEvents.h
+++ b/platform/ios/src/MGLMapboxEvents.h
@@ -39,17 +39,13 @@ extern NSString *const MGLEventGesturePitchStart;
 typedef NS_DICTIONARY_OF(NSString *, id) MGLMapboxEventAttributes;
 typedef NS_MUTABLE_DICTIONARY_OF(NSString *, id) MGLMutableMapboxEventAttributes;
 
-@interface MGLMapboxEvents : NSObject <NSURLSessionDelegate>
+@interface MGLMapboxEvents : NSObject
 
 + (nullable instancetype)sharedManager;
 
 // You must call these methods from the main thread.
 //
-+ (void)pauseMetricsCollection;
-+ (void)resumeMetricsCollection;
 + (void)pushEvent:(NSString *)event withAttributes:(MGLMapboxEventAttributes *)attributeDictionary;
-+ (void)pushDebugEvent:(NSString *)event withAttributes:(MGLMapboxEventAttributes *)attributeDictionary;
-+ (void)validate;
 + (void)ensureMetricsOptoutExists;
 + (void)flush;
 + (BOOL)checkPushEnabled;


### PR DESCRIPTION
##### Background

When Mapbox telemetry is used in a host application that has background.location permissions AND `always` permissions granted by the user, the location manager utility will attempt to gather anonymous location data in the background to [improve map quality](https://www.mapbox.com/telemetry). Previously, the Mapbox SDK did little to optimize background data collection for the case of stationary devices. Running location services in the background, even in a passive way, consumes resources and contributes to battery drain and background activity time of the host application in the iOS battery report.

##### What's in this PR?

This change makes background data gathering more efficient by disabling standard location updates when the device has been stationary for at least five minutes. It also establishes region monitoring and significant location change monitoring so that if the device appears to be in motion again then background telemetry data collection can resume. All of this reduces the amount of time required for telemetry data collection to the time the device is in motion only. It also only applies to host apps that already run in the background and have the `always` location permission from  their users.

This also includes some changes to make the internal pause/resume API of the `MGLMapboxEvents` class less complex and autonomous. The side effects of the map view waking or sleeping are no longer required for mapbox events to work as intended.

##### Addresses:
- https://github.com/mapbox/mapbox-gl-native/issues/1422
- https://github.com/mapbox/mapbox-gl-native/issues/1424
- https://github.com/mapbox/mapbox-gl-native/issues/3916
- https://github.com/mapbox/mapbox-gl-native/issues/4030

##### Subsumes:
- https://github.com/mapbox/mapbox-gl-native/pull/3659

cc @1ec5 @friedbunny 
fyi @bleege @mick @camilleanne @willwhite 