### PR TITLE
[core] Fix deleter mismatch

### DIFF
--- a/platform/default/webp_reader.cpp
+++ b/platform/default/webp_reader.cpp
@@ -15,8 +15,11 @@ PremultipliedImage decodeWebP(const uint8_t* data, size_t size) {
         throw std::runtime_error("failed to retrieve WebP basic header information");
     }
 
-    std::unique_ptr<uint8_t[]> webp(WebPDecodeRGBA(data, size, &width, &height));
-    if (!webp) {
+    int stride = width * 4;
+    size_t webpSize = stride * height;
+    auto webp = std::make_unique<uint8_t[]>(webpSize);
+
+    if (!WebPDecodeRGBAInto(data, size, webp.get(), webpSize, stride)) {
         throw std::runtime_error("failed to decode WebP data");
     }
 


### PR DESCRIPTION
`delete []` was being called for a `malloc()` allocated C buffer.

Found by valgrind:

```
==23065== Mismatched free() / delete / delete []
==23065==    at 0x4C2F77B: operator delete[](void*) (vg_replace_malloc.c:621)
==23065==    by 0x50C5529: std::default_delete<unsigned char []>::operator()(unsigned char*) const (unique_ptr.h:119)
==23065==    by 0x523EC85: std::unique_ptr<unsigned char [], std::default_delete<unsigned char []> >::reset(unsigned char*) (unique_ptr.h:581)
==23065==    by 0x523E3D4: mbgl::Raster::upload(mbgl::gl::ObjectStore&) (raster.cpp:63)
==23065==    by 0x520CA08: mbgl::RasterBucket::upload(mbgl::gl::ObjectStore&) (raster_bucket.cpp:16)
==23065==    by 0x520E56A: mbgl::Painter::render(mbgl::style::Style const&, mbgl::FrameData const&, mbgl::SpriteAtlas&) (painter.cpp:130)
==23065==    by 0x52BE15A: mbgl::Map::Impl::render() (map.cpp:265)
==23065==    by 0x52BD9BE: mbgl::Map::render() (map.cpp:175)
==23065==    by 0x50C9EB4: QMapboxGL::render() (qmapboxgl.cpp:579)
==23065==    by 0x4056D3: MapWindow::paintGL() (mapwindow.cpp:166)
```