### PR TITLE
Fix ℹ️ accessibility and make the user dot less noisy

### DIFF
--- a/platform/ios/resources/Base.lproj/Localizable.strings
+++ b/platform/ios/resources/Base.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "INFO_A11Y_LABEL" = "About this map";
 
 /* Accessibility label */
-"LOGO_A11Y_LABEL" = "Mapbox logo";
+"LOGO_A11Y_LABEL" = "Mapbox";
 
 /* Accessibility label */
 "MAP_A11Y_LABEL" = "Map";

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3738,6 +3738,13 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         duration = MAX([newLocation.timestamp timeIntervalSinceDate:oldLocation.timestamp], MGLUserLocationAnimationDuration);
     }
     [self updateUserLocationAnnotationViewAnimatedWithDuration:duration];
+    
+    if (self.userTrackingMode == MGLUserTrackingModeNone &&
+        self.userLocationAnnotationView.accessibilityElementIsFocused &&
+        [UIApplication sharedApplication].applicationState == UIApplicationStateActive)
+    {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self.userLocationAnnotationView);
+    }
 }
 
 - (void)didUpdateLocationWithUserTrackingAnimated:(BOOL)animated
@@ -4109,7 +4116,10 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
             if ( ! [self isSuppressingChangeDelimiters] && [self.delegate respondsToSelector:@selector(mapView:regionDidChangeAnimated:)])
             {
-                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
+                if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive)
+                {
+                    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
+                }
                 BOOL animated = change == mbgl::MapChangeRegionDidChangeAnimated;
                 [self.delegate mapView:self regionDidChangeAnimated:animated];
             }
@@ -4257,8 +4267,6 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             [self deselectAnnotation:self.selectedAnnotation animated:YES];
         }
     }
-    
-    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
 }
 
 /// Intended center point of the user location annotation view with respect to

--- a/platform/ios/src/MGLUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLUserLocationAnnotationView.m
@@ -57,7 +57,7 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
         self.annotation = [[MGLUserLocation alloc] initWithMapView:mapView];
         _mapView = mapView;
         [self setupLayers];
-        self.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitAdjustable;
+        self.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitAdjustable | UIAccessibilityTraitUpdatesFrequently;
         
         _accessibilityCoordinateFormatter = [[MGLCoordinateFormatter alloc] init];
         _accessibilityCoordinateFormatter.unitStyle = NSFormattingUnitStyleLong;
@@ -115,6 +115,16 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
 - (void)accessibilityDecrement
 {
     [self.mapView accessibilityDecrement];
+}
+
+- (void)setHidden:(BOOL)hidden
+{
+    BOOL oldValue = super.hidden;
+    [super setHidden:hidden];
+    if (oldValue != hidden)
+    {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
+    }
 }
 
 - (void)setTintColor:(UIColor *)tintColor


### PR DESCRIPTION
The user location annotation view is created lazily, so if the user dot isn’t within view at launch, it doesn’t exist by the time UIKit first queries MGLMapView for child accessibility elements. This caused console spew about missing accessibility elements and prevented the ℹ️ from being visible to XCUITest.

Constantly posting accessibility layout change notifications on every location change made it very difficult to stay focused on an accessibility element, be it the user dot or some other element. Now we only post the notification when the user dot is focused, user tracking mode is off (so the user dot actually has a chance to move around), and the application is active (not in the middle of application switching). We also keep the focus on the user dot in that case, so you don’t have to find it again.

/ref #1496
/cc @friedbunny