### PR TITLE
[ios] Fix points/shapes typo that caused crash

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2902,7 +2902,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         for (size_t i = 0; i < annotationTags.size(); ++i)
         {
             MGLAnnotationTag annotationTag = annotationTags[i];
-            id <MGLAnnotation> annotation = userPoints[i];
+            id <MGLAnnotation> annotation = userShapes[i];
             
             MGLAnnotationContext context;
             context.annotation = annotation;


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/pull/5097 introduced different arrays for points and shapes, but only ever attempted to use the points array. Adding a shape would crash.

/cc @1ec5