### PR TITLE
Deprecate -[MGLMapView emptyMemoryCache]

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.  If you’d like 
 - Added a `-reloadStyle:` action to MGLMapView to force a reload of the current style. ([#4728](https://github.com/mapbox/mapbox-gl-native/pull/4728))
 - A more specific user agent string is now sent with style and tile requests. ([#4012](https://github.com/mapbox/mapbox-gl-native/pull/4012))
 - Removed unused SVG files from the SDK’s resource bundle. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
+- Deprecated `-[MGLMapView emptyMemoryCache]`. ([#4725](https://github.com/mapbox/mapbox-gl-native/pull/4725))
 
 ## 3.2.0
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -159,7 +159,6 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
                             ((debugMask & MGLMapDebugCollisionBoxesMask)
                              ? @"Hide Collision Boxes"
                              : @"Show Collision Boxes"),
-                            @"Empty Memory",
                             @"Add 100 Points",
                             @"Add 1,000 Points",
                             @"Add 10,000 Points",
@@ -201,21 +200,17 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 5)
     {
-        [self.mapView emptyMemoryCache];
+        [self parseFeaturesAddingCount:100];
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 6)
     {
-        [self parseFeaturesAddingCount:100];
+        [self parseFeaturesAddingCount:1000];
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 7)
     {
-        [self parseFeaturesAddingCount:1000];
-    }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 8)
-    {
         [self parseFeaturesAddingCount:10000];
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 9)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 8)
     {
         // PNW triangle
         //
@@ -282,19 +277,19 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
             free(polygonCoordinates);
         }
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 10)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 9)
     {
         [self startWorldTour:actionSheet];
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 11)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 10)
     {
         [self presentAnnotationWithCustomCallout];
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 12)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 11)
     {
         [self.mapView removeAnnotations:self.mapView.annotations];
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 13)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 12)
     {
         if (_isShowingCustomStyleLayer)
         {
@@ -305,12 +300,12 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
             [self insertCustomStyleLayer];
         }
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 14)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 13)
     {
         NSString *fileContents = [NSString stringWithContentsOfFile:[self telemetryDebugLogfilePath] encoding:NSUTF8StringEncoding error:nil];
         NSLog(@"%@", fileContents);
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 15)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 14)
     {
         NSString *filePath = [self telemetryDebugLogfilePath];
         if ([[NSFileManager defaultManager] isDeletableFileAtPath:filePath]) {

--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -1,25 +1,11 @@
 #import "MBXBenchViewController.h"
 
 #import <Mapbox/Mapbox.h>
+#import "MGLMapView_Internal.h"
 
 #include "locations.hpp"
 
 #include <chrono>
-
-@interface MGLMapView (MBXBenchmarkAdditions)
-
-#pragma mark - Debugging
-
-/** Triggers another render pass even when it is not necessary. */
-- (void)setNeedsGLDisplay;
-
-/** Returns whether the map view is currently loading or processing any assets required to render the map */
-- (BOOL)isFullyLoaded;
-
-/** Empties the in-memory tile cache. */
-- (void)didReceiveMemoryWarning;
-
-@end
 
 @interface MBXBenchViewController () <MGLMapViewDelegate>
 

--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -16,6 +16,9 @@
 /** Returns whether the map view is currently loading or processing any assets required to render the map */
 - (BOOL)isFullyLoaded;
 
+/** Empties the in-memory tile cache. */
+- (void)didReceiveMemoryWarning;
+
 @end
 
 @interface MBXBenchViewController () <MGLMapViewDelegate>
@@ -142,7 +145,7 @@ static const int benchmarkDuration = 200; // frames
         {
             // Start the benchmarking timer.
             state = State::WarmingUp;
-            [self.mapView emptyMemoryCache];
+            [self.mapView didReceiveMemoryWarning];
             NSLog(@"- Warming up for %d frames...", warmupDuration);
             [mapView setNeedsGLDisplay];
         }

--- a/platform/ios/include/MGLMapView.h
+++ b/platform/ios/include/MGLMapView.h
@@ -989,10 +989,7 @@ IB_DESIGNABLE
 
 - (void)toggleDebug __attribute__((deprecated("Use -setDebugMask:.")));
 
-/**
-    Empties the in-memory tile cache.
- */
-- (void)emptyMemoryCache;
+- (void)emptyMemoryCache __attribute__((deprecated));
 
 /**
     Resets the map to the minimum zoom level, a center coordinate of (0, 0), and

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DA17BE301CC4BAC300402C41 /* MGLMapView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */; };
+		DA17BE311CC4BDAA00402C41 /* MGLMapView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */; };
 		DA1DC96A1CB6C6B7006E619F /* MBXCustomCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1DC9671CB6C6B7006E619F /* MBXCustomCalloutView.m */; };
 		DA1DC96B1CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1DC9691CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m */; };
 		DA1DC9701CB6C6CE006E619F /* points.geojson in Resources */ = {isa = PBXBuildFile; fileRef = DA1DC96C1CB6C6CE006E619F /* points.geojson */; };
@@ -239,6 +241,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MGLMapView_Internal.h; path = src/MGLMapView_Internal.h; sourceTree = "<group>"; };
 		DA1DC94A1CB6C1C2006E619F /* Mapbox GL.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mapbox GL.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA1DC9501CB6C1C2006E619F /* MBXAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBXAppDelegate.h; sourceTree = "<group>"; };
 		DA1DC9531CB6C1C2006E619F /* MBXViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBXViewController.h; sourceTree = "<group>"; };
@@ -591,6 +594,7 @@
 				DA8848481CBAFB9800AB86E3 /* MGLMapboxEvents.h */,
 				DA8848491CBAFB9800AB86E3 /* MGLMapboxEvents.m */,
 				DA8848361CBAFB8500AB86E3 /* MGLMapView.h */,
+				DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */,
 				DA8848371CBAFB8500AB86E3 /* MGLMapView+IBAdditions.h */,
 				DA8848381CBAFB8500AB86E3 /* MGLMapView+MGLCustomStyleLayerAdditions.h */,
 				DA88484A1CBAFB9800AB86E3 /* MGLMapView.mm */,
@@ -735,6 +739,7 @@
 				DA8848551CBAFB9800AB86E3 /* MGLLocationManager.h in Headers */,
 				DA88483F1CBAFB8500AB86E3 /* MGLUserLocation.h in Headers */,
 				DA88483D1CBAFB8500AB86E3 /* MGLMapView+IBAdditions.h in Headers */,
+				DA17BE301CC4BAC300402C41 /* MGLMapView_Internal.h in Headers */,
 				DA88481E1CBAFA6200AB86E3 /* MGLMultiPoint_Private.h in Headers */,
 				DA8847F71CBAFA5100AB86E3 /* MGLOverlay.h in Headers */,
 				DA88488B1CBB037E00AB86E3 /* SMCalloutView.h in Headers */,
@@ -772,6 +777,7 @@
 				DABFB8721CBE9A0F00D62B32 /* MGLUserLocation.h in Headers */,
 				DABFB8661CBE99E500D62B32 /* MGLPointAnnotation.h in Headers */,
 				DABFB8621CBE99E500D62B32 /* MGLOfflinePack.h in Headers */,
+				DA17BE311CC4BDAA00402C41 /* MGLMapView_Internal.h in Headers */,
 				DABFB86C1CBE99E500D62B32 /* MGLTypes.h in Headers */,
 				DABFB8691CBE99E500D62B32 /* MGLShape.h in Headers */,
 				DABFB8701CBE9A0F00D62B32 /* MGLMapView+IBAdditions.h in Headers */,

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1,6 +1,4 @@
-#import "MGLMapView.h"
-#import "MGLMapView+IBAdditions.h"
-#import "MGLMapView+MGLCustomStyleLayerAdditions.h"
+#import "MGLMapView_Internal.h"
 
 #import <mbgl/platform/log.hpp>
 #import <mbgl/gl/gl.hpp>

--- a/platform/ios/src/MGLMapView_Internal.h
+++ b/platform/ios/src/MGLMapView_Internal.h
@@ -1,0 +1,14 @@
+#import <Mapbox/Mapbox.h>
+
+@interface MGLMapView (Internal)
+
+/** Triggers another render pass even when it is not necessary. */
+- (void)setNeedsGLDisplay;
+
+/** Returns whether the map view is currently loading or processing any assets required to render the map */
+- (BOOL)isFullyLoaded;
+
+/** Empties the in-memory tile cache. */
+- (void)didReceiveMemoryWarning;
+
+@end


### PR DESCRIPTION
Marked `-[MGLMapView emptyMemoryCache]` as deprecated. Removed the option to empty the in-memory tile cache from iosapp. Split out a project-internal header for methods on MGLMapView that ios-bench needs, to reduce the likelihood of a redeclared category getting out of sync.

Fixes #1833.

/cc @kkaefer