### PR TITLE
[build] Do not run unit tests for Qt5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ matrix:
       env: FLAVOR=qt5 BUILDTYPE=Release _CXX=g++-4.9 _CC=gcc-4.9
       addons: *qt5
       script:
-        - make qt-app test-qt
+        - make qt-app
 
 cache:
   directories:


### PR DESCRIPTION
ccache is not enabled for Trusty public bots on Travis.

Disabling unit tests for Qt5 for now so it will take
less time.

Fixes #4855. (not really, but better than nothing)