### PR TITLE
Ignore multipoints when added as annotations

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -575,7 +575,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
 - (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id<MGLAnnotation>)annotation
 {
     // Use GL backed pins for dropped pin annotations
-    if ([annotation isMemberOfClass:[MBXDroppedPinAnnotation class]])
+    if ([annotation isKindOfClass:[MBXDroppedPinAnnotation class]])
     {
         return nil;
     }

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -882,9 +882,10 @@ IB_DESIGNABLE
  Adds an annotation to the map view.
  
  @note `MGLMultiPolyline`, `MGLMultiPolygon`, and `MGLShapeCollection` objects
-    cannot be added to the map view at this time. Any multipolyline,
-    multipolygon, or shape collection object that is passed into this method is
-    silently ignored.
+    cannot be added to the map view at this time. Nor can `MGLMultiPoint`
+    objects that are not instances of `MGLPolyline` or `MGLPolygon`. Any
+    multipoint, multipolyline, multipolygon, or shape collection object that is
+    specified is silently ignored.
  
  @param annotation The annotation object to add to the receiver. This object
     must conform to the `MGLAnnotation` protocol. The map view retains the
@@ -895,9 +896,10 @@ IB_DESIGNABLE
  Adds an array of annotations to the map view.
  
  @note `MGLMultiPolyline`, `MGLMultiPolygon`, and `MGLShapeCollection` objects
-    cannot be added to the map view at this time. Any multipolyline,
-    multipolygon, or shape collection objects that are passed in are silently
-    ignored.
+    cannot be added to the map view at this time. Nor can `MGLMultiPoint`
+    objects that are not instances of `MGLPolyline` or `MGLPolygon`. Any
+    multipoint, multipolyline, multipolygon, or shape collection objects that
+    are specified are silently ignored.
  
  @param annotations An array of annotation objects. Each object in the array
     must conform to the `MGLAnnotation` protocol. The map view retains each

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2835,7 +2835,14 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
         if ([annotation isKindOfClass:[MGLMultiPoint class]])
         {
-            // The multipoint knows how to style itself (with the map view’s help).
+            // Actual multipoints aren’t supported as annotations.
+            if ([annotation isMemberOfClass:[MGLMultiPoint class]]
+                || [annotation isMemberOfClass:[MGLMultiPointFeature class]])
+            {
+                continue;
+            }
+            
+            // The polyline or polygon knows how to style itself (with the map view’s help).
             MGLMultiPoint *multiPoint = (MGLMultiPoint *)annotation;
             if (!multiPoint.pointCount) {
                 continue;
@@ -2846,13 +2853,9 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             context.annotation = annotation;
             _annotationContextsByAnnotationTag[annotationTag] = context;
         }
-        else if ([annotation isKindOfClass:[MGLMultiPolyline class]]
-                 || [annotation isKindOfClass:[MGLMultiPolygon class]]
-                 || [annotation isKindOfClass:[MGLShapeCollection class]])
-        {
-            continue;
-        }
-        else
+        else if ( ! [annotation isKindOfClass:[MGLMultiPolyline class]]
+                 || ![annotation isKindOfClass:[MGLMultiPolygon class]]
+                 || ![annotation isKindOfClass:[MGLShapeCollection class]])
         {
             MGLAnnotationView *annotationView;
             NSString *symbolName;

--- a/platform/osx/app/MapDocument.m
+++ b/platform/osx/app/MapDocument.m
@@ -18,7 +18,18 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     NSMutableArray *flattenedShapes = [NSMutableArray arrayWithCapacity:shapes.count];
     for (id <MGLAnnotation> shape in shapes) {
         NSArray *subshapes;
-        if ([shape isKindOfClass:[MGLMultiPolyline class]]) {
+        // Flatten multipoints but not polylines or polygons.
+        if ([shape isMemberOfClass:[MGLMultiPoint class]]) {
+            NSUInteger pointCount = [(MGLMultiPoint *)shape pointCount];
+            CLLocationCoordinate2D *coordinates = [(MGLMultiPoint *)shape coordinates];
+            NSMutableArray *pointAnnotations = [NSMutableArray arrayWithCapacity:pointCount];
+            for (NSUInteger i = 0; i < pointCount; i++) {
+                MGLPointAnnotation *pointAnnotation = [[MGLPointAnnotation alloc] init];
+                pointAnnotation.coordinate = coordinates[i];
+                [pointAnnotations addObject:pointAnnotation];
+            }
+            subshapes = pointAnnotations;
+        } else if ([shape isKindOfClass:[MGLMultiPolyline class]]) {
             subshapes = [(MGLMultiPolyline *)shape polylines];
         } else if ([shape isKindOfClass:[MGLMultiPolygon class]]) {
             subshapes = [(MGLMultiPolygon *)shape polygons];

--- a/platform/osx/src/MGLMapView.h
+++ b/platform/osx/src/MGLMapView.h
@@ -535,9 +535,10 @@ IB_DESIGNABLE
  Adds an annotation to the map view.
  
  @note `MGLMultiPolyline`, `MGLMultiPolygon`, and `MGLShapeCollection` objects
-    cannot be added to the map view at this time. Any multipolyline,
-    multipolygon, or shape collection object that is passed into this method is
-    silently ignored.
+    cannot be added to the map view at this time. Nor can `MGLMultiPoint`
+    objects that are not instances of `MGLPolyline` or `MGLPolygon`. Any
+    multipoint, multipolyline, multipolygon, or shape collection object that is
+    specified is silently ignored.
  
  @param annotation The annotation object to add to the receiver. This object
     must conform to the `MGLAnnotation` protocol. The map view retains the
@@ -549,9 +550,10 @@ IB_DESIGNABLE
  Adds an array of annotations to the map view.
  
  @note `MGLMultiPolyline`, `MGLMultiPolygon`, and `MGLShapeCollection` objects
-    cannot be added to the map view at this time. Any multipolyline,
-    multipolygon, or shape collection objects that are passed in are silently
-    ignored.
+    cannot be added to the map view at this time. Nor can `MGLMultiPoint`
+    objects that are not instances of `MGLPolyline` or `MGLPolygon`. Any
+    multipoint, multipolyline, multipolygon, or shape collection objects that
+    are specified are silently ignored.
  
  @param annotations An array of annotation objects. Each object in the array
     must conform to the `MGLAnnotation` protocol. The map view retains each

--- a/platform/osx/src/MGLMapView.mm
+++ b/platform/osx/src/MGLMapView.mm
@@ -1608,6 +1608,12 @@ public:
         NSAssert([annotation conformsToProtocol:@protocol(MGLAnnotation)], @"Annotation does not conform to MGLAnnotation");
         
         if ([annotation isKindOfClass:[MGLMultiPoint class]]) {
+            // Actual multipoints aren’t supported as annotations.
+            if ([annotation isMemberOfClass:[MGLMultiPoint class]]
+                || [annotation isMemberOfClass:[MGLMultiPointFeature class]]) {
+                continue;
+            }
+            
             // The multipoint knows how to style itself (with the map view’s help).
             MGLMultiPoint *multiPoint = (MGLMultiPoint *)annotation;
             if (!multiPoint.pointCount) {
@@ -1618,11 +1624,9 @@ public:
             MGLAnnotationContext context;
             context.annotation = annotation;
             _annotationContextsByAnnotationTag[annotationTag] = context;
-        } else if ([annotation isKindOfClass:[MGLMultiPolyline class]]
-                   || [annotation isKindOfClass:[MGLMultiPolygon class]]
-                   || [annotation isKindOfClass:[MGLShapeCollection class]]) {
-            continue;
-        } else {
+        } else if (![annotation isKindOfClass:[MGLMultiPolyline class]]
+                   || ![annotation isKindOfClass:[MGLMultiPolygon class]]
+                   || ![annotation isKindOfClass:[MGLShapeCollection class]]) {
             MGLAnnotationImage *annotationImage = nil;
             if (delegateHasImagesForAnnotations) {
                 annotationImage = [self.delegate mapView:self imageForAnnotation:annotation];


### PR DESCRIPTION
Ignore multipoints (as opposed to polylines and polygons) when adding annotations, just like we ignore multipolylines, multipolygons, and shape collections. Asserting on all these cases would be just as reasonable, but the other types are already ignored so I figure it’s best to be consistent.

In osxapp, break multipoint features into points before adding them as annotations.

Split out from #5245.