### PR TITLE
[core] Re-close polygons after clipping with clipper

### DIFF
--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -28,6 +28,8 @@ static ClipperLib::Path toClipperPath(const GeometryCoordinates& ring) {
 
 static GeometryCoordinates fromClipperPath(const ClipperLib::Path& path) {
     GeometryCoordinates result;
+    result.reserve(path.size() + 1);
+    
     result.reserve(path.size());
     for (const auto& p : path) {
         using Coordinate = GeometryCoordinates::coordinate_type;
@@ -37,6 +39,12 @@ static GeometryCoordinates fromClipperPath(const ClipperLib::Path& path) {
         assert(p.y <= std::numeric_limits<Coordinate>::max());
         result.emplace_back(Coordinate(p.x), Coordinate(p.y));
     }
+    
+    // Clipper does not repeat initial point, but our geometry model requires it.
+    if (!result.empty()) {
+        result.push_back(result.front());
+    }
+    
     return result;
 }
 


### PR DESCRIPTION
This manually includes in the implementation change in https://github.com/mapbox/mapbox-gl-native/commit/903d609b40b6d0f4873f7bb46d96f4a06d7b17d6 from the master branch for the iOS 3.3.0 release.

cc @jfirebaugh @1ec5 