### PR TITLE
Rename VectorTileData => GeometryTileData

### DIFF
--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -22,7 +22,7 @@
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/tile_cover.hpp>
 
-#include <mbgl/tile/vector_tile_data.hpp>
+#include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/tile/raster_tile_data.hpp>
 #include <mbgl/style/parser.hpp>
 #include <mbgl/gl/debugging.hpp>
@@ -215,8 +215,8 @@ std::unique_ptr<TileData> Source::createTile(const OverscaledTileID& overscaledT
             return nullptr;
         }
 
-        data = std::make_unique<VectorTileData>(overscaledTileID, std::move(monitor), id,
-                                                parameters.style, parameters.mode, callback);
+        data = std::make_unique<GeometryTileData>(overscaledTileID, std::move(monitor), id,
+                                                  parameters.style, parameters.mode, callback);
     }
 
     return data;

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -1,4 +1,4 @@
-#include <mbgl/tile/vector_tile_data.hpp>
+#include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/tile/geometry_tile.hpp>
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/util/worker.hpp>
@@ -11,12 +11,12 @@
 
 namespace mbgl {
 
-VectorTileData::VectorTileData(const OverscaledTileID& id_,
-                               std::unique_ptr<GeometryTileMonitor> monitor_,
-                               std::string sourceID,
-                               style::Style& style_,
-                               const MapMode mode_,
-                               const std::function<void(std::exception_ptr)>& callback)
+GeometryTileData::GeometryTileData(const OverscaledTileID& id_,
+                                   std::unique_ptr<GeometryTileMonitor> monitor_,
+                                   std::string sourceID,
+                                   style::Style& style_,
+                                   const MapMode mode_,
+                                   const std::function<void(std::exception_ptr)>& callback)
     : TileData(id_),
       style(style_),
       worker(style_.workers),
@@ -27,8 +27,7 @@ VectorTileData::VectorTileData(const OverscaledTileID& id_,
                  *style_.glyphStore,
                  obsolete,
                  mode_),
-      monitor(std::move(monitor_))
-{
+      monitor(std::move(monitor_)) {
     tileRequest = monitor->monitorTile([callback, this](std::exception_ptr err,
                                                         std::unique_ptr<GeometryTile> tile,
                                                         optional<Timestamp> modified_,
@@ -93,11 +92,11 @@ VectorTileData::VectorTileData(const OverscaledTileID& id_,
     });
 }
 
-VectorTileData::~VectorTileData() {
+GeometryTileData::~GeometryTileData() {
     cancel();
 }
 
-bool VectorTileData::parsePending(std::function<void(std::exception_ptr)> callback) {
+bool GeometryTileData::parsePending(std::function<void(std::exception_ptr)> callback) {
     if (workRequest) {
         // There's already parsing or placement going on.
         return false;
@@ -139,7 +138,7 @@ bool VectorTileData::parsePending(std::function<void(std::exception_ptr)> callba
     return true;
 }
 
-Bucket* VectorTileData::getBucket(const style::Layer& layer) {
+Bucket* GeometryTileData::getBucket(const style::Layer& layer) {
     const auto it = buckets.find(layer.baseImpl->bucketName());
     if (it == buckets.end()) {
         return nullptr;
@@ -149,7 +148,8 @@ Bucket* VectorTileData::getBucket(const style::Layer& layer) {
     return it->second.get();
 }
 
-void VectorTileData::redoPlacement(const PlacementConfig newConfig, const std::function<void()>& callback) {
+void GeometryTileData::redoPlacement(const PlacementConfig newConfig,
+                                     const std::function<void()>& callback) {
     if (newConfig != placedConfig) {
         targetConfig = newConfig;
 
@@ -157,7 +157,7 @@ void VectorTileData::redoPlacement(const PlacementConfig newConfig, const std::f
     }
 }
 
-void VectorTileData::redoPlacement(const std::function<void()>& callback) {
+void GeometryTileData::redoPlacement(const std::function<void()>& callback) {
     // Don't start a new placement request when the current one hasn't completed yet, or when
     // we are parsing buckets.
     if (workRequest) return;
@@ -187,11 +187,11 @@ void VectorTileData::redoPlacement(const std::function<void()>& callback) {
     });
 }
 
-void VectorTileData::queryRenderedFeatures(
-        std::unordered_map<std::string, std::vector<Feature>>& result,
-        const GeometryCoordinates& queryGeometry,
-        const TransformState& transformState,
-        const optional<std::vector<std::string>>& layerIDs) {
+void GeometryTileData::queryRenderedFeatures(
+    std::unordered_map<std::string, std::vector<Feature>>& result,
+    const GeometryCoordinates& queryGeometry,
+    const TransformState& transformState,
+    const optional<std::vector<std::string>>& layerIDs) {
 
     if (!featureIndex || !geometryTile) return;
 
@@ -206,7 +206,7 @@ void VectorTileData::queryRenderedFeatures(
                         style);
 }
 
-void VectorTileData::cancel() {
+void GeometryTileData::cancel() {
     obsolete = true;
     tileRequest.reset();
     workRequest.reset();

--- a/src/mbgl/tile/geometry_tile_data.hpp
+++ b/src/mbgl/tile/geometry_tile_data.hpp
@@ -19,16 +19,16 @@ namespace style {
 class Style;
 }
 
-class VectorTileData : public TileData {
+class GeometryTileData : public TileData {
 public:
-    VectorTileData(const OverscaledTileID&,
-                   std::unique_ptr<GeometryTileMonitor> monitor,
-                   std::string sourceID,
-                   style::Style&,
-                   const MapMode,
-                   const std::function<void(std::exception_ptr)>& callback);
+    GeometryTileData(const OverscaledTileID&,
+                     std::unique_ptr<GeometryTileMonitor> monitor,
+                     std::string sourceID,
+                     style::Style&,
+                     const MapMode,
+                     const std::function<void(std::exception_ptr)>& callback);
 
-    ~VectorTileData();
+    ~GeometryTileData();
 
     Bucket* getBucket(const style::Layer&) override;
 


### PR DESCRIPTION
We're using the term "vector tile" to refer to the encoded vector tiles and "geometry tile" to the parsed representation that is made up of geometries. This aligns the naming in our code base.