### PR TITLE
[android] #5335 Fix unresponsive MyBearingTracking.COMPASS bearing indicator

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -67,6 +67,14 @@ public class MyLocationView extends View {
     private ValueAnimator accuracyAnimator;
     private ValueAnimator directionAnimator;
 
+    private ValueAnimator.AnimatorUpdateListener invalidateSelfOnUpdateListener =
+            new ValueAnimator.AnimatorUpdateListener() {
+                @Override
+                public void onAnimationUpdate(ValueAnimator animation) {
+                    invalidate();
+                }
+            };
+
     private Drawable foregroundDrawable;
     private Drawable foregroundBearingDrawable;
     private Drawable backgroundDrawable;
@@ -444,6 +452,7 @@ public class MyLocationView extends View {
 
         directionAnimator = ValueAnimator.ofFloat(oldDir, newDir);
         directionAnimator.setDuration(375);
+        directionAnimator.addUpdateListener(invalidateSelfOnUpdateListener);
         directionAnimator.start();
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -526,24 +526,19 @@ public class MyLocationView extends View {
                 return;
             }
 
-            long currentTime = SystemClock.elapsedRealtime();
-            if (currentTime < mCompassUpdateNextTimestamp) {
-                return;
-            }
-
             int type = event.sensor.getType();
-            float[] data;
             if (type == Sensor.TYPE_ACCELEROMETER) {
-                data = mGData;
+                System.arraycopy(event.values, 0, mGData, 0, 3);
             } else if (type == Sensor.TYPE_MAGNETIC_FIELD) {
-                data = mMData;
+                System.arraycopy(event.values, 0, mMData, 0, 3);
             } else {
                 // we should not be here.
                 return;
             }
 
-            for (int i = 0; i < 3; i++) {
-                data[i] = event.values[i];
+            long currentTime = SystemClock.elapsedRealtime();
+            if (currentTime < mCompassUpdateNextTimestamp) {
+                return;
             }
 
             SensorManager.getRotationMatrix(mR, mI, mGData, mMData);


### PR DESCRIPTION
Fixes issues outlined in #5335

1. Always record latest accelerometer and magnetometer sensor values regardless of MyLocationView update throttling.
2. Invalidate MyLocationView during bearing indicator animation.

Depends on #5331 being fixed first, else using `MyBearingTracking.COMPASS` mode simply causes a crash.