### PR TITLE
use Clock::time_point::max() instead of frame time

### DIFF
--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -175,7 +175,7 @@ void Style::cascade(const TimePoint& timePoint, MapMode mode) {
 
     const StyleCascadeParameters parameters {
         classIDs,
-        timePoint,
+        mode == MapMode::Continuous ? timePoint : Clock::time_point::max(),
         mode == MapMode::Continuous ? transitionProperties.value_or(immediateTransition) : immediateTransition
     };
 
@@ -195,7 +195,7 @@ void Style::recalculate(float z, const TimePoint& timePoint, MapMode mode) {
 
     const StyleCalculationParameters parameters {
         z,
-        timePoint,
+        mode == MapMode::Continuous ? timePoint : Clock::time_point::max(),
         zoomHistory,
         mode == MapMode::Continuous ? util::DEFAULT_FADE_DURATION : Duration::zero()
     };


### PR DESCRIPTION
For `Style::cascade` and `Style::recalculate`, when rendering with `MapMode::Still`. Fixes a subtle race condition with animated transitions exacerbated by cd1a06c2dc209da81b3d745c088e568b3b14809f.

/cc @brunoabinader @bsudekum @miccolis