### PR TITLE
[core] look for loaded parent tiles in cache

### DIFF
--- a/src/mbgl/source/source.cpp
+++ b/src/mbgl/source/source.cpp
@@ -328,7 +328,7 @@ bool Source::findLoadedChildren(const TileID& tileID, int32_t maxCoveringZoom, s
  *
  * @return boolean Whether a parent was found.
  */
-void Source::findLoadedParent(const TileID& tileID, int32_t minCoveringZoom, std::vector<TileID>& retain) {
+void Source::findLoadedParent(const TileID& tileID, int32_t minCoveringZoom, std::vector<TileID>& retain, const StyleUpdateParameters& parameters) {
     for (int32_t z = tileID.z - 1; z >= minCoveringZoom; --z) {
         const TileID parent_id = tileID.parent(z, info->maxZoom);
         const TileData::State state = hasTile(parent_id);
@@ -337,6 +337,12 @@ void Source::findLoadedParent(const TileID& tileID, int32_t minCoveringZoom, std
             if (state == TileData::State::parsed) {
                 return;
             }
+        }
+
+        if (cache.has(parent_id.normalized().to_uint64())) {
+            addTile(parent_id, parameters);
+            retain.emplace_back(parent_id);
+            return;
         }
     }
 }
@@ -400,7 +406,7 @@ bool Source::update(const StyleUpdateParameters& parameters) {
             // Then, if there are no complete child tiles, try to find existing
             // parent tiles that completely cover the missing tile.
             if (!complete) {
-                findLoadedParent(tileID, minCoveringZoom, retain);
+                findLoadedParent(tileID, minCoveringZoom, retain, parameters);
             }
         }
     }

--- a/src/mbgl/source/source.hpp
+++ b/src/mbgl/source/source.hpp
@@ -88,7 +88,7 @@ private:
                              bool isNewTile);
     bool handlePartialTile(const TileID&);
     bool findLoadedChildren(const TileID&, int32_t maxCoveringZoom, std::vector<TileID>& retain);
-    void findLoadedParent(const TileID&, int32_t minCoveringZoom, std::vector<TileID>& retain);
+    void findLoadedParent(const TileID&, int32_t minCoveringZoom, std::vector<TileID>& retain, const StyleUpdateParameters&);
 
     TileData::State addTile(const TileID&, const StyleUpdateParameters&);
     TileData::State hasTile(const TileID&);


### PR DESCRIPTION
fix #4047

port https://github.com/mapbox/mapbox-gl-js/pull/2158


> When the required tiles aren't loaded yet it tries to find parent tiles that area loaded that a cover the area. It used to just look for parents in the set of previously rendered tiles. There are many cases where the parents aren't in that set but they are in the cache.
>
> This reduces the amount of the viewport not covered by tiles. It makes tile loading look a lot faster.
>
> It helps a lot when you:
>
> zoom in and the pan around
>zoom in quickly and then zoom out more slowly

:eyes: @jfirebaugh 