### PR TITLE
Remove blocking on future in Thread constructor

### DIFF
--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -28,37 +28,37 @@ template <class Object>
 class Thread {
 public:
     template <class... Args>
-    Thread(const ThreadContext&, Args&&... args);
+    Thread(const ThreadContext&, Args... args);
     ~Thread();
 
     // Invoke object->fn(args...) in the runloop thread.
     template <typename Fn, class... Args>
-    void invoke(Fn fn, Args&&... args) {
-        loop->invoke(bind(fn), std::forward<Args>(args)...);
+    void invoke(Fn fn, Args... args) {
+        loop->invoke(bind<Fn, void>(fn), std::move(args)...);
     }
 
     // Invoke object->fn(args...) in the runloop thread, then invoke callback(result) in the current thread.
     template <typename Fn, class Cb, class... Args>
     std::unique_ptr<AsyncRequest>
-    invokeWithCallback(Fn fn, Cb&& callback, Args&&... args) {
-        return loop->invokeWithCallback(bind(fn), callback, std::forward<Args>(args)...);
+    invokeWithCallback(Fn fn, Cb callback, Args... args) {
+        return loop->invokeWithCallback(bind<Fn, void>(fn), std::move(callback), std::move(args)...);
     }
 
     // Invoke object->fn(args...) in the runloop thread, and wait for the result.
     template <class R, typename Fn, class... Args>
-    R invokeSync(Fn fn, Args&&... args) {
-        std::packaged_task<R (std::decay_t<Args>...)> task(bind(fn));
+    R invokeSync(Fn fn, Args... args) {
+        std::packaged_task<R (Args...)> task(bind<Fn, R>(fn));
         std::future<R> future = task.get_future();
-        loop->invoke(std::move(task), std::forward<Args>(args)...);
+        loop->invoke(std::move(task), std::move(args)...);
         return future.get();
     }
 
     // Invoke object->fn(args...) in the runloop thread, and wait for it to complete.
     template <typename Fn, class... Args>
-    void invokeSync(Fn fn, Args&&... args) {
-        std::packaged_task<void (std::decay_t<Args>...)> task(bind(fn));
+    void invokeSync(Fn fn, Args... args) {
+        std::packaged_task<void (Args...)> task(bind<Fn, void>(fn));
         std::future<void> future = task.get_future();
-        loop->invoke(std::move(task), std::forward<Args>(args)...);
+        loop->invoke(std::move(task), std::move(args)...);
         future.get();
     }
 
@@ -68,11 +68,10 @@ private:
     Thread& operator=(const Thread&) = delete;
     Thread& operator=(Thread&&) = delete;
 
-    template <typename Fn>
+    template <class Fn, class R>
     auto bind(Fn fn) {
-        return [fn, this] (auto &&... args)
-        -> decltype((object->*fn)(std::forward<decltype(args)>(args)...)) {
-             return (object->*fn)(std::forward<decltype(args)>(args)...);
+        return [fn, this] (auto... args) -> R {
+             return (object->*fn)(std::move(args)...);
         };
     }
 
@@ -88,10 +87,10 @@ private:
 
 template <class Object>
 template <class... Args>
-Thread<Object>::Thread(const ThreadContext& context, Args&&... args) {
+Thread<Object>::Thread(const ThreadContext& context, Args... args) {
     // Note: We're using std::tuple<> to store the arguments because GCC 4.9 has a bug
     // when expanding parameters packs captured in lambdas.
-    std::tuple<Args...> params = std::forward_as_tuple(::std::forward<Args>(args)...);
+    std::tuple<Args...> params = std::forward_as_tuple(std::move(args)...);
 
     thread = std::thread([&] {
 #if defined(__APPLE__)

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -73,7 +73,7 @@ Worker::parseRasterTile(std::unique_ptr<RasterBucket> bucket,
                         const std::shared_ptr<const std::string> data,
                         std::function<void(RasterTileParseResult)> callback) {
     current = (current + 1) % threads.size();
-    return threads[current]->invokeWithCallback(&Worker::Impl::parseRasterTile, callback, bucket,
+    return threads[current]->invokeWithCallback(&Worker::Impl::parseRasterTile, callback, std::move(bucket),
                                                 data);
 }
 


### PR DESCRIPTION
The `Thread` constructor has [this line](https://github.com/mapbox/mapbox-gl-native/blob/8112ac3371230d0d99733c4b71fb2fac3d610404/src/mbgl/util/thread.hpp#L109-L109), which blocks the launching thread until construction of the `Object` template parameter has completed on the launched thread. This is not necessary, and should be removed so as to avoid potentially blocking the main thread for an indeterminate amount of time.

It isn't necessary because there's no way that launching thread can access `object` directly. It can only ask the `Thread` to `invoke` methods, and execution of the invocation is guaranteed to happen, on the launched thread, only after `object` is constructed.

This was a factor in #4501.