### PR TITLE
[ios] Make MGLCoordinateInCoordinateBounds() public

### DIFF
--- a/platform/darwin/src/MGLGeometry.h
+++ b/platform/darwin/src/MGLGeometry.h
@@ -64,6 +64,14 @@ NS_INLINE BOOL MGLCoordinateBoundsEqualToCoordinateBounds(MGLCoordinateBounds bo
             bounds1.ne.longitude == bounds2.ne.longitude);
 }
 
+/** Returns `YES` if the coordinate is within the coordinate bounds. */
+NS_INLINE BOOL MGLCoordinateInCoordinateBounds(CLLocationCoordinate2D coordinate, MGLCoordinateBounds bounds) {
+    return (coordinate.latitude  >= bounds.sw.latitude  &&
+            coordinate.latitude  <= bounds.ne.latitude  &&
+            coordinate.longitude >= bounds.sw.longitude &&
+            coordinate.longitude <= bounds.ne.longitude);
+}
+
 /** Returns the area spanned by the coordinate bounds. */
 NS_INLINE MGLCoordinateSpan MGLCoordinateBoundsGetCoordinateSpan(MGLCoordinateBounds bounds) {
     return MGLCoordinateSpanMake(bounds.ne.latitude - bounds.sw.latitude,

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -29,11 +29,6 @@ NS_INLINE mbgl::LatLngBounds MGLLatLngBoundsFromCoordinateBounds(MGLCoordinateBo
                                     MGLLatLngFromLocationCoordinate2D(coordinateBounds.ne));
 }
 
-NS_INLINE BOOL MGLCoordinateInCoordinateBounds(CLLocationCoordinate2D coordinate, MGLCoordinateBounds coordinateBounds) {
-    mbgl::LatLngBounds bounds = MGLLatLngBoundsFromCoordinateBounds(coordinateBounds);
-    return bounds.contains(MGLLatLngFromLocationCoordinate2D(coordinate));
-}
-
 #if TARGET_OS_IPHONE
 NS_INLINE mbgl::EdgeInsets MGLEdgeInsetsFromNSEdgeInsets(UIEdgeInsets insets) {
     return { insets.top, insets.left, insets.bottom, insets.right };

--- a/platform/darwin/test/MGLGeometryTests.mm
+++ b/platform/darwin/test/MGLGeometryTests.mm
@@ -78,4 +78,25 @@
                           @"Northeast should round-trip.");
 }
 
+- (void)testCoordinateInCoordinateBounds {
+    CLLocationCoordinate2D ne = CLLocationCoordinate2DMake(41, -111);
+    CLLocationCoordinate2D sw = CLLocationCoordinate2DMake(45, -104);
+    MGLCoordinateBounds wyoming = MGLCoordinateBoundsMake(ne, sw);
+
+    CLLocationCoordinate2D centerOfWyoming = CLLocationCoordinate2DMake(43, -107.5);
+
+    XCTAssertTrue(MGLCoordinateInCoordinateBounds(ne, wyoming));
+    XCTAssertTrue(MGLCoordinateInCoordinateBounds(sw, wyoming));
+    XCTAssertTrue(MGLCoordinateInCoordinateBounds(centerOfWyoming, wyoming));
+
+    CLLocationCoordinate2D australia = CLLocationCoordinate2DMake(-25, 135);
+    CLLocationCoordinate2D brazil = CLLocationCoordinate2DMake(-12, -50);
+    CLLocationCoordinate2D china = CLLocationCoordinate2DMake(35, 100);
+
+    XCTAssertFalse(MGLCoordinateInCoordinateBounds(australia, wyoming));
+    XCTAssertFalse(MGLCoordinateInCoordinateBounds(brazil, wyoming));
+    XCTAssertFalse(MGLCoordinateInCoordinateBounds(china, wyoming));
+    XCTAssertFalse(MGLCoordinateInCoordinateBounds(kCLLocationCoordinate2DInvalid, wyoming));
+}
+
 @end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -25,6 +25,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 - Suppressed “Unable to make space for entry” console spew. ([#4708](https://github.com/mapbox/mapbox-gl-native/pull/4708))
 - Removed unused SVG files from the SDK’s resource bundle. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Deprecated `-[MGLMapView emptyMemoryCache]`. ([#4725](https://github.com/mapbox/mapbox-gl-native/pull/4725))
+- Added `MGLCoordinateInCoordinateBounds()`, a function that tests whether or not a coordinate is in a given bounds. ([#5053](https://github.com/mapbox/mapbox-gl-native/pull/5053))
 
 ## 3.2.2
 


### PR DESCRIPTION
Makes the formerly-private `MGLCoordinateInCoordinateBounds()` function publicly available.

- The old private function converted `MGLCoordinateBounds`→`mbgl::LatLngBounds` and `CLLocationCoordinate2D`→`mbgl:LatLng`.

- The new public function compares `CLLocationCoordinate2D` and `MGLCoordinateBounds` directly.

/cc @1ec5