### PR TITLE
[core] Added CharArrayBuffer

### DIFF
--- a/include/mbgl/util/char_array_buffer.hpp
+++ b/include/mbgl/util/char_array_buffer.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <streambuf>
+
+namespace mbgl {
+namespace util {
+
+// ref https://artofcode.wordpress.com/2010/12/12/deriving-from-stdstreambuf/
+
+class CharArrayBuffer : public std::streambuf
+{
+public:
+    CharArrayBuffer(char const* data, std::size_t size)
+        : begin_(data), end_(data + size), current_(data) {}
+
+private:
+    int_type underflow() final {
+        if (current_ == end_) {
+            return traits_type::eof();
+        }
+        return traits_type::to_int_type(*current_);
+    }
+
+    int_type uflow() final {
+        if (current_ == end_) {
+            return traits_type::eof();
+        }
+        return traits_type::to_int_type(*current_++);
+    }
+
+    int_type pbackfail(int_type ch) final {
+        if (current_ == begin_ || (ch != traits_type::eof() && ch != current_[-1])) {
+            return traits_type::eof();
+        }
+        return traits_type::to_int_type(*--current_);
+    }
+
+    std::streamsize showmanyc() final {
+        return end_ - current_;
+    }
+
+    pos_type seekoff(off_type off, std::ios_base::seekdir dir, std::ios_base::openmode) final {
+        if (dir == std::ios_base::beg) current_ = std::min(begin_ + off, end_);
+        else if (dir == std::ios_base::cur) current_ = std::min(current_ + off, end_);
+        else current_ = std::max(end_ - off, begin_); // dir == std::ios_base::end
+        return pos_type(off_type(current_ - begin_));
+    }
+
+    char const * const begin_;
+    char const * const end_;
+    char const * current_;
+};
+
+} // namespace util
+} // namespace mbgl

--- a/platform/default/jpeg_reader.cpp
+++ b/platform/default/jpeg_reader.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/util/image.hpp>
+#include <mbgl/util/char_array_buffer.hpp>
 
 #include <istream>
 #include <sstream>
@@ -21,7 +22,7 @@ struct jpeg_stream_wrapper {
 
 static void init_source(j_decompress_ptr cinfo) {
     jpeg_stream_wrapper* wrap = reinterpret_cast<jpeg_stream_wrapper*>(cinfo->src);
-    wrap->stream->seekg(0);
+    wrap->stream->seekg(0, std::ios_base::beg);
 }
 
 static boolean fill_input_buffer(j_decompress_ptr cinfo) {
@@ -89,8 +90,8 @@ struct jpeg_info_guard {
 };
 
 PremultipliedImage decodeJPEG(const uint8_t* data, size_t size) {
-    std::istringstream source(std::string(reinterpret_cast<const char*>(data), size));
-    std::istream stream(source.rdbuf());
+    util::CharArrayBuffer dataBuffer { reinterpret_cast<const char*>(data), size };
+    std::istream stream(&dataBuffer);
 
     jpeg_decompress_struct cinfo;
     jpeg_info_guard iguard(&cinfo);

--- a/platform/default/png_reader.cpp
+++ b/platform/default/png_reader.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/premultiply.hpp>
+#include <mbgl/util/char_array_buffer.hpp>
 #include <mbgl/platform/log.hpp>
 
 #include <istream>
@@ -44,8 +45,8 @@ struct png_struct_guard {
 };
 
 PremultipliedImage decodePNG(const uint8_t* data, size_t size) {
-    std::istringstream source(std::string(reinterpret_cast<const char*>(data), size));
-    std::istream stream(source.rdbuf());
+    util::CharArrayBuffer dataBuffer { reinterpret_cast<const char*>(data), size };
+    std::istream stream(&dataBuffer);
 
     png_byte header[8] = { 0 };
     stream.read(reinterpret_cast<char*>(header), 8);


### PR DESCRIPTION
Implements a custom `std::streambuf` that reads directly from a char array. This buffer assumes that the array remains valid during its entire lifetime. This avoid creating temporary `std::string` objects and thus optimizes image decode.

Suggested by @artemp in https://github.com/mapbox/mapbox-gl-native/pull/5417#issuecomment-227700063.

:eyes: @artemp @jfirebaugh 