### PR TITLE
[core] Wireframe debug mode

### DIFF
--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -42,6 +42,7 @@ enum class MapDebugOptions : EnumType {
     ParseStatus = 1 << 2,
     Timestamps  = 1 << 3,
     Collision   = 1 << 4,
+    Wireframe   = 1 << 5,
 };
 
 inline MapDebugOptions operator| (const MapDebugOptions& lhs, const MapDebugOptions& rhs) {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -28,6 +28,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 - Added `MGLCoordinateInCoordinateBounds()`, a function that tests whether or not a coordinate is in a given bounds. ([#5053](https://github.com/mapbox/mapbox-gl-native/pull/5053))
 - An MGLAnnotationView can be repositioned in relation to the associated MGLAnnotation.coordinate by changing its `centerOffset` property. ([#5059](https://github.com/mapbox/mapbox-gl-native/issues/5059))
 - An MGLAnnotationView can be rotated to match the rotation pitch of the associated map view.
+- Added a new option to `MGLMapDebugMaskOptions`, `MGLMapDebugWireframesMask`, that shows wireframes instead of the usual rendered output. ([#4359](https://github.com/mapbox/mapbox-gl-native/pull/4359))
 
 ## 3.2.2
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -181,6 +181,9 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         ((debugMask & MGLMapDebugCollisionBoxesMask)
          ? @"Hide Collision Boxes"
          : @"Show Collision Boxes"),
+        ((debugMask & MGLMapDebugWireframesMask)
+         ? @"Hide Wireframes"
+         : @"Show Wireframes"),
         @"Add 100 Points",
         @"Add 1,000 Points",
         @"Add 10,000 Points",
@@ -222,17 +225,21 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 5)
     {
-        [self parseFeaturesAddingCount:100];
+        self.mapView.debugMask ^= MGLMapDebugWireframesMask;
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 6)
     {
-        [self parseFeaturesAddingCount:1000];
+        [self parseFeaturesAddingCount:100];
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 7)
     {
-        [self parseFeaturesAddingCount:10000];
+        [self parseFeaturesAddingCount:1000];
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 8)
+    {
+        [self parseFeaturesAddingCount:10000];
+    }
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 9)
     {
         // PNW triangle
         //
@@ -299,19 +306,19 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
             free(polygonCoordinates);
         }
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 9)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 10)
     {
         [self startWorldTour:actionSheet];
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 10)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 11)
     {
         [self presentAnnotationWithCustomCallout];
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 11)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 12)
     {
         [self.mapView removeAnnotations:self.mapView.annotations];
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 12)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 13)
     {
         if (_isShowingCustomStyleLayer)
         {
@@ -322,12 +329,12 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
             [self insertCustomStyleLayer];
         }
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 13)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 14)
     {
         NSString *fileContents = [NSString stringWithContentsOfFile:[self telemetryDebugLogfilePath] encoding:NSUTF8StringEncoding error:nil];
         NSLog(@"%@", fileContents);
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 14)
+    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 15)
     {
         NSString *filePath = [self telemetryDebugLogfilePath];
         if ([[NSFileManager defaultManager] isDeletableFileAtPath:filePath]) {

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -42,6 +42,9 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
     /** Edges of glyphs and symbols are shown as faint, green lines to help
         diagnose collision and label placement issues. */
     MGLMapDebugCollisionBoxesMask = 1 << 4,
+    /** Line widths, backgrounds, and fill colors are ignored to create a
+        wireframe effect. */
+    MGLMapDebugWireframesMask = 1 << 5,
 };
 
 /**

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1820,6 +1820,10 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     {
         mask |= MGLMapDebugCollisionBoxesMask;
     }
+    if (options & mbgl::MapDebugOptions::Wireframe)
+    {
+        mask |= MGLMapDebugWireframesMask;
+    }
     return mask;
 }
 
@@ -1841,6 +1845,10 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     if (debugMask & MGLMapDebugCollisionBoxesMask)
     {
         options |= mbgl::MapDebugOptions::Collision;
+    }
+    if (debugMask & MGLMapDebugWireframesMask)
+    {
+        options |= mbgl::MapDebugOptions::Wireframe;
     }
     _mbglMap->setDebug(options);
 }

--- a/platform/osx/CHANGELOG.md
+++ b/platform/osx/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed an issue in which Mapbox.framework was nested inside another folder named Mapbox.framework. ([#4998](https://github.com/mapbox/mapbox-gl-native/pull/4998))
 * Fixed a crash passing a mixture of point and shape annotations into `-[MGLMapView addAnnotations:]`. ([#5097](https://github.com/mapbox/mapbox-gl-native/pull/5097))
+* Added a new option to `MGLMapDebugMaskOptions`, `MGLMapDebugWireframesMask`, that shows wireframes instead of the usual rendered output. ([#4359](https://github.com/mapbox/mapbox-gl-native/pull/4359))
 
 ## 0.1.0
 

--- a/platform/osx/app/Base.lproj/MainMenu.xib
+++ b/platform/osx/app/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -459,6 +459,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleCollisionBoxes:" target="-1" id="EYa-7n-iWZ"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show Wireframes" id="hSX-Be-8xC">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleWireframes:" target="-1" id="usj-ug-upt"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="dYw-bb-tr1"/>

--- a/platform/osx/app/MapDocument.m
+++ b/platform/osx/app/MapDocument.m
@@ -244,6 +244,10 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     self.mapView.debugMask ^= MGLMapDebugCollisionBoxesMask;
 }
 
+- (IBAction)toggleWireframes:(id)sender {
+    self.mapView.debugMask ^= MGLMapDebugWireframesMask;
+}
+
 - (IBAction)toggleShowsToolTipsOnDroppedPins:(id)sender {
     _showsToolTipsOnDroppedPins = !_showsToolTipsOnDroppedPins;
 }
@@ -518,6 +522,11 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     if (menuItem.action == @selector(toggleCollisionBoxes:)) {
         BOOL isShown = self.mapView.debugMask & MGLMapDebugCollisionBoxesMask;
         menuItem.title = isShown ? @"Hide Collision Boxes" : @"Show Collision Boxes";
+        return YES;
+    }
+    if (menuItem.action == @selector(toggleWireframes:)) {
+        BOOL isShown = self.mapView.debugMask & MGLMapDebugWireframesMask;
+        menuItem.title = isShown ? @"Hide Wireframes" : @"Show Wireframes";
         return YES;
     }
     if (menuItem.action == @selector(toggleShowsToolTipsOnDroppedPins:)) {

--- a/platform/osx/src/MGLMapView.h
+++ b/platform/osx/src/MGLMapView.h
@@ -20,6 +20,10 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
     /** Edges of glyphs and symbols are shown as faint, green lines to help
         diagnose collision and label placement issues. */
     MGLMapDebugCollisionBoxesMask = 1 << 4,
+    
+    /** Line widths, backgrounds, and fill colors are ignored to create a
+        wireframe effect. */
+    MGLMapDebugWireframesMask = 1 << 5,
 };
 
 @class MGLAnnotationImage;

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -2366,6 +2366,9 @@ public:
     if (options & mbgl::MapDebugOptions::Collision) {
         mask |= MGLMapDebugCollisionBoxesMask;
     }
+    if (options & mbgl::MapDebugOptions::Wireframe) {
+        mask |= MGLMapDebugWireframesMask;
+    }
     return mask;
 }
 
@@ -2382,6 +2385,9 @@ public:
     }
     if (debugMask & MGLMapDebugCollisionBoxesMask) {
         options |= mbgl::MapDebugOptions::Collision;
+    }
+    if (debugMask & MGLMapDebugWireframesMask) {
+        options |= mbgl::MapDebugOptions::Wireframe;
     }
     _mbglMap->setDebug(options);
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -796,8 +796,10 @@ void Map::setDebug(MapDebugOptions debugOptions) {
 }
 
 void Map::cycleDebugOptions() {
-    if (impl->debugOptions & MapDebugOptions::Collision)
+    if (impl->debugOptions & MapDebugOptions::Wireframe)
         impl->debugOptions = MapDebugOptions::NoDebug;
+    else if (impl->debugOptions & MapDebugOptions::Collision)
+        impl->debugOptions = MapDebugOptions::Collision | MapDebugOptions::Wireframe;
     else if (impl->debugOptions & MapDebugOptions::Timestamps)
         impl->debugOptions = impl->debugOptions | MapDebugOptions::Collision;
     else if (impl->debugOptions & MapDebugOptions::ParseStatus)

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -141,7 +141,11 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         config.depthTest = GL_FALSE;
         config.depthMask = GL_TRUE;
         config.colorMask = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
-        config.clearColor = { background[0], background[1], background[2], background[3] };
+        if (frame.debugOptions & MapDebugOptions::Wireframe) {
+            config.clearColor = { 0.0f, 0.0f, 0.0f, 1.0f };
+        } else {
+            config.clearColor = { background[0], background[1], background[2], background[3] };
+        }
         config.clearStencil = 0;
         config.clearDepth = 1;
         MBGL_CHECK_ERROR(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -33,10 +33,18 @@ void Painter::renderFill(FillBucket& bucket,
         stroke_color[3] *= properties.fillOpacity;
     }
 
-    const bool pattern = !properties.fillPattern.value.from.empty();
-
+    bool pattern = !properties.fillPattern.value.from.empty();
     bool outline = properties.fillAntialias && !pattern && stroke_color != fill_color;
     bool fringeline = properties.fillAntialias && !pattern && stroke_color == fill_color;
+
+    bool wireframe = frame.debugOptions & MapDebugOptions::Wireframe;
+    if (wireframe) {
+        fill_color = {{ 1.0f, 1.0f, 1.0f, 1.0f }};
+        stroke_color = {{ 1.0f, 1.0f, 1.0f, 1.0f }};
+        pattern = false;
+        outline = true;
+        fringeline = true;
+    }
 
     config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
@@ -154,8 +162,7 @@ void Painter::renderFill(FillBucket& bucket,
                 bucket.drawVertices(*outlinePatternShader, glObjectStore);
             }
         }
-    }
-    else {
+    } else if (!wireframe) {
         // No image fill.
         if ((fill_color[3] >= 1.0f) == (pass == RenderPass::Opaque)) {
             // Only draw the fill when it's either opaque and we're drawing opaque

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -30,13 +30,15 @@ void Painter::renderLine(LineBucket& bucket,
     // Retina devices need a smaller distance to avoid aliasing.
     float antialiasing = 1.0 / frame.pixelRatio;
 
+    bool wireframe = frame.debugOptions & MapDebugOptions::Wireframe;
+
     float blur = properties.lineBlur + antialiasing;
-    float edgeWidth = properties.lineWidth / 2.0;
+    float edgeWidth = wireframe ? 1 : properties.lineWidth / 2.0;
     float inset = -1;
     float offset = 0;
     float shift = 0;
 
-    if (properties.lineGapWidth != 0) {
+    if (properties.lineGapWidth != 0 && !wireframe) {
         inset = properties.lineGapWidth / 2.0 + antialiasing * 0.5;
         edgeWidth = properties.lineWidth;
 
@@ -46,11 +48,14 @@ void Painter::renderLine(LineBucket& bucket,
 
     float outset = offset + edgeWidth + antialiasing / 2.0 + shift;
 
-    Color color = properties.lineColor;
-    color[0] *= properties.lineOpacity;
-    color[1] *= properties.lineOpacity;
-    color[2] *= properties.lineOpacity;
-    color[3] *= properties.lineOpacity;
+    Color color = {{ 1.0f, 1.0f, 1.0f, 1.0f }};
+    if (!wireframe) {
+        color = properties.lineColor;
+        color[0] *= properties.lineOpacity;
+        color[1] *= properties.lineOpacity;
+        color[2] *= properties.lineOpacity;
+        color[3] *= properties.lineOpacity;
+    }
 
     const float ratio = 1.0 / tileID.pixelsToTileUnits(1.0, state.getZoom());
 


### PR DESCRIPTION
Together with `MapDebugOptions::Collision`, provides _wireframe_ rendering output so all drawn objects are visible. This mode ignores the line width, background and fill colors for better visualization.

/cc @mapbox/gl 