### PR TITLE
[iOS] Use CFBundleIdentifier instead of CFBundleName in UA string

### DIFF
--- a/platform/ios/src/MGLAPIClient.m
+++ b/platform/ios/src/MGLAPIClient.m
@@ -115,7 +115,7 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
 }
 
 - (void)setupUserAgent {
-    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
     NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *appBuildNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
     NSString *semanticVersion = [NSBundle mgl_frameworkInfoDictionary][@"MGLSemanticVersionString"];


### PR DESCRIPTION
Although often recommended, CFBundleName is not guaranteed to exist in an app's configuration. As an identifier of telemetry data, even when it is present it can be inconsistent because of localization.

CFBundleIdentifier, although possibly longer, will be consistent across locales and for the lifetime of an app in the App Store even if the app name changes in any locale.

cc @1ec5 @mick @camilleanne