### PR TITLE
Documentation for Qt SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SDK | Languages | Build status
 [Mapbox iOS SDK](platform/ios/) | Objective-C or Swift | [![Bitrise](https://www.bitrise.io/app/7514e4cf3da2cc57.svg?token=OwqZE5rSBR9MVWNr_lf4sA&branch=master)](https://www.bitrise.io/app/7514e4cf3da2cc57)
 [Mapbox OS X SDK](platform/osx/) | Objective-C or Swift | [![Bitrise](https://www.bitrise.io/app/155ef7da24b38dcd.svg?token=4KSOw_gd6WxTnvGE2rMttg&branch=master)](https://www.bitrise.io/app/155ef7da24b38dcd)
 [node-mapbox-gl-native](platform/node/) | Node.js | [![Linux](https://travis-ci.org/mapbox/mapbox-gl-native.svg?branch=master)](https://travis-ci.org/mapbox/mapbox-gl-native/builds) / [![OS X](https://www.bitrise.io/app/55e3a9bf71202106.svg?token=5qf5ZUcKVN3LDnHhW7rO0w)](https://www.bitrise.io/app/55e3a9bf71202106)
-[Mapbox GL Qt](platform/qt) | C++03 | [![Travis](https://travis-ci.org/mapbox/mapbox-gl-native.svg?branch=master)](https://travis-ci.org/mapbox/mapbox-gl-native/builds)
+[Mapbox Qt SDK](platform/qt) | C++03 | [![Travis](https://travis-ci.org/mapbox/mapbox-gl-native.svg?branch=master)](https://travis-ci.org/mapbox/mapbox-gl-native/builds)
 
 Additional Mapbox GL Native–based libraries are developed outside of this repository:
 

--- a/platform/qt/README.md
+++ b/platform/qt/README.md
@@ -1,0 +1,66 @@
+# Mapbox Qt SDK
+
+[![Travis](https://travis-ci.org/mapbox/mapbox-gl-native.svg?branch=master)](https://travis-ci.org/mapbox/mapbox-gl-native/builds)
+
+Provides [Qt](http://www.qt.io/) example applications and APIs via `QMapboxGL`
+and `QQuickMapboxGL`:
+
+**QMapboxGL** - implements a C++03x-conformant API that has been tested from Qt
+4.7 onwards (Travis CI currently builds it using both Qt 4 and Qt 5).
+
+**QQuickMapboxGL** - implements a Qt Quick (QML) item that can be added to a
+scene. Because `QQuickFramebufferObject` has been added in Qt version 5.2, we
+support this API from this version onwards.
+
+![Mapbox Qt QML
+example](https://c2.staticflickr.com/8/7689/26247088394_01541b34de_o.png)
+
+### Developing
+
+[Qt supports many platforms](https://www.qt.io/qt-framework/#section-4) - so far
+we have been testing our code on Linux and OS X desktops, as well as embedded
+devices such as Raspberry Pi 3.
+
+If you need to maintain backwards compatibility with prior releases of
+Qt, chose `QMapboxGL`. Otherwise, go for `QQuickMapboxGL`.
+
+Both `QMapboxGL` and `QQuickMapboxGL` requires a [Mapbox access
+token](https://www.mapbox.com/help/define-access-token/) at runtime - you need
+to provide it by setting the environment variable `MAPBOX_ACCESS_TOKEN`:
+
+    export MAPBOX_ACCESS_TOKEN=MYTOKEN
+
+#### Linux
+
+For Linux (Ubuntu) desktop, together with these [build
+instructions](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/linux#build),
+you also need:
+
+    sudo apt-get install qt5-default qtlocation5-dev qtpositioning5-dev \
+    qml-module-qtquick2 qml-module-qtpositioning qml-module-qtgraphicaleffects \
+    qml-module-qtquick-layouts qml-module-qtquick-controls
+
+#### OS X
+
+For OS X desktop, you can install Qt 5 via [Homebrew](http://brew.sh):
+
+    brew install qt5
+
+We provide the following build targets for our Qt SDK:
+
+### Build instructions
+
+#### Qt library
+
+```make qt-lib``` to build the `qmapboxgl` shared library. Public API headers
+can be found in [platform/qt/include](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/qt/include) folder.
+
+#### QMapboxGL example application
+
+```make qt-app``` or ```make run-qt-app``` to run the application at the end of
+build.
+
+#### QQuickMapboxGL example application:
+
+```make qt-qml-app``` or ```make run-qt-qml-app``` to run the application at the
+end of build.


### PR DESCRIPTION
The Qt SDK currently lacks any form of documentation. Each platform in this repository should have – at a minimum – a readme and installation guide in the subdirectory under platform/. A changelog would also be helpful once we start tagging releases.

/cc @brunoabinader @tmpsantos @tmcw