### PR TITLE
raster-opacity is broken

### DIFF
--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -26,7 +26,7 @@ void Painter::renderRaster(RasterBucket& bucket,
         rasterShader.u_matrix = matrix;
         rasterShader.u_buffer_scale = 1.0f;
         rasterShader.u_opacity0 = properties.rasterOpacity;
-        rasterShader.u_opacity1 = 1.0f - properties.rasterOpacity;
+        rasterShader.u_opacity1 = 0;
 
         rasterShader.u_brightness_low = properties.rasterBrightnessMin;
         rasterShader.u_brightness_high = properties.rasterBrightnessMax;


### PR DESCRIPTION
This isn't failing the test-suite outright because the tests are ignored for other reasons, but, `raster-opacity/literal`:

![image](https://cloud.githubusercontent.com/assets/98601/16637991/591af230-4398-11e6-9507-0801c65cf9b1.png)
