### PR TITLE
[core] Remove redundant inline syntax

### DIFF
--- a/include/mbgl/gl/gl.hpp
+++ b/include/mbgl/gl/gl.hpp
@@ -60,14 +60,14 @@ namespace gl {
 #endif
     
 struct Error : ::std::runtime_error {
-    inline Error(GLenum err, const std::string &msg) : ::std::runtime_error(msg), code(err) {};
+    Error(GLenum err, const std::string &msg) : ::std::runtime_error(msg), code(err) {};
     const GLenum code;
 };
 
 void checkError(const char *cmd, const char *file, int line);
 
 #if defined(DEBUG)
-#define MBGL_CHECK_ERROR(cmd) ([&]() { struct __MBGL_C_E { inline ~__MBGL_C_E() { ::mbgl::gl::checkError(#cmd, __FILE__, __LINE__); } } __MBGL_C_E; return cmd; }())
+#define MBGL_CHECK_ERROR(cmd) ([&]() { struct __MBGL_C_E { ~__MBGL_C_E() { ::mbgl::gl::checkError(#cmd, __FILE__, __LINE__); } } __MBGL_C_E; return cmd; }())
 #else
 #define MBGL_CHECK_ERROR(cmd) (cmd)
 #endif

--- a/include/mbgl/gl/gl_helper.hpp
+++ b/include/mbgl/gl/gl_helper.hpp
@@ -6,9 +6,9 @@ namespace gl {
 template <typename T>
 class Preserve {
 public:
-    inline Preserve() : data(T::Get()) {
+    Preserve() : data(T::Get()) {
     }
-    inline ~Preserve() {
+    ~Preserve() {
         T::Set(data);
     }
 

--- a/include/mbgl/gl/gl_values.hpp
+++ b/include/mbgl/gl/gl_values.hpp
@@ -13,10 +13,10 @@ namespace gl {
 struct ClearDepth {
     using Type = GLfloat;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glClearDepth(value));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type clearDepth;
         MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_CLEAR_VALUE, &clearDepth));
         return clearDepth;
@@ -26,10 +26,10 @@ struct ClearDepth {
 struct ClearColor {
     using Type = Color;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glClearColor(value.r, value.g, value.b, value.a));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLfloat floats[4];
         MBGL_CHECK_ERROR(glGetFloatv(GL_COLOR_CLEAR_VALUE, floats));
         return { floats[0], floats[1], floats[2], floats[3] };
@@ -39,10 +39,10 @@ struct ClearColor {
 struct ClearStencil {
     using Type = GLint;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glClearStencil(value));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type clearStencil;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_CLEAR_VALUE, &clearStencil));
         return clearStencil;
@@ -52,10 +52,10 @@ struct ClearStencil {
 struct StencilMask {
     using Type = GLuint;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glStencilMask(value));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLint stencilMask;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_WRITEMASK, &stencilMask));
         return stencilMask;
@@ -65,10 +65,10 @@ struct StencilMask {
 struct DepthMask {
     using Type = GLboolean;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glDepthMask(value));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type depthMask;
         MBGL_CHECK_ERROR(glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask));
         return depthMask;
@@ -78,10 +78,10 @@ struct DepthMask {
 struct ColorMask {
     struct Type { bool r, g, b, a; };
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glColorMask(value.r, value.g, value.b, value.a));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLboolean bools[4];
         MBGL_CHECK_ERROR(glGetBooleanv(GL_COLOR_WRITEMASK, bools));
         return { static_cast<bool>(bools[0]), static_cast<bool>(bools[1]),
@@ -89,17 +89,17 @@ struct ColorMask {
     }
 };
 
-inline bool operator!=(const ColorMask::Type& a, const ColorMask::Type& b) {
+constexpr bool operator!=(const ColorMask::Type& a, const ColorMask::Type& b) {
     return a.r != b.r || a.g != b.g || a.b != b.b || a.a != b.a;
 }
 
 struct StencilFunc {
     struct Type { GLenum func; GLint ref; GLuint mask; };
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glStencilFunc(value.func, value.ref, value.mask));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLint func, ref, mask;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FUNC, &func));
         MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_REF, &ref));
@@ -108,17 +108,17 @@ struct StencilFunc {
     }
 };
 
-inline bool operator!=(const StencilFunc::Type& a, const StencilFunc::Type& b) {
+constexpr bool operator!=(const StencilFunc::Type& a, const StencilFunc::Type& b) {
     return a.func != b.func || a.ref != b.ref || a.mask != b.mask;
 }
 
 struct StencilTest {
     using Type = bool;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(value ? glEnable(GL_STENCIL_TEST) : glDisable(GL_STENCIL_TEST));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type stencilTest;
         MBGL_CHECK_ERROR(stencilTest = glIsEnabled(GL_STENCIL_TEST));
         return stencilTest;
@@ -128,10 +128,10 @@ struct StencilTest {
 struct StencilOp {
     struct Type { GLenum sfail, dpfail, dppass; };
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glStencilOp(value.sfail, value.dpfail, value.dppass));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLint sfail, dpfail, dppass;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FAIL, &sfail));
         MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_FAIL, &dpfail));
@@ -143,27 +143,27 @@ struct StencilOp {
 struct DepthRange {
     struct Type { GLfloat near, far; };
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glDepthRange(value.near, value.far));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLfloat floats[2];
         MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_RANGE, floats));
         return { floats[0], floats[1] };
     }
 };
 
-inline bool operator!=(const DepthRange::Type& a, const DepthRange::Type& b) {
+constexpr bool operator!=(const DepthRange::Type& a, const DepthRange::Type& b) {
     return a.near != b.near || a.far != b.far;
 }
 
 struct DepthTest {
     using Type = bool;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(value ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type depthTest;
         MBGL_CHECK_ERROR(depthTest = glIsEnabled(GL_DEPTH_TEST));
         return depthTest;
@@ -173,10 +173,10 @@ struct DepthTest {
 struct DepthFunc {
     using Type = GLenum;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glDepthFunc(value));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLint depthFunc;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_DEPTH_FUNC, &depthFunc));
         return depthFunc;
@@ -186,10 +186,10 @@ struct DepthFunc {
 struct Blend {
     using Type = bool;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(value ? glEnable(GL_BLEND) : glDisable(GL_BLEND));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type blend;
         MBGL_CHECK_ERROR(blend = glIsEnabled(GL_BLEND));
         return blend;
@@ -199,10 +199,10 @@ struct Blend {
 struct BlendFunc {
     struct Type { GLenum sfactor, dfactor; };
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glBlendFunc(value.sfactor, value.dfactor));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLint sfactor, dfactor;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_SRC_ALPHA, &sfactor));
         MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_DST_ALPHA, &dfactor));
@@ -213,10 +213,10 @@ struct BlendFunc {
 struct Program {
     using Type = GLuint;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glUseProgram(value));
     }
-    inline static Type Get() {
+    static Type Get() {
         GLint program;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_CURRENT_PROGRAM, &program));
         return program;
@@ -226,10 +226,10 @@ struct Program {
 struct LineWidth {
     using Type = GLfloat;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glLineWidth(value));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type lineWidth;
         MBGL_CHECK_ERROR(glGetFloatv(GL_LINE_WIDTH, &lineWidth));
         return lineWidth;
@@ -239,10 +239,10 @@ struct LineWidth {
 struct ActiveTexture {
     using Type = GLint;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glActiveTexture(value));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type activeTexture;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture));
         return activeTexture;
@@ -254,10 +254,10 @@ struct ActiveTexture {
 struct PixelZoom {
     struct Type { GLfloat xfactor; GLfloat yfactor; };
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glPixelZoom(value.xfactor, value.yfactor));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type value;
         MBGL_CHECK_ERROR(glGetFloatv(GL_ZOOM_X, &value.xfactor));
         MBGL_CHECK_ERROR(glGetFloatv(GL_ZOOM_Y, &value.yfactor));
@@ -265,17 +265,17 @@ struct PixelZoom {
     }
 };
 
-inline bool operator!=(const PixelZoom::Type& a, const PixelZoom::Type& b) {
+constexpr bool operator!=(const PixelZoom::Type& a, const PixelZoom::Type& b) {
     return a.xfactor != b.xfactor || a.yfactor != b.yfactor;
 }
 
 struct RasterPos {
     using Type = std::array<GLdouble, 4>;
     static const Type Default;
-    inline static void Set(const Type& value) {
+    static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glRasterPos4d(value[0], value[1], value[2], value[3]));
     }
-    inline static Type Get() {
+    static Type Get() {
         Type pos;
         MBGL_CHECK_ERROR(glGetDoublev(GL_CURRENT_RASTER_POSITION, pos.data()));
         return pos;

--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -67,10 +67,10 @@ struct AnimationOptions {
     std::function<void()> transitionFinishFn;
     
     /** Creates an animation with no options specified. */
-    inline AnimationOptions() {}
+    AnimationOptions() {}
     
     /** Creates an animation with the specified duration. */
-    inline AnimationOptions(Duration d)
+    AnimationOptions(Duration d)
         : duration(d) {}
 };
 

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mbgl/util/traits.hpp>
+
 #include <cstdint>
 
 namespace mbgl {
@@ -48,17 +50,16 @@ enum class MapDebugOptions : EnumType {
 #endif // GL_ES_VERSION_2_0
 };
 
-inline MapDebugOptions operator| (const MapDebugOptions& lhs, const MapDebugOptions& rhs) {
-    return MapDebugOptions(static_cast<EnumType>(lhs) | static_cast<EnumType>(rhs));
+constexpr MapDebugOptions operator|(MapDebugOptions lhs, MapDebugOptions rhs) {
+    return MapDebugOptions(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs));
 }
 
-inline MapDebugOptions& operator|=(MapDebugOptions& lhs, const MapDebugOptions& rhs) {
-    lhs = lhs | rhs;
-    return lhs;
+constexpr MapDebugOptions& operator|=(MapDebugOptions& lhs, MapDebugOptions rhs) {
+    return (lhs = lhs | rhs);
 }
 
-inline bool operator& (const MapDebugOptions& lhs, const MapDebugOptions& rhs) {
-    return static_cast<EnumType>(lhs) & static_cast<EnumType>(rhs);
+constexpr bool operator&(MapDebugOptions lhs, MapDebugOptions rhs) {
+    return mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs);
 }
 
 } // namespace mbgl

--- a/include/mbgl/map/update.hpp
+++ b/include/mbgl/map/update.hpp
@@ -17,16 +17,15 @@ enum class Update : uint8_t {
     AnnotationData            = 1 << 7,
 };
 
-inline Update operator| (const Update& lhs, const Update& rhs) {
+constexpr Update operator|(Update lhs, Update rhs) {
     return Update(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs));
 }
 
-inline Update& operator|=(Update& lhs, const Update& rhs) {
-    lhs = lhs | rhs;
-    return lhs;
+constexpr Update& operator|=(Update& lhs, const Update& rhs) {
+    return (lhs = lhs | rhs);
 }
 
-inline bool operator& (const Update& lhs, const Update& rhs) {
+constexpr bool operator& (Update lhs, Update rhs) {
     return mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs);
 }
 

--- a/include/mbgl/platform/log.hpp
+++ b/include/mbgl/platform/log.hpp
@@ -37,27 +37,27 @@ private:
 
 public:
     template <typename ...Args>
-    static inline void Debug(Event event, Args&& ...args) {
+    static void Debug(Event event, Args&& ...args) {
         Record(EventSeverity::Debug, event, ::std::forward<Args>(args)...);
     }
 
     template <typename ...Args>
-    static inline void Info(Event event, Args&& ...args) {
+    static void Info(Event event, Args&& ...args) {
         Record(EventSeverity::Info, event, ::std::forward<Args>(args)...);
     }
 
     template <typename ...Args>
-    static inline void Warning(Event event, Args&& ...args) {
+    static void Warning(Event event, Args&& ...args) {
         Record(EventSeverity::Warning, event, ::std::forward<Args>(args)...);
     }
 
     template <typename ...Args>
-    static inline void Error(Event event, Args&& ...args) {
+    static void Error(Event event, Args&& ...args) {
         Record(EventSeverity::Error, event, ::std::forward<Args>(args)...);
     }
 
     template <typename ...Args>
-    static inline void Record(EventSeverity severity, Event event, Args&& ...args) {
+    static void Record(EventSeverity severity, Event event, Args&& ...args) {
         if (!includes(severity, disabledEventSeverities) &&
             !includes(event, disabledEvents) &&
             !includes({ severity, event }, disabledEventPermutations)) {

--- a/include/mbgl/style/filter_evaluator.hpp
+++ b/include/mbgl/style/filter_evaluator.hpp
@@ -173,7 +173,7 @@ private:
 };
 
 template <class PropertyAccessor>
-inline bool Filter::operator()(FeatureType type, PropertyAccessor accessor) const {
+bool Filter::operator()(FeatureType type, PropertyAccessor accessor) const {
     return FilterBase::visit(*this, FilterEvaluator<PropertyAccessor> { type, accessor });
 }
 

--- a/include/mbgl/util/color.hpp
+++ b/include/mbgl/util/color.hpp
@@ -20,15 +20,15 @@ public:
     static optional<Color> parse(const std::string&);
 };
 
-inline bool operator==(const Color& colorA, const Color& colorB) {
+constexpr bool operator==(const Color& colorA, const Color& colorB) {
     return colorA.r == colorB.r && colorA.g == colorB.g && colorA.b == colorB.b && colorA.a == colorB.a;
 }
 
-inline bool operator!=(const Color& colorA, const Color& colorB) {
+constexpr bool operator!=(const Color& colorA, const Color& colorB) {
     return !(colorA == colorB);
 }
 
-inline Color operator*(const Color& color, float alpha) {
+constexpr Color operator*(const Color& color, float alpha) {
     return {
         color.r * alpha,
         color.g * alpha,

--- a/include/mbgl/util/exception.hpp
+++ b/include/mbgl/util/exception.hpp
@@ -6,23 +6,23 @@ namespace mbgl {
 namespace util {
 
 struct Exception : std::runtime_error {
-    inline Exception(const char *msg) : std::runtime_error(msg) {}
-    inline Exception(const std::string &msg) : std::runtime_error(msg) {}
+    Exception(const char *msg) : std::runtime_error(msg) {}
+    Exception(const std::string &msg) : std::runtime_error(msg) {}
 };
 
 struct SpriteImageException : Exception {
-    inline SpriteImageException(const char *msg) : Exception(msg) {}
-    inline SpriteImageException(const std::string &msg) : Exception(msg) {}
+    SpriteImageException(const char *msg) : Exception(msg) {}
+    SpriteImageException(const std::string &msg) : Exception(msg) {}
 };
 
 struct MisuseException : Exception {
-    inline MisuseException(const char *msg) : Exception(msg) {}
-    inline MisuseException(const std::string &msg) : Exception(msg) {}
+    MisuseException(const char *msg) : Exception(msg) {}
+    MisuseException(const std::string &msg) : Exception(msg) {}
 };
 
 struct ShaderException : Exception {
-    inline ShaderException(const char *msg) : Exception(msg) {}
-    inline ShaderException(const std::string &msg) : Exception(msg) {}
+    ShaderException(const char *msg) : Exception(msg) {}
+    ShaderException(const std::string &msg) : Exception(msg) {}
 };
 
 } // namespace util

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -57,11 +57,11 @@ public:
     LatLng(const UnwrappedTileID& id);
 };
 
-inline bool operator==(const LatLng& a, const LatLng& b) {
+constexpr bool operator==(const LatLng& a, const LatLng& b) {
     return a.latitude == b.latitude && a.longitude == b.longitude;
 }
 
-inline bool operator!=(const LatLng& a, const LatLng& b) {
+constexpr bool operator!=(const LatLng& a, const LatLng& b) {
     return !(a == b);
 }
 
@@ -78,7 +78,7 @@ public:
     }
 };
 
-inline bool operator==(const ProjectedMeters& a, const ProjectedMeters& b) {
+constexpr bool operator==(const ProjectedMeters& a, const ProjectedMeters& b) {
     return a.northing == b.northing && a.easting == b.easting;
 }
 
@@ -164,15 +164,15 @@ private:
     LatLngBounds(LatLng sw_, LatLng ne_)
         : sw(std::move(sw_)), ne(std::move(ne_)) {}
 
-    friend bool operator==(const LatLngBounds&, const LatLngBounds&);
-    friend bool operator!=(const LatLngBounds&, const LatLngBounds&);
+    friend constexpr bool operator==(const LatLngBounds&, const LatLngBounds&);
+    friend constexpr bool operator!=(const LatLngBounds&, const LatLngBounds&);
 };
 
-inline bool operator==(const LatLngBounds& a, const LatLngBounds& b) {
+constexpr bool operator==(const LatLngBounds& a, const LatLngBounds& b) {
     return a.sw == b.sw && a.ne == b.ne;
 }
 
-inline bool operator!=(const LatLngBounds& a, const LatLngBounds& b) {
+constexpr bool operator!=(const LatLngBounds& a, const LatLngBounds& b) {
     return !(a == b);
 }
 

--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -11,14 +11,14 @@ namespace mbgl {
 class Projection {
 
 public:
-    static inline double getMetersPerPixelAtLatitude(double lat, double zoom) {
+    static double getMetersPerPixelAtLatitude(double lat, double zoom) {
         const double constrainedZoom = util::clamp(zoom, util::MIN_ZOOM, util::MAX_ZOOM);
         const double mapPixelWidthAtZoom = std::pow(2.0, constrainedZoom) * util::tileSize;
         const double constrainedLatitude = util::clamp(lat, -util::LATITUDE_MAX, util::LATITUDE_MAX);
         return std::cos(constrainedLatitude * util::DEG2RAD) * util::M2PI * util::EARTH_RADIUS_M / mapPixelWidthAtZoom;
     }
 
-    static inline ProjectedMeters projectedMetersForLatLng(const LatLng& latLng) {
+    static ProjectedMeters projectedMetersForLatLng(const LatLng& latLng) {
         const double constrainedLatitude = util::clamp(latLng.latitude, -util::LATITUDE_MAX, util::LATITUDE_MAX);
         const double constrainedLongitude = util::clamp(latLng.longitude, -util::LONGITUDE_MAX, util::LONGITUDE_MAX);
 
@@ -31,7 +31,7 @@ public:
         return ProjectedMeters(northing, easting);
     }
 
-    static inline LatLng latLngForProjectedMeters(const ProjectedMeters& projectedMeters) {
+    static LatLng latLngForProjectedMeters(const ProjectedMeters& projectedMeters) {
         double latitude = (2 * std::atan(std::exp(projectedMeters.northing / util::EARTH_RADIUS_M)) - (M_PI / 2)) * util::RAD2DEG;
         double longitude = projectedMeters.easting * util::RAD2DEG / util::EARTH_RADIUS_M;
 

--- a/include/mbgl/util/range.hpp
+++ b/include/mbgl/util/range.hpp
@@ -13,12 +13,12 @@ public:
 };
 
 template <class T>
-inline bool operator==(const Range<T>& a, const Range<T>& b) {
+bool operator==(const Range<T>& a, const Range<T>& b) {
     return a.min == b.min && a.max == b.max;
 }
 
 template <class T>
-inline bool operator!=(const Range<T>& a, const Range<T>& b) {
+bool operator!=(const Range<T>& a, const Range<T>& b) {
     return !(a == b);
 }
 

--- a/include/mbgl/util/traits.hpp
+++ b/include/mbgl/util/traits.hpp
@@ -5,8 +5,8 @@
 namespace mbgl {
 
 template<typename T>
-constexpr auto underlying_type(T t) -> typename std::underlying_type<T>::type {
-    return static_cast<typename std::underlying_type<T>::type>(t);
+constexpr auto underlying_type(T t) -> typename std::underlying_type_t<T> {
+    return typename std::underlying_type_t<T>(t);
 }
 
 } // namespace mbgl

--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -5,7 +5,7 @@
 #include <png.h>
 
 template<size_t max, typename... Args>
-inline static std::string sprintf(const char *msg, Args... args) {
+static std::string sprintf(const char *msg, Args... args) {
     char res[max];
     int len = snprintf(res, sizeof(res), msg, args...);
     return std::string(res, len);

--- a/platform/default/sqlite3.hpp
+++ b/platform/default/sqlite3.hpp
@@ -22,8 +22,8 @@ enum OpenFlag : int {
 };
 
 struct Exception : std::runtime_error {
-    inline Exception(int err, const char *msg) : std::runtime_error(msg), code(err) {}
-    inline Exception(int err, const std::string& msg) : std::runtime_error(msg), code(err) {}
+    Exception(int err, const char *msg) : std::runtime_error(msg), code(err) {}
+    Exception(int err, const std::string& msg) : std::runtime_error(msg), code(err) {}
     const int code = 0;
 };
 

--- a/platform/node/src/node_style_properties.hpp
+++ b/platform/node/src/node_style_properties.hpp
@@ -9,7 +9,7 @@
 
 namespace node_mbgl {
 
-inline PropertySetters makeLayoutPropertySetters() {
+PropertySetters makeLayoutPropertySetters() {
     using namespace mbgl::style;
     PropertySetters result;
 
@@ -60,7 +60,7 @@ inline PropertySetters makeLayoutPropertySetters() {
     return result;
 }
 
-inline PropertySetters makePaintPropertySetters() {
+PropertySetters makePaintPropertySetters() {
     using namespace mbgl::style;
     PropertySetters result;
 

--- a/platform/node/src/node_style_properties.hpp.ejs
+++ b/platform/node/src/node_style_properties.hpp.ejs
@@ -6,7 +6,7 @@
 
 namespace node_mbgl {
 
-inline PropertySetters makeLayoutPropertySetters() {
+PropertySetters makeLayoutPropertySetters() {
     using namespace mbgl::style;
     PropertySetters result;
 
@@ -19,7 +19,7 @@ inline PropertySetters makeLayoutPropertySetters() {
     return result;
 }
 
-inline PropertySetters makePaintPropertySetters() {
+PropertySetters makePaintPropertySetters() {
     using namespace mbgl::style;
     PropertySetters result;
 

--- a/src/mbgl/annotation/symbol_annotation_impl.hpp
+++ b/src/mbgl/annotation/symbol_annotation_impl.hpp
@@ -55,7 +55,7 @@ namespace index {
 template <>
 struct indexable<std::shared_ptr<const mbgl::SymbolAnnotationImpl>> {
     using result_type = mbgl::LatLng;
-    inline mbgl::LatLng operator()(const std::shared_ptr<const mbgl::SymbolAnnotationImpl>& v) const {
+    mbgl::LatLng operator()(const std::shared_ptr<const mbgl::SymbolAnnotationImpl>& v) const {
         const mbgl::Point<double>& p = v->annotation.geometry;
         return mbgl::LatLng(p.y, p.x);
     }

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -27,11 +27,11 @@ public:
 
     // Returns the number of elements in this buffer. This is not the number of
     // bytes, but rather the number of coordinates with associated information.
-    inline GLsizei index() const {
+    GLsizei index() const {
         return static_cast<GLsizei>(pos / itemSize);
     }
 
-    inline bool empty() const {
+    bool empty() const {
         return pos == 0;
     }
 
@@ -65,7 +65,7 @@ public:
     }
 
     // Uploads the buffer to the GPU to be available when we need it.
-    inline void upload(gl::ObjectStore& store) {
+    void upload(gl::ObjectStore& store) {
         if (!buffer) {
             bind(store);
         }
@@ -73,7 +73,7 @@ public:
 
 protected:
     // increase the buffer size by at least /required/ bytes.
-    inline void *addElement() {
+    void *addElement() {
         if (buffer) {
             throw std::runtime_error("Can't add elements after buffer was bound to GPU");
         }

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -20,7 +20,7 @@ public:
     ~VertexArrayObject();
 
     template <typename Shader, typename VertexBuffer>
-    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset, gl::ObjectStore& store) {
+    void bind(Shader& shader, VertexBuffer &vertexBuffer, GLbyte *offset, gl::ObjectStore& store) {
         bindVertexArrayObject(store);
         if (bound_shader == 0) {
             vertexBuffer.bind(store);
@@ -34,7 +34,7 @@ public:
     }
 
     template <typename Shader, typename VertexBuffer, typename ElementsBuffer>
-    inline void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset, gl::ObjectStore& store) {
+    void bind(Shader& shader, VertexBuffer &vertexBuffer, ElementsBuffer &elementsBuffer, GLbyte *offset, gl::ObjectStore& store) {
         bindVertexArrayObject(store);
         if (bound_shader == 0) {
             vertexBuffer.bind(store);

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -41,7 +41,7 @@ public:
 
     virtual bool needsClipping() const = 0;
 
-    inline bool needsUpload() const {
+    bool needsUpload() const {
         return !uploaded;
     }
 

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -15,11 +15,11 @@
 namespace mapbox {
 namespace util {
 template <> struct nth<0, mbgl::GeometryCoordinate> {
-    inline static int64_t get(const mbgl::GeometryCoordinate& t) { return t.x; };
+    static int64_t get(const mbgl::GeometryCoordinate& t) { return t.x; };
 };
 
 template <> struct nth<1, mbgl::GeometryCoordinate> {
-    inline static int64_t get(const mbgl::GeometryCoordinate& t) { return t.y; };
+    static int64_t get(const mbgl::GeometryCoordinate& t) { return t.y; };
 };
 } // namespace util
 } // namespace mapbox

--- a/src/mbgl/renderer/render_pass.hpp
+++ b/src/mbgl/renderer/render_pass.hpp
@@ -12,16 +12,16 @@ enum class RenderPass : uint8_t {
     Translucent = 1 << 1,
 };
 
-constexpr inline RenderPass operator|(RenderPass a, RenderPass b) {
-    return static_cast<RenderPass>(mbgl::underlying_type(a) | mbgl::underlying_type(b));
+constexpr RenderPass operator|(RenderPass a, RenderPass b) {
+    return RenderPass(mbgl::underlying_type(a) | mbgl::underlying_type(b));
 }
 
-inline RenderPass operator|=(RenderPass& a, RenderPass b) {
+constexpr RenderPass& operator|=(RenderPass& a, RenderPass b) {
     return (a = a | b);
 }
 
-constexpr inline RenderPass operator&(RenderPass a, RenderPass b) {
-    return static_cast<RenderPass>(mbgl::underlying_type(a) & mbgl::underlying_type(b));
+constexpr RenderPass operator&(RenderPass a, RenderPass b) {
+    return RenderPass(mbgl::underlying_type(a) & mbgl::underlying_type(b));
 }
 
 } // namespace mbgl

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -56,14 +56,14 @@ public:
     // the texture is only bound when the data is out of date (=dirty).
     void upload(gl::ObjectStore&);
 
-    inline dimension getWidth() const { return width; }
-    inline dimension getHeight() const { return height; }
-    inline dimension getTextureWidth() const { return pixelWidth; }
-    inline dimension getTextureHeight() const { return pixelHeight; }
-    inline float getPixelRatio() const { return pixelRatio; }
+    dimension getWidth() const { return width; }
+    dimension getHeight() const { return height; }
+    dimension getTextureWidth() const { return pixelWidth; }
+    dimension getTextureHeight() const { return pixelHeight; }
+    float getPixelRatio() const { return pixelRatio; }
 
     // Only for use in tests.
-    inline const uint32_t* getData() const { return data.get(); }
+    const uint32_t* getData() const { return data.get(); }
 
 private:
     const GLsizei width, height;
@@ -71,8 +71,8 @@ private:
     const float pixelRatio;
 
     struct Holder : private util::noncopyable {
-        inline Holder(std::shared_ptr<const SpriteImage>, Rect<dimension>);
-        inline Holder(Holder&&);
+        Holder(std::shared_ptr<const SpriteImage>, Rect<dimension>);
+        Holder(Holder&&);
         std::shared_ptr<const SpriteImage> spriteImage;
         const Rect<dimension> pos;
     };

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -46,7 +46,7 @@ SpriteImagePtr createSpriteImage(const PremultipliedImage& image,
 
 namespace {
 
-inline uint16_t getUInt16(const JSValue& value, const char* name, const uint16_t def = 0) {
+uint16_t getUInt16(const JSValue& value, const char* name, const uint16_t def = 0) {
     if (value.HasMember(name)) {
         auto& v = value[name];
         if (v.IsUint() && v.GetUint() <= std::numeric_limits<uint16_t>::max()) {
@@ -60,7 +60,7 @@ inline uint16_t getUInt16(const JSValue& value, const char* name, const uint16_t
     return def;
 }
 
-inline double getDouble(const JSValue& value, const char* name, const double def = 0) {
+double getDouble(const JSValue& value, const char* name, const double def = 0) {
     if (value.HasMember(name)) {
         auto& v = value[name];
         if (v.IsNumber()) {
@@ -73,7 +73,7 @@ inline double getDouble(const JSValue& value, const char* name, const double def
     return def;
 }
 
-inline bool getBoolean(const JSValue& value, const char* name, const bool def = false) {
+bool getBoolean(const JSValue& value, const char* name, const bool def = false) {
     if (value.HasMember(name)) {
         auto& v = value[name];
         if (v.IsBool()) {

--- a/src/mbgl/storage/response.cpp
+++ b/src/mbgl/storage/response.cpp
@@ -28,7 +28,7 @@ Response::Error::Error(Reason reason_, std::string message_)
 std::ostream& operator<<(std::ostream& os, Response::Error::Reason r) {
     switch (r) {
     case Response::Error::Reason::Success:
-        return os << "Response::Error::Reason::NotFound";
+        return os << "Response::Error::Reason::Success";
     case Response::Error::Reason::NotFound:
         return os << "Response::Error::Reason::NotFound";
     case Response::Error::Reason::Server:

--- a/src/mbgl/style/property_evaluator.cpp
+++ b/src/mbgl/style/property_evaluator.cpp
@@ -11,27 +11,27 @@ namespace mbgl {
 namespace style {
 
 template <typename T>
-inline T defaultStopsValue();
+T defaultStopsValue();
 
-template <> inline bool defaultStopsValue() { return true; }
-template <> inline float defaultStopsValue() { return 1.0f; }
-template <> inline Color defaultStopsValue() { return { 0, 0, 0, 1 }; }
-template <> inline std::vector<float> defaultStopsValue() { return {{ 1, 0 }}; }
-template <> inline std::vector<std::string> defaultStopsValue() { return {{}}; }
-template <> inline std::array<float, 2> defaultStopsValue() { return {{ 0, 0 }}; }
-template <> inline std::array<float, 4> defaultStopsValue() { return {{ 0, 0, 0, 0 }}; }
+template <> bool defaultStopsValue() { return true; }
+template <> float defaultStopsValue() { return 1.0f; }
+template <> Color defaultStopsValue() { return { 0, 0, 0, 1 }; }
+template <> std::vector<float> defaultStopsValue() { return {{ 1, 0 }}; }
+template <> std::vector<std::string> defaultStopsValue() { return {{}}; }
+template <> std::array<float, 2> defaultStopsValue() { return {{ 0, 0 }}; }
+template <> std::array<float, 4> defaultStopsValue() { return {{ 0, 0, 0, 0 }}; }
 
-template <> inline std::string defaultStopsValue() { return {}; }
-template <> inline TranslateAnchorType defaultStopsValue() { return {}; }
-template <> inline RotateAnchorType defaultStopsValue() { return {}; }
-template <> inline LineCapType defaultStopsValue() { return {}; }
-template <> inline LineJoinType defaultStopsValue() { return {}; }
-template <> inline SymbolPlacementType defaultStopsValue() { return {}; }
-template <> inline TextAnchorType defaultStopsValue() { return {}; }
-template <> inline TextJustifyType defaultStopsValue() { return {}; }
-template <> inline TextTransformType defaultStopsValue() { return {}; }
-template <> inline AlignmentType defaultStopsValue() { return {}; }
-template <> inline IconTextFitType defaultStopsValue() { return {}; };
+template <> std::string defaultStopsValue() { return {}; }
+template <> TranslateAnchorType defaultStopsValue() { return {}; }
+template <> RotateAnchorType defaultStopsValue() { return {}; }
+template <> LineCapType defaultStopsValue() { return {}; }
+template <> LineJoinType defaultStopsValue() { return {}; }
+template <> SymbolPlacementType defaultStopsValue() { return {}; }
+template <> TextAnchorType defaultStopsValue() { return {}; }
+template <> TextJustifyType defaultStopsValue() { return {}; }
+template <> TextTransformType defaultStopsValue() { return {}; }
+template <> AlignmentType defaultStopsValue() { return {}; }
+template <> IconTextFitType defaultStopsValue() { return {}; };
 
 template <typename T>
 T PropertyEvaluator<T>::operator()(const Function<T>& fn) const {
@@ -114,7 +114,7 @@ Faded<T> CrossFadedPropertyEvaluator<T>::operator()(const T& constant) const {
 }
 
 template <typename T>
-inline T getBiggestStopLessThan(const Function<T>& function, float z) {
+T getBiggestStopLessThan(const Function<T>& function, float z) {
     const auto& stops = function.getStops();
     for (uint32_t i = 0; i < stops.size(); i++) {
         if (stops[i].first > z) {

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -33,7 +33,7 @@ namespace mbgl {
     class CollisionFeature {
         public:
             // for text
-            inline explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
+            explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const Shaping &shapedText,
                     const float boxScale, const float padding, const bool alongLine, const IndexedSubfeature& indexedFeature_)
                 : CollisionFeature(line, anchor,
@@ -41,7 +41,7 @@ namespace mbgl {
                         boxScale, padding, alongLine, indexedFeature_, false) {}
 
             // for icons
-            inline explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
+            explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const PositionedIcon &shapedIcon,
                     const float boxScale, const float padding, const bool alongLine, const IndexedSubfeature& indexedFeature_)
                 : CollisionFeature(line, anchor,

--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -28,8 +28,8 @@ struct GlyphMetrics {
 };
 
 struct Glyph {
-    inline explicit Glyph() : rect(0, 0, 0, 0), metrics() {}
-    inline explicit Glyph(Rect<uint16_t> rect_, GlyphMetrics metrics_)
+    explicit Glyph() : rect(0, 0, 0, 0), metrics() {}
+    explicit Glyph(Rect<uint16_t> rect_, GlyphMetrics metrics_)
         : rect(std::move(rect_)), metrics(std::move(metrics_)) {}
 
     operator bool() const {
@@ -44,7 +44,7 @@ typedef std::map<uint32_t, Glyph> GlyphPositions;
 
 class PositionedGlyph {
 public:
-    inline explicit PositionedGlyph(uint32_t glyph_, float x_, float y_)
+    explicit PositionedGlyph(uint32_t glyph_, float x_, float y_)
         : glyph(glyph_), x(x_), y(y_) {}
 
     uint32_t glyph = 0;
@@ -54,8 +54,8 @@ public:
 
 class Shaping {
     public:
-    inline explicit Shaping() : top(0), bottom(0), left(0), right(0) {}
-    inline explicit Shaping(float x, float y, std::u32string text_)
+    explicit Shaping() : top(0), bottom(0), left(0), right(0) {}
+    explicit Shaping(float x, float y, std::u32string text_)
         : text(std::move(text_)), top(y), bottom(y), left(x), right(x) {}
     std::vector<PositionedGlyph> positionedGlyphs;
     std::u32string text;

--- a/src/mbgl/text/placement_config.hpp
+++ b/src/mbgl/text/placement_config.hpp
@@ -4,15 +4,15 @@ namespace mbgl {
 
 class PlacementConfig {
 public:
-    inline PlacementConfig(float angle_ = 0, float pitch_ = 0, bool debug_ = false)
+    PlacementConfig(float angle_ = 0, float pitch_ = 0, bool debug_ = false)
         : angle(angle_), pitch(pitch_), debug(debug_) {
     }
 
-    inline bool operator==(const PlacementConfig& rhs) const {
+    bool operator==(const PlacementConfig& rhs) const {
         return angle == rhs.angle && pitch == rhs.pitch && debug == rhs.debug;
     }
 
-    inline bool operator!=(const PlacementConfig& rhs) const {
+    bool operator!=(const PlacementConfig& rhs) const {
         return !operator==(rhs);
     }
 

--- a/src/mbgl/text/shaping.hpp
+++ b/src/mbgl/text/shaping.hpp
@@ -15,8 +15,8 @@ class SymbolLayoutProperties;
 
 class PositionedIcon {
     public:
-        inline explicit PositionedIcon() {}
-        inline explicit PositionedIcon(const SpriteAtlasElement& _image,
+        explicit PositionedIcon() {}
+        explicit PositionedIcon(const SpriteAtlasElement& _image,
                 float _top, float _bottom, float _left, float _right) :
             image(_image), top(_top), bottom(_bottom), left(_left), right(_right) {}
 

--- a/src/mbgl/util/clip_id.hpp
+++ b/src/mbgl/util/clip_id.hpp
@@ -12,17 +12,17 @@
 namespace mbgl {
 
 struct ClipID {
-    inline ClipID() {}
-    inline ClipID(const std::string &mask_, const std::string &reference_) : mask(mask_), reference(reference_) {}
+    ClipID() {}
+    ClipID(const std::string &mask_, const std::string &reference_) : mask(mask_), reference(reference_) {}
 
     std::bitset<8> mask;
     std::bitset<8> reference;
 
-    inline bool operator==(const ClipID &other) const {
+    bool operator==(const ClipID &other) const {
         return mask == other.mask && reference == other.reference;
     }
 
-    inline ClipID& operator|=(const ClipID &other) {
+    ClipID& operator|=(const ClipID &other) {
         mask |= other.mask;
         reference |= other.reference;
         return *this;

--- a/src/mbgl/util/dtoa.cpp
+++ b/src/mbgl/util/dtoa.cpp
@@ -9,7 +9,7 @@ namespace {
 
 // From https://github.com/miloyip/rapidjson/blob/master/include/rapidjson/internal/dtoa.h
 
-inline char* Prettify(char* buffer, int length, int k) {
+char* Prettify(char* buffer, int length, int k) {
     constexpr int maxDecimalPlaces = 324;
     const int kk = length + k;  // 10^(kk-1) <= v < 10^kk
 
@@ -91,6 +91,14 @@ char* dtoa(double value, char* buffer) {
         rapidjson::internal::Grisu2(value, buffer, &length, &K);
         return Prettify(buffer, length, K);
     }
+}
+
+std::string dtoa(double value) {
+    std::string data;
+    data.resize(25);
+    auto end = dtoa(value, const_cast<char*>(data.data()));
+    data.resize(end - data.data());
+    return data;
 }
 
 } // namespace util

--- a/src/mbgl/util/dtoa.hpp
+++ b/src/mbgl/util/dtoa.hpp
@@ -6,14 +6,7 @@ namespace mbgl {
 namespace util {
 
 char* dtoa(double value, char* buffer);
-
-inline std::string dtoa(double value) {
-    std::string data;
-    data.resize(25);
-    auto end = dtoa(value, const_cast<char*>(data.data()));
-    data.resize(end - data.data());
-    return data;
-}
+std::string dtoa(double value);
 
 } // end namespace util
 } // end namespace mbgl

--- a/src/mbgl/util/exclusive.hpp
+++ b/src/mbgl/util/exclusive.hpp
@@ -10,12 +10,12 @@ namespace util {
 template <class T>
 class exclusive {
 public:
-    inline exclusive(T* val, std::unique_ptr<std::lock_guard<std::mutex>> mtx) : ptr(val), lock(std::move(mtx)) {}
+    exclusive(T* val, std::unique_ptr<std::lock_guard<std::mutex>> mtx) : ptr(val), lock(std::move(mtx)) {}
 
-    inline T* operator->() { return ptr; }
-    inline const T* operator->() const { return ptr; }
-    inline T* operator*() { return ptr; }
-    inline const T* operator*() const { return ptr; }
+    T* operator->() { return ptr; }
+    const T* operator->() const { return ptr; }
+    T* operator*() { return ptr; }
+    const T* operator*() const { return ptr; }
 
 private:
     T *ptr;

--- a/src/mbgl/util/geo.cpp
+++ b/src/mbgl/util/geo.cpp
@@ -8,12 +8,12 @@ namespace mbgl {
 
 namespace {
 
-inline double lat(const uint8_t z, const int64_t y) {
+double lat(const uint8_t z, const int64_t y) {
     const double n = M_PI - 2.0 * M_PI * y / std::pow(2.0, z);
     return util::RAD2DEG * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
 }
 
-inline double lon(const uint8_t z, const int64_t x) {
+double lon(const uint8_t z, const int64_t x) {
     return x / std::pow(2.0, z) * util::DEGREES_MAX - util::LONGITUDE_MAX;
 }
 

--- a/src/mbgl/util/io.hpp
+++ b/src/mbgl/util/io.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 namespace util {
 
 struct IOException : std::runtime_error {
-    inline IOException(int err, const char* msg) : std::runtime_error(msg), code(err) {
+    IOException(int err, const char* msg) : std::runtime_error(msg), code(err) {
     }
     const int code = 0;
 };

--- a/src/mbgl/util/math.hpp
+++ b/src/mbgl/util/math.hpp
@@ -14,18 +14,18 @@ namespace util {
 // Find the angle of the two vectors, solving the formula for the cross product
 // a x b = |a||b|sin(θ) for θ.
 template <typename T = double, typename S>
-inline T angle_between(const Point<S>& a, const Point<S>& b) {
+T angle_between(const Point<S>& a, const Point<S>& b) {
     return std::atan2((a.x * b.y - a.y * b.x), a.x * b.x + a.y * b.y);
 }
 
 template <typename T = double, typename S>
-inline T angle_to(const Point<S>& a, const Point<S>& b) {
+T angle_to(const Point<S>& a, const Point<S>& b) {
     return std::atan2(a.y - b.y, a.x - b.x);
 }
 
 // Reflect an angle around 0 degrees
 template <typename T>
-inline std::array<T, 2> flip(const std::array<T, 2>& c) {
+std::array<T, 2> flip(const std::array<T, 2>& c) {
     return {{
         static_cast<T>(2 * M_PI - c[0]),
         static_cast<T>(2 * M_PI - c[1])
@@ -33,7 +33,7 @@ inline std::array<T, 2> flip(const std::array<T, 2>& c) {
 }
 
 template <typename T, typename S1, typename S2>
-inline Point<T> normal(const S1& a, const S2& b) {
+Point<T> normal(const S1& a, const S2& b) {
     T dx = b.x - a.x;
     T dy = b.y - a.y;
     T c = std::sqrt(dx * dx + dy * dy);
@@ -41,12 +41,12 @@ inline Point<T> normal(const S1& a, const S2& b) {
 }
 
 template <typename T>
-inline T perp(const T& a) {
+T perp(const T& a) {
     return T(-a.y, a.x);
 }
 
 template <typename T, typename S1, typename S2>
-inline T dist(const S1& a, const S2& b) {
+T dist(const S1& a, const S2& b) {
     T dx = b.x - a.x;
     T dy = b.y - a.y;
     T c = std::sqrt(dx * dx + dy * dy);
@@ -54,7 +54,7 @@ inline T dist(const S1& a, const S2& b) {
 }
 
 template <typename T, typename S1, typename S2>
-inline T distSqr(const S1& a, const S2& b) {
+T distSqr(const S1& a, const S2& b) {
     T dx = b.x - a.x;
     T dy = b.y - a.y;
     T c = dx * dx + dy * dy;
@@ -62,23 +62,23 @@ inline T distSqr(const S1& a, const S2& b) {
 }
 
 template <typename T>
-inline T round(const T& a) {
+T round(const T& a) {
     return T(::round(a.x), ::round(a.y));
 }
 
 template <typename T>
-inline T length(T a, T b) {
+T length(T a, T b) {
     return std::sqrt(a * a + b * b);
 }
 
 // Take the magnitude of vector a.
 template <typename T = double, typename S>
-inline T mag(const S& a) {
+T mag(const S& a) {
     return std::sqrt(a.x * a.x + a.y * a.y);
 }
 
 template <typename S>
-inline S unit(const S& a) {
+S unit(const S& a) {
     auto magnitude = mag(a);
     if (magnitude == 0) {
         return a;
@@ -87,7 +87,7 @@ inline S unit(const S& a) {
 }
 
 template <typename T, typename S = double>
-inline T rotate(const T& a, S angle) {
+T rotate(const T& a, S angle) {
     S cos = std::cos(angle);
     S sin = std::sin(angle);
     S x = cos * a.x - sin * a.y;
@@ -96,7 +96,7 @@ inline T rotate(const T& a, S angle) {
 }
 
 template <typename T>
-inline Point<T> matrixMultiply(const std::array<T, 4>& m, const Point<T>& p) {
+Point<T> matrixMultiply(const std::array<T, 4>& m, const Point<T>& p) {
     return Point<T>(m[0] * p.x + m[1] * p.y, m[2] * p.x + m[3] * p.y);
 }
 

--- a/src/mbgl/util/ptr.hpp
+++ b/src/mbgl/util/ptr.hpp
@@ -10,14 +10,14 @@ template <typename T>
 class ptr : public ::std::shared_ptr<T> {
 public:
     template <typename... Args>
-    inline ptr(Args &&... args)
+    ptr(Args &&... args)
         : ::std::shared_ptr<T>(::std::forward<Args>(args)...) {}
 
-    inline auto operator->() const -> decltype(this->::std::shared_ptr<T>::operator->()) {
+    auto operator->() const -> decltype(this->::std::shared_ptr<T>::operator->()) {
         assert(*this);
         return ::std::shared_ptr<T>::operator->();
     }
-    inline auto operator*() const -> decltype(this->::std::shared_ptr<T>::operator*()) {
+    auto operator*() const -> decltype(this->::std::shared_ptr<T>::operator*()) {
         assert(*this);
         return ::std::shared_ptr<T>::operator*();
     }

--- a/src/mbgl/util/rect.hpp
+++ b/src/mbgl/util/rect.hpp
@@ -4,21 +4,21 @@ namespace mbgl {
 
 template <typename T>
 struct Rect {
-    inline Rect() = default;
-    inline Rect(T x_, T y_, T w_, T h_) : x(x_), y(y_), w(w_), h(h_) {}
+    Rect() = default;
+    Rect(T x_, T y_, T w_, T h_) : x(x_), y(y_), w(w_), h(h_) {}
     T x = 0, y = 0;
     T w = 0, h = 0;
 
     template <typename Number>
-    inline Rect operator *(Number value) const {
+    Rect operator *(Number value) const {
         return Rect(x * value, y * value, w * value, h * value);
     }
 
     template <typename R>
-    inline bool operator==(const R& r) const {
+    bool operator==(const R& r) const {
         return x == r.x && y == r.y && w == r.w && h == r.h;
     }
 
-    inline bool hasArea() const { return w != 0 && h != 0; }
+    bool hasArea() const { return w != 0 && h != 0; }
 };
 } // namespace mbgl

--- a/src/mbgl/util/stopwatch.hpp
+++ b/src/mbgl/util/stopwatch.hpp
@@ -26,12 +26,12 @@ private:
 };
 #else
 class stopwatch {
-    inline stopwatch(Event event = Event::General);
-    inline stopwatch(EventSeverity severity, Event event = Event::General);
-    inline stopwatch(const std::string &name, Event event = Event::General);
-    inline stopwatch(const std::string &name, EventSeverity severity, Event event = Event::General);
-    inline void report(const std::string &name) {}
-    inline ~stopwatch() {}
+    stopwatch(Event event = Event::General);
+    stopwatch(EventSeverity severity, Event event = Event::General);
+    stopwatch(const std::string &name, Event event = Event::General);
+    stopwatch(const std::string &name, EventSeverity severity, Event event = Event::General);
+    void report(const std::string &name) {}
+    ~stopwatch() {}
 };
 #endif
 } // namespace util

--- a/src/mbgl/util/thread_local.hpp
+++ b/src/mbgl/util/thread_local.hpp
@@ -12,12 +12,12 @@ namespace util {
 template <class T>
 class ThreadLocal : public noncopyable {
 public:
-    inline ThreadLocal(T* val) {
+    ThreadLocal(T* val) {
         ThreadLocal();
         set(val);
     }
 
-    inline ThreadLocal() {
+    ThreadLocal() {
         int ret = pthread_key_create(&key, [](void *ptr) {
             delete reinterpret_cast<T *>(ptr);
         });
@@ -27,13 +27,13 @@ public:
         }
     }
 
-    inline ~ThreadLocal() {
+    ~ThreadLocal() {
         if (pthread_key_delete(key)) {
             throw std::runtime_error("Failed to delete local storage key.");
         }
     }
 
-    inline T* get() {
+    T* get() {
         T* ret = reinterpret_cast<T*>(pthread_getspecific(key));
         if (!ret) {
             return nullptr;
@@ -42,7 +42,7 @@ public:
         return ret;
     }
 
-    inline void set(T* ptr) {
+    void set(T* ptr) {
         if (pthread_setspecific(key, ptr)) {
             throw std::runtime_error("Failed to set local storage.");
         }


### PR DESCRIPTION
- Removed all `inline` usage from functions implemented inside a class definition
- Replaced `inline` with `constexpr` for non-member functions defined in headers whenever possible

The remaining `inline` usage in the code is either a non-member function defined in header that uses a _non-constexpr function_ e.g. `mbgl::util::now()` or a member function defined in a header, but outside of the class definition e.g. `*TileID` functions in order to comply with the [one definition rule](https://en.wikipedia.org/wiki/One_Definition_Rule).

Fixes #5352.

:eyes: @jfirebaugh @kkaefer @tmpsantos @1ec5 