### PR TITLE
Cancel out TileID::overscaling() in most places

### DIFF
--- a/src/mbgl/layer/line_layer.cpp
+++ b/src/mbgl/layer/line_layer.cpp
@@ -69,7 +69,7 @@ bool LineLayer::recalculate(const StyleCalculationParameters& parameters) {
 }
 
 std::unique_ptr<Bucket> LineLayer::createBucket(StyleBucketParameters& parameters) const {
-    auto bucket = std::make_unique<LineBucket>(parameters.tileID.overscaling());
+    auto bucket = std::make_unique<LineBucket>(parameters.tileID.overscaleFactor());
 
     bucket->layout = layout;
 

--- a/src/mbgl/layer/symbol_layer.cpp
+++ b/src/mbgl/layer/symbol_layer.cpp
@@ -113,7 +113,7 @@ bool SymbolLayer::recalculate(const StyleCalculationParameters& parameters) {
 }
 
 std::unique_ptr<Bucket> SymbolLayer::createBucket(StyleBucketParameters& parameters) const {
-    auto bucket = std::make_unique<SymbolBucket>(parameters.tileID.overscaling(),
+    auto bucket = std::make_unique<SymbolBucket>(parameters.tileID.overscaleFactor(),
                                                  parameters.tileID.z,
                                                  parameters.mode);
 

--- a/src/mbgl/map/tile_id.hpp
+++ b/src/mbgl/map/tile_id.hpp
@@ -26,8 +26,8 @@ public:
         return ((std::pow(2, z) * y + x) * 32) + z;
     }
 
-    float overscaling() const {
-        return std::pow(2, z - sourceZ);
+    uint32_t overscaleFactor() const {
+        return static_cast<uint32_t>(1) << (z - sourceZ);
     }
 
     bool operator==(const TileID& rhs) const {

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -13,7 +13,7 @@
 
 using namespace mbgl;
 
-LineBucket::LineBucket(float overscaling_) : overscaling(overscaling_) {
+LineBucket::LineBucket(uint32_t overscaling_) : overscaling(overscaling_) {
 }
 
 LineBucket::~LineBucket() {

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -24,7 +24,7 @@ class LineBucket : public Bucket {
     using TriangleGroup = ElementGroup<3>;
 
 public:
-    LineBucket(float overscaling);
+    LineBucket(uint32_t overscaling);
     ~LineBucket() override;
 
     void upload(gl::GLObjectStore&) override;
@@ -63,7 +63,7 @@ private:
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
 
-    const float overscaling;
+    const uint32_t overscaling;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -344,7 +344,7 @@ mat4 Painter::translatedMatrix(const mat4& matrix, const std::array<float, 2> &t
     if (translation[0] == 0 && translation[1] == 0) {
         return matrix;
     } else {
-        const double factor = ((double)(1 << id.z)) / state.getScale() * (util::EXTENT / util::tileSize / id.overscaling());
+        const double factor = double(1ll << id.sourceZ) * util::EXTENT / util::tileSize / state.getScale();
 
         mat4 vtxMatrix;
         if (anchor == TranslateAnchorType::Viewport) {

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -65,7 +65,8 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
 
         // Image fill.
         if (pass == RenderPass::Translucent && posA && posB) {
-            float factor = (util::EXTENT / util::tileSize / std::pow(2, state.getIntegerZoom() - id.z)) / id.overscaling();
+            const float factor =
+                (util::EXTENT / util::tileSize / std::pow(2, state.getIntegerZoom() - id.sourceZ));
 
             mat3 patternMatrixA;
             matrix::identity(patternMatrixA);

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -51,7 +51,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
     color[2] *= properties.opacity;
     color[3] *= properties.opacity;
 
-    float ratio = state.getScale() / std::pow(2, id.z) / (util::EXTENT / (util::tileSize * id.overscaling()));
+    const float ratio = state.getScale() / (1ll << id.sourceZ) * util::tileSize / util::EXTENT;
 
     mat2 antialiasingMatrix;
     matrix::identity(antialiasingMatrix);
@@ -85,7 +85,10 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
 
         const float widthA = posA.width * properties.dasharray.value.fromScale;
         const float widthB = posB.width * properties.dasharray.value.toScale;
-        float patternratio = std::pow(2.0, std::floor(::log2(state.getScale())) - id.z) / (util::EXTENT / util::tileSize) * id.overscaling();
+
+        const float patternratio =
+            std::pow(2.0, state.getIntegerZoom() - id.sourceZ) * util::tileSize / util::EXTENT;
+
         float scaleXA = patternratio / widthA / properties.dashLineWidth;
         float scaleYA = -posA.height / 2.0;
         float scaleXB = patternratio / widthB / properties.dashLineWidth;
@@ -111,7 +114,7 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         if (!imagePosA || !imagePosB)
             return;
 
-        float factor = util::EXTENT / (util::tileSize * id.overscaling()) / std::pow(2, state.getIntegerZoom() - id.z);
+        const float factor = util::EXTENT / util::tileSize / std::pow(2.0f, state.getIntegerZoom() - id.sourceZ);
 
         config.program = linepatternShader->getID();
 

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -34,7 +34,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
 
     if (skewed) {
         matrix::identity(exMatrix);
-        s = util::EXTENT / util::tileSize / id.overscaling() / std::pow(2, state.getZoom() - id.z);
+        s = util::EXTENT / util::tileSize / std::pow(2, state.getZoom() - id.sourceZ);
         gammaScale = 1.0f / std::cos(state.getPitch());
     } else {
         exMatrix = extrudeMatrix;
@@ -195,7 +195,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
 
             if (skewed) {
                 matrix::identity(exMatrix);
-                s = util::EXTENT / util::tileSize / id.overscaling() / std::pow(2, state.getZoom() - id.z);
+                s = util::EXTENT / util::tileSize / std::pow(2, state.getZoom() - id.sourceZ);
             } else {
                 exMatrix = extrudeMatrix;
                 matrix::rotate_z(exMatrix, exMatrix, state.getNorthOrientationAngle());

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -56,7 +56,7 @@ SymbolInstance::SymbolInstance(Anchor& anchor, const GeometryCoordinates& line,
     iconCollisionFeature(line, anchor, shapedIcon, iconBoxScale, iconPadding, iconAlongLine) {};
 
 
-SymbolBucket::SymbolBucket(float overscaling_, float zoom_, const MapMode mode_)
+SymbolBucket::SymbolBucket(uint32_t overscaling_, float zoom_, const MapMode mode_)
     : overscaling(overscaling_),
       zoom(zoom_),
       tileSize(util::tileSize * overscaling_),

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -67,7 +67,7 @@ class SymbolBucket : public Bucket {
     typedef ElementGroup<1> CollisionBoxElementGroup;
 
 public:
-    SymbolBucket(float overscaling, float zoom, const MapMode);
+    SymbolBucket(uint32_t overscaling, float zoom, const MapMode);
     ~SymbolBucket() override;
 
     void upload(gl::GLObjectStore&) override;
@@ -117,7 +117,7 @@ private:
 
     const float overscaling;
     const float zoom;
-    const float tileSize;
+    const uint32_t tileSize;
     const float tilePixelRatio;
     const MapMode mode;
 


### PR DESCRIPTION
We don't actually need it because it can be cancelled out.