### PR TITLE
Upgrade Nan to fix v8::ObjectTemplate::Set() with non-primitive values is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "nan": "^2.2.1",
+    "nan": "^2.3.3",
     "node-pre-gyp": "^0.6.26"
   },
   "devDependencies": {


### PR DESCRIPTION
With Node 6, we're seeing `v8::ObjectTemplate::Set() with non-primitive values is deprecated` messages in the console. Simply upgrading NAN fixes this.