### PR TITLE
Fix jazzy build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ iframework: $(IOS_PROJ_PATH)
 	./platform/ios/scripts/package.sh
 
 ifabric: $(IOS_PROJ_PATH)
-	BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO BUNDLE_RESOURCES=YES \
+	BITCODE=$(BITCODE) FORMAT=static BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO BUNDLE_RESOURCES=YES \
 	./platform/ios/scripts/package.sh
 
 idocument:

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -11,8 +11,8 @@ head: |
 objc: Yes
 skip_undocumented: Yes
 hide_documentation_coverage: Yes
-umbrella_header: platform/ios/include/Mapbox.h
-framework_root: platform/darwin/include
+umbrella_header: src/Mapbox.h
+framework_root: ../darwin/src
 
 custom_categories:
   - name: Maps

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -33,7 +33,7 @@ rm -rf ${OUTPUT}
 mkdir -p ${OUTPUT}
 
 jazzy \
-    --config platform/ios/jazzy.yml
+    --config platform/ios/jazzy.yml \
     --sdk iphonesimulator \
     --swift-version $SWIFT_VERSION \
     --github-file-prefix https://github.com/mapbox/mapbox-gl-native/tree/${BRANCH} \


### PR DESCRIPTION
Fixed some regressions introduced in 9c9ff2d2d4aeac9f605a6ca23447e54adea9f6bd for #4802. A backslash was missing from a shell script, causing arguments to get dropped and output to go in the repo root. Paths in the jazzy configuration file needed to be updated so jazzy could find the headers.

Also, only build the static framework for Fabric. Fabric’s Mac application has no use for the dynamic framework.

/cc @boundsj