### PR TITLE
5541 mapbox account manager

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
@@ -2,8 +2,10 @@ package com.mapbox.mapboxsdk;
 
 import android.content.Context;
 import android.text.TextUtils;
+
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.InvalidAccessTokenException;
+import com.mapbox.mapboxsdk.exceptions.MapboxAccountManagerNotStartedException;
 import com.mapbox.mapboxsdk.telemetry.MapboxEventManager;
 
 public class MapboxAccountManager {
@@ -16,8 +18,9 @@ public class MapboxAccountManager {
     /**
      * MapboxAccountManager should NOT be instantiated directly.
      * Use @see MapboxAccountManager#getInstance() instead.
+     *
      * @param applicationContext Context used to get ApplicationContext
-     * @param accessToken Mapbox Access Token
+     * @param accessToken        Mapbox Access Token
      */
     private MapboxAccountManager(Context applicationContext, String accessToken) {
         super();
@@ -29,7 +32,7 @@ public class MapboxAccountManager {
      * Primary entry point to Mapbox for implementing developers.
      * Must be configured in either Application.onCreate() or Launch Activity.onCreate()
      *
-     * @param context Context used to get Application Context
+     * @param context     Context used to get Application Context
      * @param accessToken Mapbox Access Token.  You can get one on the Mapbox Web site.
      * @return MapboxAccountManager instance for app
      */
@@ -49,11 +52,16 @@ public class MapboxAccountManager {
      * @return MapboxAccountManager instance for app.  May be NULL if not configured yet.
      */
     public static MapboxAccountManager getInstance() {
+        if (mapboxAccountManager == null) {
+            throw new MapboxAccountManagerNotStartedException();
+        }
+
         return mapboxAccountManager;
     }
 
     /**
      * Access Token for this application
+     *
      * @return Mapbox Access Token
      */
     public String getAccessToken() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/MapboxAccountManagerNotStartedException.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/MapboxAccountManagerNotStartedException.java
@@ -1,0 +1,23 @@
+package com.mapbox.mapboxsdk.exceptions;
+
+
+import android.content.Context;
+import android.os.Bundle;
+
+import com.mapbox.mapboxsdk.MapboxAccountManager;
+import com.mapbox.mapboxsdk.maps.MapView;
+
+/**
+ * A MapboxAccountManagerNotStartedException is thrown by {@link com.mapbox.mapboxsdk.maps.MapView}
+ * when {@link MapboxAccountManager} is not started before {@link MapView#onCreate(Bundle)}.
+ *
+ * @see MapView#onCreate(Bundle)
+ * @see MapboxAccountManager#start(Context, String)
+ */
+public class MapboxAccountManagerNotStartedException extends RuntimeException {
+
+    public MapboxAccountManagerNotStartedException() {
+        super("\nMapboxAccountManager was not started correctly. Use MapboxAccountManager#start(Context, String) to initialise. " +
+                "\nMore information in this guide https://www.mapbox.com/help/first-steps-android-sdk/#access-tokens.");
+    }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -196,7 +196,7 @@ public class MapView extends FrameLayout {
 
         // Reference the TextureView
         SurfaceView surfaceView = (SurfaceView) view.findViewById(R.id.surfaceView);
-        
+
         // Check if we are in Android Studio UI editor to avoid error in layout preview
         if (isInEditMode()) {
             return;
@@ -262,13 +262,7 @@ public class MapView extends FrameLayout {
         }
 
         // access token
-        String accessToken;
-        if (MapboxAccountManager.getInstance() != null) {
-            accessToken = MapboxAccountManager.getInstance().getAccessToken();
-        } else {
-            accessToken = options.getAccessToken();
-        }
-
+        String accessToken = options.getAccessToken();
         if (!TextUtils.isEmpty(accessToken)) {
             mMapboxMap.setAccessToken(accessToken);
         }
@@ -364,8 +358,17 @@ public class MapView extends FrameLayout {
      */
     @UiThread
     public void onCreate(@Nullable Bundle savedInstanceState) {
+        String accessToken = mMapboxMap.getAccessToken();
+        if (TextUtils.isEmpty(accessToken)) {
+            accessToken = MapboxAccountManager.getInstance().getAccessToken();
+            mMapboxMap.setAccessToken(accessToken);
+        } else {
+            // user provided access token through xml attributes, need to start MapboxAccountManager
+            MapboxAccountManager.start(getContext(), accessToken);
+        }
+
         // Force a check for an access token
-        MapboxAccountManager.validateAccessToken(getAccessToken());
+        MapboxAccountManager.validateAccessToken(accessToken);
 
         if (savedInstanceState != null && savedInstanceState.getBoolean(MapboxConstants.STATE_HAS_SAVED_STATE)) {
 


### PR DESCRIPTION
Proposed solution that closes #5541:
 - remove requirement to call `MapboxAccountManager` before `setContentView`
 - introduces a concrete `MapboxAccountManagerNotStartedException`

This solution was tested against: 
 - `MapboxAccountManager.start` after setContentView in Activity
 - setting up an accesstoken in xml
 - setting up an accesstoken via MapboxMapOptions
 - setting up an accesstoken via `MapboxAccountManager.start` in Application object

cc @bleege @cammace @danswick @ivovandongen @zugaldia 