### PR TITLE
Add ability to disable overdraw shaders 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,13 @@ after_script:
 
 matrix:
   include:
-    # Clang 3.5 - Release - Node
+    # Clang 3.5 - Debug - Node
     - os: linux
       sudo: required
       dist: trusty
       language: node
-      compiler: "node4-clang35-release"
-      env: BUILDTYPE=Release _CXX=clang++-3.5 _CC=clang-3.5
+      compiler: "node4-clang35-debug"
+      env: BUILDTYPE=Debug _CXX=clang++-3.5 _CC=clang-3.5
       addons: *clang35
       script:
         - nvm install 4

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 * The `text-pitch-alignment` property is now supported in stylesheets for improved street label legibility on a tilted map. ([#5288](https://github.com/mapbox/mapbox-gl-native/pull/5288))
 * The `icon-text-fit` and `icon-text-fit-padding` properties are now supported in stylesheets, allowing the background of a shield to automatically resize to fit the shield’s text. ([#5334](https://github.com/mapbox/mapbox-gl-native/pull/5334))
 * Improved the performance of relocating a non-view-backed point annotation by changing its `coordinate` property. ([#5385](https://github.com/mapbox/mapbox-gl-native/pull/5385))
+* MGLMapDebugOverdrawVisualizationMask does nothing in Release builds of the SDK. This is disabled for performance reasons. ([#5555](https://github.com/mapbox/mapbox-gl-native/pull/5555))
 
 ## 3.3.1
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -57,6 +57,7 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
     MGLMapDebugCollisionBoxesMask = 1 << 4,
     /** Each drawing operation is replaced by a translucent fill. Overlapping
         drawing operations appear more prominent to help diagnose overdrawing.
+        @note This option does nothing in Release builds of the SDK.
      */
     MGLMapDebugOverdrawVisualizationMask = 1 << 5,
 };

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -15,6 +15,7 @@
 * The `icon-text-fit` and `icon-text-fit-padding` properties are now supported in stylesheets, allowing the background of a shield to automatically resize to fit the shield’s text. ([#5334](https://github.com/mapbox/mapbox-gl-native/pull/5334))
 * Improved the performance of relocating a point annotation by changing its `coordinate` property. ([#5385](https://github.com/mapbox/mapbox-gl-native/pull/5385))
 * Replaced the wireframe debug mask with an overdraw visualization debug mask to match Mapbox GL JS’s overdraw inspector. ([#5403](https://github.com/mapbox/mapbox-gl-native/pull/5403))
+* MGLMapDebugOverdrawVisualizationMask and MGLMapDebugStencilBufferMask does nothing in Release builds of the SDK. These are disabled for performance reasons. ([#5555](https://github.com/mapbox/mapbox-gl-native/pull/5555))
 
 ## 0.2.0
 

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -23,10 +23,13 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
     
     /** Each drawing operation is replaced by a translucent fill. Overlapping
         drawing operations appear more prominent to help diagnose overdrawing.
+        @note This option does nothing in Release builds of the SDK.
      */
     MGLMapDebugOverdrawVisualizationMask = 1 << 5,
     
-    /** The stencil buffer is shown instead of the color buffer. */
+    /** The stencil buffer is shown instead of the color buffer.
+        @note This option does nothing in Release builds of the SDK.
+     */
     MGLMapDebugStencilBufferMask = 1 << 6,
 };
 

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+* Map debug options 'overdraw' and 'stencil clip' are now disabled (no-ops) in release mode. ([#5555](https://github.com/mapbox/mapbox-gl-native/pull/5555))
+
 # 3.3.0
 
 - Adds runtime styling API ([#5318](https://github.com/mapbox/mapbox-gl-native/pull/5318), [#5380](https://github.com/mapbox/mapbox-gl-native/pull/5380), [#5428](https://github.com/mapbox/mapbox-gl-native/pull/5428), [#5429](https://github.com/mapbox/mapbox-gl-native/pull/5429), [#5462](https://github.com/mapbox/mapbox-gl-native/pull/5462), [#5614](https://github.com/mapbox/mapbox-gl-native/pull/5614), [#5670](https://github.com/mapbox/mapbox-gl-native/pull/5670))

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -159,10 +159,12 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         drawClippingMasks(parameters, generator.getStencils());
     }
 
+#if defined(DEBUG)
     if (frame.debugOptions & MapDebugOptions::StencilClip) {
         renderClipMasks();
         return;
     }
+#endif
 
     // Actually render the layers
     if (debug::renderTree) { Log::Info(Event::Render, "{"); indent++; }

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -46,7 +46,9 @@ Painter::Painter(const TransformState& state_,
     gl::debugging::enable();
 
     shaders = std::make_unique<Shaders>(store);
+#if defined(DEBUG)
     overdrawShaders = std::make_unique<Shaders>(store, Shader::Overdraw);
+#endif
 
     // Reset GL values
     config.setDirty();
@@ -69,7 +71,11 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     frame = frame_;
 
     PaintParameters parameters {
+#if defined(DEBUG)
         isOverdraw() ? *overdrawShaders : *shaders
+#else
+        *shaders
+#endif
     };
 
     glyphAtlas = style.glyphAtlas.get();

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -139,7 +139,11 @@ private:
 
     void setDepthSublayer(int n);
 
+#if defined(DEBUG)
     bool isOverdraw() const { return frame.debugOptions & MapDebugOptions::Overdraw; }
+#else
+    bool isOverdraw() const { return false; }
+#endif
 
     mat4 projMatrix;
 
@@ -174,7 +178,9 @@ private:
     FrameHistory frameHistory;
 
     std::unique_ptr<Shaders> shaders;
+#if defined(DEBUG)
     std::unique_ptr<Shaders> overdrawShaders;
+#endif
 
     // Set up the stencil quad we're using to generate the stencil mask.
     StaticVertexBuffer tileStencilBuffer {

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -86,7 +86,10 @@ public:
     // Renders the red debug frame around a tile, visualizing its perimeter.
     void renderDebugFrame(const mat4 &matrix);
 
+#if defined(DEBUG)
+    // Renders tile clip boundaries, using stencil buffer to calculate fill color.
     void renderClipMasks();
+#endif
 
     void renderDebugText(Tile&, const mat4&);
     void renderFill(PaintParameters&, FillBucket&, const style::FillLayer&, const RenderTile&);

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -87,6 +87,7 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, (GLsizei)tileBorderBuffer.index()));
 }
 
+#if defined(DEBUG)
 void Painter::renderClipMasks() {
     config.stencilTest = GL_FALSE;
     config.depthTest = GL_FALSE;
@@ -122,5 +123,6 @@ void Painter::renderClipMasks() {
     MBGL_CHECK_ERROR(glDrawPixels(fbSize[0], fbSize[1], GL_LUMINANCE, GL_UNSIGNED_BYTE, pixels.get()));
 #endif // GL_ES_VERSION_2_0
 }
+#endif // defined(DEBUG)
 
 } // namespace mbgl


### PR DESCRIPTION
#5371 and #5534 add a second set of shaders for overdraw mode. We should completely disable this with `ifdefs` or so when we're building a release build for publication to avoid additional shader compilation overhead. Overdraw mode is a debugging tool and shouldn't be in the SDK.

/cc @brunoabinader 