### PR TITLE
TexturePool should use RAII

### DIFF
--- a/src/mbgl/gl/object_store.hpp
+++ b/src/mbgl/gl/object_store.hpp
@@ -20,27 +20,27 @@ class ObjectStore;
 
 struct ProgramDeleter {
     ObjectStore* store;
-    void operator()(GLuint id) const;
+    void operator()(GLuint) const;
 };
 
 struct ShaderDeleter {
     ObjectStore* store;
-    void operator()(GLuint id) const;
+    void operator()(GLuint) const;
 };
 
 struct BufferDeleter {
     ObjectStore* store;
-    void operator()(GLuint id) const;
+    void operator()(GLuint) const;
 };
 
 struct TextureDeleter {
     ObjectStore* store;
-    void operator()(GLuint id) const;
+    void operator()(GLuint) const;
 };
 
 struct VAODeleter {
     ObjectStore* store;
-    void operator()(GLuint id) const;
+    void operator()(GLuint) const;
 };
 
 using ObjectPool = std::array<GLuint, TextureMax>;
@@ -62,36 +62,36 @@ public:
     ~ObjectStore();
 
     UniqueProgram createProgram() {
-        return UniqueProgram(MBGL_CHECK_ERROR(glCreateProgram()), { this });
+        return UniqueProgram { MBGL_CHECK_ERROR(glCreateProgram()), { this } };
     }
 
     UniqueShader createShader(GLenum type) {
-        return UniqueShader(MBGL_CHECK_ERROR(glCreateShader(type)), { this });
+        return UniqueShader { MBGL_CHECK_ERROR(glCreateShader(type)), { this } };
     }
 
     UniqueBuffer createBuffer() {
         GLuint id = 0;
         MBGL_CHECK_ERROR(glGenBuffers(1, &id));
-        return UniqueBuffer(std::move(id), { this });
+        return UniqueBuffer { std::move(id), { this } };
     }
 
     UniqueTexture createTexture() {
         GLuint id = 0;
         MBGL_CHECK_ERROR(glGenTextures(1, &id));
-        return UniqueTexture(std::move(id), { this });
+        return UniqueTexture { std::move(id), { this } };
     }
 
     UniqueVAO createVAO() {
         GLuint id = 0;
         MBGL_CHECK_ERROR(gl::GenVertexArrays(1, &id));
-        return UniqueVAO(std::move(id), { this });
+        return UniqueVAO { std::move(id), { this } };
     }
 
     UniqueTexturePool createTexturePool() {
         ObjectPool ids;
         MBGL_CHECK_ERROR(glGenTextures(TextureMax, ids.data()));
         assert(ids.size() == size_t(TextureMax));
-        return UniqueTexturePool(std::move(ids), { this });
+        return UniqueTexturePool { std::move(ids), { this } };
     }
 
     // Actually remove the objects we marked as abandoned with the above methods.

--- a/src/mbgl/gl/texture_pool.cpp
+++ b/src/mbgl/gl/texture_pool.cpp
@@ -7,35 +7,68 @@
 namespace mbgl {
 namespace gl {
 
-GLuint TexturePool::getTextureID(gl::ObjectStore& store) {
-    auto nextAvailableID = [](auto& pool_) {
-        auto it = pool_.availableIDs.begin();
-        GLuint id = *it;
-        pool_.availableIDs.erase(it);
-        return id;
+class TexturePool::Impl : private util::noncopyable {
+public:
+    class Group : private util::noncopyable {
+        public:
+            Group(gl::ObjectStore& store) : pool(store.createTexturePool()), availableIDs(gl::TextureMax) {
+                std::copy(pool.get().begin(), pool.get().end(), availableIDs.begin());
+            }
+
+            Group(Group&& o) : pool(std::move(o.pool)), availableIDs(std::move(o.availableIDs)) {}
+            Group& operator=(Group&& o) { pool = std::move(o.pool); availableIDs = std::move(o.availableIDs); return *this; }
+
+            gl::UniqueTexturePool pool;
+            std::vector<GLuint> availableIDs;
     };
 
-    for (auto& pool : pools) {
-        if (pool.availableIDs.empty()) continue;
-        return nextAvailableID(pool);
+    GLuint getTextureID(gl::ObjectStore& store) {
+        auto nextAvailableID = [](auto& pool_) {
+            auto it = pool_.availableIDs.begin();
+            GLuint id = *it;
+            pool_.availableIDs.erase(it);
+            return id;
+        };
+
+        for (auto& pool : pools) {
+            if (pool.availableIDs.empty()) continue;
+            return nextAvailableID(pool);
+        }
+
+        // All texture IDs are in use.
+        pools.emplace_back(Group { store });
+        return nextAvailableID(pools.back());
     }
 
-    // All texture IDs are in use.
-    pools.emplace_back(Impl { store });
-    return nextAvailableID(pools.back());
+    void releaseTextureID(GLuint& id) {
+        for (auto it = pools.begin(); it != pools.end(); ++it) {
+            if (std::find(it->pool.get().begin(), it->pool.get().end(), id) != it->pool.get().end()) {
+                it->availableIDs.push_back(id);
+                id = 0;
+                if (GLsizei(it->availableIDs.size()) == gl::TextureMax) {
+                    pools.erase(it);
+                }
+                return;
+            }
+        }
+    }
+
+private:
+    std::vector<Group> pools;
+};
+
+TexturePool::TexturePool() : impl(std::make_unique<Impl>()) {
+}
+
+TexturePool::~TexturePool() {
+}
+
+GLuint TexturePool::getTextureID(gl::ObjectStore& store) {
+    return impl->getTextureID(store);
 }
 
 void TexturePool::releaseTextureID(GLuint& id) {
-    for (auto it = pools.begin(); it != pools.end(); ++it) {
-        if (std::find(it->pool.get().begin(), it->pool.get().end(), id) != it->pool.get().end()) {
-            it->availableIDs.push_back(id);
-            id = 0;
-            if (GLsizei(it->availableIDs.size()) == gl::TextureMax) {
-                pools.erase(it);
-            }
-            return;
-        }
-    }
+    impl->releaseTextureID(id);
 }
 
 } // namespace gl

--- a/src/mbgl/gl/texture_pool.hpp
+++ b/src/mbgl/gl/texture_pool.hpp
@@ -4,20 +4,32 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/object_store.hpp>
 
+#include <unique_resource.hpp>
+
 #include <memory>
 
 namespace mbgl {
 namespace gl {
+
+class TexturePool;
+
+struct TextureReleaser {
+    TexturePool* pool;
+    void operator()(GLuint) const;
+};
+
+using SharedTexture = std_experimental::unique_resource<GLuint, TextureReleaser>;
 
 class TexturePool : private util::noncopyable {
 public:
     TexturePool();
     ~TexturePool();
 
-    GLuint getTextureID(gl::ObjectStore&);
-    void releaseTextureID(GLuint&);
+    SharedTexture acquireTexture(gl::ObjectStore&);
 
 private:
+    friend TextureReleaser;
+
     class Impl;
     const std::unique_ptr<Impl> impl;
 };

--- a/src/mbgl/gl/texture_pool.hpp
+++ b/src/mbgl/gl/texture_pool.hpp
@@ -4,33 +4,22 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/object_store.hpp>
 
-#include <algorithm>
 #include <memory>
-#include <vector>
 
 namespace mbgl {
 namespace gl {
 
 class TexturePool : private util::noncopyable {
 public:
+    TexturePool();
+    ~TexturePool();
+
     GLuint getTextureID(gl::ObjectStore&);
     void releaseTextureID(GLuint&);
 
 private:
-    class Impl : private util::noncopyable {
-    public:
-        Impl(gl::ObjectStore& store) : pool(store.createTexturePool()), availableIDs(gl::TextureMax) {
-            std::copy(pool.get().begin(), pool.get().end(), availableIDs.begin());
-        }
-
-        Impl(Impl&& o) : pool(std::move(o.pool)), availableIDs(std::move(o.availableIDs)) {}
-        Impl& operator=(Impl&& o) { pool = std::move(o.pool); availableIDs = std::move(o.availableIDs); return *this; }
-
-        gl::UniqueTexturePool pool;
-        std::vector<GLuint> availableIDs;
-    };
-
-    std::vector<Impl> pools;
+    class Impl;
+    const std::unique_ptr<Impl> impl;
 };
 
 } // namespace gl

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -13,12 +13,6 @@ Raster::Raster(gl::TexturePool& texturePool_)
     : texturePool(texturePool_)
 {}
 
-Raster::~Raster() {
-    if (textured) {
-        texturePool.releaseTextureID(textureID);
-    }
-}
-
 bool Raster::isLoaded() const {
     std::lock_guard<std::mutex> lock(mtx);
     return loaded;
@@ -42,10 +36,10 @@ void Raster::bind(bool linear, gl::ObjectStore& store) {
         return;
     }
 
-    if (img.data && !textured) {
+    if (img.data && !texture) {
         upload(store);
-    } else if (textured) {
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, textureID));
+    } else if (texture) {
+        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
     }
 
     GLint new_filter = linear ? GL_LINEAR : GL_NEAREST;
@@ -57,15 +51,14 @@ void Raster::bind(bool linear, gl::ObjectStore& store) {
 }
 
 void Raster::upload(gl::ObjectStore& store) {
-    if (img.data && !textured) {
-        textureID = texturePool.getTextureID(store);
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, textureID));
+    if (img.data && !texture) {
+        texture = texturePool.acquireTexture(store);
+        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
 #endif
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
         MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, img.data.release()));
-        textured = true;
     }
 }

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/ptr.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <mutex>
 
@@ -14,7 +15,6 @@ class Raster : public std::enable_shared_from_this<Raster> {
 
 public:
     Raster(gl::TexturePool&);
-    ~Raster();
 
     // load image data
     void load(PremultipliedImage);
@@ -33,11 +33,8 @@ public:
     GLsizei width = 0;
     GLsizei height = 0;
 
-    // has been uploaded to texture
-    bool textured = false;
-
-    // the uploaded texture
-    GLuint textureID = 0;
+    // GL buffer object handle.
+    mbgl::optional<gl::SharedTexture> texture;
 
     // texture opacity
     double opacity = 0;

--- a/test/gl/object.cpp
+++ b/test/gl/object.cpp
@@ -130,29 +130,31 @@ TEST(GLObject, TexturePool) {
 
     mbgl::gl::TexturePool pool;
 
+    std::vector<mbgl::gl::SharedTexture> ids;
+
     // Fill an entire texture pool.
     for (auto i = 0; i != mbgl::gl::TextureMax; ++i) {
-        EXPECT_EQ(pool.getTextureID(store), GLuint(i + 1));
+        ids.push_back(pool.acquireTexture(store));
+        EXPECT_EQ(ids.back().get(), GLuint(i + 1));
         EXPECT_TRUE(store.empty());
     }
 
     // Reuse texture ids from the same pool.
     for (auto i = 0; i != mbgl::gl::TextureMax; ++i) {
-        GLuint id = i + 1;
-        pool.releaseTextureID(id);
-        EXPECT_EQ(id, 0);
-        EXPECT_EQ(pool.getTextureID(store), GLuint(i + 1));
+        ids[i].reset();
+        ids.push_back(pool.acquireTexture(store));
+        EXPECT_EQ(ids.back().get(), GLuint(i + 1));
         EXPECT_TRUE(store.empty());
     }
 
     // Trigger a new texture pool creation.
     {
-        GLuint id = pool.getTextureID(store);
+        mbgl::gl::SharedTexture id = pool.acquireTexture(store);
         EXPECT_EQ(id, mbgl::gl::TextureMax + 1);
         EXPECT_TRUE(store.empty());
 
-        pool.releaseTextureID(id);
-        EXPECT_EQ(id, 0);
+        id.reset();
+
         // Last used texture from pool triggers pool recycling.
         EXPECT_FALSE(store.empty());
 
@@ -161,35 +163,26 @@ TEST(GLObject, TexturePool) {
     }
 
     // First pool is still full, thus creating a new pool.
-    GLuint id1 = pool.getTextureID(store);
-    EXPECT_GT(id1, mbgl::gl::TextureMax);
+    mbgl::gl::SharedTexture id1 = pool.acquireTexture(store);
+    EXPECT_GT(id1.get(), mbgl::gl::TextureMax);
     EXPECT_TRUE(store.empty());
 
     // Release all textures from the first pool.
-    for (auto i = 0; i != mbgl::gl::TextureMax; ++i) {
-        GLuint id = i + 1;
-        pool.releaseTextureID(id);
-        if (i == mbgl::gl::TextureMax - 1) {
-            // Last texture from pool triggers pool recycling.
-            EXPECT_FALSE(store.empty());
-        } else {
-            EXPECT_TRUE(store.empty());
-        }
-    }
+    ids.clear();
+    EXPECT_FALSE(store.empty());
 
     store.performCleanup();
     EXPECT_TRUE(store.empty());
 
     // The first pool is now gone, the next pool is now in use.
-    GLuint id2 = pool.getTextureID(store);
-    EXPECT_GT(id2, id1);
-    pool.releaseTextureID(id2);
-    EXPECT_EQ(id2, 0);
+    mbgl::gl::SharedTexture id2 = pool.acquireTexture(store);
+    EXPECT_GT(id2.get(), id1.get());
+
+    id2.reset();
     EXPECT_TRUE(store.empty());
 
     // Last used texture from the pool triggers pool recycling.
-    pool.releaseTextureID(id1);
-    EXPECT_EQ(id1, 0);
+    id1.reset();
     EXPECT_FALSE(store.empty());
 
     store.performCleanup();


### PR DESCRIPTION
TexturePool is a very risky class at the moment. To make it safe:

* The `getTextureID` method should return an RAII object that releases the texture back to the pool on destruction.
* `TexturePool` should release all texture resources in its destructor. Before doing so, it should assert that there are no active acquisitions -- the pool itself must outlive the RAII'ed acquisitions.