### PR TITLE
[android] - fixes onMapReady when airplane mode is enabled

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -400,7 +400,7 @@ public class MapView extends FrameLayout {
         addOnMapChangedListener(new OnMapChangedListener() {
             @Override
             public void onMapChanged(@MapChange int change) {
-                if (change == DID_FINISH_RENDERING_MAP_FULLY_RENDERED && mInitialLoad) {
+                if (change == WILL_START_RENDERING_MAP && mInitialLoad) {
                     mInitialLoad = false;
                     reloadIcons();
                     reloadMarkers();


### PR DESCRIPTION
Proposed fix for fixing OnMapReady not being called when airplane mode is enabled in context of offline maps. This PR targets to be merged with the `4.0.1` bugfix release branch.

We used to wait for `DID_FINISH_RENDERING_MAP_FULLY_RENDERED=13` but that didn't solve the issue for all cases. This PR proposes to hook into `WILL_START_RENDERING_MAP=8` event instead.

cc @jfirebaugh @danswick @cammace 