### PR TITLE
[core] Update RasterShader to support crossfading

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "csscolorparser": "^1.0.2",
     "ejs": "^2.4.1",
     "express": "^4.11.1",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#59e998295d548f208ee3ec10cdd21ff2630e2079",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#d3a10d1a46b99d3da264cf2d1903cbde6fea3185",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#194fc55b6a7dd54c1e2cf2dd9048fbb5e836716d",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2e5addbbd6b3eafaa2984bfd863fd28071f2e481",
     "node-gyp": "^3.3.1",

--- a/src/mbgl/geometry/static_vertex_buffer.cpp
+++ b/src/mbgl/geometry/static_vertex_buffer.cpp
@@ -3,11 +3,21 @@
 
 namespace mbgl {
 
-StaticVertexBuffer::StaticVertexBuffer(std::initializer_list<std::pair<int16_t, int16_t>> init) {
+StaticVertexBuffer::StaticVertexBuffer(std::initializer_list<std::array<VertexType, 2>> init) {
     for (const auto& vertex : init) {
-        vertex_type *vertices = static_cast<vertex_type *>(addElement());
-        vertices[0] = vertex.first;
-        vertices[1] = vertex.second;
+        VertexType* vertices = static_cast<VertexType*>(addElement());
+        vertices[0] = std::get<0>(vertex);
+        vertices[1] = std::get<1>(vertex);
+    }
+}
+
+StaticRasterVertexBuffer::StaticRasterVertexBuffer(std::initializer_list<std::array<VertexType, 4>> init) {
+    for (const auto& vertex : init) {
+        VertexType* vertices = static_cast<VertexType*>(addElement());
+        vertices[0] = std::get<0>(vertex);
+        vertices[1] = std::get<1>(vertex);
+        vertices[2] = std::get<2>(vertex);
+        vertices[3] = std::get<3>(vertex);
     }
 }
 

--- a/src/mbgl/geometry/static_vertex_buffer.hpp
+++ b/src/mbgl/geometry/static_vertex_buffer.hpp
@@ -2,10 +2,8 @@
 
 #include <mbgl/geometry/buffer.hpp>
 
-#include <vector>
-#include <cstddef>
+#include <array>
 #include <cstdint>
-#include <cmath>
 
 namespace mbgl {
 
@@ -15,9 +13,18 @@ class StaticVertexBuffer : public Buffer<
     32 // default length
 > {
 public:
-    typedef int16_t vertex_type;
+    using VertexType = int16_t;
+    StaticVertexBuffer(std::initializer_list<std::array<VertexType, 2>>);
+};
 
-    StaticVertexBuffer(std::initializer_list<std::pair<int16_t, int16_t>> init);
+class StaticRasterVertexBuffer : public Buffer<
+    8, // bytes per vertex (4 * signed short == 8 bytes)
+    GL_ARRAY_BUFFER,
+    32 // default length
+> {
+public:
+    using VertexType = int16_t;
+    StaticRasterVertexBuffer(std::initializer_list<std::array<VertexType, 4>>);
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -133,6 +133,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         MBGL_DEBUG_GROUP("upload");
 
         tileStencilBuffer.upload(store);
+        rasterBoundsBuffer.upload(store);
         tileBorderBuffer.upload(store);
         spriteAtlas->upload(store);
         lineAtlas->upload(store);

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -242,6 +242,11 @@ private:
     VertexArrayObject backgroundPatternArray;
     VertexArrayObject backgroundArray;
 
+    VertexArrayObject coveringPlaingOverdrawArray;
+    VertexArrayObject coveringRasterOverdrawArray;
+    VertexArrayObject backgroundPatternOverdrawArray;
+    VertexArrayObject backgroundOverdrawArray;
+
     // Set up the tile boundary lines we're using to draw the tile outlines.
     StaticVertexBuffer tileBorderBuffer = {
         { 0, 0 },
@@ -252,8 +257,6 @@ private:
     };
 
     VertexArrayObject tileBorderArray;
-
-    VertexArrayObject coveringRasterOverdrawArray;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -225,16 +225,23 @@ private:
     std::unique_ptr<CircleShader> circleOverdrawShader;
 
     // Set up the stencil quad we're using to generate the stencil mask.
-    StaticVertexBuffer tileStencilBuffer = {
+    StaticVertexBuffer tileStencilBuffer {
         // top left triangle
-        { 0, 0 },
-        { util::EXTENT, 0 },
-        { 0, util::EXTENT },
+        {{ 0, 0 }},
+        {{ util::EXTENT, 0 }},
+        {{ 0, util::EXTENT }},
 
         // bottom right triangle
-        { util::EXTENT, 0 },
-        { 0, util::EXTENT },
-        { util::EXTENT, util::EXTENT },
+        {{ util::EXTENT, 0 }},
+        {{ 0, util::EXTENT }},
+        {{ util::EXTENT, util::EXTENT }},
+    };
+
+    StaticRasterVertexBuffer rasterBoundsBuffer {
+        {{ 0, 0, 0, 0 }},
+        {{ util::EXTENT, 0, 32767, 0 }},
+        {{ 0, util::EXTENT, 0, 32767 }},
+        {{ util::EXTENT, util::EXTENT, 32767, 32767 }},
     };
 
     VertexArrayObject coveringPlainArray;
@@ -248,12 +255,12 @@ private:
     VertexArrayObject backgroundOverdrawArray;
 
     // Set up the tile boundary lines we're using to draw the tile outlines.
-    StaticVertexBuffer tileBorderBuffer = {
-        { 0, 0 },
-        { util::EXTENT, 0 },
-        { util::EXTENT, util::EXTENT },
-        { 0, util::EXTENT },
-        { 0, 0 },
+    StaticVertexBuffer tileBorderBuffer {
+        {{ 0, 0 }},
+        {{ util::EXTENT, 0 }},
+        {{ util::EXTENT, util::EXTENT }},
+        {{ 0, util::EXTENT }},
+        {{ 0, 0 }},
     };
 
     VertexArrayObject tileBorderArray;

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -21,8 +21,11 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
     optional<SpriteAtlasPosition> imagePosA;
     optional<SpriteAtlasPosition> imagePosB;
 
-    const auto& shaderPattern = isOverdraw() ? patternOverdrawShader : patternShader;
-    const auto& shaderPlain = isOverdraw() ? plainOverdrawShader : plainShader;
+    const bool overdraw = isOverdraw();
+    const auto& shaderPattern = overdraw ? patternOverdrawShader : patternShader;
+    const auto& shaderPlain = overdraw ? plainOverdrawShader : plainShader;
+    auto& arrayBackgroundPattern = overdraw ? backgroundPatternOverdrawArray : backgroundPatternArray;
+    auto& arrayBackground = overdraw ? backgroundOverdrawArray : backgroundArray;
 
     if (isPatterned) {
         imagePosA = spriteAtlas->getPosition(properties.backgroundPattern.value.from, true);
@@ -41,14 +44,14 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         shaderPattern->u_opacity = properties.backgroundOpacity;
 
         spriteAtlas->bind(true, store);
-        backgroundPatternArray.bind(*shaderPattern, tileStencilBuffer, BUFFER_OFFSET(0), store);
+        arrayBackgroundPattern.bind(*shaderPattern, tileStencilBuffer, BUFFER_OFFSET(0), store);
 
     } else {
         config.program = shaderPlain->getID();
         shaderPlain->u_color = properties.backgroundColor;
         shaderPlain->u_opacity = properties.backgroundOpacity;
 
-        backgroundArray.bind(*shaderPlain, tileStencilBuffer, BUFFER_OFFSET(0), store);
+        arrayBackground.bind(*shaderPlain, tileStencilBuffer, BUFFER_OFFSET(0), store);
     }
 
     config.stencilTest = GL_FALSE;

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -115,9 +115,6 @@ void Painter::renderFill(FillBucket& bucket,
                 config.program = shaderOutlinePattern->getID();
                 shaderOutlinePattern->u_matrix = vertexMatrix;
 
-                // Draw the entire line
-                shaderOutline->u_world = worldSize;
-
                 shaderOutlinePattern->u_pattern_tl_a = imagePosA->tl;
                 shaderOutlinePattern->u_pattern_br_a = imagePosA->br;
                 shaderOutlinePattern->u_pattern_tl_b = imagePosB->tl;
@@ -132,6 +129,9 @@ void Painter::renderFill(FillBucket& bucket,
                 shaderOutlinePattern->u_tile_units_to_pixels = 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom());
                 shaderOutlinePattern->u_pixel_coord_upper = {{ float(pixelX >> 16), float(pixelY >> 16) }};
                 shaderOutlinePattern->u_pixel_coord_lower = {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }};
+
+                // Draw the entire line
+                shaderOutlinePattern->u_world = worldSize;
 
                 config.activeTexture = GL_TEXTURE0;
                 spriteAtlas->bind(true, store);

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -26,12 +26,16 @@ void RasterBucket::setImage(PremultipliedImage image) {
 }
 
 void RasterBucket::drawRaster(RasterShader& shader,
-                              StaticVertexBuffer& vertices,
+                              StaticRasterVertexBuffer& vertices,
                               VertexArrayObject& array,
+                              gl::Config& config,
                               gl::ObjectStore& store) {
+    config.activeTexture = GL_TEXTURE0;
+    raster.bind(true, store);
+    config.activeTexture = GL_TEXTURE1;
     raster.bind(true, store);
     array.bind(shader, vertices, BUFFER_OFFSET_0, store);
-    MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
+    MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, (GLsizei)vertices.index()));
 }
 
 bool RasterBucket::hasData() const {

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -2,11 +2,12 @@
 
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/util/raster.hpp>
+#include <mbgl/gl/gl_config.hpp>
 
 namespace mbgl {
 
 class RasterShader;
-class StaticVertexBuffer;
+class StaticRasterVertexBuffer;
 class VertexArrayObject;
 
 class RasterBucket : public Bucket {
@@ -18,7 +19,7 @@ public:
 
     void setImage(PremultipliedImage);
 
-    void drawRaster(RasterShader&, StaticVertexBuffer&, VertexArrayObject&, gl::ObjectStore&);
+    void drawRaster(RasterShader&, StaticRasterVertexBuffer&, VertexArrayObject&, gl::Config&, gl::ObjectStore&);
 
     Raster raster;
 };

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -13,8 +13,13 @@ RasterShader::RasterShader(gl::ObjectStore& store, bool overdraw)
 }
 
 void RasterShader::bind(GLbyte* offset) {
+    const GLint stride = 8;
+
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
-    MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 0, offset));
+    MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, stride, offset));
+
+    MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_texture_pos));
+    MBGL_CHECK_ERROR(glVertexAttribPointer(a_texture_pos, 2, GL_SHORT, false, stride, offset + 4));
 }
 
 } // namespace mbgl

--- a/src/mbgl/shader/raster_shader.hpp
+++ b/src/mbgl/shader/raster_shader.hpp
@@ -12,14 +12,18 @@ public:
     void bind(GLbyte *offset) final;
 
     UniformMatrix<4>                u_matrix            = {"u_matrix",            *this};
-    Uniform<GLint>                  u_image             = {"u_image",             *this};
-    Uniform<GLfloat>                u_opacity           = {"u_opacity",           *this};
-    Uniform<GLfloat>                u_buffer            = {"u_buffer",            *this};
+    Uniform<GLint>                  u_image0            = {"u_image0",            *this};
+    Uniform<GLint>                  u_image1            = {"u_image1",            *this};
+    Uniform<GLfloat>                u_opacity0          = {"u_opacity0",          *this};
+    Uniform<GLfloat>                u_opacity1          = {"u_opacity1",          *this};
+    Uniform<GLfloat>                u_buffer_scale      = {"u_buffer_scale",      *this};
     Uniform<GLfloat>                u_brightness_low    = {"u_brightness_low",    *this};
     Uniform<GLfloat>                u_brightness_high   = {"u_brightness_high",   *this};
     Uniform<GLfloat>                u_saturation_factor = {"u_saturation_factor", *this};
     Uniform<GLfloat>                u_contrast_factor   = {"u_contrast_factor",   *this};
     Uniform<std::array<GLfloat, 3>> u_spin_weights      = {"u_spin_weights",      *this};
+    Uniform<std::array<GLfloat, 2>> u_tl_parent         = {"u_tl_parent",         *this};
+    Uniform<GLfloat>                u_scale_parent      = {"u_scale_parent",      *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -50,6 +50,7 @@ Shader::Shader(const char* name_, const char* vertexSource, const char* fragment
     MBGL_CHECK_ERROR(glBindAttribLocation(program.get(), a_data, "a_data"));
     MBGL_CHECK_ERROR(glBindAttribLocation(program.get(), a_data1, "a_data1"));
     MBGL_CHECK_ERROR(glBindAttribLocation(program.get(), a_data2, "a_data2"));
+    MBGL_CHECK_ERROR(glBindAttribLocation(program.get(), a_texture_pos, "a_texture_pos"));
 
     // Link program
     GLint status;

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -21,12 +21,13 @@ public:
 protected:
     Shader(const char* name_, const char* vertex, const char* fragment, gl::ObjectStore&, bool overdraw = false);
 
-    static constexpr GLint     a_pos = 0;
-    static constexpr GLint a_extrude = 1;
-    static constexpr GLint  a_offset = 2;
-    static constexpr GLint    a_data = 3;
-    static constexpr GLint   a_data1 = 4;
-    static constexpr GLint   a_data2 = 5;
+    static constexpr GLint         a_pos = 0;
+    static constexpr GLint     a_extrude = 1;
+    static constexpr GLint      a_offset = 2;
+    static constexpr GLint        a_data = 3;
+    static constexpr GLint       a_data1 = 4;
+    static constexpr GLint       a_data2 = 5;
+    static constexpr GLint a_texture_pos = 6;
 
 private:
     bool compileShader(gl::UniqueShader&, const GLchar *source);


### PR DESCRIPTION
So far this has been the trickiest pending task from https://github.com/mapbox/mapbox-gl-shaders/issues/1. I'm afraid this will require help from someone with more GL expertise. I've started updating `RasterShader` according to the new shader code and am assuming that `tile == parentTile` for testing purposes.

Question: If `u_buffer_scale` is always 1 - why do we need to expose this as a uniform? I assume we want to eventually expose this as as data-driven style property?

Part of https://github.com/mapbox/mapbox-gl-native/issues/115.

:eyes: @kkaefer @lucaswoj @ansis @jfirebaugh