### PR TITLE
mapbox: URL containing query string causes infinite loop

### DIFF
--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -20,13 +20,14 @@ bool isMapboxURL(const std::string& url) {
 std::vector<std::string> getMapboxURLPathname(const std::string& url) {
     std::vector<std::string> pathname;
     std::size_t startIndex = protocol.length();
-    while (startIndex < url.length()) {
+    std::size_t end = url.find_first_of("?#");
+    if (end == std::string::npos) {
+        end = url.length();
+    }
+    while (startIndex < end) {
         std::size_t endIndex = url.find("/", startIndex);
         if (endIndex == std::string::npos) {
-            endIndex = url.find_first_of("?#");
-        }
-        if (endIndex == std::string::npos) {
-            endIndex = url.length();
+            endIndex = end;
         }
         pathname.push_back(url.substr(startIndex, endIndex - startIndex));
         startIndex = endIndex + 1;

--- a/test/util/mapbox.cpp
+++ b/test/util/mapbox.cpp
@@ -7,34 +7,65 @@
 
 using namespace mbgl;
 
-// TODO: correct all EXPECT_EQ(actual, expected) to EXPECT_EQ(expected, actual)
 
 TEST(Mapbox, SourceURL) {
-    EXPECT_EQ(mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "key"), "https://api.mapbox.com/v4/user.map.json?access_token=key&secure");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "token"), "https://api.mapbox.com/v4/user.map.json?access_token=token&secure");
-    EXPECT_THROW(mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", ""), std::runtime_error);
+    EXPECT_EQ(
+        "https://api.mapbox.com/v4/user.map.json?access_token=key&secure",
+        mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "key"));
+    EXPECT_EQ(
+        "https://api.mapbox.com/v4/user.map.json?access_token=token&secure",
+        mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "token"));
+    EXPECT_THROW(
+        std::runtime_error,
+        mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", ""));
 }
 
 TEST(Mapbox, GlyphsURL) {
-    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/boxmap/Comic%20Sans/0-255.pbf", "key"), "https://api.mapbox.com/fonts/v1/boxmap/Comic%20Sans/0-255.pbf?access_token=key");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/boxmap/{fontstack}/{range}.pbf", "key"), "https://api.mapbox.com/fonts/v1/boxmap/{fontstack}/{range}.pbf?access_token=key");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("http://path", "key"), "http://path");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeGlyphsURL("mapbox://path", "key"), "mapbox://path");
+    EXPECT_EQ(
+        "https://api.mapbox.com/fonts/v1/boxmap/Comic%20Sans/0-255.pbf?access_token=key",
+        mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/boxmap/Comic%20Sans/0-255.pbf", "key"));
+    EXPECT_EQ(
+        "https://api.mapbox.com/fonts/v1/boxmap/{fontstack}/{range}.pbf?access_token=key",
+        mbgl::util::mapbox::normalizeGlyphsURL("mapbox://fonts/boxmap/{fontstack}/{range}.pbf", "key"));
+    EXPECT_EQ(
+        "http://path",
+        mbgl::util::mapbox::normalizeGlyphsURL("http://path", "key"));
+    EXPECT_EQ(
+        "mapbox://path",
+        mbgl::util::mapbox::normalizeGlyphsURL("mapbox://path", "key"));
 }
 
 TEST(Mapbox, StyleURL) {
-    EXPECT_EQ(mbgl::util::mapbox::normalizeStyleURL("mapbox://foo", "key"), "mapbox://foo");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeStyleURL("mapbox://styles/user/style", "key"), "https://api.mapbox.com/styles/v1/user/style?access_token=key");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeStyleURL("mapbox://styles/user/style/draft", "key"), "https://api.mapbox.com/styles/v1/user/style/draft?access_token=key");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeStyleURL("http://path", "key"), "http://path");
+    EXPECT_EQ(
+        "mapbox://foo",
+        mbgl::util::mapbox::normalizeStyleURL("mapbox://foo", "key"));
+    EXPECT_EQ(
+        "https://api.mapbox.com/styles/v1/user/style?access_token=key",
+        mbgl::util::mapbox::normalizeStyleURL("mapbox://styles/user/style", "key"));
+    EXPECT_EQ(
+        "https://api.mapbox.com/styles/v1/user/style/draft?access_token=key",
+        mbgl::util::mapbox::normalizeStyleURL("mapbox://styles/user/style/draft", "key"));
+    EXPECT_EQ(
+        "http://path",
+        mbgl::util::mapbox::normalizeStyleURL("http://path", "key"));
 }
 
 TEST(Mapbox, SpriteURL) {
-    EXPECT_EQ(mbgl::util::mapbox::normalizeSpriteURL("map/box/sprites@2x.json", "key"), "map/box/sprites@2x.json");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeSpriteURL("mapbox://foo", "key"), "mapbox://foo");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeSpriteURL("mapbox://sprites/mapbox/streets-v8.json", "key"), "https://api.mapbox.com/styles/v1/mapbox/streets-v8/sprite.json?access_token=key");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeSpriteURL("mapbox://sprites/mapbox/streets-v8@2x.png", "key"), "https://api.mapbox.com/styles/v1/mapbox/streets-v8/sprite@2x.png?access_token=key");
-    EXPECT_EQ(mbgl::util::mapbox::normalizeSpriteURL("mapbox://sprites/mapbox/streets-v8/draft@2x.png", "key"), "https://api.mapbox.com/styles/v1/mapbox/streets-v8/draft/sprite@2x.png?access_token=key");
+    EXPECT_EQ(
+        "map/box/sprites@2x.json",
+        mbgl::util::mapbox::normalizeSpriteURL("map/box/sprites@2x.json", "key"));
+    EXPECT_EQ(
+        "mapbox://foo",
+        mbgl::util::mapbox::normalizeSpriteURL("mapbox://foo", "key"));
+    EXPECT_EQ(
+        "https://api.mapbox.com/styles/v1/mapbox/streets-v8/sprite.json?access_token=key",
+        mbgl::util::mapbox::normalizeSpriteURL("mapbox://sprites/mapbox/streets-v8.json", "key"));
+    EXPECT_EQ(
+        "https://api.mapbox.com/styles/v1/mapbox/streets-v8/sprite@2x.png?access_token=key",
+        mbgl::util::mapbox::normalizeSpriteURL("mapbox://sprites/mapbox/streets-v8@2x.png", "key"));
+    EXPECT_EQ(
+        "https://api.mapbox.com/styles/v1/mapbox/streets-v8/draft/sprite@2x.png?access_token=key",
+        mbgl::util::mapbox::normalizeSpriteURL("mapbox://sprites/mapbox/streets-v8/draft@2x.png", "key"));
 }
 
 TEST(Mapbox, TileURL) {

--- a/test/util/mapbox.cpp
+++ b/test/util/mapbox.cpp
@@ -13,8 +13,8 @@ TEST(Mapbox, SourceURL) {
         "https://api.mapbox.com/v4/user.map.json?access_token=key&secure",
         mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "key"));
     EXPECT_EQ(
-        "https://api.mapbox.com/v4/user.map.json?access_token=token&secure",
-        mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "token"));
+        "http://path",
+        mbgl::util::mapbox::normalizeSourceURL("http://path", "key");
     EXPECT_THROW(
         std::runtime_error,
         mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", ""));

--- a/test/util/mapbox.cpp
+++ b/test/util/mapbox.cpp
@@ -14,10 +14,10 @@ TEST(Mapbox, SourceURL) {
         mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", "key"));
     EXPECT_EQ(
         "http://path",
-        mbgl::util::mapbox::normalizeSourceURL("http://path", "key");
+        mbgl::util::mapbox::normalizeSourceURL("http://path", "key"));
     EXPECT_THROW(
-        std::runtime_error,
-        mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", ""));
+        mbgl::util::mapbox::normalizeSourceURL("mapbox://user.map", ""),
+        std::runtime_error);
 }
 
 TEST(Mapbox, GlyphsURL) {


### PR DESCRIPTION
If `getMapboxURLPathname` parse a url with querystring, such as `mapbox://p/a/t/h?query=aa`, an infinite loop happens and crash your computer. This is a serious bug which will affect all platforms.  You should fix it ASAP!  