### PR TITLE
Restore macOS unit tests on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,10 @@ offline: $(MACOS_PROJ_PATH)
 node: $(MACOS_PROJ_PATH)
 	set -o pipefail && $(MACOS_XCODEBUILD) -scheme 'mbgl-node' build $(XCPRETTY)
 
+.PHONY: macos-test
+macos-test: $(MACOS_PROJ_PATH)
+	set -o pipefail && $(MACOS_XCODEBUILD) -scheme 'CI' test $(XCPRETTY)
+
 .PHONY: xpackage
 xpackage: $(MACOS_PROJ_PATH)
 	SYMBOLS=$(SYMBOLS) ./platform/macos/scripts/package.sh

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -59,7 +59,7 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
                                                              appropriateForURL:nil
                                                                         create:YES
                                                                          error:nil];
-    NSString *bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
+    NSString *bundleIdentifier = [self bundleIdentifier];
     if (!bundleIdentifier) {
         // There’s no main bundle identifier when running in a unit test bundle.
         bundleIdentifier = [NSBundle bundleForClass:self].bundleIdentifier;
@@ -93,7 +93,7 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
     NSString *legacyCachePath = [legacyPaths.firstObject stringByAppendingPathComponent:MGLOfflineStorageFileName3_2_0_beta_1];
 #elif TARGET_OS_MAC
     // ~/Library/Caches/tld.app.bundle.id/offline.db
-    NSString *bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
+    NSString *bundleIdentifier = [self bundleIdentifier];
     NSURL *legacyCacheDirectoryURL = [[NSFileManager defaultManager] URLForDirectory:NSCachesDirectory
                                                                             inDomain:NSUserDomainMask
                                                                    appropriateForURL:nil
@@ -135,6 +135,15 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = @"MaximumCount";
                                                context:NULL];
     }
     return self;
+}
+
++ (NSString *)bundleIdentifier {
+    NSString *bundleIdentifier = [NSBundle mainBundle].bundleIdentifier;
+    if (!bundleIdentifier) {
+        // There’s no main bundle identifier when running in a unit test bundle.
+        bundleIdentifier = [NSBundle bundleForClass:self].bundleIdentifier;
+    }
+    return bundleIdentifier;
 }
 
 - (void)dealloc {

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -23,7 +23,7 @@ workflows:
                 envman add --key SKIPCI --value false
             fi
     - script:
-        title: Run build
+        title: Install Dependencies
         run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
@@ -32,12 +32,28 @@ workflows:
             brew install cmake
             brew tap mapbox/homebrew-ios-sim-3
             brew install mapbox/homebrew-ios-sim-3/ios-sim
-            gem install xcpretty --no-rdoc --no-ri
-            gem install jazzy --no-rdoc --no-ri
-            export BUILDTYPE=Debug
-            make ios
-            make ios-test
         - is_debug: 'yes'
+    - script:
+        title: Generate Workspace
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            export BUILDTYPE=Debug
+            make iproj
+        - is_debug: 'yes'
+    - xcode-test:
+        title: Run SDK Unit Tests
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - project_path: platform/ios/ios.xcworkspace
+        - scheme: CI
+    - deploy-to-bitrise-io:
+        title: Deploy to Bitrise.io
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - notify_user_groups: none
     - slack:
         title: Post to Slack
         run_if: '{{enveq "SKIPCI" "false"}}'

--- a/platform/macos/bitrise.yml
+++ b/platform/macos/bitrise.yml
@@ -34,6 +34,7 @@ workflows:
             export BUILDTYPE=Debug
             make macos
             make test
+            make macos-test
         - is_debug: 'yes'
     - slack:
         title: Post to Slack

--- a/platform/macos/bitrise.yml
+++ b/platform/macos/bitrise.yml
@@ -23,7 +23,7 @@ workflows:
                 envman add --key SKIPCI --value false
             fi
     - script:
-        title: Run build script
+        title: Install Dependencies
         run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
@@ -31,11 +31,43 @@ workflows:
             set -eu -o pipefail
             brew install cmake
             gem install xcpretty --no-rdoc --no-ri
+        - is_debug: 'yes'
+    - script:
+        title: Generate Workspace
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
             export BUILDTYPE=Debug
-            make macos
+            make xproj
+        - is_debug: 'yes'
+    - script:
+        title: Run Core Tests
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            export BUILDTYPE=Debug
             make test
+        - is_debug: 'yes'
+    - script:
+        title: Run SDK Unit Tests
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            export BUILDTYPE=Debug
+            export XCPRETTY="| tee ${BITRISE_DEPLOY_DIR}/raw-xcodebuild-output.txt | xcpretty --color --report html --output ${BITRISE_DEPLOY_DIR}/xcode-test-results.html"
             make macos-test
         - is_debug: 'yes'
+    - deploy-to-bitrise-io:
+        title: Deploy to Bitrise.io
+        run_if: '{{enveq "SKIPCI" "false"}}'
+        inputs:
+        - notify_user_groups: none
     - slack:
         title: Post to Slack
         run_if: '{{enveq "SKIPCI" "false"}}'


### PR DESCRIPTION
Restored the make rule for running macOS SDK unit tests. Invoke that rule on Bitrise. Note that the tests will fail to build until #5994 is merged.

Fixes #5991.

/cc @kkaefer