### PR TITLE
Use default images for world tour destinations

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -553,7 +553,7 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     NSMutableArray *annotations = [NSMutableArray arrayWithCapacity:numberOfAnnotations];
     for (NSUInteger i = 0; i < numberOfAnnotations; i++)
     {
-        MGLPointAnnotation *annotation = [[MGLPointAnnotation alloc] init];
+        MBXDroppedPinAnnotation *annotation = [[MBXDroppedPinAnnotation alloc] init];
         annotation.coordinate = WorldTourDestinations[i];
         [annotations addObject:annotation];
     }


### PR DESCRIPTION
Use the default red pin images for world tour destinations in iosapp instead of the two-character box usually used for the “Add _n_ Points” actions.

Fixes a regression introduced in #4783.