### PR TITLE
Use staging server in simulator

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.  If you’d like 
 - Fixed an issue preventing KVO change notifications from being generated on MGLMapView’s `userTrackingMode` key path when `-setUserTrackingMode:animated:` is called. ([#4724](https://github.com/mapbox/mapbox-gl-native/pull/4724))
 - Added a `-reloadStyle:` action to MGLMapView to force a reload of the current style. ([#4728](https://github.com/mapbox/mapbox-gl-native/pull/4728))
 - A more specific user agent string is now sent with style and tile requests. ([#4012](https://github.com/mapbox/mapbox-gl-native/pull/4012))
+- Mapbox Telemetry is automatically disabled while the host application is running in the iOS Simulator. ([#4726](https://github.com/mapbox/mapbox-gl-native/pull/4726))
 - Removed unused SVG files from the SDK’s resource bundle. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Deprecated `-[MGLMapView emptyMemoryCache]`. ([#4725](https://github.com/mapbox/mapbox-gl-native/pull/4725))
 

--- a/platform/ios/app/Info.plist
+++ b/platform/ios/app/Info.plist
@@ -24,17 +24,6 @@
 	<string>7877</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>cloudfront-staging.tilestream.net</key>
-			<dict>
-				<key>NSExceptionRequiresForwardSecrecy</key>
-				<false/>
-			</dict>
-		</dict>
-	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2014–2016 Mapbox</string>
 	<key>NSLocationAlwaysUsageDescription</key>

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -42,7 +42,6 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
             @"MBXUserTrackingMode": @(MGLUserTrackingModeNone),
             @"MBXShowsUserLocation": @NO,
             @"MBXDebug": @NO,
-            @"MGLTelemetryTestServerURL": @"https://cloudfront-staging.tilestream.net",
         }];
     }
 }

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -140,6 +140,9 @@ const NSTimeInterval MGLFlushInterval = 180;
              @"MGLMapboxAccountType": accountTypeNumber ?: @0,
              @"MGLMapboxMetricsEnabled": @YES,
              @"MGLMapboxMetricsDebugLoggingEnabled": @NO,
+#if TARGET_OS_SIMULATOR
+             @"MGLTelemetryTestServerURL": @"https://cloudfront-staging.tilestream.net",
+#endif
          }];
     }
 }
@@ -360,7 +363,7 @@ const NSTimeInterval MGLFlushInterval = 180;
         [self pushTurnstileEvent];
     }
     
-    if ([self isPaused]) {
+    if (self.paused) {
         return;
     }
     
@@ -450,7 +453,7 @@ const NSTimeInterval MGLFlushInterval = 180;
 // Called implicitly from public use of +flush.
 //
 - (void)postEvents:(NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events {
-    if ([self isPaused]) {
+    if (self.paused) {
         return;
     }
     

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -140,16 +140,17 @@ const NSTimeInterval MGLFlushInterval = 180;
              @"MGLMapboxAccountType": accountTypeNumber ?: @0,
              @"MGLMapboxMetricsEnabled": @YES,
              @"MGLMapboxMetricsDebugLoggingEnabled": @NO,
-#if TARGET_OS_SIMULATOR
-             @"MGLTelemetryTestServerURL": @"https://cloudfront-staging.tilestream.net",
-#endif
          }];
     }
 }
 
 + (BOOL)isEnabled {
+#if TARGET_OS_SIMULATOR
+    return NO;
+#else
     return ([[NSUserDefaults standardUserDefaults] boolForKey:@"MGLMapboxMetricsEnabled"] &&
             [[NSUserDefaults standardUserDefaults] integerForKey:@"MGLMapboxAccountType"] == 0);
+#endif
 }
 
 - (BOOL)debugLoggingEnabled {

--- a/platform/ios/uitest/App-Info.plist
+++ b/platform/ios/uitest/App-Info.plist
@@ -28,8 +28,6 @@
 	<string>pk.eyJ1IjoianVzdGluIiwiYSI6Ik9RX3RRQzAifQ.dmOg_BAp1ywuDZMM7YsXRg</string>
 	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
 	<true/>
-	<key>MGLMetricsTestServerURL</key>
-	<string>https://cloudfront-staging.tilestream.net</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>Strictly for testing purposes, promise!</string>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
~~Use the staging telemetry server when compiled for the iOS Simulator. An alternative would’ve been to disable telemetry altogether in this scenario, but I think leaving it enabled and sending it to the staging endpoint leaves open the possibility of testing telemetry with mocked requests (#2822).~~

Disable telemetry when compiled for the iOS Simulator.

Fixes #3621.

/cc @boundsj @friedbunny @bleege