### PR TITLE
[core] Use default transition ease for style transition

### DIFF
--- a/include/mbgl/style/transition_options.hpp
+++ b/include/mbgl/style/transition_options.hpp
@@ -6,13 +6,9 @@
 namespace mbgl {
 namespace style {
 
-class TransitionOptions {
-public:
-    TransitionOptions(optional<Duration> duration_ = {}, optional<Duration> delay_ = {})
-        : duration(std::move(duration_)), delay(std::move(delay_)) {}
-
-    optional<Duration> duration;
-    optional<Duration> delay;
+struct TransitionOptions {
+    optional<Duration> duration = {};
+    optional<Duration> delay = {};
 };
 
 } // namespace style

--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/unitbezier.hpp>
 
 #include <cmath>
 #include <string>
@@ -39,6 +40,8 @@ constexpr uint64_t DEFAULT_MAX_CACHE_SIZE = 50 * 1024 * 1024;
 
 constexpr Duration DEFAULT_FADE_DURATION = Milliseconds(300);
 constexpr Seconds CLOCK_SKEW_RETRY_TIMEOUT { 30 };
+
+constexpr UnitBezier DEFAULT_TRANSITION_EASE = { 0, 0, 0.25, 1 };
 
 } // namespace util
 

--- a/include/mbgl/util/unitbezier.hpp
+++ b/include/mbgl/util/unitbezier.hpp
@@ -31,32 +31,31 @@ namespace mbgl {
 namespace util {
 
 struct UnitBezier {
-    UnitBezier(double p1x, double p1y, double p2x, double p2y) {
-        // Calculate the polynomial coefficients, implicit first and last control points are (0,0) and (1,1).
-        cx = 3.0 * p1x;
-        bx = 3.0 * (p2x - p1x) - cx;
-        ax = 1.0 - cx - bx;
-
-        cy = 3.0 * p1y;
-        by = 3.0 * (p2y - p1y) - cy;
-        ay = 1.0 - cy - by;
+    // Calculate the polynomial coefficients, implicit first and last control points are (0,0) and (1,1).
+    constexpr UnitBezier(double p1x, double p1y, double p2x, double p2y)
+        : cx(3.0 * p1x)
+        , bx(3.0 * (p2x - p1x) - cx)
+        , ax(1.0 - cx - bx)
+        , cy(3.0 * p1y)
+        , by(3.0 * (p2y - p1y) - cy)
+        , ay(1.0 - cy - by) {
     }
 
-    double sampleCurveX(double t) {
+    double sampleCurveX(double t) const {
         // `ax t^3 + bx t^2 + cx t' expanded using Horner's rule.
         return ((ax * t + bx) * t + cx) * t;
     }
 
-    double sampleCurveY(double t) {
+    double sampleCurveY(double t) const {
         return ((ay * t + by) * t + cy) * t;
     }
 
-    double sampleCurveDerivativeX(double t) {
+    double sampleCurveDerivativeX(double t) const {
         return (3.0 * ax * t + 2.0 * bx) * t + cx;
     }
 
     // Given an x value, find a parametric value it came from.
-    double solveCurveX(double x, double epsilon) {
+    double solveCurveX(double x, double epsilon) const {
         double t0;
         double t1;
         double t2;
@@ -100,18 +99,18 @@ struct UnitBezier {
         return t2;
     }
 
-    double solve(double x, double epsilon) {
+    double solve(double x, double epsilon) const {
         return sampleCurveY(solveCurveX(x, epsilon));
     }
 
 private:
-    double ax;
-    double bx;
-    double cx;
+    const double cx;
+    const double bx;
+    const double ax;
 
-    double ay;
-    double by;
-    double cy;
+    const double cy;
+    const double by;
+    const double ay;
 };
 
 } // namespace util

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -889,7 +889,7 @@ void nativeSetVisibleCoordinateBounds(JNIEnv *env, jni::jobject* obj, jlong nati
     if (duration > 0) {
         animationOptions.duration.emplace(mbgl::Milliseconds(duration));
         // equivalent to kCAMediaTimingFunctionDefault in iOS
-        animationOptions.easing = mbgl::util::UnitBezier(0.25, 0.1, 0.25, 0.1);
+        animationOptions.easing.emplace(mbgl::util::UnitBezier { 0.25, 0.1, 0.25, 0.1 });
     }
 
     nativeMapView->getMap().easeTo(cameraOptions, animationOptions);
@@ -1054,7 +1054,7 @@ void nativeEaseTo(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jdoubl
 
     if (!easing) {
        // add a linear interpolator instead of easing
-       animationOptions.easing = mbgl::util::UnitBezier(0, 0, 1, 1);
+       animationOptions.easing.emplace(mbgl::util::UnitBezier { 0, 0, 1, 1 });
     }
 
     nativeMapView->getMap().easeTo(cameraOptions, animationOptions);

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2196,8 +2196,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     mbgl::AnimationOptions animationOptions;
     if (duration)
     {
-        animationOptions.duration = MGLDurationInSeconds(duration);
-        animationOptions.easing = MGLUnitBezierForMediaTimingFunction(function);
+        animationOptions.duration.emplace(MGLDurationInSeconds(duration));
+        animationOptions.easing.emplace(MGLUnitBezierForMediaTimingFunction(function));
     }
     if (completion)
     {
@@ -2349,8 +2349,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     mbgl::AnimationOptions animationOptions;
     if (duration > 0)
     {
-        animationOptions.duration = MGLDurationInSeconds(duration);
-        animationOptions.easing = MGLUnitBezierForMediaTimingFunction(function);
+        animationOptions.duration.emplace(MGLDurationInSeconds(duration));
+        animationOptions.easing.emplace(MGLUnitBezierForMediaTimingFunction(function));
     }
     if (completion)
     {
@@ -2456,8 +2456,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     mbgl::AnimationOptions animationOptions;
     if (duration > 0)
     {
-        animationOptions.duration = MGLDurationInSeconds(duration);
-        animationOptions.easing = MGLUnitBezierForMediaTimingFunction(function);
+        animationOptions.duration.emplace(MGLDurationInSeconds(duration));
+        animationOptions.easing.emplace(MGLUnitBezierForMediaTimingFunction(function));
     }
     if (completion)
     {

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1037,8 +1037,8 @@ public:
     mbgl::CameraOptions cameraOptions = [self cameraOptionsObjectForAnimatingToCamera:camera];
     mbgl::AnimationOptions animationOptions;
     if (duration > 0) {
-        animationOptions.duration = MGLDurationInSeconds(duration);
-        animationOptions.easing = MGLUnitBezierForMediaTimingFunction(function);
+        animationOptions.duration.emplace(MGLDurationInSeconds(duration));
+        animationOptions.easing.emplace(MGLUnitBezierForMediaTimingFunction(function));
     }
     if (completion) {
         animationOptions.transitionFinishFn = [completion]() {

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -67,12 +67,21 @@ void MapWindow::changeStyle()
 
 void MapWindow::keyPressEvent(QKeyEvent *ev)
 {
+    static const QMapbox::TransitionOptions transition { 300, {} };
+
     switch (ev->key()) {
     case Qt::Key_S:
         changeStyle();
         break;
     case Qt::Key_Tab:
         m_map.cycleDebugOptions();
+        break;
+    case Qt::Key_R:
+        if (m_map.hasClass("night")) {
+            m_map.removeClass("night", transition);
+        } else {
+            m_map.addClass("night", transition);
+        }
         break;
     default:
         break;

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -54,6 +54,11 @@ struct Q_DECL_EXPORT CustomLayerRenderParameters {
     double altitude;
 };
 
+struct Q_DECL_EXPORT TransitionOptions {
+    QVariant duration; // qint64
+    QVariant delay; // qint64
+};
+
 typedef void (*CustomLayerInitializeFunction)(void* context) ;
 typedef void (*CustomLayerRenderFunction)(void* context, const CustomLayerRenderParameters&);
 typedef void (*CustomLayerDeinitializeFunction)(void* context);

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -159,9 +159,12 @@ public:
     void setGestureInProgress(bool inProgress);
 
     void addClass(const QString &);
+    void addClass(const QString &, const QMapbox::TransitionOptions &);
     void removeClass(const QString &);
+    void removeClass(const QString &, const QMapbox::TransitionOptions &);
     bool hasClass(const QString &) const;
     void setClasses(const QStringList &);
+    void setClasses(const QStringList &, const QMapbox::TransitionOptions &);
     QStringList getClasses() const;
 
     QMapbox::AnnotationID addPointAnnotation(const QMapbox::PointAnnotation &);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -584,7 +584,7 @@ void Transform::startTransition(const CameraOptions& camera,
         if (t >= 1.0) {
             result = frame(1.0);
         } else {
-            util::UnitBezier ease = animation.easing ? *animation.easing : util::UnitBezier(0, 0, 0.25, 1);
+            util::UnitBezier ease = animation.easing ? *animation.easing : util::DEFAULT_TRANSITION_EASE;
             result = frame(ease.solve(t, 0.001));
         }
         

--- a/src/mbgl/style/cascade_parameters.hpp
+++ b/src/mbgl/style/cascade_parameters.hpp
@@ -9,8 +9,6 @@
 namespace mbgl {
 namespace style {
 
-class TransitionOptions;
-
 class CascadeParameters {
 public:
     std::vector<ClassID> classes;

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/style/cascade_parameters.hpp>
 #include <mbgl/style/calculation_parameters.hpp>
+#include <mbgl/util/constants.hpp>
 #include <mbgl/util/interpolate.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/rapidjson.hpp>
@@ -124,18 +125,18 @@ private:
         }
 
         Result calculate(const Evaluator<T>& evaluator, const TimePoint& now) {
-            Result final = PropertyValue<T>::visit(value, evaluator);
+            Result finalValue = PropertyValue<T>::visit(value, evaluator);
             if (!prior) {
                 // No prior value.
-                return final;
+                return finalValue;
             } else if (now >= end) {
                 // Transition from prior value is now complete.
                 prior.reset();
-                return final;
+                return finalValue;
             } else {
                 // Interpolate between recursively-calculated prior value and final.
                 float t = std::chrono::duration<float>(now - begin) / (end - begin);
-                return util::interpolate(prior->calculate(evaluator, now), final, t);
+                return util::interpolate(prior->calculate(evaluator, now), finalValue, util::DEFAULT_TRANSITION_EASE.solve(t, 0.001));
             }
         }
 

--- a/src/mbgl/style/property_parsing.cpp
+++ b/src/mbgl/style/property_parsing.cpp
@@ -150,7 +150,7 @@ optional<TransitionOptions> parseTransitionOptions(const char *, const JSValue& 
         return {};
     }
 
-    return TransitionOptions(duration, delay);
+    return TransitionOptions { duration, delay };
 }
 
 } // namespace style

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -180,7 +180,7 @@ void Style::update(const UpdateParameters& parameters) {
 void Style::cascade(const TimePoint& timePoint, MapMode mode) {
     // When in continuous mode, we can either have user- or style-defined
     // transitions. Still mode is always immediate.
-    static const TransitionOptions immediateTransition;
+    static const TransitionOptions immediateTransition {};
 
     std::vector<ClassID> classIDs;
     for (const auto& className : classes) {


### PR DESCRIPTION
Use a shared default `UnitBezier` transition ease for both transform and style transitions. `UnitBezier` is now `constexpr` and all its functions can be safely marked `const`.

Fixes #363.

👀 @jfirebaugh @kkaefer @1ec5 