### PR TITLE
[core] Use gyp's direct_dependent_settings to propagate variant cflags

### DIFF
--- a/bin/glfw.gypi
+++ b/bin/glfw.gypi
@@ -6,6 +6,7 @@
       'type': 'executable',
 
       'dependencies': [
+        'core',
         'platform-lib',
         'copy_certificate_bundle',
       ],
@@ -27,7 +28,6 @@
       'variables': {
         'cflags_cc': [
           '<@(glfw_cflags)',
-          '<@(variant_cflags)',
         ],
         'ldflags': [
           '<@(glfw_ldflags)',

--- a/mbgl.gypi
+++ b/mbgl.gypi
@@ -283,6 +283,17 @@
           }]
         ],
       },
+
+      'direct_dependent_settings': {
+        'cflags_cc': [
+          '<@(variant_cflags)',
+        ],
+        'xcode_settings': {
+          'OTHER_CPLUSPLUSFLAGS': [
+            '<@(variant_cflags)',
+          ],
+        },
+      },
     },
     {
       'target_name': 'copy_certificate_bundle',

--- a/platform/android/platform.gyp
+++ b/platform/android/platform.gyp
@@ -51,7 +51,6 @@
         '<@(rapidjson_cflags)',
         '<@(nunicode_cflags)',
         '<@(sqlite_cflags)',
-        '<@(variant_cflags)',
         '<@(jni.hpp_cflags)',
         '<@(libzip_cflags)',
         '<@(libpng_cflags)',

--- a/platform/ios/platform.gyp
+++ b/platform/ios/platform.gyp
@@ -113,7 +113,6 @@
           '<@(sqlite_cflags)',
           '<@(zlib_cflags)',
           '<@(rapidjson_cflags)',
-          '<@(variant_cflags)',
         ],
         'ldflags': [
           '<@(sqlite_ldflags)',

--- a/platform/linux/platform.gyp
+++ b/platform/linux/platform.gyp
@@ -75,7 +75,6 @@
         '<@(nunicode_cflags)',
         '<@(sqlite_cflags)',
         '<@(rapidjson_cflags)',
-        '<@(variant_cflags)',
         '<@(libcurl_cflags)',
         '<@(libpng_cflags)',
         '<@(libjpeg-turbo_cflags)',

--- a/platform/osx/platform.gyp
+++ b/platform/osx/platform.gyp
@@ -70,7 +70,6 @@
           '<@(sqlite_cflags)',
           '<@(zlib_cflags)',
           '<@(rapidjson_cflags)',
-          '<@(variant_cflags)',
         ],
         'CLANG_ENABLE_OBJC_ARC': 'YES',
         'CLANG_ENABLE_MODULES': 'YES',

--- a/platform/qt/platform.gyp
+++ b/platform/qt/platform.gyp
@@ -83,7 +83,6 @@
           '<@(qt_network_cflags)',
           '<@(rapidjson_cflags)',
           '<@(sqlite_cflags)',
-          '<@(variant_cflags)',
           '<@(webp_cflags)',
           '-fPIC',
         ],

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -5,6 +5,9 @@
       'type': 'static_library',
       'standalone_static_library': 1,
       'hard_dependency': 1,
+      'dependencies': [
+        'core',
+      ],
 
       'include_dirs': [
         '../include',
@@ -87,7 +90,6 @@
           '<@(geojsonvt_cflags)',
           '<@(rapidjson_cflags)',
           '<@(pixelmatch_cflags)',
-          '<@(variant_cflags)',
         ],
         'ldflags': [
           '<@(gtest_ldflags)',


### PR DESCRIPTION
variant.hpp is used for types that are included in the public API, so all dependents must be able to include the header.

cc @springmeyer 