### PR TITLE
[node] Don't fire callback when the AsyncRequest was canceled

### DIFF
--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -528,12 +528,13 @@ std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resou
     Nan::HandleScope scope;
 
     auto requestHandle = NodeRequest::Create(resource, callback_)->ToObject();
+    auto request = Nan::ObjectWrap::Unwrap<NodeRequest>(requestHandle);
     auto callbackHandle = Nan::New<v8::Function>(NodeRequest::Respond, requestHandle);
 
     v8::Local<v8::Value> argv[] = { requestHandle, callbackHandle };
     Nan::MakeCallback(handle()->GetInternalField(1)->ToObject(), "request", 2, argv);
 
-    return std::make_unique<mbgl::AsyncRequest>();
+    return std::make_unique<NodeRequest::NodeAsyncRequest>(request);
 }
 
-}
+} // namespace node_mbgl

--- a/platform/node/src/node_request.hpp
+++ b/platform/node/src/node_request.hpp
@@ -12,6 +12,7 @@
 namespace node_mbgl {
 
 class NodeFileSource;
+class NodeRequest;
 
 class NodeRequest : public Nan::ObjectWrap {
 public:
@@ -24,9 +25,17 @@ public:
     static Nan::Persistent<v8::Function> constructor;
 
     NodeRequest(mbgl::FileSource::Callback);
+    ~NodeRequest();
+
+    struct NodeAsyncRequest : public mbgl::AsyncRequest {
+        NodeAsyncRequest(NodeRequest*);
+        ~NodeAsyncRequest() override;
+        NodeRequest* request;
+    };
 
 private:
     mbgl::FileSource::Callback callback;
+    NodeAsyncRequest* asyncRequest = nullptr;
 };
 
 }

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -220,6 +220,26 @@ test('Map', function(t) {
             t.end();
         });
 
+        t.test('returns an error delayed', function(t) {
+            var delay = 0;
+            var map = new mbgl.Map({
+                request: function(req, callback) {
+                    delay += 100;
+                    setTimeout(function() {
+                        callback(new Error('not found'));
+                    }, delay);
+                },
+                ratio: 1
+            });
+            map.load(style);
+            map.render({ zoom: 1 }, function(err, data) {
+                map.release();
+
+                t.ok(err, 'returns error');
+                t.end();
+            });
+        });
+
         t.test('returns an error', function(t) {
             var map = new mbgl.Map(options);
             map.load(style);


### PR DESCRIPTION
When requesting a resource in the node bindings, we're currently [returning a plain `AsyncRequest` object](https://github.com/mapbox/mapbox-gl-native/blob/c111250fcccaf5e57154852606ee740f0db242c1/platform/node/src/node_map.cpp#L536). This means that when we cancel the file request, we're not canceling the associated JS `request()` call. We can't do that because it's immediate, but that immediate function call is async, so it could fire the passed `callback` function later on, at a point when the `AsyncRequest` has long been destroyed.