### PR TITLE
[core] Lower current scheduler priority if SCHED_IDLE is not supported

### DIFF
--- a/include/mbgl/platform/platform.hpp
+++ b/include/mbgl/platform/platform.hpp
@@ -14,6 +14,12 @@ std::string uppercase(const std::string &string);
 // Lowercase a string, potentially using platform-specific routines.
 std::string lowercase(const std::string &string);
 
+// Gets the name of the current thread.
+std::string getCurrentThreadName();
+
+// Set the name of the current thread, truncated at 15.
+void setCurrentThreadName(const std::string& name);
+
 // Makes the current thread low priority.
 void makeThreadLowPriority();
 

--- a/platform/android/platform.gyp
+++ b/platform/android/platform.gyp
@@ -31,7 +31,7 @@
         'src/log_android.cpp',
         'src/http_file_source.cpp',
         'src/asset_file_source.cpp',
-        '../default/thread.cpp',
+        'src/thread.cpp',
         '../default/string_stdlib.cpp',
         '../default/image.cpp',
         '../default/png_reader.cpp',

--- a/platform/android/src/asset_file_source.cpp
+++ b/platform/android/src/asset_file_source.cpp
@@ -100,7 +100,7 @@ private:
 
 AssetFileSource::AssetFileSource(const std::string& root)
     : thread(std::make_unique<util::Thread<Impl>>(
-        util::ThreadContext{"AssetFileSource"},
+        util::ThreadContext{"AssetFileSource", util::ThreadPriority::Low},
         root)) {
 }
 

--- a/platform/android/src/run_loop.cpp
+++ b/platform/android/src/run_loop.cpp
@@ -1,5 +1,6 @@
 #include "run_loop_impl.hpp"
 
+#include <mbgl/platform/platform.hpp>
 #include <mbgl/util/thread_context.hpp>
 #include <mbgl/util/thread_local.hpp>
 #include <mbgl/util/timer.hpp>
@@ -75,7 +76,7 @@ private:
 
 RunLoop::Impl::Impl(RunLoop* runLoop_, RunLoop::Type type) : runLoop(runLoop_) {
     using namespace mbgl::android;
-    detach = attach_jni_thread(theJVM, &env, "");
+    detach = attach_jni_thread(theJVM, &env, platform::getCurrentThreadName());
 
     loop = ALooper_prepare(0);
     assert(loop);

--- a/platform/android/src/thread.cpp
+++ b/platform/android/src/thread.cpp
@@ -1,0 +1,37 @@
+#include <mbgl/platform/log.hpp>
+#include <mbgl/platform/platform.hpp>
+
+#include <sys/prctl.h>
+#include <sys/resource.h>
+
+// Implementation based on Chromium's platform_thread_android.cc.
+
+namespace mbgl {
+namespace platform {
+
+std::string getCurrentThreadName() {
+    char name[32] = "unknown";
+
+    if (prctl(PR_GET_NAME, name) == -1) {
+        Log::Warning(Event::General, "Couldn't get thread name");
+    }
+
+    return name;
+}
+
+void setCurrentThreadName(const std::string& name) {
+    if (prctl(PR_SET_NAME, name.c_str()) == -1) {
+        Log::Warning(Event::General, "Couldn't set thread name");
+    }
+}
+
+void makeThreadLowPriority() {
+    // ANDROID_PRIORITY_LOWEST = 19
+    //
+    // Supposedly would set the priority for the whole process, but
+    // on Linux/Android it only sets for the current thread.
+    setpriority(PRIO_PROCESS, 0, 19);
+}
+
+} // namespace platform
+} // namespace mbgl

--- a/platform/darwin/src/nsthread.mm
+++ b/platform/darwin/src/nsthread.mm
@@ -2,8 +2,21 @@
 
 #include <mbgl/platform/platform.hpp>
 
+#include <pthread.h>
+
 namespace mbgl {
 namespace platform {
+
+std::string getCurrentThreadName() {
+    char name[32] = "unknown";
+    pthread_getname_np(pthread_self(), name, sizeof(name));
+
+    return name;
+}
+
+void setCurrentThreadName(const std::string& name) {
+    pthread_setname_np(name.c_str());
+}
 
 void makeThreadLowPriority() {
     [[NSThread currentThread] setThreadPriority:0.0];

--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -57,7 +57,7 @@ private:
 
 AssetFileSource::AssetFileSource(const std::string& root)
     : thread(std::make_unique<util::Thread<Impl>>(
-        util::ThreadContext{"AssetFileSource"},
+        util::ThreadContext{"AssetFileSource", util::ThreadPriority::Low},
         root)) {
 }
 

--- a/platform/default/thread.cpp
+++ b/platform/default/thread.cpp
@@ -11,42 +11,26 @@ namespace platform {
 
 std::string getCurrentThreadName() {
     char name[32] = "unknown";
-#if defined(__APPLE__)
     pthread_getname_np(pthread_self(), name, sizeof(name));
-#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 12)
-    pthread_getname_np(pthread_self(), name, sizeof(name));
-#endif
-#endif
+
     return name;
 }
 
 void setCurrentThreadName(const std::string& name) {
-#if defined(__APPLE__)
-    pthread_setname_np(name.c_str());
-#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 12)
     if (name.size() > 15) { // Linux hard limit (see manpages).
         pthread_setname_np(pthread_self(), name.substr(0, 15).c_str());
     } else {
         pthread_setname_np(pthread_self(), name.c_str());
     }
-#endif
-#endif
-    (void)name;
 }
 
 void makeThreadLowPriority() {
-#ifdef SCHED_IDLE
     struct sched_param param;
     param.sched_priority = 0;
-    int status = sched_setscheduler(0, SCHED_IDLE, &param);
-    if (status != 0) {
+
+    if (sched_setscheduler(0, SCHED_IDLE, &param) != 0) {
         Log::Warning(Event::General, "Couldn't set thread scheduling policy");
     }
-#else
-#pragma message("Building without thread priority control")
-#endif
 }
 
 } // namespace platform

--- a/platform/default/thread.cpp
+++ b/platform/default/thread.cpp
@@ -26,7 +26,11 @@ void setCurrentThreadName(const std::string& name) {
     pthread_setname_np(name.c_str());
 #elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2, 12)
-    pthread_setname_np(pthread_self(), name.c_str());
+    if (name.size() > 15) { // Linux hard limit (see manpages).
+        pthread_setname_np(pthread_self(), name.substr(0, 15).c_str());
+    } else {
+        pthread_setname_np(pthread_self(), name.c_str());
+    }
 #endif
 #endif
     (void)name;

--- a/platform/default/thread.cpp
+++ b/platform/default/thread.cpp
@@ -1,15 +1,36 @@
 #include <mbgl/platform/platform.hpp>
-
 #include <mbgl/platform/log.hpp>
 
+#include <string>
+
 #include <pthread.h>
-#ifdef __linux__
-#include <linux/sched.h>
-#endif
 #include <sched.h>
 
 namespace mbgl {
 namespace platform {
+
+std::string getCurrentThreadName() {
+    char name[32] = "unknown";
+#if defined(__APPLE__)
+    pthread_getname_np(pthread_self(), name, sizeof(name));
+#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 12)
+    pthread_getname_np(pthread_self(), name, sizeof(name));
+#endif
+#endif
+    return name;
+}
+
+void setCurrentThreadName(const std::string& name) {
+#if defined(__APPLE__)
+    pthread_setname_np(name.c_str());
+#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 12)
+    pthread_setname_np(pthread_self(), name.c_str());
+#endif
+#endif
+    (void)name;
+}
 
 void makeThreadLowPriority() {
 #ifdef SCHED_IDLE

--- a/platform/qt/platform.gyp
+++ b/platform/qt/platform.gyp
@@ -47,7 +47,6 @@
         '../default/online_file_source.cpp',
         '../default/sqlite3.cpp',
         '../default/string_stdlib.cpp',
-        '../default/thread.cpp',
         'include/qmapbox.hpp',
         'include/qmapboxgl.hpp',
         'include/qquickmapboxgl.hpp',
@@ -168,16 +167,25 @@
         ['OS == "mac"', {
           'xcode_settings': {
             'OTHER_CPLUSPLUSFLAGS': [ '<@(cflags)' ],
-          }
+          },
+          'sources': [
+            '../darwin/src/nsthread.mm',
+          ],
         }, {
           'cflags_cc': [ '<@(cflags)' ],
+          'sources': [
+            '../default/thread.cpp',
+          ],
         }]
       ],
 
       'link_settings': {
         'conditions': [
           ['OS == "mac"', {
-            'libraries': [ '<@(libraries)' ],
+            'libraries': [
+              '<@(libraries)',
+              '$(SDKROOT)/System/Library/Frameworks/Cocoa.framework',
+            ],
             'xcode_settings': { 'OTHER_LDFLAGS': [ '<@(ldflags)' ] }
           }, {
             'libraries': [ '<@(libraries)', '<@(ldflags)' ],

--- a/src/mbgl/platform/log.cpp
+++ b/src/mbgl/platform/log.cpp
@@ -50,7 +50,7 @@ void Log::record(EventSeverity severity, Event event, int64_t code, const std::s
 
     std::stringstream logStream;
 
-    logStream << "{" << util::getCurrentThreadName() << "}";
+    logStream << "{" << platform::getCurrentThreadName() << "}";
     logStream << "[" << Enum<Event>::toString(event) << "]";
 
     if (code >= 0) {

--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -86,29 +86,6 @@ private:
     RunLoop* loop = nullptr;
 };
 
-inline std::string getCurrentThreadName() {
-    char name[32] = "unknown";
-#if defined(__APPLE__)
-    pthread_getname_np(pthread_self(), name, sizeof(name));
-#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 12)
-    pthread_getname_np(pthread_self(), name, sizeof(name));
-#endif
-#endif
-    return name;
-}
-
-inline void setCurrentThreadName(const std::string& name) {
-#if defined(__APPLE__)
-        pthread_setname_np(name.c_str());
-#elif defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 12)
-        pthread_setname_np(pthread_self(), name.c_str());
-#endif
-#endif
-    (void)name;
-}
-
 template <class Object>
 template <class... Args>
 Thread<Object>::Thread(const ThreadContext& context, Args&&... args) {
@@ -117,7 +94,7 @@ Thread<Object>::Thread(const ThreadContext& context, Args&&... args) {
     std::tuple<Args...> params = std::forward_as_tuple(::std::forward<Args>(args)...);
 
     thread = std::thread([&] {
-        setCurrentThreadName(context.name);
+        platform::setCurrentThreadName(context.name);
 
         if (context.priority == ThreadPriority::Low) {
             platform::makeThreadLowPriority();


### PR DESCRIPTION
Still reduces scheduler priority for Android NDK API lower than 21 where SCHED_IDLE is not defined.

Fixes #5535