### PR TITLE
Sets the loading flag in the style request handler to ensure that the…

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -307,6 +307,7 @@ void Map::setStyleURL(const std::string& url) {
         } else if (res.notModified || res.noContent) {
             return;
         } else {
+            impl->loading = true;
             impl->loadStyleJSON(*res.data);
         }
     });


### PR DESCRIPTION
… correct Map event fires when a stale style gets refreshed from the server.