### PR TITLE
Specify ultra light weight literally

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -579,8 +579,9 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     UIGraphicsBeginImageContextWithOptions(scaleImage.size, NO, [UIScreen mainScreen].scale);
     [scaleImage drawInRect:{ CGPointZero, scaleImage.size }];
     
+    CGFloat weight = &UIFontWeightUltraLight ? UIFontWeightUltraLight : -0.8;
     NSAttributedString *north = [[NSAttributedString alloc] initWithString:NSLocalizedStringWithDefaultValue(@"COMPASS_NORTH", nil, nil, @"N", @"Compass abbreviation for north") attributes:@{
-        NSFontAttributeName: [UIFont systemFontOfSize:9 weight:UIFontWeightUltraLight],
+        NSFontAttributeName: [UIFont systemFontOfSize:9 weight:weight],
         NSForegroundColorAttributeName: [UIColor whiteColor],
     }];
     CGRect stringRect = CGRectMake((scaleImage.size.width - north.size.width) / 2,


### PR DESCRIPTION
Fixed a crash on iOS 8.1 and below due to specifying the compass legend’s font weight using a font weight constant that was introduced in iOS 8.2. `UIFontWeightUltraLight` happens to equal −0.8 on iOS 9 in the default configuration. I think it’s reasonable to hardcode this value as a fallback; we still use the system constant when it’s available.

Fixes #5486, a regression introduced in #4783.

/cc @friedbunny