### PR TITLE
[default] uv_run should use UV_RUN_NOWAIT

### DIFF
--- a/platform/default/run_loop.cpp
+++ b/platform/default/run_loop.cpp
@@ -158,7 +158,7 @@ void RunLoop::run() {
 void RunLoop::runOnce() {
     MBGL_VERIFY_THREAD(tid);
 
-    uv_run(impl->loop, UV_RUN_ONCE);
+    uv_run(impl->loop, UV_RUN_NOWAIT);
 }
 
 void RunLoop::stop() {


### PR DESCRIPTION
UV_RUN_ONCE might block and that is not the semantics we expect from RunLoop::runOnce().