### PR TITLE
[ios] Add description strings to constituent classes

### DIFF
--- a/platform/darwin/include/MGLGeometry.h
+++ b/platform/darwin/include/MGLGeometry.h
@@ -80,7 +80,7 @@ NS_INLINE BOOL MGLCoordinateBoundsIsEmpty(MGLCoordinateBounds bounds) {
 
 /** Returns a formatted string for the given coordinate bounds. */
 NS_INLINE NSString *MGLStringFromCoordinateBounds(MGLCoordinateBounds bounds) {
-    return [NSString stringWithFormat:@"{{%.1f, %.1f}, {%.1f, %.1f}}",
+    return [NSString stringWithFormat:@"{ sw = {%.1f, %.1f}, ne = {%.1f, %.1f}}",
             bounds.sw.latitude, bounds.sw.longitude,
             bounds.ne.latitude, bounds.ne.longitude];
 }

--- a/platform/darwin/src/MGLMapCamera.mm
+++ b/platform/darwin/src/MGLMapCamera.mm
@@ -94,7 +94,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p centerCoordinate:%f, %f altitude:%.0fm heading:%.0f° pitch:%.0f°>",
+    return [NSString stringWithFormat:@"<%@: %p; centerCoordinate = %f, %f; altitude = %.0fm; heading = %.0f°; pitch = %.0f°>",
             NSStringFromClass([self class]), (void *)self, _centerCoordinate.latitude, _centerCoordinate.longitude, _altitude, _heading, _pitch];
 }
 

--- a/platform/darwin/src/MGLMultiPoint.mm
+++ b/platform/darwin/src/MGLMultiPoint.mm
@@ -128,4 +128,10 @@ mbgl::Color MGLColorObjectFromCGColorRef(CGColorRef cgColor) {
     return mbgl::ShapeAnnotation::Properties();
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; count = %lu; bounds = %@>",
+            NSStringFromClass([self class]), (void *)self, (unsigned long)_count, MGLStringFromCoordinateBounds(_bounds)];
+}
+
 @end

--- a/platform/darwin/src/MGLPointAnnotation.m
+++ b/platform/darwin/src/MGLPointAnnotation.m
@@ -4,4 +4,13 @@
 
 @synthesize coordinate;
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; title = %@; subtitle = %@; coordinate = %f, %f>",
+            NSStringFromClass([self class]), (void *)self,
+            self.title ? [NSString stringWithFormat:@"\"%@\"", self.title] : self.title,
+            self.subtitle ? [NSString stringWithFormat:@"\"%@\"", self.subtitle] : self.subtitle,
+            coordinate.latitude, coordinate.longitude];
+}
+
 @end

--- a/platform/ios/src/MGLUserLocation.m
+++ b/platform/ios/src/MGLUserLocation.m
@@ -71,4 +71,16 @@ NS_ASSUME_NONNULL_END
     return (_title ? _title : @"You Are Here");
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; location = %f, %f; updating = %@; altitude = %.0fm; heading = %.0f°; title = %@; subtitle = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.location.coordinate.latitude, self.location.coordinate.longitude,
+            self.updating ? @"yes" : @"no",
+            self.location.altitude,
+            self.heading.trueHeading,
+            self.title ? [NSString stringWithFormat:@"\"%@\"", self.title] : self.title,
+            self.subtitle ? [NSString stringWithFormat:@"\"%@\"", self.subtitle] : self.subtitle];
+}
+
 @end


### PR DESCRIPTION
Adds description strings to:

- `MGLPointAnnotation`
- `MGLMultiPoint` (includes `MGLPolygon` & `MGLPolyline`)
- `MGLUserLocation`

This enables better debugging at break points:

```
(lldb) po mapView.annotations
<__NSArrayI 0x1517ae0a0>(
<MGLPolygon: 0x1517e5470; count = 3; bounds.ne = 46.000000, -121.000000; bounds.sw = 44.000000, -122.000000>,
<MGLPolyline: 0x1533c4cb0; count = 2834; bounds.ne = 48.680179, -122.846243; bounds.sw = 48.655880, -122.858304>,
<MGLPolygon: 0x153530080; count = 65; bounds.ne = 39.834352, -74.976614; bounds.sw = 38.448923, -75.802605>,
<MGLPolygon: 0x153530150; count = 150; bounds.ne = 42.519158, -74.689313; bounds.sw = 39.722485, -80.507165>,
<MGLPolygon: 0x1535303f0; count = 177; bounds.ne = 41.357463, -73.899234; bounds.sw = 38.784524, -75.551217>,
<MGLPointAnnotation: 0x15173da30; title = "Dropped Marker"; subtitle = "lat: 40.722, lon: -73.986"; coordinate = 40.722038, -73.986476>
)

(lldb) po mapView.userLocation
<MGLUserLocation: 0x14f6fa2d0; location = 40.722, -73.986; updating = no; altitude = 34m; heading = 0°; title = "You Are Here"; subtitle = (null)>
```

/cc @1ec5 @boundsj