### PR TITLE
Fix direction formatter edge cases

### DIFF
--- a/platform/darwin/src/MGLClockDirectionFormatter.m
+++ b/platform/darwin/src/MGLClockDirectionFormatter.m
@@ -19,7 +19,10 @@
 }
 
 - (NSString *)stringFromDirection:(CLLocationDirection)direction {
-    NSInteger hour = round(-wrap(-direction, -360, 0) / 360 * 12);
+    NSInteger hour = round(wrap(direction, 0, 360) / 360 * 12);
+    if (hour == 0) {
+        hour = 12;
+    }
     NSString *format;
     switch (self.unitStyle) {
         case NSFormattingUnitStyleShort:

--- a/platform/darwin/src/MGLCompassDirectionFormatter.m
+++ b/platform/darwin/src/MGLCompassDirectionFormatter.m
@@ -98,7 +98,7 @@
         NSAssert(shortStrings.count == longStrings.count, @"Long and short compass direction string arrays must have the same size.");
     });
     
-    NSInteger cardinalPoint = round(wrap(direction, 0, 360) / 360 * shortStrings.count);
+    NSInteger cardinalPoint = wrap(round(wrap(direction, 0, 360) / 360 * shortStrings.count), 0, shortStrings.count);
     switch (self.unitStyle) {
         case NSFormattingUnitStyleShort:
             return shortStrings[cardinalPoint];

--- a/platform/darwin/test/MGLClockDirectionFormatterTests.m
+++ b/platform/darwin/test/MGLClockDirectionFormatterTests.m
@@ -49,6 +49,26 @@ static NSString * const MGLTestLocaleIdentifier = @"en-US";
     XCTAssertEqualObjects(@"9:00", [shortFormatter stringFromDirection:direction]);
     XCTAssertEqualObjects(@"9 o’clock", [mediumFormatter stringFromDirection:direction]);
     XCTAssertEqualObjects(@"9 o’clock", [longFormatter stringFromDirection:direction]);
+    
+    direction = 359.34951805867024;
+    XCTAssertEqualObjects(@"12:00", [shortFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"12 o’clock", [mediumFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"12 o’clock", [longFormatter stringFromDirection:direction]);
+    
+    direction = 360;
+    XCTAssertEqualObjects(@"12:00", [shortFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"12 o’clock", [mediumFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"12 o’clock", [longFormatter stringFromDirection:direction]);
+    
+    direction = 360.1;
+    XCTAssertEqualObjects(@"12:00", [shortFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"12 o’clock", [mediumFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"12 o’clock", [longFormatter stringFromDirection:direction]);
+    
+    direction = 720;
+    XCTAssertEqualObjects(@"12:00", [shortFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"12 o’clock", [mediumFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"12 o’clock", [longFormatter stringFromDirection:direction]);
 }
 
 @end

--- a/platform/darwin/test/MGLCompassDirectionFormatterTests.m
+++ b/platform/darwin/test/MGLCompassDirectionFormatterTests.m
@@ -64,7 +64,17 @@
     XCTAssertEqualObjects(@"west", [mediumFormatter stringFromDirection:direction]);
     XCTAssertEqualObjects(@"west", [longFormatter stringFromDirection:direction]);
     
+    direction = 359.34951805867024;
+    XCTAssertEqualObjects(@"N", [shortFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"north", [mediumFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"north", [longFormatter stringFromDirection:direction]);
+    
     direction = 360;
+    XCTAssertEqualObjects(@"N", [shortFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"north", [mediumFormatter stringFromDirection:direction]);
+    XCTAssertEqualObjects(@"north", [longFormatter stringFromDirection:direction]);
+    
+    direction = 360.1;
     XCTAssertEqualObjects(@"N", [shortFormatter stringFromDirection:direction]);
     XCTAssertEqualObjects(@"north", [mediumFormatter stringFromDirection:direction]);
     XCTAssertEqualObjects(@"north", [longFormatter stringFromDirection:direction]);


### PR DESCRIPTION
Fixed an issue causing angles that are multiples of 360°, such as 720°, to be described as 0 o’clock. Fixed a crash when a compass direction is close enough to 360° to round up to 360°.