### PR TITLE
[core] remove unused code in value.hpp

### DIFF
--- a/src/mbgl/style/value.hpp
+++ b/src/mbgl/style/value.hpp
@@ -15,29 +15,6 @@ std::string toString(const Value &value);
 
 Value parseValue(const JSValue&);
 
-namespace util {
-inline bool parseNumericString(const std::string &str, double &result) {
-    char *end = nullptr;
-    const char *begin = str.c_str();
-    result = std::strtod(begin, &end);
-    while (*end != '\0' && isspace(*end)) end++; // eat whitespace after the end
-    return errno == 0 && end - begin == long(str.size());
-}
-} // namespace util
-
-template <typename T>
-T toNumber(const Value &value) {
-    if (value.is<std::string>()) {
-        double val;
-        return util::parseNumericString(value.get<std::string>(), val) ? val : 0;
-    }
-    else if (value.is<bool>()) return value.get<bool>();
-    else if (value.is<int64_t>()) return value.get<int64_t>();
-    else if (value.is<uint64_t>()) return value.get<uint64_t>();
-    else if (value.is<double>()) return value.get<double>();
-    else return 0;
-}
-
 } // namespace mbgl
 
 #endif


### PR DESCRIPTION
Noticed this dead code while reviewing `mapbox::variant` usage with @artemp