### PR TITLE
Prompt for access token in ios-bench; restore iosapp scheme

### DIFF
--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -31,13 +31,7 @@ You can customize the build output by passing the following arguments into the `
 
 ### Access tokens
 
-_The demo applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/)._
-
-Set up the access token by editing the scheme for the application target, then adding an environment variable with the name `MAPBOX_ACCESS_TOKEN`.
-
-![edit scheme](https://cloud.githubusercontent.com/assets/98601/5460702/c4610262-8519-11e4-873a-8597821da468.png)
-
-![setting access token in Xcode scheme](https://cloud.githubusercontent.com/assets/162976/5349358/0a086f00-7f8c-11e4-8433-bdbaccda2b58.png)
+The included applications use Mapbox vector tiles, which require a Mapbox account and API access token. Obtain an access token on the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/). You will be prompted for this access token the first time you launch the demo or benchmarking application. In the iOS Simulator, you can paste your access token by pressing Command-V, holding down the left mouse button in the text field, and pressing the Paste button that appears.
 
 ### Test
 

--- a/platform/ios/benchmark/MBXBenchAppDelegate.h
+++ b/platform/ios/benchmark/MBXBenchAppDelegate.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+extern NSString * const MBXMapboxAccessTokenDefaultsKey;
+
 @interface MBXBenchAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/platform/ios/benchmark/MBXBenchAppDelegate.m
+++ b/platform/ios/benchmark/MBXBenchAppDelegate.m
@@ -2,23 +2,23 @@
 #import "MBXBenchViewController.h"
 #import <Mapbox/Mapbox.h>
 
+NSString * const MBXMapboxAccessTokenDefaultsKey = @"MBXMapboxAccessToken";
+
 @implementation MBXBenchAppDelegate
 
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    NSString* accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
-    if (accessToken) {
-        // Store to preferences so that we can launch the app later on without having to specify
-        // token.
-        [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:@"access_token"];
-    } else {
-        // Try to retrieve from preferences, maybe we've stored them there previously and can reuse
-        // the token.
-        accessToken = [[NSUserDefaults standardUserDefaults] objectForKey:@"access_token"];
-    }
-    if (!accessToken) {
-        NSLog(@"No access token set. Mapbox vector tiles won't work.");
-    } else {
+    if (![MGLAccountManager accessToken]) {
+        NSString *accessToken = [[NSProcessInfo processInfo] environment][@"MAPBOX_ACCESS_TOKEN"];
+        if (accessToken) {
+            // Store to preferences so that we can launch the app later on without having to specify
+            // token.
+            [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:MBXMapboxAccessTokenDefaultsKey];
+        } else {
+            // Try to retrieve from preferences, maybe we've stored them there previously and can reuse
+            // the token.
+            accessToken = [[NSUserDefaults standardUserDefaults] objectForKey:MBXMapboxAccessTokenDefaultsKey];
+        }
         [MGLAccountManager setAccessToken:accessToken];
     }
 

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA1DC9491CB6C1C2006E619F"
+               BuildableName = "Mapbox GL.app"
+               BlueprintName = "iosapp"
+               ReferencedContainer = "container:ios.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA1DC9491CB6C1C2006E619F"
+            BuildableName = "Mapbox GL.app"
+            BlueprintName = "iosapp"
+            ReferencedContainer = "container:ios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA1DC9491CB6C1C2006E619F"
+            BuildableName = "Mapbox GL.app"
+            BlueprintName = "iosapp"
+            ReferencedContainer = "container:ios.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA1DC9491CB6C1C2006E619F"
+            BuildableName = "Mapbox GL.app"
+            BlueprintName = "iosapp"
+            ReferencedContainer = "container:ios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/platform/osx/osx.xcodeproj/xcshareddata/xcschemes/osxapp.xcscheme
+++ b/platform/osx/osx.xcodeproj/xcshareddata/xcschemes/osxapp.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA839E911CC2E3400062CAFB"
+               BuildableName = "Mapbox GL.app"
+               BlueprintName = "osxapp"
+               ReferencedContainer = "container:osx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAE6C3301CC30DB200DB3429"
+               BuildableName = "test.xctest"
+               BlueprintName = "test"
+               ReferencedContainer = "container:osx.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA839E911CC2E3400062CAFB"
+            BuildableName = "Mapbox GL.app"
+            BlueprintName = "osxapp"
+            ReferencedContainer = "container:osx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA839E911CC2E3400062CAFB"
+            BuildableName = "Mapbox GL.app"
+            BlueprintName = "osxapp"
+            ReferencedContainer = "container:osx.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA839E911CC2E3400062CAFB"
+            BuildableName = "Mapbox GL.app"
+            BlueprintName = "osxapp"
+            ReferencedContainer = "container:osx.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
ios-bench now prompts for an access token on first launch just as iosapp and osxapp do (#4728). ios-bench waits to start benchmarking until after the access token is entered. If this application needs to run without user intervention, the `MAPBOX_ACCESS_TOKEN` environment variable is still supported.

Removed the `MAPBOX_ACCESS_TOKEN` environment variable from iOS contributor documentation. Since the tendency to inadvertently commit this environment variable was the reason for removing the iosapp scheme in #4737, I’ve reverted that change, so the contributor documentation is once again accurate.

/cc @jfirebaugh @boundsj @friedbunny @kkaefer