### PR TITLE
Remove extraneous nil check from MGLOfflineRegionObserver

### DIFF
--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -189,16 +189,12 @@ NSError *MGLErrorFromResponseError(mbgl::Response::Error error) {
 
 void MBGLOfflineRegionObserver::statusChanged(mbgl::OfflineRegionStatus status) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSCAssert(pack, @"MBGLOfflineRegionObserver is dangling without an associated MGLOfflinePack.");
-        
         [pack offlineRegionStatusDidChange:status];
     });
 }
 
 void MBGLOfflineRegionObserver::responseError(mbgl::Response::Error error) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSCAssert(pack, @"MBGLOfflineRegionObserver is dangling without an associated MGLOfflinePack.");
-        
         if ([pack.delegate respondsToSelector:@selector(offlinePack:didReceiveError:)]) {
             [pack.delegate offlinePack:pack didReceiveError:MGLErrorFromResponseError(error)];
         }
@@ -207,8 +203,6 @@ void MBGLOfflineRegionObserver::responseError(mbgl::Response::Error error) {
 
 void MBGLOfflineRegionObserver::mapboxTileCountLimitExceeded(uint64_t limit) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSCAssert(pack, @"MBGLOfflineRegionObserver is dangling without an associated MGLOfflinePack.");
-        
         if ([pack.delegate respondsToSelector:@selector(offlinePack:didReceiveMaximumAllowedMapboxTiles:)]) {
             [pack.delegate offlinePack:pack didReceiveMaximumAllowedMapboxTiles:limit];
         }


### PR DESCRIPTION
Due to ARC, MGLOfflinePack can be deallocated at any time following its initialization. `-dealloc` ensures that the offline region observer is unset, but that step is asynchronous; there is no guarantee that it completes before the first status change update. In fact, the pack is deallocated before the first status change update unless it is captured outside of the MGLOfflinePackAdditionCompletionHandler. The pack nil check is unnecessary because the subsequent code would be a no-op.

This is an alternative fix for #4287.

/cc @jfirebaugh @boundsj @bsudekum