### PR TITLE
[android] #4912 - remove lollipop attribute from background drawable

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -174,7 +174,7 @@ public class MapboxMapOptions implements Parcelable {
 
             mapboxMapOptions.locationEnabled(typedArray.getBoolean(R.styleable.MapView_my_location_enabled, false));
             mapboxMapOptions.myLocationForegroundTintColor(typedArray.getColor(R.styleable.MapView_my_location_foreground_tint, Color.TRANSPARENT));
-            mapboxMapOptions.myLocationBackgroundTintColor(typedArray.getColor(R.styleable.MapView_my_location_background_tint, Color.WHITE));
+            mapboxMapOptions.myLocationBackgroundTintColor(typedArray.getColor(R.styleable.MapView_my_location_background_tint, Color.TRANSPARENT));
 
             Drawable foregroundDrawable = typedArray.getDrawable(R.styleable.MapView_my_location_foreground);
             if(foregroundDrawable==null){

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/drawable/ic_mylocationview_background.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/drawable/ic_mylocationview_background.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
 
-    <solid android:color="?attr/colorPrimaryDark" />
+    <solid android:color="@color/white" />
 
     <size
         android:width="@dimen/my_locationview_outer_circle"


### PR DESCRIPTION
closes #4912 