### PR TITLE
Annotation view implicit animation

### DIFF
--- a/platform/ios/app/MBXAnnotationView.h
+++ b/platform/ios/app/MBXAnnotationView.h
@@ -1,7 +1,4 @@
 #import <Mapbox/Mapbox.h>
 
 @interface MBXAnnotationView : MGLAnnotationView
-
-@property (nonatomic) UIColor *centerColor;
-
 @end

--- a/platform/ios/app/MBXAnnotationView.m
+++ b/platform/ios/app/MBXAnnotationView.m
@@ -1,28 +1,16 @@
 #import "MBXAnnotationView.h"
 
 @interface MBXAnnotationView ()
-
-@property (nonatomic) UIView *centerView;
-
 @end
 
 @implementation MBXAnnotationView
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    if (!self.centerView) {
-        self.backgroundColor = [UIColor blueColor];
-        self.centerView = [[UIView alloc] initWithFrame:CGRectInset(self.bounds, 1.0, 1.0)];
-        self.centerView.backgroundColor = self.centerColor;
-        [self addSubview:self.centerView];
-    }
-}
-
-- (void)setCenterColor:(UIColor *)centerColor {
-    if (![_centerColor isEqual:centerColor]) {
-        _centerColor = centerColor;
-        self.centerView.backgroundColor = centerColor;
-    }
+    
+    self.layer.borderColor = [UIColor blueColor].CGColor;
+    self.layer.borderWidth = 1;
+    self.layer.cornerRadius = 2;
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated

--- a/platform/ios/app/MBXAnnotationView.m
+++ b/platform/ios/app/MBXAnnotationView.m
@@ -51,6 +51,7 @@
         case MGLAnnotationViewDragStateCanceling:
             break;
         case MGLAnnotationViewDragStateEnding: {
+            self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 2, 2);
             [UIView animateWithDuration:.4 delay:0 usingSpringWithDamping:.4 initialSpringVelocity:.5 options:UIViewAnimationOptionCurveLinear animations:^{
                 self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1, 1);
             } completion:nil];
@@ -60,5 +61,17 @@
     
 }
 
+- (nullable id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
+{
+    if (([event isEqualToString:@"transform"] || [event isEqualToString:@"position"])
+        && self.dragState == MGLAnnotationViewDragStateNone)
+    {
+        CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:event];
+        animation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+        animation.speed = 0.1;
+        return animation;
+    }
+    return [super actionForLayer:layer forKey:event];
+}
 
 @end

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -587,22 +587,20 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     {
         annotationView = [[MBXAnnotationView alloc] initWithReuseIdentifier:MBXViewControllerAnnotationViewReuseIdentifer];
         annotationView.frame = CGRectMake(0, 0, 10, 10);
-        annotationView.centerColor = [UIColor whiteColor];
-       
+        annotationView.backgroundColor = [UIColor whiteColor];
+        
         // uncomment to make the annotation view draggable
         // also note that having two long press gesture recognizers on overlapping views (`self.view` & `annotationView`) will cause weird behaviour
         // comment out the pin dropping functionality in the handleLongPress: method in this class to make draggable annotation views play nice
         annotationView.draggable = YES;
-
-       
+        
         // uncomment to force annotation view to maintain a constant size when the map is tilted
         // by default, annotation views will shrink and grow as the move towards and away from the
         // horizon. Relatedly, annotations backed by GL sprites ONLY scale with viewing distance currently.
         // annotationView.scalesWithViewingDistance = NO;
-        
     } else {
         // orange indicates that the annotation view was reused
-        annotationView.centerColor = [UIColor orangeColor];
+        annotationView.backgroundColor = [UIColor orangeColor];
     }
     return annotationView;
 }

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -911,8 +911,8 @@
 			children = (
 				40EDA1BD1CFE0D4A00D9EA68 /* MGLAnnotationContainerView.h */,
 				40EDA1BE1CFE0D4A00D9EA68 /* MGLAnnotationContainerView.m */,
-				4018B1C31CDC277F00F666AF /* MGLAnnotationView_Private.h */,
 				4018B1C51CDC277F00F666AF /* MGLAnnotationView.h */,
+				4018B1C31CDC277F00F666AF /* MGLAnnotationView_Private.h */,
 				4018B1C41CDC277F00F666AF /* MGLAnnotationView.mm */,
 				DA8848341CBAFB8500AB86E3 /* MGLAnnotationImage.h */,
 				DA8848401CBAFB9800AB86E3 /* MGLAnnotationImage_Private.h */,

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -56,7 +56,7 @@
 
 - (void)setCenter:(CGPoint)center
 {
-    [self setCenter:center pitch:0];
+    [self setCenter:center pitch:self.mapView.camera.pitch];
 }
 
 - (void)setCenter:(CGPoint)center pitch:(CGFloat)pitch

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -243,7 +243,7 @@
 - (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
 {
     // Allow mbgl to drive animation of this view’s bounds.
-    if ([event isEqualToString:@"bounds"])
+    if ([event isEqualToString:@"bounds"] || [event isEqualToString:@"position"])
     {
         return [NSNull null];
     }

--- a/platform/ios/src/MGLAnnotationView_Private.h
+++ b/platform/ios/src/MGLAnnotationView_Private.h
@@ -11,8 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite, nullable) id <MGLAnnotation> annotation;
 @property (nonatomic, weak) MGLMapView *mapView;
 
-- (void)setCenter:(CGPoint)center pitch:(CGFloat)pitch;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4576,8 +4576,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
                     [self.glView addSubview:annotationView];
                 }
                 
-                CGPoint center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
-                [annotationView setCenter:center pitch:self.camera.pitch];
+                annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
                 annotationView.mapView = self;
                 annotationContext.annotationView = annotationView;
             }
@@ -4590,8 +4589,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         }
         else
         {
-            CGPoint center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
-            [annotationView setCenter:center pitch:self.camera.pitch];
+            annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
         }
     }
 }


### PR DESCRIPTION
This PR is a subset of #5245 that focuses on improving KVO compliance and animation in MGLAnnotationView:

* Fixed a bug causing an annotation view to be scaled based on a pitch of 0° when setting the view’s center offset.
* Always reposition the annotation view using the standard `-setCenter:` setter, fixing KVO compliance for the center key path and making the view behave more like a normal view. `-setCenter:` updates the transform by side effect, and it always starts from the identity transform to avoid surprises.
* An annotation view moves immediately when you change its `centerOffset` or `scalesWithViewingDistance` property.
* Made annotation views’ positions animatable. In iosapp, tapping the callout view of a D.C. fire hydrant annotation causes the annotation view to slide to the center of the screen, smoothly growing or shrinking when the map is tilted. The view still moves instantaneously with the map as you manipulate it with gestures, including when dragging the annotation. (Fixes #5230.)
* In iosapp, eliminated the center view of MBXAnnotationView in favor of applying a background color and border to the annotation view’s layer.

/cc @boundsj @frederoni @friedbunny