### PR TITLE
[build] `Command not found` when building on Linux

### DIFF
--- a/scripts/main.mk
+++ b/scripts/main.mk
@@ -144,7 +144,7 @@ run-glfw-app:
 run-valgrind-glfw-app:
 	cd $(PLATFORM_OUTPUT)/$(BUILDTYPE) && valgrind --leak-check=full --suppressions=../../../scripts/valgrind.sup ./mapbox-glfw
 
-ifneq (,$(shell command -v gdb))
+ifneq (,$(shell which gdb))
   GDB = gdb -batch -return-child-result -ex 'set print thread-events off' -ex 'run' -ex 'thread apply all bt' --args
 endif
 


### PR DESCRIPTION
```
$ make android -j8
make -f scripts/main.mk PLATFORM=android SUBPLATFORM=arm-v7 Makefile/all
make[1]: Entering directory '/opt/tmpsantos/Projects/mapbox-gl-native'
make[1]: command: Command not found
```

Build continues normally after that but we are missing a step or calling something that we should not be calling. Also happens when building GLFW.