### PR TITLE
[ios] Limit annotation view pan gesture check to own recognizer

### DIFF
--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -235,7 +235,7 @@
 {
     BOOL isDragging = self.dragState == MGLAnnotationViewDragStateDragging;
     
-    if ([gestureRecognizer isKindOfClass:UIPanGestureRecognizer.class] && !(isDragging))
+    if (gestureRecognizer == _panGestureRecognizer && !(isDragging))
     {
         return NO;
     }


### PR DESCRIPTION
Fixes #5539. Allows non-dragging pans that are initiated on view annotations to pan the underlying map.

Annotation views each have long press and pan gesture recognizers. If a view is not draggable or not in a positive dragging state, the pan gesture recognizer should not begin. This commit makes the criteria for rejecting pans more strict — only `_panGestureRecognizer` should be rejected, not the entire `UIPanGestureRecognizer` class.

/cc @frederoni @1ec5