### PR TITLE
Place unit test fixtures in correct place when creating iOS project

### DIFF
--- a/test/test.gypi
+++ b/test/test.gypi
@@ -136,8 +136,7 @@
           },
           'copies': [
             { 'destination': '<(PRODUCT_DIR)/$(WRAPPER_NAME)/test',
-              # Hack: When a filename begins with a $, gyp doesn't prepend $(SRCROOT)
-              'files': [ '$()../test/fixtures' ],
+              'files': [ '../test/fixtures' ],
             },
           ]
         }, {


### PR DESCRIPTION
`make iproj` was producing a project with a broken `$()../test` folder containing a missing `fixtures` item. 

@kkaefer The "gyp doesn't prepend $(SRCROOT)” hack you mention doesn’t appear to be necessary — at least not on my system, running Xcode 7.3.

![screen-shot-2016-03-22-at-6_15_29-pm](https://cloud.githubusercontent.com/assets/1198851/13969875/a3c559dc-f05b-11e5-8710-5bde3bd5a1a4.png)



Refs https://github.com/mapbox/mapbox-gl-native/commit/c587eefbb1290cc01e3e14a0ae18a2d316a498fd#diff-6df1c496c702460f8a63d53bce86b8c7R139