### PR TITLE
implement queryRenderedFeatures

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -158,6 +158,10 @@ public:
                         const char* before = nullptr);
     void removeCustomLayer(const std::string& id);
 
+    // Feature queries
+    std::vector<std::string> queryRenderedFeatures(const ScreenCoordinate&, const optional<std::vector<std::string>>& layerIDs = {});
+    std::vector<std::string> queryRenderedFeatures(const std::array<ScreenCoordinate, 2>&, const optional<std::vector<std::string>>& layerIDs = {});
+
     // Memory
     void setSourceTileCacheSize(size_t);
     void onLowMemory();

--- a/include/mbgl/util/math.hpp
+++ b/include/mbgl/util/math.hpp
@@ -88,6 +88,14 @@ inline T dist(const S1& a, const S2& b) {
     return c;
 }
 
+template <typename T, typename S1, typename S2>
+inline T distSqr(const S1& a, const S2& b) {
+    T dx = b.x - a.x;
+    T dy = b.y - a.y;
+    T c = dx * dx + dy * dy;
+    return c;
+}
+
 template <typename T>
 inline T round(const T& a) {
     return T(::round(a.x), ::round(a.y));
@@ -111,6 +119,15 @@ inline S unit(const S& a) {
         return a;
     }
     return a * (1 / magnitude);
+}
+
+template <typename T, typename S = double>
+inline T rotate(const T& a, S angle) {
+    S cos = std::cos(angle);
+    S sin = std::sin(angle);
+    S x = cos * a.x - sin * a.y;
+    S y = sin * a.x + cos * a.y;
+    return T(x, y);
 }
 
 template <typename T>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.3.5",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#d974ec6b3748a258f8ddd7528e049493390177b4",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#e211ead52b9268c53f998096d5f6ba15977cf4ea",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",
     "tape": "^4.5.1"
@@ -30,7 +30,7 @@
     "preinstall": "npm install node-pre-gyp",
     "install": "node-pre-gyp install --fallback-to-build=false || make node",
     "test": "tape platform/node/test/js/**/*.test.js",
-    "test-suite": "node platform/node/test/render.test.js"
+    "test-suite": "node platform/node/test/render.test.js && node platform/node/test/query.test.js"
   },
   "gypfile": true,
   "binary": {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -50,6 +50,7 @@ NAN_MODULE_INIT(NodeMap::Init) {
     Nan::SetPrototypeMethod(tpl, "render", Render);
     Nan::SetPrototypeMethod(tpl, "release", Release);
     Nan::SetPrototypeMethod(tpl, "dumpDebugLogs", DumpDebugLogs);
+    Nan::SetPrototypeMethod(tpl, "queryRenderedFeatures", QueryRenderedFeatures);
 
     constructor.Reset(tpl->GetFunction());
     Nan::Set(target, Nan::New("Map").ToLocalChecked(), tpl->GetFunction());
@@ -446,6 +447,55 @@ NAN_METHOD(NodeMap::DumpDebugLogs) {
 
     nodeMap->map->dumpDebugLogs();
     info.GetReturnValue().SetUndefined();
+}
+
+NAN_METHOD(NodeMap::QueryRenderedFeatures) {
+    auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
+    Nan::HandleScope scope;
+
+    if (!nodeMap->isValid()) return Nan::ThrowError(releasedMessage());
+
+    if (info.Length() <= 0 || !info[0]->IsArray()) {
+        return Nan::ThrowTypeError("First argument must be an array");
+    }
+
+    auto posOrBox = info[0].As<v8::Array>();
+    if (posOrBox->Length() != 2) {
+        return Nan::ThrowTypeError("First argument must have two components");
+    }
+
+    try {
+        std::vector<std::string> result;
+
+        if (Nan::Get(posOrBox, 0).ToLocalChecked()->IsArray()) {
+
+            auto pos0 = Nan::Get(posOrBox, 0).ToLocalChecked().As<v8::Array>();
+            auto pos1 = Nan::Get(posOrBox, 1).ToLocalChecked().As<v8::Array>();
+
+            std::array<mbgl::ScreenCoordinate, 2> queryBox = {{{
+                    Nan::Get(pos0, 0).ToLocalChecked()->NumberValue(),
+                    Nan::Get(pos0, 1).ToLocalChecked()->NumberValue()
+                }, {
+                    Nan::Get(pos1, 0).ToLocalChecked()->NumberValue(),
+                    Nan::Get(pos1, 1).ToLocalChecked()->NumberValue()
+                }}};
+            result = nodeMap->map->queryRenderedFeatures(queryBox);
+
+        } else {
+            mbgl::ScreenCoordinate queryPoint(
+                Nan::Get(posOrBox, 0).ToLocalChecked()->NumberValue(),
+                Nan::Get(posOrBox, 1).ToLocalChecked()->NumberValue());
+            result = nodeMap->map->queryRenderedFeatures(queryPoint);
+        }
+
+        auto array = Nan::New<v8::Array>();
+        for (unsigned int i = 0; i < result.size(); i++) {
+            array->Set(i, Nan::New<v8::String>(result[i]).ToLocalChecked());
+        }
+        info.GetReturnValue().Set(array);
+    } catch (const std::exception &ex) {
+        return Nan::ThrowError(ex.what());
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -27,6 +27,7 @@ public:
     static NAN_METHOD(Render);
     static NAN_METHOD(Release);
     static NAN_METHOD(DumpDebugLogs);
+    static NAN_METHOD(QueryRenderedFeatures);
 
     void startRender(RenderOptions options);
     void renderFinished();

--- a/platform/node/test/query.test.js
+++ b/platform/node/test/query.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var suite = require('mapbox-gl-test-suite').render;
+var suite = require('mapbox-gl-test-suite').query;
 var suiteImplementation = require('./suite_implementation');
 
 var tests;

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var mbgl = require('../../../lib/mapbox-gl-native');
+var request = require('request');
+
+mbgl.on('message', function(msg) {
+    console.log('%s (%s): %s', msg.severity, msg.class, msg.text);
+});
+
+module.exports = function (style, options, callback) {
+    var map = new mbgl.Map({
+        ratio: options.pixelRatio,
+        request: function(req, callback) {
+            request(req.url, {encoding: null}, function (err, response, body) {
+                if (err) {
+                    callback(err);
+                } else if (response.statusCode != 200) {
+                    callback(new Error(response.statusMessage));
+                } else {
+                    callback(null, {data: body});
+                }
+            });
+        }
+    });
+
+    var timedOut = false;
+    var watchdog = setTimeout(function () {
+        timedOut = true;
+        map.dumpDebugLogs();
+        callback(new Error('timed out after 20 seconds'));
+    }, 20000);
+
+    options.center = style.center;
+    options.zoom = style.zoom;
+    options.bearing = style.bearing;
+    options.pitch = style.pitch;
+    options.debug = {
+        tileBorders: options.debug,
+        collision: options.collisionDebug
+    };
+
+    map.load(style);
+
+    map.render(options, function (err, pixels) {
+        var results = options.queryGeometry ?
+            map.queryRenderedFeatures(options.queryGeometry) :
+            [];
+        map.release();
+        if (timedOut) return;
+        clearTimeout(watchdog);
+        callback(err, pixels, results.map(prepareFeatures));
+    });
+
+    function prepareFeatures(json) {
+        var r = JSON.parse(json);
+        delete r.layer;
+        r.geometry = null;
+        return r;
+    }
+};

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -27,6 +27,7 @@ class AnnotationTileLayer : public GeometryTileLayer {
 public:
     std::size_t featureCount() const override { return features.size(); }
     util::ptr<const GeometryTileFeature> getFeature(std::size_t i) const override { return features[i]; }
+    std::string getName() const override { return ""; };
 
     std::vector<util::ptr<const AnnotationTileFeature>> features;
 };

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -1,0 +1,236 @@
+#include <mbgl/geometry/feature_index.hpp>
+#include <mbgl/util/math.hpp>
+#include <mbgl/style/style.hpp>
+#include <mbgl/style/style_layer.hpp>
+#include <mbgl/layer/symbol_layer.hpp>
+#include <mbgl/util/get_geometries.hpp>
+#include <mbgl/text/collision_tile.hpp>
+#include <mbgl/util/rapidjson.hpp>
+#include <rapidjson/writer.h>
+
+#include <cassert>
+#include <string>
+
+using namespace mbgl;
+
+FeatureIndex::FeatureIndex() {}
+
+void FeatureIndex::insert(const GeometryCollection& geometries, std::size_t index,
+        const std::string& sourceLayerName, const std::string& bucketName) {
+
+    auto sortIndex = treeBoxes.size();
+
+    for (auto& ring : geometries) {
+
+        float minX = std::numeric_limits<float>::infinity();
+        float minY = std::numeric_limits<float>::infinity();
+        float maxX = -std::numeric_limits<float>::infinity();
+        float maxY = -std::numeric_limits<float>::infinity();
+        for (auto& p : ring) {
+            const float x = p.x;
+            const float y = p.y;
+            minX = util::min(minX, x);
+            minY = util::min(minY, y);
+            maxX = util::max(maxX, x);
+            maxY = util::max(maxY, y);
+        }
+
+        treeBoxes.emplace_back(
+            TreeBox {
+                TreePoint { minX, minY },
+                TreePoint { maxX, maxY }
+            },
+            IndexedSubfeature { index, sourceLayerName, bucketName, sortIndex }
+        );
+    }
+}
+
+void FeatureIndex::loadTree() {
+    tree.insert(treeBoxes.begin(), treeBoxes.end());
+}
+
+bool vectorContains(const std::vector<std::string>& vector, const std::string& s) {
+    return std::find(vector.begin(), vector.end(), s) != vector.end();
+}
+
+bool vectorsIntersect(const std::vector<std::string>& vectorA, const std::vector<std::string>& vectorB) {
+    for (auto& a : vectorA) {
+        if (vectorContains(vectorB, a)) return true;;
+    }
+    return false;
+}
+
+
+bool topDown(const FeatureTreeBox& a, const FeatureTreeBox& b) {
+    return std::get<1>(a).sortIndex > std::get<1>(b).sortIndex;
+}
+
+bool topDownSymbols(const IndexedSubfeature& a, const IndexedSubfeature& b) {
+    return a.sortIndex < b.sortIndex;
+}
+
+void FeatureIndex::query(
+        std::unordered_map<std::string, std::vector<std::string>>& result,
+        const GeometryCollection& queryGeometry,
+        const float bearing,
+        const double tileSize,
+        const double scale,
+        const optional<std::vector<std::string>>& filterLayerIDs,
+        const GeometryTile& geometryTile,
+        const Style& style) const {
+
+    const float pixelsToTileUnits = util::EXTENT / tileSize / scale;
+
+    float additionalRadius = style.getQueryRadius() * pixelsToTileUnits;
+
+    float minX = std::numeric_limits<float>::infinity();
+    float minY = std::numeric_limits<float>::infinity();
+    float maxX = -std::numeric_limits<float>::infinity();
+    float maxY = -std::numeric_limits<float>::infinity();
+
+    for (auto& ring : queryGeometry) {
+        for (auto& p : ring) {
+            minX = util::min<float>(minX, p.x);
+            minY = util::min<float>(minY, p.y);
+            maxX = util::max<float>(maxX, p.x);
+            maxY = util::max<float>(maxY, p.y);
+        }
+    }
+
+    TreeBox queryBox = {
+        TreePoint { minX - additionalRadius, minY - additionalRadius },
+        TreePoint { maxX + additionalRadius, maxY + additionalRadius }
+    };
+
+    // query circle, line, fill features
+    std::vector<FeatureTreeBox> matchingBoxes;
+    tree.query(bgi::intersects(queryBox), std::back_inserter(matchingBoxes));
+    std::sort(matchingBoxes.begin(), matchingBoxes.end(), topDown);
+
+    size_t previousSortIndex = std::numeric_limits<size_t>::max();
+    for (auto& matchingBox : matchingBoxes) {
+        auto& indexedFeature = std::get<1>(matchingBox);
+
+        // If this feature is the same as the previous feature, skip it.
+        if (indexedFeature.sortIndex == previousSortIndex) continue;
+        previousSortIndex = indexedFeature.sortIndex;
+
+        addFeature(result, indexedFeature, queryGeometry, filterLayerIDs, geometryTile, style, bearing, pixelsToTileUnits);
+    }
+
+    // query symbol features
+    assert(collisionTile);
+    std::vector<IndexedSubfeature> symbolFeatures = collisionTile->queryRenderedSymbols(minX, minY, maxX, maxY, scale);
+    std::sort(symbolFeatures.begin(), symbolFeatures.end(), topDownSymbols);
+    for (auto& symbolFeature : symbolFeatures) {
+        addFeature(result, symbolFeature, queryGeometry, filterLayerIDs, geometryTile, style, bearing, pixelsToTileUnits);
+    }
+}
+
+void FeatureIndex::addFeature(
+    std::unordered_map<std::string, std::vector<std::string>>& result,
+    const IndexedSubfeature& indexedFeature,
+    const GeometryCollection& queryGeometry,
+    const optional<std::vector<std::string>>& filterLayerIDs,
+    const GeometryTile& geometryTile,
+    const Style& style,
+    const float bearing,
+    const float pixelsToTileUnits) const {
+
+    auto& layerIDs = bucketLayerIDs.at(indexedFeature.bucketName);
+
+    if (filterLayerIDs && !vectorsIntersect(layerIDs, *filterLayerIDs)) return;
+
+    auto sourceLayer = geometryTile.getLayer(indexedFeature.sourceLayerName);
+    assert(sourceLayer);
+    auto feature = sourceLayer->getFeature(indexedFeature.index);
+    assert(feature);
+
+    for (auto& layerID : layerIDs) {
+
+        if (filterLayerIDs && !vectorContains(*filterLayerIDs, layerID)) continue;
+
+        auto styleLayer = style.getLayer(layerID);
+        if (!styleLayer) continue;
+
+        if (!styleLayer->is<SymbolLayer>()) {
+            auto geometries = getGeometries(*feature);
+            if (!styleLayer->queryIntersectsGeometry(queryGeometry, geometries, bearing, pixelsToTileUnits)) continue;
+        }
+
+        auto& layerResult = result[layerID];
+
+        auto properties = feature->getProperties();
+        rapidjson::StringBuffer buffer;
+        buffer.Clear();
+        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+        writer.StartObject();
+        writer.Key("type");
+        writer.String("Feature");
+        auto id = feature->getID();
+        if (id) {
+            writer.Key("id");
+            writer.Double(feature->getID());
+        }
+        writer.Key("properties");
+        writer.StartObject();
+        for (auto& prop : properties) {
+            std::string key = prop.first;
+            Value& value = prop.second;
+
+            writer.Key(key.c_str());
+
+            if (value.is<std::string>()) {
+                writer.String(value.get<std::string>().c_str());
+            } else if (value.is<bool>()) {
+                writer.Bool(value.get<bool>());
+            } else if (value.is<int64_t>()) {
+                writer.Int64(value.get<int64_t>());
+            } else if (value.is<uint64_t>()) {
+                writer.Uint64(value.get<uint64_t>());
+            } else if (value.is<double>()) {
+                writer.Double(value.get<double>());
+            }
+        }
+        writer.EndObject();
+        writer.EndObject();
+
+        layerResult.push_back(buffer.GetString());
+    }
+}
+
+optional<GeometryCollection> FeatureIndex::translateQueryGeometry(
+        const GeometryCollection& queryGeometry,
+        const std::array<float, 2>& translate,
+        const TranslateAnchorType anchorType,
+        const float bearing,
+        const float pixelsToTileUnits) {
+
+    if (translate[0] == 0 && translate[1] == 0) return {};
+
+    GeometryCoordinate translateVec(translate[0] * pixelsToTileUnits, translate[1] * pixelsToTileUnits);
+
+    if (anchorType == TranslateAnchorType::Viewport) {
+        translateVec = util::rotate(translateVec, -bearing);
+    }
+
+    GeometryCollection translated;
+    for (auto& ring : queryGeometry) {
+        translated.emplace_back();
+        auto& translatedRing = translated.back();
+        for (auto& p : ring) {
+            translatedRing.push_back(p - translateVec);
+        }
+    }
+    return translated;
+}
+
+void FeatureIndex::addBucketLayerName(const std::string& bucketName, const std::string& layerID) {
+    auto& layerIDs = bucketLayerIDs[bucketName];
+    layerIDs.push_back(layerID);
+}
+
+void FeatureIndex::setCollisionTile(std::unique_ptr<CollisionTile> collisionTile_) {
+    collisionTile = std::move(collisionTile_);
+}

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -2,29 +2,11 @@
 #define MBGL_GEOMETRY_FEATURE_INDEX
 
 #include <mbgl/tile/geometry_tile.hpp>
+#include <mbgl/util/grid_index.hpp>
 
 #include <vector>
 #include <string>
 #include <unordered_map>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wshadow"
-#ifdef __clang__
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#endif
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wdeprecated-register"
-#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/point.hpp>
-#include <boost/geometry/geometries/box.hpp>
-#include <boost/geometry/index/rtree.hpp>
-#pragma GCC diagnostic pop
 
 namespace mbgl {
 
@@ -40,20 +22,11 @@ class IndexedSubfeature {
         size_t sortIndex;
 };
 
-namespace bg = boost::geometry;
-namespace bgm = bg::model;
-namespace bgi = bg::index;
-typedef bgm::point<float, 2, bg::cs::cartesian> TreePoint;
-typedef bgm::box<TreePoint> TreeBox;
-typedef std::pair<TreeBox, IndexedSubfeature> FeatureTreeBox;
-typedef bgi::rtree<FeatureTreeBox, bgi::linear<16, 4>> FeatureTree;
-
 class FeatureIndex {
     public:
         FeatureIndex();
 
         void insert(const GeometryCollection&, std::size_t index, const std::string& sourceLayerName, const std::string& bucketName);
-        void loadTree();
 
         void query(
                 std::unordered_map<std::string, std::vector<std::string>>& result,
@@ -89,8 +62,8 @@ class FeatureIndex {
                 const float pixelsToTileUnits) const;
 
         std::unique_ptr<CollisionTile> collisionTile;
-        std::vector<FeatureTreeBox> treeBoxes;
-        FeatureTree tree;
+        GridIndex<IndexedSubfeature> grid;
+        unsigned int sortIndex = 0;
 
         std::unordered_map<std::string,std::vector<std::string>> bucketLayerIDs;
 

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -1,0 +1,100 @@
+#ifndef MBGL_GEOMETRY_FEATURE_INDEX
+#define MBGL_GEOMETRY_FEATURE_INDEX
+
+#include <mbgl/tile/geometry_tile.hpp>
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wshadow"
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#endif
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wdeprecated-register"
+#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/box.hpp>
+#include <boost/geometry/index/rtree.hpp>
+#pragma GCC diagnostic pop
+
+namespace mbgl {
+
+class Style;
+class CollisionTile;
+enum class TranslateAnchorType : bool;
+
+class IndexedSubfeature {
+    public:
+        std::size_t index;
+        std::string sourceLayerName;
+        std::string bucketName;
+        size_t sortIndex;
+};
+
+namespace bg = boost::geometry;
+namespace bgm = bg::model;
+namespace bgi = bg::index;
+typedef bgm::point<float, 2, bg::cs::cartesian> TreePoint;
+typedef bgm::box<TreePoint> TreeBox;
+typedef std::pair<TreeBox, IndexedSubfeature> FeatureTreeBox;
+typedef bgi::rtree<FeatureTreeBox, bgi::linear<16, 4>> FeatureTree;
+
+class FeatureIndex {
+    public:
+        FeatureIndex();
+
+        void insert(const GeometryCollection&, std::size_t index, const std::string& sourceLayerName, const std::string& bucketName);
+        void loadTree();
+
+        void query(
+                std::unordered_map<std::string, std::vector<std::string>>& result,
+                const GeometryCollection& queryGeometry,
+                const float bearing,
+                const double tileSize,
+                const double scale,
+                const optional<std::vector<std::string>>& layerIDs,
+                const GeometryTile& geometryTile,
+                const Style&) const;
+
+        static optional<GeometryCollection> translateQueryGeometry(
+                const GeometryCollection& queryGeometry,
+                const std::array<float, 2>& translate,
+                const TranslateAnchorType,
+                const float bearing,
+                const float pixelsToTileUnits);
+
+        void addBucketLayerName(const std::string &bucketName, const std::string &layerName);
+
+        void setCollisionTile(std::unique_ptr<CollisionTile>);
+
+    private:
+
+        void addFeature(
+                std::unordered_map<std::string, std::vector<std::string>>& result,
+                const IndexedSubfeature &indexedFeature,
+                const GeometryCollection& queryGeometry,
+                const optional<std::vector<std::string>>& filterLayerIDs,
+                const GeometryTile& geometryTile,
+                const Style& style,
+                const float bearing,
+                const float pixelsToTileUnits) const;
+
+        std::unique_ptr<CollisionTile> collisionTile;
+        std::vector<FeatureTreeBox> treeBoxes;
+        FeatureTree tree;
+
+        std::unordered_map<std::string,std::vector<std::string>> bucketLayerIDs;
+
+};
+}
+
+#endif

--- a/src/mbgl/layer/circle_layer.cpp
+++ b/src/mbgl/layer/circle_layer.cpp
@@ -2,6 +2,9 @@
 #include <mbgl/style/style_bucket_parameters.hpp>
 #include <mbgl/renderer/circle_bucket.hpp>
 #include <mbgl/util/get_geometries.hpp>
+#include <mbgl/geometry/feature_index.hpp>
+#include <mbgl/util/math.hpp>
+#include <mbgl/util/intersection_tests.hpp>
 
 namespace mbgl {
 
@@ -46,11 +49,34 @@ bool CircleLayer::recalculate(const StyleCalculationParameters& parameters) {
 std::unique_ptr<Bucket> CircleLayer::createBucket(StyleBucketParameters& parameters) const {
     auto bucket = std::make_unique<CircleBucket>(parameters.mode);
 
-    parameters.eachFilteredFeature(filter, [&] (const auto& feature) {
-        bucket->addGeometry(getGeometries(feature));
+    auto& name = bucketName();
+    parameters.eachFilteredFeature(filter, [&] (const auto& feature, std::size_t index, const std::string& layerName) {
+        auto geometries = getGeometries(feature);
+        bucket->addGeometry(geometries);
+        parameters.featureIndex.insert(geometries, index, layerName, name);
     });
 
     return std::move(bucket);
+}
+
+float CircleLayer::getQueryRadius() const {
+    const std::array<float, 2>& translate = paint.circleTranslate;
+    return paint.circleRadius + util::length(translate[0], translate[1]);
+}
+
+bool CircleLayer::queryIntersectsGeometry(
+        const GeometryCollection& queryGeometry,
+        const GeometryCollection& geometry,
+        const float bearing,
+        const float pixelsToTileUnits) const {                
+
+    auto translatedQueryGeometry = FeatureIndex::translateQueryGeometry(
+            queryGeometry, paint.circleTranslate, paint.circleTranslateAnchor, bearing, pixelsToTileUnits);
+
+    auto circleRadius = paint.circleRadius * pixelsToTileUnits;
+
+    return util::multiPolygonIntersectsBufferedMultiPoint(
+            translatedQueryGeometry.value_or(queryGeometry), geometry, circleRadius);
 }
 
 } // namespace mbgl

--- a/src/mbgl/layer/circle_layer.hpp
+++ b/src/mbgl/layer/circle_layer.hpp
@@ -29,6 +29,13 @@ public:
 
     std::unique_ptr<Bucket> createBucket(StyleBucketParameters&) const override;
 
+    float getQueryRadius() const override;
+    bool queryIntersectsGeometry(
+            const GeometryCollection& queryGeometry,
+            const GeometryCollection& geometry,
+            const float bearing,
+            const float pixelsToTileUnits) const override;
+
     CirclePaintProperties paint;
 };
 

--- a/src/mbgl/layer/fill_layer.hpp
+++ b/src/mbgl/layer/fill_layer.hpp
@@ -30,6 +30,13 @@ public:
 
     std::unique_ptr<Bucket> createBucket(StyleBucketParameters&) const override;
 
+    float getQueryRadius() const override;
+    bool queryIntersectsGeometry(
+            const GeometryCollection& queryGeometry,
+            const GeometryCollection& geometry,
+            const float bearing,                
+            const float pixelsToTileUnits) const override; 
+
     FillPaintProperties paint;
 };
 

--- a/src/mbgl/layer/line_layer.cpp
+++ b/src/mbgl/layer/line_layer.cpp
@@ -3,6 +3,9 @@
 #include <mbgl/renderer/line_bucket.hpp>
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/util/get_geometries.hpp>
+#include <mbgl/geometry/feature_index.hpp>
+#include <mbgl/util/math.hpp>
+#include <mbgl/util/intersection_tests.hpp>
 
 namespace mbgl {
 
@@ -80,11 +83,76 @@ std::unique_ptr<Bucket> LineLayer::createBucket(StyleBucketParameters& parameter
     bucket->layout.lineMiterLimit.calculate(p);
     bucket->layout.lineRoundLimit.calculate(p);
 
-    parameters.eachFilteredFeature(filter, [&] (const auto& feature) {
-        bucket->addGeometry(getGeometries(feature));
+    auto& name = bucketName();
+    parameters.eachFilteredFeature(filter, [&] (const auto& feature, std::size_t index, const std::string& layerName) {
+        auto geometries = getGeometries(feature);
+        bucket->addGeometry(geometries);
+        parameters.featureIndex.insert(geometries, index, layerName, name);
     });
 
     return std::move(bucket);
+}
+
+
+float LineLayer::getLineWidth() const {
+    if (paint.lineGapWidth > 0) {
+        return paint.lineGapWidth + 2 * paint.lineWidth;
+    } else {
+        return paint.lineWidth;
+    }
+}
+
+optional<GeometryCollection> offsetLine(const GeometryCollection& rings, const float offset) {
+    if (offset == 0) return {};
+
+    GeometryCollection newRings;
+    vec2<double> zero(0, 0);
+    for (auto& ring : rings) {
+        newRings.emplace_back();
+        auto& newRing = newRings.back();
+
+        for (auto i = ring.begin(); i != ring.end(); i++) {
+            auto& p = *i;
+
+            auto aToB = i == ring.begin() ?
+                zero :
+                util::perp(util::unit(vec2<double>(p - *(i - 1))));
+            auto bToC = i + 1 == ring.end() ?
+                zero :
+                util::perp(util::unit(vec2<double>(*(i + 1) - p)));
+            auto extrude = util::unit(aToB + bToC);
+
+            const double cosHalfAngle = extrude.x * bToC.x + extrude.y * bToC.y;
+            extrude *= (1.0 / cosHalfAngle);
+
+            newRing.push_back((extrude * offset) + p);
+        }
+    }
+
+    return newRings;
+}
+
+float LineLayer::getQueryRadius() const {
+    const std::array<float, 2>& translate = paint.lineTranslate;
+    return getLineWidth() / 2.0 + std::abs(paint.lineOffset) + util::length(translate[0], translate[1]);
+}
+
+bool LineLayer::queryIntersectsGeometry(
+        const GeometryCollection& queryGeometry,
+        const GeometryCollection& geometry,
+        const float bearing,
+        const float pixelsToTileUnits) const {
+
+    const float halfWidth = getLineWidth() / 2.0 * pixelsToTileUnits;
+
+    auto translatedQueryGeometry = FeatureIndex::translateQueryGeometry(
+            queryGeometry, paint.lineTranslate, paint.lineTranslateAnchor, bearing, pixelsToTileUnits);
+    auto offsetGeometry = offsetLine(geometry, paint.lineOffset * pixelsToTileUnits);
+
+    return util::multiPolygonIntersectsBufferedMultiLine(
+            translatedQueryGeometry.value_or(queryGeometry),
+            offsetGeometry.value_or(geometry),
+            halfWidth);
 }
 
 } // namespace mbgl

--- a/src/mbgl/layer/line_layer.hpp
+++ b/src/mbgl/layer/line_layer.hpp
@@ -42,10 +42,19 @@ public:
 
     std::unique_ptr<Bucket> createBucket(StyleBucketParameters&) const override;
 
+    float getQueryRadius() const override;
+    bool queryIntersectsGeometry(
+            const GeometryCollection& queryGeometry,
+            const GeometryCollection& geometry,
+            const float bearing,
+            const float pixelsToTileUnits) const override;
+
     LineLayoutProperties layout;
     LinePaintProperties paint;
 
     float dashLineWidth = 1;
+private:
+    float getLineWidth() const;
 };
 
 template <>

--- a/src/mbgl/layer/symbol_layer.cpp
+++ b/src/mbgl/layer/symbol_layer.cpp
@@ -116,7 +116,9 @@ bool SymbolLayer::recalculate(const StyleCalculationParameters& parameters) {
 std::unique_ptr<Bucket> SymbolLayer::createBucket(StyleBucketParameters& parameters) const {
     auto bucket = std::make_unique<SymbolBucket>(parameters.tileID.overscaleFactor(),
                                                  parameters.tileID.z,
-                                                 parameters.mode);
+                                                 parameters.mode,
+                                                 id,
+                                                 parameters.layer.getName());
 
     bucket->layout = layout;
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -32,12 +32,14 @@ class SpriteAtlas;
 class SpriteStore;
 class GlyphAtlas;
 class GlyphStore;
+class IndexedSubfeature;
 
 class SymbolFeature {
 public:
     GeometryCollection geometry;
     std::u32string label;
     std::string sprite;
+    std::size_t index;
 };
 
 struct Anchor;
@@ -49,7 +51,7 @@ class SymbolInstance {
                 const SymbolLayoutProperties& layout, const bool inside, const uint32_t index,
                 const float textBoxScale, const float textPadding, const float textAlongLine,
                 const float iconBoxScale, const float iconPadding, const float iconAlongLine,
-                const GlyphPositions& face);
+                const GlyphPositions& face, const IndexedSubfeature& indexedfeature);
         float x;
         float y;
         uint32_t index;
@@ -67,7 +69,7 @@ class SymbolBucket : public Bucket {
     typedef ElementGroup<1> CollisionBoxElementGroup;
 
 public:
-    SymbolBucket(uint32_t overscaling, float zoom, const MapMode);
+    SymbolBucket(uint32_t overscaling, float zoom, const MapMode, const std::string& bucketName_, const std::string& sourceLayerName_);
     ~SymbolBucket() override;
 
     void upload(gl::GLObjectStore&) override;
@@ -95,7 +97,8 @@ public:
 private:
     void addFeature(const GeometryCollection &lines,
             const Shaping &shapedText, const PositionedIcon &shapedIcon,
-            const GlyphPositions &face);
+            const GlyphPositions &face,
+            const size_t index);
     bool anchorIsTooClose(const std::u32string &text, const float repeatDistance, Anchor &anchor);
     std::map<std::u32string, std::vector<Anchor>> compareText;
     
@@ -124,6 +127,8 @@ private:
     const uint32_t tileSize;
     const float tilePixelRatio;
     const MapMode mode;
+    const std::string bucketName;
+    const std::string sourceLayerName;
 
     std::set<GlyphRange> ranges;
     std::vector<SymbolInstance> symbolInstances;

--- a/src/mbgl/source/source.hpp
+++ b/src/mbgl/source/source.hpp
@@ -20,12 +20,14 @@ class GeoJSONVT;
 
 namespace mbgl {
 
+class Style;
 class StyleUpdateParameters;
 class Painter;
 class FileSource;
 class AsyncRequest;
 class TransformState;
 class Tile;
+class TileCoordinate;
 struct ClipID;
 struct box;
 
@@ -69,6 +71,12 @@ public:
 
     std::forward_list<Tile *> getLoadedTiles() const;
     const std::vector<Tile*>& getTiles() const;
+
+    std::unordered_map<std::string, std::vector<std::string>> queryRenderedFeatures(
+            const std::vector<TileCoordinate>& queryGeometry,
+            const double zoom,
+            const double bearing,
+            const optional<std::vector<std::string>>& layerIDs);
 
     void setCacheSize(size_t);
     void onLowMemory();

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -30,6 +30,7 @@ class StyleLayer;
 class Tile;
 class Bucket;
 class StyleUpdateParameters;
+class TileCoordinate;
 
 struct RenderItem {
     inline RenderItem(const StyleLayer& layer_,
@@ -106,6 +107,14 @@ public:
     std::vector<std::string> getClasses() const;
 
     RenderData getRenderData() const;
+
+    std::vector<std::string> queryRenderedFeatures(
+            const std::vector<TileCoordinate>& queryGeometry,
+            const double zoom,
+            const double bearing,
+            const optional<std::vector<std::string>>& layerIDs);
+
+    float getQueryRadius() const;
 
     void setSourceTileCacheSize(size_t);
     void onLowMemory();

--- a/src/mbgl/style/style_bucket_parameters.cpp
+++ b/src/mbgl/style/style_bucket_parameters.cpp
@@ -5,7 +5,8 @@
 namespace mbgl {
 
 void StyleBucketParameters::eachFilteredFeature(const Filter& filter,
-                                                std::function<void (const GeometryTileFeature&)> function) {
+                                                std::function<void (const GeometryTileFeature&, std::size_t index, const std::string& layerName)> function) {
+    auto name = layer.getName();
     for (std::size_t i = 0; !cancelled() && i < layer.featureCount(); i++) {
         auto feature = layer.getFeature(i);
 
@@ -13,7 +14,7 @@ void StyleBucketParameters::eachFilteredFeature(const Filter& filter,
         if (!Filter::visit(filter, evaluator))
             continue;
 
-        function(*feature);
+        function(*feature, i, name);
     }
 }
 

--- a/src/mbgl/style/style_bucket_parameters.hpp
+++ b/src/mbgl/style/style_bucket_parameters.hpp
@@ -16,6 +16,7 @@ class SpriteStore;
 class GlyphAtlas;
 class GlyphStore;
 class CollisionTile;
+class FeatureIndex;
 
 class StyleBucketParameters {
 public:
@@ -27,6 +28,7 @@ public:
                           SpriteStore& spriteStore_,
                           GlyphAtlas& glyphAtlas_,
                           GlyphStore& glyphStore_,
+                          FeatureIndex& featureIndex_,
                           const MapMode mode_)
         : tileID(tileID_),
           layer(layer_),
@@ -36,13 +38,14 @@ public:
           spriteStore(spriteStore_),
           glyphAtlas(glyphAtlas_),
           glyphStore(glyphStore_),
+          featureIndex(featureIndex_),
           mode(mode_) {}
 
     bool cancelled() const {
         return state == TileData::State::obsolete;
     }
 
-    void eachFilteredFeature(const Filter&, std::function<void (const GeometryTileFeature&)>);
+    void eachFilteredFeature(const Filter&, std::function<void (const GeometryTileFeature&, std::size_t index, const std::string& layerName)>);
 
     const TileID& tileID;
     const GeometryTileLayer& layer;
@@ -52,6 +55,7 @@ public:
     SpriteStore& spriteStore;
     GlyphAtlas& glyphAtlas;
     GlyphStore& glyphStore;
+    FeatureIndex& featureIndex;
     const MapMode mode;
 };
 

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/renderer/render_pass.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/rapidjson.hpp>
+#include <mbgl/tile/geometry_tile.hpp>
 
 #include <memory>
 #include <string>
@@ -59,6 +60,13 @@ public:
 
     // Checks whether this layer can be rendered.
     bool needsRendering() const;
+
+    virtual float getQueryRadius() const { return 0; }
+    virtual bool queryIntersectsGeometry(
+            const GeometryCollection&,
+            const GeometryCollection&,
+            const float,
+            const float) const { return false; };
 
 public:
     std::string id;

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -5,7 +5,8 @@ namespace mbgl {
 
 CollisionFeature::CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
         const float top, const float bottom, const float left, const float right,
-        const float boxScale, const float padding, const bool alongLine, const bool straight) {
+        const float boxScale, const float padding, const bool alongLine, const IndexedSubfeature& indexedFeature,
+        const bool straight) {
 
     if (top == 0 && bottom == 0 && left == 0 && right == 0) return;
 
@@ -28,18 +29,19 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates &line, const Anchor
             // used for icon labels that are aligned with the line, but don't curve along it
             const vec2<double> vector = util::unit(vec2<double>(line[anchor.segment + 1] - line[anchor.segment])) * length;
             const GeometryCoordinates newLine({ anchorPoint - vector, anchorPoint + vector });
-            bboxifyLabel(newLine, anchorPoint, 0, length, height);
+            bboxifyLabel(newLine, anchorPoint, 0, length, height, indexedFeature);
         } else {
             // used for text labels that curve along a line
-            bboxifyLabel(line, anchorPoint, anchor.segment, length, height);
+            bboxifyLabel(line, anchorPoint, anchor.segment, length, height, indexedFeature);
         }
     } else {
-        boxes.emplace_back(anchor, x1, y1, x2, y2, std::numeric_limits<float>::infinity());
+        boxes.emplace_back(anchor, x1, y1, x2, y2, std::numeric_limits<float>::infinity(), indexedFeature);
     }
 }
 
 void CollisionFeature::bboxifyLabel(const GeometryCoordinates &line,
-        GeometryCoordinate &anchorPoint, const int segment, const float labelLength, const float boxSize) {
+        GeometryCoordinate &anchorPoint, const int segment, const float labelLength, const float boxSize,
+        const IndexedSubfeature& indexedFeature) {
 
     const float step = boxSize / 2;
     const unsigned int nBoxes = std::floor(labelLength / step);
@@ -95,7 +97,7 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates &line,
         const float distanceToInnerEdge = std::max(std::fabs(boxDistanceToAnchor - firstBoxOffset) - step / 2, 0.0f);
         const float maxScale = labelLength / 2 / distanceToInnerEdge;
 
-        boxes.emplace_back(boxAnchor, -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, maxScale);
+        boxes.emplace_back(boxAnchor, -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, maxScale, indexedFeature);
     }
 }
 

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -5,14 +5,16 @@
 #include <mbgl/geometry/anchor.hpp>
 #include <mbgl/text/shaping.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
+#include <mbgl/geometry/feature_index.hpp>
 
 #include <vector>
 
 namespace mbgl {
     class CollisionBox {
         public:
-            explicit CollisionBox(const vec2<float> &_anchor, float _x1, float _y1, float _x2, float _y2, float _maxScale) :
-                anchor(_anchor), x1(_x1), y1(_y1), x2(_x2), y2(_y2), maxScale(_maxScale) {}
+            explicit CollisionBox(const vec2<float> &_anchor, float _x1, float _y1, float _x2, float _y2, float _maxScale,
+                    const IndexedSubfeature& indexedFeature_ = { 0, "", "", 0 }) :
+                anchor(_anchor), x1(_x1), y1(_y1), x2(_x2), y2(_y2), maxScale(_maxScale), indexedFeature(indexedFeature_) {}
 
             // the box is centered around the anchor point
             vec2<float> anchor;
@@ -29,6 +31,8 @@ namespace mbgl {
 
             // the scale at which the label can first be shown
             float placementScale = 0.0f;
+
+            IndexedSubfeature indexedFeature;
     };
 
     class CollisionFeature {
@@ -36,28 +40,31 @@ namespace mbgl {
             // for text
             inline explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const Shaping &shapedText,
-                    const float boxScale, const float padding, const bool alongLine)
+                    const float boxScale, const float padding, const bool alongLine, const IndexedSubfeature& indexedFeature)
                 : CollisionFeature(line, anchor,
                         shapedText.top, shapedText.bottom, shapedText.left, shapedText.right,
-                        boxScale, padding, alongLine, false) {}
+                        boxScale, padding, alongLine, indexedFeature, false) {}
 
             // for icons
             inline explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const PositionedIcon &shapedIcon,
-                    const float boxScale, const float padding, const bool alongLine)
+                    const float boxScale, const float padding, const bool alongLine, const IndexedSubfeature& indexedFeature)
                 : CollisionFeature(line, anchor,
                         shapedIcon.top, shapedIcon.bottom, shapedIcon.left, shapedIcon.right,
-                        boxScale, padding, alongLine, true) {}
+                        boxScale, padding, alongLine, indexedFeature, true) {}
 
             explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const float top, const float bottom, const float left, const float right,
-                    const float boxScale, const float padding, const bool alongLine, const bool straight);
+                    const float boxScale, const float padding, const bool alongLine,
+                    const IndexedSubfeature&, const bool straight);
 
 
             std::vector<CollisionBox> boxes;
 
         private:
-            void bboxifyLabel(const GeometryCoordinates &line, GeometryCoordinate &anchorPoint, const int segment, const float length, const float height);
+            void bboxifyLabel(const GeometryCoordinates &line, GeometryCoordinate &anchorPoint,
+                    const int segment, const float length, const float height,
+                    const IndexedSubfeature&);
     };
 } // namespace mbgl
 

--- a/src/mbgl/text/collision_tile.hpp
+++ b/src/mbgl/text/collision_tile.hpp
@@ -33,12 +33,16 @@ typedef bgm::box<CollisionPoint> Box;
 typedef std::pair<Box, CollisionBox> CollisionTreeBox;
 typedef bgi::rtree<CollisionTreeBox, bgi::linear<16, 4>> Tree;
 
+class IndexedSubfeature;
+
 class CollisionTile {
 public:
     explicit CollisionTile(PlacementConfig);
 
     float placeFeature(const CollisionFeature& feature, const bool allowOverlap, const bool avoidEdges);
-    void insertFeature(CollisionFeature& feature, const float minPlacementScale);
+    void insertFeature(CollisionFeature& feature, const float minPlacementScale, const bool ignorePlacement);
+
+    std::vector<IndexedSubfeature> queryRenderedSymbols(const float minX, const float minY, const float maxX, const float maxY, const float scale);
 
     const PlacementConfig config;
 
@@ -50,9 +54,10 @@ private:
     float findPlacementScale(float minPlacementScale,
             const vec2<float>& anchor, const CollisionBox& box,
             const vec2<float>& blockingAnchor, const CollisionBox& blocking);
-    Box getTreeBox(const vec2<float>& anchor, const CollisionBox& box);
+    Box getTreeBox(const vec2<float>& anchor, const CollisionBox& box, const float scale = 1.0);
 
     Tree tree;
+    Tree ignoredTree;
     std::array<float, 4> rotationMatrix;
     std::array<float, 4> reverseRotationMatrix;
     std::array<CollisionBox, 4> edges;

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -39,6 +39,7 @@ public:
     GeoJSONTileLayer(Features&&);
     std::size_t featureCount() const override;
     util::ptr<const GeometryTileFeature> getFeature(std::size_t) const override;
+    std::string getName() const override { return ""; };
 
 private:
     const Features features;

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <functional>
 
 namespace mbgl {
@@ -38,6 +39,8 @@ public:
     virtual ~GeometryTileFeature() = default;
     virtual FeatureType getType() const = 0;
     virtual optional<Value> getValue(const std::string& key) const = 0;
+    virtual std::unordered_map<std::string,Value> getProperties() const { return std::unordered_map<std::string,Value>{}; };
+    virtual uint64_t getID() const { return 0; }
     virtual GeometryCollection getGeometries() const = 0;
     virtual uint32_t getExtent() const { return defaultExtent; }
 };
@@ -47,6 +50,7 @@ public:
     virtual ~GeometryTileLayer() = default;
     virtual std::size_t featureCount() const = 0;
     virtual util::ptr<const GeometryTileFeature> getFeature(std::size_t) const = 0;
+    virtual std::string getName() const = 0;
 };
 
 class GeometryTile : private util::noncopyable {

--- a/src/mbgl/tile/tile_data.cpp
+++ b/src/mbgl/tile/tile_data.cpp
@@ -29,4 +29,12 @@ void TileData::dumpDebugLogs() const {
     Log::Info(Event::General, "TileData::state: %s", TileData::StateToString(state));
 }
 
+void TileData::queryRenderedFeatures(
+        std::unordered_map<std::string, std::vector<std::string>>&,
+        const GeometryCollection&,
+        const double,
+        const double,
+        const double,
+        const optional<std::vector<std::string>>&) {}
+
 } // namespace mbgl

--- a/src/mbgl/tile/tile_data.hpp
+++ b/src/mbgl/tile/tile_data.hpp
@@ -7,11 +7,13 @@
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/text/placement_config.hpp>
+#include <mbgl/tile/geometry_tile.hpp>
 
 #include <atomic>
 #include <string>
 #include <memory>
 #include <functional>
+#include <unordered_map>
 
 namespace mbgl {
 
@@ -81,6 +83,14 @@ public:
     virtual bool parsePending(std::function<void (std::exception_ptr)>) { return true; }
     virtual void redoPlacement(PlacementConfig, const std::function<void()>&) {}
     virtual void redoPlacement(const std::function<void()>&) {}
+
+    virtual void queryRenderedFeatures(
+            std::unordered_map<std::string, std::vector<std::string>>& result,
+            const GeometryCollection& queryGeometry,
+            const double bearing,
+            const double tileSize,
+            const double scale,
+            const optional<std::vector<std::string>>& layerIDs);
 
     bool isReady() const {
         return isReadyState(state);

--- a/src/mbgl/tile/tile_worker.cpp
+++ b/src/mbgl/tile/tile_worker.cpp
@@ -95,7 +95,6 @@ TileParseResult TileWorker::prepareResult(const PlacementConfig& config) {
 
     if (result.state == TileData::State::parsed) {
         featureIndex->setCollisionTile(placeLayers(config));
-        featureIndex->loadTree();
         result.featureIndex = std::move(featureIndex);
         result.geometryTile = std::move(geometryTile);
     }

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -7,6 +7,7 @@
 #include <mbgl/util/variant.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/text/placement_config.hpp>
+#include <mbgl/geometry/feature_index.hpp>
 
 #include <string>
 #include <memory>
@@ -27,14 +28,16 @@ class SymbolLayer;
 
 // We're using this class to shuttle the resulting buckets from the worker thread to the MapContext
 // thread. This class is movable-only because the vector contains movable-only value elements.
-class TileParseResultBuckets {
+class TileParseResultData {
 public:
     TileData::State state = TileData::State::invalid;
     std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
+    std::unique_ptr<FeatureIndex> featureIndex;
+    std::unique_ptr<const GeometryTile> geometryTile;
 };
 
 using TileParseResult = variant<
-    TileParseResultBuckets, // success
+    TileParseResultData, // success
     std::exception_ptr>;    // error
 
 class TileWorker : public util::noncopyable {
@@ -54,13 +57,14 @@ public:
 
     TileParseResult parsePendingLayers(PlacementConfig);
 
-    void redoPlacement(const std::unordered_map<std::string, std::unique_ptr<Bucket>>*,
+    std::unique_ptr<CollisionTile> redoPlacement(const std::unordered_map<std::string, std::unique_ptr<Bucket>>*,
                        PlacementConfig);
 
 private:
-    void parseLayer(const StyleLayer*, const GeometryTile&);
+    TileParseResult prepareResult(const PlacementConfig& config);
+    void parseLayer(const StyleLayer*);
     void insertBucket(const std::string& name, std::unique_ptr<Bucket>);
-    void placeLayers(PlacementConfig);
+    std::unique_ptr<CollisionTile> placeLayers(PlacementConfig);
 
     const TileID id;
     const std::string sourceID;
@@ -75,6 +79,9 @@ private:
 
     std::vector<std::unique_ptr<StyleLayer>> layers;
 
+    std::unique_ptr<FeatureIndex> featureIndex;
+    std::unique_ptr<const GeometryTile> geometryTile;
+
     // Contains buckets that we couldn't parse so far due to missing resources.
     // They will be attempted on subsequent parses.
     std::list<std::pair<const SymbolLayer*, std::unique_ptr<Bucket>>> pending;
@@ -84,7 +91,7 @@ private:
     std::unordered_map<std::string, std::unique_ptr<Bucket>> placementPending;
 
     // Temporary holder
-    TileParseResultBuckets result;
+    TileParseResultData result;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -6,6 +6,8 @@
 #include <mbgl/util/pbf.hpp>
 
 #include <map>
+#include <unordered_map>
+#include <functional>
 
 namespace mbgl {
 
@@ -17,6 +19,8 @@ public:
 
     FeatureType getType() const override { return type; }
     optional<Value> getValue(const std::string&) const override;
+    std::unordered_map<std::string,Value> getProperties() const override;
+    uint64_t getID() const override;
     GeometryCollection getGeometries() const override;
     uint32_t getExtent() const override;
 
@@ -34,6 +38,7 @@ public:
 
     std::size_t featureCount() const override { return features.size(); }
     util::ptr<const GeometryTileFeature> getFeature(std::size_t) const override;
+    std::string getName() const override;
 
 private:
     friend class VectorTile;
@@ -41,7 +46,8 @@ private:
 
     std::string name;
     uint32_t extent = 4096;
-    std::map<std::string, uint32_t> keys;
+    std::map<std::string, uint32_t> keysMap;
+    std::vector<std::reference_wrapper<const std::string>> keys;
     std::vector<Value> values;
     std::vector<pbf> features;
 };

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -14,6 +14,7 @@ namespace mbgl {
 class Style;
 class AsyncRequest;
 class GeometryTileMonitor;
+class FeatureIndex;
 
 class VectorTileData : public TileData {
 public:
@@ -35,6 +36,14 @@ public:
 
     bool hasData() const override;
 
+    void queryRenderedFeatures(
+            std::unordered_map<std::string, std::vector<std::string>>& result,
+            const GeometryCollection& queryGeometry,
+            const double bearing,
+            const double tileSize,
+            const double scale,
+            const optional<std::vector<std::string>>& layerIDs) override;
+
     void cancel() override;
 
 private:
@@ -49,6 +58,9 @@ private:
     // Contains all the Bucket objects for the tile. Buckets are render
     // objects and they get added by tile parsing operations.
     std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
+
+    std::unique_ptr<FeatureIndex> featureIndex;
+    std::unique_ptr<const GeometryTile> geometryTile;
 
     // Stores the placement configuration of the text that is currently placed on the screen.
     PlacementConfig placedConfig;

--- a/src/mbgl/util/grid_index.cpp
+++ b/src/mbgl/util/grid_index.cpp
@@ -1,0 +1,82 @@
+#include <mbgl/util/grid_index.hpp>
+#include <mbgl/geometry/feature_index.hpp>
+
+#include <unordered_set>
+
+namespace mbgl {
+
+
+template <class T>
+GridIndex<T>::GridIndex(int32_t extent_, int32_t n_, int32_t padding_) :
+    extent(extent_),
+    n(n_),
+    padding(padding_),
+    d(n + 2 * padding),
+    scale(double(n) / double(extent)),
+    min(-double(padding) / n * extent),
+    max(extent + double(padding) / n * extent)
+    {
+        cells.resize(d * d);
+    };
+
+template <class T>
+void GridIndex<T>::insert(T&& t, BBox&& bbox) {
+    size_t uid = elements.size();
+
+    auto cx1 = convertToCellCoord(bbox.x1);
+    auto cy1 = convertToCellCoord(bbox.y1);
+    auto cx2 = convertToCellCoord(bbox.x2);
+    auto cy2 = convertToCellCoord(bbox.y2);
+
+    for (int32_t x = cx1; x <= cx2; x++) {
+        for (int32_t y = cy1; y <= cy2; y++) {
+            auto cellIndex = d * y + x;
+            cells[cellIndex].push_back(uid);
+        }
+    }
+
+    elements.emplace_back(t, bbox);
+}
+
+template <class T>
+std::vector<T> GridIndex<T>::query(const BBox& queryBBox) const {
+    std::vector<T> result;
+    std::unordered_set<size_t> seenUids;
+
+    auto cx1 = convertToCellCoord(queryBBox.x1);
+    auto cy1 = convertToCellCoord(queryBBox.y1);
+    auto cx2 = convertToCellCoord(queryBBox.x2);
+    auto cy2 = convertToCellCoord(queryBBox.y2);
+
+    for (int32_t x = cx1; x <= cx2; x++) {
+        for (int32_t y = cy1; y <= cy2; y++) {
+            auto cellIndex = d * y + x;
+            for (auto uid : cells[cellIndex]) {
+                if (seenUids.count(uid) == 0) {
+                    seenUids.insert(uid);
+
+                    auto& pair = elements.at(uid);
+                    auto& bbox = pair.second;
+                    if (queryBBox.x1 <= bbox.x2 &&
+                        queryBBox.y1 <= bbox.y2 &&
+                        queryBBox.x2 >= bbox.x1 &&
+                        queryBBox.y2 >= bbox.y1) {
+
+                        result.push_back(pair.first);
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+
+template <class T>
+int32_t GridIndex<T>::convertToCellCoord(int32_t x) const {
+    return std::max(0.0, std::min(d - 1.0, std::floor(x * scale) + padding));
+}
+
+template class GridIndex<IndexedSubfeature>;
+}

--- a/src/mbgl/util/grid_index.hpp
+++ b/src/mbgl/util/grid_index.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace mbgl {
+
+template <class T>
+class GridIndex {
+    public:
+
+    GridIndex(int32_t extent_, int32_t n_, int32_t padding_);
+
+    struct BBox {
+        int32_t x1;
+        int32_t y1;
+        int32_t x2;
+        int32_t y2;
+    };
+
+    void insert(T&& t, BBox&& bbox);
+    std::vector<T> query(const BBox& bbox) const;
+
+    private:
+
+    int32_t convertToCellCoord(int32_t x) const;
+
+    const int32_t extent;
+    const int32_t n;
+    const int32_t padding;
+    const int32_t d;
+    const double scale;
+    const int32_t min;
+    const int32_t max;
+
+    std::vector<std::pair<T, BBox>> elements;
+    std::vector<std::vector<size_t>> cells;
+
+};
+
+}

--- a/src/mbgl/util/intersection_tests.hpp
+++ b/src/mbgl/util/intersection_tests.hpp
@@ -1,0 +1,16 @@
+#ifndef MBGL_UTIL_INTERSECTION_TESTS
+#define MBGL_UTIL_INTERSECTION_TESTS
+
+#include <mbgl/tile/geometry_tile.hpp>
+
+namespace mbgl {
+namespace util {
+
+bool multiPolygonIntersectsBufferedMultiPoint(const GeometryCollection&, const GeometryCollection&, float radius);
+bool multiPolygonIntersectsBufferedMultiLine(const GeometryCollection&, const GeometryCollection&, float radius);
+bool multiPolygonIntersectsMultiPolygon(const GeometryCollection&, const GeometryCollection&);
+
+}
+} // namespace mbgl
+
+#endif

--- a/src/mbgl/util/tile_coordinate.cpp
+++ b/src/mbgl/util/tile_coordinate.cpp
@@ -1,0 +1,1 @@
+#include <mbgl/util/tile_coordinate.hpp>

--- a/src/mbgl/util/tile_coordinate.hpp
+++ b/src/mbgl/util/tile_coordinate.hpp
@@ -1,0 +1,39 @@
+#ifndef MBGL_UTIL_TILE_COORDINATE
+#define MBGL_UTIL_TILE_COORDINATE
+
+#include <mbgl/style/types.hpp>
+#include <mbgl/map/transform_state.hpp>
+
+
+namespace mbgl {
+
+class TransformState;
+
+// Has floating point x/y coordinates.
+// Used for computing the tiles that need to be visible in the viewport.
+class TileCoordinate {
+public:
+    double x, y, z;
+
+    static TileCoordinate fromLatLng(const TransformState& state, double zoom, const LatLng& latLng) {
+        const double scale = std::pow(2, zoom - state.getZoom());
+        return {
+            state.lngX(latLng.longitude) * scale / util::tileSize,
+            state.latY(latLng.latitude) * scale / util::tileSize,
+            zoom
+        };
+    }
+
+    static TileCoordinate fromScreenCoordinate(const TransformState& state, double zoom, const ScreenCoordinate& point) {
+        return fromLatLng(state, zoom, state.screenCoordinateToLatLng(point));
+    }
+
+    TileCoordinate zoomTo(double zoom) const {
+        double scale = std::pow(2, zoom - z);
+        return { x * scale, y * scale, zoom };
+    }
+};
+
+} // namespace mbgl
+
+#endif

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -8,25 +8,6 @@ namespace mbgl {
 
 namespace {
 
-// Has floating point x/y coordinates.
-// Used for computing the tiles that need to be visible in the viewport.
-class TileCoordinate {
-public:
-    double x, y;
-
-    static TileCoordinate fromLatLng(const TransformState& state, double zoom, const LatLng& latLng) {
-        const double scale = std::pow(2, zoom - state.getZoom());
-        return {
-            state.lngX(latLng.longitude) * scale / util::tileSize,
-            state.latY(latLng.latitude) * scale / util::tileSize,
-        };
-    }
-
-    static TileCoordinate fromScreenCoordinate(const TransformState& state, double zoom, const ScreenCoordinate& point) {
-        return fromLatLng(state, zoom, state.screenCoordinateToLatLng(point));
-    }
-};
-
 // Taken from polymaps src/Layer.js
 // https://github.com/simplegeo/polymaps/blob/master/src/Layer.js#L333-L383
 struct edge {

--- a/src/mbgl/util/tile_cover.hpp
+++ b/src/mbgl/util/tile_cover.hpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/map/tile_id.hpp>
 #include <mbgl/style/types.hpp>
+#include <mbgl/util/tile_coordinate.hpp>
 
 #include <vector>
 

--- a/src/mbgl/util/worker.cpp
+++ b/src/mbgl/util/worker.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/renderer/raster_bucket.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
 #include <mbgl/style/style_layer.hpp>
+#include <mbgl/text/collision_tile.hpp>
 
 #include <cassert>
 #include <future>
@@ -53,9 +54,8 @@ public:
     void redoPlacement(TileWorker* worker,
                        const std::unordered_map<std::string, std::unique_ptr<Bucket>>* buckets,
                        PlacementConfig config,
-                       std::function<void()> callback) {
-        worker->redoPlacement(buckets, config);
-        callback();
+                       std::function<void(std::unique_ptr<CollisionTile>)> callback) {
+        callback(worker->redoPlacement(buckets, config));
     }
 };
 
@@ -101,7 +101,7 @@ std::unique_ptr<AsyncRequest>
 Worker::redoPlacement(TileWorker& worker,
                       const std::unordered_map<std::string, std::unique_ptr<Bucket>>& buckets,
                       PlacementConfig config,
-                      std::function<void()> callback) {
+                      std::function<void(std::unique_ptr<CollisionTile>)> callback) {
     current = (current + 1) % threads.size();
     return threads[current]->invokeWithCallback(&Worker::Impl::redoPlacement, callback, &worker,
                                                 &buckets, config);

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -13,6 +13,7 @@ namespace mbgl {
 class AsyncRequest;
 class RasterBucket;
 class GeometryTileLoader;
+class CollisionTile;
 
 using RasterTileParseResult = variant<
     std::unique_ptr<Bucket>, // success
@@ -52,7 +53,7 @@ public:
     Request redoPlacement(TileWorker&,
                           const std::unordered_map<std::string, std::unique_ptr<Bucket>>&,
                           PlacementConfig config,
-                          std::function<void()> callback);
+                          std::function<void(std::unique_ptr<CollisionTile>)> callback);
 
 private:
     class Impl;

--- a/test/util/merge_lines.cpp
+++ b/test/util/merge_lines.cpp
@@ -8,21 +8,21 @@ const std::u32string bbb = U"b";
 TEST(MergeLines, SameText) {
     // merges lines with the same text
     std::vector<mbgl::SymbolFeature> input1 = {
-        { {{{0, 0}, {1, 0}, {2, 0}}}, aaa, "" },
-        { {{{4, 0}, {5, 0}, {6, 0}}}, bbb, "" },
-        { {{{8, 0}, {9, 0}}}, aaa, "" },
-        { {{{2, 0}, {3, 0}, {4, 0}}}, aaa, "" },
-        { {{{6, 0}, {7, 0}, {8, 0}}}, aaa, "" },
-        { {{{5, 0}, {6, 0}}}, aaa, "" }
+        { {{{0, 0}, {1, 0}, {2, 0}}}, aaa, "", 0 },
+        { {{{4, 0}, {5, 0}, {6, 0}}}, bbb, "", 0 },
+        { {{{8, 0}, {9, 0}}}, aaa, "", 0 },
+        { {{{2, 0}, {3, 0}, {4, 0}}}, aaa, "", 0 },
+        { {{{6, 0}, {7, 0}, {8, 0}}}, aaa, "", 0 },
+        { {{{5, 0}, {6, 0}}}, aaa, "", 0 }
     };
 
     const std::vector<mbgl::SymbolFeature> expected1 = {
-        { {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}}}, aaa, "" },
-        { {{{4, 0}, {5, 0}, {6, 0}}}, bbb, "" },
-        { {{{5, 0}, {6, 0}, {7, 0}, {8, 0}, {9, 0}}}, aaa, "" },
-        { {{}}, aaa, "" },
-        { {{}}, aaa, "" },
-        { {{}}, aaa, "" }
+        { {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}}}, aaa, "", 0 },
+        { {{{4, 0}, {5, 0}, {6, 0}}}, bbb, "", 0 },
+        { {{{5, 0}, {6, 0}, {7, 0}, {8, 0}, {9, 0}}}, aaa, "", 0 },
+        { {{}}, aaa, "", 0 },
+        { {{}}, aaa, "", 0 },
+        { {{}}, aaa, "", 0 }
     };
 
     mbgl::util::mergeLines(input1);
@@ -35,15 +35,15 @@ TEST(MergeLines, SameText) {
 TEST(MergeLines, BothEnds) {
     // mergeLines handles merge from both ends
     std::vector<mbgl::SymbolFeature> input2 = {
-        { {{{0, 0}, {1, 0}, {2, 0}}}, aaa, "" },
-        { {{{4, 0}, {5, 0}, {6, 0}}}, aaa, "" },
-        { {{{2, 0}, {3, 0}, {4, 0}}}, aaa, "" }
+        { {{{0, 0}, {1, 0}, {2, 0}}}, aaa, "", 0 },
+        { {{{4, 0}, {5, 0}, {6, 0}}}, aaa, "", 0 },
+        { {{{2, 0}, {3, 0}, {4, 0}}}, aaa, "", 0 }
     };
 
     const std::vector<mbgl::SymbolFeature> expected2 = {
-        { {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}, {6, 0}}}, aaa, "" },
-        { {{}}, aaa, "" },
-        { {{}}, aaa, "" }
+        { {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}, {6, 0}}}, aaa, "", 0 },
+        { {{}}, aaa, "", 0 },
+        { {{}}, aaa, "", 0 }
     };
 
     mbgl::util::mergeLines(input2);
@@ -56,15 +56,15 @@ TEST(MergeLines, BothEnds) {
 TEST(MergeLines, CircularLines) {
     // mergeLines handles circular lines
     std::vector<mbgl::SymbolFeature> input3 = {
-        { {{{0, 0}, {1, 0}, {2, 0}}}, aaa, "" },
-        { {{{2, 0}, {3, 0}, {4, 0}}}, aaa, "" },
-        { {{{4, 0}, {0, 0}}}, aaa, "" }
+        { {{{0, 0}, {1, 0}, {2, 0}}}, aaa, "", 0 },
+        { {{{2, 0}, {3, 0}, {4, 0}}}, aaa, "", 0 },
+        { {{{4, 0}, {0, 0}}}, aaa, "", 0 }
     };
 
     const std::vector<mbgl::SymbolFeature> expected3 = {
-        { {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {0, 0}}}, aaa, "" },
-        { {{}}, aaa, "" },
-        { {{}}, aaa, "" }
+        { {{{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {0, 0}}}, aaa, "", 0 },
+        { {{}}, aaa, "", 0 },
+        { {{}}, aaa, "", 0 }
     };
 
     mbgl::util::mergeLines(input3);


### PR DESCRIPTION
`queryRenderedFeatures` is mostly implemented. 48/50 query tests are passing. Two are skipped because different [constrain behaviour](https://github.com/mapbox/mapbox-gl-native/issues/4655) is causing errors.

#### Questions
- What should `queryRenderedFeatures` argument signatures be? [js api here](https://www.mapbox.com/mapbox-gl-js/api/#Map.queryRenderedFeatures)
- What should the return type be? This will use geometry.hpp, right?
- Should we support filters? Can [`FilterExpression`](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/style/filter_expression.hpp) be made public? 


**If any of the above are not quick to decide or quick to implement, can we punt and merge this as is?** The current external api is not something we want to have people use but it would be good to have this in master with tests running on ci. It's already a huge pull request.

`querySourceFeatures` is not implemented because it depends heavily on the return type question. It can be done in a separate pr once that's answered.

---
@jfirebaugh can you review or assign reviewing to someone else?

---

my other remaining tasks are:
- [x] fix this build error. Any ideas? https://www.bitrise.io/build/108bf7df608dc23c
- [x] track down this segfault https://www.bitrise.io/build/e63b43e20310d3e0
- [x] implement querying for symbols with `-ignore-placement: true`