### PR TITLE
AnnotationTileLayer vends its own name

### DIFF
--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<AnnotationTile> AnnotationManager::getTile(const CanonicalTileID
 
     AnnotationTileLayer& pointLayer = *tile->layers.emplace(
         PointLayerID,
-        std::make_unique<AnnotationTileLayer>()).first->second;
+        std::make_unique<AnnotationTileLayer>(PointLayerID)).first->second;
 
     LatLngBounds tileBounds(tileID);
 

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -21,6 +21,9 @@ optional<Value> AnnotationTileFeature::getValue(const std::string& key) const {
     return optional<Value>();
 }
 
+AnnotationTileLayer::AnnotationTileLayer(const std::string &name_)
+    : name(name_) {}
+
 util::ptr<GeometryTileLayer> AnnotationTile::getLayer(const std::string& name) const {
     auto it = layers.find(name);
     if (it != layers.end()) {

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -24,11 +24,16 @@ public:
 
 class AnnotationTileLayer : public GeometryTileLayer {
 public:
+    AnnotationTileLayer(const std::string&);
+
     std::size_t featureCount() const override { return features.size(); }
     util::ptr<const GeometryTileFeature> getFeature(std::size_t i) const override { return features[i]; }
-    std::string getName() const override { return ""; };
+    std::string getName() const override { return name; };
 
     std::vector<util::ptr<const AnnotationTileFeature>> features;
+
+private:
+    std::string name;
 };
 
 class AnnotationTile : public GeometryTile {

--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -119,7 +119,7 @@ void ShapeAnnotationImpl::updateTile(const CanonicalTileID& tileID, AnnotationTi
         return;
 
     AnnotationTileLayer& layer = *tile.layers.emplace(layerID,
-        std::make_unique<AnnotationTileLayer>()).first->second;
+        std::make_unique<AnnotationTileLayer>(layerID)).first->second;
 
     for (auto& shapeFeature : shapeTile.features) {
         FeatureType featureType = FeatureType::Unknown;

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -259,3 +259,23 @@ TEST(Annotations, SwitchStyle) {
 
     checkRendering(map, "switch_style");
 }
+
+TEST(Annotations, QueryRenderedFeatures) {
+    util::RunLoop loop;
+
+    auto display = std::make_shared<mbgl::HeadlessDisplay>();
+    HeadlessView view(display, 1);
+    StubFileSource fileSource;
+
+    Map map(view, fileSource, MapMode::Still);
+    map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"), "");
+    map.addAnnotationIcon("default_marker", namedMarker("default_marker.png"));
+    const LatLng latLng(0, 0);
+    map.addPointAnnotation(PointAnnotation(latLng, "default_marker"));
+
+    test::render(map);
+    
+    auto point = map.pixelForLatLng(latLng);
+    auto features = map.queryRenderedFeatures(point);
+    EXPECT_EQ(features.size(), 1);
+}


### PR DESCRIPTION
Fixes #5159.

@jfirebaugh, any idea why no features are returned in the test? When I put this fix into my branch in #5110, annotation features are returned by `queryRenderedFeatures()`.