### PR TITLE
[core] Fix memory leak in Raster image data

### DIFF
--- a/include/mbgl/util/image.hpp
+++ b/include/mbgl/util/image.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mbgl/util/noncopyable.hpp>
+
 #include <string>
 #include <memory>
 #include <algorithm>
@@ -12,7 +14,7 @@ enum ImageAlphaMode {
 };
 
 template <ImageAlphaMode Mode>
-class Image {
+class Image : private util::noncopyable {
 public:
     Image() = default;
 
@@ -25,6 +27,18 @@ public:
         : width(w),
           height(h),
           data(std::move(data_)) {}
+
+    Image(Image&& o)
+        : width(o.width),
+          height(o.height),
+          data(std::move(o.data)) {}
+
+    Image& operator=(Image&& o) {
+        width = o.width;
+        height = o.height;
+        data = std::move(o.data);
+        return *this;
+    }
 
     bool operator==(const Image& rhs) const {
         return width == rhs.width && height == rhs.height &&

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -59,6 +59,7 @@ void Raster::upload(gl::ObjectStore& store) {
 #endif
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-        MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, img.data.release()));
+        MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, img.data.get()));
+        img.data.reset();
     }
 }


### PR DESCRIPTION
Revert 61dad6eae59e284fdba63fcd76d9192aba900db4. No one owned the data after release(), so this wasn't being free'd. `reset()` does that, thus this patch causes a huge memory leak.

:eyes: @tmpsantos @kkaefer 