### PR TITLE
Store glActiveTexture in GLConfig

### DIFF
--- a/include/mbgl/gl/gl_values.hpp
+++ b/include/mbgl/gl/gl_values.hpp
@@ -240,6 +240,19 @@ struct LineWidth {
     }
 };
 
+struct ActiveTexture {
+    using Type = GLint;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glActiveTexture(value));
+    }
+    inline static Type Get() {
+        Type activeTexture;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture));
+        return activeTexture;
+    }
+};
+
 #ifndef GL_ES_VERSION_2_0
 
 struct PixelZoom {

--- a/src/mbgl/gl/gl_config.cpp
+++ b/src/mbgl/gl/gl_config.cpp
@@ -19,6 +19,7 @@ const ClearColor::Type ClearColor::Default = { 0, 0, 0, 0 };
 const ClearStencil::Type ClearStencil::Default = 0;
 const Program::Type Program::Default = 0;
 const LineWidth::Type LineWidth::Default = 1;
+const ActiveTexture::Type ActiveTexture::Default = GL_TEXTURE0;
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/gl_config.hpp
+++ b/src/mbgl/gl/gl_config.hpp
@@ -55,6 +55,7 @@ public:
         clearStencil.reset();
         program.reset();
         lineWidth.reset();
+        activeTexture.reset();
     }
 
     void setDirty() {
@@ -74,6 +75,7 @@ public:
         clearStencil.setDirty();
         program.setDirty();
         lineWidth.setDirty();
+        activeTexture.setDirty();
     }
 
     Value<StencilFunc> stencilFunc;
@@ -92,6 +94,7 @@ public:
     Value<ClearStencil> clearStencil;
     Value<Program> program;
     Value<LineWidth> lineWidth;
+    Value<ActiveTexture> activeTexture;
 };
 
 } // namespace gl

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -102,7 +102,7 @@ void Painter::renderFill(FillBucket& bucket, const FillLayer& layer, const TileI
             patternShader->u_offset_a = std::array<float, 2>{{offsetAx, offsetAy}};
             patternShader->u_offset_b = std::array<float, 2>{{offsetBx, offsetBy}};
 
-            MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0));
+            config.activeTexture = GL_TEXTURE0;
             spriteAtlas->bind(true, glObjectStore);
 
             // Draw the actual triangles into the color & stencil buffer.

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -81,7 +81,6 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
 
         LinePatternPos posA = lineAtlas->getDashPosition(properties.dasharray.value.from, layout.cap == CapType::Round, glObjectStore);
         LinePatternPos posB = lineAtlas->getDashPosition(properties.dasharray.value.to, layout.cap == CapType::Round, glObjectStore);
-        lineAtlas->bind(glObjectStore);
 
         const float widthA = posA.width * properties.dasharray.value.fromScale * properties.dashLineWidth;
         const float widthB = posB.width * properties.dasharray.value.toScale * properties.dashLineWidth;
@@ -95,12 +94,15 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         linesdfShader->u_tex_y_a = posA.y;
         linesdfShader->u_patternscale_b = {{ scaleXB, scaleYB }};
         linesdfShader->u_tex_y_b = posB.y;
-        linesdfShader->u_image = 0;
         linesdfShader->u_sdfgamma = lineAtlas->width / (std::min(widthA, widthB) * 256.0 * data.pixelRatio) / 2;
         linesdfShader->u_mix = properties.dasharray.value.t;
         linesdfShader->u_extra = extra;
         linesdfShader->u_offset = -properties.offset;
         linesdfShader->u_antialiasingmatrix = antialiasingMatrix;
+
+        linesdfShader->u_image = 0;
+        config.activeTexture = GL_TEXTURE0;
+        lineAtlas->bind(glObjectStore);
 
         bucket.drawLineSDF(*linesdfShader, glObjectStore);
 
@@ -139,7 +141,8 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         linepatternShader->u_offset = -properties.offset;
         linepatternShader->u_antialiasingmatrix = antialiasingMatrix;
 
-        MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0));
+        linepatternShader->u_image = 0;
+        config.activeTexture = GL_TEXTURE0;
         spriteAtlas->bind(true, glObjectStore);
 
         bucket.drawLinePatterns(*linepatternShader, glObjectStore);

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -23,6 +23,10 @@ void Painter::renderRaster(RasterBucket& bucket, const RasterLayer& layer, const
         rasterShader->u_spin_weights = spinWeights(properties.hueRotate);
 
         config.stencilTest = GL_FALSE;
+
+        rasterShader->u_image = 0;
+        config.activeTexture = GL_TEXTURE0;
+
         config.depthFunc.reset();
         config.depthTest = GL_TRUE;
         config.depthMask = GL_FALSE;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -174,6 +174,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
         SpriteAtlas* activeSpriteAtlas = layer.spriteAtlas;
         const bool iconScaled = fontScale != 1 || data.pixelRatio != activeSpriteAtlas->getPixelRatio() || bucket.iconsNeedLinear;
         const bool iconTransformed = layout.icon.rotationAlignment == RotationAlignmentType::Map || angleOffset != 0 || state.getPitch() != 0;
+        config.activeTexture = GL_TEXTURE0;
         activeSpriteAtlas->bind(sdf || state.isChanging() || iconScaled || iconTransformed, glObjectStore);
 
         if (sdf) {
@@ -242,6 +243,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
             config.depthTest = GL_FALSE;
         }
 
+        config.activeTexture = GL_TEXTURE0;
         glyphAtlas->bind(glObjectStore);
 
         renderSDF(bucket,

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -29,7 +29,6 @@ void RasterBucket::setImage(PremultipliedImage image) {
 
 void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array, gl::GLObjectStore& glObjectStore) {
     raster.bind(true, glObjectStore);
-    shader.u_image = 0;
     array.bind(shader, vertices, BUFFER_OFFSET_0, glObjectStore);
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
 }

--- a/src/mbgl/shader/linepattern_shader.hpp
+++ b/src/mbgl/shader/linepattern_shader.hpp
@@ -28,6 +28,7 @@ public:
     Uniform<GLfloat>                u_opacity        = {"u_opacity",        *this};
     Uniform<GLfloat>                u_extra          = {"u_extra",          *this};
     Uniform<GLfloat>                u_offset         = {"u_offset",         *this};
+    Uniform<GLint>                  u_image          = {"u_image",          *this};
     UniformMatrix<2>                u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
 
 private:


### PR DESCRIPTION
We're currently calling this function manually in some places, but we should move that value to `GLConfig` so that it can be reset properly if the need arises. 