### PR TITLE
[ios] Hit test the user location annotation dot specifically (redone for release branch)

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1392,17 +1392,21 @@ mbgl::Duration MGLDurationInSeconds(NSTimeInterval duration)
         return;
     }
 
-    CGPoint tapPoint = [singleTap locationInView:self];
-
-    CALayer *hitLayer = self.userLocationVisible ? [self.userLocationAnnotationView.layer.presentationLayer hitTest:tapPoint] : nil;
-    if (hitLayer && hitLayer != self.userLocationAnnotationView.haloLayer.presentationLayer)
+    if (self.userLocationVisible)
     {
-        if ( ! _userLocationAnnotationIsSelected)
+        CGPoint tapPointForUserLocation = [singleTap locationInView:self.userLocationAnnotationView];
+        CALayer *hitLayer = [self.userLocationAnnotationView.hitTestLayer hitTest:tapPointForUserLocation];
+        if (hitLayer)
         {
-            [self selectAnnotation:self.userLocation animated:YES];
+            if ( ! _userLocationAnnotationIsSelected)
+            {
+                [self selectAnnotation:self.userLocation animated:YES];
+            }
+            return;
         }
-        return;
     }
+
+    CGPoint tapPoint = [singleTap locationInView:self];
     
     MGLAnnotationTag hitAnnotationTag = [self annotationTagAtPoint:tapPoint persistingResults:YES];
     if (hitAnnotationTag != MGLAnnotationTagNotFound)

--- a/platform/ios/src/MGLUserLocationAnnotationView.h
+++ b/platform/ios/src/MGLUserLocationAnnotationView.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) MGLMapView *mapView;
 @property (nonatomic) MGLUserLocation *annotation;
 @property (nonatomic, readonly, nullable) CALayer *haloLayer;
+@property (nonatomic, readonly) CALayer *hitTestLayer;
 
 - (instancetype)initInMapView:(MGLMapView *)mapView NS_DESIGNATED_INITIALIZER;
 - (void)setupLayers;

--- a/platform/ios/src/MGLUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLUserLocationAnnotationView.m
@@ -147,6 +147,12 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
     }
 }
 
+- (CALayer *)hitTestLayer
+{
+    // only the main dot should be interactive (i.e., exclude the accuracy ring and halo)
+    return _dotBorderLayer ?: _puckDot;
+}
+
 - (void)setupLayers
 {
     if (CLLocationCoordinate2DIsValid(self.annotation.coordinate))


### PR DESCRIPTION
Fixes #5571 (which wasn’t completely covered by #5816). Rather than try to exclude layers in the touch hit test, this specifically only checks against the main layer for the user dot or puck.

Essentially a back-port of e4a9173a2a5c585dda3fa7a0f955cff1552f8d25 from #5882.

/cc @1ec5 @frederoni