### PR TITLE
Add package 'offline' to proguard keeps

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -27,5 +27,8 @@
 # Package camera
 -keep class com.mapbox.mapboxsdk.camera.** { *; }
 
+# Package offline
+-keep class com.mapbox.mapboxsdk.offline.** { *; }
+
 # Gesture package
 -keep class almeros.android.multitouch.gesturedetectors.** { *; }


### PR DESCRIPTION
To avoid release build crashes at runtime due to missing classes.