### PR TITLE
[Android] Telemetry Service will be disable at first launch

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/telemetry/MapboxEventManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/telemetry/MapboxEventManager.java
@@ -118,7 +118,7 @@ public class MapboxEventManager {
         SharedPreferences prefs = context.getSharedPreferences(MapboxConstants.MAPBOX_SHARED_PREFERENCES_FILE, Context.MODE_PRIVATE);
 
         // Determine if Telemetry Should Be Enabled
-        setTelemetryEnabled(prefs.getBoolean(MapboxConstants.MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_ENABLED, true));
+        setTelemetryEnabled(prefs.getBoolean(MapboxConstants.MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_ENABLED, false));
 
         // Load / Create Vendor Id
         if (prefs.contains(MapboxConstants.MAPBOX_SHARED_PREFERENCE_KEY_VENDORID)) {


### PR DESCRIPTION
If user simple add MapView (or fragment with them) him don't need use TelemetryService

At first time it fix necessity declare service in manifest.xml 
At second time if user really need use telemetry him call setTelemetryEnabled(boolean) method
At third at secure this beforehand  https://github.com/mapbox/mapbox-gl-native/commit/9324862aad5d71b43679dd59a5e48087a45446c5 

@tobrun @bleege 