### PR TITLE
[android] Remove logging of location due to privacy leak.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationServices.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationServices.java
@@ -123,7 +123,7 @@ public class LocationServices implements com.mapzen.android.lost.api.LocationLis
      */
     @Override
     public void onLocationChanged(Location location) {
-        Log.d(TAG, "onLocationChanged()..." + location);
+//        Log.d(TAG, "onLocationChanged()..." + location);
         this.lastLocation = location;
 
         // Update Listeners

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/telemetry/TelemetryLocationReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/telemetry/TelemetryLocationReceiver.java
@@ -63,7 +63,7 @@ public class TelemetryLocationReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         Location location = (Location)intent.getExtras().get(LocationManager.KEY_LOCATION_CHANGED);
         if (location != null) {
-            Log.d(TAG, "location received = " + location);
+//            Log.d(TAG, "location received = " + location);
             MapboxEventManager.getMapboxEventManager().addLocationEvent(location);
         } else {
             Log.d(TAG, "location NOT received");


### PR DESCRIPTION
* Location logs are not just kept on the device.
* Some logging packages, e.g., Firebase, now have the option to upload logs to cloud.
* This closes a potential privacy leak.
