### PR TITLE
Add total and avg FPS to final benchmark summary

### DIFF
--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -81,13 +81,17 @@ static const int benchmarkDuration = 200; // frames
         // Do nothing. The benchmark is completed.
         NSLog(@"Benchmark completed.");
         NSLog(@"Result:");
+        double totalFPS = 0;
         size_t colWidth = 0;
         for (const auto& row : result) {
             colWidth = std::max(row.first.size(), colWidth);
         }
         for (const auto& row : result) {
             NSLog(@"| %-*s | %4.1f fps |", int(colWidth), row.first.c_str(), row.second);
+            totalFPS += row.second;
         }
+        NSLog(@"Total FPS: %4.1f", totalFPS);
+        NSLog(@"Average FPS: %4.1f", totalFPS / result.size());
         exit(0);
     }
 }


### PR DESCRIPTION
Adds total and average frames per second to the summarized console output from a run of the iOS Bench GL app.

Sample output from #4704, last two lines are new:
 
```
2016-04-14 18:43:02.102 Bench GL[640:263343] Result:
2016-04-14 18:43:02.102 Bench GL[640:263343] | paris      | 60.0 fps |
2016-04-14 18:43:02.103 Bench GL[640:263343] | paris2     | 59.9 fps |
2016-04-14 18:43:02.103 Bench GL[640:263343] | alps       | 53.1 fps |
2016-04-14 18:43:02.103 Bench GL[640:263343] | us east    | 60.3 fps |
2016-04-14 18:43:02.103 Bench GL[640:263343] | greater la | 60.1 fps |
2016-04-14 18:43:02.103 Bench GL[640:263343] | sf         | 59.9 fps |
2016-04-14 18:43:02.103 Bench GL[640:263343] | oakland    | 60.0 fps |
2016-04-14 18:43:02.103 Bench GL[640:263343] | germany    | 59.8 fps |
2016-04-14 18:43:02.104 Bench GL[640:263343] Total FPS: 473.1
2016-04-14 18:43:02.104 Bench GL[640:263343] Average FPS: 59.1
```

/cc @kkaefer @1ec5