### PR TITLE
Avoid following symlinks copying framework

### DIFF
--- a/platform/macos/scripts/package.sh
+++ b/platform/macos/scripts/package.sh
@@ -38,7 +38,7 @@ xcodebuild \
 
 step "Copying dynamic framework into place"
 mkdir -p "${OUTPUT}/${NAME}.framework"
-cp -r ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework/* "${OUTPUT}/${NAME}.framework"
+ditto ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework "${OUTPUT}/${NAME}.framework"
 if [[ -e ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework.dSYM ]]; then
     cp -r ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework.dSYM "${OUTPUT}"
 fi


### PR DESCRIPTION
Use `ditto` to avoid following symlinks when copying the framework into place.

Fixes #5818.

/cc @frederoni