### PR TITLE
[node] Added 'removeLayer' binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#4d1f89514bf03536c8e682439df165c33a37122a",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#83b1a3e5837d785af582efd5ed1a212f2df6a4ae",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#d4c5c157397a2df619ba1eecf69a08b34159b3e1",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#3fabb909ba50af1175a2409e9a3cda56fb41b5c7",
     "node-gyp": "^3.3.1",
     "request": "^2.72.0",
     "tape": "^4.5.1"

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -60,6 +60,7 @@ NAN_MODULE_INIT(NodeMap::Init) {
     Nan::SetPrototypeMethod(tpl, "addClass", AddClass);
     Nan::SetPrototypeMethod(tpl, "addSource", AddSource);
     Nan::SetPrototypeMethod(tpl, "addLayer", AddLayer);
+    Nan::SetPrototypeMethod(tpl, "removeLayer", RemoveLayer);
     Nan::SetPrototypeMethod(tpl, "setLayoutProperty", SetLayoutProperty);
     Nan::SetPrototypeMethod(tpl, "setPaintProperty", SetPaintProperty);
     Nan::SetPrototypeMethod(tpl, "setFilter", SetFilter);
@@ -529,6 +530,24 @@ NAN_METHOD(NodeMap::AddLayer) {
     }
 
     nodeMap->map->addLayer(std::move(*layer));
+}
+
+NAN_METHOD(NodeMap::RemoveLayer) {
+    using namespace mbgl::style;
+    using namespace mbgl::style::conversion;
+
+    auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
+    if (!nodeMap->map) return Nan::ThrowError(releasedMessage());
+
+    if (info.Length() != 1) {
+        return Nan::ThrowTypeError("One argument required");
+    }
+
+    if (!info[0]->IsString()) {
+        return Nan::ThrowTypeError("First argument must be a string");
+    }
+
+    nodeMap->map->removeLayer(*Nan::Utf8String(info[0]));
 }
 
 NAN_METHOD(NodeMap::SetLayoutProperty) {

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -28,6 +28,7 @@ public:
     static NAN_METHOD(AddClass);
     static NAN_METHOD(AddSource);
     static NAN_METHOD(AddLayer);
+    static NAN_METHOD(RemoveLayer);
     static NAN_METHOD(SetLayoutProperty);
     static NAN_METHOD(SetPaintProperty);
     static NAN_METHOD(SetFilter);


### PR DESCRIPTION
Changes:
- Added `removeLayer` Node binding to support https://github.com/mapbox/mapbox-gl-test-suite/commit/f496dcdb9cfe93adbee83a2f2f47b1c93860e56c
- Updated `mapbox-gl-test-suite` to https://github.com/mapbox/mapbox-gl-test-suite/commit/3fabb909ba50af1175a2409e9a3cda56fb41b5c7
 - Added regression test for https://github.com/mapbox/mapbox-gl-native/pull/5648

:eyes: @mikemorris @bsudekum 