### PR TITLE
[WIP] Configurable degrees of freedom for annotation views

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -30,6 +30,8 @@ class Image;
 class Style;
 } // namespace style
 
+using mat4 = std::array<double, 16>;
+
 class Map : private util::noncopyable {
 public:
     explicit Map(Backend&,
@@ -139,6 +141,7 @@ public:
     // Projection
     ScreenCoordinate pixelForLatLng(const LatLng&) const;
     LatLng latLngForPixel(const ScreenCoordinate&) const;
+    void getProjMatrix(mat4& matrix, uint16_t nearZ = 1) const;
 
     // Annotations
     void addAnnotationImage(std::unique_ptr<style::Image>);

--- a/platform/ios/Mapbox.playground/Contents.swift
+++ b/platform/ios/Mapbox.playground/Contents.swift
@@ -118,7 +118,7 @@ class MapDelegate: NSObject, MGLMapViewDelegate {
             let av = PlaygroundAnnotationView(reuseIdentifier: "annotation")
             av.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
             av.centerOffset = CGVector(dx: -15, dy: -15)
-            av.flat = true
+            av.freeAxes = .X;
             let centerView = UIView(frame: CGRectInset(av.bounds, 3, 3))
             centerView.backgroundColor = UIColor.whiteColor()
             av.addSubview(centerView)

--- a/platform/ios/Mapbox.playground/Contents.swift
+++ b/platform/ios/Mapbox.playground/Contents.swift
@@ -118,6 +118,7 @@ class MapDelegate: NSObject, MGLMapViewDelegate {
             let av = PlaygroundAnnotationView(reuseIdentifier: "annotation")
             av.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
             av.centerOffset = CGVector(dx: -15, dy: -15)
+            av.flat = true
             let centerView = UIView(frame: CGRectInset(av.bounds, 3, 3))
             centerView.backgroundColor = UIColor.whiteColor()
             av.addSubview(centerView)

--- a/platform/ios/app/MBXAnnotationView.m
+++ b/platform/ios/app/MBXAnnotationView.m
@@ -17,8 +17,8 @@
 {
     [super setSelected:selected animated:animated];
 
-    self.layer.borderColor = selected ? [UIColor blackColor].CGColor : [UIColor whiteColor].CGColor;
-    self.layer.borderWidth = selected ? 2.0 : 0;
+    self.layer.borderColor = selected ? [UIColor blackColor].CGColor : [UIColor blueColor].CGColor;
+    self.layer.borderWidth = selected ? 2.0 : 1.0;
 }
 
 - (void)setDragState:(MGLAnnotationViewDragState)dragState animated:(BOOL)animated

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1720,6 +1720,10 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         // method in this class to make draggable annotation views play nice.
         annotationView.draggable = YES;
 
+        // uncomment to flatten the annotation view against the map when the map is tilted
+        // this currently causes severe performance issues when more than 2k annotations are visible
+        // annotationView.flat = YES;
+        
         // Uncomment to force annotation view to maintain a constant size when
         // the map is tilted. By default, annotation views will shrink and grow
         // as they move towards and away from the horizon. Relatedly, annotations

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1713,6 +1713,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         annotationView = [[MBXAnnotationView alloc] initWithReuseIdentifier:MBXViewControllerAnnotationViewReuseIdentifer];
         annotationView.frame = CGRectMake(0, 0, 30, 30);
         annotationView.backgroundColor = [UIColor whiteColor];
+        annotationView.layer.borderColor = [UIColor blueColor].CGColor;
+        annotationView.layer.borderWidth = 2;
+        annotationView.layer.cornerRadius = 4;
 
         // Note that having two long press gesture recognizers on overlapping
         // views (`self.view` & `annotationView`) will cause weird behaviour.
@@ -1731,7 +1734,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         // annotationView.scalesWithViewingDistance = NO;
     } else {
         // orange indicates that the annotation view was reused
-        annotationView.backgroundColor = [UIColor orangeColor];
+        annotationView.layer.borderColor = [UIColor orangeColor].CGColor;
     }
     return annotationView;
 }

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1711,7 +1711,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     if (!annotationView)
     {
         annotationView = [[MBXAnnotationView alloc] initWithReuseIdentifier:MBXViewControllerAnnotationViewReuseIdentifer];
-        annotationView.frame = CGRectMake(0, 0, 10, 10);
+        annotationView.frame = CGRectMake(0, 0, 30, 30);
         annotationView.backgroundColor = [UIColor whiteColor];
 
         // Note that having two long press gesture recognizers on overlapping
@@ -1720,9 +1720,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         // method in this class to make draggable annotation views play nice.
         annotationView.draggable = YES;
 
-        // uncomment to flatten the annotation view against the map when the map is tilted
+        // uncomment to lay the annotation view flat against the map when the map is tilted
         // this currently causes severe performance issues when more than 2k annotations are visible
-        // annotationView.flat = YES;
+//        annotationView.freeAxes = MGLAnnotationViewBillboardAxisX;
         
         // Uncomment to force annotation view to maintain a constant size when
         // the map is tilted. By default, annotation views will shrink and grow

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -37,6 +37,57 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
 };
 
 /**
+ Options for locking the orientation of an `MGLAnnotationView` along one or more
+ axes for a billboard effect.
+ */
+typedef NS_OPTIONS(NSUInteger, MGLAnnotationViewBillboardAxis)
+{
+    /**
+     Orients the annotation view such that its x-axis is always fixed with
+     respect to the map.
+     
+     If this option is unset, the annotation view remains unchanged as the map’s
+     pitch increases, so that the view appears to stand upright on the tilted
+     map. If this option is set, the annotation view tilts as the map’s pitch
+     increases, so that the view appears to lie flat against the tilted map.
+     
+     For example, you would set this option if the annotation view depicts an
+     arrow that should always point due south. You would unset this option if
+     the arrow should always point down towards the ground.
+     */
+    MGLAnnotationViewBillboardAxisX = 0x1 << 0,
+    
+    /**
+     Orients the annotation view such that its y-axis is always fixed with
+     respect to the map.
+     
+     If this option is unset, the annotation view remains unchanged as the map
+     is rotated. If this option is set, the annotation view rotates as the map
+     rotates.
+     
+     For example, you would set this option if the annotation view should be
+     aligned with a street, regardless of the direction from which the user
+     views the street.
+     */
+    MGLAnnotationViewBillboardAxisY = 0x1 << 1,
+    
+    /**
+     Orients the annotation view such that its z-axis is always fixed with
+     respect to the map.
+     
+     Because `MGLMapView` does not support changes to its bank, or roll, this
+     option has no effect.
+     */
+    MGLAnnotationViewBillboardAxisZ = 0x1 << 2,
+    
+    /**
+     Orients the annotation view such that all three axes are always fixed with
+     respect to the map.
+     */
+    MGLAnnotationViewBillboardAxisAll = (MGLAnnotationViewBillboardAxisX | MGLAnnotationViewBillboardAxisY | MGLAnnotationViewBillboardAxisZ),
+};
+
+/**
  The `MGLAnnotationView` class is responsible for marking a point annotation
  with a view. Annotation views represent an annotation object, which is an
  object that corresponds to the `MGLAnnotation` protocol. When an annotation’s
@@ -126,8 +177,14 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
 
  You specify the reuse identifier when you create the view. You use the
  identifier later to retrieve an annotation view that was created previously but
+<<<<<<< HEAD
  which is currently unused because its annotation is not on-screen.
 
+=======
+ which is currently unused because its annotation does not lie within the map
+ view’s viewport.
+ 
+>>>>>>> 8d2bb2d42... [ios] Annotation view degrees of freedom
  If you define distinctly different types of annotations (with distinctly
  different annotation views to go with them), you can differentiate between the
  annotation types by specifying different reuse identifiers for each one.
@@ -155,19 +212,13 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
 @property (nonatomic) CGVector centerOffset;
 
 /**
- A Boolean value indicating whether the view lies flat against the map as it
- tilts.
+ An option that specifies the annotation view’s degrees of freedom.
  
- If this option is unset, the annotation view remains unchanged as the map’s
- pitch increases, so that the view appears to stand upright on the tilted map.
- If this option is set, the annotation view tilts as the map’s pitch increases,
- so that the view appears to lie flat against the tilted map.
- 
- For example, you would set this option if the annotation view depicts an arrow
- that should always point due south. You would unset this option if the arrow
- should always point down towards the ground.
+ By default, none of the axes are free; in other words, the annotation view is
+ oriented like a billboard with respect to the x-, y-, and z-axes. See
+ `MGLAnnotationViewBillboardAxis` for available options.
  */
-@property (nonatomic, assign, getter=isFlat) BOOL flat;
+@property (nonatomic, assign) MGLAnnotationViewBillboardAxis freeAxes;
 
 /**
  A Boolean value that determines whether the annotation view grows and shrinks
@@ -185,19 +236,6 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
  view’s legibility is important.
  */
 @property (nonatomic, assign) BOOL scalesWithViewingDistance;
-
-/**
- A Boolean value that determines whether the annotation view rotates together
- with the map.
-
- When the value of this property is `YES` and the map is rotated, the annotation
- view rotates. This is also the behavior of `MGLAnnotationImage` objects. When the
- value of this property is `NO` the annotation has its rotation angle fixed.
-
- The default value of this property is `NO`. Set this property to `YES` if the
- view’s rotation is important.
- */
-@property (nonatomic, assign) BOOL rotatesToMatchCamera;
 
 #pragma mark Managing the Selection State
 

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -155,6 +155,21 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
 @property (nonatomic) CGVector centerOffset;
 
 /**
+ A Boolean value indicating whether the view lies flat against the map as it
+ tilts.
+ 
+ If this option is unset, the annotation view remains unchanged as the map’s
+ pitch increases, so that the view appears to stand upright on the tilted map.
+ If this option is set, the annotation view tilts as the map’s pitch increases,
+ so that the view appears to lie flat against the tilted map.
+ 
+ For example, you would set this option if the annotation view depicts an arrow
+ that should always point due south. You would unset this option if the arrow
+ should always point down towards the ground.
+ */
+@property (nonatomic, assign, getter=isFlat) BOOL flat;
+
+/**
  A Boolean value that determines whether the annotation view grows and shrinks
  as the distance between the viewpoint and the annotation view changes on a
  tilted map.

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -243,7 +243,12 @@ CATransform3D MGLTransform3DFromMatrix4(GLKMatrix4 matrix) {
         freeTransform.m34 = -1.0 / (1.0 - furthestDistance * 0.5);
         
         freeTransform = CATransform3DRotate(freeTransform, MGLRadiansFromDegrees(camera.pitch), -1.0, 0, 0);
-//        self.layer.anchorPoint = [self convertPoint:self.superview.center toView:self];
+        CGPoint anchorPoint = [self convertPoint:self.superview.center toView:self];
+        anchorPoint.x -= self.center.x;
+        anchorPoint.x /= CGRectGetWidth(self.bounds);
+        anchorPoint.y -= self.center.y;
+        anchorPoint.y /= CGRectGetHeight(self.bounds);
+        self.layer.anchorPoint = anchorPoint;
     }
 //    if (camera.heading >= 0 && (self.freeAxes & MGLAnnotationViewBillboardAxisY))
 //    {

--- a/platform/ios/src/MGLAnnotationView_Private.h
+++ b/platform/ios/src/MGLAnnotationView_Private.h
@@ -1,9 +1,13 @@
 #import "MGLAnnotationView.h"
 #import "MGLAnnotation.h"
 
+#import <GLKit/GLKit.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class MGLMapView;
+
+CATransform3D MGLTransform3DFromMatrix4(GLKMatrix4 matrix);
 
 @interface MGLAnnotationView (Private)
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5048,12 +5048,16 @@ public:
     // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`.
     double farZ = furthestDistance * 1.01;
     
-    GLKMatrix4 projectionMatrix = GLKMatrix4MakePerspective(fov, CGRectGetWidth(self.bounds) / CGRectGetHeight(self.bounds), 1, farZ);
+//    GLKMatrix4 projectionMatrix = GLKMatrix4MakePerspective(fov, CGRectGetWidth(self.bounds) / CGRectGetHeight(self.bounds), 1, farZ);
+//    projectionMatrix = GLKMatrix4Translate(projectionMatrix, 0, 0, -cameraToCenterDistance);
+//    projectionMatrix = GLKMatrix4RotateX(projectionMatrix, camera.pitch);
 //    CATransform3D projectionTransform = MGLTransform3DFromMatrix4(projectionMatrix);
     
     CATransform3D projectionTransform = CATransform3DIdentity;
     projectionTransform.m34 = -1.0 / (1.0 - furthestDistance * 0.5);
+//    projectionTransform = CATransform3DTranslate(projectionTransform, 0, 0, -cameraToCenterDistance);
     projectionTransform = CATransform3DRotate(projectionTransform, MGLRadiansFromDegrees(camera.pitch), -1, 0, 0);
+//    projectionTransform = CATransform3DScale(projectionTransform, 1, 1, 1.0 / [self metersPerPointAtLatitude:camera.centerCoordinate.latitude]);
 //    self.annotationContainerView.layer.sublayerTransform = projectionTransform;
 
     // Update the center of visible annotation views

--- a/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/src/MGLMapView_Private.h
@@ -17,6 +17,8 @@ extern const CGSize MGLAnnotationAccessibilityElementMinimumSize;
 
 - (mbgl::Map *)mbglMap;
 
+- (CATransform3D)projectionTransform;
+
 /** Returns whether the map view is currently loading or processing any assets required to render the map */
 - (BOOL)isFullyLoaded;
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -699,6 +699,10 @@ LatLng Map::latLngForPixel(const ScreenCoordinate& pixel) const {
     return impl->transform.screenCoordinateToLatLng(pixel);
 }
 
+void Map::getProjMatrix(mat4& matrix, uint16_t nearZ) const {
+    impl->transform.getState().getProjMatrix(matrix, nearZ);
+}
+
 #pragma mark - Annotations
 
 void Map::addAnnotationImage(std::unique_ptr<style::Image> image) {


### PR DESCRIPTION
Replaced MGLAnnotationView’s `flat` property with a `freeAxes` property that allows 0–2 degrees of freedom (pitch and/or rotation) for various “billboard” effects. (Fixes #2528.) Currently, y-free annotation views are rendered incorrectly when rotated and tilted. Other than that issue and #5090, most of the transforms are working:

| Rotated | Tilted | Neither free | x free | y free | Both free |
| --- | --- | --- | --- | --- | --- |
| ✖️ | ✖️ | <img src="https://cloud.githubusercontent.com/assets/1231218/15814806/cdeaf9b2-2b7d-11e6-84d7-e0ef7bcbc68e.png" alt="none unrotated untilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15814884/51338bea-2b7e-11e6-926b-f6e3e1f9ca64.png" alt="x unrotated untilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15814997/eebe7f50-2b7e-11e6-91ab-b2a3130d4d05.png" alt="y unrotated untilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15815063/4ea715e4-2b7f-11e6-96ae-dff3f9465b11.png" alt="xy unrotated untilted" width="100"> |
| ✔️ | ✖️ | <img src="https://cloud.githubusercontent.com/assets/1231218/15814826/e21abf94-2b7d-11e6-8c47-b8614b7f00ab.png" alt="none rotated untilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15814896/62ff8252-2b7e-11e6-8e22-0a8ff5b0b15c.png" alt="x rotated untilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15815014/ffbe675c-2b7e-11e6-8cb7-6ee6eb2f3e37.png" alt="y rotated untilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15815077/5eb5276e-2b7f-11e6-9b99-65f150775ed8.png" alt="xy rotated untilted" width="100"> |
| ✖️ | ✔️ | <img src="https://cloud.githubusercontent.com/assets/1231218/15814844/059cc85e-2b7e-11e6-9863-2969ed8174b9.png" alt="none unrotated tilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15814923/82ad758c-2b7e-11e6-9233-a7a5a1d9224c.png" alt="x unrotated tilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15815040/17f5bbb8-2b7f-11e6-93c1-3c5e9a4de33b.png" alt="y unrotated tilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15815090/7103bcdc-2b7f-11e6-887b-6138c6d6ad05.png" alt="xy unrotated tilted" width="100"> |
| ✔️ | ✔️ | <img src="https://cloud.githubusercontent.com/assets/1231218/15814858/160f1f5c-2b7e-11e6-94dd-1901078a8422.png" alt="none rotated tilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15814937/94ae7dda-2b7e-11e6-8ee4-03721ede7d51.png" alt="x rotated tilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15815047/2b2472b0-2b7f-11e6-8bfb-0a9b17e04b79.png" alt="y rotated tilted" width="100"> | <img src="https://cloud.githubusercontent.com/assets/1231218/15815101/84a559b2-2b7f-11e6-833e-ed725fbac120.png" alt="xy rotated tilted" width="100"> |

This PR also applies perspective to x-free annotation views. (#5090) The effect is equivalent to #5218. The fix will require exposing the coordinate-to-point transformation matrix in `mbgl::TransformState` so that the SDK can convert it into a `CATransform3D`.

At times, I’m seeing an orange screen of death when there are a thousand annotations and the views start getting recycled:

![orange](https://cloud.githubusercontent.com/assets/1231218/15814732/5f8819f0-2b7d-11e6-9810-8611951e52ab.png)

To do:
- [ ] Plumb projection matrix through to MGLAnnotationView
- [ ] Fix orange screen bug seen in iosapp with 1,000 point annotations
- [ ] Fix y-free annotation views when tilted and rotated

This PR previously contained the following changes that have been split out:
- ~~`-[MGLMapView addAnnotations:]` ignores multipoints (other than polylines and polygons) like it ignores multipolylines, multipolygons, and shape collections.~~ Split out into #5262.
- ~~Fixed an issue that caused a default annotation icon to appear beneath an annotation view when relocating the annotation.~~ Split out into #5263.
- ~~Bring annotation view to the front when selected. (Fixes #991.)~~ Split out into #5264.
- ~~Reformatted and copyedited MGLAnnotationView documentation. Removed the unnecessary custom getter on scalesWithViewingDistance.~~ Split out into #5545.
- ~~Fixed a bug causing a flat annotation view’s pitch to be reset to 0° when setting the view’s center offset.~~ Split out into #5550.
- ~~Made annotation views’ positions animatable. In iosapp, tapping the callout view of a D.C. fire hydrant annotation causes the annotation view to slide to the center of the screen; the view still moves instantaneously with the map as you manipulate it with gestures. (#5230)~~ Split out into #5550.
- ~~In iosapp, eliminated the center view of MBXAnnotationView in favor of applying a background color and border to the annotation view’s layer.~~ Split out into #5550.

/cc @boundsj @friedbunny
