### PR TITLE
Add -fvisibility=hidden param to Android build

### DIFF
--- a/mbgl.gypi
+++ b/mbgl.gypi
@@ -108,6 +108,8 @@
               'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES',
               'DEAD_CODE_STRIPPING': 'NO',
             },
+          }, 'OS=="android"', {
+            'cflags_cc': [ '-g', '-Os', '-fvisibility=hidden' ],
           }, {
             'cflags_cc': [ '-g', '-O3' ],
           }],

--- a/platform/android/platform.gyp
+++ b/platform/android/platform.gyp
@@ -1,6 +1,7 @@
 {
   'variables': {
     'loop_lib': 'android',
+    'OS': 'android',
     'headless_lib': 'none',
     'coverage': 0,
   },


### PR DESCRIPTION
This piece from Realm on [Reducing your Android APK size When Using Native Libraries](https://realm.io/news/reducing-apk-size-native-libraries/) suggests the following approach to reducing library size:

> At that point both our core (libtightdb) and the JNI code was compiled with GCC with the -Os flag, which tries to optimize the library for size while maintaining decent performance. We also enabled -visibility=hidden to hide most of the unneeded ELF symbols.

Per convo with @tmpsantos we don't use the `-Os` flag as we optimize for performance, but we could benefit from `-visibility=hidden` as Qt does.

It'd be interesting to compare library size before and after adding those flags.
