### PR TITLE
[ios] Set backup exclusion flag after initializing DefaultFileSource

### DIFF
--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -64,12 +64,6 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
         NSURL *cacheURL = [cacheDirectoryURL URLByAppendingPathComponent:MGLOfflineStorageFileName];
         NSString *cachePath = cacheURL ? cacheURL.path : @"";
         
-        // Avoid backing up the offline cache onto iCloud, because it can be
-        // redownloaded. Ideally, we’d even put the ambient cache in Caches, so
-        // it can be reclaimed by the system when disk space runs low. But
-        // unfortunately it has to live in the same file as offline resources.
-        [cacheURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:NULL];
-        
         // Move the offline cache from v3.2.0-beta.1 to a location that can also
         // be used for ambient caching.
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
@@ -92,7 +86,13 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
         }
         
         _mbglFileSource = new mbgl::DefaultFileSource(cachePath.UTF8String, [NSBundle mainBundle].resourceURL.path.UTF8String);
-        
+
+        // Avoid backing up the offline cache onto iCloud, because it can be
+        // redownloaded. Ideally, we’d even put the ambient cache in Caches, so
+        // it can be reclaimed by the system when disk space runs low. But
+        // unfortunately it has to live in the same file as offline resources.
+        [cacheURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:NULL];
+
         // Observe for changes to the global access token (and find out the current one).
         [[MGLAccountManager sharedManager] addObserver:self
                                             forKeyPath:@"accessToken"

--- a/platform/darwin/test/MGLOfflineStorageTests.m
+++ b/platform/darwin/test/MGLOfflineStorageTests.m
@@ -116,7 +116,7 @@
     [cacheURL getResourceValue:&exclusionFlag
                         forKey:NSURLIsExcludedFromBackupKey
                          error:&error];
-    XCTAssertTrue([exclusionFlag boolValue], @"Backup exclusion flag should be set for cache database.");
+    XCTAssertTrue(exclusionFlag && [exclusionFlag boolValue], @"Backup exclusion flag should be set for cache database.");
     XCTAssertNil(error, @"No errors should be returned when checking backup exclusion flag.");
 }
 

--- a/platform/darwin/test/MGLOfflineStorageTests.m
+++ b/platform/darwin/test/MGLOfflineStorageTests.m
@@ -97,6 +97,29 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)testBackupExclusion {
+    NSURL *cacheDirectoryURL = [[NSFileManager defaultManager] URLForDirectory:NSApplicationSupportDirectory
+                                                                      inDomain:NSUserDomainMask
+                                                             appropriateForURL:nil
+                                                                        create:NO
+                                                                         error:nil];
+    // Unit tests don't use the main bundle; use com.mapbox.ios.sdk instead.
+    NSString *bundleIdentifier = [NSBundle bundleForClass:[MGLMapView class]].bundleIdentifier;
+    cacheDirectoryURL = [cacheDirectoryURL URLByAppendingPathComponent:bundleIdentifier];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:cacheDirectoryURL.path], @"Cache directory should exist.");
+
+    NSURL *cacheURL = [cacheDirectoryURL URLByAppendingPathComponent:@"cache.db"];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:cacheURL.path], @"Cache database should exist.");
+
+    NSError *error = nil;
+    NSNumber *exclusionFlag = nil;
+    [cacheURL getResourceValue:&exclusionFlag
+                        forKey:NSURLIsExcludedFromBackupKey
+                         error:&error];
+    XCTAssertTrue([exclusionFlag boolValue], @"Backup exclusion flag should be set for cache database.");
+    XCTAssertNil(error, @"No errors should be returned when checking backup exclusion flag.");
+}
+
 - (void)testRemovePack {
     NSUInteger countOfPacks = [MGLOfflineStorage sharedOfflineStorage].packs.count;
     

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -29,6 +29,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 - An MGLAnnotationView can be repositioned in relation to the associated MGLAnnotation.coordinate by changing its `centerOffset` property. ([#5059](https://github.com/mapbox/mapbox-gl-native/issues/5059))
 - An MGLAnnotationView can be rotated to match the rotation pitch of the associated map view.
 - Added a new option to `MGLMapDebugMaskOptions`, `MGLMapDebugWireframesMask`, that shows wireframes instead of the usual rendered output. ([#4359](https://github.com/mapbox/mapbox-gl-native/pull/4359))
+- Fixed an issue (speculatively) where the tile cache could be included in iCloud backups. ([#5124](https://github.com/mapbox/mapbox-gl-native/pull/5124))
 
 ## 3.2.2
 


### PR DESCRIPTION
Speculatively fixes #5112, where apps mistakenly backup the offline/ambient cache.

This moves the backup exclusion flag to a point just after `DefaultFileSource` has been created/initialized, ensuring that this flag is set on every launch.

As with the other offline storage tests, the new `-testBackupExclusion` must be run in alphabetical order — or, at least after the cache has been initialized. The cache file will persist in the simulator when you run these tests locally.

/cc @1ec5