### PR TITLE
Darwin RunLoop: abort signaled AsyncTasks

### DIFF
--- a/platform/darwin/src/async_task.cpp
+++ b/platform/darwin/src/async_task.cpp
@@ -29,7 +29,7 @@ public:
     }
 
     ~Impl() {
-        CFRunLoopRemoveSource(loop, source, kCFRunLoopDefaultMode);
+        CFRunLoopSourceInvalidate(source);
         CFRelease(source);
     }
 


### PR DESCRIPTION
When signaling an `AsyncTask`, then destroying the task before it fired, the Darwin `RunLoop` implementation currently crashes.