### PR TITLE
Prompt for access token in iosapp

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.  If you’d like 
 - Removed the `armv7s` slice from the SDK to reduce its size. iPhone 5 and iPhone 5c automatically use the `armv7` slice instead. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - The user dot now moves smoothly between user location updates while user location tracking is disabled. ([#1582](https://github.com/mapbox/mapbox-gl-native/pull/1582))
 - User location heading updates now resume properly when an app becomes active again. ([#4674](https://github.com/mapbox/mapbox-gl-native/pull/4674))
+- Added a `-reloadStyle:` action to MGLMapView to force a reload of the current style. ([#4728](https://github.com/mapbox/mapbox-gl-native/pull/4728))
 - A more specific user agent string is now sent with style and tile requests. ([#4012](https://github.com/mapbox/mapbox-gl-native/pull/4012))
 - Removed unused SVG files from the SDK’s resource bundle. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 

--- a/platform/ios/app/MBXAppDelegate.h
+++ b/platform/ios/app/MBXAppDelegate.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+extern NSString * const MBXMapboxAccessTokenDefaultsKey;
+
 @interface MBXAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/platform/ios/app/MBXAppDelegate.m
+++ b/platform/ios/app/MBXAppDelegate.m
@@ -2,6 +2,8 @@
 #import "MBXViewController.h"
 #import <Mapbox/Mapbox.h>
 
+NSString * const MBXMapboxAccessTokenDefaultsKey = @"MBXMapboxAccessToken";
+
 @implementation MBXAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -12,14 +14,12 @@
         if (accessToken) {
             // Store to preferences so that we can launch the app later on without having to specify
             // token.
-            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:@"access_token"];
+            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:MBXMapboxAccessTokenDefaultsKey];
         } else {
             // Try to retrieve from preferences, maybe we've stored them there previously and can reuse
             // the token.
-            accessToken = [[NSUserDefaults standardUserDefaults] objectForKey:@"access_token"];
+            accessToken = [[NSUserDefaults standardUserDefaults] objectForKey:MBXMapboxAccessTokenDefaultsKey];
         }
-        if ( ! accessToken) NSLog(@"No access token set. Mapbox vector tiles won't work.");
-
         [MGLAccountManager setAccessToken:accessToken];
     }
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1,4 +1,6 @@
 #import "MBXViewController.h"
+
+#import "MBXAppDelegate.h"
 #import "MBXCustomCalloutView.h"
 #import "MBXOfflinePacksTableViewController.h"
 
@@ -57,6 +59,34 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     [self cycleStyles:self];
 
     [self restoreState:nil];
+    
+    if ( ! [MGLAccountManager accessToken].length)
+    {
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Access Token" message:@"Enter your Mapbox access token to load Mapbox-hosted tiles and styles:" preferredStyle:UIAlertControllerStyleAlert];
+        [alertController addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField)
+         {
+             textField.keyboardType = UIKeyboardTypeURL;
+             textField.autocorrectionType = UITextAutocorrectionTypeNo;
+             textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+         }];
+        
+        [alertController addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+        UIAlertAction *OKAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action)
+        {
+            UITextField *textField = alertController.textFields.firstObject;
+            NSString *accessToken = textField.text;
+            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:MBXMapboxAccessTokenDefaultsKey];
+            [MGLAccountManager setAccessToken:accessToken];
+            [self.mapView reloadStyle:self];
+        }];
+        [alertController addAction:OKAction];
+        
+        if ([alertController respondsToSelector:@selector(setPreferredAction:)])
+        {
+            alertController.preferredAction = OKAction;
+        }
+        [self presentViewController:alertController animated:YES completion:nil];
+    }
 }
 
 - (void)saveState:(__unused NSNotification *)notification

--- a/platform/ios/include/MGLMapView.h
+++ b/platform/ios/include/MGLMapView.h
@@ -136,6 +136,20 @@ IB_DESIGNABLE
 @property (nonatomic, null_resettable) NSURL *styleURL;
 
 /**
+ Reloads the style.
+ 
+ You do not normally need to call this method. The map view automatically
+ responds to changes in network connectivity by reloading the style. You may
+ need to call this method if you change the access token after a style has
+ loaded but before loading a style associated with a different Mapbox account.
+ 
+ This method does not bust the cache. Even if the style has recently changed on
+ the server, calling this method does not necessarily ensure that the map view
+ reflects those changes.
+ */
+- (IBAction)reloadStyle:(id)sender;
+
+/**
  A control indicating the map's direction and allowing the user to manipulate
  the direction, positioned in the upper-right corner.
  */

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -291,6 +291,12 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     _mbglMap->setStyleURL([[styleURL absoluteString] UTF8String]);
 }
 
+- (IBAction)reloadStyle:(__unused id)sender {
+    NSURL *styleURL = self.styleURL;
+    _mbglMap->setStyleURL("");
+    self.styleURL = styleURL;
+}
+
 - (void)commonInit
 {
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;


### PR DESCRIPTION
If no access token is found in user defaults at launch, iosapp prompts the user for an access token. Renamed the user defaults key for the access token to conform to Cocoa naming conventions. The `MAPBOX_ACCESS_TOKEN` environment variable is still honored.

Added an action to MGLMapView that reloads the current style. Note that it doesn’t clear the cache; it’s pretty much only useful for ensuring that a change in access token is reflected on the map or for forcing the map view to retry loading tiles independently of the exponential back-off strategy.

Fixes #3102 and fixes #4696.

/cc @friedbunny @kkaefer