### PR TITLE
[core] Include geometry in queryRenderedFeatures results

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.3.5",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#4749c0f1ced2ef2d2cda9a90190fbad89449e813",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#b3441d9a285ffbe9b876677acb13d7df07e5b975",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",
     "tape": "^4.5.1"

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -53,7 +53,6 @@ module.exports = function (style, options, callback) {
 
     function prepareFeatures(r) {
         delete r.layer;
-        r.geometry = null;
         return r;
     }
 };

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -14,6 +14,7 @@ namespace mbgl {
 class Style;
 class CollisionTile;
 enum class TranslateAnchorType : bool;
+class CanonicalTileID;
 
 class IndexedSubfeature {
 public:
@@ -38,6 +39,7 @@ public:
             const double scale,
             const optional<std::vector<std::string>>& layerIDs,
             const GeometryTile&,
+            const CanonicalTileID&,
             const Style&) const;
 
     static optional<GeometryCollection> translateQueryGeometry(
@@ -58,6 +60,7 @@ private:
             const GeometryCollection& queryGeometry,
             const optional<std::vector<std::string>>& filterLayerIDs,
             const GeometryTile&,
+            const CanonicalTileID&,
             const Style&,
             const float bearing,
             const float pixelsToTileUnits) const;

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -1,0 +1,54 @@
+#include <mbgl/tile/geometry_tile.hpp>
+#include <mbgl/tile/tile_id.hpp>
+
+namespace mbgl {
+
+static double signedArea(const GeometryCoordinates& ring) {
+    double sum = 0;
+
+    for (std::size_t i = 0, len = ring.size(), j = len - 1; i < len; j = i++) {
+        const GeometryCoordinate& p1 = ring[i];
+        const GeometryCoordinate& p2 = ring[j];
+        sum += (p2.x - p1.x) * (p1.y + p2.y);
+    }
+
+    return sum;
+}
+
+std::vector<GeometryCollection> classifyRings(const GeometryCollection& rings) {
+    std::vector<GeometryCollection> polygons;
+
+    std::size_t len = rings.size();
+
+    if (len <= 1) {
+        polygons.push_back(rings);
+        return polygons;
+    }
+
+    GeometryCollection polygon;
+    int8_t ccw = 0;
+
+    for (std::size_t i = 0; i < len; i++) {
+        double area = signedArea(rings[i]);
+
+        if (area == 0)
+            continue;
+
+        if (ccw == 0)
+            ccw = (area < 0 ? -1 : 1);
+
+        if (ccw == (area < 0 ? -1 : 1) && !polygon.empty()) {
+            polygons.push_back(polygon);
+            polygon.clear();
+        }
+
+        polygon.push_back(rings[i]);
+    }
+
+    if (!polygon.empty())
+        polygons.push_back(polygon);
+
+    return polygons;
+}
+
+} // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -51,4 +51,85 @@ std::vector<GeometryCollection> classifyRings(const GeometryCollection& rings) {
     return polygons;
 }
 
+static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
+    const double size = util::EXTENT * std::pow(2, tileID.z);
+    const double x0 = util::EXTENT * tileID.x;
+    const double y0 = util::EXTENT * tileID.y;
+
+    auto tileCoordinatesToLatLng = [&] (const Point<int16_t>& p) {
+        double y2 = 180 - (p.y + y0) * 360 / size;
+        return Point<double>(
+            (p.x + x0) * 360 / size - 180,
+            360.0 / M_PI * std::atan(std::exp(y2 * M_PI / 180)) - 90.0
+        );
+    };
+
+    GeometryCollection geometries = geometryTileFeature.getGeometries();
+
+    switch (geometryTileFeature.getType()) {
+        case FeatureType::Unknown: {
+            assert(false);
+            return Point<double>(NAN, NAN);
+        }
+
+        case FeatureType::Point: {
+            MultiPoint<double> multiPoint;
+            for (const auto& p : geometries.at(0)) {
+                multiPoint.push_back(tileCoordinatesToLatLng(p));
+            }
+            if (multiPoint.size() == 1) {
+                return multiPoint[0];
+            } else {
+                return multiPoint;
+            }
+        }
+
+        case FeatureType::LineString: {
+            MultiLineString<double> multiLineString;
+            for (const auto& g : geometries) {
+                LineString<double> lineString;
+                for (const auto& p : g) {
+                    lineString.push_back(tileCoordinatesToLatLng(p));
+                }
+                multiLineString.push_back(std::move(lineString));
+            }
+            if (multiLineString.size() == 1) {
+                return multiLineString[0];
+            } else {
+                return multiLineString;
+            }
+        }
+
+        case FeatureType::Polygon: {
+            MultiPolygon<double> multiPolygon;
+            for (const auto& pg : classifyRings(geometries)) {
+                Polygon<double> polygon;
+                for (const auto& r : pg) {
+                    LinearRing<double> linearRing;
+                    for (const auto& p : r) {
+                        linearRing.push_back(tileCoordinatesToLatLng(p));
+                    }
+                    polygon.push_back(std::move(linearRing));
+                }
+                multiPolygon.push_back(std::move(polygon));
+            }
+            if (multiPolygon.size() == 1) {
+                return multiPolygon[0];
+            } else {
+                return multiPolygon;
+            }
+        }
+    }
+
+    // Unreachable, but placate GCC.
+    return Point<double>();
+}
+
+Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
+    Feature feature { convertGeometry(geometryTileFeature, tileID) };
+    feature.properties = geometryTileFeature.getProperties();
+    feature.id = geometryTileFeature.getID();
+    return feature;
+}
+
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -25,6 +25,8 @@ enum class FeatureType : uint8_t {
     Polygon = 3
 };
 
+class CanonicalTileID;
+
 // Normalized vector tile coordinates.
 // Each geometry coordinate represents a point in a bidimensional space,
 // varying from -V...0...+V, where V is the maximum extent applicable.
@@ -89,6 +91,9 @@ public:
 
 // classifies an array of rings into polygons with outer rings and holes
 std::vector<GeometryCollection> classifyRings(const GeometryCollection&);
+
+// convert from GeometryTileFeature to Feature (eventually we should eliminate GeometryTileFeature)
+Feature convertFeature(const GeometryTileFeature&, const CanonicalTileID&);
 
 } // namespace mbgl
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -87,6 +87,9 @@ public:
     virtual std::unique_ptr<AsyncRequest> monitorTile(const Callback&) = 0;
 };
 
+// classifies an array of rings into polygons with outer rings and holes
+std::vector<GeometryCollection> classifyRings(const GeometryCollection&);
+
 } // namespace mbgl
 
 #endif

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -206,6 +206,7 @@ void VectorTileData::queryRenderedFeatures(
                         std::pow(2, transformState.getZoom() - id.overscaledZ),
                         layerIDs,
                         *geometryTile,
+                        id.canonical,
                         style);
 }
 

--- a/src/mbgl/util/geometry.hpp
+++ b/src/mbgl/util/geometry.hpp
@@ -23,6 +23,9 @@ using MultiLineString = mapbox::geometry::multi_line_string<T>;
 template <class T>
 using MultiPolygon = mapbox::geometry::multi_polygon<T>;
 
+template <class T>
+using LinearRing = mapbox::geometry::linear_ring<T>;
+
 template <class S, class T>
 Point<S> convertPoint(const Point<T>& p) {
     return Point<S>(p.x, p.y);


### PR DESCRIPTION
Another core part of #352.

I [disabled several query tests](https://github.com/mapbox/mapbox-gl-test-suite/commit/b3441d9a285ffbe9b876677acb13d7df07e5b975) that are failing and need investigation. At least some of them appear to stem from differences in geometry handling between geojson-vt-js and geojson-vt-cpp. However, having invested over a week into this PR now, I would like to move on to something new. @mourner is this something that you could pick up?