### PR TITLE
Unify FileRequest and WorkRequest

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -30,7 +30,7 @@ public:
     void setAccessToken(const std::string&);
     std::string getAccessToken() const;
 
-    std::unique_ptr<FileRequest> request(const Resource&, Callback) override;
+    std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
     /*
      * Retrieve all regions in the offline database.

--- a/include/mbgl/storage/file_source.hpp
+++ b/include/mbgl/storage/file_source.hpp
@@ -5,16 +5,12 @@
 #include <mbgl/storage/resource.hpp>
 
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/async_request.hpp>
 
 #include <functional>
 #include <memory>
 
 namespace mbgl {
-
-class FileRequest : private util::noncopyable {
-public:
-    virtual ~FileRequest() = default;
-};
 
 class FileSource : private util::noncopyable {
 public:
@@ -24,10 +20,10 @@ public:
 
     // Request a resource. The callback will be called asynchronously, in the same
     // thread as the request was made. This thread must have an active RunLoop. The
-    // request may be cancelled before completion by releasing the returned FileRequest.
+    // request may be cancelled before completion by releasing the returned AsyncRequest.
     // If the request is cancelled before the callback is executed, the callback will
     // not be executed.
-    virtual std::unique_ptr<FileRequest> request(const Resource&, Callback) = 0;
+    virtual std::unique_ptr<AsyncRequest> request(const Resource&, Callback) = 0;
 };
 
 } // namespace mbgl

--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -17,7 +17,7 @@ public:
     void setAccessToken(const std::string& t) { accessToken = t; }
     std::string getAccessToken() const { return accessToken; }
 
-    std::unique_ptr<FileRequest> request(const Resource&, Callback) override;
+    std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
 private:
     friend class OnlineFileRequestImpl;

--- a/include/mbgl/util/async_request.hpp
+++ b/include/mbgl/util/async_request.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <mbgl/util/noncopyable.hpp>
+
+namespace mbgl {
+
+class AsyncRequest : private util::noncopyable {
+public:
+    virtual ~AsyncRequest() = default;
+};
+
+} // namespace mbgl

--- a/include/mbgl/util/run_loop.hpp
+++ b/include/mbgl/util/run_loop.hpp
@@ -58,7 +58,7 @@ public:
 
     // Post the cancellable work fn(args...) to this RunLoop.
     template <class Fn, class... Args>
-    std::unique_ptr<WorkRequest>
+    std::unique_ptr<AsyncRequest>
     invokeCancellable(Fn&& fn, Args&&... args) {
         auto flag = std::make_shared<std::atomic<bool>>();
         *flag = false;
@@ -76,7 +76,7 @@ public:
 
     // Invoke fn(args...) on this RunLoop, then invoke callback(results...) on the current RunLoop.
     template <class Fn, class Cb, class... Args>
-    std::unique_ptr<WorkRequest>
+    std::unique_ptr<AsyncRequest>
     invokeWithCallback(Fn&& fn, Cb&& callback, Args&&... args) {
         auto flag = std::make_shared<std::atomic<bool>>();
         *flag = false;

--- a/include/mbgl/util/work_request.hpp
+++ b/include/mbgl/util/work_request.hpp
@@ -1,7 +1,7 @@
 #ifndef MBGL_UTIL_WORK_REQUEST
 #define MBGL_UTIL_WORK_REQUEST
 
-#include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/async_request.hpp>
 
 #include <memory>
 
@@ -9,11 +9,11 @@ namespace mbgl {
 
 class WorkTask;
 
-class WorkRequest : public util::noncopyable {
+class WorkRequest : public AsyncRequest {
 public:
     using Task = std::shared_ptr<WorkTask>;
     WorkRequest(Task);
-    ~WorkRequest();
+    ~WorkRequest() override;
 
 private:
     std::shared_ptr<WorkTask> task;

--- a/platform/android/src/asset_file_source.cpp
+++ b/platform/android/src/asset_file_source.cpp
@@ -35,7 +35,7 @@ struct ZipFileHolder {
 
 namespace mbgl {
 
-class AssetFileRequest : public FileRequest {
+class AssetFileRequest : public AsyncRequest {
 public:
     AssetFileRequest(std::unique_ptr<WorkRequest> workRequest_)
         : workRequest(std::move(workRequest_)) {
@@ -106,8 +106,8 @@ AssetFileSource::AssetFileSource(const std::string& root)
 
 AssetFileSource::~AssetFileSource() = default;
 
-std::unique_ptr<FileRequest> AssetFileSource::request(const Resource& resource, Callback callback) {
-    return std::make_unique<AssetFileRequest>(thread->invokeWithCallback(&Impl::request, callback, resource.url));
+std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource, Callback callback) {
+    return thread->invokeWithCallback(&Impl::request, callback, resource.url);
 }
 
 }

--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -12,15 +12,6 @@
 
 namespace mbgl {
 
-class AssetFileRequest : public FileRequest {
-public:
-    AssetFileRequest(std::unique_ptr<WorkRequest> workRequest_)
-        : workRequest(std::move(workRequest_)) {
-    }
-
-    std::unique_ptr<WorkRequest> workRequest;
-};
-
 class AssetFileSource::Impl {
 public:
     Impl(const std::string& root_)
@@ -72,8 +63,8 @@ AssetFileSource::AssetFileSource(const std::string& root)
 
 AssetFileSource::~AssetFileSource() = default;
 
-std::unique_ptr<FileRequest> AssetFileSource::request(const Resource& resource, Callback callback) {
-    return std::make_unique<AssetFileRequest>(thread->invokeWithCallback(&Impl::request, callback, resource.url));
+std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource, Callback callback) {
+    return thread->invokeWithCallback(&Impl::request, callback, resource.url);
 }
 
 } // namespace mbgl

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -196,8 +196,7 @@ void OfflineDownload::activateDownload() {
 }
 
 void OfflineDownload::deactivateDownload() {
-    workRequests.clear();
-    fileRequests.clear();
+    requests.clear();
 }
 
 void OfflineDownload::ensureTiles(SourceType type, uint16_t tileSize, const SourceInfo& info) {
@@ -209,9 +208,9 @@ void OfflineDownload::ensureTiles(SourceType type, uint16_t tileSize, const Sour
 void OfflineDownload::ensureResource(const Resource& resource, std::function<void (Response)> callback) {
     status.requiredResourceCount++;
 
-    auto workRequestsIt = workRequests.insert(workRequests.begin(), nullptr);
+    auto workRequestsIt = requests.insert(requests.begin(), nullptr);
     *workRequestsIt = util::RunLoop::Get()->invokeCancellable([=] () {
-        workRequests.erase(workRequestsIt);
+        requests.erase(workRequestsIt);
 
         optional<std::pair<Response, uint64_t>> offlineResponse = offlineDatabase.getRegionResource(id, resource);
         if (offlineResponse) {
@@ -238,14 +237,14 @@ void OfflineDownload::ensureResource(const Resource& resource, std::function<voi
             return;
         }
 
-        auto fileRequestsIt = fileRequests.insert(fileRequests.begin(), nullptr);
+        auto fileRequestsIt = requests.insert(requests.begin(), nullptr);
         *fileRequestsIt = onlineFileSource.request(resource, [=] (Response onlineResponse) {
             if (onlineResponse.error) {
                 observer->responseError(*onlineResponse.error);
                 return;
             }
 
-            fileRequests.erase(fileRequestsIt);
+            requests.erase(fileRequestsIt);
 
             if (callback) {
                 callback(onlineResponse);

--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -11,8 +11,7 @@ namespace mbgl {
 
 class OfflineDatabase;
 class FileSource;
-class WorkRequest;
-class FileRequest;
+class AsyncRequest;
 class Resource;
 class Response;
 class SourceInfo;
@@ -56,8 +55,7 @@ private:
     FileSource& onlineFileSource;
     OfflineRegionStatus status;
     std::unique_ptr<OfflineRegionObserver> observer;
-    std::list<std::unique_ptr<WorkRequest>> workRequests;
-    std::list<std::unique_ptr<FileRequest>> fileRequests;
+    std::list<std::unique_ptr<AsyncRequest>> requests;
     std::set<std::string> requiredSourceURLs;
 };
 

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -42,7 +42,7 @@ public:
     NodeMap(v8::Local<v8::Object>);
     ~NodeMap();
 
-    std::unique_ptr<mbgl::FileRequest> request(const mbgl::Resource&, Callback);
+    std::unique_ptr<mbgl::AsyncRequest> request(const mbgl::Resource&, Callback);
 
     mbgl::HeadlessView view;
     std::unique_ptr<mbgl::Map> map;

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -37,7 +37,7 @@ AnnotationTileMonitor::~AnnotationTileMonitor() {
     data.getAnnotationManager()->removeTileMonitor(*this);
 }
 
-std::unique_ptr<FileRequest> AnnotationTileMonitor::monitorTile(const GeometryTileMonitor::Callback& callback_) {
+std::unique_ptr<AsyncRequest> AnnotationTileMonitor::monitorTile(const GeometryTileMonitor::Callback& callback_) {
     callback = callback_;
     data.getAnnotationManager()->addTileMonitor(*this);
     return nullptr;

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -47,7 +47,7 @@ public:
     ~AnnotationTileMonitor();
 
     void update(std::unique_ptr<GeometryTile>);
-    std::unique_ptr<FileRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
+    std::unique_ptr<AsyncRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
 
     TileID tileID;
 

--- a/src/mbgl/map/map_context.hpp
+++ b/src/mbgl/map/map_context.hpp
@@ -20,7 +20,7 @@ class View;
 class MapData;
 class Painter;
 class SpriteImage;
-class FileRequest;
+class AsyncRequest;
 class PropertyTransition;
 
 namespace gl { class TexturePool; }
@@ -106,7 +106,7 @@ private:
     std::string styleURL;
     std::string styleJSON;
 
-    std::unique_ptr<FileRequest> styleRequest;
+    std::unique_ptr<AsyncRequest> styleRequest;
 
     Map::StillImageCallback callback;
     size_t sourceCacheSize;

--- a/src/mbgl/source/source.hpp
+++ b/src/mbgl/source/source.hpp
@@ -23,7 +23,7 @@ namespace mbgl {
 class StyleUpdateParameters;
 class Painter;
 class FileSource;
-class FileRequest;
+class AsyncRequest;
 class TransformState;
 class Tile;
 struct ClipID;
@@ -107,7 +107,7 @@ private:
     std::map<TileID, std::weak_ptr<TileData>> tileDataMap;
     TileCache cache;
 
-    std::unique_ptr<FileRequest> req;
+    std::unique_ptr<AsyncRequest> req;
 
     Observer nullObserver;
     Observer* observer = &nullObserver;

--- a/src/mbgl/sprite/sprite_store.cpp
+++ b/src/mbgl/sprite/sprite_store.cpp
@@ -14,8 +14,8 @@ namespace mbgl {
 struct SpriteStore::Loader {
     std::shared_ptr<const std::string> image;
     std::shared_ptr<const std::string> json;
-    std::unique_ptr<FileRequest> jsonRequest;
-    std::unique_ptr<FileRequest> spriteRequest;
+    std::unique_ptr<AsyncRequest> jsonRequest;
+    std::unique_ptr<AsyncRequest> spriteRequest;
 };
 
 SpriteStore::SpriteStore(float pixelRatio_)

--- a/src/mbgl/storage/asset_file_source.hpp
+++ b/src/mbgl/storage/asset_file_source.hpp
@@ -14,7 +14,7 @@ public:
     AssetFileSource(const std::string& assetRoot);
     ~AssetFileSource() override;
 
-    std::unique_ptr<FileRequest> request(const Resource&, Callback) override;
+    std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
 private:
     class Impl;

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -13,7 +13,7 @@
 namespace mbgl {
 
 class FontStack;
-class FileRequest;
+class AsyncRequest;
 class FileSource;
 
 class GlyphPBF : private util::noncopyable {
@@ -31,7 +31,7 @@ public:
 
 private:
     std::atomic<bool> parsed;
-    std::unique_ptr<FileRequest> req;
+    std::unique_ptr<AsyncRequest> req;
     GlyphStore::Observer* observer = nullptr;
 };
 

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -124,7 +124,7 @@ void GeoJSONTileMonitor::update() {
     }
 }
 
-std::unique_ptr<FileRequest>
+std::unique_ptr<AsyncRequest>
 GeoJSONTileMonitor::monitorTile(const GeometryTileMonitor::Callback& cb) {
     callback = cb;
     update();

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -58,7 +58,7 @@ public:
     GeoJSONTileMonitor(mapbox::geojsonvt::GeoJSONVT*, const TileID&);
     virtual ~GeoJSONTileMonitor();
 
-    std::unique_ptr<FileRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
+    std::unique_ptr<AsyncRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
 
     void setGeoJSONVT(mapbox::geojsonvt::GeoJSONVT*);
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -55,7 +55,7 @@ public:
     virtual util::ptr<GeometryTileLayer> getLayer(const std::string&) const = 0;
 };
 
-class FileRequest;
+class AsyncRequest;
 
 class GeometryTileMonitor : private util::noncopyable {
 public:
@@ -73,7 +73,7 @@ public:
      *
      * To cease monitoring, release the returned Request.
      */
-    virtual std::unique_ptr<FileRequest> monitorTile(const Callback&) = 0;
+    virtual std::unique_ptr<AsyncRequest> monitorTile(const Callback&) = 0;
 };
 
 class GeometryTileFeatureExtractor {

--- a/src/mbgl/tile/raster_tile_data.hpp
+++ b/src/mbgl/tile/raster_tile_data.hpp
@@ -7,9 +7,8 @@
 namespace mbgl {
 
 class FileSource;
-class FileRequest;
+class AsyncRequest;
 class StyleLayer;
-class WorkRequest;
 namespace gl { class TexturePool; }
 
 class RasterTileData : public TileData {
@@ -29,9 +28,9 @@ public:
 private:
     gl::TexturePool& texturePool;
     Worker& worker;
-    std::unique_ptr<FileRequest> req;
+    std::unique_ptr<AsyncRequest> req;
     std::unique_ptr<Bucket> bucket;
-    std::unique_ptr<WorkRequest> workRequest;
+    std::unique_ptr<AsyncRequest> workRequest;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -188,7 +188,7 @@ VectorTileMonitor::VectorTileMonitor(const TileID& tileID_, float pixelRatio_, c
       fileSource(fileSource_) {
 }
 
-std::unique_ptr<FileRequest> VectorTileMonitor::monitorTile(const GeometryTileMonitor::Callback& callback) {
+std::unique_ptr<AsyncRequest> VectorTileMonitor::monitorTile(const GeometryTileMonitor::Callback& callback) {
     const Resource resource = Resource::tile(urlTemplate, pixelRatio, tileID.x, tileID.y, tileID.sourceZ);
     return fileSource.request(resource, [callback, this](Response res) {
         if (res.error) {

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -65,7 +65,7 @@ class VectorTileMonitor : public GeometryTileMonitor {
 public:
     VectorTileMonitor(const TileID&, float pixelRatio, const std::string& urlTemplate, FileSource&);
 
-    std::unique_ptr<FileRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
+    std::unique_ptr<AsyncRequest> monitorTile(const GeometryTileMonitor::Callback&) override;
 
 private:
     TileID tileID;

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -12,8 +12,7 @@
 namespace mbgl {
 
 class Style;
-class WorkRequest;
-class FileRequest;
+class AsyncRequest;
 class GeometryTileMonitor;
 
 class VectorTileData : public TileData {
@@ -42,8 +41,8 @@ private:
     TileWorker tileWorker;
 
     std::unique_ptr<GeometryTileMonitor> monitor;
-    std::unique_ptr<FileRequest> tileRequest;
-    std::unique_ptr<WorkRequest> workRequest;
+    std::unique_ptr<AsyncRequest> tileRequest;
+    std::unique_ptr<AsyncRequest> workRequest;
 
     // Contains all the Bucket objects for the tile. Buckets are render
     // objects and they get added by tile parsing operations.

--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -37,7 +37,7 @@ public:
 
     // Invoke object->fn(args...) in the runloop thread, then invoke callback(result) in the current thread.
     template <typename Fn, class Cb, class... Args>
-    std::unique_ptr<WorkRequest>
+    std::unique_ptr<AsyncRequest>
     invokeWithCallback(Fn fn, Cb&& callback, Args&&... args) {
         return loop->invokeWithCallback(bind(fn), callback, std::forward<Args>(args)...);
     }

--- a/src/mbgl/util/work_queue.cpp
+++ b/src/mbgl/util/work_queue.cpp
@@ -12,7 +12,7 @@ WorkQueue::WorkQueue() : runLoop(RunLoop::Get()) {
 WorkQueue::~WorkQueue() {
     assert(runLoop == RunLoop::Get());
 
-    // Cancel all pending WorkRequests.
+    // Cancel all pending AsyncRequests.
     while (!queue.empty()) {
         queue.pop();
     }

--- a/src/mbgl/util/work_queue.hpp
+++ b/src/mbgl/util/work_queue.hpp
@@ -2,7 +2,7 @@
 #define MBGL_UTIL_WORK_QUEUE
 
 #include <mbgl/util/noncopyable.hpp>
-#include <mbgl/util/work_request.hpp>
+#include <mbgl/util/async_request.hpp>
 
 #include <functional>
 #include <memory>
@@ -31,7 +31,7 @@ public:
 private:
     void pop(const std::function<void()>&);
 
-    std::queue<std::unique_ptr<WorkRequest>> queue;
+    std::queue<std::unique_ptr<AsyncRequest>> queue;
     std::mutex queueMutex;
 
     RunLoop* runLoop;

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -68,7 +68,7 @@ Worker::Worker(std::size_t count) {
 
 Worker::~Worker() = default;
 
-std::unique_ptr<WorkRequest>
+std::unique_ptr<AsyncRequest>
 Worker::parseRasterTile(std::unique_ptr<RasterBucket> bucket,
                         const std::shared_ptr<const std::string> data,
                         std::function<void(RasterTileParseResult)> callback) {
@@ -77,7 +77,7 @@ Worker::parseRasterTile(std::unique_ptr<RasterBucket> bucket,
                                                 data);
 }
 
-std::unique_ptr<WorkRequest>
+std::unique_ptr<AsyncRequest>
 Worker::parseGeometryTile(TileWorker& worker,
                           std::vector<std::unique_ptr<StyleLayer>> layers,
                           std::unique_ptr<GeometryTile> tile,
@@ -88,7 +88,7 @@ Worker::parseGeometryTile(TileWorker& worker,
                                                 std::move(layers), std::move(tile), config);
 }
 
-std::unique_ptr<WorkRequest>
+std::unique_ptr<AsyncRequest>
 Worker::parsePendingGeometryTileLayers(TileWorker& worker,
                                        PlacementConfig config,
                                        std::function<void(TileParseResult)> callback) {
@@ -97,7 +97,7 @@ Worker::parsePendingGeometryTileLayers(TileWorker& worker,
                                                 callback, &worker, config);
 }
 
-std::unique_ptr<WorkRequest>
+std::unique_ptr<AsyncRequest>
 Worker::redoPlacement(TileWorker& worker,
                       const std::unordered_map<std::string, std::unique_ptr<Bucket>>& buckets,
                       PlacementConfig config,

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -10,7 +10,7 @@
 
 namespace mbgl {
 
-class WorkRequest;
+class AsyncRequest;
 class RasterBucket;
 class GeometryTileLoader;
 
@@ -33,7 +33,7 @@ public:
     // bind references to itself, and if and when those lambdas execute, the references
     // will still be valid.
 
-    using Request = std::unique_ptr<WorkRequest>;
+    using Request = std::unique_ptr<AsyncRequest>;
 
     Request parseRasterTile(std::unique_ptr<RasterBucket> bucket,
                             std::shared_ptr<const std::string> data,

--- a/test/include/mbgl/test/stub_file_source.hpp
+++ b/test/include/mbgl/test/stub_file_source.hpp
@@ -13,7 +13,7 @@ public:
     StubFileSource();
     ~StubFileSource() override;
 
-    std::unique_ptr<FileRequest> request(const Resource&, Callback) override;
+    std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
     using ResponseFunction = std::function<optional<Response> (const Resource&)>;
 
@@ -36,7 +36,7 @@ private:
     // The default behavior is to throw if no per-kind callback has been set.
     optional<Response> defaultResponse(const Resource&);
 
-    std::unordered_map<FileRequest*, std::tuple<Resource, ResponseFunction, Callback>> pending;
+    std::unordered_map<AsyncRequest*, std::tuple<Resource, ResponseFunction, Callback>> pending;
     util::Timer timer;
 };
 

--- a/test/src/stub_file_source.cpp
+++ b/test/src/stub_file_source.cpp
@@ -4,7 +4,7 @@ namespace mbgl {
 
 using namespace std::chrono_literals;
 
-class StubFileRequest : public FileRequest {
+class StubFileRequest : public AsyncRequest {
 public:
     StubFileRequest(StubFileSource& fileSource_)
         : fileSource(fileSource_) {
@@ -32,7 +32,7 @@ StubFileSource::StubFileSource() {
 
 StubFileSource::~StubFileSource() = default;
 
-std::unique_ptr<FileRequest> StubFileSource::request(const Resource& resource, Callback callback) {
+std::unique_ptr<AsyncRequest> StubFileSource::request(const Resource& resource, Callback callback) {
     auto req = std::make_unique<StubFileRequest>(*this);
     pending.emplace(req.get(), std::make_tuple(resource, response, callback));
     return std::move(req);

--- a/test/storage/asset_file_source.cpp
+++ b/test/storage/asset_file_source.cpp
@@ -44,7 +44,7 @@ private:
     unsigned numRequests = 1000;
 
     mbgl::AssetFileSource* fs;
-    std::unique_ptr<mbgl::FileRequest> request;
+    std::unique_ptr<mbgl::AsyncRequest> request;
 
     std::function<void(mbgl::Response)> requestCallback;
 };
@@ -74,7 +74,7 @@ TEST_F(Storage, AssetStress) {
     };
 
     std::vector<std::unique_ptr<util::Thread<TestWorker>>> threads;
-    std::vector<std::unique_ptr<mbgl::WorkRequest>> requests;
+    std::vector<std::unique_ptr<mbgl::AsyncRequest>> requests;
     util::ThreadContext context = { "Test", util::ThreadType::Map, util::ThreadPriority::Regular };
 
     for (unsigned i = 0; i < numThreads; ++i) {
@@ -101,7 +101,7 @@ TEST_F(Storage, AssetEmptyFile) {
 
     AssetFileSource fs(getFileSourceRoot());
 
-    std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "asset://empty" }, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://empty" }, [&](Response res) {
         req.reset();
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());
@@ -122,7 +122,7 @@ TEST_F(Storage, AssetNonEmptyFile) {
 
     AssetFileSource fs(getFileSourceRoot());
 
-    std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "asset://nonempty" }, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://nonempty" }, [&](Response res) {
         req.reset();
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());
@@ -143,7 +143,7 @@ TEST_F(Storage, AssetNonExistentFile) {
 
     AssetFileSource fs(getFileSourceRoot());
 
-    std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "asset://does_not_exist" }, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://does_not_exist" }, [&](Response res) {
         req.reset();
         ASSERT_NE(nullptr, res.error);
         EXPECT_EQ(Response::Error::Reason::NotFound, res.error->reason);
@@ -165,7 +165,7 @@ TEST_F(Storage, AssetReadDirectory) {
 
     AssetFileSource fs(getFileSourceRoot());
 
-    std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "asset://directory" }, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://directory" }, [&](Response res) {
         req.reset();
         ASSERT_NE(nullptr, res.error);
         EXPECT_EQ(Response::Error::Reason::NotFound, res.error->reason);
@@ -187,7 +187,7 @@ TEST_F(Storage, AssetURLEncoding) {
 
     AssetFileSource fs(getFileSourceRoot());
 
-    std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "asset://%6eonempty" }, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://%6eonempty" }, [&](Response res) {
         req.reset();
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());

--- a/test/storage/default_file_source.cpp
+++ b/test/storage/default_file_source.cpp
@@ -16,8 +16,8 @@ TEST_F(DefaultFileSourceTest, TEST_REQUIRES_SERVER(CacheResponse)) {
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/cache" };
     Response response;
 
-    std::unique_ptr<FileRequest> req1;
-    std::unique_ptr<FileRequest> req2;
+    std::unique_ptr<AsyncRequest> req1;
+    std::unique_ptr<AsyncRequest> req2;
 
     req1 = fs.request(resource, [&](Response res) {
         req1.reset();
@@ -57,8 +57,8 @@ TEST_F(DefaultFileSourceTest, TEST_REQUIRES_SERVER(CacheRevalidateSame)) {
     DefaultFileSource fs(":memory:", ".");
 
     const Resource revalidateSame { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
-    std::unique_ptr<FileRequest> req1;
-    std::unique_ptr<FileRequest> req2;
+    std::unique_ptr<AsyncRequest> req1;
+    std::unique_ptr<AsyncRequest> req2;
     uint16_t counter = 0;
 
     // First request causes the response to get cached.
@@ -107,8 +107,8 @@ TEST_F(DefaultFileSourceTest, TEST_REQUIRES_SERVER(CacheRevalidateModified)) {
 
     const Resource revalidateModified{ Resource::Unknown,
                                        "http://127.0.0.1:3000/revalidate-modified" };
-    std::unique_ptr<FileRequest> req1;
-    std::unique_ptr<FileRequest> req2;
+    std::unique_ptr<AsyncRequest> req1;
+    std::unique_ptr<AsyncRequest> req2;
     uint16_t counter = 0;
 
     // First request causes the response to get cached.
@@ -155,8 +155,8 @@ TEST_F(DefaultFileSourceTest, TEST_REQUIRES_SERVER(CacheRevalidateEtag)) {
     DefaultFileSource fs(":memory:", ".");
 
     const Resource revalidateEtag { Resource::Unknown, "http://127.0.0.1:3000/revalidate-etag" };
-    std::unique_ptr<FileRequest> req1;
-    std::unique_ptr<FileRequest> req2;
+    std::unique_ptr<AsyncRequest> req1;
+    std::unique_ptr<AsyncRequest> req2;
     uint16_t counter = 0;
 
     // First request causes the response to get cached.

--- a/test/storage/http_cancel.cpp
+++ b/test/storage/http_cancel.cpp
@@ -35,10 +35,10 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPCancelMultiple)) {
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 
-    std::unique_ptr<FileRequest> req2 = fs.request(resource, [&](Response) {
+    std::unique_ptr<AsyncRequest> req2 = fs.request(resource, [&](Response) {
         ADD_FAILURE() << "Callback should not be called";
     });
-    std::unique_ptr<FileRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
         req.reset();
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());

--- a/test/storage/http_error.cpp
+++ b/test/storage/http_error.cpp
@@ -17,7 +17,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPTemporaryError)) {
 
     const auto start = Clock::now();
 
-    std::unique_ptr<FileRequest> req1 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/temporary-error" }, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req1 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/temporary-error" }, [&](Response res) {
         static int counter = 0;
         switch (counter++) {
         case 0: {
@@ -61,7 +61,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPConnectionError)) {
 
     const auto start = Clock::now();
 
-    std::unique_ptr<FileRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3001/" }, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3001/" }, [&](Response res) {
         static int counter = 0;
         static int wait = 0;
         const auto duration = std::chrono::duration<const double>(Clock::now() - start).count();

--- a/test/storage/http_expires.cpp
+++ b/test/storage/http_expires.cpp
@@ -17,7 +17,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPRetryDelayOnExpiredTile)) {
     int counter = 0;
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test?expires=10000" };
-    std::unique_ptr<FileRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
         counter++;
         EXPECT_EQ(nullptr, res.error);
         EXPECT_GT(SystemClock::now(), res.expires);
@@ -46,7 +46,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPRetryOnClockSkew)) {
     int counter = 0;
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/clockskew" };
-    std::unique_ptr<FileRequest> req1 = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req1 = fs.request(resource, [&](Response res) {
         switch (counter++) {
         case 0: {
             EXPECT_EQ(nullptr, res.error);
@@ -81,14 +81,14 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPRespectPriorExpires)) {
     Resource resource1{ Resource::Unknown, "http://127.0.0.1:3000/test" };
     resource1.priorExpires = SystemClock::now() + Seconds(100000);
 
-    std::unique_ptr<FileRequest> req1 = fs.request(resource1, [&](Response) {
+    std::unique_ptr<AsyncRequest> req1 = fs.request(resource1, [&](Response) {
         FAIL() << "Should never be called";
     });
 
     // No expiration time, should be requested immediately.
     Resource resource2{ Resource::Unknown, "http://127.0.0.1:3000/test" };
 
-    std::unique_ptr<FileRequest> req2 = fs.request(resource2, [&](Response) {
+    std::unique_ptr<AsyncRequest> req2 = fs.request(resource2, [&](Response) {
         HTTPRespectPriorExpires.finish();
         loop.stop();
     });
@@ -97,7 +97,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPRespectPriorExpires)) {
     Resource resource3{ Resource::Unknown, "http://127.0.0.1:3000/test" };
     resource3.priorExpires = SystemClock::now() + Seconds(100000);
 
-    std::unique_ptr<FileRequest> req3 = fs.request(resource3, [&](Response) {
+    std::unique_ptr<AsyncRequest> req3 = fs.request(resource3, [&](Response) {
         FAIL() << "Should never be called";
     });
 

--- a/test/storage/http_header_parsing.cpp
+++ b/test/storage/http_header_parsing.cpp
@@ -14,7 +14,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPExpiresParsing)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req1 = fs.request({ Resource::Unknown,
+    std::unique_ptr<AsyncRequest> req1 = fs.request({ Resource::Unknown,
                  "http://127.0.0.1:3000/test?modified=1420794326&expires=1420797926&etag=foo" },
                [&](Response res) {
         req1.reset();
@@ -39,7 +39,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPCacheControlParsing)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" },
+    std::unique_ptr<AsyncRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=120" },
                [&](Response res) {
         req2.reset();
         EXPECT_EQ(nullptr, res.error);

--- a/test/storage/http_load.cpp
+++ b/test/storage/http_load.cpp
@@ -16,7 +16,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPLoad)) {
     const int max = 10000;
     int number = 1;
 
-    std::unique_ptr<FileRequest> reqs[concurrency];
+    std::unique_ptr<AsyncRequest> reqs[concurrency];
 
     std::function<void(int)> req = [&](int i) {
         const auto current = number++;

--- a/test/storage/http_other_loop.cpp
+++ b/test/storage/http_other_loop.cpp
@@ -13,7 +13,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPOtherLoop)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" },
+    std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" },
                [&](Response res) {
         req.reset();
         EXPECT_EQ(nullptr, res.error);

--- a/test/storage/http_reading.cpp
+++ b/test/storage/http_reading.cpp
@@ -16,7 +16,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPTest)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req1 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" },
+    std::unique_ptr<AsyncRequest> req1 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/test" },
                [&](Response res) {
         req1.reset();
         EXPECT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Main));
@@ -41,7 +41,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTP404)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/doesnotexist" },
+    std::unique_ptr<AsyncRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/doesnotexist" },
                [&](Response res) {
         req2.reset();
         EXPECT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Main));
@@ -67,7 +67,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPTile404)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req2 = fs.request({ Resource::Tile, "http://127.0.0.1:3000/doesnotexist" },
+    std::unique_ptr<AsyncRequest> req2 = fs.request({ Resource::Tile, "http://127.0.0.1:3000/doesnotexist" },
                [&](Response res) {
         req2.reset();
         EXPECT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Main));
@@ -92,7 +92,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTP200EmptyData)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/empty-data" },
+    std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/empty-data" },
                [&](Response res) {
         req.reset();
         EXPECT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Main));
@@ -117,7 +117,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTP204)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/no-content" },
+    std::unique_ptr<AsyncRequest> req2 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/no-content" },
                [&](Response res) {
         req2.reset();
         EXPECT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Main));
@@ -142,7 +142,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTP500)) {
     util::RunLoop loop;
     OnlineFileSource fs;
 
-    std::unique_ptr<FileRequest> req3 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/permanent-error" },
+    std::unique_ptr<AsyncRequest> req3 = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/permanent-error" },
                [&](Response res) {
         req3.reset();
         EXPECT_TRUE(util::ThreadContext::currentlyOn(util::ThreadType::Main));

--- a/test/storage/http_retry_network_status.cpp
+++ b/test/storage/http_retry_network_status.cpp
@@ -23,7 +23,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPNetworkStatusChange)) {
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/delayed" };
 
     // This request takes 200 milliseconds to answer.
-    std::unique_ptr<FileRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
          req.reset();
          EXPECT_EQ(nullptr, res.error);
          ASSERT_TRUE(res.data.get());
@@ -57,7 +57,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPNetworkStatusChangePreempt)) {
     const auto start = Clock::now();
 
     const Resource resource{ Resource::Unknown, "http://127.0.0.1:3001/test" };
-    std::unique_ptr<FileRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
         static int counter = 0;
         const auto duration = std::chrono::duration<const double>(Clock::now() - start).count();
         if (counter == 0) {
@@ -120,7 +120,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPNetworkStatusOnlineOffline)) {
         NetworkStatus::Set(NetworkStatus::Status::Online);
     });
 
-    std::unique_ptr<FileRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
         req.reset();
 
         EXPECT_EQ(nullptr, res.error);

--- a/test/storage/http_timeout.cpp
+++ b/test/storage/http_timeout.cpp
@@ -16,7 +16,7 @@ TEST_F(Storage, TEST_REQUIRES_SERVER(HTTPTimeout)) {
     int counter = 0;
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test?cachecontrol=max-age=1" };
-    std::unique_ptr<FileRequest> req = fs.request(resource, [&](Response res) {
+    std::unique_ptr<AsyncRequest> req = fs.request(resource, [&](Response res) {
         counter++;
         EXPECT_EQ(nullptr, res.error);
         ASSERT_TRUE(res.data.get());

--- a/test/util/async_task.cpp
+++ b/test/util/async_task.cpp
@@ -105,7 +105,7 @@ TEST(AsyncTask, ThreadSafety) {
     };
 
     std::vector<std::unique_ptr<Thread<TestWorker>>> threads;
-    std::vector<std::unique_ptr<mbgl::WorkRequest>> requests;
+    std::vector<std::unique_ptr<mbgl::AsyncRequest>> requests;
     ThreadContext context = {"Test", ThreadType::Map, ThreadPriority::Regular};
 
     for (unsigned i = 0; i < numThreads; ++i) {

--- a/test/util/thread.cpp
+++ b/test/util/thread.cpp
@@ -67,7 +67,7 @@ TEST(Thread, invoke) {
     const std::thread::id tid = std::this_thread::get_id();
 
     RunLoop loop;
-    std::vector<std::unique_ptr<mbgl::WorkRequest>> requests;
+    std::vector<std::unique_ptr<mbgl::AsyncRequest>> requests;
 
     loop.invoke([&] {
         EXPECT_EQ(tid, std::this_thread::get_id());
@@ -123,7 +123,7 @@ TEST(Thread, context) {
     const std::thread::id tid = std::this_thread::get_id();
 
     RunLoop loop;
-    std::vector<std::unique_ptr<mbgl::WorkRequest>> requests;
+    std::vector<std::unique_ptr<mbgl::AsyncRequest>> requests;
 
     loop.invoke([&] {
         Thread<TestObject> thread({"Test", ThreadType::Worker, ThreadPriority::Low}, tid);


### PR DESCRIPTION
* Replace `FileRequest` with a more generically named `AsyncRequest`.
* `WorkRequest` should inherit from `AsyncRequest` and be an implementation detail. `RunLoop::invoke{Cancellable,WithCallback}` should return `std::unique_ptr<AsyncRequest>`.

This will allow code that makes either or both kinds of async requests to treat them uniformly.