### PR TITLE
Unify offline and ambient caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,10 @@ Known issues:
 - Black Screen On Ice Cream Sandwich and Jelly Bean devices ([#2802](https://github.com/mapbox/mapbox-gl-native/issues/2802))
   - Resolved in 2.2.0
 
-## iOS master
+## iOS 3.2.0
 
 - Offline packs can now be downloaded to allow users to view specific regions of the map offline. A new MGLOfflineStorage class provides APIs for managing MGLOfflinePacks. ([#4221](https://github.com/mapbox/mapbox-gl-native/pull/4221))
+- Tiles and other resources are cached in the same file that holds offline resources. The combined cache file is located in a subdirectory of the user’s Application Support directory, which means iOS will not delete the file when disk space runs low. ([#4377](https://github.com/mapbox/mapbox-gl-native/pull/4377))
 - The user dot no longer disappears after panning the map across the antimeridian at low zoom levels. ([#4275](https://github.com/mapbox/mapbox-gl-native/pull/4275))
 - The map no longer recoils when panning quickly at low zoom levels. ([#4214](https://github.com/mapbox/mapbox-gl-native/pull/4214))
 - An icon laid out along a line no longer appears if it would extend past the end of the line. Some one-way arrows no longer point the wrong way. ([#3839](https://github.com/mapbox/mapbox-gl-native/pull/3839))


### PR DESCRIPTION
Now there’s only one instance of `mbgl::OfflineFileSource`, created when the shared MGLOfflineStorage object is initialized. Also create and use the shared MGLOfflineStorage object when initializing an MGLMapView object.

The unified cache file is located in a subdirectory of Application Support, where the SDK has control over the file’s lifetime. The subdirectory is already named after the host application’s bundle identifier, ensuring that each Mapbox-powered application has an independent tile limit.

If there’s an ambient cache in a subdirectory of Caches, delete it. If there’s an offline cache in a subdirectory of Documents on iOS or Caches on OS X, move it to the unified cache location in a subdirectory of Application Support.

There are a couple consequences to this approach:

1. On iOS, it isn’t possible for a user to export their offline cache to another device or import it from another device. The application would have to move the file into Documents first.
1. If disk space runs low on the iOS device, the unified cache will continue to eat up disk space, potentially due to ambiently cached content, and the only way to reclaim that space would be to delete the application (along with all the offline content). See #4376 for a possible solution.
1. On OS X, it isn’t possible for two Mapbox-powered applications to share an ambient cache. The unified cache’s path must include the application’s bundle identifier, because otherwise one application’s offline packs would count against another application’s limits.

Fixes the iOS/OS X side of #4338.

/cc @jfirebaugh @boundsj