### PR TITLE
[core] Guard against camera's `minScale` being NaN

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -503,13 +503,16 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
     double height = nePixel.y - swPixel.y;
 
     // Calculate the zoom level.
-    double scaleX = getWidth() / width;
-    double scaleY = getHeight() / height;
-    if (padding && *padding) {
-        scaleX -= (padding->left + padding->right) / width;
-        scaleY -= (padding->top + padding->bottom) / height;
+    double minScale = INFINITY;
+    if (width > 0 || height > 0) {
+        double scaleX = getWidth() / width;
+        double scaleY = getHeight() / height;
+        if (padding && *padding) {
+            scaleX -= (padding->left + padding->right) / width;
+            scaleY -= (padding->top + padding->bottom) / height;
+        }
+        minScale = util::min(scaleX, scaleY);
     }
-    double minScale = ::fmin(scaleX, scaleY);
     double zoom = util::log2(getScale() * minScale);
     zoom = util::clamp(zoom, getMinZoom(), getMaxZoom());
 


### PR DESCRIPTION
Fixes a bug where calculating a camera's padded bounds for a single point would cause division by zero, resulting in NaN for `minScale`. This invalid `minScale` would then be used to create an invalid padded `centerPixel`.

This was introduced by 8e30a4a0806e970e727c3563b8ed57dbaf9a0fa0 in #4285, where the scale and padding calculations were split.

The “Add Custom Callout Point” option in ios-app exercises this bug, where the map zooms in on a single annotation, à la:

```objc
[self.mapView showAnnotations:@[ oneSingularAnnotation ] animated:NO];
```

/cc @brunoabinader @1ec5