### PR TITLE
Correct map accessibility value

### DIFF
--- a/platform/ios/resources/en.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/en.lproj/Localizable.stringsdict
@@ -5,22 +5,18 @@
 	<key>MAP_A11Y_VALUE</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@count@</string>
+		<string>Zoom %dx
+%#@count@ visible</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
-			<key>zero</key>
-			<string>Zoom %dx
-no annotations visible</string>
 			<key>one</key>
-			<string>Zoom %dx
-%d annotation visible</string>
+			<string>%d annotation</string>
 			<key>other</key>
-			<string>Zoom %dx
-%d annotations visible</string>
+			<string>%d annotations</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1860,7 +1860,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
 - (NSString *)accessibilityValue
 {
-    double zoomLevel = round(self.zoomLevel - 1);
+    double zoomLevel = round(self.zoomLevel + 1);
     return [NSString stringWithFormat:NSLocalizedStringWithDefaultValue(@"MAP_A11Y_VALUE", nil, nil, @"Zoom %dx\n%ld annotation(s) visible", @"Map accessibility value"), (int)zoomLevel, (long)self.accessibilityAnnotationCount];
 }
 


### PR DESCRIPTION
Corrected the English override strings for the map view’s accessibility value. Prior to this change, the accessibility value would say “0 annotation” instead of “0 annotations” for some reason.

The zoom level in the map view’s accessibility value is off by two.

/cc @friedbunny