### PR TITLE
Remove TileData::State

### DIFF
--- a/src/mbgl/algorithm/update_renderables_impl.hpp
+++ b/src/mbgl/algorithm/update_renderables_impl.hpp
@@ -17,7 +17,7 @@ bool tryTile(const UnwrappedTileID& renderTileID,
              Renderables& renderables) {
     if (renderables.find(renderTileID) == renderables.end()) {
         const auto it = dataTiles.find(dataTileID);
-        if (it == dataTiles.end() || !it->second->isReady()) {
+        if (it == dataTiles.end() || !it->second->isRenderable()) {
             return false;
         }
 

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -11,17 +11,20 @@
 using namespace mbgl;
 
 DebugBucket::DebugBucket(const OverscaledTileID& id,
-                         const TileData::State state_,
+                         const bool renderable_,
+                         const bool complete_,
                          optional<Timestamp> modified_,
                          optional<Timestamp> expires_,
                          MapDebugOptions debugMode_)
-    : state(state_),
+    : renderable(renderable_),
+      complete(complete_),
       modified(std::move(modified_)),
       expires(std::move(expires_)),
       debugMode(debugMode_) {
     double baseline = 200;
     if (debugMode & MapDebugOptions::ParseStatus) {
-        const std::string text = util::toString(id) + " - " + TileData::StateToString(state);
+        const std::string text = util::toString(id) + " - " +
+                                 (complete ? "complete" : renderable ? "renderable" : "pending");
         fontBuffer.addText(text.c_str(), 50, baseline, 5);
         baseline += 200;
     }

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -16,7 +16,9 @@ class GLObjectStore;
 
 class DebugBucket : private util::noncopyable {
 public:
-    DebugBucket(const OverscaledTileID& id, TileData::State,
+    DebugBucket(const OverscaledTileID& id,
+                bool renderable,
+                bool complete,
                 optional<Timestamp> modified,
                 optional<Timestamp> expires,
                 MapDebugOptions);
@@ -24,7 +26,8 @@ public:
     void drawLines(PlainShader&, gl::GLObjectStore&);
     void drawPoints(PlainShader&, gl::GLObjectStore&);
 
-    const TileData::State state;
+    const bool renderable;
+    const bool complete;
     const optional<Timestamp> modified;
     const optional<Timestamp> expires;
     const MapDebugOptions debugMode;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -29,11 +29,14 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
 
     config.depthTest = GL_FALSE;
 
-    if (!tileData.debugBucket || tileData.debugBucket->state != tileData.getState()
-                              || !(tileData.debugBucket->modified == tileData.modified)
-                              || !(tileData.debugBucket->expires == tileData.expires)
-                              || tileData.debugBucket->debugMode != frame.debugOptions) {
-        tileData.debugBucket = std::make_unique<DebugBucket>(tileData.id, tileData.getState(), tileData.modified, tileData.expires, frame.debugOptions);
+    if (!tileData.debugBucket || tileData.debugBucket->renderable != tileData.isRenderable() ||
+        tileData.debugBucket->complete != tileData.isComplete() ||
+        !(tileData.debugBucket->modified == tileData.modified) ||
+        !(tileData.debugBucket->expires == tileData.expires) ||
+        tileData.debugBucket->debugMode != frame.debugOptions) {
+        tileData.debugBucket = std::make_unique<DebugBucket>(
+            tileData.id, tileData.isRenderable(), tileData.isComplete(), tileData.modified,
+            tileData.expires, frame.debugOptions);
     }
 
     config.program = plainShader->getID();

--- a/src/mbgl/source/source.cpp
+++ b/src/mbgl/source/source.cpp
@@ -63,7 +63,7 @@ bool Source::isLoaded() const {
     if (!loaded) return false;
 
     for (const auto& pair : tileDataMap) {
-        if (pair.second->getState() != TileData::State::parsed) {
+        if (!pair.second->isComplete()) {
             return false;
         }
     }

--- a/src/mbgl/source/source.cpp
+++ b/src/mbgl/source/source.cpp
@@ -307,8 +307,7 @@ bool Source::update(const StyleUpdateParameters& parameters) {
     for (auto& pair : tileDataMap) {
         const auto& dataTileID = pair.first;
         auto tileData = pair.second.get();
-        if (parameters.shouldReparsePartialTiles &&
-            tileData->getState() == TileData::State::partial) {
+        if (parameters.shouldReparsePartialTiles && tileData->isIncomplete()) {
             auto callback = std::bind(&Source::tileLoadingCallback, this, dataTileID,
                                       std::placeholders::_1, false);
 

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -288,7 +288,7 @@ RenderData Style::getRenderData() const {
 
         for (auto& pair : source->getTiles()) {
             auto& tile = pair.second;
-            if (!tile.data.isReady()) {
+            if (!tile.data.isRenderable()) {
                 continue;
             }
 

--- a/src/mbgl/style/style_bucket_parameters.hpp
+++ b/src/mbgl/style/style_bucket_parameters.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <mbgl/map/mode.hpp>
+#include <mbgl/tile/tile_id.hpp>
 #include <mbgl/style/filter.hpp>
-#include <mbgl/tile/tile_data.hpp>
 
 #include <functional>
 
@@ -21,7 +21,7 @@ class StyleBucketParameters {
 public:
     StyleBucketParameters(const OverscaledTileID& tileID_,
                           const GeometryTileLayer& layer_,
-                          const std::atomic<TileData::State>& state_,
+                          const std::atomic<bool>& obsolete_,
                           uintptr_t tileUID_,
                           bool& partialParse_,
                           SpriteStore& spriteStore_,
@@ -31,7 +31,7 @@ public:
                           const MapMode mode_)
         : tileID(tileID_),
           layer(layer_),
-          state(state_),
+          obsolete(obsolete_),
           tileUID(tileUID_),
           partialParse(partialParse_),
           spriteStore(spriteStore_),
@@ -41,14 +41,14 @@ public:
           mode(mode_) {}
 
     bool cancelled() const {
-        return state == TileData::State::obsolete;
+        return obsolete;
     }
 
     void eachFilteredFeature(const Filter&, std::function<void (const GeometryTileFeature&, std::size_t index, const std::string& layerName)>);
 
     const OverscaledTileID& tileID;
     const GeometryTileLayer& layer;
-    const std::atomic<TileData::State>& state;
+    const std::atomic<bool>& obsolete;
     uintptr_t tileUID;
     bool& partialParse;
     SpriteStore& spriteStore;

--- a/src/mbgl/style/style_bucket_parameters.hpp
+++ b/src/mbgl/style/style_bucket_parameters.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/style/filter.hpp>
 
 #include <functional>
+#include <atomic>
 
 namespace mbgl {
 

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -27,7 +27,7 @@ RasterTileData::RasterTileData(const OverscaledTileID& id_,
             modified = res.modified;
             expires = res.expires;
         } else if (res.noContent) {
-            state = State::parsed;
+            availableData = DataAvailability::All;
             modified = res.modified;
             expires = res.expires;
             workRequest.reset();
@@ -43,13 +43,13 @@ RasterTileData::RasterTileData(const OverscaledTileID& id_,
 
                 std::exception_ptr error;
                 if (result.is<std::unique_ptr<Bucket>>()) {
-                    state = State::parsed;
                     bucket = std::move(result.get<std::unique_ptr<Bucket>>());
                 } else {
                     error = result.get<std::exception_ptr>();
-                    state = State::parsed;
                     bucket.reset();
                 }
+
+                availableData = DataAvailability::All;
 
                 callback(error);
             });

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -66,7 +66,6 @@ Bucket* RasterTileData::getBucket(StyleLayer const&) {
 }
 
 void RasterTileData::cancel() {
-    state = State::obsolete;
     req = nullptr;
     workRequest.reset();
 }

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -47,7 +47,7 @@ RasterTileData::RasterTileData(const OverscaledTileID& id_,
                     bucket = std::move(result.get<std::unique_ptr<Bucket>>());
                 } else {
                     error = result.get<std::exception_ptr>();
-                    state = State::obsolete;
+                    state = State::parsed;
                     bucket.reset();
                 }
 
@@ -66,9 +66,7 @@ Bucket* RasterTileData::getBucket(StyleLayer const&) {
 }
 
 void RasterTileData::cancel() {
-    if (state != State::obsolete) {
-        state = State::obsolete;
-    }
+    state = State::obsolete;
     req = nullptr;
     workRequest.reset();
 }

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -82,7 +82,3 @@ void RasterTileData::cancel() {
     req = nullptr;
     workRequest.reset();
 }
-
-bool RasterTileData::hasData() const {
-    return bucket.get() != nullptr;
-}

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -18,8 +18,6 @@ RasterTileData::RasterTileData(const OverscaledTileID& id_,
     : TileData(id_),
       texturePool(texturePool_),
       worker(worker_) {
-    state = State::loading;
-
     const Resource resource =
         Resource::tile(urlTemplate, pixelRatio, id.canonical.x, id.canonical.y, id.canonical.z);
     req = fileSource.request(resource, [callback, this](Response res) {
@@ -39,17 +37,9 @@ RasterTileData::RasterTileData(const OverscaledTileID& id_,
             modified = res.modified;
             expires = res.expires;
 
-            // Only overwrite the state when we didn't have a previous tile.
-            if (state == State::loading) {
-                state = State::loaded;
-            }
-
             workRequest.reset();
             workRequest = worker.parseRasterTile(std::make_unique<RasterBucket>(texturePool), res.data, [this, callback] (RasterTileParseResult result) {
                 workRequest.reset();
-                if (state != State::loaded) {
-                    return;
-                }
 
                 std::exception_ptr error;
                 if (result.is<std::unique_ptr<Bucket>>()) {

--- a/src/mbgl/tile/raster_tile_data.hpp
+++ b/src/mbgl/tile/raster_tile_data.hpp
@@ -23,7 +23,6 @@ public:
 
     void cancel() override;
     Bucket* getBucket(StyleLayer const &layer_desc) override;
-    bool hasData() const override;
 
 private:
     gl::TexturePool& texturePool;

--- a/src/mbgl/tile/tile_cache.cpp
+++ b/src/mbgl/tile/tile_cache.cpp
@@ -18,7 +18,7 @@ void TileCache::setSize(size_t size_) {
 }
 
 void TileCache::add(const OverscaledTileID& key, std::unique_ptr<TileData> data) {
-    if (!data->isReady() || !size) {
+    if (!data->isRenderable() || !size) {
         return;
     }
 
@@ -48,7 +48,7 @@ std::unique_ptr<TileData> TileCache::get(const OverscaledTileID& key) {
         data = std::move(it->second);
         tiles.erase(it);
         orderedKeys.remove(key);
-        assert(data->isReady());
+        assert(data->isRenderable());
     }
 
     return data;

--- a/src/mbgl/tile/tile_data.cpp
+++ b/src/mbgl/tile/tile_data.cpp
@@ -6,16 +6,14 @@ namespace mbgl {
 
 TileData::TileData(const OverscaledTileID& id_)
     : id(id_),
-      state(State::initial) {
+      state(State::loading) {
 }
 
 TileData::~TileData() = default;
 
 const char* TileData::StateToString(const State state) {
     switch (state) {
-        case TileData::State::initial: return "initial";
         case TileData::State::loading : return "loading";
-        case TileData::State::loaded : return "loaded";
         case TileData::State::obsolete : return "obsolete";
         case TileData::State::parsed : return "parsed";
         case TileData::State::partial : return "partial";

--- a/src/mbgl/tile/tile_data.cpp
+++ b/src/mbgl/tile/tile_data.cpp
@@ -5,24 +5,15 @@
 namespace mbgl {
 
 TileData::TileData(const OverscaledTileID& id_)
-    : id(id_),
-      state(State::loading) {
+    : id(id_) {
 }
 
 TileData::~TileData() = default;
 
-const char* TileData::StateToString(const State state) {
-    switch (state) {
-        case TileData::State::loading : return "loading";
-        case TileData::State::parsed : return "parsed";
-        case TileData::State::partial : return "partial";
-        default: return "<unknown>";
-    }
-}
-
 void TileData::dumpDebugLogs() const {
     Log::Info(Event::General, "TileData::id: %s", util::toString(id).c_str());
-    Log::Info(Event::General, "TileData::state: %s", TileData::StateToString(state));
+    Log::Info(Event::General, "TileData::renderable: %s", isRenderable() ? "yes" : "no");
+    Log::Info(Event::General, "TileData::complete: %s", isComplete() ? "yes" : "no");
 }
 
 void TileData::queryRenderedFeatures(

--- a/src/mbgl/tile/tile_data.cpp
+++ b/src/mbgl/tile/tile_data.cpp
@@ -14,7 +14,6 @@ TileData::~TileData() = default;
 const char* TileData::StateToString(const State state) {
     switch (state) {
         case TileData::State::initial: return "initial";
-        case TileData::State::invalid : return "invalid";
         case TileData::State::loading : return "loading";
         case TileData::State::loaded : return "loaded";
         case TileData::State::obsolete : return "obsolete";

--- a/src/mbgl/tile/tile_data.cpp
+++ b/src/mbgl/tile/tile_data.cpp
@@ -14,7 +14,6 @@ TileData::~TileData() = default;
 const char* TileData::StateToString(const State state) {
     switch (state) {
         case TileData::State::loading : return "loading";
-        case TileData::State::obsolete : return "obsolete";
         case TileData::State::parsed : return "parsed";
         case TileData::State::partial : return "partial";
         default: return "<unknown>";

--- a/src/mbgl/tile/tile_data.hpp
+++ b/src/mbgl/tile/tile_data.hpp
@@ -66,13 +66,6 @@ public:
 
     static const char* StateToString(State);
 
-    // Tile data considered "Ready" can be used for rendering. Data in
-    // partial state is still waiting for network resources but can also
-    // be rendered, although layers will be missing.
-    inline static bool isReadyState(const State& state) {
-        return state == State::partial || state == State::parsed;
-    }
-
     TileData(const OverscaledTileID&);
     virtual ~TileData();
 
@@ -91,8 +84,11 @@ public:
             const TransformState&,
             const optional<std::vector<std::string>>& layerIDs);
 
-    bool isReady() const {
-        return isReadyState(state);
+    // Tile data considered "Renderable" can be used for rendering. Data in
+    // partial state is still waiting for network resources but can also
+    // be rendered, although layers will be missing.
+    bool isRenderable() const {
+        return state == State::partial || state == State::parsed;
     }
 
     // Returns true when there's at least some data that we can render.

--- a/src/mbgl/tile/tile_data.hpp
+++ b/src/mbgl/tile/tile_data.hpp
@@ -27,14 +27,6 @@ public:
     // initial:
     //   Initial state, only used when the TileData object is created.
     //
-    // invalid:
-    //   FIXME: This state has a bit of overlap with 'initial' and 'obsolete'.
-    //
-    //   We report TileData being 'invalid' on Source::hasTile if we don't have the
-    //   TileData yet, then Source creates a request. This is misleading because
-    //   the TileData object is not effectively on the 'invalid' state and will
-    //   cause tiles on 'invalid' state to get reloaded.
-    //
     // loading:
     //   A request to the FileSource was made for the actual tile data and TileData
     //   is waiting for it to arrive.
@@ -56,7 +48,6 @@ public:
     //   request cancellation or because the tile is no longer in use.
     enum class State {
         initial,
-        invalid,
         loading,
         loaded,
         partial,

--- a/src/mbgl/tile/tile_data.hpp
+++ b/src/mbgl/tile/tile_data.hpp
@@ -82,9 +82,6 @@ public:
         return state == State::partial || state == State::parsed;
     }
 
-    // Returns true when there's at least some data that we can render.
-    virtual bool hasData() const = 0;
-
     State getState() const {
         return state;
     }

--- a/src/mbgl/tile/tile_data.hpp
+++ b/src/mbgl/tile/tile_data.hpp
@@ -9,7 +9,6 @@
 #include <mbgl/text/placement_config.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
 
-#include <atomic>
 #include <string>
 #include <memory>
 #include <functional>
@@ -36,15 +35,10 @@ public:
     // parsed:
     //   TileData is fully parsed and its contents won't change from this point. This
     //   is the only state which is safe to cache this object.
-    //
-    // obsolete:
-    //   The TileData can go to obsolete from any state, due to parsing or loading error,
-    //   request cancellation or because the tile is no longer in use.
     enum class State {
         loading,
         partial,
         parsed,
-        obsolete
     };
 
     static const char* StateToString(State);
@@ -92,7 +86,7 @@ public:
     std::unique_ptr<DebugBucket> debugBucket;
 
 protected:
-    std::atomic<State> state;
+    State state;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/tile_data.hpp
+++ b/src/mbgl/tile/tile_data.hpp
@@ -24,15 +24,9 @@ class TransformState;
 
 class TileData : private util::noncopyable {
 public:
-    // initial:
-    //   Initial state, only used when the TileData object is created.
-    //
     // loading:
     //   A request to the FileSource was made for the actual tile data and TileData
     //   is waiting for it to arrive.
-    //
-    // loaded:
-    //   The actual tile data has arrived and the tile can be parsed.
     //
     // partial:
     //   TileData is partially parsed, some buckets are still waiting for dependencies
@@ -47,9 +41,7 @@ public:
     //   The TileData can go to obsolete from any state, due to parsing or loading error,
     //   request cancellation or because the tile is no longer in use.
     enum class State {
-        initial,
         loading,
-        loaded,
         partial,
         parsed,
         obsolete
@@ -80,6 +72,10 @@ public:
     // be rendered, although layers will be missing.
     bool isRenderable() const {
         return state == State::partial || state == State::parsed;
+    }
+
+    bool isComplete() const {
+        return state == State::parsed;
     }
 
     State getState() const {

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -29,7 +29,7 @@ class SymbolLayer;
 // thread. This class is movable-only because the vector contains movable-only value elements.
 class TileParseResultData {
 public:
-    TileData::State state = TileData::State::invalid;
+    TileData::State state;
     std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
     std::unique_ptr<FeatureIndex> featureIndex;
     std::unique_ptr<const GeometryTile> geometryTile;

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <mbgl/map/mode.hpp>
-#include <mbgl/tile/tile_data.hpp>
+#include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/variant.hpp>
 #include <mbgl/util/ptr.hpp>
@@ -29,7 +29,7 @@ class SymbolLayer;
 // thread. This class is movable-only because the vector contains movable-only value elements.
 class TileParseResultData {
 public:
-    TileData::State state;
+    bool complete = false;
     std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
     std::unique_ptr<FeatureIndex> featureIndex;
     std::unique_ptr<const GeometryTile> geometryTile;
@@ -46,7 +46,7 @@ public:
                SpriteStore&,
                GlyphAtlas&,
                GlyphStore&,
-               const std::atomic<TileData::State>&,
+               const std::atomic<bool>&,
                const MapMode);
     ~TileWorker();
 
@@ -71,7 +71,7 @@ private:
     SpriteStore& spriteStore;
     GlyphAtlas& glyphAtlas;
     GlyphStore& glyphStore;
-    const std::atomic<TileData::State>& state;
+    const std::atomic<bool>& obsolete;
     const MapMode mode;
 
     bool partialParse = false;

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <list>
+#include <atomic>
 #include <unordered_map>
 
 namespace mbgl {

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -53,7 +53,7 @@ VectorTileData::VectorTileData(const OverscaledTileID& id_,
 
         if (state == State::loading) {
             state = State::loaded;
-        } else if (isReady()) {
+        } else if (isRenderable()) {
             state = State::partial;
         }
 

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -216,8 +216,4 @@ void VectorTileData::cancel() {
     workRequest.reset();
 }
 
-bool VectorTileData::hasData() const {
-    return !buckets.empty();
-}
-
 } // namespace mbgl

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -25,7 +25,7 @@ VectorTileData::VectorTileData(const OverscaledTileID& id_,
                  *style_.spriteStore,
                  *style_.glyphAtlas,
                  *style_.glyphStore,
-                 state,
+                 obsolete,
                  mode_),
       monitor(std::move(monitor_))
 {
@@ -66,7 +66,7 @@ VectorTileData::VectorTileData(const OverscaledTileID& id_,
             std::exception_ptr error;
             if (result.is<TileParseResultData>()) {
                 auto& resultBuckets = result.get<TileParseResultData>();
-                state = resultBuckets.state;
+                state = resultBuckets.complete ? State::parsed : State::partial;
 
                 // Persist the configuration we just placed so that we can later check whether we need to
                 // place again in case the configuration has changed.
@@ -109,7 +109,7 @@ bool VectorTileData::parsePending(std::function<void(std::exception_ptr)> callba
         std::exception_ptr error;
         if (result.is<TileParseResultData>()) {
             auto& resultBuckets = result.get<TileParseResultData>();
-            state = resultBuckets.state;
+            state = resultBuckets.complete ? State::parsed : State::partial;
 
             // Move over all buckets we received in this parse request, potentially overwriting
             // existing buckets in case we got a refresh parse.
@@ -205,7 +205,7 @@ void VectorTileData::queryRenderedFeatures(
 }
 
 void VectorTileData::cancel() {
-    state = State::obsolete;
+    obsolete = true;
     tileRequest.reset();
     workRequest.reset();
 }

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -64,6 +64,9 @@ private:
     // Stores the placement configuration of how the text should be placed. This isn't necessarily
     // the one that is being displayed.
     PlacementConfig targetConfig;
+
+    // Used to signal the worker that it should abandon parsing this tile as soon as possible.
+    std::atomic<bool> obsolete { false };
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/vector_tile_data.hpp
+++ b/src/mbgl/tile/vector_tile_data.hpp
@@ -34,8 +34,6 @@ public:
     void redoPlacement(PlacementConfig config, const std::function<void()>&) override;
     void redoPlacement(const std::function<void()>&) override;
 
-    bool hasData() const override;
-
     void queryRenderedFeatures(
             std::unordered_map<std::string, std::vector<Feature>>& result,
             const GeometryCoordinates& queryGeometry,

--- a/test/algorithm/mock.hpp
+++ b/test/algorithm/mock.hpp
@@ -44,7 +44,7 @@ struct MockBucket {};
 
 
 struct MockTileData {
-    bool isReady() {
+    bool isRenderable() {
         return ready;
     }
 


### PR DESCRIPTION
It's time to remove the `TileData::State` enum. This enum holds linear state and should represent the lifecycle of a tile, but it's a stretch to say that it's linear. This removes it completely in favor of a clear API and a separate `obsolete` variable for `VectorTileData` objects.