### PR TITLE
[android] - fix scheduled build with cmake dependency

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -63,7 +63,7 @@ workflows:
             set -eu -o pipefail
 
             curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
-            apt-get install -y pkg-config python-pip python-dev build-essential nodejs
+            apt-get install -y pkg-config python-pip python-dev build-essential nodejs cmake
             pip install awscli
 
             aws s3 cp s3://mapbox/android/signing-credentials/secring.gpg platform/android/MapboxGLAndroidSDK/secring.gpg


### PR DESCRIPTION
Fixes our daily snapshot build by adding the cmake dependency.