### PR TITLE
[ios] fixes #5128 selected property to MGLAnnotationView

### DIFF
--- a/platform/ios/app/MBXAnnotationView.m
+++ b/platform/ios/app/MBXAnnotationView.m
@@ -25,4 +25,12 @@
     }
 }
 
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated
+{
+    [super setSelected:selected animated:animated];
+    
+    self.layer.borderColor = selected ? [UIColor blackColor].CGColor : [UIColor whiteColor].CGColor;
+    self.layer.borderWidth = selected ? 2.0 : 0;
+}
+
 @end

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -41,6 +41,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, getter=isFlat) BOOL flat;
 
 /**
+ Defaults to NO. Becomes YES when clicked on in the map view.
+ */
+@property (nonatomic, assign, getter=isSelected) BOOL selected;
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated;
+
+/**
  Setting this property to YES will cause the annotation view to shrink as it approaches the horizon and grow as it moves away from the
  horizon when the associated map view is tilted. Conversely, setting this property to NO will ensure that the annotation view maintains
  a constant size even when the map view is tilted. To maintain consistency with annotation representations that are not backed by an

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -37,6 +37,16 @@
     self.center = self.center;
 }
 
+- (void)setSelected:(BOOL)selected
+{
+    [self setSelected:selected animated:NO];
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated
+{
+    _selected = selected;
+}
+
 - (void)setCenter:(CGPoint)center
 {
     [self setCenter:center pitch:0];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3376,7 +3376,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         self.userTrackingMode = MGLUserTrackingModeNone;
     }
 
-    [self deselectAnnotation:self.selectedAnnotation animated:NO];
+    [self deselectAnnotation:self.selectedAnnotation animated:animated];
     
     // Add the annotation to the map if it hasn’t been added yet.
     MGLAnnotationTag annotationTag = [self annotationTagForAnnotation:annotation];
@@ -3401,6 +3401,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             positioningRect = annotationView.frame;
             
             [annotationView.superview bringSubviewToFront:annotationView];
+            
+            [annotationView setSelected:YES animated:animated];
         }
     }
     
@@ -3554,6 +3556,19 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     {
         // dismiss popup
         [self.calloutViewForSelectedAnnotation dismissCalloutAnimated:animated];
+        
+        // deselect annotation view
+        MGLAnnotationTag annotationTag = [self annotationTagForAnnotation:annotation];
+        if (annotationTag != MGLAnnotationTagNotFound)
+        {
+            MGLAnnotationContext &annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
+            MGLAnnotationView *annotationView = annotationContext.annotationView;
+            
+            if (annotationView)
+            {
+                [annotationView setSelected:NO animated:animated];
+            }
+        }
 
         // clean up
         self.calloutViewForSelectedAnnotation = nil;


### PR DESCRIPTION
Fixes [#5128](https://github.com/mapbox/mapbox-gl-native/issues/5128)
Simply added `selected` property to `MGLAnnotationView` and hooked it up.
Also notice the small change in `selectAnnotation:animated:` to make deselection animatable.