### PR TITLE
[core] Remove trailing zeros in float→string conversion

### DIFF
--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <cassert>
 #include <exception>
+#include <cmath>
 
 namespace mbgl {
 namespace util {
@@ -14,7 +15,7 @@ inline std::string toString(T t) {
 }
 
 inline std::string toString(double num) {
-    if (num - (int)num > 0.0 || num + (int)num < 0.0) {
+    if (std::fmod(num, 1)) {
         std::string str = std::to_string(num);
         str.erase(str.find_last_not_of('0') + 1, std::string::npos);
         if (str.back() == '.') {

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <cassert>
 #include <exception>
-#include <cmath>
+#include <sstream>
 
 namespace mbgl {
 namespace util {
@@ -15,16 +15,9 @@ inline std::string toString(T t) {
 }
 
 inline std::string toString(double num) {
-    if (std::fmod(num, 1)) {
-        std::string str = std::to_string(num);
-        str.erase(str.find_last_not_of('0') + 1, std::string::npos);
-        if (str.back() == '.') {
-            str.pop_back();
-        }
-        return str;
-    } else {
-        return std::to_string(int(num));
-    }
+    std::ostringstream formatted;
+    formatted << num;
+    return formatted.str();
 }
 
 inline std::string toString(int8_t num) {

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -10,15 +10,19 @@ namespace util {
 
 template <class T>
 inline std::string toString(T t) {
-    if (t - (int)t > 0.0 || t + (int)t < 0.0) {
-        std::string str = std::to_string(t);
+    return std::to_string(t);
+}
+
+inline std::string toString(double num) {
+    if (num - (int)num > 0.0 || num + (int)num < 0.0) {
+        std::string str = std::to_string(num);
         str.erase(str.find_last_not_of('0') + 1, std::string::npos);
         if (str.back() == '.') {
             str.pop_back();
         }
         return str;
     } else {
-        return std::to_string(int(t));
+        return std::to_string(int(num));
     }
 }
 

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -10,7 +10,16 @@ namespace util {
 
 template <class T>
 inline std::string toString(T t) {
-    return std::to_string(t);
+    if (t - (int)t > 0.0 || t + (int)t < 0.0) {
+        std::string str = std::to_string(t);
+        str.erase(str.find_last_not_of('0') + 1, std::string::npos);
+        if (str.back() == '.') {
+            str.pop_back();
+        }
+        return str;
+    } else {
+        return std::to_string(int(t));
+    }
 }
 
 inline std::string toString(int8_t num) {

--- a/test/test.gypi
+++ b/test/test.gypi
@@ -25,6 +25,7 @@
         'util/image.cpp',
         'util/mapbox.cpp',
         'util/merge_lines.cpp',
+        'util/number_conversions.cpp',
         'util/run_loop.cpp',
         'util/text_conversions.cpp',
         'util/thread.cpp',

--- a/test/util/number_conversions.cpp
+++ b/test/util/number_conversions.cpp
@@ -6,6 +6,12 @@
 using namespace mbgl;
 
 TEST(NumberConversions, number_to_string) {
+    EXPECT_EQ("0", util::toString(0));
+    EXPECT_EQ("10", util::toString(10));
+    EXPECT_EQ("-10", util::toString(-10));
+    EXPECT_EQ("10", util::toString(10.0));
+    EXPECT_EQ("-10", util::toString(-10.0));
+
     EXPECT_EQ("1", util::toString(1));
     EXPECT_EQ("-1", util::toString(-1));
     EXPECT_EQ("32768", util::toString(32768));
@@ -35,4 +41,12 @@ TEST(NumberConversions, number_to_string) {
     EXPECT_EQ("-1.123457", util::toString(-1.123456789));
     EXPECT_EQ("32768.123457", util::toString(32768.123456789));
     EXPECT_EQ("-32768.123457", util::toString(-32768.123456789));
+
+    EXPECT_EQ("3.141593", util::toString(3.1415926535897932385128089594061862044327426701784));
+
+    EXPECT_EQ("0.000053", util::toString((long double)5.32e-5));
+    EXPECT_EQ("0.000000", util::toString((long double)5.32e-40));
+
+    EXPECT_EQ("10", util::toString(unsigned(10)));
+    EXPECT_EQ("10", util::toString(unsigned(10.0)));
 }

--- a/test/util/number_conversions.cpp
+++ b/test/util/number_conversions.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/util/string.hpp>
+
+using namespace mbgl;
+
+TEST(NumberConversions, number_to_string) {
+    EXPECT_EQ("1", util::toString(1));
+    EXPECT_EQ("-1", util::toString(-1));
+    EXPECT_EQ("32768", util::toString(32768));
+    EXPECT_EQ("-32768", util::toString(-32768));
+
+    EXPECT_EQ("1", util::toString(1.000000));
+    EXPECT_EQ("-1", util::toString(-1.000000));
+    EXPECT_EQ("32768", util::toString(32768.000000));
+    EXPECT_EQ("-32768", util::toString(-32768.000000));
+
+    EXPECT_EQ("1.01", util::toString(1.01));
+    EXPECT_EQ("-1.01", util::toString(-1.01));
+    EXPECT_EQ("32768.01", util::toString(32768.01));
+    EXPECT_EQ("-32768.01", util::toString(-32768.01));
+
+    EXPECT_EQ("1.01", util::toString(1.0100));
+    EXPECT_EQ("-1.01", util::toString(-1.0100));
+    EXPECT_EQ("32768.01", util::toString(32768.0100));
+    EXPECT_EQ("-32768.01", util::toString(-32768.0100));
+
+    EXPECT_EQ("1.123456", util::toString(1.123456));
+    EXPECT_EQ("-1.123456", util::toString(-1.123456));
+    EXPECT_EQ("32768.123456", util::toString(32768.123456));
+    EXPECT_EQ("-32768.123456", util::toString(-32768.123456));
+
+    EXPECT_EQ("1.123457", util::toString(1.123456789));
+    EXPECT_EQ("-1.123457", util::toString(-1.123456789));
+    EXPECT_EQ("32768.123457", util::toString(32768.123456789));
+    EXPECT_EQ("-32768.123457", util::toString(-32768.123456789));
+}

--- a/test/util/number_conversions.cpp
+++ b/test/util/number_conversions.cpp
@@ -43,6 +43,7 @@ TEST(NumberConversions, number_to_string) {
     EXPECT_EQ("-32768.123457", util::toString(-32768.123456789));
 
     EXPECT_EQ("3.141593", util::toString(3.1415926535897932385128089594061862044327426701784));
+    EXPECT_EQ("-3.141593", util::toString(-3.1415926535897932385128089594061862044327426701784));
 
     EXPECT_EQ("0.000053", util::toString((long double)5.32e-5));
     EXPECT_EQ("0.000000", util::toString((long double)5.32e-40));

--- a/test/util/number_conversions.cpp
+++ b/test/util/number_conversions.cpp
@@ -22,28 +22,31 @@ TEST(NumberConversions, number_to_string) {
     EXPECT_EQ("32768", util::toString(32768.000000));
     EXPECT_EQ("-32768", util::toString(-32768.000000));
 
+    // By default, ostringstream limits the output to 6 significant digits then trims any trailing zeros past the decimal point.
     EXPECT_EQ("1.01", util::toString(1.01));
     EXPECT_EQ("-1.01", util::toString(-1.01));
-    EXPECT_EQ("32768.01", util::toString(32768.01));
-    EXPECT_EQ("-32768.01", util::toString(-32768.01));
+    EXPECT_EQ("32768", util::toString(32768.01));
+    EXPECT_EQ("-32768", util::toString(-32768.01));
 
     EXPECT_EQ("1.01", util::toString(1.0100));
     EXPECT_EQ("-1.01", util::toString(-1.0100));
-    EXPECT_EQ("32768.01", util::toString(32768.0100));
-    EXPECT_EQ("-32768.01", util::toString(-32768.0100));
+    EXPECT_EQ("32768", util::toString(32768.0100));
+    EXPECT_EQ("-32768", util::toString(-32768.0100));
 
-    EXPECT_EQ("1.123456", util::toString(1.123456));
-    EXPECT_EQ("-1.123456", util::toString(-1.123456));
-    EXPECT_EQ("32768.123456", util::toString(32768.123456));
-    EXPECT_EQ("-32768.123456", util::toString(-32768.123456));
+    EXPECT_EQ("1.12346", util::toString(1.123456));
+    EXPECT_EQ("-1.12346", util::toString(-1.123456));
+    EXPECT_EQ("32768.1", util::toString(32768.123456));
+    EXPECT_EQ("-32768.1", util::toString(-32768.123456));
 
-    EXPECT_EQ("1.123457", util::toString(1.123456789));
-    EXPECT_EQ("-1.123457", util::toString(-1.123456789));
-    EXPECT_EQ("32768.123457", util::toString(32768.123456789));
-    EXPECT_EQ("-32768.123457", util::toString(-32768.123456789));
+    EXPECT_EQ("1.12346", util::toString(1.123456789));
+    EXPECT_EQ("-1.12346", util::toString(-1.123456789));
+    EXPECT_EQ("32768.1", util::toString(32768.123456789));
+    EXPECT_EQ("-32768.1", util::toString(-32768.123456789));
 
-    EXPECT_EQ("3.141593", util::toString(3.1415926535897932385128089594061862044327426701784));
-    EXPECT_EQ("-3.141593", util::toString(-3.1415926535897932385128089594061862044327426701784));
+    EXPECT_EQ("3.14159", util::toString(3.1415926535897932385128089594061862044327426701784));
+    EXPECT_EQ("-3.14159", util::toString(-3.1415926535897932385128089594061862044327426701784));
+
+    EXPECT_EQ("123456789", util::toString(123456789));
 
     EXPECT_EQ("0.000053", util::toString((long double)5.32e-5));
     EXPECT_EQ("0.000000", util::toString((long double)5.32e-40));

--- a/test/util/text_conversions.cpp
+++ b/test/util/text_conversions.cpp
@@ -30,6 +30,6 @@ TEST(TextConversions, to_lower) {
     EXPECT_EQ(std::string("weisskopfseeadler"), platform::lowercase("weiSSkopfseeadler")); // DE
 
     EXPECT_EQ(std::string("azərbaycan"), platform::lowercase("AZƏRBAYCAN")); // AZ
-    EXPECT_EQ(std::string("ὀδυσσεύς"), platform::lowercase("ὈΔΥΣΣΕΎΣ")); // GR
 
+    EXPECT_EQ(std::string("ὀδυσσεύς"), platform::lowercase("ὈΔΥΣΣΕΎΣ")); // GR
 }


### PR DESCRIPTION
With the replacement of `boost::lexical_cast` with `std:to_string` in #4916, symbol labels that used floating point numbers could end up looking like “12345.000000” when the passed in number was actually just “12345”.

The fix here is two-fold:
- Cast sufficiently int-like floats to int.
- Otherwise, let `std::to_string` convert the float to a string, then trim trailing zeros and hanging decimal points.

If this passes muster, we should consider including it in iOS v3.2.2 and the next Android release.

Fixes #998.

/cc @jfirebaugh @1ec5 @tobrun