### PR TITLE
[android] #4078 fixed exceptions referring to install.md

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/InvalidAccessTokenException.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/InvalidAccessTokenException.java
@@ -13,7 +13,7 @@ import com.mapbox.mapboxsdk.maps.MapView;
 public class InvalidAccessTokenException extends RuntimeException {
 
     public InvalidAccessTokenException() {
-        super("Using MapView requires setting a valid access token. See the INSTALL.md");
+        super("\nUsing MapView requires setting a valid access token. Please see https://www.mapbox.com/help/create-api-access-token/ to learn how to create one.\n     Lastly, follow the steps in this guide https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens in order to include the access token in your app.");
     }
 
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/TelemetryServiceNotConfiguredException.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/TelemetryServiceNotConfiguredException.java
@@ -12,7 +12,7 @@ import com.mapbox.mapboxsdk.maps.MapView;
 public class TelemetryServiceNotConfiguredException extends RuntimeException {
 
     public TelemetryServiceNotConfiguredException() {
-        super("Using Mapbox Android SDK requires configuring TelemetryService. See the INSTALL.md");
+        super("\nUsing Mapbox Android SDK requires configuring TelemetryService. This only requires two steps:\n    1. Include the WAKE_LOCK permission within your applications AndroidManifest.xml\n    2. Add the \"com.mapbox.mapboxsdk.telemetry.TelemetryService\" service in your applications AndroidManifest.xml\n    For more help, visit https://www.mapbox.com/android-sdk/");
     }
 
 }


### PR DESCRIPTION
Removes referring to install.md when access token and telemetry exception occurs. Instead it now describes the steps to take in order to resolve the problem.