### PR TITLE
[core] Stop any OfflineDownload before deleting a region

### DIFF
--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -88,6 +88,7 @@ public:
 
     void deleteRegion(OfflineRegion&& region, std::function<void (std::exception_ptr)> callback) {
         try {
+            downloads.erase(region.getID());
             offlineDatabase.deleteRegion(std::move(region));
             callback({});
         } catch (...) {


### PR DESCRIPTION
No progress events should be processed after deleting a region.

Fixes #4403

@friedbunny Can you test against Sirius? This is timing dependent and difficult to write an automated test for.