### PR TITLE
Update frame size when changing dot/puck mode

### DIFF
--- a/platform/ios/src/MGLUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLUserLocationAnnotationView.m
@@ -181,6 +181,22 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
     }
 }
 
+- (void)updateFrameWithSize:(CGFloat)size
+{
+    CGSize newSize = CGSizeMake(size, size);
+    if (CGSizeEqualToSize(self.frame.size, newSize))
+    {
+        return;
+    }
+
+    // Update frame size, keeping the existing center point.
+    CGPoint oldCenter = self.center;
+    CGRect newFrame = self.frame;
+    newFrame.size = newSize;
+    [self setFrame:newFrame];
+    [self setCenter:oldCenter];
+}
+
 - (void)drawPuck
 {
     if ( ! _puckModeActivated)
@@ -193,6 +209,8 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
         _haloLayer = nil;
         _dotBorderLayer = nil;
         _dotLayer = nil;
+
+        [self updateFrameWithSize:MGLUserLocationAnnotationPuckSize];
     }
 
     // background dot (white with black shadow)
@@ -268,6 +286,8 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
 
         _puckDot = nil;
         _puckArrow = nil;
+
+        [self updateFrameWithSize:MGLUserLocationAnnotationDotSize];
     }
     
     BOOL showHeadingIndicator = _mapView.userTrackingMode == MGLUserTrackingModeFollowWithHeading;


### PR DESCRIPTION
![dotpuck](https://cloud.githubusercontent.com/assets/1198851/14797819/940e9fb4-0b02-11e6-9345-4618d97ad9da.png)

The user dot/puck was keeping whichever frame size it was initialized with. This had no apparent ill effects, except that the accessibility frame would be incorrect when the user location annotation type changed.

- Updates the accessibility frame (by proxy) when changing between dot and puck
- Keeps the same center point while updating the frame
- `updateFrameWithSize:` does not take CGSize because there is not yet
  support for non-square user location annotations

Fixes #4823.

/cc @1ec5