### PR TITLE
[core] Factor out thread name setter/getter

### DIFF
--- a/src/mbgl/platform/log.cpp
+++ b/src/mbgl/platform/log.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/platform/log.hpp>
 #include <mbgl/util/enum.hpp>
+#include <mbgl/util/thread.hpp>
 
 #include <cstdio>
 #include <cstdarg>
@@ -49,18 +50,7 @@ void Log::record(EventSeverity severity, Event event, int64_t code, const std::s
 
     std::stringstream logStream;
 
-#if defined(__APPLE__)
-    char name[32];
-    pthread_getname_np(pthread_self(), name, sizeof(name));
-    logStream << "{" << name << "}";
-#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 12)
-    char name[32];
-    pthread_getname_np(pthread_self(), name, sizeof(name));
-    logStream << "{" << name << "}";
-#endif
-#endif
-
+    logStream << "{" << util::getCurrentThreadName() << "}";
     logStream << "[" << Enum<Event>::toString(event) << "]";
 
     if (code >= 0) {

--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -87,6 +87,29 @@ private:
     RunLoop* loop = nullptr;
 };
 
+inline std::string getCurrentThreadName() {
+    char name[32] = "unknown";
+#if defined(__APPLE__)
+    pthread_getname_np(pthread_self(), name, sizeof(name));
+#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 12)
+    pthread_getname_np(pthread_self(), name, sizeof(name));
+#endif
+#endif
+    return name;
+}
+
+inline void setCurrentThreadName(const std::string& name) {
+#if defined(__APPLE__)
+        pthread_setname_np(name.c_str());
+#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 12)
+        pthread_setname_np(pthread_self(), name.c_str());
+#endif
+#endif
+    (void)name;
+}
+
 template <class Object>
 template <class... Args>
 Thread<Object>::Thread(const ThreadContext& context, Args&&... args) {
@@ -95,13 +118,7 @@ Thread<Object>::Thread(const ThreadContext& context, Args&&... args) {
     std::tuple<Args...> params = std::forward_as_tuple(::std::forward<Args>(args)...);
 
     thread = std::thread([&] {
-#if defined(__APPLE__)
-        pthread_setname_np(context.name.c_str());
-#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 12)
-        pthread_setname_np(pthread_self(), context.name.c_str());
-#endif
-#endif
+        setCurrentThreadName(context.name);
 
         if (context.priority == ThreadPriority::Low) {
             platform::makeThreadLowPriority();


### PR DESCRIPTION
Follow-up to #5389. Unfortunately Apple headers defines a different `pthread_getname_np` from Glibc, so creating a common `#define` would eventually add more code lines than the contrary. I left them out of `Thread` because it is a template class.

:eyes: @jfirebaugh @kkaefer 