### PR TITLE
[android] #5587 - SurfaceView compatible snapshot API

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -13,6 +13,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.PointF;
 import android.graphics.RectF;
@@ -158,6 +159,7 @@ public class MapView extends FrameLayout {
     private String mInitalStyle;
 
     private List<OnMapReadyCallback> mOnMapReadyCallbackList;
+    private SnapshotRequest mSnapshotRequest;
 
     @UiThread
     public MapView(@NonNull Context context) {
@@ -197,7 +199,7 @@ public class MapView extends FrameLayout {
 
         // Reference the TextureView
         SurfaceView surfaceView = (SurfaceView) view.findViewById(R.id.surfaceView);
-        
+
         // Check if we are in Android Studio UI editor to avoid error in layout preview
         if (isInEditMode()) {
             return;
@@ -1801,7 +1803,7 @@ public class MapView extends FrameLayout {
                 return false;
             }
 
-         //   requestDisallowInterceptTouchEvent(true);
+            requestDisallowInterceptTouchEvent(true);
 
             // reset tracking modes if gesture occurs
             resetTrackingModesIfRequired();
@@ -2639,21 +2641,51 @@ public class MapView extends FrameLayout {
         return mMyLocationView;
     }
 
+    //
+    // Snapshot API
+    //
+
     @UiThread
     void snapshot(@NonNull final MapboxMap.SnapshotReadyCallback callback, @Nullable final Bitmap bitmap) {
-//        TextureView textureView = (TextureView) findViewById(R.id.textureView);
-//        final boolean canUseBitmap = bitmap != null && textureView.getWidth() == bitmap.getWidth() && textureView.getHeight() == bitmap.getHeight();
-//
-//        setDrawingCacheEnabled(true);
-//        Bitmap content = Bitmap.createBitmap(getDrawingCache());
-//        setDrawingCacheEnabled(false);
-//
-//        Bitmap output = Bitmap.createBitmap(content.getWidth(), content.getHeight(), Bitmap.Config.ARGB_8888);
-//        Canvas canvas = new Canvas(output);
-//        canvas.drawBitmap(canUseBitmap ? textureView.getBitmap(bitmap) : textureView.getBitmap(), 0, 0, null);
-//        canvas.drawBitmap(content, new Matrix(), null);
-//        callback.onSnapshotReady(output);
-        throw new RuntimeException("TextureView code needs to be migrated to SurfaceView");
+        mSnapshotRequest = new SnapshotRequest(bitmap, callback);
+        mNativeMapView.scheduleTakeSnapshot();
+        mNativeMapView.render();
+    }
+
+    // Called when the snapshot method was executed
+    // Called via JNI from NativeMapView
+    // Forward to any listeners
+    protected void onSnapshotReady(byte[] bytes) {
+        if (mSnapshotRequest != null && bytes != null) {
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inBitmap = mSnapshotRequest.getBitmap();  // the old Bitmap to be reused
+            options.inMutable = true;
+            options.inSampleSize = 1;
+            Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
+
+            MapboxMap.SnapshotReadyCallback callback = mSnapshotRequest.getCallback();
+            if (callback != null) {
+                callback.onSnapshotReady(bitmap);
+            }
+        }
+    }
+
+    private class SnapshotRequest {
+        private Bitmap bitmap;
+        private MapboxMap.SnapshotReadyCallback callback;
+
+        public SnapshotRequest(Bitmap bitmap, MapboxMap.SnapshotReadyCallback callback) {
+            this.bitmap = bitmap;
+            this.callback = callback;
+        }
+
+        public Bitmap getBitmap() {
+            return bitmap;
+        }
+
+        public MapboxMap.SnapshotReadyCallback getCallback() {
+            return callback;
+        }
     }
 
     //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -470,6 +470,10 @@ final class NativeMapView {
         return nativeGetCameraValues(mNativeMapViewPtr);
     }
 
+    public void scheduleTakeSnapshot() {
+        nativeScheduleTakeSnapshot(mNativeMapViewPtr);
+    }
+
     //
     // Callbacks
     //
@@ -484,6 +488,10 @@ final class NativeMapView {
 
     protected void onFpsChanged(double fps) {
         mMapView.onFpsChanged(fps);
+    }
+
+    protected void onSnapshotReady(byte[] bytes){
+        mMapView.onSnapshotReady(bytes);
     }
 
     //
@@ -633,7 +641,7 @@ final class NativeMapView {
     private native LatLng nativeLatLngForPixel(long nativeMapViewPtr, float x, float y);
 
     private native double nativeGetTopOffsetPixelsForAnnotationSymbol(long nativeMapViewPtr, String symbolName);
-    
+
     private native void nativeJumpTo(long nativeMapViewPtr, double angle, double latitude, double longitude, double pitch, double zoom);
 
     private native void nativeEaseTo(long nativeMapViewPtr, double angle, double latitude, double longitude, long duration, double pitch, double zoom, boolean easingInterpolator);
@@ -645,4 +653,6 @@ final class NativeMapView {
     private native void nativeRemoveCustomLayer(long nativeMapViewPtr, String id);
 
     private native double[] nativeGetCameraValues(long mNativeMapViewPtr);
+
+    private native void nativeScheduleTakeSnapshot(long nativeMapViewPtr);
 }

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -42,6 +42,7 @@ std::string androidRelease;
 jni::jmethodID* onInvalidateId = nullptr;
 jni::jmethodID* onMapChangedId = nullptr;
 jni::jmethodID* onFpsChangedId = nullptr;
+jni::jmethodID* onSnapshotReadyId = nullptr;
 
 jni::jclass* latLngClass = nullptr;
 jni::jmethodID* latLngConstructorId = nullptr;
@@ -1085,6 +1086,13 @@ void nativeRemoveCustomLayer(JNIEnv *env, jni::jobject* obj, jlong nativeMapView
     nativeMapView->getMap().removeLayer(std_string_from_jstring(env, id));
 }
 
+void nativeScheduleTakeSnapshot(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
+    mbgl::Log::Error(mbgl::Event::JNI, "nativeRenderToOffscreen");
+    assert(nativeMapViewPtr != 0);
+    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
+    nativeMapView->scheduleTakeSnapshot();
+}
+
 // Offline calls begin
 
 jlong createDefaultFileSource(JNIEnv *env, jni::jobject* obj, jni::jstring* cachePath_, jni::jstring* assetRoot_, jlong maximumCacheSize) {
@@ -1624,6 +1632,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     onInvalidateId = &jni::GetMethodID(env, nativeMapViewClass, "onInvalidate", "()V");
     onMapChangedId = &jni::GetMethodID(env, nativeMapViewClass, "onMapChanged", "(I)V");
     onFpsChangedId = &jni::GetMethodID(env, nativeMapViewClass, "onFpsChanged", "(D)V");
+    onSnapshotReadyId = &jni::GetMethodID(env, nativeMapViewClass, "onSnapshotReady","([B)V");
 
     #define MAKE_NATIVE_METHOD(name, sig) jni::MakeNativeMethod<decltype(name), name>( #name, sig )
 
@@ -1699,7 +1708,8 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
         MAKE_NATIVE_METHOD(nativeFlyTo, "(JDDDJDD)V"),
         MAKE_NATIVE_METHOD(nativeAddCustomLayer, "(JLcom/mapbox/mapboxsdk/layers/CustomLayer;Ljava/lang/String;)V"),
         MAKE_NATIVE_METHOD(nativeRemoveCustomLayer, "(JLjava/lang/String;)V"),
-        MAKE_NATIVE_METHOD(nativeSetContentPadding, "(JDDDD)V")
+        MAKE_NATIVE_METHOD(nativeSetContentPadding, "(JDDDD)V"),
+        MAKE_NATIVE_METHOD(nativeScheduleTakeSnapshot, "(J)V")
     );
 
     // Offline begin

--- a/platform/android/src/jni.hpp
+++ b/platform/android/src/jni.hpp
@@ -19,6 +19,7 @@ extern std::string androidRelease;
 extern jmethodID onInvalidateId;
 extern jmethodID onMapChangedId;
 extern jmethodID onFpsChangedId;
+extern jmethodID onSnapshotReadyId;
 
 extern bool attach_jni_thread(JavaVM* vm, JNIEnv** env, std::string threadName);
 extern void detach_jni_thread(JavaVM* vm, JNIEnv** env, bool detach);

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -49,6 +49,8 @@ public:
     mbgl::EdgeInsets getInsets() { return insets;}
     void setInsets(mbgl::EdgeInsets insets_);
 
+    void scheduleTakeSnapshot();
+
 private:
     EGLConfig chooseConfig(const EGLConfig configs[], EGLint numConfigs);
 
@@ -79,6 +81,7 @@ private:
     bool firstTime = false;
     bool fpsEnabled = false;
     bool sizeChanged = false;
+    bool snapshot = false;
     double fps = 0.0;
 
     int width = 0;


### PR DESCRIPTION
closes #5587. Merges into `5000-SurfaceView` of #5801.