### PR TITLE
Rename Custom Dynamic InfoWindow Adapter in testapp

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -21,9 +21,9 @@
     <string name="activity_view_marker_scale">Scaling in the View Marker API</string>
 
     <!-- InfoWindow-->
-    <string name="activity_info_window">Standard InfoWindow example</string>
-    <string name="activity_infowindow_adapter">Custom InfoWindow Adapter</string>
-    <string name="activity_dynamic_infowindow_adapter">Custom Dynamic InfoWindow Adapter</string>
+    <string name="activity_info_window">Standard InfoWindow</string>
+    <string name="activity_infowindow_adapter">Custom InfoWindow</string>
+    <string name="activity_dynamic_infowindow_adapter">Custom Dynamic InfoWindow</string>
 
     <!-- Camera -->
     <string name="activity_camera_animation_types">Animation Types</string>


### PR DESCRIPTION
Fixes #5398.

I also standardized the other InfoWindow examples.

/cc: @cammace 