### PR TITLE
[ios] fix potential for very slow animations of user location dot

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3774,7 +3774,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     NSTimeInterval duration = MGLAnimationDuration;
     if (oldLocation && ! CGPointEqualToPoint(self.userLocationAnnotationView.center, CGPointZero))
     {
-        duration = MAX([newLocation.timestamp timeIntervalSinceDate:oldLocation.timestamp], MGLUserLocationAnimationDuration);
+        duration = MIN([newLocation.timestamp timeIntervalSinceDate:oldLocation.timestamp], MGLUserLocationAnimationDuration);
     }
     [self updateUserLocationAnnotationViewAnimatedWithDuration:duration];
     


### PR DESCRIPTION
It seems there was a logic error in calculating the duration for animating the user's current location dot. Since the code used the MAX of 1 second, or the time between the current location and previous location, it could easily result in animations of 30 seconds or more in cases where there's a gap in location updates. This could happen in common situations such as when the user is indoors. The result was a very slow and strange movement of the location dot. Pretty sure MIN is more appropriate here, as it puts a cap on the animation duration.