### PR TITLE
[Qt] QMapboxGL pixel ratio is wrong for Retina displays

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -149,13 +149,16 @@ void MapWindow::initializeGL()
 
 void MapWindow::resizeGL(int w, int h)
 {
-    m_map.resize(QSize(w, h));
+    QSize size(w, h);
+#if QT_VERSION >= 0x050000
+    size /= qApp->devicePixelRatio();
+#endif
+    m_map.resize(size);
+    glViewport(0, 0, size.width(), size.height());
 }
 
 void MapWindow::paintGL()
 {
-    glViewport(0, 0, width(), height());
-
     m_frameDraws++;
     m_map.render();
 }

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -11,7 +11,12 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/traits.hpp>
 
+#if QT_VERSION >= 0x050000
+#include <QGuiApplication>
+#else
 #include <QCoreApplication>
+#endif
+
 #include <QImage>
 #include <QMapboxGL>
 #include <QMargins>
@@ -636,8 +641,12 @@ QMapboxGLPrivate::~QMapboxGLPrivate()
 
 float QMapboxGLPrivate::getPixelRatio() const
 {
+#if QT_VERSION >= 0x050000
+    return qApp->devicePixelRatio();
+#else
     // FIXME: Should handle pixel ratio.
     return 1.0;
+#endif
 }
 
 std::array<uint16_t, 2> QMapboxGLPrivate::getSize() const

--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -3,6 +3,7 @@
 #include <QMapboxGL>
 #include <QQuickMapboxGL>
 
+#include <QGuiApplication>
 #include <QSize>
 #include <QOpenGLFramebufferObject>
 #include <QOpenGLFramebufferObjectFormat>
@@ -27,7 +28,7 @@ QQuickMapboxGLRenderer::~QQuickMapboxGLRenderer()
 
 QOpenGLFramebufferObject* QQuickMapboxGLRenderer::createFramebufferObject(const QSize &size)
 {
-    m_map->resize(size);
+    m_map->resize(size / qApp->devicePixelRatio());
 
     QOpenGLFramebufferObjectFormat format;
     format.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);


### PR DESCRIPTION
<img width="912" alt="screen shot 2016-04-28 at 2 50 45 pm" src="https://cloud.githubusercontent.com/assets/76133/14884895/b1515044-0d50-11e6-96fd-ce4a16df8931.png">
Some issues to consider:
- `Map::Impl` only reads the pixel ratio once in the ctor. In my environment, I have an external  monitor connected to my MacBook. When moving the application window between them, the pixel ratio should be updated.
- We're hardcoding the pixel ratio to 1 in https://github.com/mapbox/mapbox-gl-native/blob/master/platform/qt/src/qmapboxgl.cpp#L597.

/cc @tmpsantos