### PR TITLE
upload new symbol buffers in upload pass

### DIFF
--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -572,6 +572,7 @@ void SymbolBucket::addToDebugBuffers(CollisionTile &collisionTile) {
 void SymbolBucket::swapRenderData() {
     if (renderDataInProgress) {
         renderData = std::move(renderDataInProgress);
+        uploaded = false;
     }
 }
 


### PR DESCRIPTION
fix #4131 

When the map is rotated and symbol buffers are recalculated we don't reset `uploaded` so the buffers don't get uploaded during the upload pass. This fixes that by resetting `uploaded`.