### PR TITLE
Stub out C nullability block type qualifiers for Xcode 6.4

### DIFF
--- a/platform/darwin/include/MGLTypes.h
+++ b/platform/darwin/include/MGLTypes.h
@@ -8,6 +8,8 @@
     #define nullable
     #define nonnull
     #define null_resettable
+    #define _Nullable
+    #define _Nonnull
 #endif
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
This change fixes the build in Xcode 6.4.

/ref https://github.com/mapbox/mapbox-gl-native/pull/4455#issuecomment-200992226
/cc @boundsj