### PR TITLE
[core] Update time point in map context on every update

### DIFF
--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -164,6 +164,11 @@ void MapContext::update() {
         return;
     }
 
+    // This time point is used to:
+    // - Calculate style property transitions;
+    // - Hint style sources to notify when all its tiles are loaded;
+    frameData.timePoint = Clock::now();
+
     if (style->loaded && updateFlags & Update::Annotations) {
         data.getAnnotationManager()->updateStyle(*style);
         updateFlags |= Update::Classes;
@@ -181,12 +186,8 @@ void MapContext::update() {
 
     if (data.mode == MapMode::Continuous) {
         asyncInvalidate.send();
-    } else {
-        // Update time point so style sources can check they are loaded.
-        frameData.timePoint = Clock::now();
-        if (callback && style->isLoaded()) {
-            renderSync(transformState, frameData);
-        }
+    } else if (callback && isLoaded()) {
+        renderSync(transformState, frameData);
     }
 
     updateFlags = Update::Nothing;

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -1,9 +1,10 @@
 #include <mbgl/renderer/frame_history.hpp>
+#include <mbgl/util/math.hpp>
 
 using namespace mbgl;
 
 // Record frame history that will be used to calculate fading params
-void FrameHistory::record(const TimePoint now, float zoom) {
+void FrameHistory::record(const TimePoint& now, float zoom) {
     // first frame ever
     if (history.empty()) {
         history.emplace_back(FrameSnapshot{TimePoint::min(), zoom});
@@ -47,7 +48,7 @@ bool FrameHistory::needsAnimation(const Duration& duration) const {
     return false;
 }
 
-FadeProperties FrameHistory::getFadeProperties(const TimePoint now, const Duration& duration) {
+FadeProperties FrameHistory::getFadeProperties(const TimePoint& now, const Duration& duration) {
     // Remove frames until only one is outside the duration, or until there are only three
     while (history.size() > 3 && history[1].now + duration < now) {
         history.pop_front();
@@ -61,8 +62,8 @@ FadeProperties FrameHistory::getFadeProperties(const TimePoint now, const Durati
     float startingZ = history.front().z;
     const FrameSnapshot lastFrame = history.back();
     float endingZ = lastFrame.z;
-    float lowZ = ::fmin(startingZ, endingZ);
-    float highZ = ::fmax(startingZ, endingZ);
+    float lowZ = util::min(startingZ, endingZ);
+    float highZ = util::max(startingZ, endingZ);
 
     // Calculate the speed of zooming, and how far it would zoom in terms of zoom levels in one
     // duration

--- a/src/mbgl/renderer/frame_history.hpp
+++ b/src/mbgl/renderer/frame_history.hpp
@@ -11,7 +11,6 @@
 namespace mbgl {
 
 struct FrameSnapshot {
-    explicit inline FrameSnapshot(TimePoint now_, float z_) : now(now_), z(z_) {}
     const TimePoint now;
     float z;
 };
@@ -26,12 +25,12 @@ struct FadeProperties {
 class FrameHistory {
 public:
     // Record frame history that will be used to calculate fading params
-    void record(TimePoint now, float zoom);
+    void record(const TimePoint&, float zoom);
 
-    bool needsAnimation(const Duration& duration) const;
-    FadeProperties getFadeProperties(TimePoint now, const Duration& duration);
+    bool needsAnimation(const Duration&) const;
+    FadeProperties getFadeProperties(const TimePoint&, const Duration&);
 
-public:
+private:
     std::deque<FrameSnapshot> history;
 };
 


### PR DESCRIPTION
Previous behavior prevented view from notifying when map was fully loaded, because the style sources relies on a future time point for checking if their tiles are updated. This was first caught only in still mode, but also happens in continuous mode for platforms that rely on `View::notifyMapChange` for updating the view.

Fixes #4439.

/cc @tobrun @jfirebaugh 