### PR TITLE
[android] - fixes style init bug, added unit test to prevent regression

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -188,7 +188,7 @@ public class MapView extends FrameLayout {
         mOnMapChangedListener = new CopyOnWriteArrayList<>();
         mMapboxMap = new MapboxMap(this);
         mIcons = new ArrayList<>();
-        mStyleInitializer = new StyleInitializer();
+        mStyleInitializer = new StyleInitializer(context);
         View view = LayoutInflater.from(context).inflate(R.layout.mapview_internal, this);
 
         if (!isInEditMode()) {
@@ -2673,13 +2673,13 @@ public class MapView extends FrameLayout {
     /**
      * Class responsible for managing state of Style loading.
      */
-    private class StyleInitializer {
+    static class StyleInitializer {
 
         private String mStyle;
         private boolean mDefaultStyle;
 
-        public StyleInitializer() {
-            mStyle = Style.getMapboxStreetsUrl(getResources().getInteger(R.integer.style_version));
+        StyleInitializer(@NonNull  Context context) {
+            mStyle = Style.getMapboxStreetsUrl(context.getResources().getInteger(R.integer.style_version));
             mDefaultStyle = true;
         }
 
@@ -2688,6 +2688,10 @@ public class MapView extends FrameLayout {
         }
 
         void setStyle(@NonNull String style, boolean defaultStyle) {
+            if (style == null) {
+                // don't override default style
+                return;
+            }
             mStyle = style;
             mDefaultStyle = defaultStyle;
         }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/StyleInitializerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/StyleInitializerTest.java
@@ -1,0 +1,75 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.content.Context;
+import android.content.res.Resources;
+
+import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.model.constants.AppConstant;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StyleInitializerTest {
+
+    @InjectMocks
+    Context context = mock(Context.class);
+
+    @InjectMocks
+    Resources resources = mock(Resources.class);
+
+    MapView.StyleInitializer initializer;
+
+    @Before
+    public void beforeTest() {
+        MockitoAnnotations.initMocks(this);
+        when(context.getResources()).thenReturn(resources);
+        when(resources.getInteger(R.integer.style_version)).thenReturn(AppConstant.STYLE_VERSION);
+        initializer = new MapView.StyleInitializer(context);
+    }
+
+    @Test
+    public void testSanity() {
+        assertNotNull("initializer should not be null", initializer);
+    }
+
+    @Test
+    public void testDefaultStyle() {
+        assertTrue(initializer.isDefaultStyle());
+        assertEquals(String.format(Locale.US, "mapbox://styles/mapbox/streets-v%d", AppConstant.STYLE_VERSION), "mapbox://styles/mapbox/streets-v9");
+    }
+
+    @Test
+    public void testUpdateStyle() {
+        String customStyle = "test";
+        initializer.setStyle(customStyle);
+        assertFalse(initializer.isDefaultStyle());
+        assertEquals(customStyle, initializer.getStyle());
+    }
+
+    @Test
+    public void testUpdateStyleNull() {
+        String customStyle = null;
+        initializer.setStyle(customStyle);
+        assertTrue(initializer.isDefaultStyle());
+        assertEquals(String.format(Locale.US, "mapbox://styles/mapbox/streets-v%d", AppConstant.STYLE_VERSION), "mapbox://styles/mapbox/streets-v9");
+    }
+
+    @Test
+    public void testOverrideDefaultStyle() {
+        String customStyle = "test";
+        initializer.setStyle(customStyle, true);
+        assertTrue(initializer.isDefaultStyle());
+        assertEquals(customStyle, initializer.getStyle());
+    }
+}


### PR DESCRIPTION
Fixes the issue that the style field within the initialiser is set to null.
Backed up these changes with unit tests.