### PR TITLE
[ios] Pass along `animated` property when selecting annotation views

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3463,8 +3463,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
             positioningRect = annotationView.frame;
             
             [annotationView.superview bringSubviewToFront:annotationView];
-            
-            annotationView.selected = YES;
+
+            [annotationView setSelected:YES animated:animated];
         }
     }
     


### PR DESCRIPTION
Fixes a bug where the selection of annotation views would never be animated, because `-[MGLMapView selectAnnotation:animated:]` wasn’t passing along its `animated` value.

This change means that tapped view annotations now properly receive `animated = YES` — e.g., when a custom view annotation class overrides `-setSelected:animated:`.

I’ve put this on the v3.3.0 milestone because it’s a minor change that shouldn’t need serious testing. We could push this to v3.3.1, though, if we don’t think there’s enough time for another RC before release.

/cc @boundsj @frederoni @1ec5