### PR TITLE
[ios] omit podspec for static lib

### DIFF
--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -192,7 +192,6 @@ function create_local_podspec {
 
 if [[ ${BUILD_STATIC} == true ]]; then
     stat "${OUTPUT}/static/${NAME}.framework"
-    create_local_podspec "static"
 fi
 if [[ ${BUILD_DYNAMIC} == true ]]; then
     stat "${OUTPUT}/dynamic/${NAME}.framework"


### PR DESCRIPTION
Resource bundle and required frameworks were not included so let's omit podspec for static lib until next release