### PR TITLE
[ios] [WiP] #5036 draggable annotation views

### DIFF
--- a/platform/darwin/src/MGLAnnotation.h
+++ b/platform/darwin/src/MGLAnnotation.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  The center point (specified as a map coordinate) of the annotation. (required)
  (read-only)
  */
-@property (nonatomic, readonly) CLLocationCoordinate2D coordinate;
+@property (nonatomic, readwrite) CLLocationCoordinate2D coordinate;
 
 @optional
 

--- a/platform/ios/app/MBXAnnotationView.m
+++ b/platform/ios/app/MBXAnnotationView.m
@@ -25,4 +25,33 @@
     }
 }
 
+- (void)setDragState:(MGLAnnotationViewDragState)dragState animated:(BOOL)animated
+{
+    [super setDragState:dragState animated:NO];
+    
+    switch (dragState) {
+        case MGLAnnotationViewDragStateNone:
+            break;
+        case MGLAnnotationViewDragStateStarting: {
+            [UIView animateWithDuration:.4 delay:0 usingSpringWithDamping:.4 initialSpringVelocity:.5 options:UIViewAnimationOptionCurveLinear animations:^{
+                self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 2, 2);
+            } completion:nil];
+            break;
+        }
+        case MGLAnnotationViewDragStateDragging:
+            break;
+        case MGLAnnotationViewDragStateCanceling:
+            break;
+        case MGLAnnotationViewDragStateEnding: {
+            [UIView animateWithDuration:.4 delay:0 usingSpringWithDamping:.4 initialSpringVelocity:.5 options:UIViewAnimationOptionCurveLinear animations:^{
+                self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1, 1);
+            } completion:nil];
+            break;
+        }
+    }
+    
+}
+
+
+
 @end

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -409,6 +409,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
 
 - (IBAction)handleLongPress:(UILongPressGestureRecognizer *)longPress
 {
+    /*
     if (longPress.state == UIGestureRecognizerStateBegan)
     {
         CGPoint point = [longPress locationInView:longPress.view];
@@ -427,7 +428,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         pin.subtitle = [[[MGLCoordinateFormatter alloc] init] stringFromCoordinate:pin.coordinate];
         // Calling `addAnnotation:` on mapView is not required since `selectAnnotation:animated` has the side effect of adding the annotation if required
         [self.mapView selectAnnotation:pin animated:YES];
-    }
+    }*/
 }
 
 - (IBAction)cycleStyles:(__unused id)sender
@@ -586,7 +587,12 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         annotationView = [[MBXAnnotationView alloc] initWithReuseIdentifier:MBXViewControllerAnnotationViewReuseIdentifer];
         annotationView.frame = CGRectMake(0, 0, 10, 10);
         annotationView.centerColor = [UIColor whiteColor];
-       
+        
+        // uncomment to make the annotation view draggable
+        // also note that having two long press gesture recognizers on overlapping views (`self.view` & `annotationView`) will cause weird behaviour
+        // comment out the pin dropping functionality in the handleLongPress: method in this class to make draggable annotation views play nice
+        annotationView.draggable = YES;
+        
         // uncomment to flatten the annotation view against the map when the map is tilted
         // this currently causes severe performance issues when more than 2k annotations are visible
         // annotationView.flat = YES;

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -4,6 +4,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
+    MGLAnnotationViewDragStateNone = 0,     // View is sitting on the map
+    MGLAnnotationViewDragStateStarting,     // View is beginning to drag and animation starts
+    MGLAnnotationViewDragStateDragging,     // View is being dragged
+    MGLAnnotationViewDragStateCanceling,    // View dragging was cancelled and will be returned to its starting positon.
+    MGLAnnotationViewDragStateEnding        // View was dragged, new coordinate has been set and stop animation is finishing
+};
+
 /** The MGLAnnotationView class is responsible for representing point-based annotation markers as a view. Annotation views represent an annotation object, which is an object that corresponds to the MGLAnnotation protocol. When an annotation’s coordinate point is visible on the map view, the map view delegate is asked to provide a corresponding annotation view. If an annotation view is created with a reuse identifier, the map view may recycle the view when it goes offscreen. */
 @interface MGLAnnotationView : UIView
 
@@ -47,6 +55,23 @@ NS_ASSUME_NONNULL_BEGIN
  MGLAnnotationView object, the default value of this property is YES.
  */
 @property (nonatomic, assign, getter=isScaledWithViewingDistance) BOOL scalesWithViewingDistance;
+
+/**
+ Setting this property to YES will make the view draggable. Long press followed by a pan gesture will start to move the
+ view around the map. Each update will center the annotation view. setCoordinate: is called on the associated annotation when panning ends successfully.
+ */
+@property (nonatomic, assign, getter=isDraggable) BOOL draggable;
+
+/**
+ All states are handled automatically when `draggable` is set to YES.
+ Custom animations can be achieved by overriding setDragState:animated:
+ */
+@property (nonatomic, readonly) MGLAnnotationViewDragState dragState;
+
+/**
+ Implementer may override this method to use a custom animation for the different MGLAnnotationViewDragState.
+ */
+- (void)setDragState:(MGLAnnotationViewDragState)dragState animated:(BOOL)animated __attribute__((objc_requires_super));
 
 /**
  Called when the view is removed from the reuse queue.

--- a/platform/ios/src/MGLAnnotationView_Private.h
+++ b/platform/ios/src/MGLAnnotationView_Private.h
@@ -3,10 +3,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class MGLMapView;
+
 @interface MGLAnnotationView (Private)
 
 @property (nonatomic) id<MGLAnnotation> annotation;
 @property (nonatomic, readwrite, nullable) NSString *reuseIdentifier;
+@property (nonatomic, weak) MGLMapView *mapView;
 
 - (void)setCenter:(CGPoint)center pitch:(CGFloat)pitch;
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4507,6 +4507,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         else
         {
             CGPoint center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
+            annotationView.mapView = self;
             [annotationView setCenter:center pitch:self.camera.pitch];
         }
     }


### PR DESCRIPTION
This PR is still WiP or even PoC as I'm trying to figure out all implications of it and aligning it with [#5245](https://github.com/mapbox/mapbox-gl-native/pull/5245)

**TODO**
- [ ] Figure out if this solution will work at all.
- [ ] Applying transformations is being omitted while dragging which could lead to unexpected behaviour if `freeAxes`/`flat` is set.
- [ ] Current animation only scales the annotation view, but the most common use case will likely be a pin annotation being lifted. Add this functionality and demo in `MBXViewController`

***TBC***

/cc @friedbunny @1ec5 @boundsj 