### PR TITLE
[ios] Satisfy compiler warning when dequeueing subclasses of MGLAnnotationView or MGLAnnotationImage

### DIFF
--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -944,7 +944,7 @@ IB_DESIGNABLE
  @return An annotation image object with the given identifier, or `nil` if no
     such object exists in the reuse queue.
  */
-- (nullable MGLAnnotationImage *)dequeueReusableAnnotationImageWithIdentifier:(NSString *)identifier;
+- (nullable __kindof MGLAnnotationImage *)dequeueReusableAnnotationImageWithIdentifier:(NSString *)identifier;
 
 /**
  Returns a reusable annotation view object associated with its identifier.
@@ -960,7 +960,7 @@ IB_DESIGNABLE
  @return An annotation view object with the given identifier, or `nil` if no
     such object exists in the reuse queue.
  */
-- (nullable MGLAnnotationView *)dequeueReusableAnnotationViewWithIdentifier:(NSString *)identifier;
+- (nullable __kindof MGLAnnotationView *)dequeueReusableAnnotationViewWithIdentifier:(NSString *)identifier;
 
 #pragma mark Managing Annotation Selections
 


### PR DESCRIPTION
When using a subclass of `MGLAnnotationView` or `MGLAnnotationImage`, the following warning occurs when calling `dequeueReusableAnnotationImageWithIdentifier` or `dequeueReusableAnnotationViewWithIdentifier`:

`Incompatible pointer types initializing 'MyClassName *' with an expression of type 'MGLAnnotationView * _Nullable'`

This change eliminates the warning  and matches Apple's implementation of `UITableViewCell`.