### PR TITLE
Only set preferred action on iOS 9+

### DIFF
--- a/platform/ios/app/MBXOfflinePacksTableViewController.m
+++ b/platform/ios/app/MBXOfflinePacksTableViewController.m
@@ -100,7 +100,9 @@ static NSString * const MBXOfflinePacksTableViewActiveCellReuseIdentifier = @"Ac
         }];
     }];
     [alertController addAction:downloadAction];
-    alertController.preferredAction = downloadAction;
+    if ([alertController respondsToSelector:@selector(setPreferredAction:)]) {
+        alertController.preferredAction = downloadAction;
+    }
     
     [self presentViewController:alertController animated:YES completion:nil];
 }


### PR DESCRIPTION
Fixed a crash on iOS 8 when presenting the Add Offline Pack dialog.

Fixes #4305.

/cc @jfirebaugh @boundsj