### PR TITLE
Ensure mapView is set when positioning annotation view

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4586,8 +4586,8 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
                     [self.glView addSubview:annotationView];
                 }
                 
-                annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
                 annotationView.mapView = self;
+                annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
                 annotationContext.annotationView = annotationView;
             }
         }


### PR DESCRIPTION
Ensure the `mapView` property is set when positioning the annotation view, in case the map view needs to be consulted about its rotation or pitch. I overlooked this reversed order when implementing #5550.

/cc @frederoni @boundsj @friedbunny