### PR TITLE
[android] Add support for timers on the main thread

### DIFF
--- a/platform/android/src/run_loop.cpp
+++ b/platform/android/src/run_loop.cpp
@@ -80,8 +80,6 @@ RunLoop::Impl::Impl(RunLoop* runLoop_, RunLoop::Type type) : runLoop(runLoop_) {
     case Type::Default:
         ret = ALooper_addFd(loop, fds[PIPE_OUT], ALOOPER_POLL_CALLBACK,
             ALOOPER_EVENT_INPUT, looperCallbackDefault, this);
-        running = true;
-        isDefaultLoop = true;
         break;
     }
 

--- a/platform/android/src/run_loop_impl.hpp
+++ b/platform/android/src/run_loop_impl.hpp
@@ -41,7 +41,6 @@ public:
     ALooper* loop = nullptr;
     RunLoop* runLoop = nullptr;
     util::Atomic<bool> running;
-    bool isDefaultLoop = false;
 
 private:
     friend RunLoop;

--- a/platform/android/src/run_loop_impl.hpp
+++ b/platform/android/src/run_loop_impl.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/util/atomic.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/thread.hpp>
 
 #include <list>
 #include <memory>
@@ -14,6 +15,8 @@ struct ALooper;
 
 namespace mbgl {
 namespace util {
+
+class Alarm;
 
 class RunLoop::Impl {
 public:
@@ -49,6 +52,8 @@ private:
 
     JNIEnv *env = nullptr;
     bool detach = false;
+
+    std::unique_ptr<Thread<Alarm>> alarm;
 
     std::recursive_mutex mtx;
     std::list<Runnable*> runnables;

--- a/platform/android/src/timer.cpp
+++ b/platform/android/src/timer.cpp
@@ -3,7 +3,6 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/timer.hpp>
 
-#include <cassert>
 #include <functional>
 
 namespace mbgl {
@@ -12,7 +11,6 @@ namespace util {
 class Timer::Impl : public RunLoop::Impl::Runnable {
 public:
     Impl() {
-        assert(!loop->isDefaultLoop);
         loop->initRunnable(this);
     }
 

--- a/test/util/timer.cpp
+++ b/test/util/timer.cpp
@@ -10,7 +10,7 @@
 using namespace mbgl::util;
 
 TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Basic)) {
-    RunLoop loop(RunLoop::Type::New);
+    RunLoop loop;
 
     Timer timer;
 
@@ -34,7 +34,7 @@ TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Basic)) {
 }
 
 TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Repeat)) {
-    RunLoop loop(RunLoop::Type::New);
+    RunLoop loop;
 
     Timer timer;
 
@@ -60,7 +60,7 @@ TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Repeat)) {
 }
 
 TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Stop)) {
-    RunLoop loop(RunLoop::Type::New);
+    RunLoop loop;
 
     Timer timer1;
     Timer timer2;
@@ -96,7 +96,7 @@ TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(Stop)) {
 }
 
 TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(DestroyShouldStop)) {
-    RunLoop loop(RunLoop::Type::New);
+    RunLoop loop;
 
     auto timer1 = std::make_unique<Timer>();
     Timer timer2;
@@ -132,7 +132,7 @@ TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(DestroyShouldStop)) {
 }
 
 TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(StartOverrides)) {
-    RunLoop loop(RunLoop::Type::New);
+    RunLoop loop;
 
     Timer timer;
 
@@ -166,7 +166,7 @@ TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(StartOverrides)) {
 }
 
 TEST(Timer, TEST_REQUIRES_ACCURATE_TIMING(CanStopNonStartedTimer)) {
-    RunLoop loop(RunLoop::Type::New);
+    RunLoop loop;
 
     Timer timer;
     timer.stop();


### PR DESCRIPTION
Wake up the main thread run loop with a file descriptor event from a thread that exists for this sole purpose.

This was probably causing expired tiles to not be re-requested.

/cc @ivovandongen