### PR TITLE
Move OpenGL code away from Buckets

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,3 +16,4 @@ BreakBeforeBraces: Attach
 ColumnLimit: 100
 Cpp11BracedListStyle: false
 SpacesBeforeTrailingComments: 1
+SortIncludes: false

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -46,7 +46,7 @@ public:
     }
 
     virtual void placeFeatures(CollisionTile&) {}
-    virtual void swapRenderData() {}
+    virtual void swapRenderable() {}
 
 protected:
     util::Atomic<bool> uploaded;

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -1,10 +1,12 @@
 #include <mbgl/renderer/circle_bucket.hpp>
+
 #include <mbgl/renderer/circle_renderable.hpp>
 #include <mbgl/renderer/painter.hpp>
 
-#include <mbgl/shader/circle_shader.hpp>
 #include <mbgl/style/layers/circle_layer.hpp>
 #include <mbgl/util/constants.hpp>
+
+#include <cassert>
 
 namespace mbgl {
 
@@ -16,6 +18,11 @@ CircleBucket::CircleBucket(MapMode mode_)
 
 CircleBucket::~CircleBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
+}
+
+CircleRenderable& CircleBucket::getRenderable() const {
+    assert(renderable);
+    return *renderable;
 }
 
 void CircleBucket::upload(gl::ObjectStore& store) {
@@ -87,31 +94,6 @@ void CircleBucket::addGeometry(const GeometryCollection& geometryCollection) {
             group.vertex_length += 4;
             group.elements_length += 2;
         }
-    }
-}
-
-void CircleBucket::drawCircles(CircleShader& shader, gl::ObjectStore& store) {
-    if (!renderable) {
-        return;
-    }
-    auto& vertexBuffer = renderable->vertexBuffer;
-    auto& elementsBuffer = renderable->elementsBuffer;
-    auto& triangleGroups = renderable->triangleGroups;
-
-    GLbyte* vertexIndex = BUFFER_OFFSET(0);
-    GLbyte* elementsIndex = BUFFER_OFFSET(0);
-
-    for (auto& group : triangleGroups) {
-        assert(group);
-
-        if (!group->elements_length) continue;
-
-        group->array[0].bind(shader, vertexBuffer, elementsBuffer, vertexIndex, store);
-
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elementsIndex));
-
-        vertexIndex += group->vertex_length * vertexBuffer.itemSize;
-        elementsIndex += group->elements_length * elementsBuffer.itemSize;
     }
 }
 

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -26,10 +26,7 @@ CircleRenderable& CircleBucket::getRenderable() const {
 }
 
 void CircleBucket::upload(gl::ObjectStore& store) {
-    if (renderable) {
-        renderable->vertexBuffer.upload(store);
-        renderable->elementsBuffer.upload(store);
-    }
+    renderable->upload(store);
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -1,19 +1,15 @@
 #pragma once
 
 #include <mbgl/renderer/bucket.hpp>
-#include <mbgl/map/mode.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
-#include <mbgl/geometry/elements_buffer.hpp>
-#include <mbgl/geometry/circle_buffer.hpp>
+#include <mbgl/map/mode.hpp>
 
 namespace mbgl {
 
-class CircleVertexBuffer;
+class CircleRenderable;
 class CircleShader;
 
 class CircleBucket : public Bucket {
-    using TriangleGroup = ElementGroup<3>;
-
 public:
     CircleBucket(const MapMode);
     ~CircleBucket() override;
@@ -28,12 +24,9 @@ public:
     void drawCircles(CircleShader&, gl::ObjectStore&);
 
 private:
-    CircleVertexBuffer vertexBuffer_;
-    TriangleElementsBuffer elementsBuffer_;
-
-    std::vector<std::unique_ptr<TriangleGroup>> triangleGroups_;
-
     const MapMode mode;
+
+    std::unique_ptr<CircleRenderable> renderable;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -7,12 +7,13 @@
 namespace mbgl {
 
 class CircleRenderable;
-class CircleShader;
 
 class CircleBucket : public Bucket {
 public:
     CircleBucket(const MapMode);
     ~CircleBucket() override;
+
+    CircleRenderable& getRenderable() const;
 
     void upload(gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
@@ -20,8 +21,6 @@ public:
     bool hasData() const override;
     bool needsClipping() const override;
     void addGeometry(const GeometryCollection&);
-
-    void drawCircles(CircleShader&, gl::ObjectStore&);
 
 private:
     const MapMode mode;

--- a/src/mbgl/renderer/circle_renderable.hpp
+++ b/src/mbgl/renderer/circle_renderable.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <mbgl/geometry/elements_buffer.hpp>
+#include <mbgl/geometry/circle_buffer.hpp>
+
+namespace mbgl {
+
+class CircleRenderable {
+public:
+    using TriangleGroup = ElementGroup<3>;
+
+    CircleVertexBuffer vertexBuffer;
+    TriangleElementsBuffer elementsBuffer;
+    std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/circle_renderable.hpp
+++ b/src/mbgl/renderer/circle_renderable.hpp
@@ -1,13 +1,22 @@
 #pragma once
 
+#include <mbgl/renderer/renderable.hpp>
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/geometry/circle_buffer.hpp>
 
 namespace mbgl {
 
-class CircleRenderable {
+class CircleRenderable : public Renderable {
 public:
     using TriangleGroup = ElementGroup<3>;
+
+    void upload(gl::ObjectStore& store) override {
+        if (!uploaded) {
+            vertexBuffer.upload(store);
+            elementsBuffer.upload(store);
+            uploaded = true;
+        }
+    }
 
     CircleVertexBuffer vertexBuffer;
     TriangleElementsBuffer elementsBuffer;

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -1,6 +1,6 @@
 #include <mbgl/renderer/debug_bucket.hpp>
+#include <mbgl/renderer/debug_renderable.hpp>
 #include <mbgl/renderer/painter.hpp>
-#include <mbgl/shader/plain_shader.hpp>
 #include <mbgl/util/string.hpp>
 
 #include <mbgl/gl/gl.hpp>
@@ -11,43 +11,38 @@
 using namespace mbgl;
 
 DebugBucket::DebugBucket(const OverscaledTileID& id,
-                         const bool renderable_,
-                         const bool complete_,
+                         const bool isRenderable_,
+                         const bool isComplete_,
                          optional<Timestamp> modified_,
                          optional<Timestamp> expires_,
                          MapDebugOptions debugMode_)
-    : renderable(renderable_),
-      complete(complete_),
+    : isRenderable(isRenderable_),
+      isComplete(isComplete_),
       modified(std::move(modified_)),
       expires(std::move(expires_)),
-      debugMode(debugMode_) {
+      debugMode(debugMode_),
+      renderable(std::make_unique<DebugRenderable>()) {
     double baseline = 200;
     if (debugMode & MapDebugOptions::ParseStatus) {
-        const std::string text = util::toString(id) + " - " +
-                                 (complete ? "complete" : renderable ? "renderable" : "pending");
-        fontBuffer.addText(text.c_str(), 50, baseline, 5);
+        const std::string text =
+            util::toString(id) + " - " +
+            (isComplete ? "complete" : isRenderable ? "renderable" : "pending");
+        renderable->fontBuffer.addText(text.c_str(), 50, baseline, 5);
         baseline += 200;
     }
 
     if (debugMode & MapDebugOptions::Timestamps && modified && expires) {
         const std::string modifiedText = "modified: " + util::iso8601(*modified);
-        fontBuffer.addText(modifiedText.c_str(), 50, baseline, 5);
+        renderable->fontBuffer.addText(modifiedText.c_str(), 50, baseline, 5);
 
         const std::string expiresText = "expires: " + util::iso8601(*expires);
-        fontBuffer.addText(expiresText.c_str(), 50, baseline + 200, 5);
+        renderable->fontBuffer.addText(expiresText.c_str(), 50, baseline + 200, 5);
     }
 }
 
-void DebugBucket::drawLines(PlainShader& shader, gl::ObjectStore& store) {
-    if (!fontBuffer.empty()) {
-        array.bind(shader, fontBuffer, BUFFER_OFFSET_0, store);
-        MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, (GLsizei)(fontBuffer.index())));
-    }
-}
+DebugBucket::~DebugBucket() = default;
 
-void DebugBucket::drawPoints(PlainShader& shader, gl::ObjectStore& store) {
-    if (!fontBuffer.empty()) {
-        array.bind(shader, fontBuffer, BUFFER_OFFSET_0, store);
-        MBGL_CHECK_ERROR(glDrawArrays(GL_POINTS, 0, (GLsizei)(fontBuffer.index())));
-    }
+DebugRenderable& DebugBucket::getRenderable() const {
+    assert(renderable);
+    return *renderable;
 }

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <mbgl/tile/tile_data.hpp>
 #include <mbgl/map/mode.hpp>
-#include <mbgl/geometry/debug_font_buffer.hpp>
-#include <mbgl/geometry/vao.hpp>
+#include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/optional.hpp>
 
 namespace mbgl {
 
-class PlainShader;
+class OverscaledTileID;
+class DebugRenderable;
 
 namespace gl {
 class ObjectStore;
@@ -17,24 +17,23 @@ class ObjectStore;
 class DebugBucket : private util::noncopyable {
 public:
     DebugBucket(const OverscaledTileID& id,
-                bool renderable,
-                bool complete,
+                bool isRenderable,
+                bool isComplete,
                 optional<Timestamp> modified,
                 optional<Timestamp> expires,
                 MapDebugOptions);
+    ~DebugBucket();
 
-    void drawLines(PlainShader&, gl::ObjectStore&);
-    void drawPoints(PlainShader&, gl::ObjectStore&);
+    DebugRenderable& getRenderable() const;
 
-    const bool renderable;
-    const bool complete;
+    const bool isRenderable;
+    const bool isComplete;
     const optional<Timestamp> modified;
     const optional<Timestamp> expires;
     const MapDebugOptions debugMode;
 
 private:
-    DebugFontBuffer fontBuffer;
-    VertexArrayObject array;
+    std::unique_ptr<DebugRenderable> renderable;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/debug_renderable.hpp
+++ b/src/mbgl/renderer/debug_renderable.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <mbgl/geometry/debug_font_buffer.hpp>
+#include <mbgl/geometry/vao.hpp>
+
+namespace mbgl {
+
+class DebugRenderable {
+public:
+    DebugFontBuffer fontBuffer;
+    VertexArrayObject array;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/debug_renderable.hpp
+++ b/src/mbgl/renderer/debug_renderable.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
+#include <mbgl/renderer/renderable.hpp>
 #include <mbgl/geometry/debug_font_buffer.hpp>
 #include <mbgl/geometry/vao.hpp>
 
 namespace mbgl {
 
-class DebugRenderable {
+class DebugRenderable : public Renderable {
 public:
+    void upload(gl::ObjectStore& store) override {
+        if (!uploaded) {
+            fontBuffer.upload(store);
+            uploaded = true;
+        }
+    }
+
     DebugFontBuffer fontBuffer;
     VertexArrayObject array;
 };

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -1,14 +1,9 @@
 #include <mbgl/renderer/fill_bucket.hpp>
-#include <mbgl/renderer/fill_renderable.hpp>
-#include <mbgl/style/layers/fill_layer.hpp>
-#include <mbgl/renderer/painter.hpp>
-#include <mbgl/shader/plain_shader.hpp>
-#include <mbgl/shader/pattern_shader.hpp>
-#include <mbgl/shader/outline_shader.hpp>
-#include <mbgl/shader/outlinepattern_shader.hpp>
-#include <mbgl/gl/gl.hpp>
-#include <mbgl/platform/log.hpp>
 
+#include <mbgl/renderer/fill_renderable.hpp>
+#include <mbgl/renderer/painter.hpp>
+
+#include <mbgl/style/layers/fill_layer.hpp>
 #include <mapbox/earcut.hpp>
 
 #include <cassert>
@@ -35,6 +30,11 @@ FillBucket::FillBucket() : renderable(std::make_unique<FillRenderable>()) {
 }
 
 FillBucket::~FillBucket() {
+}
+
+FillRenderable& FillBucket::getRenderable() const {
+    assert(renderable);
+    return *renderable;
 }
 
 void FillBucket::addGeometry(const GeometryCollection& geometry) {
@@ -127,82 +127,6 @@ bool FillBucket::hasData() const {
 
 bool FillBucket::needsClipping() const {
     return true;
-}
-
-void FillBucket::drawFill(PlainShader& shader, gl::ObjectStore& store) {
-    if (!renderable) {
-        return;
-    }
-    auto& vertexBuffer = renderable->vertexBuffer;
-    auto& triangleElementsBuffer = renderable->triangleElementsBuffer;
-    auto& triangleGroups = renderable->triangleGroups;
-
-    GLbyte* vertex_index = BUFFER_OFFSET(0);
-    GLbyte* elements_index = BUFFER_OFFSET(0);
-    for (auto& group : triangleGroups) {
-        assert(group);
-        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
-        vertex_index += group->vertex_length * vertexBuffer.itemSize;
-        elements_index += group->elements_length * triangleElementsBuffer.itemSize;
-    }
-}
-
-void FillBucket::drawFill(PatternShader& shader, gl::ObjectStore& store) {
-    if (!renderable) {
-        return;
-    }
-    auto& vertexBuffer = renderable->vertexBuffer;
-    auto& triangleElementsBuffer = renderable->triangleElementsBuffer;
-    auto& triangleGroups = renderable->triangleGroups;
-
-    GLbyte* vertex_index = BUFFER_OFFSET(0);
-    GLbyte* elements_index = BUFFER_OFFSET(0);
-    for (auto& group : triangleGroups) {
-        assert(group);
-        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
-        vertex_index += group->vertex_length * vertexBuffer.itemSize;
-        elements_index += group->elements_length * triangleElementsBuffer.itemSize;
-    }
-}
-
-void FillBucket::drawFillOutline(OutlineShader& shader, gl::ObjectStore& store) {
-    if (!renderable) {
-        return;
-    }
-    auto& vertexBuffer = renderable->vertexBuffer;
-    auto& lineElementsBuffer = renderable->lineElementsBuffer;
-    auto& lineGroups = renderable->lineGroups;
-
-    GLbyte* vertex_index = BUFFER_OFFSET(0);
-    GLbyte* elements_index = BUFFER_OFFSET(0);
-    for (auto& group : lineGroups) {
-        assert(group);
-        group->array[0].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT, elements_index));
-        vertex_index += group->vertex_length * vertexBuffer.itemSize;
-        elements_index += group->elements_length * lineElementsBuffer.itemSize;
-    }
-}
-
-void FillBucket::drawFillOutline(OutlinePatternShader& shader, gl::ObjectStore& store) {
-    if (!renderable) {
-        return;
-    }
-    auto& vertexBuffer = renderable->vertexBuffer;
-    auto& lineElementsBuffer = renderable->lineElementsBuffer;
-    auto& lineGroups = renderable->lineGroups;
-
-    GLbyte* vertex_index = BUFFER_OFFSET(0);
-    GLbyte* elements_index = BUFFER_OFFSET(0);
-    for (auto& group : lineGroups) {
-        assert(group);
-        group->array[1].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT, elements_index));
-        vertex_index += group->vertex_length * vertexBuffer.itemSize;
-        elements_index += group->elements_length * lineElementsBuffer.itemSize;
-    }
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -129,7 +129,7 @@ bool FillBucket::needsClipping() const {
     return true;
 }
 
-void FillBucket::drawElements(PlainShader& shader, gl::ObjectStore& store) {
+void FillBucket::drawFill(PlainShader& shader, gl::ObjectStore& store) {
     if (!renderable) {
         return;
     }
@@ -148,7 +148,7 @@ void FillBucket::drawElements(PlainShader& shader, gl::ObjectStore& store) {
     }
 }
 
-void FillBucket::drawElements(PatternShader& shader, gl::ObjectStore& store) {
+void FillBucket::drawFill(PatternShader& shader, gl::ObjectStore& store) {
     if (!renderable) {
         return;
     }
@@ -167,7 +167,7 @@ void FillBucket::drawElements(PatternShader& shader, gl::ObjectStore& store) {
     }
 }
 
-void FillBucket::drawVertices(OutlineShader& shader, gl::ObjectStore& store) {
+void FillBucket::drawFillOutline(OutlineShader& shader, gl::ObjectStore& store) {
     if (!renderable) {
         return;
     }
@@ -186,7 +186,7 @@ void FillBucket::drawVertices(OutlineShader& shader, gl::ObjectStore& store) {
     }
 }
 
-void FillBucket::drawVertices(OutlinePatternShader& shader, gl::ObjectStore& store) {
+void FillBucket::drawFillOutline(OutlinePatternShader& shader, gl::ObjectStore& store) {
     if (!renderable) {
         return;
     }

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -104,13 +104,7 @@ void FillBucket::addGeometry(const GeometryCollection& geometry) {
 }
 
 void FillBucket::upload(gl::ObjectStore& store) {
-    if (renderable) {
-        renderable->vertexBuffer.upload(store);
-        renderable->triangleElementsBuffer.upload(store);
-        renderable->lineElementsBuffer.upload(store);
-    }
-
-    // From now on, we're going to render during the opaque and translucent pass.
+    renderable->upload(store);
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -2,8 +2,6 @@
 
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
-#include <mbgl/geometry/elements_buffer.hpp>
-#include <mbgl/geometry/fill_buffer.hpp>
 
 #include <vector>
 #include <memory>
@@ -14,6 +12,7 @@ class OutlinePatternShader;
 class PlainShader;
 class PatternShader;
 class OutlineShader;
+class FillRenderable;
 
 class FillBucket : public Bucket {
 public:
@@ -33,15 +32,7 @@ public:
     void drawVertices(OutlinePatternShader&, gl::ObjectStore&);
 
 private:
-    FillVertexBuffer vertexBuffer;
-    TriangleElementsBuffer triangleElementsBuffer;
-    LineElementsBuffer lineElementsBuffer;
-
-    typedef ElementGroup<2> TriangleGroup;
-    typedef ElementGroup<2> LineGroup;
-
-    std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
-    std::vector<std::unique_ptr<LineGroup>> lineGroups;
+    std::unique_ptr<FillRenderable> renderable;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -3,15 +3,8 @@
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
 
-#include <vector>
-#include <memory>
-
 namespace mbgl {
 
-class OutlinePatternShader;
-class PlainShader;
-class PatternShader;
-class OutlineShader;
 class FillRenderable;
 
 class FillBucket : public Bucket {
@@ -19,17 +12,14 @@ public:
     FillBucket();
     ~FillBucket() override;
 
+    FillRenderable& getRenderable() const;
+
     void upload(gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool needsClipping() const override;
 
     void addGeometry(const GeometryCollection&);
-
-    void drawFill(PlainShader&, gl::ObjectStore&);
-    void drawFill(PatternShader&, gl::ObjectStore&);
-    void drawFillOutline(OutlineShader&, gl::ObjectStore&);
-    void drawFillOutline(OutlinePatternShader&, gl::ObjectStore&);
 
 private:
     std::unique_ptr<FillRenderable> renderable;

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -26,10 +26,10 @@ public:
 
     void addGeometry(const GeometryCollection&);
 
-    void drawElements(PlainShader&, gl::ObjectStore&);
-    void drawElements(PatternShader&, gl::ObjectStore&);
-    void drawVertices(OutlineShader&, gl::ObjectStore&);
-    void drawVertices(OutlinePatternShader&, gl::ObjectStore&);
+    void drawFill(PlainShader&, gl::ObjectStore&);
+    void drawFill(PatternShader&, gl::ObjectStore&);
+    void drawFillOutline(OutlineShader&, gl::ObjectStore&);
+    void drawFillOutline(OutlinePatternShader&, gl::ObjectStore&);
 
 private:
     std::unique_ptr<FillRenderable> renderable;

--- a/src/mbgl/renderer/fill_renderable.hpp
+++ b/src/mbgl/renderer/fill_renderable.hpp
@@ -1,14 +1,24 @@
 #pragma once
 
+#include <mbgl/renderer/renderable.hpp>
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/geometry/fill_buffer.hpp>
 
 namespace mbgl {
 
-class FillRenderable {
+class FillRenderable : public Renderable {
 public:
     using TriangleGroup = ElementGroup<2>;
     using LineGroup = ElementGroup<2>;
+
+    void upload(gl::ObjectStore& store) override {
+        if (!uploaded) {
+            vertexBuffer.upload(store);
+            triangleElementsBuffer.upload(store);
+            lineElementsBuffer.upload(store);
+            uploaded = true;
+        }
+    }
 
     FillVertexBuffer vertexBuffer;
     TriangleElementsBuffer triangleElementsBuffer;

--- a/src/mbgl/renderer/fill_renderable.hpp
+++ b/src/mbgl/renderer/fill_renderable.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <mbgl/geometry/elements_buffer.hpp>
+#include <mbgl/geometry/fill_buffer.hpp>
+
+namespace mbgl {
+
+class FillRenderable {
+public:
+    using TriangleGroup = ElementGroup<2>;
+    using LineGroup = ElementGroup<2>;
+
+    FillVertexBuffer vertexBuffer;
+    TriangleElementsBuffer triangleElementsBuffer;
+    LineElementsBuffer lineElementsBuffer;
+    std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
+    std::vector<std::unique_ptr<LineGroup>> lineGroups;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -451,12 +451,7 @@ void LineBucket::addPieSliceVertex(const GeometryCoordinate& currentVertex,
 }
 
 void LineBucket::upload(gl::ObjectStore& store) {
-    if (renderable) {
-        renderable->vertexBuffer.upload(store);
-        renderable->triangleElementsBuffer.upload(store);
-    }
-
-    // From now on, we're only going to render during the translucent pass.
+    renderable->upload(store);
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -24,6 +24,11 @@ LineBucket::~LineBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
+LineRenderable& LineBucket::getRenderable() const {
+    assert(renderable);
+    return *renderable;
+}
+
 void LineBucket::addGeometry(const GeometryCollection& geometryCollection) {
     for (auto& line : geometryCollection) {
         addGeometry(line);
@@ -468,75 +473,6 @@ bool LineBucket::hasData() const {
 
 bool LineBucket::needsClipping() const {
     return true;
-}
-
-void LineBucket::drawLines(LineShader& shader, gl::ObjectStore& store) {
-    if (!renderable) {
-        return;
-    }
-    auto& vertexBuffer = renderable->vertexBuffer;
-    auto& triangleElementsBuffer = renderable->triangleElementsBuffer;
-    auto& triangleGroups = renderable->triangleGroups;
-
-    GLbyte* vertex_index = BUFFER_OFFSET(0);
-    GLbyte* elements_index = BUFFER_OFFSET(0);
-    for (auto& group : triangleGroups) {
-        assert(group);
-        if (!group->elements_length) {
-            continue;
-        }
-        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
-                                        elements_index));
-        vertex_index += group->vertex_length * vertexBuffer.itemSize;
-        elements_index += group->elements_length * triangleElementsBuffer.itemSize;
-    }
-}
-
-void LineBucket::drawLineSDF(LineSDFShader& shader, gl::ObjectStore& store) {
-    if (!renderable) {
-        return;
-    }
-    auto& vertexBuffer = renderable->vertexBuffer;
-    auto& triangleElementsBuffer = renderable->triangleElementsBuffer;
-    auto& triangleGroups = renderable->triangleGroups;
-
-    GLbyte* vertex_index = BUFFER_OFFSET(0);
-    GLbyte* elements_index = BUFFER_OFFSET(0);
-    for (auto& group : triangleGroups) {
-        assert(group);
-        if (!group->elements_length) {
-            continue;
-        }
-        group->array[2].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
-                                        elements_index));
-        vertex_index += group->vertex_length * vertexBuffer.itemSize;
-        elements_index += group->elements_length * triangleElementsBuffer.itemSize;
-    }
-}
-
-void LineBucket::drawLinePatterns(LinepatternShader& shader, gl::ObjectStore& store) {
-    if (!renderable) {
-        return;
-    }
-    auto& vertexBuffer = renderable->vertexBuffer;
-    auto& triangleElementsBuffer = renderable->triangleElementsBuffer;
-    auto& triangleGroups = renderable->triangleGroups;
-
-    GLbyte* vertex_index = BUFFER_OFFSET(0);
-    GLbyte* elements_index = BUFFER_OFFSET(0);
-    for (auto& group : triangleGroups) {
-        assert(group);
-        if (!group->elements_length) {
-            continue;
-        }
-        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
-                                        elements_index));
-        vertex_index += group->vertex_length * vertexBuffer.itemSize;
-        elements_index += group->elements_length * triangleElementsBuffer.itemSize;
-    }
 }
 
 }

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -8,15 +8,14 @@
 
 namespace mbgl {
 
-class LineShader;
-class LineSDFShader;
-class LinepatternShader;
 class LineRenderable;
 
 class LineBucket : public Bucket {
 public:
     LineBucket(uint32_t overscaling);
     ~LineBucket() override;
+
+    LineRenderable& getRenderable() const;
 
     void upload(gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
@@ -25,10 +24,6 @@ public:
 
     void addGeometry(const GeometryCollection&);
     void addGeometry(const GeometryCoordinates& line);
-
-    void drawLines(LineShader&, gl::ObjectStore&);
-    void drawLineSDF(LineSDFShader&, gl::ObjectStore&);
-    void drawLinePatterns(LinepatternShader&, gl::ObjectStore&);
 
 private:
     struct TriangleElement {

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -2,24 +2,18 @@
 
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
-#include <mbgl/geometry/vao.hpp>
-#include <mbgl/geometry/elements_buffer.hpp>
-#include <mbgl/geometry/line_buffer.hpp>
 #include <mbgl/style/layers/line_layer_properties.hpp>
 
 #include <vector>
 
 namespace mbgl {
 
-class LineVertexBuffer;
-class TriangleElementsBuffer;
 class LineShader;
 class LineSDFShader;
 class LinepatternShader;
+class LineRenderable;
 
 class LineBucket : public Bucket {
-    using TriangleGroup = ElementGroup<3>;
-
 public:
     LineBucket(uint32_t overscaling);
     ~LineBucket() override;
@@ -52,16 +46,13 @@ public:
     style::LineLayoutProperties layout;
 
 private:
-    LineVertexBuffer vertexBuffer;
-    TriangleElementsBuffer triangleElementsBuffer;
-
     GLint e1;
     GLint e2;
     GLint e3;
 
-    std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
-
     const uint32_t overscaling;
+
+    std::unique_ptr<LineRenderable> renderable;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/line_renderable.hpp
+++ b/src/mbgl/renderer/line_renderable.hpp
@@ -1,13 +1,22 @@
 #pragma once
 
+#include <mbgl/renderer/renderable.hpp>
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/geometry/line_buffer.hpp>
 
 namespace mbgl {
 
-class LineRenderable {
+class LineRenderable : public Renderable {
 public:
     using TriangleGroup = ElementGroup<3>;
+
+    void upload(gl::ObjectStore& store) override {
+        if (!uploaded) {
+            vertexBuffer.upload(store);
+            triangleElementsBuffer.upload(store);
+            uploaded = true;
+        }
+    }
 
     LineVertexBuffer vertexBuffer;
     TriangleElementsBuffer triangleElementsBuffer;

--- a/src/mbgl/renderer/line_renderable.hpp
+++ b/src/mbgl/renderer/line_renderable.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <mbgl/geometry/elements_buffer.hpp>
+#include <mbgl/geometry/line_buffer.hpp>
+
+namespace mbgl {
+
+class LineRenderable {
+public:
+    using TriangleGroup = ElementGroup<3>;
+
+    LineVertexBuffer vertexBuffer;
+    TriangleElementsBuffer triangleElementsBuffer;
+    std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -91,10 +91,10 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     spriteAtlas = style.spriteAtlas.get();
     lineAtlas = style.lineAtlas.get();
 
-    RenderData renderData = style.getRenderData();
-    const std::vector<RenderItem>& order = renderData.order;
-    const std::set<Source*>& sources = renderData.sources;
-    const Color& background = renderData.backgroundColor;
+    RenderData renderable = style.getRenderData();
+    const std::vector<RenderItem>& order = renderable.order;
+    const std::set<Source*>& sources = renderable.sources;
+    const Color& background = renderable.backgroundColor;
 
     // Update the default matrices to the current viewport dimensions.
     state.getProjMatrix(projMatrix);

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -39,6 +39,7 @@ class FillBucket;
 class LineBucket;
 class CircleBucket;
 class SymbolBucket;
+class SymbolRenderable;
 class RasterBucket;
 
 class SDFShader;
@@ -131,13 +132,13 @@ private:
 
     void setClipping(const ClipID&);
 
-    void renderSDF(SymbolBucket &bucket,
+    void renderSDF(SymbolRenderable &renderable,
                    const UnwrappedTileID &tileID,
                    const mat4 &matrixSymbol,
                    float scaleDivisor,
                    std::array<float, 2> texsize,
                    SDFShader& sdfShader,
-                   void (SymbolBucket::*drawSDF)(SDFShader&, gl::ObjectStore&),
+                   void (*drawSDF)(SymbolRenderable&, SDFShader&, gl::ObjectStore&),
 
                    // Layout
                    style::RotationAlignmentType rotationAlignment,

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -41,7 +41,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         patternShader->u_opacity = properties.backgroundOpacity;
 
         spriteAtlas->bind(true, store);
-        backgroundPatternArray.bind(*patternShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
+        backgroundPatternArray.bind(*patternShader, tileStencilBuffer, BUFFER_OFFSET_0, store);
 
     } else {
         if (wireframe) {
@@ -53,7 +53,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         }
 
         config.program = plainShader->getID();
-        backgroundArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
+        backgroundArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET_0, store);
     }
 
     config.stencilTest = GL_FALSE;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/debug_bucket.hpp>
+#include <mbgl/renderer/debug_renderable.hpp>
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/tile/tile_data.hpp>
 #include <mbgl/shader/plain_shader.hpp>
@@ -10,6 +11,20 @@
 #include <mbgl/gl/gl_helper.hpp>
 
 using namespace mbgl;
+
+namespace {
+
+void drawLines(DebugRenderable& renderable, PlainShader& shader, gl::ObjectStore& store) {
+    renderable.array.bind(shader, renderable.fontBuffer, BUFFER_OFFSET_0, store);
+    MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, (GLsizei)(renderable.fontBuffer.index())));
+}
+
+void drawPoints(DebugRenderable& renderable, PlainShader& shader, gl::ObjectStore& store) {
+    renderable.array.bind(shader, renderable.fontBuffer, BUFFER_OFFSET_0, store);
+    MBGL_CHECK_ERROR(glDrawArrays(GL_POINTS, 0, (GLsizei)(renderable.fontBuffer.index())));
+}
+
+} // namespace
 
 void Painter::renderTileDebug(const Tile& tile) {
     MBGL_DEBUG_GROUP(std::string { "debug " } + util::toString(tile.id));
@@ -27,10 +42,8 @@ void Painter::renderTileDebug(const Tile& tile) {
 void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
     MBGL_DEBUG_GROUP("debug text");
 
-    config.depthTest = GL_FALSE;
-
-    if (!tileData.debugBucket || tileData.debugBucket->renderable != tileData.isRenderable() ||
-        tileData.debugBucket->complete != tileData.isComplete() ||
+    if (!tileData.debugBucket || tileData.debugBucket->isRenderable != tileData.isRenderable() ||
+        tileData.debugBucket->isComplete != tileData.isComplete() ||
         !(tileData.debugBucket->modified == tileData.modified) ||
         !(tileData.debugBucket->expires == tileData.expires) ||
         tileData.debugBucket->debugMode != frame.debugOptions) {
@@ -39,24 +52,30 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
             tileData.expires, frame.debugOptions);
     }
 
+    if (tileData.debugBucket->getRenderable().fontBuffer.empty()) {
+        return;
+    }
+
+    config.depthTest = GL_FALSE;
+
     config.program = plainShader->getID();
     plainShader->u_matrix = matrix;
 
     // Draw white outline
     plainShader->u_color = {{ 1.0f, 1.0f, 1.0f, 1.0f }};
     config.lineWidth = 4.0f * frame.pixelRatio;
-    tileData.debugBucket->drawLines(*plainShader, store);
+    drawLines(tileData.debugBucket->getRenderable(), *plainShader, store);
 
 #ifndef GL_ES_VERSION_2_0
     // Draw line "end caps"
     MBGL_CHECK_ERROR(glPointSize(2));
-    tileData.debugBucket->drawPoints(*plainShader, store);
+    drawPoints(tileData.debugBucket->getRenderable(), *plainShader, store);
 #endif
 
     // Draw black text.
     plainShader->u_color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
     config.lineWidth = 2.0f * frame.pixelRatio;
-    tileData.debugBucket->drawLines(*plainShader, store);
+    drawLines(tileData.debugBucket->getRenderable(), *plainShader, store);
 
     config.depthFunc.reset();
     config.depthTest = GL_TRUE;

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -64,7 +64,7 @@ void Painter::renderFill(FillBucket& bucket,
             static_cast<float>(frame.framebufferSize[1])
         }};
         setDepthSublayer(0);
-        bucket.drawVertices(*outlineShader, store);
+        bucket.drawFillOutline(*outlineShader, store);
     }
 
     if (pattern) {
@@ -119,7 +119,7 @@ void Painter::renderFill(FillBucket& bucket,
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(0);
-            bucket.drawElements(*patternShader, store);
+            bucket.drawFill(*patternShader, store);
 
             if (properties.fillAntialias && stroke_color == fill_color) {
                 config.program = outlinePatternShader->getID();
@@ -156,7 +156,7 @@ void Painter::renderFill(FillBucket& bucket,
                 spriteAtlas->bind(true, store);
 
                 setDepthSublayer(2);
-                bucket.drawVertices(*outlinePatternShader, store);
+                bucket.drawFillOutline(*outlinePatternShader, store);
             }
         }
     } else if (!wireframe) {
@@ -173,7 +173,7 @@ void Painter::renderFill(FillBucket& bucket,
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(1);
-            bucket.drawElements(*plainShader, store);
+            bucket.drawFill(*plainShader, store);
         }
     }
 
@@ -194,7 +194,7 @@ void Painter::renderFill(FillBucket& bucket,
         }};
 
         setDepthSublayer(2);
-        bucket.drawVertices(*outlineShader, store);
+        bucket.drawFillOutline(*outlineShader, store);
     }
 }
 

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/fill_bucket.hpp>
+#include <mbgl/renderer/fill_renderable.hpp>
 #include <mbgl/style/layers/fill_layer.hpp>
 #include <mbgl/style/layers/fill_layer_impl.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
@@ -11,6 +12,68 @@
 namespace mbgl {
 
 using namespace style;
+
+namespace {
+
+void drawFill(FillRenderable& renderable, PlainShader& shader, gl::ObjectStore& store) {
+    GLbyte* vertex_index = BUFFER_OFFSET_0;
+    GLbyte* elements_index = BUFFER_OFFSET_0;
+    for (auto& group : renderable.triangleGroups) {
+        assert(group);
+        group->array[0].bind(shader, renderable.vertexBuffer, renderable.triangleElementsBuffer,
+                             vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
+                                        elements_index));
+        vertex_index += group->vertex_length * renderable.vertexBuffer.itemSize;
+        elements_index += group->elements_length * renderable.triangleElementsBuffer.itemSize;
+    }
+}
+
+void drawFill(FillRenderable& renderable, PatternShader& shader, gl::ObjectStore& store) {
+    GLbyte* vertex_index = BUFFER_OFFSET_0;
+    GLbyte* elements_index = BUFFER_OFFSET_0;
+    for (auto& group : renderable.triangleGroups) {
+        assert(group);
+        group->array[1].bind(shader, renderable.vertexBuffer, renderable.triangleElementsBuffer,
+                             vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
+                                        elements_index));
+        vertex_index += group->vertex_length * renderable.vertexBuffer.itemSize;
+        elements_index += group->elements_length * renderable.triangleElementsBuffer.itemSize;
+    }
+}
+
+void drawFillOutline(FillRenderable& renderable, OutlineShader& shader, gl::ObjectStore& store) {
+    GLbyte* vertex_index = BUFFER_OFFSET_0;
+    GLbyte* elements_index = BUFFER_OFFSET_0;
+    for (auto& group : renderable.lineGroups) {
+        assert(group);
+        group->array[0].bind(shader, renderable.vertexBuffer, renderable.lineElementsBuffer,
+                             vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT,
+                                        elements_index));
+        vertex_index += group->vertex_length * renderable.vertexBuffer.itemSize;
+        elements_index += group->elements_length * renderable.lineElementsBuffer.itemSize;
+    }
+}
+
+void drawFillOutline(FillRenderable& renderable,
+                     OutlinePatternShader& shader,
+                     gl::ObjectStore& store) {
+    GLbyte* vertex_index = BUFFER_OFFSET_0;
+    GLbyte* elements_index = BUFFER_OFFSET_0;
+    for (auto& group : renderable.lineGroups) {
+        assert(group);
+        group->array[1].bind(shader, renderable.vertexBuffer, renderable.lineElementsBuffer,
+                             vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT,
+                                        elements_index));
+        vertex_index += group->vertex_length * renderable.vertexBuffer.itemSize;
+        elements_index += group->elements_length * renderable.lineElementsBuffer.itemSize;
+    }
+}
+
+} // namespace
 
 void Painter::renderFill(FillBucket& bucket,
                          const FillLayer& layer,
@@ -64,7 +127,7 @@ void Painter::renderFill(FillBucket& bucket,
             static_cast<float>(frame.framebufferSize[1])
         }};
         setDepthSublayer(0);
-        bucket.drawFillOutline(*outlineShader, store);
+        drawFillOutline(bucket.getRenderable(), *outlineShader, store);
     }
 
     if (pattern) {
@@ -119,7 +182,7 @@ void Painter::renderFill(FillBucket& bucket,
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(0);
-            bucket.drawFill(*patternShader, store);
+            drawFill(bucket.getRenderable(), *patternShader, store);
 
             if (properties.fillAntialias && stroke_color == fill_color) {
                 config.program = outlinePatternShader->getID();
@@ -156,7 +219,7 @@ void Painter::renderFill(FillBucket& bucket,
                 spriteAtlas->bind(true, store);
 
                 setDepthSublayer(2);
-                bucket.drawFillOutline(*outlinePatternShader, store);
+                drawFillOutline(bucket.getRenderable(), *outlinePatternShader, store);
             }
         }
     } else if (!wireframe) {
@@ -173,7 +236,7 @@ void Painter::renderFill(FillBucket& bucket,
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(1);
-            bucket.drawFill(*plainShader, store);
+            drawFill(bucket.getRenderable(), *plainShader, store);
         }
     }
 
@@ -194,7 +257,7 @@ void Painter::renderFill(FillBucket& bucket,
         }};
 
         setDepthSublayer(2);
-        bucket.drawFillOutline(*outlineShader, store);
+        drawFillOutline(bucket.getRenderable(), *outlineShader, store);
     }
 }
 

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/renderer/raster_bucket.hpp>
+#include <mbgl/renderer/raster_renderable.hpp>
 #include <mbgl/style/layers/raster_layer.hpp>
 #include <mbgl/style/layers/raster_layer_impl.hpp>
 #include <mbgl/shader/raster_shader.hpp>
@@ -8,6 +9,20 @@
 namespace mbgl {
 
 using namespace style;
+
+namespace {
+
+void drawRaster(RasterRenderable& renderable,
+                RasterShader& shader,
+                StaticVertexBuffer& vertices,
+                VertexArrayObject& array,
+                gl::ObjectStore& store) {
+    renderable.raster.bind(true, store);
+    array.bind(shader, vertices, BUFFER_OFFSET_0, store);
+    MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
+}
+
+} // namespace
 
 void Painter::renderRaster(RasterBucket& bucket,
                            const RasterLayer& layer,
@@ -37,7 +52,8 @@ void Painter::renderRaster(RasterBucket& bucket,
         config.depthTest = GL_TRUE;
         config.depthMask = GL_FALSE;
         setDepthSublayer(0);
-        bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray, store);
+        drawRaster(bucket.getRenderable(), *rasterShader, tileStencilBuffer, coveringRasterArray,
+                   store);
     }
 }
 

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -1,7 +1,6 @@
 #include <mbgl/renderer/raster_bucket.hpp>
 #include <mbgl/renderer/raster_renderable.hpp>
 #include <mbgl/style/layers/raster_layer.hpp>
-#include <mbgl/shader/raster_shader.hpp>
 #include <mbgl/renderer/painter.hpp>
 
 namespace mbgl {
@@ -13,6 +12,11 @@ RasterBucket::RasterBucket(gl::TexturePool& texturePool)
 }
 
 RasterBucket::~RasterBucket() = default;
+
+RasterRenderable& RasterBucket::getRenderable() const {
+    assert(renderable);
+    return *renderable;
+}
 
 void RasterBucket::upload(gl::ObjectStore& store) {
     if (hasData()) {
@@ -31,12 +35,6 @@ void RasterBucket::render(Painter& painter,
 
 void RasterBucket::setImage(PremultipliedImage image) {
     renderable->raster.load(std::move(image));
-}
-
-void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array, gl::ObjectStore& store) {
-    renderable->raster.bind(true, store);
-    array.bind(shader, vertices, BUFFER_OFFSET_0, store);
-    MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
 }
 
 bool RasterBucket::hasData() const {

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/renderer/raster_bucket.hpp>
+#include <mbgl/renderer/raster_renderable.hpp>
 #include <mbgl/style/layers/raster_layer.hpp>
 #include <mbgl/shader/raster_shader.hpp>
 #include <mbgl/renderer/painter.hpp>
@@ -8,14 +9,17 @@ namespace mbgl {
 using namespace style;
 
 RasterBucket::RasterBucket(gl::TexturePool& texturePool)
-: raster(texturePool) {
+    : renderable(std::make_unique<RasterRenderable>(texturePool)) {
 }
+
+RasterBucket::~RasterBucket() = default;
 
 void RasterBucket::upload(gl::ObjectStore& store) {
     if (hasData()) {
-        raster.upload(store);
-        uploaded = true;
+        renderable->raster.upload(store);
     }
+
+    uploaded = true;
 }
 
 void RasterBucket::render(Painter& painter,
@@ -26,21 +30,21 @@ void RasterBucket::render(Painter& painter,
 }
 
 void RasterBucket::setImage(PremultipliedImage image) {
-    raster.load(std::move(image));
+    renderable->raster.load(std::move(image));
 }
 
 void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array, gl::ObjectStore& store) {
-    raster.bind(true, store);
+    renderable->raster.bind(true, store);
     array.bind(shader, vertices, BUFFER_OFFSET_0, store);
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
 }
 
 bool RasterBucket::hasData() const {
-    return raster.isLoaded();
+    return renderable && renderable->raster.isLoaded();
 }
 
 bool RasterBucket::needsClipping() const {
     return false;
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -19,10 +19,7 @@ RasterRenderable& RasterBucket::getRenderable() const {
 }
 
 void RasterBucket::upload(gl::ObjectStore& store) {
-    if (hasData()) {
-        renderable->raster.upload(store);
-    }
-
+    renderable->upload(store);
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -1,17 +1,21 @@
 #pragma once
 
 #include <mbgl/renderer/bucket.hpp>
-#include <mbgl/util/raster.hpp>
+#include <mbgl/util/image.hpp>
 
 namespace mbgl {
 
 class RasterShader;
 class StaticVertexBuffer;
 class VertexArrayObject;
+class RasterRenderable;
+
+namespace gl { class TexturePool; }
 
 class RasterBucket : public Bucket {
 public:
     RasterBucket(gl::TexturePool&);
+    ~RasterBucket() override;
 
     void upload(gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
@@ -22,7 +26,8 @@ public:
 
     void drawRaster(RasterShader&, StaticVertexBuffer&, VertexArrayObject&, gl::ObjectStore&);
 
-    Raster raster;
+private:
+    std::unique_ptr<RasterRenderable> renderable;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -5,9 +5,6 @@
 
 namespace mbgl {
 
-class RasterShader;
-class StaticVertexBuffer;
-class VertexArrayObject;
 class RasterRenderable;
 
 namespace gl { class TexturePool; }
@@ -17,14 +14,14 @@ public:
     RasterBucket(gl::TexturePool&);
     ~RasterBucket() override;
 
+    RasterRenderable& getRenderable() const;
+
     void upload(gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool needsClipping() const override;
 
     void setImage(PremultipliedImage);
-
-    void drawRaster(RasterShader&, StaticVertexBuffer&, VertexArrayObject&, gl::ObjectStore&);
 
 private:
     std::unique_ptr<RasterRenderable> renderable;

--- a/src/mbgl/renderer/raster_renderable.hpp
+++ b/src/mbgl/renderer/raster_renderable.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <mbgl/util/raster.hpp>
+
+namespace mbgl {
+
+class RasterRenderable {
+public:
+    inline RasterRenderable(gl::TexturePool& texturePool) : raster(texturePool) {
+    }
+
+    Raster raster;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/raster_renderable.hpp
+++ b/src/mbgl/renderer/raster_renderable.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
+#include <mbgl/renderer/renderable.hpp>
 #include <mbgl/util/raster.hpp>
 
 namespace mbgl {
 
-class RasterRenderable {
+class RasterRenderable : public Renderable {
 public:
     inline RasterRenderable(gl::TexturePool& texturePool) : raster(texturePool) {
+    }
+
+    void upload(gl::ObjectStore& store) override {
+        if (!uploaded) {
+            raster.upload(store);
+            uploaded = true;
+        }
     }
 
     Raster raster;

--- a/src/mbgl/renderer/renderable.hpp
+++ b/src/mbgl/renderer/renderable.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <mbgl/util/noncopyable.hpp>
+
+namespace mbgl {
+
+namespace gl {class ObjectStore; }
+
+class Renderable : private util::noncopyable  {
+public:
+    virtual void upload(gl::ObjectStore&) = 0;
+
+protected:
+    bool uploaded = false;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -77,15 +77,7 @@ SymbolRenderable& SymbolBucket::getRenderable() const {
 }
 
 void SymbolBucket::upload(gl::ObjectStore& store) {
-    if (hasTextData()) {
-        renderable->text.vertices.upload(store);
-        renderable->text.triangles.upload(store);
-    }
-    if (hasIconData()) {
-        renderable->icon.vertices.upload(store);
-        renderable->icon.triangles.upload(store);
-    }
-
+    renderable->upload(store);
     uploaded = true;
 }
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -16,9 +16,6 @@
 #include <mbgl/text/glyph_set.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/text/collision_tile.hpp>
-#include <mbgl/shader/sdf_shader.hpp>
-#include <mbgl/shader/icon_shader.hpp>
-#include <mbgl/shader/collision_box_shader.hpp>
 
 #include <mbgl/util/utf.hpp>
 #include <mbgl/util/token.hpp>
@@ -72,6 +69,11 @@ SymbolBucket::SymbolBucket(uint32_t overscaling_, float zoom_, const MapMode mod
 
 SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
+}
+
+SymbolRenderable& SymbolBucket::getRenderable() const {
+    assert(renderable);
+    return *renderable;
 }
 
 void SymbolBucket::upload(gl::ObjectStore& store) {
@@ -600,51 +602,4 @@ void SymbolBucket::swapRenderable() {
     }
 }
 
-void SymbolBucket::drawGlyphs(SDFShader& shader, gl::ObjectStore& store) {
-    GLbyte *vertex_index = BUFFER_OFFSET_0;
-    GLbyte *elements_index = BUFFER_OFFSET_0;
-    auto& text = renderable->text;
-    for (auto &group : text.groups) {
-        assert(group);
-        group->array[0].bind(shader, text.vertices, text.triangles, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
-        vertex_index += group->vertex_length * text.vertices.itemSize;
-        elements_index += group->elements_length * text.triangles.itemSize;
-    }
-}
-
-void SymbolBucket::drawIcons(SDFShader& shader, gl::ObjectStore& store) {
-    GLbyte *vertex_index = BUFFER_OFFSET_0;
-    GLbyte *elements_index = BUFFER_OFFSET_0;
-    auto& icon = renderable->icon;
-    for (auto &group : icon.groups) {
-        assert(group);
-        group->array[0].bind(shader, icon.vertices, icon.triangles, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
-        vertex_index += group->vertex_length * icon.vertices.itemSize;
-        elements_index += group->elements_length * icon.triangles.itemSize;
-    }
-}
-
-void SymbolBucket::drawIcons(IconShader& shader, gl::ObjectStore& store) {
-    GLbyte *vertex_index = BUFFER_OFFSET_0;
-    GLbyte *elements_index = BUFFER_OFFSET_0;
-    auto& icon = renderable->icon;
-    for (auto &group : icon.groups) {
-        assert(group);
-        group->array[1].bind(shader, icon.vertices, icon.triangles, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
-        vertex_index += group->vertex_length * icon.vertices.itemSize;
-        elements_index += group->elements_length * icon.triangles.itemSize;
-    }
-}
-
-void SymbolBucket::drawCollisionBoxes(CollisionBoxShader& shader, gl::ObjectStore& store) {
-    GLbyte *vertex_index = BUFFER_OFFSET_0;
-    auto& collisionBox = renderable->collisionBox;
-    for (auto &group : collisionBox.groups) {
-        group->array[0].bind(shader, collisionBox.vertices, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, group->vertex_length));
-    }
-}
 } // namespace mbgl

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -3,34 +3,20 @@
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
 #include <mbgl/map/mode.hpp>
-#include <mbgl/geometry/vao.hpp>
-#include <mbgl/geometry/elements_buffer.hpp>
-#include <mbgl/geometry/text_buffer.hpp>
-#include <mbgl/geometry/icon_buffer.hpp>
-#include <mbgl/geometry/collision_box_buffer.hpp>
-#include <mbgl/text/glyph.hpp>
 #include <mbgl/text/collision_feature.hpp>
-#include <mbgl/text/shaping.hpp>
 #include <mbgl/text/quads.hpp>
 #include <mbgl/style/filter.hpp>
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
-
-#include <memory>
-#include <map>
-#include <set>
-#include <vector>
+#include <mbgl/text/glyph_range.hpp>
 
 namespace mbgl {
 
 class SDFShader;
 class IconShader;
 class CollisionBoxShader;
-class CollisionTile;
-class SpriteAtlas;
-class SpriteStore;
 class GlyphAtlas;
 class GlyphStore;
-class IndexedSubfeature;
+class SymbolRenderable;
 
 class SymbolFeature {
 public:
@@ -39,8 +25,6 @@ public:
     std::string sprite;
     std::size_t index;
 };
-
-struct Anchor;
 
 class SymbolInstance {
     public:
@@ -61,10 +45,6 @@ class SymbolInstance {
 };
 
 class SymbolBucket : public Bucket {
-    typedef ElementGroup<1> TextElementGroup;
-    typedef ElementGroup<2> IconElementGroup;
-    typedef ElementGroup<1> CollisionBoxElementGroup;
-
 public:
     SymbolBucket(uint32_t overscaling, float zoom, const MapMode, const std::string& bucketName_, const std::string& sourceLayerName_);
     ~SymbolBucket() override;
@@ -98,10 +78,10 @@ private:
             const size_t index);
     bool anchorIsTooClose(const std::u32string &text, const float repeatDistance, Anchor &anchor);
     std::map<std::u32string, std::vector<Anchor>> compareText;
-    
+
     void addToDebugBuffers(CollisionTile &collisionTile);
 
-    void swapRenderData() override;
+    void swapRenderable() override;
 
     // Adds placed items to the buffer.
     template <typename Buffer, typename GroupType>
@@ -118,7 +98,6 @@ public:
     bool iconsNeedLinear = false;
 
 private:
-
     const float overscaling;
     const float zoom;
     const uint32_t tileSize;
@@ -131,27 +110,8 @@ private:
     std::vector<SymbolInstance> symbolInstances;
     std::vector<SymbolFeature> features;
 
-    struct SymbolRenderData {
-        struct TextBuffer {
-            TextVertexBuffer vertices;
-            TriangleElementsBuffer triangles;
-            std::vector<std::unique_ptr<TextElementGroup>> groups;
-        } text;
-
-        struct IconBuffer {
-            IconVertexBuffer vertices;
-            TriangleElementsBuffer triangles;
-            std::vector<std::unique_ptr<IconElementGroup>> groups;
-        } icon;
-
-        struct CollisionBoxBuffer {
-            CollisionBoxVertexBuffer vertices;
-            std::vector<std::unique_ptr<CollisionBoxElementGroup>> groups;
-        } collisionBox;
-    };
-
-    std::unique_ptr<SymbolRenderData> renderData;
-    std::unique_ptr<SymbolRenderData> renderDataInProgress;
+    std::unique_ptr<SymbolRenderable> renderable;
+    std::unique_ptr<SymbolRenderable> renderableInProgress;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -11,9 +11,6 @@
 
 namespace mbgl {
 
-class SDFShader;
-class IconShader;
-class CollisionBoxShader;
 class GlyphAtlas;
 class GlyphStore;
 class SymbolRenderable;
@@ -49,6 +46,8 @@ public:
     SymbolBucket(uint32_t overscaling, float zoom, const MapMode, const std::string& bucketName_, const std::string& sourceLayerName_);
     ~SymbolBucket() override;
 
+    SymbolRenderable& getRenderable() const;
+
     void upload(gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
@@ -61,11 +60,6 @@ public:
                      SpriteAtlas&,
                      GlyphAtlas&,
                      GlyphStore&);
-
-    void drawGlyphs(SDFShader&, gl::ObjectStore&);
-    void drawIcons(SDFShader&, gl::ObjectStore&);
-    void drawIcons(IconShader&, gl::ObjectStore&);
-    void drawCollisionBoxes(CollisionBoxShader&, gl::ObjectStore&);
 
     void parseFeatures(const GeometryTileLayer&, const style::Filter&);
     bool needsDependencies(GlyphStore&, SpriteStore&);

--- a/src/mbgl/renderer/symbol_renderable.hpp
+++ b/src/mbgl/renderer/symbol_renderable.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mbgl/geometry/elements_buffer.hpp>
+#include <mbgl/geometry/text_buffer.hpp>
+#include <mbgl/geometry/icon_buffer.hpp>
+#include <mbgl/geometry/collision_box_buffer.hpp>
+
+namespace mbgl {
+
+class SymbolRenderable {
+public:
+    using TextElementGroup = ElementGroup<1>;
+    using IconElementGroup = ElementGroup<2>;
+    using CollisionBoxElementGroup = ElementGroup<1>;
+
+    struct TextBuffer {
+        TextVertexBuffer vertices;
+        TriangleElementsBuffer triangles;
+        std::vector<std::unique_ptr<TextElementGroup>> groups;
+    } text;
+
+    struct IconBuffer {
+        IconVertexBuffer vertices;
+        TriangleElementsBuffer triangles;
+        std::vector<std::unique_ptr<IconElementGroup>> groups;
+    } icon;
+
+    struct CollisionBoxBuffer {
+        CollisionBoxVertexBuffer vertices;
+        std::vector<std::unique_ptr<CollisionBoxElementGroup>> groups;
+    } collisionBox;
+};
+
+} // namespace mbgl

--- a/src/mbgl/renderer/symbol_renderable.hpp
+++ b/src/mbgl/renderer/symbol_renderable.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/renderer/renderable.hpp>
 #include <mbgl/geometry/elements_buffer.hpp>
 #include <mbgl/geometry/text_buffer.hpp>
 #include <mbgl/geometry/icon_buffer.hpp>
@@ -7,11 +8,25 @@
 
 namespace mbgl {
 
-class SymbolRenderable {
+class SymbolRenderable : public Renderable {
 public:
     using TextElementGroup = ElementGroup<1>;
     using IconElementGroup = ElementGroup<2>;
     using CollisionBoxElementGroup = ElementGroup<1>;
+
+    void upload(gl::ObjectStore& store) override {
+        if (!uploaded) {
+            if (!text.groups.empty()) {
+                text.vertices.upload(store);
+                text.triangles.upload(store);
+            }
+            if (!icon.groups.empty()) {
+                icon.vertices.upload(store);
+                icon.triangles.upload(store);
+            }
+            uploaded = true;
+        }
+    }
 
     struct TextBuffer {
         TextVertexBuffer vertices;

--- a/src/mbgl/tile/tile_data.cpp
+++ b/src/mbgl/tile/tile_data.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/tile/tile_data.hpp>
 #include <mbgl/renderer/debug_bucket.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/platform/log.hpp>
 
 namespace mbgl {
 

--- a/src/mbgl/tile/tile_worker.cpp
+++ b/src/mbgl/tile/tile_worker.cpp
@@ -107,7 +107,7 @@ TileParseResult TileWorker::prepareResult(const PlacementConfig& config) {
 std::unique_ptr<CollisionTile> TileWorker::placeLayers(const PlacementConfig config) {
     auto collisionTile = redoPlacement(&placementPending, config);
     for (auto &p : placementPending) {
-        p.second->swapRenderData();
+        p.second->swapRenderable();
         insertBucket(p.first, std::move(p.second));
     }
     placementPending.clear();

--- a/src/mbgl/tile/vector_tile_data.cpp
+++ b/src/mbgl/tile/vector_tile_data.cpp
@@ -170,7 +170,7 @@ void VectorTileData::redoPlacement(const std::function<void()>& callback) {
         placedConfig = config;
 
         for (auto& bucket : buckets) {
-            bucket.second->swapRenderData();
+            bucket.second->swapRenderable();
         }
 
         if (featureIndex) {


### PR DESCRIPTION
We currently have some OpenGL rendering code in the buckets, but the buckets shouldn't be part of the renderer (they're part of the TileData object), so I'd like to separate them.