### PR TITLE
Use gesture recognizer for context menu

### DIFF
--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog for Mapbox macOS SDK
 
 ## master
+
+* Right-clicking to open MGLMapView’s context menu no longer prevents the user from subsequently panning the map by clicking and dragging. ([#5593](https://github.com/mapbox/mapbox-gl-native/pull/5593))
 * Replaced the wireframe debug mask with an overdraw visualization debug mask to match Mapbox GL JS’s overdraw inspector. ([#5403](https://github.com/mapbox/mapbox-gl-native/pull/5403))
 
 ## 0.2.0

--- a/platform/macos/app/AppDelegate.m
+++ b/platform/macos/app/AppDelegate.m
@@ -249,7 +249,7 @@ NSString * const MGLLastMapDebugMaskDefaultsKey = @"MGLLastMapDebugMask";
     alert.informativeText = @"\
 • To scroll, swipe with two fingers on a trackpad, or drag the cursor, or press the arrow keys.\n\
 • To zoom in, pinch two fingers apart on a trackpad, or double-click, or hold down Shift while dragging the cursor down, or hold down Option while pressing the up key.\n\
-• To zoom out, pinch two fingers together on a trackpad, or double-tap on a mouse, or hold down Shift while dragging the cursor up, or hold down Option while pressing the down key.\n\
+• To zoom out, pinch two fingers together on a trackpad, or double-tap with two fingers on a trackpad, or double-tap on a mouse, or hold down Shift while dragging the cursor up, or hold down Option while pressing the down key.\n\
 • To rotate, move two fingers opposite each other in a circle on a trackpad, or hold down Option while dragging the cursor left and right, or hold down Option while pressing the left and right arrow keys.\n\
 • To tilt, hold down Option while dragging the cursor up and down.\n\
 • To drop a pin, click and hold.\

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -395,6 +395,10 @@ public:
     clickGestureRecognizer.delaysPrimaryMouseButtonEvents = NO;
     [self addGestureRecognizer:clickGestureRecognizer];
     
+    NSClickGestureRecognizer *rightClickGestureRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(handleRightClickGesture:)];
+    rightClickGestureRecognizer.buttonMask = 0x2;
+    [self addGestureRecognizer:rightClickGestureRecognizer];
+    
     NSClickGestureRecognizer *doubleClickGestureRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleClickGesture:)];
     doubleClickGestureRecognizer.numberOfClicksRequired = 2;
     doubleClickGestureRecognizer.delaysPrimaryMouseButtonEvents = NO;
@@ -1356,6 +1360,14 @@ public:
         }
     } else {
         [self deselectAnnotation:self.selectedAnnotation];
+    }
+}
+
+/// Right-click to show the context menu.
+- (void)handleRightClickGesture:(NSClickGestureRecognizer *)gestureRecognizer {
+    NSMenu *menu = [self menuForEvent:[NSApp currentEvent]];
+    if (menu) {
+        [NSMenu popUpContextMenu:menu withEvent:[NSApp currentEvent] forView:self];
     }
 }
 


### PR DESCRIPTION
NSView’s built-in context menu handling preempts non-right-click gesture recognizers, so preempt it with a right-click gesture recognizer that does essentially the same thing. With this change, two-finger double-tapping on a trackpad also zooms out, consistent with MapKit.

Fixes #5078.

/cc @kkaefer