### PR TITLE
[Qt] s/mapRegionDidChange()/mapChanged(QMapboxGL::MapChange)/ signal

### DIFF
--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -1,6 +1,8 @@
 #ifndef MBGL_MAP_UPDATE
 #define MBGL_MAP_UPDATE
 
+#include <mbgl/util/traits.hpp>
+
 #include <cstdint>
 
 namespace mbgl {
@@ -16,7 +18,7 @@ enum class Update : uint8_t {
 };
 
 inline Update operator| (const Update& lhs, const Update& rhs) {
-    return Update(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
+    return Update(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs));
 }
 
 inline Update& operator|=(Update& lhs, const Update& rhs) {
@@ -25,7 +27,7 @@ inline Update& operator|=(Update& lhs, const Update& rhs) {
 }
 
 inline bool operator& (const Update& lhs, const Update& rhs) {
-    return static_cast<uint8_t>(lhs) & static_cast<uint8_t>(rhs);
+    return mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs);
 }
 
 } // namespace mbgl

--- a/include/mbgl/util/traits.hpp
+++ b/include/mbgl/util/traits.hpp
@@ -1,0 +1,15 @@
+#ifndef MBGL_UTIL_TRAITS
+#define MBGL_UTIL_TRAITS
+
+#include <type_traits>
+
+namespace mbgl {
+
+template<typename T>
+constexpr auto underlying_type(T t) -> typename std::underlying_type<T>::type {
+    return static_cast<typename std::underlying_type<T>::type>(t);
+}
+
+} // namespace mbgl
+
+#endif // MBGL_UTIL_TRAITS

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -31,7 +31,8 @@ public:
     };
 
     enum ConstrainMode {
-        ConstrainHeightOnly = 0,
+        NoConstrain = 0,
+        ConstrainHeightOnly,
         ConstrainWidthAndHeight
     };
 
@@ -89,19 +90,19 @@ public:
     // Reflects mbgl::MapChange.
     enum MapChange {
         MapChangeRegionWillChange = 0,
-        MapChangeRegionWillChangeAnimated = 1,
-        MapChangeRegionIsChanging = 2,
-        MapChangeRegionDidChange = 3,
-        MapChangeRegionDidChangeAnimated = 4,
-        MapChangeWillStartLoadingMap = 5,
-        MapChangeDidFinishLoadingMap = 6,
-        MapChangeDidFailLoadingMap = 7,
-        MapChangeWillStartRenderingFrame = 8,
-        MapChangeDidFinishRenderingFrame = 9,
-        MapChangeDidFinishRenderingFrameFullyRendered = 10,
-        MapChangeWillStartRenderingMap = 11,
-        MapChangeDidFinishRenderingMap = 12,
-        MapChangeDidFinishRenderingMapFullyRendered = 13
+        MapChangeRegionWillChangeAnimated,
+        MapChangeRegionIsChanging,
+        MapChangeRegionDidChange,
+        MapChangeRegionDidChangeAnimated,
+        MapChangeWillStartLoadingMap,
+        MapChangeDidFinishLoadingMap,
+        MapChangeDidFailLoadingMap,
+        MapChangeWillStartRenderingFrame,
+        MapChangeDidFinishRenderingFrame,
+        MapChangeDidFinishRenderingFrameFullyRendered,
+        MapChangeWillStartRenderingMap,
+        MapChangeDidFinishRenderingMap,
+        MapChangeDidFinishRenderingMapFullyRendered
     };
 
     QMapboxGL(QObject *parent = 0, const QMapboxGLSettings& = QMapboxGLSettings());

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -75,6 +75,7 @@ class Q_DECL_EXPORT QMapboxGL : public QObject
     Q_PROPERTY(double zoom READ zoom WRITE setZoom)
     Q_PROPERTY(double bearing READ bearing WRITE setBearing)
     Q_PROPERTY(double pitch READ pitch WRITE setPitch)
+    Q_ENUMS(MapChange)
 
 public:
     // Determines the orientation of the map.
@@ -83,6 +84,24 @@ public:
         NorthRightwards,
         NorthDownwards,
         NorthLeftwards,
+    };
+
+    // Reflects mbgl::MapChange.
+    enum MapChange {
+        MapChangeRegionWillChange = 0,
+        MapChangeRegionWillChangeAnimated = 1,
+        MapChangeRegionIsChanging = 2,
+        MapChangeRegionDidChange = 3,
+        MapChangeRegionDidChangeAnimated = 4,
+        MapChangeWillStartLoadingMap = 5,
+        MapChangeDidFinishLoadingMap = 6,
+        MapChangeDidFailLoadingMap = 7,
+        MapChangeWillStartRenderingFrame = 8,
+        MapChangeDidFinishRenderingFrame = 9,
+        MapChangeDidFinishRenderingFrameFullyRendered = 10,
+        MapChangeWillStartRenderingMap = 11,
+        MapChangeDidFinishRenderingMap = 12,
+        MapChangeDidFinishRenderingMapFullyRendered = 13
     };
 
     QMapboxGL(QObject *parent = 0, const QMapboxGLSettings& = QMapboxGLSettings());
@@ -182,12 +201,14 @@ public slots:
 
 signals:
     void needsRendering();
-    void mapRegionDidChange();
+    void mapChanged(QMapboxGL::MapChange);
 
 private:
     Q_DISABLE_COPY(QMapboxGL)
 
     QMapboxGLPrivate *d_ptr;
 };
+
+Q_DECLARE_METATYPE(QMapboxGL::MapChange);
 
 #endif // QMAPBOXGL_H

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/storage/network_status.hpp>
 #include <mbgl/util/default_styles.hpp>
+#include <mbgl/util/traits.hpp>
 
 #include <QMapbox>
 
@@ -8,31 +9,20 @@
 #include <QOpenGLContext>
 #endif
 
+// mbgl::MapMode
+static_assert(mbgl::underlying_type(QMapbox::Online) == mbgl::underlying_type(mbgl::NetworkStatus::Status::Online), "error");
+static_assert(mbgl::underlying_type(QMapbox::Offline) == mbgl::underlying_type(mbgl::NetworkStatus::Status::Offline), "error");
+
 namespace QMapbox {
 
 Q_DECL_EXPORT NetworkMode networkMode()
 {
-    switch (mbgl::NetworkStatus::Get()) {
-    case mbgl::NetworkStatus::Status::Online:
-        return NetworkMode::Online;
-    case mbgl::NetworkStatus::Status::Offline:
-        return NetworkMode::Offline;
-    }
-
-    // Silence compile warnings, should never happen.
-    return NetworkMode::Online;
+    return static_cast<NetworkMode>(mbgl::NetworkStatus::Get());
 }
 
 Q_DECL_EXPORT void setNetworkMode(NetworkMode mode)
 {
-    switch (mode) {
-    case Online:
-        mbgl::NetworkStatus::Set(mbgl::NetworkStatus::Status::Online);
-        break;
-    case Offline:
-        mbgl::NetworkStatus::Set(mbgl::NetworkStatus::Status::Offline);
-        break;
-    }
+    mbgl::NetworkStatus::Set(static_cast<mbgl::NetworkStatus::Status>(mode));
 }
 
 Q_DECL_EXPORT QList<QPair<QString, QString>>& defaultStyles()

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -584,9 +584,11 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
         static_cast<mbgl::GLContextMode>(settings.contextMode()),
         static_cast<mbgl::ConstrainMode>(settings.constrainMode())))
 {
+    qRegisterMetaType<QMapboxGL::MapChange>("QMapboxGL::MapChange");
+
     fileSourceObj->setAccessToken(settings.accessToken().toStdString());
     connect(this, SIGNAL(needsRendering()), q_ptr, SIGNAL(needsRendering()), Qt::QueuedConnection);
-    connect(this, SIGNAL(mapRegionDidChange()), q_ptr, SIGNAL(mapRegionDidChange()));
+    connect(this, SIGNAL(mapChanged(QMapboxGL::MapChange)), q_ptr, SIGNAL(mapChanged(QMapboxGL::MapChange)), Qt::QueuedConnection);
 }
 
 QMapboxGLPrivate::~QMapboxGLPrivate()
@@ -619,16 +621,7 @@ void QMapboxGLPrivate::invalidate()
 
 void QMapboxGLPrivate::notifyMapChange(mbgl::MapChange change)
 {
-    // Map thread.
-    switch (change) {
-    case mbgl::MapChangeRegionDidChange:
-    case mbgl::MapChangeRegionDidChangeAnimated:
-    case mbgl::MapChangeRegionIsChanging:
-        emit mapRegionDidChange();
-        break;
-    default:
-        break;
-    }
+    emit mapChanged(static_cast<QMapboxGL::MapChange>(change));
 }
 
 void QMapboxGLPrivate::connectionEstablished()

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/storage/network_status.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/traits.hpp>
 #include <mbgl/util/vec.hpp>
 
 #include <QCoreApplication>
@@ -21,6 +22,41 @@
 #include <memory>
 
 using namespace QMapbox;
+
+// mbgl::MapMode
+static_assert(mbgl::underlying_type(QMapboxGLSettings::ContinuousMap) == mbgl::underlying_type(mbgl::MapMode::Continuous), "error");
+static_assert(mbgl::underlying_type(QMapboxGLSettings::StillMap) == mbgl::underlying_type(mbgl::MapMode::Still), "error");
+
+// mbgl::GLContextMode
+static_assert(mbgl::underlying_type(QMapboxGLSettings::UniqueGLContext) == mbgl::underlying_type(mbgl::GLContextMode::Unique), "error");
+static_assert(mbgl::underlying_type(QMapboxGLSettings::SharedGLContext) == mbgl::underlying_type(mbgl::GLContextMode::Shared), "error");
+
+// mbgl::ConstrainMode
+static_assert(mbgl::underlying_type(QMapboxGLSettings::NoConstrain) == mbgl::underlying_type(mbgl::ConstrainMode::None), "error");
+static_assert(mbgl::underlying_type(QMapboxGLSettings::ConstrainHeightOnly) == mbgl::underlying_type(mbgl::ConstrainMode::HeightOnly), "error");
+static_assert(mbgl::underlying_type(QMapboxGLSettings::ConstrainWidthAndHeight) == mbgl::underlying_type(mbgl::ConstrainMode::WidthAndHeight), "error");
+
+// mbgl::NorthOrientation
+static_assert(mbgl::underlying_type(QMapboxGL::NorthUpwards) == mbgl::underlying_type(mbgl::NorthOrientation::Upwards), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::NorthRightwards) == mbgl::underlying_type(mbgl::NorthOrientation::Rightwards), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::NorthDownwards) == mbgl::underlying_type(mbgl::NorthOrientation::Downwards), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::NorthLeftwards) == mbgl::underlying_type(mbgl::NorthOrientation::Leftwards), "error");
+
+// mbgl::MapChange
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeRegionWillChange) == mbgl::underlying_type(mbgl::MapChangeRegionWillChange), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeRegionWillChangeAnimated) == mbgl::underlying_type(mbgl::MapChangeRegionWillChangeAnimated), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeRegionIsChanging) == mbgl::underlying_type(mbgl::MapChangeRegionIsChanging), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeRegionDidChange) == mbgl::underlying_type(mbgl::MapChangeRegionDidChange), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeRegionDidChangeAnimated) == mbgl::underlying_type(mbgl::MapChangeRegionDidChangeAnimated), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeWillStartLoadingMap) == mbgl::underlying_type(mbgl::MapChangeWillStartLoadingMap), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeDidFinishLoadingMap) == mbgl::underlying_type(mbgl::MapChangeDidFinishLoadingMap), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeDidFailLoadingMap) == mbgl::underlying_type(mbgl::MapChangeDidFailLoadingMap), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeWillStartRenderingFrame) == mbgl::underlying_type(mbgl::MapChangeWillStartRenderingFrame), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeDidFinishRenderingFrame) == mbgl::underlying_type(mbgl::MapChangeDidFinishRenderingFrame), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeDidFinishRenderingFrameFullyRendered) == mbgl::underlying_type(mbgl::MapChangeDidFinishRenderingFrameFullyRendered), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeWillStartRenderingMap) == mbgl::underlying_type(mbgl::MapChangeWillStartRenderingMap), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeDidFinishRenderingMap) == mbgl::underlying_type(mbgl::MapChangeDidFinishRenderingMap), "error");
+static_assert(mbgl::underlying_type(QMapboxGL::MapChangeDidFinishRenderingMapFullyRendered) == mbgl::underlying_type(mbgl::MapChangeDidFinishRenderingMapFullyRendered), "error");
 
 QMapboxGLSettings::QMapboxGLSettings()
     : m_mapMode(QMapboxGLSettings::ContinuousMap)
@@ -257,24 +293,12 @@ void QMapboxGL::setPitch(double pitch_)
 
 QMapboxGL::NorthOrientation QMapboxGL::northOrientation() const
 {
-    using NO = mbgl::NorthOrientation;
-    switch (d_ptr->mapObj->getNorthOrientation()) {
-        case NO::Rightwards: return NorthRightwards;
-        case NO::Downwards: return NorthDownwards;
-        case NO::Leftwards: return NorthLeftwards;
-        default: return NorthUpwards;
-    }
+    return static_cast<QMapboxGL::NorthOrientation>(d_ptr->mapObj->getNorthOrientation());
 }
 
 void QMapboxGL::setNorthOrientation(NorthOrientation orientation)
 {
-    using NO = mbgl::NorthOrientation;
-    switch (orientation) {
-        case NorthRightwards: d_ptr->mapObj->setNorthOrientation(NO::Rightwards); break;
-        case NorthDownwards: d_ptr->mapObj->setNorthOrientation(NO::Downwards); break;
-        case NorthLeftwards: d_ptr->mapObj->setNorthOrientation(NO::Leftwards); break;
-        default: d_ptr->mapObj->setNorthOrientation(NO::Upwards); break;
-    }
+    d_ptr->mapObj->setNorthOrientation(static_cast<mbgl::NorthOrientation>(orientation));
 }
 
 void QMapboxGL::setGestureInProgress(bool inProgress)

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -11,11 +11,6 @@
 #include <QObject>
 #include <QSize>
 
-#include <memory>
-
-class QMapboxGL;
-class QMapboxGLSettings;
-
 class QMapboxGLPrivate : public QObject, public mbgl::View
 {
     Q_OBJECT
@@ -50,8 +45,8 @@ public slots:
     void connectionEstablished();
 
 signals:
-    void mapRegionDidChange();
     void needsRendering();
+    void mapChanged(QMapboxGL::MapChange);
 };
 
 #endif // QMAPBOXGL_P_H

--- a/src/mbgl/renderer/render_pass.hpp
+++ b/src/mbgl/renderer/render_pass.hpp
@@ -1,8 +1,9 @@
 #ifndef MBGL_RENDERER_RENDER_PASS
 #define MBGL_RENDERER_RENDER_PASS
 
+#include <mbgl/util/traits.hpp>
+
 #include <cstdint>
-#include <type_traits>
 
 namespace mbgl {
 
@@ -13,8 +14,7 @@ enum class RenderPass : uint8_t {
 };
 
 constexpr inline RenderPass operator|(RenderPass a, RenderPass b) {
-    return static_cast<RenderPass>(static_cast<std::underlying_type<RenderPass>::type>(a) |
-                                   static_cast<std::underlying_type<RenderPass>::type>(b));
+    return static_cast<RenderPass>(mbgl::underlying_type(a) | mbgl::underlying_type(b));
 }
 
 inline RenderPass operator|=(RenderPass& a, RenderPass b) {
@@ -22,8 +22,7 @@ inline RenderPass operator|=(RenderPass& a, RenderPass b) {
 }
 
 constexpr inline RenderPass operator&(RenderPass a, RenderPass b) {
-    return static_cast<RenderPass>(static_cast<std::underlying_type<RenderPass>::type>(a) &
-                                   static_cast<std::underlying_type<RenderPass>::type>(b));
+    return static_cast<RenderPass>(mbgl::underlying_type(a) & mbgl::underlying_type(b));
 }
 
 } // namespace mbgl


### PR DESCRIPTION
This replaces the previous `mapRegionDidChange()` signal with `mapChanged(QMapboxGL::MapChange)`, where `QMapboxGL::MapChange` reflects `mbgl::MapChange`.

/cc @tmpsantos 