### PR TITLE
Source subclasses

### DIFF
--- a/include/mbgl/storage/offline.hpp
+++ b/include/mbgl/storage/offline.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/range.hpp>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/storage/response.hpp>
@@ -12,7 +13,6 @@
 namespace mbgl {
 
 class TileID;
-class Tileset;
 
 /*
  * An offline region defined by a style URL, geographic bounding box, zoom range, and
@@ -30,7 +30,7 @@ public:
     OfflineTilePyramidRegionDefinition(std::string, LatLngBounds, double, double, float);
 
     /* Private */
-    std::vector<CanonicalTileID> tileCover(SourceType, uint16_t tileSize, const Tileset&) const;
+    std::vector<CanonicalTileID> tileCover(SourceType, uint16_t tileSize, const Range<uint8_t>& zoomRange) const;
 
     const std::string styleURL;
     const LatLngBounds bounds;

--- a/include/mbgl/util/range.hpp
+++ b/include/mbgl/util/range.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace mbgl {
+
+template <class T>
+class Range {
+public:
+    Range(const T& min_, const T& max_)
+        : min(min_), max(max_) {}
+
+    T min;
+    T max;
+};
+
+template <class T>
+inline bool operator==(const Range<T>& a, const Range<T>& b) {
+    return a.min == b.min && a.max == b.max;
+}
+
+template <class T>
+inline bool operator!=(const Range<T>& a, const Range<T>& b) {
+    return !(a == b);
+}
+
+} // namespace mbgl

--- a/platform/default/mbgl/storage/offline.cpp
+++ b/platform/default/mbgl/storage/offline.cpp
@@ -23,9 +23,9 @@ OfflineTilePyramidRegionDefinition::OfflineTilePyramidRegionDefinition(
     }
 }
 
-std::vector<CanonicalTileID> OfflineTilePyramidRegionDefinition::tileCover(SourceType type, uint16_t tileSize, const Tileset& tileset) const {
-    double minZ = std::max<double>(util::coveringZoomLevel(minZoom, type, tileSize), tileset.minZoom);
-    double maxZ = std::min<double>(util::coveringZoomLevel(maxZoom, type, tileSize), tileset.maxZoom);
+std::vector<CanonicalTileID> OfflineTilePyramidRegionDefinition::tileCover(SourceType type, uint16_t tileSize, const Range<uint8_t>& zoomRange) const {
+    double minZ = std::max<double>(util::coveringZoomLevel(minZoom, type, tileSize), zoomRange.min);
+    double maxZ = std::min<double>(util::coveringZoomLevel(maxZoom, type, tileSize), zoomRange.max);
 
     assert(minZ >= 0);
     assert(maxZ >= 0);

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -74,7 +74,7 @@ std::vector<Resource> OfflineDownload::glyphResources(const style::Parser& parse
 std::vector<Resource> OfflineDownload::tileResources(SourceType type, uint16_t tileSize, const Tileset& tileset) const {
     std::vector<Resource> result;
 
-    for (const auto& tile : definition.tileCover(type, tileSize, tileset)) {
+    for (const auto& tile : definition.tileCover(type, tileSize, tileset.zoomRange)) {
         result.push_back(Resource::tile(tileset.tiles[0], definition.pixelRatio, tile.x, tile.y, tile.z));
     }
 

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -108,13 +108,13 @@ OfflineRegionStatus OfflineDownload::getStatus() const {
         case SourceType::Raster: {
             style::TileSource* tileSource = static_cast<style::TileSource*>(source.get());
             if (tileSource->getTileset()) {
-                result.requiredResourceCount += tileResources(source->type, source->tileSize, *tileSource->getTileset()).size();
+                result.requiredResourceCount += tileResources(source->type, tileSource->getTileSize(), *tileSource->getTileset()).size();
             } else {
                 result.requiredResourceCount += 1;
                 optional<Response> sourceResponse = offlineDatabase.get(Resource::source(tileSource->getURL()));
                 if (sourceResponse) {
-                    result.requiredResourceCount += tileResources(source->type, source->tileSize,
-                        *style::parseTileJSON(*sourceResponse->data, tileSource->getURL(), source->type, source->tileSize)).size();
+                    result.requiredResourceCount += tileResources(source->type, tileSource->getTileSize(),
+                        *style::parseTileJSON(*sourceResponse->data, tileSource->getURL(), source->type, tileSource->getTileSize())).size();
                 } else {
                     result.requiredResourceCountIsPrecise = false;
                 }
@@ -156,12 +156,12 @@ void OfflineDownload::activateDownload() {
 
         for (const auto& source : parser.sources) {
             SourceType type = source->type;
-            uint16_t tileSize = source->tileSize;
 
             switch (type) {
             case SourceType::Vector:
             case SourceType::Raster: {
-                style::TileSource* tileSource = static_cast<style::TileSource*>(source.get());
+                const style::TileSource* tileSource = static_cast<style::TileSource*>(source.get());
+                const uint16_t tileSize = tileSource->getTileSize();
                 if (tileSource->getTileset()) {
                     ensureTiles(type, tileSize, *tileSource->getTileset());
                 } else {

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -107,7 +107,7 @@ std::unique_ptr<AnnotationTileData> AnnotationManager::getTileData(const Canonic
 void AnnotationManager::updateStyle(Style& style) {
     // Create annotation source, point layer, and point bucket
     if (!style.getSource(SourceID)) {
-        std::unique_ptr<Source> source = std::make_unique<AnnotationSource>(SourceID, "", util::tileSize, std::make_unique<Tileset>(), nullptr);
+        std::unique_ptr<Source> source = std::make_unique<AnnotationSource>(SourceID, "", util::tileSize, std::make_unique<Tileset>());
         source->enabled = true;
         style.addSource(std::move(source));
 

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -1,10 +1,10 @@
 #include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/annotation/annotation_source.hpp>
 #include <mbgl/annotation/annotation_tile.hpp>
 #include <mbgl/annotation/symbol_annotation_impl.hpp>
 #include <mbgl/annotation/line_annotation_impl.hpp>
 #include <mbgl/annotation/fill_annotation_impl.hpp>
 #include <mbgl/annotation/style_sourced_annotation_impl.hpp>
-#include <mbgl/style/source.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
@@ -107,7 +107,7 @@ std::unique_ptr<AnnotationTileData> AnnotationManager::getTileData(const Canonic
 void AnnotationManager::updateStyle(Style& style) {
     // Create annotation source, point layer, and point bucket
     if (!style.getSource(SourceID)) {
-        std::unique_ptr<Source> source = std::make_unique<Source>(SourceType::Annotations, SourceID, "", util::tileSize, std::make_unique<Tileset>(), nullptr);
+        std::unique_ptr<Source> source = std::make_unique<AnnotationSource>(SourceID, "", util::tileSize, std::make_unique<Tileset>(), nullptr);
         source->enabled = true;
         style.addSource(std::move(source));
 

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -107,7 +107,7 @@ std::unique_ptr<AnnotationTileData> AnnotationManager::getTileData(const Canonic
 void AnnotationManager::updateStyle(Style& style) {
     // Create annotation source, point layer, and point bucket
     if (!style.getSource(SourceID)) {
-        std::unique_ptr<Source> source = std::make_unique<AnnotationSource>(SourceID, "", util::tileSize, std::make_unique<Tileset>());
+        std::unique_ptr<Source> source = std::make_unique<AnnotationSource>();
         source->enabled = true;
         style.addSource(std::move(source));
 

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -1,10 +1,16 @@
 #include <mbgl/annotation/annotation_source.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/annotation/annotation_tile.hpp>
 
 namespace mbgl {
 
 AnnotationSource::AnnotationSource()
     : Source(SourceType::Annotations, AnnotationManager::SourceID, "", util::tileSize, std::make_unique<Tileset>()) {
+}
+
+std::unique_ptr<Tile> AnnotationSource::createTile(const OverscaledTileID& tileID,
+                                                   const style::UpdateParameters& parameters) {
+    return std::make_unique<AnnotationTile>(tileID, id, parameters);
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -5,7 +5,7 @@
 namespace mbgl {
 
 AnnotationSource::AnnotationSource()
-    : Source(SourceType::Annotations, AnnotationManager::SourceID, "", util::tileSize, std::make_unique<Tileset>()) {
+    : Source(SourceType::Annotations, AnnotationManager::SourceID, "", util::tileSize) {
 }
 
 Range<uint8_t> AnnotationSource::getZoomRange() {

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -1,12 +1,10 @@
 #include <mbgl/annotation/annotation_source.hpp>
+#include <mbgl/annotation/annotation_manager.hpp>
 
 namespace mbgl {
 
-AnnotationSource::AnnotationSource(std::string id_,
-                                   std::string url_,
-                                   uint16_t tileSize_,
-                                   std::unique_ptr<Tileset>&& tileset_)
-    : Source(SourceType::Annotations, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
+AnnotationSource::AnnotationSource()
+    : Source(SourceType::Annotations, AnnotationManager::SourceID, "", util::tileSize, std::make_unique<Tileset>()) {
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -8,6 +8,10 @@ AnnotationSource::AnnotationSource()
     : Source(SourceType::Annotations, AnnotationManager::SourceID, "", util::tileSize, std::make_unique<Tileset>()) {
 }
 
+Range<uint8_t> AnnotationSource::getZoomRange() {
+    return { 0, 22 };
+}
+
 void AnnotationSource::load(FileSource&) {
     loaded = true;
 }

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -8,6 +8,10 @@ AnnotationSource::AnnotationSource()
     : Source(SourceType::Annotations, AnnotationManager::SourceID, "", util::tileSize, std::make_unique<Tileset>()) {
 }
 
+void AnnotationSource::load(FileSource&) {
+    loaded = true;
+}
+
 std::unique_ptr<Tile> AnnotationSource::createTile(const OverscaledTileID& tileID,
                                                    const style::UpdateParameters& parameters) {
     return std::make_unique<AnnotationTile>(tileID, id, parameters);

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -1,0 +1,13 @@
+#include <mbgl/annotation/annotation_source.hpp>
+
+namespace mbgl {
+
+AnnotationSource::AnnotationSource(std::string id_,
+                                   std::string url_,
+                                   uint16_t tileSize_,
+                                   std::unique_ptr<Tileset>&& tileset_,
+                                   std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
+    : Source(SourceType::Annotations, std::move(id_), std::move(url_), tileSize_, std::move(tileset_), std::move(geojsonvt_)) {
+}
+
+} // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -5,9 +5,8 @@ namespace mbgl {
 AnnotationSource::AnnotationSource(std::string id_,
                                    std::string url_,
                                    uint16_t tileSize_,
-                                   std::unique_ptr<Tileset>&& tileset_,
-                                   std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
-    : Source(SourceType::Annotations, std::move(id_), std::move(url_), tileSize_, std::move(tileset_), std::move(geojsonvt_)) {
+                                   std::unique_ptr<Tileset>&& tileset_)
+    : Source(SourceType::Annotations, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
 }
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -5,7 +5,7 @@
 namespace mbgl {
 
 AnnotationSource::AnnotationSource()
-    : Source(SourceType::Annotations, AnnotationManager::SourceID, "", util::tileSize) {
+    : Source(SourceType::Annotations, AnnotationManager::SourceID, util::tileSize) {
 }
 
 Range<uint8_t> AnnotationSource::getZoomRange() {

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -5,7 +5,7 @@
 namespace mbgl {
 
 AnnotationSource::AnnotationSource()
-    : Source(SourceType::Annotations, AnnotationManager::SourceID, util::tileSize) {
+    : Source(SourceType::Annotations, AnnotationManager::SourceID) {
 }
 
 Range<uint8_t> AnnotationSource::getZoomRange() {

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <mbgl/style/source.hpp>
+
+namespace mbgl {
+
+class AnnotationSource : public style::Source {
+public:
+    AnnotationSource(std::string id,
+                     std::string url,
+                     uint16_t tileSize,
+                     std::unique_ptr<Tileset>&&,
+                     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+};
+
+} // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -11,6 +11,7 @@ public:
     void load(FileSource&) final;
 
 private:
+    Range<uint8_t> getZoomRange() final;
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const style::UpdateParameters&) final;
 };
 

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -11,7 +11,9 @@ public:
     void load(FileSource&) final;
 
 private:
+    uint16_t getTileSize() const final { return util::tileSize; }
     Range<uint8_t> getZoomRange() final;
+
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const style::UpdateParameters&) final;
 };
 

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -7,6 +7,9 @@ namespace mbgl {
 class AnnotationSource : public style::Source {
 public:
     AnnotationSource();
+
+private:
+    std::unique_ptr<Tile> createTile(const OverscaledTileID&, const style::UpdateParameters&) final;
 };
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -9,8 +9,7 @@ public:
     AnnotationSource(std::string id,
                      std::string url,
                      uint16_t tileSize,
-                     std::unique_ptr<Tileset>&&,
-                     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+                     std::unique_ptr<Tileset>&&);
 };
 
 } // namespace mbgl

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -8,6 +8,8 @@ class AnnotationSource : public style::Source {
 public:
     AnnotationSource();
 
+    void load(FileSource&) final;
+
 private:
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const style::UpdateParameters&) final;
 };

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -6,10 +6,7 @@ namespace mbgl {
 
 class AnnotationSource : public style::Source {
 public:
-    AnnotationSource(std::string id,
-                     std::string url,
-                     uint16_t tileSize,
-                     std::unique_ptr<Tileset>&&);
+    AnnotationSource();
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -161,11 +161,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         // Update all clipping IDs.
         algorithm::ClipIDGenerator generator;
         for (const auto& source : sources) {
-            if (source->type == SourceType::Vector || source->type == SourceType::GeoJSON ||
-                source->type == SourceType::Annotations) {
-                source->updateClipIDs(generator);
-            }
-            source->updateMatrices(projMatrix, state);
+            source->startRender(generator, projMatrix, state);
         }
 
         drawClippingMasks(generator.getStencils());

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -212,11 +212,11 @@ void Parser::parseSources(const JSValue& value) {
                 }
             }
 
-            source = std::make_unique<RasterSource>(id, url, tileSize, std::move(tileset), std::move(geojsonvt));
+            source = std::make_unique<RasterSource>(id, url, tileSize, std::move(tileset));
             break;
 
         case SourceType::Vector:
-            source = std::make_unique<VectorSource>(id, url, tileSize, std::move(tileset), std::move(geojsonvt));
+            source = std::make_unique<VectorSource>(id, url, tileSize, std::move(tileset));
             break;
 
         case SourceType::GeoJSON:

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -254,8 +254,8 @@ std::unique_ptr<Tileset> parseTileJSON(const std::string& json, const std::strin
 std::unique_ptr<Tileset> parseTileJSON(const JSValue& value) {
     auto tileset = std::make_unique<Tileset>();
     parseTileJSONMember(value, tileset->tiles, "tiles");
-    parseTileJSONMember(value, tileset->minZoom, "minzoom");
-    parseTileJSONMember(value, tileset->maxZoom, "maxzoom");
+    parseTileJSONMember(value, tileset->zoomRange.min, "minzoom");
+    parseTileJSONMember(value, tileset->zoomRange.max, "maxzoom");
     parseTileJSONMember(value, tileset->attribution, "attribution");
 
     std::array<double, 4> array;

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -12,9 +12,6 @@
 
 #include <mbgl/platform/log.hpp>
 
-#include <mapbox/geojsonvt.hpp>
-#include <mapbox/geojsonvt/convert.hpp>
-
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/util/mapbox.hpp>
 #include <mbgl/util/enum.hpp>
@@ -175,19 +172,15 @@ void Parser::parseSources(const JSValue& value) {
             continue;
         }
 
+        const std::string id { nameVal.GetString(), nameVal.GetStringLength() };
+
+        std::unique_ptr<Tileset> tileset;
+        std::unique_ptr<Source> source;
+
         // Sources can have URLs, either because they reference an external TileJSON file, or
         // because reference a GeoJSON file. They don't have to have one though when all source
         // parameters are specified inline.
         std::string url;
-
-        uint16_t tileSize = util::tileSize;
-
-        std::unique_ptr<Tileset> tileset;
-        std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
-
-        const std::string id { nameVal.GetString(), nameVal.GetStringLength() };
-        std::unique_ptr<Source> source;
-
         if (sourceVal.HasMember("url")) {
             const JSValue& urlVal = sourceVal["url"];
             if (urlVal.IsString()) {
@@ -200,18 +193,19 @@ void Parser::parseSources(const JSValue& value) {
             tileset = parseTileJSON(sourceVal);
         }
 
+        uint16_t tileSize = util::tileSize;
+        if (sourceVal.HasMember("tileSize")) {
+            const JSValue& tileSizeVal = sourceVal["tileSize"];
+            if (tileSizeVal.IsNumber() && tileSizeVal.GetUint64() <= std::numeric_limits<uint16_t>::max()) {
+                tileSize = tileSizeVal.GetUint64();
+            } else {
+                Log::Error(Event::ParseStyle, "invalid tileSize");
+                continue;
+            }
+        }
+
         switch (*type) {
         case SourceType::Raster:
-            if (sourceVal.HasMember("tileSize")) {
-                const JSValue& tileSizeVal = sourceVal["tileSize"];
-                if (tileSizeVal.IsNumber() && tileSizeVal.GetUint64() <= std::numeric_limits<uint16_t>::max()) {
-                    tileSize = tileSizeVal.GetUint64();
-                } else {
-                    Log::Error(Event::ParseStyle, "invalid tileSize");
-                    continue;
-                }
-            }
-
             source = std::make_unique<RasterSource>(id, url, tileSize, std::move(tileset));
             break;
 
@@ -220,30 +214,7 @@ void Parser::parseSources(const JSValue& value) {
             break;
 
         case SourceType::GeoJSON:
-            tileset = std::make_unique<Tileset>();
-
-            // We should probably split this up to have URLs in the url property, and actual data
-            // in the data property. Until then, we're going to detect the content based on the
-            // object type.
-            if (sourceVal.HasMember("data")) {
-                const JSValue& dataVal = sourceVal["data"];
-                if (dataVal.IsString()) {
-                    // We need to load an external GeoJSON file
-                    url = { dataVal.GetString(), dataVal.GetStringLength() };
-                } else if (dataVal.IsObject()) {
-                    // We need to parse dataVal as a GeoJSON object
-                    geojsonvt = parseGeoJSON(dataVal);
-                    tileset->maxZoom = geojsonvt->options.maxZoom;
-                } else {
-                    Log::Error(Event::ParseStyle, "GeoJSON data must be a URL or an object");
-                    continue;
-                }
-            } else {
-                Log::Error(Event::ParseStyle, "GeoJSON source must have a data value");
-                continue;
-            }
-
-            source = std::make_unique<GeoJSONSource>(id, url, tileSize, std::move(tileset), std::move(geojsonvt));
+            source = GeoJSONSource::parse(id, sourceVal);
             break;
 
         default:
@@ -251,25 +222,10 @@ void Parser::parseSources(const JSValue& value) {
             continue;
         }
 
-        sourcesMap.emplace(id, source.get());
-        sources.emplace_back(std::move(source));
-    }
-}
-
-std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> parseGeoJSON(const JSValue& value) {
-    using namespace mapbox::geojsonvt;
-
-    Options options;
-    options.buffer = util::EXTENT / util::tileSize * 128;
-    options.extent = util::EXTENT;
-
-    try {
-        return std::make_unique<GeoJSONVT>(Convert::convert(value, 0), options);
-    } catch (const std::exception& ex) {
-        Log::Error(Event::ParseStyle, "Failed to parse GeoJSON data: %s", ex.what());
-        // Create an empty GeoJSON VT object to make sure we're not infinitely waiting for
-        // tiles to load.
-        return std::make_unique<GeoJSONVT>(std::vector<ProjectedFeature>{}, options);
+        if (source) {
+            sourcesMap.emplace(id, source.get());
+            sources.emplace_back(std::move(source));
+        }
     }
 }
 

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -15,6 +15,7 @@
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/util/mapbox.hpp>
 #include <mbgl/util/enum.hpp>
+#include <mbgl/util/tileset.hpp>
 
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -216,7 +216,7 @@ void Parser::parseSources(const JSValue& value) {
             break;
 
         case SourceType::Vector:
-            source = std::make_unique<VectorSource>(id, url, tileSize, std::move(tileset));
+            source = std::make_unique<VectorSource>(id, url, std::move(tileset));
             break;
 
         case SourceType::GeoJSON:

--- a/src/mbgl/style/parser.hpp
+++ b/src/mbgl/style/parser.hpp
@@ -14,6 +14,9 @@
 #include <forward_list>
 
 namespace mbgl {
+
+class Tileset;
+
 namespace style {
 
 std::unique_ptr<Tileset> parseTileJSON(const std::string& json, const std::string& sourceURL, SourceType, uint16_t tileSize);

--- a/src/mbgl/style/parser.hpp
+++ b/src/mbgl/style/parser.hpp
@@ -13,6 +13,12 @@
 #include <unordered_map>
 #include <forward_list>
 
+namespace mapbox {
+namespace geojsonvt {
+class GeoJSONVT;
+} // namespace geojsonvt
+} // namespace mapbox
+
 namespace mbgl {
 namespace style {
 

--- a/src/mbgl/style/parser.hpp
+++ b/src/mbgl/style/parser.hpp
@@ -13,19 +13,11 @@
 #include <unordered_map>
 #include <forward_list>
 
-namespace mapbox {
-namespace geojsonvt {
-class GeoJSONVT;
-} // namespace geojsonvt
-} // namespace mapbox
-
 namespace mbgl {
 namespace style {
 
 std::unique_ptr<Tileset> parseTileJSON(const std::string& json, const std::string& sourceURL, SourceType, uint16_t tileSize);
 std::unique_ptr<Tileset> parseTileJSON(const JSValue&);
-
-std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> parseGeoJSON(const JSValue&);
 
 Filter parseFilter(const JSValue&);
 

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -22,6 +22,8 @@
 #include <mbgl/gl/debugging.hpp>
 
 #include <mbgl/algorithm/update_renderables.hpp>
+#include <mbgl/algorithm/generate_clip_ids.hpp>
+#include <mbgl/algorithm/generate_clip_ids_impl.hpp>
 
 #include <mapbox/geometry/envelope.hpp>
 
@@ -58,7 +60,15 @@ void Source::invalidateTiles() {
     cache.clear();
 }
 
-void Source::updateMatrices(const mat4 &projMatrix, const TransformState &transform) {
+void Source::startRender(algorithm::ClipIDGenerator& generator,
+                         const mat4& projMatrix,
+                         const TransformState& transform) {
+    if (type == SourceType::Vector ||
+        type == SourceType::GeoJSON ||
+        type == SourceType::Annotations) {
+        generator.update(renderTiles);
+    }
+
     for (auto& pair : renderTiles) {
         auto& tile = pair.second;
         transform.matrixFor(tile.matrix, tile.id);
@@ -66,7 +76,7 @@ void Source::updateMatrices(const mat4 &projMatrix, const TransformState &transf
     }
 }
 
-void Source::finishRender(Painter &painter) {
+void Source::finishRender(Painter& painter) {
     for (auto& pair : renderTiles) {
         auto& tile = pair.second;
         painter.renderTileDebug(tile);

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -105,8 +105,8 @@ bool Source::update(const UpdateParameters& parameters) {
     int32_t dataTileZoom = overscaledZoom;
 
     std::vector<UnwrappedTileID> idealTiles;
-    if (overscaledZoom >= tileset->minZoom) {
-        int32_t idealZoom = std::min<int32_t>(tileset->maxZoom, overscaledZoom);
+    if (overscaledZoom >= tileset->zoomRange.min) {
+        int32_t idealZoom = std::min<int32_t>(tileset->zoomRange.max, overscaledZoom);
 
         // Make sure we're not reparsing overzoomed raster tiles.
         if (type == SourceType::Raster) {
@@ -150,7 +150,7 @@ bool Source::update(const UpdateParameters& parameters) {
 
     renderTiles.clear();
     algorithm::updateRenderables(getTileFn, createTileFn, retainTileFn, renderTileFn,
-                                 idealTiles, *tileset, dataTileZoom);
+                                 idealTiles, tileset->zoomRange, dataTileZoom);
 
     if (type != SourceType::Raster && type != SourceType::Annotations && cache.getSize() == 0) {
         size_t conservativeCacheSize =

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -23,8 +23,6 @@
 
 #include <mbgl/algorithm/update_renderables.hpp>
 
-#include <mapbox/geojsonvt.hpp>
-#include <mapbox/geojsonvt/convert.hpp>
 #include <mapbox/geometry/envelope.hpp>
 
 #include <algorithm>

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -100,13 +100,15 @@ bool Source::update(const UpdateParameters& parameters) {
         return allTilesUpdated;
     }
 
+    const Range<uint8_t> zoomRange = getZoomRange();
+
     // Determine the overzooming/underzooming amounts and required tiles.
     int32_t overscaledZoom = util::coveringZoomLevel(parameters.transformState.getZoom(), type, tileSize);
     int32_t dataTileZoom = overscaledZoom;
 
     std::vector<UnwrappedTileID> idealTiles;
-    if (overscaledZoom >= tileset->zoomRange.min) {
-        int32_t idealZoom = std::min<int32_t>(tileset->zoomRange.max, overscaledZoom);
+    if (overscaledZoom >= zoomRange.min) {
+        int32_t idealZoom = std::min<int32_t>(zoomRange.max, overscaledZoom);
 
         // Make sure we're not reparsing overzoomed raster tiles.
         if (type == SourceType::Raster) {
@@ -150,7 +152,7 @@ bool Source::update(const UpdateParameters& parameters) {
 
     renderTiles.clear();
     algorithm::updateRenderables(getTileFn, createTileFn, retainTileFn, renderTileFn,
-                                 idealTiles, tileset->zoomRange, dataTileZoom);
+                                 idealTiles, zoomRange, dataTileZoom);
 
     if (type != SourceType::Raster && type != SourceType::Annotations && cache.getSize() == 0) {
         size_t conservativeCacheSize =

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -3,23 +3,12 @@
 #include <mbgl/map/transform.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/painter.hpp>
-#include <mbgl/util/exception.hpp>
-#include <mbgl/util/constants.hpp>
-#include <mbgl/storage/resource.hpp>
-#include <mbgl/storage/response.hpp>
-#include <mbgl/style/layer.hpp>
 #include <mbgl/style/update_parameters.hpp>
 #include <mbgl/style/query_parameters.hpp>
 #include <mbgl/platform/log.hpp>
-#include <mbgl/math/minmax.hpp>
 #include <mbgl/math/clamp.hpp>
-#include <mbgl/util/std.hpp>
-#include <mbgl/util/token.hpp>
-#include <mbgl/util/string.hpp>
 #include <mbgl/util/tile_cover.hpp>
 #include <mbgl/util/enum.hpp>
-
-#include <mbgl/gl/debugging.hpp>
 
 #include <mbgl/algorithm/update_renderables.hpp>
 #include <mbgl/algorithm/generate_clip_ids.hpp>

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -47,14 +47,12 @@ Source::Source(SourceType type_,
                std::string id_,
                std::string url_,
                uint16_t tileSize_,
-               std::unique_ptr<Tileset>&& tileset_,
-               std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
+               std::unique_ptr<Tileset>&& tileset_)
     : type(type_),
       id(std::move(id_)),
       url(std::move(url_)),
       tileSize(tileSize_),
       tileset(std::move(tileset_)),
-      geojsonvt(std::move(geojsonvt_)),
       observer(&nullObserver) {
 }
 

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -20,10 +20,6 @@
 #include <mbgl/util/tile_cover.hpp>
 #include <mbgl/util/enum.hpp>
 
-#include <mbgl/tile/raster_tile.hpp>
-#include <mbgl/tile/geojson_tile.hpp>
-#include <mbgl/tile/vector_tile.hpp>
-#include <mbgl/annotation/annotation_tile.hpp>
 #include <mbgl/style/parser.hpp>
 #include <mbgl/gl/debugging.hpp>
 
@@ -182,23 +178,6 @@ void Source::finishRender(Painter &painter) {
 
 const std::map<UnwrappedTileID, RenderTile>& Source::getRenderTiles() const {
     return renderTiles;
-}
-
-std::unique_ptr<Tile> Source::createTile(const OverscaledTileID& overscaledTileID,
-                                             const UpdateParameters& parameters) {
-    // If we don't find working tile data, we're just going to load it.
-    if (type == SourceType::Raster) {
-        return std::make_unique<RasterTile>(overscaledTileID, parameters, *tileset);
-    } else if (type == SourceType::Vector) {
-        return std::make_unique<VectorTile>(overscaledTileID, id, parameters, *tileset);
-    } else if (type == SourceType::Annotations) {
-        return std::make_unique<AnnotationTile>(overscaledTileID, id, parameters);
-    } else if (type == SourceType::GeoJSON) {
-        return std::make_unique<GeoJSONTile>(overscaledTileID, id, parameters, geojsonvt.get());
-    } else {
-        Log::Warning(Event::Style, "Source type '%s' is not implemented", Enum<SourceType>::toString(type));
-        return nullptr;
-    }
 }
 
 Tile* Source::getTile(const OverscaledTileID& overscaledTileID) const {

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -32,10 +32,9 @@ namespace style {
 
 static SourceObserver nullObserver;
 
-Source::Source(SourceType type_, std::string id_, uint16_t tileSize_)
+Source::Source(SourceType type_, std::string id_)
     : type(type_),
       id(std::move(id_)),
-      tileSize(tileSize_),
       observer(&nullObserver) {
 }
 
@@ -94,6 +93,7 @@ bool Source::update(const UpdateParameters& parameters) {
         return allTilesUpdated;
     }
 
+    const uint16_t tileSize = getTileSize();
     const Range<uint8_t> zoomRange = getZoomRange();
 
     // Determine the overzooming/underzooming amounts and required tiles.

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -32,13 +32,9 @@ namespace style {
 
 static SourceObserver nullObserver;
 
-Source::Source(SourceType type_,
-               std::string id_,
-               std::string url_,
-               uint16_t tileSize_)
+Source::Source(SourceType type_, std::string id_, uint16_t tileSize_)
     : type(type_),
       id(std::move(id_)),
-      url(std::move(url_)),
       tileSize(tileSize_),
       observer(&nullObserver) {
 }

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -35,13 +35,11 @@ static SourceObserver nullObserver;
 Source::Source(SourceType type_,
                std::string id_,
                std::string url_,
-               uint16_t tileSize_,
-               std::unique_ptr<Tileset>&& tileset_)
+               uint16_t tileSize_)
     : type(type_),
       id(std::move(id_)),
       url(std::move(url_)),
       tileSize(tileSize_),
-      tileset(std::move(tileset_)),
       observer(&nullObserver) {
 }
 

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -59,10 +59,6 @@ bool Source::isLoaded() const {
     return true;
 }
 
-bool Source::isLoading() const {
-    return !loaded && req.operator bool();
-}
-
 void Source::invalidateTiles() {
     tiles.clear();
     renderTiles.clear();

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -43,7 +43,6 @@ public:
 
     bool loaded = false;
     virtual void load(FileSource&) = 0;
-    bool isLoading() const;
     bool isLoaded() const;
 
     const Tileset* getTileset() const { return tileset.get(); }

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -44,8 +44,7 @@ public:
            std::string id,
            std::string url,
            uint16_t tileSize,
-           std::unique_ptr<Tileset>&&,
-           std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+           std::unique_ptr<Tileset>&&);
     ~Source() override;
 
     bool loaded = false;
@@ -99,8 +98,10 @@ private:
 private:
     std::unique_ptr<const Tileset> tileset;
 
+protected:
     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
 
+private:
     // Stores the time when this source was most recently updated.
     TimePoint updated = TimePoint::min();
 

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -93,12 +93,10 @@ private:
     void onTileError(Tile&, std::exception_ptr) override;
     void onNeedsRepaint() override;
 
-    std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&);
-
-private:
-    std::unique_ptr<const Tileset> tileset;
+    virtual std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) = 0;
 
 protected:
+    std::unique_ptr<const Tileset> tileset;
     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
 
 private:

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -16,12 +16,6 @@
 #include <vector>
 #include <map>
 
-namespace mapbox {
-namespace geojsonvt {
-class GeoJSONVT;
-} // namespace geojsonvt
-} // namespace mapbox
-
 namespace mbgl {
 
 class Painter;
@@ -99,7 +93,6 @@ protected:
     void invalidateTiles();
 
     std::unique_ptr<const Tileset> tileset;
-    std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
     std::unique_ptr<AsyncRequest> req;
 
     SourceObserver* observer = nullptr;

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -48,7 +48,7 @@ public:
     ~Source() override;
 
     bool loaded = false;
-    void load(FileSource&);
+    virtual void load(FileSource&) = 0;
     bool isLoading() const;
     bool isLoaded() const;
 
@@ -96,8 +96,13 @@ private:
     virtual std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) = 0;
 
 protected:
+    void invalidateTiles();
+
     std::unique_ptr<const Tileset> tileset;
     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
+    std::unique_ptr<AsyncRequest> req;
+
+    SourceObserver* observer = nullptr;
 
 private:
     // Stores the time when this source was most recently updated.
@@ -106,10 +111,6 @@ private:
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     std::map<UnwrappedTileID, RenderTile> renderTiles;
     TileCache cache;
-
-    std::unique_ptr<AsyncRequest> req;
-
-    SourceObserver* observer = nullptr;
 };
 
 } // namespace style

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -85,6 +85,7 @@ private:
     void onTileError(Tile&, std::exception_ptr) override;
     void onNeedsRepaint() override;
 
+    virtual Range<uint8_t> getZoomRange() = 0;
     virtual std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) = 0;
 
 protected:

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -20,7 +20,6 @@ namespace mbgl {
 
 class Painter;
 class FileSource;
-class AsyncRequest;
 class TransformState;
 class RenderTile;
 struct ClipID;
@@ -92,7 +91,6 @@ protected:
     void invalidateTiles();
 
     std::unique_ptr<const Tileset> tileset;
-    std::unique_ptr<AsyncRequest> req;
 
     SourceObserver* observer = nullptr;
 

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -32,7 +32,7 @@ class SourceObserver;
 
 class Source : public TileObserver, private util::noncopyable {
 public:
-    Source(SourceType, std::string id, uint16_t tileSize);
+    Source(SourceType, std::string id);
     ~Source() override;
 
     bool loaded = false;
@@ -68,7 +68,6 @@ public:
 
     const SourceType type;
     const std::string id;
-    uint16_t tileSize = util::tileSize;
     bool enabled = false;
 
 private:
@@ -77,6 +76,7 @@ private:
     void onTileError(Tile&, std::exception_ptr) override;
     void onNeedsRepaint() override;
 
+    virtual uint16_t getTileSize() const = 0;
     virtual Range<uint8_t> getZoomRange() = 0;
     virtual std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) = 0;
 

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -32,10 +32,7 @@ class SourceObserver;
 
 class Source : public TileObserver, private util::noncopyable {
 public:
-    Source(SourceType,
-           std::string id,
-           std::string url,
-           uint16_t tileSize);
+    Source(SourceType, std::string id, uint16_t tileSize);
     ~Source() override;
 
     bool loaded = false;
@@ -71,7 +68,6 @@ public:
 
     const SourceType type;
     const std::string id;
-    const std::string url;
     uint16_t tileSize = util::tileSize;
     bool enabled = false;
 

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -10,9 +10,8 @@
 #include <mbgl/util/mat4.hpp>
 #include <mbgl/util/rapidjson.hpp>
 #include <mbgl/util/feature.hpp>
-#include <mbgl/util/tileset.hpp>
+#include <mbgl/util/range.hpp>
 
-#include <forward_list>
 #include <vector>
 #include <map>
 
@@ -36,15 +35,12 @@ public:
     Source(SourceType,
            std::string id,
            std::string url,
-           uint16_t tileSize,
-           std::unique_ptr<Tileset>&&);
+           uint16_t tileSize);
     ~Source() override;
 
     bool loaded = false;
     virtual void load(FileSource&) = 0;
     bool isLoaded() const;
-
-    const Tileset* getTileset() const { return tileset.get(); }
 
     // Request or parse all the tiles relevant for the "TransformState". This method
     // will return true if all the tiles were scheduled for updating of false if
@@ -90,8 +86,6 @@ private:
 
 protected:
     void invalidateTiles();
-
-    std::unique_ptr<const Tileset> tileset;
 
     SourceObserver* observer = nullptr;
 

--- a/src/mbgl/style/source.hpp
+++ b/src/mbgl/style/source.hpp
@@ -23,6 +23,10 @@ class TransformState;
 class RenderTile;
 struct ClipID;
 
+namespace algorithm {
+class ClipIDGenerator;
+} // namespace algorithm
+
 namespace style {
 
 class Style;
@@ -45,13 +49,10 @@ public:
     // new data available that a tile in the "partial" state might be interested at.
     bool update(const UpdateParameters&);
 
-    template <typename ClipIDGenerator>
-    void updateClipIDs(ClipIDGenerator& generator) {
-        generator.update(renderTiles);
-    }
-
-    void updateMatrices(const mat4 &projMatrix, const TransformState &transform);
-    void finishRender(Painter &painter);
+    void startRender(algorithm::ClipIDGenerator&,
+                     const mat4& projMatrix,
+                     const TransformState&);
+    void finishRender(Painter&);
 
     const std::map<UnwrappedTileID, RenderTile>& getRenderTiles() const;
 

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<GeoJSONSource> GeoJSONSource::parse(const std::string& id,
 GeoJSONSource::GeoJSONSource(std::string id_,
                              std::string url_,
                              std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
-    : Source(SourceType::GeoJSON, std::move(id_), util::tileSize),
+    : Source(SourceType::GeoJSON, std::move(id_)),
       url(url_),
       geojsonvt(std::move(geojsonvt_)) {
 }

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -3,8 +3,10 @@
 #include <mbgl/style/parser.hpp>
 #include <mbgl/tile/geojson_tile.hpp>
 #include <mbgl/storage/file_source.hpp>
+#include <mbgl/platform/log.hpp>
 
 #include <mapbox/geojsonvt.hpp>
+#include <mapbox/geojsonvt/convert.hpp>
 
 #include <rapidjson/error/en.h>
 
@@ -13,12 +15,58 @@
 namespace mbgl {
 namespace style {
 
+std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> parseGeoJSON(const JSValue& value) {
+    using namespace mapbox::geojsonvt;
+
+    Options options;
+    options.buffer = util::EXTENT / util::tileSize * 128;
+    options.extent = util::EXTENT;
+
+    try {
+        return std::make_unique<GeoJSONVT>(Convert::convert(value, 0), options);
+    } catch (const std::exception& ex) {
+        Log::Error(Event::ParseStyle, "Failed to parse GeoJSON data: %s", ex.what());
+        // Create an empty GeoJSON VT object to make sure we're not infinitely waiting for
+        // tiles to load.
+        return std::make_unique<GeoJSONVT>(std::vector<ProjectedFeature>{}, options);
+    }
+}
+
+std::unique_ptr<GeoJSONSource> GeoJSONSource::parse(const std::string& id,
+                                                    const JSValue& value) {
+    auto tileset = std::make_unique<Tileset>();
+    std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
+    std::string url;
+
+    // We should probably split this up to have URLs in the url property, and actual data
+    // in the data property. Until then, we're going to detect the content based on the
+    // object type.
+    if (!value.HasMember("data")) {
+        Log::Error(Event::ParseStyle, "GeoJSON source must have a data value");
+        return nullptr;
+    }
+
+    const JSValue& dataVal = value["data"];
+    if (dataVal.IsString()) {
+        // We need to load an external GeoJSON file
+        url = { dataVal.GetString(), dataVal.GetStringLength() };
+    } else if (dataVal.IsObject()) {
+        // We need to parse dataVal as a GeoJSON object
+        geojsonvt = parseGeoJSON(dataVal);
+        tileset->maxZoom = geojsonvt->options.maxZoom;
+    } else {
+        Log::Error(Event::ParseStyle, "GeoJSON data must be a URL or an object");
+        return nullptr;
+    }
+
+    return std::make_unique<GeoJSONSource>(id, url, std::move(tileset), std::move(geojsonvt));
+}
+
 GeoJSONSource::GeoJSONSource(std::string id_,
                              std::string url_,
-                             uint16_t tileSize_,
                              std::unique_ptr<Tileset>&& tileset_,
                              std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
-    : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)),
+    : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), util::tileSize, std::move(tileset_)),
       geojsonvt(std::move(geojsonvt_)) {
 }
 

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -1,0 +1,15 @@
+#include <mbgl/style/sources/geojson_source.hpp>
+
+namespace mbgl {
+namespace style {
+
+GeoJSONSource::GeoJSONSource(std::string id_,
+                             std::string url_,
+                             uint16_t tileSize_,
+                             std::unique_ptr<Tileset>&& tileset_,
+                             std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
+    : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), tileSize_, std::move(tileset_), std::move(geojsonvt_)) {
+}
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -1,7 +1,14 @@
 #include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/style/source_observer.hpp>
+#include <mbgl/style/parser.hpp>
 #include <mbgl/tile/geojson_tile.hpp>
+#include <mbgl/storage/file_source.hpp>
 
 #include <mapbox/geojsonvt.hpp>
+
+#include <rapidjson/error/en.h>
+
+#include <sstream>
 
 namespace mbgl {
 namespace style {
@@ -13,6 +20,49 @@ GeoJSONSource::GeoJSONSource(std::string id_,
                              std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
     : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
     geojsonvt = std::move(geojsonvt_);
+}
+
+void GeoJSONSource::load(FileSource& fileSource) {
+    if (url.empty()) {
+        // If the URL is empty, the GeoJSON was specified inline in the stylesheet.
+        loaded = true;
+        return;
+    }
+
+    if (req) {
+        return;
+    }
+
+    req = fileSource.request(Resource::source(url), [this](Response res) {
+        if (res.error) {
+            observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error(res.error->message)));
+        } else if (res.notModified) {
+            return;
+        } else if (res.noContent) {
+            observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error("unexpectedly empty GeoJSON")));
+        } else {
+            std::unique_ptr<Tileset> newTileset = std::make_unique<Tileset>();
+
+            rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> d;
+            d.Parse<0>(res.data->c_str());
+
+            if (d.HasParseError()) {
+                std::stringstream message;
+                message << d.GetErrorOffset() << " - " << rapidjson::GetParseError_En(d.GetParseError());
+                observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error(message.str())));
+                return;
+            }
+
+            geojsonvt = style::parseGeoJSON(d);
+            newTileset->maxZoom = geojsonvt->options.maxZoom;
+
+            invalidateTiles();
+
+            tileset = std::move(newTileset);
+            loaded = true;
+            observer->onSourceLoaded(*this);
+        }
+    });
 }
 
 std::unique_ptr<Tile> GeoJSONSource::createTile(const OverscaledTileID& tileID,

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<GeoJSONSource> GeoJSONSource::parse(const std::string& id,
     } else if (dataVal.IsObject()) {
         // We need to parse dataVal as a GeoJSON object
         geojsonvt = parseGeoJSON(dataVal);
-        tileset->maxZoom = geojsonvt->options.maxZoom;
+        tileset->zoomRange.max = geojsonvt->options.maxZoom;
     } else {
         Log::Error(Event::ParseStyle, "GeoJSON data must be a URL or an object");
         return nullptr;
@@ -104,7 +104,7 @@ void GeoJSONSource::load(FileSource& fileSource) {
             }
 
             geojsonvt = style::parseGeoJSON(d);
-            newTileset->maxZoom = geojsonvt->options.maxZoom;
+            newTileset->zoomRange.max = geojsonvt->options.maxZoom;
 
             invalidateTiles();
 

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -63,7 +63,8 @@ std::unique_ptr<GeoJSONSource> GeoJSONSource::parse(const std::string& id,
 GeoJSONSource::GeoJSONSource(std::string id_,
                              std::string url_,
                              std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
-    : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), util::tileSize),
+    : Source(SourceType::GeoJSON, std::move(id_), util::tileSize),
+      url(url_),
       geojsonvt(std::move(geojsonvt_)) {
 }
 

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/tile/geojson_tile.hpp>
 
 #include <mapbox/geojsonvt.hpp>
 
@@ -12,6 +13,11 @@ GeoJSONSource::GeoJSONSource(std::string id_,
                              std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
     : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
     geojsonvt = std::move(geojsonvt_);
+}
+
+std::unique_ptr<Tile> GeoJSONSource::createTile(const OverscaledTileID& tileID,
+                                                const UpdateParameters& parameters) {
+    return std::make_unique<GeoJSONTile>(tileID, id, parameters, geojsonvt.get());
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -22,6 +22,8 @@ GeoJSONSource::GeoJSONSource(std::string id_,
       geojsonvt(std::move(geojsonvt_)) {
 }
 
+GeoJSONSource::~GeoJSONSource() = default;
+
 void GeoJSONSource::load(FileSource& fileSource) {
     if (url.empty()) {
         // If the URL is empty, the GeoJSON was specified inline in the stylesheet.

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -18,8 +18,8 @@ GeoJSONSource::GeoJSONSource(std::string id_,
                              uint16_t tileSize_,
                              std::unique_ptr<Tileset>&& tileset_,
                              std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
-    : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
-    geojsonvt = std::move(geojsonvt_);
+    : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)),
+      geojsonvt(std::move(geojsonvt_)) {
 }
 
 void GeoJSONSource::load(FileSource& fileSource) {

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -1,5 +1,7 @@
 #include <mbgl/style/sources/geojson_source.hpp>
 
+#include <mapbox/geojsonvt.hpp>
+
 namespace mbgl {
 namespace style {
 
@@ -8,7 +10,8 @@ GeoJSONSource::GeoJSONSource(std::string id_,
                              uint16_t tileSize_,
                              std::unique_ptr<Tileset>&& tileset_,
                              std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
-    : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), tileSize_, std::move(tileset_), std::move(geojsonvt_)) {
+    : Source(SourceType::GeoJSON, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
+    geojsonvt = std::move(geojsonvt_);
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/geojson_source.cpp
+++ b/src/mbgl/style/sources/geojson_source.cpp
@@ -53,7 +53,6 @@ std::unique_ptr<GeoJSONSource> GeoJSONSource::parse(const std::string& id,
     } else if (dataVal.IsObject()) {
         // We need to parse dataVal as a GeoJSON object
         geojsonvt = parseGeoJSON(dataVal);
-        tileset->zoomRange.max = geojsonvt->options.maxZoom;
     } else {
         Log::Error(Event::ParseStyle, "GeoJSON data must be a URL or an object");
         return nullptr;
@@ -71,6 +70,10 @@ GeoJSONSource::GeoJSONSource(std::string id_,
 }
 
 GeoJSONSource::~GeoJSONSource() = default;
+
+Range<uint8_t> GeoJSONSource::getZoomRange() {
+    return { 0, geojsonvt->options.maxZoom };
+}
 
 void GeoJSONSource::load(FileSource& fileSource) {
     if (url.empty()) {

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -2,6 +2,8 @@
 
 #include <mbgl/style/source.hpp>
 
+#include <mbgl/util/rapidjson.hpp>
+
 namespace mapbox {
 namespace geojsonvt {
 class GeoJSONVT;
@@ -16,9 +18,11 @@ namespace style {
 
 class GeoJSONSource : public Source {
 public:
+    static std::unique_ptr<GeoJSONSource> parse(const std::string& id,
+                                                const JSValue&);
+
     GeoJSONSource(std::string id,
                   std::string url,
-                  uint16_t tileSize,
                   std::unique_ptr<Tileset>&&,
                   std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
     ~GeoJSONSource() final;

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <mbgl/style/source.hpp>
+
+namespace mbgl {
+namespace style {
+
+class GeoJSONSource : public Source {
+public:
+    GeoJSONSource(std::string id,
+                  std::string url,
+                  uint16_t tileSize,
+                  std::unique_ptr<Tileset>&&,
+                  std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+};
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -2,6 +2,12 @@
 
 #include <mbgl/style/source.hpp>
 
+namespace mapbox {
+namespace geojsonvt {
+class GeoJSONVT;
+} // namespace geojsonvt
+} // namespace mapbox
+
 namespace mbgl {
 namespace style {
 
@@ -17,6 +23,8 @@ public:
 
 private:
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
+
+    std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -9,6 +9,9 @@ class GeoJSONVT;
 } // namespace mapbox
 
 namespace mbgl {
+
+class AsyncRequest;
+
 namespace style {
 
 class GeoJSONSource : public Source {
@@ -18,6 +21,7 @@ public:
                   uint16_t tileSize,
                   std::unique_ptr<Tileset>&&,
                   std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+    ~GeoJSONSource() final;
 
     void load(FileSource&) final;
 
@@ -25,6 +29,7 @@ private:
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 
     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
+    std::unique_ptr<AsyncRequest> req;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -30,6 +30,7 @@ public:
     void load(FileSource&) final;
 
 private:
+    Range<uint8_t> getZoomRange() final;
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 
     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -28,10 +28,13 @@ public:
 
     void load(FileSource&) final;
 
+    const std::string& getURL() const { return url; }
+
 private:
     Range<uint8_t> getZoomRange() final;
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 
+    const std::string url;
     std::unique_ptr<mapbox::geojsonvt::GeoJSONVT> geojsonvt;
     std::unique_ptr<AsyncRequest> req;
 };

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -23,7 +23,6 @@ public:
 
     GeoJSONSource(std::string id,
                   std::string url,
-                  std::unique_ptr<Tileset>&&,
                   std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
     ~GeoJSONSource() final;
 

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -13,6 +13,8 @@ public:
                   std::unique_ptr<Tileset>&&,
                   std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
 
+    void load(FileSource&) final;
+
 private:
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 };

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -31,6 +31,7 @@ public:
     const std::string& getURL() const { return url; }
 
 private:
+    uint16_t getTileSize() const final { return util::tileSize; }
     Range<uint8_t> getZoomRange() final;
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 

--- a/src/mbgl/style/sources/geojson_source.hpp
+++ b/src/mbgl/style/sources/geojson_source.hpp
@@ -12,6 +12,9 @@ public:
                   uint16_t tileSize,
                   std::unique_ptr<Tileset>&&,
                   std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+
+private:
+    std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -6,9 +6,8 @@ namespace style {
 RasterSource::RasterSource(std::string id_,
                            std::string url_,
                            uint16_t tileSize_,
-                           std::unique_ptr<Tileset>&& tileset_,
-                           std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
-    : Source(SourceType::Raster, std::move(id_), std::move(url_), tileSize_, std::move(tileset_), std::move(geojsonvt_)) {
+                           std::unique_ptr<Tileset>&& tileset_)
+    : Source(SourceType::Raster, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -1,0 +1,15 @@
+#include <mbgl/style/sources/raster_source.hpp>
+
+namespace mbgl {
+namespace style {
+
+RasterSource::RasterSource(std::string id_,
+                           std::string url_,
+                           uint16_t tileSize_,
+                           std::unique_ptr<Tileset>&& tileset_,
+                           std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
+    : Source(SourceType::Raster, std::move(id_), std::move(url_), tileSize_, std::move(tileset_), std::move(geojsonvt_)) {
+}
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/style/sources/raster_source.hpp>
+#include <mbgl/tile/raster_tile.hpp>
 
 namespace mbgl {
 namespace style {
@@ -8,6 +9,11 @@ RasterSource::RasterSource(std::string id_,
                            uint16_t tileSize_,
                            std::unique_ptr<Tileset>&& tileset_)
     : Source(SourceType::Raster, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
+}
+
+std::unique_ptr<Tile> RasterSource::createTile(const OverscaledTileID& tileID,
+                                               const UpdateParameters& parameters) {
+    return std::make_unique<RasterTile>(tileID, parameters, *tileset);
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/raster_source.cpp
+++ b/src/mbgl/style/sources/raster_source.cpp
@@ -8,7 +8,7 @@ RasterSource::RasterSource(std::string id_,
                            std::string url_,
                            uint16_t tileSize_,
                            std::unique_ptr<Tileset>&& tileset_)
-    : Source(SourceType::Raster, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
+    : TileSource(SourceType::Raster, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
 }
 
 std::unique_ptr<Tile> RasterSource::createTile(const OverscaledTileID& tileID,

--- a/src/mbgl/style/sources/raster_source.hpp
+++ b/src/mbgl/style/sources/raster_source.hpp
@@ -11,6 +11,9 @@ public:
                  std::string url,
                  uint16_t tileSize,
                  std::unique_ptr<Tileset>&&);
+
+private:
+    std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/raster_source.hpp
+++ b/src/mbgl/style/sources/raster_source.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <mbgl/style/source.hpp>
+
+namespace mbgl {
+namespace style {
+
+class RasterSource : public Source {
+public:
+    RasterSource(std::string id,
+                 std::string url,
+                 uint16_t tileSize,
+                 std::unique_ptr<Tileset>&&,
+                 std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+};
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/raster_source.hpp
+++ b/src/mbgl/style/sources/raster_source.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <mbgl/style/source.hpp>
+#include <mbgl/style/tile_source.hpp>
 
 namespace mbgl {
 namespace style {
 
-class RasterSource : public Source {
+class RasterSource : public TileSource {
 public:
     RasterSource(std::string id,
                  std::string url,

--- a/src/mbgl/style/sources/raster_source.hpp
+++ b/src/mbgl/style/sources/raster_source.hpp
@@ -10,8 +10,7 @@ public:
     RasterSource(std::string id,
                  std::string url,
                  uint16_t tileSize,
-                 std::unique_ptr<Tileset>&&,
-                 std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+                 std::unique_ptr<Tileset>&&);
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/style/sources/vector_source.hpp>
+#include <mbgl/tile/vector_tile.hpp>
 
 namespace mbgl {
 namespace style {
@@ -7,6 +8,11 @@ VectorSource::VectorSource(std::string id_,
                            std::string url_,
                            std::unique_ptr<Tileset>&& tileset_)
     : Source(SourceType::Vector, std::move(id_), std::move(url_), util::tileSize, std::move(tileset_)) {
+}
+
+std::unique_ptr<Tile> VectorSource::createTile(const OverscaledTileID& tileID,
+                                               const UpdateParameters& parameters) {
+    return std::make_unique<VectorTile>(tileID, id, parameters, *tileset);
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -5,9 +5,8 @@ namespace style {
 
 VectorSource::VectorSource(std::string id_,
                            std::string url_,
-                           uint16_t tileSize_,
                            std::unique_ptr<Tileset>&& tileset_)
-    : Source(SourceType::Vector, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
+    : Source(SourceType::Vector, std::move(id_), std::move(url_), util::tileSize, std::move(tileset_)) {
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -7,7 +7,7 @@ namespace style {
 VectorSource::VectorSource(std::string id_,
                            std::string url_,
                            std::unique_ptr<Tileset>&& tileset_)
-    : Source(SourceType::Vector, std::move(id_), std::move(url_), util::tileSize, std::move(tileset_)) {
+    : TileSource(SourceType::Vector, std::move(id_), std::move(url_), util::tileSize, std::move(tileset_)) {
 }
 
 std::unique_ptr<Tile> VectorSource::createTile(const OverscaledTileID& tileID,

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -1,0 +1,15 @@
+#include <mbgl/style/sources/vector_source.hpp>
+
+namespace mbgl {
+namespace style {
+
+VectorSource::VectorSource(std::string id_,
+                           std::string url_,
+                           uint16_t tileSize_,
+                           std::unique_ptr<Tileset>&& tileset_,
+                           std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
+    : Source(SourceType::Vector, std::move(id_), std::move(url_), tileSize_, std::move(tileset_), std::move(geojsonvt_)) {
+}
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/vector_source.cpp
+++ b/src/mbgl/style/sources/vector_source.cpp
@@ -6,9 +6,8 @@ namespace style {
 VectorSource::VectorSource(std::string id_,
                            std::string url_,
                            uint16_t tileSize_,
-                           std::unique_ptr<Tileset>&& tileset_,
-                           std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&& geojsonvt_)
-    : Source(SourceType::Vector, std::move(id_), std::move(url_), tileSize_, std::move(tileset_), std::move(geojsonvt_)) {
+                           std::unique_ptr<Tileset>&& tileset_)
+    : Source(SourceType::Vector, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/vector_source.hpp
+++ b/src/mbgl/style/sources/vector_source.hpp
@@ -10,6 +10,9 @@ public:
     VectorSource(std::string id,
                  std::string url,
                  std::unique_ptr<Tileset>&&);
+
+private:
+    std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/vector_source.hpp
+++ b/src/mbgl/style/sources/vector_source.hpp
@@ -9,7 +9,6 @@ class VectorSource : public Source {
 public:
     VectorSource(std::string id,
                  std::string url,
-                 uint16_t tileSize,
                  std::unique_ptr<Tileset>&&);
 };
 

--- a/src/mbgl/style/sources/vector_source.hpp
+++ b/src/mbgl/style/sources/vector_source.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <mbgl/style/source.hpp>
+
+namespace mbgl {
+namespace style {
+
+class VectorSource : public Source {
+public:
+    VectorSource(std::string id,
+                 std::string url,
+                 uint16_t tileSize,
+                 std::unique_ptr<Tileset>&&,
+                 std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+};
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/vector_source.hpp
+++ b/src/mbgl/style/sources/vector_source.hpp
@@ -10,8 +10,7 @@ public:
     VectorSource(std::string id,
                  std::string url,
                  uint16_t tileSize,
-                 std::unique_ptr<Tileset>&&,
-                 std::unique_ptr<mapbox::geojsonvt::GeoJSONVT>&&);
+                 std::unique_ptr<Tileset>&&);
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/vector_source.hpp
+++ b/src/mbgl/style/sources/vector_source.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <mbgl/style/source.hpp>
+#include <mbgl/style/tile_source.hpp>
 
 namespace mbgl {
 namespace style {
 
-class VectorSource : public Source {
+class VectorSource : public TileSource {
 public:
     VectorSource(std::string id,
                  std::string url,

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -214,7 +214,7 @@ void Style::recalculate(float z, const TimePoint& timePoint, MapMode mode) {
         Source* source = getSource(layer->baseImpl->source);
         if (source && layer->baseImpl->needsRendering()) {
             source->enabled = true;
-            if (!source->loaded && !source->isLoading()) {
+            if (!source->loaded) {
                 source->load(fileSource);
             }
         }

--- a/src/mbgl/style/tile_source.cpp
+++ b/src/mbgl/style/tile_source.cpp
@@ -14,6 +14,8 @@ TileSource::TileSource(SourceType type_,
     : Source(type_, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
 }
 
+TileSource::~TileSource() = default;
+
 void TileSource::load(FileSource& fileSource) {
     if (url.empty()) {
         // If the URL is empty, the TileJSON was specified inline in the stylesheet.

--- a/src/mbgl/style/tile_source.cpp
+++ b/src/mbgl/style/tile_source.cpp
@@ -1,0 +1,15 @@
+#include <mbgl/style/tile_source.hpp>
+
+namespace mbgl {
+namespace style {
+
+TileSource::TileSource(SourceType type_,
+                       std::string id_,
+                       std::string url_,
+                       uint16_t tileSize_,
+                       std::unique_ptr<Tileset>&& tileset_)
+    : Source(type_, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
+}
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/tile_source.cpp
+++ b/src/mbgl/style/tile_source.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/style/tile_source.hpp>
 #include <mbgl/style/source_observer.hpp>
 #include <mbgl/style/parser.hpp>
+#include <mbgl/util/tileset.hpp>
 #include <mbgl/storage/file_source.hpp>
 
 namespace mbgl {
@@ -11,7 +12,8 @@ TileSource::TileSource(SourceType type_,
                        std::string url_,
                        uint16_t tileSize_,
                        std::unique_ptr<Tileset>&& tileset_)
-    : Source(type_, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
+    : Source(type_, std::move(id_), std::move(url_), tileSize_),
+      tileset(std::move(tileset_)) {
 }
 
 TileSource::~TileSource() = default;

--- a/src/mbgl/style/tile_source.cpp
+++ b/src/mbgl/style/tile_source.cpp
@@ -1,4 +1,7 @@
 #include <mbgl/style/tile_source.hpp>
+#include <mbgl/style/source_observer.hpp>
+#include <mbgl/style/parser.hpp>
+#include <mbgl/storage/file_source.hpp>
 
 namespace mbgl {
 namespace style {
@@ -9,6 +12,65 @@ TileSource::TileSource(SourceType type_,
                        uint16_t tileSize_,
                        std::unique_ptr<Tileset>&& tileset_)
     : Source(type_, std::move(id_), std::move(url_), tileSize_, std::move(tileset_)) {
+}
+
+void TileSource::load(FileSource& fileSource) {
+    if (url.empty()) {
+        // If the URL is empty, the TileJSON was specified inline in the stylesheet.
+        loaded = true;
+        return;
+    }
+
+    if (req) {
+        return;
+    }
+
+    // URL may either be a TileJSON file, or a GeoJSON file.
+    req = fileSource.request(Resource::source(url), [this](Response res) {
+        if (res.error) {
+            observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error(res.error->message)));
+        } else if (res.notModified) {
+            return;
+        } else if (res.noContent) {
+            observer->onSourceError(*this, std::make_exception_ptr(std::runtime_error("unexpectedly empty TileJSON")));
+        } else {
+            std::unique_ptr<Tileset> newTileset;
+
+            // Create a new copy of the Tileset object that holds the base values we've parsed
+            // from the stylesheet. Then merge in the values parsed from the TileJSON we retrieved
+            // via the URL.
+            try {
+                newTileset = style::parseTileJSON(*res.data, url, type, tileSize);
+            } catch (...) {
+                observer->onSourceError(*this, std::current_exception());
+                return;
+            }
+
+            // Check whether previous information specifies different tile
+            if (tileset && tileset->tiles != newTileset->tiles) {
+                // Tile URLs changed: force tiles to be reloaded.
+                invalidateTiles();
+
+                // Tile size changed: We need to recalculate the tiles we need to load because we
+                // might have to load tiles for a different zoom level
+                // This is done automatically when we trigger the onSourceLoaded observer below.
+
+                // Min/Max zoom changed: We need to recalculate what tiles to load, if we have tiles
+                // loaded that are outside the new zoom range
+                // This is done automatically when we trigger the onSourceLoaded observer below.
+
+                // Attribution changed: We need to notify the embedding application that this
+                // changed. See https://github.com/mapbox/mapbox-gl-native/issues/2723
+                // This is not yet implemented.
+
+                // Center/bounds changed: We're not using these values currently
+            }
+
+            tileset = std::move(newTileset);
+            loaded = true;
+            observer->onSourceLoaded(*this);
+        }
+    });
 }
 
 } // namespace style

--- a/src/mbgl/style/tile_source.cpp
+++ b/src/mbgl/style/tile_source.cpp
@@ -12,7 +12,8 @@ TileSource::TileSource(SourceType type_,
                        std::string url_,
                        uint16_t tileSize_,
                        std::unique_ptr<Tileset>&& tileset_)
-    : Source(type_, std::move(id_), tileSize_),
+    : Source(type_, std::move(id_)),
+      tileSize(tileSize_),
       url(std::move(url_)),
       tileset(std::move(tileset_)) {
 }

--- a/src/mbgl/style/tile_source.cpp
+++ b/src/mbgl/style/tile_source.cpp
@@ -16,6 +16,10 @@ TileSource::TileSource(SourceType type_,
 
 TileSource::~TileSource() = default;
 
+Range<uint8_t> TileSource::getZoomRange() {
+    return tileset->zoomRange;
+}
+
 void TileSource::load(FileSource& fileSource) {
     if (url.empty()) {
         // If the URL is empty, the TileJSON was specified inline in the stylesheet.

--- a/src/mbgl/style/tile_source.cpp
+++ b/src/mbgl/style/tile_source.cpp
@@ -12,7 +12,8 @@ TileSource::TileSource(SourceType type_,
                        std::string url_,
                        uint16_t tileSize_,
                        std::unique_ptr<Tileset>&& tileset_)
-    : Source(type_, std::move(id_), std::move(url_), tileSize_),
+    : Source(type_, std::move(id_), tileSize_),
+      url(std::move(url_)),
       tileset(std::move(tileset_)) {
 }
 

--- a/src/mbgl/style/tile_source.hpp
+++ b/src/mbgl/style/tile_source.hpp
@@ -24,11 +24,13 @@ public:
 
     void load(FileSource&) final;
 
+    const std::string& getURL() const { return url; }
     const Tileset* getTileset() const { return tileset.get(); }
 
 protected:
     Range<uint8_t> getZoomRange() final;
 
+    const std::string url;
     std::unique_ptr<const Tileset> tileset;
     std::unique_ptr<AsyncRequest> req;
 };

--- a/src/mbgl/style/tile_source.hpp
+++ b/src/mbgl/style/tile_source.hpp
@@ -16,6 +16,8 @@ public:
                std::string url,
                uint16_t tileSize,
                std::unique_ptr<Tileset>&&);
+
+    void load(FileSource&) final;
 };
 
 } // namespace style

--- a/src/mbgl/style/tile_source.hpp
+++ b/src/mbgl/style/tile_source.hpp
@@ -3,6 +3,9 @@
 #include <mbgl/style/source.hpp>
 
 namespace mbgl {
+
+class AsyncRequest;
+
 namespace style {
 
 /*
@@ -16,8 +19,12 @@ public:
                std::string url,
                uint16_t tileSize,
                std::unique_ptr<Tileset>&&);
+    ~TileSource() override;
 
     void load(FileSource&) final;
+
+private:
+    std::unique_ptr<AsyncRequest> req;
 };
 
 } // namespace style

--- a/src/mbgl/style/tile_source.hpp
+++ b/src/mbgl/style/tile_source.hpp
@@ -4,6 +4,7 @@
 
 namespace mbgl {
 
+class Tileset;
 class AsyncRequest;
 
 namespace style {
@@ -23,9 +24,12 @@ public:
 
     void load(FileSource&) final;
 
-private:
+    const Tileset* getTileset() const { return tileset.get(); }
+
+protected:
     Range<uint8_t> getZoomRange() final;
 
+    std::unique_ptr<const Tileset> tileset;
     std::unique_ptr<AsyncRequest> req;
 };
 

--- a/src/mbgl/style/tile_source.hpp
+++ b/src/mbgl/style/tile_source.hpp
@@ -24,6 +24,8 @@ public:
     void load(FileSource&) final;
 
 private:
+    Range<uint8_t> getZoomRange() final;
+
     std::unique_ptr<AsyncRequest> req;
 };
 

--- a/src/mbgl/style/tile_source.hpp
+++ b/src/mbgl/style/tile_source.hpp
@@ -25,11 +25,13 @@ public:
     void load(FileSource&) final;
 
     const std::string& getURL() const { return url; }
+    uint16_t getTileSize() const final { return tileSize; }
     const Tileset* getTileset() const { return tileset.get(); }
 
 protected:
     Range<uint8_t> getZoomRange() final;
 
+    const uint16_t tileSize;
     const std::string url;
     std::unique_ptr<const Tileset> tileset;
     std::unique_ptr<AsyncRequest> req;

--- a/src/mbgl/style/tile_source.hpp
+++ b/src/mbgl/style/tile_source.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <mbgl/style/source.hpp>
+
+namespace mbgl {
+namespace style {
+
+/*
+   Shared implementation for VectorSource and RasterSource. Should eventually
+   be refactored to use composition rather than inheritance.
+*/
+class TileSource : public Source {
+public:
+    TileSource(SourceType,
+               std::string id,
+               std::string url,
+               uint16_t tileSize,
+               std::unique_ptr<Tileset>&&);
+};
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -20,6 +20,8 @@ RasterTile::RasterTile(const OverscaledTileID& id_,
       loader(*this, id_, parameters, tileset) {
 }
 
+RasterTile::~RasterTile() = default;
+
 void RasterTile::setError(std::exception_ptr err) {
     observer->onTileError(*this, err);
 }

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -21,6 +21,7 @@ public:
     RasterTile(const OverscaledTileID&,
                    const style::UpdateParameters&,
                    const Tileset&);
+    ~RasterTile() final;
 
     void setNecessity(Necessity) final;
 

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -22,6 +22,7 @@ public:
                const OverscaledTileID&,
                const style::UpdateParameters&,
                const Tileset&);
+    ~TileLoader();
 
     using Necessity = Resource::Necessity;
 

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -44,6 +44,9 @@ TileLoader<T>::TileLoader(T& tile_,
 }
 
 template <typename T>
+TileLoader<T>::~TileLoader() = default;
+
+template <typename T>
 void TileLoader<T>::loadOptional() {
     assert(!request);
 

--- a/src/mbgl/util/tileset.hpp
+++ b/src/mbgl/util/tileset.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/range.hpp>
 #include <mbgl/util/geo.hpp>
 
 #include <array>
@@ -13,8 +14,7 @@ namespace mbgl {
 class Tileset {
 public:
     std::vector<std::string> tiles;
-    uint8_t minZoom = 0;
-    uint8_t maxZoom = 22;
+    Range<uint8_t> zoomRange { 0, 22 };
     std::string attribution;
     LatLng center;
     double zoom = 0;

--- a/test/algorithm/mock.hpp
+++ b/test/algorithm/mock.hpp
@@ -7,16 +7,12 @@
 #include <map>
 
 #include <mbgl/tile/tile_id.hpp>
-
-struct MockSourceInfo {
-    uint8_t maxZoom = 16;
-    uint8_t minZoom = 0;
-};
+#include <mbgl/util/range.hpp>
 
 struct MockTileData;
 
 struct MockSource {
-    MockSourceInfo info;
+    mbgl::Range<uint8_t> zoomRange { 0, 16 };
     std::map<mbgl::OverscaledTileID, std::unique_ptr<MockTileData>> dataTiles;
     std::set<mbgl::UnwrappedTileID> idealTiles;
 

--- a/test/algorithm/update_renderables.cpp
+++ b/test/algorithm/update_renderables.cpp
@@ -132,7 +132,7 @@ TEST(UpdateRenderables, SingleTile) {
     tile_1_1_1_1->renderable = true;
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 1, 1 } }, Found },       // found ideal tile
                   RetainTileDataAction{ { 1, { 1, 1, 1 } }, Required }, //
@@ -143,7 +143,7 @@ TEST(UpdateRenderables, SingleTile) {
     // Check a repeated render with the same data.
     log.clear();
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 1, 1 } }, Found },       // found ideal tile
                   RetainTileDataAction{ { 1, { 1, 1, 1 } }, Required }, //
@@ -155,7 +155,7 @@ TEST(UpdateRenderables, SingleTile) {
     log.clear();
     source.idealTiles.emplace(UnwrappedTileID{ 1, 0, 1 });
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 1 } }, NotFound },    // missing ideal tile
                   CreateTileDataAction{ { 1, { 1, 0, 1 } } },           // create ideal tile
@@ -176,7 +176,7 @@ TEST(UpdateRenderables, SingleTile) {
     log.clear();
     source.dataTiles[{ 1, { 1, 0, 1 } }]->triedOptional = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 1 } }, Found },       // missing ideal tile
                   RetainTileDataAction{ { 1, { 1, 0, 1 } }, Required }, //
@@ -199,7 +199,7 @@ TEST(UpdateRenderables, SingleTile) {
     auto tile_1_1_0_1 = source.createTileData(OverscaledTileID{ 1, 0, 1 });
     tile_1_1_0_1->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 1 } }, Found },       // newly added tile
                   RetainTileDataAction{ { 1, { 1, 0, 1 } }, Required }, //
@@ -218,7 +218,7 @@ TEST(UpdateRenderables, SingleTile) {
     auto tile_1_1_0_0 = source.createTileData(OverscaledTileID{ 1, 0, 0 });
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, Found },       // found tile, not ready
                   RetainTileDataAction{ { 1, { 1, 0, 0 } }, Required }, //
@@ -244,7 +244,7 @@ TEST(UpdateRenderables, SingleTile) {
     log.clear();
     tile_1_1_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, Found },       // found tile, now ready
                   RetainTileDataAction{ { 1, { 1, 0, 0 } }, Required }, //
@@ -277,7 +277,7 @@ TEST(UpdateRenderables, UseParentTile) {
     auto tile_0_0_0_0 = source.createTileData(OverscaledTileID{ 0, 0, 0 });
     tile_0_0_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 1 } }, NotFound },    // missing ideal tile
                   CreateTileDataAction{ { 1, { 1, 0, 1 } } },           //
@@ -320,7 +320,7 @@ TEST(UpdateRenderables, DontUseWrongParentTile) {
     auto tile_1_1_1_0 = source.createTileData(OverscaledTileID{ 1, 1, 0 });
     tile_1_1_1_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 2, { 2, 0, 0 } }, NotFound },    // missing ideal tile
                   CreateTileDataAction{ { 2, { 2, 0, 0 } } },           //
@@ -338,7 +338,7 @@ TEST(UpdateRenderables, DontUseWrongParentTile) {
     log.clear();
     source.dataTiles[{ 2, { 2, 0, 0 } }]->triedOptional = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 2, { 2, 0, 0 } }, Found },       // non-ready ideal tile
                   RetainTileDataAction{ { 2, { 2, 0, 0 } }, Required }, //
@@ -357,7 +357,7 @@ TEST(UpdateRenderables, DontUseWrongParentTile) {
     log.clear();
     source.idealTiles.emplace(UnwrappedTileID{ 2, 2, 0 });
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 2, { 2, 0, 0 } }, Found },       // non-ready ideal tile
                   RetainTileDataAction{ { 2, { 2, 0, 0 } }, Required }, //
@@ -402,7 +402,7 @@ TEST(UpdateRenderables, UseParentTileWhenChildNotReady) {
 
     // Make sure that it renders the parent tile.
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 1 } }, Found },       // found, but not ready
                   RetainTileDataAction{ { 1, { 1, 0, 1 } }, Required }, //
@@ -420,7 +420,7 @@ TEST(UpdateRenderables, UseParentTileWhenChildNotReady) {
     log.clear();
     tile_1_1_0_1->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 1 } }, Found },       // found and ready
                   RetainTileDataAction{ { 1, { 1, 0, 1 } }, Required }, //
@@ -447,7 +447,7 @@ TEST(UpdateRenderables, UseOverlappingParentTile) {
     tile_1_1_0_1->renderable = true;
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, NotFound },    // ideal tile not found
                   CreateTileDataAction{ { 1, { 1, 0, 0 } } },           //
@@ -483,7 +483,7 @@ TEST(UpdateRenderables, UseChildTiles) {
     tile_1_1_1_0->renderable = true;
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 0);
+                                 source.idealTiles, source.zoomRange, 0);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 0, { 0, 0, 0 } }, NotFound },    // ideal tile, missing
                   CreateTileDataAction{ { 0, { 0, 0, 0 } } },           //
@@ -517,7 +517,7 @@ TEST(UpdateRenderables, PreferChildTiles) {
     tile_2_2_0_0->renderable = true;
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, NotFound },    // ideal tile, not found
                   CreateTileDataAction{ { 1, { 1, 0, 0 } } },           //
@@ -540,7 +540,7 @@ TEST(UpdateRenderables, PreferChildTiles) {
     auto tile_2_2_0_1 = source.createTileData(OverscaledTileID{ 2, 0, 1 });
     tile_2_2_0_1->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, Found }, // ideal tile, not ready
                   // ideal tile was added in previous invocation, but is not yet ready
@@ -563,7 +563,7 @@ TEST(UpdateRenderables, PreferChildTiles) {
     auto tile_2_2_1_0 = source.createTileData(OverscaledTileID{ 2, 1, 0 });
     tile_2_2_1_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, Found }, // ideal tile, not ready
                   // ideal tile was added in first invocation, but is not yet ready
@@ -589,7 +589,7 @@ TEST(UpdateRenderables, PreferChildTiles) {
     auto tile_2_2_1_1 = source.createTileData(OverscaledTileID{ 2, 1, 1 });
     tile_2_2_1_1->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, Found }, // ideal tile, not ready
                   // ideal tile was added in first invocation, but is not yet ready
@@ -627,7 +627,7 @@ TEST(UpdateRenderables, UseParentAndChildTiles) {
 
     // Check that it uses the child tile and the parent tile to cover the rest.
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, NotFound },    // ideal tile, missing
                   CreateTileDataAction{ { 1, { 1, 0, 0 } } },           //
@@ -648,7 +648,7 @@ TEST(UpdateRenderables, UseParentAndChildTiles) {
     log.clear();
     source.dataTiles.erase(OverscaledTileID{ 2, 0, 0 });
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 1, { 1, 0, 0 } }, Required }, //
@@ -671,14 +671,14 @@ TEST(UpdateRenderables, DontUseTilesLowerThanMinzoom) {
     auto retainTileData = retainTileDataFn(log);
     auto renderTile = renderTileFn(log);
 
-    source.info.minZoom = 2;
+    source.zoomRange.min = 2;
     source.idealTiles.emplace(UnwrappedTileID{ 2, 0, 0 });
 
     auto tile_1_1_0_0 = source.createTileData(OverscaledTileID{ 1, 0, 0 });
     tile_1_1_0_0->renderable = true;
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 2, { 2, 0, 0 } }, NotFound },    // ideal tile, missing
                   CreateTileDataAction{ { 2, { 2, 0, 0 } } },           //
@@ -700,14 +700,14 @@ TEST(UpdateRenderables, UseOverzoomedTileAfterMaxzoom) {
     auto retainTileData = retainTileDataFn(log);
     auto renderTile = renderTileFn(log);
 
-    source.info.maxZoom = 2;
+    source.zoomRange.max = 2;
     source.idealTiles.emplace(UnwrappedTileID{ 2, 0, 0 });
 
     // Add a child tile (that should never occur in practice) and make sure it's not selected.
     auto tile_3_3_0_0 = source.createTileData(OverscaledTileID{ 3, 0, 0 });
     tile_3_3_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(
         ActionLog({
             GetTileDataAction{ { 2, { 2, 0, 0 } }, NotFound },    // ideal tile, missing
@@ -723,7 +723,7 @@ TEST(UpdateRenderables, UseOverzoomedTileAfterMaxzoom) {
     log.clear();
     source.dataTiles[{ 2, { 2, 0, 0 } }]->triedOptional = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(
         ActionLog({
             GetTileDataAction{ { 2, { 2, 0, 0 } }, Found },       // ideal tile, missing
@@ -741,7 +741,7 @@ TEST(UpdateRenderables, UseOverzoomedTileAfterMaxzoom) {
     auto tile_2_2_0_0 = source.createTileData(OverscaledTileID{ 2, { 2, 0, 0 } });
     tile_2_2_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 3);
+                                 source.idealTiles, source.zoomRange, 3);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 3, { 2, 0, 0 } }, NotFound },    // ideal tile, missing
                   CreateTileDataAction{ { 3, { 2, 0, 0 } } },           //
@@ -758,7 +758,7 @@ TEST(UpdateRenderables, UseOverzoomedTileAfterMaxzoom) {
     auto tile_3_2_0_0 = source.createTileData(OverscaledTileID{ 3, { 2, 0, 0 } });
     tile_3_2_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 3);
+                                 source.idealTiles, source.zoomRange, 3);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 3, { 2, 0, 0 } }, Found },       //
                   RetainTileDataAction{ { 3, { 2, 0, 0 } }, Required }, //
@@ -769,7 +769,7 @@ TEST(UpdateRenderables, UseOverzoomedTileAfterMaxzoom) {
     // Check that it's switching back to the tile that has the matching overzoom value.
     log.clear();
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 2, { 2, 0, 0 } }, Found },       //
                   RetainTileDataAction{ { 2, { 2, 0, 0 } }, Required }, //
@@ -784,7 +784,7 @@ TEST(UpdateRenderables, UseOverzoomedTileAfterMaxzoom) {
 
     // Use the overzoomed tile even though it doesn't match the zoom level.
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 2, { 2, 0, 0 } }, NotFound },    //
                   CreateTileDataAction{ { 2, { 2, 0, 0 } } },           //
@@ -804,14 +804,14 @@ TEST(UpdateRenderables, AscendToNonOverzoomedTiles) {
     auto retainTileData = retainTileDataFn(log);
     auto renderTile = renderTileFn(log);
 
-    source.info.maxZoom = 2;
+    source.zoomRange.max = 2;
     source.idealTiles.emplace(UnwrappedTileID{ 2, 0, 0 });
 
     // Add a matching overzoomed tile and make sure it gets selected.
     auto tile_3_2_0_0 = source.createTileData(OverscaledTileID{ 3, { 2, 0, 0 } });
     tile_3_2_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 3);
+                                 source.idealTiles, source.zoomRange, 3);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 3, { 2, 0, 0 } }, Found },       //
                   RetainTileDataAction{ { 3, { 2, 0, 0 } }, Required }, //
@@ -826,7 +826,7 @@ TEST(UpdateRenderables, AscendToNonOverzoomedTiles) {
     auto tile_2_2_0_0 = source.createTileData(OverscaledTileID{ 2, { 2, 0, 0 } });
     tile_2_2_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 3);
+                                 source.idealTiles, source.zoomRange, 3);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 3, { 2, 0, 0 } }, NotFound },    //
                   CreateTileDataAction{ { 3, { 2, 0, 0 } } },           //
@@ -845,7 +845,7 @@ TEST(UpdateRenderables, AscendToNonOverzoomedTiles) {
     auto tile_1_1_0_0 = source.createTileData(OverscaledTileID{ 1, { 1, 0, 0 } });
     tile_1_1_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 3);
+                                 source.idealTiles, source.zoomRange, 3);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 3, { 2, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 3, { 2, 0, 0 } }, Required }, //
@@ -861,7 +861,7 @@ TEST(UpdateRenderables, AscendToNonOverzoomedTiles) {
     log.clear();
     source.dataTiles[{ 3, { 2, 0, 0 } }]->triedOptional = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 3);
+                                 source.idealTiles, source.zoomRange, 3);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 3, { 2, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 3, { 2, 0, 0 } }, Required }, //
@@ -888,7 +888,7 @@ TEST(UpdateRenderables, DoNotAscendMultipleTimesIfNotFound) {
     source.idealTiles.emplace(UnwrappedTileID{ 8, 1, 0 });
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 8);
+                                 source.idealTiles, source.zoomRange, 8);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 8, { 8, 0, 0 } }, NotFound },    // ideal tile
                   CreateTileDataAction{ { 8, { 8, 0, 0 } } },           //
@@ -923,7 +923,7 @@ TEST(UpdateRenderables, DoNotAscendMultipleTimesIfNotFound) {
     tile_4_0_0_0->renderable = true;
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 8);
+                                 source.idealTiles, source.zoomRange, 8);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 8, { 8, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 8, { 8, 0, 0 } }, Required }, //
@@ -963,7 +963,7 @@ TEST(UpdateRenderables, DontRetainUnusedNonIdealTiles) {
     source.createTileData(OverscaledTileID{ 2, 0, 0 });
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 2);
+                                 source.idealTiles, source.zoomRange, 2);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 2, { 2, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 2, { 2, 0, 0 } }, Required }, //
@@ -995,7 +995,7 @@ TEST(UpdateRenderables, WrappedTiles) {
     tile_0_0_0_0->renderable = true;
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 1);
+                                 source.idealTiles, source.zoomRange, 1);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 1, { 1, 1, 0 } }, NotFound },    // ideal tile 1/-1/0
                   CreateTileDataAction{ { 1, { 1, 1, 0 } } },           //
@@ -1051,7 +1051,7 @@ TEST(UpdateRenderables, RepeatedRenderWithMissingOptionals) {
     source.idealTiles.emplace(UnwrappedTileID{ 6, 0, 0 });
 
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 6);
+                                 source.idealTiles, source.zoomRange, 6);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 6, { 6, 0, 0 } }, NotFound },    // ideal tile, not found
                   CreateTileDataAction{ { 6, { 6, 0, 0 } } },           //
@@ -1072,7 +1072,7 @@ TEST(UpdateRenderables, RepeatedRenderWithMissingOptionals) {
     // Repeat.
     log.clear();
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 6);
+                                 source.idealTiles, source.zoomRange, 6);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 6, { 6, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 6, { 6, 0, 0 } }, Required }, //
@@ -1093,7 +1093,7 @@ TEST(UpdateRenderables, RepeatedRenderWithMissingOptionals) {
     log.clear();
     source.dataTiles[{ 6, { 6, 0, 0 } }]->triedOptional = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 6);
+                                 source.idealTiles, source.zoomRange, 6);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 6, { 6, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 6, { 6, 0, 0 } }, Required }, //
@@ -1115,7 +1115,7 @@ TEST(UpdateRenderables, RepeatedRenderWithMissingOptionals) {
     // Repeat.
     log.clear();
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 6);
+                                 source.idealTiles, source.zoomRange, 6);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 6, { 6, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 6, { 6, 0, 0 } }, Required }, //
@@ -1137,7 +1137,7 @@ TEST(UpdateRenderables, RepeatedRenderWithMissingOptionals) {
     log.clear();
     source.dataTiles[{ 5, { 5, 0, 0 } }]->triedOptional = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 6);
+                                 source.idealTiles, source.zoomRange, 6);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 6, { 6, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 6, { 6, 0, 0 } }, Required }, //
@@ -1161,7 +1161,7 @@ TEST(UpdateRenderables, RepeatedRenderWithMissingOptionals) {
     log.clear();
     source.dataTiles[{ 4, { 4, 0, 0 } }]->triedOptional = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 6);
+                                 source.idealTiles, source.zoomRange, 6);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 6, { 6, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 6, { 6, 0, 0 } }, Required }, //
@@ -1186,7 +1186,7 @@ TEST(UpdateRenderables, RepeatedRenderWithMissingOptionals) {
     log.clear();
     source.dataTiles[{ 3, { 3, 0, 0 } }]->triedOptional = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 6);
+                                 source.idealTiles, source.zoomRange, 6);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 6, { 6, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 6, { 6, 0, 0 } }, Required }, //
@@ -1213,7 +1213,7 @@ TEST(UpdateRenderables, RepeatedRenderWithMissingOptionals) {
     auto tile_3_3_0_0 = source.dataTiles[{ 3, { 3, 0, 0 } }].get();
     tile_3_3_0_0->renderable = true;
     algorithm::updateRenderables(getTileData, createTileData, retainTileData, renderTile,
-                                 source.idealTiles, source.info, 6);
+                                 source.idealTiles, source.zoomRange, 6);
     EXPECT_EQ(ActionLog({
                   GetTileDataAction{ { 6, { 6, 0, 0 } }, Found },       // ideal tile, not ready
                   RetainTileDataAction{ { 6, { 6, 0, 0 } }, Required }, //

--- a/test/storage/offline.cpp
+++ b/test/storage/offline.cpp
@@ -1,5 +1,4 @@
 #include <mbgl/storage/offline.hpp>
-#include <mbgl/util/tileset.hpp>
 #include <mbgl/tile/tile_id.hpp>
 
 #include <gtest/gtest.h>
@@ -14,49 +13,42 @@ static const LatLngBounds sanFranciscoWrapped =
 
 TEST(OfflineTilePyramidRegionDefinition, TileCoverEmpty) {
     OfflineTilePyramidRegionDefinition region("", LatLngBounds::empty(), 0, 20, 1.0);
-    Tileset tileset;
 
-    EXPECT_EQ((std::vector<CanonicalTileID>{}), region.tileCover(SourceType::Vector, 512, tileset));
+    EXPECT_EQ((std::vector<CanonicalTileID>{}), region.tileCover(SourceType::Vector, 512, { 0, 22 }));
 }
 
 TEST(OfflineTilePyramidRegionDefinition, TileCoverZoomIntersection) {
     OfflineTilePyramidRegionDefinition region("", sanFrancisco, 2, 2, 1.0);
-    Tileset tileset;
 
-    tileset.minZoom = 0;
     EXPECT_EQ((std::vector<CanonicalTileID>{ { 2, 0, 1 } }),
-              region.tileCover(SourceType::Vector, 512, tileset));
+              region.tileCover(SourceType::Vector, 512, { 0, 22 }));
 
-    tileset.minZoom = 3;
-    EXPECT_EQ((std::vector<CanonicalTileID>{}), region.tileCover(SourceType::Vector, 512, tileset));
+    EXPECT_EQ((std::vector<CanonicalTileID>{}), region.tileCover(SourceType::Vector, 512, { 3, 22 }));
 }
 
 TEST(OfflineTilePyramidRegionDefinition, TileCoverTileSize) {
     OfflineTilePyramidRegionDefinition region("", LatLngBounds::world(), 0, 0, 1.0);
-    Tileset tileset;
 
     EXPECT_EQ((std::vector<CanonicalTileID>{ { 0, 0, 0 } }),
-              region.tileCover(SourceType::Vector, 512, tileset));
+              region.tileCover(SourceType::Vector, 512, { 0, 22 }));
 
     EXPECT_EQ((std::vector<CanonicalTileID>{ { 1, 0, 0 }, { 1, 0, 1 }, { 1, 1, 0 }, { 1, 1, 1 } }),
-              region.tileCover(SourceType::Vector, 256, tileset));
+              region.tileCover(SourceType::Vector, 256, { 0, 22 }));
 }
 
 TEST(OfflineTilePyramidRegionDefinition, TileCoverZoomRounding) {
     OfflineTilePyramidRegionDefinition region("", sanFrancisco, 0.6, 0.7, 1.0);
-    Tileset tileset;
 
     EXPECT_EQ((std::vector<CanonicalTileID>{ { 0, 0, 0 } }),
-              region.tileCover(SourceType::Vector, 512, tileset));
+              region.tileCover(SourceType::Vector, 512, { 0, 22 }));
 
     EXPECT_EQ((std::vector<CanonicalTileID>{ { 1, 0, 0 } }),
-              region.tileCover(SourceType::Raster, 512, tileset));
+              region.tileCover(SourceType::Raster, 512, { 0, 22 }));
 }
 
 TEST(OfflineTilePyramidRegionDefinition, TileCoverWrapped) {
     OfflineTilePyramidRegionDefinition region("", sanFranciscoWrapped, 0, 0, 1.0);
-    Tileset tileset;
 
     EXPECT_EQ((std::vector<CanonicalTileID>{ { 0, 0, 0 } }),
-              region.tileCover(SourceType::Vector, 512, tileset));
+              region.tileCover(SourceType::Vector, 512, { 0, 22 }));
 }

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -2,7 +2,10 @@
 #include <mbgl/test/stub_file_source.hpp>
 #include <mbgl/test/stub_style_observer.hpp>
 
-#include <mbgl/style/source.hpp>
+#include <mbgl/style/sources/raster_source.hpp>
+#include <mbgl/style/sources/vector_source.hpp>
+#include <mbgl/style/sources/geojson_source.hpp>
+
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/io.hpp>
@@ -83,7 +86,7 @@ TEST(Source, LoadingFail) {
         test.end();
     };
 
-    Source source(SourceType::Vector, "source", "url", 512, nullptr, nullptr);
+    VectorSource source("source", "url", 512, nullptr, nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
 
@@ -106,7 +109,7 @@ TEST(Source, LoadingCorrupt) {
         test.end();
     };
 
-    Source source(SourceType::Vector, "source", "url", 512, nullptr, nullptr);
+    VectorSource source("source", "url", 512, nullptr, nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
 
@@ -134,7 +137,7 @@ TEST(Source, RasterTileEmpty) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    Source source(SourceType::Raster, "source", "", 512, std::move(tileset), nullptr);
+    RasterSource source("source", "", 512, std::move(tileset), nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -163,7 +166,7 @@ TEST(Source, VectorTileEmpty) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    Source source(SourceType::Vector, "source", "", 512, std::move(tileset), nullptr);
+    VectorSource source("source", "", 512, std::move(tileset), nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -192,7 +195,7 @@ TEST(Source, RasterTileFail) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    Source source(SourceType::Raster, "source", "", 512, std::move(tileset), nullptr);
+    RasterSource source("source", "", 512, std::move(tileset), nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -221,7 +224,7 @@ TEST(Source, VectorTileFail) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    Source source(SourceType::Vector, "source", "", 512, std::move(tileset), nullptr);
+    VectorSource source("source", "", 512, std::move(tileset), nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -249,7 +252,7 @@ TEST(Source, RasterTileCorrupt) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    Source source(SourceType::Raster, "source", "", 512, std::move(tileset), nullptr);
+    RasterSource source("source", "", 512, std::move(tileset), nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -281,7 +284,7 @@ TEST(Source, VectorTileCorrupt) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    Source source(SourceType::Vector, "source", "", 512, std::move(tileset), nullptr);
+    VectorSource source("source", "", 512, std::move(tileset), nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -308,7 +311,7 @@ TEST(Source, RasterTileCancel) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    Source source(SourceType::Raster, "source", "", 512, std::move(tileset), nullptr);
+    RasterSource source("source", "", 512, std::move(tileset), nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -335,7 +338,7 @@ TEST(Source, VectorTileCancel) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    Source source(SourceType::Vector, "source", "", 512, std::move(tileset), nullptr);
+    VectorSource source("source", "", 512, std::move(tileset), nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -86,7 +86,7 @@ TEST(Source, LoadingFail) {
         test.end();
     };
 
-    VectorSource source("source", "url", 512, nullptr);
+    VectorSource source("source", "url", nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
 
@@ -109,7 +109,7 @@ TEST(Source, LoadingCorrupt) {
         test.end();
     };
 
-    VectorSource source("source", "url", 512, nullptr);
+    VectorSource source("source", "url", nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
 
@@ -166,7 +166,7 @@ TEST(Source, VectorTileEmpty) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    VectorSource source("source", "", 512, std::move(tileset));
+    VectorSource source("source", "", std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -224,7 +224,7 @@ TEST(Source, VectorTileFail) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    VectorSource source("source", "", 512, std::move(tileset));
+    VectorSource source("source", "", std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -284,7 +284,7 @@ TEST(Source, VectorTileCorrupt) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    VectorSource source("source", "", 512, std::move(tileset));
+    VectorSource source("source", "", std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -338,7 +338,7 @@ TEST(Source, VectorTileCancel) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    VectorSource source("source", "", 512, std::move(tileset));
+    VectorSource source("source", "", std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -82,7 +82,7 @@ TEST(Source, LoadingFail) {
     };
 
     test.observer.sourceError = [&] (Source& source, std::exception_ptr error) {
-        EXPECT_EQ("url", source.url);
+        EXPECT_EQ("source", source.id);
         EXPECT_EQ("Failed by the test case", util::toString(error));
         test.end();
     };
@@ -105,7 +105,7 @@ TEST(Source, LoadingCorrupt) {
     };
 
     test.observer.sourceError = [&] (Source& source, std::exception_ptr error) {
-        EXPECT_EQ("url", source.url);
+        EXPECT_EQ("source", source.id);
         EXPECT_EQ("0 - Invalid value.", util::toString(error));
         test.end();
     };

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -86,7 +86,7 @@ TEST(Source, LoadingFail) {
         test.end();
     };
 
-    VectorSource source("source", "url", 512, nullptr, nullptr);
+    VectorSource source("source", "url", 512, nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
 
@@ -109,7 +109,7 @@ TEST(Source, LoadingCorrupt) {
         test.end();
     };
 
-    VectorSource source("source", "url", 512, nullptr, nullptr);
+    VectorSource source("source", "url", 512, nullptr);
     source.setObserver(&test.observer);
     source.load(test.fileSource);
 
@@ -137,7 +137,7 @@ TEST(Source, RasterTileEmpty) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    RasterSource source("source", "", 512, std::move(tileset), nullptr);
+    RasterSource source("source", "", 512, std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -166,7 +166,7 @@ TEST(Source, VectorTileEmpty) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    VectorSource source("source", "", 512, std::move(tileset), nullptr);
+    VectorSource source("source", "", 512, std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -195,7 +195,7 @@ TEST(Source, RasterTileFail) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    RasterSource source("source", "", 512, std::move(tileset), nullptr);
+    RasterSource source("source", "", 512, std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -224,7 +224,7 @@ TEST(Source, VectorTileFail) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    VectorSource source("source", "", 512, std::move(tileset), nullptr);
+    VectorSource source("source", "", 512, std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -252,7 +252,7 @@ TEST(Source, RasterTileCorrupt) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    RasterSource source("source", "", 512, std::move(tileset), nullptr);
+    RasterSource source("source", "", 512, std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -284,7 +284,7 @@ TEST(Source, VectorTileCorrupt) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    VectorSource source("source", "", 512, std::move(tileset), nullptr);
+    VectorSource source("source", "", 512, std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -311,7 +311,7 @@ TEST(Source, RasterTileCancel) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    RasterSource source("source", "", 512, std::move(tileset), nullptr);
+    RasterSource source("source", "", 512, std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);
@@ -338,7 +338,7 @@ TEST(Source, VectorTileCancel) {
     auto tileset = std::make_unique<Tileset>();
     tileset->tiles = { "tiles" };
 
-    VectorSource source("source", "", 512, std::move(tileset), nullptr);
+    VectorSource source("source", "", 512, std::move(tileset));
     source.setObserver(&test.observer);
     source.load(test.fileSource);
     source.update(test.updateParameters);

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/tileset.hpp>
 #include <mbgl/platform/log.hpp>
 
 #include <mbgl/map/transform.hpp>

--- a/test/style/style_parser.cpp
+++ b/test/style/style_parser.cpp
@@ -93,8 +93,8 @@ TEST(StyleParser, ParseTileJSONRaster) {
         SourceType::Raster,
         256);
 
-    EXPECT_EQ(0, result->minZoom);
-    EXPECT_EQ(15, result->maxZoom);
+    EXPECT_EQ(0, result->zoomRange.min);
+    EXPECT_EQ(15, result->zoomRange.max);
     EXPECT_EQ("attribution", result->attribution);
 #if !defined(__ANDROID__) && !defined(__APPLE__)
     EXPECT_EQ("mapbox://tiles/mapbox.satellite/{z}/{x}/{y}{ratio}.webp", result->tiles[0]);
@@ -110,8 +110,8 @@ TEST(StyleParser, ParseTileJSONVector) {
         SourceType::Vector,
         256);
 
-    EXPECT_EQ(0, result->minZoom);
-    EXPECT_EQ(15, result->maxZoom);
+    EXPECT_EQ(0, result->zoomRange.min);
+    EXPECT_EQ(15, result->zoomRange.max);
     EXPECT_EQ("attribution", result->attribution);
     EXPECT_EQ("mapbox://tiles/mapbox.streets/{z}/{x}/{y}.vector.pbf", result->tiles[0]);
 }

--- a/test/style/style_parser.cpp
+++ b/test/style/style_parser.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/style/parser.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/enum.hpp>
+#include <mbgl/util/tileset.hpp>
 
 #include <rapidjson/document.h>
 


### PR DESCRIPTION
Introduce `Source` subclasses in preparation for a runtime API. Full inheritance tree is:

* `Source`
  * `TileSource`
    * `RasterSource`
    * `VectorSource`
  * `GeoJSONSource`
  * `AnnotationSource`
