### PR TITLE
Restore FBO and Viewport on GL reset

### DIFF
--- a/include/mbgl/gl/gl.hpp
+++ b/include/mbgl/gl/gl.hpp
@@ -21,6 +21,7 @@
     #elif TARGET_OS_MAC
         #include <OpenGL/OpenGL.h>
         #include <OpenGL/gl.h>
+        #include <OpenGL/glext.h>
     #else
         #error Unsupported Apple platform
     #endif

--- a/include/mbgl/gl/gl_values.hpp
+++ b/include/mbgl/gl/gl_values.hpp
@@ -271,6 +271,31 @@ struct ActiveTexture {
     }
 };
 
+struct BindFramebuffer {
+    using Type = GLint;
+    static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glBindFramebuffer(GL_FRAMEBUFFER, value));
+    }
+    static Type Get() {
+        Type activeFBO;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &activeFBO));
+        return activeFBO;
+    }
+};
+
+struct Viewport {
+    using Type = std::array<GLint, 4>;
+    static void Set(const Type& value) {
+        MBGL_CHECK_ERROR(glViewport(value[0], value[1], value[2], value[3]));
+    }
+    static Type Get() {
+        Type pos;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_VIEWPORT, pos.data()));
+        return pos;
+    }
+};
+
+
 #ifndef GL_ES_VERSION_2_0
 
 struct PixelZoom {

--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -26,6 +26,7 @@ struct CustomLayerRenderParameters {
     double bearing;
     double pitch;
     double altitude;
+    int framebuffer;
 };
 
 /**

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -51,6 +51,7 @@ struct Q_DECL_EXPORT CustomLayerRenderParameters {
     double bearing;
     double pitch;
     double altitude;
+    int framebuffer;
 };
 
 struct Q_DECL_EXPORT TransitionOptions {

--- a/src/mbgl/gl/gl_config.hpp
+++ b/src/mbgl/gl/gl_config.hpp
@@ -9,6 +9,20 @@
 namespace mbgl {
 namespace gl {
 
+
+template <typename T, typename = void>
+struct DefaultValue {
+    static typename T::Type Get() {
+        return T::Get();
+    }
+};
+template <typename T>
+struct DefaultValue<T, decltype(T::Default, void())> {
+    static typename T::Type Get() {
+        return T::Default;
+    }
+};
+
 template <typename T>
 class Value {
 public:
@@ -25,7 +39,7 @@ public:
     }
 
     void reset() {
-        *this = T::Default;
+        *this = defaultValue;
     }
 
     void setDirty() {
@@ -40,8 +54,13 @@ public:
         return dirty;
     }
 
+    void setDefaultValue(const typename T::Type& value) {
+        defaultValue = value;
+    }
+
 private:
-    typename T::Type current = T::Default;
+    typename T::Type defaultValue = DefaultValue<T>::Get();
+    typename T::Type current = defaultValue;
     bool dirty = false;
 };
 
@@ -66,6 +85,8 @@ public:
         program.reset();
         lineWidth.reset();
         activeTexture.reset();
+        bindFramebuffer.reset();
+        viewport.reset();
 #ifndef GL_ES_VERSION_2_0
         pixelZoom.reset();
         rasterPos.reset();
@@ -91,6 +112,8 @@ public:
         program.setDirty();
         lineWidth.setDirty();
         activeTexture.setDirty();
+        bindFramebuffer.setDirty();
+        viewport.setDirty();
 #ifndef GL_ES_VERSION_2_0
         pixelZoom.setDirty();
         rasterPos.setDirty();
@@ -115,6 +138,8 @@ public:
     Value<Program> program;
     Value<LineWidth> lineWidth;
     Value<ActiveTexture> activeTexture;
+    Value<BindFramebuffer> bindFramebuffer;
+    Value<Viewport> viewport;
 #ifndef GL_ES_VERSION_2_0
     Value<PixelZoom> pixelZoom;
     Value<RasterPos> rasterPos;

--- a/src/mbgl/gl/object_store.cpp
+++ b/src/mbgl/gl/object_store.cpp
@@ -34,6 +34,11 @@ void VAODeleter::operator()(GLuint id) const {
     store->abandonedVAOs.push_back(id);
 }
 
+void FBODeleter::operator()(GLuint id) const {
+    assert(store);
+    store->abandonedFBOs.push_back(id);
+}
+
 ObjectStore::~ObjectStore() {
     assert(pooledTextures.empty());
     assert(abandonedPrograms.empty());
@@ -41,6 +46,7 @@ ObjectStore::~ObjectStore() {
     assert(abandonedBuffers.empty());
     assert(abandonedTextures.empty());
     assert(abandonedVAOs.empty());
+    assert(abandonedFBOs.empty());
 }
 
 void ObjectStore::reset() {
@@ -73,6 +79,11 @@ void ObjectStore::performCleanup() {
     if (!abandonedVAOs.empty()) {
         MBGL_CHECK_ERROR(gl::DeleteVertexArrays(int(abandonedVAOs.size()), abandonedVAOs.data()));
         abandonedVAOs.clear();
+    }
+
+    if (!abandonedFBOs.empty()) {
+        MBGL_CHECK_ERROR(glDeleteFramebuffers(int(abandonedFBOs.size()), abandonedFBOs.data()));
+        abandonedFBOs.clear();
     }
 }
 

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -263,7 +263,7 @@ void Painter::renderPass(PaintParameters& parameters,
         } else if (layer.is<CustomLayer>()) {
             MBGL_DEBUG_GROUP(layer.baseImpl->id + " - custom");
             VertexArrayObject::Unbind();
-            layer.as<CustomLayer>()->impl->render(state);
+            layer.as<CustomLayer>()->impl->render(state, config.bindFramebuffer.getCurrent());
             config.setDirty();
             config.bindFramebuffer.reset();
             config.viewport.reset();

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -64,6 +64,10 @@ void Painter::setClipping(const ClipID& clip) {
 }
 
 void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& annotationSpriteAtlas) {
+    if (frame.framebufferSize != frame_.framebufferSize) {
+        config.viewport.setDefaultValue(
+            { { 0, 0, frame_.framebufferSize[0], frame_.framebufferSize[1] } });
+    }
     frame = frame_;
 
     PaintParameters parameters {
@@ -120,6 +124,8 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
     // tiles whatsoever.
     {
         MBGL_DEBUG_GROUP("clear");
+        config.bindFramebuffer.reset();
+        config.viewport.reset();
         config.stencilFunc.reset();
         config.stencilTest = GL_TRUE;
         config.stencilMask = 0xFF;
@@ -259,6 +265,8 @@ void Painter::renderPass(PaintParameters& parameters,
             VertexArrayObject::Unbind();
             layer.as<CustomLayer>()->impl->render(state);
             config.setDirty();
+            config.bindFramebuffer.reset();
+            config.viewport.reset();
         } else {
             MBGL_DEBUG_GROUP(layer.baseImpl->id + " - " + util::toString(item.tile->id));
             if (item.bucket->needsClipping()) {

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -43,7 +43,7 @@ void CustomLayer::Impl::initialize() {
     initializeFn(context);
 }
 
-void CustomLayer::Impl::render(const TransformState& state) const {
+void CustomLayer::Impl::render(const TransformState& state, int framebuffer) const {
     assert(renderFn);
 
     CustomLayerRenderParameters parameters;
@@ -56,6 +56,7 @@ void CustomLayer::Impl::render(const TransformState& state) const {
     parameters.bearing = -state.getAngle() * util::RAD2DEG;
     parameters.pitch = state.getPitch();
     parameters.altitude = state.getAltitude();
+    parameters.framebuffer = framebuffer;
 
     renderFn(context, parameters);
 }

--- a/src/mbgl/style/layers/custom_layer_impl.hpp
+++ b/src/mbgl/style/layers/custom_layer_impl.hpp
@@ -21,7 +21,7 @@ public:
     ~Impl() final;
 
     void initialize();
-    void render(const TransformState&) const;
+    void render(const TransformState&, int framebuffer) const;
 
 private:
     std::unique_ptr<Layer> clone() const override;


### PR DESCRIPTION
When resetting the GL configuration object, we are currently not resetting the Framebuffer binding and the viewport.