### PR TITLE
[core] [Qt] Avoid NaNs in TransformState unit conversions

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -45,24 +45,23 @@ Transform::Transform(std::function<void(MapChange)> callback_,
 #pragma mark - Map View
 
 bool Transform::resize(const std::array<uint16_t, 2> size) {
-    if (state.width != size[0] || state.height != size[1]) {
-
-        if (callback) {
-            callback(MapChangeRegionWillChange);
-        }
-
-        state.width = size[0];
-        state.height = size[1];
-        state.constrain(state.scale, state.x, state.y);
-
-        if (callback) {
-            callback(MapChangeRegionDidChange);
-        }
-
-        return true;
-    } else {
+    if (state.width == size[0] && state.height == size[1]) {
         return false;
     }
+
+    if (callback) {
+        callback(MapChangeRegionWillChange);
+    }
+
+    state.width = size[0];
+    state.height = size[1];
+    state.constrain(state.scale, state.x, state.y);
+
+    if (callback) {
+        callback(MapChangeRegionDidChange);
+    }
+
+    return true;
 }
 
 #pragma mark - Camera

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -230,6 +230,10 @@ double TransformState::worldSize() const {
 }
 
 ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) const {
+    if (width == 0 || height == 0) {
+        return {};
+    }
+
     mat4 mat = coordinatePointMatrix(getZoom());
     vec4 p;
     Point<double> pt = project(latLng) / double(util::tileSize);
@@ -239,6 +243,10 @@ ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) 
 }
 
 LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng::WrapMode wrapMode) const {
+    if (width == 0 || height == 0) {
+        return {};
+    }
+
     float targetZ = 0;
     mat4 mat = coordinatePointMatrix(getZoom());
 


### PR DESCRIPTION
Fix cases where e.g. state has either zero width or height, causing the unit conversion functions to return NaNs.

:eyes: @kkaefer @jfirebaugh @ansis 