### PR TITLE
[android] #4429 Removed NonNull from OnMapReady

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/OnMapReadyCallback.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/OnMapReadyCallback.java
@@ -1,12 +1,10 @@
 package com.mapbox.mapboxsdk.maps;
 
-import android.support.annotation.NonNull;
-
 /**
  * Interface definition for a callback to be invoked when the map is ready to be used.
  * <p>
  * Once an instance of this interface is set on a {@link MapFragment} or {@link MapView} object,
- * the onMapReady(MapboxMap) method is triggered when the map is ready to be used and provides a non-null instance of {@link MapboxMap}.
+ * the onMapReady(MapboxMap) method is triggered when the map is ready to be used and provides an instance of {@link MapboxMap}.
  * </p>
  */
 public interface OnMapReadyCallback {
@@ -14,8 +12,8 @@ public interface OnMapReadyCallback {
     /**
      * Called when the map is ready to be used.
      *
-     * @param mapboxMap A non-null instance of a MapboxMap associated with the {@link MapFragment}
-     *                  or {@link MapView} that defines the callback.
+     * @param mapboxMap An instance of MapboxMap associated with the {@link MapFragment} or
+     *                  {@link MapView} that defines the callback.
      */
-    void onMapReady(@NonNull MapboxMap mapboxMap);
+    void onMapReady(MapboxMap mapboxMap);
 }


### PR DESCRIPTION
As @tobrun and I discussed in issue #4429, I've removed the NonNull annotation from onMapReady as it isn't needed. 