### PR TITLE
[tidy] Install mason clang-tidy if CLANG_TIDY is not set

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,2 @@
 Checks: 'modernize-*,misc-static-assert,llvm-namespace-comment,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-core.uninitialized.UndefReturn'
+HeaderFilterRegex: 'mbgl'

--- a/Makefile
+++ b/Makefile
@@ -306,10 +306,12 @@ compdb-macos: platform/macos/platform.gyp $(MACOS_OUTPUT_PATH)/config.gypi
 tidy: compdb tidy-$(HOST_PLATFORM)
 
 tidy-linux:
+	if test -z $(CLANG_TIDY); then .mason/mason install clang-tidy 3.8; fi
 	deps/ninja/ninja-linux -C $(LINUX_OUTPUT_PATH)/$(BUILDTYPE) headers
 	scripts/clang-tidy.sh $(LINUX_OUTPUT_PATH)/$(BUILDTYPE)
 
 tidy-macos:
+	if test -z $(CLANG_TIDY); then .mason/mason install clang-tidy 3.8; fi
 	deps/ninja/ninja-macos -C $(MACOS_OUTPUT_PATH)/$(BUILDTYPE) headers
 	scripts/clang-tidy.sh $(MACOS_OUTPUT_PATH)/$(BUILDTYPE)
 

--- a/platform/osx/bitrise-tidy.yml
+++ b/platform/osx/bitrise-tidy.yml
@@ -31,7 +31,6 @@ workflows:
             set -eu -o pipefail
             export BUILDTYPE=Release
             make compdb
-            .mason/mason install clang-tidy 3.8
             make tidy
         - is_debug: 'no'
     - slack:

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -18,7 +18,7 @@ command -v ${CLANG_TIDY} >/dev/null 2>&1 || {
 cd $1
 
 function check_tidy() {
-    OUTPUT=$(${CLANG_TIDY} $0 -p=. -header-filter='mbgl' 2>/dev/null)
+    OUTPUT=$(${CLANG_TIDY} -p=$PWD $0 2>/dev/null)
     if [[ -n $OUTPUT ]]; then
         echo "Error: A clang-tidy warning/error happened:"
         echo -e "$OUTPUT"


### PR DESCRIPTION
Also use HeaderFilterRegex in `.clang-tidy` instead of passing it as a parameter on the command call.

:eyes: @kkaefer