### PR TITLE
[build] Mixed npm/mason output in clean build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ else
 .mason/mason: ;
 endif
 
+.NOTPARALLEL: node_modules
 node_modules: package.json
 	npm update # Install dependencies but don't run our own install script.
 


### PR DESCRIPTION
A clean build e.g. `make qt-app` is causing mixed npm/mason output:
```
./configure platform/qt/scripts/configure.sh build/qt-osx-x86_64/config.gypi osx x86_64
npm update # Install dependencies but don't run our own install script.
* Using Python 2.7.10
* Installed system-provided Qt 5.6.0
normalizeTree → correctMk ▌ ╢░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░╟
normalizeTree → addLocalD ▐ ╢░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░╟
* Installed binary package at /Users/bruno/work/mapbox-gl-native/mason_packages/headers/unique_resource/dev
* Downloading binary package headers/protozero/1.3.0.tar.gz...
* Installed binary package at /Users/bruno/work/mapbox-gl-native/mason_packages/headers/protozero/1.3.0
fetchMetadata → 304       ▀ ╢████████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░╟
...
```

By adding `.NOTPARALLEL: node_modules`, `npm update` will be called after mason setup. While this might have a small impact in build times on clean environments e.g. build bots, output is cleaner.

👀 @jfirebaugh @kkaefer