### PR TITLE
[glfw] Annotations are misplaced when zooming out

### DIFF
--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -211,13 +211,9 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
 }
 
 mbgl::LatLng GLFWView::makeRandomPoint() const {
-    const auto nw = map->latLngForPixel({ 0, 0 });
-    const auto se = map->latLngForPixel({ double(width), double(height) });
-
-    const double lon = nw.longitude + (se.longitude - nw.longitude) * (double(std::rand()) / RAND_MAX);
-    const double lat = se.latitude + (nw.latitude - se.latitude) * (double(std::rand()) / RAND_MAX);
-
-    return { lat, lon };
+    const double x = width * double(std::rand()) / RAND_MAX;
+    const double y = height * double(std::rand()) / RAND_MAX;
+    return map->latLngForPixel({ x, y });
 }
 
 std::shared_ptr<const mbgl::SpriteImage>


### PR DESCRIPTION
Steps to reproduce:

1. Run GLFW client `make run-linux`
2. Zoom out e.g. via mouse scroll
3. Press `3` to add some point annotations - usually these are randomly placed in both latitude and longitude, but they all appear at the horizontal edges of the screen (screenshot below):
![screen shot 2016-03-31 at 3 49 59 pm](https://cloud.githubusercontent.com/assets/76133/14176209/9301abba-f758-11e5-943e-05c50fd806e7.png)

This issue seems old (if not always present), as I bisected it up to 3 months old commits. I suspect the following:
- We're not properly clamping the scale/zoom value when issuing `scaleBy`; or
- There's a bug in `PointAnnotationImpl::updateLayer`; or
- `GLFWView::makeRandomPoint` is bogus for the following scenario.

/cc @mapbox/gl 