### PR TITLE
[iOS] Convert telemetry test server setting to user default

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -40,9 +40,8 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
             @"MBXUserTrackingMode": @(MGLUserTrackingModeNone),
             @"MBXShowsUserLocation": @NO,
             @"MBXDebug": @NO,
+            @"MGLTelemetryTestServerURL": @"https://cloudfront-staging.tilestream.net",
         }];
-        
-        
     }
 }
 

--- a/platform/ios/app/app-info.plist
+++ b/platform/ios/app/app-info.plist
@@ -24,8 +24,6 @@
 	<string>7877</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MGLMetricsTestServerURL</key>
-	<string>https://cloudfront-staging.tilestream.net</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>
@@ -40,9 +38,9 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2014–2016 Mapbox</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>The map will ALWAYS display the user's location.</string>
+	<string>The map will ALWAYS display the user’s location.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>The map will display the user's location.</string>
+	<string>The map will display the user’s location.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>Default</string>
 	<key>UIMainStoryboardFile</key>

--- a/platform/ios/src/MGLAPIClient.m
+++ b/platform/ios/src/MGLAPIClient.m
@@ -87,7 +87,7 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
 }
 
 - (void)setupBaseURL {
-    NSString *testServerURL = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLMetricsTestServerURL"];
+    NSString *testServerURL = [[NSUserDefaults standardUserDefaults] stringForKey:@"MGLTelemetryTestServerURL"];
     if (testServerURL) {
         _baseURL = testServerURL;
         _usesTestServer = YES;


### PR DESCRIPTION
- Previously looked in app's Info.plist, now looks at NSUserDefaults
- Deprecation should be unnecessary for this internal test setting
- ~~Harmonized name with other keys (added 'Mapbox’)~~ Key name is `MGLTelemetryTestServerURL`

/cc @boundsj @1ec5