### PR TITLE
[qt] Implement Qt runtime style API

### DIFF
--- a/include/mbgl/style/conversion/make_property_setters.hpp
+++ b/include/mbgl/style/conversion/make_property_setters.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 // This file is generated. Edit make_property_setters.hpp.ejs, then run `make style-code`.
 
 #include <mbgl/style/conversion/property_setter.hpp>

--- a/include/mbgl/style/conversion/make_property_setters.hpp.ejs
+++ b/include/mbgl/style/conversion/make_property_setters.hpp.ejs
@@ -1,3 +1,5 @@
+#pragma once
+
 // This file is generated. Edit make_property_setters.hpp.ejs, then run `make style-code`.
 
 #include <mbgl/style/conversion/property_setter.hpp>

--- a/include/mbgl/style/conversion/property_setter.hpp
+++ b/include/mbgl/style/conversion/property_setter.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <mbgl/style/layer.hpp>
 #include <mbgl/style/conversion.hpp>
 #include <mbgl/style/conversion/constant.hpp>

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -64,8 +64,78 @@ typedef void (*CustomLayerDeinitializeFunction)(void* context);
 
 Q_DECL_EXPORT void initializeGLExtensions();
 
-}
+// Runtime Style API
+
+enum FilterValueType {
+    NullFilterValueType,
+    BooleanFilterValueType,
+    UnsignedIntegerFilterValueType,
+    SignedIntegerFilterValueType,
+    DoubleFilterValueType,
+    StringFilterValueType,
+    ListFilterValueType,
+    MapFilterValueType,
+};
+
+enum FilterType {
+    EqualsFilterType,
+    NotEqualsFilterType,
+    GreaterThanFilterType,
+    GreaterThanEqualsFilterType,
+    LessThanFilterType,
+    LessThanEqualsFilterType,
+    InFilterType,
+    NotInFilterType,
+    AllFilterType,
+    AnyFilterType,
+    NoneFilterType,
+    HasFilterType,
+    NotHasFilterType,
+};
+
+struct Q_DECL_EXPORT FilterValue {
+    QVariant value;
+    FilterValueType type;
+};
+
+typedef QList<FilterValue> FilterValueList;
+typedef QMap<QString, FilterValue> FilterValueMap;
+
+// BinaryFilterForm, SetFilterForm, CompoundFilterForm, UnaryFilterForm
+typedef QVariant FilterForm;
+
+struct Q_DECL_EXPORT Filter {
+    FilterType type;
+    FilterForm form;
+};
+
+struct Q_DECL_EXPORT BinaryFilterForm {
+    QString key;
+    FilterValue value;
+};
+
+struct Q_DECL_EXPORT SetFilterForm {
+    QString key;
+    FilterValueList values;
+};
+
+struct Q_DECL_EXPORT CompoundFilterForm {
+    QList<Filter> filters;
+};
+
+struct Q_DECL_EXPORT UnaryFilterForm {
+    QString key;
+};
+
+} // namespace QMapbox
 
 Q_DECLARE_METATYPE(QMapbox::Coordinate);
+
+Q_DECLARE_METATYPE(QMapbox::FilterValueList);
+Q_DECLARE_METATYPE(QMapbox::FilterValueMap);
+Q_DECLARE_METATYPE(QMapbox::BinaryFilterForm);
+Q_DECLARE_METATYPE(QMapbox::SetFilterForm);
+Q_DECLARE_METATYPE(QMapbox::CompoundFilterForm);
+Q_DECLARE_METATYPE(QMapbox::UnaryFilterForm);
 
 #endif // QMAPBOX_H

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -127,10 +127,30 @@ struct Q_DECL_EXPORT UnaryFilterForm {
     QString key;
 };
 
+enum LayerType {
+    FillLayer,
+    LineLayer,
+    CircleLayer,
+    SymbolLayer,
+    RasterLayer,
+    BackgroundLayer,
+};
+
+struct Q_DECL_EXPORT Layer {
+    LayerType type;
+    QString layerID;
+    QVariant sourceID; // QString
+    QVariant sourceLayer; // QString
+    QVariant filter; // Filter
+    QVariant minZoom; // float
+    QVariant maxZoom; // float
+};
+
 } // namespace QMapbox
 
 Q_DECLARE_METATYPE(QMapbox::Coordinate);
 
+Q_DECLARE_METATYPE(QMapbox::Filter);
 Q_DECLARE_METATYPE(QMapbox::FilterValueList);
 Q_DECLARE_METATYPE(QMapbox::FilterValueMap);
 Q_DECLARE_METATYPE(QMapbox::BinaryFilterForm);

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -170,6 +170,83 @@ struct Q_DECL_EXPORT Tileset {
     QVariant attribution; // QString
 };
 
+// Undefined, T, Function<T>
+// T can be QColor, Enum (QString), QString, bool, float,
+// PropertyValueNumbers, PropertyValueStrings
+typedef QVariant PropertyValue;
+
+typedef QList<float> PropertyValueNumbers;
+typedef QStringList PropertyValueStrings;
+
+typedef QPair<float, PropertyValue> PropertyValueFunctionStop;
+typedef QList<PropertyValueFunctionStop> PropertyValueFunctionStops;
+
+struct Q_DECL_EXPORT PropertyValueFunction {
+    float base;
+    PropertyValueFunctionStops stops;
+};
+
+enum PaintPropertyType {
+    // Background
+    BackgroundColor,
+    BackgroundPattern,
+    BackgroundOpacity,
+
+    // Circle
+    CircleRadius,
+    CircleColor,
+    CircleBlur,
+    CircleOpacity,
+    CircleTranslate,
+    CircleTranslateAnchor,
+
+    // Fill
+    FillAntialias,
+    FillOpacity,
+    FillColor,
+    FillOutlineColor,
+    FillTranslate,
+    FillTranslateAnchor,
+    FillPattern,
+
+    // Line
+    LineOpacity,
+    LineColor,
+    LineTranslate,
+    LineTranslateAnchor,
+    LineWidth,
+    LineGapWidth,
+    LineOffset,
+    LineBlur,
+    LineDasharray,
+    LinePattern,
+
+    // Raster
+    RasterOpacity,
+    RasterHueRotate,
+    RasterBrightnessMin,
+    RasterBrightnessMax,
+    RasterSaturation,
+    RasterContrast,
+    RasterFadeDuration,
+
+    // Symbol
+    IconOpacity,
+    IconColor,
+    IconHaloColor,
+    IconHaloWidth,
+    IconHaloBlur,
+    IconTranslate,
+    IconTranslateAnchor,
+    TextOpacity,
+    TextColor,
+    TextHaloColor,
+    TextHaloWidth,
+    TextHaloBlur,
+    TextTranslate,
+    TextTranslateAnchor,
+};
+
 } // namespace QMapbox
 
 Q_DECLARE_METATYPE(QMapbox::Coordinate);
@@ -183,5 +260,11 @@ Q_DECLARE_METATYPE(QMapbox::CompoundFilterForm);
 Q_DECLARE_METATYPE(QMapbox::UnaryFilterForm);
 
 Q_DECLARE_METATYPE(QMapbox::Tileset);
+
+Q_DECLARE_METATYPE(QMapbox::PropertyValueNumbers);
+Q_DECLARE_METATYPE(QMapbox::PropertyValueStrings);
+Q_DECLARE_METATYPE(QMapbox::PropertyValueFunctionStop);
+Q_DECLARE_METATYPE(QMapbox::PropertyValueFunctionStops);
+Q_DECLARE_METATYPE(QMapbox::PropertyValueFunction);
 
 #endif // QMAPBOX_H

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -247,6 +247,52 @@ enum PaintPropertyType {
     TextTranslateAnchor,
 };
 
+enum LayoutPropertyType {
+    Visibility,
+
+    // Line
+    LineCap,
+    LineJoin,
+    LineMiterLimit,
+    LineRoundLimit,
+
+    // Symbol
+    SymbolPlacement,
+    SymbolSpacing,
+    SymbolAvoidEdges,
+    IconAllowOverlap,
+    IconIgnorePlacement,
+    IconOptional,
+    IconRotationAlignment,
+    IconSize,
+    IconTextFit,
+    IconTextFitPadding,
+    IconImage,
+    IconRotate,
+    IconPadding,
+    IconKeepUpright,
+    IconOffset,
+    TextPitchAlignment,
+    TextRotationAlignment,
+    TextField,
+    TextFont,
+    TextSize,
+    TextMaxWidth,
+    TextLineHeight,
+    TextLetterSpacing,
+    TextJustify,
+    TextAnchor,
+    TextMaxAngle,
+    TextRotate,
+    TextPadding,
+    TextKeepUpright,
+    TextTransform,
+    TextOffset,
+    TextAllowOverlap,
+    TextIgnorePlacement,
+    TextOptional,
+};
+
 } // namespace QMapbox
 
 Q_DECLARE_METATYPE(QMapbox::Coordinate);

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -5,6 +5,7 @@
 #include <QPair>
 #include <QVariant>
 #include <QString>
+#include <QStringList>
 
 // This header follows the Qt coding style: https://wiki.qt.io/Qt_Coding_Style
 
@@ -146,6 +147,29 @@ struct Q_DECL_EXPORT Layer {
     QVariant maxZoom; // float
 };
 
+// Tileset, QString (URL)
+typedef QVariant SourceUrlOrTileset;
+
+enum SourceType {
+    RasterSource,
+    VectorSource,
+    GeoJSONSource,
+};
+
+struct Q_DECL_EXPORT Source {
+    SourceType type;
+    QString sourceID;
+    SourceUrlOrTileset urlOrTileset;
+    QVariant tileSize; // uint16_t
+};
+
+struct Q_DECL_EXPORT Tileset {
+    QStringList tiles;
+    QVariant minzoom; // float
+    QVariant maxzoom; // flaot
+    QVariant attribution; // QString
+};
+
 } // namespace QMapbox
 
 Q_DECLARE_METATYPE(QMapbox::Coordinate);
@@ -157,5 +181,7 @@ Q_DECLARE_METATYPE(QMapbox::BinaryFilterForm);
 Q_DECLARE_METATYPE(QMapbox::SetFilterForm);
 Q_DECLARE_METATYPE(QMapbox::CompoundFilterForm);
 Q_DECLARE_METATYPE(QMapbox::UnaryFilterForm);
+
+Q_DECLARE_METATYPE(QMapbox::Tileset);
 
 #endif // QMAPBOX_H

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -204,6 +204,8 @@ public:
         char* before = NULL);
     void removeCustomLayer(const QString& id);
 
+    void setFilter(const QString &layerID, const QMapbox::Filter &filter);
+
 public slots:
     void render();
     void connectionEstablished();

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -208,6 +208,7 @@ public:
     void removeLayer(const QString &layerID);
     void addSource(const QMapbox::Source &source);
     void removeSource(const QString &sourceID);
+    void setPaintProperty(const QString &layerID, QMapbox::PaintPropertyType, const QMapbox::PropertyValue &, const QString &klass = QString());
 
 public slots:
     void render();

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -209,6 +209,7 @@ public:
     void addSource(const QMapbox::Source &source);
     void removeSource(const QString &sourceID);
     void setPaintProperty(const QString &layerID, QMapbox::PaintPropertyType, const QMapbox::PropertyValue &, const QString &klass = QString());
+    void setLayoutProperty(const QString &layerID, QMapbox::LayoutPropertyType, const QMapbox::PropertyValue &);
 
 public slots:
     void render();

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -202,9 +202,10 @@ public:
         QMapbox::CustomLayerDeinitializeFunction,
         void* context,
         char* before = NULL);
-    void removeCustomLayer(const QString& id);
 
     void setFilter(const QString &layerID, const QMapbox::Filter &filter);
+    void addLayer(const QMapbox::Layer &layer);
+    void removeLayer(const QString &layerID);
 
 public slots:
     void render();

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -206,6 +206,8 @@ public:
     void setFilter(const QString &layerID, const QMapbox::Filter &filter);
     void addLayer(const QMapbox::Layer &layer);
     void removeLayer(const QString &layerID);
+    void addSource(const QMapbox::Source &source);
+    void removeSource(const QString &sourceID);
 
 public slots:
     void render();

--- a/platform/qt/platform.gyp
+++ b/platform/qt/platform.gyp
@@ -69,6 +69,8 @@
         'src/run_loop_impl.hpp',
         'src/timer.cpp',
         'src/timer_impl.hpp',
+        'src/property_setter.hpp',
+        'src/make_property_setters.hpp',
       ],
 
       'variables': {

--- a/platform/qt/src/async_task_impl.hpp
+++ b/platform/qt/src/async_task_impl.hpp
@@ -16,7 +16,7 @@ class AsyncTask::Impl : public QObject {
     Q_OBJECT
 
 public:
-    Impl(std::function<void()>&& fn);
+    Impl(std::function<void()> &&);
 
     void maySend();
 
@@ -34,5 +34,5 @@ private:
 };
 
 
-}
-}
+} // namespace util
+} // namespace mbgl

--- a/platform/qt/src/http_file_source.hpp
+++ b/platform/qt/src/http_file_source.hpp
@@ -24,14 +24,14 @@ public:
     Impl();
     virtual ~Impl() = default;
 
-    void request(HTTPRequest*);
-    void cancel(HTTPRequest*);
+    void request(HTTPRequest *);
+    void cancel(HTTPRequest *);
 
 public slots:
-    void replyFinish(QNetworkReply* reply);
+    void replyFinish(QNetworkReply *);
 
 private:
-    QMap<QUrl, QPair<QNetworkReply*, QVector<HTTPRequest*>>> m_pending;
+    QMap<QUrl, QPair<QNetworkReply *, QVector<HTTPRequest *>>> m_pending;
     QNetworkAccessManager *m_manager;
     QSslConfiguration m_ssl;
 };

--- a/platform/qt/src/http_request.hpp
+++ b/platform/qt/src/http_request.hpp
@@ -15,13 +15,13 @@ class Response;
 class HTTPRequest : public AsyncRequest
 {
 public:
-    HTTPRequest(HTTPFileSource::Impl*, const Resource&, FileSource::Callback);
+    HTTPRequest(HTTPFileSource::Impl *, const Resource&, FileSource::Callback);
     virtual ~HTTPRequest();
 
     QUrl requestUrl() const;
     QNetworkRequest networkRequest() const;
 
-    void handleNetworkReply(QNetworkReply *reply);
+    void handleNetworkReply(QNetworkReply *);
 
 private:
     HTTPFileSource::Impl* m_context;

--- a/platform/qt/src/make_property_setters.hpp
+++ b/platform/qt/src/make_property_setters.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+// This file is generated. Edit make_property_setters.hpp.ejs, then run `make style-code`.
+
+#include "property_setter.hpp"
+
+#include <mbgl/style/layers/fill_layer.hpp>
+#include <mbgl/style/layers/line_layer.hpp>
+#include <mbgl/style/layers/symbol_layer.hpp>
+#include <mbgl/style/layers/circle_layer.hpp>
+#include <mbgl/style/layers/raster_layer.hpp>
+#include <mbgl/style/layers/background_layer.hpp>
+
+#include <QMapbox>
+
+#include <map>
+
+namespace mbgl {
+namespace style {
+namespace conversion {
+
+auto makeQtLayoutPropertySetters() {
+    std::map<QMapbox::LayoutPropertyType, QtLayoutPropertySetter> result;
+
+    result[QMapbox::Visibility] = &setQtVisibility;
+    result[QMapbox::LineCap] = makeQtPropertySetter(&LineLayer::setLineCap);
+    result[QMapbox::LineJoin] = makeQtPropertySetter(&LineLayer::setLineJoin);
+    result[QMapbox::LineMiterLimit] = makeQtPropertySetter(&LineLayer::setLineMiterLimit);
+    result[QMapbox::LineRoundLimit] = makeQtPropertySetter(&LineLayer::setLineRoundLimit);
+    result[QMapbox::SymbolPlacement] = makeQtPropertySetter(&SymbolLayer::setSymbolPlacement);
+    result[QMapbox::SymbolSpacing] = makeQtPropertySetter(&SymbolLayer::setSymbolSpacing);
+    result[QMapbox::SymbolAvoidEdges] = makeQtPropertySetter(&SymbolLayer::setSymbolAvoidEdges);
+    result[QMapbox::IconAllowOverlap] = makeQtPropertySetter(&SymbolLayer::setIconAllowOverlap);
+    result[QMapbox::IconIgnorePlacement] = makeQtPropertySetter(&SymbolLayer::setIconIgnorePlacement);
+    result[QMapbox::IconOptional] = makeQtPropertySetter(&SymbolLayer::setIconOptional);
+    result[QMapbox::IconRotationAlignment] = makeQtPropertySetter(&SymbolLayer::setIconRotationAlignment);
+    result[QMapbox::IconSize] = makeQtPropertySetter(&SymbolLayer::setIconSize);
+    result[QMapbox::IconTextFit] = makeQtPropertySetter(&SymbolLayer::setIconTextFit);
+    result[QMapbox::IconTextFitPadding] = makeQtPropertySetter(&SymbolLayer::setIconTextFitPadding);
+    result[QMapbox::IconImage] = makeQtPropertySetter(&SymbolLayer::setIconImage);
+    result[QMapbox::IconRotate] = makeQtPropertySetter(&SymbolLayer::setIconRotate);
+    result[QMapbox::IconPadding] = makeQtPropertySetter(&SymbolLayer::setIconPadding);
+    result[QMapbox::IconKeepUpright] = makeQtPropertySetter(&SymbolLayer::setIconKeepUpright);
+    result[QMapbox::IconOffset] = makeQtPropertySetter(&SymbolLayer::setIconOffset);
+    result[QMapbox::TextPitchAlignment] = makeQtPropertySetter(&SymbolLayer::setTextPitchAlignment);
+    result[QMapbox::TextRotationAlignment] = makeQtPropertySetter(&SymbolLayer::setTextRotationAlignment);
+    result[QMapbox::TextField] = makeQtPropertySetter(&SymbolLayer::setTextField);
+    result[QMapbox::TextFont] = makeQtPropertySetter(&SymbolLayer::setTextFont);
+    result[QMapbox::TextSize] = makeQtPropertySetter(&SymbolLayer::setTextSize);
+    result[QMapbox::TextMaxWidth] = makeQtPropertySetter(&SymbolLayer::setTextMaxWidth);
+    result[QMapbox::TextLineHeight] = makeQtPropertySetter(&SymbolLayer::setTextLineHeight);
+    result[QMapbox::TextLetterSpacing] = makeQtPropertySetter(&SymbolLayer::setTextLetterSpacing);
+    result[QMapbox::TextJustify] = makeQtPropertySetter(&SymbolLayer::setTextJustify);
+    result[QMapbox::TextAnchor] = makeQtPropertySetter(&SymbolLayer::setTextAnchor);
+    result[QMapbox::TextMaxAngle] = makeQtPropertySetter(&SymbolLayer::setTextMaxAngle);
+    result[QMapbox::TextRotate] = makeQtPropertySetter(&SymbolLayer::setTextRotate);
+    result[QMapbox::TextPadding] = makeQtPropertySetter(&SymbolLayer::setTextPadding);
+    result[QMapbox::TextKeepUpright] = makeQtPropertySetter(&SymbolLayer::setTextKeepUpright);
+    result[QMapbox::TextTransform] = makeQtPropertySetter(&SymbolLayer::setTextTransform);
+    result[QMapbox::TextOffset] = makeQtPropertySetter(&SymbolLayer::setTextOffset);
+    result[QMapbox::TextAllowOverlap] = makeQtPropertySetter(&SymbolLayer::setTextAllowOverlap);
+    result[QMapbox::TextIgnorePlacement] = makeQtPropertySetter(&SymbolLayer::setTextIgnorePlacement);
+    result[QMapbox::TextOptional] = makeQtPropertySetter(&SymbolLayer::setTextOptional);
+
+    return result;
+}
+
+auto makeQtPaintPropertySetters() {
+    std::map<QMapbox::PaintPropertyType, QtPaintPropertySetter> result;
+
+    result[QMapbox::FillAntialias] = makeQtPropertySetter(&FillLayer::setFillAntialias);
+    result[QMapbox::FillOpacity] = makeQtPropertySetter(&FillLayer::setFillOpacity);
+    result[QMapbox::FillColor] = makeQtPropertySetter(&FillLayer::setFillColor);
+    result[QMapbox::FillOutlineColor] = makeQtPropertySetter(&FillLayer::setFillOutlineColor);
+    result[QMapbox::FillTranslate] = makeQtPropertySetter(&FillLayer::setFillTranslate);
+    result[QMapbox::FillTranslateAnchor] = makeQtPropertySetter(&FillLayer::setFillTranslateAnchor);
+    result[QMapbox::FillPattern] = makeQtPropertySetter(&FillLayer::setFillPattern);
+    result[QMapbox::LineOpacity] = makeQtPropertySetter(&LineLayer::setLineOpacity);
+    result[QMapbox::LineColor] = makeQtPropertySetter(&LineLayer::setLineColor);
+    result[QMapbox::LineTranslate] = makeQtPropertySetter(&LineLayer::setLineTranslate);
+    result[QMapbox::LineTranslateAnchor] = makeQtPropertySetter(&LineLayer::setLineTranslateAnchor);
+    result[QMapbox::LineWidth] = makeQtPropertySetter(&LineLayer::setLineWidth);
+    result[QMapbox::LineGapWidth] = makeQtPropertySetter(&LineLayer::setLineGapWidth);
+    result[QMapbox::LineOffset] = makeQtPropertySetter(&LineLayer::setLineOffset);
+    result[QMapbox::LineBlur] = makeQtPropertySetter(&LineLayer::setLineBlur);
+    result[QMapbox::LineDasharray] = makeQtPropertySetter(&LineLayer::setLineDasharray);
+    result[QMapbox::LinePattern] = makeQtPropertySetter(&LineLayer::setLinePattern);
+    result[QMapbox::IconOpacity] = makeQtPropertySetter(&SymbolLayer::setIconOpacity);
+    result[QMapbox::IconColor] = makeQtPropertySetter(&SymbolLayer::setIconColor);
+    result[QMapbox::IconHaloColor] = makeQtPropertySetter(&SymbolLayer::setIconHaloColor);
+    result[QMapbox::IconHaloWidth] = makeQtPropertySetter(&SymbolLayer::setIconHaloWidth);
+    result[QMapbox::IconHaloBlur] = makeQtPropertySetter(&SymbolLayer::setIconHaloBlur);
+    result[QMapbox::IconTranslate] = makeQtPropertySetter(&SymbolLayer::setIconTranslate);
+    result[QMapbox::IconTranslateAnchor] = makeQtPropertySetter(&SymbolLayer::setIconTranslateAnchor);
+    result[QMapbox::TextOpacity] = makeQtPropertySetter(&SymbolLayer::setTextOpacity);
+    result[QMapbox::TextColor] = makeQtPropertySetter(&SymbolLayer::setTextColor);
+    result[QMapbox::TextHaloColor] = makeQtPropertySetter(&SymbolLayer::setTextHaloColor);
+    result[QMapbox::TextHaloWidth] = makeQtPropertySetter(&SymbolLayer::setTextHaloWidth);
+    result[QMapbox::TextHaloBlur] = makeQtPropertySetter(&SymbolLayer::setTextHaloBlur);
+    result[QMapbox::TextTranslate] = makeQtPropertySetter(&SymbolLayer::setTextTranslate);
+    result[QMapbox::TextTranslateAnchor] = makeQtPropertySetter(&SymbolLayer::setTextTranslateAnchor);
+    result[QMapbox::CircleRadius] = makeQtPropertySetter(&CircleLayer::setCircleRadius);
+    result[QMapbox::CircleColor] = makeQtPropertySetter(&CircleLayer::setCircleColor);
+    result[QMapbox::CircleBlur] = makeQtPropertySetter(&CircleLayer::setCircleBlur);
+    result[QMapbox::CircleOpacity] = makeQtPropertySetter(&CircleLayer::setCircleOpacity);
+    result[QMapbox::CircleTranslate] = makeQtPropertySetter(&CircleLayer::setCircleTranslate);
+    result[QMapbox::CircleTranslateAnchor] = makeQtPropertySetter(&CircleLayer::setCircleTranslateAnchor);
+    result[QMapbox::RasterOpacity] = makeQtPropertySetter(&RasterLayer::setRasterOpacity);
+    result[QMapbox::RasterHueRotate] = makeQtPropertySetter(&RasterLayer::setRasterHueRotate);
+    result[QMapbox::RasterBrightnessMin] = makeQtPropertySetter(&RasterLayer::setRasterBrightnessMin);
+    result[QMapbox::RasterBrightnessMax] = makeQtPropertySetter(&RasterLayer::setRasterBrightnessMax);
+    result[QMapbox::RasterSaturation] = makeQtPropertySetter(&RasterLayer::setRasterSaturation);
+    result[QMapbox::RasterContrast] = makeQtPropertySetter(&RasterLayer::setRasterContrast);
+    result[QMapbox::RasterFadeDuration] = makeQtPropertySetter(&RasterLayer::setRasterFadeDuration);
+    result[QMapbox::BackgroundColor] = makeQtPropertySetter(&BackgroundLayer::setBackgroundColor);
+    result[QMapbox::BackgroundPattern] = makeQtPropertySetter(&BackgroundLayer::setBackgroundPattern);
+    result[QMapbox::BackgroundOpacity] = makeQtPropertySetter(&BackgroundLayer::setBackgroundOpacity);
+
+    return result;
+}
+
+} // namespace conversion
+} // namespace style
+} // namespace mbgl

--- a/platform/qt/src/make_property_setters.hpp.ejs
+++ b/platform/qt/src/make_property_setters.hpp.ejs
@@ -1,0 +1,46 @@
+#pragma once
+
+// This file is generated. Edit make_property_setters.hpp.ejs, then run `make style-code`.
+
+#include "property_setter.hpp"
+
+<% for (const layer of locals.layers) { -%>
+#include <mbgl/style/layers/<%- layer.type %>_layer.hpp>
+<% } -%>
+
+#include <QMapbox>
+
+#include <map>
+
+namespace mbgl {
+namespace style {
+namespace conversion {
+
+auto makeQtLayoutPropertySetters() {
+    std::map<QMapbox::LayoutPropertyType, QtLayoutPropertySetter> result;
+
+    result[QMapbox::Visibility] = &setQtVisibility;
+<% for (const layer of locals.layers) { -%>
+<% for (const property of layer.layoutProperties) { -%>
+    result[QMapbox::<%- camelize(property.name) %>] = makeQtPropertySetter(&<%- camelize(layer.type) %>Layer::set<%- camelize(property.name) %>);
+<% } -%>
+<% } -%>
+
+    return result;
+}
+
+auto makeQtPaintPropertySetters() {
+    std::map<QMapbox::PaintPropertyType, QtPaintPropertySetter> result;
+
+<% for (const layer of locals.layers) { -%>
+<% for (const property of layer.paintProperties) { -%>
+    result[QMapbox::<%- camelize(property.name) %>] = makeQtPropertySetter(&<%- camelize(layer.type) %>Layer::set<%- camelize(property.name) %>);
+<% } -%>
+<% } -%>
+
+    return result;
+}
+
+} // namespace conversion
+} // namespace style
+} // namespace mbgl

--- a/platform/qt/src/property_setter.hpp
+++ b/platform/qt/src/property_setter.hpp
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <mbgl/style/layer.hpp>
+#include <mbgl/style/types.hpp>
+#include <mbgl/style/conversion.hpp>
+#include <mbgl/style/conversion/constant.hpp>
+#include <mbgl/style/conversion/property_value.hpp>
+#include <mbgl/util/color.hpp>
+#include <mbgl/util/enum.hpp>
+
+#include <functional>
+#include <string>
+#include <utility>
+
+#include <QColor>
+#include <QVariant>
+
+namespace mbgl {
+namespace style {
+namespace conversion {
+
+using QtLayoutPropertySetter = std::function<optional<Error> (Layer &, const QVariant &)>;
+using QtPaintPropertySetter = std::function<optional<Error> (Layer &, const QVariant &, const optional<std::string> &)>;
+
+template <typename T, class Enable = void>
+struct FromQMapboxPropertyValueConverter;
+
+template <>
+struct FromQMapboxPropertyValueConverter<bool> {
+    bool operator()(const QVariant &value) {
+        return value.toBool();
+    }
+};
+
+template <>
+struct FromQMapboxPropertyValueConverter<float> {
+    float operator()(const QVariant &value) {
+        return value.toFloat();
+    }
+};
+
+template <>
+struct FromQMapboxPropertyValueConverter<std::string> {
+    std::string operator()(const QVariant &value) {
+        return value.toString().toStdString();
+    }
+};
+
+template <typename T>
+struct FromQMapboxPropertyValueConverter<T, typename std::enable_if_t<std::is_enum<T>::value>> {
+    T operator()(const QVariant &value) {
+        std::string string = value.toString().toStdString();
+        return *Enum<T>::toEnum(string);
+    }
+};
+
+template <>
+struct FromQMapboxPropertyValueConverter<Color> {
+    Color operator()(const QVariant &value) {
+        QColor color = value.value<QColor>();
+        return { float(color.redF()), float(color.greenF()), float(color.blueF()), float(color.alphaF()) };
+    }
+};
+
+template <>
+struct FromQMapboxPropertyValueConverter<std::array<float, 2>> {
+    std::array<float, 2> operator()(const QVariant &value) {
+        QMapbox::PropertyValueNumbers numbers = value.value<QMapbox::PropertyValueNumbers>();
+        return {{ numbers[0], numbers[1] }};
+    }
+};
+
+template <>
+struct FromQMapboxPropertyValueConverter<std::array<float, 4>> {
+    std::array<float, 4> operator()(const QVariant &value) {
+        QMapbox::PropertyValueNumbers numbers = value.value<QMapbox::PropertyValueNumbers>();
+        return {{ numbers[0], numbers[1], numbers[2], numbers[3] }};
+    }
+};
+
+template <>
+struct FromQMapboxPropertyValueConverter<std::vector<float>> {
+    std::vector<float> operator()(const QVariant &value) {
+        QMapbox::PropertyValueNumbers numbers = value.value<QMapbox::PropertyValueNumbers>();
+        std::vector<float> mbglNumbers;
+        for (const auto number : numbers) {
+            mbglNumbers.emplace_back(number);
+        }
+        return mbglNumbers;
+    }
+};
+
+template <>
+struct FromQMapboxPropertyValueConverter<std::vector<std::string>> {
+    std::vector<std::string> operator()(const QVariant &value) {
+        QMapbox::PropertyValueStrings strings = value.value<QMapbox::PropertyValueStrings>();
+        std::vector<std::string> mbglStrings;
+        for (const auto string : strings) {
+            mbglStrings.emplace_back(string.toStdString());
+        }
+        return mbglStrings;
+    }
+};
+
+template <class L, class T, class...Args>
+auto makeQtPropertySetter(void (L::*setter)(PropertyValue<T>, const Args&...args)) {
+    return [setter] (Layer &layer, const QVariant &value, const Args&...args) -> optional<Error> {
+        L* typedLayer = layer.as<L>();
+        if (!typedLayer) {
+            return Error { "layer doesn't support this property" };
+        }
+
+        Result<PropertyValue<T>> typedValue = [&value]() -> Result<PropertyValue<T>> {
+            Q_UNUSED(value);
+
+            if (value.isNull()) {
+                return {};
+            } else if (value.canConvert<QMapbox::PropertyValueFunction>()) {
+                QMapbox::PropertyValueFunction function = value.value<QMapbox::PropertyValueFunction>();
+                std::vector<std::pair<float, T>> mbglStops;
+                for (const auto& stop : function.stops) {
+                    mbglStops.emplace_back(std::make_pair<float, T>(float(stop.first), FromQMapboxPropertyValueConverter<T>()(stop.second)));
+                }
+                return Function<T>(mbglStops, function.base);
+            }
+
+            return FromQMapboxPropertyValueConverter<T>()(value);
+        }();
+
+        if (!typedValue) {
+            return typedValue.error();
+        }
+
+        (typedLayer->*setter)(*typedValue, args...);
+        return {};
+    };
+}
+
+optional<Error> setQtVisibility(Layer &layer, const QVariant &value) {
+    layer.setVisibility(static_cast<VisibilityType>(value.toBool()));
+    return {};
+}
+
+} // namespace conversion
+} // namespace style
+} // namespace mbgl

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -609,7 +609,6 @@ void QMapboxGL::connectionEstablished()
 
 QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settings)
     : QObject(q)
-    , size(0, 0)
     , q_ptr(q)
     , fileSourceObj(std::make_unique<mbgl::DefaultFileSource>(
         settings.cacheDatabasePath().toStdString(),

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1,4 +1,5 @@
 #include "qmapboxgl_p.hpp"
+#include "make_property_setters.hpp"
 
 #include <mbgl/annotation/annotation.hpp>
 #include <mbgl/gl/gl.hpp>
@@ -870,6 +871,23 @@ void QMapboxGL::addSource(const QMapbox::Source &source) {
 
 void QMapboxGL::removeSource(const QString &sourceID) {
     d_ptr->mapObj->removeSource(sourceID.toStdString());
+}
+
+void QMapboxGL::setPaintProperty(const QString &layerID, QMapbox::PaintPropertyType type, const QMapbox::PropertyValue &value, const QString &klass) {
+    mbgl::style::Layer *layer = d_ptr->mapObj->getLayer(layerID.toStdString());
+    if (!layer) {
+        return;
+    }
+
+    static const auto setters = mbgl::style::conversion::makeQtPaintPropertySetters();
+    auto it = setters.find(type);
+    if (it == setters.end()) {
+        return;
+    }
+
+    it->second(*layer, value, klass.toStdString());
+
+    d_ptr->mapObj->update(mbgl::Update::RecalculateStyle);
 }
 
 void QMapboxGL::render()

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -890,6 +890,23 @@ void QMapboxGL::setPaintProperty(const QString &layerID, QMapbox::PaintPropertyT
     d_ptr->mapObj->update(mbgl::Update::RecalculateStyle);
 }
 
+void QMapboxGL::setLayoutProperty(const QString &layerID, QMapbox::LayoutPropertyType type, const QMapbox::PropertyValue &value) {
+    mbgl::style::Layer *layer = d_ptr->mapObj->getLayer(layerID.toStdString());
+    if (!layer) {
+        return;
+    }
+
+    static const auto setters = mbgl::style::conversion::makeQtLayoutPropertySetters();
+    auto it = setters.find(type);
+    if (it == setters.end()) {
+        return;
+    }
+
+    it->second(*layer, value);
+
+    d_ptr->mapObj->update(mbgl::Update::RecalculateStyle);
+}
+
 void QMapboxGL::render()
 {
     d_ptr->dirty = false;

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -1,5 +1,4 @@
-#ifndef QMAPBOXGL_P_H
-#define QMAPBOXGL_P_H
+#pragma once
 
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/view.hpp>
@@ -15,7 +14,7 @@ class QMapboxGLPrivate : public QObject, public mbgl::View
     Q_OBJECT
 
 public:
-    explicit QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &);
+    explicit QMapboxGLPrivate(QMapboxGL *, const QMapboxGLSettings &);
     virtual ~QMapboxGLPrivate();
 
     // mbgl::View implementation.
@@ -26,17 +25,17 @@ public:
     void activate() final {}
     void deactivate() final {}
     void invalidate() final;
-    void notifyMapChange(mbgl::MapChange change) final;
+    void notifyMapChange(mbgl::MapChange) final;
 
     mbgl::EdgeInsets margins;
-    QSize size;
+    QSize size { 0, 0 };
 
-    QMapboxGL *q_ptr = nullptr;
+    QMapboxGL *q_ptr { nullptr };
 
     std::unique_ptr<mbgl::DefaultFileSource> fileSourceObj;
     std::unique_ptr<mbgl::Map> mapObj;
 
-    bool dirty = false;
+    bool dirty { false };
 
 public slots:
     void connectionEstablished();
@@ -45,5 +44,3 @@ signals:
     void needsRendering();
     void mapChanged(QMapboxGL::MapChange);
 };
-
-#endif // QMAPBOXGL_P_H

--- a/platform/qt/src/qquickmapboxglrenderer.hpp
+++ b/platform/qt/src/qquickmapboxglrenderer.hpp
@@ -1,5 +1,4 @@
-#ifndef QQUICKMAPBOXGLRENDERER_H
-#define QQUICKMAPBOXGLRENDERER_H
+#pragma once
 
 #include <QObject>
 #include <QQuickFramebufferObject>
@@ -18,18 +17,16 @@ public:
     QQuickMapboxGLRenderer();
     virtual ~QQuickMapboxGLRenderer();
 
-    virtual QOpenGLFramebufferObject* createFramebufferObject(const QSize& size);
+    virtual QOpenGLFramebufferObject * createFramebufferObject(const QSize &);
 
     virtual void render();
-    virtual void synchronize(QQuickFramebufferObject *item);
+    virtual void synchronize(QQuickFramebufferObject *);
 
 signals:
-    void centerChanged(const QGeoCoordinate &coordinate);
+    void centerChanged(const QGeoCoordinate &);
 
 private:
     bool m_initialized = false;
 
     QScopedPointer<QMapboxGL> m_map;
 };
-
-#endif // QQUICKMAPBOXGLRENDERER_H

--- a/platform/qt/src/run_loop_impl.hpp
+++ b/platform/qt/src/run_loop_impl.hpp
@@ -35,5 +35,5 @@ public slots:
     void onWriteEvent(int fd);
 };
 
-}
-}
+} // namespace util
+} // namespace mbgl

--- a/platform/qt/src/timer_impl.hpp
+++ b/platform/qt/src/timer_impl.hpp
@@ -14,7 +14,7 @@ class Timer::Impl : public QObject {
 public:
     Impl();
 
-    void start(uint64_t timeout, uint64_t repeat, std::function<void ()>&& cb);
+    void start(uint64_t timeout, uint64_t repeat, std::function<void ()> &&);
     void stop();
 
 public slots:
@@ -27,5 +27,5 @@ private:
     QTimer timer;
 };
 
-}
-}
+} // namespace util
+} // namespace mbgl

--- a/scripts/generate-style-code.js
+++ b/scripts/generate-style-code.js
@@ -113,3 +113,6 @@ for (const layer of layers) {
 
 const propertySettersHpp = ejs.compile(fs.readFileSync('include/mbgl/style/conversion/make_property_setters.hpp.ejs', 'utf8'), {strict: true});
 fs.writeFileSync('include/mbgl/style/conversion/make_property_setters.hpp', propertySettersHpp({layers: layers}));
+
+const qtPropertySettersHpp = ejs.compile(fs.readFileSync('platform/qt/src/make_property_setters.hpp.ejs', 'utf8'), {strict: true});
+fs.writeFileSync('platform/qt/src/make_property_setters.hpp', qtPropertySettersHpp({layers: layers}));


### PR DESCRIPTION
Implements:
- [x] Set filters
- [x] Non-custom layers (line, circle, symbol, raster, background)
- [x] Sources (raster, vector, GeoJSON*)
- [x] Set paint properties
- [x] Set layout properties

Caveats:
- Use `QVariant` to abstract variant types
- Strict type check for filter values via `Qmapbox::FilterValueType`
- Implemented Qt-specific conversion helpers
- Replace `QMapboxGL::removeCustomLayer()` with generic `QMapboxGL::removeLayer()`
- `QMapboxGL` is getting big - we might want to move the conversion functions to a separate file

Missing:
- Inline GeoJSON data input for GeoJSON source
- Static assertion checks

Fixes #5511.

:eyes: @yhahn @tmpsantos 