### PR TITLE
Fix dangling KVO observer crash

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -508,6 +508,9 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [_attributionButton removeObserver:self forKeyPath:@"hidden"];
     
+    // Removing the annotations unregisters any outstanding KVO observers.
+    [self removeAnnotations:self.annotations];
+    
     [self validateDisplayLink];
 
     if (_mbglMap)

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -450,6 +450,9 @@ public:
     [self.calloutForSelectedAnnotation close];
     self.calloutForSelectedAnnotation = nil;
     
+    // Removing the annotations unregisters any outstanding KVO observers.
+    [self removeAnnotations:self.annotations];
+    
     if (_mbglMap) {
         delete _mbglMap;
         _mbglMap = nullptr;


### PR DESCRIPTION
Fixed a crash when deallocating an MGLMapView that has point annotations. Now we explicitly remove all the annotations from the view and thus remove all remaining KVO observers on those annotations.

Fixes #4805.

/cc @boundsj @friedbunny