### PR TITLE
Source-driven attribution

### DIFF
--- a/platform/darwin/src/MGLAttributionInfo.h
+++ b/platform/darwin/src/MGLAttributionInfo.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosFromHTMLString:(NSString *)htmlString fontSize:(CGFloat)fontSize linkColor:(nullable MGLColor *)linkColor;
 
-- (instancetype)initWithTitle:(NSAttributedString *)title URL:(NSURL *)URL;
+- (instancetype)initWithTitle:(NSAttributedString *)title URL:(nullable NSURL *)URL;
 
 @property (nonatomic) NSAttributedString *title;
 @property (nonatomic, nullable) NSURL *URL;

--- a/platform/darwin/src/MGLAttributionInfo.h
+++ b/platform/darwin/src/MGLAttributionInfo.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 #import "MGLTypes.h"
 
@@ -15,12 +16,16 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Parses and returns the attribution infos contained in the given HTML source
  code string.
+ 
+ @param htmlString The HTML source code to parse.
+ @param fontSize The default text size in points.
+ @param linkColor The default link color.
  */
-+ (NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosFromHTMLString:(NSString *)htmlString;
++ (NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosFromHTMLString:(NSString *)htmlString fontSize:(CGFloat)fontSize linkColor:(nullable MGLColor *)linkColor;
 
-- (instancetype)initWithTitle:(NSString *)title URL:(NSURL *)URL;
+- (instancetype)initWithTitle:(NSAttributedString *)title URL:(NSURL *)URL;
 
-@property (nonatomic) NSString *title;
+@property (nonatomic) NSAttributedString *title;
 @property (nonatomic) NSURL *URL;
 
 @end

--- a/platform/darwin/src/MGLAttributionInfo.h
+++ b/platform/darwin/src/MGLAttributionInfo.h
@@ -3,8 +3,6 @@
 
 #import "MGLTypes.h"
 
-#include <vector>
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -27,6 +25,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSAttributedString *title;
 @property (nonatomic, nullable) NSURL *URL;
+
+@end
+
+@interface NSMutableArray (MGLAttributionInfoAdditions)
+
+/**
+ Adds the given attribution info object to the receiver as long as it isn’t
+ redundant to any object already in the receiver. Any existing object that is
+ redundant to the given object is replaced by the given object.
+ 
+ @param info The info object to add to the receiver.
+ @return True if the given info object was added to the receiver.
+ */
+- (void)growArrayByAddingAttributionInfo:(MGLAttributionInfo *)info;
+
+/**
+ Adds each of the given attribution info objects to the receiver as long as it
+ isn’t redundant to any object already in the receiver. Any existing object that
+ is redundant to the given object is replaced by the given object.
+ 
+ @param infos An array of info objects to add to the receiver.
+ */
+- (void)growArrayByAddingAttributionInfosFromArray:(NS_ARRAY_OF(MGLAttributionInfo *) *)infos;
 
 @end
 

--- a/platform/darwin/src/MGLAttributionInfo.h
+++ b/platform/darwin/src/MGLAttributionInfo.h
@@ -1,0 +1,28 @@
+#import <Foundation/Foundation.h>
+
+#import "MGLTypes.h"
+
+#include <vector>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Information about an attribution statement, usually a copyright or trademark
+ statement, associated with a map source.
+ */
+@interface MGLAttributionInfo : NSObject
+
+/**
+ Parses and returns the attribution infos contained in the given HTML source
+ code string.
+ */
++ (NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosFromHTMLString:(NSString *)htmlString;
+
+- (instancetype)initWithTitle:(NSString *)title URL:(NSURL *)URL;
+
+@property (nonatomic) NSString *title;
+@property (nonatomic) NSURL *URL;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLAttributionInfo.h
+++ b/platform/darwin/src/MGLAttributionInfo.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithTitle:(NSAttributedString *)title URL:(NSURL *)URL;
 
 @property (nonatomic) NSAttributedString *title;
-@property (nonatomic) NSURL *URL;
+@property (nonatomic, nullable) NSURL *URL;
 
 @end
 

--- a/platform/darwin/src/MGLAttributionInfo.h
+++ b/platform/darwin/src/MGLAttributionInfo.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
+#import <CoreLocation/CoreLocation.h>
 
 #import "MGLTypes.h"
 
@@ -25,6 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSAttributedString *title;
 @property (nonatomic, nullable) NSURL *URL;
+@property (nonatomic, getter=isFeedbackLink) BOOL feedbackLink;
+
+- (nullable NSURL *)feedbackURLAtCenterCoordinate:(CLLocationCoordinate2D)centerCoordinate zoomLevel:(double)zoomLevel;
 
 @end
 

--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -64,8 +64,9 @@ static NSString * const MGLAttributionFeedbackURLString = @"https://www.mapbox.c
         }
         
         // Omit whitespace-only strings.
-        NSAttributedString *title = [attributedString attributedSubstringFromRange:range];
-        if (![title.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length) {
+        NSAttributedString *title = [[attributedString attributedSubstringFromRange:range]
+                                     mgl_attributedStringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (!title.length) {
             return;
         }
         

--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -56,18 +56,19 @@ static NSString * const MGLAttributionFeedbackURLString = @"https://www.mapbox.c
                                  inRange:attributedString.mgl_wholeRange
                                  options:0
                               usingBlock:^(id _Nullable value, NSRange range, BOOL * _Nonnull stop) {
-        if (!value) {
-            return;
-        }
-        
         // Omit the Map Feedback link because the SDK already provides the appropriate UI for giving feedback.
         // Ideally we’d look for class="mapbox-improve-map", but NSAttributedString loses that information.
-        NSCAssert([value isKindOfClass:[NSURL class]], @"URL attribute must be an NSURL.");
+        NSCAssert(!value || [value isKindOfClass:[NSURL class]], @"If present, URL attribute must be an NSURL.");
         if ([value isEqual:[NSURL URLWithString:MGLAttributionFeedbackURLString]]) {
             return;
         }
         
+        // Omit whitespace-only strings.
         NSAttributedString *title = [attributedString attributedSubstringFromRange:range];
+        if (![title.string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length) {
+            return;
+        }
+        
         MGLAttributionInfo *info = [[MGLAttributionInfo alloc] initWithTitle:title URL:value];
         [infos addObject:info];
     }];

--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -1,0 +1,63 @@
+#import "MGLAttributionInfo.h"
+#import "NSString+MGLAdditions.h"
+
+#if TARGET_OS_IPHONE
+    #import <UIKit/UIKit.h>
+#else
+    #import <Cocoa/Cocoa.h>
+#endif
+
+#include <string>
+
+/**
+ Absolute string of the URL to the Map Feedback tool.
+ */
+static NSString * const MGLAttributionFeedbackURLString = @"https://www.mapbox.com/map-feedback/";
+
+@implementation MGLAttributionInfo
+
++ (NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosFromHTMLString:(NSString *)htmlString {
+    NSMutableArray *infos = [NSMutableArray array];
+    NSData *htmlData = [htmlString dataUsingEncoding:NSUTF8StringEncoding];
+#if TARGET_OS_IPHONE
+    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithData:htmlData
+                                                                            options:@{
+        NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType,
+        NSCharacterEncodingDocumentAttribute: @(NSUTF8StringEncoding),
+    }
+                                                                 documentAttributes:nil
+                                                                              error:NULL];
+#else
+    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithHTML:htmlData documentAttributes:nil];
+#endif
+    NSString *string = attributedString.string;
+    [attributedString enumerateAttribute:NSLinkAttributeName
+                                 inRange:attributedString.mgl_wholeRange
+                                 options:0
+                              usingBlock:^(id _Nullable value, NSRange range, BOOL * _Nonnull stop) {
+        if (!value) {
+            return;
+        }
+        
+        // Omit the Map Feedback link because the SDK already provides the appropriate UI for giving feedback.
+        NSCAssert([value isKindOfClass:[NSURL class]], @"URL attribute must be an NSURL.");
+        if ([value isEqual:[NSURL URLWithString:MGLAttributionFeedbackURLString]]) {
+            return;
+        }
+        
+        NSString *title = [[string substringWithRange:range] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        MGLAttributionInfo *info = [[MGLAttributionInfo alloc] initWithTitle:title URL:value];
+        [infos addObject:info];
+    }];
+    return infos;
+}
+
+- (instancetype)initWithTitle:(NSString *)title URL:(NSURL *)URL {
+    if (self = [super init]) {
+        _title = title;
+        _URL = URL;
+    }
+    return self;
+}
+
+@end

--- a/platform/darwin/src/MGLGeoJSONSource.mm
+++ b/platform/darwin/src/MGLGeoJSONSource.mm
@@ -18,6 +18,8 @@ const MGLGeoJSONSourceOption MGLGeoJSONSourceOptionSimplificationTolerance = @"M
 
 @interface MGLGeoJSONSource ()
 
+- (instancetype)initWithRawSource:(mbgl::style::GeoJSONSource *)rawSource NS_DESIGNATED_INITIALIZER;
+
 @property (nonatomic, readwrite) NSDictionary *options;
 @property (nonatomic) mbgl::style::GeoJSONSource *rawSource;
 
@@ -58,6 +60,10 @@ const MGLGeoJSONSourceOption MGLGeoJSONSourceOptionSimplificationTolerance = @"M
         [self commonInit];
     }
     return self;
+}
+
+- (instancetype)initWithRawSource:(mbgl::style::GeoJSONSource *)rawSource {
+    return [super initWithRawSource:rawSource];
 }
 
 - (void)addToMapView:(MGLMapView *)mapView

--- a/platform/darwin/src/MGLGeoJSONSource_Private.h
+++ b/platform/darwin/src/MGLGeoJSONSource_Private.h
@@ -1,9 +1,10 @@
 #import "MGLGeoJSONSource.h"
-#import "MGLGeoJSONSource_Private.h"
 
 #include <mbgl/style/sources/geojson_source.hpp>
 
 @interface MGLGeoJSONSource (Private)
+
+- (instancetype)initWithRawSource:(mbgl::style::GeoJSONSource *)rawSource;
 
 - (mbgl::style::GeoJSONOptions)geoJSONOptions;
 

--- a/platform/darwin/src/MGLRasterSource.mm
+++ b/platform/darwin/src/MGLRasterSource.mm
@@ -1,4 +1,4 @@
-#import "MGLRasterSource.h"
+#import "MGLRasterSource_Private.h"
 
 #import "MGLMapView_Private.h"
 #import "MGLSource_Private.h"
@@ -8,6 +8,8 @@
 #include <mbgl/style/sources/raster_source.hpp>
 
 @interface MGLRasterSource ()
+
+- (instancetype)initWithRawSource:(mbgl::style::RasterSource *)rawSource NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic) mbgl::style::RasterSource *rawSource;
 
@@ -35,6 +37,16 @@
         _tileSet = tileSet;
         _tileSize = tileSize;
         [self commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithRawSource:(mbgl::style::RasterSource *)rawSource {
+    if (self = [super initWithRawSource:rawSource]) {
+        if (auto attribution = rawSource->getAttribution()) {
+            _tileSet = [[MGLTileSet alloc] initWithTileURLTemplates:@[]];
+            _tileSet.attribution = @(attribution->c_str());
+        }
     }
     return self;
 }

--- a/platform/darwin/src/MGLRasterSource_Private.h
+++ b/platform/darwin/src/MGLRasterSource_Private.h
@@ -1,0 +1,13 @@
+#import "MGLRasterSource.h"
+
+namespace mbgl {
+    namespace style {
+        class RasterSource;
+    }
+}
+
+@interface MGLRasterSource (Private)
+
+- (instancetype)initWithRawSource:(mbgl::style::RasterSource *)rawSource;
+
+@end

--- a/platform/darwin/src/MGLSource.mm
+++ b/platform/darwin/src/MGLSource.mm
@@ -20,6 +20,14 @@
     return self;
 }
 
+- (instancetype)initWithRawSource:(mbgl::style::Source *)rawSource {
+    NSString *identifier = @(rawSource->getID().c_str());
+    if (self = [self initWithIdentifier:identifier]) {
+        _rawSource = rawSource;
+    }
+    return self;
+}
+
 - (void)addToMapView:(MGLMapView *)mapView {
     [NSException raise:NSInvalidArgumentException format:
      @"The source %@ cannot be added to the style. "

--- a/platform/darwin/src/MGLSource_Private.h
+++ b/platform/darwin/src/MGLSource_Private.h
@@ -1,11 +1,19 @@
 #import "MGLSource.h"
 
-#include <mbgl/mbgl.hpp>
-#include <mbgl/style/source.hpp>
+namespace mbgl {
+    namespace style {
+        class Source;
+    }
+}
 
 @class MGLMapView;
 
 @interface MGLSource (Private)
+
+/**
+ Initializes and returns a source with a raw pointer to the backing store.
+ */
+- (instancetype)initWithRawSource:(mbgl::style::Source *)rawSource;
 
 /**
  A raw pointer to the mbgl object, which is always initialized, either to the 

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -17,9 +17,12 @@
 #import "NSDate+MGLAdditions.h"
 
 #import "MGLSource.h"
-#import "MGLVectorSource.h"
+#import "MGLVectorSource_Private.h"
 #import "MGLRasterSource.h"
 #import "MGLGeoJSONSource.h"
+
+#import "MGLAttributionInfo.h"
+#import "MGLTileSet_Private.h"
 
 #include <mbgl/util/default_styles.hpp>
 #include <mbgl/sprite/sprite_image.hpp>
@@ -158,25 +161,18 @@ static NSURL *MGLStyleURL_emerald;
     return rawSource ? [self sourceFromMBGLSource:rawSource] : nil;
 }
 
-- (MGLSource *)sourceFromMBGLSource:(mbgl::style::Source *)mbglSource {
-    NSString *identifier = @(mbglSource->getID().c_str());
-    
+- (MGLSource *)sourceFromMBGLSource:(mbgl::style::Source *)source {
     // TODO: Fill in options specific to the respective source classes
     // https://github.com/mapbox/mapbox-gl-native/issues/6584
-    MGLSource *source;
-    if (mbglSource->is<mbgl::style::VectorSource>()) {
-        source = [[MGLVectorSource alloc] initWithIdentifier:identifier];
-    } else if (mbglSource->is<mbgl::style::GeoJSONSource>()) {
-        source = [[MGLGeoJSONSource alloc] initWithIdentifier:identifier];
-    } else if (mbglSource->is<mbgl::style::RasterSource>()) {
-        source = [[MGLRasterSource alloc] initWithIdentifier:identifier];
+    if (auto vectorSource = source->as<mbgl::style::VectorSource>()) {
+        return [[MGLVectorSource alloc] initWithRawSource:vectorSource];
+    } else if (auto geoJSONSource = source->as<mbgl::style::GeoJSONSource>()) {
+        return [[MGLGeoJSONSource alloc] initWithRawSource:geoJSONSource];
+    } else if (auto rasterSource = source->as<mbgl::style::RasterSource>()) {
+        return [[MGLRasterSource alloc] initWithRawSource:rasterSource];
     } else {
-        source = [[MGLSource alloc] initWithIdentifier:identifier];
+        return [[MGLSource alloc] initWithRawSource:source];
     }
-    
-    source.rawSource = mbglSource;
-
-    return source;
 }
 
 - (void)addSource:(MGLSource *)source
@@ -204,6 +200,33 @@ static NSURL *MGLStyleURL_emerald;
          source];
     }
     [source removeFromMapView:self.mapView];
+}
+
+- (NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfos {
+    // It’d be incredibly convenient to use -sources here, but this operation
+    // depends on the sources being sorted in ascending order by creation, as
+    // with the std::vector used in mbgl.
+    auto rawSources = self.mapView.mbglMap->getSources();
+    NSMutableSet *seenTitles = [NSMutableSet setWithCapacity:rawSources.size()];
+    NSMutableArray *infos = [NSMutableArray arrayWithCapacity:rawSources.size()];
+    for (auto rawSource = rawSources.begin(); rawSource != rawSources.end(); ++rawSource) {
+        MGLSource *source = [self sourceFromMBGLSource:*rawSource];
+        if (![source isKindOfClass:[MGLVectorSource class]]
+            && ![source isKindOfClass:[MGLRasterSource class]]) {
+            continue;
+        }
+        
+        NSArray *tileSetInfos = [(id)source tileSet].attributionInfos;
+        for (MGLAttributionInfo *info in tileSetInfos) {
+            // Omit redundant attribution strings.
+            if ([seenTitles containsObject:info.title]) {
+                continue;
+            }
+            [seenTitles addObject:info.title];
+            [infos addObject:info];
+        }
+    }
+    return infos;
 }
 
 #pragma mark Style layers

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -202,7 +202,7 @@ static NSURL *MGLStyleURL_emerald;
     [source removeFromMapView:self.mapView];
 }
 
-- (NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfos {
+- (nullable NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosWithFontSize:(CGFloat)fontSize linkColor:(nullable MGLColor *)linkColor {
     // It’d be incredibly convenient to use -sources here, but this operation
     // depends on the sources being sorted in ascending order by creation, as
     // with the std::vector used in mbgl.
@@ -216,13 +216,13 @@ static NSURL *MGLStyleURL_emerald;
             continue;
         }
         
-        NSArray *tileSetInfos = [(id)source tileSet].attributionInfos;
+        NSArray *tileSetInfos = [[(id)source tileSet] attributionInfosWithFontSize:fontSize linkColor:linkColor];
         for (MGLAttributionInfo *info in tileSetInfos) {
             // Omit redundant attribution strings.
-            if ([seenTitles containsObject:info.title]) {
+            if ([seenTitles containsObject:info.title.string]) {
                 continue;
             }
-            [seenTitles addObject:info.title];
+            [seenTitles addObject:info.title.string];
             [infos addObject:info];
         }
     }

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -207,7 +207,6 @@ static NSURL *MGLStyleURL_emerald;
     // depends on the sources being sorted in ascending order by creation, as
     // with the std::vector used in mbgl.
     auto rawSources = self.mapView.mbglMap->getSources();
-    NSMutableSet *seenTitles = [NSMutableSet setWithCapacity:rawSources.size()];
     NSMutableArray *infos = [NSMutableArray arrayWithCapacity:rawSources.size()];
     for (auto rawSource = rawSources.begin(); rawSource != rawSources.end(); ++rawSource) {
         MGLSource *source = [self sourceFromMBGLSource:*rawSource];
@@ -217,14 +216,7 @@ static NSURL *MGLStyleURL_emerald;
         }
         
         NSArray *tileSetInfos = [[(id)source tileSet] attributionInfosWithFontSize:fontSize linkColor:linkColor];
-        for (MGLAttributionInfo *info in tileSetInfos) {
-            // Omit redundant attribution strings.
-            if ([seenTitles containsObject:info.title.string]) {
-                continue;
-            }
-            [seenTitles addObject:info.title.string];
-            [infos addObject:info];
-        }
+        [infos growArrayByAddingAttributionInfosFromArray:tileSetInfos];
     }
     return infos;
 }

--- a/platform/darwin/src/MGLStyle_Private.h
+++ b/platform/darwin/src/MGLStyle_Private.h
@@ -2,11 +2,10 @@
 
 #import "MGLStyleLayer.h"
 #import "MGLFillStyleLayer.h"
-#import <mbgl/util/default_styles.hpp>
-#include <mbgl/mbgl.hpp>
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class MGLAttributionInfo;
 @class MGLMapView;
 @class MGLOpenGLStyleLayer;
 
@@ -15,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithMapView:(MGLMapView *)mapView;
 
 @property (nonatomic, readonly, weak) MGLMapView *mapView;
+
+@property (nonatomic, readonly) NS_ARRAY_OF(MGLAttributionInfo *) *attributionInfos;
 
 @property (nonatomic, readonly, strong) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLOpenGLStyleLayer *) *openGLLayers;
 

--- a/platform/darwin/src/MGLStyle_Private.h
+++ b/platform/darwin/src/MGLStyle_Private.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, weak) MGLMapView *mapView;
 
-@property (nonatomic, readonly) NS_ARRAY_OF(MGLAttributionInfo *) *attributionInfos;
+- (nullable NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosWithFontSize:(CGFloat)fontSize linkColor:(nullable MGLColor *)linkColor;
 
 @property (nonatomic, readonly, strong) NS_MUTABLE_DICTIONARY_OF(NSString *, MGLOpenGLStyleLayer *) *openGLLayers;
 

--- a/platform/darwin/src/MGLTileSet.h
+++ b/platform/darwin/src/MGLTileSet.h
@@ -17,6 +17,32 @@ typedef NS_ENUM(NSUInteger, MGLTileSetScheme) {
  */
 @interface MGLTileSet : NSObject
 
+#pragma mark Creating a Tile Set
+
+/**
+ Initializes and returns a new tile set object.
+ 
+ @param tileURLTemplates An `NSArray` of `NSString` objects that represent the 
+    tile templates.
+ @return The initialized tile set object.
+ */
+- (instancetype)initWithTileURLTemplates:(NS_ARRAY_OF(NSString *) *)tileURLTemplates;
+
+/**
+ Initializes and returns a new tile set object.
+ 
+ @param tileURLTemplates An `NSArray` of `NSString` objects that represent the 
+    tile templates.
+ @param minimumZoomLevel An `NSUInteger`; specifies the minimum zoom level at 
+    which to display tiles.
+ @param maximumZoomLevel An `NSUInteger`; specifies the maximum zoom level at 
+    which to display tiles.
+ @return The initialized tile set object.
+ */
+- (instancetype)initWithTileURLTemplates:(NS_ARRAY_OF(NSString *) *)tileURLTemplates minimumZoomLevel:(NSUInteger)minimumZoomLevel maximumZoomLevel:(NSUInteger)maximumZoomLevel;
+
+#pragma mark Accessing Tile Set Metadata
+
 /**
  An `NSArray` of `NSString` objects that represent the tile templates.
  */
@@ -50,28 +76,6 @@ typedef NS_ENUM(NSUInteger, MGLTileSetScheme) {
  of the tile coordinates. The default is `MGLTileSetSchemeXYZ`.
  */
 @property (nonatomic) MGLTileSetScheme scheme;
-
-/**
- Initializes and returns a new tile set object.
- 
- @param tileURLTemplates An `NSArray` of `NSString` objects that represent the 
-    tile templates.
- @return The initialized tile set object.
- */
-- (instancetype)initWithTileURLTemplates:(NS_ARRAY_OF(NSString *) *)tileURLTemplates;
-
-/**
- Initializes and returns a new tile set object.
- 
- @param tileURLTemplates An `NSArray` of `NSString` objects that represent the 
-    tile templates.
- @param minimumZoomLevel An `NSUInteger`; specifies the minimum zoom level at 
-    which to display tiles.
- @param maximumZoomLevel An `NSUInteger`; specifies the maximum zoom level at 
-    which to display tiles.
- @return The initialized tile set object.
- */
-- (instancetype)initWithTileURLTemplates:(NS_ARRAY_OF(NSString *) *)tileURLTemplates minimumZoomLevel:(NSUInteger)minimumZoomLevel maximumZoomLevel:(NSUInteger)maximumZoomLevel;
 
 @end
 

--- a/platform/darwin/src/MGLTileSet.mm
+++ b/platform/darwin/src/MGLTileSet.mm
@@ -59,8 +59,10 @@
     _maximumZoomLevel = maximumZoomLevel;
 }
 
-- (NS_ARRAY_OF (MGLAttributionInfo *) *)attributionInfos {
-    return [MGLAttributionInfo attributionInfosFromHTMLString:self.attribution];
+- (nullable NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosWithFontSize:(CGFloat)fontSize linkColor:(nullable MGLColor *)linkColor {
+    return [MGLAttributionInfo attributionInfosFromHTMLString:self.attribution
+                                                     fontSize:fontSize
+                                                    linkColor:linkColor];
 }
 
 - (mbgl::Tileset)mbglTileset

--- a/platform/darwin/src/MGLTileSet.mm
+++ b/platform/darwin/src/MGLTileSet.mm
@@ -1,5 +1,7 @@
 #import "MGLTileSet.h"
 
+#import "MGLAttributionInfo.h"
+
 #include <mbgl/util/tileset.hpp>
 
 @implementation MGLTileSet
@@ -55,6 +57,10 @@
     }
     
     _maximumZoomLevel = maximumZoomLevel;
+}
+
+- (NS_ARRAY_OF (MGLAttributionInfo *) *)attributionInfos {
+    return [MGLAttributionInfo attributionInfosFromHTMLString:self.attribution];
 }
 
 - (mbgl::Tileset)mbglTileset

--- a/platform/darwin/src/MGLTileSet_Private.h
+++ b/platform/darwin/src/MGLTileSet_Private.h
@@ -2,8 +2,20 @@
 
 #include <mbgl/util/tileset.hpp>
 
+NS_ASSUME_NONNULL_BEGIN
+
+@class MGLAttributionInfo;
+
 @interface MGLTileSet (Private)
+
+/**
+ A structured representation of the `attribution` property. The default value is
+ `nil`.
+ */
+@property (nonatomic, copy, nullable) NS_ARRAY_OF(MGLAttributionInfo *) *attributionInfos;
 
 - (mbgl::Tileset)mbglTileset;
 
-@end 
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLTileSet_Private.h
+++ b/platform/darwin/src/MGLTileSet_Private.h
@@ -11,8 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A structured representation of the `attribution` property. The default value is
  `nil`.
+ 
+ @param fontSize The default text size in points.
+ @param linkColor The default link color.
  */
-@property (nonatomic, copy, nullable) NS_ARRAY_OF(MGLAttributionInfo *) *attributionInfos;
+- (nullable NS_ARRAY_OF(MGLAttributionInfo *) *)attributionInfosWithFontSize:(CGFloat)fontSize linkColor:(nullable MGLColor *)linkColor;
 
 - (mbgl::Tileset)mbglTileset;
 

--- a/platform/darwin/src/MGLVectorSource.mm
+++ b/platform/darwin/src/MGLVectorSource.mm
@@ -1,4 +1,4 @@
-#import "MGLVectorSource.h"
+#import "MGLVectorSource_Private.h"
 
 #import "MGLMapView_Private.h"
 #import "MGLSource_Private.h"
@@ -8,6 +8,8 @@
 #include <mbgl/style/sources/vector_source.hpp>
 
 @interface MGLVectorSource ()
+
+- (instancetype)initWithRawSource:(mbgl::style::VectorSource *)rawSource NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic) mbgl::style::VectorSource *rawSource;
 
@@ -34,6 +36,16 @@
     {
         _tileSet = tileSet;
         [self commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithRawSource:(mbgl::style::VectorSource *)rawSource {
+    if (self = [super initWithRawSource:rawSource]) {
+        if (auto attribution = rawSource->getAttribution()) {
+            _tileSet = [[MGLTileSet alloc] initWithTileURLTemplates:@[]];
+            _tileSet.attribution = @(attribution->c_str());
+        }
     }
     return self;
 }

--- a/platform/darwin/src/MGLVectorSource_Private.h
+++ b/platform/darwin/src/MGLVectorSource_Private.h
@@ -1,0 +1,13 @@
+#import "MGLVectorSource.h"
+
+namespace mbgl {
+    namespace style {
+        class VectorSource;
+    }
+}
+
+@interface MGLVectorSource (Private)
+
+- (instancetype)initWithRawSource:(mbgl::style::VectorSource *)rawSource;
+
+@end

--- a/platform/darwin/src/NSString+MGLAdditions.h
+++ b/platform/darwin/src/NSString+MGLAdditions.h
@@ -4,8 +4,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSString (MGLAdditions)
 
+/** Returns the range spanning the entire receiver. */
+- (NSRange)mgl_wholeRange;
+
 /** Returns the receiver if non-empty or nil if empty. */
 - (nullable NSString *)mgl_stringOrNilIfEmpty;
+
+@end
+
+@interface NSAttributedString (MGLAdditions)
+
+/** Returns the range spanning the entire receiver. */
+- (NSRange)mgl_wholeRange;
 
 @end
 

--- a/platform/darwin/src/NSString+MGLAdditions.h
+++ b/platform/darwin/src/NSString+MGLAdditions.h
@@ -17,6 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** Returns the range spanning the entire receiver. */
 - (NSRange)mgl_wholeRange;
 
+/** Returns a copy of the receiver with leading and trailing members of the given set removed. */
+- (NSAttributedString *)mgl_attributedStringByTrimmingCharactersInSet:(NSCharacterSet *)set;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/NSString+MGLAdditions.m
+++ b/platform/darwin/src/NSString+MGLAdditions.m
@@ -2,9 +2,23 @@
 
 @implementation NSString (MGLAdditions)
 
+- (NSRange)mgl_wholeRange
+{
+    return NSMakeRange(0, self.length);
+}
+
 - (nullable NSString *)mgl_stringOrNilIfEmpty
 {
     return self.length ? self : nil;
+}
+
+@end
+
+@implementation NSAttributedString (MGLAdditions)
+
+- (NSRange)mgl_wholeRange
+{
+    return NSMakeRange(0, self.length);
 }
 
 @end

--- a/platform/darwin/src/NSString+MGLAdditions.m
+++ b/platform/darwin/src/NSString+MGLAdditions.m
@@ -2,13 +2,11 @@
 
 @implementation NSString (MGLAdditions)
 
-- (NSRange)mgl_wholeRange
-{
+- (NSRange)mgl_wholeRange {
     return NSMakeRange(0, self.length);
 }
 
-- (nullable NSString *)mgl_stringOrNilIfEmpty
-{
+- (nullable NSString *)mgl_stringOrNilIfEmpty {
     return self.length ? self : nil;
 }
 
@@ -16,9 +14,18 @@
 
 @implementation NSAttributedString (MGLAdditions)
 
-- (NSRange)mgl_wholeRange
-{
+- (NSRange)mgl_wholeRange {
     return NSMakeRange(0, self.length);
+}
+
+- (NSAttributedString *)mgl_attributedStringByTrimmingCharactersInSet:(NSCharacterSet *)set {
+    NSScanner *scanner = [NSScanner scannerWithString:self.string];
+    scanner.charactersToBeSkipped = nil;
+    NSString *prefix;
+    [scanner scanCharactersFromSet:set intoString:&prefix];
+    
+    NSString *trimmedString = [self.string stringByTrimmingCharactersInSet:set];
+    return [self attributedSubstringFromRange:NSMakeRange(prefix.length, trimmedString.length)];
 }
 
 @end

--- a/platform/darwin/test/MGLAttributionInfoTests.m
+++ b/platform/darwin/test/MGLAttributionInfoTests.m
@@ -12,7 +12,7 @@
 - (void)testParsing {
     static NSString * const htmlStrings[] = {
         @"<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> "
-        @"<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap</a> "
+        @"<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">©️ OpenStreetMap</a> "
         @"CC&nbsp;BY-SA "
         @"<a class=\"mapbox-improve-map\" href=\"https://www.mapbox.com/map-feedback/\" target=\"_blank\">Improve this map</a>",
     };
@@ -30,11 +30,51 @@
     XCTAssertEqualObjects(infos[0].title.string, @"© Mapbox");
     XCTAssertEqualObjects(infos[0].URL, [NSURL URLWithString:@"https://www.mapbox.com/about/maps/"]);
     
-    XCTAssertEqualObjects(infos[1].title.string, @"© OpenStreetMap");
+    XCTAssertEqualObjects(infos[1].title.string, @"©️ OpenStreetMap");
     XCTAssertEqualObjects(infos[1].URL, [NSURL URLWithString:@"http://www.openstreetmap.org/about/"]);
     
     XCTAssertEqualObjects(infos[2].title.string, @"CC\u00a0BY-SA");
     XCTAssertNil(infos[2].URL);
+}
+
+- (void)testStyle {
+    static NSString * const htmlStrings[] = {
+        @"<a href=\"https://www.mapbox.com/\">Mapbox</a>",
+    };
+    
+    CGFloat fontSize = 72;
+    MGLColor *color = [MGLColor redColor];
+    NS_MUTABLE_ARRAY_OF(MGLAttributionInfo *) *infos = [NSMutableArray array];
+    for (NSUInteger i = 0; i < sizeof(htmlStrings) / sizeof(htmlStrings[0]); i++) {
+        NSArray *subinfos = [MGLAttributionInfo attributionInfosFromHTMLString:htmlStrings[i]
+                                                                      fontSize:72
+                                                                     linkColor:color];
+        [infos growArrayByAddingAttributionInfosFromArray:subinfos];
+    }
+    
+    XCTAssertEqual(infos.count, 1);
+    
+    XCTAssertEqualObjects(infos[0].title.string, @"Mapbox");
+    XCTAssertEqualObjects([infos[0].title attribute:NSLinkAttributeName atIndex:0 effectiveRange:nil], [NSURL URLWithString:@"https://www.mapbox.com/"]);
+    XCTAssertEqualObjects([infos[0].title attribute:NSUnderlineStyleAttributeName atIndex:0 effectiveRange:nil], @(NSUnderlineStyleSingle));
+    
+#if TARGET_OS_IPHONE
+    UIFont *font;
+#else
+    NSFont *font;
+#endif
+    font = [infos[0].title attribute:NSFontAttributeName atIndex:0 effectiveRange:nil];
+    XCTAssertEqual(font.pointSize, fontSize);
+    
+    CGFloat r, g, b, a;
+    [color getRed:&r green:&g blue:&b alpha:&a];
+    MGLColor *linkColor = [infos[0].title attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil];
+    CGFloat linkR, linkG, linkB, linkA;
+    [linkColor getRed:&linkR green:&linkG blue:&linkB alpha:&linkA];
+    XCTAssertEqual(r, linkR);
+    XCTAssertEqual(g, linkG);
+    XCTAssertEqual(b, linkB);
+    XCTAssertEqual(a, linkA);
 }
 
 - (void)testDedupe {

--- a/platform/darwin/test/MGLAttributionInfoTests.m
+++ b/platform/darwin/test/MGLAttributionInfoTests.m
@@ -3,24 +3,52 @@
 
 #import "MGLAttributionInfo.h"
 
-static NSString * const HTMLAttributionStrings[] = {
-    @"World",
-    @"Hello World",
-    @"Another Source",
-    @"Hello",
-    @"Hello World",
-};
-
 @interface MGLAttributionInfoTests : XCTestCase
 
 @end
 
 @implementation MGLAttributionInfoTests
 
-- (void)testDedupe {
+- (void)testParsing {
+    static NSString * const htmlStrings[] = {
+        @"<a href=\"https://www.mapbox.com/about/maps/\" target=\"_blank\">&copy; Mapbox</a> "
+        @"<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap</a> "
+        @"CC&nbsp;BY-SA "
+        @"<a class=\"mapbox-improve-map\" href=\"https://www.mapbox.com/map-feedback/\" target=\"_blank\">Improve this map</a>",
+    };
+    
     NS_MUTABLE_ARRAY_OF(MGLAttributionInfo *) *infos = [NSMutableArray array];
-    for (NSUInteger i = 0; i < sizeof(HTMLAttributionStrings) / sizeof(HTMLAttributionStrings[0]); i++) {
-        NSArray *subinfos = [MGLAttributionInfo attributionInfosFromHTMLString:HTMLAttributionStrings[i]
+    for (NSUInteger i = 0; i < sizeof(htmlStrings) / sizeof(htmlStrings[0]); i++) {
+        NSArray *subinfos = [MGLAttributionInfo attributionInfosFromHTMLString:htmlStrings[i]
+                                                                      fontSize:0
+                                                                     linkColor:nil];
+        [infos growArrayByAddingAttributionInfosFromArray:subinfos];
+    }
+    
+    XCTAssertEqual(infos.count, 3);
+    
+    XCTAssertEqualObjects(infos[0].title.string, @"© Mapbox");
+    XCTAssertEqualObjects(infos[0].URL, [NSURL URLWithString:@"https://www.mapbox.com/about/maps/"]);
+    
+    XCTAssertEqualObjects(infos[1].title.string, @"© OpenStreetMap");
+    XCTAssertEqualObjects(infos[1].URL, [NSURL URLWithString:@"http://www.openstreetmap.org/about/"]);
+    
+    XCTAssertEqualObjects(infos[2].title.string, @"CC\u00a0BY-SA");
+    XCTAssertNil(infos[2].URL);
+}
+
+- (void)testDedupe {
+    static NSString * const htmlStrings[] = {
+        @"World",
+        @"Hello World",
+        @"Another Source",
+        @"Hello",
+        @"Hello World",
+    };
+    
+    NS_MUTABLE_ARRAY_OF(MGLAttributionInfo *) *infos = [NSMutableArray array];
+    for (NSUInteger i = 0; i < sizeof(htmlStrings) / sizeof(htmlStrings[0]); i++) {
+        NSArray *subinfos = [MGLAttributionInfo attributionInfosFromHTMLString:htmlStrings[i]
                                                                       fontSize:0
                                                                      linkColor:nil];
         [infos growArrayByAddingAttributionInfosFromArray:subinfos];

--- a/platform/darwin/test/MGLAttributionInfoTests.m
+++ b/platform/darwin/test/MGLAttributionInfoTests.m
@@ -1,0 +1,34 @@
+#import <Mapbox/Mapbox.h>
+#import <XCTest/XCTest.h>
+
+#import "MGLAttributionInfo.h"
+
+static NSString * const HTMLAttributionStrings[] = {
+    @"World",
+    @"Hello World",
+    @"Another Source",
+    @"Hello",
+    @"Hello World",
+};
+
+@interface MGLAttributionInfoTests : XCTestCase
+
+@end
+
+@implementation MGLAttributionInfoTests
+
+- (void)testDedupe {
+    NS_MUTABLE_ARRAY_OF(MGLAttributionInfo *) *infos = [NSMutableArray array];
+    for (NSUInteger i = 0; i < sizeof(HTMLAttributionStrings) / sizeof(HTMLAttributionStrings[0]); i++) {
+        NSArray *subinfos = [MGLAttributionInfo attributionInfosFromHTMLString:HTMLAttributionStrings[i]
+                                                                      fontSize:0
+                                                                     linkColor:nil];
+        [infos growArrayByAddingAttributionInfosFromArray:subinfos];
+    }
+    
+    XCTAssertEqual(infos.count, 2);
+    XCTAssertEqualObjects(infos[0].title.string, @"Hello World");
+    XCTAssertEqualObjects(infos[1].title.string, @"Another Source");
+}
+
+@end

--- a/platform/darwin/test/MGLAttributionInfoTests.m
+++ b/platform/darwin/test/MGLAttributionInfoTests.m
@@ -25,16 +25,29 @@
         [infos growArrayByAddingAttributionInfosFromArray:subinfos];
     }
     
-    XCTAssertEqual(infos.count, 3);
+    XCTAssertEqual(infos.count, 4);
     
+    CLLocationCoordinate2D mapbox = CLLocationCoordinate2DMake(12.9810816, 77.6368034);
     XCTAssertEqualObjects(infos[0].title.string, @"© Mapbox");
     XCTAssertEqualObjects(infos[0].URL, [NSURL URLWithString:@"https://www.mapbox.com/about/maps/"]);
+    XCTAssertFalse(infos[0].feedbackLink);
+    XCTAssertNil([infos[0] feedbackURLAtCenterCoordinate:mapbox zoomLevel:14]);
     
     XCTAssertEqualObjects(infos[1].title.string, @"©️ OpenStreetMap");
     XCTAssertEqualObjects(infos[1].URL, [NSURL URLWithString:@"http://www.openstreetmap.org/about/"]);
+    XCTAssertFalse(infos[1].feedbackLink);
+    XCTAssertNil([infos[1] feedbackURLAtCenterCoordinate:mapbox zoomLevel:14]);
     
     XCTAssertEqualObjects(infos[2].title.string, @"CC\u00a0BY-SA");
     XCTAssertNil(infos[2].URL);
+    XCTAssertFalse(infos[2].feedbackLink);
+    XCTAssertNil([infos[2] feedbackURLAtCenterCoordinate:mapbox zoomLevel:14]);
+    
+    XCTAssertEqualObjects(infos[3].title.string, @"Improve this map");
+    XCTAssertEqualObjects(infos[3].URL, [NSURL URLWithString:@"https://www.mapbox.com/map-feedback/"]);
+    XCTAssertTrue(infos[3].feedbackLink);
+    XCTAssertEqualObjects([infos[3] feedbackURLAtCenterCoordinate:mapbox zoomLevel:14],
+                          [NSURL URLWithString:@"https://www.mapbox.com/map-feedback/#/77.63680/12.98108/15"]);
 }
 
 - (void)testStyle {

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -22,6 +22,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * `-[MGLMapView resetPosition]` now resets to the current style’s default center coordinates, zoom level, direction, and pitch, if specified. ([#6127](https://github.com/mapbox/mapbox-gl-native/pull/6127))
 * Fixed an issue where feature querying sometimes failed to return the expected features when the map was tilted. ([#6773](https://github.com/mapbox/mapbox-gl-native/pull/6773))
 * MGLFeature’s `attributes` and `identifier` properties are now writable. ([#6728](https://github.com/mapbox/mapbox-gl-native/pull/6728))
+* The action sheet that appears when tapping the information button in the bottom-right corner now lists the correct attribution for the current style. ([#5999](https://github.com/mapbox/mapbox-gl-native/pull/5999))
 * The `text-pitch-alignment` property is now supported in stylesheets for improved street label legibility on a tilted map. ([#5288](https://github.com/mapbox/mapbox-gl-native/pull/5288))
 * The `icon-text-fit` and `icon-text-fit-padding` properties are now supported in stylesheets, allowing the background of a shield to automatically resize to fit the shield’s text. ([#5334](https://github.com/mapbox/mapbox-gl-native/pull/5334))
 * The `circle-pitch-scale` property is now supported in stylesheets, allowing circle features in a tilted base map to scale or remain the same size as the viewing distance changes. ([#5576](https://github.com/mapbox/mapbox-gl-native/pull/5576))

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -411,6 +411,7 @@
 		DAED38641D62D0FC00D7640F /* NSURL+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED38611D62D0FC00D7640F /* NSURL+MGLAdditions.h */; };
 		DAED38651D62D0FC00D7640F /* NSURL+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DAED38621D62D0FC00D7640F /* NSURL+MGLAdditions.m */; };
 		DAED38661D62D0FC00D7640F /* NSURL+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DAED38621D62D0FC00D7640F /* NSURL+MGLAdditions.m */; };
+		DAEDC4341D603417000224FF /* MGLAttributionInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAEDC4331D603417000224FF /* MGLAttributionInfoTests.m */; };
 		DD0902A91DB1929D00C5BDCE /* MGLNetworkConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DD0902A21DB18DE700C5BDCE /* MGLNetworkConfiguration.m */; };
 		DD0902AA1DB1929D00C5BDCE /* MGLNetworkConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DD0902A21DB18DE700C5BDCE /* MGLNetworkConfiguration.m */; };
 		DD0902AB1DB192A800C5BDCE /* MGLNetworkConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DD0902A41DB18F1B00C5BDCE /* MGLNetworkConfiguration.h */; };
@@ -781,6 +782,7 @@
 		DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLShapeCollection.mm; sourceTree = "<group>"; };
 		DAED38611D62D0FC00D7640F /* NSURL+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+MGLAdditions.h"; sourceTree = "<group>"; };
 		DAED38621D62D0FC00D7640F /* NSURL+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+MGLAdditions.m"; sourceTree = "<group>"; };
+		DAEDC4331D603417000224FF /* MGLAttributionInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLAttributionInfoTests.m; path = ../../darwin/test/MGLAttributionInfoTests.m; sourceTree = "<group>"; };
 		DD0902A21DB18DE700C5BDCE /* MGLNetworkConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfiguration.m; sourceTree = "<group>"; };
 		DD0902A41DB18F1B00C5BDCE /* MGLNetworkConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLNetworkConfiguration.h; sourceTree = "<group>"; };
 		DD4823721D94AE6C00EB71B7 /* fill_filter_style.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fill_filter_style.json; sourceTree = "<group>"; };
@@ -1066,6 +1068,7 @@
 			isa = PBXGroup;
 			children = (
 				357579811D502AD4000B822E /* Styling */,
+				DAEDC4331D603417000224FF /* MGLAttributionInfoTests.m */,
 				353D23951D0B0DFE002BE09D /* MGLAnnotationViewTests.m */,
 				DA35A2C31CCA9F8300E826B2 /* MGLClockDirectionFormatterTests.m */,
 				DA35A2C41CCA9F8300E826B2 /* MGLCompassDirectionFormatterTests.m */,
@@ -1921,6 +1924,7 @@
 				DA35A2C61CCA9F8300E826B2 /* MGLCompassDirectionFormatterTests.m in Sources */,
 				3575798E1D502EC7000B822E /* MGLRuntimeStylingHelper.m in Sources */,
 				4085AF091D933DEA00F11B22 /* MGLTileSetTests.mm in Sources */,
+				DAEDC4341D603417000224FF /* MGLAttributionInfoTests.m in Sources */,
 				357579851D502AF5000B822E /* MGLSymbolStyleLayerTests.m in Sources */,
 				357579871D502AFE000B822E /* MGLLineStyleLayerTests.m in Sources */,
 				357579891D502B06000B822E /* MGLCircleStyleLayerTests.m in Sources */,

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -172,6 +172,10 @@
 		7E016D851D9E890300A29A21 /* MGLPolygon+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E016D821D9E890300A29A21 /* MGLPolygon+MGLAdditions.h */; };
 		7E016D861D9E890300A29A21 /* MGLPolygon+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E016D831D9E890300A29A21 /* MGLPolygon+MGLAdditions.m */; };
 		7E016D871D9E890300A29A21 /* MGLPolygon+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E016D831D9E890300A29A21 /* MGLPolygon+MGLAdditions.m */; };
+		DA00FC8E1D5EEB0D009AABC8 /* MGLAttributionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DA00FC8C1D5EEB0D009AABC8 /* MGLAttributionInfo.h */; };
+		DA00FC8F1D5EEB0D009AABC8 /* MGLAttributionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DA00FC8C1D5EEB0D009AABC8 /* MGLAttributionInfo.h */; };
+		DA00FC901D5EEB0D009AABC8 /* MGLAttributionInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA00FC8D1D5EEB0D009AABC8 /* MGLAttributionInfo.mm */; };
+		DA00FC911D5EEB0D009AABC8 /* MGLAttributionInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA00FC8D1D5EEB0D009AABC8 /* MGLAttributionInfo.mm */; };
 		DA0CD5901CF56F6A00A5F5A5 /* MGLFeatureTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */; };
 		DA17BE301CC4BAC300402C41 /* MGLMapView_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Private.h */; };
 		DA17BE311CC4BDAA00402C41 /* MGLMapView_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DA17BE2F1CC4BAC300402C41 /* MGLMapView_Private.h */; };
@@ -601,6 +605,8 @@
 		7E016D7D1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolyline+MGLAdditions.m"; sourceTree = "<group>"; };
 		7E016D821D9E890300A29A21 /* MGLPolygon+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolygon+MGLAdditions.h"; sourceTree = "<group>"; };
 		7E016D831D9E890300A29A21 /* MGLPolygon+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolygon+MGLAdditions.m"; sourceTree = "<group>"; };
+		DA00FC8C1D5EEB0D009AABC8 /* MGLAttributionInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAttributionInfo.h; sourceTree = "<group>"; };
+		DA00FC8D1D5EEB0D009AABC8 /* MGLAttributionInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLAttributionInfo.mm; sourceTree = "<group>"; };
 		DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLFeatureTests.mm; path = ../../darwin/test/MGLFeatureTests.mm; sourceTree = "<group>"; };
 		DA17BE2F1CC4BAC300402C41 /* MGLMapView_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLMapView_Private.h; sourceTree = "<group>"; };
 		DA1DC94A1CB6C1C2006E619F /* Mapbox GL.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mapbox GL.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1111,6 +1117,8 @@
 				DA8848001CBAFA6200AB86E3 /* MGLAccountManager.m */,
 				DD0902A41DB18F1B00C5BDCE /* MGLNetworkConfiguration.h */,
 				DD0902A21DB18DE700C5BDCE /* MGLNetworkConfiguration.m */,
+				DA00FC8C1D5EEB0D009AABC8 /* MGLAttributionInfo.h */,
+				DA00FC8D1D5EEB0D009AABC8 /* MGLAttributionInfo.mm */,
 				DA8847E21CBAFA5100AB86E3 /* MGLMapCamera.h */,
 				DA8848031CBAFA6200AB86E3 /* MGLMapCamera.mm */,
 				DA8847EC1CBAFA5100AB86E3 /* MGLStyle.h */,
@@ -1422,6 +1430,7 @@
 				353933FE1D3FB7DD003F57D7 /* MGLSymbolStyleLayer.h in Headers */,
 				DA8848861CBB033F00AB86E3 /* Fabric+FABKits.h in Headers */,
 				DA8848201CBAFA6200AB86E3 /* MGLOfflinePack_Private.h in Headers */,
+				DA00FC8E1D5EEB0D009AABC8 /* MGLAttributionInfo.h in Headers */,
 				DA8847FA1CBAFA5100AB86E3 /* MGLPolyline.h in Headers */,
 				3566C7711D4A9198008152BC /* MGLSource_Private.h in Headers */,
 				4018B1C91CDC288A00F666AF /* MGLAnnotationView_Private.h in Headers */,
@@ -1593,6 +1602,7 @@
 				DABFB8601CBE99E500D62B32 /* MGLMapCamera.h in Headers */,
 				DA737EE21D056A4E005BDA16 /* MGLMapViewDelegate.h in Headers */,
 				DABFB86A1CBE99E500D62B32 /* MGLStyle.h in Headers */,
+				DA00FC8F1D5EEB0D009AABC8 /* MGLAttributionInfo.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1951,6 +1961,7 @@
 				400533021DB0862B0069F638 /* NSArray+MGLAdditions.mm in Sources */,
 				35136D421D42274500C20EFD /* MGLRasterStyleLayer.mm in Sources */,
 				3538AA1F1D542239008EC33D /* MGLForegroundStyleLayer.m in Sources */,
+				DA00FC901D5EEB0D009AABC8 /* MGLAttributionInfo.mm in Sources */,
 				DA88482D1CBAFA6200AB86E3 /* NSBundle+MGLAdditions.m in Sources */,
 				DA88485B1CBAFB9800AB86E3 /* MGLUserLocation.m in Sources */,
 				350098BD1D480108004B2AF0 /* MGLVectorSource.mm in Sources */,
@@ -2025,6 +2036,7 @@
 				400533031DB086490069F638 /* NSArray+MGLAdditions.mm in Sources */,
 				35136D431D42274500C20EFD /* MGLRasterStyleLayer.mm in Sources */,
 				3538AA201D542239008EC33D /* MGLForegroundStyleLayer.m in Sources */,
+				DA00FC911D5EEB0D009AABC8 /* MGLAttributionInfo.mm in Sources */,
 				DAA4E4201CBB730400178DFB /* MGLOfflinePack.mm in Sources */,
 				DAA4E4331CBB730400178DFB /* MGLUserLocation.m in Sources */,
 				350098BE1D480108004B2AF0 /* MGLVectorSource.mm in Sources */,

--- a/platform/ios/resources/Base.lproj/Localizable.strings
+++ b/platform/ios/resources/Base.lproj/Localizable.strings
@@ -19,12 +19,6 @@
 /* Compass abbreviation for north */
 "COMPASS_NORTH" = "N";
 
-/* Copyright notice in attribution sheet */
-"COPY_MAPBOX" = "© Mapbox";
-
-/* Copyright notice in attribution sheet */
-"COPY_OSM" = "© OpenStreetMap";
-
 /* Instructions in Interface Builder designable; {key}, {plist file name} */
 "DESIGNABLE" = "To display a Mapbox-hosted map here, set %1$@ to your access token in %2$@\n\nFor detailed instructions, see:";
 

--- a/platform/ios/resources/Base.lproj/Localizable.strings
+++ b/platform/ios/resources/Base.lproj/Localizable.strings
@@ -40,9 +40,6 @@
 /* Map accessibility value */
 "MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld annotation(s) visible";
 
-/* Action in attribution sheet */
-"MAP_FEEDBACK" = "Improve This Map";
-
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1773,7 +1773,10 @@ public:
     else if (buttonIndex > 0)
     {
         MGLAttributionInfo *info = _attributionInfos[buttonIndex + actionSheet.firstOtherButtonIndex];
-        [[UIApplication sharedApplication] openURL:info.URL];
+        if (info.URL)
+        {
+            [[UIApplication sharedApplication] openURL:info.URL];
+        }
     }
 }
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1726,10 +1726,10 @@ public:
     _attributionInfos = [self.style attributionInfosWithFontSize:[UIFont buttonFontSize] linkColor:nil];
     for (MGLAttributionInfo *info in _attributionInfos)
     {
-        [self.attributionSheet addButtonWithTitle:info.title.string];
+        NSString *title = [info.title.string capitalizedStringWithLocale:[NSLocale currentLocale]];
+        [self.attributionSheet addButtonWithTitle:title];
     }
     
-    [self.attributionSheet addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"MAP_FEEDBACK", nil, nil, @"Improve This Map", @"Action in attribution sheet")];
     [self.attributionSheet addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"TELEMETRY_NAME", nil, nil, @"Mapbox Telemetry", @"Action in attribution sheet")];
     
     [self.attributionSheet showFromRect:self.attributionButton.frame inView:self animated:YES];
@@ -1737,14 +1737,7 @@ public:
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    if (buttonIndex == actionSheet.numberOfButtons - 2)
-    {
-        NSString *feedbackURL = [NSString stringWithFormat:@"https://www.mapbox.com/map-feedback/#/%.5f/%.5f/%i",
-                                 self.longitude, self.latitude, (int)round(self.zoomLevel + 1)];
-        [[UIApplication sharedApplication] openURL:
-         [NSURL URLWithString:feedbackURL]];
-    }
-    else if (buttonIndex == actionSheet.numberOfButtons - 1)
+    if (buttonIndex == actionSheet.numberOfButtons - 1)
     {
         NSString *message;
         NSString *participate;
@@ -1773,9 +1766,14 @@ public:
     else if (buttonIndex > 0)
     {
         MGLAttributionInfo *info = _attributionInfos[buttonIndex + actionSheet.firstOtherButtonIndex];
-        if (info.URL)
+        NSURL *url = info.URL;
+        if (url)
         {
-            [[UIApplication sharedApplication] openURL:info.URL];
+            if (info.feedbackLink)
+            {
+                url = [info feedbackURLAtCenterCoordinate:self.centerCoordinate zoomLevel:self.zoomLevel];
+            }
+            [[UIApplication sharedApplication] openURL:url];
         }
     }
 }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1723,10 +1723,10 @@ public:
                                           destructiveButtonTitle:nil
                                                otherButtonTitles:nil];
     
-    _attributionInfos = self.style.attributionInfos;
+    _attributionInfos = [self.style attributionInfosWithFontSize:[UIFont buttonFontSize] linkColor:nil];
     for (MGLAttributionInfo *info in _attributionInfos)
     {
-        [self.attributionSheet addButtonWithTitle:info.title];
+        [self.attributionSheet addButtonWithTitle:info.title.string];
     }
     
     [self.attributionSheet addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"MAP_FEEDBACK", nil, nil, @"Improve This Map", @"Action in attribution sheet")];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -55,6 +55,7 @@
 #import "MGLCompactCalloutView.h"
 #import "MGLAnnotationContainerView.h"
 #import "MGLAnnotationContainerView_Private.h"
+#import "MGLAttributionInfo.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -310,6 +311,8 @@ public:
     BOOL _delegateHasLineWidthsForShapeAnnotations;
 
     MGLCompassDirectionFormatter *_accessibilityCompassFormatter;
+    
+    NS_ARRAY_OF(MGLAttributionInfo *) *_attributionInfos;
 }
 
 #pragma mark - Setup & Teardown -
@@ -1714,44 +1717,34 @@ public:
 
 - (void)showAttribution
 {
-    if ( ! self.attributionSheet)
+    self.attributionSheet = [[UIActionSheet alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"SDK_NAME", nil, nil, @"Mapbox iOS SDK", @"Action sheet title")
+                                                        delegate:self
+                                               cancelButtonTitle:NSLocalizedStringWithDefaultValue(@"CANCEL", nil, nil, @"Cancel", @"")
+                                          destructiveButtonTitle:nil
+                                               otherButtonTitles:nil];
+    
+    _attributionInfos = self.style.attributionInfos;
+    for (MGLAttributionInfo *info in _attributionInfos)
     {
-        self.attributionSheet = [[UIActionSheet alloc] initWithTitle:NSLocalizedStringWithDefaultValue(@"SDK_NAME", nil, nil, @"Mapbox iOS SDK", @"Action sheet title")
-                                                            delegate:self
-                                                   cancelButtonTitle:NSLocalizedStringWithDefaultValue(@"CANCEL", nil, nil, @"Cancel", @"")
-                                              destructiveButtonTitle:nil
-                                                   otherButtonTitles:
-                                 NSLocalizedStringWithDefaultValue(@"COPY_MAPBOX", nil, nil, @"© Mapbox", @"Copyright notice in attribution sheet"),
-                                 NSLocalizedStringWithDefaultValue(@"COPY_OSM", nil, nil, @"© OpenStreetMap", @"Copyright notice in attribution sheet"),
-                                 NSLocalizedStringWithDefaultValue(@"MAP_FEEDBACK", nil, nil, @"Improve This Map", @"Action in attribution sheet"),
-                                 NSLocalizedStringWithDefaultValue(@"TELEMETRY_NAME", nil, nil, @"Mapbox Telemetry", @"Action in attribution sheet"),
-                                 nil];
-
+        [self.attributionSheet addButtonWithTitle:info.title];
     }
-
+    
+    [self.attributionSheet addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"MAP_FEEDBACK", nil, nil, @"Improve This Map", @"Action in attribution sheet")];
+    [self.attributionSheet addButtonWithTitle:NSLocalizedStringWithDefaultValue(@"TELEMETRY_NAME", nil, nil, @"Mapbox Telemetry", @"Action in attribution sheet")];
+    
     [self.attributionSheet showFromRect:self.attributionButton.frame inView:self animated:YES];
 }
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    if (buttonIndex == actionSheet.firstOtherButtonIndex)
-    {
-        [[UIApplication sharedApplication] openURL:
-         [NSURL URLWithString:@"https://www.mapbox.com/about/maps/"]];
-    }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 1)
-    {
-        [[UIApplication sharedApplication] openURL:
-         [NSURL URLWithString:@"http://www.openstreetmap.org/about/"]];
-    }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 2)
+    if (buttonIndex == actionSheet.numberOfButtons - 2)
     {
         NSString *feedbackURL = [NSString stringWithFormat:@"https://www.mapbox.com/map-feedback/#/%.5f/%.5f/%i",
                                  self.longitude, self.latitude, (int)round(self.zoomLevel + 1)];
         [[UIApplication sharedApplication] openURL:
          [NSURL URLWithString:feedbackURL]];
     }
-    else if (buttonIndex == actionSheet.firstOtherButtonIndex + 3)
+    else if (buttonIndex == actionSheet.numberOfButtons - 1)
     {
         NSString *message;
         NSString *participate;
@@ -1776,6 +1769,11 @@ public:
                                               cancelButtonTitle:participate
                                               otherButtonTitles:NSLocalizedStringWithDefaultValue(@"TELEMETRY_MORE", nil, nil, @"Tell Me More", @"Telemetry prompt button"), optOut, nil];
         [alert show];
+    }
+    else if (buttonIndex > 0)
+    {
+        MGLAttributionInfo *info = _attributionInfos[buttonIndex + actionSheet.firstOtherButtonIndex];
+        [[UIApplication sharedApplication] openURL:info.URL];
     }
 }
 
@@ -4692,6 +4690,10 @@ public:
             {
                 [self.delegate mapView:self didFinishLoadingStyle:self.style];
             }
+            break;
+        }
+        case mbgl::MapChangeSourceDidChange:
+        {
             break;
         }
     }

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fixed an issue where the style zoom levels were not respected when deciding when to render a layer. ([#5811](https://github.com/mapbox/mapbox-gl-native/issues/5811))
 * Fixed an issue where feature querying sometimes failed to return the expected features when the map was tilted. ([#6773](https://github.com/mapbox/mapbox-gl-native/pull/6773))
 * MGLFeature’s `attributes` and `identifier` properties are now writable. ([#6728](https://github.com/mapbox/mapbox-gl-native/pull/6728))
+* Attribution views now display the correct attribution for the current style. ([#5999](https://github.com/mapbox/mapbox-gl-native/pull/5999))
 * If MGLMapView is unable to obtain or parse a style, it now calls its delegate’s `-mapViewDidFailLoadingMap:withError:` method. ([#6145](https://github.com/mapbox/mapbox-gl-native/pull/6145))
 * Added the `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` delegate method, which offers the earliest opportunity to modify the layout or appearance of the current style before the map view is displayed to the user. ([#6636](https://github.com/mapbox/mapbox-gl-native/pull/6636))
 * Fixed an issue causing stepwise zoom functions to be misinterpreted. ([#6328](https://github.com/mapbox/mapbox-gl-native/pull/6328))

--- a/platform/macos/INSTALL.md
+++ b/platform/macos/INSTALL.md
@@ -28,6 +28,7 @@ In a storyboard or XIB:
 3. MGLMapView needs to be layer-backed:
   * You can make the window layer-backed by selecting the window and checking Full Size Content View in the Attributes inspector. This allows the map view to underlap the title bar and toolbar.
   * Alternatively, if you don’t want the entire window to be layer-backed, you can make just the map view layer-backed by selecting it and checking its entry under the View Effects inspector’s Core Animation Layer section.
+4. Add a map feedback item to your Help menu. (Drag Menu Item from the Object library into Main Menu ‣ Help ‣ Menu.) Title it “Improve This Map” or similar, and connect it to the `giveFeedback:` action of First Responder.
 
 If you need to manipulate the map view programmatically:
 

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -666,15 +666,6 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     }];
 }
 
-#pragma mark Help methods
-
-- (IBAction)giveFeedback:(id)sender {
-    CLLocationCoordinate2D centerCoordinate = self.mapView.centerCoordinate;
-    NSURL *feedbackURL = [NSURL URLWithString:[NSString stringWithFormat:@"https://www.mapbox.com/map-feedback/#/%.5f/%.5f/%.0f",
-                                               centerCoordinate.longitude, centerCoordinate.latitude, round(self.mapView.zoomLevel + 1)]];
-    [[NSWorkspace sharedWorkspace] openURL:feedbackURL];
-}
-
 #pragma mark Mouse events
 
 - (void)handlePressGesture:(NSPressGestureRecognizer *)gestureRecognizer {

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		5548BE781D09E718005DDE81 /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE6C3451CC31D1200DB3429 /* libmbgl-core.a */; };
 		558F18221D0B13B100123F46 /* libmbgl-loop.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 558F18211D0B13B000123F46 /* libmbgl-loop.a */; };
 		55D9B4B11D005D3900C1CCE2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D9B4B01D005D3900C1CCE2 /* libz.tbd */; };
+		DA00FC8A1D5EEAC3009AABC8 /* MGLAttributionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DA00FC881D5EEAC3009AABC8 /* MGLAttributionInfo.h */; };
+		DA00FC8B1D5EEAC3009AABC8 /* MGLAttributionInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA00FC891D5EEAC3009AABC8 /* MGLAttributionInfo.mm */; };
 		DA0CD58E1CF56F5800A5F5A5 /* MGLFeatureTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA0CD58D1CF56F5800A5F5A5 /* MGLFeatureTests.mm */; };
 		DA2207BC1DC076940002F84D /* MGLStyleValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2207BB1DC076940002F84D /* MGLStyleValueTests.swift */; };
 		DA2784FE1DF03060001D5B8D /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA2784FD1DF03060001D5B8D /* Media.xcassets */; };
@@ -83,6 +85,8 @@
 		DA6408D81DA4E5DA00908C90 /* MGLVectorStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DA6408D61DA4E5DA00908C90 /* MGLVectorStyleLayer.m */; };
 		DA7262071DEEDD460043BB89 /* MGLOpenGLStyleLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7262051DEEDD460043BB89 /* MGLOpenGLStyleLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA7262081DEEDD460043BB89 /* MGLOpenGLStyleLayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA7262061DEEDD460043BB89 /* MGLOpenGLStyleLayer.mm */; };
+		DA7DC9811DED5F5C0027472F /* MGLVectorSource_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7DC9801DED5F5C0027472F /* MGLVectorSource_Private.h */; };
+		DA7DC9831DED647F0027472F /* MGLRasterSource_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DA7DC9821DED647F0027472F /* MGLRasterSource_Private.h */; };
 		DA839E971CC2E3400062CAFB /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DA839E961CC2E3400062CAFB /* AppDelegate.m */; };
 		DA839E9A1CC2E3400062CAFB /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DA839E991CC2E3400062CAFB /* main.m */; };
 		DA839E9D1CC2E3400062CAFB /* MapDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = DA839E9C1CC2E3400062CAFB /* MapDocument.m */; };
@@ -184,7 +188,7 @@
 		DAE6C3A61CC31E9400DB3429 /* MGLMapViewDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE6C3A21CC31E9400DB3429 /* MGLMapViewDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAE6C3B11CC31EF300DB3429 /* MGLAnnotationImage.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE6C3A71CC31EF300DB3429 /* MGLAnnotationImage.m */; };
 		DAE6C3B21CC31EF300DB3429 /* MGLAttributionButton.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE6C3A81CC31EF300DB3429 /* MGLAttributionButton.h */; };
-		DAE6C3B31CC31EF300DB3429 /* MGLAttributionButton.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE6C3A91CC31EF300DB3429 /* MGLAttributionButton.m */; };
+		DAE6C3B31CC31EF300DB3429 /* MGLAttributionButton.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAE6C3A91CC31EF300DB3429 /* MGLAttributionButton.mm */; };
 		DAE6C3B41CC31EF300DB3429 /* MGLCompassCell.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE6C3AA1CC31EF300DB3429 /* MGLCompassCell.h */; };
 		DAE6C3B51CC31EF300DB3429 /* MGLCompassCell.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE6C3AB1CC31EF300DB3429 /* MGLCompassCell.m */; };
 		DAE6C3B61CC31EF300DB3429 /* MGLMapView_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DAE6C3AC1CC31EF300DB3429 /* MGLMapView_Private.h */; };
@@ -300,6 +304,8 @@
 		558F18211D0B13B000123F46 /* libmbgl-loop.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-loop.a"; path = "../../build/osx/Debug/libmbgl-loop.a"; sourceTree = "<group>"; };
 		55D9B4B01D005D3900C1CCE2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		55FE0E8D1D100A0900FD240B /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = ../../build/macos/config.xcconfig; sourceTree = "<group>"; };
+		DA00FC881D5EEAC3009AABC8 /* MGLAttributionInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAttributionInfo.h; sourceTree = "<group>"; };
+		DA00FC891D5EEAC3009AABC8 /* MGLAttributionInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLAttributionInfo.mm; sourceTree = "<group>"; };
 		DA0CD58D1CF56F5800A5F5A5 /* MGLFeatureTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLFeatureTests.mm; path = ../../darwin/test/MGLFeatureTests.mm; sourceTree = "<group>"; };
 		DA2207BA1DC076930002F84D /* test-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "test-Bridging-Header.h"; sourceTree = "<group>"; };
 		DA2207BB1DC076940002F84D /* MGLStyleValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MGLStyleValueTests.swift; sourceTree = "<group>"; };
@@ -324,6 +330,8 @@
 		DA6408D61DA4E5DA00908C90 /* MGLVectorStyleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLVectorStyleLayer.m; sourceTree = "<group>"; };
 		DA7262051DEEDD460043BB89 /* MGLOpenGLStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLOpenGLStyleLayer.h; sourceTree = "<group>"; };
 		DA7262061DEEDD460043BB89 /* MGLOpenGLStyleLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLOpenGLStyleLayer.mm; sourceTree = "<group>"; };
+		DA7DC9801DED5F5C0027472F /* MGLVectorSource_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLVectorSource_Private.h; sourceTree = "<group>"; };
+		DA7DC9821DED647F0027472F /* MGLRasterSource_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLRasterSource_Private.h; sourceTree = "<group>"; };
 		DA839E921CC2E3400062CAFB /* Mapbox GL.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Mapbox GL.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA839E951CC2E3400062CAFB /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		DA839E961CC2E3400062CAFB /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -440,7 +448,7 @@
 		DAE6C3A21CC31E9400DB3429 /* MGLMapViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLMapViewDelegate.h; sourceTree = "<group>"; };
 		DAE6C3A71CC31EF300DB3429 /* MGLAnnotationImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLAnnotationImage.m; sourceTree = "<group>"; };
 		DAE6C3A81CC31EF300DB3429 /* MGLAttributionButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAttributionButton.h; sourceTree = "<group>"; };
-		DAE6C3A91CC31EF300DB3429 /* MGLAttributionButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLAttributionButton.m; sourceTree = "<group>"; };
+		DAE6C3A91CC31EF300DB3429 /* MGLAttributionButton.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLAttributionButton.mm; sourceTree = "<group>"; };
 		DAE6C3AA1CC31EF300DB3429 /* MGLCompassCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLCompassCell.h; sourceTree = "<group>"; };
 		DAE6C3AB1CC31EF300DB3429 /* MGLCompassCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLCompassCell.m; sourceTree = "<group>"; };
 		DAE6C3AC1CC31EF300DB3429 /* MGLMapView_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLMapView_Private.h; sourceTree = "<group>"; };
@@ -543,11 +551,13 @@
 				DA8F25991D51CAD00010E6B5 /* MGLSource_Private.h */,
 				352742801D4C243B00A1ECE6 /* MGLSource.mm */,
 				DA8F25951D51CAC70010E6B5 /* MGLVectorSource.h */,
+				DA7DC9801DED5F5C0027472F /* MGLVectorSource_Private.h */,
 				DA8F25961D51CAC70010E6B5 /* MGLVectorSource.mm */,
 				352742871D4C245800A1ECE6 /* MGLGeoJSONSource.h */,
 				DA87A99B1DC9D8DD00810D09 /* MGLGeoJSONSource_Private.h */,
 				352742881D4C245800A1ECE6 /* MGLGeoJSONSource.mm */,
 				352742831D4C244700A1ECE6 /* MGLRasterSource.h */,
+				DA7DC9821DED647F0027472F /* MGLRasterSource_Private.h */,
 				352742841D4C244700A1ECE6 /* MGLRasterSource.mm */,
 				DA551B7F1DB496AC0009AFAF /* MGLTileSet.h */,
 				DA551B801DB496AC0009AFAF /* MGLTileSet_Private.h */,
@@ -879,6 +889,8 @@
 				DAE6C36B1CC31E2A00DB3429 /* MGLAccountManager.m */,
 				DD0902B01DB1AC6400C5BDCE /* MGLNetworkConfiguration.h */,
 				DD0902AF1DB1AC6400C5BDCE /* MGLNetworkConfiguration.m */,
+				DA00FC881D5EEAC3009AABC8 /* MGLAttributionInfo.h */,
+				DA00FC891D5EEAC3009AABC8 /* MGLAttributionInfo.mm */,
 				DAE6C34D1CC31E0400DB3429 /* MGLMapCamera.h */,
 				DAE6C36E1CC31E2A00DB3429 /* MGLMapCamera.mm */,
 				DAE6C3571CC31E0400DB3429 /* MGLStyle.h */,
@@ -900,7 +912,7 @@
 				DAC2ABC41CC6D343006D18C4 /* MGLAnnotationImage_Private.h */,
 				DAE6C3A71CC31EF300DB3429 /* MGLAnnotationImage.m */,
 				DAE6C3A81CC31EF300DB3429 /* MGLAttributionButton.h */,
-				DAE6C3A91CC31EF300DB3429 /* MGLAttributionButton.m */,
+				DAE6C3A91CC31EF300DB3429 /* MGLAttributionButton.mm */,
 				DAE6C3AA1CC31EF300DB3429 /* MGLCompassCell.h */,
 				DAE6C3AB1CC31EF300DB3429 /* MGLCompassCell.m */,
 				DAE6C3A01CC31E9400DB3429 /* MGLMapView.h */,
@@ -934,11 +946,13 @@
 				DA8F258F1D51CA600010E6B5 /* MGLRasterStyleLayer.h in Headers */,
 				3508EC641D749D39009B0EE4 /* NSExpression+MGLAdditions.h in Headers */,
 				DAE6C38D1CC31E2A00DB3429 /* MGLOfflineRegion_Private.h in Headers */,
+				DA7DC9831DED647F0027472F /* MGLRasterSource_Private.h in Headers */,
 				408AA8651DAEEE3400022900 /* MGLPolygon+MGLAdditions.h in Headers */,
 				DA8F259C1D51CB000010E6B5 /* MGLStyleValue_Private.h in Headers */,
 				DAE6C35B1CC31E0400DB3429 /* MGLAnnotation.h in Headers */,
 				DAE6C3B61CC31EF300DB3429 /* MGLMapView_Private.h in Headers */,
 				3527428D1D4C24AB00A1ECE6 /* MGLCircleStyleLayer.h in Headers */,
+				DA00FC8A1D5EEAC3009AABC8 /* MGLAttributionInfo.h in Headers */,
 				DAE6C3B21CC31EF300DB3429 /* MGLAttributionButton.h in Headers */,
 				40B77E451DB11BC9003DA2FE /* NSArray+MGLAdditions.h in Headers */,
 				35C5D8471D6DD66D00E95907 /* NSComparisonPredicate+MGLAdditions.h in Headers */,
@@ -959,6 +973,7 @@
 				DAE6C39C1CC31E2A00DB3429 /* NSString+MGLAdditions.h in Headers */,
 				3529039B1D6C63B80002C7DF /* NSPredicate+MGLAdditions.h in Headers */,
 				DA8F25971D51CAC70010E6B5 /* MGLVectorSource.h in Headers */,
+				DA7DC9811DED5F5C0027472F /* MGLVectorSource_Private.h in Headers */,
 				DAE6C3861CC31E2A00DB3429 /* MGLGeometry_Private.h in Headers */,
 				DAE6C3841CC31E2A00DB3429 /* MGLAccountManager_Private.h in Headers */,
 				DAE6C3691CC31E0400DB3429 /* MGLTypes.h in Headers */,
@@ -1211,7 +1226,7 @@
 				DACC22151CF3D3E200D220D9 /* MGLFeature.mm in Sources */,
 				DA7262081DEEDD460043BB89 /* MGLOpenGLStyleLayer.mm in Sources */,
 				355BA4EE1D41633E00CCC6D5 /* NSColor+MGLAdditions.mm in Sources */,
-				DAE6C3B31CC31EF300DB3429 /* MGLAttributionButton.m in Sources */,
+				DAE6C3B31CC31EF300DB3429 /* MGLAttributionButton.mm in Sources */,
 				35602BFB1D3EA99F0050646F /* MGLFillStyleLayer.mm in Sources */,
 				DAE6C3931CC31E2A00DB3429 /* MGLShape.mm in Sources */,
 				352742861D4C244700A1ECE6 /* MGLRasterSource.mm in Sources */,
@@ -1245,6 +1260,7 @@
 				408AA8681DAEEE5200022900 /* MGLPolygon+MGLAdditions.m in Sources */,
 				DAE6C3951CC31E2A00DB3429 /* MGLTilePyramidOfflineRegion.mm in Sources */,
 				DAE6C3851CC31E2A00DB3429 /* MGLAccountManager.m in Sources */,
+				DA00FC8B1D5EEAC3009AABC8 /* MGLAttributionInfo.mm in Sources */,
 				DAE6C3921CC31E2A00DB3429 /* MGLPolyline.mm in Sources */,
 				3527428A1D4C245800A1ECE6 /* MGLGeoJSONSource.mm in Sources */,
 				DAE6C3B51CC31EF300DB3429 /* MGLCompassCell.m in Sources */,

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		DAE6C3D61CC34C9900DB3429 /* MGLStyleTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAE6C3CC1CC34BD800DB3429 /* MGLStyleTests.mm */; };
 		DAED385F1D62CED700D7640F /* NSURL+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED385D1D62CED700D7640F /* NSURL+MGLAdditions.h */; };
 		DAED38601D62CED700D7640F /* NSURL+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DAED385E1D62CED700D7640F /* NSURL+MGLAdditions.m */; };
+		DAEDC4321D6033F1000224FF /* MGLAttributionInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAEDC4311D6033F1000224FF /* MGLAttributionInfoTests.m */; };
 		DD0902B21DB1AC6400C5BDCE /* MGLNetworkConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DD0902AF1DB1AC6400C5BDCE /* MGLNetworkConfiguration.m */; };
 		DD0902B31DB1AC6400C5BDCE /* MGLNetworkConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DD0902B01DB1AC6400C5BDCE /* MGLNetworkConfiguration.h */; };
 		DD58A4C91D822C6700E1F038 /* MGLExpressionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DD58A4C71D822C6200E1F038 /* MGLExpressionTests.mm */; };
@@ -467,6 +468,7 @@
 		DAE6C3CC1CC34BD800DB3429 /* MGLStyleTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLStyleTests.mm; path = ../../darwin/test/MGLStyleTests.mm; sourceTree = "<group>"; };
 		DAED385D1D62CED700D7640F /* NSURL+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+MGLAdditions.h"; sourceTree = "<group>"; };
 		DAED385E1D62CED700D7640F /* NSURL+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+MGLAdditions.m"; sourceTree = "<group>"; };
+		DAEDC4311D6033F1000224FF /* MGLAttributionInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLAttributionInfoTests.m; path = ../../darwin/test/MGLAttributionInfoTests.m; sourceTree = "<group>"; };
 		DD0902AF1DB1AC6400C5BDCE /* MGLNetworkConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfiguration.m; sourceTree = "<group>"; };
 		DD0902B01DB1AC6400C5BDCE /* MGLNetworkConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLNetworkConfiguration.h; sourceTree = "<group>"; };
 		DD58A4C71D822C6200E1F038 /* MGLExpressionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLExpressionTests.mm; path = ../../darwin/test/MGLExpressionTests.mm; sourceTree = "<group>"; };
@@ -859,6 +861,7 @@
 			isa = PBXGroup;
 			children = (
 				DA8F257D1D51C5F40010E6B5 /* Styling */,
+				DAEDC4311D6033F1000224FF /* MGLAttributionInfoTests.m */,
 				DA35A2C11CCA9F4A00E826B2 /* MGLClockDirectionFormatterTests.m */,
 				DA35A2B51CCA14D700E826B2 /* MGLCompassDirectionFormatterTests.m */,
 				DA35A2A71CC9F41600E826B2 /* MGLCoordinateFormatterTests.m */,
@@ -1302,6 +1305,7 @@
 				DA87A9981DC9D88400810D09 /* MGLGeoJSONSourceTests.mm in Sources */,
 				DA87A9A21DC9DCF100810D09 /* MGLFillStyleLayerTests.m in Sources */,
 				3599A3E81DF70E2000E77FB2 /* MGLStyleValueTests.m in Sources */,
+				DAEDC4321D6033F1000224FF /* MGLAttributionInfoTests.m in Sources */,
 				DA0CD58E1CF56F5800A5F5A5 /* MGLFeatureTests.mm in Sources */,
 				DA2207BC1DC076940002F84D /* MGLStyleValueTests.swift in Sources */,
 			);

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		DAED385F1D62CED700D7640F /* NSURL+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED385D1D62CED700D7640F /* NSURL+MGLAdditions.h */; };
 		DAED38601D62CED700D7640F /* NSURL+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DAED385E1D62CED700D7640F /* NSURL+MGLAdditions.m */; };
 		DAEDC4321D6033F1000224FF /* MGLAttributionInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAEDC4311D6033F1000224FF /* MGLAttributionInfoTests.m */; };
+		DAEDC4371D606291000224FF /* MGLAttributionButtonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAEDC4361D606291000224FF /* MGLAttributionButtonTests.m */; };
 		DD0902B21DB1AC6400C5BDCE /* MGLNetworkConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DD0902AF1DB1AC6400C5BDCE /* MGLNetworkConfiguration.m */; };
 		DD0902B31DB1AC6400C5BDCE /* MGLNetworkConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DD0902B01DB1AC6400C5BDCE /* MGLNetworkConfiguration.h */; };
 		DD58A4C91D822C6700E1F038 /* MGLExpressionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = DD58A4C71D822C6200E1F038 /* MGLExpressionTests.mm */; };
@@ -469,6 +470,7 @@
 		DAED385D1D62CED700D7640F /* NSURL+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+MGLAdditions.h"; sourceTree = "<group>"; };
 		DAED385E1D62CED700D7640F /* NSURL+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+MGLAdditions.m"; sourceTree = "<group>"; };
 		DAEDC4311D6033F1000224FF /* MGLAttributionInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLAttributionInfoTests.m; path = ../../darwin/test/MGLAttributionInfoTests.m; sourceTree = "<group>"; };
+		DAEDC4361D606291000224FF /* MGLAttributionButtonTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLAttributionButtonTests.m; sourceTree = "<group>"; };
 		DD0902AF1DB1AC6400C5BDCE /* MGLNetworkConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfiguration.m; sourceTree = "<group>"; };
 		DD0902B01DB1AC6400C5BDCE /* MGLNetworkConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLNetworkConfiguration.h; sourceTree = "<group>"; };
 		DD58A4C71D822C6200E1F038 /* MGLExpressionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLExpressionTests.mm; path = ../../darwin/test/MGLExpressionTests.mm; sourceTree = "<group>"; };
@@ -862,6 +864,7 @@
 			children = (
 				DA8F257D1D51C5F40010E6B5 /* Styling */,
 				DAEDC4311D6033F1000224FF /* MGLAttributionInfoTests.m */,
+				DAEDC4361D606291000224FF /* MGLAttributionButtonTests.m */,
 				DA35A2C11CCA9F4A00E826B2 /* MGLClockDirectionFormatterTests.m */,
 				DA35A2B51CCA14D700E826B2 /* MGLCompassDirectionFormatterTests.m */,
 				DA35A2A71CC9F41600E826B2 /* MGLCoordinateFormatterTests.m */,
@@ -1288,6 +1291,7 @@
 				DAE6C3D41CC34C9900DB3429 /* MGLOfflineRegionTests.m in Sources */,
 				DA87A9A11DC9DCB400810D09 /* MGLRuntimeStylingHelper.m in Sources */,
 				DAE6C3D61CC34C9900DB3429 /* MGLStyleTests.mm in Sources */,
+				DAEDC4371D606291000224FF /* MGLAttributionButtonTests.m in Sources */,
 				DA35A2B61CCA14D700E826B2 /* MGLCompassDirectionFormatterTests.m in Sources */,
 				DAE6C3D21CC34C9900DB3429 /* MGLGeometryTests.mm in Sources */,
 				DA87A9A41DCACC5000810D09 /* MGLSymbolStyleLayerTests.m in Sources */,

--- a/platform/macos/sdk/Base.lproj/Localizable.strings
+++ b/platform/macos/sdk/Base.lproj/Localizable.strings
@@ -1,18 +1,3 @@
-/* Linked part of copyright notice */
-"COPYRIGHT_MAPBOX" = "Mapbox";
-
-/* Copyright notice link */
-"COPYRIGHT_MAPBOX_LINK" = "https://www.mapbox.com/about/maps/";
-
-/* Linked part of copyright notice */
-"COPYRIGHT_OSM" = "OpenStreetMap";
-
-/* Copyright notice link */
-"COPYRIGHT_OSM_LINK" = "http://www.openstreetmap.org/about/";
-
-/* Copyright notice prefix */
-"COPYRIGHT_PREFIX" = "© ";
-
 /* Accessibility title */
 "MAP_A11Y_TITLE" = "Mapbox";
 

--- a/platform/macos/src/MGLAttributionButton.h
+++ b/platform/macos/src/MGLAttributionButton.h
@@ -1,5 +1,9 @@
 #import <Cocoa/Cocoa.h>
 
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
 @class MGLAttributionInfo;
 
 /// Button that looks like a hyperlink and opens a URL.
@@ -9,9 +13,11 @@
 - (instancetype)initWithAttributionInfo:(MGLAttributionInfo *)info;
 
 /// The URL to open and display as a tooltip.
-@property (nonatomic) NSURL *URL;
+@property (nonatomic, readonly, nullable) NSURL *URL;
 
 /// Opens the URL.
-- (IBAction)openURL:(id)sender;
+- (IBAction)openURL:(nullable id)sender;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/macos/src/MGLAttributionButton.h
+++ b/platform/macos/src/MGLAttributionButton.h
@@ -1,10 +1,12 @@
 #import <Cocoa/Cocoa.h>
 
+@class MGLAttributionInfo;
+
 /// Button that looks like a hyperlink and opens a URL.
 @interface MGLAttributionButton : NSButton
 
-/// Returns an `MGLAttributionButton` instance with the given title and URL.
-- (instancetype)initWithTitle:(NSString *)title URL:(NSURL *)url;
+/// Returns an `MGLAttributionButton` instance with the given info.
+- (instancetype)initWithAttributionInfo:(MGLAttributionInfo *)info;
 
 /// The URL to open and display as a tooltip.
 @property (nonatomic) NSURL *URL;

--- a/platform/macos/src/MGLAttributionButton.mm
+++ b/platform/macos/src/MGLAttributionButton.mm
@@ -25,7 +25,9 @@
         [self sizeToFit];
         
         _URL = info.URL;
-        self.toolTip = _URL.absoluteString;
+        if (_URL) {
+            self.toolTip = _URL.absoluteString;
+        }
         
         self.target = self;
         self.action = @selector(openURL:);
@@ -38,12 +40,16 @@
 }
 
 - (void)resetCursorRects {
-    // The whole button gets a pointing hand cursor, just like a hyperlink.
-    [self addCursorRect:self.bounds cursor:[NSCursor pointingHandCursor]];
+    if (self.URL) {
+        // The whole button gets a pointing hand cursor, just like a hyperlink.
+        [self addCursorRect:self.bounds cursor:[NSCursor pointingHandCursor]];
+    }
 }
 
 - (IBAction)openURL:(__unused id)sender {
-    [[NSWorkspace sharedWorkspace] openURL:self.URL];
+    if (self.URL) {
+        [[NSWorkspace sharedWorkspace] openURL:self.URL];
+    }
 }
 
 @end

--- a/platform/macos/src/MGLAttributionButton.mm
+++ b/platform/macos/src/MGLAttributionButton.mm
@@ -2,6 +2,7 @@
 #import "MGLAttributionInfo.h"
 
 #import "NSBundle+MGLAdditions.h"
+#import "NSString+MGLAdditions.h"
 
 @implementation MGLAttributionButton
 
@@ -11,24 +12,16 @@
         self.bezelStyle = NSRegularSquareBezelStyle;
         
         // Extract any prefix consisting of intellectual property symbols.
-        NSScanner *scanner = [NSScanner scannerWithString:info.title];
+        NSScanner *scanner = [NSScanner scannerWithString:info.title.string];
         NSCharacterSet *symbolSet = [NSCharacterSet characterSetWithCharactersInString:@"©℗®℠™ &"];
         NSString *symbol;
         [scanner scanCharactersFromSet:symbolSet intoString:&symbol];
-        NSString *title = [info.title substringFromIndex:symbol.length];
         
-        // Start with the symbol prefix, sans underlining for aesthetic reasons. The whole string will be mini.
-        NSMutableAttributedString *attributedTitle = [[NSMutableAttributedString alloc] initWithString:symbol ?: @"" attributes:@{
-            NSFontAttributeName: [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:NSMiniControlSize]],
-        }];
-        // Append the specified title, underlining it like a hyperlink.
-        [attributedTitle appendAttributedString:
-         [[NSAttributedString alloc] initWithString:title
-                                         attributes:@{
-            NSFontAttributeName: [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:NSMiniControlSize]],
-            NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle),
-        }]];
-        self.attributedTitle = attributedTitle;
+        // Remove the underline from the symbol for aesthetic reasons.
+        NSMutableAttributedString *title = info.title.mutableCopy;
+        [title removeAttribute:NSUnderlineStyleAttributeName range:NSMakeRange(0, symbol.length)];
+        
+        self.attributedTitle = title;
         [self sizeToFit];
         
         _URL = info.URL;

--- a/platform/macos/src/MGLAttributionButton.mm
+++ b/platform/macos/src/MGLAttributionButton.mm
@@ -1,18 +1,24 @@
 #import "MGLAttributionButton.h"
+#import "MGLAttributionInfo.h"
 
 #import "NSBundle+MGLAdditions.h"
 
-@implementation MGLAttributionButton {
-    NSTrackingRectTag _trackingAreaTag;
-}
+@implementation MGLAttributionButton
 
-- (instancetype)initWithTitle:(NSString *)title URL:(NSURL *)url {
+- (instancetype)initWithAttributionInfo:(MGLAttributionInfo *)info {
     if (self = [super initWithFrame:NSZeroRect]) {
         self.bordered = NO;
         self.bezelStyle = NSRegularSquareBezelStyle;
         
-        // Start with a copyright symbol. The whole string will be mini.
-        NSMutableAttributedString *attributedTitle = [[NSMutableAttributedString alloc] initWithString:NSLocalizedStringWithDefaultValue(@"COPYRIGHT_PREFIX", nil, nil, @"© ", @"Copyright notice prefix") attributes:@{
+        // Extract any prefix consisting of intellectual property symbols.
+        NSScanner *scanner = [NSScanner scannerWithString:info.title];
+        NSCharacterSet *symbolSet = [NSCharacterSet characterSetWithCharactersInString:@"©℗®℠™ &"];
+        NSString *symbol;
+        [scanner scanCharactersFromSet:symbolSet intoString:&symbol];
+        NSString *title = [info.title substringFromIndex:symbol.length];
+        
+        // Start with the symbol prefix, sans underlining for aesthetic reasons. The whole string will be mini.
+        NSMutableAttributedString *attributedTitle = [[NSMutableAttributedString alloc] initWithString:symbol ?: @"" attributes:@{
             NSFontAttributeName: [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:NSMiniControlSize]],
         }];
         // Append the specified title, underlining it like a hyperlink.
@@ -25,7 +31,7 @@
         self.attributedTitle = attributedTitle;
         [self sizeToFit];
         
-        _URL = url;
+        _URL = info.URL;
         self.toolTip = _URL.absoluteString;
         
         self.target = self;

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -950,6 +950,25 @@ IB_DESIGNABLE
  */
 - (CLLocationDistance)metersPerPointAtLatitude:(CLLocationDegrees)latitude;
 
+#pragma mark Giving Feedback to Improve the Map
+
+/**
+ Opens one or more webpages in the default Web browser in which the user can
+ provide feedback about the map data.
+ 
+ You should add a menu item to the Help menu of your application that invokes
+ this method. Title it “Improve This Map” or similar. Set its target to the
+ first responder and its action to `giveFeedback:`.
+ 
+ This map view searches the current style’s sources for webpages to open.
+ Specifically, each source’s tile set has an `attribution` property containing
+ HTML code; if an <code>&lt;a></code> tag (link) within that code has an
+ <code>class</code> attribute set to <code>mapbox-improve-map</code>, its
+ <code>href</code> attribute defines the URL to open. Such links are omitted
+ from the attribution view.
+ */
+- (IBAction)giveFeedback:(id)sender;
+
 #pragma mark Debugging the Map
 
 /**

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -355,6 +355,7 @@ public:
 
 /// Adds legally required map attribution to the lower-left corner.
 - (void)installAttributionView {
+    [_attributionView removeFromSuperview];
     _attributionView = [[NSView alloc] initWithFrame:NSZeroRect];
     _attributionView.wantsLayer = YES;
 
@@ -418,6 +419,9 @@ public:
 /// hard-coded to the standard Mapbox and OpenStreetMap attribution.
 - (void)updateAttributionView {
     NSView *attributionView = self.attributionView;
+    for (NSView *button in attributionView.subviews) {
+        [button removeConstraints:button.constraints];
+    }
     attributionView.subviews = @[];
     [attributionView removeConstraints:attributionView.constraints];
     
@@ -463,7 +467,7 @@ public:
                                        constant:0]];
     }
     
-    if (attributionView.subviews.count) {
+    if (attributionInfos.count) {
         [attributionView addConstraint:
          [NSLayoutConstraint constraintWithItem:attributionView
                                       attribute:NSLayoutAttributeTrailing
@@ -920,7 +924,8 @@ public:
         }
         case mbgl::MapChangeSourceDidChange:
         {
-            [self updateAttributionView];
+            [self installAttributionView];
+            self.needsUpdateConstraints = YES;
             break;
         }
     }

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -421,7 +421,11 @@ public:
     attributionView.subviews = @[];
     [attributionView removeConstraints:attributionView.constraints];
     
-    for (MGLAttributionInfo *info in self.style.attributionInfos) {
+    // Make the whole string mini by default.
+    // Force links to be black, because the default blue is distracting.
+    CGFloat miniSize = [NSFont systemFontSizeForControlSize:NSMiniControlSize];
+    NSArray *attributionInfos = [self.style attributionInfosWithFontSize:miniSize linkColor:[NSColor blackColor]];
+    for (MGLAttributionInfo *info in attributionInfos) {
         // For each attribution, add a borderless button that responds to clicks
         // and feels like a hyperlink.
         NSButton *button = [[MGLAttributionButton alloc] initWithAttributionInfo:info];
@@ -449,17 +453,17 @@ public:
                                       attribute:previousView ? NSLayoutAttributeTrailing : NSLayoutAttributeLeading
                                      multiplier:1
                                        constant:8]];
-    }
-    
-    if (attributionView.subviews.count) {
         [attributionView addConstraint:
-         [NSLayoutConstraint constraintWithItem:attributionView.subviews.firstObject
+         [NSLayoutConstraint constraintWithItem:button
                                       attribute:NSLayoutAttributeTop
                                       relatedBy:NSLayoutRelationEqual
                                          toItem:attributionView
                                       attribute:NSLayoutAttributeTop
                                      multiplier:1
                                        constant:0]];
+    }
+    
+    if (attributionView.subviews.count) {
         [attributionView addConstraint:
          [NSLayoutConstraint constraintWithItem:attributionView
                                       attribute:NSLayoutAttributeTrailing

--- a/platform/macos/test/MGLAttributionButtonTests.m
+++ b/platform/macos/test/MGLAttributionButtonTests.m
@@ -1,0 +1,31 @@
+#import <Mapbox/Mapbox.h>
+#import <XCTest/XCTest.h>
+
+#import "MGLAttributionButton.h"
+#import "MGLAttributionInfo.h"
+
+@interface MGLAttributionButtonTests : XCTestCase
+
+@end
+
+@implementation MGLAttributionButtonTests
+
+- (void)testPlainSymbol {
+    NSAttributedString *title = [[NSAttributedString alloc] initWithString:@"® & ™ Mapbox" attributes:@{
+        NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle),
+    }];
+    MGLAttributionInfo *info = [[MGLAttributionInfo alloc] initWithTitle:title URL:nil];
+    MGLAttributionButton *button = [[MGLAttributionButton alloc] initWithAttributionInfo:info];
+    
+    NSRange symbolUnderlineRange;
+    NSNumber *symbolUnderline = [button.attributedTitle attribute:NSUnderlineStyleAttributeName atIndex:0 effectiveRange:&symbolUnderlineRange];
+    XCTAssertNil(symbolUnderline);
+    XCTAssertEqual(symbolUnderlineRange.length, 6);
+    
+    NSRange wordUnderlineRange;
+    NSNumber *wordUnderline = [button.attributedTitle attribute:NSUnderlineStyleAttributeName atIndex:6 effectiveRange:&wordUnderlineRange];
+    XCTAssertEqualObjects(wordUnderline, @(NSUnderlineStyleSingle));
+    XCTAssertEqual(wordUnderlineRange.length, 6);
+}
+
+@end


### PR DESCRIPTION
The attribution view on macOS and the ℹ️ action sheet on iOS now display the correct attribution based on all the sources used in the current style, instead of the Mapbox and OpenStreetMap attribution that was previously hard-coded in each implementation of MGLMapView. This means DigitalGlobe is credited for Mapbox Satellite and Satellite Streets, and attribution for third-party sources added in Mapbox Studio or using the runtime styling API is also shown.

The attribution view on macOS updates immediately whenever the style changes and a new source is loaded. Developers can (should) now hook up an Improve This Map menu item to a new `giveFeedback:` action on MGLMapView, which opens in a Web browser any feedback URL it finds in a source’s attribution HTML code.

The ℹ️ action sheet on iOS fetches the current style’s attribution information on demand.

![macos](https://cloud.githubusercontent.com/assets/1231218/20725111/acf14b02-b625-11e6-88ee-cd1803f1f441.png)

~~Implemented observer callbacks so the style knows when the source’s attribution changes and the map knows when the style’s attribution changes. Also implemented a getter for a tile source’s attribution.~~ Split out as #6431.

More to come:
- [x] ~~Attribution observer callbacks~~ (split out as #6431)
- [x] ~~Attribution accessors~~
- [x] Parse attribution HTML source code into structured data
- [x] Tests for parsing attribution strings
- [x] Dedupe attribution strings
- [x] Tests for deduping attribution strings
- [x] Update macOS attribution view dynamically (fixes the macOS side of #2723)
- [x] Use dynamic attribution in iOS attribution action sheet (fixes the iOS side of #2723)
- [x] Replace built-in “Improve This Map” link with customized/localized link from style (fixes #5775)

Depends on #6431.

/cc @kkaefer @friedbunny
