### PR TITLE
[core] Eliminate interpolate special cases

### DIFF
--- a/src/mbgl/style/function_evaluator.cpp
+++ b/src/mbgl/style/function_evaluator.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/style/function_evaluator.hpp>
 #include <mbgl/style/style_calculation_parameters.hpp>
+#include <mbgl/style/types.hpp>
 #include <mbgl/util/interpolate.hpp>
 #include <mbgl/util/chrono.hpp>
 

--- a/src/mbgl/style/function_evaluator.hpp
+++ b/src/mbgl/style/function_evaluator.hpp
@@ -2,6 +2,7 @@
 #define MBGL_STYLE_FUNCTION_EVALUATOR
 
 #include <mbgl/style/function.hpp>
+#include <mbgl/util/interpolate.hpp>
 
 namespace mbgl {
 
@@ -32,6 +33,12 @@ public:
     using ResultType = Faded<T>;
     Faded<T> operator()(const Function<T>&, const StyleCalculationParameters&) const;
 };
+
+namespace util {
+template <typename T>
+struct Interpolator<Faded<T>>
+    : Uninterpolated {};
+}
 
 } // namespace mbgl
 

--- a/src/mbgl/util/interpolate.hpp
+++ b/src/mbgl/util/interpolate.hpp
@@ -1,57 +1,64 @@
-#ifndef MBGL_UTIL_INTERPOLATE
-#define MBGL_UTIL_INTERPOLATE
+#pragma once
 
 #include <array>
 #include <vector>
-
-#include <mbgl/style/types.hpp>
-#include <mbgl/style/function_evaluator.hpp>
+#include <string>
+#include <type_traits>
+#include <utility>
 
 namespace mbgl {
 namespace util {
 
-template <typename T>
-T interpolate(const T a, const T b, const double t) {
-    return a * (1.0 - t) + b * t;
-}
+template <class T, class Enabled = void>
+struct Interpolator;
 
 template <typename T>
-inline std::array<T, 4> interpolate(const std::array<T, 4>& a, const std::array<T, 4>& b, const double t) {
-    return {{
-        interpolate(a[0], b[0], t),
-        interpolate(a[1], b[1], t),
-        interpolate(a[2], b[2], t),
-        interpolate(a[3], b[3], t)
-    }};
+T interpolate(const T& a, const T& b, const double t) {
+    return Interpolator<T>()(a, b, t);
 }
 
-template <typename T>
-inline std::array<T, 2> interpolate(const std::array<T, 2>& a, const std::array<T, 2>& b, const double t) {
-    return {{
-        interpolate(a[0], b[0], t),
-        interpolate(a[1], b[1], t)
-    }};
-}
 
-// fake interpolations that just return the first value
-template<> inline bool interpolate(const bool a, const bool, const double) { return a; }
-template<> inline std::vector<float> interpolate(const std::vector<float> a, const std::vector<float>, const double) { return a; }
-template<> inline std::vector<std::string> interpolate(const std::vector<std::string> a, const std::vector<std::string>, const double) { return a; }
-template<> inline std::string interpolate(const std::string a, const std::string, const double) { return a; }
-template<> inline TranslateAnchorType interpolate(const TranslateAnchorType a, const TranslateAnchorType, const double) { return a; }
-template<> inline RotateAnchorType interpolate(const RotateAnchorType a, const RotateAnchorType, const double) { return a; }
-template<> inline LineCapType interpolate(const LineCapType a, const LineCapType, const double) { return a; }
-template<> inline LineJoinType interpolate(const LineJoinType a, const LineJoinType, const double) { return a; }
-template<> inline SymbolPlacementType interpolate(const SymbolPlacementType a, const SymbolPlacementType, const double) { return a; }
-template<> inline TextAnchorType interpolate(const TextAnchorType a, const TextAnchorType, const double) { return a; }
-template<> inline TextJustifyType interpolate(const TextJustifyType a, const TextJustifyType, const double) { return a; }
-template<> inline TextTransformType interpolate(const TextTransformType a, const TextTransformType, const double) { return a; }
-template<> inline RotationAlignmentType interpolate(const RotationAlignmentType a, const RotationAlignmentType, const double) { return a; }
+template <class T, class Enabled>
+struct Interpolator {
+    T operator()(const T& a, const T& b, const double t) const {
+        return a * (1.0 - t) + b * t;
+    }
+};
 
-template<> inline Faded<std::string> interpolate(const Faded<std::string>, const Faded<std::string> b, const double) { return b; }
-template<> inline Faded<std::vector<float>> interpolate(const Faded<std::vector<float>>, const Faded<std::vector<float>> b, const double) { return b; }
+template <class T, std::size_t N>
+struct Interpolator<std::array<T, N>> {
+private:
+    using Array = std::array<T, N>;
+
+    template <std::size_t... I>
+    Array operator()(const Array& a, const Array& b, const double t, std::index_sequence<I...>) {
+        return {{ interpolate(a[I], b[I], t)... }};
+    }
+
+public:
+    Array operator()(const Array& a, const Array& b, const double t) {
+        return operator()(a, b, t, std::make_index_sequence<N>());
+    }
+};
+
+struct Uninterpolated {
+    template <class T>
+    T operator()(const T&, const T& b, const double) const {
+        return b;
+    }
+};
+
+template <class T>
+struct Interpolator<T, typename std::enable_if_t<std::is_enum<T>::value>>
+    : Uninterpolated {};
+
+template <>
+struct Interpolator<std::string>
+    : Uninterpolated {};
+
+template <class T>
+struct Interpolator<std::vector<T>>
+    : Uninterpolated {};
 
 } // namespace util
 } // namespace mbgl
-
-#endif


### PR DESCRIPTION
This changes some of the overloads to return the second value rather than the first. Returning the second value is consistent with -js. It also probably doesn't really matter in practice.

cc @ansis 