### PR TITLE
[ios] Limit annotation view pan gesture check to own recognizer

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.  Please read [CON
 ## 3.3.2
 
 * Fixed a crash that occurred when initializing an MGLMapView on iOS 8.1 or below. ([#5791](https://github.com/mapbox/mapbox-gl-native/pull/5791))
+* Fixed an issue where pan gestures that originated on view annotations would not pan the underlying map. ([#5813](https://github.com/mapbox/mapbox-gl-native/pull/5813))
 
 ## 3.3.1
 

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -235,7 +235,7 @@
 {
     BOOL isDragging = self.dragState == MGLAnnotationViewDragStateDragging;
     
-    if ([gestureRecognizer isKindOfClass:UIPanGestureRecognizer.class] && !(isDragging))
+    if (gestureRecognizer == _panGestureRecognizer && !(isDragging))
     {
         return NO;
     }


### PR DESCRIPTION
Fixes #5539. Allows non-dragging pan gestures that are initiated on view annotations to pan the underlying map.

(This PR is now filed against the v3.3.0 release branch and supersedes #5812.)

Annotation views each have long press and pan gesture recognizers. If a view is not draggable or not in a positive dragging state, the pan gesture recognizer should not begin. This commit makes the criteria for rejecting pans more strict — only `_panGestureRecognizer` should be rejected, not the entire `UIPanGestureRecognizer` class.

/cc @frederoni @1ec5 