### PR TITLE
Copy .der files into static framework

### DIFF
--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -210,7 +210,7 @@ else
 fi
 if [[ ${BUILD_STATIC} == true ]]; then
     mkdir -p "${OUTPUT}/static/${NAME}.framework${BUNDLE_PATH}"
-    cp -pv platform/ios/resources/* "${OUTPUT}/static/${NAME}.framework${BUNDLE_PATH}"
+    cp -pv platform/{default,ios}/resources/* "${OUTPUT}/static/${NAME}.framework${BUNDLE_PATH}"
     INFO_PLIST_PATH="${OUTPUT}/static/${NAME}.framework/Info.plist"
     cp -pv platform/ios/framework/Info.plist "${INFO_PLIST_PATH}"
     plutil -replace CFBundleExecutable -string ${NAME} "${INFO_PLIST_PATH}"


### PR DESCRIPTION
#4104 deleted redundant .der files from the iOS resources directory, exposing a bug in which we failed to copy the shared resources directory into the static framework bundle.

Fixes #4316.

/cc @RomainQuidet