### PR TITLE
Fix a bug in applying padding to the camera.

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -523,7 +523,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
             padding->left / minScale,
             padding->bottom / minScale,
         };
-        centerPixel = centerPixel - paddedNEPixel - paddedSWPixel;
+        centerPixel = centerPixel + paddedNEPixel - paddedSWPixel;
     }
     centerPixel /= 2;
 


### PR DESCRIPTION
 NE padding was applied as if it was SW, thus causing the view's center to be offset.

**Example**

Originally detected the issue when using the iOS method
`- (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated;` to show the black polyline annotation with insets of top = 20, left = 20, bottom = 80, right = 20.

Before this fix:
![screen shot 2016-05-02 at 9 44 05 am](https://cloud.githubusercontent.com/assets/1206592/14960667/9ccbefba-104a-11e6-82e5-5e7e12089675.png)

After this fix:
![screen shot 2016-05-02 at 9 42 15 am](https://cloud.githubusercontent.com/assets/1206592/14960672/a25ab3d0-104a-11e6-8ed6-45d738c91823.png)
