### PR TITLE
[offline] Accept parameters

### DIFF
--- a/bin/offline.gypi
+++ b/bin/offline.gypi
@@ -28,15 +28,20 @@
         'cflags_cc': [
           '<@(boost_cflags)',
         ],
+        'libraries': [
+          '<@(boost_libprogram_options_static_libs)'
+        ],
       },
 
       'conditions': [
         ['OS == "mac"', {
+          'libraries': [ '<@(libraries)' ],
           'xcode_settings': {
             'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
           }
         }, {
           'cflags_cc': [ '<@(cflags_cc)' ],
+          'libraries': [ '<@(libraries)' ],
         }]
       ],
     },


### PR DESCRIPTION
The defaults remains the same: Bay area at zoom 15.
The key, if not supplied, is taken from the environment.

```
Allowed options:
  -s [ --style ] URL                    Map stylesheet
  --north degrees (=37.200000000000003) North latitude
  --west degrees (=-122.8)              West longitude
  --south degrees (=38.100000000000001) South latitude
  --east degrees (=-121.7)              East longitude
  --minZoom number (=0)                 Min zoom level
  --maxZoom number (=15)                Max zoom level
  --pixelRatio number (=1)              Pixel ratio
  -t [ --token ] key                    Mapbox access token
  -o [ --output ] file (=offline.db)    Output database file name
```