### PR TITLE
Remove TexturePool dependency from Raster

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -255,7 +255,7 @@ void Map::Impl::update() {
 
 void Map::Impl::render() {
     if (!painter) {
-        painter = std::make_unique<Painter>(transform.getState(), store);
+        painter = std::make_unique<Painter>(transform.getState(), *texturePool, store);
     }
 
     FrameData frameData { view.getFramebufferSize(),

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -16,6 +16,7 @@ class UnwrappedTileID;
 class CollisionTile;
 
 namespace gl {
+class TexturePool;
 class ObjectStore;
 } // namespace gl
 
@@ -29,7 +30,7 @@ public:
 
     // As long as this bucket has a Prepare render pass, this function is getting called. Typically,
     // this only happens once when the bucket is being rendered for the first time.
-    virtual void upload(gl::ObjectStore&) = 0;
+    virtual void upload(gl::TexturePool&, gl::ObjectStore&) = 0;
 
     // Every time this bucket is getting rendered, this function is called. This happens either
     // once or twice (for Opaque and Transparent render passes).

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -16,7 +16,7 @@ CircleBucket::~CircleBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void CircleBucket::upload(gl::ObjectStore& store) {
+void CircleBucket::upload(gl::TexturePool&, gl::ObjectStore& store) {
     vertexBuffer_.upload(store);
     elementsBuffer_.upload(store);
     uploaded = true;

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -18,7 +18,7 @@ public:
     CircleBucket(const MapMode);
     ~CircleBucket() override;
 
-    void upload(gl::ObjectStore&) override;
+    void upload(gl::TexturePool&, gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
 
     bool hasData() const override;

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -95,7 +95,7 @@ void FillBucket::addGeometry(const GeometryCollection& geometry) {
     }
 }
 
-void FillBucket::upload(gl::ObjectStore& store) {
+void FillBucket::upload(gl::TexturePool&, gl::ObjectStore& store) {
     vertexBuffer.upload(store);
     triangleElementsBuffer.upload(store);
     lineElementsBuffer.upload(store);

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -20,7 +20,7 @@ public:
     FillBucket();
     ~FillBucket() override;
 
-    void upload(gl::ObjectStore&) override;
+    void upload(gl::TexturePool&, gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool needsClipping() const override;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -437,7 +437,7 @@ void LineBucket::addPieSliceVertex(const GeometryCoordinate& currentVertex,
     }
 }
 
-void LineBucket::upload(gl::ObjectStore& store) {
+void LineBucket::upload(gl::TexturePool&, gl::ObjectStore& store) {
     vertexBuffer.upload(store);
     triangleElementsBuffer.upload(store);
 

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -24,7 +24,7 @@ public:
     LineBucket(uint32_t overscaling);
     ~LineBucket() override;
 
-    void upload(gl::ObjectStore&) override;
+    void upload(gl::TexturePool&, gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool needsClipping() const override;

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -50,9 +50,10 @@ namespace mbgl {
 
 using namespace style;
 
-Painter::Painter(const TransformState& state_, gl::ObjectStore& store_)
-    : state(state_),
-      store(store_) {
+Painter::Painter(const TransformState& state_,
+                 gl::TexturePool& texturePool_,
+                 gl::ObjectStore& store_)
+    : state(state_), texturePool(texturePool_), store(store_) {
     gl::debugging::enable();
 
     plainShader = std::make_unique<PlainShader>(store);
@@ -128,7 +129,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
 
         for (const auto& item : order) {
             if (item.bucket && item.bucket->needsUpload()) {
-                item.bucket->upload(store);
+                item.bucket->upload(texturePool, store);
             }
         }
     }

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -60,6 +60,7 @@ class CollisionBoxShader;
 struct ClipID;
 
 namespace util {
+class TexturePool;
 class ObjectStore;
 } // namespace util
 
@@ -85,7 +86,7 @@ struct FrameData {
 
 class Painter : private util::noncopyable {
 public:
-    Painter(const TransformState&, gl::ObjectStore&);
+    Painter(const TransformState&, gl::TexturePool&, gl::ObjectStore&);
     ~Painter();
 
     void render(const style::Style&,
@@ -178,6 +179,7 @@ private:
     }();
 
     const TransformState& state;
+    gl::TexturePool& texturePool;
     gl::ObjectStore& store;
 
     FrameData frame;

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -37,7 +37,7 @@ void Painter::renderRaster(RasterBucket& bucket,
         config.depthTest = GL_TRUE;
         config.depthMask = GL_FALSE;
         setDepthSublayer(0);
-        bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray, store);
+        bucket.drawRaster(*rasterShader, tileStencilBuffer, coveringRasterArray, texturePool, store);
     }
 }
 

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -7,13 +7,9 @@ namespace mbgl {
 
 using namespace style;
 
-RasterBucket::RasterBucket(gl::TexturePool& texturePool)
-: raster(texturePool) {
-}
-
-void RasterBucket::upload(gl::ObjectStore& store) {
+void RasterBucket::upload(gl::TexturePool& texturePool, gl::ObjectStore& store) {
     if (hasData()) {
-        raster.upload(store);
+        raster.upload(texturePool, store);
         uploaded = true;
     }
 }
@@ -29,8 +25,12 @@ void RasterBucket::setImage(PremultipliedImage image) {
     raster.load(std::move(image));
 }
 
-void RasterBucket::drawRaster(RasterShader& shader, StaticVertexBuffer &vertices, VertexArrayObject &array, gl::ObjectStore& store) {
-    raster.bind(true, store);
+void RasterBucket::drawRaster(RasterShader& shader,
+                              StaticVertexBuffer& vertices,
+                              VertexArrayObject& array,
+                              gl::TexturePool& texturePool,
+                              gl::ObjectStore& store) {
+    raster.bind(true, texturePool, store);
     array.bind(shader, vertices, BUFFER_OFFSET_0, store);
     MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)vertices.index()));
 }

--- a/src/mbgl/renderer/raster_bucket.hpp
+++ b/src/mbgl/renderer/raster_bucket.hpp
@@ -11,16 +11,14 @@ class VertexArrayObject;
 
 class RasterBucket : public Bucket {
 public:
-    RasterBucket(gl::TexturePool&);
-
-    void upload(gl::ObjectStore&) override;
+    void upload(gl::TexturePool&, gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool needsClipping() const override;
 
     void setImage(PremultipliedImage);
 
-    void drawRaster(RasterShader&, StaticVertexBuffer&, VertexArrayObject&, gl::ObjectStore&);
+    void drawRaster(RasterShader&, StaticVertexBuffer&, VertexArrayObject&, gl::TexturePool&, gl::ObjectStore&);
 
     Raster raster;
 };

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -73,7 +73,7 @@ SymbolBucket::~SymbolBucket() {
     // Do not remove. header file only contains forward definitions to unique pointers.
 }
 
-void SymbolBucket::upload(gl::ObjectStore& store) {
+void SymbolBucket::upload(gl::TexturePool&, gl::ObjectStore& store) {
     if (hasTextData()) {
         renderData->text.vertices.upload(store);
         renderData->text.triangles.upload(store);

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -69,7 +69,7 @@ public:
     SymbolBucket(uint32_t overscaling, float zoom, const MapMode, std::string bucketName_, std::string sourceLayerName_);
     ~SymbolBucket() override;
 
-    void upload(gl::ObjectStore&) override;
+    void upload(gl::TexturePool&, gl::ObjectStore&) override;
     void render(Painter&, const style::Layer&, const UnwrappedTileID&, const mat4&) override;
     bool hasData() const override;
     bool hasTextData() const;

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -15,7 +15,6 @@ RasterTile::RasterTile(const OverscaledTileID& id_,
                        const style::UpdateParameters& parameters,
                        const Tileset& tileset)
     : Tile(id_),
-      texturePool(parameters.texturePool),
       worker(parameters.worker),
       loader(*this, id_, parameters, tileset) {
 }
@@ -42,7 +41,7 @@ void RasterTile::setData(std::shared_ptr<const std::string> data,
     }
 
     workRequest.reset();
-    workRequest = worker.parseRasterTile(std::make_unique<RasterBucket>(texturePool), data, [this] (RasterTileParseResult result) {
+    workRequest = worker.parseRasterTile(std::make_unique<RasterBucket>(), data, [this] (RasterTileParseResult result) {
         workRequest.reset();
 
         availableData = DataAvailability::All;

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -35,7 +35,6 @@ public:
     Bucket* getBucket(const style::Layer&) override;
 
 private:
-    gl::TexturePool& texturePool;
     Worker& worker;
 
     TileLoader<RasterTile> loader;

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -9,10 +9,6 @@
 
 using namespace mbgl;
 
-Raster::Raster(gl::TexturePool& texturePool_)
-    : texturePool(texturePool_)
-{}
-
 bool Raster::isLoaded() const {
     std::lock_guard<std::mutex> lock(mtx);
     return loaded;
@@ -30,14 +26,14 @@ void Raster::load(PremultipliedImage image) {
 }
 
 
-void Raster::bind(bool linear, gl::ObjectStore& store) {
+void Raster::bind(bool linear, gl::TexturePool& texturePool, gl::ObjectStore& store) {
     if (!width || !height) {
         Log::Error(Event::OpenGL, "trying to bind texture without dimension");
         return;
     }
 
     if (img.data && !texture) {
-        upload(store);
+        upload(texturePool, store);
     } else if (texture) {
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));
     }
@@ -50,7 +46,7 @@ void Raster::bind(bool linear, gl::ObjectStore& store) {
     }
 }
 
-void Raster::upload(gl::ObjectStore& store) {
+void Raster::upload(gl::TexturePool& texturePool, gl::ObjectStore& store) {
     if (img.data && !texture) {
         texture = texturePool.acquireTexture(store);
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, *texture));

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -14,16 +14,14 @@ namespace mbgl {
 class Raster : public std::enable_shared_from_this<Raster> {
 
 public:
-    Raster(gl::TexturePool&);
-
     // load image data
     void load(PremultipliedImage);
 
     // bind current texture
-    void bind(bool linear, gl::ObjectStore&);
+    void bind(bool linear, gl::TexturePool&, gl::ObjectStore&);
 
     // uploads the texture if it hasn't been uploaded yet.
-    void upload(gl::ObjectStore&);
+    void upload(gl::TexturePool&, gl::ObjectStore&);
 
     // loaded status
     bool isLoaded() const;
@@ -44,9 +42,6 @@ private:
 
     // raw pixels have been loaded
     bool loaded = false;
-
-    // shared texture pool
-    gl::TexturePool& texturePool;
 
     // min/mag filter
     GLint filter = 0;


### PR DESCRIPTION
The `Raster` object currently has a construction-time dependency on `TexturePool`, but all we do is store the reference until we need it when calling `.bind()`. Instead, we can just pass it then.