### PR TITLE
Change leak canary version from beta to stable

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -87,8 +87,8 @@ dependencies {
     compile "com.android.support:recyclerview-v7:${supportLibVersion}"
 
     // Leak Canary
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta1'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
+    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
 
     // Directions SDK
     compile('com.mapbox.mapboxsdk:mapbox-android-directions:1.0.0@aar') {


### PR DESCRIPTION
1.4-beta leak canary version is not stable. Might be safer to use the last stable version.