### PR TITLE
Make custom callout views easier to use [WIP]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = .mason
 	url = https://github.com/mapbox/mason.git
 
-[submodule "platform/ios/vendor/SMCalloutView"]
-	path = platform/ios/vendor/SMCalloutView
-	url = https://github.com/nfarina/calloutview.git
-
 [submodule "platform/ios/uitest/KIF"]
 	path = platform/ios/uitest/KIF
 	url = https://github.com/kif-framework/KIF.git

--- a/platform/darwin/src/MGLAnnotation.h
+++ b/platform/darwin/src/MGLAnnotation.h
@@ -2,6 +2,10 @@
 #import <CoreLocation/CoreLocation.h>
 #import <TargetConditionals.h>
 
+#ifdef TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
 #import "MGLTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -48,6 +52,14 @@ NS_ASSUME_NONNULL_BEGIN
  This string is displayed in the callout for the associated annotation.
  */
 @property (nonatomic, readonly, copy, nullable) NSString *subtitle;
+
+#ifdef TARGET_OS_IPHONE
+
+@property (nonatomic) BOOL canShowCallout;
+
+@property (nonatomic, nullable) UIView *callout;
+
+#endif
 
 #if !TARGET_OS_IPHONE
 

--- a/platform/darwin/src/MGLAnnotation.h
+++ b/platform/darwin/src/MGLAnnotation.h
@@ -2,7 +2,7 @@
 #import <CoreLocation/CoreLocation.h>
 #import <TargetConditionals.h>
 
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #import "MGLCalloutView.h"
 #endif
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, copy, nullable) NSString *subtitle;
 
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 
 @property (nonatomic) BOOL canShowCallout;
 

--- a/platform/darwin/src/MGLAnnotation.h
+++ b/platform/darwin/src/MGLAnnotation.h
@@ -4,6 +4,7 @@
 
 #ifdef TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#import "MGLCalloutView.h"
 #endif
 
 #import "MGLTypes.h"
@@ -57,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL canShowCallout;
 
-@property (nonatomic, nullable) UIView *callout;
+@property (nonatomic, nullable) UIView <MGLCalloutView> *calloutView;
 
 #endif
 

--- a/platform/darwin/src/MGLPointAnnotation.h
+++ b/platform/darwin/src/MGLPointAnnotation.h
@@ -1,6 +1,11 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#import "MGLCalloutView.h"
+#endif
+
 #import "MGLShape.h"
 
 #import "MGLTypes.h"
@@ -19,6 +24,14 @@ NS_ASSUME_NONNULL_BEGIN
  The coordinate point of the annotation, specified as a latitude and longitude.
  */
 @property (nonatomic, assign) CLLocationCoordinate2D coordinate;
+
+#if TARGET_OS_IPHONE
+
+@property (nonatomic) BOOL canShowCallout;
+
+@property (nonatomic, nullable) UIView <MGLCalloutView> *calloutView;
+
+#endif
 
 @end
 

--- a/platform/darwin/src/MGLPointAnnotation.m
+++ b/platform/darwin/src/MGLPointAnnotation.m
@@ -3,14 +3,17 @@
 @implementation MGLPointAnnotation
 
 @synthesize coordinate;
+@synthesize canShowCallout;
+@synthesize calloutView;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p; title = %@; subtitle = %@; coordinate = %f, %f>",
+    return [NSString stringWithFormat:@"<%@: %p; title = %@; subtitle = %@; coordinate = %f, %f; callout: %@ (%@)>",
             NSStringFromClass([self class]), (void *)self,
             self.title ? [NSString stringWithFormat:@"\"%@\"", self.title] : self.title,
             self.subtitle ? [NSString stringWithFormat:@"\"%@\"", self.subtitle] : self.subtitle,
-            coordinate.latitude, coordinate.longitude];
+            coordinate.latitude, coordinate.longitude,
+            canShowCallout ? @"yes" : @"no", calloutView];
 }
 
 @end

--- a/platform/darwin/src/MGLPointAnnotation.m
+++ b/platform/darwin/src/MGLPointAnnotation.m
@@ -3,8 +3,11 @@
 @implementation MGLPointAnnotation
 
 @synthesize coordinate;
+
+#if TARGET_OS_IPHONE
 @synthesize canShowCallout;
 @synthesize calloutView;
+#endif
 
 - (NSString *)description
 {
@@ -12,8 +15,11 @@
             NSStringFromClass([self class]), (void *)self,
             self.title ? [NSString stringWithFormat:@"\"%@\"", self.title] : self.title,
             self.subtitle ? [NSString stringWithFormat:@"\"%@\"", self.subtitle] : self.subtitle,
-            coordinate.latitude, coordinate.longitude,
-            canShowCallout ? @"yes" : @"no", calloutView];
+            coordinate.latitude, coordinate.longitude
+#if TARGET_OS_IPHONE
+            , canShowCallout ? @"yes" : @"no", calloutView
+#endif
+            ];
 }
 
 @end

--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -1,10 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
-#import "MGLCalloutView.h"
-#endif
-
 #import "MGLAnnotation.h"
 
 #import "MGLTypes.h"
@@ -30,14 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
  `nil`.
  */
 @property (nonatomic, copy, nullable) NSString *subtitle;
-
-#if TARGET_OS_IPHONE
-
-@property (nonatomic) BOOL canShowCallout;
-
-@property (nonatomic, nullable) UIView <MGLCalloutView> *calloutView;
-
-#endif
 
 #if !TARGET_OS_IPHONE
 

--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
 
+#ifdef TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
 #import "MGLAnnotation.h"
 
 #import "MGLTypes.h"
@@ -25,6 +29,14 @@ NS_ASSUME_NONNULL_BEGIN
  `nil`.
  */
 @property (nonatomic, copy, nullable) NSString *subtitle;
+
+#ifdef TARGET_OS_IPHONE
+
+@property (nonatomic) BOOL canShowCallout;
+
+@property (nonatomic, nullable) UIView *callout;
+
+#endif
 
 #if !TARGET_OS_IPHONE
 

--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -2,6 +2,7 @@
 
 #ifdef TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#import "MGLCalloutView.h"
 #endif
 
 #import "MGLAnnotation.h"
@@ -34,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL canShowCallout;
 
-@property (nonatomic, nullable) UIView *callout;
+@property (nonatomic, nullable) UIView <MGLCalloutView> *calloutView;
 
 #endif
 

--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #import "MGLCalloutView.h"
 #endif
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) NSString *subtitle;
 
-#ifdef TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
 
 @property (nonatomic) BOOL canShowCallout;
 

--- a/platform/ios/app/MBXCustomCalloutView.m
+++ b/platform/ios/app/MBXCustomCalloutView.m
@@ -10,16 +10,10 @@ static CGFloat const tipWidth = 10.0;
 @end
 
 @implementation MBXCustomCalloutView {
-    id <MGLAnnotation> _representedObject;
-    UIView *_leftAccessoryView;
-    UIView *_rightAccessoryView;
-    __weak id <MGLCalloutViewDelegate> _delegate;
+    NSString *_title;
 }
 
-@synthesize representedObject = _representedObject;
-@synthesize leftAccessoryView = _leftAccessoryView;
-@synthesize rightAccessoryView = _rightAccessoryView;
-@synthesize delegate = _delegate;
+@synthesize title = _title;
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -40,16 +34,11 @@ static CGFloat const tipWidth = 10.0;
 
 - (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view constrainedToView:(UIView *)constrainedView animated:(BOOL)animated
 {
-    if ([self.delegate respondsToSelector:@selector(calloutViewWillAppear:)])
-    {
-        [self.delegate performSelector:@selector(calloutViewWillAppear:) withObject:self];
-    }
-    
     [view addSubview:self];
     // prepare title label
-    if ([self.representedObject respondsToSelector:@selector(title)])
+    if (_title)
     {
-        self.mainLabel.text = self.representedObject.title;
+        self.mainLabel.text = _title;
         [self.mainLabel sizeToFit];
     }
     // prepare our frame
@@ -59,17 +48,14 @@ static CGFloat const tipWidth = 10.0;
     CGFloat frameOriginY = rect.origin.y - frameHeight;
     self.frame = CGRectMake(frameOriginX, frameOriginY,
                             frameWidth, frameHeight);
-    
-    if ([self.delegate respondsToSelector:@selector(calloutViewDidAppear:)])
-    {
-        [self.delegate performSelector:@selector(calloutViewDidAppear:) withObject:self];
-    }
 }
 
 - (void)dismissCalloutAnimated:(BOOL)animated
 {
     if (self.superview)
+    {
         [self removeFromSuperview];
+    }
 }
 
 #pragma mark - internals
@@ -100,6 +86,5 @@ static CGFloat const tipWidth = 10.0;
     CGContextFillPath(ctxt);
     CGPathRelease(tipPath);
 }
-
 
 @end

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -323,6 +323,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
 
                 annotation.coordinate = coordinate;
                 annotation.title = title;
+                annotation.canShowCallout = YES;
 
                 [annotations addObject:annotation];
 
@@ -748,35 +749,35 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     }];
 }
 
-- (UIView<MGLCalloutView> *)mapView:(__unused MGLMapView *)mapView calloutViewForAnnotation:(id<MGLAnnotation>)annotation
-{
-    if ([annotation respondsToSelector:@selector(title)]
-        && [annotation isKindOfClass:[MBXCustomCalloutAnnotation class]])
-    {
-        MBXCustomCalloutView *calloutView = [[MBXCustomCalloutView alloc] init];
-        calloutView.representedObject = annotation;
-        return calloutView;
-    }
-    return nil;
-}
-
-- (UIView *)mapView:(__unused MGLMapView *)mapView leftCalloutAccessoryViewForAnnotation:(__unused id<MGLAnnotation>)annotation
-{
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
-    button.frame = CGRectZero;
-    [button setTitle:@"Left" forState:UIControlStateNormal];
-    [button sizeToFit];
-    return button;
-}
-
-- (UIView *)mapView:(__unused MGLMapView *)mapView rightCalloutAccessoryViewForAnnotation:(__unused id<MGLAnnotation>)annotation
-{
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
-    button.frame = CGRectZero;
-    [button setTitle:@"Right" forState:UIControlStateNormal];
-    [button sizeToFit];
-    return button;
-}
+//- (UIView<MGLCalloutView> *)mapView:(__unused MGLMapView *)mapView calloutViewForAnnotation:(id<MGLAnnotation>)annotation
+//{
+//    if ([annotation respondsToSelector:@selector(title)]
+//        && [annotation isKindOfClass:[MBXCustomCalloutAnnotation class]])
+//    {
+//        MBXCustomCalloutView *calloutView = [[MBXCustomCalloutView alloc] init];
+//        calloutView.representedObject = annotation;
+//        return calloutView;
+//    }
+//    return nil;
+//}
+//
+//- (UIView *)mapView:(__unused MGLMapView *)mapView leftCalloutAccessoryViewForAnnotation:(__unused id<MGLAnnotation>)annotation
+//{
+//    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+//    button.frame = CGRectZero;
+//    [button setTitle:@"Left" forState:UIControlStateNormal];
+//    [button sizeToFit];
+//    return button;
+//}
+//
+//- (UIView *)mapView:(__unused MGLMapView *)mapView rightCalloutAccessoryViewForAnnotation:(__unused id<MGLAnnotation>)annotation
+//{
+//    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+//    button.frame = CGRectZero;
+//    [button setTitle:@"Right" forState:UIControlStateNormal];
+//    [button sizeToFit];
+//    return button;
+//}
 
 - (void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id <MGLAnnotation>)annotation
 {

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -430,9 +430,11 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     [self.mapView removeAnnotations:self.mapView.annotations];
     
     MBXCustomCalloutAnnotation *annotation = [[MBXCustomCalloutAnnotation alloc] init];
-    annotation.coordinate = CLLocationCoordinate2DMake(48.8533940, 2.3775439);
+    annotation.coordinate = CLLocationCoordinate2DMake(38.904722, -77.016389);//CLLocationCoordinate2DMake(48.8533940, 2.3775439);
     annotation.title = @"Custom Callout";
-    
+    annotation.canShowCallout = YES;
+    annotation.calloutView = [[MBXCustomCalloutView alloc] init];
+
     [self.mapView addAnnotation:annotation];
     [self.mapView showAnnotations:@[annotation] animated:YES];
 }
@@ -700,9 +702,15 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     return image;
 }
 
-- (BOOL)mapView:(__unused MGLMapView *)mapView annotationCanShowCallout:(__unused id <MGLAnnotation>)annotation
-{
-    return YES;
+- (void)mapView:(MGLMapView *)mapView didDeselectAnnotation:(id<MGLAnnotation>)annotation {
+    NSString *title = [(MGLPointAnnotation *)annotation title];
+    if ( ! title.length)
+    {
+        return;
+    }
+    NSString *lastTwoCharacters = [title substringFromIndex:title.length - 2];
+    MGLAnnotationImage *annotationImage = [mapView dequeueReusableAnnotationImageWithIdentifier:lastTwoCharacters];
+    annotationImage.image = annotationImage.image ? nil : [self imageWithText:lastTwoCharacters backgroundColor:[UIColor grayColor]];
 }
 
 - (CGFloat)mapView:(__unused MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		40FDA76B1CCAAA6800442548 /* MBXAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FDA76A1CCAAA6800442548 /* MBXAnnotationView.m */; };
 		554180421D2E97DE00012372 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 554180411D2E97DE00012372 /* OpenGLES.framework */; };
 		DA0CD5901CF56F6A00A5F5A5 /* MGLFeatureTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */; };
+		9686D6051CDAC6A200B6FA7B /* MBXCustomCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1DC9671CB6C6B7006E619F /* MBXCustomCalloutView.m */; };
 		DA17BE301CC4BAC300402C41 /* MGLMapView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */; };
 		DA17BE311CC4BDAA00402C41 /* MGLMapView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */; };
 		DA1DC96B1CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1DC9691CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m */; };
@@ -1345,6 +1346,7 @@
 				DA1DC96B1CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m in Sources */,
 				DA1DC99B1CB6E064006E619F /* MBXViewController.m in Sources */,
 				40FDA76B1CCAAA6800442548 /* MBXAnnotationView.m in Sources */,
+				9686D6051CDAC6A200B6FA7B /* MBXCustomCalloutView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -153,8 +153,6 @@
 		DA8848851CBB033F00AB86E3 /* FABKitProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8848811CBB033F00AB86E3 /* FABKitProtocol.h */; };
 		DA8848861CBB033F00AB86E3 /* Fabric+FABKits.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8848821CBB033F00AB86E3 /* Fabric+FABKits.h */; };
 		DA8848871CBB033F00AB86E3 /* Fabric.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8848831CBB033F00AB86E3 /* Fabric.h */; };
-		DA88488B1CBB037E00AB86E3 /* SMCalloutView.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8848891CBB037E00AB86E3 /* SMCalloutView.h */; };
-		DA88488C1CBB037E00AB86E3 /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
 		DA88488E1CBB047F00AB86E3 /* reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = DA88488D1CBB047F00AB86E3 /* reachability.h */; };
 		DA8848901CBB048E00AB86E3 /* reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488F1CBB048E00AB86E3 /* reachability.m */; };
 		DA8933A31CCC95B000E68420 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DA89339F1CCC951200E68420 /* Localizable.strings */; };
@@ -209,7 +207,6 @@
 		DAA4E4321CBB730400178DFB /* MGLMapView.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA88484A1CBAFB9800AB86E3 /* MGLMapView.mm */; };
 		DAA4E4331CBB730400178DFB /* MGLUserLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88484C1CBAFB9800AB86E3 /* MGLUserLocation.m */; };
 		DAA4E4341CBB730400178DFB /* MGLUserLocationAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88484E1CBAFB9800AB86E3 /* MGLUserLocationAnnotationView.m */; };
-		DAA4E4351CBB730400178DFB /* SMCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */; };
 		DAABF73D1CBC59BB005B1825 /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAABF73B1CBC59BB005B1825 /* libmbgl-core.a */; };
 		DAABF73E1CBC59BB005B1825 /* libmbgl-platform-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAABF73C1CBC59BB005B1825 /* libmbgl-platform-ios.a */; };
 		DABCABAC1CB80692000A7C39 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DABCABAB1CB80692000A7C39 /* main.m */; };
@@ -476,8 +473,6 @@
 		DA8848811CBB033F00AB86E3 /* FABKitProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
 		DA8848821CBB033F00AB86E3 /* Fabric+FABKits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
 		DA8848831CBB033F00AB86E3 /* Fabric.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
-		DA8848891CBB037E00AB86E3 /* SMCalloutView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMCalloutView.h; sourceTree = "<group>"; };
-		DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMCalloutView.m; sourceTree = "<group>"; };
 		DA88488D1CBB047F00AB86E3 /* reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = reachability.h; path = ../../include/mbgl/platform/darwin/reachability.h; sourceTree = "<group>"; };
 		DA88488F1CBB048E00AB86E3 /* reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = reachability.m; path = src/reachability.m; sourceTree = "<group>"; };
 		DA8933A01CCC951200E68420 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -734,7 +729,6 @@
 				DA737EE01D056A4E005BDA16 /* MGLMapViewDelegate.h */,
 				DA88484A1CBAFB9800AB86E3 /* MGLMapView.mm */,
 				DA88487F1CBB033F00AB86E3 /* Fabric */,
-				DA8848881CBB036000AB86E3 /* SMCalloutView */,
 			);
 			name = Kit;
 			path = src;
@@ -773,16 +767,6 @@
 			);
 			name = Fabric;
 			path = ../vendor/Fabric;
-			sourceTree = "<group>";
-		};
-		DA8848881CBB036000AB86E3 /* SMCalloutView */ = {
-			isa = PBXGroup;
-			children = (
-				DA8848891CBB037E00AB86E3 /* SMCalloutView.h */,
-				DA88488A1CBB037E00AB86E3 /* SMCalloutView.m */,
-			);
-			name = SMCalloutView;
-			path = ../vendor/SMCalloutView;
 			sourceTree = "<group>";
 		};
 		DA8848911CBB049300AB86E3 /* reachability */ = {
@@ -1006,7 +990,6 @@
 				DA35A29E1CC9E94C00E826B2 /* MGLCoordinateFormatter.h in Headers */,
 				DA8847F71CBAFA5100AB86E3 /* MGLOverlay.h in Headers */,
 				DA35A2B11CCA141D00E826B2 /* MGLCompassDirectionFormatter.h in Headers */,
-				DA88488B1CBB037E00AB86E3 /* SMCalloutView.h in Headers */,
 				DA8847FE1CBAFA5100AB86E3 /* MGLTypes.h in Headers */,
 				DA8847F11CBAFA5100AB86E3 /* MGLGeometry.h in Headers */,
 				DA8848221CBAFA6200AB86E3 /* MGLOfflineRegion_Private.h in Headers */,
@@ -1396,7 +1379,6 @@
 				DA8848251CBAFA6200AB86E3 /* MGLPointAnnotation.m in Sources */,
 				DA88482D1CBAFA6200AB86E3 /* NSBundle+MGLAdditions.m in Sources */,
 				DA88485B1CBAFB9800AB86E3 /* MGLUserLocation.m in Sources */,
-				DA88488C1CBB037E00AB86E3 /* SMCalloutView.m in Sources */,
 				DA35A2B81CCA9A5D00E826B2 /* MGLClockDirectionFormatter.m in Sources */,
 				DAD1657A1CF4CDFF001FF4B9 /* MGLShapeCollection.m in Sources */,
 				DA8848901CBB048E00AB86E3 /* reachability.m in Sources */,
@@ -1438,7 +1420,6 @@
 				DAA4E42E1CBB730400178DFB /* MGLAPIClient.m in Sources */,
 				DAA4E4201CBB730400178DFB /* MGLOfflinePack.mm in Sources */,
 				DAA4E4331CBB730400178DFB /* MGLUserLocation.m in Sources */,
-				DAA4E4351CBB730400178DFB /* SMCalloutView.m in Sources */,
 				DA35A2B91CCA9A5D00E826B2 /* MGLClockDirectionFormatter.m in Sources */,
 				DAD1657B1CF4CDFF001FF4B9 /* MGLShapeCollection.m in Sources */,
 				DAA4E4251CBB730400178DFB /* MGLShape.m in Sources */,

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		DA0CD5901CF56F6A00A5F5A5 /* MGLFeatureTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */; };
 		DA17BE301CC4BAC300402C41 /* MGLMapView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */; };
 		DA17BE311CC4BDAA00402C41 /* MGLMapView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */; };
-		DA1DC96A1CB6C6B7006E619F /* MBXCustomCalloutView.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1DC9671CB6C6B7006E619F /* MBXCustomCalloutView.m */; };
 		DA1DC96B1CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1DC9691CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m */; };
 		DA1DC9701CB6C6CE006E619F /* points.geojson in Resources */ = {isa = PBXBuildFile; fileRef = DA1DC96C1CB6C6CE006E619F /* points.geojson */; };
 		DA1DC9711CB6C6CE006E619F /* polyline.geojson in Resources */ = {isa = PBXBuildFile; fileRef = DA1DC96D1CB6C6CE006E619F /* polyline.geojson */; };
@@ -1344,7 +1343,6 @@
 				DA1DC9971CB6E046006E619F /* main.m in Sources */,
 				DA1DC9991CB6E054006E619F /* MBXAppDelegate.m in Sources */,
 				DA1DC96B1CB6C6B7006E619F /* MBXOfflinePacksTableViewController.m in Sources */,
-				DA1DC96A1CB6C6B7006E619F /* MBXCustomCalloutView.m in Sources */,
 				DA1DC99B1CB6E064006E619F /* MBXViewController.m in Sources */,
 				40FDA76B1CCAAA6800442548 /* MBXAnnotationView.m in Sources */,
 			);

--- a/platform/ios/src/MGLCalloutView.h
+++ b/platform/ios/src/MGLCalloutView.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import "MGLTypes.h"
 

--- a/platform/ios/src/MGLCalloutView.h
+++ b/platform/ios/src/MGLCalloutView.h
@@ -13,26 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol MGLCalloutView <NSObject>
 
-@property (nonatomic, strong) NSString *title;
-@property (nonatomic, strong) NSString *subtitle;
-
 /**
- A view that the user may tap to perform an action. This view is conventionally
- positioned on the left side of the callout view.
- */
-@property (nonatomic, strong) UIView *leftAccessoryView;
-
-/**
- A view that the user may tap to perform an action. This view is conventionally
- positioned on the right side of the callout view.
- */
-@property (nonatomic, strong) UIView *rightAccessoryView;
-
-@property (nonatomic, strong) UIView *detailAccessoryView;
-
-/**
- Presents a callout view by adding it to `view` and pointing at the given rect
- of `view`’s bounds. Constrains the callout to the bounds of the given view.
+ Presents a callout view by adding it to `inView` and pointing at the given rect of `inView`’s bounds. Constrains the callout to the bounds of the given view.
  */
 - (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view constrainedToView:(UIView *)constrainedView animated:(BOOL)animated;
 
@@ -42,6 +24,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)dismissCalloutAnimated:(BOOL)animated;
 
 @optional
+
+@property (nonatomic, strong) NSString *title;
+@property (nonatomic, strong) NSString *subtitle;
+
+/**
+ A view that the user may tap to perform an action. This view is conventionally positioned on the left side of the callout view.
+ */
+@property (nonatomic, strong) UIView *leftAccessoryView;
+
+/**
+ A view that the user may tap to perform an action. This view is conventionally positioned on the right side of the callout view.
+ */
+@property (nonatomic, strong) UIView *rightAccessoryView;
+
+@property (nonatomic, strong) UIView *detailAccessoryView;
 
 @property (nonatomic, weak) id<MGLCalloutViewDelegate> delegate;
 

--- a/platform/ios/src/MGLCalloutView.h
+++ b/platform/ios/src/MGLCalloutView.h
@@ -6,7 +6,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MGLCalloutViewDelegate;
-@protocol MGLAnnotation;
 
 /**
  A protocol for a `UIView` subclass that displays information about a selected
@@ -14,11 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol MGLCalloutView <NSObject>
 
-/**
- An object conforming to the `MGLAnnotation` protocol whose details this callout
- view displays.
- */
-@property (nonatomic, strong) id <MGLAnnotation> representedObject;
+@property (nonatomic, strong) NSString *title;
+@property (nonatomic, strong) NSString *subtitle;
 
 /**
  A view that the user may tap to perform an action. This view is conventionally
@@ -32,11 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) UIView *rightAccessoryView;
 
-/**
- An object conforming to the `MGLCalloutViewDelegate` method that receives
- messages related to the callout view’s interactive subviews.
- */
-@property (nonatomic, weak) id<MGLCalloutViewDelegate> delegate;
+@property (nonatomic, strong) UIView *detailAccessoryView;
 
 /**
  Presents a callout view by adding it to `view` and pointing at the given rect
@@ -49,43 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)dismissCalloutAnimated:(BOOL)animated;
 
-@end
-
-/**
- The `MGLCalloutViewDelegate` protocol defines a set of optional methods that
- you can use to receive messages from an object that conforms to the
- `MGLCalloutView` protocol. The callout view uses these methods to inform the
- delegate that the user has interacted with the the callout view.
- */
-@protocol MGLCalloutViewDelegate <NSObject>
-
 @optional
-/**
- Returns a Boolean value indicating whether the entire callout view “highlights”
- when tapped. The default value is `YES`, which means the callout view
- highlights when tapped.
- 
- The return value of this method is ignored unless the delegate also responds to
- the `-calloutViewTapped` method.
- */
-- (BOOL)calloutViewShouldHighlight:(UIView<MGLCalloutView> *)calloutView;
 
-/**
- Tells the delegate that the callout view has been tapped.
- */
-- (void)calloutViewTapped:(UIView<MGLCalloutView> *)calloutView;
-
-/**
- Called before the callout view appears on screen, or before the appearance
- animation will start.
- */
-- (void)calloutViewWillAppear:(UIView<MGLCalloutView> *)calloutView;
-
-/**
- Called after the callout view appears on screen, or after the appearance
- animation is complete.
- */
-- (void)calloutViewDidAppear:(UIView<MGLCalloutView> *)calloutView;
+@property (nonatomic, weak) id<MGLCalloutViewDelegate> delegate;
 
 @end
 

--- a/platform/ios/src/MGLCompactCalloutView.h
+++ b/platform/ios/src/MGLCompactCalloutView.h
@@ -7,4 +7,11 @@
 
 + (instancetype)calloutView;
 
+@property (nonatomic, strong) NSString *title;
+@property (nonatomic, strong) NSString *subtitle;
+
+@property (nonatomic, strong) UIView *leftAccessoryView;
+@property (nonatomic, strong) UIView *rightAccessoryView;
+@property (nonatomic, strong) UIView *detailAccessoryView;
+
 @end

--- a/platform/ios/src/MGLCompactCalloutView.h
+++ b/platform/ios/src/MGLCompactCalloutView.h
@@ -1,14 +1,10 @@
-#import "SMCalloutView.h"
 #import "MGLCalloutView.h"
 
 /**
- A concrete implementation of `MGLCalloutView` based on
- <a href="https://github.com/nfarina/calloutview">SMCalloutView</a>. This
- callout view displays the represented annotation’s title, subtitle, and
- accessory views in a compact, two-line layout.
+ This callout view displays the represented annotation’s title, subtitle, and accessory views in a compact, two-line layout.
  */
-@interface MGLCompactCalloutView : SMCalloutView <MGLCalloutView>
+@interface MGLCompactCalloutView : UIView <MGLCalloutView>
 
-+ (instancetype)platformCalloutView;
++ (instancetype)calloutView;
 
 @end

--- a/platform/ios/src/MGLCompactCalloutView.m
+++ b/platform/ios/src/MGLCompactCalloutView.m
@@ -146,7 +146,7 @@ static CGFloat const tipWidth = 20.0;
 
     CGFloat tipLeft = rect.origin.x + (rect.size.width / 2.0) - (tipWidth / 2.0);
     CGPoint tipBottom = CGPointMake(rect.origin.x + (rect.size.width / 2.0), rect.origin.y + rect.size.height);
-    CGFloat heightWithoutTip = rect.size.height - tipHeight;
+    CGFloat heightWithoutTip = rect.size.height - tipHeight - 1;
 
     CGContextRef currentContext = UIGraphicsGetCurrentContext();
 

--- a/platform/ios/src/MGLCompactCalloutView.m
+++ b/platform/ios/src/MGLCompactCalloutView.m
@@ -26,7 +26,7 @@ static CGFloat const tipWidth = 20.0;
 
         // Create and add a subview to hold the callout’s text
         UIButton *mainBody = [UIButton buttonWithType:UIButtonTypeSystem];
-        mainBody.backgroundColor = [self backgroundColorForCallout];
+        mainBody.backgroundColor = [UIColor whiteColor];
         mainBody.contentEdgeInsets = UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0);
         mainBody.layer.cornerRadius = 4.0;
         self.mainBody = mainBody;
@@ -96,16 +96,9 @@ static CGFloat const tipWidth = 20.0;
 
 #pragma mark - Custom view styling
 
-- (UIColor *)backgroundColorForCallout
-{
-    return [UIColor whiteColor];
-}
-
 - (void)drawRect:(CGRect)rect
 {
     // Draw the pointed tip at the bottom
-    UIColor *fillColor = [self backgroundColorForCallout];
-
     CGFloat tipLeft = rect.origin.x + (rect.size.width / 2.0) - (tipWidth / 2.0);
     CGPoint tipBottom = CGPointMake(rect.origin.x + (rect.size.width / 2.0), rect.origin.y + rect.size.height);
     CGFloat heightWithoutTip = rect.size.height - tipHeight - 1;
@@ -118,7 +111,7 @@ static CGFloat const tipWidth = 20.0;
     CGPathAddLineToPoint(tipPath, NULL, tipLeft + tipWidth, heightWithoutTip);
     CGPathCloseSubpath(tipPath);
 
-    [fillColor setFill];
+    [self.mainBody.backgroundColor setFill];
     CGContextAddPath(currentContext, tipPath);
     CGContextFillPath(currentContext);
     CGPathRelease(tipPath);

--- a/platform/ios/src/MGLCompactCalloutView.m
+++ b/platform/ios/src/MGLCompactCalloutView.m
@@ -2,30 +2,165 @@
 
 #import "MGLAnnotation.h"
 
-@implementation MGLCompactCalloutView
-{
+// Set defaults for custom tip drawing
+static CGFloat const tipHeight = 10.0;
+static CGFloat const tipWidth = 20.0;
+
+@interface MGLCompactCalloutView ()
+
+@property (strong, nonatomic) UIButton *mainBody;
+
+@end
+
+@implementation MGLCompactCalloutView {
     id <MGLAnnotation> _representedObject;
+    __unused UIView *_leftAccessoryView;/* unused */
+    __unused UIView *_rightAccessoryView;/* unused */
+    __weak id <MGLCalloutViewDelegate> _delegate;
 }
 
 @synthesize representedObject = _representedObject;
+@synthesize leftAccessoryView = _leftAccessoryView;/* unused */
+@synthesize rightAccessoryView = _rightAccessoryView;/* unused */
+@synthesize delegate = _delegate;
 
-+ (instancetype)platformCalloutView
++ (instancetype)calloutView
 {
     return [[self alloc] init];
 }
 
-- (void)setRepresentedObject:(id <MGLAnnotation>)representedObject
+- (instancetype)initWithFrame:(CGRect)frame
 {
-    _representedObject = representedObject;
-    
-    if ([representedObject respondsToSelector:@selector(title)])
+    self = [super initWithFrame:frame];
+    if (self)
     {
-        self.title = representedObject.title;
+        self.backgroundColor = [UIColor clearColor];
+
+        // Create and add a subview to hold the callout’s text
+        UIButton *mainBody = [UIButton buttonWithType:UIButtonTypeSystem];
+        mainBody.backgroundColor = [self backgroundColorForCallout];
+        mainBody.tintColor = [UIColor whiteColor];
+        mainBody.contentEdgeInsets = UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0);
+        mainBody.layer.cornerRadius = 4.0;
+        self.mainBody = mainBody;
+
+        [self addSubview:self.mainBody];
     }
-    if ([representedObject respondsToSelector:@selector(subtitle)])
+
+    return self;
+}
+
+#pragma mark - MGLCalloutView API
+
+- (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view constrainedToView:(UIView *)constrainedView animated:(BOOL)animated
+{
+    // Do not show a callout if there is no title set for the annotation
+    if (![self.representedObject respondsToSelector:@selector(title)])
     {
-        self.subtitle = representedObject.subtitle;
+        return;
     }
+
+    [view addSubview:self];
+
+    // Prepare title label
+    [self.mainBody setTitle:self.representedObject.title forState:UIControlStateNormal];
+    [self.mainBody sizeToFit];
+
+    if ([self isCalloutTappable])
+    {
+        // Handle taps and eventually try to send them to the delegate (usually the map view)
+        [self.mainBody addTarget:self action:@selector(calloutTapped) forControlEvents:UIControlEventTouchUpInside];
+    }
+    else
+    {
+        // Disable tapping and highlighting
+        self.mainBody.userInteractionEnabled = NO;
+    }
+
+    // Prepare our frame, adding extra space at the bottom for the tip
+    CGFloat frameWidth = self.mainBody.bounds.size.width;
+    CGFloat frameHeight = self.mainBody.bounds.size.height + tipHeight;
+    CGFloat frameOriginX = rect.origin.x + (rect.size.width/2.0) - (frameWidth/2.0);
+    CGFloat frameOriginY = rect.origin.y - frameHeight;
+    self.frame = CGRectMake(frameOriginX, frameOriginY,
+                            frameWidth, frameHeight);
+
+    if (animated)
+    {
+        self.alpha = 0.0;
+
+        [UIView animateWithDuration:0.2 animations:^{
+            self.alpha = 1.0;
+        }];
+    }
+}
+
+- (void)dismissCalloutAnimated:(BOOL)animated
+{
+    if (self.superview)
+    {
+        if (animated)
+        {
+            [UIView animateWithDuration:0.2 animations:^{
+                self.alpha = 0.0;
+            } completion:^(BOOL finished) {
+                [self removeFromSuperview];
+            }];
+        }
+        else
+        {
+            [self removeFromSuperview];
+        }
+    }
+}
+
+#pragma mark - Callout interaction handlers
+
+- (BOOL)isCalloutTappable
+{
+    if ([self.delegate respondsToSelector:@selector(calloutViewShouldHighlight:)]) {
+        return [self.delegate performSelector:@selector(calloutViewShouldHighlight:) withObject:self];
+    }
+
+    return NO;
+}
+
+- (void)calloutTapped
+{
+    if ([self isCalloutTappable] && [self.delegate respondsToSelector:@selector(calloutViewTapped:)])
+    {
+        [self.delegate performSelector:@selector(calloutViewTapped:) withObject:self];
+    }
+}
+
+#pragma mark - Custom view styling
+
+- (UIColor *)backgroundColorForCallout
+{
+    return [UIColor darkGrayColor];
+}
+
+- (void)drawRect:(CGRect)rect
+{
+    // Draw the pointed tip at the bottom
+    UIColor *fillColor = [self backgroundColorForCallout];
+
+    CGFloat tipLeft = rect.origin.x + (rect.size.width / 2.0) - (tipWidth / 2.0);
+    CGPoint tipBottom = CGPointMake(rect.origin.x + (rect.size.width / 2.0), rect.origin.y + rect.size.height);
+    CGFloat heightWithoutTip = rect.size.height - tipHeight;
+
+    CGContextRef currentContext = UIGraphicsGetCurrentContext();
+
+    CGMutablePathRef tipPath = CGPathCreateMutable();
+    CGPathMoveToPoint(tipPath, NULL, tipLeft, heightWithoutTip);
+    CGPathAddLineToPoint(tipPath, NULL, tipBottom.x, tipBottom.y);
+    CGPathAddLineToPoint(tipPath, NULL, tipLeft + tipWidth, heightWithoutTip);
+    CGPathCloseSubpath(tipPath);
+
+    [fillColor setFill];
+    CGContextAddPath(currentContext, tipPath);
+    CGContextFillPath(currentContext);
+    CGPathRelease(tipPath);
 }
 
 @end

--- a/platform/ios/src/MGLCompactCalloutView.m
+++ b/platform/ios/src/MGLCompactCalloutView.m
@@ -1,7 +1,5 @@
 #import "MGLCompactCalloutView.h"
 
-#import "MGLAnnotation.h"
-
 // Set defaults for custom tip drawing
 static CGFloat const tipHeight = 10.0;
 static CGFloat const tipWidth = 20.0;
@@ -12,17 +10,7 @@ static CGFloat const tipWidth = 20.0;
 
 @end
 
-@implementation MGLCompactCalloutView {
-    id <MGLAnnotation> _representedObject;
-    __unused UIView *_leftAccessoryView;/* unused */
-    __unused UIView *_rightAccessoryView;/* unused */
-    __weak id <MGLCalloutViewDelegate> _delegate;
-}
-
-@synthesize representedObject = _representedObject;
-@synthesize leftAccessoryView = _leftAccessoryView;/* unused */
-@synthesize rightAccessoryView = _rightAccessoryView;/* unused */
-@synthesize delegate = _delegate;
+@implementation MGLCompactCalloutView
 
 + (instancetype)calloutView
 {
@@ -53,8 +41,8 @@ static CGFloat const tipWidth = 20.0;
 
 - (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view constrainedToView:(UIView *)constrainedView animated:(BOOL)animated
 {
-    // Do not show a callout if there is no title set for the annotation
-    if (![self.representedObject respondsToSelector:@selector(title)])
+    // Do not show a callout if there is no title set
+    if (!self.title)
     {
         return;
     }
@@ -62,19 +50,11 @@ static CGFloat const tipWidth = 20.0;
     [view addSubview:self];
 
     // Prepare title label
-    [self.mainBody setTitle:self.representedObject.title forState:UIControlStateNormal];
+    [self.mainBody setTitle:self.title forState:UIControlStateNormal];
     [self.mainBody sizeToFit];
 
-    if ([self isCalloutTappable])
-    {
-        // Handle taps and eventually try to send them to the delegate (usually the map view)
-        [self.mainBody addTarget:self action:@selector(calloutTapped) forControlEvents:UIControlEventTouchUpInside];
-    }
-    else
-    {
-        // Disable tapping and highlighting
-        self.mainBody.userInteractionEnabled = NO;
-    }
+    // Disable tapping and highlighting
+    self.mainBody.userInteractionEnabled = NO;
 
     // Prepare our frame, adding extra space at the bottom for the tip
     CGFloat frameWidth = self.mainBody.bounds.size.width;
@@ -113,24 +93,6 @@ static CGFloat const tipWidth = 20.0;
     }
 }
 
-#pragma mark - Callout interaction handlers
-
-- (BOOL)isCalloutTappable
-{
-    if ([self.delegate respondsToSelector:@selector(calloutViewShouldHighlight:)]) {
-        return [self.delegate performSelector:@selector(calloutViewShouldHighlight:) withObject:self];
-    }
-
-    return NO;
-}
-
-- (void)calloutTapped
-{
-    if ([self isCalloutTappable] && [self.delegate respondsToSelector:@selector(calloutViewTapped:)])
-    {
-        [self.delegate performSelector:@selector(calloutViewTapped:) withObject:self];
-    }
-}
 
 #pragma mark - Custom view styling
 

--- a/platform/ios/src/MGLCompactCalloutView.m
+++ b/platform/ios/src/MGLCompactCalloutView.m
@@ -39,7 +39,6 @@ static CGFloat const tipWidth = 20.0;
         // Create and add a subview to hold the callout’s text
         UIButton *mainBody = [UIButton buttonWithType:UIButtonTypeSystem];
         mainBody.backgroundColor = [self backgroundColorForCallout];
-        mainBody.tintColor = [UIColor whiteColor];
         mainBody.contentEdgeInsets = UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0);
         mainBody.layer.cornerRadius = 4.0;
         self.mainBody = mainBody;
@@ -137,7 +136,7 @@ static CGFloat const tipWidth = 20.0;
 
 - (UIColor *)backgroundColorForCallout
 {
-    return [UIColor darkGrayColor];
+    return [UIColor whiteColor];
 }
 
 - (void)drawRect:(CGRect)rect

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -210,7 +210,6 @@ public:
                           GLKViewDelegate,
                           CLLocationManagerDelegate,
                           UIActionSheetDelegate,
-                          MGLCalloutViewDelegate,
                           UIAlertViewDelegate,
                           MGLMultiPointDelegate,
                           MGLAnnotationImageDelegate>
@@ -1580,30 +1579,30 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     }
 }
 
-- (BOOL)calloutViewShouldHighlight:(__unused MGLCompactCalloutView *)calloutView
-{
-    return [self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)];
-}
-
-- (void)calloutViewClicked:(__unused UIView<MGLCalloutView> *)calloutView
-{
-    if ([self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)])
-    {
-        id <MGLAnnotation> selectedAnnotation = self.selectedAnnotation;
-        NSAssert(selectedAnnotation, @"Selected annotation should not be nil.");
-        [self.delegate mapView:self tapOnCalloutForAnnotation:selectedAnnotation];
-    }
-}
-
-- (void)calloutViewTapped:(__unused MGLCompactCalloutView *)calloutView
-{
-    if ([self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)])
-    {
-        id <MGLAnnotation> selectedAnnotation = self.selectedAnnotation;
-        NSAssert(selectedAnnotation, @"Selected annotation should not be nil.");
-        [self.delegate mapView:self tapOnCalloutForAnnotation:selectedAnnotation];
-    }
-}
+//- (BOOL)calloutViewShouldHighlight:(__unused MGLCompactCalloutView *)calloutView
+//{
+//    return [self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)];
+//}
+//
+//- (void)calloutViewClicked:(__unused UIView<MGLCalloutView> *)calloutView
+//{
+//    if ([self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)])
+//    {
+//        id <MGLAnnotation> selectedAnnotation = self.selectedAnnotation;
+//        NSAssert(selectedAnnotation, @"Selected annotation should not be nil.");
+//        [self.delegate mapView:self tapOnCalloutForAnnotation:selectedAnnotation];
+//    }
+//}
+//
+//- (void)calloutViewTapped:(__unused MGLCompactCalloutView *)calloutView
+//{
+//    if ([self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)])
+//    {
+//        id <MGLAnnotation> selectedAnnotation = self.selectedAnnotation;
+//        NSAssert(selectedAnnotation, @"Selected annotation should not be nil.");
+//        [self.delegate mapView:self tapOnCalloutForAnnotation:selectedAnnotation];
+//    }
+//}
 
 - (void)calloutViewDidAppear:(UIView<MGLCalloutView> *)calloutView
 {
@@ -3449,62 +3448,61 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
     self.selectedAnnotation = annotation;
 
-    if ([annotation respondsToSelector:@selector(title)] &&
-        annotation.title &&
-        [self.delegate respondsToSelector:@selector(mapView:annotationCanShowCallout:)] &&
-        [self.delegate mapView:self annotationCanShowCallout:annotation])
+    if ([annotation respondsToSelector:@selector(canShowCallout)] && annotation.canShowCallout)
     {
-        // build the callout
-        UIView <MGLCalloutView> *calloutView;
-        if ([self.delegate respondsToSelector:@selector(mapView:calloutViewForAnnotation:)])
-        {
-            calloutView = [self.delegate mapView:self calloutViewForAnnotation:annotation];
-        }
-        if (!calloutView)
-        {
-            calloutView = [self calloutViewForAnnotation:annotation];
-        }
-        self.calloutViewForSelectedAnnotation = calloutView;
-
         if (_userLocationAnnotationIsSelected)
         {
             positioningRect = [self.userLocationAnnotationView.layer.presentationLayer frame];
-            
+
             CGRect implicitAnnotationFrame = [self.userLocationAnnotationView.layer.presentationLayer frame];
             CGRect explicitAnnotationFrame = self.userLocationAnnotationView.frame;
             _initialImplicitCalloutViewOffset = CGPointMake(CGRectGetMinX(explicitAnnotationFrame) - CGRectGetMinX(implicitAnnotationFrame),
                                                             CGRectGetMinY(explicitAnnotationFrame) - CGRectGetMinY(implicitAnnotationFrame));
         }
 
+        // build the callout
+        UIView <MGLCalloutView> *calloutView;
+//        if ([self.delegate respondsToSelector:@selector(mapView:calloutViewForAnnotation:)])
+//        {
+//            calloutView = [self.delegate mapView:self calloutViewForAnnotation:annotation];
+//        }
+        if (!calloutView)
+        {
+            calloutView = [self calloutViewForAnnotation:annotation];
+        }
+        self.calloutViewForSelectedAnnotation = calloutView;
+
+
+
         // consult delegate for left and/or right accessory views
-        if ([self.delegate respondsToSelector:@selector(mapView:leftCalloutAccessoryViewForAnnotation:)])
-        {
-            calloutView.leftAccessoryView = [self.delegate mapView:self leftCalloutAccessoryViewForAnnotation:annotation];
-
-            if ([calloutView.leftAccessoryView isKindOfClass:[UIControl class]])
-            {
-                UITapGestureRecognizer *calloutAccessoryTap = [[UITapGestureRecognizer alloc] initWithTarget:self
-                                                                  action:@selector(handleCalloutAccessoryTapGesture:)];
-
-                [calloutView.leftAccessoryView addGestureRecognizer:calloutAccessoryTap];
-            }
-        }
-
-        if ([self.delegate respondsToSelector:@selector(mapView:rightCalloutAccessoryViewForAnnotation:)])
-        {
-            calloutView.rightAccessoryView = [self.delegate mapView:self rightCalloutAccessoryViewForAnnotation:annotation];
-
-            if ([calloutView.rightAccessoryView isKindOfClass:[UIControl class]])
-            {
-                UITapGestureRecognizer *calloutAccessoryTap = [[UITapGestureRecognizer alloc] initWithTarget:self
-                                                                  action:@selector(handleCalloutAccessoryTapGesture:)];
-
-                [calloutView.rightAccessoryView addGestureRecognizer:calloutAccessoryTap];
-            }
-        }
+//        if ([self.delegate respondsToSelector:@selector(mapView:leftCalloutAccessoryViewForAnnotation:)])
+//        {
+//            calloutView.leftAccessoryView = [self.delegate mapView:self leftCalloutAccessoryViewForAnnotation:annotation];
+//
+//            if ([calloutView.leftAccessoryView isKindOfClass:[UIControl class]])
+//            {
+//                UITapGestureRecognizer *calloutAccessoryTap = [[UITapGestureRecognizer alloc] initWithTarget:self
+//                                                                                                      action:@selector(handleCalloutAccessoryTapGesture:)];
+//
+//                [calloutView.leftAccessoryView addGestureRecognizer:calloutAccessoryTap];
+//            }
+//        }
+//
+//        if ([self.delegate respondsToSelector:@selector(mapView:rightCalloutAccessoryViewForAnnotation:)])
+//        {
+//            calloutView.rightAccessoryView = [self.delegate mapView:self rightCalloutAccessoryViewForAnnotation:annotation];
+//
+//            if ([calloutView.rightAccessoryView isKindOfClass:[UIControl class]])
+//            {
+//                UITapGestureRecognizer *calloutAccessoryTap = [[UITapGestureRecognizer alloc] initWithTarget:self
+//                                                                                                      action:@selector(handleCalloutAccessoryTapGesture:)];
+//
+//                [calloutView.rightAccessoryView addGestureRecognizer:calloutAccessoryTap];
+//            }
+//        }
 
         // set annotation delegate to handle taps on the callout view
-        calloutView.delegate = self;
+        //calloutView.delegate = self;
 
         // present popup
         [calloutView presentCalloutFromRect:positioningRect
@@ -3525,10 +3523,11 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     }
 }
 
-- (MGLCompactCalloutView *)calloutViewForAnnotation:(id <MGLAnnotation>)annotation
+- (UIView <MGLCalloutView> *)calloutViewForAnnotation:(id <MGLAnnotation>)annotation
 {
     MGLCompactCalloutView *calloutView = [MGLCompactCalloutView calloutView];
-    calloutView.representedObject = annotation;
+    calloutView.title = annotation.title;
+    calloutView.subtitle = annotation.subtitle;
     calloutView.tintColor = self.tintColor;
 
     return calloutView;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -210,7 +210,6 @@ public:
                           GLKViewDelegate,
                           CLLocationManagerDelegate,
                           UIActionSheetDelegate,
-                          SMCalloutViewDelegate,
                           MGLCalloutViewDelegate,
                           UIAlertViewDelegate,
                           MGLMultiPointDelegate,
@@ -1586,7 +1585,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     return [self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)];
 }
 
-- (void)calloutViewClicked:(__unused SMCalloutView *)calloutView
+- (void)calloutViewClicked:(__unused UIView<MGLCalloutView> *)calloutView
 {
     if ([self.delegate respondsToSelector:@selector(mapView:tapOnCalloutForAnnotation:)])
     {
@@ -3528,7 +3527,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
 - (MGLCompactCalloutView *)calloutViewForAnnotation:(id <MGLAnnotation>)annotation
 {
-    MGLCompactCalloutView *calloutView = [MGLCompactCalloutView platformCalloutView];
+    MGLCompactCalloutView *calloutView = [MGLCompactCalloutView calloutView];
     calloutView.representedObject = annotation;
     calloutView.tintColor = self.tintColor;
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3462,17 +3462,28 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
         // build the callout
         UIView <MGLCalloutView> *calloutView;
-//        if ([self.delegate respondsToSelector:@selector(mapView:calloutViewForAnnotation:)])
-//        {
-//            calloutView = [self.delegate mapView:self calloutViewForAnnotation:annotation];
-//        }
+        if ([annotation respondsToSelector:@selector(calloutView)] && annotation.calloutView)
+        {
+            calloutView = annotation.calloutView;
+        }
         if (!calloutView)
         {
-            calloutView = [self calloutViewForAnnotation:annotation];
+            calloutView = [MGLCompactCalloutView calloutView];
         }
+
+        calloutView.tintColor = self.tintColor;
+
+        if ([calloutView respondsToSelector:@selector(title)])
+        {
+            calloutView.title = annotation.title;
+        }
+
+        if ([calloutView respondsToSelector:@selector(subtitle)])
+        {
+            calloutView.subtitle = annotation.subtitle;
+        }
+
         self.calloutViewForSelectedAnnotation = calloutView;
-
-
 
         // consult delegate for left and/or right accessory views
 //        if ([self.delegate respondsToSelector:@selector(mapView:leftCalloutAccessoryViewForAnnotation:)])
@@ -3501,9 +3512,6 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 //            }
 //        }
 
-        // set annotation delegate to handle taps on the callout view
-        //calloutView.delegate = self;
-
         // present popup
         [calloutView presentCalloutFromRect:positioningRect
                                      inView:self.glView
@@ -3521,16 +3529,6 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     {
         [self.delegate mapView:self didSelectAnnotationView:annotationView];
     }
-}
-
-- (UIView <MGLCalloutView> *)calloutViewForAnnotation:(id <MGLAnnotation>)annotation
-{
-    MGLCompactCalloutView *calloutView = [MGLCompactCalloutView calloutView];
-    calloutView.title = annotation.title;
-    calloutView.subtitle = annotation.subtitle;
-    calloutView.tintColor = self.tintColor;
-
-    return calloutView;
 }
 
 /// Returns the rectangle that represents the annotation image of the annotation

--- a/platform/ios/src/MGLUserLocation.h
+++ b/platform/ios/src/MGLUserLocation.h
@@ -47,6 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** The subtitle to display for the user location annotation. */
 @property (nonatomic, copy, nullable) NSString *subtitle;
 
+@property (nonatomic) BOOL canShowCallout;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/ios/src/MGLUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLUserLocationAnnotationView.m
@@ -61,6 +61,8 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
         
         _accessibilityCoordinateFormatter = [[MGLCoordinateFormatter alloc] init];
         _accessibilityCoordinateFormatter.unitStyle = NSFormattingUnitStyleLong;
+
+        self.annotation.canShowCallout = YES;
     }
     return self;
 }


### PR DESCRIPTION
Following on from #4392, this pull request aims to simplify custom callout view creation and usage.
### Changes
#### `MGLCalloutView` protocol
- Simplified.
- Most properties are optional, including accessory views and title strings.
- Adds `-detailAccessoryView`.
#### `MGLCalloutViewDelegate`
- Removed.
#### `MGLAnnotation` (Really, only `MGLPointAnnotation`)
- Adds `-canShowCallout` boolean property.
- Adds `-calloutView` property that conforms to `MGLCalloutView` protocol.
#### `MGLCompactCalloutView`
- Replaced `SMCalloutView` with custom implementation.
  - Current placeholder is based on the existing [custom callout view example](https://www.mapbox.com/ios-sdk/examples/custom-callout/):

![screen shot 2016-05-04 at 9 45 43 pm](https://cloud.githubusercontent.com/assets/1198851/15034259/af362a00-1241-11e6-8161-8d4544242298.png)
### Todo
- [ ] Interface Builder support.
- [ ] Accessibility.
- [ ] Hook-up accessory views.
- [ ] Handle gestures for callouts.
  - [ ] Re-enable `-[MGLMapView mapView:annotation:calloutAccessoryControlTapped:]`.
  - [ ] Add custom gesture handlers to custom callout example.
- [ ] Fit the default callout view to the viewport.
- [ ] Add `MGLCalloutView.annotation`?
  - Instead of manually re-setting the `title` and `subtitle` properties, maybe let the callout implementation do that directly with a passed-in `annotation`.
- [ ] Audit `MGLMapView` for dead delegate methods; remove or deprecate.
  - `-mapView:annotationCanShowCallout:`
  - `-mapView:calloutViewForAnnotation:`
  - `-mapView:tapOnCalloutForAnnotation:`
  - `-mapView:rightCalloutAccessoryViewForAnnotation:`
  - `-mapView:leftCalloutAccessoryViewForAnnotation:`
#### Stretch goals
- [ ] Make the default callout view swanky.
  - Animations and other polish.
- [ ] Eliminate need for public `MGLCalloutView` protocol.
- ~~Enable callout views for `MGLMultiPoint` (polylines, polygons)~~ Punted per https://github.com/mapbox/mapbox-gl-native/pull/4948#discussion_r62155897.
- [ ] Allow callout views to remain open while panning.

/cc @1ec5 @boundsj
