### PR TITLE
Remove LatLng::null, vec2::null, and operator bool

### DIFF
--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -15,17 +15,19 @@ using ScreenCoordinate = vec2<double>;
 
 class LatLng {
 public:
-    struct null {};
-
     double latitude;
     double longitude;
 
     enum WrapMode : bool { Unwrapped, Wrapped };
 
-    LatLng(null) : latitude(std::numeric_limits<double>::quiet_NaN()), longitude(latitude) {}
-
     LatLng(double lat = 0, double lon = 0, WrapMode mode = Unwrapped)
-        : latitude(lat), longitude(lon) { if (mode == Wrapped) wrap(); }
+        : latitude(lat), longitude(lon) {
+        if (std::isnan(lat)) throw std::domain_error("latitude must not be NaN");
+        if (std::isnan(lon)) throw std::domain_error("longitude must not be NaN");
+        if (!std::isfinite(lat)) throw std::domain_error("latitude must not be infinite");
+        if (!std::isfinite(lon)) throw std::domain_error("longitude must not be infinite");
+        if (mode == Wrapped) wrap();
+    }
 
     LatLng wrapped() const { return { latitude, longitude, Wrapped }; }
 
@@ -40,10 +42,6 @@ public:
         if (delta < util::LONGITUDE_MAX || delta > util::DEGREES_MAX) return;
         if (longitude > 0 && end.longitude < 0) longitude -= util::DEGREES_MAX;
         else if (longitude < 0 && end.longitude > 0) longitude += util::DEGREES_MAX;
-    }
-
-    explicit operator bool() const {
-        return !(std::isnan(latitude) || std::isnan(longitude));
     }
 
     // Constructs a LatLng object with the top left position of the specified tile.
@@ -65,12 +63,8 @@ public:
     double northing = 0;
     double easting = 0;
 
-    ProjectedMeters(double n = 0, double e = 0)
+    ProjectedMeters(double n, double e)
         : northing(n), easting(e) {}
-
-    explicit operator bool() const {
-        return !(std::isnan(northing) || std::isnan(easting));
-    }
 };
 
 class LatLngBounds {
@@ -174,10 +168,6 @@ public:
 
     MetersBounds(const ProjectedMeters& sw_, const ProjectedMeters& ne_)
         : sw(sw_), ne(ne_) {}
-
-    explicit operator bool() const {
-        return sw && ne;
-    }
 };
 
 // Determines the orientation of the map.
@@ -196,16 +186,9 @@ public:
     double bottom = 0;  ///< Number of pixels inset from the bottom edge.
     double right = 0;   ///< Number of pixels inset from the right edge.
     
-    EdgeInsets() {}
-    
     EdgeInsets(const double t, const double l, const double b, const double r)
         : top(t), left(l), bottom(b), right(r) {}
     
-    explicit operator bool() const {
-        return !(std::isnan(top) || std::isnan(left) || std::isnan(bottom) || std::isnan(right))
-            && (top || left || bottom || right);
-    }
-
     void operator+=(const EdgeInsets& o) {
         top += o.top;
         left += o.left;

--- a/include/mbgl/util/vec.hpp
+++ b/include/mbgl/util/vec.hpp
@@ -11,18 +11,9 @@ namespace mbgl {
 
 template <typename T = double>
 struct vec2 {
-    struct null {};
     typedef T Type;
 
     T x, y;
-
-    inline vec2() = default;
-
-    template<typename U = T, typename std::enable_if<std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
-    inline vec2(null) : x(std::numeric_limits<T>::quiet_NaN()), y(std::numeric_limits<T>::quiet_NaN()) {}
-
-    template<typename U = T, typename std::enable_if<!std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
-    inline vec2(null) : x(std::numeric_limits<T>::min()), y(std::numeric_limits<T>::min()) {}
 
     inline vec2(const vec2& o) = default;
 
@@ -83,16 +74,6 @@ struct vec2 {
     inline vec2 matMul(const M &m) const {
         return {m[0] * x + m[1] * y, m[2] * x + m[3] * y};
     }
-
-    template<typename U = T, typename std::enable_if<std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
-    explicit operator bool() const {
-        return !std::isnan(x) && !std::isnan(y);
-    }
-
-    template<typename U = T, typename std::enable_if<!std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
-    explicit operator bool() const {
-        return x != std::numeric_limits<T>::min() && y != std::numeric_limits<T>::min();
-    }
 };
 
 template <typename T = double>
@@ -104,19 +85,6 @@ struct vec4 {
     inline vec4(T x_, T y_, T z_, T w_) : x(x_), y(y_), z(z_), w(w_) {}
     inline bool operator==(const vec4& rhs) const {
         return x == rhs.x && y == rhs.y && z == rhs.z && w == rhs.w;
-    }
-
-    template<typename U = T, typename std::enable_if<std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
-    explicit operator bool() const {
-        return !std::isnan(x) && !std::isnan(y) && !std::isnan(z) && !std::isnan(w);
-    }
-
-    template<typename U = T, typename std::enable_if<!std::numeric_limits<U>::has_quiet_NaN, int>::type = 0>
-    explicit operator bool() const {
-        return x != std::numeric_limits<T>::min()
-            && y != std::numeric_limits<T>::min()
-            && z != std::numeric_limits<T>::min()
-            && w != std::numeric_limits<T>::min();
     }
 };
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -47,7 +47,7 @@ public:
 
     void resizeView(int width, int height);
     void resizeFramebuffer(int width, int height);
-    mbgl::EdgeInsets getInsets() { return insets;}
+    optional<mbgl::EdgeInsets> getInsets() { return insets;}
     void setInsets(mbgl::EdgeInsets insets_);
 
 private:
@@ -94,7 +94,7 @@ private:
     // Ensure these are initialised last
     std::unique_ptr<mbgl::DefaultFileSource> fileSource;
     std::unique_ptr<mbgl::Map> map;
-    mbgl::EdgeInsets insets;
+    optional<mbgl::EdgeInsets> insets;
 };
 }
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -404,7 +404,7 @@ void Map::moveBy(const ScreenCoordinate& point, const Duration& duration) {
 }
 
 void Map::setLatLng(const LatLng& latLng, const Duration& duration) {
-    setLatLng(latLng, ScreenCoordinate {}, duration);
+    setLatLng(latLng, optional<ScreenCoordinate> {}, duration);
 }
 
 void Map::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, const Duration& duration) {
@@ -504,7 +504,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
     // Calculate the zoom level.
     double scaleX = getWidth() / width;
     double scaleY = getHeight() / height;
-    if (padding && *padding) {
+    if (padding) {
         scaleX -= (padding->left + padding->right) / width;
         scaleY -= (padding->top + padding->bottom) / height;
     }
@@ -514,7 +514,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
 
     // Calculate the center point of a virtual bounds that is extended in all directions by padding.
     ScreenCoordinate centerPixel = nePixel + swPixel;
-    if (padding && *padding) {
+    if (padding) {
         ScreenCoordinate paddedNEPixel = {
             padding->right / minScale,
             padding->top / minScale,
@@ -579,7 +579,7 @@ void Map::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second
 }
 
 void Map::setBearing(double degrees, const Duration& duration) {
-    setBearing(degrees, EdgeInsets(), duration);
+    setBearing(degrees, optional<ScreenCoordinate> {}, duration);
 }
 
 void Map::setBearing(double degrees, optional<ScreenCoordinate> anchor, const Duration& duration) {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -93,13 +93,12 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     double angle = camera.angle.value_or(getAngle());
     double pitch = camera.pitch.value_or(getPitch());
 
-    if (!latLng || std::isnan(zoom)) {
+    if (std::isnan(zoom)) {
         return;
     }
 
     // Determine endpoints.
-    EdgeInsets padding;
-    if (camera.padding) padding = *camera.padding;
+    optional<EdgeInsets> padding = camera.padding;
     LatLng startLatLng = getLatLng(padding);
     // If gesture in progress, we transfer the world rounds from the end
     // longitude into start, so we can guarantee the "scroll effect" of rounding
@@ -180,13 +179,12 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
     double angle = camera.angle.value_or(getAngle());
     double pitch = camera.pitch.value_or(getPitch());
 
-    if (!latLng || std::isnan(zoom)) {
+    if (std::isnan(zoom)) {
         return;
     }
     
     // Determine endpoints.
-    EdgeInsets padding;
-    if (camera.padding) padding = *camera.padding;
+    optional<EdgeInsets> padding = camera.padding;
     LatLng startLatLng = getLatLng(padding).wrapped();
     startLatLng.unwrapForShortestPath(latLng);
 
@@ -215,9 +213,9 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
     
     /// w₀: Initial visible span, measured in pixels at the initial scale.
     /// Known henceforth as a <i>screenful</i>.
-    double w0 = padding ? std::max(state.width, state.height)
-                        : std::max(state.width - padding.left - padding.right,
-                                   state.height - padding.top - padding.bottom);
+    double w0 = padding ? std::max(state.width - padding->left - padding->right,
+                                   state.height - padding->top - padding->bottom)
+                        : std::max(state.width, state.height);
     /// w₁: Final visible span, measured in pixels with respect to the initial
     /// scale.
     double w1 = w0 / state.zoomScale(zoom - startZoom);
@@ -342,8 +340,6 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
 #pragma mark - Position
 
 void Transform::moveBy(const ScreenCoordinate& offset, const Duration& duration) {
-    if (!offset) return;
-
     ScreenCoordinate centerOffset = {
         offset.x,
         -offset.y,
@@ -360,7 +356,6 @@ void Transform::setLatLng(const LatLng& latLng, const Duration& duration) {
 }
 
 void Transform::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, const Duration& duration) {
-    if (!latLng) return;
     CameraOptions camera;
     camera.center = latLng;
     camera.padding = padding;
@@ -368,26 +363,20 @@ void Transform::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, co
 }
 
 void Transform::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, const Duration& duration) {
-    if (!latLng) return;
     CameraOptions camera;
     camera.center = latLng;
     if (anchor) {
-        EdgeInsets padding;
-        padding.top = anchor->y;
-        padding.left = anchor->x;
-        padding.bottom = state.height - anchor->y;
-        padding.right = state.width - anchor->x;
-        if (padding) camera.padding = padding;
+        camera.padding = EdgeInsets(anchor->y, anchor->x, state.height - anchor->y, state.width - anchor->x);
     }
     easeTo(camera, duration);
 }
 
 void Transform::setLatLngZoom(const LatLng& latLng, double zoom, const Duration& duration) {
-    setLatLngZoom(latLng, zoom, EdgeInsets {}, duration);
+    setLatLngZoom(latLng, zoom, {}, duration);
 }
 
 void Transform::setLatLngZoom(const LatLng& latLng, double zoom, optional<EdgeInsets> padding, const Duration& duration) {
-    if (!latLng || std::isnan(zoom)) return;
+    if (std::isnan(zoom)) return;
 
     CameraOptions camera;
     camera.center = latLng;
@@ -397,7 +386,7 @@ void Transform::setLatLngZoom(const LatLng& latLng, double zoom, optional<EdgeIn
 }
 
 LatLng Transform::getLatLng(optional<EdgeInsets> padding) const {
-    if (padding && *padding) {
+    if (padding) {
         return screenCoordinateToLatLng(padding->getCenter(state.width, state.height));
     } else {
         return state.getLatLng();
@@ -405,7 +394,7 @@ LatLng Transform::getLatLng(optional<EdgeInsets> padding) const {
 }
 
 ScreenCoordinate Transform::getScreenCoordinate(optional<EdgeInsets> padding) const {
-    if (padding && *padding) {
+    if (padding) {
         return padding->getCenter(state.width, state.height);
     } else {
         return { state.width / 2., state.height / 2. };
@@ -476,10 +465,6 @@ void Transform::setMaxZoom(const double maxZoom) {
 #pragma mark - Angle
 
 void Transform::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const Duration& duration) {
-    if (!first || !second) {
-        return;
-    }
-
     ScreenCoordinate center = getScreenCoordinate();
     const ScreenCoordinate offset = first - center;
     const double distance = std::sqrt(std::pow(2, offset.x) + std::pow(2, offset.y));
@@ -516,7 +501,7 @@ void Transform::setAngle(double angle, optional<ScreenCoordinate> anchor, const 
 
 void Transform::setAngle(double angle, optional<EdgeInsets> padding, const Duration& duration) {
     optional<ScreenCoordinate> anchor;
-    if (padding && *padding) anchor = getScreenCoordinate(padding);
+    if (padding) anchor = getScreenCoordinate(padding);
     setAngle(angle, anchor, duration);
 }
 
@@ -580,7 +565,7 @@ void Transform::startTransition(const CameraOptions& camera,
     // Associate the anchor, if given, with a coordinate.
     optional<ScreenCoordinate> anchor = camera.anchor;
     LatLng anchorLatLng;
-    if (anchor && *anchor) {
+    if (anchor) {
         anchor->y = state.getHeight() - anchor->y;
         anchorLatLng = state.screenCoordinateToLatLng(*anchor);
     }
@@ -598,7 +583,7 @@ void Transform::startTransition(const CameraOptions& camera,
             result = frame(ease.solve(t, 0.001));
         }
         
-        if (anchor && *anchor) state.moveLatLng(anchorLatLng, *anchor);
+        if (anchor) state.moveLatLng(anchorLatLng, *anchor);
         
         // At t = 1.0, a DidChangeAnimated notification should be sent from finish().
         if (t < 1.0) {
@@ -656,8 +641,6 @@ void Transform::setGestureInProgress(bool inProgress) {
 #pragma mark Conversion and projection
 
 ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const {
-    if (!latLng) return ScreenCoordinate::null();
-
     // If the center and point longitudes are not in the same side of the
     // antimeridian, we unwrap the point longitude so it would be seen if
     // e.g. the next antimeridian side is visible.
@@ -669,8 +652,6 @@ ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const
 }
 
 LatLng Transform::screenCoordinateToLatLng(const ScreenCoordinate& point) const {
-    if (!point) return LatLng::null();
-
     ScreenCoordinate flippedPoint = point;
     flippedPoint.y = state.height - flippedPoint.y;
     return state.screenCoordinateToLatLng(flippedPoint).wrapped();

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -311,8 +311,6 @@ void TransformState::constrain(double& scale_, double& x_, double& y_) const {
 }
 
 void TransformState::moveLatLng(const LatLng& latLng, const ScreenCoordinate& anchor) {
-    if (!latLng || !anchor) return;
-
     auto latLngToTileCoord = [&](const LatLng& ll) -> vec2<double> {
         return { lngX(ll.longitude), latY(ll.latitude) };
     };

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -46,44 +46,6 @@ TEST(Transform, InvalidScale) {
     ASSERT_DOUBLE_EQ(2, transform.getScale());
 }
 
-TEST(Transform, InvalidLatLng) {
-    MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
-
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(1, transform.getScale());
-
-    transform.setScale(2 << 0);
-    transform.setLatLng({ 8, 10 });
-
-    ASSERT_DOUBLE_EQ(8, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(2, transform.getScale());
-
-    transform.setLatLngZoom({ 10, 8 }, 2);
-
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(8, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(4, transform.getScale());
-
-    const double invalid = std::nan("");
-    transform.setLatLngZoom({ invalid, 8 }, 2);
-
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(8, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(4, transform.getScale());
-
-    transform.setLatLngZoom({ 10, invalid }, 2);
-
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(8, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(4, transform.getScale());
-
-    ASSERT_FALSE(transform.latLngToScreenCoordinate(LatLng::null()));
-    ASSERT_FALSE(transform.screenCoordinateToLatLng(ScreenCoordinate::null()));
-}
-
 
 TEST(Transform, InvalidBearing) {
     MockView view;
@@ -225,7 +187,7 @@ TEST(Transform, Anchor) {
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
     ASSERT_DOUBLE_EQ(0, transform.getAngle());
 
-    const ScreenCoordinate invalidAnchorPoint = ScreenCoordinate::null();
+    const optional<ScreenCoordinate> invalidAnchorPoint {};
     const ScreenCoordinate anchorPoint = { 150, 150 };
 
     const LatLng anchorLatLng = transform.getState().screenCoordinateToLatLng(anchorPoint);
@@ -332,18 +294,8 @@ TEST(Transform, Padding) {
         1000.0 / 2.0,
         1000.0 / 4.0,
     });
-    
-    EdgeInsets padding;
 
-    padding.top = 0;
-    ASSERT_FALSE(bool(padding));
-
-    padding.top = NAN;
-    ASSERT_FALSE(bool(padding));
-
-    padding.top = 1000.0 / 2.0;
-    ASSERT_TRUE(bool(padding));
-    
+    EdgeInsets padding(1000.0 / 2.0, 0, 0, 0);
     const LatLng shiftedCenter = transform.getLatLng(padding);
     ASSERT_NE(trueCenter.latitude, shiftedCenter.latitude);
     ASSERT_DOUBLE_EQ(trueCenter.longitude, shiftedCenter.longitude);


### PR DESCRIPTION
Instead of using NaN, 0 or other special values to indicate the lack of a real `LatLng` or `vec2` value, we should use `optional<LatLng>` or `optional<vec2>`.

Refs #3802, #4285.

cc @brunoabinader