### PR TITLE
[core] Quarantine style property irregularities in layer classes

### DIFF
--- a/src/mbgl/layer/circle_layer.cpp
+++ b/src/mbgl/layer/circle_layer.cpp
@@ -37,7 +37,8 @@ bool CircleLayer::recalculate(const StyleCalculationParameters& parameters) {
     hasTransitions |= paint.circleTranslateAnchor.calculate(parameters);
     hasTransitions |= paint.circleBlur.calculate(parameters);
 
-    passes = paint.isVisible() ? RenderPass::Translucent : RenderPass::None;
+    passes = (paint.circleRadius > 0 && paint.circleColor.value[3] > 0 && paint.circleOpacity > 0)
+        ? RenderPass::Translucent : RenderPass::None;
 
     return hasTransitions;
 }

--- a/src/mbgl/layer/circle_layer.hpp
+++ b/src/mbgl/layer/circle_layer.hpp
@@ -14,10 +14,6 @@ public:
     PaintProperty<std::array<float, 2>> circleTranslate { {{ 0, 0 }} };
     PaintProperty<TranslateAnchorType> circleTranslateAnchor { TranslateAnchorType::Map };
     PaintProperty<float> circleBlur { 0 };
-
-    bool isVisible() const {
-        return circleRadius > 0 && circleColor.value[3] > 0 && circleOpacity > 0;
-    }
 };
 
 class CircleLayer : public StyleLayer {

--- a/src/mbgl/layer/line_layer.cpp
+++ b/src/mbgl/layer/line_layer.cpp
@@ -48,7 +48,7 @@ bool LineLayer::recalculate(const StyleCalculationParameters& parameters) {
     StyleCalculationParameters dashArrayParams = parameters;
     dashArrayParams.z = std::floor(dashArrayParams.z);
     paint.lineWidth.calculate(dashArrayParams);
-    paint.dashLineWidth = paint.lineWidth;
+    dashLineWidth = paint.lineWidth;
 
     bool hasTransitions = false;
 
@@ -63,7 +63,8 @@ bool LineLayer::recalculate(const StyleCalculationParameters& parameters) {
     hasTransitions |= paint.lineDasharray.calculate(parameters);
     hasTransitions |= paint.linePattern.calculate(parameters);
 
-    passes = paint.isVisible() ? RenderPass::Translucent : RenderPass::None;
+    passes = (paint.lineOpacity > 0 && paint.lineColor.value[3] > 0 && paint.lineWidth > 0)
+        ? RenderPass::Translucent : RenderPass::None;
 
     return hasTransitions;
 }

--- a/src/mbgl/layer/line_layer.hpp
+++ b/src/mbgl/layer/line_layer.hpp
@@ -27,13 +27,6 @@ public:
     PaintProperty<float> lineOffset { 0 };
     PaintProperty<std::vector<float>, Faded<std::vector<float>>> lineDasharray { {} };
     PaintProperty<std::string, Faded<std::string>> linePattern { "" };
-
-    // Special case
-    float dashLineWidth = 1;
-
-    bool isVisible() const {
-        return lineOpacity > 0 && lineColor.value[3] > 0 && lineWidth > 0;
-    }
 };
 
 class LineLayer : public StyleLayer {
@@ -51,6 +44,8 @@ public:
 
     LineLayoutProperties layout;
     LinePaintProperties paint;
+
+    float dashLineWidth = 1;
 };
 
 template <>

--- a/src/mbgl/layer/symbol_layer.cpp
+++ b/src/mbgl/layer/symbol_layer.cpp
@@ -103,10 +103,12 @@ bool SymbolLayer::recalculate(const StyleCalculationParameters& parameters) {
     // text-size and icon-size are layout properties but they also need to be evaluated as paint properties:
     layout.iconSize.calculate(parameters);
     layout.textSize.calculate(parameters);
-    paint.iconSize = layout.iconSize;
-    paint.textSize = layout.textSize;
+    iconSize = layout.iconSize;
+    textSize = layout.textSize;
 
-    passes = paint.isVisible() ? RenderPass::Translucent : RenderPass::None;
+    passes = ((paint.iconOpacity > 0 && (paint.iconColor.value[3] > 0 || paint.iconHaloColor.value[3] > 0) && iconSize > 0)
+           || (paint.textOpacity > 0 && (paint.textColor.value[3] > 0 || paint.textHaloColor.value[3] > 0) && textSize > 0))
+        ? RenderPass::Translucent : RenderPass::None;
 
     return hasTransitions;
 }
@@ -157,8 +159,8 @@ std::unique_ptr<Bucket> SymbolLayer::createBucket(StyleBucketParameters& paramet
 
     bucket->layout.iconSize.calculate(StyleCalculationParameters(18));
     bucket->layout.textSize.calculate(StyleCalculationParameters(18));
-    bucket->layout.iconMaxSize = bucket->layout.iconSize;
-    bucket->layout.textMaxSize = bucket->layout.textSize;
+    bucket->iconMaxSize = bucket->layout.iconSize;
+    bucket->textMaxSize = bucket->layout.textSize;
     bucket->layout.iconSize.calculate(StyleCalculationParameters(p.z + 1));
     bucket->layout.textSize.calculate(StyleCalculationParameters(p.z + 1));
 

--- a/src/mbgl/layer/symbol_layer.hpp
+++ b/src/mbgl/layer/symbol_layer.hpp
@@ -44,10 +44,6 @@ public:
     LayoutProperty<bool> textAllowOverlap { false };
     LayoutProperty<bool> textIgnorePlacement { false };
     LayoutProperty<bool> textOptional { false };
-
-    // Special case.
-    float iconMaxSize = 1.0f;
-    float textMaxSize = 16.0f;
 };
 
 class SymbolPaintProperties {
@@ -67,15 +63,6 @@ public:
     PaintProperty<float> textHaloBlur { 0.0f };
     PaintProperty<std::array<float, 2>> textTranslate { {{ 0, 0 }} };
     PaintProperty<TranslateAnchorType> textTranslateAnchor { TranslateAnchorType::Map };
-
-    // Special case
-    float iconSize = 1.0f;
-    float textSize = 16.0f;
-
-    bool isVisible() const {
-        return (iconOpacity > 0 && (iconColor.value[3] > 0 || iconHaloColor.value[3] > 0) && iconSize > 0)
-            || (textOpacity > 0 && (textColor.value[3] > 0 || textHaloColor.value[3] > 0) && textSize > 0);
-    }
 };
 
 class SymbolLayer : public StyleLayer {
@@ -93,6 +80,9 @@ public:
 
     SymbolLayoutProperties layout;
     SymbolPaintProperties paint;
+
+    float iconSize = 1.0f;
+    float textSize = 16.0f;
 
     SpriteAtlas* spriteAtlas = nullptr;
 };

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -81,8 +81,8 @@ void Painter::renderLine(LineBucket& bucket, const LineLayer& layer, const TileI
         LinePatternPos posA = lineAtlas->getDashPosition(properties.lineDasharray.value.from, layout.lineCap == LineCapType::Round, glObjectStore);
         LinePatternPos posB = lineAtlas->getDashPosition(properties.lineDasharray.value.to, layout.lineCap == LineCapType::Round, glObjectStore);
 
-        const float widthA = posA.width * properties.lineDasharray.value.fromScale * properties.dashLineWidth;
-        const float widthB = posB.width * properties.lineDasharray.value.toScale * properties.dashLineWidth;
+        const float widthA = posA.width * properties.lineDasharray.value.fromScale * layer.dashLineWidth;
+        const float widthB = posB.width * properties.lineDasharray.value.toScale * layer.dashLineWidth;
 
         float scaleXA = 1.0 / id.pixelsToTileUnits(widthA, state.getIntegerZoom());
         float scaleYA = -posA.height / 2.0;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -172,7 +172,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
                 ? state.getAngle()
                 : 0;
 
-        const float fontSize = paint.iconSize;
+        const float fontSize = layer.iconSize;
         const float fontScale = fontSize / 1.0f;
 
         SpriteAtlas* activeSpriteAtlas = layer.spriteAtlas;
@@ -198,7 +198,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
                       paint.iconHaloBlur,
                       paint.iconTranslate,
                       paint.iconTranslateAnchor,
-                      paint.iconSize);
+                      layer.iconSize);
         } else {
             mat4 vtxMatrix = translatedMatrix(matrix, paint.iconTranslate, id, paint.iconTranslateAnchor);
 
@@ -274,7 +274,7 @@ void Painter::renderSymbol(SymbolBucket& bucket, const SymbolLayer& layer, const
                   paint.textHaloBlur,
                   paint.textTranslate,
                   paint.textTranslateAnchor,
-                  paint.textSize);
+                  layer.textSize);
     }
 
     if (bucket.hasCollisionBoxData()) {

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -286,7 +286,7 @@ void SymbolBucket::addFeature(const GeometryCollection &lines,
 
     const float fontScale = layout.textSize / glyphSize;
     const float textBoxScale = tilePixelRatio * fontScale;
-    const float textMaxBoxScale = tilePixelRatio * layout.textMaxSize / glyphSize;
+    const float textMaxBoxScale = tilePixelRatio * textMaxSize / glyphSize;
     const float iconBoxScale = tilePixelRatio * layout.iconSize;
     const float symbolSpacing = tilePixelRatio * layout.symbolSpacing;
     const bool avoidEdges = layout.symbolAvoidEdges && layout.symbolPlacement != SymbolPlacementType::Line;

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -111,6 +111,10 @@ private:
 
 public:
     SymbolLayoutProperties layout;
+
+    float iconMaxSize = 1.0f;
+    float textMaxSize = 16.0f;
+
     bool sdfIcons = false;
     bool iconsNeedLinear = false;
 


### PR DESCRIPTION
This moves the *{Layout,Paint}Properties classes closer to code generation.