### PR TITLE
[core] Add client defined network status

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -102,7 +102,6 @@ public:
 
     // For testing only.
     void put(const Resource&, const Response&);
-    void goOffline();
 
     class Impl;
 

--- a/include/mbgl/storage/network_status.hpp
+++ b/include/mbgl/storage/network_status.hpp
@@ -18,8 +18,8 @@ public:
         Offline,
     };
 
-    Status Get();
-    void Set(Status);
+    static Status Get();
+    static void Set(Status);
 
     static void Reachable();
 

--- a/include/mbgl/storage/network_status.hpp
+++ b/include/mbgl/storage/network_status.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_STORAGE_NETWORK_STATUS
 #define MBGL_STORAGE_NETWORK_STATUS
 
+#include <atomic>
 #include <mutex>
 #include <set>
 
@@ -12,12 +13,21 @@ class AsyncTask;
 
 class NetworkStatus {
 public:
+    enum class Status : uint8_t {
+        Online,
+        Offline,
+    };
+
+    Status Get();
+    void Set(Status);
+
     static void Reachable();
 
     static void Subscribe(util::AsyncTask* async);
     static void Unsubscribe(util::AsyncTask* async);
 
 private:
+    static std::atomic<bool> online;
     static std::mutex mtx;
     static std::set<util::AsyncTask*> observers;
 };

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/storage/asset_file_source.hpp>
-#include <mbgl/storage/network_status.hpp>
 #include <mbgl/storage/online_file_source.hpp>
 #include <mbgl/storage/offline_database.hpp>
 #include <mbgl/storage/offline_download.hpp>
@@ -40,12 +39,10 @@ public:
                 callback(*offlineResponse);
             }
 
-            if (NetworkStatus::Get() == NetworkStatus::Status::Online) {
-                onlineRequest = impl->onlineFileSource.request(revalidation, [=] (Response onlineResponse) {
-                    impl->offlineDatabase.put(revalidation, onlineResponse);
-                    callback(onlineResponse);
-                });
-            }
+            onlineRequest = impl->onlineFileSource.request(revalidation, [=] (Response onlineResponse) {
+                impl->offlineDatabase.put(revalidation, onlineResponse);
+                callback(onlineResponse);
+            });
         }
 
         std::unique_ptr<FileRequest> onlineRequest;

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -289,6 +289,15 @@ void OnlineFileRequestImpl::schedule(OnlineFileSource::Impl& impl, optional<Syst
         return;
     }
 
+    // Emulate a Connection error when the Offline mode is forced with
+    // a really long timeout. The request will get re-triggered when
+    // the NetworkStatus is set back to Online.
+    if (NetworkStatus::Get() == NetworkStatus::Status::Offline) {
+        failedRequestReason = Response::Error::Reason::Connection;
+        failedRequests = 1;
+        timeout = Duration::max();
+    }
+
     timer.start(timeout, Duration::zero(), [&] {
         impl.activateOrQueueRequest(this);
     });

--- a/src/mbgl/storage/network_status.cpp
+++ b/src/mbgl/storage/network_status.cpp
@@ -9,8 +9,26 @@
 
 namespace mbgl {
 
+std::atomic<bool> NetworkStatus::online(true);
 std::mutex NetworkStatus::mtx;
 std::set<util::AsyncTask *> NetworkStatus::observers;
+
+NetworkStatus::Status NetworkStatus::Get() {
+    if (online) {
+        return Status::Online;
+    } else {
+        return Status::Offline;
+    }
+}
+
+void NetworkStatus::Set(Status status) {
+    if (status == Status::Online) {
+        online = true;
+        Reachable();
+    } else {
+        online = false;
+    }
+}
 
 void NetworkStatus::Subscribe(util::AsyncTask *async) {
     std::lock_guard<std::mutex> lock(NetworkStatus::mtx);
@@ -23,6 +41,10 @@ void NetworkStatus::Unsubscribe(util::AsyncTask *async) {
 }
 
 void NetworkStatus::Reachable() {
+    if (!online) {
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(NetworkStatus::mtx);
     for (auto async : observers) {
         async->send();

--- a/test/api/offline.cpp
+++ b/test/api/offline.cpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/platform/default/headless_display.hpp>
 #include <mbgl/platform/default/headless_view.hpp>
+#include <mbgl/storage/network_status.hpp>
 #include <mbgl/storage/offline_database.hpp>
 #include <mbgl/storage/default_file_source.hpp>
 
@@ -38,7 +39,7 @@ TEST(API, Offline) {
     fileSource.put(Resource::spriteImage(prefix + "/offline/sprite", 1.0), expiredItem("offline/sprite.png"));
     fileSource.put(Resource::tile(prefix + "/offline/{z}-{x}-{y}.vector.pbf", 1.0, 0, 0, 0), expiredItem("offline/0-0-0.vector.pbf"));
     fileSource.put(Resource::glyphs(prefix + "/offline/{fontstack}/{range}.pbf", "Helvetica", {0, 255}), expiredItem("offline/glyph.pbf"));
-    fileSource.goOffline();
+    NetworkStatus::Set(NetworkStatus::Status::Offline);
 
     Map map(view, fileSource, MapMode::Still);
     map.setStyleURL(prefix + "/offline/style.json");
@@ -47,4 +48,6 @@ TEST(API, Offline) {
                      test::render(map),
                      0.0015,
                      0.1);
+
+    NetworkStatus::Set(NetworkStatus::Status::Online);
 }


### PR DESCRIPTION
This API will let the client force a network status. If set to Offline, we won't make network requests.

When set make to Online, it will trigger the pending requests and try to fetch tiles from the network.