### PR TITLE
[core] Fix offline status reporting regressions

### DIFF
--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -11,6 +11,7 @@ namespace mbgl {
 
 class OfflineDatabase;
 class FileSource;
+class WorkRequest;
 class FileRequest;
 class Resource;
 class Response;
@@ -55,7 +56,8 @@ private:
     FileSource& onlineFileSource;
     OfflineRegionStatus status;
     std::unique_ptr<OfflineRegionObserver> observer;
-    std::list<std::unique_ptr<FileRequest>> requests;
+    std::list<std::unique_ptr<WorkRequest>> workRequests;
+    std::list<std::unique_ptr<FileRequest>> fileRequests;
     std::set<std::string> requiredSourceURLs;
 };
 


### PR DESCRIPTION
The core of the change is ensuring that ensureResource doesn't [release Zalgo](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony): it should be consistently async, rather than async in the case that the resource doesn't exist in the database, but sync if it does.

This ensures that status is reported in a more consistent sequence, regardless of the database state.

Fixes #4245 and should help with #4229.