### PR TITLE
[ios] Restart user location heading updates on validation

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.  If you’d like 
 
 ## master
 
+- User location heading updates now resume properly when an app becomes active again. ([#4674](https://github.com/mapbox/mapbox-gl-native/pull/4674))
+
 ## 3.2.0
 
 - If you’ve previously installed the SDK as a static framework, the installation workflow has changed to address issues when submitting your application to the App Store or installing it on a device. Upon upgrading to this version of the SDK, you’ll need to add Mapbox.bundle to the Copy Bundle Resources build phase and remove Mapbox.framework from the Embed Frameworks build phase. ([#4455](https://github.com/mapbox/mapbox-gl-native/pull/4455))

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3047,6 +3047,11 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         self.locationManager.headingFilter = 5.0;
         self.locationManager.delegate = self;
         [self.locationManager startUpdatingLocation];
+
+        if (self.userTrackingMode == MGLUserTrackingModeFollowWithHeading)
+        {
+            [self.locationManager startUpdatingHeading];
+        }
     }
     else if ( ! shouldEnableLocationServices && self.locationManager)
     {


### PR DESCRIPTION
User location heading updates would not automatically restart when an app became active again.

Fixes #4668. Thanks to @JThramer for reporting.

/cc @1ec5