### PR TITLE
[Qt] Added QQuickMapboxGLStyle

### DIFF
--- a/platform/qt/include/QQuickMapboxGLStyle
+++ b/platform/qt/include/QQuickMapboxGLStyle
@@ -1,0 +1,1 @@
+#include "qquickmapboxglstyle.hpp"

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -199,8 +199,8 @@ public:
     void setMargins(const QMargins &margins);
     QMargins margins() const;
 
-    void addSource(const QString& sourceID, const QVariant& value);
-    void removeSource(const QString& sourceID);
+    void addSource(const QString &sourceID, const QVariantMap& params);
+    void removeSource(const QString &sourceID);
 
     void addCustomLayer(const QString &id,
         QMapbox::CustomLayerInitializeFunction,
@@ -208,7 +208,7 @@ public:
         QMapbox::CustomLayerDeinitializeFunction,
         void* context,
         char* before = NULL);
-    void addLayer(const QVariant &value);
+    void addLayer(const QVariantMap &params);
     void removeLayer(const QString &id);
 
     void setFilter(const QString &layer, const QVariant &filter);

--- a/platform/qt/include/qquickmapboxgl.hpp
+++ b/platform/qt/include/qquickmapboxgl.hpp
@@ -96,6 +96,10 @@ public:
 
     int swapSyncState();
 
+protected:
+    // QQuickItem implementation.
+    virtual void itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &value);
+
 signals:
     void minimumZoomLevelChanged();
     void maximumZoomLevelChanged();
@@ -115,6 +119,9 @@ signals:
 
 public slots:
     void setCenter(const QGeoCoordinate &center);
+
+private slots:
+    void onStylePropertyUpdated(const QVariantMap &params);
 
 private:
     qreal m_minimumZoomLevel = 0;

--- a/platform/qt/include/qquickmapboxgl.hpp
+++ b/platform/qt/include/qquickmapboxgl.hpp
@@ -8,6 +8,8 @@
 #include <QPointF>
 #include <QQuickFramebufferObject>
 
+#include <QQuickMapboxGLStyle>
+
 class QDeclarativeGeoServiceProvider;
 class QQuickItem;
 
@@ -29,7 +31,7 @@ class Q_DECL_EXPORT QQuickMapboxGL : public QQuickFramebufferObject
     Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
 
     // MapboxGL QML Type interface.
-    Q_PROPERTY(QString style READ style WRITE setStyle NOTIFY styleChanged)
+    Q_PROPERTY(QQuickMapboxGLStyle *style READ style WRITE setStyle NOTIFY styleChanged)
     Q_PROPERTY(qreal bearing READ bearing WRITE setBearing NOTIFY bearingChanged)
     Q_PROPERTY(qreal pitch READ pitch WRITE setPitch NOTIFY pitchChanged)
 
@@ -73,8 +75,8 @@ public:
     QList<QVariantMap>& paintPropertyChanges() { return m_paintChanges; }
 
     // MapboxGL QML Type interface.
-    void setStyle(const QString &style);
-    QString style() const;
+    void setStyle(QQuickMapboxGLStyle *);
+    QQuickMapboxGLStyle* style() const;
 
     void setBearing(qreal bearing);
     qreal bearing() const;
@@ -121,6 +123,7 @@ public slots:
     void setCenter(const QGeoCoordinate &center);
 
 private slots:
+    void onStyleChanged();
     void onStylePropertyUpdated(const QVariantMap &params);
 
 private:
@@ -136,7 +139,7 @@ private:
     QList<QVariantMap> m_layoutChanges;
     QList<QVariantMap> m_paintChanges;
 
-    QString m_style;
+    QQuickMapboxGLStyle *m_style = 0;
     qreal m_bearing = 0;
     qreal m_pitch = 0;
 

--- a/platform/qt/include/qquickmapboxgl.hpp
+++ b/platform/qt/include/qquickmapboxgl.hpp
@@ -34,19 +34,6 @@ class Q_DECL_EXPORT QQuickMapboxGL : public QQuickFramebufferObject
     Q_PROPERTY(qreal pitch READ pitch WRITE setPitch NOTIFY pitchChanged)
 
 public:
-    struct LayoutPropertyChange {
-        QString layer;
-        QString property;
-        QVariant value;
-    };
-
-    struct PaintPropertyChange {
-        QString layer;
-        QString property;
-        QVariant value;
-        QString klass;
-    };
-
     QQuickMapboxGL(QQuickItem *parent = 0);
     virtual ~QQuickMapboxGL();
 
@@ -82,8 +69,8 @@ public:
 
     Q_INVOKABLE void pan(int dx, int dy);
 
-    QList<LayoutPropertyChange>& layoutPropertyChanges() { return m_layoutChanges; }
-    QList<PaintPropertyChange>& paintPropertyChanges() { return m_paintChanges; }
+    QList<QVariantMap>& layoutPropertyChanges() { return m_layoutChanges; }
+    QList<QVariantMap>& paintPropertyChanges() { return m_paintChanges; }
 
     // MapboxGL QML Type interface.
     void setStyle(const QString &style);
@@ -96,9 +83,6 @@ public:
     qreal pitch() const;
 
     QPointF swapPan();
-
-    void setLayoutProperty(const QString &layer, const QString &property, const QVariant &value);
-    void setPaintProperty(const QString &layer, const QString &property, const QVariant &value, const QString &klass = QString());
 
     enum SyncState {
         NothingNeedsSync = 0,
@@ -142,8 +126,8 @@ private:
     QGeoCoordinate m_center;
     QGeoShape m_visibleRegion;
     QColor m_color;
-    QList<LayoutPropertyChange> m_layoutChanges;
-    QList<PaintPropertyChange> m_paintChanges;
+    QList<QVariantMap> m_layoutChanges;
+    QList<QVariantMap> m_paintChanges;
 
     QString m_style;
     qreal m_bearing = 0;

--- a/platform/qt/include/qquickmapboxglstyle.hpp
+++ b/platform/qt/include/qquickmapboxglstyle.hpp
@@ -1,0 +1,39 @@
+#ifndef QQUICKMAPBOXGLSTYLE_H
+#define QQUICKMAPBOXGLSTYLE_H
+
+#include <QQuickItem>
+
+class Q_DECL_EXPORT QQuickMapboxGLStyle : public QQuickItem
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString url READ url WRITE setUrl NOTIFY urlChanged)
+    Q_PROPERTY(QString styleClass READ styleClass WRITE setStyleClass NOTIFY classChanged)
+
+public:
+    QQuickMapboxGLStyle(QQuickItem *parent = Q_NULLPTR);
+    virtual ~QQuickMapboxGLStyle() {}
+
+    // QQuickItem implementation
+    virtual void itemChange(QQuickItem::ItemChange, const QQuickItem::ItemChangeData &);
+
+    void setUrl(const QString &);
+    QString url() const;
+
+    void setStyleClass(const QString &);
+    QString styleClass() const;
+
+signals:
+    void urlChanged(const QString &);
+    void classChanged(const QString &);
+
+    void propertyUpdated(const QVariantMap &);
+
+private:
+    QString m_url;
+    QString m_class;
+};
+
+QML_DECLARE_TYPE(QQuickMapboxGLStyle)
+
+#endif // QQUICKMAPBOXGLSTYLE_H

--- a/platform/qt/include/qquickmapboxglstyleproperty.hpp
+++ b/platform/qt/include/qquickmapboxglstyleproperty.hpp
@@ -35,9 +35,7 @@ protected:
     QQuickMapboxGLStyleProperty(QQuickItem *parent);
     virtual void updateParent() = 0;
 
-    QVariant m_layer;
-    QVariant m_property;
-    QVariant m_value;
+    QVariantMap m_map;
 };
 
 class Q_DECL_EXPORT QQuickMapboxGLLayoutStyleProperty : public QQuickMapboxGLStyleProperty
@@ -67,9 +65,6 @@ signals:
 
 protected:
     virtual void updateParent();
-
-private:
-    QVariant m_class;
 };
 
 #endif // QQUICKMAPBOXGLSTYLEPROPERTY_H

--- a/platform/qt/include/qquickmapboxglstyleproperty.hpp
+++ b/platform/qt/include/qquickmapboxglstyleproperty.hpp
@@ -12,10 +12,12 @@ class Q_DECL_EXPORT QQuickMapboxGLStyleProperty : public QQuickItem
     Q_PROPERTY(QVariant value READ value WRITE setValue NOTIFY valueChanged)
 
 public:
-    virtual ~QQuickMapboxGLStyleProperty() {}
+    enum Type {
+        LayoutType = 0,
+        PaintType,
+    };
 
-    // QQuickItem implementation
-    virtual void itemChange(QQuickItem::ItemChange, const QQuickItem::ItemChangeData &);
+    virtual ~QQuickMapboxGLStyleProperty() {}
 
     void setLayer(const QString &);
     QString layer() const;
@@ -30,10 +32,11 @@ signals:
     void layerChanged(const QString &);
     void propertyChanged(const QString &);
     void valueChanged(const QVariant &);
+    void updated(const QVariantMap& params);
 
 protected:
-    QQuickMapboxGLStyleProperty(QQuickItem *parent);
-    virtual void updateParent() = 0;
+    QQuickMapboxGLStyleProperty(QQuickItem *parent, Type);
+    void checkUpdated();
 
     QVariantMap m_map;
 };
@@ -43,9 +46,6 @@ class Q_DECL_EXPORT QQuickMapboxGLLayoutStyleProperty : public QQuickMapboxGLSty
 public:
     QQuickMapboxGLLayoutStyleProperty(QQuickItem *parent = 0);
     virtual ~QQuickMapboxGLLayoutStyleProperty() {}
-
-protected:
-    virtual void updateParent();
 };
 
 class Q_DECL_EXPORT QQuickMapboxGLPaintStyleProperty : public QQuickMapboxGLStyleProperty
@@ -62,9 +62,6 @@ public:
 
 signals:
     void classChanged(const QString &);
-
-protected:
-    virtual void updateParent();
 };
 
 #endif // QQUICKMAPBOXGLSTYLEPROPERTY_H

--- a/platform/qt/include/qquickmapboxglstyleproperty.hpp
+++ b/platform/qt/include/qquickmapboxglstyleproperty.hpp
@@ -28,6 +28,9 @@ public:
     void setValue(const QVariant &);
     QVariant value() const;
 
+public slots:
+    void checkUpdated();
+
 signals:
     void layerChanged(const QString &);
     void propertyChanged(const QString &);
@@ -36,7 +39,6 @@ signals:
 
 protected:
     QQuickMapboxGLStyleProperty(QQuickItem *parent, Type);
-    void checkUpdated();
 
     QVariantMap m_map;
 };

--- a/platform/qt/qmlapp/main.cpp
+++ b/platform/qt/qmlapp/main.cpp
@@ -4,6 +4,7 @@
 #include <qqml.h>
 
 #include <QQuickMapboxGL>
+#include <QQuickMapboxGLStyle>
 #include <QQuickMapboxGLStyleProperty>
 
 int main(int argc, char *argv[])
@@ -15,6 +16,7 @@ int main(int argc, char *argv[])
 #endif
 
     qmlRegisterType<QQuickMapboxGL>("QQuickMapboxGL", 1, 0, "MapboxMap");
+    qmlRegisterType<QQuickMapboxGLStyle>("QQuickMapboxGL", 1, 0, "MapboxStyle");
     qmlRegisterType<QQuickMapboxGLLayoutStyleProperty>("QQuickMapboxGL", 1, 0, "MapboxLayoutStyleProperty");
     qmlRegisterType<QQuickMapboxGLPaintStyleProperty>("QQuickMapboxGL", 1, 0, "MapboxPaintStyleProperty");
 

--- a/platform/qt/qmlapp/main.qml
+++ b/platform/qt/qmlapp/main.qml
@@ -277,6 +277,20 @@ ApplicationWindow {
                 onClicked: waterColorDialog.open()
             }
 
+            Button {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                text: "Light style"
+                onClicked: { mapStreets.style = "mapbox://styles/mapbox/light-v9" }
+            }
+
+            Button {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                text: "Dark style"
+                onClicked: { mapStreets.style = "mapbox://styles/mapbox/dark-v9" }
+            }
+
             CheckBox {
                 id: roadLabel
                 anchors.left: parent.left

--- a/platform/qt/qmlapp/main.qml
+++ b/platform/qt/qmlapp/main.qml
@@ -16,7 +16,7 @@ ApplicationWindow {
     ColorDialog {
         id: landColorDialog
         title: "Land color"
-        onCurrentColorChanged: { mapStreets.color = currentColor }
+        onCurrentColorChanged: { mapFront.color = currentColor }
     }
 
     ColorDialog {
@@ -26,21 +26,21 @@ ApplicationWindow {
     }
 
     MapboxLayoutStyleProperty {
-        parent: mapStreets
+        parent: styleStreets
         layer: "road-label-large"
         property: "visibility"
         value: roadLabel.checked ? "visible" : "none"
     }
 
     MapboxLayoutStyleProperty {
-        parent: mapStreets
+        parent: styleStreets
         layer: "road-label-medium"
         property: "visibility"
         value: roadLabel.checked ? "visible" : "none"
     }
 
     MapboxLayoutStyleProperty {
-        parent: mapStreets
+        parent: styleStreets
         layer: "road-label-small"
         property: "visibility"
         value: roadLabel.checked ? "visible" : "none"
@@ -70,12 +70,15 @@ ApplicationWindow {
                 anchors.fill: parent
 
                 MapboxMap {
-                    id: mapStreets
+                    id: mapFront
 
                     anchors.fill: parent
                     visible: false
 
-                    style: "mapbox://styles/mapbox/streets-v9"
+                    style: MapboxStyle {
+                        id: styleStreets
+                        url: "mapbox://styles/mapbox/streets-v9"
+                    }
 
                     center: QtPositioning.coordinate(60.170448, 24.942046) // Helsinki
                     zoomLevel: 14
@@ -124,7 +127,7 @@ ApplicationWindow {
                 OpacityMask {
                     anchors.fill: maskStreets
 
-                    source: mapStreets
+                    source: mapFront
                     maskSource: maskStreets
                 }
 
@@ -134,7 +137,7 @@ ApplicationWindow {
                     property var lastX: 0
                     property var lastY: 0
 
-                    onWheel: mapStreets.zoomLevel += 0.2 * wheel.angleDelta.y / 120
+                    onWheel: mapFront.zoomLevel += 0.2 * wheel.angleDelta.y / 120
 
                     onPressed: {
                         lastX = mouse.x
@@ -142,7 +145,7 @@ ApplicationWindow {
                     }
 
                     onPositionChanged: {
-                        mapStreets.pan(mouse.x - lastX, mouse.y - lastY)
+                        mapFront.pan(mouse.x - lastX, mouse.y - lastY)
 
                         lastX = mouse.x
                         lastY = mouse.y
@@ -154,20 +157,23 @@ ApplicationWindow {
                 anchors.fill: parent
 
                 MapboxMap {
-                    id: mapSatellite
+                    id: mapBack
 
                     anchors.fill: parent
                     visible: false
 
-                    style: "mapbox://styles/mapbox/satellite-streets-v9"
+                    style: MapboxStyle {
+                        id: styleSatellite
+                        url: "mapbox://styles/mapbox/satellite-streets-v9"
+                    }
 
-                    center: mapStreets.center
-                    zoomLevel: mapStreets.zoomLevel
-                    minimumZoomLevel: mapStreets.minimumZoomLevel
-                    maximumZoomLevel: mapStreets.maximumZoomLevel
+                    center: mapFront.center
+                    zoomLevel: mapFront.zoomLevel
+                    minimumZoomLevel: mapFront.minimumZoomLevel
+                    maximumZoomLevel: mapFront.maximumZoomLevel
 
-                    bearing: mapStreets.bearing
-                    pitch: mapStreets.pitch
+                    bearing: mapFront.bearing
+                    pitch: mapFront.pitch
 
                     Image {
                         anchors.right: parent.right
@@ -197,7 +203,7 @@ ApplicationWindow {
                 OpacityMask {
                     anchors.fill: maskSatellite
 
-                    source: mapSatellite
+                    source: mapBack
                     maskSource: maskSatellite
                 }
 
@@ -207,7 +213,7 @@ ApplicationWindow {
                     property var lastX: 0
                     property var lastY: 0
 
-                    onWheel: mapStreets.zoomLevel += 0.2 * wheel.angleDelta.y / 120
+                    onWheel: mapFront.zoomLevel += 0.2 * wheel.angleDelta.y / 120
 
                     onPressed: {
                         lastX = mouse.x
@@ -215,7 +221,7 @@ ApplicationWindow {
                     }
 
                     onPositionChanged: {
-                        mapStreets.pan(mouse.x - lastX, mouse.y - lastY)
+                        mapFront.pan(mouse.x - lastX, mouse.y - lastY)
 
                         lastX = mouse.x
                         lastY = mouse.y
@@ -281,14 +287,14 @@ ApplicationWindow {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 text: "Light style"
-                onClicked: { mapStreets.style = "mapbox://styles/mapbox/light-v9" }
+                onClicked: { styleStreets.url = "mapbox://styles/mapbox/light-v9" }
             }
 
             Button {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 text: "Dark style"
-                onClicked: { mapStreets.style = "mapbox://styles/mapbox/dark-v9" }
+                onClicked: { styleStreets.url = "mapbox://styles/mapbox/dark-v9" }
             }
 
             CheckBox {

--- a/platform/qt/qt5.cmake
+++ b/platform/qt/qt5.cmake
@@ -17,10 +17,12 @@ set(MBGL_QT_LIBRARIES
 
 add_library(qmapboxgl SHARED
     platform/qt/include/qquickmapboxgl.hpp
+    platform/qt/include/qquickmapboxglstyle.hpp
     platform/qt/include/qquickmapboxglstyleproperty.hpp
     platform/qt/src/qquickmapboxgl.cpp
     platform/qt/src/qquickmapboxglrenderer.cpp
     platform/qt/src/qquickmapboxglrenderer.hpp
+    platform/qt/src/qquickmapboxglstyle.cpp
     platform/qt/src/qquickmapboxglstyleproperty.cpp
 )
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -621,12 +621,12 @@ QMargins QMapboxGL::margins() const
     );
 }
 
-void QMapboxGL::addSource(const QString& sourceID, const QVariant& value)
+void QMapboxGL::addSource(const QString &sourceID, const QVariantMap &params)
 {
     using namespace mbgl::style;
     using namespace mbgl::style::conversion;
 
-    Result<std::unique_ptr<Source>> source = convert<std::unique_ptr<Source>>(value, sourceID.toStdString());
+    Result<std::unique_ptr<Source>> source = convert<std::unique_ptr<Source>>(QVariant(params), sourceID.toStdString());
     if (!source) {
         qWarning() << "Unable to add source:" << source.error().message.c_str();
         return;
@@ -658,12 +658,12 @@ void QMapboxGL::addCustomLayer(const QString &id,
             before ? mbgl::optional<std::string>(before) : mbgl::optional<std::string>());
 }
 
-void QMapboxGL::addLayer(const QVariant& value)
+void QMapboxGL::addLayer(const QVariantMap &params)
 {
     using namespace mbgl::style;
     using namespace mbgl::style::conversion;
 
-    Result<std::unique_ptr<Layer>> layer = convert<std::unique_ptr<Layer>>(value);
+    Result<std::unique_ptr<Layer>> layer = convert<std::unique_ptr<Layer>>(QVariant(params));
     if (!layer) {
         qWarning() << "Unable to add layer:" << layer.error().message.c_str();
         return;

--- a/platform/qt/src/qquickmapboxgl.cpp
+++ b/platform/qt/src/qquickmapboxgl.cpp
@@ -23,7 +23,9 @@ QQuickMapboxGL::~QQuickMapboxGL()
 
 QQuickFramebufferObject::Renderer *QQuickMapboxGL::createRenderer() const
 {
-    return new QQuickMapboxGLRenderer();
+    QQuickMapboxGLRenderer *renderer = new QQuickMapboxGLRenderer();
+    connect(renderer, SIGNAL(styleChanged()), this, SIGNAL(styleChanged()));
+    return renderer;
 }
 
 void QQuickMapboxGL::setPlugin(QDeclarativeGeoServiceProvider *)
@@ -267,11 +269,13 @@ void QQuickMapboxGL::itemChange(QQuickItem::ItemChange change, const QQuickItem:
     case QQuickItem::ItemChildAddedChange:
         if (QQuickMapboxGLStyleProperty *property = qobject_cast<QQuickMapboxGLStyleProperty *>(value.item)) {
             connect(property, SIGNAL(updated(QVariantMap)), this, SLOT(onStylePropertyUpdated(QVariantMap)));
+            connect(this, SIGNAL(styleChanged()), property, SLOT(checkUpdated()));
         }
         break;
     case QQuickItem::ItemChildRemovedChange:
         if (QQuickMapboxGLStyleProperty *property = qobject_cast<QQuickMapboxGLStyleProperty *>(value.item)) {
             disconnect(property, SIGNAL(updated(QVariantMap)), this, SLOT(onStylePropertyUpdated(QVariantMap)));
+            disconnect(this, SIGNAL(styleChanged()), property, SLOT(checkUpdated()));
         }
     default:
         break;

--- a/platform/qt/src/qquickmapboxgl.cpp
+++ b/platform/qt/src/qquickmapboxgl.cpp
@@ -156,7 +156,12 @@ void QQuickMapboxGL::setColor(const QColor &color)
 
     m_color = color;
 
-    setPaintProperty("background", "background-color", color);
+    QVariantMap paintProperty;
+    paintProperty["type"] = QQuickMapboxGLLayoutStyleProperty::PaintType;
+    paintProperty["layer"] = "background";
+    paintProperty["property"] = "background-color";
+    paintProperty["value"] = color;
+    onStylePropertyUpdated(paintProperty);
 
     emit colorChanged(m_color);
 }
@@ -171,18 +176,6 @@ void QQuickMapboxGL::pan(int dx, int dy)
     m_pan += QPointF(dx, -dy);
 
     m_syncState |= PanNeedsSync;
-    update();
-}
-
-void QQuickMapboxGL::setLayoutProperty(const QString &layer, const QString &property, const QVariant &value)
-{
-    m_layoutChanges.append(LayoutPropertyChange { layer, property, value });
-    update();
-}
-
-void QQuickMapboxGL::setPaintProperty(const QString &layer, const QString &property, const QVariant &value, const QString &klass)
-{
-    m_paintChanges.append(PaintPropertyChange { layer, property, value, klass });
     update();
 }
 

--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -28,9 +28,24 @@ QQuickMapboxGLRenderer::~QQuickMapboxGLRenderer()
 
 void QQuickMapboxGLRenderer::onMapChanged(QMapboxGL::MapChange change)
 {
-    if (change == QMapboxGL::MapChangeDidFinishLoadingMap) {
+    auto onMapChangeWillStartLoadingMap = [&]() {
+        m_styleLoaded = false;
+    };
+
+    auto onMapChangeDidFinishLoadingMap = [&]() {
         m_styleLoaded = true;
-        update();
+        emit styleChanged();
+    };
+
+    switch (change) {
+    case QMapboxGL::MapChangeWillStartLoadingMap:
+        onMapChangeWillStartLoadingMap();
+        break;
+    case QMapboxGL::MapChangeDidFinishLoadingMap:
+        onMapChangeDidFinishLoadingMap();
+        break;
+    default:
+        break;
     }
 }
 

--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -89,14 +89,14 @@ void QQuickMapboxGLRenderer::synchronize(QQuickFramebufferObject *item)
     if (m_styleLoaded) {
         if (!quickMap->layoutPropertyChanges().empty()) {
             for (const auto& change: quickMap->layoutPropertyChanges()) {
-                m_map->setLayoutProperty(change.layer, change.property, change.value);
+                m_map->setLayoutProperty(change.value("layer").toString(), change.value("property").toString(), change.value("value"));
             }
             quickMap->layoutPropertyChanges().clear();
         }
 
         if (!quickMap->paintPropertyChanges().empty()) {
             for (const auto& change: quickMap->paintPropertyChanges()) {
-                m_map->setPaintProperty(change.layer, change.property, change.value, change.klass);
+                m_map->setPaintProperty(change.value("layer").toString(), change.value("property").toString(), change.value("value"), change.value("class").toString());
             }
             quickMap->paintPropertyChanges().clear();
         }

--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -2,6 +2,7 @@
 
 #include <QMapboxGL>
 #include <QQuickMapboxGL>
+#include <QQuickMapboxGLStyle>
 
 #include <QSize>
 #include <QOpenGLFramebufferObject>
@@ -83,8 +84,8 @@ void QQuickMapboxGLRenderer::synchronize(QQuickFramebufferObject *item)
         m_map->setCoordinateZoom({ center.latitude(), center.longitude() }, quickMap->zoomLevel());
     }
 
-    if (syncStatus & QQuickMapboxGL::StyleNeedsSync) {
-        m_map->setStyleURL(quickMap->style());
+    if (syncStatus & QQuickMapboxGL::StyleNeedsSync && quickMap->style()) {
+        m_map->setStyleURL(quickMap->style()->url());
         m_styleLoaded = false;
     }
 

--- a/platform/qt/src/qquickmapboxglrenderer.hpp
+++ b/platform/qt/src/qquickmapboxglrenderer.hpp
@@ -25,6 +25,7 @@ public:
 
 signals:
     void centerChanged(const QGeoCoordinate &);
+    void styleChanged();
 
 public slots:
     void onMapChanged(QMapboxGL::MapChange);

--- a/platform/qt/src/qquickmapboxglstyle.cpp
+++ b/platform/qt/src/qquickmapboxglstyle.cpp
@@ -1,0 +1,59 @@
+#include <QQuickMapboxGLStyle>
+#include <QQuickMapboxGLStyleProperty>
+
+QQuickMapboxGLStyle::QQuickMapboxGLStyle(QQuickItem *parent)
+    : QQuickItem(parent)
+{
+}
+
+void QQuickMapboxGLStyle::itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &value)
+{
+    QQuickItem::itemChange(change, value);
+
+    switch (change) {
+    case QQuickItem::ItemChildAddedChange:
+        if (QQuickMapboxGLStyleProperty *property = qobject_cast<QQuickMapboxGLStyleProperty *>(value.item)) {
+            connect(property, SIGNAL(updated(QVariantMap)), this, SIGNAL(propertyUpdated(QVariantMap)));
+            connect(this, SIGNAL(urlChanged(QString)), property, SLOT(checkUpdated()));
+        }
+        break;
+    case QQuickItem::ItemChildRemovedChange:
+        if (QQuickMapboxGLStyleProperty *property = qobject_cast<QQuickMapboxGLStyleProperty *>(value.item)) {
+            disconnect(property, SIGNAL(updated(QVariantMap)), this, SIGNAL(propertyUpdated(QVariantMap)));
+            disconnect(this, SIGNAL(urlChanged(QString)), property, SLOT(checkUpdated()));
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+void QQuickMapboxGLStyle::setUrl(const QString &url)
+{
+    if (url == m_url) {
+        return;
+    }
+
+    m_url = url;
+    emit urlChanged(url);
+}
+
+QString QQuickMapboxGLStyle::url() const
+{
+    return m_url;
+}
+
+void QQuickMapboxGLStyle::setStyleClass(const QString &styleClass)
+{
+    if (styleClass == m_class) {
+        return;
+    }
+
+    m_class = styleClass;
+    emit classChanged(styleClass);
+}
+
+QString QQuickMapboxGLStyle::styleClass() const
+{
+    return m_class;
+}

--- a/platform/qt/src/qquickmapboxglstyleproperty.cpp
+++ b/platform/qt/src/qquickmapboxglstyleproperty.cpp
@@ -1,55 +1,20 @@
 #include <QQuickMapboxGLStyleProperty>
-#include <QQuickMapboxGL>
 
-QQuickMapboxGLStyleProperty::QQuickMapboxGLStyleProperty(QQuickItem *parent_)
+// QQuickMapboxGLStyleProperty
+
+QQuickMapboxGLStyleProperty::QQuickMapboxGLStyleProperty(QQuickItem *parent_, Type type)
     : QQuickItem(parent_)
 {
+    m_map["type"] = type;
 }
 
-QQuickMapboxGLLayoutStyleProperty::QQuickMapboxGLLayoutStyleProperty(QQuickItem *parent_)
-    : QQuickMapboxGLStyleProperty(parent_)
+void QQuickMapboxGLStyleProperty::checkUpdated()
 {
-}
-
-QQuickMapboxGLPaintStyleProperty::QQuickMapboxGLPaintStyleProperty(QQuickItem *parent_)
-    : QQuickMapboxGLStyleProperty(parent_)
-{
-}
-
-void QQuickMapboxGLLayoutStyleProperty::updateParent()
-{
-    if (m_map.value("layer").isNull() || m_map.value("property").isNull() || m_map.value("value").isNull()) {
-        return;
-    }
-
-    QQuickMapboxGL *map = qobject_cast<QQuickMapboxGL *>(parentItem());
-    if (map) {
-        map->setLayoutProperty(layer(), property(), value());
-    } else {
-        qWarning() << "Style property requires QQuickMapboxGL as parent item.";
-    }
-}
-
-void QQuickMapboxGLPaintStyleProperty::updateParent()
-{
-    if (m_map.value("layer").isNull() || m_map.value("property").isNull() || m_map.value("value").isNull()) {
-        return;
-    }
-
-    QQuickMapboxGL *map = qobject_cast<QQuickMapboxGL *>(parentItem());
-    if (map) {
-        map->setPaintProperty(layer(), property(), value(), styleClass());
-    } else {
-        qWarning() << "Style property requires QQuickMapboxGL as parent item.";
-    }
-}
-
-void QQuickMapboxGLStyleProperty::itemChange(QQuickItem::ItemChange change, const QQuickItem::ItemChangeData &data)
-{
-    QQuickItem::itemChange(change, data);
-
-    if (change == QQuickItem::ItemParentHasChanged) {
-        updateParent();
+    if (m_map.value("type").isValid()
+            && m_map.value("layer").isValid()
+            && m_map.value("property").isValid()
+            && m_map.value("value").isValid()) {
+        emit updated(m_map);
     }
 }
 
@@ -61,7 +26,7 @@ void QQuickMapboxGLStyleProperty::setLayer(const QString &layer)
 
     m_map["layer"] = layer;
     emit layerChanged(layer);
-    updateParent();
+    checkUpdated();
 }
 
 QString QQuickMapboxGLStyleProperty::layer() const
@@ -77,7 +42,7 @@ void QQuickMapboxGLStyleProperty::setProperty(const QString &property)
 
     m_map["property"] = property;
     emit propertyChanged(property);
-    updateParent();
+    checkUpdated();
 }
 
 QString QQuickMapboxGLStyleProperty::property() const
@@ -93,7 +58,7 @@ void QQuickMapboxGLStyleProperty::setValue(const QVariant &value)
 
     m_map["value"] = value;
     emit valueChanged(value);
-    updateParent();
+    checkUpdated();
 }
 
 QVariant QQuickMapboxGLStyleProperty::value() const
@@ -109,10 +74,24 @@ void QQuickMapboxGLPaintStyleProperty::setStyleClass(const QString &styleClass)
 
     m_map["class"] = styleClass;
     emit classChanged(styleClass);
-    updateParent();
+    checkUpdated();
 }
 
 QString QQuickMapboxGLPaintStyleProperty::styleClass() const
 {
     return m_map.value("class").toString();
+}
+
+// QQuickMapboxGLLayoutStyleProperty
+
+QQuickMapboxGLLayoutStyleProperty::QQuickMapboxGLLayoutStyleProperty(QQuickItem *parent_)
+    : QQuickMapboxGLStyleProperty(parent_, LayoutType)
+{
+}
+
+// QQuickMapboxGLPaintStyleProperty
+
+QQuickMapboxGLPaintStyleProperty::QQuickMapboxGLPaintStyleProperty(QQuickItem *parent_)
+    : QQuickMapboxGLStyleProperty(parent_, PaintType)
+{
 }

--- a/platform/qt/src/qquickmapboxglstyleproperty.cpp
+++ b/platform/qt/src/qquickmapboxglstyleproperty.cpp
@@ -18,13 +18,13 @@ QQuickMapboxGLPaintStyleProperty::QQuickMapboxGLPaintStyleProperty(QQuickItem *p
 
 void QQuickMapboxGLLayoutStyleProperty::updateParent()
 {
-    if (m_layer.isNull() || m_property.isNull() || m_value.isNull()) {
+    if (m_map.value("layer").isNull() || m_map.value("property").isNull() || m_map.value("value").isNull()) {
         return;
     }
 
     QQuickMapboxGL *map = qobject_cast<QQuickMapboxGL *>(parentItem());
     if (map) {
-        map->setLayoutProperty(layer(), property(), m_value);
+        map->setLayoutProperty(layer(), property(), value());
     } else {
         qWarning() << "Style property requires QQuickMapboxGL as parent item.";
     }
@@ -32,13 +32,13 @@ void QQuickMapboxGLLayoutStyleProperty::updateParent()
 
 void QQuickMapboxGLPaintStyleProperty::updateParent()
 {
-    if (m_layer.isNull() || m_property.isNull() || m_value.isNull()) {
+    if (m_map.value("layer").isNull() || m_map.value("property").isNull() || m_map.value("value").isNull()) {
         return;
     }
 
     QQuickMapboxGL *map = qobject_cast<QQuickMapboxGL *>(parentItem());
     if (map) {
-        map->setPaintProperty(layer(), property(), m_value, styleClass());
+        map->setPaintProperty(layer(), property(), value(), styleClass());
     } else {
         qWarning() << "Style property requires QQuickMapboxGL as parent item.";
     }
@@ -55,64 +55,64 @@ void QQuickMapboxGLStyleProperty::itemChange(QQuickItem::ItemChange change, cons
 
 void QQuickMapboxGLStyleProperty::setLayer(const QString &layer)
 {
-    if (layer == m_layer.toString()) {
+    if (m_map.value("layer").toString() == layer) {
         return;
     }
 
-    m_layer = layer;
+    m_map["layer"] = layer;
     emit layerChanged(layer);
     updateParent();
 }
 
 QString QQuickMapboxGLStyleProperty::layer() const
 {
-    return m_layer.toString();
+    return m_map.value("layer").toString();
 }
 
 void QQuickMapboxGLStyleProperty::setProperty(const QString &property)
 {
-    if (property == m_property.toString()) {
+    if (m_map.value("property").toString() == property) {
         return;
     }
 
-    m_property = property;
+    m_map["property"] = property;
     emit propertyChanged(property);
     updateParent();
 }
 
 QString QQuickMapboxGLStyleProperty::property() const
 {
-    return m_property.toString();
+    return m_map.value("property").toString();
 }
 
 void QQuickMapboxGLStyleProperty::setValue(const QVariant &value)
 {
-    if (value == m_value) {
+    if (m_map.value("value") == value) {
         return;
     }
 
-    m_value = value;
+    m_map["value"] = value;
     emit valueChanged(value);
     updateParent();
 }
 
 QVariant QQuickMapboxGLStyleProperty::value() const
 {
-    return m_value;
+    return m_map.value("value");
 }
 
 void QQuickMapboxGLPaintStyleProperty::setStyleClass(const QString &styleClass)
 {
-    if (styleClass == m_class.toString()) {
+    if (m_map.value("class").toString() == styleClass) {
         return;
     }
 
-    m_class = styleClass;
+    m_map["class"] = styleClass;
     emit classChanged(styleClass);
     updateParent();
 }
 
 QString QQuickMapboxGLPaintStyleProperty::styleClass() const
 {
-    return m_class.toString();
+    return m_map.value("class").toString();
 }

--- a/platform/qt/src/qt_conversion.hpp
+++ b/platform/qt/src/qt_conversion.hpp
@@ -42,8 +42,9 @@ inline optional<QVariant> objectMember(const QVariant& value, const char* key) {
     }
 }
 
-template <class Fn>
-optional<Error> eachMember(const QVariant& value, Fn&& fn) {
+using EachMemberFn = std::function<optional<Error>(const std::string&, const QVariant&)>;
+
+optional<Error> eachMember(const QVariant& value, EachMemberFn&& fn) {
     auto map = value.toMap();
     auto iter = map.constBegin();
 


### PR DESCRIPTION
This PR introduces a new QML item: `QQuickMapboxGLStyle`. This item is responsible for managing the Mapbox GL style, as seen on the QML example below:
```qml
...
MapboxMap {
    style: MapboxStyle {
        id: styleStreets
        style: "mapbox://styles/mapbox/streets-v9"
    }
    ...   
```

~~Now every `QQuickMapboxGLStyleProperty` can be a child item of either `QQuickMapboxGL` or `QQuickMapboxGLStyle`.~~ (as per discussion with @tmpsantos, we felt like style properties should only be children of the style to simplify the API).

A `QQuickMapboxGLStyleProperty` being a child of `QQuickMapboxGLStyle` assures that only properties associated with that particular style will reflect on the map - and that happens only when the style is the current set via `style` property.

Other changes in this PR includes:
- Invert parent/child notification mechanism: Now every parent item e.g. `QQuickMapboxGL` and `QQuickMapboxGLStyle` is responsible for connecting/disconnecting signals and slots for its child items upon insertion/removal, and not the opposite.
- Other minor cleanups and API simplifications.