### PR TITLE
[ios] fixes #5129 added annotation property to MGLAnnotationView

### DIFF
--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		353D23961D0B0DFE002BE09D /* MGLAnnotationViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 353D23951D0B0DFE002BE09D /* MGLAnnotationViewTests.m */; };
 		4018B1C71CDC287F00F666AF /* MGLAnnotationView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4018B1C41CDC277F00F666AF /* MGLAnnotationView.mm */; };
 		4018B1C81CDC287F00F666AF /* MGLAnnotationView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4018B1C41CDC277F00F666AF /* MGLAnnotationView.mm */; };
 		4018B1C91CDC288A00F666AF /* MGLAnnotationView_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 4018B1C31CDC277F00F666AF /* MGLAnnotationView_Private.h */; };
@@ -325,6 +326,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		353D23951D0B0DFE002BE09D /* MGLAnnotationViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLAnnotationViewTests.m; sourceTree = "<group>"; };
 		4018B1C31CDC277F00F666AF /* MGLAnnotationView_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAnnotationView_Private.h; sourceTree = "<group>"; };
 		4018B1C41CDC277F00F666AF /* MGLAnnotationView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLAnnotationView.mm; sourceTree = "<group>"; };
 		4018B1C51CDC277F00F666AF /* MGLAnnotationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAnnotationView.h; sourceTree = "<group>"; };
@@ -653,6 +655,7 @@
 				DA2E885D1CC0382C00F24E7B /* MGLOfflinePackTests.m */,
 				DA2E885E1CC0382C00F24E7B /* MGLOfflineRegionTests.m */,
 				DA2E885F1CC0382C00F24E7B /* MGLOfflineStorageTests.m */,
+				353D23951D0B0DFE002BE09D /* MGLAnnotationViewTests.m */,
 				DA2E88601CC0382C00F24E7B /* MGLStyleTests.mm */,
 				DA2E88551CC036F400F24E7B /* Info.plist */,
 			);
@@ -1351,6 +1354,7 @@
 				DA35A2C51CCA9F8300E826B2 /* MGLClockDirectionFormatterTests.m in Sources */,
 				DA2E88621CC0382C00F24E7B /* MGLOfflinePackTests.m in Sources */,
 				DA35A2AA1CCA058D00E826B2 /* MGLCoordinateFormatterTests.m in Sources */,
+				353D23961D0B0DFE002BE09D /* MGLAnnotationViewTests.m in Sources */,
 				DA0CD5901CF56F6A00A5F5A5 /* MGLFeatureTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -4,6 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol MGLAnnotation;
+
 /** The MGLAnnotationView class is responsible for representing point-based annotation markers as a view. Annotation views represent an annotation object, which is an object that corresponds to the MGLAnnotation protocol. When an annotation’s coordinate point is visible on the map view, the map view delegate is asked to provide a corresponding annotation view. If an annotation view is created with a reuse identifier, the map view may recycle the view when it goes offscreen. */
 @interface MGLAnnotationView : UIView
 
@@ -14,6 +16,13 @@ NS_ASSUME_NONNULL_BEGIN
  @return The initialized annotation view object.
  */
 - (instancetype)initWithReuseIdentifier:(nullable NSString *)reuseIdentifier;
+
+/**
+ This property will be set to the associated annotation when the view is visible.
+ 
+ When the view is queued and waiting to be reused, the value will be set to nil.
+ */
+@property (nonatomic, readonly, nullable) id <MGLAnnotation> annotation;
 
 /**
  The string that identifies that this annotation view is reusable. (read-only)

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -8,8 +8,8 @@
 
 @interface MGLAnnotationView ()
 
-@property (nonatomic) id<MGLAnnotation> annotation;
 @property (nonatomic, readwrite, nullable) NSString *reuseIdentifier;
+@property (nonatomic, readwrite, nullable) id <MGLAnnotation> annotation;
 
 @end
 

--- a/platform/ios/src/MGLAnnotationView_Private.h
+++ b/platform/ios/src/MGLAnnotationView_Private.h
@@ -5,8 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MGLAnnotationView (Private)
 
-@property (nonatomic) id<MGLAnnotation> annotation;
 @property (nonatomic, readwrite, nullable) NSString *reuseIdentifier;
+@property (nonatomic, readwrite, nullable) id <MGLAnnotation> annotation;
 
 - (void)setCenter:(CGPoint)center pitch:(CGFloat)pitch;
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2866,6 +2866,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
                 if (annotationView)
                 {
                     annotationViewsForAnnotation[annotationValue] = annotationView;
+                    annotationView.annotation = annotation;
                     annotationView.center = [self convertCoordinate:annotation.coordinate toPointToView:self];
                     [newAnnotationViews addObject:annotationView];
                 }
@@ -3083,6 +3084,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
 
         MGLAnnotationContext &annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
         MGLAnnotationView *annotationView = annotationContext.annotationView;
+        annotationView.annotation = nil;
         [annotationView removeFromSuperview];
 
         if (annotationTag == _selectedAnnotationTag)
@@ -4513,6 +4515,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     MGLAnnotationView *annotationView = annotationContext.annotationView;
     
     if (!annotationView) return;
+    
+    annotationView.annotation = nil;
     
     if (annotationContext.viewReuseIdentifier)
     {

--- a/platform/ios/test/MGLAnnotationViewTests.m
+++ b/platform/ios/test/MGLAnnotationViewTests.m
@@ -1,0 +1,62 @@
+#import <Mapbox/Mapbox.h>
+#import <XCTest/XCTest.h>
+
+static NSString * const MGLTestAnnotationReuseIdentifer = @"MGLTestAnnotationReuseIdentifer";
+
+@interface MGLTestAnnotation : NSObject <MGLAnnotation>
+@property (nonatomic, assign) CLLocationCoordinate2D coordinate;
+@end
+
+@implementation MGLTestAnnotation
+@end
+
+@interface MGLAnnotationViewTests : XCTestCase <MGLMapViewDelegate>
+@property (nonatomic) XCTestExpectation *expectation;
+@property (nonatomic) MGLMapView *mapView;
+@property (nonatomic, weak) MGLAnnotationView *annotationView;
+@end
+
+@implementation MGLAnnotationViewTests
+
+- (void)setUp
+{
+    [super setUp];
+    _mapView = [[MGLMapView alloc] initWithFrame:CGRectZero];
+    _mapView.delegate = self;
+}
+
+- (void)testAnnotationView
+{
+    _expectation = [self expectationWithDescription:@"annotation property"];
+    
+    MGLTestAnnotation *annotation = [[MGLTestAnnotation alloc] init];
+    [_mapView addAnnotation:annotation];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssert(_mapView.annotations.count == 1, @"number of annotations should be 1");
+    XCTAssertNotNil(_annotationView.annotation, @"annotation property should not be nil");
+    
+    [_mapView removeAnnotation:_annotationView.annotation];
+    
+    XCTAssert(_mapView.annotations.count == 0, @"number of annotations should be 0");
+    XCTAssertNil(_annotationView.annotation, @"annotation property should be nil");
+}
+
+- (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id<MGLAnnotation>)annotation
+{
+    MGLAnnotationView *annotationView = [mapView dequeueReusableAnnotationViewWithIdentifier:MGLTestAnnotationReuseIdentifer];
+    
+    if (!annotationView)
+    {
+        annotationView = [[MGLAnnotationView alloc] initWithReuseIdentifier:MGLTestAnnotationReuseIdentifer];
+    }
+    
+    _annotationView = annotationView;
+    
+    [_expectation fulfill];
+    
+    return annotationView;
+}
+
+@end


### PR DESCRIPTION
Also added a test case to make sure the `annotation` property is handled correctly but there's no reference to the `platform/ios/test/MGLAnnotationViewTests.m` file in the project file as I'm figuring out the details around [#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641).

/cc @1ec5 @boundsj @friedbunny 