### PR TITLE
[ios] fixes #5127, #5128, #5130 added enabled and selected property to MGLAnnotationView

### DIFF
--- a/platform/ios/app/MBXAnnotationView.m
+++ b/platform/ios/app/MBXAnnotationView.m
@@ -25,4 +25,12 @@
     }
 }
 
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated
+{
+    [super setSelected:selected animated:animated];
+    
+    self.layer.borderColor = selected ? [UIColor blackColor].CGColor : [UIColor whiteColor].CGColor;
+    self.layer.borderWidth = selected ? 2.0 : 0;
+}
+
 @end

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -41,6 +41,26 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, getter=isFlat) BOOL flat;
 
 /**
+ Defaults to NO and becomes YES when the view is tapped on.
+ 
+ Selecting another view will first deselect the currently selected view.
+ This property should not be changed directly.
+ */
+@property (nonatomic, assign, getter=isSelected) BOOL selected;
+
+/**
+ Subclasses may override this method in order to customize appearance.
+ This method should not be called directly.
+ */
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated;
+
+/*
+ This property defaults to YES. Setting it to NO will cause the annotation view to ignore all touch events.
+ Subclasses may use this property to customize the appearance.
+ */
+@property (nonatomic, assign, getter=isEnabled) BOOL enabled;
+
+/**
  Setting this property to YES will cause the annotation view to shrink as it approaches the horizon and grow as it moves away from the
  horizon when the associated map view is tilted. Conversely, setting this property to NO will ensure that the annotation view maintains
  a constant size even when the map view is tilted. To maintain consistency with annotation representations that are not backed by an

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -22,6 +22,7 @@
     {
         _reuseIdentifier = [reuseIdentifier copy];
         _scalesWithViewingDistance = YES;
+        _enabled = YES;
     }
     return self;
 }
@@ -35,6 +36,18 @@
 {
     _centerOffset = centerOffset;
     self.center = self.center;
+}
+
+- (void)setSelected:(BOOL)selected
+{
+    [self setSelected:selected animated:NO];
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated
+{
+    [self willChangeValueForKey:@"selected"];
+    _selected = selected;
+    [self didChangeValueForKey:@"selected"];
 }
 
 - (void)setCenter:(CGPoint)center

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -279,6 +279,27 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapView:(MGLMapView *)mapView didDeselectAnnotation:(id <MGLAnnotation>)annotation;
 
+
+/**
+ Tells the delegate that one of its annotation views was selected.
+ 
+ You can use this method to track changes in the selection state of annotation views.
+ 
+ @param mapView The map view containing the annotation.
+ @param annotationView The annotation view that was selected.
+ */
+- (void)mapView:(MGLMapView *)mapView didSelectAnnotationView:(MGLAnnotationView *)annotationView;
+
+/**
+ Tells the delegate that one of its annotation views was deselected.
+ 
+ You can use this method to track changes in the selection state of annotation views.
+ 
+ @param mapView The map view containing the annotation.
+ @param annotationView The annotation view that was deselected.
+ */
+- (void)mapView:(MGLMapView *)mapView didDeselectAnnotationView:(MGLAnnotationView *)annotationView;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Fixes  #5127 #5128 #5130 

Added `selected` and `enabled` property to `MGLAnnotationView` and hooked it up.
Added `mapView:did(De)SelectAnnotationView:` protocol methods.

@boundsj 
I kept the annotation and annotation views selection protocol methods separated but let me know if you want me to combine them into `mapView:did(De)SelectAnnotation:annotationView:`

/cc @1ec5 @friedbunny 