### PR TITLE
Make annotation views accessible to VoiceOver

### DIFF
--- a/platform/ios/src/MGLAnnotationContainerView.m
+++ b/platform/ios/src/MGLAnnotationContainerView.m
@@ -35,4 +35,18 @@
     }
 }
 
+#pragma mark UIAccessibility methods
+
+- (UIAccessibilityTraits)accessibilityTraits {
+    return UIAccessibilityTraitAdjustable;
+}
+
+- (void)accessibilityIncrement {
+    [self.superview.superview accessibilityIncrement];
+}
+
+- (void)accessibilityDecrement {
+    [self.superview.superview accessibilityDecrement];
+}
+
 @end

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -1,6 +1,8 @@
 #import "MGLAnnotationView.h"
 #import "MGLAnnotationView_Private.h"
-#import "MGLMapView.h"
+#import "MGLMapView_Internal.h"
+
+#import "NSBundle+MGLAdditions.h"
 
 #include <mbgl/util/constants.hpp>
 
@@ -101,6 +103,45 @@
         return [NSNull null];
     }
     return [super actionForLayer:layer forKey:event];
+}
+
+#pragma mark UIAccessibility methods
+
+- (BOOL)isAccessibilityElement {
+    return !self.hidden;
+}
+
+- (UIAccessibilityTraits)accessibilityTraits {
+    return UIAccessibilityTraitButton | UIAccessibilityTraitAdjustable;
+}
+
+- (NSString *)accessibilityLabel {
+    return [self.annotation respondsToSelector:@selector(title)] ? self.annotation.title : super.accessibilityLabel;
+}
+
+- (NSString *)accessibilityValue {
+    return [self.annotation respondsToSelector:@selector(subtitle)] ? self.annotation.subtitle : super.accessibilityValue;
+}
+
+- (NSString *)accessibilityHint {
+    return NSLocalizedStringWithDefaultValue(@"ANNOTATION_A11Y_HINT", nil, nil, @"Shows more info", @"Accessibility hint");
+}
+
+- (CGRect)accessibilityFrame {
+    CGRect accessibilityFrame = self.frame;
+    CGRect minimumFrame = CGRectInset({ self.center, CGSizeZero },
+                                      -MGLAnnotationAccessibilityElementMinimumSize.width / 2,
+                                      -MGLAnnotationAccessibilityElementMinimumSize.height / 2);
+    accessibilityFrame = CGRectUnion(accessibilityFrame, minimumFrame);
+    return accessibilityFrame;
+}
+
+- (void)accessibilityIncrement {
+    [self.superview accessibilityIncrement];
+}
+
+- (void)accessibilityDecrement {
+    [self.superview accessibilityDecrement];
 }
 
 @end

--- a/platform/ios/src/MGLMapView_Internal.h
+++ b/platform/ios/src/MGLMapView_Internal.h
@@ -1,5 +1,8 @@
 #import <Mapbox/Mapbox.h>
 
+/// Minimum size of an annotation’s accessibility element.
+extern const CGSize MGLAnnotationAccessibilityElementMinimumSize;
+
 @interface MGLMapView (Internal)
 
 /** Triggers another render pass even when it is not necessary. */


### PR DESCRIPTION
Corrected the accessibility frames of annotation views to match the views’ bounds instead of the bounds of the default annotation image (which could be empty if no default GL point annotation has been added).

~~Ideally, we’d figure out how to make the annotation view its own accessibility element, so that it or a subclass can specify a custom frame or Bézier path. But I’m punting on that for now to keep things simple.~~ Annotation views are now their own accessibility elements. A subclass can define a custom accessibility path.

Fixes #5038.

/cc @boundsj @friedbunny