### PR TITLE
Non-embedded static framework for iOS SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ ipackage: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DE
 ipackage-strip: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO ./platform/ios/scripts/package.sh
 ipackage-sim: Xcode/ios ; @JOBS=$(JOBS) BUILDTYPE=Debug BITCODE=$(BITCODE) FORMAT=dynamic BUILD_DEVICE=false SYMBOLS=$(SYMBOLS) ./platform/ios/scripts/package.sh
 iframework: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=dynamic BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) ./platform/ios/scripts/package.sh
+ifabric: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO BUNDLE_RESOURCES=YES ./platform/ios/scripts/package.sh
 itest: ipackage-sim ; ./platform/ios/scripts/test.sh
 idocument: ; OUTPUT=$(OUTPUT) ./platform/ios/scripts/document.sh
 

--- a/platform/ios/framework/Mapbox-static.h
+++ b/platform/ios/framework/Mapbox-static.h
@@ -1,3 +1,5 @@
 #import <GLKit/GLKit.h>
 #import <ImageIO/ImageIO.h>
 #import <MobileCoreServices/MobileCoreServices.h>
+#import <QuartzCore/QuartzCore.h>
+#import <SystemConfiguration/SystemConfiguration.h>

--- a/platform/ios/src/MGLAPIClient.m
+++ b/platform/ios/src/MGLAPIClient.m
@@ -107,8 +107,8 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
 }
 
 - (void)loadCertificate:(NSData **)certificate withResource:(NSString *)resource {
-    NSBundle *resourceBundle = [NSBundle mgl_frameworkBundle];
-    NSString *cerPath = [resourceBundle pathForResource:resource ofType:@"der"];
+    NSBundle *frameworkBundle = [NSBundle mgl_frameworkBundle];
+    NSString *cerPath = [frameworkBundle pathForResource:resource ofType:@"der" inDirectory:frameworkBundle.mgl_resourcesDirectory];
     if (cerPath != nil) {
         *certificate = [NSData dataWithContentsOfFile:cerPath];
     }
@@ -118,8 +118,8 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
     NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
     NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *appBuildNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
-    NSString *semanticVersion = [NSBundle mgl_frameworkBundle].infoDictionary[@"MGLSemanticVersionString"];
-    NSString *shortVersion = [NSBundle mgl_frameworkBundle].infoDictionary[@"CFBundleShortVersionString"];
+    NSString *semanticVersion = [NSBundle mgl_frameworkInfoDictionary][@"MGLSemanticVersionString"];
+    NSString *shortVersion = [NSBundle mgl_frameworkInfoDictionary][@"CFBundleShortVersionString"];
     NSString *sdkVersion = semanticVersion ? semanticVersion : shortVersion;
     _userAgent = [NSString stringWithFormat:@"%@/%@/%@ %@/%@", appName, appVersion, appBuildNumber, MGLAPIClientUserAgentBase, sdkVersion];
 }

--- a/platform/ios/src/MGLAccountManager.m
+++ b/platform/ios/src/MGLAccountManager.m
@@ -73,11 +73,11 @@
 #pragma mark - Fabric
 
 + (NSString *)bundleIdentifier {
-    return [NSBundle mgl_frameworkBundle].bundleIdentifier;
+    return [NSBundle mgl_frameworkBundleIdentifier];
 }
 
 + (NSString *)kitDisplayVersion {
-    return [NSBundle mgl_frameworkBundle].infoDictionary[@"CFBundleShortVersionString"];
+    return [NSBundle mgl_frameworkInfoDictionary][@"CFBundleShortVersionString"];
 }
 
 + (void)initializeIfNeeded {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3828,7 +3828,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     NSString *extension = imageName.pathExtension.length ? imageName.pathExtension : @"png";
     NSBundle *bundle = [NSBundle mgl_frameworkBundle];
     NSString *path = [bundle pathForResource:imageName.stringByDeletingPathExtension
-                                      ofType:extension];
+                                      ofType:extension
+                                 inDirectory:bundle.mgl_resourcesDirectory];
     if ( ! path)
     {
         [NSException raise:@"Resource not found" format:

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -3,7 +3,6 @@
 #import <CoreLocation/CoreLocation.h>
 #import "MGLAccountManager.h"
 #import "NSProcessInfo+MGLAdditions.h"
-#import "NSBundle+MGLAdditions.h"
 #import "NSException+MGLAdditions.h"
 #import "MGLAPIClient.h"
 #import "MGLLocationManager.h"
@@ -167,7 +166,6 @@ const NSTimeInterval MGLFlushInterval = 180;
         _locationManager.delegate = self;
         _paused = YES;
         [self resumeMetricsCollection];
-        NSBundle *resourceBundle = [NSBundle mgl_frameworkBundle];
 
         // Events Control
         _eventQueue = [[NSMutableArray alloc] init];

--- a/platform/ios/src/NSBundle+MGLAdditions.h
+++ b/platform/ios/src/NSBundle+MGLAdditions.h
@@ -8,7 +8,16 @@ void mgl_linkBundleCategory();
 
 @interface NSBundle (MGLAdditions)
 
+/// Returns the bundle containing the SDK’s classes and Info.plist file.
 + (instancetype)mgl_frameworkBundle;
+
++ (nullable NSString *)mgl_frameworkBundleIdentifier;
+
++ (nullable NS_DICTIONARY_OF(NSString *, id) *)mgl_frameworkInfoDictionary;
+
+/// The relative path to the directory containing the SDK’s resource files, or
+/// `nil` if the files are located directly within the bundle’s root directory.
+@property (readonly, copy, nullable) NSString *mgl_resourcesDirectory;
 
 @end
 

--- a/platform/ios/src/NSBundle+MGLAdditions.m
+++ b/platform/ios/src/NSBundle+MGLAdditions.m
@@ -6,16 +6,35 @@ void mgl_linkBundleCategory() {}
 
 @implementation NSBundle (MGLAdditions)
 
-+ (instancetype)mgl_frameworkBundle
-{
++ (instancetype)mgl_frameworkBundle {
     NSBundle *bundle = [self bundleForClass:[MGLAccountManager class]];
-    if (![bundle.infoDictionary[@"CFBundlePackageType"] isEqualToString:@"FMWK"]) {
+    if (![bundle.infoDictionary[@"CFBundlePackageType"] isEqualToString:@"FMWK"] && !bundle.mgl_resourcesDirectory) {
         // For static frameworks, the bundle is the containing application
         // bundle but the resources are still in the framework bundle.
         bundle = [NSBundle bundleWithPath:[bundle.privateFrameworksPath
                                            stringByAppendingPathComponent:@"Mapbox.framework"]];
     }
     return bundle;
+}
+
++ (nullable NSString *)mgl_frameworkBundleIdentifier {
+    return self.mgl_frameworkInfoDictionary[@"CFBundleIdentifier"];
+}
+
++ (nullable NS_DICTIONARY_OF(NSString *, id) *)mgl_frameworkInfoDictionary {
+    NSBundle *bundle = self.mgl_frameworkBundle;
+    if (bundle.mgl_resourcesDirectory) {
+        NSString *infoPlistPath = [bundle pathForResource:@"Info"
+                                                   ofType:@"plist"
+                                              inDirectory:bundle.mgl_resourcesDirectory];
+        return [NSDictionary dictionaryWithContentsOfFile:infoPlistPath];
+    } else {
+        return bundle.infoDictionary;
+    }
+}
+
+- (NSString *)mgl_resourcesDirectory {
+    return [self pathForResource:@"Mapbox" ofType:@"bundle"] ? @"Mapbox.bundle" : nil;
 }
 
 @end

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -92,7 +92,7 @@ typedef std::map<MGLAnnotationTag, MGLAnnotationContext> MGLAnnotationContextMap
 /// Returns an NSImage for the default marker image.
 NSImage *MGLDefaultMarkerImage() {
     NSString *path = [[NSBundle mgl_frameworkBundle] pathForResource:MGLDefaultStyleMarkerSymbolName
-                                                             ofType:@"pdf"];
+                                                              ofType:@"pdf"];
     return [[NSImage alloc] initWithContentsOfFile:path];
 }
 


### PR DESCRIPTION
Added a new `ifabric` make target for packaging up a static framework similar to the one released as 3.0.1. Place artwork and certificate assets inside Mapbox.bundle inside Mapbox.framework. Link SystemConfiguration in the umbrella header.

Distinguish between the framework bundle and the resources bundle. For the dynamic frameworks and embedded static frameworks, the two are the same; for the non-embedded static framework, the latter resides inside the former.

FABKit integration would be a lot less manual if we could rely on build settings (perhaps via an .xcconfig file) to define the bundle identifier and display version string in MGLAccountManager. Unfortunately, our use of gyp keeps those settings from making it through to the Objective-C code. This will get a lot better once we fix #3275.

Once this change lands, I’ll backport it to a branch based on the 3.1.2 release and push a one-off release to Fabric.

/cc @friedbunny