### PR TITLE
Group shaders in anonymous struct

### DIFF
--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -55,33 +55,32 @@ Painter::Painter(const TransformState& state_,
     : state(state_), store(store_) {
     gl::debugging::enable();
 
-    plainShader = std::make_unique<PlainShader>(store);
-    outlineShader = std::make_unique<OutlineShader>(store);
-    outlinePatternShader = std::make_unique<OutlinePatternShader>(store);
-    lineShader = std::make_unique<LineShader>(store);
-    linesdfShader = std::make_unique<LineSDFShader>(store);
-    linepatternShader = std::make_unique<LinepatternShader>(store);
-    patternShader = std::make_unique<PatternShader>(store);
-    iconShader = std::make_unique<IconShader>(store);
-    rasterShader = std::make_unique<RasterShader>(store);
-    sdfGlyphShader = std::make_unique<SDFShader>(store);
-    sdfIconShader = std::make_unique<SDFShader>(store);
-    collisionBoxShader = std::make_unique<CollisionBoxShader>(store);
-    circleShader = std::make_unique<CircleShader>(store);
+    shader.plain = std::make_unique<PlainShader>(store);
+    shader.outline = std::make_unique<OutlineShader>(store);
+    shader.outlinePattern = std::make_unique<OutlinePatternShader>(store);
+    shader.line = std::make_unique<LineShader>(store);
+    shader.linesdf = std::make_unique<LineSDFShader>(store);
+    shader.linepattern = std::make_unique<LinepatternShader>(store);
+    shader.pattern = std::make_unique<PatternShader>(store);
+    shader.icon = std::make_unique<IconShader>(store);
+    shader.raster = std::make_unique<RasterShader>(store);
+    shader.sdfGlyph = std::make_unique<SDFShader>(store);
+    shader.sdfIcon = std::make_unique<SDFShader>(store);
+    shader.collisionBox = std::make_unique<CollisionBoxShader>(store);
+    shader.circle = std::make_unique<CircleShader>(store);
 
-    bool overdraw = true;
-    plainOverdrawShader = std::make_unique<PlainShader>(store, overdraw);
-    outlineOverdrawShader = std::make_unique<OutlineShader>(store, overdraw);
-    outlinePatternOverdrawShader = std::make_unique<OutlinePatternShader>(store, overdraw);
-    lineOverdrawShader = std::make_unique<LineShader>(store, overdraw);
-    linesdfOverdrawShader = std::make_unique<LineSDFShader>(store, overdraw);
-    linepatternOverdrawShader = std::make_unique<LinepatternShader>(store, overdraw);
-    patternOverdrawShader = std::make_unique<PatternShader>(store, overdraw);
-    iconOverdrawShader = std::make_unique<IconShader>(store, overdraw);
-    rasterOverdrawShader = std::make_unique<RasterShader>(store, overdraw);
-    sdfGlyphOverdrawShader = std::make_unique<SDFShader>(store, overdraw);
-    sdfIconOverdrawShader = std::make_unique<SDFShader>(store, overdraw);
-    circleOverdrawShader = std::make_unique<CircleShader>(store, overdraw);
+    overdrawShader.plain = std::make_unique<PlainShader>(store, Shader::Overdraw);
+    overdrawShader.outline = std::make_unique<OutlineShader>(store, Shader::Overdraw);
+    overdrawShader.outlinePattern = std::make_unique<OutlinePatternShader>(store, Shader::Overdraw);
+    overdrawShader.line = std::make_unique<LineShader>(store, Shader::Overdraw);
+    overdrawShader.linesdf = std::make_unique<LineSDFShader>(store, Shader::Overdraw);
+    overdrawShader.linepattern = std::make_unique<LinepatternShader>(store, Shader::Overdraw);
+    overdrawShader.pattern = std::make_unique<PatternShader>(store, Shader::Overdraw);
+    overdrawShader.icon = std::make_unique<IconShader>(store, Shader::Overdraw);
+    overdrawShader.raster = std::make_unique<RasterShader>(store, Shader::Overdraw);
+    overdrawShader.sdfGlyph = std::make_unique<SDFShader>(store, Shader::Overdraw);
+    overdrawShader.sdfIcon = std::make_unique<SDFShader>(store, Shader::Overdraw);
+    overdrawShader.circle = std::make_unique<CircleShader>(store, Shader::Overdraw);
 
     // Reset GL values
     config.reset();

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -197,32 +197,36 @@ private:
 
     FrameHistory frameHistory;
 
-    std::unique_ptr<PlainShader> plainShader;
-    std::unique_ptr<OutlineShader> outlineShader;
-    std::unique_ptr<OutlinePatternShader> outlinePatternShader;
-    std::unique_ptr<LineShader> lineShader;
-    std::unique_ptr<LineSDFShader> linesdfShader;
-    std::unique_ptr<LinepatternShader> linepatternShader;
-    std::unique_ptr<PatternShader> patternShader;
-    std::unique_ptr<IconShader> iconShader;
-    std::unique_ptr<RasterShader> rasterShader;
-    std::unique_ptr<SDFShader> sdfGlyphShader;
-    std::unique_ptr<SDFShader> sdfIconShader;
-    std::unique_ptr<CollisionBoxShader> collisionBoxShader;
-    std::unique_ptr<CircleShader> circleShader;
+    struct {
+        std::unique_ptr<PlainShader> plain;
+        std::unique_ptr<OutlineShader> outline;
+        std::unique_ptr<OutlinePatternShader> outlinePattern;
+        std::unique_ptr<LineShader> line;
+        std::unique_ptr<LineSDFShader> linesdf;
+        std::unique_ptr<LinepatternShader> linepattern;
+        std::unique_ptr<PatternShader> pattern;
+        std::unique_ptr<IconShader> icon;
+        std::unique_ptr<RasterShader> raster;
+        std::unique_ptr<SDFShader> sdfGlyph;
+        std::unique_ptr<SDFShader> sdfIcon;
+        std::unique_ptr<CollisionBoxShader> collisionBox;
+        std::unique_ptr<CircleShader> circle;
+    } shader;
 
-    std::unique_ptr<PlainShader> plainOverdrawShader;
-    std::unique_ptr<OutlineShader> outlineOverdrawShader;
-    std::unique_ptr<OutlinePatternShader> outlinePatternOverdrawShader;
-    std::unique_ptr<LineShader> lineOverdrawShader;
-    std::unique_ptr<LineSDFShader> linesdfOverdrawShader;
-    std::unique_ptr<LinepatternShader> linepatternOverdrawShader;
-    std::unique_ptr<PatternShader> patternOverdrawShader;
-    std::unique_ptr<IconShader> iconOverdrawShader;
-    std::unique_ptr<RasterShader> rasterOverdrawShader;
-    std::unique_ptr<SDFShader> sdfGlyphOverdrawShader;
-    std::unique_ptr<SDFShader> sdfIconOverdrawShader;
-    std::unique_ptr<CircleShader> circleOverdrawShader;
+    struct {
+        std::unique_ptr<PlainShader> plain;
+        std::unique_ptr<OutlineShader> outline;
+        std::unique_ptr<OutlinePatternShader> outlinePattern;
+        std::unique_ptr<LineShader> line;
+        std::unique_ptr<LineSDFShader> linesdf;
+        std::unique_ptr<LinepatternShader> linepattern;
+        std::unique_ptr<PatternShader> pattern;
+        std::unique_ptr<IconShader> icon;
+        std::unique_ptr<RasterShader> raster;
+        std::unique_ptr<SDFShader> sdfGlyph;
+        std::unique_ptr<SDFShader> sdfIcon;
+        std::unique_ptr<CircleShader> circle;
+    } overdrawShader;
 
     // Set up the stencil quad we're using to generate the stencil mask.
     StaticVertexBuffer tileStencilBuffer {

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -22,8 +22,8 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
     optional<SpriteAtlasPosition> imagePosB;
 
     const bool overdraw = isOverdraw();
-    const auto& shaderPattern = overdraw ? patternOverdrawShader : patternShader;
-    const auto& shaderPlain = overdraw ? plainOverdrawShader : plainShader;
+    auto& patternShader = overdraw ? *overdrawShader.pattern : *shader.pattern;
+    auto& plainShader = overdraw ? *overdrawShader.plain : *shader.plain;
     auto& arrayBackgroundPattern = overdraw ? backgroundPatternOverdrawArray : backgroundPatternArray;
     auto& arrayBackground = overdraw ? backgroundOverdrawArray : backgroundArray;
 
@@ -34,24 +34,24 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         if (!imagePosA || !imagePosB)
             return;
 
-        config.program = shaderPattern->getID();
-        shaderPattern->u_matrix = identityMatrix;
-        shaderPattern->u_pattern_tl_a = imagePosA->tl;
-        shaderPattern->u_pattern_br_a = imagePosA->br;
-        shaderPattern->u_pattern_tl_b = imagePosB->tl;
-        shaderPattern->u_pattern_br_b = imagePosB->br;
-        shaderPattern->u_mix = properties.backgroundPattern.value.t;
-        shaderPattern->u_opacity = properties.backgroundOpacity;
+        config.program = patternShader.getID();
+        patternShader.u_matrix = identityMatrix;
+        patternShader.u_pattern_tl_a = imagePosA->tl;
+        patternShader.u_pattern_br_a = imagePosA->br;
+        patternShader.u_pattern_tl_b = imagePosB->tl;
+        patternShader.u_pattern_br_b = imagePosB->br;
+        patternShader.u_mix = properties.backgroundPattern.value.t;
+        patternShader.u_opacity = properties.backgroundOpacity;
 
         spriteAtlas->bind(true, store);
-        arrayBackgroundPattern.bind(*shaderPattern, tileStencilBuffer, BUFFER_OFFSET(0), store);
+        arrayBackgroundPattern.bind(patternShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
 
     } else {
-        config.program = shaderPlain->getID();
-        shaderPlain->u_color = properties.backgroundColor;
-        shaderPlain->u_opacity = properties.backgroundOpacity;
+        config.program = plainShader.getID();
+        plainShader.u_color = properties.backgroundColor;
+        plainShader.u_opacity = properties.backgroundOpacity;
 
-        arrayBackground.bind(*shaderPlain, tileStencilBuffer, BUFFER_OFFSET(0), store);
+        arrayBackground.bind(plainShader, tileStencilBuffer, BUFFER_OFFSET(0), store);
     }
 
     config.stencilTest = GL_FALSE;
@@ -66,20 +66,20 @@ void Painter::renderBackground(const BackgroundLayer& layer) {
         matrix::multiply(vertexMatrix, projMatrix, vertexMatrix);
 
         if (isPatterned) {
-            shaderPattern->u_matrix = vertexMatrix;
-            shaderPattern->u_pattern_size_a = imagePosA->size;
-            shaderPattern->u_pattern_size_b = imagePosB->size;
-            shaderPattern->u_scale_a = properties.backgroundPattern.value.fromScale;
-            shaderPattern->u_scale_b = properties.backgroundPattern.value.toScale;
-            shaderPattern->u_tile_units_to_pixels = 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom());
+            patternShader.u_matrix = vertexMatrix;
+            patternShader.u_pattern_size_a = imagePosA->size;
+            patternShader.u_pattern_size_b = imagePosB->size;
+            patternShader.u_scale_a = properties.backgroundPattern.value.fromScale;
+            patternShader.u_scale_b = properties.backgroundPattern.value.toScale;
+            patternShader.u_tile_units_to_pixels = 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom());
 
             GLint tileSizeAtNearestZoom = util::tileSize * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
             GLint pixelX = tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z));
             GLint pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
-            shaderPattern->u_pixel_coord_upper = {{ float(pixelX >> 16), float(pixelY >> 16) }};
-            shaderPattern->u_pixel_coord_lower = {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }};
+            patternShader.u_pixel_coord_upper = {{ float(pixelX >> 16), float(pixelY >> 16) }};
+            patternShader.u_pixel_coord_lower = {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }};
         } else {
-            shaderPlain->u_matrix = vertexMatrix;
+            plainShader.u_matrix = vertexMatrix;
         }
 
         MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, (GLsizei)tileStencilBuffer.index()));

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -27,19 +27,19 @@ void Painter::renderCircle(CircleBucket& bucket,
     mat4 vtxMatrix = translatedMatrix(matrix, properties.circleTranslate, tileID,
                                       properties.circleTranslateAnchor);
 
-    const auto& shader = isOverdraw() ? circleOverdrawShader : circleShader;
+    auto& circleShader = isOverdraw() ? *overdrawShader.circle : *shader.circle;
 
-    config.program = shader->getID();
+    config.program = circleShader.getID();
 
-    shader->u_matrix = vtxMatrix;
-    shader->u_extrude_scale = extrudeScale;
-    shader->u_devicepixelratio = frame.pixelRatio;
-    shader->u_color = properties.circleColor;
-    shader->u_radius = properties.circleRadius;
-    shader->u_blur = properties.circleBlur;
-    shader->u_opacity = properties.circleOpacity;
+    circleShader.u_matrix = vtxMatrix;
+    circleShader.u_extrude_scale = extrudeScale;
+    circleShader.u_devicepixelratio = frame.pixelRatio;
+    circleShader.u_color = properties.circleColor;
+    circleShader.u_radius = properties.circleRadius;
+    circleShader.u_blur = properties.circleBlur;
+    circleShader.u_opacity = properties.circleOpacity;
 
-    bucket.drawCircles(*shader, store);
+    bucket.drawCircles(circleShader, store);
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -12,13 +12,13 @@ void Painter::drawClippingMasks(const std::map<UnwrappedTileID, ClipID>& stencil
     MBGL_DEBUG_GROUP("clipping masks");
 
     const bool overdraw = isOverdraw();
-    const auto& shaderPlain = overdraw ? plainOverdrawShader : plainShader;
+    auto& plainShader = overdraw ? *overdrawShader.plain : *shader.plain;
     auto& arrayCoveringPlain = overdraw ? coveringPlainOverdrawArray : coveringPlainArray;
 
     mat4 matrix;
     const GLuint mask = 0b11111111;
 
-    config.program = shaderPlain->getID();
+    config.program = plainShader.getID();
     config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
     config.depthTest = GL_FALSE;
@@ -26,7 +26,7 @@ void Painter::drawClippingMasks(const std::map<UnwrappedTileID, ClipID>& stencil
     config.colorMask = { GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
     config.stencilMask = mask;
 
-    arrayCoveringPlain.bind(*shaderPlain, tileStencilBuffer, BUFFER_OFFSET_0, store);
+    arrayCoveringPlain.bind(plainShader, tileStencilBuffer, BUFFER_OFFSET_0, store);
 
     for (const auto& stencil : stencils) {
         const auto& id = stencil.first;
@@ -35,7 +35,7 @@ void Painter::drawClippingMasks(const std::map<UnwrappedTileID, ClipID>& stencil
         MBGL_DEBUG_GROUP(std::string{ "mask: " } + util::toString(id));
         state.matrixFor(matrix, id);
         matrix::multiply(matrix, projMatrix, matrix);
-        shaderPlain->u_matrix = matrix;
+        plainShader.u_matrix = matrix;
 
         const GLint ref = (GLint)(clip.reference.to_ulong());
         config.stencilFunc = { GL_ALWAYS, ref, mask };

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -40,25 +40,26 @@ void Painter::renderDebugText(Tile& tile, const mat4 &matrix) {
             tile.expires, frame.debugOptions);
     }
 
-    config.program = plainShader->getID();
-    plainShader->u_matrix = matrix;
-    plainShader->u_opacity = 1.0f;
+    auto& plainShader = *shader.plain;
+    config.program = plainShader.getID();
+    plainShader.u_matrix = matrix;
+    plainShader.u_opacity = 1.0f;
 
     // Draw white outline
-    plainShader->u_color = Color::white();
+    plainShader.u_color = Color::white();
     config.lineWidth = 4.0f * frame.pixelRatio;
-    tile.debugBucket->drawLines(*plainShader, store);
+    tile.debugBucket->drawLines(plainShader, store);
 
 #ifndef GL_ES_VERSION_2_0
     // Draw line "end caps"
     MBGL_CHECK_ERROR(glPointSize(2));
-    tile.debugBucket->drawPoints(*plainShader, store);
+    tile.debugBucket->drawPoints(plainShader, store);
 #endif
 
     // Draw black text.
-    plainShader->u_color = Color::black();
+    plainShader.u_color = Color::black();
     config.lineWidth = 2.0f * frame.pixelRatio;
-    tile.debugBucket->drawLines(*plainShader, store);
+    tile.debugBucket->drawLines(plainShader, store);
 
     config.depthFunc.reset();
     config.depthTest = GL_TRUE;
@@ -74,13 +75,14 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     config.stencilOp.reset();
     config.stencilTest = GL_TRUE;
 
-    config.program = plainShader->getID();
-    plainShader->u_matrix = matrix;
-    plainShader->u_opacity = 1.0f;
+    auto& plainShader = *shader.plain;
+    config.program = plainShader.getID();
+    plainShader.u_matrix = matrix;
+    plainShader.u_opacity = 1.0f;
 
     // draw tile outline
-    tileBorderArray.bind(*plainShader, tileBorderBuffer, BUFFER_OFFSET_0, store);
-    plainShader->u_color = { 1.0f, 0.0f, 0.0f, 1.0f };
+    tileBorderArray.bind(plainShader, tileBorderBuffer, BUFFER_OFFSET_0, store);
+    plainShader.u_color = { 1.0f, 0.0f, 0.0f, 1.0f };
     config.lineWidth = 4.0f * frame.pixelRatio;
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, (GLsizei)tileBorderBuffer.index()));
 }

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -44,23 +44,22 @@ void Painter::renderFill(FillBucket& bucket,
     config.lineWidth = 2.0f; // This is always fixed and does not depend on the pixelRatio!
 
     const bool overdraw = isOverdraw();
-    const auto& shaderOutline = overdraw ? outlineOverdrawShader : outlineShader;
-    const auto& shaderPattern = overdraw ? patternOverdrawShader : patternShader;
-    const auto& shaderOutlinePattern = overdraw ? outlinePatternOverdrawShader : outlinePatternShader;
-    const auto& shaderPlain = overdraw ? plainOverdrawShader : plainShader;
+    auto& outlineShader = overdraw ? *overdrawShader.outline : *shader.outline;
+    auto& patternShader = overdraw ? *overdrawShader.pattern : *shader.pattern;
+    auto& outlinePatternShader = overdraw ? *overdrawShader.outlinePattern : *shader.outlinePattern;
+    auto& plainShader = overdraw ? *overdrawShader.plain : *shader.plain;
 
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // befrom, we have to draw the outline first (!)
     if (outline && pass == RenderPass::Translucent) {
+        config.program = outlineShader.getID();
+        outlineShader.u_matrix = vertexMatrix;
 
-        config.program = shaderOutline->getID();
-        shaderOutline->u_matrix = vertexMatrix;
-
-        shaderOutline->u_outline_color = strokeColor;
-        shaderOutline->u_opacity = opacity;
+        outlineShader.u_outline_color = strokeColor;
+        outlineShader.u_opacity = opacity;
 
         // Draw the entire line
-        shaderOutline->u_world = worldSize;
+        outlineShader.u_world = worldSize;
         if (isOutlineColorDefined) {
             // If we defined a different color for the fill outline, we are
             // going to ignore the bits in 0x07 and just care about the global
@@ -74,7 +73,7 @@ void Painter::renderFill(FillBucket& bucket,
             // the (non-antialiased) fill.
             setDepthSublayer(0); // OK
         }
-        bucket.drawVertices(*shaderOutline, store, overdraw);
+        bucket.drawVertices(outlineShader, store, overdraw);
     }
 
     if (pattern) {
@@ -83,61 +82,61 @@ void Painter::renderFill(FillBucket& bucket,
 
         // Image fill.
         if (pass == RenderPass::Translucent && imagePosA && imagePosB) {
-            config.program = shaderPattern->getID();
-            shaderPattern->u_matrix = vertexMatrix;
-            shaderPattern->u_pattern_tl_a = imagePosA->tl;
-            shaderPattern->u_pattern_br_a = imagePosA->br;
-            shaderPattern->u_pattern_tl_b = imagePosB->tl;
-            shaderPattern->u_pattern_br_b = imagePosB->br;
-            shaderPattern->u_opacity = properties.fillOpacity;
-            shaderPattern->u_image = 0;
-            shaderPattern->u_mix = properties.fillPattern.value.t;
-            shaderPattern->u_pattern_size_a = imagePosA->size;
-            shaderPattern->u_pattern_size_b = imagePosB->size;
-            shaderPattern->u_scale_a = properties.fillPattern.value.fromScale;
-            shaderPattern->u_scale_b = properties.fillPattern.value.toScale;
-            shaderPattern->u_tile_units_to_pixels = 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom());
+            config.program = patternShader.getID();
+            patternShader.u_matrix = vertexMatrix;
+            patternShader.u_pattern_tl_a = imagePosA->tl;
+            patternShader.u_pattern_br_a = imagePosA->br;
+            patternShader.u_pattern_tl_b = imagePosB->tl;
+            patternShader.u_pattern_br_b = imagePosB->br;
+            patternShader.u_opacity = properties.fillOpacity;
+            patternShader.u_image = 0;
+            patternShader.u_mix = properties.fillPattern.value.t;
+            patternShader.u_pattern_size_a = imagePosA->size;
+            patternShader.u_pattern_size_b = imagePosB->size;
+            patternShader.u_scale_a = properties.fillPattern.value.fromScale;
+            patternShader.u_scale_b = properties.fillPattern.value.toScale;
+            patternShader.u_tile_units_to_pixels = 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom());
 
             GLint tileSizeAtNearestZoom = util::tileSize * state.zoomScale(state.getIntegerZoom() - tileID.canonical.z);
             GLint pixelX = tileSizeAtNearestZoom * (tileID.canonical.x + tileID.wrap * state.zoomScale(tileID.canonical.z));
             GLint pixelY = tileSizeAtNearestZoom * tileID.canonical.y;
-            shaderPattern->u_pixel_coord_upper = {{ float(pixelX >> 16), float(pixelY >> 16) }};
-            shaderPattern->u_pixel_coord_lower = {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }};
+            patternShader.u_pixel_coord_upper = {{ float(pixelX >> 16), float(pixelY >> 16) }};
+            patternShader.u_pixel_coord_lower = {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }};
 
             config.activeTexture = GL_TEXTURE0;
             spriteAtlas->bind(true, store);
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(0);
-            bucket.drawElements(*shaderPattern, store, overdraw);
+            bucket.drawElements(patternShader, store, overdraw);
 
             if (properties.fillAntialias && !isOutlineColorDefined) {
-                config.program = shaderOutlinePattern->getID();
-                shaderOutlinePattern->u_matrix = vertexMatrix;
+                config.program = outlinePatternShader.getID();
+                outlinePatternShader.u_matrix = vertexMatrix;
 
-                shaderOutlinePattern->u_pattern_tl_a = imagePosA->tl;
-                shaderOutlinePattern->u_pattern_br_a = imagePosA->br;
-                shaderOutlinePattern->u_pattern_tl_b = imagePosB->tl;
-                shaderOutlinePattern->u_pattern_br_b = imagePosB->br;
-                shaderOutlinePattern->u_opacity = properties.fillOpacity;
-                shaderOutlinePattern->u_image = 0;
-                shaderOutlinePattern->u_mix = properties.fillPattern.value.t;
-                shaderOutlinePattern->u_pattern_size_a = imagePosA->size;
-                shaderOutlinePattern->u_pattern_size_b = imagePosB->size;
-                shaderOutlinePattern->u_scale_a = properties.fillPattern.value.fromScale;
-                shaderOutlinePattern->u_scale_b = properties.fillPattern.value.toScale;
-                shaderOutlinePattern->u_tile_units_to_pixels = 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom());
-                shaderOutlinePattern->u_pixel_coord_upper = {{ float(pixelX >> 16), float(pixelY >> 16) }};
-                shaderOutlinePattern->u_pixel_coord_lower = {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }};
+                outlinePatternShader.u_pattern_tl_a = imagePosA->tl;
+                outlinePatternShader.u_pattern_br_a = imagePosA->br;
+                outlinePatternShader.u_pattern_tl_b = imagePosB->tl;
+                outlinePatternShader.u_pattern_br_b = imagePosB->br;
+                outlinePatternShader.u_opacity = properties.fillOpacity;
+                outlinePatternShader.u_image = 0;
+                outlinePatternShader.u_mix = properties.fillPattern.value.t;
+                outlinePatternShader.u_pattern_size_a = imagePosA->size;
+                outlinePatternShader.u_pattern_size_b = imagePosB->size;
+                outlinePatternShader.u_scale_a = properties.fillPattern.value.fromScale;
+                outlinePatternShader.u_scale_b = properties.fillPattern.value.toScale;
+                outlinePatternShader.u_tile_units_to_pixels = 1.0f / tileID.pixelsToTileUnits(1.0f, state.getIntegerZoom());
+                outlinePatternShader.u_pixel_coord_upper = {{ float(pixelX >> 16), float(pixelY >> 16) }};
+                outlinePatternShader.u_pixel_coord_lower = {{ float(pixelX & 0xFFFF), float(pixelY & 0xFFFF) }};
 
                 // Draw the entire line
-                shaderOutlinePattern->u_world = worldSize;
+                outlinePatternShader.u_world = worldSize;
 
                 config.activeTexture = GL_TEXTURE0;
                 spriteAtlas->bind(true, store);
 
                 setDepthSublayer(2);
-                bucket.drawVertices(*shaderOutlinePattern, store, overdraw);
+                bucket.drawVertices(outlinePatternShader, store, overdraw);
             }
         }
     } else {
@@ -147,31 +146,31 @@ void Painter::renderFill(FillBucket& bucket,
             // fragments or when it's translucent and we're drawing translucent
             // fragments
             // Draw filling rectangle.
-            config.program = shaderPlain->getID();
-            shaderPlain->u_matrix = vertexMatrix;
-            shaderPlain->u_color = fillColor;
-            shaderPlain->u_opacity = opacity;
+            config.program = plainShader.getID();
+            plainShader.u_matrix = vertexMatrix;
+            plainShader.u_color = fillColor;
+            plainShader.u_opacity = opacity;
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(1);
-            bucket.drawElements(*shaderPlain, store, overdraw);
+            bucket.drawElements(plainShader, store, overdraw);
         }
     }
 
     // Because we're drawing top-to-bottom, and we update the stencil mask
     // below, we have to draw the outline first (!)
     if (fringeline && pass == RenderPass::Translucent) {
-        config.program = shaderOutline->getID();
-        shaderOutline->u_matrix = vertexMatrix;
+        config.program = outlineShader.getID();
+        outlineShader.u_matrix = vertexMatrix;
 
-        shaderOutline->u_outline_color = fillColor;
-        shaderOutline->u_opacity = opacity;
+        outlineShader.u_outline_color = fillColor;
+        outlineShader.u_opacity = opacity;
 
         // Draw the entire line
-        shaderOutline->u_world = worldSize;
+        outlineShader.u_world = worldSize;
 
         setDepthSublayer(2);
-        bucket.drawVertices(*shaderOutline, store, overdraw);
+        bucket.drawVertices(outlineShader, store, overdraw);
     }
 }
 

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -19,34 +19,34 @@ void Painter::renderRaster(RasterBucket& bucket,
 
     if (bucket.hasData()) {
         const bool overdraw = isOverdraw();
-        const auto& shaderRaster = overdraw ? rasterOverdrawShader : rasterShader;
-        auto& vaoRaster = overdraw ? coveringRasterOverdrawArray : coveringRasterArray;
+        auto& rasterShader = overdraw ? *overdrawShader.raster : *shader.raster;
+        auto& rasterVAO = overdraw ? coveringRasterOverdrawArray : coveringRasterArray;
 
-        config.program = shaderRaster->getID();
-        shaderRaster->u_matrix = matrix;
-        shaderRaster->u_buffer_scale = 1.0f;
-        shaderRaster->u_opacity0 = properties.rasterOpacity;
-        shaderRaster->u_opacity1 = 1.0f - properties.rasterOpacity;
+        config.program = rasterShader.getID();
+        rasterShader.u_matrix = matrix;
+        rasterShader.u_buffer_scale = 1.0f;
+        rasterShader.u_opacity0 = properties.rasterOpacity;
+        rasterShader.u_opacity1 = 1.0f - properties.rasterOpacity;
 
-        shaderRaster->u_brightness_low = properties.rasterBrightnessMin;
-        shaderRaster->u_brightness_high = properties.rasterBrightnessMax;
-        shaderRaster->u_saturation_factor = saturationFactor(properties.rasterSaturation);
-        shaderRaster->u_contrast_factor = contrastFactor(properties.rasterContrast);
-        shaderRaster->u_spin_weights = spinWeights(properties.rasterHueRotate);
+        rasterShader.u_brightness_low = properties.rasterBrightnessMin;
+        rasterShader.u_brightness_high = properties.rasterBrightnessMax;
+        rasterShader.u_saturation_factor = saturationFactor(properties.rasterSaturation);
+        rasterShader.u_contrast_factor = contrastFactor(properties.rasterContrast);
+        rasterShader.u_spin_weights = spinWeights(properties.rasterHueRotate);
 
         config.stencilTest = GL_FALSE;
 
-        shaderRaster->u_image0 = 0; // GL_TEXTURE0
-        shaderRaster->u_image1 = 1; // GL_TEXTURE1
-        shaderRaster->u_tl_parent = {{ 0.0f, 0.0f }};
-        shaderRaster->u_scale_parent = 1.0f;
+        rasterShader.u_image0 = 0; // GL_TEXTURE0
+        rasterShader.u_image1 = 1; // GL_TEXTURE1
+        rasterShader.u_tl_parent = {{ 0.0f, 0.0f }};
+        rasterShader.u_scale_parent = 1.0f;
 
         config.depthFunc.reset();
         config.depthTest = GL_TRUE;
         config.depthMask = GL_FALSE;
         setDepthSublayer(0);
 
-        bucket.drawRaster(*shaderRaster, rasterBoundsBuffer, vaoRaster, config, store);
+        bucket.drawRaster(rasterShader, rasterBoundsBuffer, rasterVAO, config, store);
     }
 }
 

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-CircleShader::CircleShader(gl::ObjectStore& store, bool overdraw)
+CircleShader::CircleShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::circle::name,
              shaders::circle::vertex,
              shaders::circle::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void CircleShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class CircleShader : public Shader {
 public:
-    CircleShader(gl::ObjectStore&, bool overdraw = false);
+    CircleShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-IconShader::IconShader(gl::ObjectStore& store, bool overdraw)
+IconShader::IconShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::icon::name,
              shaders::icon::vertex,
              shaders::icon::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void IconShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/icon_shader.hpp
+++ b/src/mbgl/shader/icon_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class IconShader : public Shader {
 public:
-    IconShader(gl::ObjectStore&, bool overdraw = false);
+    IconShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-LineShader::LineShader(gl::ObjectStore& store, bool overdraw)
+LineShader::LineShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::line::name,
              shaders::line::vertex,
              shaders::line::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void LineShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/line_shader.hpp
+++ b/src/mbgl/shader/line_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class LineShader : public Shader {
 public:
-    LineShader(gl::ObjectStore&, bool overdraw = false);
+    LineShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-LinepatternShader::LinepatternShader(gl::ObjectStore& store, bool overdraw)
+LinepatternShader::LinepatternShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::linepattern::name,
              shaders::linepattern::vertex,
              shaders::linepattern::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void LinepatternShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/linepattern_shader.hpp
+++ b/src/mbgl/shader/linepattern_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class LinepatternShader : public Shader {
 public:
-    LinepatternShader(gl::ObjectStore&, bool overdraw = false);
+    LinepatternShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-LineSDFShader::LineSDFShader(gl::ObjectStore& store, bool overdraw)
+LineSDFShader::LineSDFShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::linesdfpattern::name,
              shaders::linesdfpattern::vertex,
              shaders::linesdfpattern::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void LineSDFShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/linesdf_shader.hpp
+++ b/src/mbgl/shader/linesdf_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class LineSDFShader : public Shader {
 public:
-    LineSDFShader(gl::ObjectStore&, bool overdraw = false);
+    LineSDFShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-OutlineShader::OutlineShader(gl::ObjectStore& store, bool overdraw)
+OutlineShader::OutlineShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::outline::name,
              shaders::outline::vertex,
              shaders::outline::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void OutlineShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/outline_shader.hpp
+++ b/src/mbgl/shader/outline_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class OutlineShader : public Shader {
 public:
-    OutlineShader(gl::ObjectStore&, bool overdraw = false);
+    OutlineShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/outlinepattern_shader.cpp
+++ b/src/mbgl/shader/outlinepattern_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-OutlinePatternShader::OutlinePatternShader(gl::ObjectStore& store, bool overdraw)
+OutlinePatternShader::OutlinePatternShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::outlinepattern::name,
              shaders::outlinepattern::vertex,
              shaders::outlinepattern::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void OutlinePatternShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/outlinepattern_shader.hpp
+++ b/src/mbgl/shader/outlinepattern_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class OutlinePatternShader : public Shader {
 public:
-    OutlinePatternShader(gl::ObjectStore&, bool overdraw = false);
+    OutlinePatternShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/pattern_shader.cpp
+++ b/src/mbgl/shader/pattern_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-PatternShader::PatternShader(gl::ObjectStore& store, bool overdraw)
+PatternShader::PatternShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::pattern::name,
              shaders::pattern::vertex,
              shaders::pattern::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void PatternShader::bind(GLbyte *offset) {

--- a/src/mbgl/shader/pattern_shader.hpp
+++ b/src/mbgl/shader/pattern_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class PatternShader : public Shader {
 public:
-    PatternShader(gl::ObjectStore&, bool overdraw = false);
+    PatternShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-PlainShader::PlainShader(gl::ObjectStore& store, bool overdraw)
+PlainShader::PlainShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::fill::name,
              shaders::fill::vertex,
              shaders::fill::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void PlainShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/plain_shader.hpp
+++ b/src/mbgl/shader/plain_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class PlainShader : public Shader {
 public:
-    PlainShader(gl::ObjectStore&, bool overdraw = false);
+    PlainShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-RasterShader::RasterShader(gl::ObjectStore& store, bool overdraw)
+RasterShader::RasterShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::raster::name,
              shaders::raster::vertex,
              shaders::raster::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void RasterShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/raster_shader.hpp
+++ b/src/mbgl/shader/raster_shader.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class RasterShader : public Shader {
 public:
-    RasterShader(gl::ObjectStore&, bool overdraw = false);
+    RasterShader(gl::ObjectStore&, Defines defines = None);
 
     void bind(GLbyte *offset) final;
 

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -5,11 +5,11 @@
 
 namespace mbgl {
 
-SDFShader::SDFShader(gl::ObjectStore& store, bool overdraw)
+SDFShader::SDFShader(gl::ObjectStore& store, Defines defines)
     : Shader(shaders::sdf::name,
              shaders::sdf::vertex,
              shaders::sdf::fragment,
-             store, overdraw) {
+             store, defines) {
 }
 
 void SDFShader::bind(GLbyte* offset) {

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 class SDFShader : public Shader {
 public:
-    SDFShader(gl::ObjectStore&, bool overdraw = false);
+    SDFShader(gl::ObjectStore&, Defines defines = None);
 
     UniformMatrix<4>                u_matrix        = {"u_matrix",        *this};
     Uniform<std::array<GLfloat, 2>> u_extrude_scale = {"u_extrude_scale", *this};

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -15,7 +15,7 @@
 
 namespace mbgl {
 
-Shader::Shader(const char* name_, const char* vertexSource, const char* fragmentSource, gl::ObjectStore& store, bool overdraw)
+Shader::Shader(const char* name_, const char* vertexSource, const char* fragmentSource, gl::ObjectStore& store, Defines defines)
     : name(name_)
     , program(store.createProgram())
     , vertexShader(store.createShader(GL_VERTEX_SHADER))
@@ -29,7 +29,7 @@ Shader::Shader(const char* name_, const char* vertexSource, const char* fragment
     }
 
     std::string fragment(fragmentSource);
-    if (overdraw) {
+    if (defines & Defines::Overdraw) {
         assert(fragment.find("#ifdef OVERDRAW_INSPECTOR") != std::string::npos);
         fragment.replace(fragment.find_first_of('\n'), 1, "\n#define OVERDRAW_INSPECTOR\n");
     }

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -18,8 +18,17 @@ public:
 
     virtual void bind(GLbyte *offset) = 0;
 
+    enum Defines : bool {
+        None = false,
+        Overdraw = true,
+    };
+
 protected:
-    Shader(const char* name_, const char* vertex, const char* fragment, gl::ObjectStore&, bool overdraw = false);
+    Shader(const char* name_,
+           const char* vertex,
+           const char* fragment,
+           gl::ObjectStore&,
+           Defines defines = Defines::None);
 
     static constexpr GLint         a_pos = 0;
     static constexpr GLint     a_extrude = 1;


### PR DESCRIPTION
After a17b0bcd82ebe8628b69588d19773d26596b86da, we now have a `linepatternShader` and a `shaderLinePattern` variable in scope, and it's only a matter of time until we mix them up and accidentally set values on the wrong name. This patch moves all shaders into a struct and aliases them when they're used to hopefully have less confusing names.