### PR TITLE
Memory leak bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ addons_shortcuts:
   addons_qt4: &qt4
     apt:
       sources:  [ 'ubuntu-toolchain-r-test' ]
-      packages: [ 'gdb', 'g++-5', 'gcc-5',
+      packages: [ 'g++-5', 'gcc-5',
                   'mesa-utils', 'qt4-default' ]
   addons_qt5: &qt5
     apt:
       sources:  [ 'ubuntu-toolchain-r-test' ]
-      packages: [ 'gdb', 'g++-5', 'gcc-5',
-                  'mesa-utils', 'qt5-default', 'libqt5opengl5-dev', 'qtdeclarative5-dev', 'qtpositioning5-dev', 'qtlocation5-dev' ]
+      packages: [ 'g++-5', 'gcc-5',
+                  'mesa-utils', 'libc6-dbg', 'qt5-default', 'libqt5opengl5-dev', 'qtdeclarative5-dev', 'qtpositioning5-dev', 'qtlocation5-dev' ]
 
 env:
   global:
@@ -112,7 +112,8 @@ matrix:
       env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5
       addons: *qt4
       script:
-        - make qt-app test-qt
+        - make qt-app
+        - make test-qt
 
     # Qt 5 - Release
     - os: linux
@@ -123,7 +124,9 @@ matrix:
       env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5
       addons: *qt5
       script:
-        - make qt-app qt-qml-app test-qt
+        - make qt-app
+        - make qt-qml-app
+        - make test-valgrind-qt
 
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,13 @@ run-qt-app: qt-app
 run-qt-qml-app: qt-qml-app
 	cd $(QT_OUTPUT_PATH)/$(BUILDTYPE) && ./qquickmapboxgl
 
+test-valgrind-qt: $(QT_MAKEFILE) node_modules
+	$(QT_ENV) $(MAKE) -j$(JOBS) -C $(QT_OUTPUT_PATH) test
+	./scripts/valgrind.sh $(QT_OUTPUT_PATH)/$(BUILDTYPE)/test --gtest_catch_exceptions=0 --gtest_filter=-*.Load
+
+run-valgrind-qt-app: qt-app
+	./scripts/valgrind.sh $(QT_OUTPUT_PATH)/$(BUILDTYPE)/qmapboxgl --test -platform offscreen
+
 #### Linux targets #####################################################
 
 LINUX_OUTPUT_PATH = build/linux-$(shell uname -m)
@@ -269,9 +276,6 @@ test: $(LINUX_MAKEFILE)
 
 run-glfw-app: glfw-app
 	cd $(LINUX_OUTPUT_PATH)/$(BUILDTYPE) && ./mapbox-glfw
-
-run-valgrind-glfw-app: glfw-app
-	cd $(LINUX_OUTPUT_PATH)/$(BUILDTYPE) && valgrind --leak-check=full --suppressions=../../../scripts/valgrind.sup ./mapbox-glfw
 
 ifneq (,$(shell which gdb))
   GDB = gdb -batch -return-child-result -ex 'set print thread-events off' -ex 'run' -ex 'thread apply all bt' --args

--- a/configure
+++ b/configure
@@ -123,6 +123,7 @@ print_flags webp static_libs cflags ldflags
 print_flags jni.hpp cflags
 print_flags earcut cflags
 print_flags benchmark static_libs cflags ldflags
+print_flags valgrind
 
 CONFIG+="  }
 }

--- a/platform/qt/scripts/configure.sh
+++ b/platform/qt/scripts/configure.sh
@@ -28,6 +28,8 @@ if [ "$MASON_PLATFORM" == "osx" ]; then
         CONFIG+="    'opengl_ldflags%': ['-framework OpenGL', '-framework CoreFoundation'],"$LN
     }
 else
+    VALGRIND_VERSION=latest
+
     function print_opengl_flags {
         CONFIG+="    'opengl_cflags%': $(quote_flags $(pkg-config gl x11 --cflags)),"$LN
         CONFIG+="    'opengl_ldflags%': $(quote_flags $(pkg-config gl x11 --libs)),"$LN

--- a/scripts/valgrind.sh
+++ b/scripts/valgrind.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+PARAMS="\
+    --leak-check=full \
+    --show-leak-kinds=definite \
+    --errors-for-leak-kinds=definite \
+    --error-exitcode=1 \
+    --gen-suppressions=all \
+    --suppressions=scripts/valgrind.sup"
+
+export VALGRIND_LIB=$(.mason/mason prefix valgrind latest)/lib/valgrind
+
+$(.mason/mason prefix valgrind latest)/bin/valgrind $PARAMS $@

--- a/scripts/valgrind.sup
+++ b/scripts/valgrind.sup
@@ -1,91 +1,182 @@
 {
-   Valgrind gets confused with buffers managed by the graphics driver
+   Graphics driver buffers
    Memcheck:Leak
    ...
-   obj:/usr/*/dri/r600_dri.so
+   obj:*/r600_dri.*
+   obj:*/r600_dri.*
+   obj:*/r600_dri.*
    ...
 }
 {
-   GLFW _glfwCreateCursor()
+   Graphics driver buffers
    Memcheck:Leak
-   match-leak-kinds: reachable
    ...
-   obj:/usr/*/libX11.so.6.3.0
-   ...
-   fun:_glfwCreateCursor
+   obj:*/i965_dri.*
+   obj:*/i965_dri.*
+   obj:*/i965_dri.*
    ...
 }
 {
-   GLFW _glfwPlatform*()
+   Graphics driver buffers
    Memcheck:Leak
-   match-leak-kinds: reachable
    ...
-   fun:_glfwPlatform*
+   obj:*/nouveau_dri.*
+   obj:*/nouveau_dri.*
+   obj:*/nouveau_dri.*
    ...
 }
 {
-   Buffer managed by OpenGL?
+   Ubuntu 16.04 - GLFW
+   Memcheck:Leak
+   ...
+   fun:glfwInit
+   ...
+}
+{
+   Ubuntu 16.04 - GLFW
    Memcheck:Cond
    ...
-   fun:_ZN4mbgl*Uniform*
-   ...
-   fun:_ZN8GLFWView10invalidateEv
+   fun:glfwInit
    ...
 }
 {
-   Buffer managed by OpenGL?
+   Ubuntu 16.04 - Qt + glib
    Memcheck:Cond
-   fun:_ZNSt7__equalILb0EE5equalIPKfS3_EEbT_S4_T0_
+   fun:g_utf8_offset_to_pointer
    ...
-   fun:_ZN4mbgl7Painter11renderLayerERKNS_10StyleLayerEPKNS_4Tile2IDEPKSt5arrayIfLm16EE
 }
 {
-   Valgrind doesn't like our make_unique (C++14 polyfill)
+   Ubuntu 16.04 - Qt + glib
+   Memcheck:Cond
+   ...
+   fun:g_signal_emit_valist
+   ...
+   fun:*QApplicationPrivate*
+   ...
+}
+{
+   Ubuntu 16.04 - Qt + X11
+   Memcheck:Param
+   writev(vector[...])
+   ...
+   obj:*/libxcb.*
+   fun:xcb_flush
+   ...
+}
+{
+   Ubuntu 16.04 - Qt + X11
    Memcheck:Leak
-   match-leak-kinds: reachable
+   ...
+   fun:_XmbTextListToTextProperty
+   ...
+   fun:*QWidget*setVisible*
+   ...
+}
+{
+   Ubuntu 16.04 - Qt + Fontconfig
+   Memcheck:Leak
+   ...
+   obj:*/libfontconfig.*
+   obj:*/libfontconfig.*
+   ...
+   fun:FcFontRenderPrepare
+   ...
+}
+{
+   Ubuntu 16.04 - Qt + Fontconfig
+   Memcheck:Leak
+   ...
+   obj:*/libfontconfig.*
+   obj:*/libfontconfig.*
+   ...
+   fun:FcPatternAddInteger
+   ...
+}
+{
+   Ubuntu 16.04 - Qt + Fontconfig
+   Memcheck:Leak
+   ...
+   obj:*/libfontconfig.*
+   obj:*/libfontconfig.*
+   ...
+   fun:FcConfigParseAndLoad
+   ...
+}
+{
+   Ubuntu 16.04 - Qt + Dbus
+   Memcheck:Leak
+   ...
+   fun:dbus_connection_send_with_reply
+   ...
+   fun:*QWidget*
+}
+{
+   Ubuntu 16.04 - Qt + Dbus
+   Memcheck:Leak
+   ...
+   fun:px_proxy_factory_get_proxies
+   obj:*/libQt5Network.*
+}
+{
+   Ubuntu 16.04 - Qt
+   Memcheck:Leak
+   ...
+   fun:*QGuiApplicationPrivate*createEventDispatcher*
+   fun:*QCoreApplication*init*
+   ...
+}
+{
+   Ubuntu 16.04 - Qt
+   Memcheck:Leak
+   ...
+   fun:*QWidget*setWindowTitle*
+   ...
+}
+{
+   Ubuntu 16.04 - Qt
+   Memcheck:Leak
+   ...
+   fun:*QNetworkConfigurationManagerPrivate*updateConfigurations*
+   ...
+}
+{
+   Ubuntu 16.04 - Mysterious leak when running utests
+   Memcheck:Leak
+   fun:calloc
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+}
+{
+   Ubuntu 16.04 - Mysterious leak when running utests
+   Memcheck:Leak
    fun:malloc
-   ...
-   fun:_ZN4mbgl4util11make_unique*
-   ...
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
+   obj:*
 }
 {
-   dlopen doing its magic
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   ...
-   fun:_dl_open
-   ...
-}
-{
-   X11 false positive
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   ...
-   obj:/usr/*/libX11.so.6.3.0
-   ...
-   fun:_XrmInitParseInfo
-   ...
-}
-{
-   OpenSSL false positive
-   Memcheck:Leak
-   ...
-   fun:CRYPTO_malloc
-   ...
-}
-{
-   OpenSSL false positive
-   Memcheck:Leak
-   ...
-   fun:CRYPTO_realloc
-   ...
-}
-{
-   Libcurl false positive
-   Memcheck:Leak
-   fun:malloc
-   ...
-   obj:/usr/*/libcurl.so.4.3.0
-   fun:curl_multi_socket_action
+   Ubuntu 14.04 - Travis CI bot using swrast
+   Memcheck:Cond
+   fun:do_stencil_test
+   fun:_swrast_stencil_and_ztest_span
+   fun:_swrast_write_rgba_span
+   fun:draw_wide_line
    ...
 }

--- a/test/storage/asset_file_source.cpp
+++ b/test/storage/asset_file_source.cpp
@@ -21,7 +21,7 @@ std::string getFileSourceRoot() {
 
 using namespace mbgl;
 
-TEST(AssetFileSource, Stress) {
+TEST(AssetFileSource, Load) {
     util::RunLoop loop;
 
     AssetFileSource fs(getFileSourceRoot());


### PR DESCRIPTION
We should perform memory checks as part of our automated build bots process. The idea is to add a new Makefile target similar to `run-valgrind-glfw-app` that could run e.g. unit tests and analyzes the data from [valgrind's memcheck](http://valgrind.org/docs/manual/mc-manual.html).

/cc @mapbox/gl 