### PR TITLE
Fix incorrect offset when fitting to bounds with padding

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -523,7 +523,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
             padding->left / minScale,
             padding->bottom / minScale,
         };
-        centerPixel = centerPixel - paddedNEPixel - paddedSWPixel;
+        centerPixel = centerPixel + paddedNEPixel - paddedSWPixel;
     }
     centerPixel /= 2;
 


### PR DESCRIPTION
This is a rebase of #4914 so that we can fast-forward merge the change and run tests against it on Bitrise. Thanks to @bwhtmn for the fix.

Fixes #4862.

/cc @friedbunny @tobrun