### PR TITLE
[core] Update SQLite schema with WAL journal mode and normal sync

### DIFF
--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -48,7 +48,8 @@ void OfflineDatabase::ensureSchema() {
             case 0: break; // cache-only database; ok to delete
             case 1: break; // cache-only database; ok to delete
             case 2: migrateToVersion3(); // fall through
-            case 3: return;
+            case 3: migrateToVersion4(); // fall through
+            case 4: return;
             default: throw std::runtime_error("unknown schema version");
             }
 
@@ -79,8 +80,10 @@ void OfflineDatabase::ensureSchema() {
 
         // If you change the schema you must write a migration from the previous version.
         db->exec("PRAGMA auto_vacuum = INCREMENTAL");
+        db->exec("PRAGMA synchronous = NORMAL");
+        db->exec("PRAGMA journal_mode = WAL");
         db->exec(schema);
-        db->exec("PRAGMA user_version = 3");
+        db->exec("PRAGMA user_version = 4");
     } catch (...) {
         Log::Error(Event::Database, "Unexpected error creating database schema: %s", util::toString(std::current_exception()).c_str());
         throw;
@@ -109,6 +112,12 @@ void OfflineDatabase::migrateToVersion3() {
     db->exec("PRAGMA auto_vacuum = INCREMENTAL");
     db->exec("VACUUM");
     db->exec("PRAGMA user_version = 3");
+}
+
+void OfflineDatabase::migrateToVersion4() {
+    db->exec("PRAGMA synchronous = NORMAL");
+    db->exec("PRAGMA journal_mode = WAL");
+    db->exec("PRAGMA user_version = 4");
 }
 
 OfflineDatabase::Statement OfflineDatabase::getStatement(const char * sql) {

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -60,6 +60,7 @@ private:
     void ensureSchema();
     void removeExisting();
     void migrateToVersion3();
+    void migrateToVersion4();
 
     class Statement {
     public:

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -40,6 +40,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Other changes
 
 * Fixed a crash that sometimes occurred when initializing an MGLMapView. ([#5932](https://github.com/mapbox/mapbox-gl-native/pull/5932))
+* Improved offline and ambient cache database performance. ([#5796](https://github.com/mapbox/mapbox-gl-native/pull/5796))
 * As the user zooms in, tiles from lower zoom levels are scaled up until tiles for higher zoom levels are loaded. ([#5143](https://github.com/mapbox/mapbox-gl-native/pull/5143))
 * MGLMapDebugOverdrawVisualizationMask no longer has any effect in Release builds of the SDK. This debug mask has been disabled for performance reasons. ([#5555](https://github.com/mapbox/mapbox-gl-native/pull/5555))
 * Fixed a typo in the documentation for the MGLCompassDirectionFormatter class. ([#5879](https://github.com/mapbox/mapbox-gl-native/pull/5879))

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue causing code signing failures and bloating the framework. ([#5850](https://github.com/mapbox/mapbox-gl-native/pull/5850))
 * Xcode 7.3 or higher is now required for using this SDK. ([#6059](https://github.com/mapbox/mapbox-gl-native/issues/6059))
 * A new runtime styling API allows you to adjust the style and content of the base map dynamically. All the options available in [Mapbox Studio](https://www.mapbox.com/studio/) are now exposed via MGLStyle and subclasses of MGLStyleLayer and MGLSource. ([#5727](https://github.com/mapbox/mapbox-gl-native/pull/5727))
+* Improved offline and ambient cache database performance. ([#5796](https://github.com/mapbox/mapbox-gl-native/pull/5796))
 * Added `showAnnotations:animated:` and `showAnnotations:edgePadding:animated:`, which moves the map viewport to show the specified annotations. ([#5749](https://github.com/mapbox/mapbox-gl-native/pull/5749))
 * To make an MGLPolyline or MGLPolygon span the antimeridian, specify coordinates with longitudes greater than 180° or less than −180°. ([#6088](https://github.com/mapbox/mapbox-gl-native/pull/6088))
 * MGLMapView’s `styleURL` property can now be set to an absolute file URL. ([#6026](https://github.com/mapbox/mapbox-gl-native/pull/6026))

--- a/test/storage/offline_database.cpp
+++ b/test/storage/offline_database.cpp
@@ -559,18 +559,18 @@ TEST(OfflineDatabase, MigrateFromV2Schema) {
 
     // v2.db is a v2 database containing a single offline region with a small number of resources.
 
-    deleteFile("test/fixtures/offline_database/v3.db");
-    writeFile("test/fixtures/offline_database/v3.db", util::read_file("test/fixtures/offline_database/v2.db"));
+    deleteFile("test/fixtures/offline_database/v4.db");
+    writeFile("test/fixtures/offline_database/v4.db", util::read_file("test/fixtures/offline_database/v2.db"));
 
     {
-        OfflineDatabase db("test/fixtures/offline_database/v3.db", 0);
+        OfflineDatabase db("test/fixtures/offline_database/v4.db", 0);
         auto regions = db.listRegions();
         for (auto& region : regions) {
             db.deleteRegion(std::move(region));
         }
     }
 
-    EXPECT_EQ(3, databaseUserVersion("test/fixtures/offline_database/v3.db"));
-    EXPECT_LT(databasePageCount("test/fixtures/offline_database/v3.db"),
+    EXPECT_EQ(4, databaseUserVersion("test/fixtures/offline_database/v4.db"));
+    EXPECT_LT(databasePageCount("test/fixtures/offline_database/v4.db"),
               databasePageCount("test/fixtures/offline_database/v2.db"));
 }


### PR DESCRIPTION
This pull request changes our offline/ambient cache database schema to use write-ahead logging and normal sync, which greatly increases the speed that resources can be written and read.

### Journal modes

SQLite offers several [journal modes](https://www.sqlite.org/pragma.html#pragma_journal_mode) — we were using the default, `DELETE`, which continuously writes a “rollback journal” that is then deleted at the end of the transaction. This mode offers good data safety and is [atomic](https://www.sqlite.org/atomiccommit.html), but is subsequently somewhat slow.

[Write-head logging](https://www.sqlite.org/wal.html) (`WAL`) is a different type of journaling that offers better performance but marginally reduced data safety. WAL effectively writes to a separate cache and periodically flushes back to the main database.

The SQLite docs go into great detail about the pros and cons of WAL, so I won’t rehash them here.

### Synchronous modes

SQLite also [offers several modes](https://www.sqlite.org/pragma.html#pragma_synchronous) of write synchronization. `FULL` is the default (which we were using) and is quite safe, but slow. `NORMAL` syncs less often (but still at “critical moments”) and is faster, but comes with a “non-zero” chance of data loss. `NORMAL` is the suggested mode to be used in conjunction with WAL and is what this PR uses.

`NORMAL` only offers a minimal performance increase, so far as I could tell.

### Performance tests with offline resources

Bottom-line: WAL offers 2× to 5× performance for us on iOS, depending on device vintage. Speeds appear to scale linearly — two rounds of tests were done with ~1000 resources and ~6000 resources. Initial writes/downloads were on my home internet connection, which was not saturated.

| | iPhone 6s (iOS 9.3.2, SQLite 3.8.10.2) | iPhone 5 (iOS 10b2, SQLite 3.13.0) |
|---|---|---|
| `DELETE` + `FULL` | 2.5 MB/s writing, 4.0 MB/s verifying | 1.2 MB/s writing, 1.8 MB/s verifying |
| `WAL` + `NORMAL` | **4.4 MB/s** writing, **21.9 MB/s** verifying | 1.2 MB/s writing, **4.2 MB/s** verifying |

The iPhone 5 appeared to be severely CPU-bound and was pegged at 100%.

### Availability

WAL was first supported in SQLite 3.7.0, which is available from iOS 5 and Android API 11 — so it should be available everywhere.

### Unknowns

- This PR will increase the chances of data loss, but it’s unknown whether or not this increase is significant.
- If data loss were to occur, the failure mode is unknown.
- Android performance is untested.
- The impact on other platforms?

/cc @mapbox/gl
