### PR TITLE
[core] [Qt] Added viewport mode

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -34,7 +34,8 @@ public:
     explicit Map(View&, FileSource&,
                  MapMode mapMode = MapMode::Continuous,
                  GLContextMode contextMode = GLContextMode::Unique,
-                 ConstrainMode constrainMode = ConstrainMode::HeightOnly);
+                 ConstrainMode constrainMode = ConstrainMode::HeightOnly,
+                 ViewportMode viewportMode = ViewportMode::Default);
     ~Map();
 
     // Register a callback that will get called (on the render thread) when all resources have
@@ -117,10 +118,14 @@ public:
     // North Orientation
     void setNorthOrientation(NorthOrientation);
     NorthOrientation getNorthOrientation() const;
-    
+
     // Constrain mode
     void setConstrainMode(ConstrainMode);
     ConstrainMode getConstrainMode() const;
+
+    // Viewport mode
+    void setViewportMode(ViewportMode);
+    ViewportMode getViewportMode() const;
 
     // Size
     uint16_t getWidth() const;

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -29,6 +29,13 @@ enum class ConstrainMode : EnumType {
     WidthAndHeight,
 };
 
+// Satisfies embedding platforms that requires the viewport coordinate systems
+// to be set according to its standards.
+enum class ViewportMode : EnumType {
+    Default,
+    FlippedY,
+};
+
 enum class MapDebugOptions : EnumType {
     NoDebug     = 0,
     TileBorders = 1 << 1,

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -96,6 +96,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     printf("- Press `N` to reset north\n");
     printf("- Press `R` to toggle any available `night` style class\n");
     printf("- Press `Z` to cycle through north orientations\n");
+    printf("- Prezz `X` to cycle through the viewport modes\n");
     printf("- Press `A` to cycle through Mapbox offices in the world + dateline monument\n");
     printf("\n");
     printf("- Press `1` through `6` to add increasing numbers of point annotations for testing\n");

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -380,7 +380,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
     // setup mbgl map
     mbgl::DefaultFileSource *mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
-    _mbglMap = new mbgl::Map(*_mbglView, *mbglFileSource, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None);
+    _mbglMap = new mbgl::Map(*_mbglView, *mbglFileSource, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
     [self validateTileCacheSize];
 
     // start paused if in IB

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -261,7 +261,7 @@ public:
     [[NSFileManager defaultManager] removeItemAtURL:legacyCacheURL error:NULL];
     
     mbgl::DefaultFileSource *mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
-    _mbglMap = new mbgl::Map(*_mbglView, *mbglFileSource, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None);
+    _mbglMap = new mbgl::Map(*_mbglView, *mbglFileSource, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
     [self validateTileCacheSize];
     
     // Install the OpenGL layer. Interface Builder’s synchronous drawing means

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -36,6 +36,11 @@ public:
         ConstrainWidthAndHeight
     };
 
+    enum ViewportMode {
+        DefaultViewport = 0,
+        FlippedYViewport
+    };
+
     MapMode mapMode() const;
     void setMapMode(MapMode);
 
@@ -44,6 +49,9 @@ public:
 
     ConstrainMode constrainMode() const;
     void setConstrainMode(ConstrainMode);
+
+    ViewportMode viewportMode() const;
+    void setViewportMode(ViewportMode);
 
     unsigned cacheDatabaseMaximumSize() const;
     void setCacheDatabaseMaximumSize(unsigned);
@@ -61,6 +69,7 @@ private:
     MapMode m_mapMode;
     GLContextMode m_contextMode;
     ConstrainMode m_constrainMode;
+    ViewportMode m_viewportMode;
 
     unsigned m_cacheMaximumSize;
     QString m_cacheDatabasePath;

--- a/platform/qt/qmlapp/main.qml
+++ b/platform/qt/qmlapp/main.qml
@@ -41,12 +41,12 @@ ApplicationWindow {
                     anchors.fill: parent
                     visible: false
 
-                    style: "mapbox://styles/mapbox/streets-v8"
+                    style: "mapbox://styles/mapbox/streets-v9"
 
                     center: QtPositioning.coordinate(60.170448, 24.942046) // Helsinki
                     zoomLevel: 14
-                    minimumZoomLevel: 4
-                    maximumZoomLevel: 16
+                    minimumZoomLevel: 0
+                    maximumZoomLevel: 20
 
                     bearing: bearingSlider.value
                     pitch: pitchSlider.value
@@ -119,7 +119,7 @@ ApplicationWindow {
                     anchors.fill: parent
                     visible: false
 
-                    style: "mapbox://styles/mapbox/satellite-hybrid-v8"
+                    style: "mapbox://styles/mapbox/satellite-streets-v9"
 
                     center: mapStreets.center
                     zoomLevel: mapStreets.zoomLevel

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -35,6 +35,10 @@ static_assert(mbgl::underlying_type(QMapboxGLSettings::NoConstrain) == mbgl::und
 static_assert(mbgl::underlying_type(QMapboxGLSettings::ConstrainHeightOnly) == mbgl::underlying_type(mbgl::ConstrainMode::HeightOnly), "error");
 static_assert(mbgl::underlying_type(QMapboxGLSettings::ConstrainWidthAndHeight) == mbgl::underlying_type(mbgl::ConstrainMode::WidthAndHeight), "error");
 
+// mbgl::ViewportMode
+static_assert(mbgl::underlying_type(QMapboxGLSettings::DefaultViewport) == mbgl::underlying_type(mbgl::ViewportMode::Default), "error");
+static_assert(mbgl::underlying_type(QMapboxGLSettings::FlippedYViewport) == mbgl::underlying_type(mbgl::ViewportMode::FlippedY), "error");
+
 // mbgl::NorthOrientation
 static_assert(mbgl::underlying_type(QMapboxGL::NorthUpwards) == mbgl::underlying_type(mbgl::NorthOrientation::Upwards), "error");
 static_assert(mbgl::underlying_type(QMapboxGL::NorthRightwards) == mbgl::underlying_type(mbgl::NorthOrientation::Rightwards), "error");
@@ -61,6 +65,7 @@ QMapboxGLSettings::QMapboxGLSettings()
     : m_mapMode(QMapboxGLSettings::ContinuousMap)
     , m_contextMode(QMapboxGLSettings::SharedGLContext)
     , m_constrainMode(QMapboxGLSettings::ConstrainHeightOnly)
+    , m_viewportMode(QMapboxGLSettings::DefaultViewport)
     , m_cacheMaximumSize(mbgl::util::DEFAULT_MAX_CACHE_SIZE)
     , m_cacheDatabasePath(":memory:")
     , m_assetPath(QCoreApplication::applicationDirPath())
@@ -95,6 +100,16 @@ QMapboxGLSettings::ConstrainMode QMapboxGLSettings::constrainMode() const
 void QMapboxGLSettings::setConstrainMode(ConstrainMode mode)
 {
     m_constrainMode = mode;
+}
+
+QMapboxGLSettings::ViewportMode QMapboxGLSettings::viewportMode() const
+{
+    return m_viewportMode;
+}
+
+void QMapboxGLSettings::setViewportMode(ViewportMode mode)
+{
+    m_viewportMode = mode;
 }
 
 unsigned QMapboxGLSettings::cacheDatabaseMaximumSize() const
@@ -605,7 +620,8 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
         *this, *fileSourceObj,
         static_cast<mbgl::MapMode>(settings.mapMode()),
         static_cast<mbgl::GLContextMode>(settings.contextMode()),
-        static_cast<mbgl::ConstrainMode>(settings.constrainMode())))
+        static_cast<mbgl::ConstrainMode>(settings.constrainMode()),
+        static_cast<mbgl::ViewportMode>(settings.viewportMode())))
 {
     qRegisterMetaType<QMapboxGL::MapChange>("QMapboxGL::MapChange");
 

--- a/platform/qt/src/qquickmapboxgl.cpp
+++ b/platform/qt/src/qquickmapboxgl.cpp
@@ -14,10 +14,6 @@
 QQuickMapboxGL::QQuickMapboxGL(QQuickItem *parent_)
     : QQuickFramebufferObject(parent_)
 {
-#if QT_VERSION >= 0x050600
-    // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/4866
-    setMirrorVertically(true);
-#endif
 }
 
 QQuickMapboxGL::~QQuickMapboxGL()
@@ -166,7 +162,7 @@ QColor QQuickMapboxGL::color() const
 
 void QQuickMapboxGL::pan(int dx, int dy)
 {
-    m_pan += QPointF(dx, dy);
+    m_pan += QPointF(dx, -dy);
 
     m_syncState |= PanNeedsSync;
     update();

--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -16,6 +16,7 @@ QQuickMapboxGLRenderer::QQuickMapboxGLRenderer()
     settings.setAccessToken(qgetenv("MAPBOX_ACCESS_TOKEN"));
     settings.setCacheDatabasePath("/tmp/mbgl-cache.db");
     settings.setCacheDatabaseMaximumSize(20 * 1024 * 1024);
+    settings.setViewportMode(QMapboxGLSettings::FlippedYViewport);
 
     m_map.reset(new QMapboxGL(nullptr, settings));
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -34,7 +34,7 @@ enum class RenderState {
 
 class Map::Impl : public Style::Observer {
 public:
-    Impl(View&, FileSource&, MapMode, GLContextMode, ConstrainMode);
+    Impl(View&, FileSource&, MapMode, GLContextMode, ConstrainMode, ViewportMode);
 
     void onResourceLoaded() override;
     void onResourceError(std::exception_ptr) override;
@@ -76,16 +76,16 @@ public:
     bool loading = false;
 };
 
-Map::Map(View& view, FileSource& fileSource, MapMode mapMode, GLContextMode contextMode, ConstrainMode constrainMode)
-    : impl(std::make_unique<Impl>(view, fileSource, mapMode, contextMode, constrainMode)) {
+Map::Map(View& view, FileSource& fileSource, MapMode mapMode, GLContextMode contextMode, ConstrainMode constrainMode, ViewportMode viewportMode)
+    : impl(std::make_unique<Impl>(view, fileSource, mapMode, contextMode, constrainMode, viewportMode)) {
     view.initialize(this);
     update(Update::Dimensions);
 }
 
-Map::Impl::Impl(View& view_, FileSource& fileSource_, MapMode mode_, GLContextMode contextMode_, ConstrainMode constrainMode_)
+Map::Impl::Impl(View& view_, FileSource& fileSource_, MapMode mode_, GLContextMode contextMode_, ConstrainMode constrainMode_, ViewportMode viewportMode_)
     : view(view_),
       fileSource(fileSource_),
-      transform(view, constrainMode_),
+      transform(view, constrainMode_, viewportMode_),
       mode(mode_),
       contextMode(contextMode_),
       pixelRatio(view.getPixelRatio()),
@@ -636,6 +636,17 @@ void Map::setConstrainMode(mbgl::ConstrainMode mode) {
 
 ConstrainMode Map::getConstrainMode() const {
     return impl->transform.getConstrainMode();
+}
+
+#pragma mark - Viewport mode
+
+void Map::setViewportMode(mbgl::ViewportMode mode) {
+    impl->transform.setViewportMode(mode);
+    update(Update::Repaint);
+}
+
+ViewportMode Map::getViewportMode() const {
+    return impl->transform.getViewportMode();
 }
 
 #pragma mark - Projection

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -36,9 +36,9 @@ static double _normalizeAngle(double angle, double anchorAngle)
     return angle;
 }
 
-Transform::Transform(View &view_, ConstrainMode constrainMode)
+Transform::Transform(View &view_, ConstrainMode constrainMode, ViewportMode viewportMode)
     : view(view_)
-    , state(constrainMode)
+    , state(constrainMode, viewportMode)
 {
 }
 
@@ -553,6 +553,16 @@ void Transform::setConstrainMode(mbgl::ConstrainMode mode) {
 
 ConstrainMode Transform::getConstrainMode() const {
     return state.getConstrainMode();
+}
+
+#pragma mark - Viewport mode
+
+void Transform::setViewportMode(mbgl::ViewportMode mode) {
+    state.viewportMode = mode;
+}
+
+ViewportMode Transform::getViewportMode() const {
+    return state.getViewportMode();
 }
 
 #pragma mark - Transition

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -20,7 +20,7 @@ class View;
 
 class Transform : private util::noncopyable {
 public:
-    Transform(View&, ConstrainMode);
+    Transform(View&, ConstrainMode, ViewportMode);
 
     // Map view
     bool resize(std::array<uint16_t, 2> size);
@@ -132,10 +132,14 @@ public:
     // North Orientation
     void setNorthOrientation(NorthOrientation);
     NorthOrientation getNorthOrientation() const;
-    
+
     // Constrain mode
     void setConstrainMode(ConstrainMode);
     ConstrainMode getConstrainMode() const;
+
+    // Viewport mode
+    void setViewportMode(ViewportMode);
+    ViewportMode getViewportMode() const;
 
     // Transitions
     bool inTransition() const;

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -7,8 +7,9 @@
 
 namespace mbgl {
 
-TransformState::TransformState(ConstrainMode constrainMode_)
+TransformState::TransformState(ConstrainMode constrainMode_, ViewportMode viewportMode_)
     : constrainMode(constrainMode_)
+    , viewportMode(viewportMode_)
 {
 }
 
@@ -39,7 +40,8 @@ void TransformState::getProjMatrix(mat4& projMatrix) const {
 
     // After the rotateX, z values are in pixel units. Convert them to
     // altitude unites. 1 altitude unit = the screen height.
-    matrix::scale(projMatrix, projMatrix, 1, -1, 1.0f / (rotatedNorth() ? getWidth() : getHeight()));
+    const bool flippedY = viewportMode == ViewportMode::FlippedY;
+    matrix::scale(projMatrix, projMatrix, 1, flippedY ? 1 : -1, 1.0f / (rotatedNorth() ? getWidth() : getHeight()));
 
     using NO = NorthOrientation;
     switch (getNorthOrientation()) {
@@ -87,6 +89,12 @@ double TransformState::getNorthOrientationAngle() const {
 
 ConstrainMode TransformState::getConstrainMode() const {
     return constrainMode;
+}
+
+#pragma mark - ViewportMode
+
+ViewportMode TransformState::getViewportMode() const {
+    return viewportMode;
 }
 
 #pragma mark - Position

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -18,7 +18,7 @@ class TransformState {
     friend class Transform;
 
 public:
-    TransformState(ConstrainMode = ConstrainMode::HeightOnly);
+    TransformState(ConstrainMode = ConstrainMode::HeightOnly, ViewportMode = ViewportMode::Default);
 
     // Matrix
     void matrixFor(mat4&, const UnwrappedTileID&) const;
@@ -31,9 +31,12 @@ public:
     // North Orientation
     NorthOrientation getNorthOrientation() const;
     double getNorthOrientationAngle() const;
-    
+
     // Constrain mode
     ConstrainMode getConstrainMode() const;
+
+    // Viewport mode
+    ViewportMode getViewportMode() const;
 
     // Position
     LatLng getLatLng(LatLng::WrapMode = LatLng::Unwrapped) const;
@@ -99,6 +102,7 @@ private:
 
 private:
     ConstrainMode constrainMode;
+    ViewportMode viewportMode;
 
     // animation state
     bool rotating = false;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -51,7 +51,8 @@ void Painter::renderSDF(SymbolBucket &bucket,
         gammaScale = 1.0f;
         matrix::rotate_z(exMatrix, exMatrix, state.getNorthOrientationAngle());
     }
-    matrix::scale(exMatrix, exMatrix, s, s, 1);
+    const bool flippedY = !skewed && state.getViewportMode() == ViewportMode::FlippedY;
+    matrix::scale(exMatrix, exMatrix, s, flippedY ? -s : s, 1);
 
     // If layerStyle.size > bucket.info.fontSize then labels may collide
     float fontSize = paintSize;
@@ -217,7 +218,8 @@ void Painter::renderSymbol(SymbolBucket& bucket,
                 matrix::rotate_z(exMatrix, exMatrix, state.getNorthOrientationAngle());
                 s = state.getAltitude();
             }
-            matrix::scale(exMatrix, exMatrix, s, s, 1);
+            const bool flippedY = !skewed && state.getViewportMode() == ViewportMode::FlippedY;
+            matrix::scale(exMatrix, exMatrix, s, flippedY ? -s : s, 1);
 
             matrix::scale(exMatrix, exMatrix, fontScale, fontScale, 1.0f);
 

--- a/test/map/transform.cpp
+++ b/test/map/transform.cpp
@@ -8,7 +8,7 @@ using namespace mbgl;
 
 TEST(Transform, InvalidScale) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
@@ -48,7 +48,7 @@ TEST(Transform, InvalidScale) {
 
 TEST(Transform, InvalidLatLng) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
@@ -84,7 +84,7 @@ TEST(Transform, InvalidLatLng) {
 
 TEST(Transform, InvalidBearing) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
@@ -111,7 +111,7 @@ TEST(Transform, PerspectiveProjection) {
     MockView view;
     LatLng loc;
 
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
     transform.setScale(2 << 9);
     transform.setPitch(0.9);
@@ -142,7 +142,7 @@ TEST(Transform, PerspectiveProjection) {
 
 TEST(Transform, UnwrappedLatLng) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
     transform.setScale(2 << 9);
     transform.setPitch(0.9);
@@ -175,7 +175,7 @@ TEST(Transform, ConstrainHeightOnly) {
     MockView view;
     LatLng loc;
 
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
     transform.setScale(std::pow(2, util::MAX_ZOOM));
 
@@ -194,7 +194,7 @@ TEST(Transform, ConstrainWidthAndHeight) {
     MockView view;
     LatLng loc;
 
-    Transform transform(view, ConstrainMode::WidthAndHeight);
+    Transform transform(view, ConstrainMode::WidthAndHeight, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
     transform.setScale(std::pow(2, util::MAX_ZOOM));
 
@@ -211,7 +211,7 @@ TEST(Transform, ConstrainWidthAndHeight) {
 
 TEST(Transform, Anchor) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
 
     const LatLng latLng { 10, -100 };
@@ -312,7 +312,7 @@ TEST(Transform, Anchor) {
 
 TEST(Transform, Padding) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
@@ -350,7 +350,7 @@ TEST(Transform, Padding) {
 
 TEST(Transform, MoveBy) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
     transform.setLatLngZoom({ 0, 0 }, 10);
 
@@ -378,7 +378,7 @@ TEST(Transform, MoveBy) {
 
 TEST(Transform, Antimeridian) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
     transform.setLatLngZoom({ 0, 0 }, 1);
 
@@ -422,7 +422,7 @@ TEST(Transform, Antimeridian) {
 
 TEST(Transform, Camera) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({{ 1000, 1000 }});
 
     const LatLng latLng1 { 45, 135 };

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -25,7 +25,7 @@ public:
     StubFileSource fileSource;
     StubStyleObserver observer;
     MockView view;
-    Transform transform { view, ConstrainMode::HeightOnly };
+    Transform transform { view, ConstrainMode::HeightOnly, ViewportMode::Default };
     TransformState transformState;
     Worker worker { 1 };
     gl::TexturePool texturePool;

--- a/test/util/tile_cover.cpp
+++ b/test/util/tile_cover.cpp
@@ -30,7 +30,7 @@ TEST(TileCover, WorldZ0) {
 
 TEST(TileCover, Pitch) {
     MockView view;
-    Transform transform(view, ConstrainMode::HeightOnly);
+    Transform transform(view, ConstrainMode::HeightOnly, ViewportMode::Default);
     transform.resize({ { 512, 512 } });
     transform.setZoom(2);
     transform.setPitch(40.0 * M_PI / 180.0);


### PR DESCRIPTION
_Viewport mode_ satisfies embedding platforms that requires the viewport coordinate systems to be set according to its standards e..g. Qt Quick requires third-party rendering code to follow its standards with regards to viewport transforms.
 
Qt 5.6 adds a [mirrorVertically](http://doc.qt.io/qt-5/qquickframebufferobject.html#mirrorVertically-prop) property that solves the solution for that version of Qt onwards. Telling Mapbox GL core to flip the Y axis makes `QQuickMapboxGL` item available from Qt 5.2 onwards.

Fixes #4866.

:eyes: @kkaefer @tmpsantos