### PR TITLE
Speed up iOS CI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ $(IOS_PROJ_PATH): platform/ios/platform.gyp platform/ios/scripts/configure.sh mb
 	$(RUN) PLATFORM=ios Xcode/__project__
 
 ios: $(IOS_PROJ_PATH)
-	set -o pipefail && xcodebuild -configuration $(BUILDTYPE) -sdk iphonesimulator \
+	set -o pipefail && xcodebuild \
+	  ARCHS=i386 ONLY_ACTIVE_ARCH=YES \
+	  -configuration $(BUILDTYPE) -sdk iphonesimulator \
 	  -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
 	  -project $(IOS_PROJ_PATH) -target All build | xcpretty
 

--- a/Makefile
+++ b/Makefile
@@ -40,19 +40,18 @@ test-osx: $(OSX_PROJ_PATH) $(OSX_PROJ_PATH)/xcshareddata/xcschemes/osxtest.xcsch
 
 IOS_PROJ_PATH = build/ios-all/platform/ios/platform.xcodeproj
 
-ios:
-	$(RUN) PLATFORM=ios Xcode/All
-
 $(IOS_PROJ_PATH): platform/ios/platform.gyp platform/ios/scripts/configure.sh mbgl.gypi test/test.gypi
 	$(RUN) PLATFORM=ios Xcode/__project__
+
+ios: $(IOS_PROJ_PATH)
+	set -o pipefail && xcodebuild -configuration $(BUILDTYPE) -sdk iphonesimulator \
+	  -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
+	  -project $(IOS_PROJ_PATH) -target All build | xcpretty
 
 iproj: $(IOS_PROJ_PATH)
 	open $(IOS_PROJ_PATH)
 
-test-ios: $(IOS_PROJ_PATH)
-	set -o pipefail && xcodebuild -project $(IOS_PROJ_PATH) -configuration $(BUILDTYPE) \
-	  -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
-	  -target test build | xcpretty
+test-ios: ios
 	ios-sim start
 	ios-sim launch build/ios-all/$(BUILDTYPE)-iphonesimulator/ios-test.app --verbose
 

--- a/mbgl.gypi
+++ b/mbgl.gypi
@@ -69,6 +69,7 @@
         'conditions': [
           ['OS=="mac"', {
             'xcode_settings': {
+              'DEBUG_INFORMATION_FORMAT': 'dwarf',
               'GCC_OPTIMIZATION_LEVEL': '0',
               'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES',
               'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',


### PR DESCRIPTION
The iOS build is topping out our build times at 30+ minutes.

We should investigate how to bring this down to the range of other builds (10-15 minutes).

Here's one thing to try: https://labs.spotify.com/2013/11/04/shaving-off-time-from-the-ios-edit-build-test-cycle/