### PR TITLE
5019 loop markers add remove

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -34,6 +34,14 @@
                 android:value="@string/category_infowindow" />
         </activity>
         <activity
+            android:name=".activity.annotation.AddRemoveMarkerActivity"
+            android:description="@string/description_add_remove_marker"
+            android:label="@string/activity_add_remove_markers">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_annotation" />
+        </activity>
+        <activity
             android:name=".activity.infowindow.InfoWindowAdapterActivity"
             android:description="@string/description_info_window_adapter"
             android:label="@string/activity_infowindow_adapter">

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AddRemoveMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AddRemoveMarkerActivity.java
@@ -138,7 +138,7 @@ public class AddRemoveMarkerActivity extends AppCompatActivity {
         Toast.makeText(this, "Cycle " + cycle + ", step " + cycleStep, Toast.LENGTH_SHORT).show();
 
         // schedule next cycle
-        cycleHandler.postDelayed(cycleRunner, 1500);
+        cycleHandler.postDelayed(cycleRunner, 2100);
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AddRemoveMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AddRemoveMarkerActivity.java
@@ -1,0 +1,185 @@
+package com.mapbox.mapboxsdk.testapp.activity.annotation;
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.MenuItem;
+import android.widget.Toast;
+
+import com.mapbox.mapboxsdk.annotations.Annotation;
+import com.mapbox.mapboxsdk.annotations.Marker;
+import com.mapbox.mapboxsdk.annotations.MarkerOptions;
+import com.mapbox.mapboxsdk.constants.MapboxConstants;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.testapp.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AddRemoveMarkerActivity extends AppCompatActivity {
+
+    private MapboxMap mMapboxMap;
+    private MapView mMapView;
+
+    private int cycleStep;
+    private int cycle;
+    private Handler cycleHandler;
+    private Runnable cycleRunner = new Runnable() {
+        @Override
+        public void run() {
+            startAddRemoveCycle();
+        }
+    };
+
+    private final static LatLng[] LAT_LNGS = new LatLng[]{
+            new LatLng(38.907327, -77.041293),
+            new LatLng(38.909698, -77.029642),
+            new LatLng(38.907227, -77.036530),
+            new LatLng(38.905607, -77.031916),
+            new LatLng(38.897424, -77.036508),
+            new LatLng(38.897642, -77.041980),
+            new LatLng(38.889876, -77.008849),
+            new LatLng(38.889441, -77.050134),
+            new LatLng(38.902580, -77.050102)
+    };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_marker_add_remove);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        final ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setDisplayShowHomeEnabled(true);
+        }
+
+        mMapView = (MapView) findViewById(R.id.mapView);
+        mMapView.setAccessToken(getString(R.string.mapbox_access_token));
+        mMapView.onCreate(savedInstanceState);
+        mMapView.getMapAsync(new OnMapReadyCallback() {
+            @Override
+            public void onMapReady(@NonNull MapboxMap mapboxMap) {
+                mMapboxMap = mapboxMap;
+                cycleHandler = new Handler();
+                startAddRemoveCycle();
+            }
+        });
+    }
+
+    public void startAddRemoveCycle() {
+        switch (cycleStep) {
+            case 0:
+                // removing old annotations
+                mMapboxMap.removeAnnotations();
+                break;
+
+            case 1:
+                // addMarker
+                for (LatLng latLng : LAT_LNGS) {
+                    Marker marker = mMapboxMap.addMarker(new MarkerOptions().position(latLng));
+                    Log.v(MapboxConstants.TAG, "Marker added via addMarker " + marker.getId());
+                }
+                break;
+
+            case 2:
+                // removing old annotations
+                mMapboxMap.removeAnnotations(mMapboxMap.getAnnotations());
+                break;
+
+            case 3:
+                // addMarkers
+                List<MarkerOptions> markerOptions = new ArrayList<>();
+                for (LatLng latLng : LAT_LNGS) {
+                    markerOptions.add(new MarkerOptions().position(latLng));
+                }
+                List<Marker> markers = mMapboxMap.addMarkers(markerOptions);
+                for (Marker m : markers) {
+                    Log.v(MapboxConstants.TAG, "Marker added via addMarkers " + m.getId());
+                }
+                break;
+
+            case 4:
+                // removing old annotations
+                List<Annotation> annotationList = mMapboxMap.getAnnotations();
+                for (Annotation annotation : annotationList) {
+                    mMapboxMap.removeAnnotation(annotation.getId());
+                }
+                break;
+
+            case 5:
+                // addMarker
+                for (LatLng latLng : LAT_LNGS) {
+                    Marker marker = mMapboxMap.addMarker(new MarkerOptions().position(latLng));
+                    Log.v(MapboxConstants.TAG, "Marker added via addMarker " + marker.getId());
+                }
+                break;
+        }
+
+        // update cycle
+        if (cycleStep == 5) {
+            cycle++;
+            cycleStep = 0;
+        } else {
+            cycleStep++;
+        }
+
+        // show data
+        Toast.makeText(this, "Cycle " + cycle + ", step " + cycleStep, Toast.LENGTH_SHORT).show();
+
+        // schedule next cycle
+        cycleHandler.postDelayed(cycleRunner, 1500);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mMapView.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mMapView.onPause();
+        cycleHandler.removeCallbacks(cycleRunner);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        mMapView.onSaveInstanceState(outState);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mMapView.onDestroy();
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        mMapView.onLowMemory();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_marker_add_remove.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_marker_add_remove.xml
@@ -16,9 +16,6 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:center_latitude="38.894364"
-        app:center_longitude="-77.036884"
-        app:style_url="@string/style_mapbox_streets"
-        app:zoom="12" />
+        app:style_url="@string/style_mapbox_streets" />
 
 </LinearLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_marker_add_remove.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_marker_add_remove.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/primary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:center_latitude="38.894364"
+        app:center_longitude="-77.036884"
+        app:style_url="@string/style_mapbox_streets"
+        app:zoom="12" />
+
+</LinearLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="activity_map_fragment">Map Fragment</string>
 
     <!-- Annotations -->
+    <string name="activity_add_remove_markers">Add/Remove Markers</string>
     <string name="activity_add_bulk_markers">Add Markers In Bulk</string>
     <string name="activity_animated_marker">Animated Marker (experimental)</string>
     <string name="activity_dynamic_marker">Dynamic Marker</string>
@@ -75,6 +76,7 @@
     <string name="description_scroll_by">Scroll with pixels in x,y direction</string>
     <string name="description_snapshot">Example to make a snapshot of the map</string>
     <string name="description_doublemap">2 maps in a view hierarchy</string>
+    <string name="description_add_remove_marker">Costantly add/remove markers to a map</string>
 
     <string name="menuitem_title_concurrent_infowindow">Concurrent Open InfoWindows</string>r
     <string name="menuitem_title_tracking_mode_dismiss_on_gesture">Dismiss location tracking on gesture</string>


### PR DESCRIPTION
Refs #5019.  Constantly add/remove markers to a map to find regressions related to 
 - onMapReady callbacks 
 - reload Markers, icons and offsets
 - ID issue

Covers regression on methods as:
 - addMarkers 
 - addMarker  
 - removeAnnotations
 - removeAnnotations(list) 
 - removeAnnotation

