### PR TITLE
[ios] fixes #4536 include podspec in iOS releases

### DIFF
--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -178,11 +178,25 @@ if [[ "${GCC_GENERATE_DEBUGGING_SYMBOLS}" == false ]]; then
     fi
 fi
 
+function create_local_podspec {
+    step "Creating local podspec"
+    POD_SOURCE_PATH='    :path => ".",'
+    POD_FRAMEWORKS="  m.vendored_frameworks = '"${NAME}".framework'"
+    [[ $SYMBOLS = YES ]] && POD_SUFFIX="-symbols" || POD_SUFFIX=""
+    POD_LOCALSPEC=${OUTPUT}/$1/${NAME}-iOS-SDK${POD_SUFFIX}.podspec
+    sed "s/.*:http.*/${POD_SOURCE_PATH}/" platform/ios/${NAME}-iOS-SDK${POD_SUFFIX}.podspec > ${POD_LOCALSPEC}
+    sed -i.bak "s/.*vendored_frameworks.*/${POD_FRAMEWORKS}/" ${POD_LOCALSPEC}
+    rm -rf ${POD_LOCALSPEC}.bak
+    cp -pv LICENSE.md ${OUTPUT}/$1/
+}
+
 if [[ ${BUILD_STATIC} == true ]]; then
     stat "${OUTPUT}/static/${NAME}.framework"
+    create_local_podspec "static"
 fi
 if [[ ${BUILD_DYNAMIC} == true ]]; then
     stat "${OUTPUT}/dynamic/${NAME}.framework"
+    create_local_podspec "dynamic"
 fi
 
 if [[ ${BUILD_STATIC} == true ]]; then


### PR DESCRIPTION
Dynamic and static framework w/ and w/o symbols seems to be working except for one case;
- `platform :ios, '7.0'` in Podfile
- `Deployment target set to 7.0` in Xcode (not using `use_frameworks!`)

Yields:
```
[!] Unable to satisfy the following requirements:

- `Mapbox-iOS-SDK (from `../mapbox-gl-native/build/ios/pkg/dynamic/Mapbox-iOS-SDK-symbols.podspec`)` required by `Podfile`

It seems like you've changed the constraints of dependency `Mapbox-iOS-SDK` inside your development pod `Mapbox-iOS-SDK`.
You should run `pod update Mapbox-iOS-SDK` to apply changes you've made.
```
- `pod update Mapbox-iOS-SDK` yields the same error message.

Podfile
```
platform :ios, '7.0'
target 'podtest' do
pod 'Mapbox-iOS-SDK', :path => "../mapbox-gl-native/build/ios/pkg/dynamic/Mapbox-iOS-SDK-symbols.podspec"
end
```
👀 @boundsj 