### PR TITLE
Fix texture leak in TexturePoolHolder

### DIFF
--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -36,7 +36,7 @@ public:
 
     // Transfers this buffer to the GPU and binds the buffer to the GL context.
     void bind(gl::GLObjectStore& glObjectStore) {
-        if (buffer) {
+        if (buffer.created()) {
             MBGL_CHECK_ERROR(glBindBuffer(bufferType, getID()));
         } else {
             buffer.create(glObjectStore);
@@ -65,7 +65,7 @@ public:
 
     // Uploads the buffer to the GPU to be available when we need it.
     inline void upload(gl::GLObjectStore& glObjectStore) {
-        if (!buffer) {
+        if (!buffer.created()) {
             bind(glObjectStore);
         }
     }
@@ -73,7 +73,7 @@ public:
 protected:
     // increase the buffer size by at least /required/ bytes.
     inline void *addElement() {
-        if (buffer) {
+        if (buffer.created()) {
             throw std::runtime_error("Can't add elements after buffer was bound to GPU");
         }
         if (length < pos + itemSize) {

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -144,7 +144,7 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
 
 void GlyphAtlas::upload(gl::GLObjectStore& glObjectStore) {
     if (dirty) {
-        const bool first = !texture;
+        const bool first = !texture.created();
         bind(glObjectStore);
 
         std::lock_guard<std::mutex> lock(mtx);
@@ -184,7 +184,7 @@ void GlyphAtlas::upload(gl::GLObjectStore& glObjectStore) {
 }
 
 void GlyphAtlas::bind(gl::GLObjectStore& glObjectStore) {
-    if (!texture) {
+    if (!texture.created()) {
         texture.create(glObjectStore);
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture.getID()));
 #ifndef GL_ES_VERSION_2_0

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -129,7 +129,7 @@ void LineAtlas::upload(gl::GLObjectStore& glObjectStore) {
 
 void LineAtlas::bind(gl::GLObjectStore& glObjectStore) {
     bool first = false;
-    if (!texture) {
+    if (!texture.created()) {
         texture.create(glObjectStore);
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture.getID()));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -26,7 +26,9 @@ void VertexArrayObject::bindVertexArrayObject(gl::GLObjectStore& glObjectStore) 
         return;
     }
 
-    if (!vao) vao.create(glObjectStore);
+    if (!vao.created()) {
+        vao.create(glObjectStore);
+    }
     MBGL_CHECK_ERROR(gl::BindVertexArray(vao.getID()));
 }
 

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -24,7 +24,7 @@ public:
         if (bound_shader == 0) {
             vertexBuffer.bind(glObjectStore);
             shader.bind(offset);
-            if (vao) {
+            if (vao.created()) {
                 storeBinding(shader, vertexBuffer.getID(), 0, offset);
             }
         } else {
@@ -39,7 +39,7 @@ public:
             vertexBuffer.bind(glObjectStore);
             elementsBuffer.bind(glObjectStore);
             shader.bind(offset);
-            if (vao) {
+            if (vao.created()) {
                 storeBinding(shader, vertexBuffer.getID(), elementsBuffer.getID(), offset);
             }
         } else {

--- a/src/mbgl/gl/gl_object_store.cpp
+++ b/src/mbgl/gl/gl_object_store.cpp
@@ -6,61 +6,61 @@ namespace mbgl {
 namespace gl {
 
 void ProgramHolder::create(GLObjectStore& objectStore_) {
-    if (id) return;
+    if (created()) return;
     objectStore = &objectStore_;
     id = MBGL_CHECK_ERROR(glCreateProgram());
 }
 
 void ProgramHolder::reset() {
-    if (!id) return;
+    if (!created()) return;
     objectStore->abandonedPrograms.push_back(id);
     id = 0;
 }
 
 void ShaderHolder::create(GLObjectStore& objectStore_) {
-    if (id) return;
+    if (created()) return;
     objectStore = &objectStore_;
     id = MBGL_CHECK_ERROR(glCreateShader(type));
 }
 
 void ShaderHolder::reset() {
-    if (!id) return;
+    if (!created()) return;
     objectStore->abandonedShaders.push_back(id);
     id = 0;
 }
 
 void BufferHolder::create(GLObjectStore& objectStore_) {
-    if (id) return;
+    if (created()) return;
     objectStore = &objectStore_;
     MBGL_CHECK_ERROR(glGenBuffers(1, &id));
 }
 
 void BufferHolder::reset() {
-    if (!id) return;
+    if (!created()) return;
     objectStore->abandonedBuffers.push_back(id);
     id = 0;
 }
 
 void TextureHolder::create(GLObjectStore& objectStore_) {
-    if (id) return;
+    if (created()) return;
     objectStore = &objectStore_;
     MBGL_CHECK_ERROR(glGenTextures(1, &id));
 }
 
 void TextureHolder::reset() {
-    if (!id) return;
+    if (!created()) return;
     objectStore->abandonedTextures.push_back(id);
     id = 0;
 }
 
 void TexturePoolHolder::create(GLObjectStore& objectStore_) {
-    if (bool()) return;
+    if (created()) return;
     objectStore = &objectStore_;
     MBGL_CHECK_ERROR(glGenTextures(TextureMax, ids.data()));
 }
 
 void TexturePoolHolder::reset() {
-    if (!bool()) return;
+    if (!created()) return;
     for (GLuint& id : ids) {
         if (id == 0) continue;
         objectStore->abandonedTextures.push_back(id);
@@ -69,13 +69,13 @@ void TexturePoolHolder::reset() {
 }
 
 void VAOHolder::create(GLObjectStore& objectStore_) {
-    if (id) return;
+    if (created()) return;
     objectStore = &objectStore_;
     MBGL_CHECK_ERROR(gl::GenVertexArrays(1, &id));
 }
 
 void VAOHolder::reset() {
-    if (!id) return;
+    if (!created()) return;
     objectStore->abandonedVAOs.push_back(id);
     id = 0;
 }

--- a/src/mbgl/gl/gl_object_store.cpp
+++ b/src/mbgl/gl/gl_object_store.cpp
@@ -61,12 +61,11 @@ void TexturePoolHolder::create(GLObjectStore& objectStore_) {
 
 void TexturePoolHolder::reset() {
     if (!bool()) return;
-    for (GLuint id : ids) {
-        if (id) {
-            objectStore->abandonedTextures.push_back(id);
-        }
-    }
-    ids.fill(0);
+    for (GLuint& id : ids) {
+        if (id == 0) continue;
+        objectStore->abandonedTextures.push_back(id);
+        id = 0;
+    };
 }
 
 void VAOHolder::create(GLObjectStore& objectStore_) {

--- a/src/mbgl/gl/gl_object_store.hpp
+++ b/src/mbgl/gl/gl_object_store.hpp
@@ -41,7 +41,7 @@ public:
     GLHolder(GLHolder&& o) noexcept : id(o.id), objectStore(o.objectStore) { o.id = 0; }
     GLHolder& operator=(GLHolder&& o) noexcept { id = o.id; objectStore = o.objectStore; o.id = 0; return *this; }
 
-    explicit operator bool() const { return id; }
+    bool created() const { return id; }
     GLuint getID() const { return id; }
 
 protected:
@@ -110,7 +110,7 @@ public:
     TexturePoolHolder(TexturePoolHolder&& o) noexcept : ids(std::move(o.ids)), objectStore(o.objectStore) { o.ids.fill(0); }
     TexturePoolHolder& operator=(TexturePoolHolder&& o) noexcept { ids = std::move(o.ids); objectStore = o.objectStore; o.ids.fill(0); return *this; }
 
-    explicit operator bool() const { return std::any_of(ids.begin(), ids.end(), [](int id) { return id; }); }
+    bool created() const { return std::any_of(ids.begin(), ids.end(), [](int id) { return id; }); }
     const std::array<GLuint, TextureMax>& getIDs() const { return ids; }
     const GLuint& operator[](size_t pos) { return ids[pos]; }
 

--- a/src/mbgl/gl/gl_object_store.hpp
+++ b/src/mbgl/gl/gl_object_store.hpp
@@ -38,8 +38,8 @@ class GLHolder : private util::noncopyable {
 public:
     GLHolder() {}
 
-    GLHolder(GLHolder&& o) noexcept : id(o.id) { o.id = 0; }
-    GLHolder& operator=(GLHolder&& o) noexcept { id = o.id; o.id = 0; return *this; }
+    GLHolder(GLHolder&& o) noexcept : id(o.id), objectStore(o.objectStore) { o.id = 0; }
+    GLHolder& operator=(GLHolder&& o) noexcept { id = o.id; objectStore = o.objectStore; o.id = 0; return *this; }
 
     explicit operator bool() const { return id; }
     GLuint getID() const { return id; }
@@ -107,10 +107,10 @@ public:
     TexturePoolHolder() { ids.fill(0); }
     ~TexturePoolHolder() { reset(); }
 
-    TexturePoolHolder(TexturePoolHolder&& o) noexcept : ids(std::move(o.ids)) {}
-    TexturePoolHolder& operator=(TexturePoolHolder&& o) noexcept { ids = std::move(o.ids); return *this; }
+    TexturePoolHolder(TexturePoolHolder&& o) noexcept : ids(std::move(o.ids)), objectStore(o.objectStore) { o.ids.fill(0); }
+    TexturePoolHolder& operator=(TexturePoolHolder&& o) noexcept { ids = std::move(o.ids); objectStore = o.objectStore; o.ids.fill(0); return *this; }
 
-    explicit operator bool() { return std::none_of(ids.begin(), ids.end(), [](int id) { return id == 0; }); }
+    explicit operator bool() const { return std::any_of(ids.begin(), ids.end(), [](int id) { return id; }); }
     const std::array<GLuint, TextureMax>& getIDs() const { return ids; }
     const GLuint& operator[](size_t pos) { return ids[pos]; }
 

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -60,7 +60,7 @@ bool FrameHistory::needsAnimation(const Duration& duration) const {
 void FrameHistory::upload(gl::GLObjectStore& glObjectStore) {
 
     if (changed) {
-        const bool first = !texture;
+        const bool first = !texture.created();
         bind(glObjectStore);
 
         if (first) {
@@ -95,7 +95,7 @@ void FrameHistory::upload(gl::GLObjectStore& glObjectStore) {
 }
 
 void FrameHistory::bind(gl::GLObjectStore& glObjectStore) {
-    if (!texture) {
+    if (!texture.created()) {
         texture.create(glObjectStore);
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture.getID()));
 #ifndef GL_ES_VERSION_2_0

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -86,7 +86,7 @@ bool Shader::compileShader(gl::ShaderHolder& shader, const GLchar *source[]) {
 }
 
 Shader::~Shader() {
-    if (program) {
+    if (program.created()) {
         MBGL_CHECK_ERROR(glDetachShader(program.getID(), vertexShader.getID()));
         MBGL_CHECK_ERROR(glDetachShader(program.getID(), fragmentShader.getID()));
     }

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -184,7 +184,7 @@ void SpriteAtlas::bind(bool linear, gl::GLObjectStore& glObjectStore) {
         return; // Empty atlas
     }
 
-    if (!texture) {
+    if (!texture.created()) {
         texture.create(glObjectStore);
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, texture.getID()));
 #ifndef GL_ES_VERSION_2_0


### PR DESCRIPTION
Fixes a misused `operator bool()` plus usage of an undefined pointer in `{GL,TexturePool}Holder` code.

:eyes: @kkaefer @jfirebaugh 

Fixes #5136.