### PR TITLE
Adding a class adds an infinite cascade loop

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -247,7 +247,7 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
     view.afterRender();
 
     if (style->hasTransitions()) {
-        updateFlags |= Update::Classes;
+        updateFlags |= Update::Zoom;
         asyncUpdate.send();
     } else if (painter->needsAnimation()) {
         updateFlags |= Update::Repaint;

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -176,6 +176,7 @@ void Style::recalculate(float z) {
                                           zoomHistory,
                                           data.getDefaultFadeDuration());
 
+    hasPendingTransitions = false;
     for (const auto& layer : layers) {
         hasPendingTransitions |= layer->recalculate(parameters);
 


### PR DESCRIPTION
In the `linuxapp`, press "R" to toggle night styles and observe how `Style::cascade` gets called ceaselessly. 