### PR TITLE
[android] Make sure we always load mapbox-gl when a native method is invoked

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineManager.java
@@ -16,6 +16,14 @@ public class OfflineManager {
 
     private final static String LOG_TAG = "OfflineManager";
 
+    //
+    // Static methods
+    //
+
+    static {
+        System.loadLibrary("mapbox-gl");
+    }
+
     // Default database name
     private final static String DATABASE_NAME = "mbgl-offline.db";
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -17,6 +17,14 @@ public class OfflineRegion {
 
     private final static String LOG_TAG = "OfflineRegion";
 
+    //
+    // Static methods
+    //
+
+    static {
+        System.loadLibrary("mapbox-gl");
+    }
+
     // Parent OfflineManager
     private OfflineManager offlineManager;
 


### PR DESCRIPTION
It's safe to call this method several times, [according to the documentation](http://docs.oracle.com/javase/7/docs/api/java/lang/Runtime.html#loadLibrary%28java.lang.String%29) if this method is called more than once with the same library name, the second and subsequent calls are ignored.

Fixes #4175

/cc: @jfirebaugh 