### PR TITLE
[android] Restore prior GLContext if exists

### DIFF
--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -61,6 +61,12 @@ private:
     jweak obj = nullptr;
 
     ANativeWindow *window = nullptr;
+
+    EGLDisplay oldDisplay = EGL_NO_DISPLAY;
+    EGLSurface oldReadSurface = EGL_NO_SURFACE;
+    EGLSurface oldDrawSurface = EGL_NO_SURFACE;
+    EGLContext oldContext = EGL_NO_CONTEXT;
+
     EGLDisplay display = EGL_NO_DISPLAY;
     EGLSurface surface = EGL_NO_SURFACE;
     EGLContext context = EGL_NO_CONTEXT;


### PR DESCRIPTION
Apparently some versions of Android, notable 4.4.4 running on my Nexus 5, creates a GLContext on the Android UIThread which is the one we are now using for rendering after #2909.

If the context is not restored, nothing gets rendered (or sometimes partially, or artifacts) because Android will try to do GL stuff on the context used by Mapbox GL and mess things up.