### PR TITLE
Build http_request_nsurl.mm with ARC

### DIFF
--- a/gyp/http-nsurl.gypi
+++ b/gyp/http-nsurl.gypi
@@ -25,7 +25,7 @@
       },
 
       'xcode_settings': {
-        'CLANG_ENABLE_OBJC_ARC': 'NO',
+        'CLANG_ENABLE_OBJC_ARC': 'YES',
       },
 
       'direct_dependent_settings': {

--- a/platform/darwin/src/http_request_nsurl.mm
+++ b/platform/darwin/src/http_request_nsurl.mm
@@ -19,7 +19,6 @@ class HTTPNSURLContext;
 class HTTPNSURLRequest : public HTTPRequestBase {
 public:
     HTTPNSURLRequest(HTTPNSURLContext*, Resource, Callback);
-    ~HTTPNSURLRequest();
 
     void cancel() final;
 
@@ -39,7 +38,6 @@ private:
 class HTTPNSURLContext : public HTTPContextBase {
 public:
     HTTPNSURLContext();
-    ~HTTPNSURLContext();
 
     HTTPRequestBase* createRequest(const Resource&, HTTPRequestBase::Callback) final;
 
@@ -58,21 +56,12 @@ HTTPNSURLContext::HTTPNSURLContext() {
         sessionConfig.URLCache = nil;
 
         session = [NSURLSession sessionWithConfiguration:sessionConfig];
-        [session retain];
 
         // Write user agent string
         userAgent = @"MapboxGL";
 
         accountType = [[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"];
     }
-}
-
-HTTPNSURLContext::~HTTPNSURLContext() {
-    [session release];
-    session = nullptr;
-
-    [userAgent release];
-    userAgent = nullptr;
 }
 
 HTTPRequestBase* HTTPNSURLContext::createRequest(const Resource& resource, HTTPRequestBase::Callback callback) {
@@ -125,21 +114,11 @@ HTTPNSURLRequest::HTTPNSURLRequest(HTTPNSURLContext* context_,
                         async.send();
                     }
               }];
-        [task retain];
         [task resume];
     }
 }
 
-HTTPNSURLRequest::~HTTPNSURLRequest() {
-    assert(!task);
-}
-
 void HTTPNSURLRequest::handleResponse() {
-    if (task) {
-        [task release];
-        task = nullptr;
-    }
-
     assert(response);
     notify(*response);
 
@@ -147,11 +126,8 @@ void HTTPNSURLRequest::handleResponse() {
 }
 
 void HTTPNSURLRequest::cancel() {
-    if (task) {
-        [task cancel];
-        [task release];
-        task = nullptr;
-    }
+    [task cancel];
+    task = nil;
 
     {
         std::lock_guard<std::mutex> lock(cancelled->second);


### PR DESCRIPTION
We should build http_request_nsurl.mm with ARC, like the rest of our Objective C code.

Flip [this line](https://github.com/mapbox/mapbox-gl-native/blob/65acf35dcfa3784de7e522926469083068599550/gyp/http-nsurl.gypi#L28) and fix the compile errors.