### PR TITLE
Display print dialog after drawing

### DIFF
--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -735,7 +735,7 @@ public:
             std::string png = encodePNG(_mbglView->readStillImage());
             NSData *data = [[NSData alloc] initWithBytes:png.data() length:png.size()];
             NSImage *image = [[NSImage alloc] initWithData:data];
-            [self printWithImage:image];
+            [self performSelector:@selector(printWithImage:) withObject:image afterDelay:0];
         }
 
 //        [self updateUserLocationAnnotationView];


### PR DESCRIPTION
This fixes a regression introduced in #2909. A print operation can’t run inside a draw operation of any sort, so defer the print operation until the next iteration of the run loop. Note that the map view still can only be printed using `-[NSView print:]` action rather than the preferred EPS- or PDF-writing methods.

Fixes #4956.

/cc @jfirebaugh