### PR TITLE
[ios] Always use symbol name for annotation update

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1768,16 +1768,12 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         if (annotation == [self annotationWithTag:annotationTag])
         {
             const mbgl::Point<double> point = MGLPointFromLocationCoordinate2D(annotation.coordinate);
-            
-            MGLAnnotationContext &annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
+
             NSString *symbolName;
-            if (!annotationContext.annotationView)
-            {
-                MGLAnnotationImage *annotationImage = [self imageOfAnnotationWithTag:annotationTag];
-                symbolName = annotationImage.styleIconIdentifier;
-            }
-            
-            _mbglMap->updateAnnotation(annotationTag, mbgl::SymbolAnnotation { point, symbolName.UTF8String ?: "" });
+            MGLAnnotationImage *annotationImage = [self imageOfAnnotationWithTag:annotationTag];
+            symbolName = annotationImage.styleIconIdentifier;
+
+            _mbglMap->updateAnnotation(annotationTag, mbgl::SymbolAnnotation { point, symbolName.UTF8String});
             if (annotationTag == _selectedAnnotationTag)
             {
                 [self deselectAnnotation:annotation animated:YES];


### PR DESCRIPTION
This removes the guard for setting the sprite symbol name when annotation coordinates are updated. The guard was added when UIView backed annotations did not have invisible image placeholders. Since images are now present for both sprite and UIView backed annotations, the guard is no longer necessary and removing it allows for the correct symbol name to be passed to the mbgl map's `updateAnnoation` method and this gets rid of `[INFO] {Worker}[Sprite]: Can't find sprite named 'default_marker'` log message.

To put it another way, this gets rid of log messages related to unknown sprite names when annotations backed by UIViews have their coordinates changed.

This is an additional fix required for https://github.com/mapbox/mapbox-gl-native/issues/5210 that was missed in https://github.com/mapbox/mapbox-gl-native/pull/5461.

cc @friedbunny 