### PR TITLE
Crash when parsing invalid sprite URL

### DIFF
--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -83,10 +83,18 @@ std::string normalizeSpriteURL(const std::string& url, const std::string& access
     std::string id, extension;
     if (isDraft) {
         size_t index = pathname[3].find_first_of("@.");
+        if (index == std::string::npos) {
+            Log::Error(Event::ParseStyle, "Invalid sprite URL");
+            return url;
+        }
         id = pathname[2];
         extension = pathname[3].substr(index);
     } else {
         size_t index = pathname[2].find_first_of("@.");
+        if (index == std::string::npos) {
+            Log::Error(Event::ParseStyle, "Invalid sprite URL");
+            return url;
+        }
         id = pathname[2].substr(0, index);
         extension = pathname[2].substr(index);
     }

--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -19,13 +19,13 @@ bool isMapboxURL(const std::string& url) {
 
 std::vector<std::string> getMapboxURLPathname(const std::string& url) {
     std::vector<std::string> pathname;
-    std::size_t startIndex = protocol.length();
-    std::size_t end = url.find_first_of("?#");
+    auto startIndex = protocol.length();
+    auto end = url.find_first_of("?#");
     if (end == std::string::npos) {
         end = url.length();
     }
     while (startIndex < end) {
-        std::size_t endIndex = url.find("/", startIndex);
+        auto endIndex = url.find("/", startIndex);
         if (endIndex == std::string::npos) {
             endIndex = end;
         }
@@ -52,16 +52,15 @@ std::string normalizeStyleURL(const std::string& url, const std::string& accessT
         return url;
     }
 
-    std::vector<std::string> pathname = getMapboxURLPathname(url);
-
+    const auto pathname = getMapboxURLPathname(url);
     if (pathname.size() < 3) {
         Log::Error(Event::ParseStyle, "Invalid style URL");
         return url;
     }
 
-    std::string user = pathname[1];
-    std::string id = pathname[2];
-    bool isDraft = pathname.size() > 3;
+    const auto& user = pathname[1];
+    const auto& id = pathname[2];
+    const bool isDraft = pathname.size() > 3;
     return baseURL + "styles/v1/" + user + "/" + id + (isDraft ? "/draft" : "") + "?access_token=" + accessToken;
 }
 
@@ -70,36 +69,33 @@ std::string normalizeSpriteURL(const std::string& url, const std::string& access
         return url;
     }
 
-    std::vector<std::string> pathname = getMapboxURLPathname(url);
-
+    const auto pathname = getMapboxURLPathname(url);
     if (pathname.size() < 3) {
         Log::Error(Event::ParseStyle, "Invalid sprite URL");
         return url;
     }
 
-    std::string user = pathname[1];
-    bool isDraft = pathname.size() > 3;
+    const auto& user = pathname[1];
+    const bool isDraft = pathname.size() > 3;
 
-    std::string id, extension;
-    if (isDraft) {
-        size_t index = pathname[3].find_first_of("@.");
-        if (index == std::string::npos) {
-            Log::Error(Event::ParseStyle, "Invalid sprite URL");
-            return url;
-        }
-        id = pathname[2];
-        extension = pathname[3].substr(index);
-    } else {
-        size_t index = pathname[2].find_first_of("@.");
-        if (index == std::string::npos) {
-            Log::Error(Event::ParseStyle, "Invalid sprite URL");
-            return url;
-        }
-        id = pathname[2].substr(0, index);
-        extension = pathname[2].substr(index);
+    const auto& name = isDraft ? pathname[3] : pathname[2];
+    const size_t index = name.find_first_of("@.");
+    if (index == std::string::npos) {
+        Log::Error(Event::ParseStyle, "Invalid sprite URL");
+        return url;
     }
+    const auto& extension = name.substr(index);
 
-    return baseURL + "styles/v1/" + user + "/" + id + "/" + (isDraft ? "draft/" : "") + "sprite" + extension + "?access_token=" + accessToken;
+    if (isDraft) {
+        const auto& id = pathname[2];
+        return baseURL + "styles/v1/" + user + "/" + id + "/draft/sprite" + extension +
+               "?access_token=" + accessToken;
+
+    } else {
+        const auto& id = pathname[2].substr(0, index);
+        return baseURL + "styles/v1/" + user + "/" + id + "/sprite" + extension + "?access_token=" +
+               accessToken;
+    }
 }
 
 std::string normalizeGlyphsURL(const std::string& url, const std::string& accessToken) {
@@ -107,16 +103,15 @@ std::string normalizeGlyphsURL(const std::string& url, const std::string& access
         return url;
     }
 
-    std::vector<std::string> pathname = getMapboxURLPathname(url);
-
+    const auto pathname = getMapboxURLPathname(url);
     if (pathname.size() < 4) {
       Log::Error(Event::ParseStyle, "Invalid glyph URL");
       return url;
     }
 
-    std::string user = pathname[1];
-    std::string fontstack = pathname[2];
-    std::string range = pathname[3];
+    const auto& user = pathname[1];
+    const auto& fontstack = pathname[2];
+    const auto& range = pathname[3];
 
     return baseURL + "fonts/v1/" + user + "/" + fontstack + "/" + range + "?access_token=" + accessToken;
 }
@@ -137,7 +132,7 @@ std::string canonicalizeTileURL(const std::string& url, SourceType type, uint16_
 
     tilesetStartIdx += sizeof("/v4/") - 1;
 
-    auto tilesetEndIdx = url.find("/", tilesetStartIdx);
+    const auto tilesetEndIdx = url.find("/", tilesetStartIdx);
     if (tilesetEndIdx == std::string::npos) {
         return url;
     }
@@ -154,12 +149,12 @@ std::string canonicalizeTileURL(const std::string& url, SourceType type, uint16_
         basenameIdx += 1;
     }
 
-    auto extensionIdx = url.find(".", basenameIdx);
+    const auto extensionIdx = url.find(".", basenameIdx);
     if (extensionIdx == std::string::npos || extensionIdx == queryIdx - 1) {
         return url;
     }
 
-    auto tileset = url.substr(tilesetStartIdx, tilesetEndIdx - tilesetStartIdx);
+    const auto tileset = url.substr(tilesetStartIdx, tilesetEndIdx - tilesetStartIdx);
     auto extension = url.substr(extensionIdx + 1, queryIdx - extensionIdx - 1);
 
 #if !defined(__ANDROID__) && !defined(__APPLE__) && !defined(QT_IMAGE_DECODERS)

--- a/test/util/mapbox.cpp
+++ b/test/util/mapbox.cpp
@@ -66,6 +66,12 @@ TEST(Mapbox, SpriteURL) {
     EXPECT_EQ(
         "https://api.mapbox.com/styles/v1/mapbox/streets-v8/draft/sprite@2x.png?access_token=key",
         mbgl::util::mapbox::normalizeSpriteURL("mapbox://sprites/mapbox/streets-v8/draft@2x.png", "key"));
+    EXPECT_EQ(
+        "mapbox://sprites/mapbox/streets-v9?fresh=true.png",
+        mbgl::util::mapbox::normalizeSpriteURL(
+            "mapbox://sprites/mapbox/streets-v9?fresh=true.png",
+            "key"));
+    EXPECT_EQ("mapbox://////", mbgl::util::mapbox::normalizeSpriteURL("mapbox://////", "key"));
 }
 
 TEST(Mapbox, TileURL) {


### PR DESCRIPTION
When a style contains a sprite URL that is invalid, Mapbox GL Native crashes when the filename of the sprite URL does not contain a file extension.

```
#18. Crashed: DefaultFileSource
0  AppName                        0x1000effdc CLSProcessRecordAllThreads + 4296146908
1  AppName                        0x1000effdc CLSProcessRecordAllThreads + 4296146908
2  AppName                        0x1000f03fc CLSProcessRecordAllThreads + 4296147964
3  AppName                        0x1000e10c0 CLSHandler + 4296085696
4  AppName                        0x1000ee704 __CLSExceptionRecord_block_invoke + 4296140548
5  libdispatch.dylib              0x182fb947c _dispatch_client_callout + 16
6  libdispatch.dylib              0x182fc4728 _dispatch_barrier_sync_f_invoke + 100
7  AppName                        0x1000ee1b0 CLSExceptionRecord + 4296139184
8  AppName                        0x1000edd34 CLSTerminateHandler() + 4296138036
9  libc++abi.dylib                0x182bc6f44 std::__terminate(void (*)()) + 16
10 libc++abi.dylib                0x182bc685c __cxxabiv1::exception_cleanup_func(_Unwind_Reason_Code, _Unwind_Exception*) + 134
11 libc++abi.dylib                0x182bc7154 operator new(unsigned long) + 96
12 AppName                        0x1001b6464 void std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >::__push_back_slow_path<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&) + 60048
13 AppName                        0x1001d2554 mbgl::util::mapbox::getMapboxURLPathname(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 68500
14 AppName                        0x1001d2cf8 mbgl::util::mapbox::normalizeSpriteURL(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 70456
15 AppName                        0x1001ef61c mbgl::OnlineFileSource::request(mbgl::Resource const&, std::__1::function<void (mbgl::Response)>) + 15900
16 AppName                        0x1001ec710 mbgl::DefaultFileSource::Impl::Task::Task(mbgl::Resource, std::__1::function<void (mbgl::Response)>, mbgl::DefaultFileSource::Impl*) + 3856
17 AppName                        0x1001ebe7c mbgl::DefaultFileSource::Impl::request(mbgl::FileRequest*, mbgl::Resource, std::__1::function<void (mbgl::Response)>) + 1660
18 AppName                        0x1001e983c mbgl::util::RunLoop::Invoker<auto mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::bind<void (mbgl::DefaultFileSource::Impl::*)(mbgl::FileRequest*, mbgl::Resource, std::__1::function<void (mbgl::Response)>)>(void (mbgl::DefaultFileSource::Impl::*)(mbgl::FileRequest*, mbgl::Resource, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::DefaultFileSource::Impl::*&&)(mbgl::FileRequest*, mbgl::Resource, std::__1::function<void (mbgl::Response)>)), std::__1::tuple<mbgl::DefaultFileSource::request(mbgl::Resource const&, std::__1::function<void (mbgl::Response)>)::DefaultFileRequest*, mbgl::Resource, std::__1::unique_ptr<mbgl::WorkRequest, std::__1::default_delete<std::__1::default_delete> > mbgl::util::RunLoop::invokeWithCallback<std::__1::tuple, std::__1::function<void (mbgl::Response)>&, mbgl::util::RunLoop::invokeWithCallback, mbgl::Resource&>(void (mbgl::DefaultFileSource::Impl::*&&)(mbgl::FileRequest*, mbgl::Resource, std::__1::function<void (mbgl::Response)>), std::__1::function<void (mbgl::Response)>&&&, mbgl::util::RunLoop::invokeWithCallback&&, mbgl::Resource&&&)::'lambda'(auto mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::bind<void (mbgl::DefaultFileSource::Impl::*)(mbgl::FileRequest*, mbgl::Resource, std::__1::function<void (mbgl::Response)>)>(void (mbgl::DefaultFileSource::Impl::*)(mbgl::FileRequest*, mbgl::Resource, std::__1::function<void (mbgl::Response)>))::'lambda'(void (mbgl::DefaultFileSource::Impl::*&&)(mbgl::FileRequest*, mbgl::Resource, std::__1::function<void (mbgl::Response)>)))> >::operator()() + 63048
19 AppName                        0x1001e7698 mbgl::util::RunLoop::process() + 54436
20 AppName                        0x100114474 uv__async_event (async.c:84)
21 AppName                        0x100114634 uv__async_io (async.c:137)
22 AppName                        0x100117070 uv__io_poll (kqueue.c:248)
23 AppName                        0x1001149d8 uv_run (core.c:342)
24 AppName                        0x1001eb9ac void mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::run<std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long long&>, 0ul, 1ul>(mbgl::util::ThreadContext, std::__1::tuple<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long long&>&&, std::__1::integer_sequence<unsigned long, 0ul, 1ul>) + 428
25 AppName                        0x1001eb8a8 std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::DefaultFileSource::Impl>::Thread<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, unsigned long long&>(mbgl::util::ThreadContext const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&&&, unsigned long long&&&)::'lambda'()> >(void*, void*) + 168
26 libsystem_pthread.dylib        0x1831d3b28 _pthread_body + 156
27 libsystem_pthread.dylib        0x1831d3a8c _pthread_body + 154
28 libsystem_pthread.dylib        0x1831d1028 thread_start + 4
```