### PR TITLE
Add mention-bot config

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,5 @@
+{
+  "requiredOrgs": ["mapbox"], // mention-bot will only mention user who are members of one of these organizations.
+  "message": "@pullRequester, thanks for your PR! By analyzing this pull request, we identified @reviewers to be potential reviewers.",
+  "numFilesToCheck": 10, // Number of files to check against, default is 5.
+}


### PR DESCRIPTION
We added [mention-bot](https://github.com/facebook/mention-bot) to this repo recently, which attempts to automatically notify relevant reviewers when someone (apparently only those with commit powers?) submits a pull request.

This PR adds a config file to the repo that makes small changes to mention-bot’s behavior:

- Limit notifications to members of the Mapbox GitHub organization.
- Tweak the message a bit for concision and punctuation.
- Experimentally bump number of PR files checked from 5 to 10.

/cc @brunoabinader @1ec5