### PR TITLE
[ios] Do not allow multipoint annotations to be assigned views

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 * Improved the performance of relocating a non-view-backed point annotation by changing its `coordinate` property. ([#5385](https://github.com/mapbox/mapbox-gl-native/pull/5385))
 * MGLMapDebugOverdrawVisualizationMask does nothing in Release builds of the SDK. This is disabled for performance reasons. ([#5555](https://github.com/mapbox/mapbox-gl-native/pull/5555))
 * Include simulator architecture slices in the dSYM file that is generated for release builds. ([#5740](https://github.com/mapbox/mapbox-gl-native/pull/5740))
+* Fixed an issue where annotation views could be assigned to multipoint annotations. ([#5770](https://github.com/mapbox/mapbox-gl-native/pull/5770))
 
 ## 3.3.1
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -242,86 +242,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 9)
     {
-        // PNW triangle
-        //
-        CLLocationCoordinate2D triangleCoordinates[3] =
-        {
-            CLLocationCoordinate2DMake(44, -122),
-            CLLocationCoordinate2DMake(46, -122),
-            CLLocationCoordinate2DMake(46, -121)
-        };
-
-        MGLPolygon *triangle = [MGLPolygon polygonWithCoordinates:triangleCoordinates count:3];
-
-        [self.mapView addAnnotation:triangle];
-
-        // Orcas Island hike
-        //
-        NSDictionary *hike = [NSJSONSerialization JSONObjectWithData:
-                                 [NSData dataWithContentsOfFile:
-                                     [[NSBundle mainBundle] pathForResource:@"polyline" ofType:@"geojson"]]
-                                                             options:0
-                                                               error:nil];
-
-        NSArray *hikeCoordinatePairs = hike[@"features"][0][@"geometry"][@"coordinates"];
-
-        CLLocationCoordinate2D *polylineCoordinates = (CLLocationCoordinate2D *)malloc([hikeCoordinatePairs count] * sizeof(CLLocationCoordinate2D));
-
-        for (NSUInteger i = 0; i < [hikeCoordinatePairs count]; i++)
-        {
-            polylineCoordinates[i] = CLLocationCoordinate2DMake([hikeCoordinatePairs[i][1] doubleValue], [hikeCoordinatePairs[i][0] doubleValue]);
-        }
-
-        MGLPolyline *polyline = [MGLPolyline polylineWithCoordinates:polylineCoordinates
-                                                               count:[hikeCoordinatePairs count]];
-
-        [self.mapView addAnnotation:polyline];
-
-        free(polylineCoordinates);
-
-        // PA/NJ/DE polys
-        //
-        NSDictionary *threestates = [NSJSONSerialization JSONObjectWithData:
-                              [NSData dataWithContentsOfFile:
-                               [[NSBundle mainBundle] pathForResource:@"threestates" ofType:@"geojson"]]
-                                                             options:0
-                                                               error:nil];
-
-        for (NSDictionary *feature in threestates[@"features"])
-        {
-            NSArray *stateCoordinatePairs = feature[@"geometry"][@"coordinates"];
-
-            while ([stateCoordinatePairs count] == 1) stateCoordinatePairs = stateCoordinatePairs[0];
-
-            CLLocationCoordinate2D *polygonCoordinates = (CLLocationCoordinate2D *)malloc([stateCoordinatePairs count] * sizeof(CLLocationCoordinate2D));
-
-            for (NSUInteger i = 0; i < [stateCoordinatePairs count]; i++)
-            {
-                polygonCoordinates[i] = CLLocationCoordinate2DMake([stateCoordinatePairs[i][1] doubleValue], [stateCoordinatePairs[i][0] doubleValue]);
-            }
-
-            MGLPolygon *polygon = [MGLPolygon polygonWithCoordinates:polygonCoordinates count:[stateCoordinatePairs count]];
-
-            [self.mapView addAnnotation:polygon];
-
-            free(polygonCoordinates);
-        }
-        
-        CLLocationCoordinate2D innerCoordinates[] = {
-            CLLocationCoordinate2DMake(-5, -5),
-            CLLocationCoordinate2DMake(-5, 5),
-            CLLocationCoordinate2DMake(5, 5),
-            CLLocationCoordinate2DMake(5, -5),
-        };
-        MGLPolygon *innerPolygon = [MGLPolygon polygonWithCoordinates:innerCoordinates count:sizeof(innerCoordinates) / sizeof(innerCoordinates[0])];
-        CLLocationCoordinate2D outerCoordinates[] = {
-            CLLocationCoordinate2DMake(-10, -20),
-            CLLocationCoordinate2DMake(-10, 10),
-            CLLocationCoordinate2DMake(10, 10),
-            CLLocationCoordinate2DMake(10, -10),
-        };
-        MGLPolygon *outerPolygon = [MGLPolygon polygonWithCoordinates:outerCoordinates count:sizeof(outerCoordinates) / sizeof(outerCoordinates[0]) interiorPolygons:@[innerPolygon]];
-        [self.mapView addAnnotation:outerPolygon];
+        [self addTestShapes];
     }
     else if (buttonIndex == actionSheet.firstOtherButtonIndex + 10)
     {
@@ -393,6 +314,92 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
             });
         }
     });
+}
+
+- (void)addTestShapes
+{
+    // Pacific Northwest triangle
+    //
+    CLLocationCoordinate2D triangleCoordinates[3] =
+    {
+        CLLocationCoordinate2DMake(44, -122),
+        CLLocationCoordinate2DMake(46, -122),
+        CLLocationCoordinate2DMake(46, -121)
+    };
+
+    MGLPolygon *triangle = [MGLPolygon polygonWithCoordinates:triangleCoordinates count:3];
+
+    [self.mapView addAnnotation:triangle];
+
+    // Orcas Island, WA hike polyline
+    //
+    NSDictionary *hike = [NSJSONSerialization JSONObjectWithData:
+                             [NSData dataWithContentsOfFile:
+                                 [[NSBundle mainBundle] pathForResource:@"polyline" ofType:@"geojson"]]
+                                                         options:0
+                                                           error:nil];
+
+    NSArray *hikeCoordinatePairs = hike[@"features"][0][@"geometry"][@"coordinates"];
+
+    CLLocationCoordinate2D *polylineCoordinates = (CLLocationCoordinate2D *)malloc([hikeCoordinatePairs count] * sizeof(CLLocationCoordinate2D));
+
+    for (NSUInteger i = 0; i < [hikeCoordinatePairs count]; i++)
+    {
+        polylineCoordinates[i] = CLLocationCoordinate2DMake([hikeCoordinatePairs[i][1] doubleValue], [hikeCoordinatePairs[i][0] doubleValue]);
+    }
+
+    MGLPolyline *polyline = [MGLPolyline polylineWithCoordinates:polylineCoordinates
+                                                           count:[hikeCoordinatePairs count]];
+
+    [self.mapView addAnnotation:polyline];
+
+    free(polylineCoordinates);
+
+    // PA/NJ/DE polygons
+    //
+    NSDictionary *threestates = [NSJSONSerialization JSONObjectWithData:
+                          [NSData dataWithContentsOfFile:
+                           [[NSBundle mainBundle] pathForResource:@"threestates" ofType:@"geojson"]]
+                                                         options:0
+                                                           error:nil];
+
+    for (NSDictionary *feature in threestates[@"features"])
+    {
+        NSArray *stateCoordinatePairs = feature[@"geometry"][@"coordinates"];
+
+        while ([stateCoordinatePairs count] == 1) stateCoordinatePairs = stateCoordinatePairs[0];
+
+        CLLocationCoordinate2D *polygonCoordinates = (CLLocationCoordinate2D *)malloc([stateCoordinatePairs count] * sizeof(CLLocationCoordinate2D));
+
+        for (NSUInteger i = 0; i < [stateCoordinatePairs count]; i++)
+        {
+            polygonCoordinates[i] = CLLocationCoordinate2DMake([stateCoordinatePairs[i][1] doubleValue], [stateCoordinatePairs[i][0] doubleValue]);
+        }
+
+        MGLPolygon *polygon = [MGLPolygon polygonWithCoordinates:polygonCoordinates count:[stateCoordinatePairs count]];
+
+        [self.mapView addAnnotation:polygon];
+
+        free(polygonCoordinates);
+    }
+
+    // Null Island polygon with an interior hole
+    //
+    CLLocationCoordinate2D innerCoordinates[] = {
+        CLLocationCoordinate2DMake(-5, -5),
+        CLLocationCoordinate2DMake(-5, 5),
+        CLLocationCoordinate2DMake(5, 5),
+        CLLocationCoordinate2DMake(5, -5),
+    };
+    MGLPolygon *innerPolygon = [MGLPolygon polygonWithCoordinates:innerCoordinates count:sizeof(innerCoordinates) / sizeof(innerCoordinates[0])];
+    CLLocationCoordinate2D outerCoordinates[] = {
+        CLLocationCoordinate2DMake(-10, -10),
+        CLLocationCoordinate2DMake(-10, 10),
+        CLLocationCoordinate2DMake(10, 10),
+        CLLocationCoordinate2DMake(10, -10),
+    };
+    MGLPolygon *outerPolygon = [MGLPolygon polygonWithCoordinates:outerCoordinates count:sizeof(outerCoordinates) / sizeof(outerCoordinates[0]) interiorPolygons:@[innerPolygon]];
+    [self.mapView addAnnotation:outerPolygon];
 }
 
 - (void)presentAnnotationWithCustomCallout

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4547,7 +4547,13 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         
         MGLAnnotationContext &annotationContext = pair.second;
         MGLAnnotationView *annotationView = annotationContext.annotationView;
-       
+
+        // Defer to the shape/polygon styling delegate methods
+        if ([annotationContext.annotation isKindOfClass:[MGLMultiPoint class]])
+        {
+            continue;
+        }
+
         if (!annotationView)
         {
             MGLAnnotationView *annotationView = [self annotationViewForAnnotation:annotationContext.annotation];


### PR DESCRIPTION
#### Changes
- Limits view annotations to single-point annotations.
- Refactors iosapp’s test shapes into a separate function.
 - Adds detail to the descriptions of individual shapes.
 - Makes the holey shape square (rather than trapezoidal, as below).

#### Issue
In v3.3.x, it was possible for any annotation class to be assigned an annotation view. If your implementation of `-mapView:viewForAnnotation:` didn't check if `annotation` was a kind of `MGLPointAnnotation`, you could end up drawing view annotations for `MGLMultiPoint` subclasses, such as `MGLPolygon`:

![screen shot 2016-07-22 at 5 00 07 pm](https://cloud.githubusercontent.com/assets/1198851/17072368/aab54132-5035-11e6-937c-c0c7fec36559.png)

As this fix uses the `MGLMultiPoint` superclass to exclude polygons and polylines, we will have to reevaluate if/when the proposed geometry class hierarchy changes in #5201 happen.

/cc @boundsj @1ec5 @incanus @frederoni