### PR TITLE
[build] Added Qt 5 build for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ addons_shortcuts:
       sources: [ 'ubuntu-toolchain-r-test', 'ubuntu-sdk-team' ]
       packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev',
                   'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils', 'qt4-default' ]
+  addons_qt5: &qt5
+    apt:
+      sources: [ 'ubuntu-toolchain-r-test', 'ubuntu-sdk-team' ]
+      packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev',
+                  'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils',
+                  'qt5-default', 'libqt5opengl5-dev' ]
 
 env:
   global:
@@ -91,6 +97,14 @@ matrix:
       compiler: ": linux-gcc49-release"
       env: FLAVOR=qt4 BUILDTYPE=Release _CXX=g++-4.9 _CC=gcc-4.9
       addons: *qt4
+      script:
+        - make test-qt
+
+    # Qt 5 - Release
+    - language: cpp
+      compiler: ": linux-gcc49-release"
+      env: FLAVOR=qt5 BUILDTYPE=Release _CXX=g++-4.9 _CC=gcc-4.9
+      addons: *qt5
       script:
         - make test-qt
 

--- a/platform/qt/app/qmapboxgl.gypi
+++ b/platform/qt/app/qmapboxgl.gypi
@@ -29,6 +29,7 @@
           '<@(opengl_cflags)',
           '<@(qt_cflags)',
           '-Wno-error',  # TODO: eliminate
+          '-fPIC',
         ],
         'ldflags': [
           '<@(opengl_ldflags)',

--- a/platform/qt/scripts/configure.sh
+++ b/platform/qt/scripts/configure.sh
@@ -31,7 +31,10 @@ function print_qt_flags {
     CONFIG+="    'qt_ldflags%': $(quote_flags $(mason ldflags Qt system "QtCore QtGui QtOpenGL QtNetwork")),"$LN
 
     QT_VERSION_MAJOR=$(qmake -query QT_VERSION | cut -d. -f1)
-    if [ ${QT_VERSION_MAJOR} -gt 4 ] ; then
+    if hash moc 2>/dev/null && hash rcc 2>/dev/null; then
+        CONFIG+="    'qt_moc%': '$(which moc)',"$LN
+        CONFIG+="    'qt_rcc%': '$(which rcc)',"$LN
+    elif [ ${QT_VERSION_MAJOR} -gt 4 ] ; then
         CONFIG+="    'qt_moc%': '$(pkg-config Qt${QT_VERSION_MAJOR}Core --variable=host_bins)/moc',"$LN
         CONFIG+="    'qt_rcc%': '$(pkg-config Qt${QT_VERSION_MAJOR}Core --variable=host_bins)/rcc',"$LN
     else


### PR DESCRIPTION
Adding a Travis build bot for Mapbox GL's Qt target using Qt 5.0.2 (provided via `ubuntu-sdk-tools` source in Travis CI).

I'm using GCC 4.9 for both Qt4 and Qt5 for now due to compiler errors while using clang 3.5 (example below):

```
/usr/include/qt5/QtCore/qurl.h:326:56: error: friend declaration specifying a default argument must be a definition
    friend __attribute__((visibility("default"))) uint qHash(const QUrl &url, uint seed = 0) noexcept;
```

/cc @tmpsantos