### PR TITLE
mbgl::FillAnnotation::outlineColor should be an optional<Color>

### DIFF
--- a/include/mbgl/annotation/annotation.hpp
+++ b/include/mbgl/annotation/annotation.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/variant.hpp>
 #include <mbgl/util/color.hpp>
+#include <mbgl/style/property_value.hpp>
 
 #include <cstdint>
 #include <vector>
@@ -28,17 +29,17 @@ using ShapeAnnotationGeometry = variant<
 class LineAnnotation {
 public:
     ShapeAnnotationGeometry geometry;
-    float opacity = 1;
-    float width = 1;
-    Color color = Color::black();
+    style::PropertyValue<float> opacity { 1.0f };
+    style::PropertyValue<float> width { 1.0f };
+    style::PropertyValue<Color> color { Color::black() };
 };
 
 class FillAnnotation {
 public:
     ShapeAnnotationGeometry geometry;
-    float opacity = 1;
-    Color color = Color::black();
-    Color outlineColor = { 0, 0, 0, -1 };
+    style::PropertyValue<float> opacity { 1.0f };
+    style::PropertyValue<Color> color { Color::black() };
+    style::PropertyValue<Color> outlineColor {};
 };
 
 // An annotation whose type and properties are sourced from a style layer.

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -754,9 +754,9 @@ jni::jarray<jlong>* nativeAddPolylines(JNIEnv *env, jni::jobject* obj, jlong nat
         jni::jobject* points = jni::GetField<jni::jobject*>(*env, polyline, *polylinePointsId);
 
         mbgl::LineAnnotation annotation { toGeometry<mbgl::LineString<double>>(env, points) };
-        annotation.opacity = jni::GetField<jfloat>(*env, polyline, *polylineAlphaId);
-        annotation.color = toColor(jni::GetField<jint>(*env, polyline, *polylineColorId));
-        annotation.width = jni::GetField<jfloat>(*env, polyline, *polylineWidthId);
+        annotation.opacity = { jni::GetField<jfloat>(*env, polyline, *polylineAlphaId) };
+        annotation.color = { toColor(jni::GetField<jint>(*env, polyline, *polylineColorId)) };
+        annotation.width = { jni::GetField<jfloat>(*env, polyline, *polylineWidthId) };
         ids.push_back(nativeMapView->getMap().addAnnotation(annotation));
 
         jni::DeleteLocalRef(*env, polyline);
@@ -781,9 +781,9 @@ jni::jarray<jlong>* nativeAddPolygons(JNIEnv *env, jni::jobject* obj, jlong nati
         jni::jobject* points = jni::GetField<jni::jobject*>(*env, polygon, *polygonPointsId);
 
         mbgl::FillAnnotation annotation { mbgl::Polygon<double> { toGeometry<mbgl::LinearRing<double>>(env, points) } };
-        annotation.opacity = jni::GetField<jfloat>(*env, polygon, *polygonAlphaId);
-        annotation.outlineColor = toColor(jni::GetField<jint>(*env, polygon, *polygonStrokeColorId));
-        annotation.color = toColor(jni::GetField<jint>(*env, polygon, *polygonFillColorId));
+        annotation.opacity = { jni::GetField<jfloat>(*env, polygon, *polygonAlphaId) };
+        annotation.outlineColor = { toColor(jni::GetField<jint>(*env, polygon, *polygonStrokeColorId)) };
+        annotation.color = { toColor(jni::GetField<jint>(*env, polygon, *polygonFillColorId)) };
         ids.push_back(nativeMapView->getMap().addAnnotation(annotation));
 
         jni::DeleteLocalRef(*env, polygon);

--- a/platform/darwin/src/MGLMultiPoint_Private.h
+++ b/platform/darwin/src/MGLMultiPoint_Private.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MGLMultiPointDelegate <NSObject>
 
 /** Returns the fill alpha value for the given annotation. */
-- (double)alphaForShapeAnnotation:(MGLShape *)annotation;
+- (float)alphaForShapeAnnotation:(MGLShape *)annotation;
 
 /** Returns the stroke color object for the given annotation. */
 - (mbgl::Color)strokeColorForShapeAnnotation:(MGLShape *)annotation;
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (mbgl::Color)fillColorForPolygonAnnotation:(MGLPolygon *)annotation;
 
 /** Returns the stroke width object for the given annotation. */
-- (CGFloat)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
+- (float)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
 
 @end
 

--- a/platform/darwin/src/MGLPolygon.mm
+++ b/platform/darwin/src/MGLPolygon.mm
@@ -44,9 +44,9 @@
     }
 
     mbgl::FillAnnotation annotation { geometry };
-    annotation.opacity = [delegate alphaForShapeAnnotation:self];
-    annotation.outlineColor = [delegate strokeColorForShapeAnnotation:self];
-    annotation.color = [delegate fillColorForPolygonAnnotation:self];
+    annotation.opacity = { [delegate alphaForShapeAnnotation:self] };
+    annotation.outlineColor = { [delegate strokeColorForShapeAnnotation:self] };
+    annotation.color = { [delegate fillColorForPolygonAnnotation:self] };
 
     return annotation;
 }

--- a/platform/darwin/src/MGLPolyline.mm
+++ b/platform/darwin/src/MGLPolyline.mm
@@ -24,9 +24,9 @@
     }
 
     mbgl::LineAnnotation annotation { geometry };
-    annotation.opacity = [delegate alphaForShapeAnnotation:self];
-    annotation.color = [delegate strokeColorForShapeAnnotation:self];
-    annotation.width = [delegate lineWidthForPolylineAnnotation:self];
+    annotation.opacity = { [delegate alphaForShapeAnnotation:self] };
+    annotation.color = { [delegate strokeColorForShapeAnnotation:self] };
+    annotation.width = { [delegate lineWidthForPolylineAnnotation:self] };
 
     return annotation;
 }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3033,13 +3033,13 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     return annotationContext.annotationView;
 }
 
-- (double)alphaForShapeAnnotation:(MGLShape *)annotation
+- (float)alphaForShapeAnnotation:(MGLShape *)annotation
 {
     if (_delegateHasAlphasForShapeAnnotations)
     {
         return [self.delegate mapView:self alphaForShapeAnnotation:annotation];
     }
-    return 1.0;
+    return 1.0f;
 }
 
 - (mbgl::Color)strokeColorForShapeAnnotation:(MGLShape *)annotation
@@ -3058,13 +3058,13 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
     return MGLColorObjectFromUIColor(color);
 }
 
-- (CGFloat)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation
+- (float)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation
 {
     if (_delegateHasLineWidthsForShapeAnnotations)
     {
         return [self.delegate mapView:self lineWidthForPolylineAnnotation:(MGLPolyline *)annotation];
     }
-    return 3.0;
+    return 3.0f;
 }
 
 - (void)installAnnotationImage:(MGLAnnotationImage *)annotationImage

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -247,7 +247,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param annotation The annotation being rendered.
  @return A line width for the polyline, measured in points.
  */
-- (CGFloat)mapView:(MGLMapView *)mapView lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
+- (float)mapView:(MGLMapView *)mapView lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
 
 #pragma mark Managing Annotation Views
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2097,11 +2097,11 @@ public:
 
 #pragma mark MGLMultiPointDelegate methods
 
-- (double)alphaForShapeAnnotation:(MGLShape *)annotation {
+- (float)alphaForShapeAnnotation:(MGLShape *)annotation {
     if (_delegateHasAlphasForShapeAnnotations) {
         return [self.delegate mapView:self alphaForShapeAnnotation:annotation];
     }
-    return 1.0;
+    return 1.0f;
 }
 
 - (mbgl::Color)strokeColorForShapeAnnotation:(MGLShape *)annotation {
@@ -2118,11 +2118,11 @@ public:
     return MGLColorObjectFromNSColor(color);
 }
 
-- (CGFloat)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation {
+- (float)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation {
     if (_delegateHasLineWidthsForShapeAnnotations) {
         return [self.delegate mapView:self lineWidthForPolylineAnnotation:(MGLPolyline *)annotation];
     }
-    return 3.0;
+    return 3.0f;
 }
 
 #pragma mark MGLPopoverDelegate methods

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param annotation The annotation being rendered.
  @return A line width for the polyline, measured in points.
  */
-- (CGFloat)mapView:(MGLMapView *)mapView lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
+- (float)mapView:(MGLMapView *)mapView lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
 
 #pragma mark Selecting Annotations
 

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -24,11 +24,8 @@ void Painter::renderFill(PaintParameters& parameters,
     Color fillColor = properties.fillColor;
     float opacity = properties.fillOpacity;
 
-    Color strokeColor = properties.fillOutlineColor;
-    bool isOutlineColorDefined = strokeColor.a >= 0;
-    if (!isOutlineColorDefined) {
-        strokeColor = fillColor;
-    }
+    const bool isOutlineColorDefined = !properties.fillOutlineColor.isUndefined();
+    Color strokeColor = isOutlineColorDefined? properties.fillOutlineColor : fillColor;
 
     auto worldSize = util::convert<GLfloat>(frame.framebufferSize);
 

--- a/src/mbgl/style/layers/background_layer_properties.hpp
+++ b/src/mbgl/style/layers/background_layer_properties.hpp
@@ -17,7 +17,7 @@ public:
     void cascade(const CascadeParameters&);
     bool recalculate(const CalculationParameters&);
 
-    PaintProperty<Color> backgroundColor { { 0, 0, 0, 1 } };
+    PaintProperty<Color> backgroundColor { Color::black() };
     PaintProperty<std::string, CrossFadedPropertyEvaluator> backgroundPattern { "" };
     PaintProperty<float> backgroundOpacity { 1 };
 };

--- a/src/mbgl/style/layers/circle_layer_properties.hpp
+++ b/src/mbgl/style/layers/circle_layer_properties.hpp
@@ -18,7 +18,7 @@ public:
     bool recalculate(const CalculationParameters&);
 
     PaintProperty<float> circleRadius { 5 };
-    PaintProperty<Color> circleColor { { 0, 0, 0, 1 } };
+    PaintProperty<Color> circleColor { Color::black() };
     PaintProperty<float> circleBlur { 0 };
     PaintProperty<float> circleOpacity { 1 };
     PaintProperty<std::array<float, 2>> circleTranslate { {{ 0, 0 }} };

--- a/src/mbgl/style/layers/fill_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_layer_properties.hpp
@@ -20,7 +20,7 @@ public:
     PaintProperty<bool> fillAntialias { true };
     PaintProperty<float> fillOpacity { 1 };
     PaintProperty<Color> fillColor { { 0, 0, 0, 1 } };
-    PaintProperty<Color> fillOutlineColor { { 0, 0, 0, -1 } };
+    PaintProperty<Color> fillOutlineColor { {} };
     PaintProperty<std::array<float, 2>> fillTranslate { {{ 0, 0 }} };
     PaintProperty<TranslateAnchorType> fillTranslateAnchor { TranslateAnchorType::Map };
     PaintProperty<std::string, CrossFadedPropertyEvaluator> fillPattern { "" };

--- a/src/mbgl/style/layers/fill_layer_properties.hpp
+++ b/src/mbgl/style/layers/fill_layer_properties.hpp
@@ -19,7 +19,7 @@ public:
 
     PaintProperty<bool> fillAntialias { true };
     PaintProperty<float> fillOpacity { 1 };
-    PaintProperty<Color> fillColor { { 0, 0, 0, 1 } };
+    PaintProperty<Color> fillColor { Color::black() };
     PaintProperty<Color> fillOutlineColor { {} };
     PaintProperty<std::array<float, 2>> fillTranslate { {{ 0, 0 }} };
     PaintProperty<TranslateAnchorType> fillTranslateAnchor { TranslateAnchorType::Map };

--- a/src/mbgl/style/layers/line_layer_properties.hpp
+++ b/src/mbgl/style/layers/line_layer_properties.hpp
@@ -28,7 +28,7 @@ public:
     bool recalculate(const CalculationParameters&);
 
     PaintProperty<float> lineOpacity { 1 };
-    PaintProperty<Color> lineColor { { 0, 0, 0, 1 } };
+    PaintProperty<Color> lineColor { Color::black() };
     PaintProperty<std::array<float, 2>> lineTranslate { {{ 0, 0 }} };
     PaintProperty<TranslateAnchorType> lineTranslateAnchor { TranslateAnchorType::Map };
     PaintProperty<float> lineWidth { 1 };

--- a/src/mbgl/style/layers/symbol_layer_properties.hpp
+++ b/src/mbgl/style/layers/symbol_layer_properties.hpp
@@ -58,15 +58,15 @@ public:
     bool recalculate(const CalculationParameters&);
 
     PaintProperty<float> iconOpacity { 1 };
-    PaintProperty<Color> iconColor { { 0, 0, 0, 1 } };
-    PaintProperty<Color> iconHaloColor { { 0, 0, 0, 0 } };
+    PaintProperty<Color> iconColor { Color::black() };
+    PaintProperty<Color> iconHaloColor { {} };
     PaintProperty<float> iconHaloWidth { 0 };
     PaintProperty<float> iconHaloBlur { 0 };
     PaintProperty<std::array<float, 2>> iconTranslate { {{ 0, 0 }} };
     PaintProperty<TranslateAnchorType> iconTranslateAnchor { TranslateAnchorType::Map };
     PaintProperty<float> textOpacity { 1 };
-    PaintProperty<Color> textColor { { 0, 0, 0, 1 } };
-    PaintProperty<Color> textHaloColor { { 0, 0, 0, 0 } };
+    PaintProperty<Color> textColor { Color::black() };
+    PaintProperty<Color> textHaloColor { {} };
     PaintProperty<float> textHaloWidth { 0 };
     PaintProperty<float> textHaloBlur { 0 };
     PaintProperty<std::array<float, 2>> textTranslate { {{ 0, 0 }} };

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -39,8 +39,12 @@ public:
         return *this;
     }
 
+    bool isUndefined() const {
+        return values.find(ClassID::Default) == values.end();
+    }
+
     const PropertyValue<T>& get() const {
-        return values.at(ClassID::Default);
+        return isUndefined() ? values.at(ClassID::Fallback) : values.at(ClassID::Default);
     }
 
     void set(const PropertyValue<T>& value_, const optional<std::string>& klass) {

--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -53,8 +53,8 @@ TEST(Annotations, LineAnnotation) {
 
     LineString<double> line = {{ { 0, 0 }, { 45, 45 }, { 30, 0 } }};
     LineAnnotation annotation { line };
-    annotation.color = { 255, 0, 0, 1 };
-    annotation.width = 5;
+    annotation.color = { { 255, 0, 0, 1 } };
+    annotation.width = { 5 };
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotation(annotation);
@@ -69,7 +69,7 @@ TEST(Annotations, FillAnnotation) {
 
     Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
     FillAnnotation annotation { polygon };
-    annotation.color = { 255, 0, 0, 1 };
+    annotation.color = { { 255, 0, 0, 1 } };
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotation(annotation);
@@ -110,7 +110,7 @@ TEST(Annotations, NonImmediateAdd) {
 
     Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
     FillAnnotation annotation { polygon };
-    annotation.color = { 255, 0, 0, 1 };
+    annotation.color = { { 255, 0, 0, 1 } };
 
     test.map.addAnnotation(annotation);
     test.checkRendering("non_immediate_add");
@@ -162,8 +162,8 @@ TEST(Annotations, RemoveShape) {
 
     LineString<double> line = {{ { 0, 0 }, { 45, 45 } }};
     LineAnnotation annotation { line };
-    annotation.color = { 255, 0, 0, 1 };
-    annotation.width = 5;
+    annotation.color = { { 255, 0, 0, 1 } };
+    annotation.width = { 5 };
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     AnnotationID shape = test.map.addAnnotation(annotation);


### PR DESCRIPTION
Ref: [include/mbgl/annotation/annotation.hpp#L41](https://github.com/mapbox/mapbox-gl-native/blob/master/include/mbgl/annotation/annotation.hpp#L41)

This implies adapting all platform-specific code to return an optional color value for this, specifically:
- Android: [platform/android/src/jni.cpp#L788](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/src/jni.cpp#L788)
- Darwin: [platform/darwin/src/MGLPolygon.mm#L48](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/darwin/src/MGLPolygon.mm#L48)

Then we could cleanup the outline color check done in [src/mbgl/renderer/painter_fill.cpp#L27-L31](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/renderer/painter_fill.cpp#L27-L31).

/cc @tobrun @1ec5 @jfirebaugh 