### PR TITLE
Expose setStyleJson from native class to MapboxMap and MapboxView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -811,6 +811,23 @@ public class MapView extends FrameLayout {
     public String getStyleUrl() {
         return mStyleUrl;
     }
+    
+        /**
+     * <p>
+     * Loads a new map style from the specified bundled style.
+     * </p>
+     *
+     * @param newStyleJson The bundled style json code.
+     * @param base one of 'mapbox://', 'http://', 'https://', 'assets/'.     
+     * @see Style
+     */
+    @UiThread
+    public void setStyleJson(@NonNull String newStyleJson, @NonNull String base) {
+        if (mDestroyed) {
+            return;
+        }
+        mNativeMapView.setStyleJson(newStyleJson, base);
+    }
 
     //
     // Access token

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -494,6 +494,12 @@ public class MapboxMap {
         mMapView.setStyleUrl(url);
     }
 
+    @UiThread
+    public void setStyleJson(@NonNull String newStyleJson, @NonNull String base) {
+        mMapView.setStyleJson(newStyleJson, base);
+    }
+
+
     /**
      * <p>
      * Loads a new map style from the specified bundled style.


### PR DESCRIPTION
Here is the use case:
I need app the be able load style json from internal storage. So it could be updated periodically without publishing new version of functionality or publishing new style to mapbox studio (the phone might not have wireless connection during the day).
I've tried setStyleUrl - but it supports only http://. mapbox:// or assists//, but reject to load information from file://

`E/mbgl: {Map}[Setup]: loading style failed: unexpected url: file:/storage/emulated/0/Download/test_aoi_style.json`