### PR TITLE
[Qt] Always use setCoordinateZoom()

### DIFF
--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -53,13 +53,9 @@ void QQuickMapboxGLRenderer::synchronize(QQuickFramebufferObject *item)
     auto quickMap = static_cast<QQuickMapboxGL*>(item);
     auto syncStatus = quickMap->swapSyncState();
 
-    if (syncStatus & QQuickMapboxGL::ZoomNeedsSync) {
-        m_map->setZoom(quickMap->zoomLevel());
-    }
-
-    if (syncStatus & QQuickMapboxGL::CenterNeedsSync) {
+    if (syncStatus & QQuickMapboxGL::CenterNeedsSync || syncStatus & QQuickMapboxGL::ZoomNeedsSync) {
         const auto& center = quickMap->center();
-        m_map->setCoordinate(QMapbox::Coordinate(center.latitude(), center.longitude()));
+        m_map->setCoordinateZoom({ center.latitude(), center.longitude() }, quickMap->zoomLevel());
     }
 
     if (syncStatus & QQuickMapboxGL::StyleNeedsSync) {


### PR DESCRIPTION
Because at low zoom levels setting a new coordinate won't
correspond to the actual coordinate on the map.

/cc @brunoabinader