### PR TITLE
[ios] Add a property for bytes used by offline tiles

### DIFF
--- a/include/mbgl/storage/offline.hpp
+++ b/include/mbgl/storage/offline.hpp
@@ -93,9 +93,14 @@ public:
     uint64_t completedResourceCount = 0;
 
     /**
-     * The cumulative size, in bytes, of all resources that have been fully downloaded.
+     * The cumulative size, in bytes, of all resources (inclusive of tiles) that have been fully downloaded.
      */
     uint64_t completedResourceSize = 0;
+    
+    /**
+     * The cumulative size, in bytes, of all tiles that have been fully downloaded.
+     */
+    uint64_t completedTileSize = 0;
 
     /**
      * The number of resources that are known to be required for this region. See the

--- a/platform/darwin/src/MGLOfflinePack.h
+++ b/platform/darwin/src/MGLOfflinePack.h
@@ -60,9 +60,13 @@ typedef struct MGLOfflinePackProgress {
      */
     uint64_t countOfResourcesCompleted;
     /**
-     The cumulative size of the downloaded resources on disk, measured in bytes.
+     The cumulative size of the downloaded resources (inclusive of tiles) on disk, measured in bytes.
      */
     uint64_t countOfBytesCompleted;
+    /**
+     The cumulative size of the downloaded tiles on disk, measured in bytes.
+     */
+    uint64_t countOfTileBytesCompleted;
     /**
      The minimum number of resources that must be downloaded in order to view
      the pack’s full region without any omissions.

--- a/platform/darwin/src/MGLOfflinePack.mm
+++ b/platform/darwin/src/MGLOfflinePack.mm
@@ -153,6 +153,7 @@ private:
     MGLOfflinePackProgress progress;
     progress.countOfResourcesCompleted = status.completedResourceCount;
     progress.countOfBytesCompleted = status.completedResourceSize;
+    progress.countOfTileBytesCompleted = status.completedTileSize;
     progress.countOfResourcesExpected = status.requiredResourceCount;
     progress.maximumResourcesExpected = status.requiredResourceCountIsPrecise ? status.requiredResourceCount : UINT64_MAX;
     self.progress = progress;

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -220,6 +220,10 @@ void OfflineDownload::ensureResource(const Resource& resource, std::function<voi
 
             status.completedResourceCount++;
             status.completedResourceSize += offlineResponse->second;
+            if (resource.kind == Resource::Kind::Tile) {
+                status.completedTileSize += offlineResponse->second;
+            }
+            
             observer->statusChanged(status);
             
             if (status.complete()) {
@@ -247,7 +251,11 @@ void OfflineDownload::ensureResource(const Resource& resource, std::function<voi
             }
 
             status.completedResourceCount++;
-            status.completedResourceSize += offlineDatabase.putRegionResource(id, resource, onlineResponse);
+            uint64_t resourceSize = offlineDatabase.putRegionResource(id, resource, onlineResponse);
+            status.completedResourceSize += resourceSize;
+            if (resource.kind == Resource::Kind::Tile) {
+                status.completedTileSize += resourceSize;
+            }
 
             observer->statusChanged(status);
             


### PR DESCRIPTION
Having a separate property for the bytes used by offline tiles allows their data usage to be distinguished from the style data (which is often shared between multiple offline packs). I was finding it to be confusing/misleading when even a region containing a handful of times had a large size, due to the shared resources.