### PR TITLE
[ios, macos] Use common instead of default mode for run loop source

### DIFF
--- a/platform/darwin/src/async_task.cpp
+++ b/platform/darwin/src/async_task.cpp
@@ -25,7 +25,7 @@ public:
             perform
         };
         source = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &context);
-        CFRunLoopAddSource(loop, source, kCFRunLoopDefaultMode);
+        CFRunLoopAddSource(loop, source, kCFRunLoopCommonModes);
     }
 
     ~Impl() {


### PR DESCRIPTION
The map events instigated by certain actions (i.e. updates from a UIScrollView) are not processed by the run loop with `kCFRunLoopDefaultMode`until the thread is idle. This changes the mode to `kCFRunLoopCommonModes` to avoid this issue.

cc @1ec5 @jfirebaugh 