### PR TITLE
Allow Mapbox to be served to devices without Wi-Fi

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.mapbox.mapboxsdk">
 
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
+    <uses-feature android:name="android.hardware.wifi" android:required="false" /> <!-- Implied by ACCESS_WIFI_STATE. -->
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
android.permission.ACCESS_WIFI_STATE implies an android.hardware.wifi
requirement. Make Wi-Fi optional.