### PR TITLE
Deactivate offline region upon completion

### DIFF
--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -222,6 +222,10 @@ void OfflineDownload::ensureResource(const Resource& resource, std::function<voi
             status.completedResourceCount++;
             status.completedResourceSize += offlineResponse->second;
             observer->statusChanged(status);
+            
+            if (status.complete()) {
+                setState(OfflineRegionDownloadState::Inactive);
+            }
 
             return;
         }
@@ -251,6 +255,10 @@ void OfflineDownload::ensureResource(const Resource& resource, std::function<voi
             status.completedResourceSize += offlineDatabase.putRegionResource(id, resource, onlineResponse);
 
             observer->statusChanged(status);
+            
+            if (status.complete()) {
+                setState(OfflineRegionDownloadState::Inactive);
+            }
         });
     });
 }


### PR DESCRIPTION
I think it’s reasonable for the SDKs to expect that the `mbgl::OfflineRegion` will automatically deactivate when complete.

/cc @jfirebaugh @bleege @boundsj