### PR TITLE
Take advantage of C99

### DIFF
--- a/platform/darwin/include/MGLTypes.h
+++ b/platform/darwin/include/MGLTypes.h
@@ -38,25 +38,22 @@ typedef NS_ENUM(NSUInteger, MGLUserTrackingMode) {
 
 NS_ASSUME_NONNULL_END
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wvariadic-macros"
-    #ifndef NS_ARRAY_OF
-        // Foundation collection classes adopted lightweight generics in iOS 9.0 and OS X 10.11 SDKs.
-        #if __has_feature(objc_generics) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100)
-            /** Inserts a type specifier for a pointer to a lightweight generic with the given collection and object classes. Use a `*` for any non-`id` object classes but no `*` for the collection class. */
-            #define NS_ARRAY_OF(ObjectClass...)                 NSArray <ObjectClass>
-            #define NS_MUTABLE_ARRAY_OF(ObjectClass...)         NSMutableArray <ObjectClass>
-            #define NS_SET_OF(ObjectClass...)                   NSSet <ObjectClass>
-            #define NS_MUTABLE_SET_OF(ObjectClass...)           NSMutableSet <ObjectClass>
-            #define NS_DICTIONARY_OF(ObjectClass...)            NSDictionary <ObjectClass>
-            #define NS_MUTABLE_DICTIONARY_OF(ObjectClass...)    NSMutableDictionary <ObjectClass>
-        #else
-            #define NS_ARRAY_OF(ObjectClass...)                 NSArray
-            #define NS_MUTABLE_ARRAY_OF(ObjectClass...)         NSMutableArray
-            #define NS_SET_OF(ObjectClass...)                   NSSet
-            #define NS_MUTABLE_SET_OF(ObjectClass...)           NSMutableSet
-            #define NS_DICTIONARY_OF(ObjectClass...)            NSDictionary
-            #define NS_MUTABLE_DICTIONARY_OF(ObjectClass...)    NSMutableDictionary
-        #endif
+#ifndef NS_ARRAY_OF
+    // Foundation collection classes adopted lightweight generics in iOS 9.0 and OS X 10.11 SDKs.
+    #if __has_feature(objc_generics) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100)
+        /** Inserts a type specifier for a pointer to a lightweight generic with the given collection and object classes. Use a `*` for any non-`id` object classes but no `*` for the collection class. */
+        #define NS_ARRAY_OF(ObjectClass...)                 NSArray <ObjectClass>
+        #define NS_MUTABLE_ARRAY_OF(ObjectClass...)         NSMutableArray <ObjectClass>
+        #define NS_SET_OF(ObjectClass...)                   NSSet <ObjectClass>
+        #define NS_MUTABLE_SET_OF(ObjectClass...)           NSMutableSet <ObjectClass>
+        #define NS_DICTIONARY_OF(ObjectClass...)            NSDictionary <ObjectClass>
+        #define NS_MUTABLE_DICTIONARY_OF(ObjectClass...)    NSMutableDictionary <ObjectClass>
+    #else
+        #define NS_ARRAY_OF(ObjectClass...)                 NSArray
+        #define NS_MUTABLE_ARRAY_OF(ObjectClass...)         NSMutableArray
+        #define NS_SET_OF(ObjectClass...)                   NSSet
+        #define NS_MUTABLE_SET_OF(ObjectClass...)           NSMutableSet
+        #define NS_DICTIONARY_OF(ObjectClass...)            NSDictionary
+        #define NS_MUTABLE_DICTIONARY_OF(ObjectClass...)    NSMutableDictionary
     #endif
-#pragma clang diagnostic pop
+#endif

--- a/platform/darwin/test/MGLGeometryTests.mm
+++ b/platform/darwin/test/MGLGeometryTests.mm
@@ -1,8 +1,5 @@
 #import "../../darwin/src/MGLGeometry_Private.h"
 
-#pragma clang diagnostic ignored "-Wgnu-statement-expression"
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-
 #import <XCTest/XCTest.h>
 
 @interface MGLGeometryTests : XCTestCase

--- a/platform/darwin/test/MGLOfflinePackTests.m
+++ b/platform/darwin/test/MGLOfflinePackTests.m
@@ -1,8 +1,4 @@
 #import <Mapbox/Mapbox.h>
-
-#pragma clang diagnostic ignored "-Wgnu-statement-expression"
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-
 #import <XCTest/XCTest.h>
 
 @interface MGLOfflinePackTests : XCTestCase

--- a/platform/darwin/test/MGLOfflineRegionTests.m
+++ b/platform/darwin/test/MGLOfflineRegionTests.m
@@ -1,8 +1,5 @@
 #import <Mapbox/Mapbox.h>
 
-#pragma clang diagnostic ignored "-Wgnu-statement-expression"
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-
 #import <XCTest/XCTest.h>
 
 @interface MGLOfflineRegionTests : XCTestCase

--- a/platform/darwin/test/MGLOfflineStorageTests.m
+++ b/platform/darwin/test/MGLOfflineStorageTests.m
@@ -1,8 +1,5 @@
 #import <Mapbox/Mapbox.h>
 
-#pragma clang diagnostic ignored "-Wgnu-statement-expression"
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-
 #import <XCTest/XCTest.h>
 
 @interface MGLOfflineStorageTests : XCTestCase
@@ -33,8 +30,8 @@
     NSURL *styleURL = [MGLStyle lightStyleURL];
     /// Somewhere near Grape Grove, Ohio, United States.
     MGLCoordinateBounds bounds = {
-        { 39.70358155855172, -83.69506472545841 },
-        { 39.703818870225376, -83.69420641857361 },
+        { .latitude = 39.70358155855172, .longitude = -83.69506472545841 },
+        { .latitude = 39.703818870225376, .longitude = -83.69420641857361 },
     };
     double zoomLevel = 20;
     MGLTilePyramidOfflineRegion *region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:styleURL bounds:bounds fromZoomLevel:zoomLevel toZoomLevel:zoomLevel];

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -2,9 +2,6 @@
 
 #import <mbgl/util/default_styles.hpp>
 
-#pragma clang diagnostic ignored "-Wgnu-statement-expression"
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-
 #import <XCTest/XCTest.h>
 
 @interface MGLStyleTests : XCTestCase

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -11,10 +11,10 @@
 static NSString * const kCustomCalloutTitle = @"Custom Callout";
 
 static const CLLocationCoordinate2D WorldTourDestinations[] = {
-    { 38.9131982, -77.0325453144239 },
-    { 37.7757368, -122.4135302 },
-    { 12.9810816, 77.6368034 },
-    { -13.15589555, -74.2178961777998 },
+    { .latitude = 38.9131982, .longitude = -77.0325453144239 },
+    { .latitude = 37.7757368, .longitude = -122.4135302 },
+    { .latitude = 12.9810816, .longitude = 77.6368034 },
+    { .latitude = -13.15589555, .longitude = -74.2178961777998 },
 };
 
 @interface MBXViewController () <UIActionSheetDelegate, MGLMapViewDelegate>

--- a/platform/ios/src/MGLAPIClient.m
+++ b/platform/ios/src/MGLAPIClient.m
@@ -54,7 +54,7 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
             statusError = [NSError errorWithDomain:MGLErrorDomain code:1 userInfo:userInfo];
         }
         if (completionHandler) {
-            error = error ? error : statusError;
+            error = error ?: statusError;
             completionHandler(error);
         }
         [self.dataTasks removeObject:dataTask];
@@ -120,7 +120,7 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
     NSString *appBuildNumber = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
     NSString *semanticVersion = [NSBundle mgl_frameworkInfoDictionary][@"MGLSemanticVersionString"];
     NSString *shortVersion = [NSBundle mgl_frameworkInfoDictionary][@"CFBundleShortVersionString"];
-    NSString *sdkVersion = semanticVersion ? semanticVersion : shortVersion;
+    NSString *sdkVersion = semanticVersion ?: shortVersion;
     _userAgent = [NSString stringWithFormat:@"%@/%@/%@ %@/%@", appName, appVersion, appBuildNumber, MGLAPIClientUserAgentBase, sdkVersion];
 }
 

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -137,7 +137,7 @@ const NSTimeInterval MGLFlushInterval = 180;
         NSBundle *bundle = [NSBundle mainBundle];
         NSNumber *accountTypeNumber = [bundle objectForInfoDictionaryKey:@"MGLMapboxAccountType"];
         [[NSUserDefaults standardUserDefaults] registerDefaults:@{
-             @"MGLMapboxAccountType": accountTypeNumber ? accountTypeNumber : @0,
+             @"MGLMapboxAccountType": accountTypeNumber ?: @0,
              @"MGLMapboxMetricsEnabled": @YES,
              @"MGLMapboxMetricsDebugLoggingEnabled": @NO,
          }];

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -79,8 +79,8 @@ struct MGLAttribution {
     /// URL to open when the attribution button is clicked.
     NSString *urlString;
 } MGLAttributions[] = {
-    { @"Mapbox", @"https://www.mapbox.com/about/maps/" },
-    { @"OpenStreetMap", @"http://www.openstreetmap.org/about/" },
+    { .title = @"Mapbox", .urlString = @"https://www.mapbox.com/about/maps/" },
+    { .title = @"OpenStreetMap", .urlString = @"http://www.openstreetmap.org/about/" },
 };
 
 /// Unique identifier representing a single annotation in mbgl.


### PR DESCRIPTION
Now that #4641 has removed the prohibition against C99 extensions, this change removes many pragma statements that suppress warnings about variadic macros and designated initializers. Designated initializers and Elvis operators have been introduced wherever appropriate.

/ref #4191
/cc @boundsj @friedbunny