### PR TITLE
[Qt] QMapboxGLPrivate::getPixelRatio() cleanup

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -157,11 +157,7 @@ void MapWindow::initializeGL()
 void MapWindow::resizeGL(int w, int h)
 {
     QSize size(w, h);
-#if QT_VERSION >= 0x050000
-    size /= qApp->devicePixelRatio();
-#endif
     m_map.resize(size);
-    glViewport(0, 0, size.width(), size.height());
 }
 
 void MapWindow::paintGL()

--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -3,7 +3,6 @@
 #include <QMapboxGL>
 #include <QQuickMapboxGL>
 
-#include <QGuiApplication>
 #include <QSize>
 #include <QOpenGLFramebufferObject>
 #include <QOpenGLFramebufferObjectFormat>
@@ -28,7 +27,7 @@ QQuickMapboxGLRenderer::~QQuickMapboxGLRenderer()
 
 QOpenGLFramebufferObject* QQuickMapboxGLRenderer::createFramebufferObject(const QSize &size)
 {
-    m_map->resize(size / qApp->devicePixelRatio());
+    m_map->resize(size);
 
     QOpenGLFramebufferObjectFormat format;
     format.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);


### PR DESCRIPTION
From http://doc.qt.io/qt-5/qguiapplication.html#devicePixelRatio, `QWindow::devicePixelRatio` is the most reliable pixel ratio because `QGuiApplication` returns the maximum pixel ratio of all available `QScreen` objects. This is not valid for cases e.g. where two or more `QScreen` objects with different pixel ratios are present and the application window appears on the screen with lower pixel ratio.

This patch also moved `glViewport` call to QMapboxGL domain.

:eyes: @tmpsantos @kkaefer 
