### PR TITLE
Add support for full Bitcode builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,23 +125,23 @@ test-ios: ios
 	  -workspace $(IOS_WORK_PATH) -scheme CI test $(XCPRETTY)
 
 ipackage: $(IOS_PROJ_PATH)
-	BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \
+	FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \
 	./platform/ios/scripts/package.sh
 
 ipackage-strip: $(IOS_PROJ_PATH)
-	BITCODE=$(BITCODE) FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO \
+	FORMAT=$(FORMAT) BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO \
 	./platform/ios/scripts/package.sh
 
 ipackage-sim: $(IOS_PROJ_PATH)
-	BUILDTYPE=Debug BITCODE=$(BITCODE) FORMAT=dynamic BUILD_DEVICE=false SYMBOLS=$(SYMBOLS) \
+	BUILDTYPE=Debug FORMAT=dynamic BUILD_DEVICE=false SYMBOLS=$(SYMBOLS) \
 	./platform/ios/scripts/package.sh
 
 iframework: $(IOS_PROJ_PATH)
-	BITCODE=$(BITCODE) FORMAT=dynamic BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \
+	FORMAT=dynamic BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=$(SYMBOLS) \
 	./platform/ios/scripts/package.sh
 
 ifabric: $(IOS_PROJ_PATH)
-	BITCODE=$(BITCODE) FORMAT=static BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO SELF_CONTAINED=YES \
+	FORMAT=static BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO SELF_CONTAINED=YES \
 	./platform/ios/scripts/package.sh
 
 idocument:

--- a/mbgl.gypi
+++ b/mbgl.gypi
@@ -199,6 +199,7 @@
           'xcode_settings': {
             'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags_cc)' ],
             'OTHER_CFLAGS': [ '<@(cflags)' ],
+            'BITCODE_GENERATION_MODE': 'bitcode',
           },
         }, {
           'cflags_cc': [ '<@(cflags_cc)' ],

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -1713,6 +1713,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DAC07C961CBB2CD6000CB309 /* mbgl.xcconfig */;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1753,6 +1754,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DAC07C961CBB2CD6000CB309 /* mbgl.xcconfig */;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1815,6 +1817,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DAC07C961CBB2CD6000CB309 /* mbgl.xcconfig */;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				HEADER_SEARCH_PATHS = (
 					../default,
 					../../include,
@@ -1845,6 +1848,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DAC07C961CBB2CD6000CB309 /* mbgl.xcconfig */;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				HEADER_SEARCH_PATHS = (
 					../default,
 					../../include,

--- a/platform/ios/platform.gyp
+++ b/platform/ios/platform.gyp
@@ -129,6 +129,14 @@
         'CLANG_ENABLE_OBJC_ARC': 'YES',
         'CLANG_ENABLE_MODULES': 'YES',
       },
+      
+      'conditions': [
+        ['OS == "mac"', {
+          'xcode_settings': {
+            'BITCODE_GENERATION_MODE': 'bitcode',
+          },
+        },],
+      ],
 
       'link_settings': {
         'libraries': [ '<@(libraries)' ],


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/5526
Fixes https://github.com/mapbox/mapbox-gl-native/issues/5448

In https://github.com/mapbox/mapbox-gl-native/commit/f791eb32b9ebe96845e87e5a6acd3ee46182c1d5 we simplified the package script and intended to remove support for building the SDK without Bitcode support. The intention was to use the ENABLE_BITCODE project setting to do this and remove the control of that variable in the
script. However, since we use `xcodebuild build` this only uses bitcode `marker` by default and causes a failure when an app that uses the Mapbox SDK is archived.

This adds the `BITCODE_GENERATION_MODE` and `bitcode` value to the necessary iOS SDK and mbgl and platform targets. If an app that uses the Mapbox SDK is built with these flags set, it will be successfully processed in the bitcode phase in an app archive operation.

This also removes the `BITCODE` flag from the Makefile since the intention is to not support building the SDK without bitcode support and the presence of that option might be confusing.

cc @1ec5 @frederoni @friedbunny 
