### PR TITLE
[android] #5388 - moves touch handling of MarkerViews to core

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -293,6 +293,17 @@ public class MarkerViewManager {
         return markerViewMap.get(marker);
     }
 
+    @Nullable
+    public MapboxMap.MarkerViewAdapter getViewAdapter(MarkerView markerView) {
+        MapboxMap.MarkerViewAdapter adapter = null;
+        for (MapboxMap.MarkerViewAdapter a : markerViewAdapters) {
+            if (a.getMarkerClass().equals(markerView.getClass())) {
+                adapter = a;
+            }
+        }
+        return adapter;
+    }
+
     /**
      * Remove a MarkerView from a map.
      * <p>
@@ -429,21 +440,6 @@ public class MarkerViewManager {
                                 }
                             }
 
-                            adaptedView.setOnClickListener(new View.OnClickListener() {
-                                @Override
-                                public void onClick(final View v) {
-                                    boolean clickHandled = false;
-                                    if (onMarkerViewClickListener != null) {
-                                        clickHandled = onMarkerViewClickListener.onMarkerClick(marker, v, adapter);
-                                    }
-
-                                    if (!clickHandled) {
-                                        ensureInfoWindowOffset(marker);
-                                        select(marker, v, adapter);
-                                    }
-                                }
-                            });
-
                             marker.setMapboxMap(mapboxMap);
                             markerViewMap.put(marker, adaptedView);
                             if (convertView == null) {
@@ -458,6 +454,26 @@ public class MarkerViewManager {
         // trigger update to make newly added ViewMarker visible,
         // these would only be updated when the map is moved.
         update();
+    }
+
+    public void onClickMarkerView(MarkerView markerView) {
+        boolean clickHandled = false;
+
+        MapboxMap.MarkerViewAdapter adapter = getViewAdapter(markerView);
+        View view = getView(markerView);
+        if (adapter == null || view == null) {
+            // not a valid state
+            return;
+        }
+
+        if (onMarkerViewClickListener != null) {
+            clickHandled = onMarkerViewClickListener.onMarkerClick(markerView, view, adapter);
+        }
+
+        if (!clickHandled) {
+            ensureInfoWindowOffset(markerView);
+            select(markerView, view, adapter);
+        }
     }
 
     //TODO: This whole method is a stopgap for: https://github.com/mapbox/mapbox-gl-native/issues/5384

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1014,17 +1014,38 @@ public class MapView extends FrameLayout {
             icon = IconFactory.getInstance(getContext()).defaultMarker();
             Bitmap bitmap = icon.getBitmap();
             averageIconHeight = averageIconHeight + (bitmap.getHeight() / 2 - averageIconHeight) / iconSize;
-            averageIconWidth = averageIconHeight + (bitmap.getWidth() - averageIconHeight) / iconSize;
+            averageIconWidth = averageIconWidth + (bitmap.getWidth() - averageIconWidth) / iconSize;
             marker.setIcon(icon);
         } else {
             Bitmap bitmap = icon.getBitmap();
             averageIconHeight = averageIconHeight + (bitmap.getHeight() - averageIconHeight) / iconSize;
-            averageIconWidth = averageIconHeight + (bitmap.getWidth() - averageIconHeight) / iconSize;
+            averageIconWidth = averageIconWidth + (bitmap.getWidth() - averageIconWidth) / iconSize;
         }
 
         if (!icons.contains(icon)) {
             icons.add(icon);
             loadIcon(icon);
+        } else {
+            Icon oldIcon = icons.get(icons.indexOf(icon));
+            if (!oldIcon.getBitmap().sameAs(icon.getBitmap())) {
+                throw new IconBitmapChangedException();
+            }
+        }
+        return icon;
+    }
+
+    Icon loadIconForMarkerView(MarkerView marker) {
+        Icon icon = marker.getIcon();
+        int iconSize = icons.size() + 1;
+        if (icon == null) {
+            icon = IconFactory.getInstance(getContext()).defaultMarkerView();
+            marker.setIcon(icon);
+        }
+        Bitmap bitmap = icon.getBitmap();
+        averageIconHeight = averageIconHeight + (bitmap.getHeight() - averageIconHeight) / iconSize;
+        averageIconWidth = averageIconWidth + (bitmap.getWidth() - averageIconWidth) / iconSize;
+        if (!icons.contains(icon)) {
+            icons.add(icon);
         } else {
             Icon oldIcon = icons.get(icons.indexOf(icon));
             if (!oldIcon.getBitmap().sameAs(icon.getBitmap())) {
@@ -1875,9 +1896,10 @@ public class MapView extends FrameLayout {
                     if (annotation instanceof Marker) {
                         if (annotation.getId() == newSelectedMarkerId) {
                             if (selectedMarkers.isEmpty() || !selectedMarkers.contains(annotation)) {
-                                // only handle click if no marker view is available
                                 if (!(annotation instanceof MarkerView)) {
                                     mapboxMap.selectMarker((Marker) annotation);
+                                } else {
+                                    mapboxMap.getMarkerViewManager().onClickMarkerView((MarkerView) annotation);
                                 }
                             }
                             break;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -22,7 +22,6 @@ import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerOptions;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerViewOptions;
 import com.mapbox.mapboxsdk.annotations.Icon;
-import com.mapbox.mapboxsdk.annotations.IconFactory;
 import com.mapbox.mapboxsdk.annotations.InfoWindow;
 import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
@@ -1405,12 +1404,7 @@ public class MapboxMap {
 
     private MarkerView prepareViewMarker(BaseMarkerViewOptions markerViewOptions) {
         MarkerView marker = markerViewOptions.getMarker();
-
-        Icon icon = markerViewOptions.getIcon();
-        if (icon == null) {
-            icon = IconFactory.getInstance(mapView.getContext()).defaultMarkerView();
-        }
-        marker.setIcon(icon);
+        mapView.loadIconForMarkerView(marker);
         return marker;
     }
 


### PR DESCRIPTION
Refers #5388.

Notes:
- Moves touch interaction of MarkerViews to core
- Replaced average icon width/height for touch surface padding to a fixed size, since this was giving incorrect results. Will need to revisit later to fix this.
- Noticed some strange behaviour that click events were not triggered and had to wait a couple of seconds before being able to click the map. 