### PR TITLE
Wrap coordinates converted from points

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2150,7 +2150,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 - (mbgl::LatLng)convertPoint:(CGPoint)point toLatLngFromView:(nullable UIView *)view
 {
     CGPoint convertedPoint = [self convertPoint:point fromView:view];
-    return _mbglMap->latLngForPixel(mbgl::ScreenCoordinate(convertedPoint.x, convertedPoint.y));
+    return _mbglMap->latLngForPixel(mbgl::ScreenCoordinate(convertedPoint.x, convertedPoint.y)).wrapped();
 }
 
 - (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(nullable UIView *)view

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -2160,7 +2160,7 @@ public:
         convertedPoint.x,
         // mbgl origin is at the top-left corner.
         NSHeight(self.bounds) - convertedPoint.y,
-    });
+    }).wrapped();
 }
 
 - (NSRect)convertCoordinateBounds:(MGLCoordinateBounds)bounds toRectToView:(nullable NSView *)view {


### PR DESCRIPTION
The release-ios-3.2.0-android-4.0.0 branch includes #4275 but not #4285, meaning that `-[MGLMapView convertPoint:toCoordinateFromView:]` and dependent methods return latitudes that aren’t wrapped to ±180°. This change restores the wrapping on an interim basis.

@jfirebaugh has made the point that this method shouldn’t wrap anyways, but we don’t want to bump the major version number so close to a release. Although the wrapping isn’t documented anywhere, it’s consistent with MapKit, and it’s very likely that developers have come to rely on this behavior (as has iosapp). We can revisit unwrapping in a future release.

If a developer needs an unwrapped coordinate, they can detect this edge case by comparing the return values of `-[MGLMapView convertPoint:toCoordinateFromView:]` for two different points on screen (and accounting for rotation and pitch of course). In fact, this is [what `-convertRect:toRectToView:` does](https://github.com/mapbox/mapbox-gl-native/blob/fc76689a5b379f3d340652a65422c36a01ab35bb/platform/ios/src/MGLMapView.mm#L2196-L2212) (although that may be dead code due to 63820d1b4f96b4e2370fd6567a8f77149117620e for #3401).

/ref #4444
/cc @brunoabinader @bleege @boundsj