### PR TITLE
[core] Compare unsigned int to unsigned int to pass tidy check

### DIFF
--- a/test/api/annotations.cpp
+++ b/test/api/annotations.cpp
@@ -227,7 +227,7 @@ TEST(Annotations, QueryRenderedFeatures) {
     EXPECT_EQ(*features[0].id, 0);
 
     auto features2 = test.map.queryRenderedFeatures(test.map.pixelForLatLng({ 50, 0 }));
-    EXPECT_EQ(features2.size(), 1);
+    EXPECT_EQ(features2.size(), 1u);
     EXPECT_TRUE(!!features2[0].id);
     EXPECT_EQ(*features2[0].id, 1);
 }


### PR DESCRIPTION
This fixes the travis error we are seeing (i.e. https://travis-ci.org/mapbox/mapbox-gl-native/jobs/151947796) from a test added in https://github.com/mapbox/mapbox-gl-native/pull/5165

cc @1ec5 