### PR TITLE
[android] - using deprecate annotation for access token javadoc

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -834,13 +834,7 @@ public class MapView extends FrameLayout {
     //
 
     /**
-     * <p>
-     * DEPRECATED @see MapboxAccountManager#start(String)
-     * </p>
-     *
-     * <p>
      * Sets the current Mapbox access token used to load map styles and tiles.
-     * </p>
      * <p>
      * You must set a valid access token before you call {@link MapView#onCreate(Bundle)}
      * or an exception will be thrown.
@@ -848,6 +842,7 @@ public class MapView extends FrameLayout {
      *
      * @param accessToken Your public Mapbox access token.
      * @see MapView#onCreate(Bundle)
+     * @deprecated As of release 4.1.0, replaced by {@link com.mapbox.mapboxsdk.MapboxAccountManager#start(Context, String)}
      */
     @Deprecated
     @UiThread
@@ -864,13 +859,10 @@ public class MapView extends FrameLayout {
     }
 
     /**
-     * <p>
-     * DEPRECATED @see MapboxAccountManager#getAccessToken()
-     * </p>
-     *
      * Returns the current Mapbox access token used to load map styles and tiles.
      *
      * @return The current Mapbox access token.
+     * @deprecated As of release 4.1.0, replaced by {@link MapboxAccountManager#getAccessToken()}
      */
     @Deprecated
     @UiThread

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.location.Location;
 import android.os.SystemClock;
@@ -11,6 +12,8 @@ import android.support.v4.util.LongSparseArray;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
+
+import com.mapbox.mapboxsdk.MapboxAccountManager;
 import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerOptions;
 import com.mapbox.mapboxsdk.annotations.Icon;
@@ -581,16 +584,11 @@ public class MapboxMap {
     //
 
     /**
-     * <p>
-     * DEPRECATED @see MapboxAccountManager#start(String)
-     * </p>
-     *
-     * <p>
      * Sets the current Mapbox access token used to load map styles and tiles.
-     * </p>
      *
      * @param accessToken Your public Mapbox access token.
      * @see MapView#setAccessToken(String)
+     * @deprecated As of release 4.1.0, replaced by {@link com.mapbox.mapboxsdk.MapboxAccountManager#start(Context, String)}
      */
     @Deprecated
     @UiThread
@@ -599,13 +597,10 @@ public class MapboxMap {
     }
 
     /**
-     * <p>
-     * DEPRECATED @see MapboxAccountManager#getAccessToken()
-     * </p>
-     *
      * Returns the current Mapbox access token used to load map styles and tiles.
      *
      * @return The current Mapbox access token.
+     * @deprecated As of release 4.1.0, replaced by {@link MapboxAccountManager#getAccessToken()}
      */
     @Deprecated
     @UiThread


### PR DESCRIPTION
This PR uses the `@deprecation` javadoc annotation.

Before:

<img width="976" alt="screen shot 2016-05-18 at 23 08 50" src="https://cloud.githubusercontent.com/assets/2151639/15375195/16c38318-1d4e-11e6-9783-07b29c927f40.png">

After:

<img width="974" alt="screen shot 2016-05-18 at 23 08 26" src="https://cloud.githubusercontent.com/assets/2151639/15375197/1be5e4b2-1d4e-11e6-86c1-a710202c792f.png">

cc @bleege 