### PR TITLE
[core] Harden Transform anchor & padding usage

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_MAP_MAP
 #define MBGL_MAP_MAP
 
+#include <mbgl/util/optional.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/map/update.hpp>
@@ -98,23 +99,23 @@ public:
 
     // Position
     void moveBy(const ScreenCoordinate&, const Duration& = Duration::zero());
-    void setLatLng(const LatLng&, const ScreenCoordinate&, const Duration& = Duration::zero());
-    void setLatLng(const LatLng&, const EdgeInsets&, const Duration& = Duration::zero());
+    void setLatLng(const LatLng&, optional<ScreenCoordinate>, const Duration& = Duration::zero());
+    void setLatLng(const LatLng&, optional<EdgeInsets>, const Duration& = Duration::zero());
     void setLatLng(const LatLng&, const Duration& = Duration::zero());
-    LatLng getLatLng(const EdgeInsets& = {}) const;
-    void resetPosition(const EdgeInsets& = {});
+    LatLng getLatLng(optional<EdgeInsets> = {}) const;
+    void resetPosition(optional<EdgeInsets> = {});
 
     // Scale
-    void scaleBy(double ds, const ScreenCoordinate& = { NAN, NAN }, const Duration& = Duration::zero());
-    void setScale(double scale, const ScreenCoordinate& = { NAN, NAN }, const Duration& = Duration::zero());
+    void scaleBy(double ds, optional<ScreenCoordinate> = {}, const Duration& = Duration::zero());
+    void setScale(double scale, optional<ScreenCoordinate> = {}, const Duration& = Duration::zero());
     double getScale() const;
     void setZoom(double zoom, const Duration& = Duration::zero());
-    void setZoom(double zoom, const EdgeInsets&, const Duration& = Duration::zero());
+    void setZoom(double zoom, optional<EdgeInsets>, const Duration& = Duration::zero());
     double getZoom() const;
     void setLatLngZoom(const LatLng&, double zoom, const Duration& = Duration::zero());
-    void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const Duration& = Duration::zero());
-    CameraOptions cameraForLatLngBounds(const LatLngBounds&, const EdgeInsets&);
-    CameraOptions cameraForLatLngs(const std::vector<LatLng>&, const EdgeInsets&);
+    void setLatLngZoom(const LatLng&, double zoom, optional<EdgeInsets>, const Duration& = Duration::zero());
+    CameraOptions cameraForLatLngBounds(const LatLngBounds&, optional<EdgeInsets>);
+    CameraOptions cameraForLatLngs(const std::vector<LatLng>&, optional<EdgeInsets>);
     void resetZoom();
     void setMinZoom(const double minZoom);
     double getMinZoom() const;
@@ -124,15 +125,15 @@ public:
     // Rotation
     void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const Duration& = Duration::zero());
     void setBearing(double degrees, const Duration& = Duration::zero());
-    void setBearing(double degrees, const ScreenCoordinate&, const Duration& = Duration::zero());
-    void setBearing(double degrees, const EdgeInsets&, const Duration& = Duration::zero());
+    void setBearing(double degrees, optional<ScreenCoordinate>, const Duration& = Duration::zero());
+    void setBearing(double degrees, optional<EdgeInsets>, const Duration& = Duration::zero());
     double getBearing() const;
     void resetNorth(const Duration& = Milliseconds(500));
-    void resetNorth(const EdgeInsets&, const Duration& = Milliseconds(500));
+    void resetNorth(optional<EdgeInsets>, const Duration& = Milliseconds(500));
 
     // Pitch
     void setPitch(double pitch, const Duration& = Duration::zero());
-    void setPitch(double pitch, const ScreenCoordinate&, const Duration& = Duration::zero());
+    void setPitch(double pitch, optional<ScreenCoordinate>, const Duration& = Duration::zero());
     double getPitch() const;
 
     // North Orientation

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -1,6 +1,7 @@
 #ifndef MBGL_UTIL_GEO
 #define MBGL_UTIL_GEO
 
+#include <mbgl/util/math.hpp>
 #include <mbgl/util/vec.hpp>
 #include <mbgl/util/constants.hpp>
 
@@ -29,18 +30,16 @@ public:
     LatLng wrapped() const { return { latitude, longitude, Wrapped }; }
 
     void wrap() {
-        if (longitude < -util::LONGITUDE_MAX) longitude = util::LONGITUDE_MAX + std::fmod(longitude + util::LONGITUDE_MAX, util::DEGREES_MAX);
-        if (longitude > util::LONGITUDE_MAX) longitude = -util::LONGITUDE_MAX + std::fmod(longitude + util::LONGITUDE_MAX, util::DEGREES_MAX);
+        longitude = util::wrap(longitude, -util::LONGITUDE_MAX, util::LONGITUDE_MAX);
     }
 
-    // If we pass through the antimeridian, we update the start coordinate to make sure
-    // the end coordinate is always wrapped.
+    // If the distance from start to end longitudes is between half and full
+    // world, unwrap the start longitude to ensure the shortest path is taken.
     void unwrapForShortestPath(const LatLng& end) {
-        if (end.longitude < -util::LONGITUDE_MAX) {
-            longitude += util::DEGREES_MAX;
-        } else if (end.longitude > util::LONGITUDE_MAX) {
-            longitude -= util::DEGREES_MAX;
-        }
+        const double delta = std::abs(end.longitude - longitude);
+        if (delta < util::LONGITUDE_MAX || delta > util::DEGREES_MAX) return;
+        if (longitude > 0 && end.longitude < 0) longitude -= util::DEGREES_MAX;
+        else if (longitude < 0 && end.longitude > 0) longitude += util::DEGREES_MAX;
     }
 
     explicit operator bool() const {

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -14,10 +14,14 @@ using ScreenCoordinate = vec2<double>;
 
 class LatLng {
 public:
+    struct null {};
+
     double latitude;
     double longitude;
 
     enum WrapMode : bool { Unwrapped, Wrapped };
+
+    LatLng(null) : latitude(std::numeric_limits<double>::quiet_NaN()), longitude(latitude) {}
 
     LatLng(double lat = 0, double lon = 0, WrapMode mode = Unwrapped)
         : latitude(lat), longitude(lon) { if (mode == Wrapped) wrap(); }

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/platform/platform.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/map/camera.hpp>
 
 #include <cassert>
 #include <cstdlib>
@@ -94,6 +95,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     printf("- Press `N` to reset north\n");
     printf("- Press `R` to toggle any available `night` style class\n");
     printf("- Press `Z` to cycle through north orientations\n");
+    printf("- Press `A` to cycle through Mapbox offices in the world + dateline monument\n");
     printf("\n");
     printf("- Press `1` through `6` to add increasing numbers of point annotations for testing\n");
     printf("- Press `7` through `0` to add increasing numbers of shape annotations for testing\n");
@@ -166,6 +168,26 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             break;
         case GLFW_KEY_P: {
             view->addRandomCustomPointAnnotations(1);
+        } break;
+        case GLFW_KEY_A: {
+            // XXX Fix precision loss in flyTo:
+            // https://github.com/mapbox/mapbox-gl-native/issues/4298
+            static const std::vector<mbgl::LatLng> places = {
+                mbgl::LatLng { -16.796665, -179.999983 },   // Dateline monument
+                mbgl::LatLng { 12.9810542, 77.6345551 },    // Mapbox Bengaluru, India
+                mbgl::LatLng { -13.15607,-74.21773 },       // Mapbox Peru
+                mbgl::LatLng { 37.77572, -122.4158818 },    // Mapbox SF, USA
+                mbgl::LatLng { 38.91318,-77.03255 },        // Mapbox DC, USA
+            };
+            static size_t nextPlace = 0;
+            mbgl::CameraOptions cameraOptions;
+            cameraOptions.center = places[nextPlace++];
+            cameraOptions.zoom = 20;
+            cameraOptions.pitch = 30;
+
+            mbgl::AnimationOptions animationOptions(mbgl::Seconds(10));
+            view->map->flyTo(cameraOptions, animationOptions);
+            nextPlace = nextPlace % places.size();
         } break;
         }
     }

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -326,7 +326,7 @@ void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) 
         scale = 1.0 / scale;
     }
 
-    view->map->scaleBy(scale, { view->lastX, view->lastY });
+    view->map->scaleBy(scale, mbgl::ScreenCoordinate { view->lastX, view->lastY });
 }
 
 void GLFWView::onWindowResize(GLFWwindow *window, int width, int height) {
@@ -363,9 +363,9 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
             double now = glfwGetTime();
             if (now - view->lastClick < 0.4 /* ms */) {
                 if (modifiers & GLFW_MOD_SHIFT) {
-                    view->map->scaleBy(0.5, { view->lastX, view->lastY }, mbgl::Milliseconds(500));
+                    view->map->scaleBy(0.5, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::Milliseconds(500));
                 } else {
-                    view->map->scaleBy(2.0, { view->lastX, view->lastY }, mbgl::Milliseconds(500));
+                    view->map->scaleBy(2.0, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::Milliseconds(500));
                 }
             }
             view->lastClick = now;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1146,7 +1146,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
         if (log2(newScale) < _mbglMap->getMinZoom()) return;
         
-        _mbglMap->setScale(newScale, { centerPoint.x, centerPoint.y });
+        _mbglMap->setScale(newScale, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
 
         [self notifyMapChange:mbgl::MapChangeRegionIsChanging];
     }
@@ -1183,7 +1183,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
         if (velocity)
         {
-            _mbglMap->setScale(newScale, { centerPoint.x, centerPoint.y }, MGLDurationInSeconds(duration));
+            _mbglMap->setScale(newScale, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }, MGLDurationInSeconds(duration));
         }
 
         [self notifyGestureDidEndWithDrift:velocity];
@@ -1229,7 +1229,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             newDegrees = fmaxf(newDegrees, -30);
         }
         
-        _mbglMap->setBearing(newDegrees, { centerPoint.x, centerPoint.y });
+        _mbglMap->setBearing(newDegrees, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
 
         [self notifyMapChange:mbgl::MapChangeRegionIsChanging];
     }
@@ -1244,7 +1244,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             CGFloat newRadians = radians + velocity * duration * 0.1;
             CGFloat newDegrees = MGLDegreesFromRadians(newRadians) * -1;
 
-            _mbglMap->setBearing(newDegrees, { centerPoint.x, centerPoint.y }, MGLDurationInSeconds(duration));
+            _mbglMap->setBearing(newDegrees, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }, MGLDurationInSeconds(duration));
 
             [self notifyGestureDidEndWithDrift:YES];
 
@@ -1395,7 +1395,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             centerPoint = self.userLocationAnnotationViewCenter;
         }
         _mbglMap->scaleBy(powf(2, newZoom) / _mbglMap->getScale(),
-                          { centerPoint.x, centerPoint.y });
+                          mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
 
         [self notifyMapChange:mbgl::MapChangeRegionIsChanging];
     }
@@ -1430,7 +1430,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         {
             centerPoint = self.userLocationAnnotationViewCenter;
         }
-        _mbglMap->setPitch(pitchNew, centerPoint);
+        _mbglMap->setPitch(pitchNew, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
 
         [self notifyMapChange:mbgl::MapChangeRegionIsChanging];
     }
@@ -1992,7 +1992,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     else
     {
         CGPoint centerPoint = self.userLocationAnnotationViewCenter;
-        _mbglMap->setBearing(direction, { centerPoint.x, centerPoint.y },
+        _mbglMap->setBearing(direction, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y },
                              MGLDurationInSeconds(duration));
     }
 }

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -651,7 +651,7 @@ void Transform::setGestureInProgress(bool inProgress) {
 #pragma mark Conversion and projection
 
 ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const {
-    if (!latLng) return {};
+    if (!latLng) return ScreenCoordinate::null();
 
     // If the center and point coordinates are not in the same side of the
     // antimeridian, we need to unwrap the point longitude to make sure it can
@@ -672,7 +672,8 @@ ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const
 }
 
 LatLng Transform::screenCoordinateToLatLng(const ScreenCoordinate& point) const {
-    if (!point) return {};
+    if (!point) return LatLng::null();
+
     ScreenCoordinate flippedPoint = point;
     flippedPoint.y = state.height - flippedPoint.y;
     return state.screenCoordinateToLatLng(flippedPoint);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -662,5 +662,5 @@ LatLng Transform::screenCoordinateToLatLng(const ScreenCoordinate& point) const 
 
     ScreenCoordinate flippedPoint = point;
     flippedPoint.y = state.height - flippedPoint.y;
-    return state.screenCoordinateToLatLng(flippedPoint);
+    return state.screenCoordinateToLatLng(flippedPoint).wrapped();
 }

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -138,6 +138,8 @@ public:
     // Transitions
     bool inTransition() const;
     Update updateTransitions(const TimePoint& now);
+    TimePoint getTransitionStart() const { return transitionStart; }
+    Duration getTransitionDuration() const { return transitionDuration; }
     void cancelTransitions();
 
     // Gesture

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -8,6 +8,7 @@
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <cstdint>
 #include <cmath>
@@ -43,38 +44,47 @@ public:
             top to bottom and from left to right. */
     void moveBy(const ScreenCoordinate& offset, const Duration& = Duration::zero());
     void setLatLng(const LatLng&, const Duration& = Duration::zero());
-    void setLatLng(const LatLng&, const EdgeInsets&, const Duration& = Duration::zero());
-    void setLatLng(const LatLng&, const ScreenCoordinate&, const Duration& = Duration::zero());
+    void setLatLng(const LatLng&, optional<EdgeInsets>, const Duration& = Duration::zero());
+    void setLatLng(const LatLng&, optional<ScreenCoordinate>, const Duration& = Duration::zero());
     void setLatLngZoom(const LatLng&, double zoom, const Duration& = Duration::zero());
-    void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const Duration& = Duration::zero());
-    LatLng getLatLng(const EdgeInsets& = {}) const;
-    ScreenCoordinate getScreenCoordinate(const EdgeInsets& = {}) const;
+    void setLatLngZoom(const LatLng&, double zoom, optional<EdgeInsets>, const Duration& = Duration::zero());
+    LatLng getLatLng(optional<EdgeInsets> = {}) const;
+    ScreenCoordinate getScreenCoordinate(optional<EdgeInsets> = {}) const;
 
     // Zoom
 
     /** Scales the map, keeping the given point fixed within the view.
+        @param ds The difference in scale factors to scale the map by. */
+    void scaleBy(double ds, const Duration& = Duration::zero());
+    /** Scales the map, keeping the given point fixed within the view.
         @param ds The difference in scale factors to scale the map by.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void scaleBy(double ds, const ScreenCoordinate& anchor = {}, const Duration& = Duration::zero());
+    void scaleBy(double ds, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
+    /** Sets the scale factor, keeping the given point fixed within the view.
+        @param scale The new scale factor. */
+    void setScale(double scale, const Duration& = Duration::zero());
     /** Sets the scale factor, keeping the given point fixed within the view.
         @param scale The new scale factor.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void setScale(double scale, const ScreenCoordinate& anchor = {}, const Duration& = Duration::zero());
+    void setScale(double scale, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
     /** Sets the scale factor, keeping the center point fixed within the inset view.
         @param scale The new scale factor.
         @param padding The viewport padding that affects the fixed center point. */
-    void setScale(double scale, const EdgeInsets& padding, const Duration& = Duration::zero());
+    void setScale(double scale, optional<EdgeInsets> padding, const Duration& = Duration::zero());
+    /** Sets the zoom level, keeping the given point fixed within the view.
+        @param zoom The new zoom level. */
+    void setZoom(double zoom, const Duration& = Duration::zero());
     /** Sets the zoom level, keeping the given point fixed within the view.
         @param zoom The new zoom level.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void setZoom(double zoom, const ScreenCoordinate& anchor = {}, const Duration& = Duration::zero());
+    void setZoom(double zoom, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
     /** Sets the zoom level, keeping the center point fixed within the inset view.
         @param zoom The new zoom level.
         @param padding The viewport padding that affects the fixed center point. */
-    void setZoom(double zoom, const EdgeInsets& padding, const Duration& = Duration::zero());
+    void setZoom(double zoom, optional<EdgeInsets> padding, const Duration& = Duration::zero());
     /** Returns the zoom level. */
     double getZoom() const;
     /** Returns the scale factor. */
@@ -94,12 +104,12 @@ public:
         @param angle The new angle of rotation, measured in radians
             counterclockwise from true north.
         @param anchor A point relative to the top-left corner of the view. */
-    void setAngle(double angle, const ScreenCoordinate& anchor, const Duration& = Duration::zero());
+    void setAngle(double angle, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
     /** Sets the angle of rotation, keeping the center point fixed within the inset view.
         @param angle The new angle of rotation, measured in radians
             counterclockwise from true north.
         @param padding The viewport padding that affects the fixed center point. */
-    void setAngle(double angle, const EdgeInsets& padding, const Duration& = Duration::zero());
+    void setAngle(double angle, optional<EdgeInsets> padding, const Duration& = Duration::zero());
     /** Returns the angle of rotation.
         @return The angle of rotation, measured in radians counterclockwise from
             true north. */
@@ -114,7 +124,7 @@ public:
         @param angle The new pitch angle, measured in radians toward the
             horizon.
         @param anchor A point relative to the top-left corner of the view. */
-    void setPitch(double pitch, const ScreenCoordinate& anchor, const Duration& = Duration::zero());
+    void setPitch(double pitch, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
     double getPitch() const;
 
     // North Orientation

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -410,11 +410,17 @@ TEST(Transform, Antimeridian) {
     ScreenCoordinate pixelWaikiriForwards = transform.latLngToScreenCoordinate(coordinateWaikiri);
     ASSERT_DOUBLE_EQ(437.95953728819512, pixelWaikiriForwards.x);
     ASSERT_DOUBLE_EQ(pixelWaikiri.y, pixelWaikiriForwards.y);
+    LatLng coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriForwards);
+    ASSERT_NEAR(coordinateWaikiri.latitude, coordinateFromPixel.latitude, 0.000001);
+    ASSERT_NEAR(coordinateWaikiri.longitude, coordinateFromPixel.longitude, 0.000001);
 
     transform.setLatLng({ coordinateWaikiri.latitude, -179.9787 });
     ScreenCoordinate pixelWaikiriBackwards = transform.latLngToScreenCoordinate(coordinateWaikiri);
     ASSERT_DOUBLE_EQ(pixelWaikiriForwards.x, pixelWaikiriBackwards.x);
     ASSERT_DOUBLE_EQ(pixelWaikiriForwards.y, pixelWaikiriBackwards.y);
+    coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriBackwards);
+    ASSERT_NEAR(coordinateWaikiri.latitude, coordinateFromPixel.latitude, 0.000001);
+    ASSERT_NEAR(coordinateWaikiri.longitude, coordinateFromPixel.longitude, 0.000001);
 }
 
 TEST(Transform, Camera) {

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -222,17 +222,90 @@ TEST(Transform, Anchor) {
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
     ASSERT_DOUBLE_EQ(0, transform.getAngle());
 
+    const ScreenCoordinate invalidAnchorPoint = ScreenCoordinate::null();
+    const ScreenCoordinate anchorPoint = { 150, 150 };
+
+    const LatLng anchorLatLng = transform.getState().screenCoordinateToLatLng(anchorPoint);
+    ASSERT_NE(latLng.latitude, anchorLatLng.latitude);
+    ASSERT_NE(latLng.longitude, anchorLatLng.longitude);
+
+    transform.setLatLngZoom(latLng, 2);
+    transform.scaleBy(1);
+    ASSERT_DOUBLE_EQ(4, transform.getScale());
+    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+
+    transform.scaleBy(1.5, invalidAnchorPoint);
+    ASSERT_DOUBLE_EQ(6, transform.getScale());
+    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+
+    transform.scaleBy(2, anchorPoint);
+    ASSERT_DOUBLE_EQ(12, transform.getScale());
+    ASSERT_NE(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_NE(latLng.longitude, transform.getLatLng().longitude);
+
+    transform.setLatLngZoom(latLng, 10);
+    transform.setScale(2 << 2);
+    ASSERT_DOUBLE_EQ(2 << 2, transform.getScale());
+    ASSERT_NEAR(latLng.latitude, transform.getLatLng().latitude, 0.000001);
+    ASSERT_NEAR(latLng.longitude, transform.getLatLng().longitude, 0.000001);
+
+    transform.setScale(2 << 4, invalidAnchorPoint);
+    ASSERT_DOUBLE_EQ(2 << 4, transform.getScale());
+    ASSERT_NEAR(latLng.latitude, transform.getLatLng().latitude, 0.000001);
+    ASSERT_NEAR(latLng.longitude, transform.getLatLng().longitude, 0.000001);
+
+    transform.setScale(2 << 6, anchorPoint);
+    ASSERT_DOUBLE_EQ(2 << 6, transform.getScale());
+    ASSERT_NE(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_NE(latLng.longitude, transform.getLatLng().longitude);
+
+    transform.setLatLngZoom(latLng, 10);
+    transform.setZoom(2);
+    ASSERT_DOUBLE_EQ(2, transform.getZoom());
+    ASSERT_NEAR(latLng.latitude, transform.getLatLng().latitude, 0.000001);
+    ASSERT_NEAR(latLng.longitude, transform.getLatLng().longitude, 0.000001);
+
+    transform.setZoom(4, invalidAnchorPoint);
+    ASSERT_DOUBLE_EQ(4, transform.getZoom());
+    ASSERT_NEAR(latLng.latitude, transform.getLatLng().latitude, 0.000001);
+    ASSERT_NEAR(latLng.longitude, transform.getLatLng().longitude, 0.000001);
+
+    transform.setZoom(8, anchorPoint);
+    ASSERT_DOUBLE_EQ(8, transform.getZoom());
+    ASSERT_NE(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_NE(latLng.longitude, transform.getLatLng().longitude);
+
+    transform.setLatLngZoom(latLng, 10);
     transform.setAngle(M_PI_4);
     ASSERT_NEAR(M_PI_4, transform.getAngle(), 0.000001);
     ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
     ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
 
-    const ScreenCoordinate anchorPoint = { 150, 150 };
-    const LatLng anchorLatLng = transform.getState().screenCoordinateToLatLng(anchorPoint);
+    transform.setAngle(0, invalidAnchorPoint);
+    ASSERT_DOUBLE_EQ(0, transform.getAngle());
+    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+
     transform.setAngle(-45 * util::DEG2RAD, anchorPoint);
     ASSERT_NEAR(-45 / util::RAD2DEG, transform.getAngle(), 0.000001);
-    ASSERT_NE(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_NE(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_NEAR(anchorLatLng.latitude, transform.getLatLng().latitude, 1);
+    ASSERT_NEAR(anchorLatLng.longitude, transform.getLatLng().longitude, 1);
+
+    transform.setLatLngZoom(latLng, 10);
+    transform.setPitch(10 * util::DEG2RAD);
+    ASSERT_DOUBLE_EQ(10 / util::RAD2DEG, transform.getPitch());
+    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+
+    transform.setPitch(15 * util::DEG2RAD, invalidAnchorPoint);
+    ASSERT_DOUBLE_EQ(15 / util::RAD2DEG, transform.getPitch());
+    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
+    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+
+    transform.setPitch(20 * util::DEG2RAD, anchorPoint);
+    ASSERT_DOUBLE_EQ(20 / util::RAD2DEG, transform.getPitch());
     ASSERT_NEAR(anchorLatLng.latitude, transform.getLatLng().latitude, 1);
     ASSERT_NEAR(anchorLatLng.longitude, transform.getLatLng().longitude, 1);
 }

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -79,6 +79,9 @@ TEST(Transform, InvalidLatLng) {
     ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
     ASSERT_DOUBLE_EQ(8, transform.getLatLng().longitude);
     ASSERT_DOUBLE_EQ(4, transform.getScale());
+
+    ASSERT_FALSE(transform.latLngToScreenCoordinate(LatLng::null()));
+    ASSERT_FALSE(transform.screenCoordinateToLatLng(ScreenCoordinate::null()));
 }
 
 


### PR DESCRIPTION
Enforce invalid anchors via `ScreenCoordinate::null()` when neeeded, backed up by unit tests. This patch reverts some more changes from b33b2f15 related to the default value for Transform functions. As pointed out by Minh, we use invalid screen coordinates to tell the affected transform functions to use the origin instead.

/cc @1ec5 @kkaefer 