### PR TITLE
Ensure version tag always has 3 parts.

### DIFF
--- a/scripts/build-version.py
+++ b/scripts/build-version.py
@@ -43,6 +43,12 @@ else:
     tag = DEFAULT_TAG
     rev = DEFAULT_REV
 
+tag = tag + [0, 0, 0]
+tag = tag[0:3]
+
+print "Tag: {0}".format(tag)
+print "Rev: {0}".format(rev)
+
 header = """// NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.
 #pragma once
 


### PR DESCRIPTION
This patch ensures that tag always contains 3 elements, as long as tag is a list.

The `scripts/build-version.py` code sometimes doesn't work, esp. if the code is run within another git repo or alternative build system where tags are 2 elements:

```
if is_git_repo():
    raw_tag = subprocess.check_output("git describe --tags --always --abbrev=0", shell=True)
    raw_rev = subprocess.check_output("git rev-parse HEAD", shell=True)

    # When they're identical, the "git describe" can't find a tag and reports the rev instead.
    if raw_tag == raw_rev:
        tag = DEFAULT_TAG
        rev = parse_rev(raw_rev)
    else:
        tag = parse_tag(raw_tag)
        rev = parse_rev(raw_rev)
else:
    tag = DEFAULT_TAG
    rev = DEFAULT_REV

print "Tag: {0}".format(tag)
print "Rev: {0}".format(rev)
```

When building via buildroot, this prints:

```
max@dfaefaadca5c:~/buildroot$ make
>>> qmapboxgl 6abd3d7 Building
PATH="/home/user/buildroot/output/host/bin:/home/user/buildroot/output/host/sbin:/home/user/buildroot/output/host/usr/bin:/home/user/buildroot/output/host/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" /usr/bin/make -j5 BUILDTYPE=Release V=1 -C /home/user/buildroot/output/build/qmapboxgl-6abd3d7/build qt-app qt-qml-app
  LD_LIBRARY_PATH=/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/lib.host:/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../platform/qt; mkdir -p /home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/obj/gen/include/mbgl/util; ../../scripts/build-version.py "/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/obj/gen"
  LD_LIBRARY_PATH=/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/lib.host:/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../platform/qt; mkdir -p /home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/obj/gen/include/mbgl/shader; ../../scripts/build-shaders.py "/home/user/buildroot/output/build/qmapboxgl-6abd3d7/src/mbgl/shader/linesdf.vertex.glsl" "/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/obj/gen/include/mbgl/shader/linesdf.vertex.hpp"
  LD_LIBRARY_PATH=/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/lib.host:/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../platform/qt; mkdir -p /home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/obj/gen/include/mbgl/shader; ../../scripts/build-shaders.py "/home/user/buildroot/output/build/qmapboxgl-6abd3d7/src/mbgl/shader/outline.fragment.glsl" "/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/obj/gen/include/mbgl/shader/outline.fragment.hpp"
  LD_LIBRARY_PATH=/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/lib.host:/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/lib.target:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; cd ../platform/qt; mkdir -p /home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/obj/gen/include/mbgl/shader; ../../scripts/build-shaders.py "/home/user/buildroot/output/build/qmapboxgl-6abd3d7/src/mbgl/shader/linepattern.fragment.glsl" "/home/user/buildroot/output/build/qmapboxgl-6abd3d7/build/out/Release/obj/gen/include/mbgl/shader/linepattern.fragment.hpp"
Tag: [2016, 5]
Rev: 206ce569
Traceback (most recent call last):
  File "../../scripts/build-version.py", line 75, in <module>
    patch = tag[2],
IndexError: list index out of range
make[2]: *** [out/Release/obj/gen/include/mbgl/util/version.hpp] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [/home/user/buildroot/output/build/qmapboxgl-6abd3d7/.stamp_built] Error 2
make: *** [_all] Error 2
```