### PR TITLE
[android] #4243 #3643 - refactoring the onSingleTapConfirmed to tap on Markers anywhere on its Icon Bitmap

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Marker.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Marker.java
@@ -1,13 +1,16 @@
 package com.mapbox.mapboxsdk.annotations;
 
+import android.graphics.Bitmap;
+import android.graphics.PointF;
+import android.graphics.RectF;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
 
-import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 
 /**
  * Marker is an annotation that shows an icon image at a geographical location.
@@ -24,6 +27,9 @@ public class Marker extends Annotation {
     private InfoWindow infoWindow = null;
     private boolean infoWindowShown = false;
     private int topOffsetPixels;
+
+    @Nullable
+    private RectF bounds;
 
     /**
      * Constructor
@@ -92,6 +98,15 @@ public class Marker extends Annotation {
      */
     public void setIcon(@Nullable Icon icon) {
         this.icon = icon;
+        if (icon != null) {
+            Bitmap bitmap = icon.getBitmap();
+            int width = bitmap.getWidth();
+            int height = bitmap.getHeight();
+            bounds = new RectF(0, 0, width, height);
+        } else {
+            bounds = null;
+        }
+
         MapboxMap map = getMapboxMap();
         if (map != null) {
             map.updateMarker(this);
@@ -100,6 +115,19 @@ public class Marker extends Annotation {
 
     public Icon getIcon() {
         return icon;
+    }
+
+    /**
+     * Get the RectF corresponding to the Icon Bitmap bounds.
+     *
+     * @return a copy of the precomputed RectF that can be manipulated safely or null if no Bitmap has been set.
+     */
+    @Nullable
+    public RectF getBounds() {
+        if (bounds != null) {
+            return new RectF(bounds);
+        }
+        return null;
     }
 
     void setTitle(String title) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -78,6 +78,7 @@ import com.mapbox.mapboxsdk.exceptions.InvalidAccessTokenException;
 import com.mapbox.mapboxsdk.exceptions.TelemetryServiceNotConfiguredException;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.geometry.VisibleRegion;
 import com.mapbox.mapboxsdk.layers.CustomLayer;
 import com.mapbox.mapboxsdk.maps.widgets.CompassView;
 import com.mapbox.mapboxsdk.maps.widgets.UserLocationView;
@@ -1534,55 +1535,35 @@ public class MapView extends FrameLayout {
             // Open / Close InfoWindow
             PointF tapPoint = new PointF(e.getX(), e.getY());
 
-            List<Marker> selectedMarkers = mMapboxMap.getSelectedMarkers();
+            VisibleRegion visibleRegion = mMapboxMap.getProjection().getVisibleRegion();
+            LatLngBounds screenBounds = visibleRegion.latLngBounds;
 
-            final float toleranceSides = 15 * mScreenDensity;
-            final float toleranceTop = 20 * mScreenDensity;
-            final float toleranceBottom = 5 * mScreenDensity;
+            List<Marker> allMarkers = getMarkersInBounds(screenBounds);
+            boolean foundMaker = false;
 
-            RectF tapRect = new RectF(tapPoint.x - toleranceSides, tapPoint.y + toleranceTop,
-                    tapPoint.x + toleranceSides, tapPoint.y - toleranceBottom);
+            if (allMarkers != null) {
+                Collections.sort(allMarkers);
 
-            LatLngBounds.Builder builder = new LatLngBounds.Builder();
-            builder.include(fromScreenLocation(new PointF(tapRect.left, tapRect.bottom)));
-            builder.include(fromScreenLocation(new PointF(tapRect.left, tapRect.top)));
-            builder.include(fromScreenLocation(new PointF(tapRect.right, tapRect.top)));
-            builder.include(fromScreenLocation(new PointF(tapRect.right, tapRect.bottom)));
+                List<Marker> selectedMarkers = mMapboxMap.getSelectedMarkers();
+                for (Marker marker : allMarkers) {
+                    RectF rect = marker.getBounds();
+                    if (rect != null) {
+                        PointF markerPoint = toScreenLocation(marker.getPosition());
+                        rect.offset(markerPoint.x - rect.width() / 2, markerPoint.y - rect.height() / 2);
 
-            List<Marker> nearbyMarkers = getMarkersInBounds(builder.build());
-            long newSelectedMarkerId = -1;
+                        if (rect.contains(tapPoint.x, tapPoint.y)) {
+                            foundMaker = true;
 
-            if (nearbyMarkers != null && nearbyMarkers.size() > 0) {
-                Collections.sort(nearbyMarkers);
-                for (Marker nearbyMarker : nearbyMarkers) {
-                    boolean found = false;
-                    for (Marker selectedMarker : selectedMarkers) {
-                        if (selectedMarker.equals(nearbyMarker)) {
-                            found = true;
-                        }
-                    }
-                    if (!found) {
-                        newSelectedMarkerId = nearbyMarker.getId();
-                        break;
-                    }
-                }
-            }
-
-            if (newSelectedMarkerId >= 0) {
-                List<Annotation> annotations = mMapboxMap.getAnnotations();
-                int count = annotations.size();
-                for (int i = 0; i < count; i++) {
-                    Annotation annotation = annotations.get(i);
-                    if (annotation instanceof Marker) {
-                        if (annotation.getId() == newSelectedMarkerId) {
-                            if (selectedMarkers.isEmpty() || !selectedMarkers.contains(annotation)) {
-                                mMapboxMap.selectMarker((Marker) annotation);
+                            if (!selectedMarkers.contains(marker)) {
+                                mMapboxMap.selectMarker(marker);
                             }
                             break;
                         }
                     }
                 }
-            } else {
+            }
+
+            if (!foundMaker) {
                 // deselect any selected marker
                 mMapboxMap.deselectMarkers();
 
@@ -1593,7 +1574,6 @@ public class MapView extends FrameLayout {
                     listener.onMapClick(point);
                 }
             }
-
             trackGestureEvent(MapboxEvent.GESTURE_SINGLETAP, e.getX(), e.getY());
             return true;
         }


### PR DESCRIPTION
I manage the click anywhere on the markers.

Tested in the "Press For Marker" sample (manually).

I still have a problem with the `Collections.sort(allMarkers);` which sorts according to the Marker ids.
So with this code, if two markers are approximately at the same `LatLng`, the first added will always received the tap event.

Is there a way to get the marker ahead ?