### PR TITLE
[ios, osx] The return of xcpretty, part II

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,6 +48,7 @@ dependencies:
  - Apple Command Line Tools (available at [Apple Developer](https://developer.apple.com/downloads))
  - [Homebrew](http://brew.sh)
  - [Cask](http://caskroom.io/) (if building for Android)
+ - [xcpretty](https://github.com/supermarin/xcpretty) (`gem install xcpretty`)
 
 ## 3: Setting up a development environment & building
 

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ $(OSX_PROJ_PATH)/xcshareddata/xcschemes/osxtest.xcscheme: platform/osx/scripts/o
 	cp $< $@
 
 test-osx: $(OSX_PROJ_PATH) $(OSX_PROJ_PATH)/xcshareddata/xcschemes/osxtest.xcscheme node_modules/express
-	xcodebuild -project $(OSX_PROJ_PATH) -configuration $(BUILDTYPE) -target test build
+	set -o pipefail && xcodebuild -project $(OSX_PROJ_PATH) -configuration $(BUILDTYPE) -target test build | xcpretty
 	build/osx-x86_64/$(BUILDTYPE)/test || ([[ $$? == 139 || $$? == 134 ]] && cat `ls -t1 ~/Library/Logs/DiagnosticReports/* | head -n1`; exit 1)
-	xcodebuild -project $(OSX_PROJ_PATH) -configuration $(BUILDTYPE) -scheme osxtest test
+	set -o pipefail && xcodebuild -project $(OSX_PROJ_PATH) -configuration $(BUILDTYPE) -scheme osxtest test | xcpretty
 
 #### iOS targets ##############################################################
 
@@ -50,9 +50,9 @@ iproj: $(IOS_PROJ_PATH)
 	open $(IOS_PROJ_PATH)
 
 test-ios: $(IOS_PROJ_PATH)
-	xcodebuild -project $(IOS_PROJ_PATH) -configuration $(BUILDTYPE) \
+	set -o pipefail && xcodebuild -project $(IOS_PROJ_PATH) -configuration $(BUILDTYPE) \
 	  -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
-	  -target test build
+	  -target test build | xcpretty
 	ios-sim start
 	ios-sim launch build/ios-all/$(BUILDTYPE)-iphonesimulator/ios-test.app --verbose
 

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -31,6 +31,7 @@ workflows:
             set -eu -o pipefail
             brew tap mapbox/homebrew-ios-sim-3
             brew install mapbox/homebrew-ios-sim-3/ios-sim
+            gem install xcpretty --no-rdoc --no-ri
             gem install jazzy --no-rdoc --no-ri
             export BUILDTYPE=Debug
             make ios

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -88,7 +88,7 @@ if [[ "${BUILD_FOR_DEVICE}" == true ]]; then
             -project ./build/ios-all/platform/ios/platform.xcodeproj \
             -configuration ${BUILDTYPE} \
             -target platform-lib \
-            -jobs ${JOBS}
+            -jobs ${JOBS} | xcpretty
     fi
 
     if [[ ${BUILD_DYNAMIC} == true ]]; then
@@ -105,7 +105,7 @@ if [[ "${BUILD_FOR_DEVICE}" == true ]]; then
             -project ./build/ios-all/platform/ios/platform.xcodeproj \
             -configuration ${BUILDTYPE} \
             -target iossdk \
-            -jobs ${JOBS}
+            -jobs ${JOBS} | xcpretty
     fi
 fi
 
@@ -118,7 +118,7 @@ if [[ ${BUILD_STATIC} == true ]]; then
         -project ./build/ios-all/platform/ios/platform.xcodeproj \
         -configuration ${BUILDTYPE} \
         -target platform-lib \
-        -jobs ${JOBS}
+        -jobs ${JOBS} | xcpretty
 fi
 
 if [[ ${BUILD_DYNAMIC} == true ]]; then
@@ -132,7 +132,7 @@ if [[ ${BUILD_DYNAMIC} == true ]]; then
         -project ./build/ios-all/platform/ios/platform.xcodeproj \
         -configuration ${BUILDTYPE} \
         -target iossdk \
-        -jobs ${JOBS}
+        -jobs ${JOBS} | xcpretty
 fi
 
 LIBS=(core.a platform-ios.a)

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -32,6 +32,7 @@ workflows:
             brew unlink node
             brew install awscli homebrew/versions/node4-lts
             brew link homebrew/versions/node4-lts
+            gem install xcpretty --no-rdoc --no-ri
             make node
             make test-node || result=$?
             ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER} ${BITRISE_GIT_TAG:-}

--- a/platform/osx/bitrise.yml
+++ b/platform/osx/bitrise.yml
@@ -29,6 +29,7 @@ workflows:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
+            gem install xcpretty --no-rdoc --no-ri
             export BUILDTYPE=Debug
             make osx
             make test-osx

--- a/scripts/main.mk
+++ b/scripts/main.mk
@@ -108,13 +108,13 @@ Makefile/%: Makefile/__project__
 
 Xcode/%: Xcode/__project__
 	@printf "$(TEXT_BOLD)$(COLOR_GREEN)* Building target $*...$(FORMAT_END)\n"
-	xcodebuild \
+	set -o pipefail && xcodebuild \
 		CODE_SIGNING_REQUIRED=NO \
 		CODE_SIGN_IDENTITY= \
 		-project $(PLATFORM_OUTPUT)/platform/$(PLATFORM)/platform.xcodeproj \
 		-configuration $(BUILDTYPE) \
 		-target $* \
-		-jobs $(JOBS)
+		-jobs $(JOBS) | xcpretty
 
 Ninja/%: Ninja/__project__
 	@printf "$(TEXT_BOLD)$(COLOR_GREEN)* Building target $*...$(FORMAT_END)\n"


### PR DESCRIPTION
Bring back xcpretty. We've encountered issues with it in the past, but I'm willing to go back to it because the alternative -- immensely verbose build logs in which it is virtually impossible to find error output -- is worse.