### PR TITLE
[core] Update circle shader code

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "aws-sdk": "^2.3.5",
     "express": "^4.11.1",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#4a567b438be303fbbf13e5ddf49d72d8debd811d",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#13aad76282c1b6c4d38fd46f373325dfec69ab01",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#b3441d9a285ffbe9b876677acb13d7df07e5b975",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -100,6 +100,8 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     // The extrusion matrix.
     matrix::ortho(extrudeMatrix, 0, state.getWidth(), state.getHeight(), 0, 0, -1);
 
+    extrudeScale = {{ (2.0f / state.getWidth()) * state.getAltitude(), -2.0f / state.getHeight() * state.getAltitude() }};
+
     // The native matrix is a 1:1 matrix that paints the coordinates at the
     // same screen position as the vertex specifies.
     matrix::identity(nativeMatrix);

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -158,6 +158,8 @@ private:
     mat4 nativeMatrix;
     mat4 extrudeMatrix;
 
+    std::array<float, 2> extrudeScale;
+
     // used to composite images and flips the geometry upside down
     const mat4 flipMatrix = []{
         mat4 flip;

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -33,11 +33,12 @@ void Painter::renderCircle(CircleBucket& bucket,
     config.program = circleShader->getID();
 
     circleShader->u_matrix = vtxMatrix;
-    circleShader->u_exmatrix = extrudeMatrix;
+    circleShader->u_extrude_scale = extrudeScale;
+    circleShader->u_devicepixelratio = frame.pixelRatio;
     circleShader->u_color = properties.circleColor;
-    circleShader->u_opacity = properties.circleOpacity;
+    circleShader->u_radius = properties.circleRadius;
     circleShader->u_blur = std::max<float>(properties.circleBlur, antialiasing);
-    circleShader->u_size = properties.circleRadius;
+    circleShader->u_opacity = properties.circleOpacity;
 
     bucket.drawCircles(*circleShader, glObjectStore);
 }

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -11,12 +11,13 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>                 u_matrix   = {"u_matrix",   *this};
-    UniformMatrix<4>                 u_exmatrix = {"u_exmatrix", *this};
-    Uniform<std::array<GLfloat, 4>>  u_color    = {"u_color",    *this};
-    Uniform<GLfloat>                 u_opacity  = {"u_opacity",  *this};
-    Uniform<GLfloat>                 u_size     = {"u_size",     *this};
-    Uniform<GLfloat>                 u_blur     = {"u_blur",     *this};
+    UniformMatrix<4>                 u_matrix           = {"u_matrix",           *this};
+    Uniform<std::array<GLfloat, 2>>  u_extrude_scale    = {"u_extrude_scale",    *this};
+    Uniform<GLfloat>                 u_devicepixelratio = {"u_devicepixelratio", *this};
+    Uniform<std::array<GLfloat, 4>>  u_color            = {"u_color",            *this};
+    Uniform<GLfloat>                 u_radius           = {"u_radius",           *this};
+    Uniform<GLfloat>                 u_blur             = {"u_blur",             *this};
+    Uniform<GLfloat>                 u_opacity          = {"u_opacity",          *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/collision_box_shader.cpp
+++ b/src/mbgl/shader/collision_box_shader.cpp
@@ -8,9 +8,9 @@
 using namespace mbgl;
 
 CollisionBoxShader::CollisionBoxShader(gl::GLObjectStore& glObjectStore)
-    : Shader("collisionbox", shaders::collisionbox::vertex, shaders::collisionbox::fragment, glObjectStore) {
-    a_extrude = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_extrude"));
-    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
+    : Shader("collisionbox", shaders::collisionbox::vertex, shaders::collisionbox::fragment, glObjectStore)
+    , a_extrude(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_extrude")))
+    , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 
 void CollisionBoxShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -8,10 +8,10 @@
 using namespace mbgl;
 
 IconShader::IconShader(gl::GLObjectStore& glObjectStore)
-    : Shader("icon", shaders::icon::vertex, shaders::icon::fragment, glObjectStore) {
-    a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset"));
-    a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1"));
-    a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"));
+    : Shader("icon", shaders::icon::vertex, shaders::icon::fragment, glObjectStore)
+    , a_offset(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset")))
+    , a_data1(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1")))
+    , a_data2(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"))) {
 }
 
 void IconShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -8,8 +8,8 @@
 using namespace mbgl;
 
 LineShader::LineShader(gl::GLObjectStore& glObjectStore)
-    : Shader("line", shaders::line::vertex, shaders::line::fragment, glObjectStore) {
-    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
+    : Shader("line", shaders::line::vertex, shaders::line::fragment, glObjectStore)
+    , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 
 void LineShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -8,8 +8,8 @@
 using namespace mbgl;
 
 LinepatternShader::LinepatternShader(gl::GLObjectStore& glObjectStore)
-    : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment, glObjectStore) {
-    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
+    : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment, glObjectStore)
+    , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 
 void LinepatternShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -8,8 +8,8 @@
 using namespace mbgl;
 
 LineSDFShader::LineSDFShader(gl::GLObjectStore& glObjectStore)
-    : Shader("linesdfpattern", shaders::linesdfpattern::vertex, shaders::linesdfpattern::fragment, glObjectStore) {
-    a_data = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"));
+    : Shader("linesdfpattern", shaders::linesdfpattern::vertex, shaders::linesdfpattern::fragment, glObjectStore)
+    , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 
 void LineSDFShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -8,10 +8,10 @@
 using namespace mbgl;
 
 SDFShader::SDFShader(gl::GLObjectStore& glObjectStore)
-    : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment, glObjectStore) {
-    a_offset = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset"));
-    a_data1 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1"));
-    a_data2 = MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"));
+    : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment, glObjectStore)
+    , a_offset(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset")))
+    , a_data1(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1")))
+    , a_data2(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"))) {
 }
 
 void SDFGlyphShader::bind(GLbyte* offset) {


### PR DESCRIPTION
Ported the following patches:
 - [convert mat4 exMatrix to a vec2 extrudeScale](https://github.com/mapbox/mapbox-gl-shaders/commit/a8d549b7a41540d3a99767975ff1b7b18a6010e9)
 - [Enabled data-driven styling for circle-radius](https://github.com/mapbox/mapbox-gl-shaders/commit/4356e41fa657837904d189e604468617ee601ddb)
 - [Reduce shader boilerplate, refactor "Bucket"](https://github.com/mapbox/mapbox-gl-shaders/commit/7d3da8f1914954fd96f305b7116cfd127a616551)

Shader PR: https://github.com/mapbox/mapbox-gl-shaders/pull/4

Part of https://github.com/mapbox/mapbox-gl-shaders/issues/1.

/cc @jfirebaugh @kkaefer @ansis