### PR TITLE
[core] Singleton pattern for mbgl::gl::{ObjectStore,TexturePool}

### DIFF
--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -36,11 +36,11 @@ public:
     }
 
     // Transfers this buffer to the GPU and binds the buffer to the GL context.
-    void bind(gl::ObjectStore& store) {
+    void bind() {
         if (buffer) {
             MBGL_CHECK_ERROR(glBindBuffer(bufferType, *buffer));
         } else {
-            buffer = store.createBuffer();
+            buffer = gl::ObjectStore::get().createBuffer();
             MBGL_CHECK_ERROR(glBindBuffer(bufferType, *buffer));
             if (array == nullptr) {
                 Log::Debug(Event::OpenGL, "Buffer doesn't contain elements");
@@ -65,9 +65,9 @@ public:
     }
 
     // Uploads the buffer to the GPU to be available when we need it.
-    inline void upload(gl::ObjectStore& store) {
+    inline void upload() {
         if (!buffer) {
-            bind(store);
+            bind();
         }
     }
 

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -142,10 +142,10 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
     }
 }
 
-void GlyphAtlas::upload(gl::ObjectStore& store) {
+void GlyphAtlas::upload() {
     if (dirty) {
         const bool first = !texture;
-        bind(store);
+        bind();
 
         std::lock_guard<std::mutex> lock(mtx);
 
@@ -183,9 +183,9 @@ void GlyphAtlas::upload(gl::ObjectStore& store) {
     }
 }
 
-void GlyphAtlas::bind(gl::ObjectStore& store) {
+void GlyphAtlas::bind() {
     if (!texture) {
-        texture = store.createTexture();
+        texture = gl::ObjectStore::get().createTexture();
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -28,11 +28,11 @@ public:
     void removeGlyphs(uintptr_t tileUID);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind(gl::ObjectStore&);
+    void bind();
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload(gl::ObjectStore&);
+    void upload();
 
     const GLsizei width;
     const GLsizei height;

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -21,7 +21,7 @@ LineAtlas::LineAtlas(GLsizei w, GLsizei h)
 LineAtlas::~LineAtlas() {
 }
 
-LinePatternPos LineAtlas::getDashPosition(const std::vector<float> &dasharray, bool round, gl::ObjectStore& store) {
+LinePatternPos LineAtlas::getDashPosition(const std::vector<float> &dasharray, bool round) {
     size_t key = round ? std::numeric_limits<size_t>::min() : std::numeric_limits<size_t>::max();
     for (const float part : dasharray) {
         boost::hash_combine<float>(key, part);
@@ -30,7 +30,7 @@ LinePatternPos LineAtlas::getDashPosition(const std::vector<float> &dasharray, b
     // Note: We're not handling hash collisions here.
     const auto it = positions.find(key);
     if (it == positions.end()) {
-        auto inserted = positions.emplace(key, addDash(dasharray, round, store));
+        auto inserted = positions.emplace(key, addDash(dasharray, round));
         assert(inserted.second);
         return inserted.first->second;
     } else {
@@ -38,7 +38,7 @@ LinePatternPos LineAtlas::getDashPosition(const std::vector<float> &dasharray, b
     }
 }
 
-LinePatternPos LineAtlas::addDash(const std::vector<float> &dasharray, bool round, gl::ObjectStore& store) {
+LinePatternPos LineAtlas::addDash(const std::vector<float> &dasharray, bool round) {
 
     int n = round ? 7 : 0;
     int dashheight = 2 * n + 1;
@@ -116,21 +116,21 @@ LinePatternPos LineAtlas::addDash(const std::vector<float> &dasharray, bool roun
     nextRow += dashheight;
 
     dirty = true;
-    bind(store);
+    bind();
 
     return position;
 };
 
-void LineAtlas::upload(gl::ObjectStore& store) {
+void LineAtlas::upload() {
     if (dirty) {
-        bind(store);
+        bind();
     }
 }
 
-void LineAtlas::bind(gl::ObjectStore& store) {
+void LineAtlas::bind() {
     bool first = false;
     if (!texture) {
-        texture = store.createTexture();
+        texture = gl::ObjectStore::get().createTexture();
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <map>
+#include <memory>
 
 namespace mbgl {
 
@@ -21,14 +22,14 @@ public:
     ~LineAtlas();
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind(gl::ObjectStore&);
+    void bind();
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload(gl::ObjectStore&);
+    void upload();
 
-    LinePatternPos getDashPosition(const std::vector<float>&, bool, gl::ObjectStore&);
-    LinePatternPos addDash(const std::vector<float> &dasharray, bool round, gl::ObjectStore&);
+    LinePatternPos getDashPosition(const std::vector<float>&, bool);
+    LinePatternPos addDash(const std::vector<float> &dasharray, bool round);
 
     const GLsizei width;
     const GLsizei height;

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -16,7 +16,7 @@ VertexArrayObject::VertexArrayObject() {
 VertexArrayObject::~VertexArrayObject() {
 }
 
-void VertexArrayObject::bindVertexArrayObject(gl::ObjectStore& store) {
+void VertexArrayObject::bindVertexArrayObject() {
     if (!gl::GenVertexArrays || !gl::BindVertexArray) {
         static bool reported = false;
         if (!reported) {
@@ -27,7 +27,7 @@ void VertexArrayObject::bindVertexArrayObject(gl::ObjectStore& store) {
     }
 
     if (!vao) {
-        vao = store.createVAO();
+        vao = gl::ObjectStore::get().createVAO();
     }
     MBGL_CHECK_ERROR(gl::BindVertexArray(*vao));
 }

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -2,7 +2,6 @@
 
 #include <mbgl/shader/shader.hpp>
 #include <mbgl/gl/gl.hpp>
-#include <mbgl/gl/object_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/optional.hpp>
 
@@ -20,10 +19,10 @@ public:
     ~VertexArrayObject();
 
     template <typename Shader, typename VertexBuffer>
-    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset, gl::ObjectStore& store) {
-        bindVertexArrayObject(store);
+    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset) {
+        bindVertexArrayObject();
         if (bound_shader == 0) {
-            vertexBuffer.bind(store);
+            vertexBuffer.bind();
             shader.bind(offset);
             if (vao) {
                 storeBinding(shader, vertexBuffer.getID(), 0, offset);
@@ -34,11 +33,11 @@ public:
     }
 
     template <typename Shader, typename VertexBuffer, typename ElementsBuffer>
-    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset, gl::ObjectStore& store) {
-        bindVertexArrayObject(store);
+    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset) {
+        bindVertexArrayObject();
         if (bound_shader == 0) {
-            vertexBuffer.bind(store);
-            elementsBuffer.bind(store);
+            vertexBuffer.bind();
+            elementsBuffer.bind();
             shader.bind(offset);
             if (vao) {
                 storeBinding(shader, vertexBuffer.getID(), elementsBuffer.getID(), offset);
@@ -53,7 +52,7 @@ public:
     }
 
 private:
-    void bindVertexArrayObject(gl::ObjectStore&);
+    void bindVertexArrayObject();
     void storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
     void verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
 

--- a/src/mbgl/gl/object_store.cpp
+++ b/src/mbgl/gl/object_store.cpp
@@ -6,35 +6,30 @@ namespace mbgl {
 namespace gl {
 
 void ProgramDeleter::operator()(GLuint id) const {
-    assert(store);
-    store->abandonedPrograms.push_back(id);
+    gl::ObjectStore::get().abandonedPrograms.push_back(id);
 }
 
 void ShaderDeleter::operator()(GLuint id) const {
-    assert(store);
-    store->abandonedShaders.push_back(id);
+    gl::ObjectStore::get().abandonedShaders.push_back(id);
 }
 
 void BufferDeleter::operator()(GLuint id) const {
-    assert(store);
-    store->abandonedBuffers.push_back(id);
+    gl::ObjectStore::get().abandonedBuffers.push_back(id);
 }
 
 void TextureDeleter::operator()(GLuint id) const {
-    assert(store);
-    store->abandonedTextures.push_back(id);
+    gl::ObjectStore::get().abandonedTextures.push_back(id);
 }
 
 void VAODeleter::operator()(GLuint id) const {
-    assert(store);
-    store->abandonedVAOs.push_back(id);
+    gl::ObjectStore::get().abandonedVAOs.push_back(id);
 }
 
 void TexturePoolDeleter::operator()(ObjectPool ids) const {
-    assert(store);
+    auto& store = gl::ObjectStore::get();
     for (GLuint& id : ids) {
         if (id) {
-            store->abandonedTextures.push_back(id);
+            store.abandonedTextures.push_back(id);
             id = 0;
         };
     }

--- a/src/mbgl/gl/texture_pool.cpp
+++ b/src/mbgl/gl/texture_pool.cpp
@@ -52,13 +52,11 @@ public:
         }
     }
 
-private:
     std::vector<Pool> pools;
 };
 
 void TextureReleaser::operator()(GLuint id) const {
-    assert(pool);
-    pool->impl->releaseTexture(id);
+    TexturePool::get().impl->releaseTexture(id);
 }
 
 TexturePool::TexturePool() : impl(std::make_unique<Impl>()) {
@@ -68,7 +66,11 @@ TexturePool::~TexturePool() {
 }
 
 PooledTexture TexturePool::acquireTexture() {
-    return PooledTexture { impl->acquireTexture() , { this } };
+    return PooledTexture { impl->acquireTexture() , TextureReleaser {} };
+}
+
+void TexturePool::clear() {
+    impl->pools.clear();
 }
 
 } // namespace gl

--- a/src/mbgl/gl/texture_pool.cpp
+++ b/src/mbgl/gl/texture_pool.cpp
@@ -11,7 +11,7 @@ class TexturePool::Impl : private util::noncopyable {
 public:
     class Pool : private util::noncopyable {
         public:
-            Pool(gl::ObjectStore& store) : pool(store.createTexturePool()), availableIDs(gl::TextureMax) {
+            Pool() : pool(ObjectStore::get().createTexturePool()), availableIDs(gl::TextureMax) {
                 std::copy(pool.get().begin(), pool.get().end(), availableIDs.begin());
             }
 
@@ -22,7 +22,7 @@ public:
             std::vector<GLuint> availableIDs;
     };
 
-    GLuint acquireTexture(gl::ObjectStore& store) {
+    GLuint acquireTexture() {
         auto nextAvailableID = [](auto& pool_) {
             auto it = pool_.availableIDs.begin();
             GLuint id = *it;
@@ -36,7 +36,7 @@ public:
         }
 
         // All texture IDs are in use.
-        pools.emplace_back(Pool { store });
+        pools.emplace_back(Pool {});
         return nextAvailableID(pools.back());
     }
 
@@ -67,8 +67,8 @@ TexturePool::TexturePool() : impl(std::make_unique<Impl>()) {
 TexturePool::~TexturePool() {
 }
 
-PooledTexture TexturePool::acquireTexture(gl::ObjectStore& store) {
-    return PooledTexture { impl->acquireTexture(store) , { this } };
+PooledTexture TexturePool::acquireTexture() {
+    return PooledTexture { impl->acquireTexture() , { this } };
 }
 
 } // namespace gl

--- a/src/mbgl/gl/texture_pool.hpp
+++ b/src/mbgl/gl/texture_pool.hpp
@@ -25,7 +25,7 @@ public:
     TexturePool();
     ~TexturePool();
 
-    PooledTexture acquireTexture(gl::ObjectStore&);
+    PooledTexture acquireTexture();
 
 private:
     friend TextureReleaser;

--- a/src/mbgl/gl/texture_pool.hpp
+++ b/src/mbgl/gl/texture_pool.hpp
@@ -11,10 +11,7 @@
 namespace mbgl {
 namespace gl {
 
-class TexturePool;
-
 struct TextureReleaser {
-    TexturePool* pool;
     void operator()(GLuint) const;
 };
 
@@ -22,12 +19,19 @@ using PooledTexture = std_experimental::unique_resource<GLuint, TextureReleaser>
 
 class TexturePool : private util::noncopyable {
 public:
-    TexturePool();
+    static TexturePool& get() {
+        static TexturePool pool;
+        return pool;
+    }
+
     ~TexturePool();
 
     PooledTexture acquireTexture();
+    void clear();
 
 private:
+    TexturePool();
+
     friend TextureReleaser;
 
     class Impl;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -57,7 +57,6 @@ public:
 
     MapDebugOptions debugOptions { MapDebugOptions::NoDebug };
 
-    gl::ObjectStore store;
     Update updateFlags = Update::Nothing;
     util::AsyncTask asyncUpdate;
 
@@ -114,7 +113,7 @@ Map::~Map() {
     impl->texturePool.reset();
     impl->annotationManager.reset();
 
-    impl->store.performCleanup();
+    gl::ObjectStore::get().performCleanup();
 
     impl->view.deactivate();
 }
@@ -250,7 +249,7 @@ void Map::Impl::update() {
 
 void Map::Impl::render() {
     if (!painter) {
-        painter = std::make_unique<Painter>(transform.getState(), store);
+        painter = std::make_unique<Painter>(transform.getState());
     }
 
     FrameData frameData { view.getFramebufferSize(),
@@ -269,7 +268,7 @@ void Map::Impl::render() {
         callback = nullptr;
     }
 
-    store.performCleanup();
+    gl::ObjectStore::get().performCleanup();
 
     if (style->hasTransitions()) {
         updateFlags |= Update::RecalculateStyle;
@@ -830,7 +829,7 @@ void Map::setSourceTileCacheSize(size_t size) {
 }
 
 void Map::onLowMemory() {
-    impl->store.performCleanup();
+    gl::ObjectStore::get().performCleanup();
     if (!impl->style) return;
     impl->style->onLowMemory();
     impl->view.invalidate();

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -61,7 +61,6 @@ public:
     util::AsyncTask asyncUpdate;
 
     std::unique_ptr<AnnotationManager> annotationManager;
-    std::unique_ptr<gl::TexturePool> texturePool;
     std::unique_ptr<Painter> painter;
     std::unique_ptr<Style> style;
 
@@ -97,8 +96,7 @@ Map::Impl::Impl(View& view_,
       contextMode(contextMode_),
       pixelRatio(view.getPixelRatio()),
       asyncUpdate([this] { update(); }),
-      annotationManager(std::make_unique<AnnotationManager>(pixelRatio)),
-      texturePool(std::make_unique<gl::TexturePool>()) {
+      annotationManager(std::make_unique<AnnotationManager>(pixelRatio)) {
 }
 
 Map::~Map() {
@@ -110,9 +108,9 @@ Map::~Map() {
     // cleaned up by store.performCleanup();
     impl->style.reset();
     impl->painter.reset();
-    impl->texturePool.reset();
     impl->annotationManager.reset();
 
+    gl::TexturePool::get().clear();
     gl::ObjectStore::get().performCleanup();
 
     impl->view.deactivate();
@@ -228,7 +226,6 @@ void Map::Impl::update() {
                                        transform.getState(),
                                        style->workers,
                                        fileSource,
-                                       *texturePool,
                                        style->shouldReparsePartialTiles,
                                        mode,
                                        *annotationManager,

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -29,7 +29,7 @@ public:
 
     // As long as this bucket has a Prepare render pass, this function is getting called. Typically,
     // this only happens once when the bucket is being rendered for the first time.
-    virtual void upload(gl::ObjectStore&) = 0;
+    virtual void upload() = 0;
 
     // Every time this bucket is getting rendered, this function is called. This happens either
     // once or twice (for Opaque and Transparent render passes).

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -16,9 +16,9 @@ CircleBucket::~CircleBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void CircleBucket::upload(gl::ObjectStore& store) {
-    vertexBuffer_.upload(store);
-    elementsBuffer_.upload(store);
+void CircleBucket::upload() {
+    vertexBuffer_.upload();
+    elementsBuffer_.upload();
     uploaded = true;
 }
 
@@ -82,7 +82,7 @@ void CircleBucket::addGeometry(const GeometryCollection& geometryCollection) {
     }
 }
 
-void CircleBucket::drawCircles(CircleShader& shader, gl::ObjectStore& store) {
+void CircleBucket::drawCircles(CircleShader& shader) {
     GLbyte* vertexIndex = BUFFER_OFFSET(0);
     GLbyte* elementsIndex = BUFFER_OFFSET(0);
 
@@ -91,7 +91,7 @@ void CircleBucket::drawCircles(CircleShader& shader, gl::ObjectStore& store) {
 
         if (!group->elements_length) continue;
 
-        group->array[0].bind(shader, vertexBuffer_, elementsBuffer_, vertexIndex, store);
+        group->array[0].bind(shader, vertexBuffer_, elementsBuffer_, vertexIndex);
 
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elementsIndex));
 

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -18,14 +18,14 @@ public:
     CircleBucket(const MapMode);
     ~CircleBucket() override;
 
-    void upload(gl::ObjectStore&) override;
+    void upload() override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
 
     bool hasData() const override;
     bool needsClipping() const override;
     void addGeometry(const GeometryCollection&);
 
-    void drawCircles(CircleShader&, gl::ObjectStore&);
+    void drawCircles(CircleShader&);
 
 private:
     CircleVertexBuffer vertexBuffer_;

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -38,16 +38,16 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
     }
 }
 
-void DebugBucket::drawLines(PlainShader& shader, gl::ObjectStore& store) {
+void DebugBucket::drawLines(PlainShader& shader) {
     if (!fontBuffer.empty()) {
-        array.bind(shader, fontBuffer, BUFFER_OFFSET_0, store);
+        array.bind(shader, fontBuffer, BUFFER_OFFSET_0);
         MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, (GLsizei)(fontBuffer.index())));
     }
 }
 
-void DebugBucket::drawPoints(PlainShader& shader, gl::ObjectStore& store) {
+void DebugBucket::drawPoints(PlainShader& shader) {
     if (!fontBuffer.empty()) {
-        array.bind(shader, fontBuffer, BUFFER_OFFSET_0, store);
+        array.bind(shader, fontBuffer, BUFFER_OFFSET_0);
         MBGL_CHECK_ERROR(glDrawArrays(GL_POINTS, 0, (GLsizei)(fontBuffer.index())));
     }
 }

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -10,10 +10,6 @@ namespace mbgl {
 
 class PlainShader;
 
-namespace gl {
-class ObjectStore;
-}
-
 class DebugBucket : private util::noncopyable {
 public:
     DebugBucket(const OverscaledTileID& id,
@@ -23,8 +19,8 @@ public:
                 optional<Timestamp> expires,
                 MapDebugOptions);
 
-    void drawLines(PlainShader&, gl::ObjectStore&);
-    void drawPoints(PlainShader&, gl::ObjectStore&);
+    void drawLines(PlainShader&);
+    void drawPoints(PlainShader&);
 
     const bool renderable;
     const bool complete;

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -96,10 +96,10 @@ void FillBucket::addGeometry(const GeometryCollection& geometry) {
     }
 }
 
-void FillBucket::upload(gl::ObjectStore& store) {
-    vertexBuffer.upload(store);
-    triangleElementsBuffer.upload(store);
-    lineElementsBuffer.upload(store);
+void FillBucket::upload() {
+    vertexBuffer.upload();
+    triangleElementsBuffer.upload();
+    lineElementsBuffer.upload();
 
     // From now on, we're going to render during the opaque and translucent pass.
     uploaded = true;
@@ -120,48 +120,48 @@ bool FillBucket::needsClipping() const {
     return true;
 }
 
-void FillBucket::drawElements(PlainShader& shader, gl::ObjectStore& store) {
+void FillBucket::drawElements(PlainShader& shader) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
-        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * triangleElementsBuffer.itemSize;
     }
 }
 
-void FillBucket::drawElements(PatternShader& shader, gl::ObjectStore& store) {
+void FillBucket::drawElements(PatternShader& shader) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
-        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * triangleElementsBuffer.itemSize;
     }
 }
 
-void FillBucket::drawVertices(OutlineShader& shader, gl::ObjectStore& store) {
+void FillBucket::drawVertices(OutlineShader& shader) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : lineGroups) {
         assert(group);
-        group->array[0].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index, store);
+        group->array[0].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * lineElementsBuffer.itemSize;
     }
 }
 
-void FillBucket::drawVertices(OutlinePatternShader& shader, gl::ObjectStore& store) {
+void FillBucket::drawVertices(OutlinePatternShader& shader) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : lineGroups) {
         assert(group);
-        group->array[1].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index, store);
+        group->array[1].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * lineElementsBuffer.itemSize;

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -20,17 +20,17 @@ public:
     FillBucket();
     ~FillBucket() override;
 
-    void upload(gl::ObjectStore&) override;
+    void upload() override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool needsClipping() const override;
 
     void addGeometry(const GeometryCollection&);
 
-    void drawElements(PlainShader&, gl::ObjectStore&);
-    void drawElements(PatternShader&, gl::ObjectStore&);
-    void drawVertices(OutlineShader&, gl::ObjectStore&);
-    void drawVertices(OutlinePatternShader&, gl::ObjectStore&);
+    void drawElements(PlainShader&);
+    void drawElements(PatternShader&);
+    void drawVertices(OutlineShader&);
+    void drawVertices(OutlinePatternShader&);
 
 private:
     FillVertexBuffer vertexBuffer;

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -57,11 +57,11 @@ bool FrameHistory::needsAnimation(const Duration& duration) const {
     return (time - previousTime) < duration;
 }
 
-void FrameHistory::upload(gl::ObjectStore& store) {
+void FrameHistory::upload() {
 
     if (changed) {
         const bool first = !texture;
-        bind(store);
+        bind();
 
         if (first) {
             MBGL_CHECK_ERROR(glTexImage2D(
@@ -94,9 +94,9 @@ void FrameHistory::upload(gl::ObjectStore& store) {
     }
 }
 
-void FrameHistory::bind(gl::ObjectStore& store) {
+void FrameHistory::bind() {
     if (!texture) {
-        texture = store.createTexture();
+        texture = gl::ObjectStore::get().createTexture();
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));

--- a/src/mbgl/renderer/frame_history.hpp
+++ b/src/mbgl/renderer/frame_history.hpp
@@ -3,9 +3,9 @@
 #include <array>
 
 #include <mbgl/platform/platform.hpp>
-#include <mbgl/gl/object_store.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/optional.hpp>
+#include <mbgl/gl/object_store.hpp>
 
 namespace mbgl {
 
@@ -15,8 +15,8 @@ public:
     void record(const TimePoint&, float zoom, const Duration&);
 
     bool needsAnimation(const Duration&) const;
-    void bind(gl::ObjectStore&);
-    void upload(gl::ObjectStore&);
+    void bind();
+    void upload();
 
 private:
     const int width = 256;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -437,9 +437,9 @@ void LineBucket::addPieSliceVertex(const GeometryCoordinate& currentVertex,
     }
 }
 
-void LineBucket::upload(gl::ObjectStore& store) {
-    vertexBuffer.upload(store);
-    triangleElementsBuffer.upload(store);
+void LineBucket::upload() {
+    vertexBuffer.upload();
+    triangleElementsBuffer.upload();
 
     // From now on, we're only going to render during the translucent pass.
     uploaded = true;
@@ -460,7 +460,7 @@ bool LineBucket::needsClipping() const {
     return true;
 }
 
-void LineBucket::drawLines(LineShader& shader, gl::ObjectStore& store) {
+void LineBucket::drawLines(LineShader& shader) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -468,7 +468,7 @@ void LineBucket::drawLines(LineShader& shader, gl::ObjectStore& store) {
         if (!group->elements_length) {
             continue;
         }
-        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        group->array[0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
@@ -476,7 +476,7 @@ void LineBucket::drawLines(LineShader& shader, gl::ObjectStore& store) {
     }
 }
 
-void LineBucket::drawLineSDF(LineSDFShader& shader, gl::ObjectStore& store) {
+void LineBucket::drawLineSDF(LineSDFShader& shader) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -484,7 +484,7 @@ void LineBucket::drawLineSDF(LineSDFShader& shader, gl::ObjectStore& store) {
         if (!group->elements_length) {
             continue;
         }
-        group->array[2].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        group->array[2].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
@@ -492,7 +492,7 @@ void LineBucket::drawLineSDF(LineSDFShader& shader, gl::ObjectStore& store) {
     }
 }
 
-void LineBucket::drawLinePatterns(LinepatternShader& shader, gl::ObjectStore& store) {
+void LineBucket::drawLinePatterns(LinepatternShader& shader) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -500,7 +500,7 @@ void LineBucket::drawLinePatterns(LinepatternShader& shader, gl::ObjectStore& st
         if (!group->elements_length) {
             continue;
         }
-        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        group->array[1].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -24,7 +24,7 @@ public:
     LineBucket(uint32_t overscaling);
     ~LineBucket() override;
 
-    void upload(gl::ObjectStore&) override;
+    void upload() override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool needsClipping() const override;
@@ -32,9 +32,9 @@ public:
     void addGeometry(const GeometryCollection&);
     void addGeometry(const GeometryCoordinates& line);
 
-    void drawLines(LineShader&, gl::ObjectStore&);
-    void drawLineSDF(LineSDFShader&, gl::ObjectStore&);
-    void drawLinePatterns(LinepatternShader&, gl::ObjectStore&);
+    void drawLines(LineShader&);
+    void drawLineSDF(LineSDFShader&);
+    void drawLinePatterns(LinepatternShader&);
 
 private:
     struct TriangleElement {

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -49,24 +49,22 @@ namespace mbgl {
 
 using namespace style;
 
-Painter::Painter(const TransformState& state_, gl::ObjectStore& store_)
-    : state(state_),
-      store(store_) {
+Painter::Painter(const TransformState& state_) : state(state_) {
     gl::debugging::enable();
 
-    plainShader = std::make_unique<PlainShader>(store);
-    outlineShader = std::make_unique<OutlineShader>(store);
-    outlinePatternShader = std::make_unique<OutlinePatternShader>(store);
-    lineShader = std::make_unique<LineShader>(store);
-    linesdfShader = std::make_unique<LineSDFShader>(store);
-    linepatternShader = std::make_unique<LinepatternShader>(store);
-    patternShader = std::make_unique<PatternShader>(store);
-    iconShader = std::make_unique<IconShader>(store);
-    rasterShader = std::make_unique<RasterShader>(store);
-    sdfGlyphShader = std::make_unique<SDFGlyphShader>(store);
-    sdfIconShader = std::make_unique<SDFIconShader>(store);
-    collisionBoxShader = std::make_unique<CollisionBoxShader>(store);
-    circleShader = std::make_unique<CircleShader>(store);
+    plainShader = std::make_unique<PlainShader>();
+    outlineShader = std::make_unique<OutlineShader>();
+    outlinePatternShader = std::make_unique<OutlinePatternShader>();
+    lineShader = std::make_unique<LineShader>();
+    linesdfShader = std::make_unique<LineSDFShader>();
+    linepatternShader = std::make_unique<LinepatternShader>();
+    patternShader = std::make_unique<PatternShader>();
+    iconShader = std::make_unique<IconShader>();
+    rasterShader = std::make_unique<RasterShader>();
+    sdfGlyphShader = std::make_unique<SDFGlyphShader>();
+    sdfIconShader = std::make_unique<SDFIconShader>();
+    collisionBoxShader = std::make_unique<CollisionBoxShader>();
+    circleShader = std::make_unique<CircleShader>();
 
     // Reset GL values
     config.reset();
@@ -117,17 +115,17 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     {
         MBGL_DEBUG_GROUP("upload");
 
-        tileStencilBuffer.upload(store);
-        tileBorderBuffer.upload(store);
-        spriteAtlas->upload(store);
-        lineAtlas->upload(store);
-        glyphAtlas->upload(store);
-        frameHistory.upload(store);
-        annotationSpriteAtlas.upload(store);
+        tileStencilBuffer.upload();
+        tileBorderBuffer.upload();
+        spriteAtlas->upload();
+        lineAtlas->upload();
+        glyphAtlas->upload();
+        frameHistory.upload();
+        annotationSpriteAtlas.upload();
 
         for (const auto& item : order) {
             if (item.bucket && item.bucket->needsUpload()) {
-                item.bucket->upload(store);
+                item.bucket->upload();
             }
         }
     }

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -60,7 +60,6 @@ class CollisionBoxShader;
 struct ClipID;
 
 namespace util {
-class ObjectStore;
 }
 
 namespace style {
@@ -85,7 +84,7 @@ struct FrameData {
 
 class Painter : private util::noncopyable {
 public:
-    Painter(const TransformState&, gl::ObjectStore&);
+    Painter(const TransformState&);
     ~Painter();
 
     void render(const style::Style&,
@@ -137,7 +136,7 @@ private:
                    float scaleDivisor,
                    std::array<float, 2> texsize,
                    SDFShader& sdfShader,
-                   void (SymbolBucket::*drawSDF)(SDFShader&, gl::ObjectStore&),
+                   void (SymbolBucket::*drawSDF)(SDFShader&),
 
                    // Layout
                    style::RotationAlignmentType rotationAlignment,
@@ -175,7 +174,6 @@ private:
     }();
 
     const TransformState& state;
-    gl::ObjectStore& store;
 
     FrameData frame;
 

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -40,8 +40,8 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         patternShader->u_mix = properties.backgroundPattern.value.t;
         patternShader->u_opacity = properties.backgroundOpacity;
 
-        spriteAtlas->bind(true, store);
-        backgroundPatternArray.bind(*patternShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
+        spriteAtlas->bind(true);
+        backgroundPatternArray.bind(*patternShader, tileStencilBuffer, BUFFER_OFFSET(0));
 
     } else {
         if (wireframe) {
@@ -53,7 +53,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         }
 
         config.program = plainShader->getID();
-        backgroundArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
+        backgroundArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET(0));
     }
 
     config.stencilTest = GL_FALSE;

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -43,7 +43,7 @@ void Painter::renderCircle(CircleBucket& bucket,
     circleShader->u_blur = std::max<float>(properties.circleBlur, antialiasing);
     circleShader->u_opacity = properties.circleOpacity;
 
-    bucket.drawCircles(*circleShader, store);
+    bucket.drawCircles(*circleShader);
 }
 
 }

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -22,7 +22,7 @@ void Painter::drawClippingMasks(const std::map<UnwrappedTileID, ClipID>& stencil
     config.colorMask = { GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
     config.stencilMask = mask;
 
-    coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET_0, store);
+    coveringPlainArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET_0);
 
     for (const auto& stencil : stencils) {
         const auto& id = stencil.first;

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -45,18 +45,18 @@ void Painter::renderDebugText(TileData& tileData, const mat4 &matrix) {
     // Draw white outline
     plainShader->u_color = {{ 1.0f, 1.0f, 1.0f, 1.0f }};
     config.lineWidth = 4.0f * frame.pixelRatio;
-    tileData.debugBucket->drawLines(*plainShader, store);
+    tileData.debugBucket->drawLines(*plainShader);
 
 #ifndef GL_ES_VERSION_2_0
     // Draw line "end caps"
     MBGL_CHECK_ERROR(glPointSize(2));
-    tileData.debugBucket->drawPoints(*plainShader, store);
+    tileData.debugBucket->drawPoints(*plainShader);
 #endif
 
     // Draw black text.
     plainShader->u_color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
     config.lineWidth = 2.0f * frame.pixelRatio;
-    tileData.debugBucket->drawLines(*plainShader, store);
+    tileData.debugBucket->drawLines(*plainShader);
 
     config.depthFunc.reset();
     config.depthTest = GL_TRUE;
@@ -76,7 +76,7 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     plainShader->u_matrix = matrix;
 
     // draw tile outline
-    tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET_0, store);
+    tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET_0);
     plainShader->u_color = {{ 1.0f, 0.0f, 0.0f, 1.0f }};
     config.lineWidth = 4.0f * frame.pixelRatio;
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, (GLsizei)tileBorderBuffer.index()));

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -64,7 +64,7 @@ void Painter::renderFill(FillBucket& bucket,
             static_cast<float>(frame.framebufferSize[1])
         }};
         setDepthSublayer(0);
-        bucket.drawVertices(*outlineShader, store);
+        bucket.drawVertices(*outlineShader);
     }
 
     if (pattern) {
@@ -115,11 +115,11 @@ void Painter::renderFill(FillBucket& bucket,
             patternShader->u_offset_b = std::array<float, 2>{{offsetBx, offsetBy}};
 
             config.activeTexture = GL_TEXTURE0;
-            spriteAtlas->bind(true, store);
+            spriteAtlas->bind(true);
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(0);
-            bucket.drawElements(*patternShader, store);
+            bucket.drawElements(*patternShader);
 
             if (properties.fillAntialias && stroke_color == fill_color) {
                 config.program = outlinePatternShader->getID();
@@ -153,10 +153,10 @@ void Painter::renderFill(FillBucket& bucket,
                 outlinePatternShader->u_offset_b = std::array<float, 2>{{offsetBx, offsetBy}};
 
                 config.activeTexture = GL_TEXTURE0;
-                spriteAtlas->bind(true, store);
+                spriteAtlas->bind(true);
 
                 setDepthSublayer(2);
-                bucket.drawVertices(*outlinePatternShader, store);
+                bucket.drawVertices(*outlinePatternShader);
             }
         }
     } else if (!wireframe) {
@@ -173,7 +173,7 @@ void Painter::renderFill(FillBucket& bucket,
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(1);
-            bucket.drawElements(*plainShader, store);
+            bucket.drawElements(*plainShader);
         }
     }
 
@@ -194,7 +194,7 @@ void Painter::renderFill(FillBucket& bucket,
         }};
 
         setDepthSublayer(2);
-        bucket.drawVertices(*outlineShader, store);
+        bucket.drawVertices(*outlineShader);
     }
 }
 

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -75,8 +75,8 @@ void Painter::renderLine(LineBucket& bucket,
         linesdfShader->u_color = color;
         linesdfShader->u_opacity = opacity;
 
-        LinePatternPos posA = lineAtlas->getDashPosition(properties.lineDasharray.value.from, layout.lineCap == LineCapType::Round, store);
-        LinePatternPos posB = lineAtlas->getDashPosition(properties.lineDasharray.value.to, layout.lineCap == LineCapType::Round, store);
+        LinePatternPos posA = lineAtlas->getDashPosition(properties.lineDasharray.value.from, layout.lineCap == LineCapType::Round);
+        LinePatternPos posB = lineAtlas->getDashPosition(properties.lineDasharray.value.to, layout.lineCap == LineCapType::Round);
 
         const float widthA = posA.width * properties.lineDasharray.value.fromScale * layer.impl->dashLineWidth;
         const float widthB = posB.width * properties.lineDasharray.value.toScale * layer.impl->dashLineWidth;
@@ -98,9 +98,9 @@ void Painter::renderLine(LineBucket& bucket,
 
         linesdfShader->u_image = 0;
         config.activeTexture = GL_TEXTURE0;
-        lineAtlas->bind(store);
+        lineAtlas->bind();
 
-        bucket.drawLineSDF(*linesdfShader, store);
+        bucket.drawLineSDF(*linesdfShader);
 
     } else if (!properties.linePattern.value.from.empty()) {
         optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(properties.linePattern.value.from, true);
@@ -140,9 +140,9 @@ void Painter::renderLine(LineBucket& bucket,
 
         linepatternShader->u_image = 0;
         config.activeTexture = GL_TEXTURE0;
-        spriteAtlas->bind(true, store);
+        spriteAtlas->bind(true);
 
-        bucket.drawLinePatterns(*linepatternShader, store);
+        bucket.drawLinePatterns(*linepatternShader);
 
     } else {
         config.program = lineShader->getID();
@@ -160,7 +160,7 @@ void Painter::renderLine(LineBucket& bucket,
         lineShader->u_color = color;
         lineShader->u_opacity = opacity;
 
-        bucket.drawLines(*lineShader, store);
+        bucket.drawLines(*lineShader);
     }
 }
 

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -37,7 +37,7 @@ void Painter::renderRaster(RasterBucket& bucket,
         config.depthTest = GL_TRUE;
         config.depthMask = GL_FALSE;
         setDepthSublayer(0);
-        bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray, store);
+        bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray);
     }
 }
 

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -21,7 +21,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
                         float sdfFontSize,
                         std::array<float, 2> texsize,
                         SDFShader& sdfShader,
-                        void (SymbolBucket::*drawSDF)(SDFShader&, gl::ObjectStore&),
+                        void (SymbolBucket::*drawSDF)(SDFShader&),
 
                         // Layout
                         RotationAlignmentType rotationAlignment,
@@ -69,7 +69,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
     sdfShader.u_zoom = (state.getZoom() - zoomAdjust) * 10; // current zoom level
 
     config.activeTexture = GL_TEXTURE1;
-    frameHistory.bind(store);
+    frameHistory.bind();
     sdfShader.u_fadetexture = 1;
 
     // The default gamma value has to be adjust for the current pixelratio so that we're not
@@ -89,7 +89,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
         sdfShader.u_buffer = (haloOffset - haloWidth / fontScale) / sdfPx;
 
         setDepthSublayer(0);
-        (bucket.*drawSDF)(sdfShader, store);
+        (bucket.*drawSDF)(sdfShader);
     }
 
     // Then, we draw the text/icon over the halo
@@ -100,7 +100,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
         sdfShader.u_buffer = (256.0f - 64.0f) / 256.0f;
 
         setDepthSublayer(1);
-        (bucket.*drawSDF)(sdfShader, store);
+        (bucket.*drawSDF)(sdfShader);
     }
 }
 
@@ -156,7 +156,7 @@ void Painter::renderSymbol(SymbolBucket& bucket,
         const bool iconScaled = fontScale != 1 || frame.pixelRatio != activeSpriteAtlas->getPixelRatio() || bucket.iconsNeedLinear;
         const bool iconTransformed = layout.iconRotationAlignment == RotationAlignmentType::Map || angleOffset != 0 || state.getPitch() != 0;
         config.activeTexture = GL_TEXTURE0;
-        activeSpriteAtlas->bind(sdf || state.isChanging() || iconScaled || iconTransformed, store);
+        activeSpriteAtlas->bind(sdf || state.isChanging() || iconScaled || iconTransformed);
 
         if (sdf) {
             renderSDF(bucket,
@@ -203,11 +203,11 @@ void Painter::renderSymbol(SymbolBucket& bucket,
             iconShader->u_opacity = paint.iconOpacity;
 
             config.activeTexture = GL_TEXTURE1;
-            frameHistory.bind(store);
+            frameHistory.bind();
             iconShader->u_fadetexture = 1;
 
             setDepthSublayer(0);
-            bucket.drawIcons(*iconShader, store);
+            bucket.drawIcons(*iconShader);
         }
     }
 
@@ -220,7 +220,7 @@ void Painter::renderSymbol(SymbolBucket& bucket,
         }
 
         config.activeTexture = GL_TEXTURE0;
-        glyphAtlas->bind(store);
+        glyphAtlas->bind();
 
         renderSDF(bucket,
                   tileID,
@@ -254,7 +254,7 @@ void Painter::renderSymbol(SymbolBucket& bucket,
         config.lineWidth = 1.0f;
 
         setDepthSublayer(0);
-        bucket.drawCollisionBoxes(*collisionBoxShader, store);
+        bucket.drawCollisionBoxes(*collisionBoxShader);
 
     }
 

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -7,10 +7,6 @@ namespace mbgl {
 
 using namespace style;
 
-RasterBucket::RasterBucket(gl::TexturePool& texturePool)
-: raster(texturePool) {
-}
-
 void RasterBucket::upload() {
     if (hasData()) {
         raster.upload();

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -11,9 +11,9 @@ RasterBucket::RasterBucket(gl::TexturePool& texturePool)
 : raster(texturePool) {
 }
 
-void RasterBucket::upload(gl::ObjectStore& store) {
+void RasterBucket::upload() {
     if (hasData()) {
-        raster.upload(store);
+        raster.upload();
         uploaded = true;
     }
 }
@@ -29,9 +29,9 @@ void RasterBucket::setImage(PremultipliedImage image) {
     raster.load(std::move(image));
 }
 
-void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array, gl::ObjectStore& store) {
-    raster.bind(true, store);
-    array.bind(shader, vertices, BUFFER_OFFSET_0, store);
+void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array) {
+    raster.bind(true);
+    array.bind(shader, vertices, BUFFER_OFFSET_0);
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
 }
 

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -11,8 +11,6 @@ class VertexArrayObject;
 
 class RasterBucket : public Bucket {
 public:
-    RasterBucket(gl::TexturePool&);
-
     void upload() override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -13,14 +13,14 @@ class RasterBucket : public Bucket {
 public:
     RasterBucket(gl::TexturePool&);
 
-    void upload(gl::ObjectStore&) override;
+    void upload() override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool needsClipping() const override;
 
     void setImage(PremultipliedImage);
 
-    void drawRaster(RasterShader&, StaticVertexBuffer&, VertexArrayObject&, gl::ObjectStore&);
+    void drawRaster(RasterShader&, StaticVertexBuffer&, VertexArrayObject&);
 
     Raster raster;
 };

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -73,14 +73,14 @@ SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void SymbolBucket::upload(gl::ObjectStore& store) {
+void SymbolBucket::upload() {
     if (hasTextData()) {
-        renderData->text.vertices.upload(store);
-        renderData->text.triangles.upload(store);
+        renderData->text.vertices.upload();
+        renderData->text.triangles.upload();
     }
     if (hasIconData()) {
-        renderData->icon.vertices.upload(store);
-        renderData->icon.triangles.upload(store);
+        renderData->icon.vertices.upload();
+        renderData->icon.triangles.upload();
     }
 
     uploaded = true;
@@ -598,50 +598,50 @@ void SymbolBucket::swapRenderData() {
     }
 }
 
-void SymbolBucket::drawGlyphs(SDFShader& shader, gl::ObjectStore& store) {
+void SymbolBucket::drawGlyphs(SDFShader& shader) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& text = renderData->text;
     for (auto &group : text.groups) {
         assert(group);
-        group->array[0].bind(shader, text.vertices, text.triangles, vertex_index, store);
+        group->array[0].bind(shader, text.vertices, text.triangles, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * text.vertices.itemSize;
         elements_index += group->elements_length * text.triangles.itemSize;
     }
 }
 
-void SymbolBucket::drawIcons(SDFShader& shader, gl::ObjectStore& store) {
+void SymbolBucket::drawIcons(SDFShader& shader) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& icon = renderData->icon;
     for (auto &group : icon.groups) {
         assert(group);
-        group->array[0].bind(shader, icon.vertices, icon.triangles, vertex_index, store);
+        group->array[0].bind(shader, icon.vertices, icon.triangles, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * icon.vertices.itemSize;
         elements_index += group->elements_length * icon.triangles.itemSize;
     }
 }
 
-void SymbolBucket::drawIcons(IconShader& shader, gl::ObjectStore& store) {
+void SymbolBucket::drawIcons(IconShader& shader) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& icon = renderData->icon;
     for (auto &group : icon.groups) {
         assert(group);
-        group->array[1].bind(shader, icon.vertices, icon.triangles, vertex_index, store);
+        group->array[1].bind(shader, icon.vertices, icon.triangles, vertex_index);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
         vertex_index += group->vertex_length * icon.vertices.itemSize;
         elements_index += group->elements_length * icon.triangles.itemSize;
     }
 }
 
-void SymbolBucket::drawCollisionBoxes(CollisionBoxShader& shader, gl::ObjectStore& store) {
+void SymbolBucket::drawCollisionBoxes(CollisionBoxShader& shader) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     auto& collisionBox = renderData->collisionBox;
     for (auto &group : collisionBox.groups) {
-        group->array[0].bind(shader, collisionBox.vertices, vertex_index, store);
+        group->array[0].bind(shader, collisionBox.vertices, vertex_index);
         MBGL_CHECK_ERROR(glDrawArrays(GL_LINES, 0, group->vertex_length));
     }
 }

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -69,7 +69,7 @@ public:
     SymbolBucket(uint32_t overscaling, float zoom, const MapMode, const std::string& bucketName_, const std::string& sourceLayerName_);
     ~SymbolBucket() override;
 
-    void upload(gl::ObjectStore&) override;
+    void upload() override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool hasTextData() const;
@@ -82,10 +82,10 @@ public:
                      GlyphAtlas&,
                      GlyphStore&);
 
-    void drawGlyphs(SDFShader&, gl::ObjectStore&);
-    void drawIcons(SDFShader&, gl::ObjectStore&);
-    void drawIcons(IconShader&, gl::ObjectStore&);
-    void drawCollisionBoxes(CollisionBoxShader&, gl::ObjectStore&);
+    void drawGlyphs(SDFShader&);
+    void drawIcons(SDFShader&);
+    void drawIcons(IconShader&);
+    void drawCollisionBoxes(CollisionBoxShader&);
 
     void parseFeatures(const GeometryTileLayer&, const style::Filter&);
     bool needsDependencies(GlyphStore&, SpriteStore&);

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-CircleShader::CircleShader(gl::ObjectStore& store)
-    : Shader("circle", shaders::circle::vertex, shaders::circle::fragment, store) {
+CircleShader::CircleShader()
+    : Shader("circle", shaders::circle::vertex, shaders::circle::fragment) {
 }
 
 void CircleShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class CircleShader : public Shader {
 public:
-    CircleShader(gl::ObjectStore&);
+    CircleShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/collision_box_shader.cpp
+++ b/src/mbgl/shader/collision_box_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-CollisionBoxShader::CollisionBoxShader(gl::ObjectStore& store)
-    : Shader("collisionbox", shaders::collisionbox::vertex, shaders::collisionbox::fragment, store)
+CollisionBoxShader::CollisionBoxShader()
+    : Shader("collisionbox", shaders::collisionbox::vertex, shaders::collisionbox::fragment)
     , a_extrude(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_extrude")))
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }

--- a/src/mbgl/shader/collision_box_shader.hpp
+++ b/src/mbgl/shader/collision_box_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class CollisionBoxShader : public Shader {
 public:
-    CollisionBoxShader(gl::ObjectStore&);
+    CollisionBoxShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-IconShader::IconShader(gl::ObjectStore& store)
-    : Shader("icon", shaders::icon::vertex, shaders::icon::fragment, store)
+IconShader::IconShader()
+    : Shader("icon", shaders::icon::vertex, shaders::icon::fragment)
     , a_offset(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset")))
     , a_data1(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1")))
     , a_data2(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"))) {

--- a/src/mbgl/shader/icon_shader.hpp
+++ b/src/mbgl/shader/icon_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class IconShader : public Shader {
 public:
-    IconShader(gl::ObjectStore&);
+    IconShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-LineShader::LineShader(gl::ObjectStore& store)
-    : Shader("line", shaders::line::vertex, shaders::line::fragment, store)
+LineShader::LineShader()
+    : Shader("line", shaders::line::vertex, shaders::line::fragment)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/line_shader.hpp
+++ b/src/mbgl/shader/line_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class LineShader : public Shader {
 public:
-    LineShader(gl::ObjectStore&);
+    LineShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-LinepatternShader::LinepatternShader(gl::ObjectStore& store)
-    : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment, store)
+LinepatternShader::LinepatternShader()
+    : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/linepattern_shader.hpp
+++ b/src/mbgl/shader/linepattern_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class LinepatternShader : public Shader {
 public:
-    LinepatternShader(gl::ObjectStore&);
+    LinepatternShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-LineSDFShader::LineSDFShader(gl::ObjectStore& store)
-    : Shader("linesdfpattern", shaders::linesdfpattern::vertex, shaders::linesdfpattern::fragment, store)
+LineSDFShader::LineSDFShader()
+    : Shader("linesdfpattern", shaders::linesdfpattern::vertex, shaders::linesdfpattern::fragment)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/linesdf_shader.hpp
+++ b/src/mbgl/shader/linesdf_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class LineSDFShader : public Shader {
 public:
-    LineSDFShader(gl::ObjectStore&);
+    LineSDFShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-OutlineShader::OutlineShader(gl::ObjectStore& store)
-    : Shader("outline", shaders::outline::vertex, shaders::outline::fragment, store) {
+OutlineShader::OutlineShader()
+    : Shader("outline", shaders::outline::vertex, shaders::outline::fragment) {
 }
 
 void OutlineShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/outline_shader.hpp
+++ b/src/mbgl/shader/outline_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class OutlineShader : public Shader {
 public:
-    OutlineShader(gl::ObjectStore&);
+    OutlineShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/outlinepattern_shader.cpp
+++ b/src/mbgl/shader/outlinepattern_shader.cpp
@@ -7,12 +7,8 @@
 
 using namespace mbgl;
 
-OutlinePatternShader::OutlinePatternShader(gl::ObjectStore& store)
-    : Shader(
-        "outlinepattern",
-        shaders::outlinepattern::vertex, shaders::outlinepattern::fragment,
-        store
-    ) {
+OutlinePatternShader::OutlinePatternShader()
+    : Shader("outlinepattern", shaders::outlinepattern::vertex, shaders::outlinepattern::fragment) {
 }
 
 void OutlinePatternShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/outlinepattern_shader.hpp
+++ b/src/mbgl/shader/outlinepattern_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class OutlinePatternShader : public Shader {
 public:
-    OutlinePatternShader(gl::ObjectStore&);
+    OutlinePatternShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/pattern_shader.cpp
+++ b/src/mbgl/shader/pattern_shader.cpp
@@ -7,12 +7,8 @@
 
 using namespace mbgl;
 
-PatternShader::PatternShader(gl::ObjectStore& store)
-    : Shader(
-        "pattern",
-        shaders::pattern::vertex, shaders::pattern::fragment,
-        store
-    ) {
+PatternShader::PatternShader()
+    : Shader("pattern", shaders::pattern::vertex, shaders::pattern::fragment) {
 }
 
 void PatternShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/pattern_shader.hpp
+++ b/src/mbgl/shader/pattern_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class PatternShader : public Shader {
 public:
-    PatternShader(gl::ObjectStore&);
+    PatternShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-PlainShader::PlainShader(gl::ObjectStore& store)
-    : Shader("fill", shaders::fill::vertex, shaders::fill::fragment, store) {
+PlainShader::PlainShader()
+    : Shader("fill", shaders::fill::vertex, shaders::fill::fragment) {
 }
 
 void PlainShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/plain_shader.hpp
+++ b/src/mbgl/shader/plain_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class PlainShader : public Shader {
 public:
-    PlainShader(gl::ObjectStore&);
+    PlainShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-RasterShader::RasterShader(gl::ObjectStore& store)
-    : Shader("raster", shaders::raster::vertex, shaders::raster::fragment, store) {
+RasterShader::RasterShader()
+    : Shader("raster", shaders::raster::vertex, shaders::raster::fragment) {
 }
 
 void RasterShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/raster_shader.hpp
+++ b/src/mbgl/shader/raster_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class RasterShader : public Shader {
 public:
-    RasterShader(gl::ObjectStore&);
+    RasterShader();
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -7,8 +7,8 @@
 
 using namespace mbgl;
 
-SDFShader::SDFShader(gl::ObjectStore& store)
-    : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment, store)
+SDFShader::SDFShader()
+    : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment)
     , a_offset(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset")))
     , a_data1(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1")))
     , a_data2(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"))) {

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class SDFShader : public Shader {
 public:
-    SDFShader(gl::ObjectStore&);
+    SDFShader();
 
     UniformMatrix<4>                u_matrix        = {"u_matrix",        *this};
     Uniform<std::array<GLfloat, 2>> u_extrude_scale = {"u_extrude_scale", *this};
@@ -29,13 +29,13 @@ protected:
 
 class SDFGlyphShader : public SDFShader {
 public:
-    SDFGlyphShader(gl::ObjectStore& store) : SDFShader(store) {}
+    SDFGlyphShader() : SDFShader() {}
     void bind(GLbyte *offset) final;
 };
 
 class SDFIconShader : public SDFShader {
 public:
-    SDFIconShader(gl::ObjectStore& store) : SDFShader(store) {}
+    SDFIconShader() : SDFShader() {}
     void bind(GLbyte *offset) final;
 };
 

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -13,11 +13,11 @@
 
 namespace mbgl {
 
-Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSource, gl::ObjectStore& store)
+Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSource)
     : name(name_)
-    , program(store.createProgram())
-    , vertexShader(store.createShader(GL_VERTEX_SHADER))
-    , fragmentShader(store.createShader(GL_FRAGMENT_SHADER))
+    , program(gl::ObjectStore::get().createProgram())
+    , vertexShader(gl::ObjectStore::get().createShader(GL_VERTEX_SHADER))
+    , fragmentShader(gl::ObjectStore::get().createShader(GL_FRAGMENT_SHADER))
 {
     util::stopwatch stopwatch("shader compilation", Event::Shader);
 

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class Shader : private util::noncopyable {
 public:
-    Shader(const GLchar *name, const GLchar *vertex, const GLchar *fragment, gl::ObjectStore&);
+    Shader(const GLchar *name, const GLchar *vertex, const GLchar *fragment);
 
     ~Shader();
     const GLchar *name;

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -142,9 +142,9 @@ void SpriteAtlas::copy(const Holder& holder, const bool wrap) {
     dirty = true;
 }
 
-void SpriteAtlas::upload(gl::ObjectStore& objectStore) {
+void SpriteAtlas::upload() {
     if (dirty) {
-        bind(false, objectStore);
+        bind(false);
     }
 }
 
@@ -179,13 +179,13 @@ void SpriteAtlas::updateDirty() {
     }
 }
 
-void SpriteAtlas::bind(bool linear, gl::ObjectStore& objectStore) {
+void SpriteAtlas::bind(bool linear) {
     if (!data) {
         return; // Empty atlas
     }
 
     if (!texture) {
-        texture = objectStore.createTexture();
+        texture = gl::ObjectStore::get().createTexture();
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -51,14 +51,14 @@ public:
     optional<SpriteAtlasPosition> getPosition(const std::string& name, bool repeating = false);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind(bool linear, gl::ObjectStore&);
+    void bind(bool linear);
 
     // Updates sprites in the atlas texture that may have changed in the source SpriteStore object.
     void updateDirty();
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload(gl::ObjectStore&);
+    void upload();
 
     inline dimension getWidth() const { return width; }
     inline dimension getHeight() const { return height; }

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -199,8 +199,8 @@ std::unique_ptr<TileData> Source::createTile(const OverscaledTileID& overscaledT
     // If we don't find working tile data, we're just going to load it.
     if (type == SourceType::Raster) {
         data = std::make_unique<RasterTileData>(overscaledTileID, parameters.pixelRatio,
-                                                tileset->tiles.at(0), parameters.texturePool,
-                                                parameters.worker, parameters.fileSource, callback);
+                                                tileset->tiles.at(0), parameters.worker,
+                                                parameters.fileSource, callback);
     } else {
         std::unique_ptr<GeometryTileMonitor> monitor;
 

--- a/src/mbgl/style/update_parameters.hpp
+++ b/src/mbgl/style/update_parameters.hpp
@@ -7,7 +7,6 @@ namespace mbgl {
 class TransformState;
 class Worker;
 class FileSource;
-namespace gl { class TexturePool; }
 class AnnotationManager;
 
 namespace style {
@@ -22,7 +21,6 @@ public:
                           const TransformState& transformState_,
                           Worker& worker_,
                           FileSource& fileSource_,
-                          gl::TexturePool& texturePool_,
                           bool shouldReparsePartialTiles_,
                           const MapMode mode_,
                           AnnotationManager& annotationManager_,
@@ -33,7 +31,6 @@ public:
           transformState(transformState_),
           worker(worker_),
           fileSource(fileSource_),
-          texturePool(texturePool_),
           shouldReparsePartialTiles(shouldReparsePartialTiles_),
           mode(mode_),
           annotationManager(annotationManager_),
@@ -45,7 +42,6 @@ public:
     const TransformState& transformState;
     Worker& worker;
     FileSource& fileSource;
-    gl::TexturePool& texturePool;
     bool shouldReparsePartialTiles;
     const MapMode mode;
     AnnotationManager& annotationManager;

--- a/src/mbgl/tile/raster_tile_data.cpp
+++ b/src/mbgl/tile/raster_tile_data.cpp
@@ -11,12 +11,10 @@ using namespace mbgl;
 RasterTileData::RasterTileData(const OverscaledTileID& id_,
                                float pixelRatio,
                                const std::string& urlTemplate,
-                               gl::TexturePool &texturePool_,
                                Worker& worker_,
                                FileSource& fileSource,
                                const std::function<void(std::exception_ptr)>& callback)
     : TileData(id_),
-      texturePool(texturePool_),
       worker(worker_) {
     const Resource resource =
         Resource::tile(urlTemplate, pixelRatio, id.canonical.x, id.canonical.y, id.canonical.z);
@@ -38,7 +36,7 @@ RasterTileData::RasterTileData(const OverscaledTileID& id_,
             expires = res.expires;
 
             workRequest.reset();
-            workRequest = worker.parseRasterTile(std::make_unique<RasterBucket>(texturePool), res.data, [this, callback] (RasterTileParseResult result) {
+            workRequest = worker.parseRasterTile(std::make_unique<RasterBucket>(), res.data, [this, callback] (RasterTileParseResult result) {
                 workRequest.reset();
 
                 std::exception_ptr error;

--- a/src/mbgl/tile/raster_tile_data.hpp
+++ b/src/mbgl/tile/raster_tile_data.hpp
@@ -8,8 +8,6 @@ namespace mbgl {
 class FileSource;
 class AsyncRequest;
 
-namespace gl { class TexturePool; }
-
 namespace style {
 class Layer;
 }
@@ -19,7 +17,6 @@ public:
     RasterTileData(const OverscaledTileID&,
                    float pixelRatio,
                    const std::string& urlTemplate,
-                   gl::TexturePool&,
                    Worker&,
                    FileSource&,
                    const std::function<void(std::exception_ptr)>& callback);
@@ -29,7 +26,6 @@ public:
     Bucket* getBucket(const style::Layer&) override;
 
 private:
-    gl::TexturePool& texturePool;
     Worker& worker;
     std::unique_ptr<AsyncRequest> req;
     std::unique_ptr<Bucket> bucket;

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -9,10 +9,6 @@
 
 using namespace mbgl;
 
-Raster::Raster(gl::TexturePool& texturePool_)
-    : texturePool(texturePool_)
-{}
-
 bool Raster::isLoaded() const {
     std::lock_guard<std::mutex> lock(mtx);
     return loaded;
@@ -52,7 +48,7 @@ void Raster::bind(bool linear) {
 
 void Raster::upload() {
     if (img.data && !texture) {
-        texture = texturePool.acquireTexture();
+        texture = gl::TexturePool::get().acquireTexture();
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -30,14 +30,14 @@ void Raster::load(PremultipliedImage image) {
 }
 
 
-void Raster::bind(bool linear, gl::ObjectStore& store) {
+void Raster::bind(bool linear) {
     if (!width || !height) {
         Log::Error(Event::OpenGL, "trying to bind texture without dimension");
         return;
     }
 
     if (img.data && !texture) {
-        upload(store);
+        upload();
     } else if (texture) {
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
     }
@@ -50,9 +50,9 @@ void Raster::bind(bool linear, gl::ObjectStore& store) {
     }
 }
 
-void Raster::upload(gl::ObjectStore& store) {
+void Raster::upload() {
     if (img.data && !texture) {
-        texture = texturePool.acquireTexture(store);
+        texture = texturePool.acquireTexture();
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
 #ifndef GL_ES_VERSION_2_0
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -20,10 +20,10 @@ public:
     void load(PremultipliedImage);
 
     // bind current texture
-    void bind(bool linear, gl::ObjectStore&);
+    void bind(bool linear);
 
     // uploads the texture if it hasn't been uploaded yet.
-    void upload(gl::ObjectStore&);
+    void upload();
 
     // loaded status
     bool isLoaded() const;

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -14,8 +14,6 @@ namespace mbgl {
 class Raster : public std::enable_shared_from_this<Raster> {
 
 public:
-    Raster(gl::TexturePool&);
-
     // load image data
     void load(PremultipliedImage);
 
@@ -44,9 +42,6 @@ private:
 
     // raw pixels have been loaded
     bool loaded = false;
-
-    // shared texture pool
-    gl::TexturePool& texturePool;
 
     // min/mag filter
     GLint filter = 0;

--- a/test/gl/object.cpp
+++ b/test/gl/object.cpp
@@ -70,7 +70,7 @@ TEST(GLObject, Store) {
     mbgl::HeadlessView view(std::make_shared<mbgl::HeadlessDisplay>(), 1);
     view.activate();
 
-    mbgl::gl::ObjectStore store;
+    auto& store = mbgl::gl::ObjectStore::get();
     EXPECT_TRUE(store.empty());
 
     mbgl::gl::UniqueProgram program = store.createProgram();
@@ -125,7 +125,7 @@ TEST(GLObject, TexturePool) {
     mbgl::HeadlessView view(std::make_shared<mbgl::HeadlessDisplay>(), 1);
     view.activate();
 
-    mbgl::gl::ObjectStore store;
+    auto& store = mbgl::gl::ObjectStore::get();
     EXPECT_TRUE(store.empty());
 
     mbgl::gl::TexturePool pool;
@@ -134,7 +134,7 @@ TEST(GLObject, TexturePool) {
 
     // Fill an entire texture pool.
     for (auto i = 0; i != mbgl::gl::TextureMax; ++i) {
-        ids.push_back(pool.acquireTexture(store));
+        ids.push_back(pool.acquireTexture());
         EXPECT_EQ(ids.back().get(), GLuint(i + 1));
         EXPECT_TRUE(store.empty());
     }
@@ -142,14 +142,14 @@ TEST(GLObject, TexturePool) {
     // Reuse texture ids from the same pool.
     for (auto i = 0; i != mbgl::gl::TextureMax; ++i) {
         ids[i].reset();
-        ids.push_back(pool.acquireTexture(store));
+        ids.push_back(pool.acquireTexture());
         EXPECT_EQ(ids.back().get(), GLuint(i + 1));
         EXPECT_TRUE(store.empty());
     }
 
     // Trigger a new texture pool creation.
     {
-        mbgl::gl::PooledTexture id = pool.acquireTexture(store);
+        mbgl::gl::PooledTexture id = pool.acquireTexture();
         EXPECT_EQ(id, mbgl::gl::TextureMax + 1);
         EXPECT_TRUE(store.empty());
 
@@ -163,7 +163,7 @@ TEST(GLObject, TexturePool) {
     }
 
     // First pool is still full, thus creating a new pool.
-    mbgl::gl::PooledTexture id1 = pool.acquireTexture(store);
+    mbgl::gl::PooledTexture id1 = pool.acquireTexture();
     EXPECT_GT(id1.get(), mbgl::gl::TextureMax);
     EXPECT_TRUE(store.empty());
 
@@ -175,7 +175,7 @@ TEST(GLObject, TexturePool) {
     EXPECT_TRUE(store.empty());
 
     // The first pool is now gone, the next pool is now in use.
-    mbgl::gl::PooledTexture id2 = pool.acquireTexture(store);
+    mbgl::gl::PooledTexture id2 = pool.acquireTexture();
     EXPECT_GT(id2.get(), id1.get());
 
     id2.reset();

--- a/test/gl/object.cpp
+++ b/test/gl/object.cpp
@@ -128,7 +128,7 @@ TEST(GLObject, TexturePool) {
     auto& store = mbgl::gl::ObjectStore::get();
     EXPECT_TRUE(store.empty());
 
-    mbgl::gl::TexturePool pool;
+    auto& pool = mbgl::gl::TexturePool::get();
 
     std::vector<mbgl::gl::PooledTexture> ids;
 
@@ -183,6 +183,16 @@ TEST(GLObject, TexturePool) {
 
     // Last used texture from the pool triggers pool recycling.
     id1.reset();
+    EXPECT_FALSE(store.empty());
+
+    store.performCleanup();
+    EXPECT_TRUE(store.empty());
+
+    // Force texture pool clearing.
+    id1 = pool.acquireTexture();
+    EXPECT_TRUE(store.empty());
+
+    pool.clear();
     EXPECT_FALSE(store.empty());
 
     store.performCleanup();

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -10,7 +10,6 @@
 
 #include <mbgl/map/transform.hpp>
 #include <mbgl/util/worker.hpp>
-#include <mbgl/gl/texture_pool.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/update_parameters.hpp>
 #include <mbgl/style/layers/line_layer.hpp>
@@ -28,7 +27,6 @@ public:
     Transform transform;
     TransformState transformState;
     Worker worker { 1 };
-    gl::TexturePool texturePool;
     AnnotationManager annotationManager { 1.0 };
     style::Style style { fileSource, 1.0 };
 
@@ -39,7 +37,6 @@ public:
         transformState,
         worker,
         fileSource,
-        texturePool,
         true,
         MapMode::Continuous,
         annotationManager,


### PR DESCRIPTION
These objects can be safely using singleton pattern, which reduces a lot of redundant code and improves readability. Both objects resides on the same thread thus no need for ThreadLocal storage.

:eyes: @tmpsantos @kkaefer @jfirebaugh 