### PR TITLE
[core] Fix non-anchored Transform::setAngle

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -502,7 +502,7 @@ void Transform::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& 
 }
 
 void Transform::setAngle(double angle, const Duration& duration) {
-    setAngle(angle, ScreenCoordinate {}, duration);
+    setAngle(angle, ScreenCoordinate { NAN, NAN }, duration);
 }
 
 void Transform::setAngle(double angle, const ScreenCoordinate& anchor, const Duration& duration) {

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -212,24 +212,29 @@ TEST(Transform, ConstrainWidthAndHeight) {
 TEST(Transform, Anchor) {
     MockView view;
     Transform transform(view, ConstrainMode::HeightOnly);
+    transform.resize({{ 1000, 1000 }});
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(1, transform.getScale());
+    const LatLng latLng { 10, -100 };
+    transform.setLatLngZoom(latLng, 10);
 
-    transform.setLatLngZoom({ 10, -100 }, 10);
-
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(-100, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
     ASSERT_DOUBLE_EQ(0, transform.getAngle());
 
-    const ScreenCoordinate anchorPoint = {0, 0};
-    const LatLng anchorLatLng = transform.getState().screenCoordinateToLatLng(anchorPoint);
-    transform.setAngle(M_PI_4, anchorPoint);
-
+    transform.setAngle(M_PI_4);
     ASSERT_NEAR(M_PI_4, transform.getAngle(), 0.000001);
-    ASSERT_NE(anchorLatLng, transform.getLatLng());
+    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+
+    const ScreenCoordinate anchorPoint = { 150, 150 };
+    const LatLng anchorLatLng = transform.getState().screenCoordinateToLatLng(anchorPoint);
+    transform.setAngle(-45 * util::DEG2RAD, anchorPoint);
+    ASSERT_NEAR(-45 / util::RAD2DEG, transform.getAngle(), 0.000001);
+    ASSERT_NE(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_NE(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_NEAR(anchorLatLng.latitude, transform.getLatLng().latitude, 1);
+    ASSERT_NEAR(anchorLatLng.longitude, transform.getLatLng().longitude, 1);
 }
 
 TEST(Transform, Padding) {


### PR DESCRIPTION
This reverts a line change from b33b2f15, because we explicitely want
the anchor to be invalid. You were right, @1ec5, when addressing this in https://github.com/mapbox/mapbox-gl-native/pull/4214/files#r55699097 :+1:

/cc @1ec5 @kkaefer 