### PR TITLE
[core] Refactor wireframe to match JS overdraw

### DIFF
--- a/include/mbgl/gl/gl_values.hpp
+++ b/include/mbgl/gl/gl_values.hpp
@@ -214,6 +214,19 @@ constexpr bool operator!=(const BlendFunc::Type& a, const BlendFunc::Type& b) {
     return a.sfactor != b.sfactor || a.dfactor != b.dfactor;
 }
 
+struct BlendColor {
+    using Type = Color;
+    static const Type Default;
+    inline static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glBlendColor(value.r, value.g, value.b, value.a));
+    }
+    inline static Type Get() {
+        GLfloat floats[4];
+        MBGL_CHECK_ERROR(glGetFloatv(GL_BLEND_COLOR, floats));
+        return { floats[0], floats[1], floats[2], floats[3] };
+    }
+};
+
 struct Program {
     using Type = GLuint;
     static const Type Default;

--- a/include/mbgl/gl/gl_values.hpp
+++ b/include/mbgl/gl/gl_values.hpp
@@ -210,6 +210,10 @@ struct BlendFunc {
     }
 };
 
+constexpr bool operator!=(const BlendFunc::Type& a, const BlendFunc::Type& b) {
+    return a.sfactor != b.sfactor || a.dfactor != b.dfactor;
+}
+
 struct Program {
     using Type = GLuint;
     static const Type Default;

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -43,7 +43,7 @@ enum class MapDebugOptions : EnumType {
     ParseStatus = 1 << 2,
     Timestamps  = 1 << 3,
     Collision   = 1 << 4,
-    Wireframe   = 1 << 5,
+    Overdraw    = 1 << 5,
 // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/5117
 #ifndef GL_ES_VERSION_2_0
     StencilClip = 1 << 6,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#59e998295d548f208ee3ec10cdd21ff2630e2079",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#194fc55b6a7dd54c1e2cf2dd9048fbb5e836716d",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3a6baea2f364410e6d0873b71babfe0484870a72",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#85d2319dd5ad75da1f39b8cd9e08f1e51ede58cb",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",
     "tape": "^4.5.1"

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -33,7 +33,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 - Removed unused SVG files from the SDK’s resource bundle. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Deprecated `-[MGLMapView emptyMemoryCache]`. ([#4725](https://github.com/mapbox/mapbox-gl-native/pull/4725))
 - Added `MGLCoordinateInCoordinateBounds()`, a function that tests whether or not a coordinate is in a given bounds. ([#5053](https://github.com/mapbox/mapbox-gl-native/pull/5053))
-- Added a new option to `MGLMapDebugMaskOptions`, `MGLMapDebugWireframesMask`, that shows wireframes instead of the usual rendered output. ([#4359](https://github.com/mapbox/mapbox-gl-native/pull/4359))
+- Added a new option to `MGLMapDebugMaskOptions`, `MGLMapDebugOverdrawsMask`, that shows wireframes for overdraw inspection instead of the usual rendered output. ([#4359](https://github.com/mapbox/mapbox-gl-native/pull/4359))
 
 ## 3.2.3
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -181,9 +181,9 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         ((debugMask & MGLMapDebugCollisionBoxesMask)
          ? @"Hide Collision Boxes"
          : @"Show Collision Boxes"),
-        ((debugMask & MGLMapDebugWireframesMask)
-         ? @"Hide Wireframes"
-         : @"Show Wireframes"),
+        ((debugMask & MGLMapDebugOverdrawsMask)
+         ? @"Hide Overdraws"
+         : @"Show Overdraws"),
         @"Add 100 Points",
         @"Add 1,000 Points",
         @"Add 10,000 Points",
@@ -226,7 +226,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 5)
     {
-        self.mapView.debugMask ^= MGLMapDebugWireframesMask;
+        self.mapView.debugMask ^= MGLMapDebugOverdrawsMask;
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 6)
     {

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -43,9 +43,8 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
     /** Edges of glyphs and symbols are shown as faint, green lines to help
         diagnose collision and label placement issues. */
     MGLMapDebugCollisionBoxesMask = 1 << 4,
-    /** Line widths, backgrounds, and fill colors are ignored to create a
-        wireframe effect. */
-    MGLMapDebugWireframesMask = 1 << 5,
+    /** Overdraw inspector. */
+    MGLMapDebugOverdrawsMask = 1 << 5,
 };
 
 /**

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1829,9 +1829,9 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     {
         mask |= MGLMapDebugCollisionBoxesMask;
     }
-    if (options & mbgl::MapDebugOptions::Wireframe)
+    if (options & mbgl::MapDebugOptions::Overdraw)
     {
-        mask |= MGLMapDebugWireframesMask;
+        mask |= MGLMapDebugOverdrawsMask;
     }
     return mask;
 }
@@ -1855,9 +1855,9 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     {
         options |= mbgl::MapDebugOptions::Collision;
     }
-    if (debugMask & MGLMapDebugWireframesMask)
+    if (debugMask & MGLMapDebugOverdrawsMask)
     {
-        options |= mbgl::MapDebugOptions::Wireframe;
+        options |= mbgl::MapDebugOptions::Overdraw;
     }
     _mbglMap->setDebug(options);
 }

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog for Mapbox macOS SDK
 
 ## master
+* Refactor wireframe mode to match GL JS overdraw implementation. ([#5403](https://github.com/mapbox/mapbox-gl-native/pull/5403)).
 
 ## 0.2.0
 

--- a/platform/macos/app/Base.lproj/MainMenu.xib
+++ b/platform/macos/app/Base.lproj/MainMenu.xib
@@ -461,10 +461,10 @@
                                     <action selector="toggleCollisionBoxes:" target="-1" id="EYa-7n-iWZ"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Show Wireframes" id="hSX-Be-8xC">
+                            <menuItem title="Show Overdraws" id="hSX-Be-8xC">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="toggleWireframes:" target="-1" id="usj-ug-upt"/>
+                                    <action selector="toggleOverdraws:" target="-1" id="usj-ug-upt"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="2EG-Hp-4FA"/>

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -276,8 +276,8 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     self.mapView.debugMask ^= MGLMapDebugCollisionBoxesMask;
 }
 
-- (IBAction)toggleWireframes:(id)sender {
-    self.mapView.debugMask ^= MGLMapDebugWireframesMask;
+- (IBAction)toggleOverdraws:(id)sender {
+    self.mapView.debugMask ^= MGLMapDebugOverdrawsMask;
 }
 
 - (IBAction)showColorBuffer:(id)sender {
@@ -604,9 +604,9 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
         menuItem.title = isShown ? @"Hide Collision Boxes" : @"Show Collision Boxes";
         return YES;
     }
-    if (menuItem.action == @selector(toggleWireframes:)) {
-        BOOL isShown = self.mapView.debugMask & MGLMapDebugWireframesMask;
-        menuItem.title = isShown ? @"Hide Wireframes" : @"Show Wireframes";
+    if (menuItem.action == @selector(toggleOverdraws:)) {
+        BOOL isShown = self.mapView.debugMask & MGLMapDebugOverdrawsMask;
+        menuItem.title = isShown ? @"Hide Overdraws" : @"Show Overdraws";
         return YES;
     }
     if (menuItem.action == @selector(showColorBuffer:)) {

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -21,9 +21,8 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
         diagnose collision and label placement issues. */
     MGLMapDebugCollisionBoxesMask = 1 << 4,
     
-    /** Line widths, backgrounds, and fill colors are ignored to create a
-        wireframe effect. */
-    MGLMapDebugWireframesMask = 1 << 5,
+    /** Overdraw inspector. */
+    MGLMapDebugOverdrawsMask = 1 << 5,
     
     /** The stencil buffer is shown instead of the color buffer. */
     MGLMapDebugStencilBufferMask = 1 << 6,

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2398,8 +2398,8 @@ public:
     if (options & mbgl::MapDebugOptions::Collision) {
         mask |= MGLMapDebugCollisionBoxesMask;
     }
-    if (options & mbgl::MapDebugOptions::Wireframe) {
-        mask |= MGLMapDebugWireframesMask;
+    if (options & mbgl::MapDebugOptions::Overdraw) {
+        mask |= MGLMapDebugOverdrawsMask;
     }
     if (options & mbgl::MapDebugOptions::StencilClip) {
         mask |= MGLMapDebugStencilBufferMask;
@@ -2421,8 +2421,8 @@ public:
     if (debugMask & MGLMapDebugCollisionBoxesMask) {
         options |= mbgl::MapDebugOptions::Collision;
     }
-    if (debugMask & MGLMapDebugWireframesMask) {
-        options |= mbgl::MapDebugOptions::Wireframe;
+    if (debugMask & MGLMapDebugOverdrawsMask) {
+        options |= mbgl::MapDebugOptions::Overdraw;
     }
     if (debugMask & MGLMapDebugStencilBufferMask) {
         options |= mbgl::MapDebugOptions::StencilClip;

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -285,6 +285,11 @@ NodeMap::RenderOptions NodeMap::ParseOptions(v8::Local<v8::Object> obj) {
                 options.debugOptions = options.debugOptions | mbgl::MapDebugOptions::Collision;
             }
         }
+        if (Nan::Has(debug, Nan::New("overdraw").ToLocalChecked()).FromJust()) {
+            if (Nan::Get(debug, Nan::New("overdraw").ToLocalChecked()).ToLocalChecked()->BooleanValue()) {
+                options.debugOptions = mbgl::MapDebugOptions::Overdraw;
+            }
+        }
     }
 
     return options;

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -36,7 +36,8 @@ module.exports = function (style, options, callback) {
     options.pitch = style.pitch;
     options.debug = {
         tileBorders: options.debug,
-        collision: options.collisionDebug
+        collision: options.collisionDebug,
+        overdraw: options.showOverdrawInspector,
     };
 
     map.load(style);

--- a/scripts/build-shaders.py
+++ b/scripts/build-shaders.py
@@ -50,6 +50,11 @@ namespace mbgl {{
 namespace shaders {{
 namespace {name} {{
 
+#ifndef MBGL_SHADER_NAME_{NAME}
+#define MBGL_SHADER_NAME_{NAME}
+constexpr const char* name = "{name}";
+#endif // MBGL_SHADER_NAME_{NAME}
+
 #ifdef GL_ES_VERSION_2_0
 constexpr const char* {type} = R"MBGL_SHADER(precision highp float;\n{data})MBGL_SHADER";
 #else

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -31,7 +31,7 @@ void VertexArrayObject::bindVertexArrayObject(gl::ObjectStore& store) {
     MBGL_CHECK_ERROR(gl::BindVertexArray(*vao));
 }
 
-void VertexArrayObject::verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer,
+void VertexArrayObject::verifyBinding(Shader& shader, GLuint vertexBuffer, GLuint elementsBuffer,
                                       GLbyte *offset) {
     if (bound_shader != shader.getID()) {
         throw std::runtime_error(std::string("trying to rebind VAO to another shader from " +

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -10,8 +10,6 @@
 
 namespace mbgl {
 
-class Shader;
-
 class VertexArrayObject : public util::noncopyable {
 public:
     static void Unbind();
@@ -19,8 +17,8 @@ public:
     VertexArrayObject();
     ~VertexArrayObject();
 
-    template <typename Shader, typename VertexBuffer>
-    void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset, gl::ObjectStore& store) {
+    template <typename VertexBuffer>
+    void bind(Shader& shader, VertexBuffer& vertexBuffer, GLbyte* offset, gl::ObjectStore& store) {
         bindVertexArrayObject(store);
         if (bound_shader == 0) {
             vertexBuffer.bind(store);
@@ -33,8 +31,8 @@ public:
         }
     }
 
-    template <typename Shader, typename VertexBuffer, typename ElementsBuffer>
-    void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset, gl::ObjectStore& store) {
+    template <typename VertexBuffer, typename ElementsBuffer>
+    void bind(Shader& shader, VertexBuffer& vertexBuffer, ElementsBuffer& elementsBuffer, GLbyte* offset, gl::ObjectStore& store) {
         bindVertexArrayObject(store);
         if (bound_shader == 0) {
             vertexBuffer.bind(store);
@@ -62,7 +60,7 @@ private:
     // For debug reasons, we're storing the bind information so that we can
     // detect errors and report
     GLuint bound_shader = 0;
-    const char *bound_shader_name = "";
+    const char* bound_shader_name = "";
     GLuint bound_vertex_buffer = 0;
     GLuint bound_elements_buffer = 0;
     GLbyte *bound_offset = nullptr;

--- a/src/mbgl/gl/gl_config.cpp
+++ b/src/mbgl/gl/gl_config.cpp
@@ -13,6 +13,7 @@ const DepthTest::Type DepthTest::Default = GL_FALSE;
 const DepthFunc::Type DepthFunc::Default = GL_LEQUAL;
 const Blend::Type Blend::Default = GL_TRUE;
 const BlendFunc::Type BlendFunc::Default = { GL_ONE, GL_ONE_MINUS_SRC_ALPHA };
+const BlendColor::Type BlendColor::Default = { 0, 0, 0, 0 };
 const ColorMask::Type ColorMask::Default = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
 const ClearDepth::Type ClearDepth::Default = 1;
 const ClearColor::Type ClearColor::Default = { 0, 0, 0, 0 };

--- a/src/mbgl/gl/gl_config.hpp
+++ b/src/mbgl/gl/gl_config.hpp
@@ -56,6 +56,7 @@ public:
         depthFunc.reset();
         blend.reset();
         blendFunc.reset();
+        blendColor.reset();
         colorMask.reset();
         clearDepth.reset();
         clearColor.reset();
@@ -80,6 +81,7 @@ public:
         depthFunc.setDirty();
         blend.setDirty();
         blendFunc.setDirty();
+        blendColor.setDirty();
         colorMask.setDirty();
         clearDepth.setDirty();
         clearColor.setDirty();
@@ -103,6 +105,7 @@ public:
     Value<DepthFunc> depthFunc;
     Value<Blend> blend;
     Value<BlendFunc> blendFunc;
+    Value<BlendColor> blendColor;
     Value<ColorMask> colorMask;
     Value<ClearDepth> clearDepth;
     Value<ClearColor> clearColor;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -794,7 +794,7 @@ void Map::cycleDebugOptions() {
         impl->debugOptions = MapDebugOptions::NoDebug;
 #endif // GL_ES_VERSION_2_0
     else if (impl->debugOptions & MapDebugOptions::Collision)
-        impl->debugOptions = MapDebugOptions::Collision | MapDebugOptions::Wireframe;
+        impl->debugOptions = MapDebugOptions::Wireframe;
     else if (impl->debugOptions & MapDebugOptions::Timestamps)
         impl->debugOptions = impl->debugOptions | MapDebugOptions::Collision;
     else if (impl->debugOptions & MapDebugOptions::ParseStatus)

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -787,14 +787,14 @@ void Map::cycleDebugOptions() {
 #ifndef GL_ES_VERSION_2_0
     if (impl->debugOptions & MapDebugOptions::StencilClip)
         impl->debugOptions = MapDebugOptions::NoDebug;
-    else if (impl->debugOptions & MapDebugOptions::Wireframe)
+    else if (impl->debugOptions & MapDebugOptions::Overdraw)
         impl->debugOptions = MapDebugOptions::StencilClip;
 #else
-    if (impl->debugOptions & MapDebugOptions::Wireframe)
+    if (impl->debugOptions & MapDebugOptions::Overdraw)
         impl->debugOptions = MapDebugOptions::NoDebug;
 #endif // GL_ES_VERSION_2_0
     else if (impl->debugOptions & MapDebugOptions::Collision)
-        impl->debugOptions = MapDebugOptions::Wireframe;
+        impl->debugOptions = MapDebugOptions::Overdraw;
     else if (impl->debugOptions & MapDebugOptions::Timestamps)
         impl->debugOptions = impl->debugOptions | MapDebugOptions::Collision;
     else if (impl->debugOptions & MapDebugOptions::ParseStatus)

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -145,7 +145,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         config.depthMask = GL_TRUE;
         config.colorMask = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
 
-        if (isWireframe()) {
+        if (isOverdraw()) {
             config.blend = GL_TRUE;
             config.blendFunc = { GL_CONSTANT_COLOR, GL_ONE };
             const float overdraw = 1.0f / 8.0f;
@@ -248,7 +248,7 @@ void Painter::renderPass(RenderPass pass_,
         if (!layer.baseImpl->hasRenderPass(pass))
             continue;
 
-        if (isWireframe()) {
+        if (isOverdraw()) {
             config.blend = GL_TRUE;
         } else if (pass == RenderPass::Translucent) {
             config.blendFunc.reset();

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -156,7 +156,7 @@ private:
 
     void setDepthSublayer(int n);
 
-    bool isWireframe() const { return frame.debugOptions & MapDebugOptions::Wireframe; }
+    bool isOverdraw() const { return frame.debugOptions & MapDebugOptions::Overdraw; }
 
     mat4 projMatrix;
     mat4 nativeMatrix;

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -156,6 +156,8 @@ private:
 
     void setDepthSublayer(int n);
 
+    bool isWireframe() const { return frame.debugOptions & MapDebugOptions::Wireframe; }
+
     mat4 projMatrix;
     mat4 nativeMatrix;
 

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -21,9 +21,6 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
     optional<SpriteAtlasPosition> imagePosA;
     optional<SpriteAtlasPosition> imagePosB;
 
-    bool wireframe = frame.debugOptions & MapDebugOptions::Wireframe;
-    isPatterned &= !wireframe;
-
     if (isPatterned) {
         imagePosA = spriteAtlas->getPosition(properties.backgroundPattern.value.from, true);
         imagePosB = spriteAtlas->getPosition(properties.backgroundPattern.value.to, true);
@@ -31,7 +28,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         if (!imagePosA || !imagePosB)
             return;
 
-        config.program = patternShader->getID();
+        config.program = isWireframe() ? patternShader->getOverdrawID() : patternShader->getID();
         patternShader->u_matrix = identityMatrix;
         patternShader->u_pattern_tl_a = imagePosA->tl;
         patternShader->u_pattern_br_a = imagePosA->br;
@@ -44,15 +41,10 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         backgroundPatternArray.bind(*patternShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
 
     } else {
-        if (wireframe) {
-            plainShader->u_color = Color::black();
-            plainShader->u_opacity = 1.0f;
-        } else {
-            plainShader->u_color = properties.backgroundColor;
-            plainShader->u_opacity = properties.backgroundOpacity;
-        }
+        plainShader->u_color = properties.backgroundColor;
+        plainShader->u_opacity = properties.backgroundOpacity;
 
-        config.program = plainShader->getID();
+        config.program = isWireframe() ? plainShader->getOverdrawID() : plainShader->getID();
         backgroundArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
     }
 

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -28,7 +28,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         if (!imagePosA || !imagePosB)
             return;
 
-        config.program = isWireframe() ? patternShader->getOverdrawID() : patternShader->getID();
+        config.program = isOverdraw() ? patternShader->getOverdrawID() : patternShader->getID();
         patternShader->u_matrix = identityMatrix;
         patternShader->u_pattern_tl_a = imagePosA->tl;
         patternShader->u_pattern_br_a = imagePosA->br;
@@ -44,7 +44,7 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         plainShader->u_color = properties.backgroundColor;
         plainShader->u_opacity = properties.backgroundOpacity;
 
-        config.program = isWireframe() ? plainShader->getOverdrawID() : plainShader->getID();
+        config.program = isOverdraw() ? plainShader->getOverdrawID() : plainShader->getID();
         backgroundArray.bind(*plainShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
     }
 

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -27,7 +27,7 @@ void Painter::renderCircle(CircleBucket& bucket,
     mat4 vtxMatrix = translatedMatrix(matrix, properties.circleTranslate, tileID,
                                       properties.circleTranslateAnchor);
 
-    config.program = circleShader->getID();
+    config.program = isWireframe() ? circleShader->getOverdrawID() : circleShader->getID();
 
     circleShader->u_matrix = vtxMatrix;
     circleShader->u_extrude_scale = extrudeScale;

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -27,7 +27,7 @@ void Painter::renderCircle(CircleBucket& bucket,
     mat4 vtxMatrix = translatedMatrix(matrix, properties.circleTranslate, tileID,
                                       properties.circleTranslateAnchor);
 
-    config.program = isWireframe() ? circleShader->getOverdrawID() : circleShader->getID();
+    config.program = isOverdraw() ? circleShader->getOverdrawID() : circleShader->getID();
 
     circleShader->u_matrix = vtxMatrix;
     circleShader->u_extrude_scale = extrudeScale;

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -46,7 +46,7 @@ void Painter::renderFill(FillBucket& bucket,
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // befrom, we have to draw the outline first (!)
     if (outline && pass == RenderPass::Translucent) {
-        config.program = isWireframe() ? outlineShader->getOverdrawID() : outlineShader->getID();
+        config.program = isOverdraw() ? outlineShader->getOverdrawID() : outlineShader->getID();
         outlineShader->u_matrix = vertexMatrix;
 
         outlineShader->u_outline_color = strokeColor;
@@ -76,7 +76,7 @@ void Painter::renderFill(FillBucket& bucket,
 
         // Image fill.
         if (pass == RenderPass::Translucent && imagePosA && imagePosB) {
-            config.program = isWireframe() ? patternShader->getOverdrawID() : patternShader->getID();
+            config.program = isOverdraw() ? patternShader->getOverdrawID() : patternShader->getID();
             patternShader->u_matrix = vertexMatrix;
             patternShader->u_pattern_tl_a = imagePosA->tl;
             patternShader->u_pattern_br_a = imagePosA->br;
@@ -105,7 +105,7 @@ void Painter::renderFill(FillBucket& bucket,
             bucket.drawElements(*patternShader, store);
 
             if (properties.fillAntialias && !isOutlineColorDefined) {
-                config.program = isWireframe() ? outlinePatternShader->getOverdrawID() : outlinePatternShader->getID();
+                config.program = isOverdraw() ? outlinePatternShader->getOverdrawID() : outlinePatternShader->getID();
                 outlinePatternShader->u_matrix = vertexMatrix;
 
                 // Draw the entire line
@@ -140,7 +140,7 @@ void Painter::renderFill(FillBucket& bucket,
             // fragments or when it's translucent and we're drawing translucent
             // fragments
             // Draw filling rectangle.
-            config.program = isWireframe() ? plainShader->getOverdrawID() : plainShader->getID();
+            config.program = isOverdraw() ? plainShader->getOverdrawID() : plainShader->getID();
             plainShader->u_matrix = vertexMatrix;
             plainShader->u_color = fillColor;
             plainShader->u_opacity = opacity;
@@ -154,7 +154,7 @@ void Painter::renderFill(FillBucket& bucket,
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // below, we have to draw the outline first (!)
     if (fringeline && pass == RenderPass::Translucent) {
-        config.program = isWireframe() ? outlineShader->getOverdrawID() : outlineShader->getID();
+        config.program = isOverdraw() ? outlineShader->getOverdrawID() : outlineShader->getID();
         outlineShader->u_matrix = vertexMatrix;
 
         outlineShader->u_outline_color = fillColor;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -57,7 +57,7 @@ void Painter::renderLine(LineBucket& bucket,
 
     if (!properties.lineDasharray.value.from.empty()) {
 
-        config.program = isWireframe() ? linesdfShader->getOverdrawID() : linesdfShader->getID();
+        config.program = isOverdraw() ? linesdfShader->getOverdrawID() : linesdfShader->getID();
 
         linesdfShader->u_matrix = vtxMatrix;
         linesdfShader->u_linewidth = properties.lineWidth / 2;
@@ -102,7 +102,7 @@ void Painter::renderLine(LineBucket& bucket,
         if (!imagePosA || !imagePosB)
             return;
 
-        config.program = isWireframe() ? linepatternShader->getOverdrawID() : linepatternShader->getID();
+        config.program = isOverdraw() ? linepatternShader->getOverdrawID() : linepatternShader->getID();
 
         linepatternShader->u_matrix = vtxMatrix;
         linepatternShader->u_linewidth = properties.lineWidth / 2;
@@ -138,7 +138,7 @@ void Painter::renderLine(LineBucket& bucket,
         bucket.drawLinePatterns(*linepatternShader, store);
 
     } else {
-        config.program = isWireframe() ? lineShader->getOverdrawID() : lineShader->getID();
+        config.program = isOverdraw() ? lineShader->getOverdrawID() : lineShader->getID();
 
         lineShader->u_matrix = vtxMatrix;
         lineShader->u_linewidth = properties.lineWidth / 2;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -33,17 +33,10 @@ void Painter::renderLine(LineBucket& bucket,
     // Retina devices need a smaller distance to avoid aliasing.
     float antialiasing = 1.0 / frame.pixelRatio;
 
-    bool wireframe = frame.debugOptions & MapDebugOptions::Wireframe;
-
     float blur = properties.lineBlur + antialiasing;
 
-    Color color = Color::white();
-    float opacity = 1.0f;
-    if (!wireframe) {
-        color = properties.lineColor;
-        opacity = properties.lineOpacity;
-    }
-
+    const Color color = properties.lineColor;
+    const float opacity = properties.lineOpacity;
     const float ratio = 1.0 / tileID.pixelsToTileUnits(1.0, state.getZoom());
 
     mat2 antialiasingMatrix;
@@ -64,7 +57,7 @@ void Painter::renderLine(LineBucket& bucket,
 
     if (!properties.lineDasharray.value.from.empty()) {
 
-        config.program = linesdfShader->getID();
+        config.program = isWireframe() ? linesdfShader->getOverdrawID() : linesdfShader->getID();
 
         linesdfShader->u_matrix = vtxMatrix;
         linesdfShader->u_linewidth = properties.lineWidth / 2;
@@ -109,7 +102,7 @@ void Painter::renderLine(LineBucket& bucket,
         if (!imagePosA || !imagePosB)
             return;
 
-        config.program = linepatternShader->getID();
+        config.program = isWireframe() ? linepatternShader->getOverdrawID() : linepatternShader->getID();
 
         linepatternShader->u_matrix = vtxMatrix;
         linepatternShader->u_linewidth = properties.lineWidth / 2;
@@ -145,7 +138,7 @@ void Painter::renderLine(LineBucket& bucket,
         bucket.drawLinePatterns(*linepatternShader, store);
 
     } else {
-        config.program = lineShader->getID();
+        config.program = isWireframe() ? lineShader->getOverdrawID() : lineShader->getID();
 
         lineShader->u_matrix = vtxMatrix;
         lineShader->u_linewidth = properties.lineWidth / 2;

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -18,7 +18,7 @@ void Painter::renderRaster(RasterBucket& bucket,
     const RasterPaintProperties& properties = layer.impl->paint;
 
     if (bucket.hasData()) {
-        config.program = rasterShader->getID();
+        config.program = isWireframe() ? rasterShader->getOverdrawID() : rasterShader->getID();
         rasterShader->u_matrix = matrix;
         rasterShader->u_buffer = 0;
         rasterShader->u_opacity = properties.rasterOpacity;

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -18,7 +18,7 @@ void Painter::renderRaster(RasterBucket& bucket,
     const RasterPaintProperties& properties = layer.impl->paint;
 
     if (bucket.hasData()) {
-        config.program = isWireframe() ? rasterShader->getOverdrawID() : rasterShader->getID();
+        config.program = isOverdraw() ? rasterShader->getOverdrawID() : rasterShader->getID();
         rasterShader->u_matrix = matrix;
         rasterShader->u_buffer = 0;
         rasterShader->u_opacity = properties.rasterOpacity;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -58,7 +58,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
         exScale = {{ exScale[0] * scale, exScale[1] * scale }};
     }
 
-    config.program = isWireframe() ? sdfShader.getOverdrawID() : sdfShader.getID();
+    config.program = isOverdraw() ? sdfShader.getOverdrawID() : sdfShader.getID();
     sdfShader.u_matrix = vtxMatrix;
     sdfShader.u_extrude_scale = exScale;
     sdfShader.u_texsize = texsize;
@@ -199,7 +199,7 @@ void Painter::renderSymbol(SymbolBucket& bucket,
                 exScale = {{ exScale[0] * scale, exScale[1] * scale }};
             }
 
-            config.program = isWireframe() ? iconShader->getOverdrawID() : iconShader->getID();
+            config.program = isOverdraw() ? iconShader->getOverdrawID() : iconShader->getID();
             iconShader->u_matrix = vtxMatrix;
             iconShader->u_extrude_scale = exScale;
             iconShader->u_texsize = {{ float(activeSpriteAtlas->getWidth()) / 4.0f, float(activeSpriteAtlas->getHeight()) / 4.0f }};

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -58,7 +58,7 @@ void Painter::renderSDF(SymbolBucket &bucket,
         exScale = {{ exScale[0] * scale, exScale[1] * scale }};
     }
 
-    config.program = sdfShader.getID();
+    config.program = isWireframe() ? sdfShader.getOverdrawID() : sdfShader.getID();
     sdfShader.u_matrix = vtxMatrix;
     sdfShader.u_extrude_scale = exScale;
     sdfShader.u_texsize = texsize;
@@ -199,7 +199,7 @@ void Painter::renderSymbol(SymbolBucket& bucket,
                 exScale = {{ exScale[0] * scale, exScale[1] * scale }};
             }
 
-            config.program = iconShader->getID();
+            config.program = isWireframe() ? iconShader->getOverdrawID() : iconShader->getID();
             iconShader->u_matrix = vtxMatrix;
             iconShader->u_extrude_scale = exScale;
             iconShader->u_texsize = {{ float(activeSpriteAtlas->getWidth()) / 4.0f, float(activeSpriteAtlas->getHeight()) / 4.0f }};

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/circle.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::circle;
 
 CircleShader::CircleShader(gl::ObjectStore& store)
-    : Shader("circle", shaders::circle::vertex, shaders::circle::fragment, store) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void CircleShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/collision_box_shader.cpp
+++ b/src/mbgl/shader/collision_box_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/collisionbox.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::collisionbox;
 
 CollisionBoxShader::CollisionBoxShader(gl::ObjectStore& store)
-    : Shader("collisionbox", shaders::collisionbox::vertex, shaders::collisionbox::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_extrude(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_extrude")))
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/icon.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::icon;
 
 IconShader::IconShader(gl::ObjectStore& store)
-    : Shader("icon", shaders::icon::vertex, shaders::icon::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_offset(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset")))
     , a_data1(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1")))
     , a_data2(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"))) {

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/line.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::line;
 
 LineShader::LineShader(gl::ObjectStore& store)
-    : Shader("line", shaders::line::vertex, shaders::line::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/linepattern.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::linepattern;
 
 LinepatternShader::LinepatternShader(gl::ObjectStore& store)
-    : Shader("linepattern", shaders::linepattern::vertex, shaders::linepattern::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/linesdfpattern.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::linesdfpattern;
 
 LineSDFShader::LineSDFShader(gl::ObjectStore& store)
-    : Shader("linesdfpattern", shaders::linesdfpattern::vertex, shaders::linesdfpattern::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_data(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data"))) {
 }
 

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/outline.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::outline;
 
 OutlineShader::OutlineShader(gl::ObjectStore& store)
-    : Shader("outline", shaders::outline::vertex, shaders::outline::fragment, store) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void OutlineShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/outlinepattern_shader.cpp
+++ b/src/mbgl/shader/outlinepattern_shader.cpp
@@ -3,16 +3,11 @@
 #include <mbgl/shader/outlinepattern.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::outlinepattern;
 
 OutlinePatternShader::OutlinePatternShader(gl::ObjectStore& store)
-    : Shader(
-        "outlinepattern",
-        shaders::outlinepattern::vertex, shaders::outlinepattern::fragment,
-        store
-    ) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void OutlinePatternShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/pattern_shader.cpp
+++ b/src/mbgl/shader/pattern_shader.cpp
@@ -3,16 +3,11 @@
 #include <mbgl/shader/pattern.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::pattern;
 
 PatternShader::PatternShader(gl::ObjectStore& store)
-    : Shader(
-        "pattern",
-        shaders::pattern::vertex, shaders::pattern::fragment,
-        store
-    ) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void PatternShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/fill.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::fill;
 
 PlainShader::PlainShader(gl::ObjectStore& store)
-    : Shader("fill", shaders::fill::vertex, shaders::fill::fragment, store) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void PlainShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/raster.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::raster;
 
 RasterShader::RasterShader(gl::ObjectStore& store)
-    : Shader("raster", shaders::raster::vertex, shaders::raster::fragment, store) {
+    : Shader(::name, ::vertex, ::fragment, store) {
 }
 
 void RasterShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -3,12 +3,11 @@
 #include <mbgl/shader/sdf.fragment.hpp>
 #include <mbgl/gl/gl.hpp>
 
-#include <cstdio>
-
 using namespace mbgl;
+using namespace shaders::sdf;
 
 SDFShader::SDFShader(gl::ObjectStore& store)
-    : Shader("sdf", shaders::sdf::vertex, shaders::sdf::fragment, store)
+    : Shader(::name, ::vertex, ::fragment, store)
     , a_offset(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_offset")))
     , a_data1(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data1")))
     , a_data2(MBGL_CHECK_ERROR(glGetAttribLocation(getID(), "a_data2"))) {

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <cassert>
 #include <iostream>
+#include <string>
 #include <fstream>
 #include <cstdio>
 
@@ -21,12 +22,12 @@ Shader::Shader(const char* name_, const char* vertexSource, const char* fragment
 {
     util::stopwatch stopwatch("shader compilation", Event::Shader);
 
-    if (!compileShader(vertexShader, &vertexSource)) {
+    if (!compileShader(vertexShader, vertexSource)) {
         Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertexSource);
         throw util::ShaderException(std::string { "Vertex shader " } + name + " failed to compile");
     }
 
-    if (!compileShader(fragmentShader, &fragmentSource)) {
+    if (!compileShader(fragmentShader, fragmentSource)) {
         Log::Error(Event::Shader, "Fragment shader %s failed to compile: %s", name, fragmentSource);
         throw util::ShaderException(std::string { "Fragment shader " } + name + " failed to compile");
     }
@@ -35,32 +36,50 @@ Shader::Shader(const char* name_, const char* vertexSource, const char* fragment
     MBGL_CHECK_ERROR(glAttachShader(program.get(), vertexShader.get()));
     MBGL_CHECK_ERROR(glAttachShader(program.get(), fragmentShader.get()));
 
-    {
-        // Link program
-        GLint status;
-        MBGL_CHECK_ERROR(glLinkProgram(program.get()));
+    linkProgram(program);
 
-        MBGL_CHECK_ERROR(glGetProgramiv(program.get(), GL_LINK_STATUS, &status));
-        if (status == 0) {
-            GLint logLength;
-            MBGL_CHECK_ERROR(glGetProgramiv(program.get(), GL_INFO_LOG_LENGTH, &logLength));
-            const auto log = std::make_unique<GLchar[]>(logLength);
-            if (logLength > 0) {
-                MBGL_CHECK_ERROR(glGetProgramInfoLog(program.get(), logLength, &logLength, log.get()));
-                Log::Error(Event::Shader, "Program failed to link: %s", log.get());
-            }
-            throw util::ShaderException(std::string { "Program " } + name + " failed to link: " + log.get());
+    std::string overdrawSource(fragmentSource);
+    if (overdrawSource.find("#ifdef OVERDRAW_INSPECTOR") != std::string::npos) {
+        programOverdraw = store.createProgram();
+        overdrawShader = store.createShader(GL_FRAGMENT_SHADER);
+
+        overdrawSource.replace(overdrawSource.find_first_of('\n'), 1, "\n#define OVERDRAW_INSPECTOR\n");
+        if (!compileShader(*overdrawShader, overdrawSource.c_str())) {
+            Log::Error(Event::Shader, "Overdraw shader %s failed to compile: %s", name, overdrawSource.c_str());
+            throw util::ShaderException(std::string { "Overdraw shader " } + name + " failed to compile");
         }
+
+        MBGL_CHECK_ERROR(glAttachShader(*programOverdraw, vertexShader.get()));
+        MBGL_CHECK_ERROR(glAttachShader(*programOverdraw, *overdrawShader));
+        linkProgram(*programOverdraw);
     }
 
     a_pos = MBGL_CHECK_ERROR(glGetAttribLocation(program.get(), "a_pos"));
 }
 
-bool Shader::compileShader(gl::UniqueShader& shader, const GLchar *source[]) {
+void Shader::linkProgram(gl::UniqueProgram& program_) {
+    // Link program
+    GLint status;
+     MBGL_CHECK_ERROR(glLinkProgram(program_.get()));
+
+    MBGL_CHECK_ERROR(glGetProgramiv(program_.get(), GL_LINK_STATUS, &status));
+    if (status == 0) {
+        GLint logLength;
+        MBGL_CHECK_ERROR(glGetProgramiv(program_.get(), GL_INFO_LOG_LENGTH, &logLength));
+        const auto log = std::make_unique<GLchar[]>(logLength);
+        if (logLength > 0) {
+            MBGL_CHECK_ERROR(glGetProgramInfoLog(program_.get(), logLength, &logLength, log.get()));
+            Log::Error(Event::Shader, "Program failed to link: %s", log.get());
+        }
+        throw util::ShaderException(std::string { "Program " } + name + " failed to link: " + log.get());
+    }
+}
+
+bool Shader::compileShader(gl::UniqueShader& shader, const GLchar *source) {
     GLint status = 0;
 
-    const GLsizei lengths = static_cast<GLsizei>(std::strlen(*source));
-    MBGL_CHECK_ERROR(glShaderSource(shader.get(), 1, source, &lengths));
+    const GLsizei lengths = static_cast<GLsizei>(std::strlen(source));
+    MBGL_CHECK_ERROR(glShaderSource(shader.get(), 1, &source, &lengths));
 
     MBGL_CHECK_ERROR(glCompileShader(shader.get()));
 
@@ -89,6 +108,10 @@ Shader::~Shader() {
     if (program.get()) {
         MBGL_CHECK_ERROR(glDetachShader(program.get(), vertexShader.get()));
         MBGL_CHECK_ERROR(glDetachShader(program.get(), fragmentShader.get()));
+    }
+    if (programOverdraw) {
+        MBGL_CHECK_ERROR(glDetachShader(*programOverdraw, vertexShader.get()));
+        MBGL_CHECK_ERROR(glDetachShader(*programOverdraw, *overdrawShader));
     }
 }
 

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -13,7 +13,7 @@
 
 namespace mbgl {
 
-Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSource, gl::ObjectStore& store)
+Shader::Shader(const char* name_, const char* vertexSource, const char* fragmentSource, gl::ObjectStore& store)
     : name(name_)
     , program(store.createProgram())
     , vertexShader(store.createShader(GL_VERTEX_SHADER))
@@ -21,13 +21,13 @@ Shader::Shader(const char *name_, const GLchar *vertSource, const GLchar *fragSo
 {
     util::stopwatch stopwatch("shader compilation", Event::Shader);
 
-    if (!compileShader(vertexShader, &vertSource)) {
-        Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertSource);
+    if (!compileShader(vertexShader, &vertexSource)) {
+        Log::Error(Event::Shader, "Vertex shader %s failed to compile: %s", name, vertexSource);
         throw util::ShaderException(std::string { "Vertex shader " } + name + " failed to compile");
     }
 
-    if (!compileShader(fragmentShader, &fragSource)) {
-        Log::Error(Event::Shader, "Fragment shader %s failed to compile: %s", name, fragSource);
+    if (!compileShader(fragmentShader, &fragmentSource)) {
+        Log::Error(Event::Shader, "Fragment shader %s failed to compile: %s", name, fragmentSource);
         throw util::ShaderException(std::string { "Fragment shader " } + name + " failed to compile");
     }
 

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -8,10 +8,8 @@ namespace mbgl {
 
 class Shader : private util::noncopyable {
 public:
-    Shader(const GLchar *name, const GLchar *vertex, const GLchar *fragment, gl::ObjectStore&);
-
     ~Shader();
-    const GLchar *name;
+    const char* name;
 
     GLuint getID() const {
         return program.get();
@@ -20,6 +18,7 @@ public:
     virtual void bind(GLbyte *offset) = 0;
 
 protected:
+    Shader(const char* name_, const char* vertex, const char* fragment, gl::ObjectStore&);
     GLint a_pos = -1;
 
 private:

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/object_store.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/optional.hpp>
 
 namespace mbgl {
 
@@ -15,6 +16,10 @@ public:
         return program.get();
     }
 
+    GLuint getOverdrawID() const {
+        return programOverdraw ? *programOverdraw : 0;
+    }
+
     virtual void bind(GLbyte *offset) = 0;
 
 protected:
@@ -22,11 +27,15 @@ protected:
     GLint a_pos = -1;
 
 private:
-    bool compileShader(gl::UniqueShader&, const GLchar *source[]);
+    bool compileShader(gl::UniqueShader&, const GLchar *source);
+    void linkProgram(gl::UniqueProgram&);
 
     gl::UniqueProgram program;
     gl::UniqueShader vertexShader;
     gl::UniqueShader fragmentShader;
+
+    mbgl::optional<gl::UniqueProgram> programOverdraw;
+    mbgl::optional<gl::UniqueShader> overdrawShader;
 };
 
 } // namespace mbgl

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -272,8 +272,8 @@ RenderData Style::getRenderData(MapDebugOptions debugOptions) const {
             continue;
 
         if (const BackgroundLayer* background = layer->as<BackgroundLayer>()) {
-            if (debugOptions & MapDebugOptions::Wireframe) {
-                // We want to skip glClear optimization in wireframe mode.
+            if (debugOptions & MapDebugOptions::Overdraw) {
+                // We want to skip glClear optimization in overdraw mode.
                 result.order.emplace_back(*layer);
                 continue;
             }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -258,7 +258,7 @@ bool Style::isLoaded() const {
     return true;
 }
 
-RenderData Style::getRenderData() const {
+RenderData Style::getRenderData(MapDebugOptions debugOptions) const {
     RenderData result;
 
     for (const auto& source : sources) {
@@ -272,6 +272,11 @@ RenderData Style::getRenderData() const {
             continue;
 
         if (const BackgroundLayer* background = layer->as<BackgroundLayer>()) {
+            if (debugOptions & MapDebugOptions::Wireframe) {
+                // We want to skip glClear optimization in wireframe mode.
+                result.order.emplace_back(*layer);
+                continue;
+            }
             const BackgroundPaintProperties& paint = background->impl->paint;
             if (layer.get() == layers[0].get() && paint.backgroundPattern.value.from.empty()) {
                 // This is a solid background. We can use glClear().

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -74,7 +74,7 @@ public:
     void setClasses(const std::vector<std::string>&, const TransitionOptions& = {});
     std::vector<std::string> getClasses() const;
 
-    RenderData getRenderData() const;
+    RenderData getRenderData(MapDebugOptions) const;
 
     std::vector<Feature> queryRenderedFeatures(const QueryParameters&) const;
 


### PR DESCRIPTION
This PR:
- Adds a new `BlendColor` GL configuration value
- Generates an additional overdraw fragment shader & program for each shader type
- Refactors the wireframe mode to behave like JS _overdraw_ mode, where each render pass over the same place increases the color by 1/8 from black to white.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/5371.

Snapshot:
![screen shot 2016-06-18 at 7 33 39 pm](https://cloud.githubusercontent.com/assets/76133/16172180/94a57368-358b-11e6-9c80-c28bec6f9d00.png)

Notes:
- Although similar, it seems that `Wireframe` and `Overdraw` serves different purposes - we could add a new debug mode instead of replacing `wireframe` implementation.
- Do we really need to overdraw SDFs?

:eyes: @mapbox/gl 