### PR TITLE
Fix 'make linux' build on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(OSX_OUTPUT_PATH)/mbgl.xcconfig: $(OSX_OUTPUT_PATH)/config.gypi
 	./scripts/export-xcconfig.py $< $@
 
 $(OSX_PROJ_PATH): platform/osx/platform.gyp $(OSX_OUTPUT_PATH)/config.gypi $(OSX_OUTPUT_PATH)/mbgl.xcconfig $(GYP_DEPENDENCIES)
-	./deps/run_gyp -f xcode --depth=. --generator-output=$(OSX_OUTPUT_PATH) $<
+	./deps/run_gyp -f xcode --depth=. -I$(OSX_OUTPUT_PATH)/config.gypi --generator-output=$(OSX_OUTPUT_PATH) $<
 
 osx: $(OSX_PROJ_PATH)
 	set -o pipefail && xcodebuild \

--- a/platform/osx/bitrise.yml
+++ b/platform/osx/bitrise.yml
@@ -33,6 +33,8 @@ workflows:
             export BUILDTYPE=Debug
             make osx
             make test-osx
+            make linux
+            make test-linux
         - is_debug: 'yes'
     - slack:
         title: Post to Slack

--- a/platform/osx/platform.gyp
+++ b/platform/osx/platform.gyp
@@ -5,7 +5,7 @@
     'coverage': 0,
   },
   'includes': [
-    '../../build/osx/config.gypi',
+    '../../build/osx-x86_64/config.gypi',
     '../../mbgl.gypi',
     '../../test/test.gypi',
     '../../bin/glfw.gypi',

--- a/platform/osx/platform.gyp
+++ b/platform/osx/platform.gyp
@@ -5,7 +5,6 @@
     'coverage': 0,
   },
   'includes': [
-    '../../build/osx-x86_64/config.gypi',
     '../../mbgl.gypi',
     '../../test/test.gypi',
     '../../bin/glfw.gypi',

--- a/scripts/main.mk
+++ b/scripts/main.mk
@@ -48,12 +48,12 @@ ifeq ($(PLATFORM),qt)
 endif
 
 # Defaults if not set
+export PLATFORM_SLUG ?= $(PLATFORM)-$(SUBPLATFORM)
 export PLATFORM_OUTPUT ?= ./build/$(PLATFORM_SLUG)
 export PLATFORM_CONFIG_INPUT ?= platform/$(MASON_PLATFORM)/scripts/configure.sh
 export PLATFORM_CONFIG_OUTPUT ?= $(PLATFORM_OUTPUT)/config.gypi
 export MASON_PLATFORM ?= $(PLATFORM)
 export MASON_PLATFORM_VERSION ?= $(SUBPLATFORM)
-export PLATFORM_SLUG ?= $(PLATFORM)-$(SUBPLATFORM)
 
 ifneq (,$(findstring clang,$(CXX)))
 	CXX_HOST = "clang"


### PR DESCRIPTION
The "make linux" target is really just "build an app using GLFW that runs on unix". As such this works on OS X and well as Linux, however the OS X build appears to have regressed. This pull fixes this error:

```
$ make linux
/Applications/Xcode.app/Contents/Developer/usr/bin/make -f scripts/main.mk Makefile/glfw-app
* Recreating project...
deps/run_gyp platform/osx/platform.gyp -I./build/osx-x86_64/config.gypi -Dcoverage=0 -Dcxx_host="clang" -Goutput_dir=. --depth=. --generator-output=./build/osx-x86_64 -f make
gyp: build/osx/config.gypi not found (cwd: /Users/dane/projects/mbgl) while reading includes of platform/osx/platform.gyp
make[1]: *** [Makefile/__project__] Error 1
make: *** [glfw-app] Error 2
```

Question: can we run `make linux` on OS X CI to ensure this does not break again? /cc @1ec5 @jfirebaugh 