### PR TITLE
[android] Remove onStart() and onStop() lifecycle methods from MapView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -76,7 +76,6 @@ public final class MapFragment extends Fragment {
     @Override
     public void onStart() {
         super.onStart();
-        mMap.onStart();
         mMap.getMapAsync(mOnMapReadyCallback);
     }
 
@@ -115,7 +114,6 @@ public final class MapFragment extends Fragment {
     @Override
     public void onStop() {
         super.onStop();
-        mMap.onStop();
     }
 
     /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -482,22 +482,6 @@ public class MapView extends FrameLayout {
     }
 
     /**
-     * You must call this method from the parent's {@link Activity#onStart()} or {@link Fragment#onStart()}.
-     */
-    @UiThread
-    public void onStart() {
-        mUserLocationView.onStart();
-    }
-
-    /**
-     * You must call this method from the parent's {@link Activity#onStop()} or {@link Fragment#onStop()}
-     */
-    @UiThread
-    public void onStop() {
-        mUserLocationView.onStop();
-    }
-
-    /**
      * You must call this method from the parent's {@link Activity#onPause()} or {@link Fragment#onPause()}.
      */
     @UiThread

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -76,7 +76,6 @@ public class SupportMapFragment extends Fragment {
     @Override
     public void onStart() {
         super.onStart();
-        mMap.onStart();
         mMap.getMapAsync(mOnMapReadyCallback);
     }
 
@@ -115,7 +114,6 @@ public class SupportMapFragment extends Fragment {
     @Override
     public void onStop() {
         super.onStop();
-        mMap.onStop();
     }
 
     /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/UserLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/UserLocationView.java
@@ -198,17 +198,6 @@ public final class UserLocationView extends View {
         mProjection = mapboxMap.getProjection();
     }
 
-    public void onStart() {
-        if (mMyBearingTrackingMode == MyBearingTracking.COMPASS) {
-            mBearingChangeListener.onStart(getContext());
-        }
-    }
-
-    public void onStop() {
-        mBearingChangeListener.onStop();
-        cancelAnimations();
-    }
-
     @Override
     public void onDraw(Canvas canvas) {
         super.onDraw(canvas);
@@ -395,9 +384,9 @@ public final class UserLocationView extends View {
         if (myBearingTrackingMode == MyBearingTracking.COMPASS) {
             mShowAccuracy = false;
             mShowDirection = true;
-            mBearingChangeListener.onStart(getContext());
+            mBearingChangeListener.onResume();
         } else {
-            mBearingChangeListener.onStop();
+            mBearingChangeListener.onPause();
             if (myBearingTrackingMode == MyBearingTracking.GPS) {
                 mShowDirection = (mUserLocation != null) && mUserLocation.hasBearing();
             } else {
@@ -433,12 +422,12 @@ public final class UserLocationView extends View {
             mMagnetometer = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
         }
 
-        public void onStart(Context context) {
+        public void onResume() {
             mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
             mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME);
         }
 
-        public void onStop() {
+        public void onPause() {
             mSensorManager.unregisterListener(this, mAccelerometer);
             mSensorManager.unregisterListener(this, mMagnetometer);
         }
@@ -661,11 +650,16 @@ public final class UserLocationView extends View {
 
     public void onPause() {
         mPaused = true;
+        mBearingChangeListener.onPause();
+        cancelAnimations();
         toggleGps(false);
     }
 
     public void onResume() {
         mPaused = false;
+        if (mMyBearingTrackingMode == MyBearingTracking.COMPASS) {
+            mBearingChangeListener.onResume();
+        }
         if (isEnabled()) {
             toggleGps(true);
         }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/AnimatedMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/AnimatedMarkerActivity.java
@@ -86,12 +86,6 @@ public class AnimatedMarkerActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -101,12 +95,6 @@ public class AnimatedMarkerActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/BulkMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/BulkMarkerActivity.java
@@ -85,12 +85,6 @@ public class BulkMarkerActivity extends AppCompatActivity implements AdapterView
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -100,12 +94,6 @@ public class BulkMarkerActivity extends AppCompatActivity implements AdapterView
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/CameraActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/CameraActivity.java
@@ -128,12 +128,6 @@ public class CameraActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -143,12 +137,6 @@ public class CameraActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/CoordinateChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/CoordinateChangeActivity.java
@@ -70,12 +70,6 @@ public class CoordinateChangeActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -85,12 +79,6 @@ public class CoordinateChangeActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/DirectionsActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/DirectionsActivity.java
@@ -142,12 +142,6 @@ public class DirectionsActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -157,12 +151,6 @@ public class DirectionsActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/DoubleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/DoubleMapActivity.java
@@ -109,13 +109,6 @@ public class DoubleMapActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onStart() {
-            super.onStart();
-            mMapView.onStart();
-            mMapViewMini.onStart();
-        }
-
-        @Override
         public void onResume() {
             super.onResume();
             mMapView.onResume();
@@ -127,13 +120,6 @@ public class DoubleMapActivity extends AppCompatActivity {
             super.onPause();
             mMapView.onPause();
             mMapViewMini.onPause();
-        }
-
-        @Override
-        public void onStop() {
-            super.onStop();
-            mMapView.onStop();
-            mMapViewMini.onStop();
         }
 
         @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/DynamicMarkerChangeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/DynamicMarkerChangeActivity.java
@@ -88,13 +88,6 @@ public class DynamicMarkerChangeActivity extends AppCompatActivity {
         mMarker.setIcon(mIconFactory.fromResource(first ? R.drawable.ic_chelsea : R.drawable.ic_arsenal));
     }
 
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
     @Override
     public void onResume() {
         super.onResume();
@@ -105,12 +98,6 @@ public class DynamicMarkerChangeActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/GeocoderActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/GeocoderActivity.java
@@ -98,18 +98,6 @@ public class GeocoderActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mapView.onStart();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mapView.onStop();
-    }
-
-    @Override
     public void onPause() {
         super.onPause();
         mapView.onPause();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/InfoWindowActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/InfoWindowActivity.java
@@ -109,12 +109,6 @@ public class InfoWindowActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -124,12 +118,6 @@ public class InfoWindowActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/InfoWindowAdapterActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/InfoWindowAdapterActivity.java
@@ -100,12 +100,6 @@ public class InfoWindowAdapterActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -115,12 +109,6 @@ public class InfoWindowAdapterActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/InfoWindowConcurrentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/InfoWindowConcurrentActivity.java
@@ -59,12 +59,6 @@ public class InfoWindowConcurrentActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -74,12 +68,6 @@ public class InfoWindowConcurrentActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/LatLngBoundsActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/LatLngBoundsActivity.java
@@ -84,12 +84,6 @@ public class LatLngBoundsActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -99,12 +93,6 @@ public class LatLngBoundsActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/ManualZoomActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/ManualZoomActivity.java
@@ -93,12 +93,6 @@ public class ManualZoomActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -108,12 +102,6 @@ public class ManualZoomActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/MapPaddingActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/MapPaddingActivity.java
@@ -60,12 +60,6 @@ public class MapPaddingActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -75,12 +69,6 @@ public class MapPaddingActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/MaxMinZoomActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/MaxMinZoomActivity.java
@@ -54,12 +54,6 @@ public class MaxMinZoomActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -69,12 +63,6 @@ public class MaxMinZoomActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/MyLocationTrackingModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/MyLocationTrackingModeActivity.java
@@ -171,12 +171,6 @@ public class MyLocationTrackingModeActivity extends AppCompatActivity implements
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -192,12 +186,6 @@ public class MyLocationTrackingModeActivity extends AppCompatActivity implements
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         mMapView.onSaveInstanceState(outState);
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/OfflineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/OfflineActivity.java
@@ -123,12 +123,6 @@ public class OfflineActivity extends AppCompatActivity
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -138,12 +132,6 @@ public class OfflineActivity extends AppCompatActivity
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/PolylineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/PolylineActivity.java
@@ -118,12 +118,6 @@ public class PolylineActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -133,12 +127,6 @@ public class PolylineActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/PressForMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/PressForMarkerActivity.java
@@ -104,12 +104,6 @@ public class PressForMarkerActivity extends AppCompatActivity implements MapboxM
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -126,12 +120,6 @@ public class PressForMarkerActivity extends AppCompatActivity implements MapboxM
         super.onSaveInstanceState(outState);
         mMapView.onSaveInstanceState(outState);
         outState.putParcelableArrayList(STATE_MARKER_LIST, (ArrayList<MarkerOptions>) mMarkerList);
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/ScrollByActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/ScrollByActivity.java
@@ -77,12 +77,6 @@ public class ScrollByActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         mMapView.onResume();
@@ -92,12 +86,6 @@ public class ScrollByActivity extends AppCompatActivity {
     public void onPause() {
         super.onPause();
         mMapView.onPause();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/TiltActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/TiltActivity.java
@@ -47,18 +47,6 @@ public class TiltActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        mMapView.onStart();
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mMapView.onStop();
-    }
-
-    @Override
     public void onPause() {
         super.onPause();
         mMapView.onPause();


### PR DESCRIPTION
- Removes `onStart()` and `onStop()` from MapView and UserLocationView.
- Moves sensor event listener registering / unregistering from UserLocationView `onStart()` and `onStop()` to `onResume()` and `onPause()`, respectively.

Motivation:
- Parity with the [Google Maps Android API v2 regarding MapView lifecycle requirements](https://developers.google.com/android/reference/com/google/android/gms/maps/MapView).
- Simpler API for users who choose to manage MapView directly.
- Android guidelines [recommend registering and unregistering sensor event listeners in `onResume()` and `onPause()`](http://developer.android.com/guide/topics/sensors/sensors_overview.html#sensors-monitor) to reduce battery drain in situations where the Activity is paused but not stopped, e.g. when the user locks the device and the screen is off.