### PR TITLE
[core] Assert and guard against null std::exception_ptr in toString

### DIFF
--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -28,6 +28,12 @@ inline std::string toString(uint8_t num) {
 }
 
 inline std::string toString(std::exception_ptr error) {
+    assert(error);
+
+    if (!error) {
+        return "(null)";
+    }
+
     try {
         std::rethrow_exception(error);
     } catch (const std::exception& ex) {


### PR DESCRIPTION
It appears that if `std::rethrow_exception` is called with a null `std::exception_ptr`, it calls `std::terminate`. Such a crash was confirmed in #4202 and may be the cause of the crashes in #3280 and #4330.

We don't expect `util::toString` to be called with a null `std::exception_ptr` and would like to be notified in debug builds if that happens. But we'd also prefer not to terminate the process in release builds. Therefore, split the difference and add both an `assert` and a guard clause.

#4330 is on the `android-v4.0.0` milestone, so targeting this change at `release-ios-3.2.0-android-4.0.0`.

:eyes: @zugaldia @1ec5 @kkaefer