### PR TITLE
[#4517] [android] [bug] fix two tap gestures when zoomGesturesEnabled = false

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1418,7 +1418,9 @@ public class MapView extends FrameLayout {
 
             case MotionEvent.ACTION_POINTER_DOWN:
                 // Second pointer down
-                mTwoTap = event.getPointerCount() == 2;
+                mTwoTap = event.getPointerCount() == 2
+                        && !mDestroyed
+                        && mMapboxMap.getUiSettings().isZoomGesturesEnabled();
                 if (mTwoTap) {
                     // Confirmed 2nd Finger Down
                     trackGestureEvent(MapboxEvent.GESTURE_TWO_FINGER_SINGLETAP, event.getX(), event.getY());


### PR DESCRIPTION
Related to #4517 - [android] [bug] two pointers tap not disabled when zoomGesturesEnabled = false