### PR TITLE
[core] Localize and simplify state for MapChangeDidFinishLoadingMap event

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -205,6 +205,7 @@ private:
     };
 
     RenderState renderState = RenderState::never;
+    bool loading = false;
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -78,8 +78,8 @@ void Map::renderSync() {
     } else if (renderState != RenderState::fully) {
         renderState = RenderState::fully;
         view.notifyMapChange(MapChangeDidFinishRenderingMapFullyRendered);
-        if (data->loading) {
-            data->loading = false;
+        if (loading) {
+            loading = false;
             view.notifyMapChange(MapChangeDidFinishLoadingMap);
         }
     }
@@ -101,11 +101,13 @@ void Map::update(Update flags) {
 #pragma mark - Style
 
 void Map::setStyleURL(const std::string &url) {
+    loading = true;
     view.notifyMapChange(MapChangeWillStartLoadingMap);
     context->invoke(&MapContext::setStyleURL, url);
 }
 
 void Map::setStyleJSON(const std::string& json, const std::string& base) {
+    loading = true;
     view.notifyMapChange(MapChangeWillStartLoadingMap);
     context->invoke(&MapContext::setStyleJSON, json, base);
 }

--- a/src/mbgl/map/map_context.cpp
+++ b/src/mbgl/map/map_context.cpp
@@ -109,7 +109,6 @@ void MapContext::setStyleURL(const std::string& url) {
                 Log::Error(Event::Setup, "style %s could not be found or is an incompatible legacy map or style", styleURL.c_str());
             } else {
                 Log::Error(Event::Setup, "loading style failed: %s", res.error->message.c_str());
-                data.loading = false;
             }
         } else if (res.notModified || res.noContent) {
             return;
@@ -141,10 +140,6 @@ void MapContext::loadStyleJSON(const std::string& json, const std::string& base)
 
     // force style cascade, causing all pending transitions to complete.
     style->cascade();
-
-    // set loading here so we don't get a false loaded event as soon as map is
-    // created but before a style is loaded
-    data.loading = true;
 
     updateFlags |= Update::DefaultTransition | Update::Classes | Update::Zoom | Update::Annotations;
     asyncUpdate.send();

--- a/src/mbgl/map/map_data.hpp
+++ b/src/mbgl/map/map_data.hpp
@@ -149,7 +149,6 @@ public:
     bool paused = false;
     std::mutex mutexPause;
     std::condition_variable condPause;
-    bool loading = false;
 };
 
 } // namespace mbgl


### PR DESCRIPTION
Fixes #4500 for iOS.

Only `Map` needs to track the loaded state, and it can simply be set when beginning to load a style and reset when finished.

The only commit related to `MapData::loading` that I could find was 2ee7b0218929d56c9331ded5ef695fc6bc59f70b. I thought I remembered some additional adjustments to how this variable was used based on past bugs, but could not find any. There is one branch that references it, [`tmpsantos-MapChangeDidFinishLoadingMap`](https://github.com/mapbox/mapbox-gl-native/tree/tmpsantos-MapChangeDidFinishLoadingMap), which looks to be obsolete. @tmpsantos do you remember what this was about? Is anyone else aware of subtleties relating to `MapData::loading` or `MapChangeDidFinishLoadingMap` that I forgot to take into account?

This provides an alternative fix for #4512 on Android, but the least risky approach would be to continue using that workaround for the release and perhaps revert it on the main branch.

I attempted to write a test for `MapChangeDidFinishLoadingMap`, but it is very difficult. It will be easier once #2909 lands.

:eyes: @1ec5 @brunoabinader @tmpsantos