### PR TITLE
Fix for label collision forcing immediate mode rendering on some hardware.

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -233,9 +233,6 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
 
     transformState = state;
 
-    // Cleanup OpenGL objects that we abandoned since the last render call.
-    glObjectStore.performCleanup();
-
     if (!painter) painter = std::make_unique<Painter>(data, transformState, glObjectStore);
     painter->render(*style, frame, data.getAnnotationManager()->getSpriteAtlas());
 
@@ -243,6 +240,9 @@ bool MapContext::renderSync(const TransformState& state, const FrameData& frame)
         callback(nullptr, view.readStillImage());
         callback = nullptr;
     }
+
+    // Cleanup OpenGL objects that we abandoned since the last render call.
+    glObjectStore.performCleanup();
 
     view.afterRender();
 


### PR DESCRIPTION
Hardware without VAO support was being forced through the immediate mode render path on frames where label collision attempted to swap resources. Moving resource cleanup to the end of the frame appears to alleviate the issue. Here are some instruments traces I took that show cpu performance before and after the fix. If you want to see the results for yourself, my fork has a branch called `immediateModeReproCase` that will disable VAOs and force the glfw map to spin continuously. without the fix, framerate suffers greatly.

[immediateModeTraces.zip](https://github.com/mapbox/mapbox-gl-native/files/159220/immediateModeTraces.zip)

It's possible that there is an issue still hiding somewhere in our resource management code, but there shouldn't be any harm in moving resource cleanup to the end of the frame.

