### PR TITLE
Don't lookup sources constantly

### DIFF
--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -114,7 +114,7 @@ void AnnotationManager::updateStyle(Style& style) {
 
         std::unique_ptr<SymbolLayer> layer = std::make_unique<SymbolLayer>();
         layer->id = PointLayerID;
-        layer->source = SourceID;
+        layer->sourceID = SourceID;
         layer->sourceLayer = PointLayerID;
         layer->layout.iconImage = std::string("{sprite}");
         layer->layout.iconAllowOverlap = true;

--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -39,7 +39,7 @@ void ShapeAnnotationImpl::updateStyle(Style& style) {
         layer->paint.lineColor = properties.color;
 
         layer->id = layerID;
-        layer->source = AnnotationManager::SourceID;
+        layer->sourceID = AnnotationManager::SourceID;
         layer->sourceLayer = layer->id;
 
         style.addLayer(std::move(layer), AnnotationManager::PointLayerID);
@@ -55,7 +55,7 @@ void ShapeAnnotationImpl::updateStyle(Style& style) {
         layer->paint.fillOutlineColor = properties.outlineColor;
 
         layer->id = layerID;
-        layer->source = AnnotationManager::SourceID;
+        layer->sourceID = AnnotationManager::SourceID;
         layer->sourceLayer = layer->id;
 
         style.addLayer(std::move(layer), AnnotationManager::PointLayerID);
@@ -72,7 +72,7 @@ void ShapeAnnotationImpl::updateStyle(Style& style) {
 
         layer->id = layerID;
         layer->ref = "";
-        layer->source = AnnotationManager::SourceID;
+        layer->sourceID = AnnotationManager::SourceID;
         layer->sourceLayer = layer->id;
         layer->visibility = VisibilityType::Visible;
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -136,6 +136,8 @@ void Style::addLayer(std::unique_ptr<StyleLayer> layer, optional<std::string> be
         customLayer->initialize();
     }
 
+    layer->source = getSource(layer->sourceID);
+
     layers.emplace(before ? findLayer(*before) : layers.end(), std::move(layer));
 }
 
@@ -205,8 +207,8 @@ void Style::recalculate(float z, const TimePoint& timePoint, MapMode mode) {
     for (const auto& layer : layers) {
         hasPendingTransitions |= layer->recalculate(parameters);
 
-        Source* source = getSource(layer->sourceID);
-        if (source && layer->needsRendering()) {
+        Source* source = layer->source;
+        if (layer->source && layer->needsRendering()) {
             source->enabled = true;
             if (!source->loaded && !source->isLoading()) {
                 source->load(fileSource);
@@ -276,7 +278,7 @@ RenderData Style::getRenderData() const {
             continue;
         }
 
-        Source* source = getSource(layer->sourceID);
+        Source* source = layer->source;
         if (!source) {
             Log::Warning(Event::Render, "can't find source for layer '%s'", layer->id.c_str());
             continue;

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -205,7 +205,7 @@ void Style::recalculate(float z, const TimePoint& timePoint, MapMode mode) {
     for (const auto& layer : layers) {
         hasPendingTransitions |= layer->recalculate(parameters);
 
-        Source* source = getSource(layer->source);
+        Source* source = getSource(layer->sourceID);
         if (source && layer->needsRendering()) {
             source->enabled = true;
             if (!source->loaded && !source->isLoading()) {
@@ -276,7 +276,7 @@ RenderData Style::getRenderData() const {
             continue;
         }
 
-        Source* source = getSource(layer->source);
+        Source* source = getSource(layer->sourceID);
         if (!source) {
             Log::Warning(Event::Render, "can't find source for layer '%s'", layer->id.c_str());
             continue;

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -71,7 +71,7 @@ public:
 public:
     std::string id;
     std::string ref;
-    std::string source;
+    std::string sourceID;
     std::string sourceLayer;
     Filter filter;
     float minZoom = -std::numeric_limits<float>::infinity();

--- a/src/mbgl/style/style_layer.hpp
+++ b/src/mbgl/style/style_layer.hpp
@@ -18,6 +18,7 @@ class StyleCascadeParameters;
 class StyleCalculationParameters;
 class StyleBucketParameters;
 class Bucket;
+class Source;
 
 class StyleLayer {
 public:
@@ -77,6 +78,8 @@ public:
     float minZoom = -std::numeric_limits<float>::infinity();
     float maxZoom = std::numeric_limits<float>::infinity();
     VisibilityType visibility = VisibilityType::Visible;
+
+    Source* source = nullptr;
 
 protected:
     enum class Type {

--- a/src/mbgl/style/style_parser.cpp
+++ b/src/mbgl/style/style_parser.cpp
@@ -432,10 +432,10 @@ void StyleParser::parseLayer(const std::string& id, const JSValue& value, std::u
         if (value.HasMember("source")) {
             const JSValue& value_source = value["source"];
             if (value_source.IsString()) {
-                layer->source = { value_source.GetString(), value_source.GetStringLength() };
-                auto source_it = sourcesMap.find(layer->source);
+                layer->sourceID = { value_source.GetString(), value_source.GetStringLength() };
+                auto source_it = sourcesMap.find(layer->sourceID);
                 if (source_it == sourcesMap.end()) {
-                    Log::Warning(Event::ParseStyle, "can't find source '%s' required for layer '%s'", layer->source.c_str(), layer->id.c_str());
+                    Log::Warning(Event::ParseStyle, "can't find source '%s' required for layer '%s'", layer->sourceID.c_str(), layer->id.c_str());
                 }
             } else {
                 Log::Warning(Event::ParseStyle, "source of layer '%s' must be a string", layer->id.c_str());

--- a/src/mbgl/tile/tile_worker.cpp
+++ b/src/mbgl/tile/tile_worker.cpp
@@ -139,7 +139,7 @@ void TileWorker::parseLayer(const StyleLayer* layer) {
         return;
 
     // Skip this bucket if we are to not render this
-    if ((layer->source != sourceID) ||
+    if ((layer->sourceID != sourceID) ||
         (id.overscaledZ < std::floor(layer->minZoom)) ||
         (id.overscaledZ >= std::ceil(layer->maxZoom)) ||
         (layer->visibility == VisibilityType::None)) {

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -275,7 +275,7 @@ TEST(Source, VectorTileCorrupt) {
 
     // Need to have at least one layer that uses the source.
     auto layer = std::make_unique<LineLayer>();
-    layer->source = "source";
+    layer->sourceID = "source";
     layer->sourceLayer = "water";
     test.style.addLayer(std::move(layer));
 


### PR DESCRIPTION
Every time we're accessing a layer's source, we're looking it up by it's ID. However, they never change, so we can just store the pointer directly in the Layer object.