### PR TITLE
[ios] Also pass `animated` property when deselecting annotation views

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3632,7 +3632,7 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         {
             MGLAnnotationContext &annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
             annotationView = annotationContext.annotationView;
-            annotationView.selected = NO;
+            [annotationView setSelected:NO animated:animated];
         }
 
         // clean up


### PR DESCRIPTION
This is the view annotation deselection counterpart to https://github.com/mapbox/mapbox-gl-native/pull/5646's selection (that I neglected to check). Going to put this on v3.3.1, as this is a minor fix and we can live without it in the short term.

/cc @1ec5 @boundsj @frederoni