### PR TITLE
Reorganize jazzy’s navigation categories; cleanup docs

### DIFF
--- a/platform/darwin/src/MGLAccountManager.h
+++ b/platform/darwin/src/MGLAccountManager.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The MGLAccountManager object provides a global way to set a Mapbox API access
- token, as well as other settings used framework-wide.
+ token.
  */
 @interface MGLAccountManager : NSObject
 

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -29,7 +29,10 @@ typedef NS_ENUM(NSInteger, MGLErrorCode) {
     MGLErrorCodeConnectionFailed = 3,
 };
 
-/** The mode used to track the user location on the map. */
+/**
+ The mode used to track the user location on the map. Used with
+ `MGLMapView.userTrackingMode`.
+ */
 typedef NS_ENUM(NSUInteger, MGLUserTrackingMode) {
     /** The map does not follow the user location. */
     MGLUserTrackingModeNone              = 0,

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -27,7 +27,6 @@ custom_categories:
     children:
       - MGLAnnotation
       - MGLAnnotationImage
-      - MGLAnnotationVerticalAlignment
       - MGLAnnotationView
       - MGLAnnotationViewDragState
       - MGLCalloutView

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -28,7 +28,6 @@ custom_categories:
       - MGLAnnotation
       - MGLAnnotationImage
       - MGLAnnotationView
-      - MGLAnnotationViewDragState
       - MGLCalloutView
       - MGLCalloutViewDelegate
       - MGLMultiPoint

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -57,17 +57,8 @@ custom_categories:
       - MGLOfflineRegion
       - MGLOfflineStorage
       - MGLOfflinePack
-      - MGLOfflinePackAdditionCompletionHandler
-      - MGLOfflinePackErrorNotification
-      - MGLOfflinePackErrorUserInfoKey
-      - MGLOfflinePackMaximumCountUserInfoKey
-      - MGLOfflinePackMaximumMapboxTilesReachedNotification
       - MGLOfflinePackProgress
-      - MGLOfflinePackProgressChangedNotification
-      - MGLOfflinePackProgressUserInfoKey
-      - MGLOfflinePackRemovalCompletionHandler
       - MGLOfflinePackState
-      - MGLOfflinePackStateUserInfoKey
       - MGLTilePyramidOfflineRegion
   - name: Geometry
     children:

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -19,14 +19,9 @@ custom_categories:
     children:
       - MGLAccountManager
       - MGLMapCamera
-      - MGLMapDebugMaskOptions
       - MGLMapView
-      - MGLMapViewDecelerationRateFast
-      - MGLMapViewDecelerationRateImmediate
-      - MGLMapViewDecelerationRateNormal
       - MGLMapViewDelegate
       - MGLStyle
-      - MGLStyleDefaultVersion
       - MGLUserTrackingMode
   - name: Annotations
     children:

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol MGLAnnotation;
 
-/** These constants indicate the current drag state of an annotation view. **/
+/** These constants indicate the current drag state of an annotation view. */
 typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
     /**
      The view is not involved in a drag operation.

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
  leaves the viewport, the map view moves its associated view to a reuse queue.
  When a new annotation becomes visible, you can request a view for that
  annotation by passing the appropriate reuse identifier string to the
- `-[MGLMapView dequeueReusableAnnotationViewWithIdentifier:` method.
+ `-[MGLMapView dequeueReusableAnnotationViewWithIdentifier:]` method.
  
  @param reuseIdentifier A unique string identifier for this view that allows you
     to reuse this view with multiple similar annotations. You can set this

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -31,8 +31,8 @@ extern const CGFloat MGLMapViewDecelerationRateFast;
 extern const CGFloat MGLMapViewDecelerationRateImmediate;
 
 /**
- The vertical alignment of an annotation within a map view. Used with the
- `MGLMapView.userLocationVerticalAlignment` property.
+ The vertical alignment of an annotation within a map view. Used with
+ `MGLMapView.userLocationVerticalAlignment`.
  */
 typedef NS_ENUM(NSUInteger, MGLAnnotationVerticalAlignment) {
     /** Aligns the annotation vertically in the center of the map view. */

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -31,10 +31,8 @@ extern const CGFloat MGLMapViewDecelerationRateFast;
 extern const CGFloat MGLMapViewDecelerationRateImmediate;
 
 /**
- The vertical alignment of an annotation within a map view.
-
- @note This is currently used with the `MGLMapView.userLocationVerticalAlignment`
- property.
+ The vertical alignment of an annotation within a map view. Used with the
+ `MGLMapView.userLocationVerticalAlignment` property.
  */
 typedef NS_ENUM(NSUInteger, MGLAnnotationVerticalAlignment) {
     /** Aligns the annotation vertically in the center of the map view. */

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -30,7 +30,12 @@ extern const CGFloat MGLMapViewDecelerationRateFast;
 /** Disables decleration in a map view. */
 extern const CGFloat MGLMapViewDecelerationRateImmediate;
 
-/** The vertical alignment of an annotation within a map view. */
+/**
+ The vertical alignment of an annotation within a map view.
+
+ @note This is currently used with the `MGLMapView.userLocationVerticalAlignment`
+ property.
+ */
 typedef NS_ENUM(NSUInteger, MGLAnnotationVerticalAlignment) {
     /** Aligns the annotation vertically in the center of the map view. */
     MGLAnnotationVerticalAlignmentCenter = 0,

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -18,11 +18,9 @@ custom_categories:
     children:
       - MGLAccountManager
       - MGLMapCamera
-      - MGLMapDebugMaskOptions
       - MGLMapView
       - MGLMapViewDelegate
       - MGLStyle
-      - MGLStyleDefaultVersion
       - MGLUserTrackingMode
   - name: Annotations
     children:
@@ -52,17 +50,8 @@ custom_categories:
       - MGLOfflineRegion
       - MGLOfflineStorage
       - MGLOfflinePack
-      - MGLOfflinePackAdditionCompletionHandler
-      - MGLOfflinePackErrorNotification
-      - MGLOfflinePackErrorUserInfoKey
-      - MGLOfflinePackMaximumCountUserInfoKey
-      - MGLOfflinePackMaximumMapboxTilesReachedNotification
       - MGLOfflinePackProgress
-      - MGLOfflinePackProgressChangedNotification
-      - MGLOfflinePackProgressUserInfoKey
-      - MGLOfflinePackRemovalCompletionHandler
       - MGLOfflinePackState
-      - MGLOfflinePackStateUserInfoKey
       - MGLTilePyramidOfflineRegion
   - name: Geometry
     children:
@@ -75,6 +64,7 @@ custom_categories:
       - MGLCoordinateBoundsMake
       - MGLCoordinateBoundsOffset
       - MGLCoordinateFormatter
+      - MGLCoordinateInCoordinateBounds
       - MGLCoordinateSpan
       - MGLCoordinateSpanEqualToCoordinateSpan
       - MGLCoordinateSpanMake


### PR DESCRIPTION
This pull request reorganizes jazzy’s navigation categories by demoting less commonly used parts of our SDK to generic “Other” categories at the bottom of the list. In particular, this makes the Maps and Offline sections easier to understand.

I’ve also cleaned up some typos in the inline documentation and added two back-references to enum docs about which MGLMapView properties they are used with.

![mapbox-ios-sdk-reference- 20160712](https://cloud.githubusercontent.com/assets/1198851/16775499/e41e8276-482e-11e6-813f-2e1d1bd9e263.jpg)

/cc @1ec5