### PR TITLE
Rename overdraw to overdraw visualization

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 
 ## master
 
+## 3.3.0
+
 - Applications linking against the SDK static framework no longer need to add `-ObjC` to the Other Linker Flags (`OTHER_LDFLAGS`) build setting. If you previously added this flag solely for this SDK, removing the flag may potentially reduce the overall size of your application. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Removed the `armv7s` slice from the SDK to reduce its size. iPhone 5 and iPhone 5c automatically use the `armv7` slice instead. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - MGLPointAnnotation and custom MGLAnnotation implementations (but not MGLMultiPoint) can be backed by an MGLAnnotationView instead of an MGLAnnotationImage. MGLAnnotationView is a subclass of UIView, so you can use Core Animation and other familiar technologies with it. To associate an MGLAnnotation with an MGLAnnotationView, implement `-mapView:viewForAnnotation:` in your MGLMapViewDelegate class. ([#4801](https://github.com/mapbox/mapbox-gl-native/pull/4801))
@@ -33,7 +35,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 - Removed unused SVG files from the SDK’s resource bundle. ([#4641](https://github.com/mapbox/mapbox-gl-native/pull/4641))
 - Deprecated `-[MGLMapView emptyMemoryCache]`. ([#4725](https://github.com/mapbox/mapbox-gl-native/pull/4725))
 - Added `MGLCoordinateInCoordinateBounds()`, a function that tests whether or not a coordinate is in a given bounds. ([#5053](https://github.com/mapbox/mapbox-gl-native/pull/5053))
-- Added a new option to `MGLMapDebugMaskOptions`, `MGLMapDebugOverdrawsMask`, that shows wireframes for overdraw inspection instead of the usual rendered output. ([#4359](https://github.com/mapbox/mapbox-gl-native/pull/4359))
+- Added a new option to `MGLMapDebugMaskOptions`, `MGLMapDebugOverdrawVisualizationMask`, that highlights overlapping drawing operations instead of the usual rendered output. ([#5403](https://github.com/mapbox/mapbox-gl-native/pull/5403))
 
 ## 3.2.3
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -181,9 +181,9 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         ((debugMask & MGLMapDebugCollisionBoxesMask)
          ? @"Hide Collision Boxes"
          : @"Show Collision Boxes"),
-        ((debugMask & MGLMapDebugOverdrawsMask)
-         ? @"Hide Overdraws"
-         : @"Show Overdraws"),
+        ((debugMask & MGLMapDebugOverdrawVisualizationMask)
+         ? @"Hide Overdraw Visualization"
+         : @"Show Overdraw Visualization"),
         @"Add 100 Points",
         @"Add 1,000 Points",
         @"Add 10,000 Points",
@@ -226,7 +226,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 5)
     {
-        self.mapView.debugMask ^= MGLMapDebugOverdrawsMask;
+        self.mapView.debugMask ^= MGLMapDebugOverdrawVisualizationMask;
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 6)
     {

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -43,8 +43,10 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
     /** Edges of glyphs and symbols are shown as faint, green lines to help
         diagnose collision and label placement issues. */
     MGLMapDebugCollisionBoxesMask = 1 << 4,
-    /** Overdraw inspector. */
-    MGLMapDebugOverdrawsMask = 1 << 5,
+    /** Each drawing operation is replaced by a translucent fill. Overlapping
+        drawing operations appear more prominent to help diagnose overdrawing.
+     */
+    MGLMapDebugOverdrawVisualizationMask = 1 << 5,
 };
 
 /**

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1831,7 +1831,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     }
     if (options & mbgl::MapDebugOptions::Overdraw)
     {
-        mask |= MGLMapDebugOverdrawsMask;
+        mask |= MGLMapDebugOverdrawVisualizationMask;
     }
     return mask;
 }
@@ -1855,7 +1855,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     {
         options |= mbgl::MapDebugOptions::Collision;
     }
-    if (debugMask & MGLMapDebugOverdrawsMask)
+    if (debugMask & MGLMapDebugOverdrawVisualizationMask)
     {
         options |= mbgl::MapDebugOptions::Overdraw;
     }

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog for Mapbox macOS SDK
 
 ## master
-* Refactor wireframe mode to match GL JS overdraw implementation. ([#5403](https://github.com/mapbox/mapbox-gl-native/pull/5403)).
+* Replaced the wireframe debug mask with an overdraw visualization debug mask to match Mapbox GL JS’s overdraw inspector. ([#5403](https://github.com/mapbox/mapbox-gl-native/pull/5403))
 
 ## 0.2.0
 

--- a/platform/macos/app/Base.lproj/MainMenu.xib
+++ b/platform/macos/app/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11129.15" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11129.15"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -461,10 +461,10 @@
                                     <action selector="toggleCollisionBoxes:" target="-1" id="EYa-7n-iWZ"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Show Overdraws" id="hSX-Be-8xC">
+                            <menuItem title="Show Overdraw Visualization" id="hSX-Be-8xC">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="toggleOverdraws:" target="-1" id="usj-ug-upt"/>
+                                    <action selector="toggleOverdrawVisualization:" target="-1" id="usj-ug-upt"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="2EG-Hp-4FA"/>
@@ -591,7 +591,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="109" y="131" width="350" height="84"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <view key="contentView" id="eA4-n3-qPe">
                 <rect key="frame" x="0.0" y="0.0" width="350" height="84"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -666,7 +666,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="830" y="430" width="400" height="300"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <view key="contentView" id="8ha-hw-zOD">
                 <rect key="frame" x="0.0" y="0.0" width="400" height="300"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -674,11 +674,11 @@
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q8b-0e-dLv">
                         <rect key="frame" x="-1" y="20" width="402" height="281"/>
                         <clipView key="contentView" id="J9U-Yx-o2S">
-                            <rect key="frame" x="1" y="0.0" width="400" height="265"/>
+                            <rect key="frame" x="1" y="0.0" width="400" height="280"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" headerView="MAZ-Iq-hBi" id="Ato-Vu-HYT">
-                                    <rect key="frame" x="0.0" y="0.0" width="423" height="242"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="423" height="257"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -276,8 +276,8 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     self.mapView.debugMask ^= MGLMapDebugCollisionBoxesMask;
 }
 
-- (IBAction)toggleOverdraws:(id)sender {
-    self.mapView.debugMask ^= MGLMapDebugOverdrawsMask;
+- (IBAction)toggleOverdrawVisualization:(id)sender {
+    self.mapView.debugMask ^= MGLMapDebugOverdrawVisualizationMask;
 }
 
 - (IBAction)showColorBuffer:(id)sender {
@@ -604,9 +604,9 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
         menuItem.title = isShown ? @"Hide Collision Boxes" : @"Show Collision Boxes";
         return YES;
     }
-    if (menuItem.action == @selector(toggleOverdraws:)) {
-        BOOL isShown = self.mapView.debugMask & MGLMapDebugOverdrawsMask;
-        menuItem.title = isShown ? @"Hide Overdraws" : @"Show Overdraws";
+    if (menuItem.action == @selector(toggleOverdrawVisualization:)) {
+        BOOL isShown = self.mapView.debugMask & MGLMapDebugOverdrawVisualizationMask;
+        menuItem.title = isShown ? @"Hide Overdraw Visualization" : @"Show Overdraw Visualization";
         return YES;
     }
     if (menuItem.action == @selector(showColorBuffer:)) {

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -21,8 +21,10 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
         diagnose collision and label placement issues. */
     MGLMapDebugCollisionBoxesMask = 1 << 4,
     
-    /** Overdraw inspector. */
-    MGLMapDebugOverdrawsMask = 1 << 5,
+    /** Each drawing operation is replaced by a translucent fill. Overlapping
+        drawing operations appear more prominent to help diagnose overdrawing.
+     */
+    MGLMapDebugOverdrawVisualizationMask = 1 << 5,
     
     /** The stencil buffer is shown instead of the color buffer. */
     MGLMapDebugStencilBufferMask = 1 << 6,

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2399,7 +2399,7 @@ public:
         mask |= MGLMapDebugCollisionBoxesMask;
     }
     if (options & mbgl::MapDebugOptions::Overdraw) {
-        mask |= MGLMapDebugOverdrawsMask;
+        mask |= MGLMapDebugOverdrawVisualizationMask;
     }
     if (options & mbgl::MapDebugOptions::StencilClip) {
         mask |= MGLMapDebugStencilBufferMask;
@@ -2421,7 +2421,7 @@ public:
     if (debugMask & MGLMapDebugCollisionBoxesMask) {
         options |= mbgl::MapDebugOptions::Collision;
     }
-    if (debugMask & MGLMapDebugOverdrawsMask) {
+    if (debugMask & MGLMapDebugOverdrawVisualizationMask) {
         options |= mbgl::MapDebugOptions::Overdraw;
     }
     if (debugMask & MGLMapDebugStencilBufferMask) {


### PR DESCRIPTION
A verb doesn’t make sense in this enum value. Besides, overdrawing is the bug that this effect exposes, not the effect itself. Instead, use a descriptive, Cocoa-compliant word for this effect and describe it in detail in the documentation comment. The core implementation continues to use the same term as GL JS.

/ref #5403
/cc @brunoabinader @friedbunny