### PR TITLE
[qt] if `qmake` isn't available, try `qmake-qt5`

### DIFF
--- a/platform/qt/scripts/configure.sh
+++ b/platform/qt/scripts/configure.sh
@@ -38,7 +38,12 @@ fi
 function print_qt_flags {
     mason install Qt system
 
-    QT_VERSION_MAJOR=$(qmake -query QT_VERSION | cut -d. -f1)
+    QMAKE="qmake"
+    if [ ! $(which ${QMAKE} 2>/dev/null) ]; then
+        QMAKE="qmake-qt5"
+    fi
+
+    QT_VERSION_MAJOR=$(${QMAKE} -query QT_VERSION | cut -d. -f1)
     CONFIG+="    'qt_version_major%': ['${QT_VERSION_MAJOR}'],"$LN
     CONFIG+="    'qt_image_decoders%': [0],"$LN
 


### PR DESCRIPTION
At least on the Fedora system I'm using the qt5 development packages don't provide a binary named `qmake` (at least not one that would be in `$PATH`). This is a simple change that uses `qmake-qt5` if `qmake` isn't found. If `qmake` is available the behaviour is as before.

It does NOT test whether `qmake-qt5` is available. That is similar to the behaviour this script had before: if `qmake` wasn't found, it just exits with an error. 