### PR TITLE
Fix crash removing offline pack while another pack is downloading

### DIFF
--- a/platform/darwin/include/MGLOfflineStorage.h
+++ b/platform/darwin/include/MGLOfflineStorage.h
@@ -66,7 +66,7 @@ typedef void (^MGLOfflinePackListingCompletionHandler)(NS_ARRAY_OF(MGLOfflinePac
  @param completion The completion handler to call once the pack has been added.
     This handler is executed asynchronously on the main queue.
  */
-- (void)addPackForRegion:(id <MGLOfflineRegion>)region withContext:(NSData *)context completionHandler:(MGLOfflinePackAdditionCompletionHandler)completion;
+- (void)addPackForRegion:(id <MGLOfflineRegion>)region withContext:(NSData *)context completionHandler:(nullable MGLOfflinePackAdditionCompletionHandler)completion;
 
 /**
  Unregisters the given offline pack and frees any resources that are no longer
@@ -82,7 +82,7 @@ typedef void (^MGLOfflinePackListingCompletionHandler)(NS_ARRAY_OF(MGLOfflinePac
  @param completion The completion handler to call once the pack has been
     removed. This handler is executed asynchronously on the main queue.
  */
-- (void)removePack:(MGLOfflinePack *)pack withCompletionHandler:(MGLOfflinePackRemovalCompletionHandler)completion;
+- (void)removePack:(MGLOfflinePack *)pack withCompletionHandler:(nullable MGLOfflinePackRemovalCompletionHandler)completion;
 
 /**
  Asynchronously calls a completion callback with all existing offline packs.

--- a/platform/ios/app/MBXOfflinePacksTableViewController.m
+++ b/platform/ios/app/MBXOfflinePacksTableViewController.m
@@ -164,12 +164,9 @@ static NSString * const MBXOfflinePacksTableViewActiveCellReuseIdentifier = @"Ac
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     if (editingStyle == UITableViewCellEditingStyleDelete) {
         MGLOfflinePack *pack = self.offlinePacks[indexPath.row];
-        __weak MBXOfflinePacksTableViewController *weakSelf = self;
-        [[MGLOfflineStorage sharedOfflineStorage] removePack:pack withCompletionHandler:^(NSError *error) {
-            MBXOfflinePacksTableViewController *strongSelf = weakSelf;
-            [strongSelf.offlinePacks removeObjectAtIndex:indexPath.row];
-            [strongSelf.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
-        }];
+        [self.offlinePacks removeObjectAtIndex:indexPath.row];
+        [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+        [[MGLOfflineStorage sharedOfflineStorage] removePack:pack withCompletionHandler:nil];
     }
 }
 


### PR DESCRIPTION
Remove all references to an offline pack before the call to `-[MGLOfflineStorage removePackWithCompletionHander:]`. Allow null completion handlers in MGLOfflineStorage APIs.

Fixes #4286.

/cc @boundsj