### PR TITLE
Reset the translation to zero without adjusting for view

### DIFF
--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1232,7 +1232,7 @@ public:
         if (gestureRecognizer.state == NSGestureRecognizerStateChanged) {
             delta.y *= -1;
             [self offsetCenterCoordinateBy:delta animated:NO];
-            [gestureRecognizer setTranslation:NSZeroPoint inView:self];
+            [gestureRecognizer setTranslation:NSZeroPoint inView:nil];
         }
     }
 }


### PR DESCRIPTION
Pan translations are broken for any MGLMapView with a non-zero frame origin. Fix this by using the 'nil' view when resetting the pan gesture recognizer translation.

To test this bug, set the leading-edge constraint of the map view in the test application to any non-zero value and try to pan the map.