### PR TITLE
Fix nested framework

### DIFF
--- a/platform/osx/scripts/package.sh
+++ b/platform/osx/scripts/package.sh
@@ -37,10 +37,7 @@ xcodebuild \
     -jobs ${JOBS} | xcpretty
 
 step "Copying dynamic framework into place"
-mkdir -p ${OUTPUT}/${NAME}.framework
-cp -r \
-    ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework \
-    ${OUTPUT}/${NAME}.framework
+cp -r ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework "${OUTPUT}"
 if [[ -e ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework.dSYM ]]; then
     cp -r ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework.dSYM "${OUTPUT}"
 fi


### PR DESCRIPTION
An error in the packaging script caused Mapbox.framework to be placed inside a folder named Mapbox.framework. This change moves the framework up one level.