### PR TITLE
Map jumps from one position to another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Known issues:
 
 ## iOS master
 
+- Fixed a bounce-back effect when panning the map. ([#4214](https://github.com/mapbox/mapbox-gl-native/pull/4214))
 - An icon laid out along a line no longer appears if it would extend past the end of the line. Some one-way arrows no longer point the wrong way. ([#3839](https://github.com/mapbox/mapbox-gl-native/pull/3839))
 - Reduce slanted segments in dashed lines near corners. ([#3914](https://github.com/mapbox/mapbox-gl-native/pull/3914))
 - Telemetry location gathering now only occurs when the device is in motion. ([#4115](https://github.com/mapbox/mapbox-gl-native/pull/4115))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Known issues:
 
 ## iOS master
 
+- Fixed screen coordinates for LatLng coordinates accross the antimeridian. ([#4215](https://github.com/mapbox/mapbox-gl-native/issues/4155))
 - Fixed a bounce-back effect when panning the map. ([#4214](https://github.com/mapbox/mapbox-gl-native/pull/4214))
 - An icon laid out along a line no longer appears if it would extend past the end of the line. Some one-way arrows no longer point the wrong way. ([#3839](https://github.com/mapbox/mapbox-gl-native/pull/3839))
 - Reduce slanted segments in dashed lines near corners. ([#3914](https://github.com/mapbox/mapbox-gl-native/pull/3914))

--- a/include/mbgl/annotation/point_annotation.hpp
+++ b/include/mbgl/annotation/point_annotation.hpp
@@ -9,9 +9,8 @@ namespace mbgl {
 
 class PointAnnotation {
 public:
-    inline PointAnnotation(const LatLng& position_, const std::string& icon_ = "")
-        : position(position_), icon(icon_) {
-    }
+    PointAnnotation(const LatLng& position_, const std::string& icon_ = "")
+        : position(position_.wrapped()), icon(icon_) {}
 
     const LatLng position;
     const std::string icon;

--- a/include/mbgl/annotation/shape_annotation.hpp
+++ b/include/mbgl/annotation/shape_annotation.hpp
@@ -33,11 +33,24 @@ public:
         std::string>; // creates an annotation whose type and properties are sourced from a style layer
 
     ShapeAnnotation(const AnnotationSegments& segments_, const Properties& properties_)
-        : segments(segments_), properties(properties_) {
-    }
+        : segments(wrapCoordinates(segments_)), properties(properties_) {}
 
     const AnnotationSegments segments;
     const Properties properties;
+
+private:
+    AnnotationSegments wrapCoordinates(const AnnotationSegments& segments_) {
+        AnnotationSegments wrappedSegments;
+        // Wrap all segments coordinates.
+        for (const auto& segment_ : segments_) {
+            AnnotationSegment wrappedSegment;
+            for (const auto& latLng_ : segment_) {
+                wrappedSegment.push_back(latLng_.wrapped());
+            }
+            wrappedSegments.push_back(wrappedSegment);
+        }
+        return wrappedSegments;
+    }
 };
 
 } // namespace mbgl

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -25,19 +25,17 @@ public:
     LatLng wrapped() const { return { latitude, longitude, Wrapped }; }
 
     void wrap() {
-        if (longitude < -util::LONGITUDE_MAX) longitude = std::fmod(longitude, util::LONGITUDE_MAX * 2);
-        if (longitude > util::LONGITUDE_MAX) longitude = -util::LONGITUDE_MAX + std::fmod(longitude, util::LONGITUDE_MAX);
+        if (longitude < -util::LONGITUDE_MAX) longitude = util::LONGITUDE_MAX + std::fmod(longitude + util::LONGITUDE_MAX, util::DEGREES_MAX);
+        if (longitude > util::LONGITUDE_MAX) longitude = -util::LONGITUDE_MAX + std::fmod(longitude + util::LONGITUDE_MAX, util::DEGREES_MAX);
     }
 
-    /** If a path crossing the antemeridian would be shorter, extend the final
-      coordinate so that interpolating between the two endpoints will cross it. */
-    void unwrapForShortestPath(const LatLng& start) {
-        if (std::abs(start.longitude) + std::abs(longitude) > util::LONGITUDE_MAX) {
-            if (start.longitude > 0 && longitude < 0) {
-                longitude += util::DEGREES_MAX;
-            } else if (start.longitude < 0 && longitude > 0) {
-                longitude -= util::DEGREES_MAX;
-            }
+    // If we pass through the antimeridian, we update the start coordinate to make sure
+    // the end coordinate is always wrapped.
+    void unwrapForShortestPath(const LatLng& end) {
+        if (end.longitude < -util::LONGITUDE_MAX) {
+            longitude += util::DEGREES_MAX;
+        } else if (end.longitude > util::LONGITUDE_MAX) {
+            longitude -= util::DEGREES_MAX;
         }
     }
 

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -199,9 +199,10 @@ public:
         : top(t), left(l), bottom(b), right(r) {}
     
     explicit operator bool() const {
-        return top || left || bottom || right;
+        return !(std::isnan(top) || std::isnan(left) || std::isnan(bottom) || std::isnan(right))
+            && (top || left || bottom || right);
     }
-    
+
     void operator+=(const EdgeInsets& o) {
         top += o.top;
         left += o.left;

--- a/include/mbgl/util/vec.hpp
+++ b/include/mbgl/util/vec.hpp
@@ -105,6 +105,18 @@ struct vec3 {
     inline bool operator==(const vec3& rhs) const {
         return x == rhs.x && y == rhs.y && z == rhs.z;
     }
+
+    template<typename U = T, typename std::enable_if<std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
+    inline operator bool() const {
+        return !std::isnan(x) && !std::isnan(y) && !std::isnan(z);
+    }
+
+    template<typename U = T, typename std::enable_if<!std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
+    inline operator bool() const {
+        return x != std::numeric_limits<T>::min()
+            && y != std::numeric_limits<T>::min()
+            && z != std::numeric_limits<T>::min();
+    }
 };
 
 template <typename T = double>
@@ -116,6 +128,19 @@ struct vec4 {
     inline vec4(T x_, T y_, T z_, T w_) : x(x_), y(y_), z(z_), w(w_) {}
     inline bool operator==(const vec4& rhs) const {
         return x == rhs.x && y == rhs.y && z == rhs.z && w == rhs.w;
+    }
+
+    template<typename U = T, typename std::enable_if<std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
+    inline operator bool() const {
+        return !std::isnan(x) && !std::isnan(y) && !std::isnan(z) && !std::isnan(w);
+    }
+
+    template<typename U = T, typename std::enable_if<!std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
+    inline operator bool() const {
+        return x != std::numeric_limits<T>::min()
+            && y != std::numeric_limits<T>::min()
+            && z != std::numeric_limits<T>::min()
+            && w != std::numeric_limits<T>::min();
     }
 };
 

--- a/src/mbgl/annotation/point_annotation_impl.cpp
+++ b/src/mbgl/annotation/point_annotation_impl.cpp
@@ -14,8 +14,8 @@ void PointAnnotationImpl::updateLayer(const TileID& tileID, AnnotationTileLayer&
 
     mbgl::ScreenCoordinate projected = point.position.project();
     projected *= 1 << tileID.z;
-    projected.x -= int16_t(projected.x);
-    projected.y -= int16_t(projected.y);
+    projected.x = std::fmod(projected.x, 1);
+    projected.y = std::fmod(projected.y, 1);
     projected *= GeometryTileFeature::defaultExtent;
 
     layer.features.emplace_back(

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -95,12 +95,17 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     if (camera.padding) {
         padding = *camera.padding;
     }
-    const LatLng startLatLng = getLatLng(padding);
+
+    LatLng startLatLng = getLatLng(padding);
+    startLatLng.unwrapForShortestPath(latLng);
+
+    // Make sure the end coordinate always remains valid.
+    latLng.wrap();
+
     const ScreenCoordinate startPoint = {
         state.lngX(startLatLng.longitude),
         state.latY(startLatLng.latitude),
     };
-    latLng.unwrapForShortestPath(getLatLng());
     const ScreenCoordinate endPoint = {
         state.lngX(latLng.longitude),
         state.latY(latLng.latitude),
@@ -136,7 +141,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
         ScreenCoordinate framePoint = util::interpolate(startPoint, endPoint, t);
         LatLng frameLatLng = {
             state.yLat(framePoint.y, startWorldSize),
-            state.xLng(framePoint.x, startWorldSize),
+            state.xLng(framePoint.x, startWorldSize)
         };
         double frameScale = util::interpolate(startScale, scale, t);
         state.setLatLngZoom(frameLatLng, state.scaleZoom(frameScale));
@@ -178,12 +183,17 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
     if (camera.padding) {
         padding = *camera.padding;
     }
-    const LatLng startLatLng = getLatLng(padding);
+
+    LatLng startLatLng = getLatLng(padding);
+    startLatLng.unwrapForShortestPath(latLng);
+
+    // Make sure the end coordinate always remains valid.
+    latLng.wrap();
+
     const ScreenCoordinate startPoint = {
         state.lngX(startLatLng.longitude),
         state.latY(startLatLng.latitude),
     };
-    latLng.unwrapForShortestPath(getLatLng());
     const ScreenCoordinate endPoint = {
         state.lngX(latLng.longitude),
         state.latY(latLng.latitude),

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -423,7 +423,7 @@ ScreenCoordinate Transform::getScreenCoordinate(const EdgeInsets& padding) const
 #pragma mark - Zoom
 
 void Transform::scaleBy(double ds, const ScreenCoordinate& center, const Duration& duration) {
-    if (std::isnan(ds)) {
+    if (std::isnan(ds) || !center) {
         return;
     }
 
@@ -463,10 +463,12 @@ void Transform::setScale(double scale, const EdgeInsets& padding, const Duration
 }
 
 void Transform::setMinZoom(const double minZoom) {
+    if (std::isnan(minZoom)) return;
     state.setMinZoom(minZoom);
 }
 
 void Transform::setMaxZoom(const double maxZoom) {
+    if (std::isnan(maxZoom)) return;
     state.setMaxZoom(maxZoom);
 }
 
@@ -657,12 +659,14 @@ void Transform::setGestureInProgress(bool inProgress) {
 #pragma mark Conversion and projection
 
 ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const {
+    if (!latLng) return {};
     ScreenCoordinate point = state.latLngToScreenCoordinate(latLng);
     point.y = state.height - point.y;
     return point;
 }
 
 LatLng Transform::screenCoordinateToLatLng(const ScreenCoordinate& point) const {
+    if (!point) return {};
     ScreenCoordinate flippedPoint = point;
     flippedPoint.y = state.height - flippedPoint.y;
     return state.screenCoordinateToLatLng(flippedPoint);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -660,7 +660,21 @@ void Transform::setGestureInProgress(bool inProgress) {
 
 ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const {
     if (!latLng) return {};
-    ScreenCoordinate point = state.latLngToScreenCoordinate(latLng);
+
+    // If the center and point coordinates are not in the same side of the
+    // antimeridian, we need to unwrap the point longitude to make sure it can
+    // still be seen from the visible side of the antimeridian that is opposite
+    // to the center side.
+    double longitude = latLng.longitude;
+    const double centerLng = getLatLng().longitude;
+    if (centerLng - latLng.longitude > util::LONGITUDE_MAX) {
+        if (centerLng > 0 && latLng.longitude < 0) {
+            longitude += util::DEGREES_MAX;
+        } else if (centerLng < 0 && latLng.longitude > 0) {
+            longitude -= util::DEGREES_MAX;
+        }
+    }
+    ScreenCoordinate point = state.latLngToScreenCoordinate({ latLng.latitude, longitude });
     point.y = state.height - point.y;
     return point;
 }

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -35,10 +35,6 @@ static double _normalizeAngle(double angle, double anchorAngle)
     return angle;
 }
 
-inline bool _validPoint(const ScreenCoordinate& point) {
-    return !std::isnan(point.x) && !std::isnan(point.y);
-}
-
 Transform::Transform(View &view_, ConstrainMode constrainMode)
     : view(view_)
     , state(constrainMode)
@@ -341,9 +337,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
 #pragma mark - Position
 
 void Transform::moveBy(const ScreenCoordinate& offset, const Duration& duration) {
-    if (!_validPoint(offset)) {
-        return;
-    }
+    if (!offset) return;
 
     ScreenCoordinate centerOffset = {
         offset.x,
@@ -583,7 +577,7 @@ void Transform::startTransition(const CameraOptions& camera,
     // Associate the anchor, if given, with a coordinate.
     ScreenCoordinate anchor = camera.anchor ? *camera.anchor : ScreenCoordinate(NAN, NAN);
     LatLng anchorLatLng;
-    if (_validPoint(anchor)) {
+    if (anchor) {
         anchor.y = state.getHeight() - anchor.y;
         anchorLatLng = state.screenCoordinateToLatLng(anchor);
     }
@@ -601,9 +595,7 @@ void Transform::startTransition(const CameraOptions& camera,
             result = frame(ease.solve(t, 0.001));
         }
         
-        if (_validPoint(anchor)) {
-            state.moveLatLng(anchorLatLng, anchor);
-        }
+        if (anchor) state.moveLatLng(anchorLatLng, anchor);
         
         // At t = 1.0, a DidChangeAnimated notification should be sent from finish().
         if (t < 1.0) {

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -48,6 +48,7 @@ public:
     void setLatLngZoom(const LatLng&, double zoom, const Duration& = Duration::zero());
     void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const Duration& = Duration::zero());
     LatLng getLatLng(const EdgeInsets& = {}) const;
+    ScreenCoordinate getScreenCoordinate(const EdgeInsets& = {}) const;
 
     // Zoom
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -56,12 +56,12 @@ public:
         @param ds The difference in scale factors to scale the map by.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void scaleBy(double ds, const ScreenCoordinate& anchor = {NAN, NAN}, const Duration& = Duration::zero());
+    void scaleBy(double ds, const ScreenCoordinate& anchor = {}, const Duration& = Duration::zero());
     /** Sets the scale factor, keeping the given point fixed within the view.
         @param scale The new scale factor.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void setScale(double scale, const ScreenCoordinate& anchor = {NAN, NAN}, const Duration& = Duration::zero());
+    void setScale(double scale, const ScreenCoordinate& anchor = {}, const Duration& = Duration::zero());
     /** Sets the scale factor, keeping the center point fixed within the inset view.
         @param scale The new scale factor.
         @param padding The viewport padding that affects the fixed center point. */
@@ -70,7 +70,7 @@ public:
         @param zoom The new zoom level.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void setZoom(double zoom, const ScreenCoordinate& anchor = {NAN, NAN}, const Duration& = Duration::zero());
+    void setZoom(double zoom, const ScreenCoordinate& anchor = {}, const Duration& = Duration::zero());
     /** Sets the zoom level, keeping the center point fixed within the inset view.
         @param zoom The new zoom level.
         @param padding The viewport padding that affects the fixed center point. */

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -89,38 +89,11 @@ ConstrainMode TransformState::getConstrainMode() const {
 #pragma mark - Position
 
 LatLng TransformState::getLatLng(LatLng::WrapMode wrapMode) const {
-    LatLng ll {
+    return {
         util::RAD2DEG * (2 * std::atan(std::exp(y / Cc)) - 0.5 * M_PI),
         -x / Bc,
         wrapMode
     };
-
-    if (wrapMode == LatLng::Unwrapped) return ll;
-
-    // adjust for date line
-    double w = worldSize() / 2;
-    double x_ = x;
-    if (x_ > w) {
-        while (x_ > w) {
-            x_ -= w;
-            if (ll.longitude < 0) {
-                ll.longitude += util::LONGITUDE_MAX;
-            } else if (ll.longitude > 0) {
-                ll.longitude -= util::LONGITUDE_MAX;
-            }
-        }
-    } else if (x_ < -w) {
-        while (x_ < -w) {
-            x_ += w;
-            if (ll.longitude < 0) {
-                ll.longitude -= util::LONGITUDE_MAX;
-            } else if (ll.longitude > 0) {
-                ll.longitude -= util::LONGITUDE_MAX;
-            }
-        }
-    }
-
-    return ll;
 }
 
 double TransformState::pixel_x() const {
@@ -350,7 +323,7 @@ void TransformState::moveLatLng(const LatLng& latLng, const ScreenCoordinate& an
 
     auto centerCoord = latLngToTileCoord(getLatLng(LatLng::Unwrapped));
     auto latLngCoord = latLngToTileCoord(latLng);
-    auto anchorCoord = latLngToTileCoord(screenCoordinateToLatLng(anchor, LatLng::Unwrapped));
+    auto anchorCoord = latLngToTileCoord(screenCoordinateToLatLng(anchor));
     setLatLngZoom(tileCoordToLatLng(centerCoord + latLngCoord - anchorCoord), getZoom());
 }
 

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -37,7 +37,7 @@ public:
     ConstrainMode getConstrainMode() const;
 
     // Position
-    LatLng getLatLng(LatLng::WrapMode = LatLng::Wrapped) const;
+    LatLng getLatLng(LatLng::WrapMode = LatLng::Unwrapped) const;
     double pixel_x() const;
     double pixel_y() const;
 
@@ -65,7 +65,7 @@ public:
 
     // Conversion and projection
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&) const;
-    LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Wrapped) const;
+    LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Unwrapped) const;
 
     double xLng(double x, double worldSize) const;
     double yLat(double y, double worldSize) const;

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -23,7 +23,7 @@ public:
     }
 
     static TileCoordinate fromScreenCoordinate(const TransformState& state, double zoom, const ScreenCoordinate& point) {
-        return fromLatLng(state, zoom, state.screenCoordinateToLatLng(point, LatLng::Unwrapped));
+        return fromLatLng(state, zoom, state.screenCoordinateToLatLng(point));
     }
 };
 

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -297,3 +297,25 @@ TEST(Transform, MoveBy) {
     ASSERT_NEAR(0, trueCenter.latitude, 1.1);
     ASSERT_NEAR(0, trueCenter.longitude, 1.1);
 }
+
+TEST(Transform, Antimeridian) {
+    MockView view;
+    Transform transform(view, ConstrainMode::HeightOnly);
+    transform.resize({{ 1000, 1000 }});
+    transform.setLatLngZoom({ 0, 0 }, 1);
+
+    const LatLng coordinateSanFrancisco { 37.7833, -122.4167 };
+    ScreenCoordinate pixelSF = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
+    ASSERT_DOUBLE_EQ(151.79409149185352, pixelSF.x);
+    ASSERT_DOUBLE_EQ(383.76774094913071, pixelSF.y);
+
+    transform.setLatLng({ 0, -181 });
+    ScreenCoordinate pixelSFBackwards = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
+    ASSERT_DOUBLE_EQ(666.63617954008976, pixelSFBackwards.x);
+    ASSERT_DOUBLE_EQ(pixelSF.y, pixelSFBackwards.y);
+
+    transform.setLatLng({ 0, 179 });
+    ScreenCoordinate pixelSFForwards = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
+    ASSERT_DOUBLE_EQ(pixelSFBackwards.x, pixelSFForwards.x);
+    ASSERT_DOUBLE_EQ(pixelSFBackwards.y, pixelSFForwards.y);
+}

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -158,13 +158,17 @@ TEST(Transform, UnwrappedLatLng) {
     ASSERT_NEAR(fromScreenCoordinate.latitude,   37.999999999999829, 0.0001); // 1.71E-13
     ASSERT_NEAR(fromScreenCoordinate.longitude, -76.999999999999773, 0.0001); // 2.27E-13
 
-    LatLng wrappedForwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, 283, LatLng::Wrapped }));
+    LatLng wrappedForwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, 283 }));
     ASSERT_NEAR(wrappedForwards.latitude, 37.999999999999716, 0.0001); // 2.84E-13
-    ASSERT_DOUBLE_EQ(wrappedForwards.longitude, fromScreenCoordinate.longitude);
+    ASSERT_NEAR(wrappedForwards.longitude, 282.99999999988751, 0.0001); // 1.1249E-11
+    wrappedForwards.wrap();
+    ASSERT_NEAR(wrappedForwards.longitude, -77.000000000112493, 0.001); // 1.1249E-11
 
-    LatLng wrappedBackwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, -437, LatLng::Wrapped }));
-    ASSERT_DOUBLE_EQ(wrappedBackwards.latitude, wrappedForwards.latitude);
-    ASSERT_DOUBLE_EQ(wrappedBackwards.longitude, fromScreenCoordinate.longitude);
+    LatLng wrappedBackwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, -437 }));
+    ASSERT_NEAR(wrappedBackwards.latitude, wrappedForwards.latitude, 0.001);
+    ASSERT_NEAR(wrappedBackwards.longitude, -436.99999999988728, 0.001); // 1.1272E-11
+    wrappedBackwards.wrap();
+    ASSERT_NEAR(wrappedBackwards.longitude, -76.99999999988728, 0.001); // 1.1272E-11
 }
 
 TEST(Transform, ConstrainHeightOnly) {

--- a/test/util/geo.cpp
+++ b/test/util/geo.cpp
@@ -105,6 +105,34 @@ TEST(LatLng, FromTileID) {
     }
 }
 
+TEST(LatLng, Boundaries) {
+    LatLng coordinate;
+    ASSERT_DOUBLE_EQ(0, coordinate.latitude);
+    ASSERT_DOUBLE_EQ(0, coordinate.longitude);
+
+    coordinate.longitude = -180.1;
+    ASSERT_DOUBLE_EQ(-180.1, coordinate.longitude);
+
+    coordinate.wrap();
+    ASSERT_DOUBLE_EQ(179.90000000000001, coordinate.longitude); // 1E-14
+
+    coordinate.longitude = 180.9;
+    coordinate.wrap();
+    ASSERT_DOUBLE_EQ(-179.09999999999999, coordinate.longitude);
+
+    coordinate.longitude = -360.5;
+    coordinate.wrap();
+    ASSERT_DOUBLE_EQ(-0.5, coordinate.longitude);
+
+    coordinate.longitude = 360.5;
+    coordinate.wrap();
+    ASSERT_DOUBLE_EQ(0.5, coordinate.longitude);
+
+    coordinate.longitude = 360000.5;
+    coordinate.wrap();
+    ASSERT_DOUBLE_EQ(0.5, coordinate.longitude);
+}
+
 TEST(LatLngBounds, FromTileID) {
     {
         const LatLngBounds bounds{ TileID(0, 0, 0, 0) };


### PR DESCRIPTION
When panning the map jumps from on location to another.
I'm guessing it's something related to the dateline.
You can see the bug in action [here](https://youtu.be/t3FsKKc5meY)