### PR TITLE
[build] Fix libuv usage in OS X

### DIFF
--- a/gyp/mbgl.gyp
+++ b/gyp/mbgl.gyp
@@ -53,6 +53,14 @@
               '<@(libuv_ldflags)',
             ],
           },
+
+          'conditions': [
+              ['OS == "mac"', {
+                  'xcode_settings': {
+                      'OTHER_CPLUSPLUSFLAGS': [ '<@(libuv_cflags)' ],
+                  }
+              }]
+          ],
         }]
       ],
     },


### PR DESCRIPTION
This prevented `LOOP=uv make linux` from working in OS X.

/cc @tmpsantos @kkaefer 