### PR TITLE
[core] Preserve custom layers upon style switch

### DIFF
--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -70,7 +70,9 @@ Style::Style(FileSource& fileSource_, float pixelRatio)
 
 void Style::setJSON(const std::string& json, const std::string&) {
     sources.clear();
-    layers.clear();
+    layers.erase(std::remove_if(layers.begin(), layers.end(), [](const auto& layer) {
+            return !layer->template is<CustomLayer>();
+        }), layers.end());
     classes.clear();
 
     StyleParser parser;

--- a/test/api/custom_layer.cpp
+++ b/test/api/custom_layer.cpp
@@ -90,4 +90,8 @@ TEST(CustomLayer, Basic) {
         }, new TestLayer());
 
     test::checkImage("test/fixtures/custom_layer/basic", test::render(map));
+
+    // Custom layer should be preserved when switching styles
+    map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
+    test::checkImage("test/fixtures/custom_layer/basic", test::render(map));
 }


### PR DESCRIPTION
We are clearing all style layers in `Style::setJSON()`, which is called whenever a style change occurs. This is OK for previous style layers because we're assigning new layers based on the loaded JSON style, but we should preserve custom layers as they are not associated with a specific style.