### PR TITLE
Constrain zoom level when selecting offline pack

### DIFF
--- a/platform/ios/app/MBXOfflinePacksTableViewController.m
+++ b/platform/ios/app/MBXOfflinePacksTableViewController.m
@@ -24,6 +24,7 @@ static NSString * const MBXOfflinePacksTableViewActiveCellReuseIdentifier = @"Ac
 - (void)applyToMapView:(MGLMapView *)mapView {
     mapView.styleURL = self.styleURL;
     [mapView setVisibleCoordinateBounds:self.bounds];
+    mapView.zoomLevel = MIN(self.maximumZoomLevel, MAX(self.minimumZoomLevel, mapView.zoomLevel));
 }
 
 @end

--- a/platform/osx/app/AppDelegate.h
+++ b/platform/osx/app/AppDelegate.h
@@ -16,6 +16,8 @@ extern NSString * const MGLMapboxAccessTokenDefaultsKey;
 @property (assign) double pendingZoomLevel;
 @property (copy) MGLMapCamera *pendingCamera;
 @property (assign) MGLCoordinateBounds pendingVisibleCoordinateBounds;
+@property (assign) double pendingMinimumZoomLevel;
+@property (assign) double pendingMaximumZoomLevel;
 @property (copy) NSURL *pendingStyleURL;
 @property (assign) MGLMapDebugMaskOptions pendingDebugMask;
 

--- a/platform/osx/app/AppDelegate.m
+++ b/platform/osx/app/AppDelegate.m
@@ -204,6 +204,8 @@ NSString * const MGLLastMapDebugMaskDefaultsKey = @"MGLLastMapDebugMask";
                 if ([pack.region isKindOfClass:[MGLTilePyramidOfflineRegion class]]) {
                     MGLTilePyramidOfflineRegion *region = (MGLTilePyramidOfflineRegion *)pack.region;
                     self.pendingVisibleCoordinateBounds = region.bounds;
+                    self.pendingMinimumZoomLevel = region.minimumZoomLevel;
+                    self.pendingMaximumZoomLevel = region.maximumZoomLevel;
                     [[NSDocumentController sharedDocumentController] openUntitledDocumentAndDisplay:YES error:NULL];
                 }
                 break;

--- a/platform/osx/app/MapDocument.m
+++ b/platform/osx/app/MapDocument.m
@@ -211,6 +211,12 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     if (appDelegate.pendingDebugMask) {
         self.mapView.debugMask = appDelegate.pendingDebugMask;
     }
+    if (appDelegate.pendingMinimumZoomLevel >= 0) {
+        self.mapView.zoomLevel = MAX(appDelegate.pendingMinimumZoomLevel, self.mapView.zoomLevel);
+    }
+    if (appDelegate.pendingMaximumZoomLevel >= 0) {
+        self.mapView.zoomLevel = MIN(appDelegate.pendingMaximumZoomLevel, self.mapView.zoomLevel);
+    }
     
     // Temporarily set the display name to the default center coordinate instead
     // of “Untitled” until the binding kicks in.


### PR DESCRIPTION
When selecting an offline pack for display in iosapp or osxapp, constrain the zoom level to the pack’s minimum and maximum zoom levels.

Fixes #4787.

/cc @jfirebaugh