### PR TITLE
OS X CI flapping: osxsdk.xcscheme: No such file or directory

### DIFF
--- a/platform/osx/scripts/osxsdk.xcscheme
+++ b/platform/osx/scripts/osxsdk.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8E4ECCDD911E8B357970AAED"
+               BuildableName = "Mapbox.framework"
+               BlueprintName = "osxsdk"
+               ReferencedContainer = "container:../build/osx-x86_64/gyp/osx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "968E0619FB16F6A55E27CDF3"
+               BuildableName = "osxtest.xctest"
+               BlueprintName = "osxtest"
+               ReferencedContainer = "container:../build/osx-x86_64/gyp/osx.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8E4ECCDD911E8B357970AAED"
+            BuildableName = "Mapbox.framework"
+            BlueprintName = "osxsdk"
+            ReferencedContainer = "container:../build/osx-x86_64/gyp/osx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8E4ECCDD911E8B357970AAED"
+            BuildableName = "Mapbox.framework"
+            BlueprintName = "osxsdk"
+            ReferencedContainer = "container:../build/osx-x86_64/gyp/osx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8E4ECCDD911E8B357970AAED"
+            BuildableName = "Mapbox.framework"
+            BlueprintName = "osxsdk"
+            ReferencedContainer = "container:../build/osx-x86_64/gyp/osx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/platform/osx/scripts/test.sh
+++ b/platform/osx/scripts/test.sh
@@ -9,17 +9,8 @@ OSX_PROJ_PATH=./build/osx-x86_64/gyp/osx.xcodeproj
 
 export BUILDTYPE=${BUILDTYPE:-Release}
 
-if [[ ! -e "${OSX_PROJ_PATH}/xcshareddata/xcschemes/osxsdk.xcscheme" ]]; then
-    # Generate schemes
-    open -g "${OSX_PROJ_PATH}"
-    sleep 20
-    
-    # Share osxsdk scheme
-    mkdir -pv "${OSX_PROJ_PATH}/xcshareddata/xcschemes/"
-    mv -v \
-        "${OSX_PROJ_PATH}/xcuserdata/${USER}.xcuserdatad/xcschemes/osxsdk.xcscheme" \
-        "${OSX_PROJ_PATH}/xcshareddata/xcschemes/"
-fi
+mkdir -p "${OSX_PROJ_PATH}/xcshareddata/xcschemes"
+cp platform/osx/scripts/osxsdk.xcscheme "${OSX_PROJ_PATH}/xcshareddata/xcschemes/osxsdk.xcscheme"
 
 xcodebuild -verbose \
     -sdk macosx${OSX_SDK_VERSION} \


### PR DESCRIPTION
https://www.bitrise.io/build/70ff810c4e3cc5a9

```
* Recreating project...
mv: rename ./build/osx-x86_64/gyp/osx.xcodeproj/xcuserdata/vagrant.xcuserdatad/xcschemes/osxsdk.xcscheme to ./build/osx-x86_64/gyp/osx.xcodeproj/xcshareddata/xcschemes/osxsdk.xcscheme: No such file or directory
make: *** [xctest] Error 1
==> Script finished with exit code: 2
ERRO[11:14:20] Step (Run SDK unit tests) failed, error: (exit status 2) 
```