### PR TITLE
Add GitHub issue template!

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+Hello and thanks for contributing! To help us diagnose your problem quickly, please:
+
+ - Include a minimal demonstration of the bug, including code, logs, and screenshots.
+ - Ensure you can reproduce the bug using the latest release.
+ - Only post to report a bug or request a feature; direct all other questions to: https://stackoverflow.com/questions/tagged/mapbox
+-->
+
+**Platform:**
+**Mapbox SDK version:**
+
+### Steps to trigger behavior
+
+ 1.
+ 2.
+ 3.
+
+### Expected behavior
+
+### Actual behavior


### PR DESCRIPTION
Add an issue template that everyone will see when creating a new issue here on GitHub. (Pull requests will not see this template, that would need a separate file: `PULL_REQUEST_TEMPLATE.md`)

Cribbed from [Mapbox GL JS](https://github.com/mapbox/mapbox-gl-js/blob/7b61aa9888bd98c3b6be0a9150225a1871fdae31/ISSUE_TEMPLATE.md), per @ansis’s suggestion in #4542.

**Raw template:**

![screen shot 2016-03-30 at 8 13 58 pm](https://cloud.githubusercontent.com/assets/1198851/14161762/1df98d32-f6b4-11e5-9fbf-f12e3db00320.png)

**Markdown preview:**

![screen shot 2016-03-30 at 8 14 07 pm](https://cloud.githubusercontent.com/assets/1198851/14161765/2435751c-f6b4-11e5-92c6-3674174bea61.png)

/cc @mapbox/gl