### PR TITLE
[ios] Add simulator dSYM file to build output.

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 * The `icon-text-fit` and `icon-text-fit-padding` properties are now supported in stylesheets, allowing the background of a shield to automatically resize to fit the shield’s text. ([#5334](https://github.com/mapbox/mapbox-gl-native/pull/5334))
 * Improved the performance of relocating a non-view-backed point annotation by changing its `coordinate` property. ([#5385](https://github.com/mapbox/mapbox-gl-native/pull/5385))
 * MGLMapDebugOverdrawVisualizationMask does nothing in Release builds of the SDK. This is disabled for performance reasons. ([#5555](https://github.com/mapbox/mapbox-gl-native/pull/5555))
+* Include simulator architecture slices in the dSYM file that is generated for release builds. ([#5740](https://github.com/mapbox/mapbox-gl-native/pull/5740))
 
 ## 3.3.1
 

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -129,9 +129,19 @@ if [[ "${BUILD_FOR_DEVICE}" == true ]]; then
         cp -r \
             ${PRODUCTS}/${BUILDTYPE}-iphoneos/${NAME}.framework \
             ${OUTPUT}/dynamic/
+
         if [[ -e ${PRODUCTS}/${BUILDTYPE}-iphoneos/${NAME}.framework.dSYM ]]; then
+            step "Copying dSYM"
             cp -r ${PRODUCTS}/${BUILDTYPE}-iphoneos/${NAME}.framework.dSYM \
-                ${OUTPUT}/dynamic/
+                  ${OUTPUT}/dynamic/
+            if [[ -e ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/${NAME}.framework.dSYM ]]; then
+                step "Merging device and simulator dSYMs…"
+                lipo \
+                    ${PRODUCTS}/${BUILDTYPE}-iphoneos/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME} \
+                    ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME} \
+                    -create -output ${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}
+                lipo -info ${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}
+            fi
         fi
 
         step "Merging simulator dynamic library into device dynamic library…"
@@ -160,6 +170,7 @@ else
             ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/${NAME}.framework \
             ${OUTPUT}/dynamic/${NAME}.framework
         if [[ -e ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/${NAME}.framework.dSYM ]]; then
+            step "Copying dSYM"
             cp -r ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/${NAME}.framework.dSYM \
                 ${OUTPUT}/dynamic/
         fi


### PR DESCRIPTION
Fixes #5726 

Our release builds for device (with lipoed simulator binary) create a dSYM files for both the device and simulator. However the script only copied the device dSYM file to the output location.

This adds a step to create a dSYM file with all relevant architectures. 

cc @1ec5 @incanus 