### PR TITLE
Stencil debugging view is gone

### DIFF
--- a/include/mbgl/gl/gl_values.hpp
+++ b/include/mbgl/gl/gl_values.hpp
@@ -269,6 +269,10 @@ struct PixelZoom {
     }
 };
 
+inline bool operator!=(const PixelZoom::Type& a, const PixelZoom::Type& b) {
+    return a.xfactor != b.xfactor || a.yfactor != b.yfactor;
+}
+
 struct RasterPos {
     using Type = std::array<GLdouble, 4>;
     static const Type Default;

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -43,6 +43,10 @@ enum class MapDebugOptions : EnumType {
     Timestamps  = 1 << 3,
     Collision   = 1 << 4,
     Wireframe   = 1 << 5,
+// FIXME: https://github.com/mapbox/mapbox-gl-native/issues/5117
+#ifndef GL_ES_VERSION_2_0
+    StencilClip = 1 << 6,
+#endif // GL_ES_VERSION_2_0
 };
 
 inline MapDebugOptions operator| (const MapDebugOptions& lhs, const MapDebugOptions& rhs) {

--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -49,9 +49,6 @@ private:
     makeSpriteImage(int width, int height, float pixelRatio);
 
     void nextOrientation();
-    void toggleClipMasks();
-
-    void renderClipMasks();
 
     void addRandomPointAnnotations(int count);
     void addRandomShapeAnnotations(int count);
@@ -80,8 +77,6 @@ private:
     int fbWidth;
     int fbHeight;
     float pixelRatio;
-
-    bool showClipMasks = false;
 
     double lastX = 0, lastY = 0;
 

--- a/platform/osx/CHANGELOG.md
+++ b/platform/osx/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed an issue in which Mapbox.framework was nested inside another folder named Mapbox.framework. ([#4998](https://github.com/mapbox/mapbox-gl-native/pull/4998))
 * Fixed a crash passing a mixture of point and shape annotations into `-[MGLMapView addAnnotations:]`. ([#5097](https://github.com/mapbox/mapbox-gl-native/pull/5097))
-* Added a new option to `MGLMapDebugMaskOptions`, `MGLMapDebugWireframesMask`, that shows wireframes instead of the usual rendered output. ([#4359](https://github.com/mapbox/mapbox-gl-native/pull/4359))
+* Added new options to `MGLMapDebugMaskOptions` that show wireframes and the stencil buffer instead of the color buffer. ([#4359](https://github.com/mapbox/mapbox-gl-native/pull/4359))
 
 ## 0.1.0
 

--- a/platform/osx/app/Base.lproj/MainMenu.xib
+++ b/platform/osx/app/Base.lproj/MainMenu.xib
@@ -467,6 +467,19 @@
                                     <action selector="toggleWireframes:" target="-1" id="usj-ug-upt"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="2EG-Hp-4FA"/>
+                            <menuItem title="Show Color Buffer" id="Eao-WE-BWz">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showColorBuffer:" target="-1" id="Nuq-Qs-98g"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show Stencil Buffer" id="LlS-Yh-RkN">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showStencilBuffer:" target="-1" id="WkN-t9-Mpv"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="dYw-bb-tr1"/>
                             <menuItem title="Show Tooltips on Dropped Pins" id="uir-Rx-zmw">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/platform/osx/app/MapDocument.m
+++ b/platform/osx/app/MapDocument.m
@@ -248,6 +248,14 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     self.mapView.debugMask ^= MGLMapDebugWireframesMask;
 }
 
+- (IBAction)showColorBuffer:(id)sender {
+    self.mapView.debugMask &= ~MGLMapDebugStencilBufferMask;
+}
+
+- (IBAction)showStencilBuffer:(id)sender {
+    self.mapView.debugMask |= MGLMapDebugStencilBufferMask;
+}
+
 - (IBAction)toggleShowsToolTipsOnDroppedPins:(id)sender {
     _showsToolTipsOnDroppedPins = !_showsToolTipsOnDroppedPins;
 }
@@ -527,6 +535,16 @@ static const CLLocationCoordinate2D WorldTourDestinations[] = {
     if (menuItem.action == @selector(toggleWireframes:)) {
         BOOL isShown = self.mapView.debugMask & MGLMapDebugWireframesMask;
         menuItem.title = isShown ? @"Hide Wireframes" : @"Show Wireframes";
+        return YES;
+    }
+    if (menuItem.action == @selector(showColorBuffer:)) {
+        BOOL enabled = self.mapView.debugMask & MGLMapDebugStencilBufferMask;
+        menuItem.state = enabled ? NSOffState : NSOnState;
+        return YES;
+    }
+    if (menuItem.action == @selector(showStencilBuffer:)) {
+        BOOL enabled = self.mapView.debugMask & MGLMapDebugStencilBufferMask;
+        menuItem.state = enabled ? NSOnState : NSOffState;
         return YES;
     }
     if (menuItem.action == @selector(toggleShowsToolTipsOnDroppedPins:)) {

--- a/platform/osx/src/MGLMapView.h
+++ b/platform/osx/src/MGLMapView.h
@@ -24,6 +24,9 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
     /** Line widths, backgrounds, and fill colors are ignored to create a
         wireframe effect. */
     MGLMapDebugWireframesMask = 1 << 5,
+    
+    /** The stencil buffer is shown instead of the color buffer. */
+    MGLMapDebugStencilBufferMask = 1 << 6,
 };
 
 @class MGLAnnotationImage;

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -2369,6 +2369,9 @@ public:
     if (options & mbgl::MapDebugOptions::Wireframe) {
         mask |= MGLMapDebugWireframesMask;
     }
+    if (options & mbgl::MapDebugOptions::StencilClip) {
+        mask |= MGLMapDebugStencilBufferMask;
+    }
     return mask;
 }
 
@@ -2388,6 +2391,9 @@ public:
     }
     if (debugMask & MGLMapDebugWireframesMask) {
         options |= mbgl::MapDebugOptions::Wireframe;
+    }
+    if (debugMask & MGLMapDebugStencilBufferMask) {
+        options |= mbgl::MapDebugOptions::StencilClip;
     }
     _mbglMap->setDebug(options);
 }

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -67,8 +67,15 @@ void MapWindow::changeStyle()
 
 void MapWindow::keyPressEvent(QKeyEvent *ev)
 {
-    if (ev->key() == Qt::Key_S) {
+    switch (ev->key()) {
+    case Qt::Key_S:
         changeStyle();
+        break;
+    case Qt::Key_Tab:
+        m_map.cycleDebugOptions();
+        break;
+    default:
+        break;
     }
 
     ev->accept();

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -656,7 +656,12 @@ std::array<uint16_t, 2> QMapboxGLPrivate::getSize() const
 
 std::array<uint16_t, 2> QMapboxGLPrivate::getFramebufferSize() const
 {
+#if QT_VERSION >= 0x050000
+    return {{ static_cast<uint16_t>(size.width() * qApp->devicePixelRatio()),
+              static_cast<uint16_t>(size.height() * qApp->devicePixelRatio()) }};
+#else
     return getSize();
+#endif
 }
 
 void QMapboxGLPrivate::invalidate()

--- a/src/mbgl/gl/gl_config.cpp
+++ b/src/mbgl/gl/gl_config.cpp
@@ -21,5 +21,10 @@ const Program::Type Program::Default = 0;
 const LineWidth::Type LineWidth::Default = 1;
 const ActiveTexture::Type ActiveTexture::Default = GL_TEXTURE0;
 
+#ifndef GL_ES_VERSION_2_0
+const PixelZoom::Type PixelZoom::Default = { 1, 1 };
+const RasterPos::Type RasterPos::Default = {{ 0, 0, 0, 0 }};
+#endif // GL_ES_VERSION_2_0
+
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/gl_config.hpp
+++ b/src/mbgl/gl/gl_config.hpp
@@ -56,6 +56,10 @@ public:
         program.reset();
         lineWidth.reset();
         activeTexture.reset();
+#ifndef GL_ES_VERSION_2_0
+        pixelZoom.reset();
+        rasterPos.reset();
+#endif // GL_ES_VERSION_2_0
     }
 
     void setDirty() {
@@ -76,6 +80,10 @@ public:
         program.setDirty();
         lineWidth.setDirty();
         activeTexture.setDirty();
+#ifndef GL_ES_VERSION_2_0
+        pixelZoom.setDirty();
+        rasterPos.setDirty();
+#endif // GL_ES_VERSION_2_0
     }
 
     Value<StencilFunc> stencilFunc;
@@ -95,6 +103,10 @@ public:
     Value<Program> program;
     Value<LineWidth> lineWidth;
     Value<ActiveTexture> activeTexture;
+#ifndef GL_ES_VERSION_2_0
+    Value<PixelZoom> pixelZoom;
+    Value<RasterPos> rasterPos;
+#endif // GL_ES_VERSION_2_0
 };
 
 } // namespace gl

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -797,8 +797,15 @@ void Map::setDebug(MapDebugOptions debugOptions) {
 }
 
 void Map::cycleDebugOptions() {
+#ifndef GL_ES_VERSION_2_0
+    if (impl->debugOptions & MapDebugOptions::StencilClip)
+        impl->debugOptions = MapDebugOptions::NoDebug;
+    else if (impl->debugOptions & MapDebugOptions::Wireframe)
+        impl->debugOptions = MapDebugOptions::StencilClip;
+#else
     if (impl->debugOptions & MapDebugOptions::Wireframe)
         impl->debugOptions = MapDebugOptions::NoDebug;
+#endif // GL_ES_VERSION_2_0
     else if (impl->debugOptions & MapDebugOptions::Collision)
         impl->debugOptions = MapDebugOptions::Collision | MapDebugOptions::Wireframe;
     else if (impl->debugOptions & MapDebugOptions::Timestamps)

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -169,6 +169,11 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         drawClippingMasks(generator.getStencils());
     }
 
+    if (frame.debugOptions & MapDebugOptions::StencilClip) {
+        renderClipMasks();
+        return;
+    }
+
     // Actually render the layers
     if (debug::renderTree) { Log::Info(Event::Render, "{"); indent++; }
 

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -99,6 +99,8 @@ public:
     // Renders the red debug frame around a tile, visualizing its perimeter.
     void renderDebugFrame(const mat4 &matrix);
 
+    void renderClipMasks();
+
     void renderDebugText(TileData&, const mat4&);
     void renderFill(FillBucket&, const FillLayer&, const UnwrappedTileID&, const mat4&);
     void renderLine(LineBucket&, const LineLayer&, const UnwrappedTileID&, const mat4&);


### PR DESCRIPTION
The GLFW app had a debug view that visualized the stencil buffer rather than the color buffer. The OS X app no longer has that.