### PR TITLE
initial draft of Node.js bindings memory usage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.3.5",
+    "d3-queue": "^2.0.3",
     "express": "^4.11.1",
+    "generate-geo-testing-data": "^0.2.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#4a567b438be303fbbf13e5ddf49d72d8debd811d",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#b3441d9a285ffbe9b876677acb13d7df07e5b975",
     "node-gyp": "^3.3.1",
+    "pretty-bytes": "^3.0.1",
     "request": "^2.72.0",
     "tape": "^4.5.1"
   },

--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -33,7 +33,7 @@ var mbgl = require('mapbox-gl-native');
 var sharp = require('sharp');
 var map = new mbgl.Map({ request: function() {} });
 
-map.load(require('./test/fixtures/style.json'));
+map.load(require('./test/fixtures/tilejson/local.json'));
 
 map.render({}, function(err, buffer) {
     if (err) throw err;

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -93,7 +93,7 @@ NAN_MODULE_INIT(NodeMap::Init) {
  * @param {number} options.ratio pixel ratio
  * @example
  * var map = new mbgl.Map({ request: function() {} });
- * map.load(require('./test/fixtures/style.json'));
+ * map.load(require('./test/fixtures/tilejson/local.json'));
  * map.render({}, function(err, image) {
  *     if (err) throw err;
  *     fs.writeFileSync('image.png', image);
@@ -159,10 +159,10 @@ std::string StringifyStyle(v8::Local<v8::Value> styleHandle) {
  * @throws {Error} if stylesheet is missing or invalid
  * @example
  * // providing an object
- * map.load(require('./test/fixtures/style.json'));
+ * map.load(require('./test/fixtures/tilejson/local.json'));
  *
  * // providing a string
- * map.load(fs.readFileSync('./test/fixtures/style.json', 'utf8'));
+ * map.load(fs.readFileSync('./test/fixtures/tilejson/local.json', 'utf8'));
  */
 NAN_METHOD(NodeMap::Load) {
     auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());

--- a/platform/node/test/fixtures/tilejson/local.json
+++ b/platform/node/test/fixtures/tilejson/local.json
@@ -1,0 +1,30 @@
+{
+  "version": 8,
+  "sources": {
+    "mapbox": {
+      "type": "vector",
+      "maxzoom": 15,
+      "tiles": [
+        "./fixtures/tiles/{z}-{x}-{y}.vector.pbf"
+      ]
+    }
+  },
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "white"
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "mapbox",
+      "source-layer": "water",
+      "paint": {
+        "fill-color": "blue"
+      }
+    }
+  ]
+}

--- a/platform/node/test/fixtures/tilejson/raster.json
+++ b/platform/node/test/fixtures/tilejson/raster.json
@@ -1,0 +1,20 @@
+{
+  "version": 8,
+  "sources": {
+    "mapbox": {
+      "type": "raster",
+      "tileSize": 256,
+      "tiles": [
+        "https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.png"
+      ]
+    }
+  },
+  "layers": [
+    {
+      "id": "satellite",
+      "type": "raster",
+      "source": "mapbox",
+      "source-layer": "mapbox_satellite_full"
+    }
+  ]
+}

--- a/platform/node/test/fixtures/tilejson/vector.json
+++ b/platform/node/test/fixtures/tilejson/vector.json
@@ -1,12 +1,11 @@
 {
   "version": 8,
-  "name": "Empty",
   "sources": {
     "mapbox": {
       "type": "vector",
       "maxzoom": 15,
       "tiles": [
-        "./fixtures/tiles/{z}-{x}-{y}.vector.pbf"
+        "https://api.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf"
       ]
     }
   },

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -4,7 +4,7 @@ var test = require('tape');
 var mbgl = require('../../../../lib/mapbox-gl-native');
 var fs = require('fs');
 var path = require('path');
-var style = require('../fixtures/style.json');
+var style = require('../fixtures/tilejson/local.json');
 
 test('Map', function(t) {
     t.test('must be constructed with new', function(t) {

--- a/platform/node/test/js/memory.test.js
+++ b/platform/node/test/js/memory.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+var test = require('tape');
+var mbgl = require('../../../../lib/mapbox-gl-native');
+var fs = require('fs');
+var path = require('path');
+var style = require('../fixtures/style.json');
+
+test('Memory', function(t) {
+    var options = {
+        request: function(req, callback) {
+            fs.readFile(path.join(__dirname, '..', req.url), function(err, data) {
+                callback(err, { data: data });
+            });
+        }
+    };
+
+    t.test('setup', function(t) {
+        t.equal(JSON.stringify(style).length, 320);
+        t.end();
+    });
+
+    t.test('Map.release', function(t) {
+        var mem = process.memoryUsage().rss;
+
+        var map = new mbgl.Map(options);
+        var create = process.memoryUsage().rss - mem;
+        t.equal(create < 15e5, true, 'load rss + ' + create + ' bytes');
+
+        var prerelease = process.memoryUsage().rss;
+        map.release();
+        if (typeof gc === 'function') gc();
+        var postrelease = process.memoryUsage().rss;
+
+        // TODO: This should be a positive number, as memory usage should
+        // shrink after calling Map.release() and a garbage collection pass
+        // occurs, right?
+        var destroy = prerelease - postrelease;
+        t.equal(destroy > 0, true, 'release rss ' + destroy + ' bytes');
+
+        t.end();
+    });
+
+    t.test('bench Map.load', function(t) {
+        var map = new mbgl.Map(options);
+        
+        var time = +new Date;
+        var mem = process.memoryUsage().rss;
+
+        for (var i = 0; i < 256; i++) { map.load(style); }
+
+        time = (+new Date - time);
+        mem = process.memoryUsage().rss - mem;
+
+        // TODO: This time makes me think Map.load might be async.
+        t.equal(time < 5, true, 'load x256 took ' + time + 'ms');
+        t.equal(mem < 15e5, true, 'load rss + ' + mem + ' bytes');
+
+        map.release();
+
+        t.end();
+    });
+
+    t.skip('bench Map.render', function(t) {
+        var map = new mbgl.Map(options);
+        map.load(style);
+        
+        var time = +new Date;
+        var mem = process.memoryUsage().rss;
+
+        /*
+        for (var i = 0; i < 256; i++) map.load(style);
+        time = (+new Date - time);
+        mem = process.memoryUsage().rss - mem;
+        t.equal(time < 80e3, true, 'loadSync x256 took ' + time + 'ms');
+        t.equal(mem < 2e9, true, 'loadSync rss + ' + mem + ' bytes');
+        t.end();
+        */
+
+        map.render({}, function(err, pixels) {
+            t.error(err);
+            map.release();
+            t.ok(pixels);
+            t.ok(pixels instanceof Buffer);
+            t.equal(pixels.length, 512 * 512 * 4)
+            t.end();
+        });
+    });
+});
+
+
+/*
+(function() {
+var cache = new Cache('a', 256);
+
+[1,2,3,4].forEach(function(j) {
+    tape('bench loadSync (LRU) x' + j, function(assert) {
+        var mem = process.memoryUsage().rss;
+        for (var i = 0 * j; i < 1024 * j; i++) cache.loadSync(data, 'stat', i);
+        setTimeout(function() {
+            mem = process.memoryUsage().rss - mem;
+            if (j === 1) {
+                assert.equal(mem < 2e9, true, 'loadSync rss + ' + mem + ' bytes');
+            } else {
+                assert.equal(mem <= 5e6, true, 'loadSync rss + ' + mem + ' bytes');
+            }
+            assert.end();
+        }, 2000);
+    });
+});
+
+})();
+*/
+

--- a/platform/node/test/js/render.test.js
+++ b/platform/node/test/js/render.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var test = require('tape');
+var mbgl = require('../../../../lib/mapbox-gl-native');
+var request = require('request');
+var queue = require('d3-queue').queue;
+var generator = require('generate-geo-testing-data')(
+    { mode: 'latlon' },
+    function(width, height, lat, lon, zoom) {
+        return {
+            center: [lat, lon],
+            zoom: zoom
+        };
+    }
+);
+var prettyBytes = require('pretty-bytes');
+
+test('Render', function(t) {
+    t.test('MapboxAccessToken', function(t) {
+        t.notEqual(process.env.MapboxAccessToken, undefined, 'MapboxAccessToken environment variable is defined');
+        t.end();
+    });
+
+    function renderBench(t, style) {
+        var map = new mbgl.Map({
+            request: function(req, callback) {
+                request({
+                  url: req.url,
+                  qs: { 'access_token': process.env.MapboxAccessToken },
+                  gzip: true,
+                  encoding: null
+                }, function(err, res) {
+                    if (err) return callback(err);
+                    callback(null, { data: res.body });
+                });
+            }
+        });
+
+        map.load(style);
+        
+        var q = queue(1);
+        var iterations = 10e3;
+
+        var time = +new Date;
+        // var mem = process.memoryUsage().rss;
+
+        var deferredRender = function(callback) {
+            generator(function(options) {
+                map.render(options, function(err, pixels) {
+                    console.log(prettyBytes(process.memoryUsage().rss));
+                    callback(err);
+                });
+            });
+        };
+
+        for (var i = 0; i < iterations; i++) {
+            q.defer(deferredRender);
+        }
+
+        q.awaitAll(function(err) {
+            t.error(err);
+
+            time = (+new Date - time);
+            // mem = process.memoryUsage().rss - mem;
+            t.equal(time > 0, true, 'render x' + iterations + ' took ' + time + 'ms');
+            // t.equal(mem > 0, true, 'render rss ' + prettyBytes(mem));
+
+            t.end();
+        });
+    }
+
+    t.test('bench Map.render vector', function(t) {
+        renderBench(t, require('../fixtures/tilejson/vector.json'));
+    });
+
+    t.test('bench Map.render raster', function(t) {
+        renderBench(t, require('../fixtures/tilejson/raster.json'));
+    });
+});


### PR DESCRIPTION
`mbgl.Map.release` and `gc()` seem to be doing the opposite of what I would expect (acquiring more memory instead of freeing)? Unless my math is backwards.

I think `mbgl.Map.load` is async (not sure if the problem in https://github.com/cutting-room-floor/tilelive-gl/issues/11#issuecomment-91659773 still exists though?), which makes the timer a bit silly.

/cc @miccolis @brunoabinader 