### PR TITLE
[core] Do not use pthread_getname_np before Glibc 2.11

### DIFF
--- a/src/mbgl/platform/log.cpp
+++ b/src/mbgl/platform/log.cpp
@@ -49,11 +49,17 @@ void Log::record(EventSeverity severity, Event event, int64_t code, const std::s
 
     std::stringstream logStream;
 
-    #if !defined(__ANDROID__) && (defined( __APPLE__) || defined(__linux__))
+#if defined(__APPLE__)
     char name[32];
     pthread_getname_np(pthread_self(), name, sizeof(name));
     logStream << "{" << name << "}";
-    #endif
+#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 12)
+    char name[32];
+    pthread_getname_np(pthread_self(), name, sizeof(name));
+    logStream << "{" << name << "}";
+#endif
+#endif
 
     logStream << "[" << Enum<Event>::toString(event) << "]";
 


### PR DESCRIPTION
Follows https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/util/thread.hpp#L98-L104.

:eyes: @kkaefer @tobrun @tmpsantos