### PR TITLE
[core] Shared GL context mode rendering glyph atlas instead of the actual map

### DIFF
--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -289,4 +289,5 @@ void Painter::renderSymbol(SymbolBucket& bucket,
 
     }
 
+    config.activeTexture = GL_TEXTURE0;
 }


### PR DESCRIPTION
![screenshot from 2016-05-23 16-59-08](https://cloud.githubusercontent.com/assets/996307/15473238/bd79e62c-2107-11e6-9e79-5e0553038958.png)

Regression caused by https://github.com/mapbox/mapbox-gl-native/issues/4562