### PR TITLE
refs 654f015: bring back sprite-backed annotation option for comparison

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -639,6 +639,8 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         return nil; // use default marker
     }
 
+    NSAssert([annotation isKindOfClass:[MBXSpriteBackedAnnotation class]], @"Annotations should be sprite-backed.");
+
     NSString *title = [(MGLPointAnnotation *)annotation title];
     if (!title.length) return nil;
     NSString *lastTwoCharacters = [title substringFromIndex:title.length - 2];

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -30,6 +30,12 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
 @implementation MBXCustomCalloutAnnotation
 @end
 
+@interface MBXSpriteBackedAnnotation : MGLPointAnnotation
+@end
+
+@implementation MBXSpriteBackedAnnotation
+@end
+
 @interface MBXViewController () <UIActionSheetDelegate, MGLMapViewDelegate>
 
 @property (nonatomic) IBOutlet MGLMapView *mapView;
@@ -313,10 +319,10 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
                                                                                [feature[@"geometry"][@"coordinates"][0] doubleValue]);
                 NSString *title = feature[@"properties"][@"NAME"];
 
-                MGLPointAnnotation *annotation = [MGLPointAnnotation new];
+                MGLPointAnnotation *annotation = (useViews ? [MGLPointAnnotation new] : [MBXSpriteBackedAnnotation new]);
+
                 annotation.coordinate = coordinate;
                 annotation.title = title;
-                annotation.subtitle = [NSString stringWithFormat:@"View: %i", useViews];
 
                 [annotations addObject:annotation];
 
@@ -598,8 +604,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
 - (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id<MGLAnnotation>)annotation
 {
     // Use GL backed pins for dropped pin annotations
-    if ([annotation isKindOfClass:[MBXDroppedPinAnnotation class]] ||
-        ([annotation isKindOfClass:[MGLPointAnnotation class]] && [[(MGLPointAnnotation *)annotation subtitle] isEqualToString:@"View: 0"]))
+    if ([annotation isKindOfClass:[MBXDroppedPinAnnotation class]] || [annotation isKindOfClass:[MBXSpriteBackedAnnotation class]])
     {
         return nil;
     }
@@ -629,9 +634,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
 
 - (MGLAnnotationImage *)mapView:(MGLMapView * __nonnull)mapView imageForAnnotation:(id <MGLAnnotation> __nonnull)annotation
 {
-    if ([annotation isKindOfClass:[MBXDroppedPinAnnotation class]]    ||
-        [annotation isKindOfClass:[MBXCustomCalloutAnnotation class]] ||
-        ([annotation isKindOfClass:[MGLPointAnnotation class]] && [[(MGLPointAnnotation *)annotation subtitle] isEqualToString:@"View: 1"]))
+    if ([annotation isKindOfClass:[MBXDroppedPinAnnotation class]] || [annotation isKindOfClass:[MBXCustomCalloutAnnotation class]])
     {
         return nil; // use default marker
     }


### PR DESCRIPTION
Background in https://github.com/mapbox/mapbox-gl-native/commit/654f0156397b68420bc48dfa2d53589ea7c8042e#commitcomment-18366764. 

We should have sprite-backed annotations as an option still for comparison to view-backed until such time that view-backed performance is equal or of negligible difference. 

This more or less reverses https://github.com/mapbox/mapbox-gl-native/commit/654f0156397b68420bc48dfa2d53589ea7c8042e, though it doesn't bring back `-mapView:didDeselectAnnotation:`, of which I'm not sure what the point was—something about changing to pins if we don't have a sprite to reuse? Open to feedback here. 

Subjectively, since last being in this code, I am noticing a pretty marked performance decrease for annotation sprites, possibly related to z-ordering that I see happening during map rotation. Might be something else. I'm going to profile out of curiosity separately from this—this PR is just about the functionality. But these should be a lot faster. 

/cc @1ec5 @boundsj 