### PR TITLE
Re-enable tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,1 @@
-Checks: '-clang-analyzer-security.insecureAPI.rand'
+Checks: 'modernize-*,misc-static-assert,llvm-namespace-comment,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-core.uninitialized.UndefReturn'

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ check: test
 	scripts/collect-coverage.sh $(LINUX_OUTPUT_PATH)/$(BUILDTYPE)
 
 # Generates a compilation database with ninja for use in clang tooling
-compdb: compdb-$(HOST_PLATFORM)
+compdb: node_modules compdb-$(HOST_PLATFORM)
 
 compdb-linux: platform/linux/platform.gyp $(LINUX_OUTPUT_PATH)/config.gypi
 	$(GYP) -f ninja -I $(LINUX_OUTPUT_PATH)/config.gypi \

--- a/Makefile
+++ b/Makefile
@@ -306,11 +306,11 @@ compdb-osx: platform/osx/platform.gyp $(OSX_OUTPUT_PATH)/config.gypi
 tidy: compdb tidy-$(HOST_PLATFORM)
 
 tidy-linux:
-	deps/ninja/ninja-linux -C $(LINUX_OUTPUT_PATH)/$(BUILDTYPE) platform-lib test
+	deps/ninja/ninja-linux -C $(LINUX_OUTPUT_PATH)/$(BUILDTYPE) headers
 	scripts/clang-tidy.sh $(LINUX_OUTPUT_PATH)/$(BUILDTYPE)
 
 tidy-osx:
-	deps/ninja/ninja-osx -C $(OSX_OUTPUT_PATH)/$(BUILDTYPE) platform-lib test
+	deps/ninja/ninja-osx -C $(OSX_OUTPUT_PATH)/$(BUILDTYPE) headers
 	scripts/clang-tidy.sh $(OSX_OUTPUT_PATH)/$(BUILDTYPE)
 
 #### Miscellaneous targets #####################################################

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -27,7 +27,7 @@ struct AnimationOptions;
 
 namespace style {
 class Layer;
-}
+} // namespace style
 
 class Map : private util::noncopyable {
 public:

--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -14,7 +14,7 @@
 class GLFWView : public mbgl::View {
 public:
     GLFWView(bool fullscreen = false, bool benchmark = false);
-    ~GLFWView();
+    ~GLFWView() override;
 
     float getPixelRatio() const override;
     std::array<uint16_t, 2> getSize() const override;

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -31,7 +31,7 @@ class HeadlessView : public View {
 public:
     HeadlessView(float pixelRatio, uint16_t width = 256, uint16_t height = 256);
     HeadlessView(std::shared_ptr<HeadlessDisplay> display, float pixelRatio, uint16_t width = 256, uint16_t height = 256);
-    ~HeadlessView();
+    ~HeadlessView() override;
 
     float getPixelRatio() const override;
     std::array<uint16_t, 2> getSize() const override;

--- a/include/mbgl/storage/offline.hpp
+++ b/include/mbgl/storage/offline.hpp
@@ -27,7 +27,7 @@ class Tileset;
  */
 class OfflineTilePyramidRegionDefinition {
 public:
-    OfflineTilePyramidRegionDefinition(const std::string&, const LatLngBounds&, double, double, float);
+    OfflineTilePyramidRegionDefinition(std::string, LatLngBounds, double, double, float);
 
     /* Private */
     std::vector<CanonicalTileID> tileCover(SourceType, uint16_t tileSize, const Tileset&) const;
@@ -200,8 +200,8 @@ private:
     friend class OfflineDatabase;
 
     OfflineRegion(int64_t id,
-                  const OfflineRegionDefinition&,
-                  const OfflineRegionMetadata&);
+                  OfflineRegionDefinition,
+                  OfflineRegionMetadata);
 
     const int64_t id;
     const OfflineRegionDefinition definition;

--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -33,10 +33,10 @@ public:
         Required = true,
     };
 
-    Resource(Kind kind_, const std::string& url_, optional<TileData> tileData_ = {}, Necessity necessity_ = Required)
+    Resource(Kind kind_, std::string url_, optional<TileData> tileData_ = {}, Necessity necessity_ = Required)
         : kind(kind_),
           necessity(necessity_),
-          url(url_),
+          url(std::move(url_)),
           tileData(std::move(tileData_)) {
     }
 

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -49,7 +49,7 @@ public:
     std::string message;
 
 public:
-    Error(Reason, const std::string& = "");
+    Error(Reason, std::string = "");
 };
 
 std::ostream& operator<<(std::ostream&, Response::Error::Reason);

--- a/include/mbgl/style/function.hpp
+++ b/include/mbgl/style/function.hpp
@@ -12,8 +12,8 @@ public:
     using Stop = std::pair<float, T>;
     using Stops = std::vector<Stop>;
 
-    explicit Function(const Stops& stops_, float base_)
-        : base(base_), stops(stops_) {}
+    explicit Function(Stops stops_, float base_)
+        : base(base_), stops(std::move(stops_)) {}
 
     float getBase() const { return base; }
     const std::vector<std::pair<float, T>>& getStops() const { return stops; }

--- a/include/mbgl/style/transition_options.hpp
+++ b/include/mbgl/style/transition_options.hpp
@@ -8,8 +8,8 @@ namespace style {
 
 class TransitionOptions {
 public:
-    TransitionOptions(const optional<Duration>& duration_ = {}, const optional<Duration>& delay_ = {})
-        : duration(duration_), delay(delay_) {}
+    TransitionOptions(optional<Duration> duration_ = {}, optional<Duration> delay_ = {})
+        : duration(std::move(duration_)), delay(std::move(delay_)) {}
 
     optional<Duration> duration;
     optional<Duration> delay;

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -161,8 +161,8 @@ private:
     LatLng sw;
     LatLng ne;
 
-    LatLngBounds(const LatLng& sw_, const LatLng& ne_)
-        : sw(sw_), ne(ne_) {}
+    LatLngBounds(LatLng sw_, LatLng ne_)
+        : sw(std::move(sw_)), ne(std::move(ne_)) {}
 
     friend bool operator==(const LatLngBounds&, const LatLngBounds&);
     friend bool operator!=(const LatLngBounds&, const LatLngBounds&);

--- a/mbgl.gypi
+++ b/mbgl.gypi
@@ -125,26 +125,17 @@
   },
   'targets': [
     {
-      'target_name': 'core',
-      'product_name': 'mbgl-core',
-      'type': 'static_library',
-      'standalone_static_library': 1,
-      'hard_dependency': 1,
+      'target_name': 'headers',
+      'type': 'none',
 
       'sources': [
-        '<!@(find <(DEPTH)/src -name "*.hpp")',
-        '<!@(find <(DEPTH)/src -name "*.cpp")',
-        '<!@(find <(DEPTH)/src -name "*.c")',
-        '<!@(find <(DEPTH)/src -name "*.h")',
-        '<!@(find <(DEPTH)/include -name "*.hpp")',
-        '<!@(find <(DEPTH)/include -name "*.h")',
         '<!@(find -H <(DEPTH)/node_modules/mapbox-gl-shaders -name "*.glsl")',
         '<(SHARED_INTERMEDIATE_DIR)/include/mbgl/util/version.hpp',
       ],
 
       'rules': [
         {
-          'rule_name': 'Build Shaders',
+          'rule_name': 'shaders',
           'message': 'Building shader',
           'extension': 'glsl',
           'inputs': [ '<(DEPTH)/scripts/build-shaders.py' ],
@@ -156,17 +147,43 @@
 
       'actions': [
         {
-          'action_name': 'Build Version Header',
+          'action_name': 'version',
+          'message': 'Bulding version header',
           'inputs': [ '<(DEPTH)/scripts/build-version.py', ],
           'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/include/mbgl/util/version.hpp', ],
           'action': [ '<@(_inputs)', '<(SHARED_INTERMEDIATE_DIR)' ],
-        }
+        },
+      ],
+
+      'direct_dependent_settings': {
+        'include_dirs': [
+          '<(SHARED_INTERMEDIATE_DIR)/include',
+        ],
+      },
+    },
+    {
+      'target_name': 'core',
+      'product_name': 'mbgl-core',
+      'type': 'static_library',
+      'standalone_static_library': 1,
+      'hard_dependency': 1,
+
+      'dependencies': [
+        'headers',
+      ],
+
+      'sources': [
+        '<!@(find <(DEPTH)/src -name "*.hpp")',
+        '<!@(find <(DEPTH)/src -name "*.cpp")',
+        '<!@(find <(DEPTH)/src -name "*.c")',
+        '<!@(find <(DEPTH)/src -name "*.h")',
+        '<!@(find <(DEPTH)/include -name "*.hpp")',
+        '<!@(find <(DEPTH)/include -name "*.h")',
       ],
 
       'include_dirs': [
         'include',
         'src',
-        '<(SHARED_INTERMEDIATE_DIR)/include',
       ],
 
       'variables': {

--- a/platform/darwin/src/headless_view_cgl.cpp
+++ b/platform/darwin/src/headless_view_cgl.cpp
@@ -19,7 +19,7 @@ gl::glProc HeadlessView::initializeExtension(const char* name) {
 }
 
 void HeadlessView::createContext() {
-    CGLError error = CGLCreateContext(display->pixelFormat, NULL, &glContext);
+    CGLError error = CGLCreateContext(display->pixelFormat, nullptr, &glContext);
     if (error != kCGLNoError) {
         throw std::runtime_error(std::string("Error creating GL context object:") + CGLErrorString(error) + "\n");
     }

--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -14,8 +14,8 @@ namespace mbgl {
 
 class AssetFileSource::Impl {
 public:
-    Impl(const std::string& root_)
-        : root(root_) {
+    Impl(std::string root_)
+        : root(std::move(root_)) {
     }
 
     void request(const std::string& url, FileSource::Callback callback) {

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -23,7 +23,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     : fullscreen(fullscreen_), benchmark(benchmark_) {
     glfwSetErrorCallback(glfwError);
 
-    std::srand(std::time(0));
+    std::srand(std::time(nullptr));
 
     if (!glfwInit()) {
         mbgl::Log::Error(mbgl::Event::OpenGL, "failed to initialize glfw");
@@ -55,7 +55,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     glfwWindowHint(GLFW_STENCIL_BITS, 8);
     glfwWindowHint(GLFW_DEPTH_BITS, 16);
 
-    window = glfwCreateWindow(width, height, "Mapbox GL", monitor, NULL);
+    window = glfwCreateWindow(width, height, "Mapbox GL", monitor, nullptr);
     if (!window) {
         glfwTerminate();
         mbgl::Log::Error(mbgl::Event::OpenGL, "failed to initialize window");

--- a/platform/default/mbgl/storage/offline.cpp
+++ b/platform/default/mbgl/storage/offline.cpp
@@ -11,9 +11,9 @@
 namespace mbgl {
 
 OfflineTilePyramidRegionDefinition::OfflineTilePyramidRegionDefinition(
-    const std::string& styleURL_, const LatLngBounds& bounds_, double minZoom_, double maxZoom_, float pixelRatio_)
-    : styleURL(styleURL_),
-      bounds(bounds_),
+    std::string styleURL_, LatLngBounds bounds_, double minZoom_, double maxZoom_, float pixelRatio_)
+    : styleURL(std::move(styleURL_)),
+      bounds(std::move(bounds_)),
       minZoom(minZoom_),
       maxZoom(maxZoom_),
       pixelRatio(pixelRatio_) {
@@ -97,11 +97,11 @@ std::string encodeOfflineRegionDefinition(const OfflineRegionDefinition& region)
 }
 
 OfflineRegion::OfflineRegion(int64_t id_,
-                             const OfflineRegionDefinition& definition_,
-                             const OfflineRegionMetadata& metadata_)
+                             OfflineRegionDefinition definition_,
+                             OfflineRegionMetadata metadata_)
     : id(id_),
-      definition(definition_),
-      metadata(metadata_) {
+      definition(std::move(definition_)),
+      metadata(std::move(metadata_)) {
 }
 
 OfflineRegion::OfflineRegion(OfflineRegion&&) = default;

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -18,8 +18,8 @@ OfflineDatabase::Statement::~Statement() {
     stmt.clearBindings();
 }
 
-OfflineDatabase::OfflineDatabase(const std::string& path_, uint64_t maximumCacheSize_)
-    : path(path_),
+OfflineDatabase::OfflineDatabase(std::string path_, uint64_t maximumCacheSize_)
+    : path(std::move(path_)),
       maximumCacheSize(maximumCacheSize_) {
     ensureSchema();
 }

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -15,8 +15,8 @@ namespace mapbox {
 namespace sqlite {
 class Database;
 class Statement;
-}
-}
+} // namespace sqlite
+} // namespace mapbox
 
 namespace mbgl {
 

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -27,8 +27,7 @@ class OfflineDatabase : private util::noncopyable {
 public:
     // Limits affect ambient caching (put) only; resources required by offline
     // regions are exempt.
-    OfflineDatabase(const std::string& path,
-                    uint64_t maximumCacheSize = util::DEFAULT_MAX_CACHE_SIZE);
+    OfflineDatabase(std::string path, uint64_t maximumCacheSize = util::DEFAULT_MAX_CACHE_SIZE);
     ~OfflineDatabase();
 
     optional<Response> get(const Resource&);

--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -17,7 +17,7 @@ class Tileset;
 
 namespace style {
 class Parser;
-}
+} // namespace style
 
 /**
  * Coordinates the request and storage of all resources for an offline region.

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -27,7 +27,7 @@ public:
     using Callback = std::function<void (Response)>;
 
     OnlineFileRequest(Resource, Callback, OnlineFileSource::Impl&);
-    ~OnlineFileRequest();
+    ~OnlineFileRequest() override;
 
     void networkIsReachableAgain();
     void schedule(optional<Timestamp> expires);

--- a/platform/default/online_file_source.cpp
+++ b/platform/default/online_file_source.cpp
@@ -26,7 +26,7 @@ class OnlineFileRequest : public AsyncRequest {
 public:
     using Callback = std::function<void (Response)>;
 
-    OnlineFileRequest(const Resource&, Callback, OnlineFileSource::Impl&);
+    OnlineFileRequest(Resource, Callback, OnlineFileSource::Impl&);
     ~OnlineFileRequest();
 
     void networkIsReachableAgain();
@@ -182,9 +182,9 @@ std::unique_ptr<AsyncRequest> OnlineFileSource::request(const Resource& resource
     return std::make_unique<OnlineFileRequest>(res, callback, *impl);
 }
 
-OnlineFileRequest::OnlineFileRequest(const Resource& resource_, Callback callback_, OnlineFileSource::Impl& impl_)
+OnlineFileRequest::OnlineFileRequest(Resource resource_, Callback callback_, OnlineFileSource::Impl& impl_)
     : impl(impl_),
-      resource(resource_),
+      resource(std::move(resource_)),
       callback(std::move(callback_)) {
     impl.add(this);
 

--- a/platform/osx/bitrise-tidy.yml
+++ b/platform/osx/bitrise-tidy.yml
@@ -1,0 +1,54 @@
+format_version: 1.1.0
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+trigger_map:
+- pattern: "*"
+  is_pull_request_allowed: true
+  workflow: primary
+
+workflows:
+  primary:
+    steps:
+    - script:
+        title: Check for skipping CI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
+                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
+                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
+                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[ci skip\]/p')" ]]; then
+                envman add --key SKIPCI --value true
+            else
+                envman add --key SKIPCI --value false
+            fi
+    - script:
+        title: Run build script
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            export BUILDTYPE=Release
+            make compdb
+            .mason/mason install clang-tidy 3.8
+            make tidy
+        - is_debug: 'no'
+    - slack:
+        title: Post to Slack
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - webhook_url: "$SLACK_HOOK_URL"
+        - channel: "#gl-bots"
+        - from_username: 'Bitrise clang-tidy'
+        - from_username_on_error: 'Bitrise clang-tidy'
+        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+            passed'
+        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+            failed'
+        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
+        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png

--- a/scripts/build-version.py
+++ b/scripts/build-version.py
@@ -67,8 +67,8 @@ extern const char *revision;
 extern const char *string;
 extern const unsigned int number;
 
-}} // namespace mbgl
 }} // namespace version
+}} // namespace mbgl
 """.format(
     major = tag[0],
     minor = tag[1],

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -17,5 +17,18 @@ command -v ${CLANG_TIDY} >/dev/null 2>&1 || {
 
 cd $1
 
+function check_tidy() {
+    OUTPUT=$(${CLANG_TIDY} $0 -p=. -header-filter='mbgl' 2>/dev/null)
+    if [[ -n $OUTPUT ]]; then
+        echo "Error: A clang-tidy warning/error happened:"
+        echo -e "$OUTPUT"
+        exit 1
+    fi
+}
+
+export CLANG_TIDY
+export -f check_tidy
+
+echo "Running clang-tidy checks... (this might take a while)"
 git ls-files '../../../src/mbgl/*.cpp' '../../../platform/*.cpp' '../../../test/*.cpp' | \
-    xargs -I{} -P ${JOBS} ${CLANG_TIDY} {} -p=. -header-filter='mbgl' || exit 1
+    xargs -I{} -P ${JOBS} bash -c 'check_tidy' {}

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -3,24 +3,19 @@
 set -e
 set -o pipefail
 
-directory=$1
-
 export PATH="`pwd`/.mason:${PATH}" MASON_DIR="`pwd`/.mason"
 
-command -v ${CLANG_TIDY:-clang-tidy} >/dev/null 2>&1 || {
-    echo "Can't find ${CLANG_TIDY:-clang-tidy} in PATH."
+CLANG_TIDY=${CLANG_TIDY:-$(mason prefix clang-tidy 3.8)/bin/clang-tidy}
+
+command -v ${CLANG_TIDY} >/dev/null 2>&1 || {
+    echo "Can't find ${CLANG_TIDY} in PATH."
     if [ -z ${CLANG_TIDY} ]; then
         echo "Alternatively, you can set CLANG_TIDY to point to clang-tidy."
-    fi
-    if [ `uname -s` = 'Linux' ]; then
-        echo "On Debian-based distros, you can install them via 'apt-get install clang-tidy'"
-    elif [ `uname -s` = 'Darwin' ]; then
-        echo "On OS X, you can install them via 'brew install llvm --with-clang --with-clang-extra-tools'"
     fi
     exit 1
 }
 
-cd "${directory}"
+cd $1
 
 git ls-files '../../../src/mbgl/*.cpp' '../../../platform/*.cpp' '../../../test/*.cpp' | \
-    xargs -I{} -P ${JOBS} ${CLANG_TIDY:-clang-tidy} -header-filter='\/mbgl\/' {}
+    xargs -I{} -P ${JOBS} ${CLANG_TIDY} {} -p=. -header-filter='mbgl' || exit 1

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -21,7 +21,7 @@ class ShapeAnnotationImpl;
 
 namespace style {
 class Style;
-}
+} // namespace style
 
 class AnnotationManager : private util::noncopyable {
 public:

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -36,8 +36,8 @@ optional<Value> AnnotationTileFeature::getValue(const std::string& key) const {
     return optional<Value>();
 }
 
-AnnotationTileLayer::AnnotationTileLayer(const std::string &name_)
-    : name(name_) {}
+AnnotationTileLayer::AnnotationTileLayer(std::string name_)
+    : name(std::move(name_)) {}
 
 util::ptr<GeometryTileLayer> AnnotationTileData::getLayer(const std::string& name) const {
     auto it = layers.find(name);

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -16,7 +16,7 @@ public:
     AnnotationTile(const OverscaledTileID&,
                        std::string sourceID,
                        const style::UpdateParameters&);
-    ~AnnotationTile();
+    ~AnnotationTile() override;
 
     void setNecessity(Necessity) final;
 

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -9,7 +9,7 @@ class AnnotationManager;
 
 namespace style {
 class UpdateParameters;
-}
+} // namespace style
 
 class AnnotationTile : public GeometryTile {
 public:

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -40,7 +40,7 @@ public:
 
 class AnnotationTileLayer : public GeometryTileLayer {
 public:
-    AnnotationTileLayer(const std::string&);
+    AnnotationTileLayer(std::string);
 
     std::size_t featureCount() const override { return features.size(); }
     util::ptr<const GeometryTileFeature> getFeature(std::size_t i) const override { return features[i]; }

--- a/src/mbgl/annotation/fill_annotation_impl.cpp
+++ b/src/mbgl/annotation/fill_annotation_impl.cpp
@@ -7,9 +7,9 @@ namespace mbgl {
 
 using namespace style;
 
-FillAnnotationImpl::FillAnnotationImpl(const AnnotationID id_, const FillAnnotation& annotation_, const uint8_t maxZoom_)
+FillAnnotationImpl::FillAnnotationImpl(AnnotationID id_, FillAnnotation annotation_, uint8_t maxZoom_)
     : ShapeAnnotationImpl(id_, maxZoom_),
-      annotation(annotation_) {
+      annotation(std::move(annotation_)) {
 }
 
 void FillAnnotationImpl::updateStyle(Style& style) const {

--- a/src/mbgl/annotation/fill_annotation_impl.hpp
+++ b/src/mbgl/annotation/fill_annotation_impl.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class FillAnnotationImpl : public ShapeAnnotationImpl {
 public:
-    FillAnnotationImpl(const AnnotationID, const FillAnnotation&, const uint8_t maxZoom);
+    FillAnnotationImpl(AnnotationID, FillAnnotation, uint8_t maxZoom);
 
     void updateStyle(style::Style&) const final;
     const ShapeAnnotationGeometry& geometry() const final;

--- a/src/mbgl/annotation/line_annotation_impl.cpp
+++ b/src/mbgl/annotation/line_annotation_impl.cpp
@@ -7,9 +7,9 @@ namespace mbgl {
 
 using namespace style;
 
-LineAnnotationImpl::LineAnnotationImpl(const AnnotationID id_, const LineAnnotation& annotation_, const uint8_t maxZoom_)
+LineAnnotationImpl::LineAnnotationImpl(AnnotationID id_, LineAnnotation annotation_, uint8_t maxZoom_)
     : ShapeAnnotationImpl(id_, maxZoom_),
-      annotation(annotation_) {
+      annotation(std::move(annotation_)) {
 }
 
 void LineAnnotationImpl::updateStyle(Style& style) const {

--- a/src/mbgl/annotation/line_annotation_impl.hpp
+++ b/src/mbgl/annotation/line_annotation_impl.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class LineAnnotationImpl : public ShapeAnnotationImpl {
 public:
-    LineAnnotationImpl(const AnnotationID, const LineAnnotation&, const uint8_t maxZoom);
+    LineAnnotationImpl(AnnotationID, LineAnnotation, uint8_t maxZoom);
 
     void updateStyle(style::Style&) const final;
     const ShapeAnnotationGeometry& geometry() const final;

--- a/src/mbgl/annotation/shape_annotation_impl.hpp
+++ b/src/mbgl/annotation/shape_annotation_impl.hpp
@@ -14,7 +14,7 @@ class CanonicalTileID;
 
 namespace style {
 class Style;
-}
+} // namespace style
 
 class ShapeAnnotationImpl {
 public:

--- a/src/mbgl/annotation/style_sourced_annotation_impl.cpp
+++ b/src/mbgl/annotation/style_sourced_annotation_impl.cpp
@@ -9,9 +9,9 @@ namespace mbgl {
 
 using namespace style;
 
-StyleSourcedAnnotationImpl::StyleSourcedAnnotationImpl(const AnnotationID id_, const StyleSourcedAnnotation& annotation_, const uint8_t maxZoom_)
+StyleSourcedAnnotationImpl::StyleSourcedAnnotationImpl(AnnotationID id_, StyleSourcedAnnotation annotation_, uint8_t maxZoom_)
     : ShapeAnnotationImpl(id_, maxZoom_),
-      annotation(annotation_) {
+      annotation(std::move(annotation_)) {
 }
 
 void StyleSourcedAnnotationImpl::updateStyle(Style& style) const {

--- a/src/mbgl/annotation/style_sourced_annotation_impl.hpp
+++ b/src/mbgl/annotation/style_sourced_annotation_impl.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class StyleSourcedAnnotationImpl : public ShapeAnnotationImpl {
 public:
-    StyleSourcedAnnotationImpl(const AnnotationID, const StyleSourcedAnnotation&, const uint8_t maxZoom);
+    StyleSourcedAnnotationImpl(AnnotationID, StyleSourcedAnnotation, uint8_t maxZoom);
 
     void updateStyle(style::Style&) const final;
     const ShapeAnnotationGeometry& geometry() const final;

--- a/src/mbgl/annotation/symbol_annotation_impl.cpp
+++ b/src/mbgl/annotation/symbol_annotation_impl.cpp
@@ -5,9 +5,9 @@
 
 namespace mbgl {
 
-SymbolAnnotationImpl::SymbolAnnotationImpl(const AnnotationID id_, const SymbolAnnotation& annotation_)
+SymbolAnnotationImpl::SymbolAnnotationImpl(AnnotationID id_, SymbolAnnotation annotation_)
 : id(id_),
-  annotation(annotation_) {
+  annotation(std::move(annotation_)) {
 }
 
 void SymbolAnnotationImpl::updateLayer(const CanonicalTileID& tileID, AnnotationTileLayer& layer) const {

--- a/src/mbgl/annotation/symbol_annotation_impl.hpp
+++ b/src/mbgl/annotation/symbol_annotation_impl.hpp
@@ -37,7 +37,7 @@ class CanonicalTileID;
 
 class SymbolAnnotationImpl {
 public:
-    SymbolAnnotationImpl(const AnnotationID, const SymbolAnnotation&);
+    SymbolAnnotationImpl(AnnotationID, SymbolAnnotation);
 
     void updateLayer(const CanonicalTileID&, AnnotationTileLayer&) const;
 

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -13,7 +13,7 @@ namespace mbgl {
 
 namespace style {
 class Style;
-}
+} // namespace style
 
 class CollisionTile;
 class CanonicalTileID;
@@ -73,4 +73,4 @@ private:
 
     std::unordered_map<std::string, std::vector<std::string>> bucketLayerIDs;
 };
-}
+} // namespace mbgl

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -52,7 +52,7 @@ Rect<uint16_t> GlyphAtlas::addGlyph(uintptr_t tileUID,
     const uint8_t buffer = 3;
 
     std::map<uint32_t, GlyphValue>& face = index[fontStack];
-    std::map<uint32_t, GlyphValue>::iterator it = face.find(glyph.id);
+    auto it = face.find(glyph.id);
 
     // The glyph is already in this texture.
     if (it != face.end()) {

--- a/src/mbgl/geometry/glyph_atlas.cpp
+++ b/src/mbgl/geometry/glyph_atlas.cpp
@@ -19,8 +19,7 @@ GlyphAtlas::GlyphAtlas(uint16_t width_, uint16_t height_)
       dirty(true) {
 }
 
-GlyphAtlas::~GlyphAtlas() {
-}
+GlyphAtlas::~GlyphAtlas() = default;
 
 void GlyphAtlas::addGlyphs(uintptr_t tileUID,
                            const std::u32string& text,

--- a/src/mbgl/geometry/glyph_atlas.hpp
+++ b/src/mbgl/geometry/glyph_atlas.hpp
@@ -39,8 +39,8 @@ public:
 
 private:
     struct GlyphValue {
-        GlyphValue(const Rect<uint16_t>& rect_, uintptr_t id)
-            : rect(rect_), ids({ id }) {}
+        GlyphValue(Rect<uint16_t> rect_, uintptr_t id)
+            : rect(std::move(rect_)), ids({ id }) {}
         Rect<uint16_t> rect;
         std::set<uintptr_t> ids;
     };

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -18,8 +18,7 @@ LineAtlas::LineAtlas(GLsizei w, GLsizei h)
       dirty(true) {
 }
 
-LineAtlas::~LineAtlas() {
-}
+LineAtlas::~LineAtlas() = default;
 
 LinePatternPos LineAtlas::getDashPosition(const std::vector<float> &dasharray, bool round, gl::ObjectStore& store) {
     size_t key = round ? std::numeric_limits<size_t>::min() : std::numeric_limits<size_t>::max();

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -13,8 +13,7 @@ void VertexArrayObject::Unbind() {
 VertexArrayObject::VertexArrayObject() {
 }
 
-VertexArrayObject::~VertexArrayObject() {
-}
+VertexArrayObject::~VertexArrayObject() = default;
 
 void VertexArrayObject::bindVertexArrayObject(gl::ObjectStore& store) {
     if (!gl::GenVertexArrays || !gl::BindVertexArray) {

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -65,7 +65,7 @@ private:
     const char *bound_shader_name = "";
     GLuint bound_vertex_buffer = 0;
     GLuint bound_elements_buffer = 0;
-    GLbyte *bound_offset = 0;
+    GLbyte *bound_offset = nullptr;
 };
 
 } // namespace mbgl

--- a/src/mbgl/gl/object_store.hpp
+++ b/src/mbgl/gl/object_store.hpp
@@ -7,7 +7,6 @@
 
 #include <array>
 #include <algorithm>
-#include <cassert>
 #include <memory>
 #include <vector>
 
@@ -90,7 +89,7 @@ public:
     UniqueTexturePool createTexturePool() {
         ObjectPool ids;
         MBGL_CHECK_ERROR(glGenTextures(TextureMax, ids.data()));
-        assert(ids.size() == size_t(TextureMax));
+        static_assert(ids.size() == size_t(TextureMax), "Texture ids size mismatch");
         return UniqueTexturePool { std::move(ids), { this } };
     }
 

--- a/src/mbgl/gl/texture_pool.cpp
+++ b/src/mbgl/gl/texture_pool.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/gl/object_store.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <vector>
 
 namespace mbgl {

--- a/src/mbgl/gl/texture_pool.cpp
+++ b/src/mbgl/gl/texture_pool.cpp
@@ -64,8 +64,7 @@ void TextureReleaser::operator()(GLuint id) const {
 TexturePool::TexturePool() : impl(std::make_unique<Impl>()) {
 }
 
-TexturePool::~TexturePool() {
-}
+TexturePool::~TexturePool() = default;
 
 PooledTexture TexturePool::acquireTexture(gl::ObjectStore& store) {
     return PooledTexture { impl->acquireTexture(store) , { this } };

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -17,11 +17,11 @@ class CollisionTile;
 
 namespace gl {
 class ObjectStore;
-}
+} // namespace gl
 
 namespace style {
 class Layer;
-}
+} // namespace style
 
 class Bucket : private util::noncopyable {
 public:

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -100,4 +100,4 @@ void CircleBucket::drawCircles(CircleShader& shader, gl::ObjectStore& store) {
     }
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -12,7 +12,7 @@ class PlainShader;
 
 namespace gl {
 class ObjectStore;
-}
+} // namespace gl
 
 class DebugBucket : private util::noncopyable {
 public:

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -21,8 +21,8 @@ template <> struct nth<0, mbgl::GeometryCoordinate> {
 template <> struct nth<1, mbgl::GeometryCoordinate> {
     inline static int64_t get(const mbgl::GeometryCoordinate& t) { return t.y; };
 };
-}
-}
+} // namespace util
+} // namespace mapbox
 
 namespace mbgl {
 
@@ -168,4 +168,4 @@ void FillBucket::drawVertices(OutlinePatternShader& shader, gl::ObjectStore& sto
     }
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -33,8 +33,7 @@ struct GeometryTooLongException : std::exception {};
 FillBucket::FillBucket() {
 }
 
-FillBucket::~FillBucket() {
-}
+FillBucket::~FillBucket() = default;
 
 void FillBucket::addGeometry(const GeometryCollection& geometry) {
     for (auto& polygon : classifyRings(geometry)) {

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -508,4 +508,4 @@ void LineBucket::drawLinePatterns(LinepatternShader& shader, gl::ObjectStore& st
     }
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -310,4 +310,4 @@ void Painter::setDepthSublayer(int n) {
     config.depthRange = { nearDepth, farDepth };
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -61,7 +61,7 @@ struct ClipID;
 
 namespace util {
 class ObjectStore;
-}
+} // namespace util
 
 namespace style {
 class Style;
@@ -72,7 +72,7 @@ class CircleLayer;
 class SymbolLayer;
 class RasterLayer;
 class BackgroundLayer;
-}
+} // namespace style
 
 struct FrameData {
     std::array<uint16_t, 2> framebufferSize;

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -110,4 +110,4 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
     }
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -46,4 +46,4 @@ void Painter::renderCircle(CircleBucket& bucket,
     bucket.drawCircles(*circleShader, store);
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -198,4 +198,4 @@ void Painter::renderFill(FillBucket& bucket,
     }
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -164,4 +164,4 @@ void Painter::renderLine(LineBucket& bucket,
     }
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -69,4 +69,4 @@ std::array<float, 3> Painter::spinWeights(float spin) {
     return spin_weights;
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -271,4 +271,4 @@ void Painter::renderSymbol(SymbolBucket& bucket,
     config.activeTexture = GL_TEXTURE0;
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -43,4 +43,4 @@ bool RasterBucket::needsClipping() const {
     return false;
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/renderer/render_item.hpp
+++ b/src/mbgl/renderer/render_item.hpp
@@ -13,7 +13,7 @@ class Bucket;
 namespace style {
 class Layer;
 class Source;
-}
+} // namespace style
 
 class RenderItem {
 public:

--- a/src/mbgl/renderer/render_tile.hpp
+++ b/src/mbgl/renderer/render_tile.hpp
@@ -11,9 +11,7 @@ class Tile;
 
 class RenderTile {
 public:
-    RenderTile(const UnwrappedTileID& id_, Tile& tile_) : id(id_), tile(tile_) {
-    }
-
+    RenderTile(UnwrappedTileID id_, Tile& tile_) : id(std::move(id_)), tile(tile_) {}
     RenderTile(const RenderTile&) = delete;
     RenderTile(RenderTile&&) = default;
     RenderTile& operator=(const RenderTile&) = delete;

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -60,14 +60,14 @@ SymbolInstance::SymbolInstance(Anchor& anchor, const GeometryCoordinates& line,
     {}
 
 
-SymbolBucket::SymbolBucket(uint32_t overscaling_, float zoom_, const MapMode mode_, const std::string& bucketName_, const std::string& sourceLayerName_)
+SymbolBucket::SymbolBucket(uint32_t overscaling_, float zoom_, const MapMode mode_, std::string bucketName_, std::string sourceLayerName_)
     : overscaling(overscaling_),
       zoom(zoom_),
       tileSize(util::tileSize * overscaling_),
       tilePixelRatio(float(util::EXTENT) / tileSize),
       mode(mode_),
-      bucketName(bucketName_),
-      sourceLayerName(sourceLayerName_) {}
+      bucketName(std::move(bucketName_)),
+      sourceLayerName(std::move(sourceLayerName_)) {}
 
 SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -66,7 +66,7 @@ class SymbolBucket : public Bucket {
     typedef ElementGroup<1> CollisionBoxElementGroup;
 
 public:
-    SymbolBucket(uint32_t overscaling, float zoom, const MapMode, const std::string& bucketName_, const std::string& sourceLayerName_);
+    SymbolBucket(uint32_t overscaling, float zoom, const MapMode, std::string bucketName_, std::string sourceLayerName_);
     ~SymbolBucket() override;
 
     void upload(gl::ObjectStore&) override;

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -247,9 +247,8 @@ void SpriteAtlas::bind(bool linear, gl::ObjectStore& objectStore) {
 
 SpriteAtlas::~SpriteAtlas() = default;
 
-SpriteAtlas::Holder::Holder(const std::shared_ptr<const SpriteImage>& spriteImage_,
-                            const Rect<dimension>& pos_)
-    : spriteImage(spriteImage_), pos(pos_) {
+SpriteAtlas::Holder::Holder(std::shared_ptr<const SpriteImage> spriteImage_, Rect<dimension> pos_)
+    : spriteImage(std::move(spriteImage_)), pos(std::move(pos_)) {
 }
 
 SpriteAtlas::Holder::Holder(Holder&& h) : spriteImage(std::move(h.spriteImage)), pos(h.pos) {

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -75,7 +75,7 @@ private:
     const float pixelRatio;
 
     struct Holder : private util::noncopyable {
-        inline Holder(const std::shared_ptr<const SpriteImage>&, const Rect<dimension>&);
+        inline Holder(std::shared_ptr<const SpriteImage>, Rect<dimension>);
         inline Holder(Holder&&);
         std::shared_ptr<const SpriteImage> spriteImage;
         const Rect<dimension> pos;

--- a/src/mbgl/storage/resource.cpp
+++ b/src/mbgl/storage/resource.cpp
@@ -86,4 +86,4 @@ Resource Resource::tile(const std::string& urlTemplate,
     };
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/storage/response.cpp
+++ b/src/mbgl/storage/response.cpp
@@ -21,8 +21,8 @@ Response& Response::operator=(const Response& res) {
     return *this;
 }
 
-Response::Error::Error(Reason reason_, const std::string& message_)
-    : reason(reason_), message(message_) {
+Response::Error::Error(Reason reason_, std::string message_)
+    : reason(reason_), message(std::move(message_)) {
 }
 
 std::ostream& operator<<(std::ostream& os, Response::Error::Reason r) {

--- a/src/mbgl/style/calculation_parameters.hpp
+++ b/src/mbgl/style/calculation_parameters.hpp
@@ -12,13 +12,13 @@ public:
         : z(z_) {}
 
     CalculationParameters(float z_,
-                          const TimePoint& now_,
-                          const ZoomHistory& zoomHistory_,
-                          const Duration& defaultFadeDuration_)
+                          TimePoint now_,
+                          ZoomHistory zoomHistory_,
+                          Duration defaultFadeDuration_)
         : z(z_),
-          now(now_),
-          zoomHistory(zoomHistory_),
-          defaultFadeDuration(defaultFadeDuration_) {}
+          now(std::move(now_)),
+          zoomHistory(std::move(zoomHistory_)),
+          defaultFadeDuration(std::move(defaultFadeDuration_)) {}
 
     float z;
     TimePoint now;

--- a/src/mbgl/style/filter_evaluator.hpp
+++ b/src/mbgl/style/filter_evaluator.hpp
@@ -159,5 +159,5 @@ private:
     const GeometryTileFeature& feature;
 };
 
-} // namespace mbgl
+} // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/background_layer_properties.cpp
+++ b/src/mbgl/style/layers/background_layer_properties.cpp
@@ -1,6 +1,7 @@
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/background_layer_properties.hpp>
+#include <utility>
 
 namespace mbgl {
 namespace style {

--- a/src/mbgl/style/layers/circle_layer_properties.cpp
+++ b/src/mbgl/style/layers/circle_layer_properties.cpp
@@ -1,6 +1,7 @@
 // This file is generated. Edit scripts/generate-style-code.js, then run `make style-code`.
 
 #include <mbgl/style/layers/circle_layer_properties.hpp>
+#include <utility>
 
 namespace mbgl {
 namespace style {

--- a/src/mbgl/style/observer.hpp
+++ b/src/mbgl/style/observer.hpp
@@ -17,7 +17,7 @@ public:
      * strictly additive; e.g. when a source is loaded, both `onSourceLoaded`
      * and `onNeedsRepaint` will be called.
      */
-    virtual void onNeedsRepaint() {}
+    void onNeedsRepaint() override {}
     virtual void onResourceError(std::exception_ptr) {}
 };
 

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -118,8 +118,8 @@ private:
                       TimePoint end_,
                       PropertyValue<T> value_)
             : prior(std::move(prior_)),
-              begin(begin_),
-              end(end_),
+              begin(std::move(begin_)),
+              end(std::move(end_)),
               value(std::move(value_)) {
         }
 

--- a/src/mbgl/style/property_evaluator.hpp
+++ b/src/mbgl/style/property_evaluator.hpp
@@ -61,6 +61,6 @@ namespace util {
 template <typename T>
 struct Interpolator<style::Faded<T>>
     : Uninterpolated {};
-}
+} // namespace util
 
 } // namespace mbgl

--- a/src/mbgl/style/property_evaluator.hpp
+++ b/src/mbgl/style/property_evaluator.hpp
@@ -13,9 +13,9 @@ class PropertyEvaluator {
 public:
     using ResultType = T;
 
-    PropertyEvaluator(const CalculationParameters& parameters_, const T& defaultValue_)
+    PropertyEvaluator(const CalculationParameters& parameters_, T defaultValue_)
         : parameters(parameters_),
-          defaultValue(defaultValue_) {}
+          defaultValue(std::move(defaultValue_)) {}
 
     T operator()(const Undefined&) const { return defaultValue; }
     T operator()(const T& constant) const { return constant; }
@@ -40,9 +40,9 @@ class CrossFadedPropertyEvaluator {
 public:
     using ResultType = Faded<T>;
 
-    CrossFadedPropertyEvaluator(const CalculationParameters& parameters_, const T& defaultValue_)
+    CrossFadedPropertyEvaluator(const CalculationParameters& parameters_, T defaultValue_)
         : parameters(parameters_),
-          defaultValue(defaultValue_) {}
+          defaultValue(std::move(defaultValue_)) {}
 
     Faded<T> operator()(const Undefined&) const;
     Faded<T> operator()(const T& constant) const;

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -43,14 +43,14 @@ namespace style {
 static SourceObserver nullObserver;
 
 Source::Source(SourceType type_,
-               const std::string& id_,
-               const std::string& url_,
+               std::string id_,
+               std::string url_,
                uint16_t tileSize_,
                std::unique_ptr<Tileset>&& tileset_,
                std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
     : type(type_),
-      id(id_),
-      url(url_),
+      id(std::move(id_)),
+      url(std::move(url_)),
       tileSize(tileSize_),
       tileset(std::move(tileset_)),
       geojsonvt(std::move(geojsonvt_)),

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -46,7 +46,7 @@ public:
            uint16_t tileSize,
            std::unique_ptr<Tileset>&&,
            std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
-    ~Source();
+    ~Source() override;
 
     bool loaded = false;
     void load(FileSource&);

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -41,8 +41,8 @@ class SourceObserver;
 class Source : public TileObserver, private util::noncopyable {
 public:
     Source(SourceType,
-           const std::string& id,
-           const std::string& url,
+           std::string id,
+           std::string url,
            uint16_t tileSize,
            std::unique_ptr<Tileset>&&,
            std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -37,7 +37,7 @@ class Style : public GlyphStoreObserver,
               public util::noncopyable {
 public:
     Style(FileSource&, float pixelRatio);
-    ~Style();
+    ~Style() override;
 
     void setJSON(const std::string&);
 

--- a/src/mbgl/style/update_parameters.hpp
+++ b/src/mbgl/style/update_parameters.hpp
@@ -29,7 +29,7 @@ public:
                           Style& style_)
         : pixelRatio(pixelRatio_),
           debugOptions(debugOptions_),
-          animationTime(animationTime_),
+          animationTime(std::move(animationTime_)),
           transformState(transformState_),
           worker(worker_),
           fileSource(fileSource_),

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -5,9 +5,9 @@ namespace mbgl {
 
 CollisionFeature::CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
         const float top, const float bottom, const float left, const float right,
-        const float boxScale, const float padding, const bool alongLine, const IndexedSubfeature& indexedFeature_,
+        const float boxScale, const float padding, const bool alongLine, IndexedSubfeature indexedFeature_,
         const bool straight)
-        : indexedFeature(indexedFeature_) {
+        : indexedFeature(std::move(indexedFeature_)) {
 
     if (top == 0 && bottom == 0 && left == 0 && right == 0) return;
 

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -10,8 +10,8 @@
 namespace mbgl {
     class CollisionBox {
         public:
-            explicit CollisionBox(const Point<float> &_anchor, float _x1, float _y1, float _x2, float _y2, float _maxScale) :
-                anchor(_anchor), x1(_x1), y1(_y1), x2(_x2), y2(_y2), maxScale(_maxScale) {}
+            explicit CollisionBox(Point<float> _anchor, float _x1, float _y1, float _x2, float _y2, float _maxScale) :
+                anchor(std::move(_anchor)), x1(_x1), y1(_y1), x2(_x2), y2(_y2), maxScale(_maxScale) {}
 
             // the box is centered around the anchor point
             Point<float> anchor;
@@ -51,7 +51,7 @@ namespace mbgl {
             explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const float top, const float bottom, const float left, const float right,
                     const float boxScale, const float padding, const bool alongLine,
-                    const IndexedSubfeature&, const bool straight);
+                    IndexedSubfeature, const bool straight);
 
 
             std::vector<CollisionBox> boxes;

--- a/src/mbgl/text/collision_tile.cpp
+++ b/src/mbgl/text/collision_tile.cpp
@@ -9,7 +9,7 @@ namespace mbgl {
 
 auto infinity = std::numeric_limits<float>::infinity();
 
-CollisionTile::CollisionTile(PlacementConfig config_) : config(config_),
+CollisionTile::CollisionTile(PlacementConfig config_) : config(std::move(config_)),
     edges({{
         // left
         CollisionBox(Point<float>(0, 0), 0, -infinity, 0, infinity, infinity),

--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -29,9 +29,8 @@ struct GlyphMetrics {
 
 struct Glyph {
     inline explicit Glyph() : rect(0, 0, 0, 0), metrics() {}
-    inline explicit Glyph(const Rect<uint16_t> &rect_,
-                          const GlyphMetrics &metrics_)
-        : rect(rect_), metrics(metrics_) {}
+    inline explicit Glyph(Rect<uint16_t> rect_, GlyphMetrics metrics_)
+        : rect(std::move(rect_)), metrics(std::move(metrics_)) {}
 
     operator bool() const {
         return metrics || rect.hasArea();

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -62,10 +62,10 @@ SymbolQuads getIconQuads(Anchor& anchor, const PositionedIcon& shapedIcon,
 }
 
 struct GlyphInstance {
-    explicit GlyphInstance(const Point<float> &anchorPoint_) : anchorPoint(anchorPoint_) {}
-    explicit GlyphInstance(const Point<float> &anchorPoint_, float offset_, float minScale_, float maxScale_,
+    explicit GlyphInstance(Point<float> anchorPoint_) : anchorPoint(std::move(anchorPoint_)) {}
+    explicit GlyphInstance(Point<float> anchorPoint_, float offset_, float minScale_, float maxScale_,
             float angle_)
-        : anchorPoint(anchorPoint_), offset(offset_), minScale(minScale_), maxScale(maxScale_), angle(angle_) {}
+        : anchorPoint(std::move(anchorPoint_)), offset(offset_), minScale(minScale_), maxScale(maxScale_), angle(angle_) {}
 
     const Point<float> anchorPoint;
     const float offset = 0.0f;

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -15,18 +15,17 @@ class SymbolLayoutProperties;
 } // namespace style
 
 struct SymbolQuad {
-    explicit SymbolQuad(const Point<float> &tl_, const Point<float> &tr_,
-            const Point<float> &bl_, const Point<float> &br_,
-            const Rect<uint16_t> &tex_, float anchorAngle_, float glyphAngle_, const Point<float> &anchorPoint_,
+    explicit SymbolQuad(Point<float> tl_, Point<float> tr_, Point<float> bl_, Point<float> br_,
+            Rect<uint16_t> tex_, float anchorAngle_, float glyphAngle_, Point<float> anchorPoint_,
             float minScale_, float maxScale_)
-        : tl(tl_),
-        tr(tr_),
-        bl(bl_),
-        br(br_),
-        tex(tex_),
+        : tl(std::move(tl_)),
+        tr(std::move(tr_)),
+        bl(std::move(bl_)),
+        br(std::move(br_)),
+        tex(std::move(tex_)),
         anchorAngle(anchorAngle_),
         glyphAngle(glyphAngle_),
-        anchorPoint(anchorPoint_),
+        anchorPoint(std::move(anchorPoint_)),
         minScale(minScale_),
         maxScale(maxScale_) {}
 

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -12,7 +12,7 @@ class PositionedIcon;
 
 namespace style {
 class SymbolLayoutProperties;
-}
+} // namespace style
 
 struct SymbolQuad {
     explicit SymbolQuad(const Point<float> &tl_, const Point<float> &tr_,

--- a/src/mbgl/text/shaping.hpp
+++ b/src/mbgl/text/shaping.hpp
@@ -11,7 +11,7 @@ struct SpriteAtlasElement;
 
 namespace style {
 class SymbolLayoutProperties;
-}
+} // namespace style
 
 class PositionedIcon {
     public:

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -12,7 +12,7 @@ namespace mbgl {
 
 namespace style {
 class UpdateParameters;
-}
+} // namespace style
 
 class GeoJSONTile : public GeometryTile {
 public:

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -26,7 +26,7 @@ public:
                  style::Style&,
                  const MapMode);
 
-    ~GeometryTile();
+    ~GeometryTile() override;
 
     void setError(std::exception_ptr err);
     void setData(std::unique_ptr<GeometryTileData>);

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -17,7 +17,7 @@ class FeatureIndex;
 
 namespace style {
 class Style;
-}
+} // namespace style
 
 class GeometryTile : public Tile {
 public:

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -14,7 +14,7 @@ namespace gl { class TexturePool; }
 namespace style {
 class Layer;
 class UpdateParameters;
-}
+} // namespace style
 
 class RasterTile : public Tile {
 public:

--- a/src/mbgl/tile/tile.cpp
+++ b/src/mbgl/tile/tile.cpp
@@ -7,8 +7,7 @@ namespace mbgl {
 
 static TileObserver nullObserver;
 
-Tile::Tile(const OverscaledTileID& id_)
-    : id(id_), observer(&nullObserver) {
+Tile::Tile(OverscaledTileID id_) : id(std::move(id_)), observer(&nullObserver) {
 }
 
 Tile::~Tile() = default;

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -23,7 +23,7 @@ class TileObserver;
 
 namespace style {
 class Layer;
-}
+} // namespace style
 
 class Tile : private util::noncopyable {
 public:

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -27,7 +27,7 @@ class Layer;
 
 class Tile : private util::noncopyable {
 public:
-    Tile(const OverscaledTileID&);
+    Tile(OverscaledTileID);
     virtual ~Tile();
 
     void setObserver(TileObserver* observer);

--- a/src/mbgl/tile/tile_id.hpp
+++ b/src/mbgl/tile/tile_id.hpp
@@ -45,8 +45,7 @@ std::string toString(const CanonicalTileID&);
 // z/x/y describe the
 class OverscaledTileID {
 public:
-    OverscaledTileID(uint8_t overscaledZ, const CanonicalTileID&);
-    OverscaledTileID(uint8_t overscaledZ, CanonicalTileID&&);
+    OverscaledTileID(uint8_t overscaledZ, CanonicalTileID);
     OverscaledTileID(uint8_t overscaledZ, uint8_t z, uint32_t x, uint32_t y);
     OverscaledTileID(uint8_t z, uint32_t x, uint32_t y);
     explicit OverscaledTileID(const CanonicalTileID&);
@@ -75,8 +74,7 @@ std::string toString(const OverscaledTileID&);
 class UnwrappedTileID {
 public:
     UnwrappedTileID(uint8_t z, int64_t x, int64_t y);
-    UnwrappedTileID(int16_t wrap, const CanonicalTileID&);
-    UnwrappedTileID(int16_t wrap, CanonicalTileID&&);
+    UnwrappedTileID(int16_t wrap, CanonicalTileID);
     bool operator==(const UnwrappedTileID&) const;
     bool operator!=(const UnwrappedTileID&) const;
     bool operator<(const UnwrappedTileID&) const;
@@ -143,13 +141,8 @@ inline std::array<CanonicalTileID, 4> CanonicalTileID::children() const {
     } };
 }
 
-inline OverscaledTileID::OverscaledTileID(uint8_t overscaledZ_, const CanonicalTileID& canonical_)
-    : overscaledZ(overscaledZ_), canonical(canonical_) {
-    assert(overscaledZ >= canonical.z);
-}
-
-inline OverscaledTileID::OverscaledTileID(uint8_t overscaledZ_, CanonicalTileID&& canonical_)
-    : overscaledZ(overscaledZ_), canonical(std::forward<CanonicalTileID>(canonical_)) {
+inline OverscaledTileID::OverscaledTileID(uint8_t overscaledZ_, CanonicalTileID canonical_)
+    : overscaledZ(overscaledZ_), canonical(std::move(canonical_)) {
     assert(overscaledZ >= canonical.z);
 }
 
@@ -216,12 +209,8 @@ inline UnwrappedTileID::UnwrappedTileID(uint8_t z_, int64_t x_, int64_t y_)
           y_ < 0 ? 0 : std::min(static_cast<uint32_t>(y_), static_cast<uint32_t>(1ull << z_) - 1)) {
 }
 
-inline UnwrappedTileID::UnwrappedTileID(int16_t wrap_, const CanonicalTileID& canonical_)
-    : wrap(wrap_), canonical(canonical_) {
-}
-
-inline UnwrappedTileID::UnwrappedTileID(int16_t wrap_, CanonicalTileID&& canonical_)
-    : wrap(wrap_), canonical(std::forward<CanonicalTileID>(canonical_)) {
+inline UnwrappedTileID::UnwrappedTileID(int16_t wrap_, CanonicalTileID canonical_)
+    : wrap(wrap_), canonical(std::move(canonical_)) {
 }
 
 inline bool UnwrappedTileID::operator==(const UnwrappedTileID& rhs) const {

--- a/src/mbgl/tile/tile_source.hpp
+++ b/src/mbgl/tile/tile_source.hpp
@@ -12,7 +12,7 @@ class Tileset;
 
 namespace style {
 class UpdateParameters;
-}
+} // namespace style
 
 template <typename T>
 class TileSource : private util::noncopyable {

--- a/src/mbgl/tile/tile_worker.cpp
+++ b/src/mbgl/tile/tile_worker.cpp
@@ -19,14 +19,14 @@ namespace mbgl {
 
 using namespace mbgl::style;
 
-TileWorker::TileWorker(const OverscaledTileID& id_,
+TileWorker::TileWorker(OverscaledTileID id_,
                        std::string sourceID_,
                        SpriteStore& spriteStore_,
                        GlyphAtlas& glyphAtlas_,
                        GlyphStore& glyphStore_,
                        const util::Atomic<bool>& obsolete_,
                        const MapMode mode_)
-    : id(id_),
+    : id(std::move(id_)),
       sourceID(std::move(sourceID_)),
       spriteStore(spriteStore_),
       glyphAtlas(glyphAtlas_),

--- a/src/mbgl/tile/tile_worker.cpp
+++ b/src/mbgl/tile/tile_worker.cpp
@@ -188,4 +188,4 @@ void TileWorker::insertBucket(const std::string& name, std::unique_ptr<Bucket> b
     }
 }
 
-}
+} // namespace mbgl

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -45,7 +45,7 @@ using TileParseResult = variant<
 
 class TileWorker : public util::noncopyable {
 public:
-    TileWorker(const OverscaledTileID&,
+    TileWorker(OverscaledTileID,
                std::string sourceID,
                SpriteStore&,
                GlyphAtlas&,

--- a/src/mbgl/tile/tile_worker.hpp
+++ b/src/mbgl/tile/tile_worker.hpp
@@ -27,7 +27,7 @@ class Bucket;
 namespace style {
 class Layer;
 class SymbolLayer;
-}
+} // namespace style
 
 // We're using this class to shuttle the resulting buckets from the worker thread to the MapContext
 // thread. This class is movable-only because the vector contains movable-only value elements.

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -9,7 +9,7 @@ class Tileset;
 
 namespace style {
 class UpdateParameters;
-}
+} // namespace style
 
 class VectorTile : public GeometryTile {
 public:

--- a/src/mbgl/util/grid_index.cpp
+++ b/src/mbgl/util/grid_index.cpp
@@ -79,4 +79,4 @@ int32_t GridIndex<T>::convertToCellCoord(int32_t x) const {
 }
 
 template class GridIndex<IndexedSubfeature>;
-}
+} // namespace mbgl

--- a/src/mbgl/util/grid_index.hpp
+++ b/src/mbgl/util/grid_index.hpp
@@ -35,4 +35,4 @@ private:
 
 };
 
-}
+} // namespace mbgl

--- a/src/mbgl/util/intersection_tests.cpp
+++ b/src/mbgl/util/intersection_tests.cpp
@@ -143,5 +143,5 @@ bool multiPolygonIntersectsMultiPolygon(const GeometryCollection& multiPolygonA,
     return false;
 }
 
-}
-}
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/intersection_tests.hpp
+++ b/src/mbgl/util/intersection_tests.hpp
@@ -9,5 +9,5 @@ bool multiPolygonIntersectsBufferedMultiPoint(const GeometryCollection&, const G
 bool multiPolygonIntersectsBufferedMultiLine(const GeometryCollection&, const GeometryCollection&, float radius);
 bool multiPolygonIntersectsMultiPolygon(const GeometryCollection&, const GeometryCollection&);
 
-}
+} // namespace util
 } // namespace mbgl

--- a/src/mbgl/util/math.cpp
+++ b/src/mbgl/util/math.cpp
@@ -11,8 +11,8 @@ uint32_t ceil_log2(uint64_t x) {
     uint32_t y = (((x & (x - 1)) == 0) ? 0 : 1);
     uint32_t j = 32;
 
-    for (int32_t i = 0; i < 6; i++) {
-        const uint32_t k = (((x & t[i]) == 0) ? 0 : j);
+    for (const auto& i : t) {
+        const uint32_t k = (((x & i) == 0) ? 0 : j);
         y += k;
         x >>= k;
         j >>= 1;

--- a/src/mbgl/util/stopwatch.cpp
+++ b/src/mbgl/util/stopwatch.cpp
@@ -15,11 +15,11 @@ stopwatch::stopwatch(Event event_)
 stopwatch::stopwatch(EventSeverity severity_, Event event_)
     : severity(severity_), event(event_), start(Clock::now()) {}
 
-stopwatch::stopwatch(const std::string &name_, Event event_)
-    : name(name_), event(event_), start(Clock::now()) {}
+stopwatch::stopwatch(std::string name_, Event event_)
+    : name(std::move(name_)), event(event_), start(Clock::now()) {}
 
-stopwatch::stopwatch(const std::string &name_, EventSeverity severity_, Event event_)
-    : name(name_), severity(severity_), event(event_), start(Clock::now()) {}
+stopwatch::stopwatch(std::string name_, EventSeverity severity_, Event event_)
+    : name(std::move(name_)), severity(severity_), event(event_), start(Clock::now()) {}
 
 void stopwatch::report(const std::string &name_) {
     Duration duration = Clock::now() - start;

--- a/src/mbgl/util/stopwatch.hpp
+++ b/src/mbgl/util/stopwatch.hpp
@@ -13,8 +13,8 @@ class stopwatch {
 public:
     stopwatch(Event event = Event::General);
     stopwatch(EventSeverity severity, Event event = Event::General);
-    stopwatch(const std::string &name, Event event = Event::General);
-    stopwatch(const std::string &name, EventSeverity severity, Event event = Event::General);
+    stopwatch(std::string name, Event event = Event::General);
+    stopwatch(std::string name, EventSeverity severity, Event event = Event::General);
     void report(const std::string &name);
     ~stopwatch();
 

--- a/src/mbgl/util/thread_context.cpp
+++ b/src/mbgl/util/thread_context.cpp
@@ -1,10 +1,11 @@
 #include <mbgl/util/thread_context.hpp>
+#include <utility>
 
 namespace mbgl {
 namespace util {
 
-ThreadContext::ThreadContext(const std::string& name_, ThreadPriority priority_)
-    : name(name_),
+ThreadContext::ThreadContext(std::string name_, ThreadPriority priority_)
+    : name(std::move(name_)),
       priority(priority_) {
 }
 

--- a/src/mbgl/util/thread_context.hpp
+++ b/src/mbgl/util/thread_context.hpp
@@ -12,7 +12,7 @@ enum class ThreadPriority : bool {
 
 struct ThreadContext {
 public:
-    ThreadContext(const std::string& name, ThreadPriority priority = ThreadPriority::Regular);
+    ThreadContext(std::string name, ThreadPriority priority = ThreadPriority::Regular);
 
     std::string name;
     ThreadPriority priority;

--- a/src/mbgl/util/utf.hpp
+++ b/src/mbgl/util/utf.hpp
@@ -17,5 +17,5 @@ class utf8_to_utf32 {
     }
 };
 
-} // namespace mbgl
 } // namespace util
+} // namespace mbgl

--- a/test/api/api_misuse.cpp
+++ b/test/api/api_misuse.cpp
@@ -13,7 +13,7 @@
 using namespace mbgl;
 
 TEST(API, RenderWithoutCallback) {
-    FixtureLogObserver* log = new FixtureLogObserver();
+    auto log = new FixtureLogObserver();
     Log::setObserver(std::unique_ptr<Log::Observer>(log));
 
     util::RunLoop loop;

--- a/test/api/custom_layer.cpp
+++ b/test/api/custom_layer.cpp
@@ -56,7 +56,7 @@ public:
         MBGL_CHECK_ERROR(glUseProgram(program));
         MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, buffer));
         MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
-        MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_FLOAT, GL_FALSE, 0, NULL));
+        MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_FLOAT, GL_FALSE, 0, nullptr));
         MBGL_CHECK_ERROR(glDisable(GL_STENCIL_TEST));
         MBGL_CHECK_ERROR(glDisable(GL_DEPTH_TEST));
         MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));

--- a/test/include/mbgl/test.hpp
+++ b/test/include/mbgl/test.hpp
@@ -4,4 +4,4 @@ namespace mbgl {
 
 int runTests(int argc, char* argv[]);
 
-}
+} // namespace mbgl

--- a/test/src/mbgl/test/fixture_log_observer.cpp
+++ b/test/src/mbgl/test/fixture_log_observer.cpp
@@ -6,8 +6,8 @@ namespace mbgl {
 FixtureLog::Message::Message(EventSeverity severity_,
                              Event event_,
                              int64_t code_,
-                             const std::string& msg_)
-    : severity(severity_), event(event_), code(code_), msg(msg_) {
+                             std::string msg_)
+    : severity(severity_), event(event_), code(code_), msg(std::move(msg_)) {
 }
 
 bool FixtureLog::Message::operator==(const Message& rhs) const {

--- a/test/src/mbgl/test/fixture_log_observer.hpp
+++ b/test/src/mbgl/test/fixture_log_observer.hpp
@@ -30,10 +30,10 @@ public:
         using LogMessage = Message;
 
         Observer(FixtureLog* log = nullptr);
-        ~Observer();
+        ~Observer() override;
 
         // Log::Observer implementation
-        virtual bool onRecord(EventSeverity severity,
+        bool onRecord(EventSeverity severity,
                               Event event,
                               int64_t code,
                               const std::string& msg) override;

--- a/test/src/mbgl/test/fixture_log_observer.hpp
+++ b/test/src/mbgl/test/fixture_log_observer.hpp
@@ -12,7 +12,7 @@ namespace mbgl {
 class FixtureLog {
 public:
     struct Message {
-        Message(EventSeverity severity_, Event event_, int64_t code_, const std::string &msg_);
+        Message(EventSeverity severity_, Event event_, int64_t code_, std::string msg_);
         Message();
 
         bool operator==(const Message& rhs) const;

--- a/test/src/mbgl/test/stub_file_source.cpp
+++ b/test/src/mbgl/test/stub_file_source.cpp
@@ -10,7 +10,7 @@ public:
         : fileSource(fileSource_) {
     }
 
-    ~StubFileRequest() {
+    ~StubFileRequest() override {
         fileSource.pending.erase(this);
     }
 

--- a/test/src/mbgl/test/test.cpp
+++ b/test/src/mbgl/test/test.cpp
@@ -14,4 +14,4 @@ int runTests(int argc, char *argv[]) {
     return RUN_ALL_TESTS();
 }
 
-}
+} // namespace mbgl

--- a/test/src/mbgl/test/util.hpp
+++ b/test/src/mbgl/test/util.hpp
@@ -73,5 +73,5 @@ void checkImage(const std::string& base,
                 double imageThreshold = 0,
                 double pixelThreshold = 0);
 
-}
-}
+} // namespace test
+} // namespace mbgl

--- a/test/storage/offline_database.cpp
+++ b/test/storage/offline_database.cpp
@@ -78,7 +78,7 @@ private:
     bool locked = false;
 };
 
-}
+} // namespace
 
 TEST(OfflineDatabase, TEST_REQUIRES_WRITE(Create)) {
     using namespace mbgl;

--- a/test/style/filter.cpp
+++ b/test/style/filter.cpp
@@ -16,8 +16,8 @@ typedef std::multimap<std::string, mbgl::Value> Properties;
 
 class StubFeature : public GeometryTileFeature {
 public:
-    inline StubFeature(const Properties& properties_, FeatureType type_)
-        : properties(properties_)
+    inline StubFeature(Properties properties_, FeatureType type_)
+        : properties(std::move(properties_))
         , type(type_)
     {}
 

--- a/test/style/style_parser.cpp
+++ b/test/style/style_parser.cpp
@@ -26,7 +26,7 @@ TEST_P(StyleParserTest, ParseStyle) {
     ASSERT_FALSE(infoDoc.HasParseError());
     ASSERT_TRUE(infoDoc.IsObject());
 
-    FixtureLogObserver* observer = new FixtureLogObserver();
+    auto observer = new FixtureLogObserver();
     Log::setObserver(std::unique_ptr<Log::Observer>(observer));
 
     style::Parser parser;

--- a/test/util/thread_local.cpp
+++ b/test/util/thread_local.cpp
@@ -80,8 +80,8 @@ TEST(ThreadLocalStorage, AutoReclaim) {
 
     unsigned counter = 0;
 
-    DtorCounter* dtorCounter1 = new DtorCounter{ &counter };
-    DtorCounter* dtorCounter2 = new DtorCounter{ &counter };
+    auto dtorCounter1 = new DtorCounter{ &counter };
+    auto dtorCounter2 = new DtorCounter{ &counter };
 
     ThreadContext context = {"Test"};
 


### PR DESCRIPTION
Re-enable `clang-tidy` checks. Background:
> clang-tidy is a clang-based C++ “linter” tool. Its purpose is to provide an extensible framework for diagnosing and fixing typical programming errors, like style violations, interface misuse, or bugs that can be deduced via static analysis. 

The following checks are being performed (list is not final):
- [llvm-namespace-comment](http://clang.llvm.org/extra/clang-tidy/checks/llvm-namespace-comment.html)
- [modernize-use-nullptr](http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nullptr.html)
- [modernize-pass-by-value](http://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html)
- [modernize-use-override](http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html)
- [modernize-use-default](http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default.html)
- [modernize-use-auto](http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html)
- [modernize-loop-convert](http://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html)
- [misc-static-assert](http://clang.llvm.org/extra/clang-tidy/checks/misc-static-assert.html)

/cc @mapbox/gl 