### PR TITLE
Remove redundant GL state calls

### DIFF
--- a/include/mbgl/gl/gl_values.hpp
+++ b/include/mbgl/gl/gl_values.hpp
@@ -140,6 +140,10 @@ struct StencilOp {
     }
 };
 
+constexpr bool operator!=(const StencilOp::Type& a, const StencilOp::Type& b) {
+    return a.sfail != b.sfail || a.dpfail != b.dpfail || a.dppass != b.dppass;
+}
+
 struct DepthRange {
     struct Type { GLfloat near, far; };
     static const Type Default;

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		40EDA1C11CFE0E0500D9EA68 /* MGLAnnotationContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 40EDA1BE1CFE0D4A00D9EA68 /* MGLAnnotationContainerView.m */; };
 		40EDA1C21CFE0E0500D9EA68 /* MGLAnnotationContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 40EDA1BE1CFE0D4A00D9EA68 /* MGLAnnotationContainerView.m */; };
 		40FDA76B1CCAAA6800442548 /* MBXAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FDA76A1CCAAA6800442548 /* MBXAnnotationView.m */; };
+		554180421D2E97DE00012372 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 554180411D2E97DE00012372 /* OpenGLES.framework */; };
 		DA0CD5901CF56F6A00A5F5A5 /* MGLFeatureTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */; };
 		DA17BE301CC4BAC300402C41 /* MGLMapView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */; };
 		DA17BE311CC4BDAA00402C41 /* MGLMapView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */; };
@@ -335,6 +336,7 @@
 		40EDA1BE1CFE0D4A00D9EA68 /* MGLAnnotationContainerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLAnnotationContainerView.m; sourceTree = "<group>"; };
 		40FDA7691CCAAA6800442548 /* MBXAnnotationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBXAnnotationView.h; sourceTree = "<group>"; };
 		40FDA76A1CCAAA6800442548 /* MBXAnnotationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBXAnnotationView.m; sourceTree = "<group>"; };
+		554180411D2E97DE00012372 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLFeatureTests.mm; path = ../../darwin/test/MGLFeatureTests.mm; sourceTree = "<group>"; };
 		DA17BE2F1CC4BAC300402C41 /* MGLMapView_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLMapView_Internal.h; sourceTree = "<group>"; };
 		DA1DC94A1CB6C1C2006E619F /* Mapbox GL.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mapbox GL.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -508,6 +510,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA8847D91CBAF91600AB86E3 /* Mapbox.framework in Frameworks */,
+				554180421D2E97DE00012372 /* OpenGLES.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -623,6 +626,7 @@
 		DA1DC9921CB6DF24006E619F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				554180411D2E97DE00012372 /* OpenGLES.framework */,
 				DAABF73B1CBC59BB005B1825 /* libmbgl-core.a */,
 				DAABF73C1CBC59BB005B1825 /* libmbgl-platform-ios.a */,
 				DAA4E4021CBB5C2F00178DFB /* CoreGraphics.framework */,

--- a/src/mbgl/gl/gl_config.hpp
+++ b/src/mbgl/gl/gl_config.hpp
@@ -21,9 +21,7 @@ public:
     }
 
     void reset() {
-        dirty = true;
-        current = T::Default;
-        T::Set(current);
+        *this = T::Default;
     }
 
     void setDirty() {

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -83,6 +83,7 @@ Painter::Painter(const TransformState& state_,
     overdrawShader.circle = std::make_unique<CircleShader>(store, Shader::Overdraw);
 
     // Reset GL values
+    config.setDirty();
     config.reset();
 }
 

--- a/test/gl/object.cpp
+++ b/test/gl/object.cpp
@@ -18,10 +18,12 @@ static bool setFlag = false;
 
 struct MockGLObject {
     using Type = bool;
-    static const Type Default = false;
+    static const Type Default;
     static Type Get() { getFlag = true; return true; }
     static void Set(const Type&) { setFlag = true; }
 };
+
+const bool MockGLObject::Default = false;
 
 TEST(GLObject, Preserve) {
     getFlag = false;
@@ -61,7 +63,7 @@ TEST(GLObject, Value) {
 
     object->reset();
     EXPECT_EQ(object->getCurrent(), false);
-    EXPECT_TRUE(object->getDirty());
+    EXPECT_FALSE(object->getDirty());
     EXPECT_TRUE(setFlag);
 }
 


### PR DESCRIPTION
We frequently call our wrapped GL state/value system with `.reset()` when we want to set the value to its default value. However, `.reset()` currently forces the value without checking the previous state. This changes the behavior of `.reset()` to "set default value" (which does nothing when the value was already the default value).