### PR TITLE
Calling RunLoop::run() a second time doesn't work as expected

### DIFF
--- a/platform/default/run_loop.cpp
+++ b/platform/default/run_loop.cpp
@@ -151,6 +151,7 @@ void RunLoop::push(std::shared_ptr<WorkTask> task) {
 void RunLoop::run() {
     MBGL_VERIFY_THREAD(tid);
 
+    uv_ref(impl->holderHandle());
     uv_run(impl->loop, UV_RUN_DEFAULT);
 }
 

--- a/test/util/run_loop.cpp
+++ b/test/util/run_loop.cpp
@@ -29,3 +29,24 @@ TEST(RunLoop, MultipleStop) {
 
     loop.run();
 }
+
+TEST(RunLoop, MultipleRun) {
+    RunLoop loop(RunLoop::Type::New);
+
+    Timer timer;
+    timer.start(mbgl::Duration::zero(), mbgl::Duration::zero(), [&] {
+        loop.stop();
+    });
+
+    loop.run();
+
+    bool secondTimeout = false;
+    timer.start(mbgl::Duration::zero(), mbgl::Duration::zero(), [&] {
+        secondTimeout = true;
+        loop.stop();
+    });
+
+    loop.run();
+
+    EXPECT_TRUE(secondTimeout);
+}


### PR DESCRIPTION
If you call `RunLoop::run()` twice, the second call is equivalent to `RunLoop::runOnce()`: it only runs the loop once. The expected behavior is that the loop runs until `RunLoop::stop()` is called again.

The reason is that `holderHandle` isn't re-`uv_ref`ed. It should be, every time `RunLoop::run()` is called.