### PR TITLE
Initialize VAO extensions in Qt app

### DIFF
--- a/platform/qt/README.md
+++ b/platform/qt/README.md
@@ -30,6 +30,12 @@ to provide it by setting the environment variable `MAPBOX_ACCESS_TOKEN`:
 
     export MAPBOX_ACCESS_TOKEN=MYTOKEN
 
+#### Using QMapboxGL
+
+`QMapboxGL` is a [QObject](http://doc.qt.io/qt-5/qobject.html) - [MapWindow](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/qt/app/mapwindow.hpp) provides an example [QGLWidget](http://doc.qt.io/qt-5/qglwidget.html) that contains a `QMapboxGL` object. If you use `QMapboxGL` in non-standard Qt widgets, make sure to initialize the GL extensions required by Mapbox whenever possible:
+
+    QMapbox::initializeGLExtensions();
+
 #### Linux
 
 For Linux (Ubuntu) desktop, together with these [build

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -142,6 +142,11 @@ void MapWindow::wheelEvent(QWheelEvent *ev)
     ev->accept();
 }
 
+void MapWindow::initializeGL()
+{
+    QMapbox::initializeGLExtensions();
+}
+
 void MapWindow::resizeGL(int w, int h)
 {
     m_map.resize(QSize(w, h));

--- a/platform/qt/app/mapwindow.hpp
+++ b/platform/qt/app/mapwindow.hpp
@@ -30,6 +30,8 @@ private:
     void mousePressEvent(QMouseEvent *ev) final;
     void mouseMoveEvent(QMouseEvent *ev) final;
     void wheelEvent(QWheelEvent *ev) final;
+
+    void initializeGL() final;
     void resizeGL(int w, int h) final;
     void paintGL() final;
 

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -60,9 +60,7 @@ typedef void (*CustomLayerInitializeFunction)(void* context) ;
 typedef void (*CustomLayerRenderFunction)(void* context, const CustomLayerRenderParameters&);
 typedef void (*CustomLayerDeinitializeFunction)(void* context);
 
-#if QT_VERSION >= 0x050000
 Q_DECL_EXPORT void initializeGLExtensions();
-#endif
 
 }
 

--- a/platform/qt/platform.gyp
+++ b/platform/qt/platform.gyp
@@ -129,8 +129,12 @@
         ['<(qt_version_major) == 4', {
           'variables': {
             'cflags': [
+              '<@(qt_opengl_cflags)',
               # Qt4 generates code with unused variables.
               '-Wno-unused-variable',
+            ],
+            'ldflags': [
+              '<@(qt_opengl_ldflags)',
             ],
           },
         }],

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -7,6 +7,8 @@
 
 #if QT_VERSION >= 0x050000
 #include <QOpenGLContext>
+#else
+#include <QGLContext>
 #endif
 
 // mbgl::MapMode
@@ -39,14 +41,17 @@ Q_DECL_EXPORT QList<QPair<QString, QString>>& defaultStyles()
     return styles;
 }
 
-#if QT_VERSION >= 0x050000
 Q_DECL_EXPORT void initializeGLExtensions()
 {
     mbgl::gl::InitializeExtensions([](const char* name) {
+#if QT_VERSION >= 0x050000
         QOpenGLContext* thisContext = QOpenGLContext::currentContext();
         return thisContext->getProcAddress(name);
+#else
+        const QGLContext* thisContext = QGLContext::currentContext();
+        return reinterpret_cast<mbgl::gl::glProc>(thisContext->getProcAddress(name));
+#endif
     });
 }
-#endif
 
 }


### PR DESCRIPTION
When using Qt, we're not initializing the OpenGL extensions, so it's not using VAOs even if they're available as indicated by the message `[WARNING] {}[OpenGL]: Not using Vertex Array Objects` in the console.

/cc @tmpsantos @brunoabinader 