### PR TITLE
[android] - make animation example work with SurfaceView

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AnimatedMarkerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/AnimatedMarkerActivity.java
@@ -143,6 +143,12 @@ public class AnimatedMarkerActivity extends AppCompatActivity {
         final ValueAnimator markerAnimator = ObjectAnimator.ofObject(marker, "position", new LatLngEvaluator(), marker.getPosition(), to);
         markerAnimator.setDuration((long) (10 * marker.getPosition().distanceTo(to)));
         markerAnimator.setInterpolator(new AccelerateDecelerateInterpolator());
+        markerAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+            @Override
+            public void onAnimationUpdate(ValueAnimator animation) {
+                mMapboxMap.getMarkerViewManager().update();
+            }
+        });
 
         // Start
         markerAnimator.start();


### PR DESCRIPTION
Since introduction of SurfaceView #5000, ViewMarker location animations weren't working, adding an update listener to the example resolves this.