### PR TITLE
Reuse image buffer in HeadlessView

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -41,7 +41,7 @@ public:
 
     // Register a callback that will get called (on the render thread) when all resources have
     // been loaded and a complete render occurs.
-    using StillImageCallback = std::function<void (std::exception_ptr, PremultipliedImage&&)>;
+    using StillImageCallback = std::function<void (std::exception_ptr, std::shared_ptr<const PremultipliedImage>)>;
     void renderStill(StillImageCallback callback);
 
     // Main render function.

--- a/include/mbgl/map/view.hpp
+++ b/include/mbgl/map/view.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/map/change.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/image.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <array>
 #include <functional>
@@ -58,6 +59,8 @@ public:
     virtual void notifyMapChange(MapChange change);
 
 protected:
+    MBGL_STORE_THREAD(tid);
+
     mbgl::Map *map = nullptr;
 };
 } // namespace mbgl

--- a/include/mbgl/map/view.hpp
+++ b/include/mbgl/map/view.hpp
@@ -52,7 +52,7 @@ public:
 
     // Reads the pixel data from the current framebuffer. If your View implementation
     // doesn't support reading from the framebuffer, return a null pointer.
-    virtual PremultipliedImage readStillImage();
+    virtual std::shared_ptr<const PremultipliedImage> readStillImage();
 
     // Notifies a watcher of map x/y/scale/rotation changes.
     virtual void notifyMapChange(MapChange change);

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -41,7 +41,7 @@ public:
     void activate() override;
     void deactivate() override;
 
-    PremultipliedImage readStillImage() override;
+    std::shared_ptr<const PremultipliedImage> readStillImage() override;
 
     void resize(uint16_t width, uint16_t height);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-native",
-  "version": "3.2.1",
+  "version": "3.2.2-pre.4",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -51,6 +51,8 @@ void HeadlessView::resize(const uint16_t width, const uint16_t height) {
 }
 
 std::shared_ptr<const PremultipliedImage> HeadlessView::readStillImage() {
+    MBGL_VERIFY_THREAD(tid);
+
     assert(active);
     assert(dimensions[0] <= dimensionsLimits[0]);
     assert(dimensions[1] <= dimensionsLimits[1]);

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -40,18 +40,18 @@ void HeadlessView::resize(const uint16_t width, const uint16_t height) {
     needsResize = true;
 }
 
-PremultipliedImage HeadlessView::readStillImage() {
+std::shared_ptr<const PremultipliedImage> HeadlessView::readStillImage() {
     assert(active);
 
     const unsigned int w = dimensions[0] * pixelRatio;
     const unsigned int h = dimensions[1] * pixelRatio;
 
-    PremultipliedImage image { w, h };
-    MBGL_CHECK_ERROR(glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image.data.get()));
+    auto image = std::make_shared<PremultipliedImage>(w, h);
+    MBGL_CHECK_ERROR(glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image->data.get()));
 
-    const auto stride = image.stride();
+    const auto stride = image->stride();
     auto tmp = std::make_unique<uint8_t[]>(stride);
-    uint8_t* rgba = image.data.get();
+    uint8_t* rgba = image->data.get();
     for (int i = 0, j = h - 1; i < j; i++, j--) {
         std::memcpy(tmp.get(), rgba + i * stride, stride);
         std::memcpy(rgba + i * stride, rgba + j * stride, stride);

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -724,7 +724,7 @@ public:
 
         if (_isPrinting) {
             _isPrinting = NO;
-            std::string png = encodePNG(_mbglView->readStillImage());
+            std::string png = encodePNG(*_mbglView->readStillImage());
             NSData *data = [[NSData alloc] initWithBytes:png.data() length:png.size()];
             NSImage *image = [[NSImage alloc] initWithData:data];
             [self performSelector:@selector(printWithImage:) withObject:image afterDelay:0];
@@ -2468,17 +2468,17 @@ public:
         [NSOpenGLContext clearCurrentContext];
     }
 
-    mbgl::PremultipliedImage readStillImage() override {
+    std::shared_ptr<mbgl::PremultipliedImage> readStillImage() override {
         auto size = getFramebufferSize();
         const unsigned int w = size[0];
         const unsigned int h = size[1];
         
-        mbgl::PremultipliedImage image { w, h };
+        auto image = std::make_shared<mbgl::PremultipliedImage>(w, h);
         MBGL_CHECK_ERROR(glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image.data.get()));
         
-        const size_t stride = image.stride();
+        const size_t stride = image->stride();
         auto tmp = std::make_unique<uint8_t[]>(stride);
-        uint8_t *rgba = image.data.get();
+        uint8_t *rgba = image->data.get();
         for (int i = 0, j = h - 1; i < j; i++, j--) {
             std::memcpy(tmp.get(), rgba + i * stride, stride);
             std::memcpy(rgba + i * stride, rgba + j * stride, stride);

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -51,7 +51,8 @@ public:
     std::unique_ptr<mbgl::Map> map;
 
     std::exception_ptr error;
-    mbgl::PremultipliedImage image;
+    std::shared_ptr<const mbgl::PremultipliedImage> image =
+        std::make_shared<const mbgl::PremultipliedImage>(0,0);
     std::unique_ptr<Nan::Callback> callback;
 
     // Async for delivering the notifications of render completion.

--- a/src/mbgl/map/view.cpp
+++ b/src/mbgl/map/view.cpp
@@ -10,8 +10,8 @@ void View::initialize(Map *map_) {
     map = map_;
 }
 
-PremultipliedImage View::readStillImage() {
-    return {};
+std::shared_ptr<const PremultipliedImage> View::readStillImage() {
+    return nullptr;
 }
 
 void View::notifyMapChange(MapChange) {

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -29,7 +29,7 @@ public:
 
     void checkRendering(const char * name) {
         test::checkImage(std::string("test/fixtures/annotations/") + name,
-                         test::render(map), 0.0002, 0.1);
+                         *test::render(map), 0.0002, 0.1);
     }
 };
 

--- a/test/api/api_misuse.cpp
+++ b/test/api/api_misuse.cpp
@@ -50,7 +50,7 @@ TEST(API, RenderWithoutStyle) {
     Map map(view, fileSource, MapMode::Still);
 
     std::exception_ptr error;
-    map.renderStill([&](std::exception_ptr error_, PremultipliedImage&&) {
+    map.renderStill([&](std::exception_ptr error_, std::shared_ptr<const PremultipliedImage>) {
         error = error_;
         loop.stop();
     });

--- a/test/api/custom_layer.cpp
+++ b/test/api/custom_layer.cpp
@@ -90,5 +90,5 @@ TEST(CustomLayer, Basic) {
             delete reinterpret_cast<TestLayer*>(context);
         }, new TestLayer()));
 
-    test::checkImage("test/fixtures/custom_layer/basic", test::render(map));
+    test::checkImage("test/fixtures/custom_layer/basic", *test::render(map));
 }

--- a/test/api/render_missing.cpp
+++ b/test/api/render_missing.cpp
@@ -41,7 +41,7 @@ TEST(API, TEST_REQUIRES_SERVER(RenderMissingTile)) {
 
     // This host does not respond (== connection error).
     map.setStyleJSON(style);
-    map.renderStill([&](std::exception_ptr err, PremultipliedImage&&) {
+    map.renderStill([&](std::exception_ptr err, std::shared_ptr<const PremultipliedImage>) {
         ASSERT_TRUE(err.operator bool());
         try {
             std::rethrow_exception(err);

--- a/test/api/repeated_render.cpp
+++ b/test/api/repeated_render.cpp
@@ -33,37 +33,37 @@ TEST(API, RepeatedRender) {
 
     {
         map.setStyleJSON(style);
-        PremultipliedImage result;
-        map.renderStill([&result](std::exception_ptr, PremultipliedImage&& image) {
-            result = std::move(image);
+        std::shared_ptr<const PremultipliedImage> result;
+        map.renderStill([&result](std::exception_ptr, std::shared_ptr<const PremultipliedImage> image) {
+            result = image;
         });
 
-        while (!result.size()) {
+        while (!result) {
             loop.runOnce();
         }
 
-        ASSERT_EQ(256u, result.width);
-        ASSERT_EQ(512u, result.height);
+        ASSERT_EQ(256u, result->width);
+        ASSERT_EQ(512u, result->height);
 #if !TEST_READ_ONLY
-        util::write_file("test/fixtures/api/1.png", encodePNG(result));
+        util::write_file("test/fixtures/api/1.png", encodePNG(*result));
 #endif
     }
 
     {
         map.setStyleJSON(style);
-        PremultipliedImage result;
-        map.renderStill([&result](std::exception_ptr, PremultipliedImage&& image) {
-            result = std::move(image);
+        std::shared_ptr<const PremultipliedImage> result;
+        map.renderStill([&result](std::exception_ptr, std::shared_ptr<const PremultipliedImage> image) {
+            result = image;
         });
 
-        while (!result.size()) {
+        while (!result) {
             loop.runOnce();
         }
 
-        ASSERT_EQ(256u, result.width);
-        ASSERT_EQ(512u, result.height);
+        ASSERT_EQ(256u, result->width);
+        ASSERT_EQ(512u, result->height);
 #if !TEST_READ_ONLY
-        util::write_file("test/fixtures/api/2.png", encodePNG(result));
+        util::write_file("test/fixtures/api/2.png", encodePNG(*result));
 #endif
     }
 

--- a/test/map/map.cpp
+++ b/test/map/map.cpp
@@ -46,7 +46,7 @@ TEST(Map, Offline) {
     map.setStyleURL(prefix + "style.json");
 
     test::checkImage("test/fixtures/map/offline",
-                     test::render(map),
+                     *test::render(map),
                      0.0015,
                      0.1);
 
@@ -71,7 +71,7 @@ TEST(Map, AddLayer) {
     layer->setBackgroundColor({{ 1, 0, 0, 1 }});
     map.addLayer(std::move(layer));
 
-    test::checkImage("test/fixtures/map/add_layer", test::render(map));
+    test::checkImage("test/fixtures/map/add_layer", *test::render(map));
 }
 
 TEST(Map, RemoveLayer) {
@@ -85,5 +85,5 @@ TEST(Map, RemoveLayer) {
     map.addLayer(std::move(layer));
     map.removeLayer("background");
 
-    test::checkImage("test/fixtures/map/remove_layer", test::render(map));
+    test::checkImage("test/fixtures/map/remove_layer", *test::render(map));
 }

--- a/test/src/mbgl/test/util.cpp
+++ b/test/src/mbgl/test/util.cpp
@@ -86,13 +86,13 @@ Server::~Server() {
     }
 }
 
-PremultipliedImage render(Map& map) {
-    PremultipliedImage result;
-    map.renderStill([&result](std::exception_ptr, PremultipliedImage&& image) {
-        result = std::move(image);
+std::shared_ptr<const PremultipliedImage> render(Map& map) {
+    std::shared_ptr<const PremultipliedImage> result;
+    map.renderStill([&result](std::exception_ptr, std::shared_ptr<const PremultipliedImage> image) {
+        result = image;
     });
 
-    while (!result.size()) {
+    while (!result) {
         util::RunLoop::Get()->runOnce();
     }
 

--- a/test/src/mbgl/test/util.hpp
+++ b/test/src/mbgl/test/util.hpp
@@ -66,7 +66,7 @@ private:
     int fd = -1;
 };
 
-PremultipliedImage render(Map&);
+std::shared_ptr<const PremultipliedImage> render(Map&);
 
 void checkImage(const std::string& base,
                 const PremultipliedImage& actual,


### PR DESCRIPTION
Took a shot at wiring @tmpsantos' work on reusing the image buffer in `mbgl::HeadlessView` into the Node.js bindings, and something is definitely not right, causing segfaults during a benchmark - I'm not entirely sure how to properly handle memory management here, as I can't call `image->data.release()` with `std::shared_ptr<const mbgl::PremultipliedImage>` due to `const`, and some other stuff changed around to use `std::unique_ptr::swap` instead of `std::move`.

Can you take a closer look at this @jfirebaugh @tmpsantos, particularly the interaction between [`Nan::NewBuffer`](https://github.com/nodejs/nan/blob/master/doc/buffers.md#api_nan_new_buffer) and [`mbgl::PremultipliedImage::data`](https://github.com/mapbox/mapbox-gl-native/blob/4294b0f83a6894cd6a1679c7fb427eefeac5a7a6/include/mbgl/util/image.hpp#L54) in `NodeMap::renderFinished`?