### PR TITLE
[android] #5875 - MapboxMap options not parceling drawables

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -4,14 +4,18 @@ import android.app.Fragment;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
 import com.mapbox.mapboxsdk.MapboxAccountManager;
+import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.InvalidAccessTokenException;
 
@@ -59,6 +63,7 @@ public final class MapFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
+        Context context = inflater.getContext();
         MapboxMapOptions options = null;
 
         // Get bundle
@@ -84,6 +89,23 @@ public final class MapFragment extends Fragment {
                 options.accessToken(token);
             }
         }
+
+        Drawable foregroundDrawable = options.getMyLocationForegroundDrawable();
+        Drawable foregroundBearingDrawable = options.getMyLocationForegroundBearingDrawable();
+        if (foregroundDrawable == null || foregroundBearingDrawable == null) {
+            if (foregroundDrawable == null) {
+                foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.ic_mylocationview_normal);
+            }
+            if (foregroundBearingDrawable == null) {
+                foregroundBearingDrawable = ContextCompat.getDrawable(context, R.drawable.ic_mylocationview_bearing);
+            }
+            options.myLocationForegroundDrawables(foregroundDrawable, foregroundBearingDrawable);
+        }
+
+        if (options.getMyLocationBackgroundDrawable() == null) {
+            options.myLocationBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.ic_mylocationview_background));
+        }
+
         return mMap = new MapView(inflater.getContext(), options);
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -116,9 +116,20 @@ public class MapboxMapOptions implements Parcelable {
 
         myLocationEnabled = in.readByte() != 0;
 
-        myLocationForegroundDrawable = new BitmapDrawable((Bitmap) in.readParcelable(getClass().getClassLoader()));
-        myLocationForegroundBearingDrawable = new BitmapDrawable((Bitmap) in.readParcelable(getClass().getClassLoader()));
-        myLocationBackgroundDrawable = new BitmapDrawable((Bitmap) in.readParcelable(getClass().getClassLoader()));
+        Bitmap foregroundBitmap = in.readParcelable(getClass().getClassLoader());
+        if (foregroundBitmap != null) {
+            myLocationForegroundDrawable = new BitmapDrawable(foregroundBitmap);
+        }
+
+        Bitmap foregroundBearingBitmap = in.readParcelable(getClass().getClassLoader());
+        if(foregroundBearingBitmap!=null) {
+            myLocationForegroundBearingDrawable = new BitmapDrawable(foregroundBearingBitmap);
+        }
+
+        Bitmap backgroundBitmap = in.readParcelable(getClass().getClassLoader());
+        if(backgroundBitmap!=null){
+            myLocationBackgroundDrawable = new BitmapDrawable(backgroundBitmap);
+        }
 
         myLocationForegroundTintColor = in.readInt();
         myLocationBackgroundTintColor = in.readInt();
@@ -892,9 +903,10 @@ public class MapboxMapOptions implements Parcelable {
         dest.writeByte((byte) (zoomGesturesEnabled ? 1 : 0));
 
         dest.writeByte((byte) (myLocationEnabled ? 1 : 0));
-        dest.writeParcelable(getBitmapFromDrawable(myLocationForegroundDrawable), flags);
-        dest.writeParcelable(getBitmapFromDrawable(myLocationForegroundBearingDrawable), flags);
-        dest.writeParcelable(getBitmapFromDrawable(myLocationBackgroundDrawable), flags);
+
+        dest.writeParcelable(myLocationForegroundDrawable != null ? getBitmapFromDrawable(myLocationForegroundDrawable) : null, flags);
+        dest.writeParcelable(myLocationForegroundBearingDrawable != null ? getBitmapFromDrawable(myLocationForegroundBearingDrawable) : null, flags);
+        dest.writeParcelable(myLocationBackgroundDrawable != null ? getBitmapFromDrawable(myLocationBackgroundDrawable) : null, flags);
         dest.writeInt(myLocationForegroundTintColor);
         dest.writeInt(myLocationBackgroundTintColor);
         dest.writeIntArray(myLocationBackgroundPadding);
@@ -917,6 +929,7 @@ public class MapboxMapOptions implements Parcelable {
         if (compassGravity != options.compassGravity) return false;
         if (logoEnabled != options.logoEnabled) return false;
         if (logoGravity != options.logoGravity) return false;
+        if (attributionTintColor != options.attributionTintColor) return false;
         if (attributionEnabled != options.attributionEnabled) return false;
         if (attributionGravity != options.attributionGravity) return false;
         if (Float.compare(options.minZoom, minZoom) != 0) return false;
@@ -946,6 +959,7 @@ public class MapboxMapOptions implements Parcelable {
             return false;
         if (style != null ? !style.equals(options.style) : options.style != null) return false;
         return accessToken != null ? accessToken.equals(options.accessToken) : options.accessToken == null;
+
     }
 
     @Override
@@ -958,6 +972,7 @@ public class MapboxMapOptions implements Parcelable {
         result = 31 * result + (logoEnabled ? 1 : 0);
         result = 31 * result + logoGravity;
         result = 31 * result + Arrays.hashCode(logoMargins);
+        result = 31 * result + attributionTintColor;
         result = 31 * result + (attributionEnabled ? 1 : 0);
         result = 31 * result + attributionGravity;
         result = 31 * result + Arrays.hashCode(attributionMargins);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -2,14 +2,19 @@ package com.mapbox.mapboxsdk.maps;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.VectorDrawable;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -110,9 +115,11 @@ public class MapboxMapOptions implements Parcelable {
         zoomGesturesEnabled = in.readByte() != 0;
 
         myLocationEnabled = in.readByte() != 0;
-        //myLocationForegroundDrawable;
-        //myLocationForegroundBearingDrawable;
-        //myLocationBackgroundDrawable;
+
+        myLocationForegroundDrawable = new BitmapDrawable((Bitmap) in.readParcelable(getClass().getClassLoader()));
+        myLocationForegroundBearingDrawable = new BitmapDrawable((Bitmap) in.readParcelable(getClass().getClassLoader()));
+        myLocationBackgroundDrawable = new BitmapDrawable((Bitmap) in.readParcelable(getClass().getClassLoader()));
+
         myLocationForegroundTintColor = in.readInt();
         myLocationBackgroundTintColor = in.readInt();
         myLocationBackgroundPadding = in.createIntArray();
@@ -121,6 +128,20 @@ public class MapboxMapOptions implements Parcelable {
 
         style = in.readString();
         accessToken = in.readString();
+    }
+
+    public static Bitmap getBitmapFromDrawable(Drawable drawable) {
+        if (drawable instanceof BitmapDrawable) {
+            return ((BitmapDrawable) drawable).getBitmap();
+        } else if (drawable instanceof VectorDrawable || drawable instanceof VectorDrawableCompat) {
+            Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+            drawable.draw(canvas);
+            return bitmap;
+        } else {
+            throw new IllegalArgumentException("unsupported drawable type");
+        }
     }
 
     /**
@@ -871,9 +892,9 @@ public class MapboxMapOptions implements Parcelable {
         dest.writeByte((byte) (zoomGesturesEnabled ? 1 : 0));
 
         dest.writeByte((byte) (myLocationEnabled ? 1 : 0));
-        //myLocationForegroundDrawable;
-        //myLocationForegroundBearingDrawable;
-        //myLocationBackgroundDrawable;
+        dest.writeParcelable(getBitmapFromDrawable(myLocationForegroundDrawable), flags);
+        dest.writeParcelable(getBitmapFromDrawable(myLocationForegroundBearingDrawable), flags);
+        dest.writeParcelable(getBitmapFromDrawable(myLocationBackgroundDrawable), flags);
         dest.writeInt(myLocationForegroundTintColor);
         dest.writeInt(myLocationBackgroundTintColor);
         dest.writeIntArray(myLocationBackgroundPadding);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -7,6 +7,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.VectorDrawable;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -144,14 +145,12 @@ public class MapboxMapOptions implements Parcelable {
     public static Bitmap getBitmapFromDrawable(Drawable drawable) {
         if (drawable instanceof BitmapDrawable) {
             return ((BitmapDrawable) drawable).getBitmap();
-        } else if (drawable instanceof VectorDrawable || drawable instanceof VectorDrawableCompat) {
+        } else {
             Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
             Canvas canvas = new Canvas(bitmap);
             drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
             drawable.draw(canvas);
             return bitmap;
-        } else {
-            throw new IllegalArgumentException("unsupported drawable type");
         }
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -3,15 +3,19 @@ package com.mapbox.mapboxsdk.maps;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
 import com.mapbox.mapboxsdk.MapboxAccountManager;
+import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.InvalidAccessTokenException;
 
@@ -68,6 +72,7 @@ public class SupportMapFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
+        Context context = inflater.getContext();
         MapboxMapOptions options = null;
 
         // Get bundle
@@ -93,6 +98,23 @@ public class SupportMapFragment extends Fragment {
                 options.accessToken(token);
             }
         }
+
+        Drawable foregroundDrawable = options.getMyLocationForegroundDrawable();
+        Drawable foregroundBearingDrawable = options.getMyLocationForegroundBearingDrawable();
+        if (foregroundDrawable == null || foregroundBearingDrawable == null) {
+            if (foregroundDrawable == null) {
+                foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.ic_mylocationview_normal);
+            }
+            if (foregroundBearingDrawable == null) {
+                foregroundBearingDrawable = ContextCompat.getDrawable(context, R.drawable.ic_mylocationview_bearing);
+            }
+            options.myLocationForegroundDrawables(foregroundDrawable, foregroundBearingDrawable);
+        }
+
+        if (options.getMyLocationBackgroundDrawable() == null) {
+            options.myLocationBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.ic_mylocationview_background));
+        }
+
         return mMap = new MapView(inflater.getContext(), options);
     }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
@@ -7,6 +7,7 @@ import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.utils.MockParcel;
 
 import org.junit.Test;
 
@@ -177,13 +178,12 @@ public class MapboxMapOptionsTest {
         assertEquals(Color.BLUE, new MapboxMapOptions().myLocationBackgroundTintColor(Color.BLUE).getMyLocationBackgroundTintColor());
     }
 
-// Disabled test due to Bitmap parceable issue
-//    @Test
-//    public void testParceable() {
-//        MapboxMapOptions options = new MapboxMapOptions().camera(new CameraPosition.Builder().build()).styleUrl("s").accessToken("a").debugActive(true).compassMargins(new int[]{0, 1, 2, 3});
-//        MapboxMapOptions parceled = (MapboxMapOptions) MockParcel.obtain(options);
-//        assertEquals(options, parceled);
-//    }
+    @Test
+    public void testParceable() {
+        MapboxMapOptions options = new MapboxMapOptions().camera(new CameraPosition.Builder().build()).styleUrl("s").accessToken("a").debugActive(true).compassMargins(new int[]{0, 1, 2, 3});
+        MapboxMapOptions parceled = (MapboxMapOptions) MockParcel.obtain(options);
+        assertEquals(options, parceled);
+    }
 
     @Test
     public void testAccessToken() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
@@ -7,7 +7,6 @@ import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.utils.MockParcel;
 
 import org.junit.Test;
 
@@ -178,12 +177,13 @@ public class MapboxMapOptionsTest {
         assertEquals(Color.BLUE, new MapboxMapOptions().myLocationBackgroundTintColor(Color.BLUE).getMyLocationBackgroundTintColor());
     }
 
-    @Test
-    public void testParceable() {
-        MapboxMapOptions options = new MapboxMapOptions().camera(new CameraPosition.Builder().build()).styleUrl("s").accessToken("a").debugActive(true).compassMargins(new int[]{0, 1, 2, 3});
-        MapboxMapOptions parceled = (MapboxMapOptions) MockParcel.obtain(options);
-        assertEquals(options, parceled);
-    }
+// Disabled test due to Bitmap parceable issue
+//    @Test
+//    public void testParceable() {
+//        MapboxMapOptions options = new MapboxMapOptions().camera(new CameraPosition.Builder().build()).styleUrl("s").accessToken("a").debugActive(true).compassMargins(new int[]{0, 1, 2, 3});
+//        MapboxMapOptions parceled = (MapboxMapOptions) MockParcel.obtain(options);
+//        assertEquals(options, parceled);
+//    }
 
     @Test
     public void testAccessToken() {


### PR DESCRIPTION
closes #5875 

We weren't correctly parceling drawable related to MyLocationView. This resulted in "not" showing the MyLocationView interaction with fragments. This is the item mentioned in the Friday meeting that was supposably a blocker for release.

cc @zugaldia 