### PR TITLE
[ios] fixes #5544 support canceling a drag operation and not by default

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -605,12 +605,6 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     return annotationView;
 }
 
-- (void)mapView:(MGLMapView *)mapView didDragAnnotationView:(nonnull MGLAnnotationView *)annotationView toCoordinate:(CLLocationCoordinate2D)coordinate
-{
-    MGLPointAnnotation *annotation = (MGLPointAnnotation *)annotationView.annotation;
-    annotation.coordinate = coordinate;
-}
-
 - (BOOL)mapView:(__unused MGLMapView *)mapView annotationCanShowCallout:(__unused id <MGLAnnotation>)annotation
 {
     return YES;

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -202,9 +202,6 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
  attempting to stop an operation that has already been initiated; doing so can
  lead to undefined behavior. Once begun, the drag operation should always
  continue to completion.
- 
- `-mapView:didDragAnnotationView:toCoordinate:` is called when a view is
- dropped.
  */
 @property (nonatomic, assign, getter=isDraggable) BOOL draggable;
 

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -212,13 +212,21 @@
         [self.mapView.calloutViewForSelectedAnnotation dismissCalloutAnimated:animated];
         [self.superview bringSubviewToFront:self];
     }
-
-    if (dragState == MGLAnnotationViewDragStateEnding)
+    else if (dragState == MGLAnnotationViewDragStateCanceling)
     {
-        if ([self.mapView.delegate respondsToSelector:@selector(mapView:didDragAnnotationView:toCoordinate:)])
+        self.panGestureRecognizer.enabled = NO;
+        self.longPressRecognizer.enabled = NO;
+        self.center = [self.mapView convertCoordinate:self.annotation.coordinate toPointToView:self.mapView];
+        self.panGestureRecognizer.enabled = YES;
+        self.longPressRecognizer.enabled = YES;
+        self.dragState = MGLAnnotationViewDragStateNone;
+    }
+    else if (dragState == MGLAnnotationViewDragStateEnding)
+    {
+        if ([self.annotation respondsToSelector:@selector(setCoordinate:)])
         {
             CLLocationCoordinate2D coordinate = [self.mapView convertPoint:self.center toCoordinateFromView:self.mapView];
-            [self.mapView.delegate mapView:self.mapView didDragAnnotationView:self toCoordinate:coordinate];
+            [(NSObject *)self.annotation setValue:[NSValue valueWithMGLCoordinate:coordinate] forKey:@"coordinate"];
         }
     }
 }

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -284,27 +284,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapView:(MGLMapView *)mapView didAddAnnotationViews:(NS_ARRAY_OF(MGLAnnotationView *) *)annotationViews;
 
-#pragma mark Dragging Annotation Views
-
-/**
- Tells the delegate that the user has dragged the given annotation view to a new
- location.
- 
- This method is called as soon as the user finishes dragging and drops the
- annotation view at a new location.
- 
- To permanently move the corresponding annotation to the new geographic
- coordinate, set the annotation’s `coordinate` property to the given coordinate.
- Otherwise, the annotation view will return to the original location
- corresponding to that property’s value.
- 
- @param mapView The map view containing the annotation view.
- @param annotationView The annotation view that was dragged.
- @param coordinate The geographic coordinate corresponding to the location to
-    which the user has dragged the annotation view.
- */
-- (void)mapView:(MGLMapView *)mapView didDragAnnotationView:(MGLAnnotationView *)annotationView toCoordinate:(CLLocationCoordinate2D)coordinate;
-
 #pragma mark Selecting Annotations
 
 /**


### PR DESCRIPTION
This PR simplifies implementing draggable annotation views by removing `didDragAnnotationView:toCoordinate` and instead call `setCoordinate:` on the associated MGLAnnotation. It also adds support for canceling a drag operation by setting `dragState` to `MGLAnnotationViewDragStateCanceling` as mentioned in [#5544](https://github.com/mapbox/mapbox-gl-native/issues/5544)

👀 @1ec5 @boundsj 