### PR TITLE
[Qt] QML test app crashing on debug builds

### DIFF
--- a/platform/qt/src/async_task.cpp
+++ b/platform/qt/src/async_task.cpp
@@ -4,6 +4,8 @@
 
 #include <mbgl/util/run_loop.hpp>
 
+#include <cassert>
+
 namespace mbgl {
 namespace util {
 
@@ -20,6 +22,8 @@ void AsyncTask::Impl::maySend() {
 }
 
 void AsyncTask::Impl::runTask() {
+    assert(runLoop == RunLoop::Get());
+
     queued.clear();
     task();
 }

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -5,7 +5,6 @@
 #include <mbgl/map/view.hpp>
 #include <mbgl/storage/default_file_source.hpp>
 #include <mbgl/util/geo.hpp>
-#include <mbgl/util/run_loop.hpp>
 
 #include <QMapboxGL>
 #include <QObject>
@@ -33,8 +32,6 @@ public:
     QSize size;
 
     QMapboxGL *q_ptr = nullptr;
-
-    mbgl::util::RunLoop loop;
 
     std::unique_ptr<mbgl::DefaultFileSource> fileSourceObj;
     std::unique_ptr<mbgl::Map> mapObj;


### PR DESCRIPTION
There is a bug on the code when the `QMapboxGL` is not created on the main thread.

```
#0  0x00007f7921c69418 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007f7921c6b01a in __GI_abort () at abort.c:89
#2  0x00007f7921c61bd7 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x7f7923f590d3 "runLoop == RunLoop::Get()", 
    file=file@entry=0x7f7923f590b0 "../../src/mbgl/util/work_queue.cpp", line=line@entry=29, 
    function=function@entry=0x7f7923f59140 <mbgl::util::WorkQueue::pop(std::function<void ()> const&)::__PRETTY_FUNCTION__> "void mbgl::util::WorkQueue::pop(const std::function<void()>&)") at assert.c:92
#3  0x00007f7921c61c82 in __GI___assert_fail (assertion=0x7f7923f590d3 "runLoop == RunLoop::Get()", 
    file=0x7f7923f590b0 "../../src/mbgl/util/work_queue.cpp", line=29, 
    function=0x7f7923f59140 <mbgl::util::WorkQueue::pop(std::function<void ()> const&)::__PRETTY_FUNCTION__> "void mbgl::util::WorkQueue::pop(const std::function<void()>&)") at assert.c:101
#4  0x00007f7923be66cb in mbgl::util::WorkQueue::pop(std::function<void ()> const&) (this=0xc94708, fn=...)
    at ../../src/mbgl/util/work_queue.cpp:29
#5  0x00007f7923beb357 in std::_Mem_fn_base<void (mbgl::util::WorkQueue::*)(std::function<void ()> const&), true>::operator()<std::function<void ()>&, void>(mbgl::util::WorkQueue*, std::function<void ()>&) const (this=0x7f78e4010670, __object=0xc94708)
    at /usr/include/c++/5/functional:600
#6  0x00007f7923beb1bb in std::_Bind<std::_Mem_fn<void (mbgl::util::WorkQueue::*)(std::function<void ()> const&)> (mbgl::util::WorkQueue*, std::function<void ()>)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) (this=0x7f78e4010670, 
    __args=<unknown type in /home/tmpsantos/Projects/mapbox-gl-native/build/qt-linux-x86_64/Debug/lib.target/libqmapboxgl.so.1.0.0, CU 0xda95c0, DIE 0xdc13c8>) at /usr/include/c++/5/functional:1074
#7  0x00007f7923beb01d in std::_Bind<std::_Mem_fn<void (mbgl::util::WorkQueue::*)(std::function<void ()> const&)> (mbgl::util::WorkQueue*, std::function<void ()>)>::operator()<, void>() (this=0x7f78e4010670) at /usr/include/c++/5/functional:1133
#8  0x00007f7923beaf4e in mbgl::util::RunLoop::Invoker<std::_Bind<std::_Mem_fn<void (mbgl::util::WorkQueue::*)(std::function<void ()> const&)> (mbgl::util::WorkQueue*, std::function<void ()>)>, std::tuple<> >::invoke<>(std::integer_sequence<unsigned long>) (this=0x7f78e4010630)
    at ../../include/mbgl/util/run_loop.hpp:147
#9  0x00007f7923beaddc in mbgl::util::RunLoop::Invoker<std::_Bind<std::_Mem_fn<void (mbgl::util::WorkQueue::*)(std::function<void ()> const&)> (mbgl::util::WorkQueue*, std::function<void ()>)>, std::tuple<> >::operator()() (this=0x7f78e4010630)
    at ../../include/mbgl/util/run_loop.hpp:127
#10 0x00007f7923a6abb5 in mbgl::util::RunLoop::process (this=0xc92550) at ../../include/mbgl/util/run_loop.hpp:171
#11 0x00007f7923a73d48 in std::_Mem_fn_base<void (mbgl::util::RunLoop::*)(), true>::operator()<, void>(mbgl::util::RunLoop*) const (
    this=0xc89ab0, __object=0xc92550) at /usr/include/c++/5/functional:600
#12 0x00007f7923a73300 in std::_Bind<std::_Mem_fn<void (mbgl::util::RunLoop::*)()> (mbgl::util::RunLoop*)>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (this=0xc89ab0, 
    __args=<unknown type in /home/tmpsantos/Projects/mapbox-gl-native/build/qt-linux-x86_64/Debug/lib.target/libqmapboxgl.so.1.0.0, CU 0x3294e5, DIE 0x35d9dd>) at /usr/include/c++/5/functional:1074
#13 0x00007f7923a71eb7 in std::_Bind<std::_Mem_fn<void (mbgl::util::RunLoop::*)()> (mbgl::util::RunLoop*)>::operator()<, void>() (
    this=0xc89ab0) at /usr/include/c++/5/functional:1133
#14 0x00007f7923a70917 in std::_Function_handler<void (), std::_Bind<std::_Mem_fn<void (mbgl::util::RunLoop::*)()> (mbgl::util::RunLoop*)> >::_M_invoke(std::_Any_data const&) (__functor=...) at /usr/include/c++/5/functional:1871
#15 0x00007f7923a44f77 in std::function<void ()>::operator()() const (this=0xc928f8) at /usr/include/c++/5/functional:2267
#16 0x00007f7923a44e04 in mbgl::util::AsyncTask::Impl::runTask (this=0xc928e0) at ../../platform/qt/src/async_task.cpp:24
#17 0x00007f7923a7ba7f in mbgl::util::AsyncTask::Impl::qt_static_metacall (_o=0xc928e0, _c=QMetaObject::InvokeMetaMethod, _id=1, 
    _a=0x7f78e40106e0) at Debug/obj/gen/src/moc_async_task_impl.cpp:78
#18 0x00007f792358eea1 in QObject::event(QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#19 0x00007f792355f4f9 in QCoreApplication::notify(QObject*, QEvent*) () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
```
/cc @brunoabinader 