### PR TITLE
[core] Stop offline download at tile limit

### DIFF
--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -49,7 +49,8 @@ private:
      */
     void ensureResource(const Resource&, std::function<void (Response)> = {});
     void ensureTiles(SourceType, uint16_t, const SourceInfo&);
-
+    bool checkTileCountLimit(const Resource& resource);
+    
     int64_t id;
     OfflineRegionDefinition definition;
     OfflineDatabase& offlineDatabase;


### PR DESCRIPTION
The tile limit guard (when used) stops a download from continuing when the tile limit is reached. This wraps the guard in a method and employs it in both places currently necessary to ensure the guard has a chance to function.

cc @jfirebaugh @1ec5