### PR TITLE
Store feature keys in same order as in vector tile

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "aws-sdk": "^2.3.5",
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#36278b864e60e1dba937a6863064c03d69526854",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#b3441d9a285ffbe9b876677acb13d7df07e5b975",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f45fd7aba98650c7f3bf778c9cbbfd3b548a4ee8",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",
     "tape": "^4.5.1"

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -191,7 +191,10 @@ VectorTileLayer::VectorTileLayer(protozero::pbf_reader layer_pbf) {
             features.push_back(layer_pbf.get_message());
             break;
         case 3: // keys
-            keysMap.emplace(layer_pbf.get_string(), keysMap.size());
+            {
+                auto iter = keysMap.emplace(layer_pbf.get_string(), keysMap.size());
+                keys.emplace_back(std::reference_wrapper<const std::string>(iter.first->first));
+            }
             break;
         case 4: // values
             values.emplace_back(parseValue(layer_pbf.get_message()));
@@ -206,10 +209,6 @@ VectorTileLayer::VectorTileLayer(protozero::pbf_reader layer_pbf) {
             layer_pbf.skip();
             break;
         }
-    }
-
-    for (auto &pair : keysMap) {
-        keys.emplace_back(std::reference_wrapper<const std::string>(pair.first));
     }
 }
 


### PR DESCRIPTION
The keys in the vector tile may not be in alphabetical order. Building a vector of keys by looping over `std::map<std::string, …>` effectively sorts the keys by alphabetical order without sorting the associated values. ~~This change removes the `map` in favor of logic that [more closely matches vector-tile-js](https://github.com/mapbox/vector-tile-js/blob/91b134985381bb66fbd778720d3bbd94c3642cad/lib/vectortilelayer.js#L30).~~ This change inserts keys in the same order in which they appear in the vector tile.

Fixes #5182.

/cc @jfirebaugh