### PR TITLE
Wrapped world is blank

### DIFF
--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -16,7 +16,7 @@ TransformState::TransformState(ConstrainMode constrainMode_, ViewportMode viewpo
 #pragma mark - Matrix
 
 void TransformState::matrixFor(mat4& matrix, const UnwrappedTileID& tileID) const {
-    const uint32_t tileScale = 1u << tileID.canonical.z;
+    const uint64_t tileScale = 1ull << tileID.canonical.z;
     const double s = worldSize() / tileScale;
 
     matrix::identity(matrix);


### PR DESCRIPTION
When panning past the antimeridian, the wrapped copy of the world is blank until the antimeridian goes past the center of the view.

![macos](https://cloud.githubusercontent.com/assets/1231218/16755282/c9780c28-47af-11e6-8cb6-093e2327aef4.png)
![ios](https://cloud.githubusercontent.com/assets/1231218/16755376/eced5f54-47b0-11e6-862e-531cc7f49c97.png)

Reproduces in fe99295970a1f5e2d8834b35ce327938a1738240 on macOS and the iOS Simulator.

/cc @jfirebaugh