### PR TITLE
[core] Define mbgl::variant

### DIFF
--- a/include/mbgl/annotation/shape_annotation.hpp
+++ b/include/mbgl/annotation/shape_annotation.hpp
@@ -5,8 +5,7 @@
 #include <mbgl/style/types.hpp>
 
 #include <mbgl/util/geo.hpp>
-
-#include <mapbox/variant.hpp>
+#include <mbgl/util/variant.hpp>
 
 namespace mbgl {
 
@@ -27,7 +26,7 @@ struct LineAnnotationProperties {
 
 class ShapeAnnotation {
 public:
-    using Properties = mapbox::util::variant<
+    using Properties = variant<
         FillAnnotationProperties, // creates a fill annotation
         LineAnnotationProperties, // creates a line annotation
         std::string>; // creates an annotation whose type and properties are sourced from a style layer

--- a/src/mbgl/sprite/sprite_parser.hpp
+++ b/src/mbgl/sprite/sprite_parser.hpp
@@ -1,10 +1,9 @@
 #ifndef MBGL_SPRITE_PARSER
 #define MBGL_SPRITE_PARSER
 
-#include <mapbox/variant.hpp>
-
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/variant.hpp>
 #include <mbgl/util/geo.hpp>
 
 #include <string>
@@ -29,7 +28,7 @@ SpriteImagePtr createSpriteImage(const PremultipliedImage&,
 using Sprites = std::map<std::string, SpriteImagePtr>;
 
 
-using SpriteParseResult = mapbox::util::variant<
+using SpriteParseResult = variant<
     Sprites,             // success
     std::exception_ptr>; // error
 

--- a/src/mbgl/style/filter_expression.hpp
+++ b/src/mbgl/style/filter_expression.hpp
@@ -9,7 +9,7 @@
 
 namespace mbgl {
 
-typedef mapbox::util::variant<
+typedef variant<
     struct NullExpression,
     struct EqualsExpression,
     struct NotEqualsExpression,

--- a/src/mbgl/style/value.hpp
+++ b/src/mbgl/style/value.hpp
@@ -1,7 +1,7 @@
 #ifndef MBGL_STYLE_VALUE
 #define MBGL_STYLE_VALUE
 
-#include <mapbox/variant.hpp>
+#include <mbgl/util/variant.hpp>
 #include <mbgl/util/rapidjson.hpp>
 
 #include <cstdlib>
@@ -9,7 +9,7 @@
 
 namespace mbgl {
 
-typedef mapbox::util::variant<bool, int64_t, uint64_t, double, std::string> Value;
+typedef variant<bool, int64_t, uint64_t, double, std::string> Value;
 
 std::string toString(const Value &value);
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -1,14 +1,13 @@
 #ifndef MBGL_MAP_GEOMETRY_TILE
 #define MBGL_MAP_GEOMETRY_TILE
 
-#include <mapbox/variant.hpp>
-
 #include <mbgl/style/value.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/vec.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/variant.hpp>
 #include <mbgl/util/constants.hpp>
 
 #include <cstdint>

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -1,11 +1,10 @@
 #ifndef MBGL_MAP_TILE_WORKER
 #define MBGL_MAP_TILE_WORKER
 
-#include <mapbox/variant.hpp>
-
 #include <mbgl/map/mode.hpp>
 #include <mbgl/tile/tile_data.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/variant.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/text/placement_config.hpp>
 
@@ -34,7 +33,7 @@ public:
     std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
 };
 
-using TileParseResult = mapbox::util::variant<
+using TileParseResult = variant<
     TileParseResultBuckets, // success
     std::exception_ptr>;    // error
 

--- a/src/mbgl/util/variant.hpp
+++ b/src/mbgl/util/variant.hpp
@@ -1,0 +1,13 @@
+#ifndef MBGL_UTIL_VARIANT
+#define MBGL_UTIL_VARIANT
+
+#include <mapbox/variant.hpp>
+
+namespace mbgl {
+
+template <typename... T>
+using variant = mapbox::util::variant<T...>;
+
+} // namespace mbgl
+
+#endif

--- a/src/mbgl/util/worker.hpp
+++ b/src/mbgl/util/worker.hpp
@@ -14,7 +14,7 @@ class AsyncRequest;
 class RasterBucket;
 class GeometryTileLoader;
 
-using RasterTileParseResult = mapbox::util::variant<
+using RasterTileParseResult = variant<
     std::unique_ptr<Bucket>, // success
     std::exception_ptr>;     // error
 


### PR DESCRIPTION
For parallelism with `mbgl::optional`, and to avoid exposing namespaces other than `mbgl` in the public API.