### PR TITLE
Fix compiler warning about std::move

### DIFF
--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -142,7 +142,7 @@ static NSURL *MGLStyleURL_emerald;
 
 - (void)addSource:(MGLSource *)source
 {
-    self.mapView.mbglMap->addSource(std::move([source mbgl_source]));
+    self.mapView.mbglMap->addSource([source mbgl_source]);
 }
 
 - (void)removeSource:(MGLSource *)source


### PR DESCRIPTION
Fixes #5943.

@frederoni, do you recall why this `move` was added?