### PR TITLE
[android] #5279 - expose MarkerView alpha

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BaseMarkerViewOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BaseMarkerViewOptions.java
@@ -29,6 +29,7 @@ public abstract class BaseMarkerViewOptions<U extends MarkerView, T extends Base
     protected float rotation;
     protected boolean visible = true;
     protected boolean selected;
+    protected float alpha = 1.0f;
 
     /**
      * Default constructor
@@ -132,10 +133,21 @@ public abstract class BaseMarkerViewOptions<U extends MarkerView, T extends Base
      * Set the visibility state of the MarkerView.
      *
      * @param visible the visible state
-     * @return the object for which the method was calleds
+     * @return the object for which the method was called
      */
     public T visible(boolean visible) {
         this.visible = visible;
+        return getThis();
+    }
+
+    /**
+     * Set the alpha of the MarkerView.
+     *
+     * @param alpha the alpha value
+     * @return the object for which the method was called
+     */
+    public T alpha(float alpha) {
+        this.alpha = alpha;
         return getThis();
     }
 
@@ -236,6 +248,15 @@ public abstract class BaseMarkerViewOptions<U extends MarkerView, T extends Base
      */
     public boolean isVisible() {
         return visible;
+    }
+
+    /**
+     * Get the alpha of the MarkerView.
+     *
+     * @return the alpha value
+     */
+    public float getAlpha() {
+        return alpha;
     }
 
     /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewOptions.java
@@ -30,6 +30,7 @@ public class MarkerViewOptions extends BaseMarkerViewOptions<MarkerView, MarkerV
         infoWindowAnchor(in.readFloat(), in.readFloat());
         rotation(in.readFloat());
         visible(in.readByte() != 0);
+        alpha(in.readFloat());
         if (in.readByte() != 0) {
             // this means we have an icon
             String iconId = in.readString();
@@ -61,6 +62,7 @@ public class MarkerViewOptions extends BaseMarkerViewOptions<MarkerView, MarkerV
         out.writeFloat(getInfoWindowAnchorV());
         out.writeFloat(getRotation());
         out.writeByte((byte) (isVisible() ? 1 : 0));
+        out.writeFloat(alpha);
         Icon icon = getIcon();
         out.writeByte((byte) (icon != null ? 1 : 0));
         if (icon != null) {
@@ -80,6 +82,7 @@ public class MarkerViewOptions extends BaseMarkerViewOptions<MarkerView, MarkerV
         marker.setInfoWindowAnchor(infoWindowAnchorU, infoWindowAnchorV);
         marker.setRotation(rotation);
         marker.setVisible(visible);
+        marker.setAlpha(alpha);
         return marker;
     }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewActivity.java
@@ -90,6 +90,7 @@ public class MarkerViewActivity extends AppCompatActivity {
                     mMapboxMap.addMarker(new MarkerViewOptions()
                             .position(LAT_LNGS[i])
                             .title(String.valueOf(i))
+                            .alpha(0.5f)
                             .icon(usFlag)
                     );
                 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/model/annotations/CountryMarkerViewOptions.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/model/annotations/CountryMarkerViewOptions.java
@@ -7,6 +7,7 @@ import android.os.Parcelable;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerViewOptions;
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
+import com.mapbox.mapboxsdk.annotations.MarkerView;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 public class CountryMarkerViewOptions extends BaseMarkerViewOptions<CountryMarkerView, CountryMarkerViewOptions> {
@@ -23,8 +24,10 @@ public class CountryMarkerViewOptions extends BaseMarkerViewOptions<CountryMarke
         title(in.readString());
         flat(in.readByte() != 0);
         anchor(in.readFloat(), in.readFloat());
-        selected = in.readByte() != 0;
+        infoWindowAnchor(in.readFloat(), in.readFloat());
         rotation(in.readFloat());
+        visible(in.readByte() != 0);
+        alpha(in.readFloat());
         if (in.readByte() != 0) {
             // this means we have an icon
             String iconId = in.readString();
@@ -56,8 +59,9 @@ public class CountryMarkerViewOptions extends BaseMarkerViewOptions<CountryMarke
         out.writeFloat(getAnchorV());
         out.writeFloat(getInfoWindowAnchorU());
         out.writeFloat(getInfoWindowAnchorV());
-        out.writeByte((byte) (selected ? 1 : 0));
         out.writeFloat(getRotation());
+        out.writeByte((byte) (isVisible() ? 1 : 0));
+        out.writeFloat(getAlpha());
         Icon icon = getIcon();
         out.writeByte((byte) (icon != null ? 1 : 0));
         if (icon != null) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/model/annotations/TextMarkerViewOptions.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/model/annotations/TextMarkerViewOptions.java
@@ -7,6 +7,7 @@ import android.os.Parcelable;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerViewOptions;
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
+import com.mapbox.mapboxsdk.annotations.MarkerView;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 public class TextMarkerViewOptions extends BaseMarkerViewOptions<TextMarkerView, TextMarkerViewOptions> {
@@ -24,6 +25,8 @@ public class TextMarkerViewOptions extends BaseMarkerViewOptions<TextMarkerView,
         anchor(in.readFloat(), in.readFloat());
         infoWindowAnchor(in.readFloat(), in.readFloat());
         rotation(in.readFloat());
+        visible(in.readByte() != 0);
+        alpha(in.readFloat());
         if (in.readByte() != 0) {
             // this means we have an icon
             String iconId = in.readString();
@@ -55,6 +58,8 @@ public class TextMarkerViewOptions extends BaseMarkerViewOptions<TextMarkerView,
         out.writeFloat(getInfoWindowAnchorU());
         out.writeFloat(getInfoWindowAnchorV());
         out.writeFloat(getRotation());
+        out.writeByte((byte) (isVisible() ? 1 : 0));
+        out.writeFloat(alpha);
         Icon icon = getIcon();
         out.writeByte((byte) (icon != null ? 1 : 0));
         if (icon != null) {


### PR DESCRIPTION
Adds alpha to MarkerViewOptions classes. Was previously only possible through marker.setAlpha().
closes #5279 