### PR TITLE
Convert iosapp to pure Objective-C

### DIFF
--- a/platform/ios/app/mapboxgl-app.gypi
+++ b/platform/ios/app/mapboxgl-app.gypi
@@ -32,7 +32,7 @@
         'MBXOfflinePacksTableViewController.h',
         'MBXOfflinePacksTableViewController.m',
         'MBXViewController.h',
-        'MBXViewController.mm',
+        'MBXViewController.m',
       ],
 
       'xcode_settings': {


### PR DESCRIPTION
Converted MBXViewController from Objective-C++ to Objective-C. In the process, the dependency on default_styles.hpp was replaced by a hardcoded list of style URLs along with runtime assertions that the list of styles is the right length.

/cc @friedbunny @boundsj