### PR TITLE
Version default style URL APIs; deprecate Emerald

### DIFF
--- a/include/mbgl/util/default_styles.hpp
+++ b/include/mbgl/util/default_styles.hpp
@@ -14,16 +14,18 @@ struct DefaultStyle {
 };
 
 extern const DefaultStyle streets;
-extern const DefaultStyle emerald;
+extern const DefaultStyle outdoors;
 extern const DefaultStyle light;
 extern const DefaultStyle dark;
 extern const DefaultStyle satellite;
 extern const DefaultStyle hybrid;
 
 const DefaultStyle orderedStyles[] = {
-    streets, emerald, light, dark, satellite, hybrid,
+    streets, outdoors, light, dark, satellite, hybrid,
 };
 const size_t numOrderedStyles = sizeof(orderedStyles) / sizeof(DefaultStyle);
+
+static const unsigned currentVersion = 9;
 
 } // end namespace default_styles
 } // end namespace util

--- a/include/mbgl/util/default_styles.hpp
+++ b/include/mbgl/util/default_styles.hpp
@@ -18,10 +18,10 @@ extern const DefaultStyle outdoors;
 extern const DefaultStyle light;
 extern const DefaultStyle dark;
 extern const DefaultStyle satellite;
-extern const DefaultStyle hybrid;
+extern const DefaultStyle satelliteStreets;
 
 const DefaultStyle orderedStyles[] = {
-    streets, outdoors, light, dark, satellite, hybrid,
+    streets, outdoors, light, dark, satellite, satelliteStreets,
 };
 const size_t numOrderedStyles = sizeof(orderedStyles) / sizeof(DefaultStyle);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/Style.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/Style.java
@@ -1,11 +1,14 @@
 package com.mapbox.mapboxsdk.constants;
 
+import android.support.annotation.IntRange;
 import android.support.annotation.StringDef;
 
 import com.mapbox.mapboxsdk.maps.MapView;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Locale;
+
 /**
  * <p>
  * Style provides URLs to several professional styles designed by Mapbox.
@@ -17,10 +20,146 @@ import java.lang.annotation.RetentionPolicy;
 public class Style {
 
     /**
+     * Mapbox Streets: A complete basemap, perfect for incorporating your own data.
+     */
+    private static final String MAPBOX_STREETS_BASE = "mapbox://styles/mapbox/streets-v%d";
+    /**
+     * Outdoors: A rugged style that emphasizes physical terrain and outdoor activities.
+     */
+    private static final String OUTDOORS_BASE = "mapbox://styles/mapbox/outdoors-v%d";
+    /**
+     * Light: Subtle light backdrop for data visualizations.
+     */
+    private static final String LIGHT_BASE = "mapbox://styles/mapbox/light-v%d";
+    /**
+     * Dark: Subtle dark backdrop for data visualizations.
+     */
+    private static final String DARK_BASE = "mapbox://styles/mapbox/dark-v%d";
+    /**
+     * Satellite: A beautiful global satellite and aerial imagery layer.
+     */
+    private static final String SATELLITE_BASE = "mapbox://styles/mapbox/satellite-v%d";
+    /**
+     * Satellite Streets: Global satellite and aerial imagery with unobtrusive labels.
+     */
+    private static final String SATELLITE_STREETS_BASE = "mapbox://styles/mapbox/satellite-hybrid-v%d";
+
+    /**
+     * Get versioned url of Mapbox streets style.
+     * <p>
+     * <ul>
+     * <li>Current default version is 9.</li>
+     * </ul
+     * </p>
+     * <p>
+     * More information on the Mapbox styles API can be found on https://www.mapbox.com/api-documentation/#styles
+     * </p>
+     *
+     * @param version the version of the style.
+     * @return uri to load style from
+     */
+    public static String getMapboxStreetsUrl(int version) {
+        return String.format(Locale.US, MAPBOX_STREETS_BASE, version);
+    }
+
+    /**
+     * Get versioned url of Outdoors streets style.
+     * <p>
+     * <ul>
+     * <li>Current version is 9.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * More information on the Mapbox styles API can be found on https://www.mapbox.com/api-documentation/#styles
+     * </p>
+     *
+     * @param version the version of the style.
+     * @return uri to load style from
+     */
+    public static String getOutdoorsStyleUrl(int version) {
+        return String.format(Locale.US, OUTDOORS_BASE, version);
+    }
+
+    /**
+     * Get versioned url of Light style.
+     * <p>
+     * <ul>
+     * <li>Current default version is 9.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * More information on the Mapbox styles API can be found on https://www.mapbox.com/api-documentation/#styles
+     * </p>
+     *
+     * @param version the version of the style.
+     * @return uri to load style from
+     */
+    public static String getLightStyleUrl(int version) {
+        return String.format(Locale.US, LIGHT_BASE, version);
+    }
+
+    /**
+     * Get versioned url of Dark style.
+     * <p>
+     * <ul>
+     * <li>Current default version is 9.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * More information on the Mapbox styles API can be found on https://www.mapbox.com/api-documentation/#styles
+     * </p>
+     *
+     * @param version the version of the style.
+     * @return uri to load style from
+     */
+    public static String getDarkStyleUrl(int version) {
+        return String.format(Locale.US, DARK_BASE, version);
+    }
+
+    /**
+     * Get versioned url of Satellite style.
+     * <p>
+     * <ul>
+     * <li>Current version is 9.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * More information on the Mapbox styles API can be found on https://www.mapbox.com/api-documentation/#styles
+     * </p>
+     *
+     * @param version the version of the style.
+     * @return uri to load style from
+     */
+    public static String getSatelliteStyleUrl(int version) {
+        return String.format(Locale.US, SATELLITE_BASE, version);
+    }
+
+    /**
+     * Get versioned url of Satellite streets style.
+     * <p>
+     * <ul>
+     * <li>Current version is 9.</li>
+     * </ul>
+     * </p>
+     * <p>
+     * More information on the Mapbox styles API can be found on https://www.mapbox.com/api-documentation/#styles
+     * </p>
+     *
+     * @param version the version of the style.
+     * @return uri to load style from
+     */
+    public static String getSatelliteStreetsStyleUrl(int version) {
+        return String.format(Locale.US, SATELLITE_STREETS_BASE, version);
+    }
+
+    /**
      * Indicates the parameter accepts one of the values from {@link Style}.
+     *
+     * @deprecated use dedicated versioned methods in {@link Style} instead.
      */
     @StringDef({MAPBOX_STREETS, EMERALD, LIGHT, DARK, SATELLITE, SATELLITE_STREETS})
     @Retention(RetentionPolicy.SOURCE)
+    @Deprecated
     public @interface StyleUrl {
     }
 
@@ -28,28 +167,49 @@ public class Style {
 
     /**
      * Mapbox Streets: A complete basemap, perfect for incorporating your own data.
+     *
+     * @deprecated use {@link #getMapboxStreetsUrl(int)} instead.
      */
-    public static final String MAPBOX_STREETS = "mapbox://styles/mapbox/streets-v8";
+    @Deprecated
+    public static final String MAPBOX_STREETS = "mapbox://styles/mapbox/streets-v9";
+
     /**
      * Emerald: A versatile style, with emphasis on road networks and public transit.
+     *
+     * @deprecated this style has been deprecated and will be removed in future versions.
      */
+    @Deprecated
     public static final String EMERALD = "mapbox://styles/mapbox/emerald-v8";
+
     /**
      * Light: Subtle light backdrop for data visualizations.
+     *
+     * @deprecated use {@link #getLightStyleUrl(int)} instead.
      */
-    public static final String LIGHT = "mapbox://styles/mapbox/light-v8";
+    @Deprecated
+    public static final String LIGHT = "mapbox://styles/mapbox/light-v9";
+
     /**
      * Dark: Subtle dark backdrop for data visualizations.
+     *
+     * @deprecated use {@link #getDarkStyleUrl(int)} (int)} instead.
      */
-    public static final String DARK = "mapbox://styles/mapbox/dark-v8";
+    @Deprecated
+    public static final String DARK = "mapbox://styles/mapbox/dark-v9";
+
     /**
      * Satellite: A beautiful global satellite and aerial imagery layer.
+     *
+     * @deprecated use {@link #getSatelliteStyleUrl(int)} instead.
      */
-    public static final String SATELLITE = "mapbox://styles/mapbox/satellite-v8";
+    @Deprecated
+    public static final String SATELLITE = "mapbox://styles/mapbox/satellite-v9";
 
     /**
      * Satellite Streets: Global satellite and aerial imagery with unobtrusive labels.
+     *
+     * @deprecated use {@link #getSatelliteStreetsStyleUrl(int)} (int)} instead.
      */
-    public static final String SATELLITE_STREETS = "mapbox://styles/mapbox/satellite-hybrid-v8";
-
+    @Deprecated
+    public static final String SATELLITE_STREETS = "mapbox://styles/mapbox/satellite-hybrid-v9";
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -779,7 +779,7 @@ public class MapView extends FrameLayout {
      * <li>{@code asset://...}:
      * reads the style from the APK {@code assets/} directory.
      * This is used to load a style bundled with your app.</li>
-     * <li>{@code null}: loads the default {@link Style#MAPBOX_STREETS} style.</li>
+     * <li>{@code null}: loads the default {@link Style#getMapboxStreetsUrl(int)} style.</li>
      * </ul>
      * <p>
      * This method is asynchronous and will return immediately before the style finishes loading.
@@ -2679,7 +2679,7 @@ public class MapView extends FrameLayout {
         private boolean mDefaultStyle;
 
         public StyleInitializer() {
-            mStyle = Style.MAPBOX_STREETS;
+            mStyle = Style.getMapboxStreetsUrl(getResources().getInteger(R.integer.style_version));
             mDefaultStyle = true;
         }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -523,7 +523,7 @@ public class MapboxMap {
      * <li>{@code asset://...}:
      * reads the style from the APK {@code assets/} directory.
      * This is used to load a style bundled with your app.</li>
-     * <li>{@code null}: loads the default {@link Style#MAPBOX_STREETS} style.</li>
+     * <li>{@code null}: loads the default {@link Style#getMapboxStreetsUrl(int)} style.</li>
      * </ul>
      * <p>
      * This method is asynchronous and will return immediately before the style finishes loading.
@@ -553,8 +553,10 @@ public class MapboxMap {
      *
      * @param style The bundled style. Accepts one of the values from {@link Style}.
      * @see Style
+     * @deprecated use {@link #setStyleUrl(String)} instead with versioned url methods from {@link Style}
      */
     @UiThread
+    @Deprecated
     public void setStyle(@Style.StyleUrl String style) {
         setStyleUrl(style);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/integers.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="style_version">9</integer>
+</resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
@@ -11,10 +11,11 @@
     <string name="infoWindowAddress">Address</string>
 
     <!-- these are public -->
-    <string name="style_mapbox_streets">mapbox://styles/mapbox/streets-v8</string>
+    <!-- {@deprecated Use Style.getXStyleUrl(int version) instead.} -->
+    <string name="style_mapbox_streets">mapbox://styles/mapbox/streets-v9</string>
     <string name="style_emerald">mapbox://styles/mapbox/emerald-v8</string>
-    <string name="style_light">mapbox://styles/mapbox/light-v8</string>
-    <string name="style_dark">mapbox://styles/mapbox/dark-v8</string>
-    <string name="style_satellite">mapbox://styles/mapbox/satellite-v8</string>
-    <string name="style_satellite_streets">mapbox://styles/mapbox/satellite-hybrid-v8</string>
+    <string name="style_light">mapbox://styles/mapbox/light-v9</string>
+    <string name="style_dark">mapbox://styles/mapbox/dark-v9</string>
+    <string name="style_satellite">mapbox://styles/mapbox/satellite-v9</string>
+    <string name="style_satellite_streets">mapbox://styles/mapbox/satellite-hybrid-v9</string>
 </resources>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolygonActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolygonActivity.java
@@ -17,6 +17,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +44,7 @@ public class PolygonActivity extends AppCompatActivity {
         MapboxMapOptions options = new MapboxMapOptions()
                 .attributionTintColor(Color.RED)
                 .accessToken(getString(R.string.mapbox_access_token))
-                .styleUrl(Style.MAPBOX_STREETS)
+                .styleUrl(Style.getMapboxStreetsUrl(AppConstant.STYLE_VERSION))
                 .camera(new CameraPosition.Builder()
                         .target(new LatLng(45.520486, -122.673541))
                         .zoom(12)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/LatLngBoundsActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/LatLngBoundsActivity.java
@@ -19,6 +19,7 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.UiSettings;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
 public class LatLngBoundsActivity extends AppCompatActivity {
 
@@ -43,7 +44,7 @@ public class LatLngBoundsActivity extends AppCompatActivity {
 
         mMapView = (MapView) findViewById(R.id.mapView);
         mMapView.setAccessToken(getString(R.string.mapbox_access_token));
-        mMapView.setStyle(Style.DARK);
+        mMapView.setStyleUrl(Style.getDarkStyleUrl(AppConstant.STYLE_VERSION));
         mMapView.onCreate(savedInstanceState);
         mMapView.getMapAsync(new OnMapReadyCallback() {
             @Override
@@ -78,8 +79,6 @@ public class LatLngBoundsActivity extends AppCompatActivity {
                 Log.v(MapboxConstants.TAG, mapboxMap.getProjection().getVisibleRegion().latLngBounds.toString());
             }
         });
-
-
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ManualZoomActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/ManualZoomActivity.java
@@ -17,6 +17,7 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.UiSettings;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
 public class ManualZoomActivity extends AppCompatActivity {
 
@@ -39,7 +40,7 @@ public class ManualZoomActivity extends AppCompatActivity {
 
         mMapView = (MapView) findViewById(R.id.manualZoomMapView);
         mMapView.setAccessToken(getString(R.string.mapbox_access_token));
-        mMapView.setStyleUrl(Style.SATELLITE_STREETS);
+        mMapView.setStyleUrl(Style.getSatelliteStyleUrl(AppConstant.STYLE_VERSION));
         mMapView.onCreate(savedInstanceState);
         mMapView.getMapAsync(new OnMapReadyCallback() {
             @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
@@ -17,6 +17,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
 public class MapFragmentActivity extends AppCompatActivity {
 
@@ -40,7 +41,7 @@ public class MapFragmentActivity extends AppCompatActivity {
 
             MapboxMapOptions options = new MapboxMapOptions();
             options.accessToken(getString(R.string.mapbox_access_token));
-            options.styleUrl(Style.EMERALD);
+            options.styleUrl(Style.getOutdoorsStyleUrl(AppConstant.STYLE_VERSION));
 
             options.scrollGesturesEnabled(false);
             options.zoomGesturesEnabled(false);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
@@ -17,6 +17,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.SupportMapFragment;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
 public class SupportMapFragmentActivity extends AppCompatActivity {
 
@@ -40,7 +41,7 @@ public class SupportMapFragmentActivity extends AppCompatActivity {
 
             MapboxMapOptions options = new MapboxMapOptions();
             options.accessToken(getString(R.string.mapbox_access_token));
-            options.styleUrl(Style.SATELLITE_STREETS);
+            options.styleUrl(Style.getSatelliteStreetsStyleUrl(AppConstant.STYLE_VERSION));
 
             options.scrollGesturesEnabled(false);
             options.zoomGesturesEnabled(false);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/geocoding/GeocoderActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/geocoding/GeocoderActivity.java
@@ -27,6 +27,7 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Projection;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
 import java.util.List;
 
@@ -60,7 +61,7 @@ public class GeocoderActivity extends AppCompatActivity {
 
         mapView = (MapView) findViewById(R.id.mapView);
         mapView.setAccessToken(getString(R.string.mapbox_access_token));
-        mapView.setStyle(Style.MAPBOX_STREETS);
+        mapView.setStyleUrl(Style.getMapboxStreetsUrl(AppConstant.STYLE_VERSION));
         mapView.onCreate(savedInstanceState);
 
         final ImageView dropPinView = new ImageView(this);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -9,20 +9,31 @@ import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
+
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
-public class DebugModeActivity  extends AppCompatActivity {
+public class DebugModeActivity extends AppCompatActivity {
 
     private static final String TAG = "DebugModeActivity";
 
     private MapView mapView;
     private MapboxMap mapboxMap;
 
-    private String currentStyle = Style.MAPBOX_STREETS;
+    private int currentStyleIndex = 0;
+
+    private static final String[] STYLES = new String[]{
+            Style.getMapboxStreetsUrl(AppConstant.STYLE_VERSION),
+            Style.getOutdoorsStyleUrl(AppConstant.STYLE_VERSION),
+            Style.getLightStyleUrl(AppConstant.STYLE_VERSION),
+            Style.getDarkStyleUrl(AppConstant.STYLE_VERSION),
+            Style.getSatelliteStyleUrl(AppConstant.STYLE_VERSION),
+            Style.getSatelliteStreetsStyleUrl(AppConstant.STYLE_VERSION)
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -41,6 +52,7 @@ public class DebugModeActivity  extends AppCompatActivity {
         mapView = (MapView) findViewById(R.id.mapView);
         mapView.setTag(true);
         mapView.setAccessToken(getString(R.string.mapbox_access_token));
+        mapView.setStyleUrl(STYLES[currentStyleIndex]);
         mapView.onCreate(savedInstanceState);
 
         mapView.getMapAsync(new OnMapReadyCallback() {
@@ -65,20 +77,13 @@ public class DebugModeActivity  extends AppCompatActivity {
         fabStyles.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (currentStyle.equals(Style.MAPBOX_STREETS)) {
-                    currentStyle = Style.EMERALD;
-                } else if (currentStyle.equals(Style.EMERALD)) {
-                    currentStyle = Style.DARK;
-                } else if (currentStyle.equals(Style.DARK)) {
-                    currentStyle = Style.LIGHT;
-                } else if (currentStyle.equals(Style.LIGHT)) {
-                    currentStyle = Style.SATELLITE;
-                } else if (currentStyle.equals(Style.SATELLITE)) {
-                    currentStyle = Style.SATELLITE_STREETS;
-                } else {
-                    currentStyle = Style.MAPBOX_STREETS;
+                if (mapboxMap != null) {
+                    currentStyleIndex++;
+                    if (currentStyleIndex == STYLES.length) {
+                        currentStyleIndex = 0;
+                    }
+                    mapboxMap.setStyleUrl(STYLES[currentStyleIndex]);
                 }
-                mapboxMap.setStyle(currentStyle);
             }
         });
     }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DoubleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DoubleMapActivity.java
@@ -23,6 +23,7 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.TrackingSettings;
 import com.mapbox.mapboxsdk.maps.UiSettings;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
 public class DoubleMapActivity extends AppCompatActivity {
 
@@ -72,7 +73,7 @@ public class DoubleMapActivity extends AppCompatActivity {
             mMapView.getMapAsync(new OnMapReadyCallback() {
                 @Override
                 public void onMapReady(@NonNull MapboxMap mapboxMap) {
-                    mapboxMap.setStyle(Style.DARK);
+                    mapboxMap.setStyleUrl(Style.getDarkStyleUrl(AppConstant.STYLE_VERSION));
 
                     mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(18));
                     try {
@@ -91,7 +92,7 @@ public class DoubleMapActivity extends AppCompatActivity {
             mMapViewMini.getMapAsync(new OnMapReadyCallback() {
                 @Override
                 public void onMapReady(@NonNull MapboxMap mapboxMap) {
-                    mapboxMap.setStyle(Style.LIGHT);
+                    mapboxMap.setStyleUrl(Style.getLightStyleUrl(AppConstant.STYLE_VERSION));
                     mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(4));
 
                     UiSettings uiSettings = mapboxMap.getUiSettings();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
@@ -27,6 +27,7 @@ import com.mapbox.mapboxsdk.offline.OfflineRegionError;
 import com.mapbox.mapboxsdk.offline.OfflineRegionStatus;
 import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 import com.mapbox.mapboxsdk.testapp.model.other.OfflineDownloadRegionDialog;
 import com.mapbox.mapboxsdk.testapp.model.other.OfflineListRegionsDialog;
 
@@ -77,7 +78,7 @@ public class OfflineActivity extends AppCompatActivity
         // Set up map
         mMapView = (MapView) findViewById(R.id.mapView);
         mMapView.setAccessToken(getString(R.string.mapbox_access_token));
-        mMapView.setStyle(Style.MAPBOX_STREETS);
+        mMapView.setStyleUrl(Style.getMapboxStreetsUrl(AppConstant.STYLE_VERSION));
         mMapView.onCreate(savedInstanceState);
         mMapView.getMapAsync(new OnMapReadyCallback() {
             @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationCustomizationActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationCustomizationActivity.java
@@ -22,6 +22,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
 
 public class MyLocationCustomizationActivity extends AppCompatActivity implements LocationListener {
 
@@ -48,7 +49,7 @@ public class MyLocationCustomizationActivity extends AppCompatActivity implement
 
         MapboxMapOptions mapboxMapOptions = new MapboxMapOptions();
         mapboxMapOptions.accessToken(getString(R.string.mapbox_access_token));
-        mapboxMapOptions.styleUrl(Style.MAPBOX_STREETS);
+        mapboxMapOptions.styleUrl(Style.getMapboxStreetsUrl(AppConstant.STYLE_VERSION));
         mapboxMapOptions.locationEnabled(true);
         mapboxMapOptions.camera(new CameraPosition.Builder()
                 .target(location != null ? new LatLng(location) : new LatLng(0, 0))

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/model/constants/AppConstant.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/model/constants/AppConstant.java
@@ -1,0 +1,6 @@
+package com.mapbox.mapboxsdk.testapp.model.constants;
+
+public class AppConstant {
+
+    public final static int STYLE_VERSION = 9;
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/constants/StyleVersionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/constants/StyleVersionTest.java
@@ -1,0 +1,20 @@
+package com.mapbox.mapboxsdk.constants;
+
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class StyleVersionTest {
+
+    private static final double DELTA = 1e-15;
+
+    @Test
+    public void testSanity() {
+        assertEquals("Style version should match, when upgrading, verify that integers.xml is updated",
+                AppConstant.STYLE_VERSION,
+                9,
+                DELTA);
+    }
+}

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -5,112 +5,116 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- A version number identifying the latest released version of the suite of default styles provided by Mapbox. This version number may be passed into one of the “StyleURLWithVersion” class methods of MGLStyle.
+ A version number identifying the default version of the suite of default styles provided by Mapbox. This version number may be passed into one of the “StyleURLWithVersion” class methods of MGLStyle.
  
- The value of this constant is current as of the date on which this SDK was published. Consult the <a href="https://www.mapbox.com/api-documentation/#styles">Mapbox Styles API documentation</a> for the most up-to-date style versioning information.
+ The value of this constant generally corresponds to the latest released version as of the date on which this SDK was published. You can use this constant to ascertain the style used by `MGLMapView` and `MGLTilePyramidOfflineRegion` when no style URL is specified. Consult the <a href="https://www.mapbox.com/api-documentation/#styles">Mapbox Styles API documentation</a> for the most up-to-date style versioning information.
  
- @warning The value of this constant may change in a future release of the SDK. If you use any feature that depends on a specific implementation detail in a default style, you may use the current value of this constant or the underlying style URL, but do not use the constant itself. Such implementation details may change significantly from version to version.
+ @warning The value of this constant may change in a future release of the SDK. If you use any feature that depends on a specific aspect of a default style – for instance, the minimum zoom level that includes roads – you may use the current value of this constant or the underlying style URL, but do not use the constant itself. Such details may change significantly from version to version.
  */
-static const NSInteger MGLStyleCurrentVersion = 9;
+static const NSInteger MGLStyleDefaultVersion = 9;
 
 /**
- A collection of convenience methods for creating style URLs of default styles provided by Mapbox.
+ A collection of convenience methods for creating style URLs of default styles provided by Mapbox. <a href="https://www.mapbox.com/maps/">Learn more about Mapbox default styles</a>.
  */
 @interface MGLStyle : NSObject
 
 /**
- Returns the URL to version 8 of the Streets style.
+ Returns the URL to version 8 of the <a href="https://www.mapbox.com/maps/streets/">Mapbox Streets</a> style.
  
- Mapbox Streets is a complete base map that balances nature, commerce, and infrastructure.
+ Streets is a complete base map that balances nature, commerce, and infrastructure.
+ 
+ `MGLMapView` and `MGLTilePyramidOfflineRegion` use Mapbox Streets when no style is specified explicitly.
  */
 + (NSURL *)streetsStyleURL __attribute__((deprecated("Use -streetsStyleURLWithVersion:.")));
 
 /**
- Returns the URL to the given version of the Streets style.
+ Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/streets/">Mapbox Streets</a> style.
  
- Mapbox Streets is a complete base map that balances nature, commerce, and infrastructure.
+ Streets is a complete base map that balances nature, commerce, and infrastructure.
  
- @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ `MGLMapView` and `MGLTilePyramidOfflineRegion` use Mapbox Streets when no style is specified explicitly.
+ 
+ @param version The style’s latest released version. As of publication, the current version is `9`.
  */
 + (NSURL *)streetsStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to version 8 of the Emerald style.
+ Returns the URL to version 8 of the <a href="https://www.mapbox.com/blog/emerald-gl/">Mapbox Emerald</a> style.
  
- Mapbox Emerald is a versatile style with emphasis on road networks and public transportation.
+ Emerald is a versatile style with emphasis on road networks and public transportation.
  */
 + (NSURL *)emeraldStyleURL __attribute__((deprecated("Use <mapbox://styles/mapbox/emerald-v8>.")));
 
 /**
- Returns the URL to the given version of the Outdoors style.
+ Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/outdoors/">Mapbox Outdoors</a> style.
  
- Mapbox Outdoors is a rugged style that emphasizes physical terrain and outdoor activities.
+ Outdoors is a rugged style that emphasizes physical terrain and outdoor activities.
  
- @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ @param version The style’s latest released version. As of publication, the current version is `9`.
  */
 + (NSURL *)outdoorsStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to version 8 of the Light style.
+ Returns the URL to version 8 of the <a href="https://www.mapbox.com/maps/light-dark/">Mapbox Light</a> style.
  
- Mapbox Light is a subtle, light-colored backdrop for data visualizations.
+ Light is a subtle, light-colored backdrop for data visualizations.
  */
 + (NSURL *)lightStyleURL __attribute__((deprecated("Use -lightStyleURLWithVersion:.")));
 
 /**
- Returns the URL to the given version of the Light style.
+ Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/light-dark/">Mapbox Light</a> style.
  
- Mapbox Light is a subtle, light-colored backdrop for data visualizations.
+ Light is a subtle, light-colored backdrop for data visualizations.
  
- @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ @param version The style’s latest released version. As of publication, the current version is `9`.
  */
 + (NSURL *)lightStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to version 8 of the Dark style.
+ Returns the URL to version 8 of the <a href="https://www.mapbox.com/maps/light-dark/">Mapbox Dark</a> style.
  
- Mapbox Dark is a subtle, dark-colored backdrop for data visualizations.
+ Dark is a subtle, dark-colored backdrop for data visualizations.
  */
 + (NSURL *)darkStyleURL __attribute__((deprecated("Use -darkStyleURLWithVersion:.")));
 
 /**
- Returns the URL to the given version of the Dark style.
+ Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/light-dark/">Mapbox Dark</a> style.
  
- Mapbox Dark is a subtle, dark-colored backdrop for data visualizations.
+ Dark is a subtle, dark-colored backdrop for data visualizations.
  
- @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ @param version The style’s latest released version. As of publication, the current version is `9`.
  */
 + (NSURL *)darkStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to version 8 of the Satellite style.
+ Returns the URL to version 8 of the <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite</a> style.
  
- Mapbox Satellite is a beautiful global satellite and aerial imagery layer.
+ Satellite is a beautiful global satellite and aerial imagery layer.
  */
 + (NSURL *)satelliteStyleURL __attribute__((deprecated("Use -satelliteStyleURLWithVersion:.")));
 
 /**
- Returns the URL to the given version of the Satellite style.
+ Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite</a> style.
  
- Mapbox Satellite is a beautiful global satellite and aerial imagery layer.
+ Satellite is a beautiful global satellite and aerial imagery layer.
  
- @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ @param version The style’s latest released version. As of publication, the current version is `9`.
  */
 + (NSURL *)satelliteStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to version 8 of the Satellite Streets style.
+ Returns the URL to version 8 of the <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite Streets</a> style.
  
- Mapbox Satellite Streets combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
+ Satellite Streets combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
  */
 + (NSURL *)hybridStyleURL __attribute__((deprecated("Use -satelliteStreetsStyleURLWithVersion:.")));
 
 /**
- Returns the URL to the given version of the Satellite Streets style.
+ Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite Streets</a> style.
  
- Mapbox Satellite Streets combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
+ Satellite Streets combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
  
- @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ @param version The style’s latest released version. As of publication, the current version is `9`.
  */
 + (NSURL *)satelliteStreetsStyleURLWithVersion:(NSInteger)version;
 

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -21,7 +21,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 /**
  Returns the URL to version 8 of the <a href="https://www.mapbox.com/maps/streets/">Mapbox Streets</a> style.
  
- Streets is a complete base map that balances nature, commerce, and infrastructure.
+ Streets is a general-purpose style with detailed road and transit networks.
  
  `MGLMapView` and `MGLTilePyramidOfflineRegion` use Mapbox Streets when no style is specified explicitly.
  */
@@ -30,7 +30,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 /**
  Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/streets/">Mapbox Streets</a> style.
  
- Streets is a complete base map that balances nature, commerce, and infrastructure.
+ Streets is a general-purpose style with detailed road and transit networks.
  
  `MGLMapView` and `MGLTilePyramidOfflineRegion` use Mapbox Streets when no style is specified explicitly.
  
@@ -41,14 +41,14 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 /**
  Returns the URL to version 8 of the <a href="https://www.mapbox.com/blog/emerald-gl/">Mapbox Emerald</a> style.
  
- Emerald is a versatile style with emphasis on road networks and public transportation.
+ Emerald is a tactile style with subtle textures and dramatic hillshading.
  */
-+ (NSURL *)emeraldStyleURL __attribute__((deprecated("Use <mapbox://styles/mapbox/emerald-v8>.")));
++ (NSURL *)emeraldStyleURL __attribute__((deprecated("Create an NSURL object with the string “mapbox://styles/mapbox/emerald-v8”.")));
 
 /**
  Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/outdoors/">Mapbox Outdoors</a> style.
  
- Outdoors is a rugged style that emphasizes physical terrain and outdoor activities.
+ Outdoors is a general-purpose style tailored to outdoor activities.
  
  @param version The style’s latest released version. As of publication, the current version is `9`.
  */
@@ -89,14 +89,14 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 /**
  Returns the URL to version 8 of the <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite</a> style.
  
- Satellite is a beautiful global satellite and aerial imagery layer.
+ Satellite is high-resolution satellite and aerial imagery.
  */
 + (NSURL *)satelliteStyleURL __attribute__((deprecated("Use -satelliteStyleURLWithVersion:.")));
 
 /**
  Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite</a> style.
  
- Satellite is a beautiful global satellite and aerial imagery layer.
+ Satellite is high-resolution satellite and aerial imagery.
  
  @param version The style’s latest released version. As of publication, the current version is `9`.
  */
@@ -105,14 +105,14 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 /**
  Returns the URL to version 8 of the <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite Streets</a> style.
  
- Satellite Streets combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
+ Satellite Streets combines the high-resolution satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
  */
 + (NSURL *)hybridStyleURL __attribute__((deprecated("Use -satelliteStreetsStyleURLWithVersion:.")));
 
 /**
  Returns the URL to the given version of the <a href="https://www.mapbox.com/maps/satellite/">Mapbox Satellite Streets</a> style.
  
- Satellite Streets combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
+ Satellite Streets combines the high-resolution satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
  
  @param version The style’s latest released version. As of publication, the current version is `9`.
  */

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -19,7 +19,7 @@ static const NSInteger MGLStyleCurrentVersion = 9;
 @interface MGLStyle : NSObject
 
 /**
- Returns the URL to the current version of the Streets style.
+ Returns the URL to version 8 of the Streets style.
  
  Mapbox Streets is a complete base map that balances nature, commerce, and infrastructure.
  */
@@ -35,7 +35,7 @@ static const NSInteger MGLStyleCurrentVersion = 9;
 + (NSURL *)streetsStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to the current version of the Emerald style.
+ Returns the URL to version 8 of the Emerald style.
  
  Mapbox Emerald is a versatile style with emphasis on road networks and public transportation.
  */
@@ -51,7 +51,7 @@ static const NSInteger MGLStyleCurrentVersion = 9;
 + (NSURL *)outdoorsStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to the current version of the Light style.
+ Returns the URL to version 8 of the Light style.
  
  Mapbox Light is a subtle, light-colored backdrop for data visualizations.
  */
@@ -67,7 +67,7 @@ static const NSInteger MGLStyleCurrentVersion = 9;
 + (NSURL *)lightStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to the current version of the Dark style.
+ Returns the URL to version 8 of the Dark style.
  
  Mapbox Dark is a subtle, dark-colored backdrop for data visualizations.
  */
@@ -83,7 +83,7 @@ static const NSInteger MGLStyleCurrentVersion = 9;
 + (NSURL *)darkStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to the current version of the Satellite style.
+ Returns the URL to version 8 of the Satellite style.
  
  Mapbox Satellite is a beautiful global satellite and aerial imagery layer.
  */
@@ -99,7 +99,7 @@ static const NSInteger MGLStyleCurrentVersion = 9;
 + (NSURL *)satelliteStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to the current version of the Hybrid style.
+ Returns the URL to version 8 of the Hybrid style.
  
  Mapbox Hybrid combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels.
  */

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -4,50 +4,115 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** A collection of convenience methods for creating style URLs of default styles provided by Mapbox. These instances of NSURL are cached. */
+/**
+ A version number identifying the latest released version of the suite of default styles provided by Mapbox. This version number may be passed into one of the “StyleURLWithVersion” class methods of MGLStyle.
+ 
+ The value of this constant is current as of the date on which this SDK was published. Consult the <a href="https://www.mapbox.com/api-documentation/#styles">Mapbox Styles API documentation</a> for the most up-to-date style versioning information.
+ 
+ @warning The value of this constant may change in a future release of the SDK. If you use any feature that depends on a specific implementation detail in a default style, you may use the current value of this constant or the underlying style URL, but do not use the constant itself. Such implementation details may change significantly from version to version.
+ */
+static const NSInteger MGLStyleCurrentVersion = 9;
+
+/**
+ A collection of convenience methods for creating style URLs of default styles provided by Mapbox.
+ */
 @interface MGLStyle : NSObject
 
 /**
- Returns the Streets style URL.
+ Returns the URL to the current version of the Streets style.
  
- Mapbox Streets is a complete base map, perfect for incorporating your own data.
+ Mapbox Streets is a complete base map that balances nature, commerce, and infrastructure.
  */
-+ (NSURL *)streetsStyleURL;
++ (NSURL *)streetsStyleURL __attribute__((deprecated("Use -streetsStyleURLWithVersion:.")));
 
 /**
- Returns the Emerald style URL.
+ Returns the URL to the given version of the Streets style.
  
- Emerald is a versatile style with emphasis on road networks and public transportation.
+ Mapbox Streets is a complete base map that balances nature, commerce, and infrastructure.
+ 
+ @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
  */
-+ (NSURL *)emeraldStyleURL;
++ (NSURL *)streetsStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the Light style URL.
+ Returns the URL to the current version of the Emerald style.
  
- Light is a subtle, light-colored backdrop for data visualizations.
+ Mapbox Emerald is a versatile style with emphasis on road networks and public transportation.
  */
-+ (NSURL *)lightStyleURL;
++ (NSURL *)emeraldStyleURL __attribute__((deprecated("Use <mapbox://styles/mapbox/emerald-v8>.")));
 
 /**
- Returns the Dark style URL.
+ Returns the URL to the given version of the Outdoors style.
  
- Dark is a subtle, dark-colored backdrop for data visualizations.
+ Mapbox Outdoors is a rugged style that emphasizes physical terrain and outdoor activities.
+ 
+ @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
  */
-+ (NSURL *)darkStyleURL;
++ (NSURL *)outdoorsStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the Satellite style URL.
+ Returns the URL to the current version of the Light style.
+ 
+ Mapbox Light is a subtle, light-colored backdrop for data visualizations.
+ */
++ (NSURL *)lightStyleURL __attribute__((deprecated("Use -lightStyleURLWithVersion:.")));
+
+/**
+ Returns the URL to the given version of the Light style.
+ 
+ Mapbox Light is a subtle, light-colored backdrop for data visualizations.
+ 
+ @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ */
++ (NSURL *)lightStyleURLWithVersion:(NSInteger)version;
+
+/**
+ Returns the URL to the current version of the Dark style.
+ 
+ Mapbox Dark is a subtle, dark-colored backdrop for data visualizations.
+ */
++ (NSURL *)darkStyleURL __attribute__((deprecated("Use -darkStyleURLWithVersion:.")));
+
+/**
+ Returns the URL to the given version of the Dark style.
+ 
+ Mapbox Dark is a subtle, dark-colored backdrop for data visualizations.
+ 
+ @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ */
++ (NSURL *)darkStyleURLWithVersion:(NSInteger)version;
+
+/**
+ Returns the URL to the current version of the Satellite style.
  
  Mapbox Satellite is a beautiful global satellite and aerial imagery layer.
  */
-+ (NSURL *)satelliteStyleURL;
++ (NSURL *)satelliteStyleURL __attribute__((deprecated("Use -satelliteStyleURLWithVersion:.")));
 
 /**
- Returns the Hybrid style URL.
+ Returns the URL to the given version of the Satellite style.
  
- Hybrid combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels.
+ Mapbox Satellite is a beautiful global satellite and aerial imagery layer.
+ 
+ @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
  */
-+ (NSURL *)hybridStyleURL;
++ (NSURL *)satelliteStyleURLWithVersion:(NSInteger)version;
+
+/**
+ Returns the URL to the current version of the Hybrid style.
+ 
+ Mapbox Hybrid combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels.
+ */
++ (NSURL *)hybridStyleURL __attribute__((deprecated("Use -hybridStyleURLWithVersion:.")));
+
+/**
+ Returns the URL to the given version of the Hybrid style.
+ 
+ Mapbox Hybrid combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels.
+ 
+ @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
+ */
++ (NSURL *)hybridStyleURLWithVersion:(NSInteger)version;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -99,20 +99,20 @@ static const NSInteger MGLStyleCurrentVersion = 9;
 + (NSURL *)satelliteStyleURLWithVersion:(NSInteger)version;
 
 /**
- Returns the URL to version 8 of the Hybrid style.
+ Returns the URL to version 8 of the Satellite Streets style.
  
- Mapbox Hybrid combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels.
+ Mapbox Satellite Streets combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
  */
-+ (NSURL *)hybridStyleURL __attribute__((deprecated("Use -hybridStyleURLWithVersion:.")));
++ (NSURL *)hybridStyleURL __attribute__((deprecated("Use -satelliteStreetsStyleURLWithVersion:.")));
 
 /**
- Returns the URL to the given version of the Hybrid style.
+ Returns the URL to the given version of the Satellite Streets style.
  
- Mapbox Hybrid combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels.
+ Mapbox Satellite Streets combines the global satellite and aerial imagery of Mapbox Satellite with unobtrusive labels and translucent roads from Mapbox Streets.
  
  @param version The style’s latest released version. The current version is given by `MGLStyleCurrentVersion`.
  */
-+ (NSURL *)hybridStyleURLWithVersion:(NSInteger)version;
++ (NSURL *)satelliteStreetsStyleURLWithVersion:(NSInteger)version;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -4,27 +4,44 @@
 
 @implementation MGLStyle
 
-// name is lowercase
-#define MGL_DEFINE_STYLE(name) \
+static_assert(mbgl::util::default_styles::currentVersion == MGLStyleCurrentVersion, "mbgl::util::default_styles::currentVersion and MGLStyleCurrentVersion disagree.");
+
+/// @param name The style’s marketing name, written in lower camelCase.
+/// @param fileName The last path component in the style’s URL, excluding the version suffix.
+#define MGL_DEFINE_STYLE(name, fileName) \
     static NSURL *MGLStyleURL_##name; \
     + (NSURL *)name##StyleURL { \
         static dispatch_once_t onceToken; \
         dispatch_once(&onceToken, ^{ \
-            MGLStyleURL_##name = [NSURL URLWithString:@(mbgl::util::default_styles::name.url)]; \
+            MGLStyleURL_##name = [self name##StyleURLWithVersion:MGLStyleCurrentVersion]; \
         }); \
         return MGLStyleURL_##name; \
+    } \
+    \
+    + (NSURL *)name##StyleURL##WithVersion:(NSInteger)version { \
+        return [NSURL URLWithString:[@"mapbox://styles/mapbox/" #fileName "-v" stringByAppendingFormat:@"%li", (long)version]]; \
     }
 
-MGL_DEFINE_STYLE(streets)
-MGL_DEFINE_STYLE(emerald)
-MGL_DEFINE_STYLE(light)
-MGL_DEFINE_STYLE(dark)
-MGL_DEFINE_STYLE(satellite)
-MGL_DEFINE_STYLE(hybrid)
+MGL_DEFINE_STYLE(streets, streets)
+MGL_DEFINE_STYLE(outdoors, outdoors)
+MGL_DEFINE_STYLE(light, light)
+MGL_DEFINE_STYLE(dark, dark)
+MGL_DEFINE_STYLE(satellite, satellite)
+MGL_DEFINE_STYLE(hybrid, satellite-hybrid)
 
 // Make sure all the styles listed in mbgl::util::default_styles::orderedStyles
 // are defined above and also declared in MGLStyle.h.
 static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
               "mbgl::util::default_styles::orderedStyles and MGLStyle have different numbers of styles.");
+
+// Emerald is no longer getting new versions as a default style, so the current version is hard-coded here.
+static NSURL *MGLStyleURL_emerald;
++ (NSURL *)emeraldStyleURL {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        MGLStyleURL_emerald = [NSURL URLWithString:@"mapbox://styles/mapbox/emerald-v8"];
+    });
+    return MGLStyleURL_emerald;
+}
 
 @end

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -13,7 +13,7 @@ static_assert(mbgl::util::default_styles::currentVersion == MGLStyleCurrentVersi
     + (NSURL *)name##StyleURL { \
         static dispatch_once_t onceToken; \
         dispatch_once(&onceToken, ^{ \
-            MGLStyleURL_##name = [self name##StyleURLWithVersion:MGLStyleCurrentVersion]; \
+            MGLStyleURL_##name = [self name##StyleURLWithVersion:8]; \
         }); \
         return MGLStyleURL_##name; \
     } \

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -4,7 +4,7 @@
 
 @implementation MGLStyle
 
-static_assert(mbgl::util::default_styles::currentVersion == MGLStyleCurrentVersion, "mbgl::util::default_styles::currentVersion and MGLStyleCurrentVersion disagree.");
+static_assert(mbgl::util::default_styles::currentVersion == MGLStyleDefaultVersion, "mbgl::util::default_styles::currentVersion and MGLStyleDefaultVersion disagree.");
 
 /// @param name The style’s marketing name, written in lower camelCase.
 /// @param fileName The last path component in the style’s URL, excluding the version suffix.

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -27,12 +27,22 @@ MGL_DEFINE_STYLE(outdoors, outdoors)
 MGL_DEFINE_STYLE(light, light)
 MGL_DEFINE_STYLE(dark, dark)
 MGL_DEFINE_STYLE(satellite, satellite)
-MGL_DEFINE_STYLE(hybrid, satellite-hybrid)
+MGL_DEFINE_STYLE(satelliteStreets, satellite-streets)
 
 // Make sure all the styles listed in mbgl::util::default_styles::orderedStyles
 // are defined above and also declared in MGLStyle.h.
 static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
               "mbgl::util::default_styles::orderedStyles and MGLStyle have different numbers of styles.");
+
+// Hybrid has been renamed Satellite Streets, so the last Hybrid version is hard-coded here.
+static NSURL *MGLStyleURL_hybrid;
++ (NSURL *)hybridStyleURL {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        MGLStyleURL_hybrid = [NSURL URLWithString:@"mapbox://styles/mapbox/satellite-hybrid-v8"];
+    });
+    return MGLStyleURL_hybrid;
+}
 
 // Emerald is no longer getting new versions as a default style, so the current version is hard-coded here.
 static NSURL *MGLStyleURL_emerald;

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -33,7 +33,7 @@
 - (instancetype)initWithStyleURL:(NSURL *)styleURL bounds:(MGLCoordinateBounds)bounds fromZoomLevel:(double)minimumZoomLevel toZoomLevel:(double)maximumZoomLevel {
     if (self = [super init]) {
         if (!styleURL) {
-            styleURL = [MGLStyle streetsStyleURL];
+            styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
         }
         
         if (!styleURL.scheme) {

--- a/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
+++ b/platform/darwin/src/MGLTilePyramidOfflineRegion.mm
@@ -33,7 +33,7 @@
 - (instancetype)initWithStyleURL:(NSURL *)styleURL bounds:(MGLCoordinateBounds)bounds fromZoomLevel:(double)minimumZoomLevel toZoomLevel:(double)maximumZoomLevel {
     if (self = [super init]) {
         if (!styleURL) {
-            styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
+            styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
         }
         
         if (!styleURL.scheme) {

--- a/platform/darwin/test/MGLOfflineRegionTests.m
+++ b/platform/darwin/test/MGLOfflineRegionTests.m
@@ -11,7 +11,7 @@
 - (void)testStyleURLs {
     MGLCoordinateBounds bounds = MGLCoordinateBoundsMake(kCLLocationCoordinate2DInvalid, kCLLocationCoordinate2DInvalid);
     MGLTilePyramidOfflineRegion *region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:nil bounds:bounds fromZoomLevel:0 toZoomLevel:DBL_MAX];
-    XCTAssertEqualObjects(region.styleURL, [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion], @"Streets isn’t the default style.");
+    XCTAssertEqualObjects(region.styleURL, [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion], @"Streets isn’t the default style.");
     
     NSURL *localURL = [NSURL URLWithString:@"beautiful.style"];
     XCTAssertThrowsSpecificNamed([[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:localURL bounds:bounds fromZoomLevel:0 toZoomLevel:DBL_MAX], NSException, @"Invalid style URL", @"No exception raised when initializing region with a local file URL as the style URL.");
@@ -19,7 +19,7 @@
 
 - (void)testEquality {
     MGLCoordinateBounds bounds = MGLCoordinateBoundsMake(kCLLocationCoordinate2DInvalid, kCLLocationCoordinate2DInvalid);
-    MGLTilePyramidOfflineRegion *original = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:[MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion] bounds:bounds fromZoomLevel:5 toZoomLevel:10];
+    MGLTilePyramidOfflineRegion *original = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:[MGLStyle lightStyleURLWithVersion:MGLStyleDefaultVersion] bounds:bounds fromZoomLevel:5 toZoomLevel:10];
     MGLTilePyramidOfflineRegion *copy = [original copy];
     XCTAssertEqualObjects(original, copy, @"Tile pyramid region should be equal to its copy.");
     

--- a/platform/darwin/test/MGLOfflineRegionTests.m
+++ b/platform/darwin/test/MGLOfflineRegionTests.m
@@ -11,7 +11,7 @@
 - (void)testStyleURLs {
     MGLCoordinateBounds bounds = MGLCoordinateBoundsMake(kCLLocationCoordinate2DInvalid, kCLLocationCoordinate2DInvalid);
     MGLTilePyramidOfflineRegion *region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:nil bounds:bounds fromZoomLevel:0 toZoomLevel:DBL_MAX];
-    XCTAssertEqualObjects(region.styleURL, [MGLStyle streetsStyleURL], @"Streets isn’t the default style.");
+    XCTAssertEqualObjects(region.styleURL, [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion], @"Streets isn’t the default style.");
     
     NSURL *localURL = [NSURL URLWithString:@"beautiful.style"];
     XCTAssertThrowsSpecificNamed([[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:localURL bounds:bounds fromZoomLevel:0 toZoomLevel:DBL_MAX], NSException, @"Invalid style URL", @"No exception raised when initializing region with a local file URL as the style URL.");
@@ -19,7 +19,7 @@
 
 - (void)testEquality {
     MGLCoordinateBounds bounds = MGLCoordinateBoundsMake(kCLLocationCoordinate2DInvalid, kCLLocationCoordinate2DInvalid);
-    MGLTilePyramidOfflineRegion *original = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:[MGLStyle lightStyleURL] bounds:bounds fromZoomLevel:5 toZoomLevel:10];
+    MGLTilePyramidOfflineRegion *original = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:[MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion] bounds:bounds fromZoomLevel:5 toZoomLevel:10];
     MGLTilePyramidOfflineRegion *copy = [original copy];
     XCTAssertEqualObjects(original, copy, @"Tile pyramid region should be equal to its copy.");
     

--- a/platform/darwin/test/MGLOfflineStorageTests.m
+++ b/platform/darwin/test/MGLOfflineStorageTests.m
@@ -27,7 +27,7 @@
 - (void)testAddPack {
     NSUInteger countOfPacks = [MGLOfflineStorage sharedOfflineStorage].packs.count;
     
-    NSURL *styleURL = [MGLStyle lightStyleURL];
+    NSURL *styleURL = [MGLStyle lightStyleURLWithVersion:8];
     /// Somewhere near Grape Grove, Ohio, United States.
     MGLCoordinateBounds bounds = {
         { .latitude = 39.70358155855172, .longitude = -83.69506472545841 },

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -32,7 +32,7 @@
     XCTAssertEqualObjects([MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::light.url));
     XCTAssertEqualObjects([MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::dark.url));
     XCTAssertEqualObjects([MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::satellite.url));
-    XCTAssertEqualObjects([MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::hybrid.url));
+    XCTAssertEqualObjects([MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::satelliteStreets.url));
     
     static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
                   "MGLStyleTests isn’t testing all the styles in mbgl::util::default_styles.");

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -15,12 +15,12 @@
 - (void)testUnversionedStyleURLs {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    XCTAssertEqualObjects([MGLStyle streetsStyleURL].absoluteString, @(mbgl::util::default_styles::streets.url));
+    XCTAssertEqualObjects([MGLStyle streetsStyleURL].absoluteString, @"mapbox://styles/mapbox/streets-v8");
     XCTAssertEqualObjects([MGLStyle emeraldStyleURL].absoluteString, @"mapbox://styles/mapbox/emerald-v8");
-    XCTAssertEqualObjects([MGLStyle lightStyleURL].absoluteString, @(mbgl::util::default_styles::light.url));
-    XCTAssertEqualObjects([MGLStyle darkStyleURL].absoluteString, @(mbgl::util::default_styles::dark.url));
-    XCTAssertEqualObjects([MGLStyle satelliteStyleURL].absoluteString, @(mbgl::util::default_styles::satellite.url));
-    XCTAssertEqualObjects([MGLStyle hybridStyleURL].absoluteString, @(mbgl::util::default_styles::hybrid.url));
+    XCTAssertEqualObjects([MGLStyle lightStyleURL].absoluteString, @"mapbox://styles/mapbox/light-v8");
+    XCTAssertEqualObjects([MGLStyle darkStyleURL].absoluteString, @"mapbox://styles/mapbox/dark-v8");
+    XCTAssertEqualObjects([MGLStyle satelliteStyleURL].absoluteString, @"mapbox://styles/mapbox/satellite-v8");
+    XCTAssertEqualObjects([MGLStyle hybridStyleURL].absoluteString, @"mapbox://styles/mapbox/satellite-hybrid-v8");
 #pragma clang diagnostic pop
 }
 

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -27,18 +27,18 @@
 - (void)testVersionedStyleURLs {
     // Test that all the default styles have publicly-declared MGLStyle class
     // methods and that the URLs all have the right values.
-    XCTAssertEqualObjects([MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::streets.url));
-    XCTAssertEqualObjects([MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::outdoors.url));
-    XCTAssertEqualObjects([MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::light.url));
-    XCTAssertEqualObjects([MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::dark.url));
-    XCTAssertEqualObjects([MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::satellite.url));
-    XCTAssertEqualObjects([MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::satelliteStreets.url));
+    XCTAssertEqualObjects([MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion].absoluteString, @(mbgl::util::default_styles::streets.url));
+    XCTAssertEqualObjects([MGLStyle outdoorsStyleURLWithVersion:MGLStyleDefaultVersion].absoluteString, @(mbgl::util::default_styles::outdoors.url));
+    XCTAssertEqualObjects([MGLStyle lightStyleURLWithVersion:MGLStyleDefaultVersion].absoluteString, @(mbgl::util::default_styles::light.url));
+    XCTAssertEqualObjects([MGLStyle darkStyleURLWithVersion:MGLStyleDefaultVersion].absoluteString, @(mbgl::util::default_styles::dark.url));
+    XCTAssertEqualObjects([MGLStyle satelliteStyleURLWithVersion:MGLStyleDefaultVersion].absoluteString, @(mbgl::util::default_styles::satellite.url));
+    XCTAssertEqualObjects([MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleDefaultVersion].absoluteString, @(mbgl::util::default_styles::satelliteStreets.url));
     
     static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
                   "MGLStyleTests isn’t testing all the styles in mbgl::util::default_styles.");
 }
 
-- (void)testStyleURLComprehensiveness {
+- (void)testStyleURLDeclarations {
     // Make sure this test is comprehensive.
     const unsigned numImplicitArgs = 2 /* _cmd, self */;
     unsigned numMethods = 0;
@@ -63,12 +63,7 @@
                    mbgl::util::default_styles::numOrderedStyles, numVersionedMethods);
     
     // Test that all the versioned style methods are in the public header.
-    NSURL *styleHeaderURL = [[[NSBundle mgl_frameworkBundle].bundleURL
-                              URLByAppendingPathComponent:@"Headers" isDirectory:YES]
-                             URLByAppendingPathComponent:@"MGLStyle.h"];
-    NSError *styleHeaderError;
-    NSString *styleHeader = [NSString stringWithContentsOfURL:styleHeaderURL usedEncoding:nil error:&styleHeaderError];
-    XCTAssertNil(styleHeaderError, @"Error getting contents of MGLStyle.h.");
+    NSString *styleHeader = self.stringWithContentsOfStyleHeader;
     
     NSError *versionedMethodError;
     NSString *versionedMethodExpressionString = @(R"RE(^\+\s*\(NSURL\s*\*\s*\)\s*\w+StyleURLWithVersion\s*:\s*\(\s*NSInteger\s*\)\s*version\s*;)RE");
@@ -76,6 +71,29 @@
     XCTAssertNil(versionedMethodError, @"Error compiling regular expression to search for versioned methods.");
     NSUInteger numVersionedMethodDeclarations = [versionedMethodExpression numberOfMatchesInString:styleHeader options:0 range:NSMakeRange(0, styleHeader.length)];
     XCTAssertEqual(numVersionedMethodDeclarations, numVersionedMethods);
+    
+    // Test that “current version is” statements are present and current for all versioned style methods.
+    NSError *versionError;
+    NSString *versionExpressionString = @(R"RE(the current version is `(\d+)`)RE");
+    NSRegularExpression *versionExpression = [NSRegularExpression regularExpressionWithPattern:versionExpressionString options:0 error:&versionError];
+    XCTAssertNil(versionError, @"Error compiling regular expression to search for current version statements.");
+    NSUInteger numVersionDeclarations = [versionExpression numberOfMatchesInString:styleHeader options:0 range:NSMakeRange(0, styleHeader.length)];
+    XCTAssertEqual(numVersionDeclarations, numVersionedMethods);
+    [versionExpression enumerateMatchesInString:styleHeader options:0 range:NSMakeRange(0, styleHeader.length) usingBlock:^(NSTextCheckingResult * _Nullable result, NSMatchingFlags flags, BOOL * _Nonnull stop) {
+        XCTAssertEqual(result.numberOfRanges, 2, @"Regular expression should have one capture group.");
+        NSString *version = [styleHeader substringWithRange:[result rangeAtIndex:1]];
+        XCTAssertEqual([version integerValue], MGLStyleDefaultVersion, @"Versioned style URL method should document current version as %ld, not %ld.", MGLStyleDefaultVersion, version.integerValue);
+    }];
+}
+
+- (NSString *)stringWithContentsOfStyleHeader {
+    NSURL *styleHeaderURL = [[[NSBundle mgl_frameworkBundle].bundleURL
+                              URLByAppendingPathComponent:@"Headers" isDirectory:YES]
+                             URLByAppendingPathComponent:@"MGLStyle.h"];
+    NSError *styleHeaderError;
+    NSString *styleHeader = [NSString stringWithContentsOfURL:styleHeaderURL usedEncoding:nil error:&styleHeaderError];
+    XCTAssertNil(styleHeaderError, @"Error getting contents of MGLStyle.h.");
+    return styleHeader;
 }
 
 @end

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -1,26 +1,81 @@
 #import "MGLStyle.h"
 
+#import "NSBundle+MGLAdditions.h"
+
 #import <mbgl/util/default_styles.hpp>
 
 #import <XCTest/XCTest.h>
+#import <objc/runtime.h>
 
 @interface MGLStyleTests : XCTestCase
 @end
 
 @implementation MGLStyleTests
 
-- (void)testStyleURLs {
-    // Test that all the default styles have publicly-declared MGLStyle class
-    // methods and that the URLs are all well-formed.
+- (void)testUnversionedStyleURLs {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqualObjects([MGLStyle streetsStyleURL].absoluteString, @(mbgl::util::default_styles::streets.url));
-    XCTAssertEqualObjects([MGLStyle emeraldStyleURL].absoluteString, @(mbgl::util::default_styles::emerald.url));
+    XCTAssertEqualObjects([MGLStyle emeraldStyleURL].absoluteString, @"mapbox://styles/mapbox/emerald-v8");
     XCTAssertEqualObjects([MGLStyle lightStyleURL].absoluteString, @(mbgl::util::default_styles::light.url));
     XCTAssertEqualObjects([MGLStyle darkStyleURL].absoluteString, @(mbgl::util::default_styles::dark.url));
     XCTAssertEqualObjects([MGLStyle satelliteStyleURL].absoluteString, @(mbgl::util::default_styles::satellite.url));
     XCTAssertEqualObjects([MGLStyle hybridStyleURL].absoluteString, @(mbgl::util::default_styles::hybrid.url));
+#pragma clang diagnostic pop
+}
+
+- (void)testVersionedStyleURLs {
+    // Test that all the default styles have publicly-declared MGLStyle class
+    // methods and that the URLs all have the right values.
+    XCTAssertEqualObjects([MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::streets.url));
+    XCTAssertEqualObjects([MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::outdoors.url));
+    XCTAssertEqualObjects([MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::light.url));
+    XCTAssertEqualObjects([MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::dark.url));
+    XCTAssertEqualObjects([MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::satellite.url));
+    XCTAssertEqualObjects([MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion].absoluteString, @(mbgl::util::default_styles::hybrid.url));
     
     static_assert(6 == mbgl::util::default_styles::numOrderedStyles,
                   "MGLStyleTests isn’t testing all the styles in mbgl::util::default_styles.");
+}
+
+- (void)testStyleURLComprehensiveness {
+    // Make sure this test is comprehensive.
+    const unsigned numImplicitArgs = 2 /* _cmd, self */;
+    unsigned numMethods = 0;
+    Method *methods = class_copyMethodList(object_getClass([MGLStyle class]), &numMethods);
+    unsigned numVersionedMethods = 0;
+    for (NSUInteger i = 0; i < numMethods; i++) {
+        Method method = methods[i];
+        SEL selector = method_getName(method);
+        NSString *name = @(sel_getName(selector));
+        unsigned numArgs = method_getNumberOfArguments(method);
+        if ([name hasSuffix:@"StyleURL"]) {
+            XCTAssertEqual(numArgs, numImplicitArgs, @"Unversioned style URL method should have no parameters, but it has %u.", numArgs - numImplicitArgs);
+        } else if ([name hasSuffix:@"StyleURLWithVersion:"]) {
+            XCTAssertEqual(numArgs, numImplicitArgs + 1, @"Versioned style URL method should have one parameter, but it has %u.", numArgs - numImplicitArgs);
+            numVersionedMethods++;
+        } else {
+            XCTAssertEqual([name rangeOfString:@"URL"].location, NSNotFound, @"MGLStyle style URL method %@ is malformed.", name);
+        }
+    }
+    XCTAssertEqual(mbgl::util::default_styles::numOrderedStyles, numVersionedMethods,
+                   @"There are %lu default styles but MGLStyleTests only provides versioned style URL methods for %u of them.",
+                   mbgl::util::default_styles::numOrderedStyles, numVersionedMethods);
+    
+    // Test that all the versioned style methods are in the public header.
+    NSURL *styleHeaderURL = [[[NSBundle mgl_frameworkBundle].bundleURL
+                              URLByAppendingPathComponent:@"Headers" isDirectory:YES]
+                             URLByAppendingPathComponent:@"MGLStyle.h"];
+    NSError *styleHeaderError;
+    NSString *styleHeader = [NSString stringWithContentsOfURL:styleHeaderURL usedEncoding:nil error:&styleHeaderError];
+    XCTAssertNil(styleHeaderError, @"Error getting contents of MGLStyle.h.");
+    
+    NSError *versionedMethodError;
+    NSString *versionedMethodExpressionString = @(R"RE(^\+\s*\(NSURL\s*\*\s*\)\s*\w+StyleURLWithVersion\s*:\s*\(\s*NSInteger\s*\)\s*version\s*;)RE");
+    NSRegularExpression *versionedMethodExpression = [NSRegularExpression regularExpressionWithPattern:versionedMethodExpressionString options:NSRegularExpressionAnchorsMatchLines error:&versionedMethodError];
+    XCTAssertNil(versionedMethodError, @"Error compiling regular expression to search for versioned methods.");
+    NSUInteger numVersionedMethodDeclarations = [versionedMethodExpression numberOfMatchesInString:styleHeader options:0 range:NSMakeRange(0, styleHeader.length)];
+    XCTAssertEqual(numVersionedMethodDeclarations, numVersionedMethods);
 }
 
 @end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,7 +6,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 
 - Applications linking against the SDK static framework no longer need to add `-ObjC` to the Other Linker Flags (`OTHER_LDFLAGS`) build setting. If you previously added this flag solely for this SDK, removing the flag may potentially reduce the overall size of your application. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Removed the `armv7s` slice from the SDK to reduce its size. iPhone 5 and iPhone 5c automatically use the `armv7` slice instead. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
-- Existing MGLStyle class methods that return default style URLs have been deprecated in favor of new methods that require an explicit style version parameter. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
+- Existing MGLStyle class methods that return default style URLs have been deprecated in favor of new methods that require an explicit style version parameter. The deprecated, unversioned methods continue to return version 8 of the respective styles and will not be updated as new versions of the styles are released. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
 - Deprecated `+[MGLStyle emeraldStyleURL]` with no replacement method. To use the Emerald style going forward, we recommend that you use the underlying URL. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
 - Added `+[MGLStyle outdoorsStyleURLWithVersion:]` for the new Outdoors style. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
 - The user dot now moves smoothly between user location updates while user location tracking is disabled. ([#1582](https://github.com/mapbox/mapbox-gl-native/pull/1582))

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,9 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 
 - Applications linking against the SDK static framework no longer need to add `-ObjC` to the Other Linker Flags (`OTHER_LDFLAGS`) build setting. If you previously added this flag solely for this SDK, removing the flag may potentially reduce the overall size of your application. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Removed the `armv7s` slice from the SDK to reduce its size. iPhone 5 and iPhone 5c automatically use the `armv7` slice instead. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
+- Existing MGLStyle class methods that return default style URLs have been deprecated in favor of new methods that require an explicit style version parameter. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
+- Deprecated `+[MGLStyle emeraldStyleURL]` with no replacement method. To use the Emerald style going forward, we recommend that you use the underlying URL. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
+- Added `+[MGLStyle outdoorsStyleURLWithVersion:]` for the new Outdoors style. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
 - The user dot now moves smoothly between user location updates while user location tracking is disabled. ([#1582](https://github.com/mapbox/mapbox-gl-native/pull/1582))
 - An MGLAnnotation can be relocated by changing its `coordinate` property in a KVO-compliant way. An MGLMultiPoint cannot be relocated. ([#3835](https://github.com/mapbox/mapbox-gl-native/pull/3835))
 - Setting the `image` property of an MGLAnnotationImage to `nil` resets it to the default red pin image and reclaims resources that can be used to customize additional annotations. ([#3835](https://github.com/mapbox/mapbox-gl-native/pull/3835))

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 - Existing MGLStyle class methods that return default style URLs have been deprecated in favor of new methods that require an explicit style version parameter. The deprecated, unversioned methods continue to return version 8 of the respective styles and will not be updated as new versions of the styles are released. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
 - Deprecated `+[MGLStyle emeraldStyleURL]` with no replacement method. To use the Emerald style going forward, we recommend that you use the underlying URL. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
 - Added `+[MGLStyle outdoorsStyleURLWithVersion:]` for the new Outdoors style. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
+- The Hybrid style is now called Satellite Streets. ([#4759](https://github.com/mapbox/mapbox-gl-native/pull/4759))
 - The user dot now moves smoothly between user location updates while user location tracking is disabled. ([#1582](https://github.com/mapbox/mapbox-gl-native/pull/1582))
 - An MGLAnnotation can be relocated by changing its `coordinate` property in a KVO-compliant way. An MGLMultiPoint cannot be relocated. ([#3835](https://github.com/mapbox/mapbox-gl-native/pull/3835))
 - Setting the `image` property of an MGLAnnotationImage to `nil` resets it to the default red pin image and reclaims resources that can be used to customize additional annotations. ([#3835](https://github.com/mapbox/mapbox-gl-native/pull/3835))

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -479,7 +479,7 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
             @"Light",
             @"Dark",
             @"Satellite",
-            @"Hybrid",
+            @"Satellite Streets",
         ];
         styleURLs = @[
             [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion],
@@ -487,7 +487,7 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
             [MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion],
             [MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion],
             [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion],
-            [MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion],
+            [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion],
         ];
         NSAssert(styleNames.count == styleURLs.count, @"Style names and URLs don’t match.");
         

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -475,19 +475,19 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     dispatch_once(&onceToken, ^{
         styleNames = @[
             @"Streets",
-            @"Emerald",
+            @"Outdoors",
             @"Light",
             @"Dark",
             @"Satellite",
             @"Hybrid",
         ];
         styleURLs = @[
-            [MGLStyle streetsStyleURL],
-            [MGLStyle emeraldStyleURL],
-            [MGLStyle lightStyleURL],
-            [MGLStyle darkStyleURL],
-            [MGLStyle satelliteStyleURL],
-            [MGLStyle hybridStyleURL],
+            [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion],
+            [MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion],
+            [MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion],
+            [MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion],
+            [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion],
+            [MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion],
         ];
         NSAssert(styleNames.count == styleURLs.count, @"Style names and URLs don’t match.");
         
@@ -497,10 +497,10 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
         unsigned numStyleURLMethods = 0;
         for (NSUInteger i = 0; i < numMethods; i++) {
             Method method = methods[i];
-            if (method_getNumberOfArguments(method) == 2 /* _cmd, self */) {
+            if (method_getNumberOfArguments(method) == 3 /* _cmd, self, version */) {
                 SEL selector = method_getName(method);
                 NSString *name = @(sel_getName(selector));
-                if ([name rangeOfString:@"StyleURL"].location != NSNotFound) {
+                if ([name hasSuffix:@"StyleURLWithVersion:"]) {
                     numStyleURLMethods += 1;
                 }
             }

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -482,12 +482,12 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
             @"Satellite Streets",
         ];
         styleURLs = @[
-            [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion],
-            [MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion],
-            [MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion],
-            [MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion],
-            [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion],
-            [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion],
+            [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion],
+            [MGLStyle outdoorsStyleURLWithVersion:MGLStyleDefaultVersion],
+            [MGLStyle lightStyleURLWithVersion:MGLStyleDefaultVersion],
+            [MGLStyle darkStyleURLWithVersion:MGLStyleDefaultVersion],
+            [MGLStyle satelliteStyleURLWithVersion:MGLStyleDefaultVersion],
+            [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleDefaultVersion],
         ];
         NSAssert(styleNames.count == styleURLs.count, @"Style names and URLs don’t match.");
         

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -23,6 +23,7 @@ custom_categories:
       - MGLMapView
       - MGLMapViewDelegate
       - MGLStyle
+      - MGLStyleCurrentVersion
       - MGLUserTrackingMode
   - name: Annotations
     children:

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -23,7 +23,7 @@ custom_categories:
       - MGLMapView
       - MGLMapViewDelegate
       - MGLStyle
-      - MGLStyleCurrentVersion
+      - MGLStyleDefaultVersion
       - MGLUserTrackingMode
   - name: Annotations
     children:

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -329,7 +329,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
     if ( ! styleURL)
     {
-        styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
+        styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
     }
 
     if ( ! [styleURL scheme])

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -329,7 +329,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
     if ( ! styleURL)
     {
-        styleURL = [MGLStyle streetsStyleURL];
+        styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
     }
 
     if ( ! [styleURL scheme])

--- a/platform/osx/app/Base.lproj/MainMenu.xib
+++ b/platform/osx/app/Base.lproj/MainMenu.xib
@@ -390,7 +390,7 @@
                                     <action selector="setStyle:" target="-1" id="GXt-oK-Hy1"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Hybrid" tag="6" keyEquivalent="6" id="9BL-00-HFt">
+                            <menuItem title="Satellite Streets" tag="6" keyEquivalent="6" id="9BL-00-HFt">
                                 <connections>
                                     <action selector="setStyle:" target="-1" id="oL4-AC-waq"/>
                                 </connections>

--- a/platform/osx/app/Base.lproj/MainMenu.xib
+++ b/platform/osx/app/Base.lproj/MainMenu.xib
@@ -370,7 +370,7 @@
                                     <action selector="setStyle:" target="-1" id="I4L-Wx-UXA"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Emerald" tag="2" keyEquivalent="2" id="BBa-Qa-SQr">
+                            <menuItem title="Outdoors" tag="2" keyEquivalent="2" id="BBa-Qa-SQr">
                                 <connections>
                                     <action selector="setStyle:" target="-1" id="rM1-yG-t5u"/>
                                 </connections>

--- a/platform/osx/app/Base.lproj/MapDocument.xib
+++ b/platform/osx/app/Base.lproj/MapDocument.xib
@@ -59,9 +59,9 @@
                     <toolbarItem implicitItemIdentifier="BA3542AF-D63A-4893-9CC7-8F67EF2E82B0" label="Style" paletteLabel="Style" id="u23-0z-Otl" customClass="ValidatedToolbarItem">
                         <nil key="toolTip"/>
                         <size key="minSize" width="100" height="26"/>
-                        <size key="maxSize" width="100" height="26"/>
+                        <size key="maxSize" width="120" height="26"/>
                         <popUpButton key="view" verticalHuggingPriority="750" id="Tzm-Cy-dQg">
-                            <rect key="frame" x="0.0" y="14" width="100" height="26"/>
+                            <rect key="frame" x="0.0" y="14" width="120" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <popUpButtonCell key="cell" type="roundTextured" title="Streets" bezelStyle="texturedRounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="wvt-tP-O3a" id="3PJ-qK-Oh3">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -77,7 +77,7 @@
                                         <menuItem title="Satellite" tag="5" id="CTe-e2-o42">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                         </menuItem>
-                                        <menuItem title="Hybrid" tag="6" id="7ly-oA-0ND">
+                                        <menuItem title="Satellite Streets" tag="6" id="7ly-oA-0ND">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                         </menuItem>
                                     </items>

--- a/platform/osx/app/Base.lproj/MapDocument.xib
+++ b/platform/osx/app/Base.lproj/MapDocument.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="MapDocument">
@@ -69,7 +69,7 @@
                                 <menu key="menu" id="xf3-qk-IhF">
                                     <items>
                                         <menuItem title="Streets" state="on" tag="1" id="wvt-tP-O3a"/>
-                                        <menuItem title="Emerald" tag="2" id="RkE-lp-fL9"/>
+                                        <menuItem title="Outdoors" tag="2" id="RkE-lp-fL9"/>
                                         <menuItem title="Light" tag="3" id="R4X-kt-HHb"/>
                                         <menuItem title="Dark" tag="4" id="jUC-5X-0Zx">
                                             <modifierMask key="keyEquivalentModifierMask"/>

--- a/platform/osx/app/MapDocument.m
+++ b/platform/osx/app/MapDocument.m
@@ -135,7 +135,7 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
             styleURL = [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion];
             break;
         case 6:
-            styleURL = [MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion];
+            styleURL = [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion];
             break;
         default:
             NSAssert(NO, @"Cannot set style from control with tag %li", (long)tag);
@@ -462,7 +462,7 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
                 state = [styleURL isEqual:[MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion]];
                 break;
             case 6:
-                state = [styleURL isEqual:[MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion]];
+                state = [styleURL isEqual:[MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion]];
                 break;
             default:
                 return NO;
@@ -562,7 +562,7 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
         [MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion],
         [MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion],
         [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion],
-        [MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion],
+        [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion],
     ];
     return [styleURLs indexOfObject:self.mapView.styleURL];
 }

--- a/platform/osx/app/MapDocument.m
+++ b/platform/osx/app/MapDocument.m
@@ -120,22 +120,22 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     NSURL *styleURL;
     switch (tag) {
         case 1:
-            styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
+            styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
             break;
         case 2:
-            styleURL = [MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion];
+            styleURL = [MGLStyle outdoorsStyleURLWithVersion:MGLStyleDefaultVersion];
             break;
         case 3:
-            styleURL = [MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion];
+            styleURL = [MGLStyle lightStyleURLWithVersion:MGLStyleDefaultVersion];
             break;
         case 4:
-            styleURL = [MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion];
+            styleURL = [MGLStyle darkStyleURLWithVersion:MGLStyleDefaultVersion];
             break;
         case 5:
-            styleURL = [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion];
+            styleURL = [MGLStyle satelliteStyleURLWithVersion:MGLStyleDefaultVersion];
             break;
         case 6:
-            styleURL = [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion];
+            styleURL = [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleDefaultVersion];
             break;
         default:
             NSAssert(NO, @"Cannot set style from control with tag %li", (long)tag);
@@ -447,22 +447,22 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
         NSCellStateValue state;
         switch (menuItem.tag) {
             case 1:
-                state = [styleURL isEqual:[MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion]];
+                state = [styleURL isEqual:[MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion]];
                 break;
             case 2:
-                state = [styleURL isEqual:[MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion]];
+                state = [styleURL isEqual:[MGLStyle outdoorsStyleURLWithVersion:MGLStyleDefaultVersion]];
                 break;
             case 3:
-                state = [styleURL isEqual:[MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion]];
+                state = [styleURL isEqual:[MGLStyle lightStyleURLWithVersion:MGLStyleDefaultVersion]];
                 break;
             case 4:
-                state = [styleURL isEqual:[MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion]];
+                state = [styleURL isEqual:[MGLStyle darkStyleURLWithVersion:MGLStyleDefaultVersion]];
                 break;
             case 5:
-                state = [styleURL isEqual:[MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion]];
+                state = [styleURL isEqual:[MGLStyle satelliteStyleURLWithVersion:MGLStyleDefaultVersion]];
                 break;
             case 6:
-                state = [styleURL isEqual:[MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion]];
+                state = [styleURL isEqual:[MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleDefaultVersion]];
                 break;
             default:
                 return NO;
@@ -557,12 +557,12 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     }
     
     NSArray *styleURLs = @[
-        [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion],
-        [MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion],
-        [MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion],
-        [MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion],
-        [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion],
-        [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleCurrentVersion],
+        [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion],
+        [MGLStyle outdoorsStyleURLWithVersion:MGLStyleDefaultVersion],
+        [MGLStyle lightStyleURLWithVersion:MGLStyleDefaultVersion],
+        [MGLStyle darkStyleURLWithVersion:MGLStyleDefaultVersion],
+        [MGLStyle satelliteStyleURLWithVersion:MGLStyleDefaultVersion],
+        [MGLStyle satelliteStreetsStyleURLWithVersion:MGLStyleDefaultVersion],
     ];
     return [styleURLs indexOfObject:self.mapView.styleURL];
 }

--- a/platform/osx/app/MapDocument.m
+++ b/platform/osx/app/MapDocument.m
@@ -120,22 +120,22 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     NSURL *styleURL;
     switch (tag) {
         case 1:
-            styleURL = [MGLStyle streetsStyleURL];
+            styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
             break;
         case 2:
-            styleURL = [MGLStyle emeraldStyleURL];
+            styleURL = [MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion];
             break;
         case 3:
-            styleURL = [MGLStyle lightStyleURL];
+            styleURL = [MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion];
             break;
         case 4:
-            styleURL = [MGLStyle darkStyleURL];
+            styleURL = [MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion];
             break;
         case 5:
-            styleURL = [MGLStyle satelliteStyleURL];
+            styleURL = [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion];
             break;
         case 6:
-            styleURL = [MGLStyle hybridStyleURL];
+            styleURL = [MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion];
             break;
         default:
             NSAssert(NO, @"Cannot set style from control with tag %li", (long)tag);
@@ -447,22 +447,22 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
         NSCellStateValue state;
         switch (menuItem.tag) {
             case 1:
-                state = [styleURL isEqual:[MGLStyle streetsStyleURL]];
+                state = [styleURL isEqual:[MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion]];
                 break;
             case 2:
-                state = [styleURL isEqual:[MGLStyle emeraldStyleURL]];
+                state = [styleURL isEqual:[MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion]];
                 break;
             case 3:
-                state = [styleURL isEqual:[MGLStyle lightStyleURL]];
+                state = [styleURL isEqual:[MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion]];
                 break;
             case 4:
-                state = [styleURL isEqual:[MGLStyle darkStyleURL]];
+                state = [styleURL isEqual:[MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion]];
                 break;
             case 5:
-                state = [styleURL isEqual:[MGLStyle satelliteStyleURL]];
+                state = [styleURL isEqual:[MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion]];
                 break;
             case 6:
-                state = [styleURL isEqual:[MGLStyle hybridStyleURL]];
+                state = [styleURL isEqual:[MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion]];
                 break;
             default:
                 return NO;
@@ -557,12 +557,12 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     }
     
     NSArray *styleURLs = @[
-        [MGLStyle streetsStyleURL],
-        [MGLStyle emeraldStyleURL],
-        [MGLStyle lightStyleURL],
-        [MGLStyle darkStyleURL],
-        [MGLStyle satelliteStyleURL],
-        [MGLStyle hybridStyleURL],
+        [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion],
+        [MGLStyle outdoorsStyleURLWithVersion:MGLStyleCurrentVersion],
+        [MGLStyle lightStyleURLWithVersion:MGLStyleCurrentVersion],
+        [MGLStyle darkStyleURLWithVersion:MGLStyleCurrentVersion],
+        [MGLStyle satelliteStyleURLWithVersion:MGLStyleCurrentVersion],
+        [MGLStyle hybridStyleURLWithVersion:MGLStyleCurrentVersion],
     ];
     return [styleURLs indexOfObject:self.mapView.styleURL];
 }

--- a/platform/osx/osx.xcodeproj/project.pbxproj
+++ b/platform/osx/osx.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		DA8933AE1CCD290700E68420 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DA8933AB1CCD290700E68420 /* Localizable.strings */; };
 		DA8933B51CCD2C2500E68420 /* Foundation.strings in Resources */ = {isa = PBXBuildFile; fileRef = DA8933B31CCD2C2500E68420 /* Foundation.strings */; };
 		DA8933B81CCD2C2D00E68420 /* Foundation.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DA8933B61CCD2C2D00E68420 /* Foundation.stringsdict */; };
+		DAB6924A1CC75A31005AAB54 /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE6C3451CC31D1200DB3429 /* libmbgl-core.a */; };
 		DAC2ABC51CC6D343006D18C4 /* MGLAnnotationImage_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DAC2ABC41CC6D343006D18C4 /* MGLAnnotationImage_Private.h */; };
 		DAE6C2E21CC304F900DB3429 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = DAE6C2E11CC304F900DB3429 /* Credits.rtf */; };
 		DAE6C2ED1CC3050F00DB3429 /* DroppedPinAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE6C2E41CC3050F00DB3429 /* DroppedPinAnnotation.m */; };
@@ -115,13 +116,6 @@
 			remoteGlobalIDString = DAE6C3271CC30DB200DB3429;
 			remoteInfo = dynamic;
 		};
-		DAE6C3351CC30DB200DB3429 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = DA839E8A1CC2E3400062CAFB /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DA839E911CC2E3400062CAFB;
-			remoteInfo = osxapp;
-		};
 		DAE6C33B1CC30DB200DB3429 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DA839E8A1CC2E3400062CAFB /* Project object */;
@@ -186,8 +180,8 @@
 		DAE6C32C1CC30DB200DB3429 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DAE6C3311CC30DB200DB3429 /* test.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = test.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE6C33A1CC30DB200DB3429 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DAE6C3451CC31D1200DB3429 /* libmbgl-core.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-core.a"; path = "../../build/DerivedData/osx/Build/Products/Debug/libmbgl-core.a"; sourceTree = "<group>"; };
-		DAE6C3461CC31D1200DB3429 /* libmbgl-platform-osx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-platform-osx.a"; path = "../../build/DerivedData/osx/Build/Products/Debug/libmbgl-platform-osx.a"; sourceTree = "<group>"; };
+		DAE6C3451CC31D1200DB3429 /* libmbgl-core.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libmbgl-core.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DAE6C3461CC31D1200DB3429 /* libmbgl-platform-osx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libmbgl-platform-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAE6C34A1CC31E0400DB3429 /* MGLAccountManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAccountManager.h; sourceTree = "<group>"; };
 		DAE6C34B1CC31E0400DB3429 /* MGLAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAnnotation.h; sourceTree = "<group>"; };
 		DAE6C34C1CC31E0400DB3429 /* MGLGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLGeometry.h; sourceTree = "<group>"; };
@@ -280,6 +274,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAB6924A1CC75A31005AAB54 /* libmbgl-core.a in Frameworks */,
 				DAE6C3321CC30DB200DB3429 /* Mapbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -597,7 +592,6 @@
 			);
 			dependencies = (
 				DAE6C3341CC30DB200DB3429 /* PBXTargetDependency */,
-				DAE6C3361CC30DB200DB3429 /* PBXTargetDependency */,
 			);
 			name = test;
 			productName = dynamicTests;
@@ -749,11 +743,6 @@
 			isa = PBXTargetDependency;
 			target = DAE6C3271CC30DB200DB3429 /* dynamic */;
 			targetProxy = DAE6C3331CC30DB200DB3429 /* PBXContainerItemProxy */;
-		};
-		DAE6C3361CC30DB200DB3429 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DA839E911CC2E3400062CAFB /* osxapp */;
-			targetProxy = DAE6C3351CC30DB200DB3429 /* PBXContainerItemProxy */;
 		};
 		DAE6C33C1CC30DB200DB3429 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -532,7 +532,7 @@ public:
 
 - (nonnull NSURL *)styleURL {
     NSString *styleURLString = @(_mbglMap->getStyleURL().c_str()).mgl_stringOrNilIfEmpty;
-    return styleURLString ? [NSURL URLWithString:styleURLString] : [MGLStyle streetsStyleURL];
+    return styleURLString ? [NSURL URLWithString:styleURLString] : [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
 }
 
 - (void)setStyleURL:(nullable NSURL *)styleURL {
@@ -547,7 +547,7 @@ public:
         if (![MGLAccountManager accessToken]) {
             return;
         }
-        styleURL = [MGLStyle streetsStyleURL];
+        styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
     }
     
     if (![styleURL scheme]) {

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -532,7 +532,7 @@ public:
 
 - (nonnull NSURL *)styleURL {
     NSString *styleURLString = @(_mbglMap->getStyleURL().c_str()).mgl_stringOrNilIfEmpty;
-    return styleURLString ? [NSURL URLWithString:styleURLString] : [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
+    return styleURLString ? [NSURL URLWithString:styleURLString] : [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
 }
 
 - (void)setStyleURL:(nullable NSURL *)styleURL {
@@ -547,7 +547,7 @@ public:
         if (![MGLAccountManager accessToken]) {
             return;
         }
-        styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleCurrentVersion];
+        styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
     }
     
     if (![styleURL scheme]) {

--- a/src/mbgl/util/default_styles.cpp
+++ b/src/mbgl/util/default_styles.cpp
@@ -4,12 +4,12 @@ namespace mbgl {
 namespace util {
 namespace default_styles {
 
-const DefaultStyle streets   = { "mapbox://styles/mapbox/streets-v9",          "Streets" };
-const DefaultStyle outdoors  = { "mapbox://styles/mapbox/outdoors-v9",         "Outdoors" };
-const DefaultStyle light     = { "mapbox://styles/mapbox/light-v9",            "Light" };
-const DefaultStyle dark      = { "mapbox://styles/mapbox/dark-v9",             "Dark" };
-const DefaultStyle satellite = { "mapbox://styles/mapbox/satellite-v9",        "Satellite" };
-const DefaultStyle hybrid    = { "mapbox://styles/mapbox/satellite-hybrid-v9", "Hybrid" };
+const DefaultStyle streets          = { "mapbox://styles/mapbox/streets-v9",           "Streets" };
+const DefaultStyle outdoors         = { "mapbox://styles/mapbox/outdoors-v9",          "Outdoors" };
+const DefaultStyle light            = { "mapbox://styles/mapbox/light-v9",             "Light" };
+const DefaultStyle dark             = { "mapbox://styles/mapbox/dark-v9",              "Dark" };
+const DefaultStyle satellite        = { "mapbox://styles/mapbox/satellite-v9",         "Satellite" };
+const DefaultStyle satelliteStreets = { "mapbox://styles/mapbox/satellite-streets-v9", "Satellite Streets" };
 
 } // namespace default_styles
 } // end namespace util

--- a/src/mbgl/util/default_styles.cpp
+++ b/src/mbgl/util/default_styles.cpp
@@ -4,12 +4,12 @@ namespace mbgl {
 namespace util {
 namespace default_styles {
 
-const DefaultStyle streets   = { "mapbox://styles/mapbox/streets-v8",          "Streets" };
-const DefaultStyle emerald   = { "mapbox://styles/mapbox/emerald-v8",          "Emerald" };
-const DefaultStyle light     = { "mapbox://styles/mapbox/light-v8",            "Light" };
-const DefaultStyle dark      = { "mapbox://styles/mapbox/dark-v8",             "Dark" };
-const DefaultStyle satellite = { "mapbox://styles/mapbox/satellite-v8",        "Satellite" };
-const DefaultStyle hybrid    = { "mapbox://styles/mapbox/satellite-hybrid-v8", "Hybrid" };
+const DefaultStyle streets   = { "mapbox://styles/mapbox/streets-v9",          "Streets" };
+const DefaultStyle outdoors  = { "mapbox://styles/mapbox/outdoors-v9",         "Outdoors" };
+const DefaultStyle light     = { "mapbox://styles/mapbox/light-v9",            "Light" };
+const DefaultStyle dark      = { "mapbox://styles/mapbox/dark-v9",             "Dark" };
+const DefaultStyle satellite = { "mapbox://styles/mapbox/satellite-v9",        "Satellite" };
+const DefaultStyle hybrid    = { "mapbox://styles/mapbox/satellite-hybrid-v9", "Hybrid" };
 
 } // namespace default_styles
 } // end namespace util


### PR DESCRIPTION
Updated default styles from v8 to v9 in the centralized default style constants used by the iOS and OS X SDKs as well as by the GLFW application. Deprecated the MGLMapView class methods in favor of new methods that take a version parameter. Replaced usage of the unversioned MGLStyle methods with the corresponding versioned methods and MGLStyleCurrentVersion to ensure consistency.

Expanded MGLStyle unit tests to also assert that MGLStyle has the right number of versioned style URL methods and that they’re all public.

* [x] Deprecate unversioned style URL methods in favor of versioned methods (#4702)
* [x] Deprecate Emerald (#4577)
* [x] Rename Hybrid to Satellite Streets
* [x] Figure out how to make MGLStyleCurrentVersion not be a trap: https://github.com/mapbox/mapbox-gl-native/pull/4759#discussion_r60455953
* [x] Keep unversioned style URL methods on v8: https://github.com/mapbox/mapbox-gl-native/pull/4812#discussion_r61304626
* [ ] Revise style descriptions to match www.mapbox.com

Fixes #4577 and fixes #4702. Hold until the v9 styles near release.

/cc @jfirebaugh @friedbunny