### PR TITLE
[build] Bump Travis Qt5 version from 5.0.2 to 5.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 git:
   submodules: false
 
@@ -17,15 +15,12 @@ addons_shortcuts:
                   'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
   addons_qt4: &qt4
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'ubuntu-sdk-team' ]
-      packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev',
-                  'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils', 'qt4-default' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'mesa-utils', 'qt4-default' ]
   addons_qt5: &qt5
     apt:
-      sources: [ 'ubuntu-toolchain-r-test', 'ubuntu-sdk-team' ]
-      packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev',
-                  'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils',
-                  'qt5-default', 'libqt5opengl5-dev' ]
+      sources: [ 'ubuntu-toolchain-r-test' ]
+      packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'mesa-utils', 'qt5-default', 'libqt5opengl5-dev' ]
 
 env:
   global:
@@ -52,7 +47,9 @@ after_script:
 matrix:
   include:
     # Clang 3.5 - Release - Node
-    - language: node
+    - os: linux
+      sudo: false
+      language: node
       compiler: ": node4-clang35-release"
       env: BUILDTYPE=Release _CXX=clang++-3.5 _CC=clang-3.5
       addons: *clang35
@@ -66,7 +63,9 @@ matrix:
         - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER} ${TRAVIS_TAG:-}
 
     # GCC 4.9 - Debug - Coverage
-    - language: cpp
+    - os: linux
+      sudo: false
+      language: cpp
       compiler: ": linux-gcc49-debug"
       env: BUILDTYPE=Debug _CXX=g++-4.9 _CC=gcc-4.9 ENABLE_COVERAGE=1
       addons: *gcc49
@@ -75,25 +74,33 @@ matrix:
         - ./platform/linux/scripts/coveralls.sh
 
     # GCC 4.9 - Release
-    - language: cpp
+    - os: linux
+      sudo: false
+      language: cpp
       compiler: ": linux-gcc49-release"
       env: BUILDTYPE=Release _CXX=g++-4.9 _CC=gcc-4.9
       addons: *gcc49
 
     # Clang 3.5 - Debug
-    - language: cpp
+    - os: linux
+      sudo: false
+      language: cpp
       compiler: ": linux-clang35-debug"
       env: BUILDTYPE=Debug _CXX=clang++-3.5 _CC=clang-3.5
       addons: *clang35
 
     # Clang 3.5 - Release
-    - language: cpp
+    - os: linux
+      sudo: false
+      language: cpp
       compiler: ": linux-clang35-release"
       env: BUILDTYPE=Release _CXX=clang++-3.5 _CC=clang-3.5
       addons: *clang35
 
     # Qt 4 - Release
-    - language: cpp
+    - os: linux
+      sudo: false
+      language: cpp
       compiler: ": linux-gcc49-release"
       env: FLAVOR=qt4 BUILDTYPE=Release _CXX=g++-4.9 _CC=gcc-4.9
       addons: *qt4
@@ -101,7 +108,10 @@ matrix:
         - make qt-app test-qt
 
     # Qt 5 - Release
-    - language: cpp
+    - os: linux
+      sudo: required
+      dist: trusty
+      language: cpp
       compiler: ": linux-gcc49-release"
       env: FLAVOR=qt5 BUILDTYPE=Release _CXX=g++-4.9 _CC=gcc-4.9
       addons: *qt5


### PR DESCRIPTION
We plan to use [QQuickFramebufferObject](http://doc.qt.io/qt-5/qquickframebufferobject.html) as a base class to implement our Qt Quick item. This class has been provided by Qt Framework since Qt 5.2. Travis CI provides Qt 5.0.2 as part of `ubuntu-sdk-team` PPA which we currently use.

We need to find another PPA that provides a Qt version that is at least 5.2 to be able to build and run tests in our Qt Quick implementation.

/cc @tmpsantos 
