### PR TITLE
[wip] add OSMesa HeadlessView and build target

### DIFF
--- a/gyp/headless-osmesa.gypi
+++ b/gyp/headless-osmesa.gypi
@@ -1,0 +1,26 @@
+{
+  'targets': [
+    { 'target_name': 'headless-osmesa',
+      'product_name': 'mbgl-headless-osmesa',
+      'type': 'static_library',
+      'standalone_static_library': 1,
+
+      'sources': [
+        '../platform/default/headless_view.cpp',
+        '../platform/default/headless_view_osmesa.cpp',
+        '../platform/default/headless_display.cpp',
+      ],
+
+      'include_dirs': [
+        '../include',
+        '/usr/local/lib/osmesa/include',
+      ],
+
+      'cflags_cc': [ '<@(opengl_cflags)' ],
+
+      'link_settings': {
+        'libraries': [ '<@(opengl_ldflags)' ],
+      },
+    },
+  ],
+}

--- a/gyp/mbgl.gyp
+++ b/gyp/mbgl.gyp
@@ -70,6 +70,7 @@
     ['headless_lib == "cgl" and host == "osx"', { 'includes': [ 'headless-cgl.gypi' ] } ],
     ['headless_lib == "eagl" and host == "ios"', { 'includes': [ 'headless-eagl.gypi' ] } ],
     ['headless_lib == "glx" and host == "linux"', { 'includes': [ 'headless-glx.gypi' ] } ],
+    ['headless_lib == "osmesa" and host == "linux"', { 'includes': [ 'headless-osmesa.gypi' ] } ],
     ['platform_lib == "osx" and host == "osx"', { 'includes': [ 'platform-osx.gypi' ] } ],
     ['platform_lib == "ios" and host == "ios"', { 'includes': [ 'platform-ios.gypi' ] } ],
     ['platform_lib == "linux"', { 'includes': [ 'platform-linux.gypi' ] } ],

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -88,6 +88,7 @@ private:
 
 #if MBGL_USE_OSMESA
     OSMesaContext glContext = 0;
+    void *pBuffer = nullptr;
 #endif
 
     bool extensionsLoaded = false;

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -9,6 +9,9 @@
 #define MBGL_USE_CGL 1
 #endif
 #else
+#define MBGL_USE_OSMESA 1
+typedef struct osmesa_context* OSMesaContext;
+/*
 #define GL_GLEXT_PROTOTYPES
 #define MBGL_USE_GLX 1
 typedef struct _XDisplay Display;
@@ -16,6 +19,7 @@ typedef struct __GLXcontextRec* GLXContext;
 typedef struct __GLXFBConfigRec* GLXFBConfig;
 typedef long unsigned int XID;
 typedef XID GLXPbuffer;
+*/
 #endif
 
 #include <mbgl/mbgl.hpp>
@@ -80,6 +84,10 @@ private:
     GLXFBConfig *fbConfigs = nullptr;
     GLXContext glContext = 0;
     GLXPbuffer glxPbuffer = 0;
+#endif
+
+#if MBGL_USE_OSMESA
+    OSMesaContext glContext = 0;
 #endif
 
     bool extensionsLoaded = false;

--- a/platform/default/headless_view_osmesa.cpp
+++ b/platform/default/headless_view_osmesa.cpp
@@ -1,0 +1,114 @@
+#include <mbgl/platform/default/headless_view.hpp>
+#include <mbgl/platform/log.hpp>
+
+#include <cassert>
+
+#include <GL/osmesa.h>
+
+namespace mbgl {
+
+gl::glProc HeadlessView::initializeExtension(const char* name) {
+    return OSMesaGetProcAddress(name);
+}
+
+void HeadlessView::createContext() {
+    if (!glContext) {
+        /* Create an RGBA-mode context */
+#if OSMESA_MAJOR_VERSION * 100 + OSMESA_MINOR_VERSION >= 305
+        /* specify Z, stencil, accum sizes */
+        glContext = OSMesaCreateContextExt(OSMESA_RGBA, 16, 0, 0, NULL);
+#else
+        glContext = OSMesaCreateContext(OSMESA_RGBA, NULL);
+#endif
+
+        if (!glContext) {
+            Log::Error(Event::OpenGL, "failed to create OSMesa context");
+            OSMesaDestroyContext(glContext);
+            glContext = 0;
+        }
+    }
+
+    if (glContext == 0) {
+        throw std::runtime_error("Error creating GL context object.");
+    }
+}
+
+void HeadlessView::destroyContext() {
+    OSMesaDestroyContext(glContext);
+}
+
+void HeadlessView::resizeFramebuffer() {
+    const unsigned int w = dimensions[0] * pixelRatio;
+    const unsigned int h = dimensions[1] * pixelRatio;
+
+    // Create depth/stencil buffer
+    MBGL_CHECK_ERROR(glGenRenderbuffersEXT(1, &fboDepthStencil));
+    MBGL_CHECK_ERROR(glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, fboDepthStencil));
+    MBGL_CHECK_ERROR(glRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_DEPTH24_STENCIL8_EXT, w, h));
+    MBGL_CHECK_ERROR(glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, 0));
+
+    MBGL_CHECK_ERROR(glGenRenderbuffersEXT(1, &fboColor));
+    MBGL_CHECK_ERROR(glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, fboColor));
+    MBGL_CHECK_ERROR(glRenderbufferStorageEXT(GL_RENDERBUFFER_EXT, GL_RGBA8, w, h));
+    MBGL_CHECK_ERROR(glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, 0));
+
+    MBGL_CHECK_ERROR(glGenFramebuffersEXT(1, &fbo));
+    MBGL_CHECK_ERROR(glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fbo));
+
+    MBGL_CHECK_ERROR(glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_RENDERBUFFER_EXT, fboColor));
+    MBGL_CHECK_ERROR(glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER_EXT, fboDepthStencil));
+
+    GLenum status = MBGL_CHECK_ERROR(glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT));
+
+    if (status != GL_FRAMEBUFFER_COMPLETE_EXT) {
+        std::string error("Couldn't create framebuffer: ");
+        switch (status) {
+            case GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT_EXT: (error += "incomplete attachment"); break;
+            case GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT_EXT: error += "incomplete missing attachment"; break;
+            case GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS_EXT: error += "incomplete dimensions"; break;
+            case GL_FRAMEBUFFER_INCOMPLETE_FORMATS_EXT: error += "incomplete formats"; break;
+            case GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER_EXT: error += "incomplete draw buffer"; break;
+            case GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT: error += "incomplete read buffer"; break;
+            case GL_FRAMEBUFFER_UNSUPPORTED: error += "unsupported"; break;
+            default: error += "other"; break;
+        }
+        throw std::runtime_error(error);
+    }
+
+    MBGL_CHECK_ERROR(glViewport(0, 0, w, h));
+}
+
+void HeadlessView::clearBuffers() {
+    assert(isActive());
+
+    MBGL_CHECK_ERROR(glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0));
+
+    if (fbo) {
+        MBGL_CHECK_ERROR(glDeleteFramebuffersEXT(1, &fbo));
+        fbo = 0;
+    }
+
+    if (fboColor) {
+        MBGL_CHECK_ERROR(glDeleteRenderbuffersEXT(1, &fboColor));
+        fboColor = 0;
+    }
+
+    if (fboDepthStencil) {
+        MBGL_CHECK_ERROR(glDeleteRenderbuffersEXT(1, &fboDepthStencil));
+        fboDepthStencil = 0;
+    }
+}
+
+void HeadlessView::activateContext() {
+    if (!OSMesaMakeCurrent(glContext, nullptr, GL_UNSIGNED_BYTE, 8, 8)) {
+        throw std::runtime_error("Switching OpenGL context failed.\n");
+    }
+}
+
+void HeadlessView::deactivateContext() {
+    if (!OSMesaMakeCurrent(nullptr, nullptr, GL_UNSIGNED_BYTE, 8, 8)) {
+        throw std::runtime_error("Removing OpenGL context failed.\n");
+    }
+}
+
+} // namespace mbgl

--- a/platform/default/headless_view_osmesa.cpp
+++ b/platform/default/headless_view_osmesa.cpp
@@ -31,9 +31,21 @@ void HeadlessView::createContext() {
     if (glContext == 0) {
         throw std::runtime_error("Error creating GL context object.");
     }
+
+    // Create a dummy pbuffer. We will render to framebuffers anyway, but we need a pbuffer to
+    // activate the context.
+    pBuffer = malloc(4 * sizeof(GLubyte));
+    if (!pBuffer) {
+       throw std::runtime_error("Alloc pixel buffer failed!");
+    }
 }
 
 void HeadlessView::destroyContext() {
+    if (pBuffer) {
+        free(pBuffer);
+        pBuffer = nullptr;
+    }
+
     OSMesaDestroyContext(glContext);
 }
 
@@ -100,15 +112,14 @@ void HeadlessView::clearBuffers() {
 }
 
 void HeadlessView::activateContext() {
-    if (!OSMesaMakeCurrent(glContext, nullptr, GL_UNSIGNED_BYTE, 8, 8)) {
+    if (!OSMesaMakeCurrent(glContext, pBuffer, GL_UNSIGNED_BYTE, 1, 1)) {
         throw std::runtime_error("Switching OpenGL context failed.\n");
     }
 }
 
 void HeadlessView::deactivateContext() {
-    if (!OSMesaMakeCurrent(nullptr, nullptr, GL_UNSIGNED_BYTE, 8, 8)) {
-        throw std::runtime_error("Removing OpenGL context failed.\n");
-    }
+    // no-op
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=482787
 }
 
 } // namespace mbgl

--- a/platform/linux/scripts/configure.sh
+++ b/platform/linux/scripts/configure.sh
@@ -19,5 +19,5 @@ WEBP_VERSION=0.5.0
 
 function print_opengl_flags {
     CONFIG+="    'opengl_cflags%': $(quote_flags $(pkg-config gl x11 --cflags)),"$LN
-    CONFIG+="    'opengl_ldflags%': $(quote_flags $(pkg-config gl x11 --libs)),"$LN
+    CONFIG+="    'opengl_ldflags%': '-L/usr/local/lib/osmesa/lib -lOSMesa',"$LN
 }


### PR DESCRIPTION
Fixes #4498 

Needs some further cleanup to be used alongside the GLX HeadlessView (instead of breaking the GLX build), but this is now compiling and passing `npm test` and `npm run test-suite` on a local VM with OpenSWR on OSMesa.

Build and test string I was using:

```
CXX=g++-4.9 HEADLESS=osmesa npm install --build-from-source && LD_LIBRARY_PATH=/usr/local/lib/osmesa/lib npm test
```

/cc @zmully 
