### PR TITLE
[core] simplify conversions from pixels to tile units

### DIFF
--- a/src/mbgl/map/tile_id.cpp
+++ b/src/mbgl/map/tile_id.cpp
@@ -1,9 +1,14 @@
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/constants.hpp>
 
 #include <cassert>
 
 namespace mbgl {
+
+float TileID::pixelsToTileUnits(float pixelValue, float zoom) const {
+    return pixelValue * (util::EXTENT / (util::tileSize * overscaleFactor() * std::pow(2, zoom - z)));
+}
 
 TileID TileID::parent(uint8_t parent_z, uint8_t sourceMaxZoom) const {
     assert(parent_z < z);

--- a/src/mbgl/map/tile_id.hpp
+++ b/src/mbgl/map/tile_id.hpp
@@ -45,6 +45,7 @@ public:
         return y < rhs.y;
     }
 
+    float pixelsToTileUnits(float pixelValue, float zoom) const;
     TileID parent(uint8_t z, uint8_t sourceMaxZoom) const;
     TileID normalized() const;
     std::forward_list<TileID>

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -260,20 +260,19 @@ mat4 Painter::translatedMatrix(const mat4& matrix, const std::array<float, 2> &t
     if (translation[0] == 0 && translation[1] == 0) {
         return matrix;
     } else {
-        const double factor = double(1ll << id.sourceZ) * util::EXTENT / util::tileSize / state.getScale();
 
         mat4 vtxMatrix;
         if (anchor == TranslateAnchorType::Viewport) {
             const double sin_a = std::sin(-state.getAngle());
             const double cos_a = std::cos(-state.getAngle());
             matrix::translate(vtxMatrix, matrix,
-                    factor * (translation[0] * cos_a - translation[1] * sin_a),
-                    factor * (translation[0] * sin_a + translation[1] * cos_a),
+                    id.pixelsToTileUnits(translation[0] * cos_a - translation[1] * sin_a, state.getZoom()),
+                    id.pixelsToTileUnits(translation[0] * sin_a + translation[1] * cos_a, state.getZoom()),
                     0);
         } else {
             matrix::translate(vtxMatrix, matrix,
-                    factor * translation[0],
-                    factor * translation[1],
+                    id.pixelsToTileUnits(translation[0], state.getZoom()),
+                    id.pixelsToTileUnits(translation[1], state.getZoom()),
                     0);
         }
 

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -63,7 +63,6 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
 
         if (isPatterned) {
             patternShader->u_matrix = vtxMatrix;
-            const float factor = util::EXTENT / util::tileSize;
 
             std::array<int, 2> imageSizeScaledA = {{
                 (int)((*imagePosA).size[0] * properties.pattern.value.fromScale),
@@ -75,12 +74,12 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
             }};
 
             patternShader->u_patternscale_a = {{
-                1.0f / (factor * imageSizeScaledA[0]),
-                1.0f / (factor * imageSizeScaledA[1])
+                1.0f / id.pixelsToTileUnits(imageSizeScaledA[0], state.getIntegerZoom()),
+                1.0f / id.pixelsToTileUnits(imageSizeScaledA[1], state.getIntegerZoom())
             }};
             patternShader->u_patternscale_b = {{
-                1.0f / (factor * imageSizeScaledB[0]),
-                1.0f / (factor * imageSizeScaledB[1])
+                1.0f / id.pixelsToTileUnits(imageSizeScaledB[0], state.getIntegerZoom()),
+                1.0f / id.pixelsToTileUnits(imageSizeScaledB[1], state.getIntegerZoom())
             }};
 
             float offsetAx = (std::fmod(util::tileSize, imageSizeScaledA[0]) * id.x) / (float)imageSizeScaledA[0];

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -64,8 +64,6 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
 
         // Image fill.
         if (pass == RenderPass::Translucent && posA && posB) {
-            const float factor =
-                (util::EXTENT / util::tileSize / std::pow(2, state.getIntegerZoom() - id.sourceZ));
 
             config.program = patternShader->getID();
             patternShader->u_matrix = vtxMatrix;
@@ -87,12 +85,12 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
             }};
 
             patternShader->u_patternscale_a = {{
-                1.0f / (factor * imageSizeScaledA[0]),
-                1.0f / (factor * imageSizeScaledA[1])
+                1.0f / id.pixelsToTileUnits(imageSizeScaledA[0], state.getIntegerZoom()),
+                1.0f / id.pixelsToTileUnits(imageSizeScaledB[1], state.getIntegerZoom())
             }};
             patternShader->u_patternscale_b = {{
-                1.0f / (factor * imageSizeScaledB[0]),
-                1.0f / (factor * imageSizeScaledB[1])
+                1.0f / id.pixelsToTileUnits(imageSizeScaledB[0], state.getIntegerZoom()),
+                1.0f / id.pixelsToTileUnits(imageSizeScaledB[1], state.getIntegerZoom())
             }};
 
             float offsetAx = (std::fmod(util::tileSize, imageSizeScaledA[0]) * id.x) / (float)imageSizeScaledA[0];

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -34,7 +34,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
 
     if (skewed) {
         matrix::identity(exMatrix);
-        s = util::EXTENT / util::tileSize / std::pow(2, state.getZoom() - id.sourceZ);
+        s = id.pixelsToTileUnits(1, state.getZoom());
         gammaScale = 1.0f / std::cos(state.getPitch());
     } else {
         exMatrix = extrudeMatrix;
@@ -195,7 +195,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
 
             if (skewed) {
                 matrix::identity(exMatrix);
-                s = util::EXTENT / util::tileSize / std::pow(2, state.getZoom() - id.sourceZ);
+                s = id.pixelsToTileUnits(1, state.getZoom());
             } else {
                 exMatrix = extrudeMatrix;
                 matrix::rotate_z(exMatrix, exMatrix, state.getNorthOrientationAngle());


### PR DESCRIPTION
fix #3768

:eyes: @jfirebaugh 

This is slightly different than the -js implementation. In -js `pixelsToTileUnits` its just a regular function. Here it's a method on TileID. I think this makes sense until we refactor TileID/TileCoord and get rid of the -js and -native differences.