### PR TITLE
[core] Update icon shader code

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "aws-sdk": "^2.3.5",
     "express": "^4.11.1",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#13aad76282c1b6c4d38fd46f373325dfec69ab01",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#49022d5b92c067b8659f5700a04f376d75f2950e",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#b3441d9a285ffbe9b876677acb13d7df07e5b975",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "aws-sdk": "^2.3.5",
     "express": "^4.11.1",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#49022d5b92c067b8659f5700a04f376d75f2950e",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#36278b864e60e1dba937a6863064c03d69526854",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#b3441d9a285ffbe9b876677acb13d7df07e5b975",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -100,7 +100,9 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     // The extrusion matrix.
     matrix::ortho(extrudeMatrix, 0, state.getWidth(), state.getHeight(), 0, 0, -1);
 
-    extrudeScale = {{ (2.0f / state.getWidth()) * state.getAltitude(), -2.0f / state.getHeight() * state.getAltitude() }};
+    const float flippedY = state.getViewportMode() == ViewportMode::FlippedY;
+    extrudeScale = {{ 2.0f / state.getWidth() * state.getAltitude(),
+                      (flippedY ? 2.0f : -2.0f) / state.getHeight() * state.getAltitude() }};
 
     // The native matrix is a 1:1 matrix that paints the coordinates at the
     // same screen position as the vertex specifies.

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -97,9 +97,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     // Update the default matrices to the current viewport dimensions.
     state.getProjMatrix(projMatrix);
 
-    // The extrusion matrix.
-    matrix::ortho(extrudeMatrix, 0, state.getWidth(), state.getHeight(), 0, 0, -1);
-
+    // The extrusion scale.
     const float flippedY = state.getViewportMode() == ViewportMode::FlippedY;
     extrudeScale = {{ 2.0f / state.getWidth() * state.getAltitude(),
                       (flippedY ? 2.0f : -2.0f) / state.getHeight() * state.getAltitude() }};

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -156,7 +156,6 @@ private:
 
     mat4 projMatrix;
     mat4 nativeMatrix;
-    mat4 extrudeMatrix;
 
     std::array<float, 2> extrudeScale;
 

--- a/src/mbgl/shader/icon_shader.hpp
+++ b/src/mbgl/shader/icon_shader.hpp
@@ -11,15 +11,14 @@ public:
 
     void bind(GLbyte *offset) final;
 
-    UniformMatrix<4>                u_matrix      = {"u_matrix",      *this};
-    UniformMatrix<4>                u_exmatrix    = {"u_exmatrix",    *this};
-    Uniform<GLfloat>                u_zoom        = {"u_zoom",        *this};
-    Uniform<GLfloat>                u_opacity     = {"u_opacity",     *this};
-    Uniform<std::array<GLfloat, 2>> u_texsize     = {"u_texsize",     *this};
-    Uniform<GLint>                  u_skewed      = {"u_skewed",      *this};
-    Uniform<GLfloat>                u_extra       = {"u_extra",       *this};
-    Uniform<GLint>                  u_texture     = {"u_texture",     *this};
-    Uniform<GLint>                  u_fadetexture = {"u_fadetexture", *this};
+    UniformMatrix<4>                u_matrix        = {"u_matrix",        *this};
+    Uniform<std::array<GLfloat, 2>> u_extrude_scale = {"u_extrude_scale", *this};
+    Uniform<GLfloat>                u_zoom          = {"u_zoom",          *this};
+    Uniform<GLfloat>                u_opacity       = {"u_opacity",       *this};
+    Uniform<std::array<GLfloat, 2>> u_texsize       = {"u_texsize",       *this};
+    Uniform<GLint>                  u_skewed        = {"u_skewed",        *this};
+    Uniform<GLint>                  u_texture       = {"u_texture",       *this};
+    Uniform<GLint>                  u_fadetexture   = {"u_fadetexture",   *this};
 
 protected:
     GLint a_offset = -1;

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -9,17 +9,17 @@ class SDFShader : public Shader {
 public:
     SDFShader(gl::GLObjectStore&);
 
-    UniformMatrix<4>                u_matrix      = {"u_matrix",      *this};
-    UniformMatrix<4>                u_exmatrix    = {"u_exmatrix",    *this};
-    Uniform<std::array<GLfloat, 4>> u_color       = {"u_color",       *this};
-    Uniform<GLfloat>                u_opacity     = {"u_opacity",     *this};
-    Uniform<std::array<GLfloat, 2>> u_texsize     = {"u_texsize",     *this};
-    Uniform<GLfloat>                u_buffer      = {"u_buffer",      *this};
-    Uniform<GLfloat>                u_gamma       = {"u_gamma",       *this};
-    Uniform<GLfloat>                u_zoom        = {"u_zoom",        *this};
-    Uniform<GLint>                  u_skewed      = {"u_skewed",      *this};
-    Uniform<GLint>                  u_texture     = {"u_texture",     *this};
-    Uniform<GLint>                  u_fadetexture = {"u_fadetexture", *this};
+    UniformMatrix<4>                u_matrix        = {"u_matrix",        *this};
+    Uniform<std::array<GLfloat, 2>> u_extrude_scale = {"u_extrude_scale", *this};
+    Uniform<std::array<GLfloat, 4>> u_color         = {"u_color",         *this};
+    Uniform<GLfloat>                u_opacity       = {"u_opacity",       *this};
+    Uniform<std::array<GLfloat, 2>> u_texsize       = {"u_texsize",       *this};
+    Uniform<GLfloat>                u_buffer        = {"u_buffer",        *this};
+    Uniform<GLfloat>                u_gamma         = {"u_gamma",         *this};
+    Uniform<GLfloat>                u_zoom          = {"u_zoom",          *this};
+    Uniform<GLint>                  u_skewed        = {"u_skewed",        *this};
+    Uniform<GLint>                  u_texture       = {"u_texture",       *this};
+    Uniform<GLint>                  u_fadetexture   = {"u_fadetexture",   *this};
 
 protected:
     GLint a_offset = -1;


### PR DESCRIPTION
Ported the following patch:
- [convert mat4 exMatrix to a vec2 extrudeScale](https://github.com/mapbox/mapbox-gl-shaders/commit/a8d549b7a41540d3a99767975ff1b7b18a6010e9)

Shader PR: mapbox/mapbox-gl-shaders#5

Part of mapbox/mapbox-gl-shaders#1.

/cc @jfirebaugh @kkaefer @ansis