### PR TITLE
Reenable long tap to drop pins

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -411,7 +411,6 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
 {
     if (longPress.state == UIGestureRecognizerStateBegan)
     {
-        /*
         CGPoint point = [longPress locationInView:longPress.view];
         NSArray *features = [self.mapView visibleFeaturesAtPoint:point];
         NSString *title;
@@ -428,7 +427,6 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         pin.subtitle = [[[MGLCoordinateFormatter alloc] init] stringFromCoordinate:pin.coordinate];
         // Calling `addAnnotation:` on mapView is not required since `selectAnnotation:animated` has the side effect of adding the annotation if required
         [self.mapView selectAnnotation:pin animated:YES];
-        */
     }
 }
 

--- a/platform/ios/app/Main.storyboard
+++ b/platform/ios/app/Main.storyboard
@@ -79,7 +79,7 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="AAd-8J-9UU" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="lfd-mn-7en">
+                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="1" id="lfd-mn-7en">
                     <connections>
                         <action selector="handleLongPress:" destination="WaX-pd-UZQ" id="dkk-bc-rvl"/>
                     </connections>


### PR DESCRIPTION
Long pressing drops pins again. The minimum press duration has been extended to a second to avoid preempting the built-in gesture for draggable annotations.

/cc @frederoni