### PR TITLE
Updated readme with clear instructions that this requires Node v4.x 

### DIFF
--- a/platform/node/README.md
+++ b/platform/node/README.md
@@ -9,7 +9,7 @@ Requires a modern C++ runtime that supports C++14.
 By default, installs binaries. On these platforms no additional dependencies are needed.
 
 - 64 bit OS X or 64 bit Linux
-- Node.js v4+
+- Node.js v4.x _(note: v5+ is known to have issue)_
 
 Just run:
 


### PR DESCRIPTION
A simple update to the readme on instructions for Node version.

See https://github.com/mapbox/mapbox-gl-native/issues/5144