### PR TITLE
[core] Replace boost::lexical_cast with std::to_string

### DIFF
--- a/bin/glfw.gypi
+++ b/bin/glfw.gypi
@@ -28,7 +28,6 @@
         'cflags_cc': [
           '<@(glfw_cflags)',
           '<@(variant_cflags)',
-          '<@(boost_cflags)',
         ],
         'ldflags': [
           '<@(glfw_ldflags)',

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -2,29 +2,23 @@
 #define MBGL_UTIL_STRING
 
 #include <string>
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#include <boost/lexical_cast.hpp>
-#pragma GCC diagnostic pop
+#include <cassert>
+#include <exception>
 
 namespace mbgl {
 namespace util {
 
-template <typename... Args>
-inline std::string toString(Args&&... args) {
-    return boost::lexical_cast<std::string>(::std::forward<Args>(args)...);
+template <class T>
+inline std::string toString(T t) {
+    return std::to_string(t);
 }
 
-// boost::lexical_cast() treats this as a character, but we are using it as number types.
 inline std::string toString(int8_t num) {
-    return boost::lexical_cast<std::string>(int(num));
+    return std::to_string(int(num));
 }
 
-// boost::lexical_cast() treats this as a character, but we are using it as number types.
 inline std::string toString(uint8_t num) {
-    return boost::lexical_cast<std::string>(unsigned(num));
+    return std::to_string(unsigned(num));
 }
 
 inline std::string toString(std::exception_ptr error) {
@@ -41,18 +35,6 @@ inline std::string toString(std::exception_ptr error) {
     } catch (...) {
         return "Unknown exception type";
     }
-}
-
-template<size_t max, typename... Args>
-inline std::string sprintf(const char *msg, Args... args) {
-    char res[max];
-    int len = snprintf(res, sizeof(res), msg, args...);
-    return std::string(res, len);
-}
-
-template<size_t max, typename... Args>
-inline std::string sprintf(const std::string &msg, Args... args) {
-    return sprintf<max>(msg.c_str(), args...);
 }
 
 } // namespace util

--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -4,10 +4,17 @@
 
 #include <png.h>
 
+template<size_t max, typename... Args>
+inline static std::string sprintf(const char *msg, Args... args) {
+    char res[max];
+    int len = snprintf(res, sizeof(res), msg, args...);
+    return std::string(res, len);
+}
+
 const static bool png_version_check __attribute__((unused)) = []() {
     const png_uint_32 version = png_access_version_number();
     if (version != PNG_LIBPNG_VER) {
-        throw std::runtime_error(mbgl::util::sprintf<96>(
+        throw std::runtime_error(sprintf<96>(
             "libpng version mismatch: headers report %d.%d.%d, but library reports %d.%d.%d",
             PNG_LIBPNG_VER / 10000, (PNG_LIBPNG_VER / 100) % 100, PNG_LIBPNG_VER % 100,
             version / 10000, (version / 100) % 100, version % 100));

--- a/platform/ios/platform.gyp
+++ b/platform/ios/platform.gyp
@@ -110,7 +110,6 @@
 
       'variables': {
         'cflags_cc': [
-          '<@(boost_cflags)',
           '<@(sqlite_cflags)',
           '<@(zlib_cflags)',
           '<@(rapidjson_cflags)',

--- a/platform/osx/platform.gyp
+++ b/platform/osx/platform.gyp
@@ -67,7 +67,6 @@
 
       'xcode_settings': {
         'OTHER_CPLUSPLUSFLAGS': [
-          '<@(boost_cflags)',
           '<@(sqlite_cflags)',
           '<@(zlib_cflags)',
           '<@(rapidjson_cflags)',


### PR DESCRIPTION
This removes the only boost dependency from public headers.