### PR TITLE
[iOS] Send turnstile event as much as once per day

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -439,7 +439,9 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     _pendingLongitude = NAN;
     _targetCoordinate = kCLLocationCoordinate2DInvalid;
 
-    [MGLMapboxEvents pushEvent:MGLEventTypeMapLoad withAttributes:@{}];
+    if ([UIApplication sharedApplication].applicationState != UIApplicationStateBackground) {
+        [MGLMapboxEvents pushEvent:MGLEventTypeMapLoad withAttributes:@{}];
+    }
 }
 
 - (void)createGLView
@@ -982,6 +984,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         _displayLink.paused = NO;
 
         [self validateLocationServices];
+        
+        [MGLMapboxEvents pushEvent:MGLEventTypeMapLoad withAttributes:@{}];
     }
 }
 


### PR DESCRIPTION
Previously, the post of the turnstile event was a side effect of the
map.load event and would happen when the host app was started from a
terminated state at the first initialization of MGLMapView. The
turnstile event post was guarded with dispatch_once so that it would
only ever be sent once during the lifecycle of the application after
it started from the terminated state.

This changes that behavior by:

- Allowing a new turnstile event to be posted as much as once per
day
- Only triggering a map.view event when a map is initialized if the map
is loaded outside of the 'background' application state
- Sending a map.view event whenever a MGLMapView is instantiated
and the application did become active or enters foreground

iOS turnstile event sending behavior is now:

- A map.view event is generated whenever a map is loaded and also
when a map is shown again when the host app becomes active and moves
into the foreground
- Turnstile events are still triggered by mapviews and will be sent as
frequently as once per day for a host app that is not terminated and
also whenever a host app is terminated and restarted

cc @1ec5 