### PR TITLE
Fix offline status reporting with pre-existing tiles

### DIFF
--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -93,6 +93,10 @@ int main(int argc, char *argv[]) {
             std::cerr << error.reason << " downloading resource: " << error.message << std::endl;
         }
 
+        void mapboxTileCountLimitExceeded(uint64_t limit) override {
+            std::cerr << "Error: reached limit of " << limit << " offline tiles" << std::endl;
+        }
+
         util::RunLoop& loop;
         SystemTimePoint start;
     };

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -44,7 +44,8 @@ public:
 
     void deleteRegion(OfflineRegion&&);
 
-    optional<Response> getRegionResource(int64_t regionID, const Resource&);
+    // Return value is (response, stored size)
+    optional<std::pair<Response, uint64_t>> getRegionResource(int64_t regionID, const Resource&);
     uint64_t putRegionResource(int64_t regionID, const Resource&, const Response&);
 
     OfflineRegionDefinition getRegionDefinition(int64_t regionID);
@@ -75,14 +76,15 @@ private:
 
     Statement getStatement(const char *);
 
-    optional<Response> getTile(const Resource::TileData&);
+    optional<std::pair<Response, uint64_t>> getTile(const Resource::TileData&);
     bool putTile(const Resource::TileData&, const Response&,
                  const std::string&, bool compressed);
 
-    optional<Response> getResource(const Resource&);
+    optional<std::pair<Response, uint64_t>> getResource(const Resource&);
     bool putResource(const Resource&, const Response&,
                      const std::string&, bool compressed);
 
+    optional<std::pair<Response, uint64_t>> getInternal(const Resource&);
     std::pair<bool, uint64_t> putInternal(const Resource&, const Response&, bool evict);
 
     // Return value is true iff the resource was previously unused by any other regions.


### PR DESCRIPTION
We can't use `offlineDatabase.getRegionCompletedStatus(id)` at the beginning of the offline download to calculate starting values for `completedResourceCount` and `completedResourceSize`, because it doesn't account for tiles that might already exist in the database. We don't know which tiles are required until we've parsed the style and looked at the sources.

Instead, update `completedResourceCount` and `completedResourceSize` incrementally as we encounter resources that turn out to be in the database already.

Fixes #4147 
