### PR TITLE
Add support for circle-pitch-scale property

### DIFF
--- a/include/mbgl/style/conversion/make_property_setters.hpp
+++ b/include/mbgl/style/conversion/make_property_setters.hpp
@@ -112,6 +112,7 @@ auto makePaintPropertySetters() {
     result["circle-opacity"] = makePropertySetter<V>(&CircleLayer::setCircleOpacity);
     result["circle-translate"] = makePropertySetter<V>(&CircleLayer::setCircleTranslate);
     result["circle-translate-anchor"] = makePropertySetter<V>(&CircleLayer::setCircleTranslateAnchor);
+    result["circle-pitch-scale"] = makePropertySetter<V>(&CircleLayer::setCirclePitchScale);
 
     result["raster-opacity"] = makePropertySetter<V>(&RasterLayer::setRasterOpacity);
     result["raster-hue-rotate"] = makePropertySetter<V>(&RasterLayer::setRasterHueRotate);

--- a/include/mbgl/style/layers/circle_layer.hpp
+++ b/include/mbgl/style/layers/circle_layer.hpp
@@ -44,6 +44,9 @@ public:
     PropertyValue<TranslateAnchorType> getCircleTranslateAnchor() const;
     void setCircleTranslateAnchor(PropertyValue<TranslateAnchorType>, const optional<std::string>& klass = {});
 
+    PropertyValue<CirclePitchScaleType> getCirclePitchScale() const;
+    void setCirclePitchScale(PropertyValue<CirclePitchScaleType>, const optional<std::string>& klass = {});
+
     // Private implementation
 
     class Impl;

--- a/include/mbgl/style/types.hpp
+++ b/include/mbgl/style/types.hpp
@@ -45,6 +45,11 @@ enum class RotateAnchorType : bool {
     Viewport,
 };
 
+enum class CirclePitchScaleType : bool {
+    Map,
+    Viewport,
+};
+
 enum class SymbolPlacementType : bool {
     Point,
     Line,

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "csscolorparser": "^1.0.2",
     "ejs": "^2.4.1",
     "express": "^4.11.1",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#d3a10d1a46b99d3da264cf2d1903cbde6fea3185",
-    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#194fc55b6a7dd54c1e2cf2dd9048fbb5e836716d",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#725bd7410b612d5ddba918f6da82045e3340644e",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#4d1f89514bf03536c8e682439df165c33a37122a",
+    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#83b1a3e5837d785af582efd5ed1a212f2df6a4ae",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#d4c5c157397a2df619ba1eecf69a08b34159b3e1",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",
     "tape": "^4.5.1"

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -114,10 +114,10 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     // Update the default matrices to the current viewport dimensions.
     state.getProjMatrix(projMatrix);
 
-    // The extrusion scale.
-    const float flippedY = state.getViewportMode() == ViewportMode::FlippedY;
-    extrudeScale = {{ 2.0f / state.getWidth() * state.getAltitude(),
-                      (flippedY ? 2.0f : -2.0f) / state.getHeight() * state.getAltitude() }};
+    pixelsToGLUnits = {{ 2.0f  / state.getWidth(), -2.0f / state.getHeight() }};
+    if (state.getViewportMode() == ViewportMode::FlippedY) {
+        pixelsToGLUnits[1] *= -1;
+    }
 
     // The native matrix is a 1:1 matrix that paints the coordinates at the
     // same screen position as the vertex specifies.

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -159,7 +159,7 @@ private:
     mat4 projMatrix;
     mat4 nativeMatrix;
 
-    std::array<float, 2> extrudeScale;
+    std::array<float, 2> pixelsToGLUnits;
 
     // used to composite images and flips the geometry upside down
     const mat4 flipMatrix = []{

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -32,10 +32,18 @@ void Painter::renderCircle(CircleBucket& bucket,
     config.program = circleShader.getID();
 
     circleShader.u_matrix = vtxMatrix;
-    circleShader->u_extrude_scale = {{
-        pixelsToGLUnits[0] * state.getAltitude(),
-        pixelsToGLUnits[1] * state.getAltitude()
-    }};
+
+    if (properties.circlePitchScale == CirclePitchScaleType::Map) {
+        circleShader.u_extrude_scale = {{
+            pixelsToGLUnits[0] * state.getAltitude(),
+            pixelsToGLUnits[1] * state.getAltitude()
+        }};
+        circleShader.u_scale_with_map = true;
+    } else {
+        circleShader.u_extrude_scale = pixelsToGLUnits;
+        circleShader.u_scale_with_map = false;
+    }
+
     circleShader.u_devicepixelratio = frame.pixelRatio;
     circleShader.u_color = properties.circleColor;
     circleShader.u_radius = properties.circleRadius;

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -32,7 +32,10 @@ void Painter::renderCircle(CircleBucket& bucket,
     config.program = circleShader.getID();
 
     circleShader.u_matrix = vtxMatrix;
-    circleShader.u_extrude_scale = extrudeScale;
+    circleShader->u_extrude_scale = {{
+        pixelsToGLUnits[0] * state.getAltitude(),
+        pixelsToGLUnits[1] * state.getAltitude()
+    }};
     circleShader.u_devicepixelratio = frame.pixelRatio;
     circleShader.u_color = properties.circleColor;
     circleShader.u_radius = properties.circleRadius;

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -19,6 +19,7 @@ public:
     Uniform<GLfloat>                 u_radius           = {"u_radius",           *this};
     Uniform<GLfloat>                 u_blur             = {"u_blur",             *this};
     Uniform<GLfloat>                 u_opacity          = {"u_opacity",          *this};
+    Uniform<GLint>                   u_scale_with_map   = {"u_scale_with_map",   *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/style/layers/circle_layer.cpp
+++ b/src/mbgl/style/layers/circle_layer.cpp
@@ -109,5 +109,13 @@ void CircleLayer::setCircleTranslateAnchor(PropertyValue<TranslateAnchorType> va
     impl->paint.circleTranslateAnchor.set(value, klass);
 }
 
+PropertyValue<CirclePitchScaleType> CircleLayer::getCirclePitchScale() const {
+    return impl->paint.circlePitchScale.get();
+}
+
+void CircleLayer::setCirclePitchScale(PropertyValue<CirclePitchScaleType> value, const optional<std::string>& klass) {
+    impl->paint.circlePitchScale.set(value, klass);
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/circle_layer_properties.cpp
+++ b/src/mbgl/style/layers/circle_layer_properties.cpp
@@ -12,6 +12,7 @@ void CirclePaintProperties::cascade(const CascadeParameters& parameters) {
     circleOpacity.cascade(parameters);
     circleTranslate.cascade(parameters);
     circleTranslateAnchor.cascade(parameters);
+    circlePitchScale.cascade(parameters);
 }
 
 bool CirclePaintProperties::recalculate(const CalculationParameters& parameters) {
@@ -23,6 +24,7 @@ bool CirclePaintProperties::recalculate(const CalculationParameters& parameters)
     hasTransitions |= circleOpacity.calculate(parameters);
     hasTransitions |= circleTranslate.calculate(parameters);
     hasTransitions |= circleTranslateAnchor.calculate(parameters);
+    hasTransitions |= circlePitchScale.calculate(parameters);
 
     return hasTransitions;
 }

--- a/src/mbgl/style/layers/circle_layer_properties.hpp
+++ b/src/mbgl/style/layers/circle_layer_properties.hpp
@@ -23,6 +23,7 @@ public:
     PaintProperty<float> circleOpacity { 1 };
     PaintProperty<std::array<float, 2>> circleTranslate { {{ 0, 0 }} };
     PaintProperty<TranslateAnchorType> circleTranslateAnchor { TranslateAnchorType::Map };
+    PaintProperty<CirclePitchScaleType> circlePitchScale { CirclePitchScaleType::Map };
 };
 
 } // namespace style

--- a/src/mbgl/style/property_evaluator.cpp
+++ b/src/mbgl/style/property_evaluator.cpp
@@ -24,6 +24,7 @@ template <> std::array<float, 4> defaultStopsValue() { return {{ 0, 0, 0, 0 }}; 
 template <> std::string defaultStopsValue() { return {}; }
 template <> TranslateAnchorType defaultStopsValue() { return {}; }
 template <> RotateAnchorType defaultStopsValue() { return {}; }
+template <> CirclePitchScaleType defaultStopsValue() { return {}; }
 template <> LineCapType defaultStopsValue() { return {}; }
 template <> LineJoinType defaultStopsValue() { return {}; }
 template <> SymbolPlacementType defaultStopsValue() { return {}; }
@@ -94,6 +95,7 @@ template class PropertyEvaluator<std::array<float, 4>>;
 template class PropertyEvaluator<std::string>;
 template class PropertyEvaluator<TranslateAnchorType>;
 template class PropertyEvaluator<RotateAnchorType>;
+template class PropertyEvaluator<CirclePitchScaleType>;
 template class PropertyEvaluator<LineCapType>;
 template class PropertyEvaluator<LineJoinType>;
 template class PropertyEvaluator<SymbolPlacementType>;

--- a/src/mbgl/style/types.cpp
+++ b/src/mbgl/style/types.cpp
@@ -28,6 +28,11 @@ MBGL_DEFINE_ENUM(RotateAnchorType, {
     { RotateAnchorType::Viewport, "viewport" },
 });
 
+MBGL_DEFINE_ENUM(CirclePitchScaleType, {
+    { CirclePitchScaleType::Map, "map" },
+    { CirclePitchScaleType::Viewport, "viewport" },
+});
+
 MBGL_DEFINE_ENUM(LineCapType, {
     { LineCapType::Round, "round" },
     { LineCapType::Butt, "butt" },


### PR DESCRIPTION
Makes the behavior changed in #5006 configurable.

Corresponding commits:

* https://github.com/mapbox/mapbox-gl-style-spec/commit/83b1a3e5837d785af582efd5ed1a212f2df6a4ae
* https://github.com/mapbox/mapbox-gl-shaders/commit/4d1f89514bf03536c8e682439df165c33a37122a
* https://github.com/mapbox/mapbox-gl-test-suite/commit/f3b8d8c6e31c7f8417aab123dc7787df2b263247

GL-JS PR: https://github.com/mapbox/mapbox-gl-js/pull/2821