### PR TITLE
[android] Build ARMv8 on the `apackage` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ android: android-lib
 	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) assemble$(BUILDTYPE)
 
 # Builds all android architectures for distribution.
-apackage: android-lib-arm-v5 android-lib-arm-v7
+apackage: android-lib-arm-v5 android-lib-arm-v7 android-lib-arm-v8
 apackage: android-lib-x86 android-lib-x86-64
 apackage: android-lib-mips
 	cd platform/android && ./gradlew --parallel-threads=$(JOBS) assemble$(BUILDTYPE)


### PR DESCRIPTION
Follow-up of 51a3907.