### PR TITLE
Fix context menu on OS X

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3142,9 +3142,9 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             }
             
             // Choose the first nearby annotation.
-            if (_annotationsNearbyLastTap.size())
+            if (nearbyAnnotations.size())
             {
-                hitAnnotationTag = _annotationsNearbyLastTap.front();
+                hitAnnotationTag = nearbyAnnotations.front();
             }
         }
     }

--- a/platform/osx/app/Base.lproj/MapDocument.xib
+++ b/platform/osx/app/Base.lproj/MapDocument.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="MapDocument">
@@ -26,6 +26,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="512" height="480"/>
                         <connections>
                             <outlet property="delegate" destination="-2" id="dh2-0H-jFZ"/>
+                            <outlet property="menu" destination="XbX-6a-Mgy" id="dSu-HR-Kq2"/>
                         </connections>
                     </customView>
                 </subviews>
@@ -112,9 +113,15 @@
             <items>
                 <menuItem title="Drop Pin" id="qZJ-mM-bLj">
                     <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="dropPin:" target="-1" id="hxx-eC-kqU"/>
+                    </connections>
                 </menuItem>
                 <menuItem title="Remove Pin" id="Zhx-30-VmE">
                     <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="removePin:" target="-1" id="w0R-0B-7mG"/>
+                    </connections>
                 </menuItem>
             </items>
             <connections>

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -394,10 +394,6 @@ public:
     clickGestureRecognizer.delaysPrimaryMouseButtonEvents = NO;
     [self addGestureRecognizer:clickGestureRecognizer];
     
-    NSClickGestureRecognizer *secondaryClickGestureRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(handleSecondaryClickGesture:)];
-    secondaryClickGestureRecognizer.buttonMask = 0x2;
-    [self addGestureRecognizer:secondaryClickGestureRecognizer];
-    
     NSClickGestureRecognizer *doubleClickGestureRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleClickGesture:)];
     doubleClickGestureRecognizer.numberOfClicksRequired = 2;
     doubleClickGestureRecognizer.delaysPrimaryMouseButtonEvents = NO;
@@ -1362,18 +1358,6 @@ public:
     }
 }
 
-/// Tap with two fingers (“right-click”) to zoom out.
-- (void)handleSecondaryClickGesture:(NSClickGestureRecognizer *)gestureRecognizer {
-    if (!self.zoomEnabled || gestureRecognizer.state != NSGestureRecognizerStateEnded) {
-        return;
-    }
-    
-    _mbglMap->cancelTransitions();
-    
-    NSPoint gesturePoint = [gestureRecognizer locationInView:self];
-    [self scaleBy:0.5 atPoint:gesturePoint animated:YES];
-}
-
 /// Double-click or double-tap to zoom in.
 - (void)handleDoubleClickGesture:(NSClickGestureRecognizer *)gestureRecognizer {
     if (!self.zoomEnabled || gestureRecognizer.state != NSGestureRecognizerStateEnded
@@ -1394,6 +1378,7 @@ public:
     
     _mbglMap->cancelTransitions();
     
+    // Tap with two fingers (“right-click”) to zoom out on mice but not trackpads.
     NSPoint gesturePoint = [self convertPoint:event.locationInWindow fromView:nil];
     [self scaleBy:0.5 atPoint:gesturePoint animated:YES];
 }

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1895,8 +1895,8 @@ public:
             }
             
             // Choose the first nearby annotation.
-            if (_annotationsNearbyLastClick.size()) {
-                hitAnnotationTag = _annotationsNearbyLastClick.front();
+            if (nearbyAnnotations.size()) {
+                hitAnnotationTag = nearbyAnnotations.front();
             }
         }
     }


### PR DESCRIPTION
This PR fixes the context menu on map views in osxapp so that the menu appears and is enabled in the right situations. These connections were lost in #3427.

<img width="189" alt="drop" src="https://cloud.githubusercontent.com/assets/1231218/15127150/25753390-15ea-11e6-8e0b-5a518da7fe73.png">
<img width="269" alt="remove" src="https://cloud.githubusercontent.com/assets/1231218/15127149/2575128e-15ea-11e6-8e28-43e0bbc00156.png">

As in MapKit, a two-finger tap (the “walking fingers” gesture) should be interpreted as a secondary click to open the context menu, if applicable. It should not zoom out; rather, a double-tap on a Magic Mouse should zoom out (“smart magnification”).

This PR also fixes a longstanding issue that made the osxapp context menu only apply to the right-clicked pin after first selecting the pin. It also happened to be a latent bug in the iOS implementation.

Fixes #3493.

/cc @kkaefer