### PR TITLE
Fix background pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#8859b504ef241bca49d4c2f9a79ff4d0bfdf81a1",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#94546186df06c6d0a7432caff286055b6ae4e908",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -141,6 +141,7 @@ private:
     const mat4 identityMatrix = []{
         mat4 identity;
         matrix::identity(identity);
+        matrix::translate(identity, identity, 0, 0, 1);
         return identity;
     }();
 


### PR DESCRIPTION
Currently, background pattern doesn't work, because it's always painted above other non-translucent layers.