### PR TITLE
[Qt] Implement QQuickMapboxGL color property

### DIFF
--- a/platform/qt/include/qquickmapboxgl.hpp
+++ b/platform/qt/include/qquickmapboxgl.hpp
@@ -89,6 +89,7 @@ public:
         PanNeedsSync     = 1 << 3,
         BearingNeedsSync = 1 << 4,
         PitchNeedsSync   = 1 << 5,
+        ColorNeedsSync   = 1 << 6,
     };
 
     int swapSyncState();
@@ -122,6 +123,7 @@ private:
 
     QGeoCoordinate m_center;
     QGeoShape m_visibleRegion;
+    QColor m_color = Qt::black;
 
     QString m_style;
     qreal m_bearing = 0;

--- a/platform/qt/qmlapp/main.qml
+++ b/platform/qt/qmlapp/main.qml
@@ -3,6 +3,7 @@ import QtPositioning 5.0
 import QtQuick 2.0
 import QtQuick.Controls 1.0
 import QtQuick.Layouts 1.0
+import QtQuick.Dialogs 1.0
 
 import QQuickMapboxGL 1.0
 
@@ -11,6 +12,13 @@ ApplicationWindow {
     width: 1024
     height: 768
     visible: true
+
+    ColorDialog {
+        id: colorDialog
+        title: "Background color"
+        visible: false
+        color: "black"
+    }
 
     RowLayout {
         anchors.fill: parent
@@ -51,7 +59,7 @@ ApplicationWindow {
                     bearing: bearingSlider.value
                     pitch: pitchSlider.value
 
-                    color: "red"
+                    color: colorDialog.currentColor
                     copyrightsVisible: true
 
                     Image {
@@ -184,37 +192,50 @@ ApplicationWindow {
             }
         }
 
-        Slider {
-            id: bearingSlider
+        ColumnLayout {
+            RowLayout {
+                anchors.margins: 50
+                spacing: anchors.margins
 
-            Layout.fillHeight: true
-            orientation: Qt.Vertical
+                Slider {
+                    id: bearingSlider
 
-            value: 0
-            minimumValue: 0
-            maximumValue: 180
-        }
+                    Layout.fillHeight: true
+                    orientation: Qt.Vertical
 
-        Slider {
-            id: pitchSlider
+                    value: 0
+                    minimumValue: 0
+                    maximumValue: 180
+                }
 
-            Layout.fillHeight: true
-            orientation: Qt.Vertical
+                Slider {
+                    id: pitchSlider
 
-            value: 0
-            minimumValue: 0
-            maximumValue: 60
-        }
+                    Layout.fillHeight: true
+                    orientation: Qt.Vertical
 
-        Slider {
-            id: flipSlider
+                    value: 0
+                    minimumValue: 0
+                    maximumValue: 60
+                }
 
-            Layout.fillHeight: true
-            orientation: Qt.Vertical
+                Slider {
+                    id: flipSlider
 
-            value: 0
-            minimumValue: 0
-            maximumValue: 180
+                    Layout.fillHeight: true
+                    orientation: Qt.Vertical
+
+                    value: 0
+                    minimumValue: 0
+                    maximumValue: 180
+                }
+            }
+
+            Button {
+                id: colorChangeButton
+                text: "Change background color"
+                onClicked: colorDialog.open()
+            }
         }
     }
 }

--- a/platform/qt/src/qquickmapboxgl.cpp
+++ b/platform/qt/src/qquickmapboxgl.cpp
@@ -148,16 +148,23 @@ bool QQuickMapboxGL::copyrightsVisible() const
     return false;
 }
 
-void QQuickMapboxGL::setColor(const QColor &)
+void QQuickMapboxGL::setColor(const QColor &color)
 {
-    // TODO: can be made functional after landing #837
-    qWarning() << __PRETTY_FUNCTION__
-        << "Use Mapbox Studio to change the map background color.";
+    if (color == m_color) {
+        return;
+    }
+
+    m_color = color;
+
+    m_syncState |= ColorNeedsSync;
+    update();
+
+    emit colorChanged(m_color);
 }
 
 QColor QQuickMapboxGL::color() const
 {
-    return QColor();
+    return m_color;
 }
 
 void QQuickMapboxGL::pan(int dx, int dy)

--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -75,4 +75,8 @@ void QQuickMapboxGLRenderer::synchronize(QQuickFramebufferObject *item)
     if (syncStatus & QQuickMapboxGL::PitchNeedsSync) {
         m_map->setPitch(quickMap->pitch());
     }
+
+    if (syncStatus & QQuickMapboxGL::ColorNeedsSync && m_map->isFullyLoaded()) {
+        m_map->setPaintProperty("background", "background-color", quickMap->color());
+    }
 }


### PR DESCRIPTION
Implements background `color` property for `QQuickMapboxGL` after runtime style API has been implemented (#837 and #5642).

Example:
![qml-color-change2](https://cloud.githubusercontent.com/assets/76133/17176276/8ac459d4-5414-11e6-8def-93ee9f1ab93d.gif)
