### PR TITLE
[test] Fix use of uninitialized `dimensions` value

### DIFF
--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -7,16 +7,20 @@
 namespace mbgl {
 
 HeadlessView::HeadlessView(float pixelRatio_, uint16_t width, uint16_t height)
-    : display(std::make_shared<HeadlessDisplay>()), pixelRatio(pixelRatio_) {
-    resize(width, height);
+    : display(std::make_shared<HeadlessDisplay>())
+    , pixelRatio(pixelRatio_)
+    , dimensions({{ width, height }})
+    , needsResize(true) {
 }
 
 HeadlessView::HeadlessView(std::shared_ptr<HeadlessDisplay> display_,
                            float pixelRatio_,
                            uint16_t width,
                            uint16_t height)
-    : display(std::move(display_)), pixelRatio(pixelRatio_) {
-    resize(width, height);
+    : display(std::move(display_))
+    , pixelRatio(pixelRatio_)
+    , dimensions({{ width, height }})
+    , needsResize(true) {
 }
 
 HeadlessView::~HeadlessView() {


### PR DESCRIPTION
Instead of calling resize, which would compare against the uninitialized dimensions values, initialize dimensions and needsResize directly.

Fixes #3883.