### PR TITLE
Centralize offline pack management with KVO compliance and tests

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -49,9 +49,12 @@ custom_categories:
       - MGLOfflinePackMaximumMapboxTilesReachedNotification
       - MGLOfflinePackProgress
       - MGLOfflinePackProgressChangedNotification
+      - MGLOfflinePackProgressUserInfoKey
       - MGLOfflinePackRemovalCompletionHandler
       - MGLOfflinePackState
+      - MGLOfflinePackStateUserInfoKey
       - MGLTilePyramidOfflineRegion
+      - NSValue(MGLOfflinePackAdditions)
   - name: Geometry
     children:
       - MGLCoordinateBounds

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -43,9 +43,12 @@ custom_categories:
       - MGLOfflineStorage
       - MGLOfflinePack
       - MGLOfflinePackAdditionCompletionHandler
-      - MGLOfflinePackDelegate
-      - MGLOfflinePackListingCompletionHandler
+      - MGLOfflinePackErrorNotification
+      - MGLOfflinePackErrorUserInfoKey
+      - MGLOfflinePackMaximumCountUserInfoKey
+      - MGLOfflinePackMaximumMapboxTilesReachedNotification
       - MGLOfflinePackProgress
+      - MGLOfflinePackProgressChangedNotification
       - MGLOfflinePackRemovalCompletionHandler
       - MGLOfflinePackState
       - MGLTilePyramidOfflineRegion

--- a/platform/darwin/include/MGLOfflinePack.h
+++ b/platform/darwin/include/MGLOfflinePack.h
@@ -161,4 +161,25 @@ typedef struct MGLOfflinePackProgress {
 
 @end
 
+/**
+ Methods for round-tripping `MGLOfflinePackProgress` values.
+ */
+@interface NSValue (MGLOfflinePackAdditions)
+
+/**
+ Creates a new value object containing the given `MGLOfflinePackProgress`
+ structure.
+ 
+ @param progress The value for the new object.
+ @return A new value object that contains the offline pack progress information.
+ */
++ (NSValue *)valueWithMGLOfflinePackProgress:(MGLOfflinePackProgress)progress;
+
+/**
+ The `MGLOfflinePackProgress` structure representation of the value.
+ */
+@property (readonly) MGLOfflinePackProgress MGLOfflinePackProgressValue;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/include/MGLOfflinePack.h
+++ b/platform/darwin/include/MGLOfflinePack.h
@@ -83,6 +83,10 @@ typedef struct MGLOfflinePackProgress {
 /**
  An `MGLOfflinePack` represents a collection of resources necessary for viewing
  a region offline to a local database.
+ 
+ To create an instance of `MGLOfflinePack`, use the
+ `+[MGLOfflineStorage addPackForRegion:withContext:completionHandler:]` method.
+ A pack created using `-[MGLOfflinePack init]` is immediately invalid.
  */
 @interface MGLOfflinePack : NSObject
 
@@ -122,8 +126,6 @@ typedef struct MGLOfflinePackProgress {
  default notification center.
  */
 @property (nonatomic, readonly) MGLOfflinePackProgress progress;
-
-- (instancetype)init NS_UNAVAILABLE;
 
 /**
  Resumes downloading if the pack is inactive.

--- a/platform/darwin/include/MGLOfflinePack.h
+++ b/platform/darwin/include/MGLOfflinePack.h
@@ -148,16 +148,6 @@ typedef struct MGLOfflinePackProgress {
  */
 - (void)suspend;
 
-/**
- Request an asynchronous update to the pack’s `state` and `progress` properties.
- 
- The state and progress of an inactive or completed pack are computed lazily. If
- you need the state or progress of a pack inside an
- `MGLOfflinePackListingCompletionHandler`, set the `delegate` property then call
- this method.
- */
-- (void)requestProgress;
-
 @end
 
 /**

--- a/platform/darwin/include/MGLOfflinePack.h
+++ b/platform/darwin/include/MGLOfflinePack.h
@@ -4,8 +4,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol MGLOfflinePackDelegate;
-
 /**
  The state an offline pack is currently in.
  */
@@ -13,11 +11,9 @@ typedef NS_ENUM (NSInteger, MGLOfflinePackState) {
     /**
      It is unknown whether the pack is inactive, active, or complete.
      
-     This is the initial state of a pack that is obtained using the
-     `-[MGLOfflineStorage getPacksWithCompletionHandler:]` method. The state
-     becomes known by the time the pack’s delegate receives its first progress
-     update. For inactive packs, you must explicitly request a progress update
-     using the `-[MGLOfflinePack requestProgress]` method.
+     This is the initial state of a pack. The state becomes known by the time
+     the shared `MGLOfflineStorage` object sends its first
+     `MGLOfflinePackProgressChangedNotification`.
      
      An invalid pack always has a state of `MGLOfflinePackStateInvalid`, never
      `MGLOfflinePackStateUnknown`.
@@ -86,9 +82,7 @@ typedef struct MGLOfflinePackProgress {
 
 /**
  An `MGLOfflinePack` represents a collection of resources necessary for viewing
- a region offline to a local database. It provides an optional
- `MGLOfflinePackDelegate` object with progress updates as data or errors arrive
- from the server.
+ a region offline to a local database.
  */
 @interface MGLOfflinePack : NSObject
 
@@ -109,9 +103,11 @@ typedef struct MGLOfflinePackProgress {
  The pack’s current state.
  
  The state of an inactive or completed pack is computed lazily and is set to
- `MGLOfflinePackStateUnknown` by default. If you need the state of a pack
- inside an `MGLOfflinePackListingCompletionHandler`, set the `delegate` property
- then call the `-requestProgress` method.
+ `MGLOfflinePackStateUnknown` by default. To get notified when the state becomes
+ known, observe KVO change notifications on this pack’s `state` key path.
+ Alternatively, you can add an observer for
+ `MGLOfflinePackProgressChangedNotification`s about this pack that come from the
+ default notification center.
  */
 @property (nonatomic, readonly) MGLOfflinePackState state;
 
@@ -119,79 +115,47 @@ typedef struct MGLOfflinePackProgress {
  The pack’s current progress.
  
  The progress of an inactive or completed pack is computed lazily, and all its
- fields are set to 0 by default. If you need the progress of a pack inside an
- `MGLOfflinePackListingCompletionHandler`, set the `delegate` property then call
- the `-requestProgress` method.
+ fields are set to 0 by default. To get notified when the progress becomes
+ known, observe KVO change notifications on this pack’s `state` key path.
+ Alternatively, you can add an observer for
+ `MGLOfflinePackProgressChangedNotification`s about this pack that come from the
+ default notification center.
  */
 @property (nonatomic, readonly) MGLOfflinePackProgress progress;
-
-/**
- The pack’s delegate.
- 
- You can use the offline pack delegate to be notified of any changes in the
- pack’s progress and of any errors while downloading. For more information, see
- the `MGLOfflinePackDelegate` documentation.
- */
-@property (nonatomic, weak, nullable) id <MGLOfflinePackDelegate> delegate;
 
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
  Resumes downloading if the pack is inactive.
+ 
+ A pack resumes asynchronously. To get notified when this pack resumes, observe
+ KVO change notifications on this pack’s `state` key path. Alternatively, you
+ can add an observer for `MGLOfflinePackProgressChangedNotification`s about this
+ pack that come from the default notification center.
+ 
+ When a pack resumes after being suspended, it may begin by iterating over the
+ already downloaded resources. As a result, the `progress` structure’s
+ `countOfResourcesCompleted` field may revert to 0 before rapidly returning to
+ the level of progress at the time the pack was suspended.
+ 
+ To temporarily suspend downloading, call the `-suspend` method.
  */
 - (void)resume;
 
 /**
  Temporarily stops downloading if the pack is active.
  
+ A pack suspends asynchronously. To get notified when this pack resumes, observe
+ KVO change notifications on this pack’s `state` key path. Alternatively, you
+ can add an observer for `MGLOfflinePackProgressChangedNotification` about this
+ pack that come from the default notification center.
+ 
+ If the pack previously reached a higher level of progress before being
+ suspended, it may wait to suspend until it returns to that level.
+ 
  To resume downloading, call the `-resume` method.
  */
 - (void)suspend;
-
-@end
-
-/**
- The `MGLOfflinePackDelegate` protocol defines methods that a delegate of an
- `MGLOfflinePack` object can optionally implement to be notified of any changes
- in the pack’s download progress and of any errors while downloading.
- */
-@protocol MGLOfflinePackDelegate <NSObject>
-
-@optional
-
-/**
- Sent whenever the pack’s state or download progress changes. Every change to a
- field in the `progress` property corresponds to an invocation of this method.
- 
- @param pack The pack whose state of progress changed.
- @param progress The updated progress. To get the updated state, refer to the
-    `state` property.
- */
-- (void)offlinePack:(MGLOfflinePack *)pack progressDidChange:(MGLOfflinePackProgress)progress;
-
-/**
- Sent whenever the pack encounters an error while downloading.
- 
- Download errors may be recoverable. For example, this pack’s implementation may
- attempt to re-request failed resources based on an exponential backoff
- strategy or upon the restoration of network access.
- 
- @param pack The pack that encountered an error.
- @param error A download error. For a list of possible error codes, see
-    `MGLErrorCode`.
- */
-- (void)offlinePack:(MGLOfflinePack *)pack didReceiveError:(NSError *)error;
-
-/**
- Sent when the maximum number of Mapbox-hosted tiles has been downloaded and
- stored on the current device.
- 
- Once this limit is reached, no instance of `MGLOfflinePack` can download
- additional tiles from Mapbox APIs until already downloaded tiles are removed by
- calling the `-[MGLOfflineStorage removePack:withCompletionHandler:]` method.
- Contact your Mapbox sales representative to have the limit raised.
- */
-- (void)offlinePack:(MGLOfflinePack *)pack didReceiveMaximumAllowedMapboxTiles:(uint64_t)maximumCount;
 
 @end
 

--- a/platform/darwin/include/MGLOfflinePack.h
+++ b/platform/darwin/include/MGLOfflinePack.h
@@ -11,9 +11,11 @@ typedef NS_ENUM (NSInteger, MGLOfflinePackState) {
     /**
      It is unknown whether the pack is inactive, active, or complete.
      
-     This is the initial state of a pack. The state becomes known by the time
-     the shared `MGLOfflineStorage` object sends its first
-     `MGLOfflinePackProgressChangedNotification`.
+     This is the initial state of a pack. The state of a pack becomes known by
+     the time the shared `MGLOfflineStorage` object sends the first
+     `MGLOfflinePackProgressChangedNotification` about the pack. For inactive
+     packs, you must explicitly request a progress update using the
+     `-[MGLOfflinePack requestProgress]` method.
      
      An invalid pack always has a state of `MGLOfflinePackStateInvalid`, never
      `MGLOfflinePackStateUnknown`.
@@ -107,9 +109,10 @@ typedef struct MGLOfflinePackProgress {
  The pack’s current state.
  
  The state of an inactive or completed pack is computed lazily and is set to
- `MGLOfflinePackStateUnknown` by default. To get notified when the state becomes
- known, observe KVO change notifications on this pack’s `state` key path.
- Alternatively, you can add an observer for
+ `MGLOfflinePackStateUnknown` by default. To request the pack’s status, use the
+ `-requestProgress` method. To get notified when the state becomes known and
+ when it changes, observe KVO change notifications on this pack’s `state` key
+ path. Alternatively, you can add an observer for
  `MGLOfflinePackProgressChangedNotification`s about this pack that come from the
  default notification center.
  */
@@ -119,9 +122,10 @@ typedef struct MGLOfflinePackProgress {
  The pack’s current progress.
  
  The progress of an inactive or completed pack is computed lazily, and all its
- fields are set to 0 by default. To get notified when the progress becomes
- known, observe KVO change notifications on this pack’s `state` key path.
- Alternatively, you can add an observer for
+ fields are set to 0 by default. To request the pack’s progress, use the
+ `-requestProgress` method. To get notified when the progress becomes
+ known and when it changes, observe KVO change notifications on this pack’s
+ `state` key path. Alternatively, you can add an observer for
  `MGLOfflinePackProgressChangedNotification`s about this pack that come from the
  default notification center.
  */
@@ -158,6 +162,18 @@ typedef struct MGLOfflinePackProgress {
  To resume downloading, call the `-resume` method.
  */
 - (void)suspend;
+
+/**
+ Request an asynchronous update to the pack’s `state` and `progress` properties.
+ 
+ The state and progress of an inactive or completed pack are computed lazily. If
+ you need the state or progress of a pack whose `state` property is currently
+ set to `MGLOfflinePackStateUnknown`, observe KVO change notifications on this
+ pack’s `state` key path, then call this method. Alternatively, you can add an
+ observer for `MGLOfflinePackProgressChangedNotification` about this pack that
+ come from the default notification center.
+ */
+- (void)requestProgress;
 
 @end
 

--- a/platform/darwin/include/MGLOfflineStorage.h
+++ b/platform/darwin/include/MGLOfflineStorage.h
@@ -7,28 +7,86 @@ NS_ASSUME_NONNULL_BEGIN
 @class MGLOfflinePack;
 @protocol MGLOfflineRegion;
 
+/**
+ Posted by the shared `MGLOfflineStorage` object when an `MGLOfflinePack`
+ object’s progress changes. The progress may change due to a resource being
+ downloaded or because the pack discovers during the download that more
+ resources are required for offline viewing. This notification is posted
+ whenever any field in the `progress` property changes.
+ 
+ The `object` is the `MGLOfflinePack` object whose progress changed. For details
+ about the pack’s current progress, use the pack’s `progress` property.
+ 
+ If you only need to observe changes in a particular pack’s progress, you can
+ alternatively observe KVO change notifications to the pack’s `progress` key
+ path.
+ */
 extern NSString * const MGLOfflinePackProgressChangedNotification;
+
+/**
+ Posted by the shared `MGLOfflineStorage` object whenever an `MGLOfflinePack`
+ object encounters an error while downloading. The error may be recoverable and
+ may not warrant the user’s attention. For example, the pack’s implementation
+ may attempt to re-request failed resources based on an exponential backoff
+ strategy or upon the restoration of network access.
+ 
+ The `object` is the `MGLOfflinePack` object that encountered the error. The
+ `userInfo` dictionary contains the error object in the
+ `MGLOfflinePackErrorUserInfoKey` key.
+ */
 extern NSString * const MGLOfflinePackErrorNotification;
+
+/**
+ Posted by the shared `MGLOfflineStorage` object when the maximum number of
+ Mapbox-hosted tiles has been downloaded and stored on the current device.
+ 
+ The `object` is the `MGLOfflinePack` object that reached the tile limit in the
+ course of downloading. The `userInfo` dictionary contains the tile limit in the
+ `MGLOfflinePackMaximumCountUserInfoKey` key.
+ 
+ Once this limit is reached, no instance of `MGLOfflinePack` can download
+ additional tiles from Mapbox APIs until already downloaded tiles are removed by
+ calling the `-[MGLOfflineStorage removePack:withCompletionHandler:]` method.
+ Contact your Mapbox sales representative to have the limit raised.
+ */
 extern NSString * const MGLOfflinePackMaximumMapboxTilesReachedNotification;
 
+/**
+ The key for an `NSError` object that is encountered in the course of
+ downloading an offline pack. The error’s domain is `MGLErrorDomain`. See
+ `MGLErrorCode` for possible error codes.
+ */
 extern NSString * const MGLOfflinePackErrorUserInfoKey;
+
+/**
+ The key for an `NSNumber` object that indicates the maximum number of
+ Mapbox-hosted tiles that may be downloaded and stored on the current device.
+ Call `-unsignedLongLongValue` on the object to receive the `uint64_t`-typed
+ tile limit.
+ */
 extern NSString * const MGLOfflinePackMaximumCountUserInfoKey;
 
 /**
  A block to be called once an offline pack has been completely created and
  added.
  
+ An application typically calls the `-resume` method on the pack inside this
+ completion handler to begin the download.
+ 
  @param pack Contains a pointer to the newly added pack, or `nil` if there was
     an error creating or adding the pack.
  @param error Contains a pointer to an error object (if any) indicating why the
-    pack could not be created or added. For a list of possible error codes, see
-    `MGLErrorCode`.
+    pack could not be created or added.
  */
 typedef void (^MGLOfflinePackAdditionCompletionHandler)(MGLOfflinePack * _Nullable pack, NSError * _Nullable error);
 
 /**
  A block to be called once an offline pack has been completely invalidated and
  removed.
+ 
+ Avoid any references to the pack inside this completion handler: by the time
+ this completion handler is executed, the pack has become invalid, and any
+ messages passed to it will raise an exception.
  
  @param error Contains a pointer to an error object (if any) indicating why the
     pack could not be invalidated or removed.
@@ -38,7 +96,8 @@ typedef void (^MGLOfflinePackRemovalCompletionHandler)(NSError * _Nullable error
 /**
  MGLOfflineStorage implements a singleton (shared object) that manages offline
  packs. All of this class’s instance methods are asynchronous, reflecting the
- fact that offline resources are stored in a database.
+ fact that offline resources are stored in a database. The shared object
+ maintains a canonical collection of offline packs in its `packs` property.
  */
 @interface MGLOfflineStorage : NSObject
 
@@ -48,24 +107,35 @@ typedef void (^MGLOfflinePackRemovalCompletionHandler)(NSError * _Nullable error
 + (instancetype)sharedOfflineStorage;
 
 /**
- An array of all known offline packs.
+ An array of all known offline packs, in the order in which they were created.
  
  This property is set to `nil`, indicating that the receiver does not yet know
  the existing packs, for an undefined amount of time starting from the moment
  the shared offline storage object is initialized until the packs are fetched
  from the database. After that point, this property is always non-nil, but it
  may be empty to indicate that no packs are present.
+ 
+ To detect when the shared offline storage object has finished loading its
+ `packs` property, observe KVO change notifications on the `packs` key path.
+ The initial load results in an `NSKeyValueChangeSetting` change.
  */
-@property (nonatomic, copy, readonly, nullable) NS_ARRAY_OF(MGLOfflinePack *) *packs;
+@property (nonatomic, strong, readonly, nullable) NS_ARRAY_OF(MGLOfflinePack *) *packs;
 
 /**
  Creates and registers an offline pack that downloads the resources needed to
  use the given region offline.
  
- The resulting pack starts out with a state of `MGLOfflinePackStateInactive`. To
- begin downloading resources, call `-[MGLOfflinePack resume]`. To monitor
- download progress, set the pack’s `delegate` property to an object that
- conforms to the `MGLOfflinePackDelegate` protocol.
+ The resulting pack is added to the shared offline storage object’s `packs`
+ property, then the `completion` block is executed with that pack passed in.
+ 
+ The pack has an initial state of `MGLOfflinePackStateInactive`. To begin
+ downloading resources, call `-[MGLOfflinePack resume]` on the pack from within
+ the completion handler. To monitor download progress, add an observer for
+ `MGLOfflinePackProgressChangedNotification`s about that pack.
+ 
+ To detect when any call to this method results in a new pack, observe KVO
+ change notifications on the shared offline storage object’s `packs` key path.
+ Additions to that array result in an `NSKeyValueChangeInsertion` change.
  
  @param region A region to download.
  @param context Arbitrary data to store alongside the downloaded resources.
@@ -81,8 +151,12 @@ typedef void (^MGLOfflinePackRemovalCompletionHandler)(NSError * _Nullable error
  As soon as this method is called on a pack, the pack becomes invalid; any
  attempt to send it a message will result in an exception being thrown. If an
  error occurs and the pack cannot be removed, do not attempt to reuse the pack
- object. Instead, use the `-getPacksWithCompletionHandler:` method to obtain a
- valid pointer to the pack object.
+ object. Instead, if you need continued access to the pack, suspend all packs
+ and use the `-reloadPacks` method to obtain valid pointers to all the packs.
+ 
+ To detect when any call to this method results in a pack being removed, observe
+ KVO change notifications on the shared offline storage object’s `packs` key
+ path. Removals from that array result in an `NSKeyValueChangeRemoval` change.
  
  @param pack The offline pack to remove.
  @param completion The completion handler to call once the pack has been
@@ -91,13 +165,28 @@ typedef void (^MGLOfflinePackRemovalCompletionHandler)(NSError * _Nullable error
 - (void)removePack:(MGLOfflinePack *)pack withCompletionHandler:(nullable MGLOfflinePackRemovalCompletionHandler)completion;
 
 /**
+ Forcibly, asynchronously reloads the `packs` property. At some point after this
+ method is called, the pointer values of the `MGLOfflinePack` objects in the
+ `packs` property change, even if the underlying data for these packs has not
+ changed. If this method is called while a pack is actively downloading, the
+ behavior is undefined.
+ 
+ You typically do not need to call this method.
+ 
+ To detect when the shared offline storage object has finished reloading its
+ `packs` property, observe KVO change notifications on the `packs` key path.
+ A reload results in an `NSKeyValueChangeSetting` change.
+ */
+- (void)reloadPacks;
+
+/**
  Sets the maximum number of Mapbox-hosted tiles that may be downloaded and
  stored on the current device.
  
- Once this limit is reached,
- `-[MGLOfflinePackDelegate offlinePack:didReceiveMaximumAllowedMapboxTiles:]` is
- called on every delegate of `MGLOfflinePack` until already downloaded tiles are
- removed by calling the `-removePack:withCompletionHandler:` method.
+ Once this limit is reached, an
+ `MGLOfflinePackMaximumMapboxTilesReachedNotification` is posted for every
+ attempt to download additional tiles until already downloaded tiles are removed
+ by calling the `-removePack:withCompletionHandler:` method.
  
  @note The [Mapbox Terms of Service](https://www.mapbox.com/tos/) prohibits
     changing or bypassing this limit without permission from Mapbox. Contact

--- a/platform/darwin/include/MGLOfflineStorage.h
+++ b/platform/darwin/include/MGLOfflineStorage.h
@@ -7,6 +7,13 @@ NS_ASSUME_NONNULL_BEGIN
 @class MGLOfflinePack;
 @protocol MGLOfflineRegion;
 
+extern NSString * const MGLOfflinePackProgressChangedNotification;
+extern NSString * const MGLOfflinePackErrorNotification;
+extern NSString * const MGLOfflinePackMaximumMapboxTilesReachedNotification;
+
+extern NSString * const MGLOfflinePackErrorUserInfoKey;
+extern NSString * const MGLOfflinePackMaximumCountUserInfoKey;
+
 /**
  A block to be called once an offline pack has been completely created and
  added.
@@ -29,16 +36,6 @@ typedef void (^MGLOfflinePackAdditionCompletionHandler)(MGLOfflinePack * _Nullab
 typedef void (^MGLOfflinePackRemovalCompletionHandler)(NSError * _Nullable error);
 
 /**
- A block to be called with a complete list of offline packs.
- 
- @param pack Contains a pointer an array of packs, or `nil` if there was an
-    error obtaining the packs.
- @param error Contains a pointer to an error object (if any) indicating why the
-    list of packs could not be obtained.
- */
-typedef void (^MGLOfflinePackListingCompletionHandler)(NS_ARRAY_OF(MGLOfflinePack *) *packs, NSError * _Nullable error);
-
-/**
  MGLOfflineStorage implements a singleton (shared object) that manages offline
  packs. All of this class’s instance methods are asynchronous, reflecting the
  fact that offline resources are stored in a database.
@@ -50,7 +47,16 @@ typedef void (^MGLOfflinePackListingCompletionHandler)(NS_ARRAY_OF(MGLOfflinePac
  */
 + (instancetype)sharedOfflineStorage;
 
-- (instancetype)init NS_UNAVAILABLE;
+/**
+ An array of all known offline packs.
+ 
+ This property is set to `nil`, indicating that the receiver does not yet know
+ the existing packs, for an undefined amount of time starting from the moment
+ the shared offline storage object is initialized until the packs are fetched
+ from the database. After that point, this property is always non-nil, but it
+ may be empty to indicate that no packs are present.
+ */
+@property (nonatomic, copy, readonly, nullable) NS_ARRAY_OF(MGLOfflinePack *) *packs;
 
 /**
  Creates and registers an offline pack that downloads the resources needed to
@@ -83,14 +89,6 @@ typedef void (^MGLOfflinePackListingCompletionHandler)(NS_ARRAY_OF(MGLOfflinePac
     removed. This handler is executed asynchronously on the main queue.
  */
 - (void)removePack:(MGLOfflinePack *)pack withCompletionHandler:(nullable MGLOfflinePackRemovalCompletionHandler)completion;
-
-/**
- Asynchronously calls a completion callback with all existing offline packs.
- 
- @param completion The completion handler to call with the list of packs. This
-     handler is executed asynchronously on the main queue.
- */
-- (void)getPacksWithCompletionHandler:(MGLOfflinePackListingCompletionHandler)completion;
 
 /**
  Sets the maximum number of Mapbox-hosted tiles that may be downloaded and

--- a/platform/darwin/include/MGLOfflineStorage.h
+++ b/platform/darwin/include/MGLOfflineStorage.h
@@ -14,8 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
  resources are required for offline viewing. This notification is posted
  whenever any field in the `progress` property changes.
  
- The `object` is the `MGLOfflinePack` object whose progress changed. For details
- about the pack’s current progress, use the pack’s `progress` property.
+ The `object` is the `MGLOfflinePack` object whose progress changed. The
+ `userInfo` dictionary contains the pack’s current state in the
+ `MGLOfflinePackStateUserInfoKey` key and details about the pack’s current
+ progress in the `MGLOfflinePackProgressUserInfoKey` key. You may also consult
+ the pack’s `state` and `progress` properties, which provide the same values.
  
  If you only need to observe changes in a particular pack’s progress, you can
  alternatively observe KVO change notifications to the pack’s `progress` key
@@ -52,17 +55,37 @@ extern NSString * const MGLOfflinePackErrorNotification;
 extern NSString * const MGLOfflinePackMaximumMapboxTilesReachedNotification;
 
 /**
+ The key for an `NSNumber` object that indicates an offline pack’s current
+ state. This key is used in the `userInfo` dictionary of an
+ `MGLOfflinePackProgressChangedNotification` notification. Call `-integerValue`
+ on the object to receive the `MGLOfflinePackState`-typed state.
+ */
+extern NSString * const MGLOfflinePackStateUserInfoKey;
+
+/**
+ The key for an `NSValue` object that indicates an offline pack’s current
+ progress. This key is used in the `userInfo` dictionary of an
+ `MGLOfflinePackProgressChangedNotification` notification. Call
+ `-MGLOfflinePackProgressValue` on the object to receive the
+ `MGLOfflinePackProgress`-typed progress.
+ */
+extern NSString * const MGLOfflinePackProgressUserInfoKey;
+
+/**
  The key for an `NSError` object that is encountered in the course of
- downloading an offline pack. The error’s domain is `MGLErrorDomain`. See
- `MGLErrorCode` for possible error codes.
+ downloading an offline pack. This key is used in the `userInfo` dictionary of
+ an `MGLOfflinePackErrorNotification` notification. The error’s domain is
+ `MGLErrorDomain`. See `MGLErrorCode` for possible error codes.
  */
 extern NSString * const MGLOfflinePackErrorUserInfoKey;
 
 /**
  The key for an `NSNumber` object that indicates the maximum number of
  Mapbox-hosted tiles that may be downloaded and stored on the current device.
- Call `-unsignedLongLongValue` on the object to receive the `uint64_t`-typed
- tile limit.
+ This key is used in the `userInfo` dictionary of an
+ `MGLOfflinePackMaximumMapboxTilesReachedNotification` notification. Call
+ `-unsignedLongLongValue` on the object to receive the `uint64_t`-typed tile
+ limit.
  */
 extern NSString * const MGLOfflinePackMaximumCountUserInfoKey;
 

--- a/platform/darwin/include/MGLTilePyramidOfflineRegion.h
+++ b/platform/darwin/include/MGLTilePyramidOfflineRegion.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  An offline region defined by a style URL, geographic coordinate bounds, and
  range of zoom levels.
  */
-@interface MGLTilePyramidOfflineRegion : NSObject <MGLOfflineRegion>
+@interface MGLTilePyramidOfflineRegion : NSObject <MGLOfflineRegion, NSSecureCoding, NSCopying>
 
 /**
  URL of the style whose resources are required for offline viewing.

--- a/platform/darwin/include/MGLTilePyramidOfflineRegion.h
+++ b/platform/darwin/include/MGLTilePyramidOfflineRegion.h
@@ -17,9 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
  In addition to the JSON stylesheet, different styles may require different font
  glyphs, sprite sheets, and other resources.
  
- The URL may be a full HTTP or HTTPS URL, a Mapbox URL indicating the style’s
- map ID (`mapbox://styles/{user}/{style}`), or a path to a local file
- relative to the application’s resource path.
+ The URL may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s
+ map ID (`mapbox://styles/{user}/{style}`).
  */
 @property (nonatomic, readonly) NSURL *styleURL;
 
@@ -52,9 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
  This is the designated initializer for `MGLTilePyramidOfflineRegion`.
  
  @param styleURL URL of the map style for which to download resources. The URL
-    may be a full HTTP or HTTPS URL, a Mapbox URL indicating the style’s map ID
-    (`mapbox://styles/{user}/{style}`), or a path to a local file relative to
-    the application’s resource path. Specify `nil` for the default style.
+    may be a full HTTP or HTTPS URL or a Mapbox URL indicating the style’s map
+    ID (`mapbox://styles/{user}/{style}`). Specify `nil` for the default style.
+    Relative file URLs cannot be used as offline style URLs. To download the
+    online resources required by a local style, specify a URL to an online copy
+    of the style.
  @param bounds The coordinate bounds for the geographic region to be covered by
     the downloaded tiles.
  @param minimumZoomLevel The minimum zoom level to be covered by the downloaded

--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -48,11 +48,11 @@ private:
 @implementation MGLOfflinePack
 
 - (instancetype)init {
-    [NSException raise:@"Method unavailable"
-                format:
-     @"-[MGLOfflinePack init] is unavailable. "
-     @"Use +[MGLOfflineStorage addPackForRegion:withContext:completionHandler:] instead."];
-    return nil;
+    if (self = [super init]) {
+        _state = MGLOfflinePackStateInvalid;
+        NSLog(@"%s called; did you mean to call +[MGLOfflineStorage addPackForRegion:withContext:completionHandler:] instead?", __PRETTY_FUNCTION__);
+    }
+    return self;
 }
 
 - (instancetype)initWithMBGLRegion:(mbgl::OfflineRegion *)region {
@@ -123,7 +123,7 @@ private:
 }
 
 - (void)requestProgress {
-    MGLAssertOfflinePackIsValid();
+    NSAssert(_state != MGLOfflinePackStateInvalid, @"Cannot request progress from an invalid offline pack.");
     
     mbgl::DefaultFileSource *mbglFileSource = [[MGLOfflineStorage sharedOfflineStorage] mbglFileSource];
     

--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -40,7 +40,6 @@ private:
 
 @property (nonatomic, weak, nullable) id <MGLOfflinePackDelegate> delegate;
 @property (nonatomic, nullable, readwrite) mbgl::OfflineRegion *mbglOfflineRegion;
-@property (nonatomic, readwrite) MGLOfflinePackState state;
 @property (nonatomic, readwrite) MGLOfflinePackProgress progress;
 
 @end
@@ -123,7 +122,7 @@ private:
 }
 
 - (void)requestProgress {
-    NSAssert(_state != MGLOfflinePackStateInvalid, @"Cannot request progress from an invalid offline pack.");
+    MGLAssertOfflinePackIsValid();
     
     mbgl::DefaultFileSource *mbglFileSource = [[MGLOfflineStorage sharedOfflineStorage] mbglFileSource];
     

--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -204,3 +204,17 @@ void MBGLOfflineRegionObserver::mapboxTileCountLimitExceeded(uint64_t limit) {
         [pack.delegate offlinePack:pack didReceiveMaximumAllowedMapboxTiles:limit];
     });
 }
+
+@implementation NSValue (MGLOfflinePackAdditions)
+
++ (NSValue *)valueWithMGLOfflinePackProgress:(MGLOfflinePackProgress)progress {
+    return [NSValue value:&progress withObjCType:@encode(MGLOfflinePackProgress)];
+}
+
+- (MGLOfflinePackProgress)MGLOfflinePackProgressValue {
+    MGLOfflinePackProgress progress;
+    [self getValue:&progress];
+    return progress;
+}
+
+@end

--- a/platform/darwin/src/MGLOfflinePack_Private.h
+++ b/platform/darwin/src/MGLOfflinePack_Private.h
@@ -11,6 +11,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithMBGLRegion:(mbgl::OfflineRegion *)region;
 
 /**
+ Request an asynchronous update to the pack’s `state` and `progress` properties.
+ 
+ The state and progress of an inactive or completed pack are computed lazily. If
+ you need the state or progress of a pack inside an
+ `MGLOfflinePackListingCompletionHandler`, set the `delegate` property then call
+ this method.
+ */
+- (void)requestProgress;
+
+/**
  Invalidates the pack and ensures that no future progress update can ever
  revalidate it.
  */

--- a/platform/darwin/src/MGLOfflinePack_Private.h
+++ b/platform/darwin/src/MGLOfflinePack_Private.h
@@ -19,17 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable) mbgl::OfflineRegion *mbglOfflineRegion;
 
-- (instancetype)initWithMBGLRegion:(mbgl::OfflineRegion *)region;
+@property (nonatomic, readwrite) MGLOfflinePackState state;
 
-/**
- Request an asynchronous update to the pack’s `state` and `progress` properties.
- 
- The state and progress of an inactive or completed pack are computed lazily. If
- you need the state or progress of a pack inside an
- `MGLOfflinePackListingCompletionHandler`, set the `delegate` property then call
- this method.
- */
-- (void)requestProgress;
+- (instancetype)initWithMBGLRegion:(mbgl::OfflineRegion *)region;
 
 /**
  Invalidates the pack and ensures that no future progress update can ever

--- a/platform/darwin/src/MGLOfflinePack_Private.h
+++ b/platform/darwin/src/MGLOfflinePack_Private.h
@@ -4,7 +4,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol MGLOfflinePackDelegate;
+
 @interface MGLOfflinePack (Private)
+
+/**
+ The pack’s delegate.
+ 
+ You can use the offline pack delegate to be notified of any changes in the
+ pack’s progress and of any errors while downloading. For more information, see
+ the `MGLOfflinePackDelegate` documentation.
+ */
+@property (nonatomic, weak, nullable) id <MGLOfflinePackDelegate> delegate;
 
 @property (nonatomic, nullable) mbgl::OfflineRegion *mbglOfflineRegion;
 
@@ -25,6 +36,49 @@ NS_ASSUME_NONNULL_BEGIN
  revalidate it.
  */
 - (void)invalidate;
+
+@end
+
+/**
+ The `MGLOfflinePackDelegate` protocol defines methods that a delegate of an
+ `MGLOfflinePack` object can optionally implement to be notified of any changes
+ in the pack’s download progress and of any errors while downloading.
+ */
+@protocol MGLOfflinePackDelegate <NSObject>
+
+/**
+ Sent whenever the pack’s state or download progress changes. Every change to a
+ field in the `progress` property corresponds to an invocation of this method.
+ 
+ @param pack The pack whose state of progress changed.
+ @param progress The updated progress. To get the updated state, refer to the
+    `state` property.
+ */
+- (void)offlinePack:(MGLOfflinePack *)pack progressDidChange:(MGLOfflinePackProgress)progress;
+
+/**
+ Sent whenever the pack encounters an error while downloading.
+ 
+ Download errors may be recoverable. For example, this pack’s implementation may
+ attempt to re-request failed resources based on an exponential backoff
+ strategy or upon the restoration of network access.
+ 
+ @param pack The pack that encountered an error.
+ @param error A download error. For a list of possible error codes, see
+    `MGLErrorCode`.
+ */
+- (void)offlinePack:(MGLOfflinePack *)pack didReceiveError:(NSError *)error;
+
+/**
+ Sent when the maximum number of Mapbox-hosted tiles has been downloaded and
+ stored on the current device.
+ 
+ Once this limit is reached, no instance of `MGLOfflinePack` can download
+ additional tiles from Mapbox APIs until already downloaded tiles are removed by
+ calling the `-[MGLOfflineStorage removePack:withCompletionHandler:]` method.
+ Contact your Mapbox sales representative to have the limit raised.
+ */
+- (void)offlinePack:(MGLOfflinePack *)pack didReceiveMaximumAllowedMapboxTiles:(uint64_t)maximumCount;
 
 @end
 

--- a/platform/darwin/src/MGLOfflinePack_Private.h
+++ b/platform/darwin/src/MGLOfflinePack_Private.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Invalidates the pack and ensures that no future progress update can ever
- revalidate it.
+ revalidate it. This method must be called before the pack is deallocated.
  */
 - (void)invalidate;
 

--- a/platform/darwin/src/MGLOfflineRegion_Private.h
+++ b/platform/darwin/src/MGLOfflineRegion_Private.h
@@ -8,8 +8,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol MGLOfflineRegion_Private <MGLOfflineRegion>
 
+/**
+ Initializes and returns an offline region backed by the given C++ region
+ definition object.
+ 
+ @param definition A reference to an offline region definition backing the
+    offline region.
+ */
 - (instancetype)initWithOfflineRegionDefinition:(const mbgl::OfflineRegionDefinition &)definition;
 
+/**
+ Creates and returns a C++ offline region definition corresponding to the
+ receiver.
+ */
 - (const mbgl::OfflineRegionDefinition)offlineRegionDefinition;
 
 @end

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -178,6 +178,11 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
 - (void)_removePack:(MGLOfflinePack *)pack withCompletionHandler:(MGLOfflinePackRemovalCompletionHandler)completion {
     mbgl::OfflineRegion *mbglOfflineRegion = pack.mbglOfflineRegion;
     [pack invalidate];
+    if (!mbglOfflineRegion) {
+        completion(nil);
+        return;
+    }
+    
     self.mbglFileSource->deleteOfflineRegion(std::move(*mbglOfflineRegion), [&, completion](std::exception_ptr exception) {
         NSError *error;
         if (exception) {

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -48,8 +48,12 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
                                                                  appropriateForURL:nil
                                                                             create:YES
                                                                              error:nil];
-        cacheDirectoryURL = [cacheDirectoryURL URLByAppendingPathComponent:
-                             [NSBundle mainBundle].bundleIdentifier];
+        NSString *bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
+        if (!bundleIdentifier) {
+            // There’s no main bundle identifier when running in a unit test bundle.
+            bundleIdentifier = [NSBundle bundleForClass:[self class]].bundleIdentifier;
+        }
+        cacheDirectoryURL = [cacheDirectoryURL URLByAppendingPathComponent:bundleIdentifier];
         [[NSFileManager defaultManager] createDirectoryAtURL:cacheDirectoryURL
                                  withIntermediateDirectories:YES
                                                   attributes:nil
@@ -74,15 +78,10 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
         NSURL *legacyCacheDirectoryURL = [[NSFileManager defaultManager] URLForDirectory:NSCachesDirectory
                                                                                 inDomain:NSUserDomainMask
                                                                        appropriateForURL:nil
-                                                                                  create:YES
+                                                                                  create:NO
                                                                                    error:nil];
-        legacyCacheDirectoryURL = [legacyCacheDirectoryURL URLByAppendingPathComponent:
-                                   [NSBundle mainBundle].bundleIdentifier];
-        [[NSFileManager defaultManager] createDirectoryAtURL:legacyCacheDirectoryURL
-                                 withIntermediateDirectories:YES
-                                                  attributes:nil
-                                                       error:nil];
-        NSURL *legacyCacheURL = [legacyCacheDirectoryURL URLByAppendingPathComponent:MGLOfflineStorageLegacyFileName];
+        legacyCacheDirectoryURL = [legacyCacheDirectoryURL URLByAppendingPathComponent:bundleIdentifier];
+        NSURL *legacyCacheURL = [legacyCacheDirectoryURL URLByAppendingPathComponent:MGLOfflineStorageFileName3_2_0_beta_1];
         NSString *legacyCachePath = legacyCacheURL ? legacyCacheURL.path : @"";
 #endif
         if (![[NSFileManager defaultManager] fileExistsAtPath:cachePath]) {

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -15,6 +15,8 @@ NSString * const MGLOfflinePackProgressChangedNotification = @"MGLOfflinePackPro
 NSString * const MGLOfflinePackErrorNotification = @"MGLOfflinePackError";
 NSString * const MGLOfflinePackMaximumMapboxTilesReachedNotification = @"MGLOfflinePackMaximumMapboxTilesReached";
 
+NSString * const MGLOfflinePackStateUserInfoKey = @"State";
+NSString * const MGLOfflinePackProgressUserInfoKey = @"Progress";
 NSString * const MGLOfflinePackErrorUserInfoKey = @"Error";
 NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
 
@@ -242,7 +244,10 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
 #pragma mark MGLOfflinePackDelegate methods
 
 - (void)offlinePack:(MGLOfflinePack *)pack progressDidChange:(__unused MGLOfflinePackProgress)progress {
-    [[NSNotificationCenter defaultCenter] postNotificationName:MGLOfflinePackProgressChangedNotification object:pack];
+    [[NSNotificationCenter defaultCenter] postNotificationName:MGLOfflinePackProgressChangedNotification object:pack userInfo:@{
+        MGLOfflinePackStateUserInfoKey: @(pack.state),
+        MGLOfflinePackProgressUserInfoKey: [NSValue valueWithMGLOfflinePackProgress:progress],
+    }];
 }
 
 - (void)offlinePack:(MGLOfflinePack *)pack didReceiveError:(NSError *)error {

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -130,10 +130,10 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
 - (void)addPackForRegion:(id <MGLOfflineRegion>)region withContext:(NSData *)context completionHandler:(MGLOfflinePackAdditionCompletionHandler)completion {
     __weak MGLOfflineStorage *weakSelf = self;
     [self _addPackForRegion:region withContext:context completionHandler:^(MGLOfflinePack * _Nullable pack, NSError * _Nullable error) {
+        pack.state = MGLOfflinePackStateInactive;
         MGLOfflineStorage *strongSelf = weakSelf;
         [[strongSelf mutableArrayValueForKey:@"packs"] addObject:pack];
         pack.delegate = strongSelf;
-        [pack requestProgress];
         if (completion) {
             completion(pack, error);
         }
@@ -208,7 +208,6 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
         
         for (MGLOfflinePack *pack in packs) {
             pack.delegate = self;
-            [pack requestProgress];
         }
     }];
 }

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -195,6 +195,9 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
 
 - (void)reloadPacks {
     [self getPacksWithCompletionHandler:^(NS_ARRAY_OF(MGLOfflinePack *) *packs, __unused NSError * _Nullable error) {
+        for (MGLOfflinePack *pack in self.packs) {
+            [pack invalidate];
+        }
         self.packs = [packs mutableCopy];
         
         for (MGLOfflinePack *pack in packs) {

--- a/platform/darwin/src/MGLOfflineStorage_Private.h
+++ b/platform/darwin/src/MGLOfflineStorage_Private.h
@@ -8,6 +8,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MGLOfflineStorage (Private)
 
+/**
+ The shared file source object owned by the shared offline storage object.
+ */
 @property (nonatomic) mbgl::DefaultFileSource *mbglFileSource;
 
 @end

--- a/platform/ios/app/MBXOfflinePacksTableViewController.m
+++ b/platform/ios/app/MBXOfflinePacksTableViewController.m
@@ -70,6 +70,13 @@ static NSString * const MBXOfflinePacksTableViewActiveCellReuseIdentifier = @"Ac
                 
             default:
                 [self.tableView reloadData];
+                
+                for (MGLOfflinePack *pack in [MGLOfflineStorage sharedOfflineStorage].packs) {
+                    if (pack.state == MGLOfflinePackStateUnknown) {
+                        [pack requestProgress];
+                    }
+                }
+                
                 break;
         }
     } else {

--- a/platform/osx/app/AppDelegate.h
+++ b/platform/osx/app/AppDelegate.h
@@ -15,8 +15,8 @@ extern NSString * const MGLMapboxAccessTokenDefaultsKey;
 
 @property (assign) double pendingZoomLevel;
 @property (copy) MGLMapCamera *pendingCamera;
+@property (assign) MGLCoordinateBounds pendingVisibleCoordinateBounds;
 @property (copy) NSURL *pendingStyleURL;
 @property (assign) MGLMapDebugMaskOptions pendingDebugMask;
 
 @end
-

--- a/platform/osx/app/AppDelegate.m
+++ b/platform/osx/app/AppDelegate.m
@@ -58,6 +58,7 @@ NSString * const MGLLastMapDebugMaskDefaultsKey = @"MGLLastMapDebugMask";
 @interface AppDelegate ()
 
 @property (weak) IBOutlet NSArrayController *offlinePacksArrayController;
+@property (weak) IBOutlet NSPanel *offlinePacksPanel;
 
 @end
 
@@ -177,6 +178,14 @@ NSString * const MGLLastMapDebugMaskDefaultsKey = @"MGLLastMapDebugMask";
 
 #pragma mark Offline pack management
 
+- (IBAction)showOfflinePacksPanel:(id)sender {
+    [self.offlinePacksPanel makeKeyAndOrderFront:sender];
+    
+    for (MGLOfflinePack *pack in self.offlinePacksArrayController.arrangedObjects) {
+        [pack requestProgress];
+    }
+}
+
 - (IBAction)delete:(id)sender {
     for (MGLOfflinePack *pack in self.offlinePacksArrayController.selectedObjects) {
         [[MGLOfflineStorage sharedOfflineStorage] removePack:pack withCompletionHandler:^(NSError * _Nullable error) {
@@ -245,6 +254,9 @@ NSString * const MGLLastMapDebugMaskDefaultsKey = @"MGLLastMapDebugMask";
         return YES;
     }
     if (menuItem.action == @selector(showPreferences:)) {
+        return YES;
+    }
+    if (menuItem.action == @selector(showOfflinePacksPanel:)) {
         return YES;
     }
     if (menuItem.action == @selector(delete:)) {

--- a/platform/osx/app/MainMenu.xib
+++ b/platform/osx/app/MainMenu.xib
@@ -18,6 +18,7 @@
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
                 <outlet property="offlinePacksArrayController" destination="dWe-R6-sRz" id="Ar5-xu-ABm"/>
+                <outlet property="offlinePacksPanel" destination="Jjv-gs-Tx6" id="0vK-rR-3ZX"/>
                 <outlet property="preferencesWindow" destination="UWc-yQ-qda" id="Ota-aT-Mz2"/>
             </connections>
         </customObject>
@@ -527,7 +528,7 @@
                             <menuItem title="Offline Packs" id="YW3-jR-knj">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="makeKeyAndOrderFront:" target="Jjv-gs-Tx6" id="cJK-pv-fl5"/>
+                                    <action selector="showOfflinePacksPanel:" target="Voe-Tx-rLC" id="kj9-ht-KmF"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>

--- a/platform/osx/app/MainMenu.xib
+++ b/platform/osx/app/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10109" systemVersion="15E39d" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10109"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -17,6 +17,7 @@
         </customObject>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
+                <outlet property="offlinePacksArrayController" destination="dWe-R6-sRz" id="Ar5-xu-ABm"/>
                 <outlet property="preferencesWindow" destination="UWc-yQ-qda" id="Ota-aT-Mz2"/>
             </connections>
         </customObject>
@@ -111,6 +112,12 @@
                             <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
                                 <connections>
                                     <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Save Offline Pack…" id="UXB-sj-C7i">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="addOfflinePack:" target="-1" id="Usu-xO-QEx"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Revert to Saved" id="KaW-ft-85H">
@@ -516,6 +523,13 @@
                                     <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="Uix-g7-fAt"/>
+                            <menuItem title="Offline Packs" id="YW3-jR-knj">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="makeKeyAndOrderFront:" target="Jjv-gs-Tx6" id="cJK-pv-fl5"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
                             <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
                                 <modifierMask key="keyEquivalentModifierMask"/>
@@ -551,7 +565,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="109" y="131" width="350" height="62"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <view key="contentView" id="eA4-n3-qPe">
                 <rect key="frame" x="0.0" y="0.0" width="350" height="62"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -609,8 +623,190 @@
             <point key="canvasLocation" x="754" y="210"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="45S-yT-WUN"/>
+        <window title="Offline Packs" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="MBXOfflinePacksPanel" animationBehavior="default" id="Jjv-gs-Tx6" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="830" y="430" width="400" height="300"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+            <view key="contentView" id="8ha-hw-zOD">
+                <rect key="frame" x="0.0" y="0.0" width="400" height="300"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q8b-0e-dLv">
+                        <rect key="frame" x="-1" y="20" width="402" height="281"/>
+                        <clipView key="contentView" id="J9U-Yx-o2S">
+                            <rect key="frame" x="1" y="0.0" width="400" height="280"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" headerView="MAZ-Iq-hBi" id="Ato-Vu-HYT">
+                                    <rect key="frame" x="0.0" y="0.0" width="400" height="257"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <size key="intercellSpacing" width="3" height="2"/>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                    <tableColumns>
+                                        <tableColumn identifier="" editable="NO" width="16" minWidth="10" maxWidth="3.4028234663852886e+38" id="xtw-hQ-8C5" userLabel="State">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                            </tableHeaderCell>
+                                            <imageCell key="dataCell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="edU-Yw-20f"/>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <connections>
+                                                <binding destination="dWe-R6-sRz" name="value" keyPath="arrangedObjects.stateImage" id="2wd-1J-TZt"/>
+                                            </connections>
+                                        </tableColumn>
+                                        <tableColumn editable="NO" width="116" minWidth="40" maxWidth="1000" id="2hD-LN-h0L">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Name">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="oys-QZ-34I">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <connections>
+                                                <binding destination="dWe-R6-sRz" name="value" keyPath="arrangedObjects.context" id="NtD-s5-ZUq">
+                                                    <dictionary key="options">
+                                                        <string key="NSValueTransformerName">OfflinePackNameValueTransformer</string>
+                                                    </dictionary>
+                                                </binding>
+                                            </connections>
+                                        </tableColumn>
+                                        <tableColumn editable="NO" width="50" minWidth="40" maxWidth="1000" id="pkI-c7-xoD">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Downloaded">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="WfC-qb-HsW">
+                                                <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="sNm-Qn-ne6"/>
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <connections>
+                                                <binding destination="dWe-R6-sRz" name="value" keyPath="arrangedObjects.countOfResourcesCompleted" id="mu6-Jg-GiU"/>
+                                            </connections>
+                                        </tableColumn>
+                                        <tableColumn identifier="" editable="NO" width="50" minWidth="10" maxWidth="3.4028234663852886e+38" id="Rrd-A9-jqc">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Total">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="mHy-qJ-rOA">
+                                                <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="kyx-ZP-OBH"/>
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <connections>
+                                                <binding destination="dWe-R6-sRz" name="value" keyPath="arrangedObjects.countOfResourcesExpected" id="mh2-k0-vvB"/>
+                                            </connections>
+                                        </tableColumn>
+                                        <tableColumn identifier="" editable="NO" width="60" minWidth="10" maxWidth="3.4028234663852886e+38" id="h7m-6l-KaS">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Size">
+                                                <font key="font" metaFont="smallSystem"/>
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="701-bg-k6L">
+                                                <byteCountFormatter key="formatter" allowsNonnumericFormatting="NO" id="IXV-J9-sP3"/>
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <connections>
+                                                <binding destination="dWe-R6-sRz" name="value" keyPath="arrangedObjects.countOfBytesCompleted" id="Zsa-Na-yFN"/>
+                                            </connections>
+                                        </tableColumn>
+                                    </tableColumns>
+                                    <connections>
+                                        <action trigger="doubleAction" selector="chooseOfflinePack:" target="-1" id="pUN-eT-zRT"/>
+                                    </connections>
+                                </tableView>
+                            </subviews>
+                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </clipView>
+                        <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="QLr-6P-Ogs">
+                            <rect key="frame" x="1" y="7" width="0.0" height="16"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="q0K-eE-mzL">
+                            <rect key="frame" x="224" y="17" width="15" height="102"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <tableHeaderView key="headerView" id="MAZ-Iq-hBi">
+                            <rect key="frame" x="0.0" y="0.0" width="400" height="23"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </tableHeaderView>
+                    </scrollView>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wzf-ce-Spm">
+                        <rect key="frame" x="0.0" y="-1" width="21" height="21"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="21" id="5ST-tY-8Ph"/>
+                        </constraints>
+                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="sew-F7-i5T">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="addOfflinePack:" target="-1" id="SN0-PM-HoU"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7L7-hr-zId">
+                        <rect key="frame" x="20" y="0.0" width="21" height="19"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="21" id="JYb-AF-8gZ"/>
+                        </constraints>
+                        <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="oTF-3m-6qT">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+CA
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="delete:" target="-1" id="EGL-bf-yUD"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="7L7-hr-zId" firstAttribute="centerY" secondItem="wzf-ce-Spm" secondAttribute="centerY" id="7TI-6w-bf1"/>
+                    <constraint firstAttribute="bottom" secondItem="Q8b-0e-dLv" secondAttribute="bottom" constant="20" symbolic="YES" id="DZa-ly-bhV"/>
+                    <constraint firstItem="wzf-ce-Spm" firstAttribute="top" secondItem="Q8b-0e-dLv" secondAttribute="bottom" id="LhK-5z-CQA"/>
+                    <constraint firstItem="Q8b-0e-dLv" firstAttribute="leading" secondItem="8ha-hw-zOD" secondAttribute="leading" constant="-1" id="Oyo-ch-rZo"/>
+                    <constraint firstAttribute="bottom" secondItem="7L7-hr-zId" secondAttribute="bottom" id="TtY-j1-T5h"/>
+                    <constraint firstItem="Q8b-0e-dLv" firstAttribute="top" secondItem="8ha-hw-zOD" secondAttribute="top" constant="-1" id="WDk-Ig-Grr"/>
+                    <constraint firstAttribute="trailing" secondItem="Q8b-0e-dLv" secondAttribute="trailing" constant="-1" id="hHf-rd-Wcv"/>
+                    <constraint firstItem="7L7-hr-zId" firstAttribute="leading" secondItem="8ha-hw-zOD" secondAttribute="leading" constant="20" symbolic="YES" id="iKJ-ph-ACS"/>
+                    <constraint firstAttribute="bottom" secondItem="wzf-ce-Spm" secondAttribute="bottom" constant="-1" id="jFV-Xi-fWr"/>
+                    <constraint firstItem="wzf-ce-Spm" firstAttribute="leading" secondItem="8ha-hw-zOD" secondAttribute="leading" id="kJt-oJ-72R"/>
+                </constraints>
+            </view>
+            <point key="canvasLocation" x="720" y="317"/>
+        </window>
+        <arrayController objectClassName="MGLOfflinePack" editable="NO" avoidsEmptySelection="NO" id="dWe-R6-sRz" userLabel="Offline Packs Array Controller">
+            <declaredKeys>
+                <string>context</string>
+                <string>countOfResourcesCompleted</string>
+                <string>countOfResourcesExpected</string>
+                <string>countOfBytesCompleted</string>
+                <string>stateImage</string>
+            </declaredKeys>
+        </arrayController>
     </objects>
     <resources>
+        <image name="NSAddTemplate" width="11" height="11"/>
         <image name="NSFollowLinkFreestandingTemplate" width="14" height="14"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/platform/osx/app/OfflinePackNameValueTransformer.h
+++ b/platform/osx/app/OfflinePackNameValueTransformer.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface OfflinePackNameValueTransformer : NSValueTransformer
+
+@end

--- a/platform/osx/app/OfflinePackNameValueTransformer.m
+++ b/platform/osx/app/OfflinePackNameValueTransformer.m
@@ -1,0 +1,33 @@
+#import "OfflinePackNameValueTransformer.h"
+
+static NSString * const MBXOfflinePackContextNameKey = @"Name";
+
+@implementation OfflinePackNameValueTransformer
+
++ (Class)transformedValueClass {
+    return [NSString class];
+}
+
++ (BOOL)allowsReverseTransformation {
+    return YES;
+}
+
+- (NSString *)transformedValue:(NSData *)context {
+    NSAssert([context isKindOfClass:[NSData class]], @"Context should be NSData.");
+    
+    NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:context];
+    NSAssert([userInfo isKindOfClass:[NSDictionary class]], @"Context of offline pack isn’t a dictionary.");
+    NSString *name = userInfo[MBXOfflinePackContextNameKey];
+    NSAssert([name isKindOfClass:[NSString class]], @"Name of offline pack isn’t a string.");
+    return name;
+}
+
+- (NSData *)reverseTransformedValue:(NSString *)name {
+    NSAssert([name isKindOfClass:[NSString class]], @"Name should be a string.");
+    
+    return [NSKeyedArchiver archivedDataWithRootObject:@{
+        MBXOfflinePackContextNameKey: name,
+    }];
+}
+
+@end

--- a/platform/osx/app/mapboxgl-app.gypi
+++ b/platform/osx/app/mapboxgl-app.gypi
@@ -29,6 +29,8 @@
         './LocationCoordinate2DTransformer.m',
         './MapDocument.h',
         './MapDocument.m',
+        './OfflinePackNameValueTransformer.h',
+        './OfflinePackNameValueTransformer.m',
         './TimeIntervalTransformer.h',
         './TimeIntervalTransformer.m',
         './NSValue+Additions.h',

--- a/platform/osx/test/MGLOfflinePackTests.m
+++ b/platform/osx/test/MGLOfflinePackTests.m
@@ -1,0 +1,25 @@
+#import <Mapbox/Mapbox.h>
+
+#pragma clang diagnostic ignored "-Wgnu-statement-expression"
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
+#import <XCTest/XCTest.h>
+
+@interface MGLOfflinePackTests : XCTestCase
+
+@end
+
+@implementation MGLOfflinePackTests
+
+- (void)testInvalidation {
+    MGLOfflinePack *invalidPack = [[MGLOfflinePack alloc] init];
+    
+    XCTAssertEqual(invalidPack.state, MGLOfflinePackStateInvalid, @"Offline pack should be invalid when initialized independently of MGLOfflineStorage.");
+    
+    XCTAssertThrowsSpecificNamed(invalidPack.region, NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when accessing its region.");
+    XCTAssertThrowsSpecificNamed(invalidPack.context, NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when accessing its context.");
+    XCTAssertThrowsSpecificNamed([invalidPack resume], NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when being resumed.");
+    XCTAssertThrowsSpecificNamed([invalidPack suspend], NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when being suspended.");
+}
+
+@end

--- a/platform/osx/test/MGLOfflinePackTests.m
+++ b/platform/osx/test/MGLOfflinePackTests.m
@@ -22,4 +22,19 @@
     XCTAssertThrowsSpecificNamed([invalidPack suspend], NSException, @"Invalid offline pack", @"Invalid offline pack should raise an exception when being suspended.");
 }
 
+- (void)testProgressBoxing {
+    MGLOfflinePackProgress progress = {
+        .countOfResourcesCompleted = 1,
+        .countOfResourcesExpected = 2,
+        .countOfBytesCompleted = 7,
+        .maximumResourcesExpected = UINT64_MAX,
+    };
+    MGLOfflinePackProgress roundTrippedProgress = [NSValue valueWithMGLOfflinePackProgress:progress].MGLOfflinePackProgressValue;
+    
+    XCTAssertEqual(progress.countOfResourcesCompleted, roundTrippedProgress.countOfResourcesCompleted, @"Completed resources should round-trip.");
+    XCTAssertEqual(progress.countOfResourcesExpected, roundTrippedProgress.countOfResourcesExpected, @"Expected resources should round-trip.");
+    XCTAssertEqual(progress.countOfBytesCompleted, roundTrippedProgress.countOfBytesCompleted, @"Completed bytes should round-trip.");
+    XCTAssertEqual(progress.maximumResourcesExpected, roundTrippedProgress.maximumResourcesExpected, @"Maximum expected resources should round-trip.");
+}
+
 @end

--- a/platform/osx/test/MGLOfflineRegionTests.m
+++ b/platform/osx/test/MGLOfflineRegionTests.m
@@ -1,0 +1,35 @@
+#import <Mapbox/Mapbox.h>
+
+#pragma clang diagnostic ignored "-Wgnu-statement-expression"
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
+#import <XCTest/XCTest.h>
+
+@interface MGLOfflineRegionTests : XCTestCase
+
+@end
+
+@implementation MGLOfflineRegionTests
+
+- (void)testStyleURLs {
+    MGLCoordinateBounds bounds = MGLCoordinateBoundsMake(kCLLocationCoordinate2DInvalid, kCLLocationCoordinate2DInvalid);
+    MGLTilePyramidOfflineRegion *region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:nil bounds:bounds fromZoomLevel:0 toZoomLevel:DBL_MAX];
+    XCTAssertEqualObjects(region.styleURL, [MGLStyle streetsStyleURL], @"Streets isn’t the default style.");
+    
+    NSURL *localURL = [NSURL URLWithString:@"beautiful.style"];
+    XCTAssertThrowsSpecificNamed([[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:localURL bounds:bounds fromZoomLevel:0 toZoomLevel:DBL_MAX], NSException, @"Invalid style URL", @"No exception raised when initializing region with a local file URL as the style URL.");
+}
+
+- (void)testEquality {
+    MGLCoordinateBounds bounds = MGLCoordinateBoundsMake(kCLLocationCoordinate2DInvalid, kCLLocationCoordinate2DInvalid);
+    MGLTilePyramidOfflineRegion *original = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:[MGLStyle lightStyleURL] bounds:bounds fromZoomLevel:5 toZoomLevel:10];
+    MGLTilePyramidOfflineRegion *copy = [original copy];
+    XCTAssertEqualObjects(original, copy, @"Tile pyramid region should be equal to its copy.");
+    
+    XCTAssertEqualObjects(original.styleURL, copy.styleURL, @"Style URL has changed.");
+    XCTAssert(MGLCoordinateBoundsEqualToCoordinateBounds(original.bounds, copy.bounds), @"Bounds have changed.");
+    XCTAssertEqual(original.minimumZoomLevel, original.minimumZoomLevel, @"Minimum zoom level has changed.");
+    XCTAssertEqual(original.maximumZoomLevel, original.maximumZoomLevel, @"Maximum zoom level has changed.");
+}
+
+@end

--- a/platform/osx/test/MGLOfflineStorageTests.m
+++ b/platform/osx/test/MGLOfflineStorageTests.m
@@ -82,6 +82,18 @@
     [self expectationForNotification:MGLOfflinePackProgressChangedNotification object:pack handler:^BOOL(NSNotification * _Nonnull notification) {
         MGLOfflinePack *notificationPack = notification.object;
         XCTAssert([notificationPack isKindOfClass:[MGLOfflinePack class]], @"Object of notification should be an MGLOfflinePack.");
+        
+        NSDictionary *userInfo = notification.userInfo;
+        XCTAssertNotNil(userInfo, @"Progress change notification should have a userInfo dictionary.");
+        
+        NSNumber *stateNumber = userInfo[MGLOfflinePackStateUserInfoKey];
+        XCTAssert([stateNumber isKindOfClass:[NSNumber class]], @"Progress change notification’s state should be an NSNumber.");
+        XCTAssertEqual(stateNumber.integerValue, pack.state, @"State in a progress change notification should match the pack’s state.");
+        
+        NSValue *progressValue = userInfo[MGLOfflinePackProgressUserInfoKey];
+        XCTAssert([progressValue isKindOfClass:[NSValue class]], @"Progress change notification’s progress should be an NSValue.");
+        XCTAssertEqualObjects(progressValue, [NSValue valueWithMGLOfflinePackProgress:pack.progress], @"Progress change notification’s progress should match pack’s progress.");
+        
         return notificationPack == pack && pack.state == MGLOfflinePackStateInactive;
     }];
     [self waitForExpectationsWithTimeout:1 handler:nil];

--- a/platform/osx/test/MGLOfflineStorageTests.m
+++ b/platform/osx/test/MGLOfflineStorageTests.m
@@ -55,7 +55,7 @@
     XCTestExpectation *additionCompletionHandlerExpectation = [self expectationWithDescription:@"add pack completion handler"];
     [[MGLOfflineStorage sharedOfflineStorage] addPackForRegion:region withContext:context completionHandler:^(MGLOfflinePack * _Nullable completionHandlerPack, NSError * _Nullable error) {
         XCTAssertNotNil(completionHandlerPack, @"Added pack should exist.");
-        XCTAssertEqual(completionHandlerPack.state, MGLOfflinePackStateUnknown, @"Pack should initially have unknown state.");
+        XCTAssertEqual(completionHandlerPack.state, MGLOfflinePackStateInactive, @"New pack should initially have inactive state.");
         pack = completionHandlerPack;
         [additionCompletionHandlerExpectation fulfill];
     }];
@@ -72,7 +72,7 @@
     XCTAssert([userInfo[nameKey] isKindOfClass:[NSString class]], @"Name of offline pack isn’t a string.");
     XCTAssertEqualObjects(userInfo[nameKey], name, @"Name of offline pack has changed.");
     
-    XCTAssertEqual(pack.state, MGLOfflinePackStateUnknown, @"Pack should initially have unknown state.");
+    XCTAssertEqual(pack.state, MGLOfflinePackStateInactive, @"New pack should initially have inactive state.");
     
     [self keyValueObservingExpectationForObject:pack keyPath:@"state" handler:^BOOL(id _Nonnull observedObject, NSDictionary * _Nonnull change) {
         NSKeyValueChange changeKind = [change[NSKeyValueChangeKindKey] unsignedIntegerValue];
@@ -96,6 +96,7 @@
         
         return notificationPack == pack && pack.state == MGLOfflinePackStateInactive;
     }];
+    [pack requestProgress];
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 

--- a/platform/osx/test/MGLOfflineStorageTests.m
+++ b/platform/osx/test/MGLOfflineStorageTests.m
@@ -1,0 +1,113 @@
+#import <Mapbox/Mapbox.h>
+
+#pragma clang diagnostic ignored "-Wgnu-statement-expression"
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
+#import <XCTest/XCTest.h>
+
+@interface MGLOfflineStorageTests : XCTestCase
+
+@end
+
+@implementation MGLOfflineStorageTests
+
+- (void)testSharedObject {
+    XCTAssertEqual([MGLOfflineStorage sharedOfflineStorage], [MGLOfflineStorage sharedOfflineStorage], @"There should only be one shared offline storage object.");
+}
+
+// This test needs to come first so it can test the initial loading of packs.
+- (void)testAAALoadPacks {
+    XCTestExpectation *kvoExpectation = [self keyValueObservingExpectationForObject:[MGLOfflineStorage sharedOfflineStorage] keyPath:@"packs" handler:^BOOL(id _Nonnull observedObject, NSDictionary * _Nonnull change) {
+        NSKeyValueChange changeKind = [change[NSKeyValueChangeKindKey] unsignedIntegerValue];
+        return changeKind = NSKeyValueChangeSetting;
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertNotNil([MGLOfflineStorage sharedOfflineStorage].packs, @"Shared offline storage object should have a non-nil collection of packs by this point.");
+}
+
+- (void)testAddPack {
+    NSUInteger countOfPacks = [MGLOfflineStorage sharedOfflineStorage].packs.count;
+    
+    NSURL *styleURL = [MGLStyle lightStyleURL];
+    /// Somewhere near Grape Grove, Ohio, United States.
+    MGLCoordinateBounds bounds = {
+        { 39.70358155855172, -83.69506472545841 },
+        { 39.703818870225376, -83.69420641857361 },
+    };
+    double zoomLevel = 20;
+    MGLTilePyramidOfflineRegion *region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:styleURL bounds:bounds fromZoomLevel:zoomLevel toZoomLevel:zoomLevel];
+    
+    NSString *nameKey = @"Name";
+    NSString *name = @"🍇 Grape Grove";
+    
+    NSData *context = [NSKeyedArchiver archivedDataWithRootObject:@{
+        nameKey: name,
+    }];
+    
+    __block MGLOfflinePack *pack;
+    [self keyValueObservingExpectationForObject:[MGLOfflineStorage sharedOfflineStorage] keyPath:@"packs" handler:^BOOL(id _Nonnull observedObject, NSDictionary * _Nonnull change) {
+        NSKeyValueChange changeKind = [change[NSKeyValueChangeKindKey] unsignedIntegerValue];
+        NSIndexSet *indices = change[NSKeyValueChangeIndexesKey];
+        return changeKind == NSKeyValueChangeInsertion && indices.count == 1;
+    }];
+    XCTestExpectation *additionCompletionHandlerExpectation = [self expectationWithDescription:@"add pack completion handler"];
+    [[MGLOfflineStorage sharedOfflineStorage] addPackForRegion:region withContext:context completionHandler:^(MGLOfflinePack * _Nullable completionHandlerPack, NSError * _Nullable error) {
+        XCTAssertNotNil(completionHandlerPack, @"Added pack should exist.");
+        XCTAssertEqual(completionHandlerPack.state, MGLOfflinePackStateUnknown, @"Pack should initially have unknown state.");
+        pack = completionHandlerPack;
+        [additionCompletionHandlerExpectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertEqual([MGLOfflineStorage sharedOfflineStorage].packs.count, countOfPacks + 1, @"Added pack should have been added to the canonical collection of packs owned by the shared offline storage object. This assertion can fail if this test is run before -testAAALoadPacks.");
+    
+    XCTAssertEqual(pack, [MGLOfflineStorage sharedOfflineStorage].packs.lastObject, @"Pack should be appended to end of packs array.");
+    
+    XCTAssertEqualObjects(pack.region, region, @"Added pack’s region has changed.");
+    
+    NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
+    XCTAssert([userInfo isKindOfClass:[NSDictionary class]], @"Context of offline pack isn’t a dictionary.");
+    XCTAssert([userInfo[nameKey] isKindOfClass:[NSString class]], @"Name of offline pack isn’t a string.");
+    XCTAssertEqualObjects(userInfo[nameKey], name, @"Name of offline pack has changed.");
+    
+    XCTAssertEqual(pack.state, MGLOfflinePackStateUnknown, @"Pack should initially have unknown state.");
+    
+    [self keyValueObservingExpectationForObject:pack keyPath:@"state" handler:^BOOL(id _Nonnull observedObject, NSDictionary * _Nonnull change) {
+        NSKeyValueChange changeKind = [change[NSKeyValueChangeKindKey] unsignedIntegerValue];
+        MGLOfflinePackState state = [change[NSKeyValueChangeNewKey] integerValue];
+        return changeKind == NSKeyValueChangeSetting && state == MGLOfflinePackStateInactive;
+    }];
+    [self expectationForNotification:MGLOfflinePackProgressChangedNotification object:pack handler:^BOOL(NSNotification * _Nonnull notification) {
+        MGLOfflinePack *notificationPack = notification.object;
+        XCTAssert([notificationPack isKindOfClass:[MGLOfflinePack class]], @"Object of notification should be an MGLOfflinePack.");
+        return notificationPack == pack && pack.state == MGLOfflinePackStateInactive;
+    }];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testRemovePack {
+    NSUInteger countOfPacks = [MGLOfflineStorage sharedOfflineStorage].packs.count;
+    
+    MGLOfflinePack *pack = [MGLOfflineStorage sharedOfflineStorage].packs.lastObject;
+    XCTAssertNotNil(pack, @"Added pack should still exist.");
+    
+    XCTestExpectation *kvoExpectation = [self keyValueObservingExpectationForObject:[MGLOfflineStorage sharedOfflineStorage] keyPath:@"packs" handler:^BOOL(id _Nonnull observedObject, NSDictionary * _Nonnull change) {
+        NSKeyValueChange changeKind = [change[NSKeyValueChangeKindKey] unsignedIntegerValue];
+        NSIndexSet *indices = change[NSKeyValueChangeIndexesKey];
+        return changeKind = NSKeyValueChangeRemoval && indices.count == 1;
+    }];
+    XCTestExpectation *completionHandlerExpectation = [self expectationWithDescription:@"remove pack completion handler"];
+    [[MGLOfflineStorage sharedOfflineStorage] removePack:pack withCompletionHandler:^(NSError * _Nullable error) {
+        XCTAssertEqual(pack.state, MGLOfflinePackStateInvalid, @"Removed pack should be invalid in the completion handler.");
+        [completionHandlerExpectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertEqual(pack.state, MGLOfflinePackStateInvalid, @"Removed pack should have been invalidated synchronously.");
+    
+    XCTAssertEqual([MGLOfflineStorage sharedOfflineStorage].packs.count, countOfPacks - 1, @"Removed pack should have been removed from the canonical collection of packs owned by the shared offline storage object. This assertion can fail if this test is run before -testAAALoadPacks or -testAddPack.");
+}
+
+@end

--- a/platform/osx/test/osxtest.gypi
+++ b/platform/osx/test/osxtest.gypi
@@ -44,6 +44,9 @@
       
       'sources': [
         './MGLGeometryTests.mm',
+        './MGLOfflinePackTests.m',
+        './MGLOfflineRegionTests.m',
+        './MGLOfflineStorageTests.m',
         './MGLStyleTests.mm',
       ],
 


### PR DESCRIPTION
MGLOfflineStorage now maintains a canonical, strongly held collection of all valid offline packs and issues notifications for progress updates. MGLOfflinePackDelegate is now private and serves only as a link between MGLOfflineStorage and its MGLOfflinePacks. Clients that want to receive progress updates should use NSNotificationCenter or [key-value observing](https://developer.apple.com/library/ios/documentation/General/Conceptual/DevPedia-CocoaCore/KVO.html) (KVO) instead of the delegate pattern. ~~Progress updates come automatically: it’s no longer necessary (or possible) to call `-requestProgress` on an offline pack.~~

Client code can react to the successful addition of an offline pack either via the completion block or via a KVO insertion notification. Client code can get a list of packs synchronously, although the list is still populated asynchronously from the time MGLOfflineStorage or an MGLMapView is first initialized. The old `-getPacksWithCompletionHandler:` method is replaced with a `-reloadPacks` method for one edge case detailed in the documentation.

A battery of automated functional tests has been added for the MGLTilePyramidOfflineRegion, MGLOfflinePack, and MGLOfflineStorage classes. They test essential aspects of pack management and state changes but don’t test actual downloading; that functionality is best covered by mbgl command line tests for now. The `NS_UNAVAILABLE` attribute has been removed from `-[MGLOfflinePack init]` to facilitate testing. Packs initialized this way are doomed to invalidity, as they are disconnected from the shared MGLOfflineStorage object.

Even though an added pack’s region has a different pointer value than the region that’s passed into `-[MGLOfflineStorage addPackForRegion:withContext:completionHandler:]`, the two regions are equal by object equality, now that MGLTilePyramidOfflineRegion overrides `-isEqual:`. It also conforms to both NSSecureCoding and NSCopying.

This PR also comes with some improvements to iosapp and osxapp:

* Previously, if the user added an offline pack without specifying a name in the alert, the pack would be named “Untitled _n_” for the nth pack created since the application was launched. This logic could result in identically named packs (for example, if the user relaunches and creates another unnamed pack). Instead, use the visible coordinate bounds as a placeholder and fallback name.
* When possible, iosapp updates individual labels in a cell instead of reloading the entire cell. That way, if the user swipes to the left to reveal the Delete accessory button while the pack is actively downloading, the accessory button remains on screen as progress updates come in.
* osxapp has a new offline pack download manager that demonstrates the use of MGLOfflineStorage with Cocoa Bindings. Like the Offline Packs view controller in iosapp, new packs are added based on the foremost map view’s current state. Double-clicking a complete offline pack opens a new map window to the pack’s bounds.

Fixes #4287, fixes #4394, fixes #4421, and fixes #4426.

/cc @jfirebaugh @boundsj @friedbunny @bsudekum