### PR TITLE
TelemetryService: Catch IllegalArgumentException exception when unregisterReceiver

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/telemetry/TelemetryService.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/telemetry/TelemetryService.java
@@ -147,6 +147,11 @@ public class TelemetryService extends Service {
             Log.e(TAG, "Error while trying to sleep for 1 second: " + e);
         }
 
-        unregisterReceiver(telemetryLocationReceiver);
+        try {
+            unregisterReceiver(telemetryLocationReceiver);
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, "Error when unregisterReceiver: " + e);
+        }
+
     }
 }


### PR DESCRIPTION
If the receiver was already unregistered or was not registered, then call to unregisterReceiver throws IllegalArgumentException. In your case you need to just put special try/catch for this exception and ignore it.