### PR TITLE
[ios] Fix conflict between view dragging gesture and quick zoom

### DIFF
--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -238,7 +238,7 @@
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    return YES;
+    return otherGestureRecognizer == _longPressRecognizer || otherGestureRecognizer == _panGestureRecognizer;
 }
 
 - (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event


### PR DESCRIPTION
This stops the quick zoom gesture (double-tap and hold) from also triggering a drag, when performed on a draggable annotation view. 

Here is the buggy sequence of events:

1. MGLMapView’s quick zoom long press gesture fires [after one tap and a 0 second long press](https://github.com/mapbox/mapbox-gl-native/blob/33a8856c2af9c587e35b97658f9a7aed85a7cf60/platform/ios/src/MGLMapView.mm#L506-L507).
1. If the long press is held, MGLAnnotationView’s long press fires after the default delay (0.5 seconds).
1. Panning vertically will zoom the map and drag the annotation.

MGLAnnotationView’s drag was unconditionally allowed to fire simultaneously, even though it was also being performed with MGLMapView’s quick zoom. This PR limits MGLAnnotationView’s drag gesture by only allowing its long press and pan recognizers to fire in conjunction with one another.

/cc @frederoni @boundsj @1ec5