### PR TITLE
[build] Fix parallel 'make linux' call

### DIFF
--- a/scripts/main.mk
+++ b/scripts/main.mk
@@ -80,6 +80,7 @@ else
 .mason: ;
 endif
 
+.NOTPARALLEL: $(PLATFORM_CONFIG_OUTPUT)
 $(PLATFORM_CONFIG_OUTPUT): .mason configure $(PLATFORM_CONFIG_INPUT)
 	@printf "$(TEXT_BOLD)$(COLOR_GREEN)* Running configure...$(FORMAT_END)\n"
 	$(ENV) ./configure $(PLATFORM_CONFIG_INPUT) $(PLATFORM_CONFIG_OUTPUT)


### PR DESCRIPTION
E.g. when running `make linux -jX`, it causes `linux` target dependencies `glfw-app`, `render` and `offline` to run in parallel. This is OK, however `${PLATFORM_CONFIG_OUTPUT}` target - which collects the mason configure data, installing dependencies along the way - was run repeatedly for each of these targets, causing an unstable build. This fix addresses this by explicitly telling Makefile that `${PLATFORM_CONFIG_OUTPUT}` is not meant to be run in parallel.

/cc @tmpsantos @jfirebaugh