### PR TITLE
[core] Do the MapContext::cleanup() synchronously

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -31,7 +31,7 @@ Map::Map(View& view_, FileSource& fileSource, MapMode mapMode, GLContextMode con
 
 Map::~Map() {
     resume();
-    context->invoke(&MapContext::cleanup);
+    context->invokeSync(&MapContext::cleanup);
 }
 
 void Map::pause() {


### PR DESCRIPTION
This used to be async assuming the libuv behavior of holding the main loop until all the messages are processed and also for avoiding a deadlock at exit that no longer exits.
    
Now that we support multiple main loops implementation on different platforms, we do the cleanup synchronously to make sure all the platforms have the same behavior at exit.
    
Fixes #4631
