### PR TITLE
[core] Don't put static objects in a header file

### DIFF
--- a/include/mbgl/gl/gl.hpp
+++ b/include/mbgl/gl/gl.hpp
@@ -110,31 +110,14 @@ public:
 using glProc = void (*)();
 void InitializeExtensions(glProc (*getProcAddress)(const char *));
 
-static gl::ExtensionFunction<
-    void (GLuint array)>
-    BindVertexArray({
-        {"GL_ARB_vertex_array_object", "glBindVertexArray"},
-        {"GL_OES_vertex_array_object", "glBindVertexArrayOES"},
-        {"GL_APPLE_vertex_array_object", "glBindVertexArrayAPPLE"}
-    });
+extern ExtensionFunction<void (GLuint array)>
+    BindVertexArray;
 
-static gl::ExtensionFunction<
-    void (GLsizei n,
-          const GLuint* arrays)>
-    DeleteVertexArrays({
-        {"GL_ARB_vertex_array_object", "glDeleteVertexArrays"},
-        {"GL_OES_vertex_array_object", "glDeleteVertexArraysOES"},
-        {"GL_APPLE_vertex_array_object", "glDeleteVertexArraysAPPLE"}
-    });
+extern ExtensionFunction<void (GLsizei n, const GLuint* arrays)>
+    DeleteVertexArrays;
 
-static gl::ExtensionFunction<
-    void (GLsizei n,
-          GLuint* arrays)>
-    GenVertexArrays({
-        {"GL_ARB_vertex_array_object", "glGenVertexArrays"},
-        {"GL_OES_vertex_array_object", "glGenVertexArraysOES"},
-        {"GL_APPLE_vertex_array_object", "glGenVertexArraysAPPLE"}
-    });
+extern ExtensionFunction<void (GLsizei n, GLuint* arrays)>
+    GenVertexArrays;
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/gl.cpp
+++ b/src/mbgl/gl/gl.cpp
@@ -10,6 +10,27 @@
 namespace mbgl {
 namespace gl {
 
+ExtensionFunction<void (GLuint array)>
+    BindVertexArray({
+        {"GL_ARB_vertex_array_object", "glBindVertexArray"},
+        {"GL_OES_vertex_array_object", "glBindVertexArrayOES"},
+        {"GL_APPLE_vertex_array_object", "glBindVertexArrayAPPLE"}
+    });
+
+ExtensionFunction<void (GLsizei n, const GLuint* arrays)>
+    DeleteVertexArrays({
+        {"GL_ARB_vertex_array_object", "glDeleteVertexArrays"},
+        {"GL_OES_vertex_array_object", "glDeleteVertexArraysOES"},
+        {"GL_APPLE_vertex_array_object", "glDeleteVertexArraysAPPLE"}
+    });
+
+ExtensionFunction<void (GLsizei n, GLuint* arrays)>
+    GenVertexArrays({
+        {"GL_ARB_vertex_array_object", "glGenVertexArrays"},
+        {"GL_OES_vertex_array_object", "glGenVertexArraysOES"},
+        {"GL_APPLE_vertex_array_object", "glGenVertexArraysAPPLE"}
+    });
+
 std::vector<ExtensionFunctionBase*>& ExtensionFunctionBase::functions() {
     static std::vector<ExtensionFunctionBase*> functions;
     return functions;


### PR DESCRIPTION
This causes duplicate objects -- one for every file that includes that header.