### PR TITLE
[android] Unify cache and offline databases

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -50,8 +50,13 @@ final class NativeMapView {
 
     public NativeMapView(MapView mapView) {
         Context context = mapView.getContext();
-        String cachePath = context.getCacheDir().getAbsolutePath();
         String dataPath = context.getFilesDir().getAbsolutePath();
+
+        // With the availability of offline, we're unifying the ambient (cache) and the offline
+        // databases to be in the same folder, outside cache, to avoid automatic deletion from
+        // the system
+        String cachePath = dataPath;
+
         float pixelRatio = context.getResources().getDisplayMetrics().density;
         String apkPath = context.getPackageCodePath();
         int availableProcessors = Runtime.getRuntime().availableProcessors();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import java.io.File;
 
@@ -13,8 +14,10 @@ import java.io.File;
  */
 public class OfflineManager {
 
+    private final static String LOG_TAG = "OfflineManager";
+
     // Default database name
-    private final static String OFFLINE_DATABASE_NAME = "mbgl-offline.db";
+    private final static String DATABASE_NAME = "mbgl-offline.db";
 
     /*
      * The maximumCacheSize parameter is a limit applied to non-offline resources only,
@@ -53,8 +56,30 @@ public class OfflineManager {
     private OfflineManager(Context context) {
         // Get a pointer to the DefaultFileSource instance
         String assetRoot = context.getFilesDir().getAbsolutePath();
-        String cachePath = assetRoot  + File.separator + OFFLINE_DATABASE_NAME;
+        String cachePath = assetRoot  + File.separator + DATABASE_NAME;
         mDefaultFileSourcePtr = createDefaultFileSource(cachePath, assetRoot, DEFAULT_MAX_CACHE_SIZE);
+
+        // Delete any existing previous ambient cache database
+        deleteAmbientDatabase(context);
+    }
+
+    private void deleteAmbientDatabase(final Context context) {
+        // Delete the file in a separate thread to avoid affecting the UI
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    String path = context.getCacheDir().getAbsolutePath() + File.separator + "mbgl-cache.db";
+                    File file = new File(path);
+                    if (file.exists()) {
+                        file.delete();
+                        Log.d(LOG_TAG, "Old ambient cache database deleted to save space: " + path);
+                    }
+                } catch (Exception e) {
+                    Log.e(LOG_TAG, "Failed to delete old ambient cache database: " + e.getMessage());
+                }
+            }
+        }).start();
     }
 
     public static synchronized OfflineManager getInstance(Context context) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -76,7 +76,7 @@ NativeMapView::NativeMapView(JNIEnv *env, jobject obj_, float pixelRatio_, int a
     }
 
     fileSource = std::make_unique<mbgl::DefaultFileSource>(
-        mbgl::android::cachePath + "/mbgl-cache.db",
+        mbgl::android::cachePath + "/mbgl-offline.db",
         mbgl::android::apkPath);
 
     map = std::make_unique<mbgl::Map>(*this, *fileSource, MapMode::Continuous);


### PR DESCRIPTION
Per #4362, we're now unifying the ambient and the offline databases in one location. This PR:

1. Moves them both to a permanent storage folder.
2. Deletes any previous ambient database file.

/cc: @jfirebaugh @1ec5 