### PR TITLE
[ios] Exclude NSData category's header from dynamic framework

### DIFF
--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -53,13 +53,11 @@
 		35136D4F1D4277FC00C20EFD /* MGLSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35136D4B1D4277FC00C20EFD /* MGLSource.mm */; };
 		35305D481D22AA680007D005 /* NSData+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35305D471D22AA450007D005 /* NSData+MGLAdditions.mm */; };
 		35305D491D22AA680007D005 /* NSData+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35305D471D22AA450007D005 /* NSData+MGLAdditions.mm */; };
-		35305D4A1D22AA6A0007D005 /* NSData+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35305D461D22AA450007D005 /* NSData+MGLAdditions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		353349B31D5CC6F20094E9DE /* amsterdam.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 353349B21D5CC6F20094E9DE /* amsterdam.geojson */; };
 		3534C7921D4BC95400D874A4 /* MGLStyleAttributeFunction_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3534C7911D4BC95400D874A4 /* MGLStyleAttributeFunction_Private.hpp */; };
 		3534C7931D4BC95400D874A4 /* MGLStyleAttributeFunction_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3534C7911D4BC95400D874A4 /* MGLStyleAttributeFunction_Private.hpp */; };
 		3534C7951D4BD1D400D874A4 /* MGLStyleAttributeValue_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3534C7941D4BD1D400D874A4 /* MGLStyleAttributeValue_Private.hpp */; };
 		3534C7961D4BD1D400D874A4 /* MGLStyleAttributeValue_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3534C7941D4BD1D400D874A4 /* MGLStyleAttributeValue_Private.hpp */; };
-		353794D01D22B3BD002C281C /* NSData+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35305D461D22AA450007D005 /* NSData+MGLAdditions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3538AA171D541C43008EC33D /* MGLStyleFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3538AA151D541C43008EC33D /* MGLStyleFilter.h */; };
 		3538AA181D541C43008EC33D /* MGLStyleFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3538AA151D541C43008EC33D /* MGLStyleFilter.h */; };
 		3538AA191D541C43008EC33D /* MGLStyleFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 3538AA161D541C43008EC33D /* MGLStyleFilter.m */; };
@@ -78,6 +76,7 @@
 		353933FC1D3FB7C0003F57D7 /* MGLRasterStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 353933FA1D3FB7C0003F57D7 /* MGLRasterStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		353933FE1D3FB7DD003F57D7 /* MGLSymbolStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 353933FD1D3FB7DD003F57D7 /* MGLSymbolStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		353933FF1D3FB7DD003F57D7 /* MGLSymbolStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 353933FD1D3FB7DD003F57D7 /* MGLSymbolStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35305D4A1D22AA6A0007D005 /* NSData+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35305D461D22AA450007D005 /* NSData+MGLAdditions.h */; };
 		353D23961D0B0DFE002BE09D /* MGLAnnotationViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 353D23951D0B0DFE002BE09D /* MGLAnnotationViewTests.m */; };
 		354D42DC1D4919F900F400A1 /* NSValue+MGLStyleAttributeAdditions_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 354D42DB1D4919F900F400A1 /* NSValue+MGLStyleAttributeAdditions_Private.hpp */; };
 		354D42DD1D4919F900F400A1 /* NSValue+MGLStyleAttributeAdditions_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 354D42DB1D4919F900F400A1 /* NSValue+MGLStyleAttributeAdditions_Private.hpp */; };
@@ -1449,7 +1448,6 @@
 				DABFB8601CBE99E500D62B32 /* MGLMapCamera.h in Headers */,
 				DA737EE21D056A4E005BDA16 /* MGLMapViewDelegate.h in Headers */,
 				3538AA181D541C43008EC33D /* MGLStyleFilter.h in Headers */,
-				353794D01D22B3BD002C281C /* NSData+MGLAdditions.h in Headers */,
 				DABFB86A1CBE99E500D62B32 /* MGLStyle.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
iOS SDK v3.3.x included [NSData+MGLAdditions.h](https://github.com/mapbox/mapbox-gl-native/blob/c354ae523a00b4c0e0577c4784b53553ea1a1cb7/platform/darwin/src/NSData%2BMGLAdditions.h) in its dynamic framework package, in a “PrivateHeaders” folder:

![screen shot 2016-08-10 at 9 34 30 pm](https://cloud.githubusercontent.com/assets/1198851/17576606/7f61a43c-5f42-11e6-89b9-0c41f5c978cd.png)

This private category on NSData is for gzip compression, which is only used internally.

The file was not included in the static framework. Somewhat counterintuitively, marking headers “Private” still includes the files in packaged builds — one must mark files “Project” to exclude them:

![screen shot 2016-08-10 at 10 14 41 pm](https://cloud.githubusercontent.com/assets/1198851/17577097/e38fe310-5f47-11e6-8c31-fe41c5abab87.png)


/cc @frederoni