### PR TITLE
Xcode project for node.js bindings should always use loop=uv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ xnode: Xcode/node
 
 .PHONY: nproj
 nproj:
-	$(RUN) HTTP=none ASSET=none node/xproj
+	$(RUN) LOOP=uv HTTP=none ASSET=none node/xproj
 	open ./build/binding.xcodeproj
 
 #### Miscellaneous targets #####################################################


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/4578#issuecomment-205555132