### PR TITLE
[core] Enforce solid fragColor for debug frame/text

### DIFF
--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -42,6 +42,7 @@ void Painter::renderDebugText(Tile& tile, const mat4 &matrix) {
 
     config.program = plainShader->getID();
     plainShader->u_matrix = matrix;
+    plainShader->u_opacity = 1.0f;
 
     // Draw white outline
     plainShader->u_color = Color::white();
@@ -75,6 +76,7 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
 
     config.program = plainShader->getID();
     plainShader->u_matrix = matrix;
+    plainShader->u_opacity = 1.0f;
 
     // draw tile outline
     tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET_0, store);


### PR DESCRIPTION
Fixes an issue with rendering debug frame/text being too opaque in certain zooms.

| Before | After |
|:--:|:--:|
| <img width="400" alt="screen shot 2016-07-02 at 1 03 54 pm" src="https://cloud.githubusercontent.com/assets/76133/16539776/b69c54f8-4055-11e6-8726-940ed43ff66b.png"> | <img width="400" alt="screen shot 2016-07-02 at 1 04 07 pm" src="https://cloud.githubusercontent.com/assets/76133/16539782/eded61f4-4055-11e6-9d6d-7a948c12398b.png"> |

:eyes: @kkaefer @tmpsantos 
