### PR TITLE
[ios Fix static lib issues for signed device builds and iTunes connect uploads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ ibench: export XCODEBUILD_ARGS += -sdk iphoneos ARCHS="arm64"
 ibench: ; $(RUN) HOST=ios Xcode/ios-bench
 
 .PHONY: ipackage ipackage-strip ipackage-sim itest
-ipackage: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) ./platform/ios/scripts/package.sh
-ipackage-strip: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO ./platform/ios/scripts/package.sh
-ipackage-sim: Xcode/ios ; @JOBS=$(JOBS) BUILDTYPE=Debug BITCODE=$(BITCODE) FORMAT=dynamic BUILD_DEVICE=false SYMBOLS=$(SYMBOLS) ./platform/ios/scripts/package.sh
+ipackage: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) BUNDLE_RESOURCES=YES PLACE_RESOURCE_BUNDLES_OUTSIDE_FRAMEWORK=YES ./platform/ios/scripts/package.sh
+ipackage-strip: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO BUNDLE_RESOURCES=YES PLACE_RESOURCE_BUNDLES_OUTSIDE_FRAMEWORK=YES ./platform/ios/scripts/package.sh
+ipackage-sim: Xcode/ios ; @JOBS=$(JOBS) BUILDTYPE=Debug BITCODE=$(BITCODE) FORMAT=dynamic BUILD_DEVICE=false SYMBOLS=$(SYMBOLS) BUNDLE_RESOURCES=YES PLACE_RESOURCE_BUNDLES_OUTSIDE_FRAMEWORK=YES ./platform/ios/scripts/package.sh
 iframework: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=dynamic BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) ./platform/ios/scripts/package.sh
 ifabric: Xcode/ios ; @JOBS=$(JOBS) BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO BUNDLE_RESOURCES=YES ./platform/ios/scripts/package.sh
 itest: ipackage-sim ; ./platform/ios/scripts/test.sh

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -20,6 +20,8 @@ Mapbox welcomes participation and contributions from everyone.  If you’d like 
 - The user dot no longer lags when panning the map. ([#3683](https://github.com/mapbox/mapbox-gl-native/pull/3683))
 - The Improve This Map tool now uses the same zoom level that is currently being shown in the map view. ([#4068](https://github.com/mapbox/mapbox-gl-native/pull/4068))
 - Fixed a formatting issue in the documentation for `MGLCoordinateBoundsIsEmpty()`. ([#3958](https://github.com/mapbox/mapbox-gl-native/pull/3958))
+- The maximum maximum zoom level is now 21. ([#4417](https://github.com/mapbox/mapbox-gl-native/pull/4417))
+- Fixed issues with configuration and documentation that caused problems when installing apps built with the static binary to devices. This change also fixed App Store submission problems when uploading an app built with the static binary. ([#4455](https://github.com/mapbox/mapbox-gl-native/pull/4455))
 
 ## 3.1.2
 

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -95,7 +95,15 @@ If your application targets iOS 7.x, you’ll need to install the static framewo
 
 1. Build from source manually per above.
 
-1. Open the project editor and select your application target. Drag `build/ios/pkg/static/Mapbox.framework` into the “Embedded Binaries” section of the General tab. (Don’t drag it into the “Linked Frameworks and Libraries” section; Xcode will add it there automatically.) In the sheet that appears, make sure “Copy items if needed” is checked, then click Finish.
+1. Drag the Mapbox.bundle and Mapbox.framework files in `build/ios/pkg/static` into the Project navigator, checking "Copy items if needed". It should happen automatically, but ensure that:
+   
+   - `Mapbox.framework` is listed in your `Link Binary With Libraries` build phase.
+   - Your *Framework Search Paths* (`FRAMEWORK_SEARCH_PATHS`) build setting includes the directory that contains `Mapbox.framework`. For most projects, the default value of `$(inherited) $(PROJECT_DIR)` should be sufficient.  
+   - `Mapbox.bundle` is in your target's *Copy Bundle Resources* build phase.
+
+1. **Optional** As [noted in the documentation](https://www.mapbox.com/ios-sdk/#telemetry_opt_out) you may use the provided Settings.bundle to provide a Telemetry opt out for users. To use the provided file, drag the `Settings.bundle` file in `build/ios/pkg` into the Project navigator, checking "Copy items if needed". It should happen automatically, but ensure that:
+
+   - `Settings.bundle` is in your target's *Copy Bundle Resources* build phase. 
 
 1. Add the following Cocoa Touch frameworks and libraries to the “Linked Frameworks and Libraries” section:
 

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -27,13 +27,28 @@ if [[ ${BUNDLE_RESOURCES} ]]; then
     BUNDLE_PATH="/${NAME}.bundle"
 fi
 
+PLACE_RESOURCE_BUNDLES_OUTSIDE_FRAMEWORK=${PLACE_RESOURCE_BUNDLES_OUTSIDE_FRAMEWORK:-}
+STATIC_BUNDLE_PATH=
+if [[ ${PLACE_RESOURCE_BUNDLES_OUTSIDE_FRAMEWORK} ]]; then
+    STATIC_BUNDLE_PATH="${OUTPUT}/static${BUNDLE_PATH}"
+else
+    STATIC_BUNDLE_PATH="${OUTPUT}/static/${NAME}.framework${BUNDLE_PATH}"
+fi
+
+STATIC_SETTINGS_DIRECTORY=
+if [[ ${PLACE_RESOURCE_BUNDLES_OUTSIDE_FRAMEWORK} ]]; then
+    STATIC_SETTINGS_DIRECTORY="${OUTPUT}"
+else
+    STATIC_SETTINGS_DIRECTORY="${OUTPUT}/static/${NAME}.framework"
+fi
+
 SDK=iphonesimulator
 if [[ ${BUILD_FOR_DEVICE} == true ]]; then
     SDK=iphoneos
 fi
 IOS_SDK_VERSION=`xcrun --sdk ${SDK} --show-sdk-version`
 
-echo "Configuring ${FORMAT:-dynamic and static} ${BUILDTYPE} framework for ${SDK}; symbols: ${GCC_GENERATE_DEBUGGING_SYMBOLS}; Bitcode: ${ENABLE_BITCODE}; Mapbox.bundle: ${BUNDLE_RESOURCES}"
+echo "Configuring ${FORMAT:-dynamic and static} ${BUILDTYPE} framework for ${SDK}; symbols: ${GCC_GENERATE_DEBUGGING_SYMBOLS}; Bitcode: ${ENABLE_BITCODE}; Mapbox.bundle: ${BUNDLE_RESOURCES} bundle.outside: ${PLACE_RESOURCE_BUNDLES_OUTSIDE_FRAMEWORK}"
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
@@ -206,18 +221,19 @@ step "Copying library resources…"
 SEM_VERSION=$( git describe --tags --match=ios-v*.*.* --abbrev=0 | sed 's/^ios-v//' )
 SHORT_VERSION=${SEM_VERSION%-*}
 if [[ ${BUNDLE_RESOURCES} ]]; then
-    cp -pv LICENSE.md "${OUTPUT}/static/${NAME}.framework"
-    cp -rv platform/ios/app/Settings.bundle "${OUTPUT}/static/${NAME}.framework"
+    cp -pv LICENSE.md ${STATIC_SETTINGS_DIRECTORY}
+    cp -rv platform/ios/app/Settings.bundle ${STATIC_SETTINGS_DIRECTORY}
 else
     cp -pv LICENSE.md "${OUTPUT}"
     cp -rv platform/ios/app/Settings.bundle "${OUTPUT}"
 fi
 if [[ ${BUILD_STATIC} == true ]]; then
-    mkdir -p "${OUTPUT}/static/${NAME}.framework${BUNDLE_PATH}"
-    cp -pv platform/{default,ios}/resources/* "${OUTPUT}/static/${NAME}.framework${BUNDLE_PATH}"
+    mkdir -p ${STATIC_BUNDLE_PATH}
+    cp -pv platform/{default,ios}/resources/* ${STATIC_BUNDLE_PATH}
     INFO_PLIST_PATH="${OUTPUT}/static/${NAME}.framework/Info.plist"
     cp -pv platform/ios/framework/Info.plist "${INFO_PLIST_PATH}"
-    plutil -replace CFBundleExecutable -string ${NAME} "${INFO_PLIST_PATH}"
+    plutil -remove CFBundleExecutable "${INFO_PLIST_PATH}"
+    plutil -remove CFBundlePackageType "${INFO_PLIST_PATH}"
     plutil -replace CFBundleIdentifier -string com.mapbox.sdk.ios "${INFO_PLIST_PATH}"
     plutil -replace CFBundleName -string ${NAME} "${INFO_PLIST_PATH}"
     plutil -replace CFBundleShortVersionString -string "${SHORT_VERSION}" "${INFO_PLIST_PATH}"
@@ -225,7 +241,7 @@ if [[ ${BUILD_STATIC} == true ]]; then
     plutil -replace MGLSemanticVersionString -string "${SEM_VERSION}" "${INFO_PLIST_PATH}"
     plutil -replace MGLCommitHash -string "${HASH}" "${INFO_PLIST_PATH}"
     if [[ ${BUNDLE_RESOURCES} ]]; then
-        cp -pv "${INFO_PLIST_PATH}" "${OUTPUT}/static/${NAME}.framework${BUNDLE_PATH}/Info.plist"
+        cp -pv "${INFO_PLIST_PATH}" "${STATIC_BUNDLE_PATH}/Info.plist"
     fi
     mkdir "${OUTPUT}/static/${NAME}.framework/Modules"
     cp -pv platform/ios/framework/modulemap "${OUTPUT}/static/${NAME}.framework/Modules/module.modulemap"


### PR DESCRIPTION
Add a flavor of static build that:

- Puts resources in a Mapbox.bundle file
- Puts Mapbox.bundle and Settings.bundle at the same level as Mapbox.framework in the /static output folder
- Removes CFBundleExecutable and CFBundlePackageType from the Info.plist in Mapbox.bundle that cause errors when uploading to iTunes Connect

This also updates the `binary` instructions in INSTALL.md to reflect these changes.

Fixes #4118

cc @1ec5 