### PR TITLE
Support "#pragma mapbox:" commands in the shaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "aws-sdk": "^2.3.5",
     "express": "^4.11.1",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#36278b864e60e1dba937a6863064c03d69526854",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#e032997109c0ead5394ff64f2f0ea6b0f8efdc3f",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#f45fd7aba98650c7f3bf778c9cbbfd3b548a4ee8",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",

--- a/scripts/build-shaders.py
+++ b/scripts/build-shaders.py
@@ -18,6 +18,35 @@ shader_name, shader_type, extension = os.path.basename(input_file).split('.')
 with open(input_file, "r") as f:
     data = f.read()
 
+# Replace uniform pragmas
+
+pragma_mapbox_regex = re.compile("(\s*)\#pragma \mapbox\: (initialize|define) (.*) (lowp|mediump|highp)")
+color_regex = re.compile("(.*)color")
+
+def replace_uniform_pragmas(line):
+    # FIXME We should obtain these from the source code.
+    if pragma_mapbox_regex.match(line):
+        params = line.split()
+        u_method = params[2]
+        u_name = "color" if color_regex.match(params[3]) else params[3]
+        u_precision = params[4]
+        u_type = "vec4" if color_regex.match(u_name) else "float"
+        if u_method == "define":
+            return """uniform {precision} {type_} u_{name};""".format(
+                    precision = u_precision,
+                    type_ = u_type,
+                    name = u_name)
+        else:
+            return """    {precision} {type_} {glsl_name} = u_{name};""".format(
+                    precision = u_precision,
+                    type_ = u_type,
+                    glsl_name = params[3],
+                    name = u_name)
+    else:
+        return line
+
+data = "\n".join([replace_uniform_pragmas(line) for line in data.split("\n")])
+
 content = """#pragma once
 
 // NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.


### PR DESCRIPTION
GL JS has introduced some simple `#pragma` statements in the shaders in order to reduce data-driven styling boilerplate. 

Supporting these `#pragma` statements in GL Native will reduce the need for `#ifdef` statements in the shaders and lay some foundation for data-driven styling in GL Native. 

 - `#pragma mapbox: define foo lowp` statements: define a uniform variable `u_foo` with the specified precision 
 - `#pragma mapbox: initialize foo lowp` statements: alias the uniform variable from `u_foo` to `foo`

ref https://github.com/mapbox/mapbox-gl-js/pull/2585

cc @jfirebaugh @1ec5 @mourner 