### PR TITLE
enable circle-opacity render tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#10924ef1cea1bea0cb1fa0aac4233a037a4daecc",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#041562459dfabae1ed22a71db4d5e65cea2635db",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"


### PR DESCRIPTION
fix #2647

I think the tests changed with https://github.com/mapbox/mapbox-gl-js/commit/7658e00da603bc9721ff57f258239997888adf5f in -js.