### PR TITLE
Update annotation views before informing delegate

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4454,11 +4454,11 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         case mbgl::MapChangeDidFinishRenderingFrame:
         case mbgl::MapChangeDidFinishRenderingFrameFullyRendered:
         {
+            [self updateAnnotationViews];
             if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingFrame:fullyRendered:)])
             {
                 [self.delegate mapViewDidFinishRenderingFrame:self fullyRendered:(change == mbgl::MapChangeDidFinishRenderingFrameFullyRendered)];
             }
-            [self updateAnnotationViews];
             break;
         }
     }


### PR DESCRIPTION
On each frame update, update annotation views before informing the delegate of the new frame. This allows the delegate to manipulate annotation views without fear of the SDK overriding those modifications.

For example, if you want a particular view-backed annotation other than the selected annotation to appear in front of any other view-backed annotations, your MGLMapViewDelegate can hold a strong reference to the view it provides for that annotation and implement this method:

```objc
- (void)mapViewDidFinishRenderingFrame:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered {
    // Make way for Its Preeminence!
    [self.preeminentAnnotationView.superview bringSubviewToFront:self.preeminentAnnotationView];
}
```

/ref #991 #5264
/cc @frederoni @boundsj @zugaldia