### PR TITLE
Make constants constexpr

### DIFF
--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -11,23 +11,34 @@ namespace mbgl {
 
 namespace util {
 
-extern const float tileSize;
-extern const int32_t EXTENT;
+constexpr float tileSize = 512;
 
-extern const double DEG2RAD;
-extern const double RAD2DEG;
-extern const double M2PI;
-extern const double EARTH_RADIUS_M;
-extern const double LATITUDE_MAX;
-extern const double LONGITUDE_MAX;
-extern const double DEGREES_MAX;
-extern const double PITCH_MAX;
-extern const double MIN_ZOOM;
-extern const double MAX_ZOOM;
+/*
+ * The maximum extent of a feature that can be safely stored in the buffer.
+ * In practice, all features are converted to this extent before being added.
+ *
+ * Positions are stored as signed 16bit integers.
+ * One bit is lost for signedness to support featuers extending past the left edge of the tile.
+ * One bit is lost because the line vertex buffer packs 1 bit of other data into the int.
+ * One bit is lost to support features extending past the extent on the right edge of the tile.
+ * This leaves us with 2^13 = 8192
+ */
+constexpr int32_t EXTENT = 8192;
 
-extern const uint64_t DEFAULT_MAX_CACHE_SIZE;
+constexpr double DEG2RAD = M_PI / 180.0;
+constexpr double RAD2DEG = 180.0 / M_PI;
+constexpr double M2PI = M_PI * 2;
+constexpr double EARTH_RADIUS_M = 6378137;
+constexpr double LATITUDE_MAX = 85.051128779806604;
+constexpr double LONGITUDE_MAX = 180;
+constexpr double DEGREES_MAX = 360;
+constexpr double PITCH_MAX = M_PI / 3;
+constexpr double MIN_ZOOM = 0.0;
+constexpr double MAX_ZOOM = 25.5;
 
-extern const SystemDuration CLOCK_SKEW_RETRY_TIMEOUT;
+constexpr uint64_t DEFAULT_MAX_CACHE_SIZE = 50 * 1024 * 1024;;
+
+constexpr SystemDuration CLOCK_SKEW_RETRY_TIMEOUT = Seconds(30);
 
 } // namespace util
 

--- a/src/mbgl/util/constants.cpp
+++ b/src/mbgl/util/constants.cpp
@@ -4,39 +4,6 @@
 
 namespace mbgl {
 
-namespace util {
-
-const float tileSize = 512.0f;
-
-/*
- * The maximum extent of a feature that can be safely stored in the buffer.
- * In practice, all features are converted to this extent before being added.
- *
- * Positions are stored as signed 16bit integers.
- * One bit is lost for signedness to support featuers extending past the left edge of the tile.
- * One bit is lost because the line vertex buffer packs 1 bit of other data into the int.
- * One bit is lost to support features extending past the extent on the right edge of the tile.
- * This leaves us with 2^13 = 8192
- */
-const int32_t EXTENT = 8192;
-
-const double DEG2RAD = M_PI / 180.0;
-const double RAD2DEG = 180.0 / M_PI;
-const double M2PI = 2 * M_PI;
-const double EARTH_RADIUS_M = 6378137;
-const double LATITUDE_MAX = 85.051128779806604;
-const double LONGITUDE_MAX = 180;
-const double DEGREES_MAX = 360;
-const double PITCH_MAX = M_PI / 3;
-const double MIN_ZOOM = 0.0;
-const double MAX_ZOOM = 25.5;
-
-const uint64_t DEFAULT_MAX_CACHE_SIZE = 50 * 1024 * 1024;
-
-const SystemDuration CLOCK_SKEW_RETRY_TIMEOUT = Seconds(30);
-
-} // namespace util
-
 namespace debug {
 
 #if defined(DEBUG)


### PR DESCRIPTION
We're currently declaring all of our constants in `constants.hpp` as `extern` and actually initialize them in the corresponding C++ file. Instead, we should declare them as constexpr and assign the value in the header file directly. The fact that they are defined elsewhere is an old debugging construct that allowed me to quickly change tile sizes without recompilation.