### PR TITLE
Allow requesting optional resources

### DIFF
--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -82,21 +82,35 @@ public:
     }
 
     void request(AsyncRequest* req, Resource resource, Callback callback) {
-        auto offlineResponse = offlineDatabase.get(resource);
-
         Resource revalidation = resource;
 
-        if (offlineResponse) {
-            revalidation.priorModified = offlineResponse->modified;
-            revalidation.priorExpires = offlineResponse->expires;
-            revalidation.priorEtag = offlineResponse->etag;
-            callback(*offlineResponse);
+        const bool hasPrior = resource.priorEtag || resource.priorModified || resource.priorExpires;
+        if (!hasPrior || resource.necessity == Resource::Optional) {
+            auto offlineResponse = offlineDatabase.get(resource);
+
+            if (resource.necessity == Resource::Optional && !offlineResponse) {
+                // Ensure there's always a response that we can send, so the caller knows that
+                // there's no optional data available in the cache.
+                offlineResponse.emplace();
+                offlineResponse->noContent = true;
+                offlineResponse->error = std::make_unique<Response::Error>(
+                    Response::Error::Reason::NotFound, "Not found in offline database");
+            }
+
+            if (offlineResponse) {
+                revalidation.priorModified = offlineResponse->modified;
+                revalidation.priorExpires = offlineResponse->expires;
+                revalidation.priorEtag = offlineResponse->etag;
+                callback(*offlineResponse);
+            }
         }
 
-        tasks[req] = onlineFileSource.request(revalidation, [=] (Response onlineResponse) {
-            this->offlineDatabase.put(revalidation, onlineResponse);
-            callback(onlineResponse);
-        });
+        if (resource.necessity == Resource::Required) {
+            tasks[req] = onlineFileSource.request(revalidation, [=] (Response onlineResponse) {
+                this->offlineDatabase.put(revalidation, onlineResponse);
+                callback(onlineResponse);
+            });
+        }
     }
 
     void cancel(AsyncRequest* req) {


### PR DESCRIPTION
Right now, when calling `FileSource::request()`, we're making every effort to obtain the data. However, for #123, we need a more relaxed way to request things that can be obtained with low effort (e.g. by loading it from a cache, but *not* downloading it from the internet).