### PR TITLE
[core] Tighten LatLng and other geo.hpp class invariants

### DIFF
--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -25,8 +25,8 @@ public:
     }
 
     static ProjectedMeters projectedMetersForLatLng(const LatLng& latLng) {
-        const double constrainedLatitude = util::clamp(latLng.latitude, -util::LATITUDE_MAX, util::LATITUDE_MAX);
-        const double constrainedLongitude = util::clamp(latLng.longitude, -util::LONGITUDE_MAX, util::LONGITUDE_MAX);
+        const double constrainedLatitude = util::clamp(latLng.latitude(), -util::LATITUDE_MAX, util::LATITUDE_MAX);
+        const double constrainedLongitude = util::clamp(latLng.longitude(), -util::LONGITUDE_MAX, util::LONGITUDE_MAX);
 
         const double m = 1 - 1e-15;
         const double f = util::clamp(std::sin(util::DEG2RAD * constrainedLatitude), -m, m);
@@ -49,8 +49,8 @@ public:
 
     static Point<double> project(const LatLng& latLng, double scale) {
         return Point<double> {
-            util::LONGITUDE_MAX + latLng.longitude,
-            util::LONGITUDE_MAX - util::RAD2DEG * std::log(std::tan(M_PI / 4 + latLng.latitude * M_PI / util::DEGREES_MAX))
+            util::LONGITUDE_MAX + latLng.longitude(),
+            util::LONGITUDE_MAX - util::RAD2DEG * std::log(std::tan(M_PI / 4 + latLng.latitude() * M_PI / util::DEGREES_MAX))
         } * worldSize(scale) / util::DEGREES_MAX;
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLng.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLng.java
@@ -50,8 +50,8 @@ public class LatLng implements ILatLng, Parcelable {
    * @param longitude Longitude in degrees
    */
   public LatLng(double latitude, double longitude) {
-    this.latitude = latitude;
-    this.longitude = longitude;
+    setLatitude(latitude);
+    setLongitude(longitude);
   }
 
   /**
@@ -62,9 +62,9 @@ public class LatLng implements ILatLng, Parcelable {
    * @param altitude  Altitude in meters
    */
   public LatLng(double latitude, double longitude, double altitude) {
-    this.latitude = latitude;
-    this.longitude = longitude;
-    this.altitude = altitude;
+    setLatitude(latitude);
+    setLongitude(longitude);
+    setAltitude(altitude);
   }
 
   /**
@@ -88,12 +88,18 @@ public class LatLng implements ILatLng, Parcelable {
   }
 
   protected LatLng(Parcel in) {
-    latitude = in.readDouble();
-    longitude = in.readDouble();
-    altitude = in.readDouble();
+    setLatitude(in.readDouble());
+    setLongitude(in.readDouble());
+    setAltitude(in.readDouble());
   }
 
   public void setLatitude(double latitude) {
+    if (Double.isNaN(latitude)) {
+      throw new IllegalArgumentException("latitude must not be NaN");
+    }
+    if (Math.abs(latitude) > 90.0) {
+      throw new IllegalArgumentException("latitude must be between -90 and 90");
+    }
     this.latitude = latitude;
   }
 
@@ -103,6 +109,12 @@ public class LatLng implements ILatLng, Parcelable {
   }
 
   public void setLongitude(double longitude) {
+    if (Double.isNaN(longitude)) {
+      throw new IllegalArgumentException("longitude must not be NaN");
+    }
+    if (Double.isInfinite(longitude)) {
+      throw new IllegalArgumentException("longitude must not be infinite");
+    }
     this.longitude = longitude;
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngBoundsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngBoundsTest.java
@@ -4,7 +4,6 @@ import android.os.Parcelable;
 
 import com.mapbox.mapboxsdk.exceptions.InvalidLatLngBoundsException;
 import com.mapbox.mapboxsdk.utils.MockParcel;
-import com.mapbox.services.android.telemetry.constants.GeoConstants;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -138,21 +137,17 @@ public class LatLngBoundsTest {
   }
 
   @Test
-  public void containsNotBiggerBoundsInWorld() {
-    LatLngBounds biggerWorldBounds = new LatLngBounds.Builder()
-      .include(new LatLng(GeoConstants.MAX_LATITUDE + 10, GeoConstants.MIN_LONGITUDE - 10))
-      .include(new LatLng(GeoConstants.MIN_LATITUDE - 10, GeoConstants.MAX_LONGITUDE + 10))
+  public void containsBounds() {
+    LatLngBounds inner = new LatLngBounds.Builder()
+      .include(new LatLng(-5, -5))
+      .include(new LatLng(5, 5))
       .build();
-    assertFalse("Bounds should not be contained ", LatLngBounds.world().contains(biggerWorldBounds));
-  }
-
-  @Test
-  public void containsNotBoundsInWorld() {
-    LatLngBounds outSideWorldBounds = new LatLngBounds.Builder()
-      .include(new LatLng(GeoConstants.MAX_LATITUDE + 10, GeoConstants.MAX_LONGITUDE + 10))
-      .include(new LatLng(GeoConstants.MAX_LATITUDE + 20, GeoConstants.MAX_LONGITUDE + 20))
+    LatLngBounds outer = new LatLngBounds.Builder()
+      .include(new LatLng(-10, -10))
+      .include(new LatLng(10, 10))
       .build();
-    assertFalse("Bounds should not be contained ", LatLngBounds.world().contains(outSideWorldBounds));
+    assertTrue(outer.contains(inner));
+    assertFalse(inner.contains(outer));
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngTest.java
@@ -6,6 +6,8 @@ import android.os.Parcelable;
 import com.mapbox.mapboxsdk.utils.MockParcel;
 
 import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -77,6 +79,79 @@ public class LatLngTest {
     LatLng latLng = new LatLng(1.2, 3.4);
     latLng.setLongitude(3);
     assertEquals("longitude should match", 3, latLng.getLongitude(), DELTA);
+  }
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void testConstructorChecksLatitudeNaN() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("latitude must not be NaN");
+    new LatLng(Double.NaN, 0);
+  }
+
+  @Test
+  public void testConstructorChecksLongitudeNaN() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("longitude must not be NaN");
+    new LatLng(0, Double.NaN);
+  }
+
+  @Test
+  public void testConstructorChecksLatitudeGreaterThan90() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("latitude must be between -90 and 90");
+    new LatLng(95, 0);
+  }
+
+  @Test
+  public void testConstructorChecksLatitudeLessThanThanNegative90() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("latitude must be between -90 and 90");
+    new LatLng(-95, 0);
+  }
+
+  @Test
+  public void testConstructorChecksLongitudeInfinity() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("longitude must not be infinite");
+    new LatLng(0, Double.POSITIVE_INFINITY);
+  }
+
+  @Test
+  public void testLatitudeSetterChecksNaN() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("latitude must not be NaN");
+    new LatLng().setLatitude(Double.NaN);
+  }
+
+  @Test
+  public void testLongitudeSetterChecksNaN() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("longitude must not be NaN");
+    new LatLng().setLongitude(Double.NaN);
+  }
+
+  @Test
+  public void testLatitudeSetterChecksGreaterThan90() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("latitude must be between -90 and 90");
+    new LatLng().setLatitude(95);
+  }
+
+  @Test
+  public void testLatitudeSetterChecksLessThanThanNegative90() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("latitude must be between -90 and 90");
+    new LatLng().setLatitude(-95);
+  }
+
+  @Test
+  public void testLongitudeSetterChecksInfinity() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("longitude must not be infinite");
+    new LatLng().setLongitude(Double.NEGATIVE_INFINITY);
   }
 
   @Test

--- a/platform/android/src/geometry/lat_lng.cpp
+++ b/platform/android/src/geometry/lat_lng.cpp
@@ -3,9 +3,9 @@
 namespace mbgl {
 namespace android {
 
-jni::Object<LatLng> LatLng::New(jni::JNIEnv& env, double latitude, double longitude) {
+jni::Object<LatLng> LatLng::New(jni::JNIEnv& env, const mbgl::LatLng& latLng) {
     static auto constructor = LatLng::javaClass.GetConstructor<double, double>(env);
-    return LatLng::javaClass.New(env, constructor, latitude, longitude);
+    return LatLng::javaClass.New(env, constructor, latLng.latitude(), latLng.longitude());
 }
 
 mbgl::Point<double> LatLng::getGeometry(jni::JNIEnv& env, jni::Object<LatLng> latLng) {

--- a/platform/android/src/geometry/lat_lng.hpp
+++ b/platform/android/src/geometry/lat_lng.hpp
@@ -14,7 +14,7 @@ public:
 
     static constexpr auto Name() { return "com/mapbox/mapboxsdk/geometry/LatLng"; };
 
-    static jni::Object<LatLng> New(jni::JNIEnv&, double, double);
+    static jni::Object<LatLng> New(jni::JNIEnv&, const mbgl::LatLng&);
 
     static mbgl::Point<double> getGeometry(jni::JNIEnv&, jni::Object<LatLng>);
 

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -426,8 +426,7 @@ void NativeMapView::flyTo(jni::JNIEnv&, jni::jdouble angle, jni::jdouble latitud
 }
 
 jni::Object<LatLng> NativeMapView::getLatLng(JNIEnv& env) {
-    mbgl::LatLng latLng = map->getLatLng(insets);
-    return LatLng::New(env, latLng.latitude, latLng.longitude);
+    return LatLng::New(env, map->getLatLng(insets));
 }
 
 void NativeMapView::setLatLng(jni::JNIEnv&, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration) {
@@ -563,8 +562,8 @@ jni::Array<jni::jdouble> NativeMapView::getCameraValues(jni::JNIEnv& env) {
     //Create buffer with values
     jdouble buf[5];
     mbgl::LatLng latLng = map->getLatLng(insets);
-    buf[0] = latLng.latitude;
-    buf[1] = latLng.longitude;
+    buf[0] = latLng.latitude();
+    buf[1] = latLng.longitude();
     buf[2] = -map->getBearing();
     buf[3] = map->getPitch();
     buf[4] = map->getZoom();
@@ -650,13 +649,11 @@ jni::Object<PointF> NativeMapView::pixelForLatLng(JNIEnv& env, jdouble latitude,
 }
 
 jni::Object<LatLng> NativeMapView::latLngForProjectedMeters(JNIEnv& env, jdouble northing, jdouble easting) {
-    mbgl::LatLng latLng = map->latLngForProjectedMeters(mbgl::ProjectedMeters(northing, easting));
-    return LatLng::New(env, latLng.latitude, latLng.longitude);
+    return LatLng::New(env, map->latLngForProjectedMeters(mbgl::ProjectedMeters(northing, easting)));
 }
 
 jni::Object<LatLng> NativeMapView::latLngForPixel(JNIEnv& env, jfloat x, jfloat y) {
-    mbgl::LatLng latLng = map->latLngForPixel(mbgl::ScreenCoordinate(x, y));
-    return LatLng::New(env, latLng.latitude, latLng.longitude);
+    return LatLng::New(env, map->latLngForPixel(mbgl::ScreenCoordinate(x, y)));
 }
 
 jni::Array<jlong> NativeMapView::addPolylines(JNIEnv& env, jni::Array<jni::Object<Polyline>> polylines) {

--- a/platform/darwin/src/MGLGeometry.mm
+++ b/platform/darwin/src/MGLGeometry.mm
@@ -32,6 +32,15 @@ CGRect MGLExtendRect(CGRect rect, CGPoint point) {
     return rect;
 }
 
+mbgl::LatLng MGLLatLngFromLocationCoordinate2D(CLLocationCoordinate2D coordinate) {
+    try {
+        return mbgl::LatLng(coordinate.latitude, coordinate.longitude);
+    } catch (std::domain_error &error) {
+        [NSException raise:NSInvalidArgumentException format:@"%s", error.what()];
+        return {};
+    }
+}
+
 MGL_EXPORT
 CLLocationDistance MGLAltitudeForZoomLevel(double zoomLevel, CGFloat pitch, CLLocationDegrees latitude, CGSize size) {
     CLLocationDistance metersPerPixel = mbgl::Projection::getMetersPerPixelAtLatitude(latitude, zoomLevel);

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -12,21 +12,7 @@
 /// the given point.
 CGRect MGLExtendRect(CGRect rect, CGPoint point);
 
-NS_INLINE mbgl::LatLng MGLLatLngFromLocationCoordinate2D(CLLocationCoordinate2D coordinate) {
-    if (std::isnan(coordinate.latitude)) {
-        [NSException raise:NSInvalidArgumentException format:@"latitude must not be NaN"];
-    }
-    if (std::isnan(coordinate.longitude)) {
-        [NSException raise:NSInvalidArgumentException format:@"longitude must not be NaN"];
-    }
-    if (std::abs(coordinate.latitude) > 90.0) {
-        [NSException raise:NSInvalidArgumentException format:@"latitude must be between -90 and 90"];
-    }
-    if (!std::isfinite(coordinate.longitude)) {
-        [NSException raise:NSInvalidArgumentException format:@"longitude must not be infinite"];
-    }
-    return mbgl::LatLng(coordinate.latitude, coordinate.longitude);
-}
+mbgl::LatLng MGLLatLngFromLocationCoordinate2D(CLLocationCoordinate2D coordinate);
 
 NS_INLINE mbgl::Point<double> MGLPointFromLocationCoordinate2D(CLLocationCoordinate2D coordinate) {
     return mbgl::Point<double>(coordinate.longitude, coordinate.latitude);

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -13,6 +13,18 @@
 CGRect MGLExtendRect(CGRect rect, CGPoint point);
 
 NS_INLINE mbgl::LatLng MGLLatLngFromLocationCoordinate2D(CLLocationCoordinate2D coordinate) {
+    if (std::isnan(coordinate.latitude)) {
+        [NSException raise:NSInvalidArgumentException format:@"latitude must not be NaN"];
+    }
+    if (std::isnan(coordinate.longitude)) {
+        [NSException raise:NSInvalidArgumentException format:@"longitude must not be NaN"];
+    }
+    if (std::abs(coordinate.latitude) > 90.0) {
+        [NSException raise:NSInvalidArgumentException format:@"latitude must be between -90 and 90"];
+    }
+    if (!std::isfinite(coordinate.longitude)) {
+        [NSException raise:NSInvalidArgumentException format:@"longitude must not be infinite"];
+    }
     return mbgl::LatLng(coordinate.latitude, coordinate.longitude);
 }
 

--- a/platform/darwin/src/MGLGeometry_Private.h
+++ b/platform/darwin/src/MGLGeometry_Private.h
@@ -33,7 +33,7 @@ NS_INLINE mbgl::Point<double> MGLPointFromLocationCoordinate2D(CLLocationCoordin
 }
 
 NS_INLINE CLLocationCoordinate2D MGLLocationCoordinate2DFromLatLng(mbgl::LatLng latLng) {
-    return CLLocationCoordinate2DMake(latLng.latitude, latLng.longitude);
+    return CLLocationCoordinate2DMake(latLng.latitude(), latLng.longitude());
 }
 
 NS_INLINE MGLCoordinateBounds MGLCoordinateBoundsFromLatLngBounds(mbgl::LatLngBounds latLngBounds) {

--- a/platform/darwin/src/MGLMapCamera.mm
+++ b/platform/darwin/src/MGLMapCamera.mm
@@ -1,4 +1,5 @@
 #import "MGLMapCamera.h"
+#import "MGLGeometry_Private.h"
 
 #include <mbgl/util/projection.hpp>
 
@@ -23,8 +24,8 @@ BOOL MGLEqualFloatWithAccuracy(CGFloat left, CGFloat right, CGFloat accuracy)
                               fromEyeCoordinate:(CLLocationCoordinate2D)eyeCoordinate
                                     eyeAltitude:(CLLocationDistance)eyeAltitude
 {
-    mbgl::LatLng centerLatLng = mbgl::LatLng(centerCoordinate.latitude, centerCoordinate.longitude);
-    mbgl::LatLng eyeLatLng = mbgl::LatLng(eyeCoordinate.latitude, eyeCoordinate.longitude);
+    mbgl::LatLng centerLatLng = MGLLatLngFromLocationCoordinate2D(centerCoordinate);
+    mbgl::LatLng eyeLatLng = MGLLatLngFromLocationCoordinate2D(eyeCoordinate);
 
     mbgl::ProjectedMeters centerMeters = mbgl::Projection::projectedMetersForLatLng(centerLatLng);
     mbgl::ProjectedMeters eyeMeters = mbgl::Projection::projectedMetersForLatLng(eyeLatLng);

--- a/platform/darwin/src/MGLMapCamera.mm
+++ b/platform/darwin/src/MGLMapCamera.mm
@@ -24,17 +24,21 @@ BOOL MGLEqualFloatWithAccuracy(CGFloat left, CGFloat right, CGFloat accuracy)
                               fromEyeCoordinate:(CLLocationCoordinate2D)eyeCoordinate
                                     eyeAltitude:(CLLocationDistance)eyeAltitude
 {
-    mbgl::LatLng centerLatLng = MGLLatLngFromLocationCoordinate2D(centerCoordinate);
-    mbgl::LatLng eyeLatLng = MGLLatLngFromLocationCoordinate2D(eyeCoordinate);
-
-    mbgl::ProjectedMeters centerMeters = mbgl::Projection::projectedMetersForLatLng(centerLatLng);
-    mbgl::ProjectedMeters eyeMeters = mbgl::Projection::projectedMetersForLatLng(eyeLatLng);
-    CLLocationDirection heading = std::atan((centerMeters.northing - eyeMeters.northing) /
-                                            (centerMeters.easting - eyeMeters.easting));
-
-    double groundDistance = std::hypot(centerMeters.northing - eyeMeters.northing,
-                                       centerMeters.easting - eyeMeters.easting);
-    CGFloat pitch = std::atan(eyeAltitude / groundDistance);
+    CLLocationDirection heading = -1;
+    CGFloat pitch = -1;
+    if (CLLocationCoordinate2DIsValid(centerCoordinate) && CLLocationCoordinate2DIsValid(eyeCoordinate)) {
+        mbgl::LatLng centerLatLng = MGLLatLngFromLocationCoordinate2D(centerCoordinate);
+        mbgl::LatLng eyeLatLng = MGLLatLngFromLocationCoordinate2D(eyeCoordinate);
+        
+        mbgl::ProjectedMeters centerMeters = mbgl::Projection::projectedMetersForLatLng(centerLatLng);
+        mbgl::ProjectedMeters eyeMeters = mbgl::Projection::projectedMetersForLatLng(eyeLatLng);
+        heading = std::atan((centerMeters.northing - eyeMeters.northing) /
+                            (centerMeters.easting - eyeMeters.easting));
+        
+        double groundDistance = std::hypot(centerMeters.northing - eyeMeters.northing,
+                                           centerMeters.easting - eyeMeters.easting);
+        pitch = std::atan(eyeAltitude / groundDistance);
+    }
 
     return [[self alloc] initWithCenterCoordinate:centerCoordinate
                                          altitude:eyeAltitude

--- a/platform/darwin/src/MGLMultiPoint.mm
+++ b/platform/darwin/src/MGLMultiPoint.mm
@@ -163,6 +163,10 @@
     if (!_bounds) {
         mbgl::LatLngBounds bounds = mbgl::LatLngBounds::empty();
         for (auto coordinate : _coordinates) {
+            if (!CLLocationCoordinate2DIsValid(coordinate)) {
+                bounds = mbgl::LatLngBounds::empty();
+                break;
+            }
             bounds.extend(MGLLatLngFromLocationCoordinate2D(coordinate));
         }
         _bounds = bounds;

--- a/platform/darwin/src/MGLMultiPoint.mm
+++ b/platform/darwin/src/MGLMultiPoint.mm
@@ -163,7 +163,7 @@
     if (!_bounds) {
         mbgl::LatLngBounds bounds = mbgl::LatLngBounds::empty();
         for (auto coordinate : _coordinates) {
-            bounds.extend(mbgl::LatLng(coordinate.latitude, coordinate.longitude));
+            bounds.extend(MGLLatLngFromLocationCoordinate2D(coordinate));
         }
         _bounds = bounds;
     }

--- a/platform/darwin/src/MGLPointCollection.mm
+++ b/platform/darwin/src/MGLPointCollection.mm
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!_bounds) {
         mbgl::LatLngBounds bounds = mbgl::LatLngBounds::empty();
         for (auto coordinate : _coordinates) {
-            bounds.extend(mbgl::LatLng(coordinate.latitude, coordinate.longitude));
+            bounds.extend(MGLLatLngFromLocationCoordinate2D(coordinate));
         }
         _bounds = bounds;
     }

--- a/platform/darwin/src/MGLPointCollection.mm
+++ b/platform/darwin/src/MGLPointCollection.mm
@@ -54,6 +54,10 @@ NS_ASSUME_NONNULL_BEGIN
     if (!_bounds) {
         mbgl::LatLngBounds bounds = mbgl::LatLngBounds::empty();
         for (auto coordinate : _coordinates) {
+            if (!CLLocationCoordinate2DIsValid(coordinate)) {
+                bounds = mbgl::LatLngBounds::empty();
+                break;
+            }
             bounds.extend(MGLLatLngFromLocationCoordinate2D(coordinate));
         }
         _bounds = bounds;
@@ -119,8 +123,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p; count = %lu>",
-            NSStringFromClass([self class]), (void *)self, (unsigned long)[self pointCount]];
+    return [NSString stringWithFormat:@"<%@: %p; count = %lu; bounds = %@>",
+            NSStringFromClass([self class]), (void *)self, (unsigned long)[self pointCount],
+            MGLStringFromCoordinateBounds(self.overlayBounds)];
 }
 
 @end

--- a/platform/darwin/test/MGLShapeSourceTests.mm
+++ b/platform/darwin/test/MGLShapeSourceTests.mm
@@ -104,11 +104,11 @@
 
 - (void)testMGLShapeSourceWithPolygonFeatures {
     CLLocationCoordinate2D coordinates[] = {
-        CLLocationCoordinate2DMake(100.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 0.0)};
+        CLLocationCoordinate2DMake(0.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 100.0)};
 
     MGLPolygonFeature *polygonFeature = [MGLPolygonFeature polygonWithCoordinates:coordinates count:5];
     polygonFeature.identifier = @"feature-id";
@@ -150,18 +150,18 @@
 
 - (void)testMGLShapeSourceWithPolygonFeaturesInculdingInteriorPolygons {
     CLLocationCoordinate2D coordinates[] = {
-        CLLocationCoordinate2DMake(100.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 0.0)};
+        CLLocationCoordinate2DMake(0.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 100.0)};
 
     CLLocationCoordinate2D interiorCoordinates[] = {
-        CLLocationCoordinate2DMake(100.2, 0.2),
-        CLLocationCoordinate2DMake(100.8, 0.2),
-        CLLocationCoordinate2DMake(100.8, 0.8),
-        CLLocationCoordinate2DMake(100.2, 0.8),
-        CLLocationCoordinate2DMake(100.2, 0.2)};
+        CLLocationCoordinate2DMake(0.2, 100.2),
+        CLLocationCoordinate2DMake(0.2, 100.8),
+        CLLocationCoordinate2DMake(0.8, 100.8),
+        CLLocationCoordinate2DMake(0.8, 100.2),
+        CLLocationCoordinate2DMake(0.2, 100.2)};
 
     MGLPolygon *polygon = [MGLPolygon polygonWithCoordinates:interiorCoordinates count:5];
 
@@ -188,18 +188,18 @@
 
 - (void)testMGLShapeSourceWithMultiPolygonFeatures {
     CLLocationCoordinate2D coordinates[] = {
-        CLLocationCoordinate2DMake(100.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 0.0)};
+        CLLocationCoordinate2DMake(0.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 100.0)};
 
     CLLocationCoordinate2D interiorCoordinates[] = {
-        CLLocationCoordinate2DMake(100.2, 0.2),
-        CLLocationCoordinate2DMake(100.8, 0.2),
-        CLLocationCoordinate2DMake(100.8, 0.8),
-        CLLocationCoordinate2DMake(100.2, 0.8),
-        CLLocationCoordinate2DMake(100.2, 0.2)};
+        CLLocationCoordinate2DMake(0.2, 100.2),
+        CLLocationCoordinate2DMake(0.2, 100.8),
+        CLLocationCoordinate2DMake(0.8, 100.8),
+        CLLocationCoordinate2DMake(0.8, 100.2),
+        CLLocationCoordinate2DMake(0.2, 100.2)};
 
     MGLPolygon *polygon = [MGLPolygon polygonWithCoordinates:interiorCoordinates count:5];
 
@@ -216,7 +216,7 @@
 
 - (void)testMGLShapeSourceWithPointFeature {
     MGLPointFeature *pointFeature = [MGLPointFeature new];
-    pointFeature.coordinate = CLLocationCoordinate2DMake(100.2, 0.2);
+    pointFeature.coordinate = CLLocationCoordinate2DMake(0.2, 100.2);
 
     MGLShapeSource *source = [[MGLShapeSource alloc] initWithIdentifier:@"souce-id" shape:pointFeature options:nil];
 
@@ -226,11 +226,11 @@
 
 - (void)testMGLShapeSourceWithPointCollectionFeature {
     CLLocationCoordinate2D coordinates[] = {
-        CLLocationCoordinate2DMake(100.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 0.0)};
+        CLLocationCoordinate2DMake(0.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 100.0)};
     MGLPointCollectionFeature *pointCollectionFeature = [MGLPointCollectionFeature pointCollectionWithCoordinates:coordinates count:5];
     MGLShapeSource *source = [[MGLShapeSource alloc] initWithIdentifier:@"souce-id" shape:pointCollectionFeature options:nil];
 
@@ -240,18 +240,18 @@
 
 - (void)testMGLShapeSourceWithShapeCollectionFeatures {
     CLLocationCoordinate2D coordinates[] = {
-        CLLocationCoordinate2DMake(100.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 0.0)};
+        CLLocationCoordinate2DMake(0.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 100.0)};
 
     CLLocationCoordinate2D interiorCoordinates[] = {
-        CLLocationCoordinate2DMake(100.2, 0.2),
-        CLLocationCoordinate2DMake(100.8, 0.2),
-        CLLocationCoordinate2DMake(100.8, 0.8),
-        CLLocationCoordinate2DMake(100.2, 0.8),
-        CLLocationCoordinate2DMake(100.2, 0.2)};
+        CLLocationCoordinate2DMake(0.2, 100.2),
+        CLLocationCoordinate2DMake(0.2, 100.8),
+        CLLocationCoordinate2DMake(0.8, 100.8),
+        CLLocationCoordinate2DMake(0.8, 100.2),
+        CLLocationCoordinate2DMake(0.2, 100.2)};
 
     MGLPolygon *polygon = [MGLPolygon polygonWithCoordinates:interiorCoordinates count:5];
 
@@ -267,7 +267,7 @@
     MGLPointCollectionFeature *pointCollectionFeature = [MGLPointCollectionFeature pointCollectionWithCoordinates:coordinates count:5];
 
     MGLPointFeature *pointFeature = [MGLPointFeature new];
-    pointFeature.coordinate = CLLocationCoordinate2DMake(100.2, 0.2);
+    pointFeature.coordinate = CLLocationCoordinate2DMake(0.2, 100.2);
 
     MGLShapeCollectionFeature *shapeCollectionFeature = [MGLShapeCollectionFeature shapeCollectionWithShapes:@[polygonFeature, polylineFeature, multiPolygonFeature, multiPolylineFeature, pointCollectionFeature, pointFeature]];
 
@@ -280,11 +280,11 @@
 
 - (void)testMGLShapeSourceWithFeaturesConvenienceInitializer {
     CLLocationCoordinate2D coordinates[] = {
-        CLLocationCoordinate2DMake(100.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 0.0)};
+        CLLocationCoordinate2DMake(0.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 100.0)};
 
     MGLPolygonFeature *polygonFeature = [MGLPolygonFeature polygonWithCoordinates:coordinates count:sizeof(coordinates)/sizeof(coordinates[0]) interiorPolygons:nil];
 
@@ -302,11 +302,11 @@
 
 - (void)testMGLShapeSourceWithShapesConvenienceInitializer {
     CLLocationCoordinate2D coordinates[] = {
-        CLLocationCoordinate2DMake(100.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 0.0),
-        CLLocationCoordinate2DMake(101.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 1.0),
-        CLLocationCoordinate2DMake(100.0, 0.0)};
+        CLLocationCoordinate2DMake(0.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 101.0),
+        CLLocationCoordinate2DMake(1.0, 100.0),
+        CLLocationCoordinate2DMake(0.0, 100.0)};
 
     MGLPolygon *polygon = [MGLPolygon polygonWithCoordinates:coordinates count:sizeof(coordinates)/sizeof(coordinates[0]) interiorPolygons:nil];
 

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -255,7 +255,7 @@ mbgl::Point<double> GLFWView::makeRandomPoint() const {
     const double x = width * double(std::rand()) / RAND_MAX;
     const double y = height * double(std::rand()) / RAND_MAX;
     mbgl::LatLng latLng = map->latLngForPixel({ x, y });
-    return { latLng.longitude, latLng.latitude };
+    return { latLng.longitude(), latLng.latitude() };
 }
 
 std::shared_ptr<const mbgl::SpriteImage>

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -184,8 +184,8 @@ int main(int argc, char *argv[]) {
 
     // Save settings
     mbgl::LatLng latLng = map.getLatLng();
-    settings.latitude = latLng.latitude;
-    settings.longitude = latLng.longitude;
+    settings.latitude = latLng.latitude();
+    settings.longitude = latLng.longitude();
     settings.zoom = map.getZoom();
     settings.bearing = map.getBearing();
     settings.pitch = map.getPitch();

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2843,6 +2843,10 @@ public:
 
 - (CGPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(nullable UIView *)view
 {
+    if ( ! CLLocationCoordinate2DIsValid(coordinate))
+    {
+        return CGPointMake(NAN, NAN);
+    }
     return [self convertLatLng:MGLLatLngFromLocationCoordinate2D(coordinate) toPointToView:view];
 }
 
@@ -2860,6 +2864,10 @@ public:
 
 - (CGRect)convertCoordinateBounds:(MGLCoordinateBounds)bounds toRectToView:(nullable UIView *)view
 {
+    if ( ! CLLocationCoordinate2DIsValid(bounds.sw) || ! CLLocationCoordinate2DIsValid(bounds.ne))
+    {
+        return CGRectNull;
+    }
     return [self convertLatLngBounds:MGLLatLngBoundsFromCoordinateBounds(bounds) toRectToView:view];
 }
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2618,6 +2618,9 @@ public:
 #pragma mark Geometric methods
 
 - (NSPoint)convertCoordinate:(CLLocationCoordinate2D)coordinate toPointToView:(nullable NSView *)view {
+    if (!CLLocationCoordinate2DIsValid(coordinate)) {
+        return NSMakePoint(NAN, NAN);
+    }
     return [self convertLatLng:MGLLatLngFromLocationCoordinate2D(coordinate) toPointToView:view];
 }
 
@@ -2644,6 +2647,9 @@ public:
 }
 
 - (NSRect)convertCoordinateBounds:(MGLCoordinateBounds)bounds toRectToView:(nullable NSView *)view {
+    if (!CLLocationCoordinate2DIsValid(bounds.sw) || !CLLocationCoordinate2DIsValid(bounds.ne)) {
+        return CGRectNull;
+    }
     return [self convertLatLngBounds:MGLLatLngBoundsFromCoordinateBounds(bounds) toRectToView:view];
 }
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2676,7 +2676,7 @@ public:
             (bounds.south() + bounds.north()) / 2,
             bounds.west() - 1,
         };
-    } else if (bounds.northeast().longitude < 180) {
+    } else if (bounds.northeast().longitude() < 180) {
         outsideLatLng = {
             (bounds.south() + bounds.north()) / 2,
             bounds.east() + 1,

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -514,7 +514,7 @@ void QMapboxGL::setStyleUrl(const QString &url)
 */
 double QMapboxGL::latitude() const
 {
-    return d_ptr->mapObj->getLatLng(d_ptr->margins).latitude;
+    return d_ptr->mapObj->getLatLng(d_ptr->margins).latitude();
 }
 
 void QMapboxGL::setLatitude(double latitude_)
@@ -532,7 +532,7 @@ void QMapboxGL::setLatitude(double latitude_)
 */
 double QMapboxGL::longitude() const
 {
-    return d_ptr->mapObj->getLatLng(d_ptr->margins).longitude;
+    return d_ptr->mapObj->getLatLng(d_ptr->margins).longitude();
 }
 
 void QMapboxGL::setLongitude(double longitude_)
@@ -614,7 +614,7 @@ double QMapboxGL::maximumZoom() const
 Coordinate QMapboxGL::coordinate() const
 {
     const mbgl::LatLng& latLng = d_ptr->mapObj->getLatLng(d_ptr->margins);
-    return Coordinate(latLng.latitude, latLng.longitude);
+    return Coordinate(latLng.latitude(), latLng.longitude());
 }
 
 void QMapboxGL::setCoordinate(const QMapbox::Coordinate &coordinate_)
@@ -1130,7 +1130,7 @@ QMapbox::ProjectedMeters QMapboxGL::projectedMetersForCoordinate(const QMapbox::
 QMapbox::Coordinate QMapboxGL::coordinateForProjectedMeters(const QMapbox::ProjectedMeters &projectedMeters) const
 {
     auto latLng = d_ptr->mapObj->latLngForProjectedMeters(mbgl::ProjectedMeters { projectedMeters.first, projectedMeters.second });
-    return QMapbox::Coordinate(latLng.latitude, latLng.longitude);
+    return QMapbox::Coordinate(latLng.latitude(), latLng.longitude());
 }
 
 /*!
@@ -1160,7 +1160,7 @@ QMapbox::Coordinate QMapboxGL::coordinateForPixel(const QPointF &pixel) const
     const mbgl::LatLng latLng =
         d_ptr->mapObj->latLngForPixel(mbgl::ScreenCoordinate { pixel.x(), pixel.y() });
 
-    return Coordinate(latLng.latitude, latLng.longitude);
+    return Coordinate(latLng.latitude(), latLng.longitude());
 }
 
 /*!
@@ -1172,7 +1172,7 @@ QMapbox::CoordinateZoom QMapboxGL::coordinateZoomForBounds(const QMapbox::Coordi
     auto bounds = mbgl::LatLngBounds::hull(mbgl::LatLng { sw.first, sw.second }, mbgl::LatLng { ne.first, ne.second });
     mbgl::CameraOptions camera = d_ptr->mapObj->cameraForLatLngBounds(bounds, d_ptr->margins);
 
-    return {{ (*camera.center).latitude, (*camera.center).longitude }, *camera.zoom };
+    return {{ (*camera.center).latitude(), (*camera.center).longitude() }, *camera.zoom };
 }
 
 /*!
@@ -1198,7 +1198,7 @@ QMapbox::CoordinateZoom QMapboxGL::coordinateZoomForBounds(const QMapbox::Coordi
     setBearing(currentBearing);
     setPitch(currentPitch);
 
-    return {{ (*camera.center).latitude, (*camera.center).longitude }, *camera.zoom };
+    return {{ (*camera.center).latitude(), (*camera.center).longitude() }, *camera.zoom };
 }
 
 /*!

--- a/src/mbgl/annotation/symbol_annotation_impl.hpp
+++ b/src/mbgl/annotation/symbol_annotation_impl.hpp
@@ -27,7 +27,7 @@
 #pragma GCC diagnostic pop
 
 // Make Boost Geometry aware of our LatLng type
-BOOST_GEOMETRY_REGISTER_POINT_2D(mbgl::LatLng, double, boost::geometry::cs::cartesian, longitude, latitude)
+BOOST_GEOMETRY_REGISTER_POINT_2D_CONST(mbgl::LatLng, double, boost::geometry::cs::cartesian, longitude(), latitude())
 BOOST_GEOMETRY_REGISTER_BOX(mbgl::LatLngBounds, mbgl::LatLng, southwest(), northeast())
 
 namespace mbgl {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -616,7 +616,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
     if (width > 0 || height > 0) {
         double scaleX = double(getSize().width) / width;
         double scaleY = double(getSize().height) / height;
-        if (padding && *padding) {
+        if (padding) {
             scaleX -= (padding->left + padding->right) / width;
             scaleY -= (padding->top + padding->bottom) / height;
         }
@@ -627,7 +627,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
 
     // Calculate the center point of a virtual bounds that is extended in all directions by padding.
     ScreenCoordinate centerPixel = nePixel + swPixel;
-    if (padding && *padding) {
+    if (padding) {
         ScreenCoordinate paddedNEPixel = {
             padding->right / minScale,
             padding->top / minScale,

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -103,7 +103,9 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     // If gesture in progress, we transfer the world rounds from the end
     // longitude into start, so we can guarantee the "scroll effect" of rounding
     // the world while assuring the end longitude remains wrapped.
-    if (isGestureInProgress()) startLatLng.longitude -= unwrappedLatLng.longitude - latLng.longitude;
+    if (isGestureInProgress()) {
+        startLatLng = LatLng(startLatLng.latitude(), startLatLng.longitude() - (unwrappedLatLng.longitude() - latLng.longitude()));
+    }
     // Find the shortest path otherwise.
     else startLatLng.unwrapForShortestPath(latLng);
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -325,10 +325,10 @@ void TransformState::setLatLngZoom(const LatLng &latLng, double zoom) {
     Cc = newWorldSize / util::M2PI;
 
     const double m = 1 - 1e-15;
-    const double f = util::clamp(std::sin(util::DEG2RAD * latLng.latitude), -m, m);
+    const double f = util::clamp(std::sin(util::DEG2RAD * latLng.latitude()), -m, m);
 
     ScreenCoordinate point = {
-        -latLng.longitude * Bc,
+        -latLng.longitude() * Bc,
         0.5 * Cc * std::log((1 + f) / (1 - f)),
     };
     setScalePoint(newScale, point);

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -55,8 +55,8 @@ void CustomLayer::Impl::render(const TransformState& state) const {
 
     parameters.width = state.getSize().width;
     parameters.height = state.getSize().height;
-    parameters.latitude = state.getLatLng().latitude;
-    parameters.longitude = state.getLatLng().longitude;
+    parameters.latitude = state.getLatLng().latitude();
+    parameters.longitude = state.getLatLng().longitude();
     parameters.zoom = state.getZoom();
     parameters.bearing = -state.getAngle() * util::RAD2DEG;
     parameters.pitch = state.getPitch();

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -56,8 +56,8 @@ StyleParseResult Parser::parse(const std::string& json) {
         const JSValue& value = document["center"];
         if (value.IsArray() && value.Size() >= 2) {
             // Style spec uses lon/lat order
-            latLng.longitude = value[0].IsNumber() ? value[0].GetDouble() : 0;
-            latLng.latitude = value[1].IsNumber() ? value[1].GetDouble() : 0;
+            latLng = LatLng(value[1].IsNumber() ? value[1].GetDouble() : 0,
+                            value[0].IsNumber() ? value[0].GetDouble() : 0);
         }
     }
 

--- a/src/mbgl/util/geo.cpp
+++ b/src/mbgl/util/geo.cpp
@@ -8,28 +8,28 @@ namespace mbgl {
 
 namespace {
 
-double lat(const uint8_t z, const int64_t y) {
+double lat_(const uint8_t z, const int64_t y) {
     const double n = M_PI - 2.0 * M_PI * y / std::pow(2.0, z);
     return util::RAD2DEG * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
 }
 
-double lon(const uint8_t z, const int64_t x) {
+double lon_(const uint8_t z, const int64_t x) {
     return x / std::pow(2.0, z) * util::DEGREES_MAX - util::LONGITUDE_MAX;
 }
 
 } // end namespace
 
-LatLng::LatLng(const CanonicalTileID& id) : latitude(lat(id.z, id.y)), longitude(lon(id.z, id.x)) {
+LatLng::LatLng(const CanonicalTileID& id) : lat(lat_(id.z, id.y)), lon(lon_(id.z, id.x)) {
 }
 
 LatLng::LatLng(const UnwrappedTileID& id)
-    : latitude(lat(id.canonical.z, id.canonical.y)),
-      longitude(lon(id.canonical.z, id.canonical.x) + id.wrap * util::DEGREES_MAX) {
+    : lat(lat_(id.canonical.z, id.canonical.y)),
+      lon(lon_(id.canonical.z, id.canonical.x) + id.wrap * util::DEGREES_MAX) {
 }
 
 LatLngBounds::LatLngBounds(const CanonicalTileID& id)
-    : sw({ lat(id.z, id.y + 1), lon(id.z, id.x) }),
-      ne({ lat(id.z, id.y), lon(id.z, id.x + 1) }) {
+    : sw({ lat_(id.z, id.y + 1), lon_(id.z, id.x) }),
+      ne({ lat_(id.z, id.y), lon_(id.z, id.x + 1) }) {
 }
 
 ScreenCoordinate EdgeInsets::getCenter(uint16_t width, uint16_t height) const {

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -65,8 +65,8 @@ TEST(Map, LatLngBehavior) {
     map.setLatLng({ 1, 1 });
     auto latLng2 = map.getLatLng();
 
-    ASSERT_DOUBLE_EQ(latLng1.latitude, latLng2.latitude);
-    ASSERT_DOUBLE_EQ(latLng1.longitude, latLng2.longitude);
+    ASSERT_DOUBLE_EQ(latLng1.latitude(), latLng2.latitude());
+    ASSERT_DOUBLE_EQ(latLng1.longitude(), latLng2.longitude());
 }
 
 TEST(Map, CameraToLatLngBounds) {
@@ -86,8 +86,8 @@ TEST(Map, CameraToLatLngBounds) {
     // Map::cameraForLatLngBounds only sets zoom and center.
     CameraOptions virtualCamera = map.cameraForLatLngBounds(bounds, {});
     ASSERT_NEAR(*camera.zoom, *virtualCamera.zoom, 1e-7);
-    ASSERT_NEAR(camera.center->latitude, virtualCamera.center->latitude, 1e-7);
-    ASSERT_NEAR(camera.center->longitude, virtualCamera.center->longitude, 1e-7);
+    ASSERT_NEAR(camera.center->latitude(), virtualCamera.center->latitude(), 1e-7);
+    ASSERT_NEAR(camera.center->longitude(), virtualCamera.center->longitude(), 1e-7);
 }
 
 TEST(Map, Offline) {

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -44,40 +44,6 @@ TEST(Transform, InvalidScale) {
     ASSERT_DOUBLE_EQ(2, transform.getScale());
 }
 
-TEST(Transform, InvalidLatLng) {
-    Transform transform;
-
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(1, transform.getScale());
-
-    transform.setScale(2 << 0);
-    transform.setLatLng({ 8, 10 });
-
-    ASSERT_DOUBLE_EQ(8, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(2, transform.getScale());
-
-    transform.setLatLngZoom({ 10, 8 }, 2);
-
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(8, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(4, transform.getScale());
-
-    const double invalid = std::nan("");
-    transform.setLatLngZoom({ invalid, 8 }, 2);
-
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(8, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(4, transform.getScale());
-
-    transform.setLatLngZoom({ 10, invalid }, 2);
-
-    ASSERT_DOUBLE_EQ(10, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(8, transform.getLatLng().longitude);
-    ASSERT_DOUBLE_EQ(4, transform.getScale());
-}
-
 
 TEST(Transform, InvalidBearing) {
     Transform transform;
@@ -349,17 +315,7 @@ TEST(Transform, Padding) {
         1000.0 / 4.0,
     });
 
-    EdgeInsets padding;
-
-    padding.top = 0;
-    ASSERT_FALSE(bool(padding));
-
-    padding.top = NAN;
-    ASSERT_FALSE(bool(padding));
-
-    padding.top = 1000.0 / 2.0;
-    ASSERT_TRUE(bool(padding));
-
+    EdgeInsets padding(1000.0 / 2.0, 0, 0, 0);
     const LatLng shiftedCenter = transform.getLatLng(padding);
     ASSERT_NE(trueCenter.latitude, shiftedCenter.latitude);
     ASSERT_NEAR(trueCenter.longitude, shiftedCenter.longitude, 1e-9);

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -8,39 +8,39 @@ using namespace mbgl;
 TEST(Transform, InvalidScale) {
     Transform transform;
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getScale());
 
     transform.setScale(2 << 0);
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(2, transform.getScale());
 
     const double invalid = std::nan("");
     transform.setScale(invalid);
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(2, transform.getScale());
 
     transform.scaleBy(invalid);
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(2, transform.getScale());
 
     transform.setZoom(invalid);
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(2, transform.getScale());
 
     transform.setLatLngZoom({ 0, 0 }, invalid);
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(2, transform.getScale());
 }
 
@@ -48,23 +48,23 @@ TEST(Transform, InvalidScale) {
 TEST(Transform, InvalidBearing) {
     Transform transform;
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(1, transform.getScale());
 
     transform.setScale(2 << 0);
     transform.setAngle(2);
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(2, transform.getScale());
     ASSERT_DOUBLE_EQ(2, transform.getAngle());
 
     const double invalid = std::nan("");
     transform.setAngle(invalid);
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(2, transform.getScale());
     ASSERT_DOUBLE_EQ(2, transform.getAngle());
 }
@@ -110,16 +110,16 @@ TEST(Transform, PerspectiveProjection) {
     // expected values are from mapbox-gl-js
 
     loc = transform.getLatLng();
-    ASSERT_NEAR(-77, loc.longitude, 0.0001);
-    ASSERT_NEAR(38, loc.latitude, 0.0001);
+    ASSERT_NEAR(-77, loc.longitude(), 0.0001);
+    ASSERT_NEAR(38, loc.latitude(), 0.0001);
 
     loc = transform.getState().screenCoordinateToLatLng({ 0, 1000 });
-    ASSERT_NEAR(-77.59198961199148, loc.longitude, 0.0002);
-    ASSERT_NEAR(38.74661326302018, loc.latitude, 0.0001);
+    ASSERT_NEAR(-77.59198961199148, loc.longitude(), 0.0002);
+    ASSERT_NEAR(38.74661326302018, loc.latitude(), 0.0001);
 
     loc = transform.getState().screenCoordinateToLatLng({ 1000, 0 });
-    ASSERT_NEAR(-76.75823239205641, loc.longitude, 0.0001);
-    ASSERT_NEAR(37.692872969426375, loc.latitude, 0.0001);
+    ASSERT_NEAR(-76.75823239205641, loc.longitude(), 0.0001);
+    ASSERT_NEAR(37.692872969426375, loc.latitude(), 0.0001);
 
     ScreenCoordinate point = transform.getState().latLngToScreenCoordinate({38.74661326302018, -77.59198961199148});
     ASSERT_NEAR(point.x, 0, 0.01);
@@ -140,24 +140,24 @@ TEST(Transform, UnwrappedLatLng) {
     const TransformState& state = transform.getState();
 
     LatLng fromGetLatLng = state.getLatLng();
-    ASSERT_DOUBLE_EQ(fromGetLatLng.latitude, 38);
-    ASSERT_DOUBLE_EQ(fromGetLatLng.longitude, -77);
+    ASSERT_DOUBLE_EQ(fromGetLatLng.latitude(), 38);
+    ASSERT_DOUBLE_EQ(fromGetLatLng.longitude(), -77);
 
     LatLng fromScreenCoordinate = state.screenCoordinateToLatLng({ 500, 500 });
-    ASSERT_NEAR(fromScreenCoordinate.latitude,   37.999999999999829, 0.0001); // 1.71E-13
-    ASSERT_NEAR(fromScreenCoordinate.longitude, -76.999999999999773, 0.0001); // 2.27E-13
+    ASSERT_NEAR(fromScreenCoordinate.latitude(),   37.999999999999829, 0.0001); // 1.71E-13
+    ASSERT_NEAR(fromScreenCoordinate.longitude(), -76.999999999999773, 0.0001); // 2.27E-13
 
     LatLng wrappedForwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, 283 }));
-    ASSERT_NEAR(wrappedForwards.latitude, 37.999999999999716, 0.0001); // 2.84E-13
-    ASSERT_NEAR(wrappedForwards.longitude, 282.99999999988751, 0.0001); // 1.1249E-11
+    ASSERT_NEAR(wrappedForwards.latitude(), 37.999999999999716, 0.0001); // 2.84E-13
+    ASSERT_NEAR(wrappedForwards.longitude(), 282.99999999988751, 0.0001); // 1.1249E-11
     wrappedForwards.wrap();
-    ASSERT_NEAR(wrappedForwards.longitude, -77.000000000112493, 0.001); // 1.1249E-11
+    ASSERT_NEAR(wrappedForwards.longitude(), -77.000000000112493, 0.001); // 1.1249E-11
 
     LatLng wrappedBackwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, -437 }));
-    ASSERT_NEAR(wrappedBackwards.latitude, wrappedForwards.latitude, 0.001);
-    ASSERT_NEAR(wrappedBackwards.longitude, -436.99999999988728, 0.001); // 1.1272E-11
+    ASSERT_NEAR(wrappedBackwards.latitude(), wrappedForwards.latitude(), 0.001);
+    ASSERT_NEAR(wrappedBackwards.longitude(), -436.99999999988728, 0.001); // 1.1272E-11
     wrappedBackwards.wrap();
-    ASSERT_NEAR(wrappedBackwards.longitude, -76.99999999988728, 0.001); // 1.1272E-11
+    ASSERT_NEAR(wrappedBackwards.longitude(), -76.99999999988728, 0.001); // 1.1272E-11
 }
 
 TEST(Transform, ConstrainHeightOnly) {
@@ -169,13 +169,13 @@ TEST(Transform, ConstrainHeightOnly) {
 
     transform.setLatLng(LatLngBounds::world().southwest());
     loc = transform.getLatLng();
-    ASSERT_NEAR(-util::LATITUDE_MAX, loc.latitude, 0.001);
-    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude), 0.001);
+    ASSERT_NEAR(-util::LATITUDE_MAX, loc.latitude(), 0.001);
+    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude()), 0.001);
 
     transform.setLatLng(LatLngBounds::world().northeast());
     loc = transform.getLatLng();
-    ASSERT_NEAR(util::LATITUDE_MAX, loc.latitude, 0.001);
-    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude), 0.001);
+    ASSERT_NEAR(util::LATITUDE_MAX, loc.latitude(), 0.001);
+    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude()), 0.001);
 }
 
 TEST(Transform, ConstrainWidthAndHeight) {
@@ -187,13 +187,13 @@ TEST(Transform, ConstrainWidthAndHeight) {
 
     transform.setLatLng(LatLngBounds::world().southwest());
     loc = transform.getLatLng();
-    ASSERT_NEAR(-util::LATITUDE_MAX, loc.latitude, 0.001);
-    ASSERT_NEAR(-util::LONGITUDE_MAX, loc.longitude, 0.001);
+    ASSERT_NEAR(-util::LATITUDE_MAX, loc.latitude(), 0.001);
+    ASSERT_NEAR(-util::LONGITUDE_MAX, loc.longitude(), 0.001);
 
     transform.setLatLng(LatLngBounds::world().northeast());
     loc = transform.getLatLng();
-    ASSERT_NEAR(util::LATITUDE_MAX, loc.latitude, 0.001);
-    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude), 0.001);
+    ASSERT_NEAR(util::LATITUDE_MAX, loc.latitude(), 0.001);
+    ASSERT_NEAR(util::LONGITUDE_MAX, std::abs(loc.longitude()), 0.001);
 }
 
 TEST(Transform, Anchor) {
@@ -203,8 +203,8 @@ TEST(Transform, Anchor) {
     const LatLng latLng { 10, -100 };
     transform.setLatLngZoom(latLng, 10);
 
-    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
     ASSERT_DOUBLE_EQ(0, transform.getAngle());
 
@@ -212,102 +212,102 @@ TEST(Transform, Anchor) {
     const ScreenCoordinate anchorPoint = { 150, 150 };
 
     const LatLng anchorLatLng = transform.getState().screenCoordinateToLatLng(anchorPoint);
-    ASSERT_NE(latLng.latitude, anchorLatLng.latitude);
-    ASSERT_NE(latLng.longitude, anchorLatLng.longitude);
+    ASSERT_NE(latLng.latitude(), anchorLatLng.latitude());
+    ASSERT_NE(latLng.longitude(), anchorLatLng.longitude());
 
     transform.setLatLngZoom(latLng, 2);
     transform.scaleBy(1);
     ASSERT_DOUBLE_EQ(4, transform.getScale());
-    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.scaleBy(1.5, invalidAnchorPoint);
     ASSERT_DOUBLE_EQ(6, transform.getScale());
-    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.scaleBy(2, anchorPoint);
     ASSERT_DOUBLE_EQ(12, transform.getScale());
-    ASSERT_NE(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_NE(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_NE(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_NE(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.setLatLngZoom(latLng, 10);
     transform.setScale(2 << 2);
     ASSERT_DOUBLE_EQ(2 << 2, transform.getScale());
-    ASSERT_NEAR(latLng.latitude, transform.getLatLng().latitude, 0.000001);
-    ASSERT_NEAR(latLng.longitude, transform.getLatLng().longitude, 0.000001);
+    ASSERT_NEAR(latLng.latitude(), transform.getLatLng().latitude(), 0.000001);
+    ASSERT_NEAR(latLng.longitude(), transform.getLatLng().longitude(), 0.000001);
 
     transform.setScale(2 << 4, invalidAnchorPoint);
     ASSERT_DOUBLE_EQ(2 << 4, transform.getScale());
-    ASSERT_NEAR(latLng.latitude, transform.getLatLng().latitude, 0.000001);
-    ASSERT_NEAR(latLng.longitude, transform.getLatLng().longitude, 0.000001);
+    ASSERT_NEAR(latLng.latitude(), transform.getLatLng().latitude(), 0.000001);
+    ASSERT_NEAR(latLng.longitude(), transform.getLatLng().longitude(), 0.000001);
 
     transform.setScale(2 << 6, anchorPoint);
     ASSERT_DOUBLE_EQ(2 << 6, transform.getScale());
-    ASSERT_NE(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_NE(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_NE(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_NE(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.setLatLngZoom(latLng, 10);
     transform.setZoom(2);
     ASSERT_DOUBLE_EQ(2, transform.getZoom());
-    ASSERT_NEAR(latLng.latitude, transform.getLatLng().latitude, 0.000001);
-    ASSERT_NEAR(latLng.longitude, transform.getLatLng().longitude, 0.000001);
+    ASSERT_NEAR(latLng.latitude(), transform.getLatLng().latitude(), 0.000001);
+    ASSERT_NEAR(latLng.longitude(), transform.getLatLng().longitude(), 0.000001);
 
     transform.setZoom(4, invalidAnchorPoint);
     ASSERT_DOUBLE_EQ(4, transform.getZoom());
-    ASSERT_NEAR(latLng.latitude, transform.getLatLng().latitude, 0.000001);
-    ASSERT_NEAR(latLng.longitude, transform.getLatLng().longitude, 0.000001);
+    ASSERT_NEAR(latLng.latitude(), transform.getLatLng().latitude(), 0.000001);
+    ASSERT_NEAR(latLng.longitude(), transform.getLatLng().longitude(), 0.000001);
 
     transform.setZoom(8, anchorPoint);
     ASSERT_DOUBLE_EQ(8, transform.getZoom());
-    ASSERT_NE(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_NE(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_NE(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_NE(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.setLatLngZoom(latLng, 10);
     transform.setAngle(M_PI_4);
     ASSERT_NEAR(M_PI_4, transform.getAngle(), 0.000001);
-    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.setAngle(0, invalidAnchorPoint);
     ASSERT_DOUBLE_EQ(0, transform.getAngle());
-    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.setAngle(45 * util::DEG2RAD, anchorPoint);
     ASSERT_NEAR(45 / util::RAD2DEG, transform.getAngle(), 0.000001);
-    ASSERT_NEAR(anchorLatLng.latitude, transform.getLatLng().latitude, 1);
-    ASSERT_NEAR(anchorLatLng.longitude, transform.getLatLng().longitude, 1);
+    ASSERT_NEAR(anchorLatLng.latitude(), transform.getLatLng().latitude(), 1);
+    ASSERT_NEAR(anchorLatLng.longitude(), transform.getLatLng().longitude(), 1);
 
     transform.setLatLngZoom(latLng, 10);
     transform.setPitch(10 * util::DEG2RAD);
     ASSERT_DOUBLE_EQ(10 / util::RAD2DEG, transform.getPitch());
-    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.setPitch(15 * util::DEG2RAD, invalidAnchorPoint);
     ASSERT_DOUBLE_EQ(15 / util::RAD2DEG, transform.getPitch());
-    ASSERT_DOUBLE_EQ(latLng.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng.longitude(), transform.getLatLng().longitude());
 
     transform.setPitch(20 * util::DEG2RAD, anchorPoint);
     ASSERT_DOUBLE_EQ(20 / util::RAD2DEG, transform.getPitch());
-    ASSERT_NEAR(anchorLatLng.latitude, transform.getLatLng().latitude, 1);
-    ASSERT_NEAR(anchorLatLng.longitude, transform.getLatLng().longitude, 1);
+    ASSERT_NEAR(anchorLatLng.latitude(), transform.getLatLng().latitude(), 1);
+    ASSERT_NEAR(anchorLatLng.longitude(), transform.getLatLng().longitude(), 1);
 }
 
 TEST(Transform, Padding) {
     Transform transform;
     transform.resize({ 1000, 1000 });
 
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude());
 
     transform.setLatLngZoom({ 10, -100 }, 10);
 
     const LatLng trueCenter = transform.getLatLng();
-    ASSERT_DOUBLE_EQ(10, trueCenter.latitude);
-    ASSERT_DOUBLE_EQ(-100, trueCenter.longitude);
+    ASSERT_DOUBLE_EQ(10, trueCenter.latitude());
+    ASSERT_DOUBLE_EQ(-100, trueCenter.longitude());
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
 
     const LatLng manualShiftedCenter = transform.getState().screenCoordinateToLatLng({
@@ -317,10 +317,10 @@ TEST(Transform, Padding) {
 
     EdgeInsets padding(1000.0 / 2.0, 0, 0, 0);
     const LatLng shiftedCenter = transform.getLatLng(padding);
-    ASSERT_NE(trueCenter.latitude, shiftedCenter.latitude);
-    ASSERT_NEAR(trueCenter.longitude, shiftedCenter.longitude, 1e-9);
-    ASSERT_DOUBLE_EQ(manualShiftedCenter.latitude, shiftedCenter.latitude);
-    ASSERT_DOUBLE_EQ(manualShiftedCenter.longitude, shiftedCenter.longitude);
+    ASSERT_NE(trueCenter.latitude(), shiftedCenter.latitude());
+    ASSERT_NEAR(trueCenter.longitude(), shiftedCenter.longitude(), 1e-9);
+    ASSERT_DOUBLE_EQ(manualShiftedCenter.latitude(), shiftedCenter.latitude());
+    ASSERT_DOUBLE_EQ(manualShiftedCenter.longitude(), shiftedCenter.longitude());
 }
 
 TEST(Transform, MoveBy) {
@@ -329,8 +329,8 @@ TEST(Transform, MoveBy) {
     transform.setLatLngZoom({ 0, 0 }, 10);
 
     LatLng trueCenter = transform.getLatLng();
-    ASSERT_DOUBLE_EQ(0, trueCenter.latitude);
-    ASSERT_DOUBLE_EQ(0, trueCenter.longitude);
+    ASSERT_DOUBLE_EQ(0, trueCenter.latitude());
+    ASSERT_DOUBLE_EQ(0, trueCenter.longitude());
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
 
     for (uint8_t x = 0; x < 20; ++x) {
@@ -341,13 +341,13 @@ TEST(Transform, MoveBy) {
         transform.moveBy({ odd ? 100. : -100., forward ? 100. : -100 });
 
         trueCenter = transform.getLatLng();
-        ASSERT_NEAR(coordinate.latitude, trueCenter.latitude, 0.0001);
-        ASSERT_NEAR(coordinate.longitude, trueCenter.longitude, 0.0001);
+        ASSERT_NEAR(coordinate.latitude(), trueCenter.latitude(), 0.0001);
+        ASSERT_NEAR(coordinate.longitude(), trueCenter.longitude(), 0.0001);
     }
 
     // We have ~1.1 precision loss for each coordinate for 20 rounds of moveBy.
-    ASSERT_NEAR(0, trueCenter.latitude, 1.1);
-    ASSERT_NEAR(0, trueCenter.longitude, 1.1);
+    ASSERT_NEAR(0, trueCenter.latitude(), 1.1);
+    ASSERT_NEAR(0, trueCenter.longitude(), 1.1);
 }
 
 TEST(Transform, Antimeridian) {
@@ -376,21 +376,21 @@ TEST(Transform, Antimeridian) {
     ASSERT_NEAR(500, pixelWaikiri.x, 1e-2);
     ASSERT_NEAR(500, pixelWaikiri.y, 1e-2);
 
-    transform.setLatLng({ coordinateWaikiri.latitude, 180.0213 });
+    transform.setLatLng({ coordinateWaikiri.latitude(), 180.0213 });
     ScreenCoordinate pixelWaikiriForwards = transform.latLngToScreenCoordinate(coordinateWaikiri);
     ASSERT_NEAR(437.95953728819512, pixelWaikiriForwards.x, 1e-2);
     ASSERT_DOUBLE_EQ(pixelWaikiri.y, pixelWaikiriForwards.y);
     LatLng coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriForwards);
-    ASSERT_NEAR(coordinateWaikiri.latitude, coordinateFromPixel.latitude, 0.000001);
-    ASSERT_NEAR(coordinateWaikiri.longitude, coordinateFromPixel.longitude, 0.000001);
+    ASSERT_NEAR(coordinateWaikiri.latitude(), coordinateFromPixel.latitude(), 0.000001);
+    ASSERT_NEAR(coordinateWaikiri.longitude(), coordinateFromPixel.longitude(), 0.000001);
 
-    transform.setLatLng({ coordinateWaikiri.latitude, -179.9787 });
+    transform.setLatLng({ coordinateWaikiri.latitude(), -179.9787 });
     ScreenCoordinate pixelWaikiriBackwards = transform.latLngToScreenCoordinate(coordinateWaikiri);
     ASSERT_DOUBLE_EQ(pixelWaikiriForwards.x, pixelWaikiriBackwards.x);
     ASSERT_DOUBLE_EQ(pixelWaikiriForwards.y, pixelWaikiriBackwards.y);
     coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriBackwards);
-    ASSERT_NEAR(coordinateWaikiri.latitude, coordinateFromPixel.latitude, 0.000001);
-    ASSERT_NEAR(coordinateWaikiri.longitude, coordinateFromPixel.longitude, 0.000001);
+    ASSERT_NEAR(coordinateWaikiri.latitude(), coordinateFromPixel.latitude(), 0.000001);
+    ASSERT_NEAR(coordinateWaikiri.longitude(), coordinateFromPixel.longitude(), 0.000001);
 }
 
 TEST(Transform, Camera) {
@@ -403,8 +403,8 @@ TEST(Transform, Camera) {
     cameraOptions1.center = latLng1;
     transform.jumpTo(cameraOptions1);
 
-    ASSERT_DOUBLE_EQ(latLng1.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng1.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng1.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng1.longitude(), transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(20, transform.getZoom());
 
     const LatLng latLng2 { -45, -135 };
@@ -413,19 +413,19 @@ TEST(Transform, Camera) {
     cameraOptions2.center = latLng2;
 
     transform.jumpTo(cameraOptions2);
-    ASSERT_DOUBLE_EQ(latLng2.latitude, transform.getLatLng().latitude);
-    ASSERT_DOUBLE_EQ(latLng2.longitude, transform.getLatLng().longitude);
+    ASSERT_DOUBLE_EQ(latLng2.latitude(), transform.getLatLng().latitude());
+    ASSERT_DOUBLE_EQ(latLng2.longitude(), transform.getLatLng().longitude());
     ASSERT_DOUBLE_EQ(10, transform.getZoom());
 
     AnimationOptions easeOptions(Seconds(1));
     easeOptions.transitionFrameFn = [&](double t) {
         ASSERT_TRUE(t >= 0 && t <= 1);
-        ASSERT_GE(latLng1.latitude, transform.getLatLng().latitude);
-        ASSERT_LE(latLng1.longitude, transform.getLatLng().longitude);
+        ASSERT_GE(latLng1.latitude(), transform.getLatLng().latitude());
+        ASSERT_LE(latLng1.longitude(), transform.getLatLng().longitude());
     };
     easeOptions.transitionFinishFn = [&]() {
-        ASSERT_NEAR(latLng1.latitude, transform.getLatLng().latitude, 0.000001);
-        ASSERT_NEAR(latLng1.longitude, transform.getLatLng().longitude, 0.000001);
+        ASSERT_NEAR(latLng1.latitude(), transform.getLatLng().latitude(), 0.000001);
+        ASSERT_NEAR(latLng1.longitude(), transform.getLatLng().longitude(), 0.000001);
         ASSERT_NEAR(20, transform.getZoom(), 0.000001);
     };
 
@@ -440,14 +440,14 @@ TEST(Transform, Camera) {
     AnimationOptions flyOptions(Seconds(1));
     flyOptions.transitionFrameFn = [&](double t) {
         ASSERT_TRUE(t >= 0 && t <= 1);
-        ASSERT_LE(latLng2.latitude, transform.getLatLng().latitude);
-        ASSERT_GE(latLng2.longitude, transform.getLatLng().longitude);
+        ASSERT_LE(latLng2.latitude(), transform.getLatLng().latitude());
+        ASSERT_GE(latLng2.longitude(), transform.getLatLng().longitude());
     };
     flyOptions.transitionFinishFn = [&]() {
         // XXX Fix precision loss in flyTo:
         // https://github.com/mapbox/mapbox-gl-native/issues/4298
-        ASSERT_NEAR(latLng2.latitude, transform.getLatLng().latitude, 0.001);
-        ASSERT_NEAR(latLng2.longitude, transform.getLatLng().longitude, 0.001);
+        ASSERT_NEAR(latLng2.latitude(), transform.getLatLng().latitude(), 0.001);
+        ASSERT_NEAR(latLng2.longitude(), transform.getLatLng().longitude(), 0.001);
         ASSERT_NEAR(10, transform.getZoom(), 0.00001);
     };
 
@@ -471,8 +471,8 @@ TEST(Transform, DefaultTransform) {
 
     auto testConversions = [&](const LatLng& coord, const ScreenCoordinate& screenCoord) {
         latLng = state.screenCoordinateToLatLng(center);
-        ASSERT_NEAR(latLng.latitude, coord.latitude, 0.000001);
-        ASSERT_NEAR(latLng.longitude, coord.longitude, 0.000001);
+        ASSERT_NEAR(latLng.latitude(), coord.latitude(), 0.000001);
+        ASSERT_NEAR(latLng.longitude(), coord.longitude(), 0.000001);
         point = state.latLngToScreenCoordinate(nullIsland);
         ASSERT_DOUBLE_EQ(point.x, screenCoord.x);
         ASSERT_DOUBLE_EQ(point.y, screenCoord.y);

--- a/test/tile/tile_coordinate.test.cpp
+++ b/test/tile/tile_coordinate.test.cpp
@@ -64,8 +64,8 @@ TEST(TileCoordinate, FromLatLng) {
             const double zoom = integerZoom;
             const double maxTilesPerAxis = std::pow(2.0, zoom);
             const Point<double> tilePoint = {
-                latLng.longitude == 0 ? 0.5 : latLng.longitude == -util::LONGITUDE_MAX ? 0 : 1.0,
-                latLng.latitude  == 0 ? 0.5 : latLng.latitude  == -util::LATITUDE_MAX  ? 1.0 : 0,
+                latLng.longitude() == 0 ? 0.5 : latLng.longitude() == -util::LONGITUDE_MAX ? 0 : 1.0,
+                latLng.latitude()  == 0 ? 0.5 : latLng.latitude()  == -util::LATITUDE_MAX  ? 1.0 : 0,
             };
 
             const auto fromLatLng = TileCoordinate::fromLatLng(zoom, latLng);

--- a/test/util/geo.test.cpp
+++ b/test/util/geo.test.cpp
@@ -57,80 +57,80 @@ TEST(LatLngBounds, Empty) {
 
 TEST(LatLngBounds, Center) {
     auto result = LatLngBounds::hull({1, 2}, {3, 4}).center();
-    ASSERT_DOUBLE_EQ(2, result.latitude);
-    ASSERT_DOUBLE_EQ(3, result.longitude);
+    ASSERT_DOUBLE_EQ(2, result.latitude());
+    ASSERT_DOUBLE_EQ(3, result.longitude());
 }
 
 TEST(LatLngBounds, Southwest) {
     auto result = LatLngBounds::hull({1, 2}, {3, 4}).southwest();
-    ASSERT_DOUBLE_EQ(1, result.latitude);
-    ASSERT_DOUBLE_EQ(2, result.longitude);
+    ASSERT_DOUBLE_EQ(1, result.latitude());
+    ASSERT_DOUBLE_EQ(2, result.longitude());
 }
 
 TEST(LatLngBounds, Northeast) {
     auto result = LatLngBounds::hull({1, 2}, {3, 4}).northeast();
-    ASSERT_DOUBLE_EQ(3, result.latitude);
-    ASSERT_DOUBLE_EQ(4, result.longitude);
+    ASSERT_DOUBLE_EQ(3, result.latitude());
+    ASSERT_DOUBLE_EQ(4, result.longitude());
 }
 
 TEST(LatLngBounds, Southeast) {
     auto result = LatLngBounds::hull({1, 2}, {3, 4}).southeast();
-    ASSERT_DOUBLE_EQ(1, result.latitude);
-    ASSERT_DOUBLE_EQ(4, result.longitude);
+    ASSERT_DOUBLE_EQ(1, result.latitude());
+    ASSERT_DOUBLE_EQ(4, result.longitude());
 }
 
 TEST(LatLngBounds, Northwest) {
     auto result = LatLngBounds::hull({1, 2}, {3, 4}).northwest();
-    ASSERT_DOUBLE_EQ(3, result.latitude);
-    ASSERT_DOUBLE_EQ(2, result.longitude);
+    ASSERT_DOUBLE_EQ(3, result.latitude());
+    ASSERT_DOUBLE_EQ(2, result.longitude());
 }
 
 TEST(LatLng, FromTileID) {
     for (int i = 0; i < 20; i++) {
         const LatLng ll{ CanonicalTileID(i, 0, 0) };
-        ASSERT_DOUBLE_EQ(-util::LONGITUDE_MAX, ll.longitude);
-        ASSERT_DOUBLE_EQ(util::LATITUDE_MAX, ll.latitude);
+        ASSERT_DOUBLE_EQ(-util::LONGITUDE_MAX, ll.longitude());
+        ASSERT_DOUBLE_EQ(util::LATITUDE_MAX, ll.latitude());
     }
 
     {
         const LatLng ll{ UnwrappedTileID(0, 1, 0) };
-        ASSERT_DOUBLE_EQ(util::LONGITUDE_MAX, ll.longitude);
-        ASSERT_DOUBLE_EQ(util::LATITUDE_MAX, ll.latitude);
+        ASSERT_DOUBLE_EQ(util::LONGITUDE_MAX, ll.longitude());
+        ASSERT_DOUBLE_EQ(util::LATITUDE_MAX, ll.latitude());
     }
 
     {
         const LatLng ll{ UnwrappedTileID(0, -1, 0) };
-        ASSERT_DOUBLE_EQ(-540, ll.longitude);
-        ASSERT_DOUBLE_EQ(util::LATITUDE_MAX, ll.latitude);
+        ASSERT_DOUBLE_EQ(-540, ll.longitude());
+        ASSERT_DOUBLE_EQ(util::LATITUDE_MAX, ll.latitude());
     }
 }
 
 TEST(LatLng, Boundaries) {
     LatLng coordinate;
-    ASSERT_DOUBLE_EQ(0, coordinate.latitude);
-    ASSERT_DOUBLE_EQ(0, coordinate.longitude);
+    ASSERT_DOUBLE_EQ(0, coordinate.latitude());
+    ASSERT_DOUBLE_EQ(0, coordinate.longitude());
 
-    coordinate.longitude = -180.1;
-    ASSERT_DOUBLE_EQ(-180.1, coordinate.longitude);
+    coordinate = LatLng(0, -180.1);
+    ASSERT_DOUBLE_EQ(-180.1, coordinate.longitude());
 
     coordinate.wrap();
-    ASSERT_DOUBLE_EQ(179.90000000000001, coordinate.longitude); // 1E-14
+    ASSERT_DOUBLE_EQ(179.90000000000001, coordinate.longitude()); // 1E-14
 
-    coordinate.longitude = 180.9;
+    coordinate = LatLng(0, 180.9);
     coordinate.wrap();
-    ASSERT_DOUBLE_EQ(-179.09999999999999, coordinate.longitude);
+    ASSERT_DOUBLE_EQ(-179.09999999999999, coordinate.longitude());
 
-    coordinate.longitude = -360.5;
+    coordinate = LatLng(0, -360.5);
     coordinate.wrap();
-    ASSERT_DOUBLE_EQ(-0.5, coordinate.longitude);
+    ASSERT_DOUBLE_EQ(-0.5, coordinate.longitude());
 
-    coordinate.longitude = 360.5;
+    coordinate = LatLng(0, 360.5);
     coordinate.wrap();
-    ASSERT_DOUBLE_EQ(0.5, coordinate.longitude);
+    ASSERT_DOUBLE_EQ(0.5, coordinate.longitude());
 
-    coordinate.longitude = 360000.5;
+    coordinate = LatLng(0, 360000.5);
     coordinate.wrap();
-    ASSERT_DOUBLE_EQ(0.5, coordinate.longitude);
+    ASSERT_DOUBLE_EQ(0.5, coordinate.longitude());
 }
 
 TEST(LatLngBounds, FromTileID) {

--- a/test/util/projection.test.cpp
+++ b/test/util/projection.test.cpp
@@ -36,25 +36,20 @@ TEST(Projection, MetersPerPixelAtLatitude) {
 }
 
 TEST(Projection, ProjectedMeters) {
-    const auto southWest = LatLng { -util::LATITUDE_MAX, -util::LONGITUDE_MAX };
-    const auto northEast = LatLng { util::LATITUDE_MAX, util::LONGITUDE_MAX };
-
     auto latLng = LatLng {};
     auto projectedMeters = Projection::projectedMetersForLatLng(latLng);
     EXPECT_EQ(projectedMeters.northing, projectedMeters.easting);
     EXPECT_EQ(latLng, Projection::latLngForProjectedMeters(projectedMeters));
 
-    latLng = LatLng { std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest() };
-    projectedMeters = Projection::projectedMetersForLatLng(latLng);
-    EXPECT_EQ(projectedMeters, Projection::projectedMetersForLatLng(southWest));
+    const auto southWest = LatLng { -util::LATITUDE_MAX, -util::LONGITUDE_MAX };
+    projectedMeters = Projection::projectedMetersForLatLng(southWest);
     EXPECT_DOUBLE_EQ(projectedMeters.northing, -20037508.342789274);
     EXPECT_DOUBLE_EQ(projectedMeters.easting, -20037508.342789244);
 
-    latLng = LatLng { std::numeric_limits<double>::max(), std::numeric_limits<double>::max() };
-    projectedMeters = Projection::projectedMetersForLatLng(latLng);
-    EXPECT_EQ(projectedMeters, Projection::projectedMetersForLatLng(northEast));
-    EXPECT_DOUBLE_EQ(projectedMeters.northing, -Projection::projectedMetersForLatLng(southWest).northing);
-    EXPECT_DOUBLE_EQ(projectedMeters.easting, -Projection::projectedMetersForLatLng(southWest).easting);
+    const auto northEast = LatLng { util::LATITUDE_MAX, util::LONGITUDE_MAX };
+    projectedMeters = Projection::projectedMetersForLatLng(northEast);
+    EXPECT_DOUBLE_EQ(projectedMeters.northing, 20037508.342789274);
+    EXPECT_DOUBLE_EQ(projectedMeters.easting, 20037508.342789244);
 
     projectedMeters = ProjectedMeters { std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest() };
     latLng = Projection::latLngForProjectedMeters(projectedMeters);

--- a/test/util/projection.test.cpp
+++ b/test/util/projection.test.cpp
@@ -53,11 +53,11 @@ TEST(Projection, ProjectedMeters) {
 
     projectedMeters = ProjectedMeters { std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest() };
     latLng = Projection::latLngForProjectedMeters(projectedMeters);
-    EXPECT_EQ(latLng.latitude, -util::LATITUDE_MAX);
-    EXPECT_EQ(latLng.longitude, -util::LONGITUDE_MAX);
+    EXPECT_EQ(latLng.latitude(), -util::LATITUDE_MAX);
+    EXPECT_EQ(latLng.longitude(), -util::LONGITUDE_MAX);
 
     projectedMeters = ProjectedMeters { std::numeric_limits<double>::max(), std::numeric_limits<double>::max() };
     latLng = Projection::latLngForProjectedMeters(projectedMeters);
-    EXPECT_EQ(latLng.latitude, util::LATITUDE_MAX);
-    EXPECT_EQ(latLng.longitude, util::LONGITUDE_MAX);
+    EXPECT_EQ(latLng.latitude(), util::LATITUDE_MAX);
+    EXPECT_EQ(latLng.longitude(), util::LONGITUDE_MAX);
 }


### PR DESCRIPTION
- Remove LatLng::null and enforce non-NaN, non-infinite coordinates and -90 <= lat <= 90
- Remove unnecessary operator bool()

This has caught two bugs so far:
- lat/lng swapping in TileJSON center and bounds
- Wrong w₀ value in `Transform::flyTo`

Fixes #3802. Reroll of #4355.
