### PR TITLE
[core] fix circle rendering in still mode 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.21",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#10924ef1cea1bea0cb1fa0aac4233a037a4daecc",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#a42cd0cb818356d91fc6b61e2b64801e57486ac0",
     "node-gyp": "^3.2.1",
     "request": "^2.67.0",
     "tape": "^4.2.2"

--- a/src/mbgl/layer/circle_layer.cpp
+++ b/src/mbgl/layer/circle_layer.cpp
@@ -43,7 +43,7 @@ bool CircleLayer::recalculate(const StyleCalculationParameters& parameters) {
 }
 
 std::unique_ptr<Bucket> CircleLayer::createBucket(StyleBucketParameters& parameters) const {
-    auto bucket = std::make_unique<CircleBucket>();
+    auto bucket = std::make_unique<CircleBucket>(parameters.mode);
 
     parameters.eachFilteredFeature(filter, [&] (const auto& feature) {
         bucket->addGeometry(getGeometries(feature));

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -7,7 +7,7 @@
 
 using namespace mbgl;
 
-CircleBucket::CircleBucket() {
+CircleBucket::CircleBucket(MapMode mode_) : mode(mode_) {
 }
 
 CircleBucket::~CircleBucket() {
@@ -38,7 +38,10 @@ void CircleBucket::addGeometry(const GeometryCollection& geometryCollection) {
             auto y = geometry.y;
 
             // Do not include points that are outside the tile boundaries.
-            if (x < 0 || x >= util::EXTENT || y < 0 || y >= util::EXTENT) continue;
+            // Include all points in Still mode. You need to include points from
+            // neighbouring tiles so that they are not clipped at tile boundaries.
+            if ((mode != MapMode::Still) &&
+                (x < 0 || x >= util::EXTENT || y < 0 || y >= util::EXTENT)) continue;
 
             // this geometry will be of the Point type, and we'll derive
             // two triangles from it.

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -2,9 +2,8 @@
 #define MBGL_RENDERER_CIRCLE_BUCKET
 
 #include <mbgl/renderer/bucket.hpp>
-
+#include <mbgl/map/mode.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
-
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/geometry/circle_buffer.hpp>
 
@@ -17,7 +16,7 @@ class CircleBucket : public Bucket {
     using TriangleGroup = ElementGroup<3>;
 
 public:
-    CircleBucket();
+    CircleBucket(const MapMode);
     ~CircleBucket() override;
 
     void upload(gl::GLObjectStore&) override;
@@ -33,6 +32,8 @@ private:
     TriangleElementsBuffer elementsBuffer_;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups_;
+
+    const MapMode mode;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -17,7 +17,7 @@ void Painter::renderCircle(CircleBucket& bucket,
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
-    config.stencilTest = GL_FALSE;
+    config.stencilTest = data.mode == MapMode::Still ? GL_TRUE : GL_FALSE;
     config.depthFunc.reset();
     config.depthTest = GL_TRUE;
     config.depthMask = GL_FALSE;


### PR DESCRIPTION
fix #3764

Also switch circle rendering tests to the poi_label source layer. Still mode rendering requires that points are in the same spots in all tiles. This was not the case with the road layer.

fix #2647 - no changes were needed. I think some -js change already fixed these tests.