### PR TITLE
iosapp UI tests

### DIFF
--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -91,7 +91,7 @@ To instead run the tests in Xcode:
 
 1. Run `make iproj` to set up the workspace.
 1. Change the scheme to “test (platform project)” and press Command-R to run core unit tests.
-1. Change the scheme to “CI” and press Command-U to run SDK integration tests.
+1. Change the scheme to “iosapp” and press Command-U to run SDK unit and UI tests.
 
 ## Access tokens
 

--- a/platform/ios/app/MBXAppDelegate.m
+++ b/platform/ios/app/MBXAppDelegate.m
@@ -22,6 +22,11 @@ NSString * const MBXMapboxAccessTokenDefaultsKey = @"MBXMapboxAccessToken";
         }
         [MGLAccountManager setAccessToken:accessToken];
     }
+    
+    // Speed things up if we’re being run by a UI test bundle.
+    if ([[[NSProcessInfo processInfo] environment][@"MAPBOX_DISABLE_ANIMATIONS"] boolValue]) {
+        [UIView setAnimationsEnabled:NO];
+    }
 
     return YES;
 }

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -10,11 +10,26 @@
 #import <OpenGLES/ES2/gl.h>
 #import <objc/runtime.h>
 
-static const CLLocationCoordinate2D WorldTourDestinations[] = {
-    { .latitude = 38.9131982, .longitude = -77.0325453144239 },
-    { .latitude = 37.7757368, .longitude = -122.4135302 },
-    { .latitude = 12.9810816, .longitude = 77.6368034 },
-    { .latitude = -13.15589555, .longitude = -74.2178961777998 },
+static const struct {
+    const char *name;
+    CLLocationCoordinate2D coordinate;
+} WorldTourDestinations[] = {
+    {
+        .name = "Washington, D.C.",
+        .coordinate = { .latitude = 38.9131982, .longitude = -77.0325453144239 },
+    },
+    {
+        .name = "San Francisco",
+        .coordinate = { .latitude = 37.7757368, .longitude = -122.4135302 },
+    },
+    {
+        .name = "Bangalore",
+        .coordinate = { .latitude = 12.9810816, .longitude = 77.6368034 },
+    },
+    {
+        .name = "Ayacucho",
+        .coordinate = { .latitude = -13.15589555, .longitude = -74.2178961777998 },
+    },
 };
 
 @interface MBXDroppedPinAnnotation : MGLPointAnnotation
@@ -554,7 +569,8 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     for (NSUInteger i = 0; i < numberOfAnnotations; i++)
     {
         MBXDroppedPinAnnotation *annotation = [[MBXDroppedPinAnnotation alloc] init];
-        annotation.coordinate = WorldTourDestinations[i];
+        annotation.title = @(WorldTourDestinations[i].name);
+        annotation.coordinate = WorldTourDestinations[i].coordinate;
         [annotations addObject:annotation];
     }
     [self.mapView addAnnotations:annotations];

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -136,6 +136,10 @@ static const struct {
 
 - (void)restoreState:(__unused NSNotification *)notification
 {
+    if ([[[NSProcessInfo processInfo] environment][@"MAPBOX_CLEAN_START"] boolValue]) {
+        return;
+    }
+    
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSData *archivedCamera = [defaults objectForKey:@"MBXCamera"];
     MGLMapCamera *camera = archivedCamera ? [NSKeyedUnarchiver unarchiveObjectWithData:archivedCamera] : nil;

--- a/platform/ios/app/Main.storyboard
+++ b/platform/ios/app/Main.storyboard
@@ -60,6 +60,8 @@
                             <barButtonItem image="TrackingLocationOffMask.png" id="CQ1-GP-M6x" userLabel="User Tracking Mode">
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="User tracking mode"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="MBXUserTrackingModeButton"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityValue" value="Off"/>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="locateUser:" destination="WaX-pd-UZQ" id="XgF-DB-z3f"/>
@@ -68,6 +70,7 @@
                             <barButtonItem systemItem="organize" id="5IK-vz-jKQ" userLabel="Offline Packs">
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Offline packs"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="MBXOfflinePacksButton"/>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
                                     <segue destination="7q0-lI-zqb" kind="show" identifier="ShowOfflinePacks" id="xjx-0t-0LD"/>

--- a/platform/ios/app/Main.storyboard
+++ b/platform/ios/app/Main.storyboard
@@ -41,6 +41,7 @@
                         <barButtonItem key="leftBarButtonItem" image="settings.png" id="Jw8-JP-CaZ" userLabel="Map Settings">
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Map settings"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="MBXSettingsButton"/>
                             </userDefinedRuntimeAttributes>
                             <connections>
                                 <action selector="showSettings:" destination="WaX-pd-UZQ" id="X2C-Ee-Qvt"/>
@@ -174,6 +175,9 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="ONr-CS-J5X">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="MBXNavigationBar"/>
+                        </userDefinedRuntimeAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		DAC49C5C1CD02BC9009E1AA3 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DAC49C5F1CD02BC9009E1AA3 /* Localizable.stringsdict */; };
 		DAC49C5D1CD02BC9009E1AA3 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DAC49C5F1CD02BC9009E1AA3 /* Localizable.stringsdict */; };
 		DAC49C611CD03A96009E1AA3 /* MGLUITestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = DAC49C601CD03A96009E1AA3 /* MGLUITestCase.m */; };
+		DAC49C641CD1678F009E1AA3 /* MGLUserLocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAC49C631CD1678F009E1AA3 /* MGLUserLocationTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -479,8 +480,9 @@
 		DABCABBF1CB80717000A7C39 /* locations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = locations.cpp; sourceTree = "<group>"; };
 		DABCABC01CB80717000A7C39 /* locations.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = locations.hpp; sourceTree = "<group>"; };
 		DAC07C961CBB2CD6000CB309 /* mbgl.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = mbgl.xcconfig; path = ../../build/ios/mbgl.xcconfig; sourceTree = "<group>"; };
-		DAC49C621CD07D74009E1AA3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DAC49C601CD03A96009E1AA3 /* MGLUITestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLUITestCase.m; sourceTree = "<group>"; };
+		DAC49C621CD07D74009E1AA3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DAC49C631CD1678F009E1AA3 /* MGLUserLocationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLUserLocationTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -649,6 +651,7 @@
 				DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */,
 				DA6A65961CCF429800F21F6B /* MGLGestureTests.m */,
 				DA6A65B81CCF5DB900F21F6B /* MGLTelemetryTests.m */,
+				DAC49C631CD1678F009E1AA3 /* MGLUserLocationTests.m */,
 				DA4A0DF11CCE82500045352A /* Info.plist */,
 			);
 			name = "UI Tests";
@@ -1312,6 +1315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAC49C641CD1678F009E1AA3 /* MGLUserLocationTests.m in Sources */,
 				DAC49C611CD03A96009E1AA3 /* MGLUITestCase.m in Sources */,
 				DA6A65971CCF429800F21F6B /* MGLGestureTests.m in Sources */,
 				DA6A65B91CCF5DB900F21F6B /* MGLTelemetryTests.m in Sources */,

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		DA35A2CC1CCAAAD200E826B2 /* NSValue+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35A2C81CCAAAD200E826B2 /* NSValue+MGLAdditions.m */; };
 		DA4A0DF01CCE82500045352A /* MGLAnnotationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */; };
 		DA6A65971CCF429800F21F6B /* MGLGestureTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6A65961CCF429800F21F6B /* MGLGestureTests.m */; };
+		DA6A65B71CCF583C00F21F6B /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
+		DA6A65B91CCF5DB900F21F6B /* MGLTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6A65B81CCF5DB900F21F6B /* MGLTelemetryTests.m */; };
 		DA821D061CCC6D59007508D4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA821D041CCC6D59007508D4 /* LaunchScreen.storyboard */; };
 		DA821D071CCC6D59007508D4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA821D051CCC6D59007508D4 /* Main.storyboard */; };
 		DA8847D91CBAF91600AB86E3 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
@@ -359,6 +361,7 @@
 		DA4A26961CB6E795000B7809 /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mapbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA6A65961CCF429800F21F6B /* MGLGestureTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLGestureTests.m; sourceTree = "<group>"; };
 		DA6A65981CCF42FE00F21F6B /* MGLUITests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLUITests.h; sourceTree = "<group>"; };
+		DA6A65B81CCF5DB900F21F6B /* MGLTelemetryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLTelemetryTests.m; sourceTree = "<group>"; };
 		DA821D041CCC6D59007508D4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DA821D051CCC6D59007508D4 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		DA8847D21CBAF91600AB86E3 /* Mapbox.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mapbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -499,6 +502,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA6A65B71CCF583C00F21F6B /* Mapbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -641,6 +645,7 @@
 				DA6A65981CCF42FE00F21F6B /* MGLUITests.h */,
 				DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */,
 				DA6A65961CCF429800F21F6B /* MGLGestureTests.m */,
+				DA6A65B81CCF5DB900F21F6B /* MGLTelemetryTests.m */,
 				DA4A0DF11CCE82500045352A /* Info.plist */,
 			);
 			name = "UI Tests";
@@ -1305,6 +1310,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA6A65971CCF429800F21F6B /* MGLGestureTests.m in Sources */,
+				DA6A65B91CCF5DB900F21F6B /* MGLTelemetryTests.m in Sources */,
 				DA4A0DF01CCE82500045352A /* MGLAnnotationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		DA35A2CB1CCAAAD200E826B2 /* NSValue+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35A2C81CCAAAD200E826B2 /* NSValue+MGLAdditions.m */; };
 		DA35A2CC1CCAAAD200E826B2 /* NSValue+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35A2C81CCAAAD200E826B2 /* NSValue+MGLAdditions.m */; };
 		DA4A0DF01CCE82500045352A /* MGLAnnotationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */; };
+		DA6A65971CCF429800F21F6B /* MGLGestureTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6A65961CCF429800F21F6B /* MGLGestureTests.m */; };
 		DA821D061CCC6D59007508D4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA821D041CCC6D59007508D4 /* LaunchScreen.storyboard */; };
 		DA821D071CCC6D59007508D4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA821D051CCC6D59007508D4 /* Main.storyboard */; };
 		DA8847D91CBAF91600AB86E3 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
@@ -356,6 +357,8 @@
 		DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLAnnotationTests.m; sourceTree = "<group>"; };
 		DA4A0DF11CCE82500045352A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA4A26961CB6E795000B7809 /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mapbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA6A65961CCF429800F21F6B /* MGLGestureTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLGestureTests.m; sourceTree = "<group>"; };
+		DA6A65981CCF42FE00F21F6B /* MGLUITests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLUITests.h; sourceTree = "<group>"; };
 		DA821D041CCC6D59007508D4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DA821D051CCC6D59007508D4 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		DA8847D21CBAF91600AB86E3 /* Mapbox.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mapbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -536,7 +539,7 @@
 				DABCABA91CB80692000A7C39 /* Benchmarking App */,
 				DA8847D31CBAF91600AB86E3 /* SDK */,
 				DA2E88521CC036F400F24E7B /* SDK Tests */,
-				DA4A0DEE1CCE82500045352A /* uitest */,
+				DA4A0DEE1CCE82500045352A /* UI Tests */,
 				DA1DC9921CB6DF24006E619F /* Frameworks */,
 				DAC07C951CBB2CAD000CB309 /* Configuration */,
 				DA1DC94B1CB6C1C2006E619F /* Products */,
@@ -632,12 +635,15 @@
 			path = test;
 			sourceTree = "<group>";
 		};
-		DA4A0DEE1CCE82500045352A /* uitest */ = {
+		DA4A0DEE1CCE82500045352A /* UI Tests */ = {
 			isa = PBXGroup;
 			children = (
+				DA6A65981CCF42FE00F21F6B /* MGLUITests.h */,
 				DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */,
+				DA6A65961CCF429800F21F6B /* MGLGestureTests.m */,
 				DA4A0DF11CCE82500045352A /* Info.plist */,
 			);
+			name = "UI Tests";
 			path = uitest;
 			sourceTree = "<group>";
 		};
@@ -1298,6 +1304,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA6A65971CCF429800F21F6B /* MGLGestureTests.m in Sources */,
 				DA4A0DF01CCE82500045352A /* MGLAnnotationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		DA35A2CA1CCAAAD200E826B2 /* NSValue+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DA35A2C71CCAAAD200E826B2 /* NSValue+MGLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA35A2CB1CCAAAD200E826B2 /* NSValue+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35A2C81CCAAAD200E826B2 /* NSValue+MGLAdditions.m */; };
 		DA35A2CC1CCAAAD200E826B2 /* NSValue+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DA35A2C81CCAAAD200E826B2 /* NSValue+MGLAdditions.m */; };
+		DA4A0DF01CCE82500045352A /* MGLAnnotationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */; };
 		DA821D061CCC6D59007508D4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA821D041CCC6D59007508D4 /* LaunchScreen.storyboard */; };
 		DA821D071CCC6D59007508D4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA821D051CCC6D59007508D4 /* Main.storyboard */; };
 		DA8847D91CBAF91600AB86E3 /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8847D21CBAF91600AB86E3 /* Mapbox.framework */; };
@@ -253,6 +254,13 @@
 			remoteGlobalIDString = DA8847D11CBAF91600AB86E3;
 			remoteInfo = dynamic;
 		};
+		DA4A0DF21CCE82500045352A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA1DC9421CB6C1C2006E619F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA1DC9491CB6C1C2006E619F;
+			remoteInfo = iosapp;
+		};
 		DA8847D71CBAF91600AB86E3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DA1DC9421CB6C1C2006E619F /* Project object */;
@@ -344,6 +352,9 @@
 		DA35A2C71CCAAAD200E826B2 /* NSValue+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSValue+MGLAdditions.h"; sourceTree = "<group>"; };
 		DA35A2C81CCAAAD200E826B2 /* NSValue+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSValue+MGLAdditions.m"; sourceTree = "<group>"; };
 		DA35A2D11CCAB25200E826B2 /* jazzy.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = jazzy.yml; sourceTree = "<group>"; };
+		DA4A0DED1CCE82500045352A /* uitest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = uitest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MGLAnnotationTests.m; sourceTree = "<group>"; };
+		DA4A0DF11CCE82500045352A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA4A26961CB6E795000B7809 /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mapbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA821D041CCC6D59007508D4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DA821D051CCC6D59007508D4 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
@@ -481,6 +492,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DA4A0DEA1CCE82500045352A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA8847CE1CBAF91600AB86E3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -518,6 +536,7 @@
 				DABCABA91CB80692000A7C39 /* Benchmarking App */,
 				DA8847D31CBAF91600AB86E3 /* SDK */,
 				DA2E88521CC036F400F24E7B /* SDK Tests */,
+				DA4A0DEE1CCE82500045352A /* uitest */,
 				DA1DC9921CB6DF24006E619F /* Frameworks */,
 				DAC07C951CBB2CAD000CB309 /* Configuration */,
 				DA1DC94B1CB6C1C2006E619F /* Products */,
@@ -534,6 +553,7 @@
 				DA2E88511CC036F400F24E7B /* test.xctest */,
 				DA8933D51CCD306400E68420 /* Mapbox.bundle */,
 				DA25D5B91CCD9EDE00607828 /* Settings.bundle */,
+				DA4A0DED1CCE82500045352A /* uitest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -610,6 +630,15 @@
 			);
 			name = "SDK Tests";
 			path = test;
+			sourceTree = "<group>";
+		};
+		DA4A0DEE1CCE82500045352A /* uitest */ = {
+			isa = PBXGroup;
+			children = (
+				DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */,
+				DA4A0DF11CCE82500045352A /* Info.plist */,
+			);
+			path = uitest;
 			sourceTree = "<group>";
 		};
 		DA8847D31CBAF91600AB86E3 /* SDK */ = {
@@ -983,6 +1012,24 @@
 			productReference = DA2E88511CC036F400F24E7B /* test.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		DA4A0DEC1CCE82500045352A /* uitest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA4A0DF61CCE82500045352A /* Build configuration list for PBXNativeTarget "uitest" */;
+			buildPhases = (
+				DA4A0DE91CCE82500045352A /* Sources */,
+				DA4A0DEA1CCE82500045352A /* Frameworks */,
+				DA4A0DEB1CCE82500045352A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA4A0DF31CCE82500045352A /* PBXTargetDependency */,
+			);
+			name = uitest;
+			productName = uitest;
+			productReference = DA4A0DED1CCE82500045352A /* uitest.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		DA8847D11CBAF91600AB86E3 /* dynamic */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA8847DD1CBAF91600AB86E3 /* Build configuration list for PBXNativeTarget "dynamic" */;
@@ -1075,6 +1122,10 @@
 					DA2E88501CC036F400F24E7B = {
 						CreatedOnToolsVersion = 7.3;
 					};
+					DA4A0DEC1CCE82500045352A = {
+						CreatedOnToolsVersion = 7.3;
+						TestTargetID = DA1DC9491CB6C1C2006E619F;
+					};
 					DA8847D11CBAF91600AB86E3 = {
 						CreatedOnToolsVersion = 7.3;
 					};
@@ -1109,6 +1160,7 @@
 				DA8933D41CCD306400E68420 /* bundle */,
 				DA25D5B81CCD9EDE00607828 /* settings */,
 				DA2E88501CC036F400F24E7B /* test */,
+				DA4A0DEC1CCE82500045352A /* uitest */,
 			);
 		};
 /* End PBXProject section */
@@ -1139,6 +1191,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		DA2E884F1CC036F400F24E7B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA4A0DEB1CCE82500045352A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1232,6 +1291,14 @@
 				DA35A2C51CCA9F8300E826B2 /* MGLClockDirectionFormatterTests.m in Sources */,
 				DA2E88621CC0382C00F24E7B /* MGLOfflinePackTests.m in Sources */,
 				DA35A2AA1CCA058D00E826B2 /* MGLCoordinateFormatterTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA4A0DE91CCE82500045352A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA4A0DF01CCE82500045352A /* MGLAnnotationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1342,6 +1409,11 @@
 			isa = PBXTargetDependency;
 			target = DA8847D11CBAF91600AB86E3 /* dynamic */;
 			targetProxy = DA2E88571CC036F400F24E7B /* PBXContainerItemProxy */;
+		};
+		DA4A0DF31CCE82500045352A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA1DC9491CB6C1C2006E619F /* iosapp */;
+			targetProxy = DA4A0DF21CCE82500045352A /* PBXContainerItemProxy */;
 		};
 		DA8847D81CBAF91600AB86E3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1567,6 +1639,32 @@
 			};
 			name = Release;
 		};
+		DA4A0DF41CCE82500045352A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				INFOPLIST_FILE = uitest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.uitest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = iosapp;
+			};
+			name = Debug;
+		};
+		DA4A0DF51CCE82500045352A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				INFOPLIST_FILE = uitest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.uitest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = iosapp;
+			};
+			name = Release;
+		};
 		DA8847DB1CBAF91600AB86E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DAC07C961CBB2CD6000CB309 /* mbgl.xcconfig */;
@@ -1788,6 +1886,15 @@
 			buildConfigurations = (
 				DA2E885A1CC036F400F24E7B /* Debug */,
 				DA2E885B1CC036F400F24E7B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA4A0DF61CCE82500045352A /* Build configuration list for PBXNativeTarget "uitest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA4A0DF41CCE82500045352A /* Debug */,
+				DA4A0DF51CCE82500045352A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		DABFB8731CBE9A9900D62B32 /* Mapbox.h in Headers */ = {isa = PBXBuildFile; fileRef = DA88485E1CBAFC2E00AB86E3 /* Mapbox.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAC49C5C1CD02BC9009E1AA3 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DAC49C5F1CD02BC9009E1AA3 /* Localizable.stringsdict */; };
 		DAC49C5D1CD02BC9009E1AA3 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = DAC49C5F1CD02BC9009E1AA3 /* Localizable.stringsdict */; };
+		DAC49C611CD03A96009E1AA3 /* MGLUITestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = DAC49C601CD03A96009E1AA3 /* MGLUITestCase.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -360,7 +361,7 @@
 		DA4A0DF11CCE82500045352A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA4A26961CB6E795000B7809 /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mapbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA6A65961CCF429800F21F6B /* MGLGestureTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLGestureTests.m; sourceTree = "<group>"; };
-		DA6A65981CCF42FE00F21F6B /* MGLUITests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLUITests.h; sourceTree = "<group>"; };
+		DA6A65981CCF42FE00F21F6B /* MGLUITestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLUITestCase.h; sourceTree = "<group>"; };
 		DA6A65B81CCF5DB900F21F6B /* MGLTelemetryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLTelemetryTests.m; sourceTree = "<group>"; };
 		DA821D041CCC6D59007508D4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DA821D051CCC6D59007508D4 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
@@ -479,6 +480,7 @@
 		DABCABC01CB80717000A7C39 /* locations.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = locations.hpp; sourceTree = "<group>"; };
 		DAC07C961CBB2CD6000CB309 /* mbgl.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = mbgl.xcconfig; path = ../../build/ios/mbgl.xcconfig; sourceTree = "<group>"; };
 		DAC49C621CD07D74009E1AA3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DAC49C601CD03A96009E1AA3 /* MGLUITestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLUITestCase.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -642,7 +644,8 @@
 		DA4A0DEE1CCE82500045352A /* UI Tests */ = {
 			isa = PBXGroup;
 			children = (
-				DA6A65981CCF42FE00F21F6B /* MGLUITests.h */,
+				DA6A65981CCF42FE00F21F6B /* MGLUITestCase.h */,
+				DAC49C601CD03A96009E1AA3 /* MGLUITestCase.m */,
 				DA4A0DEF1CCE82500045352A /* MGLAnnotationTests.m */,
 				DA6A65961CCF429800F21F6B /* MGLGestureTests.m */,
 				DA6A65B81CCF5DB900F21F6B /* MGLTelemetryTests.m */,
@@ -1309,6 +1312,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAC49C611CD03A96009E1AA3 /* MGLUITestCase.m in Sources */,
 				DA6A65971CCF429800F21F6B /* MGLGestureTests.m in Sources */,
 				DA6A65B91CCF5DB900F21F6B /* MGLTelemetryTests.m in Sources */,
 				DA4A0DF01CCE82500045352A /* MGLAnnotationTests.m in Sources */,

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
@@ -66,6 +66,16 @@
                ReferencedContainer = "container:ios.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA4A0DEC1CCE82500045352A"
+               BuildableName = "uitest.xctest"
+               BlueprintName = "uitest"
+               ReferencedContainer = "container:ios.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/dynamic.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/dynamic.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
@@ -33,6 +33,16 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA2E88501CC036F400F24E7B"
+               BuildableName = "test.xctest"
+               BlueprintName = "test"
+               ReferencedContainer = "container:ios.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "DA4A0DEC1CCE82500045352A"
                BuildableName = "uitest.xctest"
                BlueprintName = "uitest"

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
@@ -26,8 +26,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA4A0DEC1CCE82500045352A"
+               BuildableName = "uitest.xctest"
+               BlueprintName = "uitest"
+               ReferencedContainer = "container:ios.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0730"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -48,6 +48,10 @@
                BlueprintName = "uitest"
                ReferencedContainer = "container:ios.xcodeproj">
             </BuildableReference>
+            <LocationScenarioReference
+               identifier = "San Francisco, CA, USA"
+               referenceType = "1">
+            </LocationScenarioReference>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -148,6 +148,11 @@ mbgl::Color MGLColorObjectFromUIColor(UIColor *color)
     return self;
 }
 
+- (NSString *)accessibilityIdentifier
+{
+    return [NSString stringWithFormat:@"MGLMapViewAnnotation %d", self.tag];
+}
+
 - (void)accessibilityIncrement
 {
     [self.accessibilityContainer accessibilityIncrement];
@@ -181,6 +186,7 @@ public:
     if (self = [super initWithAccessibilityContainer:container])
     {
         self.accessibilityTraits = UIAccessibilityTraitButton;
+        self.accessibilityIdentifier = NSStringFromClass([self class]);
         self.accessibilityLabel = [self.accessibilityContainer accessibilityLabel];
         self.accessibilityHint = @"Returns to the map";
     }
@@ -361,6 +367,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     // setup accessibility
     //
 //    self.isAccessibilityElement = YES;
+    self.accessibilityIdentifier = NSStringFromClass([self class]);
     self.accessibilityLabel = NSLocalizedStringWithDefaultValue(@"MAP_A11Y_LABEL", nil, nil, @"Map", @"Accessibility label");
     self.accessibilityTraits = UIAccessibilityTraitAllowsDirectInteraction | UIAccessibilityTraitAdjustable;
     _accessibilityCompassFormatter = [[MGLCompassDirectionFormatter alloc] init];
@@ -410,6 +417,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     //
     UIImage *logo = [[MGLMapView resourceImageNamed:@"mapbox.png"] imageWithAlignmentRectInsets:UIEdgeInsetsMake(1.5, 4, 3.5, 2)];
     _logoView = [[UIImageView alloc] initWithImage:logo];
+    _logoView.accessibilityIdentifier = @"MGLMapViewLogo";
     _logoView.accessibilityTraits = UIAccessibilityTraitStaticText;
     _logoView.accessibilityLabel = NSLocalizedStringWithDefaultValue(@"LOGO_A11Y_LABEL", nil, nil, @"Mapbox", @"Accessibility label");
     _logoView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -419,6 +427,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     // setup attribution
     //
     _attributionButton = [UIButton buttonWithType:UIButtonTypeInfoLight];
+    _attributionButton.accessibilityIdentifier = @"MGLMapViewInfo";
     _attributionButton.accessibilityLabel = NSLocalizedStringWithDefaultValue(@"INFO_A11Y_LABEL", nil, nil, @"About this map", @"Accessibility label");
     _attributionButton.accessibilityHint = NSLocalizedStringWithDefaultValue(@"INFO_A11Y_HINT", nil, nil, @"Shows credits, a feedback form, and more", @"Accessibility hint");
     [_attributionButton addTarget:self action:@selector(showAttribution) forControlEvents:UIControlEventTouchUpInside];
@@ -435,6 +444,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     _compassView.userInteractionEnabled = YES;
     [_compassView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleCompassTapGesture:)]];
     _compassView.accessibilityTraits = UIAccessibilityTraitButton;
+    _compassView.accessibilityIdentifier = @"MGLMapViewCompass";
     _compassView.accessibilityLabel = NSLocalizedStringWithDefaultValue(@"COMPASS_A11Y_LABEL", nil, nil, @"Compass", @"Accessibility label");
     _compassView.accessibilityHint = NSLocalizedStringWithDefaultValue(@"COMPASS_A11Y_HINT", nil, nil, @"Rotates the map to face due north", @"Accessibility hint");
     UIView *container = [[UIView alloc] initWithFrame:CGRectZero];

--- a/platform/ios/src/MGLUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLUserLocationAnnotationView.m
@@ -76,6 +76,11 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
     return !self.hidden;
 }
 
+- (NSString *)accessibilityIdentifier
+{
+    return NSStringFromClass([self class]);
+}
+
 - (NSString *)accessibilityLabel
 {
     return self.annotation.title;

--- a/platform/ios/uitest/Info.plist
+++ b/platform/ios/uitest/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/platform/ios/uitest/MGLAnnotationTests.m
+++ b/platform/ios/uitest/MGLAnnotationTests.m
@@ -1,0 +1,120 @@
+#import <XCTest/XCTest.h>
+
+@interface MGLAnnotationTests : XCTestCase
+
+@end
+
+@implementation MGLAnnotationTests
+
+- (void)setUp {
+    [super setUp];
+    
+    self.continueAfterFailure = NO;
+    
+    [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
+    [[[XCUIApplication alloc] init] launch];
+}
+
+- (void)testDropPin {
+    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    
+    // Drop a pin.
+    XCUIElement *mapProxyElement = mapElement.buttons[@"MGLMapViewProxyAccessibilityElement"];
+    XCTAssertFalse(mapElement.buttons[@"MGLMapViewProxyAccessibilityElement"].exists, @"Map proxy element should be absent until opening callout view.");
+    [self expectationForPredicate:[NSPredicate predicateWithFormat:@"exists == true"] evaluatedWithObject:mapProxyElement handler:nil];
+    [mapElement pressForDuration:1.1];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    // Inspect the callout view.
+    NSString *annotationTitle = @"Dropped Pin";
+    XCUIElement *calloutTitleText = mapElement.staticTexts[annotationTitle];
+    XCTAssertTrue(calloutTitleText.exists, @"Callout title should be present after opening callout.");
+    NSString *annotationSubtitle = @"17°0′56″ south, 0° west";
+    XCUIElement *calloutSubtitleText = mapElement.staticTexts[annotationSubtitle];
+    XCTAssertTrue(calloutSubtitleText.exists, @"Callout subtitle should be present after opening callout.");
+    XCUIElement *calloutLeftAccessoryButton = mapElement.buttons[@"Left"];
+    XCTAssertTrue(calloutLeftAccessoryButton.exists, @"Callout left accessory button should be present after opening callout.");
+    XCUIElement *calloutRightAccessoryButton = mapElement.buttons[@"Right"];
+    XCTAssertTrue(calloutRightAccessoryButton.exists, @"Callout right accessory button should be present after opening callout.");
+    
+    // Close the callout view by tapping on the map proxy element. Note that the map proxy element has a gaping hole in the middle to accommodate the callout view.
+    [self expectationForPredicate:[NSPredicate predicateWithFormat:@"exists == false"] evaluatedWithObject:mapProxyElement handler:nil];
+    XCUICoordinate *coordinate = [[mapProxyElement coordinateWithNormalizedOffset:CGVectorMake(0, 0)] coordinateWithOffset:CGVectorMake(100, 100)];
+    [coordinate tap];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+    
+    XCTAssertFalse(calloutTitleText.exists, @"Callout title should be absent after closing callout.");
+    XCTAssertFalse(calloutSubtitleText.exists, @"Callout subtitle should be absent after closing callout.");
+    XCTAssertFalse(calloutLeftAccessoryButton.exists, @"Callout left accessory button should be absent after closing callout.");
+    XCTAssertFalse(calloutRightAccessoryButton.exists, @"Callout right accessory button should be absent after closing callout.");
+    
+    // Inspect the annotation itself.
+    XCUIElement *annotation = mapElement.buttons[@"MGLMapViewAnnotation 0"];
+    XCTAssertTrue(annotation.exists, @"Annotation accessibility element should be present after closing callout view.");
+    XCTAssertEqualObjects(annotation.label, annotationTitle, @"Annotation label should be title.");
+    XCTAssertEqualObjects(annotation.value, annotationSubtitle, @"Annotation value should be subtitle.");
+}
+
+- (void)testFrameWithGestures {
+    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    
+    // Drop a pin.
+    XCUIElement *mapProxyElement = mapElement.buttons[@"MGLMapViewProxyAccessibilityElement"];
+    [self expectationForPredicate:[NSPredicate predicateWithFormat:@"exists == true"] evaluatedWithObject:mapProxyElement handler:nil];
+    [mapElement pressForDuration:1.1];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    // Close the callout view.
+    [self expectationForPredicate:[NSPredicate predicateWithFormat:@"exists == false"] evaluatedWithObject:mapProxyElement handler:nil];
+    XCUICoordinate *coordinate = [[mapProxyElement coordinateWithNormalizedOffset:CGVectorMake(0, 0)] coordinateWithOffset:CGVectorMake(100, 100)];
+    [coordinate tap];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+    
+    XCUIElement *annotation = mapElement.buttons[@"MGLMapViewAnnotation 0"];
+    CGRect frame = annotation.frame;
+    
+    // Make sure the annotation stays in place when zooming in.
+    [mapElement doubleTap];
+    CGRect frameAfterZoomingIn = annotation.frame;
+    XCTAssertEqualWithAccuracy(frame.origin.x, frameAfterZoomingIn.origin.x, 0.1, @"Annotation moved after zooming in.");
+    XCTAssertEqualWithAccuracy(frame.origin.y, frameAfterZoomingIn.origin.y, 0.1, @"Annotation moved after zooming in.");
+    XCTAssertEqualWithAccuracy(frame.size.width, frameAfterZoomingIn.size.width, 0.1, @"Annotation resized after zooming in.");
+    XCTAssertEqualWithAccuracy(frame.size.height, frameAfterZoomingIn.size.height, 0.1, @"Annotation resized after zooming in.");
+    
+    // Make sure the annotation moves after panning.
+    CGVector offset = CGVectorMake(50, 0);
+    XCUICoordinate *startCoordinate = [[mapElement coordinateWithNormalizedOffset:CGVectorMake(0, 0)]
+                                       coordinateWithOffset:CGVectorMake(100, 100)];
+    XCUICoordinate *endCoordinate = [startCoordinate coordinateWithOffset:offset];
+    [startCoordinate pressForDuration:0 thenDragToCoordinate:endCoordinate];
+    [mapElement tap];
+    CGRect frameAfterPanning = annotation.frame;
+    XCTAssertLessThanOrEqual(frame.origin.x + offset.dx, frameAfterPanning.origin.x, @"Annotation moved after panning right.");
+    XCTAssertEqualWithAccuracy(frame.origin.y + offset.dy, frameAfterPanning.origin.y, 0.1, @"Annotation moved after panning right.");
+    XCTAssertEqualWithAccuracy(frame.size.width, frameAfterPanning.size.width, 0.1, @"Annotation resized after panning right.");
+    XCTAssertEqualWithAccuracy(frame.size.height, frameAfterPanning.size.height, 0.1, @"Annotation resized after panning right.");
+}
+
+- (void)testRemoveAnnotations {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    
+    // Drop a pin.
+    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    XCUIElement *mapProxyElement = mapElement.buttons[@"MGLMapViewProxyAccessibilityElement"];
+    [self expectationForPredicate:[NSPredicate predicateWithFormat:@"exists == true"] evaluatedWithObject:mapProxyElement handler:nil];
+    [mapElement pressForDuration:1.1];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    // Remove all annotations, closing the callout view.
+    [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
+    [app.sheets[@"Map Settings"] swipeUp];
+    XCUIElementQuery *settingsCollectionViewsQuery = app.sheets[@"Map Settings"].collectionViews;
+    XCUIElement *removeAnnotationsButton = settingsCollectionViewsQuery.buttons[@"Remove Annotations"];
+    [self expectationForPredicate:[NSPredicate predicateWithFormat:@"exists == false"] evaluatedWithObject:mapProxyElement handler:nil];
+    [removeAnnotationsButton tap];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+    
+    XCTAssertFalse(mapElement.buttons[@"MGLMapViewAnnotation 0"].exists, @"Annotation should be gone after removing all annotations.");
+}
+
+@end

--- a/platform/ios/uitest/MGLAnnotationTests.m
+++ b/platform/ios/uitest/MGLAnnotationTests.m
@@ -1,30 +1,10 @@
-#import "MGLUITests.h"
+#import "MGLUITestCase.h"
 
-@interface MGLAnnotationTests : XCTestCase
+@interface MGLAnnotationTests : MGLUITestCase
 
 @end
 
 @implementation MGLAnnotationTests
-
-- (void)setUp {
-    [super setUp];
-    
-    self.continueAfterFailure = NO;
-    
-    [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    
-    // Bypass the access token prompt.
-    NSMutableDictionary <NSString *, NSString *> *environment = app.launchEnvironment.mutableCopy;
-    environment[@"MAPBOX_ACCESS_TOKEN"] = MGLUITestsBogusAccessToken;
-    app.launchEnvironment = environment;
-    
-    [app launch];
-    
-    // Reset the viewport.
-    [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
-    [app.sheets[@"Map Settings"].collectionViews.buttons[@"Reset Position"] tap];
-}
 
 - (void)testDropPin {
     XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
@@ -116,7 +96,7 @@
     NSPredicate *isAbsent = [NSPredicate predicateWithFormat:@"exists == NO"];
     
     // Drop a pin.
-    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    XCUIElement *mapElement = app.otherElements[@"MGLMapView"];
     XCUIElement *mapProxyElement = mapElement.buttons[@"MGLMapViewProxyAccessibilityElement"];
     [self expectationForPredicate:exists evaluatedWithObject:mapProxyElement handler:nil];
     [mapElement pressForDuration:1.1];
@@ -138,7 +118,7 @@
     [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
     
     // Add 100 points.
-    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    XCUIElement *mapElement = app.otherElements[@"MGLMapView"];
     XCUIElement *lastAnnotationElement = mapElement.buttons[@"MGLMapViewAnnotation 99"];
     [self expectationForPredicate:exists evaluatedWithObject:lastAnnotationElement handler:nil];
     [app.sheets[@"Map Settings"].collectionViews.buttons[@"Add 100 Points"] tap];
@@ -153,7 +133,7 @@
     [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
     
     // Start the world tour.
-    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    XCUIElement *mapElement = app.otherElements[@"MGLMapView"];
     [self expectationForPredicate:exists evaluatedWithObject:mapElement.buttons[@"Washington, D.C."] handler:nil];
     [app.sheets[@"Map Settings"].collectionViews.buttons[@"Start World Tour"] tap];
     [self waitForExpectationsWithTimeout:5 handler:nil];

--- a/platform/ios/uitest/MGLAnnotationTests.m
+++ b/platform/ios/uitest/MGLAnnotationTests.m
@@ -1,4 +1,4 @@
-#import <XCTest/XCTest.h>
+#import "MGLUITests.h"
 
 @interface MGLAnnotationTests : XCTestCase
 
@@ -12,7 +12,18 @@
     self.continueAfterFailure = NO;
     
     [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
-    [[[XCUIApplication alloc] init] launch];
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    
+    // Bypass the access token prompt.
+    NSMutableDictionary <NSString *, NSString *> *environment = app.launchEnvironment.mutableCopy;
+    environment[@"MAPBOX_ACCESS_TOKEN"] = MGLUITestsBogusAccessToken;
+    app.launchEnvironment = environment;
+    
+    [app launch];
+    
+    // Reset the viewport.
+    [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
+    [app.sheets[@"Map Settings"].collectionViews.buttons[@"Reset Position"] tap];
 }
 
 - (void)testDropPin {

--- a/platform/ios/uitest/MGLAnnotationTests.m
+++ b/platform/ios/uitest/MGLAnnotationTests.m
@@ -100,7 +100,7 @@
     XCUIElement *mapProxyElement = mapElement.buttons[@"MGLMapViewProxyAccessibilityElement"];
     [self expectationForPredicate:exists evaluatedWithObject:mapProxyElement handler:nil];
     [mapElement pressForDuration:1.1];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
     
     // Remove all annotations, closing the callout view.
     [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
@@ -130,13 +130,17 @@
 - (void)testTourWorld {
     XCUIApplication *app = [[XCUIApplication alloc] init];
     NSPredicate *exists = [NSPredicate predicateWithFormat:@"exists == YES"];
+    
+    XCUIElement *settingsSheet = app.sheets[@"Map Settings"];
+    [self expectationForPredicate:exists evaluatedWithObject:settingsSheet handler:nil];
     [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
     
     // Start the world tour.
     XCUIElement *mapElement = app.otherElements[@"MGLMapView"];
     [self expectationForPredicate:exists evaluatedWithObject:mapElement.buttons[@"Washington, D.C."] handler:nil];
-    [app.sheets[@"Map Settings"].collectionViews.buttons[@"Start World Tour"] tap];
-    [self waitForExpectationsWithTimeout:5 handler:nil];
+    [settingsSheet.collectionViews.buttons[@"Start World Tour"] tap];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
     [self expectationForPredicate:exists evaluatedWithObject:mapElement.buttons[@"San Francisco"] handler:nil];
     [self waitForExpectationsWithTimeout:15 handler:nil];
     [self expectationForPredicate:exists evaluatedWithObject:mapElement.buttons[@"Bangalore"] handler:nil];

--- a/platform/ios/uitest/MGLGestureTests.m
+++ b/platform/ios/uitest/MGLGestureTests.m
@@ -6,6 +6,37 @@
 
 @implementation MGLGestureTests
 
+- (void)testZoom {
+    // Tap to zoom
+    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    XCTAssertEqual([self accessibilityZoomLevel], 1, @"Map should start out at z0.");
+    [mapElement doubleTap];
+    [mapElement doubleTap];
+    XCTAssertGreaterThan([self accessibilityZoomLevel], 1, @"Double-tapping should zoom in.");
+    // Two-finger tapping has more friction than one-finger tapping.
+    [mapElement twoFingerTap];
+    [mapElement twoFingerTap];
+    [mapElement twoFingerTap];
+    XCTAssertEqual([self accessibilityZoomLevel], 1, @"Two-finger tapping should zoom back out.");
+    
+    // Pinch to zoom
+    [mapElement pinchWithScale:2 velocity:2];
+    XCTAssertGreaterThan([self accessibilityZoomLevel], 1, @"Pinching outward should zoom in.");
+    [mapElement pinchWithScale:0.025 velocity:-2];
+    [mapElement pinchWithScale:0.025 velocity:-2];
+    XCTAssertEqual([self accessibilityZoomLevel], 1, @"Pinching inward should zoom out.");
+}
+
+- (NSInteger)accessibilityZoomLevel {
+    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    XCTAssertNotNil(mapElement.value);
+    NSString *prefixString = [mapElement.value componentsSeparatedByString:@"x"].firstObject;
+    XCTAssertGreaterThan(prefixString.length, 0);
+    XCTAssertTrue([prefixString hasPrefix:@"Zoom "]);
+    NSString *zoomString = [prefixString substringFromIndex:@"Zoom ".length];
+    return zoomString.integerValue;
+}
+
 - (void)testRotate {
     XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
     XCUIElement *compassElement = mapElement.buttons[@"MGLMapViewCompass"];

--- a/platform/ios/uitest/MGLGestureTests.m
+++ b/platform/ios/uitest/MGLGestureTests.m
@@ -1,0 +1,62 @@
+#import "MGLUITests.h"
+
+@interface MGLGestureTests : XCTestCase
+
+@end
+
+@implementation MGLGestureTests
+
+- (void)setUp {
+    [super setUp];
+    
+    self.continueAfterFailure = NO;
+    [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    
+    // Bypass the access token prompt.
+    NSMutableDictionary <NSString *, NSString *> *environment = app.launchEnvironment.mutableCopy;
+    environment[@"MAPBOX_ACCESS_TOKEN"] = MGLUITestsBogusAccessToken;
+    app.launchEnvironment = environment;
+    
+    [app launch];
+    
+    // Reset the viewport.
+    [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
+    [app.sheets[@"Map Settings"].collectionViews.buttons[@"Reset Position"] tap];
+}
+
+- (void)testRotate {
+    XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];
+    XCUIElement *compassElement = mapElement.buttons[@"MGLMapViewCompass"];
+    NSPredicate *unhittable = [NSPredicate predicateWithFormat:@"hittable == NO"];
+    
+    XCTAssertFalse(compassElement.hittable, @"Compass should be absent when the map is unrotated.");
+    
+    // Attempt to rotate the map 90° counterclockwise. The map should unrotate itself.
+    [mapElement rotate:M_PI_2 withVelocity:M_PI];
+    XCTAssertTrue(compassElement.hittable, @"Compass should be present when the map is rotated.");
+    XCTAssertNotEqualWithAccuracy([compassElement.value rangeOfString:@"west"].location, NSNotFound, 1, @"Map should point west or thereabouts after rotating 90° counterclockwise. Instead, it points %@.", compassElement.value);
+    [self expectationForPredicate:unhittable evaluatedWithObject:compassElement handler:nil];
+    [self waitForExpectationsWithTimeout:3 handler:nil];
+    
+    // Zoom in until rotation is allowed.
+    [mapElement doubleTap];
+    [mapElement doubleTap];
+    [mapElement doubleTap];
+    
+    // Rotate the map 90° counterclockwise.
+    [mapElement rotate:M_PI_2 withVelocity:M_PI];
+    XCTAssertTrue(compassElement.hittable, @"Compass should be present when the map is rotated.");
+    XCTAssertNotEqualWithAccuracy([compassElement.value rangeOfString:@"west"].location, NSNotFound, 1, @"Map should point west or thereabouts after rotating 90° counterclockwise. Instead, it points %@.", compassElement.value);
+    
+    // Keep interacting with the map to make sure it doesn’t unrotate.
+    [mapElement swipeLeft];
+    [mapElement swipeRight];
+    
+    // Unrotate the map.
+    [compassElement tap];
+    [self expectationForPredicate:unhittable evaluatedWithObject:compassElement handler:nil];
+    [self waitForExpectationsWithTimeout:3 handler:nil];
+}
+
+@end

--- a/platform/ios/uitest/MGLGestureTests.m
+++ b/platform/ios/uitest/MGLGestureTests.m
@@ -1,29 +1,10 @@
-#import "MGLUITests.h"
+#import "MGLUITestCase.h"
 
-@interface MGLGestureTests : XCTestCase
+@interface MGLGestureTests : MGLUITestCase
 
 @end
 
 @implementation MGLGestureTests
-
-- (void)setUp {
-    [super setUp];
-    
-    self.continueAfterFailure = NO;
-    [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    
-    // Bypass the access token prompt.
-    NSMutableDictionary <NSString *, NSString *> *environment = app.launchEnvironment.mutableCopy;
-    environment[@"MAPBOX_ACCESS_TOKEN"] = MGLUITestsBogusAccessToken;
-    app.launchEnvironment = environment;
-    
-    [app launch];
-    
-    // Reset the viewport.
-    [app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXSettingsButton"] tap];
-    [app.sheets[@"Map Settings"].collectionViews.buttons[@"Reset Position"] tap];
-}
 
 - (void)testRotate {
     XCUIElement *mapElement = [[XCUIApplication alloc] init].otherElements[@"MGLMapView"];

--- a/platform/ios/uitest/MGLTelemetryTests.m
+++ b/platform/ios/uitest/MGLTelemetryTests.m
@@ -1,25 +1,10 @@
-#import "MGLUITests.h"
+#import "MGLUITestCase.h"
 
-@interface MGLTelemetryTests : XCTestCase
+@interface MGLTelemetryTests : MGLUITestCase
 
 @end
 
 @implementation MGLTelemetryTests
-
-- (void)setUp {
-    [super setUp];
-    
-    self.continueAfterFailure = NO;
-    [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    
-    // Bypass the access token prompt.
-    NSMutableDictionary <NSString *, NSString *> *environment = app.launchEnvironment.mutableCopy;
-    environment[@"MAPBOX_ACCESS_TOKEN"] = MGLUITestsBogusAccessToken;
-    app.launchEnvironment = environment;
-    
-    [app launch];
-}
 
 - (void)testOptOut {
     XCUIApplication *app = [[XCUIApplication alloc] init];

--- a/platform/ios/uitest/MGLTelemetryTests.m
+++ b/platform/ios/uitest/MGLTelemetryTests.m
@@ -1,0 +1,47 @@
+#import "MGLUITests.h"
+
+@interface MGLTelemetryTests : XCTestCase
+
+@end
+
+@implementation MGLTelemetryTests
+
+- (void)setUp {
+    [super setUp];
+    
+    self.continueAfterFailure = NO;
+    [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    
+    // Bypass the access token prompt.
+    NSMutableDictionary <NSString *, NSString *> *environment = app.launchEnvironment.mutableCopy;
+    environment[@"MAPBOX_ACCESS_TOKEN"] = MGLUITestsBogusAccessToken;
+    app.launchEnvironment = environment;
+    
+    [app launch];
+}
+
+- (void)testOptOut {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    XCUIElement *mapElement = app.otherElements[@"MGLMapView"];
+    XCUIElement *infoButton = mapElement.buttons[@"MGLMapViewInfo"];
+    [infoButton tap];
+    
+    XCUIElement *telemetryButton = app.sheets[@"Mapbox iOS SDK"].collectionViews.buttons[@"Mapbox Telemetry"];
+    [telemetryButton tap];
+    
+    XCUIElementQuery *collectionViewsQuery = app.alerts[@"Make Mapbox Maps Better"].collectionViews;
+    [collectionViewsQuery.buttons[@"Keep Participating"] tap];
+    [infoButton tap];
+    [telemetryButton tap];
+    [collectionViewsQuery.buttons[@"Stop Participating"] tap];
+    
+    [infoButton tap];
+    [telemetryButton tap];
+    [collectionViewsQuery.buttons[@"Don’t Participate"] tap];
+    [infoButton tap];
+    [telemetryButton tap];
+    [collectionViewsQuery.buttons[@"Participate"] tap];
+}
+
+@end

--- a/platform/ios/uitest/MGLUITestCase.h
+++ b/platform/ios/uitest/MGLUITestCase.h
@@ -1,0 +1,5 @@
+#import <XCTest/XCTest.h>
+
+@interface MGLUITestCase : XCTestCase
+
+@end

--- a/platform/ios/uitest/MGLUITestCase.m
+++ b/platform/ios/uitest/MGLUITestCase.m
@@ -1,0 +1,23 @@
+#import "MGLUITestCase.h"
+
+static NSString * const MGLUITestsBogusAccessToken = @"sk.feedCafeDeadBeef.BadeBede";
+
+@implementation MGLUITestCase
+
+- (void)setUp {
+    [super setUp];
+    
+    self.continueAfterFailure = NO;
+    [XCUIDevice sharedDevice].orientation = UIDeviceOrientationPortrait;
+    
+    // Launch the application, bypassing the access token prompt.
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    NSMutableDictionary <NSString *, NSString *> *environment = app.launchEnvironment.mutableCopy;
+    environment[@"MAPBOX_ACCESS_TOKEN"] = MGLUITestsBogusAccessToken;
+    environment[@"MAPBOX_DISABLE_ANIMATIONS"] = @"1";
+    environment[@"MAPBOX_CLEAN_START"] = @"1";
+    app.launchEnvironment = environment;
+    [app launch];
+}
+
+@end

--- a/platform/ios/uitest/MGLUITests.h
+++ b/platform/ios/uitest/MGLUITests.h
@@ -1,3 +1,0 @@
-#import <XCTest/XCTest.h>
-
-static NSString * const MGLUITestsBogusAccessToken = @"sk.feedCafeDeadBeef.BadeBede";

--- a/platform/ios/uitest/MGLUITests.h
+++ b/platform/ios/uitest/MGLUITests.h
@@ -1,0 +1,3 @@
+#import <XCTest/XCTest.h>
+
+static NSString * const MGLUITestsBogusAccessToken = @"sk.feedCafeDeadBeef.BadeBede";

--- a/platform/ios/uitest/MGLUserLocationTests.m
+++ b/platform/ios/uitest/MGLUserLocationTests.m
@@ -28,7 +28,9 @@
     }] evaluatedWithObject:userLocationAnnotationElement handler:nil];
     [userTrackingModeElement tap];
     XCTAssertEqualObjects(userTrackingModeElement.value, @"Follow location", @"User location tracking mode should be on after tapping the user tracking mode button.");
-    [self waitForExpectationsWithTimeout:5 handler:nil];
+    [self waitForExpectationsWithTimeout:10 handler:^(NSError * _Nullable error) {
+        XCTAssertNil(error, @"There was an error: %@\nUser dot is at: %f,%f %fx%f", error, userDotAnnotationFrame.origin.x, userDotAnnotationFrame.origin.y, userDotAnnotationFrame.size.width, userDotAnnotationFrame.size.height);
+    }];
     
     // Open the user dot’s callout view.
     XCUIElement *titleText = app.staticTexts[@"You Are Here"];

--- a/platform/ios/uitest/MGLUserLocationTests.m
+++ b/platform/ios/uitest/MGLUserLocationTests.m
@@ -1,0 +1,56 @@
+#import "MGLUITestCase.h"
+
+@interface MGLUserLocationTests : MGLUITestCase
+
+@end
+
+@implementation MGLUserLocationTests
+
+- (void)testUserDot {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    NSPredicate *exists = [NSPredicate predicateWithFormat:@"exists == YES"];
+    NSPredicate *isAbsent = [NSPredicate predicateWithFormat:@"exists == NO"];
+    
+    XCUIElement *userLocationAnnotationElement = app.buttons[@"MGLUserLocationAnnotationView"];
+    XCTAssertFalse(userLocationAnnotationElement.exists, @"User dot should be hidden by default.");
+    
+    XCUIElement *userTrackingModeElement = app.navigationBars[@"MBXNavigationBar"].buttons[@"MBXUserTrackingModeButton"];
+    XCTAssertEqualObjects(userTrackingModeElement.value, @"Off", @"User tracking mode should be off by default.");
+    
+    // Change to user location tracking mode.
+    [self expectationForPredicate:exists evaluatedWithObject:userLocationAnnotationElement handler:nil];
+    [userTrackingModeElement tap];
+    XCTAssertEqualObjects(userTrackingModeElement.value, @"Follow location", @"User location tracking mode should be on after tapping the user tracking mode button.");
+    [self waitForExpectationsWithTimeout:3 handler:nil];
+    CGRect userDotAnnotationFrame = userLocationAnnotationElement.frame;
+    
+    // Open the user dot’s callout view.
+    XCUIElement *titleText = app.staticTexts[@"You Are Here"];
+    [self expectationForPredicate:exists evaluatedWithObject:titleText handler:nil];
+    [userLocationAnnotationElement tap];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    // Close the user dot’s callout view by tapping on the map proxy element. Note that the map proxy element has a gaping hole in the middle to accommodate the callout view.
+    XCUIElement *mapProxyElement = app.buttons[@"MGLMapViewProxyAccessibilityElement"];
+    [self expectationForPredicate:isAbsent evaluatedWithObject:mapProxyElement handler:nil];
+    XCUICoordinate *coordinate = [[mapProxyElement coordinateWithNormalizedOffset:CGVectorMake(0, 0)] coordinateWithOffset:CGVectorMake(100, 100)];
+    [coordinate tap];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+    
+    // Change to user heading tracking mode.
+    [userTrackingModeElement tap];
+    XCTAssertEqualObjects(userTrackingModeElement.value, @"Follow location and heading", @"User heading tracking mode should be on after tapping the user tracking mode button.");
+    
+    // Change to user course tracking mode.
+    [userTrackingModeElement tap];
+    XCTAssertEqualObjects(userTrackingModeElement.value, @"Follow course", @"Course tracking mode should be on after tapping the user tracking mode button.");
+    CGRect userPuckAnnotationFrame = userLocationAnnotationElement.frame;
+    XCTAssertGreaterThan(userPuckAnnotationFrame.size.width, userDotAnnotationFrame.size.width, @"User puck should be wider than a user dot.");
+    XCTAssertGreaterThan(userPuckAnnotationFrame.size.height, userDotAnnotationFrame.size.height, @"User puck should be taller than a user dot.");
+    
+    // Turn user tracking mode off.
+    [userTrackingModeElement tap];
+    XCTAssertEqualObjects(userTrackingModeElement.value, @"Off", @"Course tracking mode should be off after tapping the user tracking mode button.");
+}
+
+@end

--- a/platform/ios/uitest/MGLUserLocationTests.m
+++ b/platform/ios/uitest/MGLUserLocationTests.m
@@ -10,6 +10,7 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
     NSPredicate *exists = [NSPredicate predicateWithFormat:@"exists == YES"];
     NSPredicate *isAbsent = [NSPredicate predicateWithFormat:@"exists == NO"];
+    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"hittable == YES"];
     
     XCUIElement *userLocationAnnotationElement = app.buttons[@"MGLUserLocationAnnotationView"];
     XCTAssertFalse(userLocationAnnotationElement.exists, @"User dot should be hidden by default.");
@@ -18,11 +19,16 @@
     XCTAssertEqualObjects(userTrackingModeElement.value, @"Off", @"User tracking mode should be off by default.");
     
     // Change to user location tracking mode.
-    [self expectationForPredicate:exists evaluatedWithObject:userLocationAnnotationElement handler:nil];
+    [self expectationForPredicate:hittable evaluatedWithObject:userLocationAnnotationElement handler:nil];
+    __block CGRect userDotAnnotationFrame;
+    [self expectationForPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nonnull evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        // The user dot happens to lie underneath the Settings button until it is shown.
+        userDotAnnotationFrame = userLocationAnnotationElement.frame;
+        return CGRectContainsPoint(userDotAnnotationFrame, CGPointMake(190, 368));
+    }] evaluatedWithObject:userLocationAnnotationElement handler:nil];
     [userTrackingModeElement tap];
     XCTAssertEqualObjects(userTrackingModeElement.value, @"Follow location", @"User location tracking mode should be on after tapping the user tracking mode button.");
     [self waitForExpectationsWithTimeout:3 handler:nil];
-    CGRect userDotAnnotationFrame = userLocationAnnotationElement.frame;
     
     // Open the user dot’s callout view.
     XCUIElement *titleText = app.staticTexts[@"You Are Here"];

--- a/platform/ios/uitest/MGLUserLocationTests.m
+++ b/platform/ios/uitest/MGLUserLocationTests.m
@@ -28,7 +28,7 @@
     XCUIElement *titleText = app.staticTexts[@"You Are Here"];
     [self expectationForPredicate:exists evaluatedWithObject:titleText handler:nil];
     [userLocationAnnotationElement tap];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
     
     // Close the user dot’s callout view by tapping on the map proxy element. Note that the map proxy element has a gaping hole in the middle to accommodate the callout view.
     XCUIElement *mapProxyElement = app.buttons[@"MGLMapViewProxyAccessibilityElement"];

--- a/platform/ios/uitest/MGLUserLocationTests.m
+++ b/platform/ios/uitest/MGLUserLocationTests.m
@@ -28,7 +28,7 @@
     }] evaluatedWithObject:userLocationAnnotationElement handler:nil];
     [userTrackingModeElement tap];
     XCTAssertEqualObjects(userTrackingModeElement.value, @"Follow location", @"User location tracking mode should be on after tapping the user tracking mode button.");
-    [self waitForExpectationsWithTimeout:3 handler:nil];
+    [self waitForExpectationsWithTimeout:5 handler:nil];
     
     // Open the user dot’s callout view.
     XCUIElement *titleText = app.staticTexts[@"You Are Here"];

--- a/platform/ios/uitest/MGLUserLocationTests.m
+++ b/platform/ios/uitest/MGLUserLocationTests.m
@@ -24,7 +24,7 @@
     [self expectationForPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nonnull evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
         // The user dot happens to lie underneath the Settings button until it is shown.
         userDotAnnotationFrame = userLocationAnnotationElement.frame;
-        return CGRectContainsPoint(userDotAnnotationFrame, CGPointMake(190, 368));
+        return userDotAnnotationFrame.origin.x > 100 && userDotAnnotationFrame.origin.y > 100;
     }] evaluatedWithObject:userLocationAnnotationElement handler:nil];
     [userTrackingModeElement tap];
     XCTAssertEqualObjects(userTrackingModeElement.value, @"Follow location", @"User location tracking mode should be on after tapping the user tracking mode button.");


### PR DESCRIPTION
Added a UI test bundle that uses XCUITest to test iosapp. The bundle contains some basic tests of annotation functionality. Gather code coverage data in the iosapp and dynamic schemes.

Added accessibility identifiers for key controls in the SDK and iosapp.
- [x] Add UI test bundle
- [x] Suppress access token prompt if necessary
- [x] Test gestures
- [x] Test point annotations
- [ ] ~~Test shape annotations (blocked by #4838)~~
- [x] Test callout views
- [x] Test compass
- [x] Test user tracking modes
- [x] Test user dot
- [x] Test ℹ️ actions
- [ ] Test offline pack table view controller
- [x] Add UI test bundle to CI scheme

Working towards #4794.

/cc @friedbunny @boundsj
