### PR TITLE
Fix cameraForLatLngs padded center pixel determination

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -515,14 +515,17 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
     ScreenCoordinate centerPixel = nePixel + swPixel;
     if (padding && *padding) {
         ScreenCoordinate paddedNEPixel = {
-            padding->right / minScale,
-            padding->top / minScale,
+            nePixel.x + padding->right / minScale,
+            nePixel.y + padding->top / minScale,
         };
         ScreenCoordinate paddedSWPixel = {
-            padding->left / minScale,
-            padding->bottom / minScale,
+            swPixel.x - padding->left / minScale,
+            swPixel.y - padding->bottom / minScale,
         };
-        centerPixel = centerPixel - paddedNEPixel - paddedSWPixel;
+        centerPixel = {
+            (paddedNEPixel.x + paddedSWPixel.x),
+            (paddedNEPixel.y + paddedSWPixel.y)
+        };
     }
     centerPixel /= 2;
 


### PR DESCRIPTION
Fixes #4862, where fitting the viewport to annotation bounds would be offset from the proper center.

This regression was introduced in https://github.com/mapbox/mapbox-gl-native/pull/4285 at https://github.com/mapbox/mapbox-gl-native/commit/8e30a4a0806e970e727c3563b8ed57dbaf9a0fa0#diff-fd1625168ba48a6fb963e63343c0ac59R283.

I looked back to the [previous version](https://github.com/mapbox/mapbox-gl-native/blob/7ced8e97ba4240679c81f28ada288fad48b81799/src/mbgl/map/map.cpp#L281-L293) and reintroduced the explicit calculations within `paddedNEPixel`, `paddedSWPixel`, and `centerPixel`, rather than relying on the [overloaded `ScreenCoordinate` `-` operator](https://github.com/mapbox/mapbox-gl-native/commit/8e30a4a0806e970e727c3563b8ed57dbaf9a0fa0#diff-fd1625168ba48a6fb963e63343c0ac59R294).

Caveat: While this patch works in my testing, I have a very shallow understanding of this code and there is likely a better fix to be had. Would really love to get your input here, @brunoabinader.