### PR TITLE
[core] Autogenerate Shader name

### DIFF
--- a/scripts/build-shaders.py
+++ b/scripts/build-shaders.py
@@ -50,6 +50,11 @@ namespace mbgl {{
 namespace shaders {{
 namespace {name} {{
 
+#ifndef MBGL_SHADER_NAME_{NAME}
+#define MBGL_SHADER_NAME_{NAME}
+constexpr const char* name = "{name}";
+#endif // MBGL_SHADER_NAME_{NAME}
+
 #ifdef GL_ES_VERSION_2_0
 constexpr const char* {type} = R"MBGL_SHADER(precision highp float;\n{data})MBGL_SHADER";
 #else

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -31,7 +31,7 @@ void VertexArrayObject::bindVertexArrayObject(gl::ObjectStore& store) {
     MBGL_CHECK_ERROR(gl::BindVertexArray(*vao));
 }
 
-void VertexArrayObject::verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer,
+void VertexArrayObject::verifyBinding(Shader& shader, GLuint vertexBuffer, GLuint elementsBuffer,
                                       GLbyte *offset) {
     if (bound_shader != shader.getID()) {
         throw std::runtime_error(std::string("trying to rebind VAO to another shader from " +

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -10,8 +10,6 @@
 
 namespace mbgl {
 
-class Shader;
-
 class VertexArrayObject : public util::noncopyable {
 public:
     static void Unbind();
@@ -19,8 +17,8 @@ public:
     VertexArrayObject();
     ~VertexArrayObject();
 
-    template <typename Shader, typename VertexBuffer>
-    void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset, gl::ObjectStore& store) {
+    template <typename VertexBuffer>
+    void bind(Shader& shader, VertexBuffer& vertexBuffer, GLbyte* offset, gl::ObjectStore& store) {
         bindVertexArrayObject(store);
         if (bound_shader == 0) {
             vertexBuffer.bind(store);
@@ -33,8 +31,8 @@ public:
         }
     }
 
-    template <typename Shader, typename VertexBuffer, typename ElementsBuffer>
-    void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset, gl::ObjectStore& store) {
+    template <typename VertexBuffer, typename ElementsBuffer>
+    void bind(Shader& shader, VertexBuffer& vertexBuffer, ElementsBuffer& elementsBuffer, GLbyte* offset, gl::ObjectStore& store) {
         bindVertexArrayObject(store);
         if (bound_shader == 0) {
             vertexBuffer.bind(store);
@@ -62,7 +60,7 @@ private:
     // For debug reasons, we're storing the bind information so that we can
     // detect errors and report
     GLuint bound_shader = 0;
-    const char *bound_shader_name = "";
+    const char* bound_shader_name = "";
     GLuint bound_vertex_buffer = 0;
     GLuint bound_elements_buffer = 0;
     GLbyte *bound_offset = nullptr;

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/circle.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::circle;
 
 CircleShader::CircleShader(gl::ObjectStore& store)
-    : Shader("circle", shaders::circle::vertex, shaders::circle::fragment, store) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void CircleShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/collision_box_shader.cpp
+++ b/src/mbgl/shader/collision_box_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/collisionbox.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::collisionbox;
 
 CollisionBoxShader::CollisionBoxShader(gl::ObjectStore& store)
-    : Shader("collisionbox", shaders::collisionbox::vertex, shaders::collisionbox::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_extrude(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_extrude")))
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/icon.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::icon;
 
 IconShader::IconShader(gl::ObjectStore& store)
-    : Shader("icon", shaders::icon::vertex, shaders::icon::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_offset(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset")))
     , a_data1(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1")))
     , a_data2(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"))) {

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/line.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::line;
 
 LineShader::LineShader(gl::ObjectStore& store)
-    : Shader("line", shaders::line::vertex, shaders::line::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/linepattern.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::linepattern;
 
 LinepatternShader::LinepatternShader(gl::ObjectStore& store)
-    : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/linesdfpattern.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::linesdfpattern;
 
 LineSDFShader::LineSDFShader(gl::ObjectStore& store)
-    : Shader("linesdfpattern", shaders::linesdfpattern::vertex, shaders::linesdfpattern::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/outline.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::outline;
 
 OutlineShader::OutlineShader(gl::ObjectStore& store)
-    : Shader("outline", shaders::outline::vertex, shaders::outline::fragment, store) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void OutlineShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/outlinepattern_shader.cpp
+++ b/src/mbgl/shader/outlinepattern_shader.cpp
@@ -3,16 +3,11 @@
 #include <mbgl/shader/outlinepattern.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::outlinepattern;
 
 OutlinePatternShader::OutlinePatternShader(gl::ObjectStore& store)
-    : Shader(
-        "outlinepattern",
-        shaders::outlinepattern::vertex, shaders::outlinepattern::fragment,
-        store
-    ) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void OutlinePatternShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/pattern_shader.cpp
+++ b/src/mbgl/shader/pattern_shader.cpp
@@ -3,16 +3,11 @@
 #include <mbgl/shader/pattern.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::pattern;
 
 PatternShader::PatternShader(gl::ObjectStore& store)
-    : Shader(
-        "pattern",
-        shaders::pattern::vertex, shaders::pattern::fragment,
-        store
-    ) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void PatternShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/fill.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::fill;
 
 PlainShader::PlainShader(gl::ObjectStore& store)
-    : Shader("fill", shaders::fill::vertex, shaders::fill::fragment, store) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void PlainShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/raster.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::raster;
 
 RasterShader::RasterShader(gl::ObjectStore& store)
-    : Shader("raster", shaders::raster::vertex, shaders::raster::fragment, store) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void RasterShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/sdf.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::sdf;
 
 SDFShader::SDFShader(gl::ObjectStore& store)
-    : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_offset(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset")))
     , a_data1(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1")))
     , a_data2(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"))) {

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -13,7 +13,7 @@
 
 namespace mbgl {
 
-Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSource, gl::ObjectStore& store)
+Shader::Shader(const char* name_, const char* vertexSource, const char* fragmentSource, gl::ObjectStore& store)
     : name(name_)
     , program(store.createProgram())
     , vertexShader(store.createShader(GL_VERTEX_SHADER))
@@ -21,13 +21,13 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
 {
     util::stopwatch stopwatch("shader compilation", Event::Shader);
 
-    if (!compileShader(vertexShader, &vertSource)) {
-        Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertSource);
+    if (!compileShader(vertexShader, &vertexSource)) {
+        Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertexSource);
         throw util::ShaderException(std::string { "Vertex shader " } + name + " failed to compile");
     }
 
-    if (!compileShader(fragmentShader, &fragSource)) {
-        Log::Error(Event::Shader, "Fragment shader %s failed to compile: %s", name, fragSource);
+    if (!compileShader(fragmentShader, &fragmentSource)) {
+        Log::Error(Event::Shader, "Fragment shader %s failed to compile: %s", name, fragmentSource);
         throw util::ShaderException(std::string { "Fragment shader " } + name + " failed to compile");
     }
 

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -8,10 +8,8 @@ namespace mbgl {
 
 class Shader : private util::noncopyable {
 public:
-    Shader(const GLchar *name, const GLchar *vertex, const GLchar *fragment, gl::ObjectStore&);
-
     ~Shader();
-    const GLchar *name;
+    const char* name;
 
     GLuint getID() const {
         return program.get();
@@ -20,6 +18,7 @@ public:
     virtual void bind(GLbyte *offset) = 0;
 
 protected:
+    Shader(const char* name_, const char* vertex, const char* fragment, gl::ObjectStore&);
     GLint a_pos = -1;
 
 private:


### PR DESCRIPTION
Also:
- Protect `Shader` ctor
- Remove redundant `typename Shader` from template functions in `VertexArrayObject`
- Code cleanups

:eyes: @kkaefer