### PR TITLE
[ios] Force update from display link when display link is created.

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1022,6 +1022,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         _displayLink.frameInterval = MGLTargetFrameInterval;
         [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
         _needsDisplayRefresh = YES;
+        [self updateFromDisplayLink];
     }
     else if ( ! isVisible && _displayLink)
     {


### PR DESCRIPTION
This forces the call of the map view's display link target when the display link is created. When a map view is shown the first time this is not required. However, if the display link was torn down and then recreated due to the map view being removed / obscured in the view hierarchy the map view delegate may expect to be informed when the map view did finish loading the map when it is shown again.

This adds a call to `updateFromDisplayLink` just after a display link is created which helps trigger a full refresh of the map in the sense that all delegate methods get exercised including `mapViewDidFinishLoadingMap`.

cc @1ec5 @friedbunny 