### PR TITLE
[build] Make `run-glfw-app` not working on Linux

### DIFF
--- a/scripts/main.mk
+++ b/scripts/main.mk
@@ -139,10 +139,10 @@ tidy: Ninja/compdb
 #### Run tests #################################################################
 
 run-glfw-app:
-	$(PLATFORM_OUTPUT)/$(BUILDTYPE)/mapbox-glfw
+	cd $(PLATFORM_OUTPUT)/$(BUILDTYPE) && ./mapbox-glfw
 
 run-valgrind-glfw-app:
-	valgrind --leak-check=full --suppressions=../../../scripts/valgrind.sup $(PLATFORM_OUTPUT)/$(BUILDTYPE)/mapbox-glfw
+	cd $(PLATFORM_OUTPUT)/$(BUILDTYPE) && valgrind --leak-check=full --suppressions=../../../scripts/valgrind.sup ./mapbox-glfw
 
 ifneq (,$(shell command -v gdb))
   GDB = gdb -batch -return-child-result -ex 'set print thread-events off' -ex 'run' -ex 'thread apply all bt' --args


### PR DESCRIPTION
There is an assumption that the certificate bundle is in the same path as the binary.