### PR TITLE
[ios] Reformat inline documentation with ticks, smart quotes, breaks

### DIFF
--- a/platform/ios/src/MGLAnnotationImage.h
+++ b/platform/ios/src/MGLAnnotationImage.h
@@ -4,7 +4,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** The MGLAnnotationImage class is responsible for presenting point-based annotations visually on a map view. Annotation image objects wrap `UIImage` objects and may be recycled later and put into a reuse queue that is maintained by the map view. */
+/**
+ The `MGLAnnotationImage` class is responsible for presenting point-based
+ annotations visually on a map view. Annotation image objects wrap `UIImage`
+ objects and may be recycled later and put into a reuse queue that is maintained
+ by the map view.
+ */
 @interface MGLAnnotationImage : NSObject
 
 #pragma mark Initializing and Preparing the Image Object
@@ -13,8 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
  Initializes and returns a new annotation image object.
  
  @param image The image to be displayed for the annotation.
- @param reuseIdentifier The string that identifies that this annotation image is reusable.
- @return The initialized annotation image object or `nil` if there was a problem initializing the object.
+ @param reuseIdentifier The string that identifies that this annotation image is
+    reusable.
+ @return The initialized annotation image object or `nil` if there was a problem
+    initializing the object.
  */
 + (instancetype)annotationImageWithImage:(UIImage *)image reuseIdentifier:(NSString *)reuseIdentifier;
 
@@ -26,16 +33,21 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The string that identifies that this annotation image is reusable. (read-only)
  
- You specify the reuse identifier when you create the image object. You use this type later to retrieve an annotation image object that was created previously but which is currently unused because its annotation is not on screen.
+ You specify the reuse identifier when you create the image object. You use this
+ type later to retrieve an annotation image object that was created previously
+ but which is currently unused because its annotation is not on screen.
  
- If you define distinctly different types of annotations (with distinctly different annotation images to go with them), you can differentiate between the annotation types by specifying different reuse identifiers for each one.
+ If you define distinctly different types of annotations (with distinctly
+ different annotation images to go with them), you can differentiate between the
+ annotation types by specifying different reuse identifiers for each one.
  */
 @property (nonatomic, readonly) NSString *reuseIdentifier;
 
 /**
  A Boolean value indicating whether the annotation is enabled.
  
- The default value of this property is `YES`. If the value of this property is `NO`, the annotation image ignores touch events and cannot be selected.
+ The default value of this property is `YES`. If the value of this property is 
+ `NO`, the annotation image ignores touch events and cannot be selected.
  */
 @property (nonatomic, getter=isEnabled) BOOL enabled;
 

--- a/platform/ios/src/MGLCalloutView.h
+++ b/platform/ios/src/MGLCalloutView.h
@@ -8,32 +8,38 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MGLAnnotation;
 
 /**
- A protocol for a `UIView` subclass that displays information about a selected annotation near that annotation.
+ A protocol for a `UIView` subclass that displays information about a selected
+ annotation near that annotation.
  */
 @protocol MGLCalloutView <NSObject>
 
 /**
- An object conforming to the `MGLAnnotation` protocol whose details this callout view displays.
+ An object conforming to the `MGLAnnotation` protocol whose details this callout
+ view displays.
  */
 @property (nonatomic, strong) id <MGLAnnotation> representedObject;
 
 /**
- A view that the user may tap to perform an action. This view is conventionally positioned on the left side of the callout view.
+ A view that the user may tap to perform an action. This view is conventionally
+ positioned on the left side of the callout view.
  */
 @property (nonatomic, strong) UIView *leftAccessoryView;
 
 /**
- A view that the user may tap to perform an action. This view is conventionally positioned on the right side of the callout view.
+ A view that the user may tap to perform an action. This view is conventionally
+ positioned on the right side of the callout view.
  */
 @property (nonatomic, strong) UIView *rightAccessoryView;
 
 /**
- An object conforming to the `MGLCalloutViewDelegate` method that receives messages related to the callout view’s interactive subviews.
+ An object conforming to the `MGLCalloutViewDelegate` method that receives
+ messages related to the callout view’s interactive subviews.
  */
 @property (nonatomic, weak) id<MGLCalloutViewDelegate> delegate;
 
 /**
- Presents a callout view by adding it to `inView` and pointing at the given rect of `inView`’s bounds. Constrains the callout to the bounds of the given view.
+ Presents a callout view by adding it to `view` and pointing at the given rect
+ of `view`’s bounds. Constrains the callout to the bounds of the given view.
  */
 - (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view constrainedToView:(UIView *)constrainedView animated:(BOOL)animated;
 
@@ -45,15 +51,21 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- The MGLCalloutViewDelegate protocol defines a set of optional methods that you can use to receive messages from an object that conforms to the MGLCalloutView protocol. The callout view uses these methods to inform the delegate that the user has interacted with the the callout view.
+ The `MGLCalloutViewDelegate` protocol defines a set of optional methods that
+ you can use to receive messages from an object that conforms to the
+ `MGLCalloutView` protocol. The callout view uses these methods to inform the
+ delegate that the user has interacted with the the callout view.
  */
 @protocol MGLCalloutViewDelegate <NSObject>
 
 @optional
 /**
- Returns a Boolean value indicating whether the entire callout view “highlights” when tapped. The default value is `YES`, which means the callout view highlights when tapped.
+ Returns a Boolean value indicating whether the entire callout view “highlights”
+ when tapped. The default value is `YES`, which means the callout view
+ highlights when tapped.
  
- The return value of this method is ignored unless the delegate also responds to the `-calloutViewTapped` method.
+ The return value of this method is ignored unless the delegate also responds to
+ the `-calloutViewTapped` method.
  */
 - (BOOL)calloutViewShouldHighlight:(UIView<MGLCalloutView> *)calloutView;
 
@@ -63,12 +75,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)calloutViewTapped:(UIView<MGLCalloutView> *)calloutView;
 
 /**
- Called before the callout view appears on screen, or before the appearance animation will start.
+ Called before the callout view appears on screen, or before the appearance
+ animation will start.
  */
 - (void)calloutViewWillAppear:(UIView<MGLCalloutView> *)calloutView;
 
 /**
- Called after the callout view appears on screen, or after the appearance animation is complete.
+ Called after the callout view appears on screen, or after the appearance
+ animation is complete.
  */
 - (void)calloutViewDidAppear:(UIView<MGLCalloutView> *)calloutView;
 

--- a/platform/ios/src/MGLCompactCalloutView.h
+++ b/platform/ios/src/MGLCompactCalloutView.h
@@ -2,7 +2,10 @@
 #import "MGLCalloutView.h"
 
 /**
- A concrete implementation of `MGLCalloutView` based on <a href="https://github.com/nfarina/calloutview">SMCalloutView</a>. This callout view displays the represented annotation’s title, subtitle, and accessory views in a compact, two-line layout.
+ A concrete implementation of `MGLCalloutView` based on
+ <a href="https://github.com/nfarina/calloutview">SMCalloutView</a>. This
+ callout view displays the represented annotation’s title, subtitle, and
+ accessory views in a compact, two-line layout.
  */
 @interface MGLCompactCalloutView : SMCalloutView <MGLCalloutView>
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationVerticalAlignment) {
     MGLAnnotationVerticalAlignmentBottom,
 };
 
-/** Options for enabling debugging features in an MGLMapView instance. */
+/** Options for enabling debugging features in an `MGLMapView` instance. */
 typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
     /** Edges of tile boundaries are shown as thick, red lines to help diagnose
         tile clipping issues. */
@@ -64,7 +64,7 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
 
 /**
  An interactive, customizable map view with an interface similar to the one
- provided by Apple's MapKit.
+ provided by Apple’s MapKit.
  
  Using `MGLMapView`, you can embed the map inside a view, allow users to
  manipulate it with standard gestures, animate the map between different
@@ -87,7 +87,7 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
  Mapbox-hosted vector tiles and styles require an API access token, which you
  can obtain from the
  <a href="https://www.mapbox.com/studio/account/tokens/">Mapbox account page</a>.
- Access tokens associate requests to Mapbox's vector tile and style APIs with
+ Access tokens associate requests to Mapbox’s vector tile and style APIs with
  your Mapbox account. They also deter other developers from using your styles
  without your permission.
  
@@ -114,9 +114,9 @@ IB_DESIGNABLE
  
  @param frame The frame for the view, measured in points.
  @param styleURL URL of the map style to display. The URL may be a full HTTP
-    or HTTPS URL, a Mapbox URL indicating the style's map ID
+    or HTTPS URL, a Mapbox URL indicating the style’s map ID
     (`mapbox://styles/{user}/{style}`), or a path to a local file relative
-    to the application's resource path. Specify `nil` for the default style.
+    to the application’s resource path. Specify `nil` for the default style.
  @return An initialized map view.
  */
 - (instancetype)initWithFrame:(CGRect)frame styleURL:(nullable NSURL *)styleURL;
@@ -124,7 +124,7 @@ IB_DESIGNABLE
 #pragma mark Accessing the Delegate
 
 /**
- The receiver's delegate.
+ The receiver’s delegate.
  
  A map view sends messages to its delegate to notify it of changes to its
  contents or the viewpoint. The delegate also provides information about
@@ -133,7 +133,7 @@ IB_DESIGNABLE
  */
 @property(nonatomic, weak, nullable) IBOutlet id<MGLMapViewDelegate> delegate;
 
-#pragma mark Configuring the Map's Appearance
+#pragma mark Configuring the Map’s Appearance
 
 /**
  URLs of the styles bundled with the library.
@@ -146,12 +146,12 @@ IB_DESIGNABLE
 /**
  URL of the style currently displayed in the receiver.
  
- The URL may be a full HTTP or HTTPS URL, a Mapbox URL indicating the style's
+ The URL may be a full HTTP or HTTPS URL, a Mapbox URL indicating the style’s
  map ID (`mapbox://styles/{user}/{style}`), or a path to a local file
- relative to the application's resource path.
+ relative to the application’s resource path.
  
  If you set this property to `nil`, the receiver will use the default style
- and this property will automatically be set to that style's URL.
+ and this property will automatically be set to that style’s URL.
  */
 @property (nonatomic, null_resettable) NSURL *styleURL;
 
@@ -170,7 +170,7 @@ IB_DESIGNABLE
 - (IBAction)reloadStyle:(id)sender;
 
 /**
- A control indicating the map's direction and allowing the user to manipulate
+ A control indicating the map’s direction and allowing the user to manipulate
  the direction, positioned in the upper-right corner.
  */
 @property (nonatomic, readonly) UIImageView *compassView;
@@ -236,18 +236,18 @@ IB_DESIGNABLE
  */
 - (void)removeStyleClass:(NSString *)styleClass;
 
-#pragma mark Displaying the User's Location
+#pragma mark Displaying the User’s Location
 
 /**
  A Boolean value indicating whether the map may display the user location.
  
  Setting this property to `YES` causes the map view to use the Core Location
  framework to find the current location. As long as this property is `YES`, the
- map view continues to track the user's location and update it periodically.
+ map view continues to track the user’s location and update it periodically.
  
- This property does not indicate whether the user's position is actually visible
+ This property does not indicate whether the user’s position is actually visible
  on the map, only whether the map view is allowed to display it. To determine
- whether the user's position is visible, use the `userLocationVisible` property.
+ whether the user’s position is visible, use the `userLocationVisible` property.
  The default value of this property is `NO`.
  
  On iOS 8 and above, your app must specify a value for
@@ -258,7 +258,7 @@ IB_DESIGNABLE
 @property (nonatomic, assign) BOOL showsUserLocation;
 
 /** 
- A Boolean value indicating whether the device's current location is visible in
+ A Boolean value indicating whether the device’s current location is visible in
  the map view.
  
  Use `showsUserLocation` to control the visibility of the on-screen user
@@ -267,7 +267,7 @@ IB_DESIGNABLE
 @property (nonatomic, assign, readonly, getter=isUserLocationVisible) BOOL userLocationVisible;
 
 /**
- Returns the annotation object indicating the user's current location.
+ Returns the annotation object indicating the user’s current location.
  */
 @property (nonatomic, readonly, nullable) MGLUserLocation *userLocation;
 
@@ -578,7 +578,7 @@ IB_DESIGNABLE
 - (IBAction)resetNorth;
 
 /**
- The coordinate bounds visible in the receiver's viewport.
+ The coordinate bounds visible in the receiver’s viewport.
  
  Changing the value of this property updates the receiver immediately. If you
  want to animate the change, call `-setVisibleCoordinateBounds:animated:`
@@ -597,7 +597,7 @@ IB_DESIGNABLE
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds animated:(BOOL)animated;
 
 /**
- Changes the receiver's viewport to fit the given coordinate bounds and
+ Changes the receiver’s viewport to fit the given coordinate bounds and
  optionally some additional padding on each side.
  
  @param bounds The bounds that the viewport will show in its entirety.
@@ -609,7 +609,7 @@ IB_DESIGNABLE
 - (void)setVisibleCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated;
 
 /**
- Changes the receiver's viewport to fit all of the given coordinates and
+ Changes the receiver’s viewport to fit all of the given coordinates and
  optionally some additional padding on each side.
  
  @param coordinates The coordinates that the viewport will show.
@@ -623,7 +623,7 @@ IB_DESIGNABLE
 - (void)setVisibleCoordinates:(CLLocationCoordinate2D *)coordinates count:(NSUInteger)count edgePadding:(UIEdgeInsets)insets animated:(BOOL)animated;
 
 /**
- Changes the receiver's viewport to fit all of the given coordinates and
+ Changes the receiver’s viewport to fit all of the given coordinates and
  optionally some additional padding on each side.
  
  @param coordinates The coordinates that the viewport will show.
@@ -657,7 +657,7 @@ IB_DESIGNABLE
  Sets the visible region so that the map displays the specified annotations with
  the specified amount of padding on each side.
 
- Calling this method updates the value in the visibleCoordinateBounds property
+ Calling this method updates the value in the `visibleCoordinateBounds` property
  and potentially other properties to reflect the new map region.
 
  @param annotations The annotations that you want to be visible in the map.
@@ -788,7 +788,7 @@ IB_DESIGNABLE
 - (MGLMapCamera *)cameraThatFitsCoordinateBounds:(MGLCoordinateBounds)bounds edgePadding:(UIEdgeInsets)insets;
 
 /**
- Returns the point in this view's coordinate system on which to "anchor" in
+ Returns the point in this view’s coordinate system on which to "anchor" in
  response to a user-initiated gesture.
  
  For example, a pinch-to-zoom gesture would anchor the map at the midpoint of
@@ -798,7 +798,7 @@ IB_DESIGNABLE
  user annotation is used as the anchor point.
  
  Subclasses may override this method to provide specialized behavior - for
- example, anchoring on the map's center point to provide a "locked" zooming
+ example, anchoring on the map’s center point to provide a "locked" zooming
  mode.
  
  @param gesture An anchorable user gesture.
@@ -850,7 +850,7 @@ IB_DESIGNABLE
 #pragma mark Converting Geographic Coordinates
 
 /**
- Converts a point in the given view's coordinate system to a geographic
+ Converts a point in the given view’s coordinate system to a geographic
  coordinate.
  
  @param point The point to convert.
@@ -860,13 +860,13 @@ IB_DESIGNABLE
 - (CLLocationCoordinate2D)convertPoint:(CGPoint)point toCoordinateFromView:(nullable UIView *)view;
 
 /**
- Converts a geographic coordinate to a point in the given view's coordinate
+ Converts a geographic coordinate to a point in the given view’s coordinate
  system.
  
  @param coordinate The geographic coordinate to convert.
  @param view The view in whose coordinate system the returned point should be
     expressed. If this parameter is `nil`, the returned point is expressed
-    in the window's coordinate system. If `view` is not `nil`, it must
+    in the window’s coordinate system. If `view` is not `nil`, it must
     belong to the same window as the map view.
  @return The point (in the appropriate view or window coordinate system)
     corresponding to the given geographic coordinate.
@@ -896,7 +896,7 @@ IB_DESIGNABLE
 - (CGRect)convertCoordinateBounds:(MGLCoordinateBounds)bounds toRectToView:(nullable UIView *)view;
 
 /**
- Returns the distance spanned by one point in the map view's coordinate system
+ Returns the distance spanned by one point in the map view’s coordinate system
  at the given latitude and current zoom level.
  
  The distance between points decreases as the latitude approaches the poles.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -204,12 +204,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns the alpha value to use when rendering a shape annotation.
  
- A value of 0.0 results in a completely transparent shape. A value of 1.0, the
- default, results in a completely opaque shape.
+ A value of `0.0` results in a completely transparent shape. A value of `1.0`,
+ the default, results in a completely opaque shape.
  
  @param mapView The map view rendering the shape annotation.
  @param annotation The annotation being rendered.
- @return An alpha value between 0 and 1.0.
+ @return An alpha value between `0` and `1.0`.
  */
 - (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation;
 
@@ -241,7 +241,7 @@ NS_ASSUME_NONNULL_BEGIN
  Returns the line width in points to use when rendering the outline of a
  polyline annotation.
  
- By default, the polyline is outlined with a line 3.0 points wide.
+ By default, the polyline is outlined with a line `3.0` points wide.
  
  @param mapView The map view rendering the polygon annotation.
  @param annotation The annotation being rendered.

--- a/platform/ios/src/MGLUserLocation.h
+++ b/platform/ios/src/MGLUserLocation.h
@@ -7,7 +7,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** The MGLUserLocation class defines a specific type of annotation that identifies the user’s current location. You do not create instances of this class directly. Instead, you retrieve an existing MGLUserLocation object from the userLocation property of the map view displayed in your application. */
+/**
+ The MGLUserLocation class defines a specific type of annotation that identifies
+ the user’s current location. You do not create instances of this class
+ directly. Instead, you retrieve an existing MGLUserLocation object from the
+ `userLocation` property of the map view displayed in your application.
+ */
 @interface MGLUserLocation : NSObject <MGLAnnotation>
 
 #pragma mark Determining the User’s Position
@@ -15,17 +20,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The current location of the device. (read-only)
 
- This property contains `nil` if the map view is not currently showing the user location or if the user’s location has not yet been determined.
+ This property contains `nil` if the map view is not currently showing the user
+ location or if the user’s location has not yet been determined.
  */
 @property (nonatomic, readonly, nullable) CLLocation *location;
 
-/** A Boolean value indicating whether the user’s location is currently being updated. (read-only) */
+/** 
+ A Boolean value indicating whether the user’s location is currently being
+ updated. (read-only)
+ */
 @property (nonatomic, readonly, getter=isUpdating) BOOL updating;
 
 /**
  The heading of the user location. (read-only)
  
- This property is `nil` if the user location tracking mode is not `MGLUserTrackingModeFollowWithHeading`.
+ This property is `nil` if the user location tracking mode is not 
+ `MGLUserTrackingModeFollowWithHeading`.
  */
 @property (nonatomic, readonly, nullable) CLHeading *heading;
 

--- a/platform/ios/src/MGLUserLocationAnnotationView.h
+++ b/platform/ios/src/MGLUserLocationAnnotationView.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class MGLMapView;
 @class MGLUserLocation;
 
-/** View representing an MGLUserLocation on screen. */
+/** View representing an `MGLUserLocation` on screen. */
 @interface MGLUserLocationAnnotationView : UIView
 
 @property (nonatomic, weak) MGLMapView *mapView;


### PR DESCRIPTION
- Makes the use of apostrophes in the iOS SDK documentation consistent by converting “dumb” `'` into smart `’`.
- Adds ticks around class/property names/values.
- Breaks lines at 80 characters.

This isn’t strictly necessary, is probably rather pedantic, and it may mildly disturb a couple of @frederoni’s inflight PR’s, but let’s yank the bandaid off and do this all at once.

/cc @1ec5 @boundsj @frederoni @incanus 