### PR TITLE
Remove MGLAnnotationView.flat

### DIFF
--- a/platform/ios/Mapbox.playground/Contents.swift
+++ b/platform/ios/Mapbox.playground/Contents.swift
@@ -75,7 +75,6 @@ class MapDelegate: NSObject, MGLMapViewDelegate {
             let av = PlaygroundAnnotationView(reuseIdentifier: "annotation")
             av.frame = CGRect(x: 0, y: 0, width: 30, height: 30)
             av.centerOffset = CGVector(dx: -15, dy: -15)
-            av.flat = true
             let centerView = UIView(frame: CGRectInset(av.bounds, 3, 3))
             centerView.backgroundColor = UIColor.whiteColor()
             av.addSubview(centerView)

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -589,10 +589,6 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         annotationView.frame = CGRectMake(0, 0, 10, 10);
         annotationView.centerColor = [UIColor whiteColor];
        
-        // uncomment to flatten the annotation view against the map when the map is tilted
-        // this currently causes severe performance issues when more than 2k annotations are visible
-        // annotationView.flat = YES;
-        
         // uncomment to make the annotation view draggable
         // also note that having two long press gesture recognizers on overlapping views (`self.view` & `annotationView`) will cause weird behaviour
         // comment out the pin dropping functionality in the handleLongPress: method in this class to make draggable annotation views play nice

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -127,21 +127,6 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
 @property (nonatomic) CGVector centerOffset;
 
 /**
- A Boolean value indicating whether the view lies flat against the map as it
- tilts.
- 
- If this option is unset, the annotation view remains unchanged as the map’s
- pitch increases, so that the view appears to stand upright on the tilted map.
- If this option is set, the annotation view tilts as the map’s pitch increases,
- so that the view appears to lie flat against the tilted map.
- 
- For example, you would set this option if the annotation view depicts an arrow
- that should always point due south. You would unset this option if the arrow
- should always point down towards the ground.
- */
-@property (nonatomic, assign, getter=isFlat) BOOL flat;
-
-/**
  A Boolean value that determines whether the annotation view grows and shrinks
  as the distance between the viewpoint and the annotation view changes on a
  tilted map.

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -71,21 +71,10 @@
         return;
     }
     
-    if (self.flat)
-    {
-        [self updatePitch:pitch];
-    }
-  
     if (self.scalesWithViewingDistance)
     {
         [self updateScaleForPitch:pitch];
     }
-}
-
-- (void)updatePitch:(CGFloat)pitch
-{
-    CATransform3D t = CATransform3DRotate(CATransform3DIdentity, MGLRadiansFromDegrees(pitch), 1.0, 0, 0);
-    self.layer.transform = t;
 }
 
 - (void)updateScaleForPitch:(CGFloat)pitch
@@ -112,7 +101,7 @@
         // reduction is then normalized for a scale of 1.0.
         CGFloat pitchAdjustedScale = 1.0 - maxScaleReduction * pitchIntensity;
         
-        CATransform3D transform = self.flat ? self.layer.transform : CATransform3DIdentity;
+        CATransform3D transform = self.layer.transform;
         self.layer.transform = CATransform3DScale(transform, pitchAdjustedScale, pitchAdjustedScale, 1);
     }
 }


### PR DESCRIPTION
Removed MGLAnnotationView’s option to lie flat against a tilted map to work around #5090.

/cc @frederoni @boundsj