### PR TITLE
Replace testAAALoadPacks with a setUp method

### DIFF
--- a/platform/darwin/test/MGLOfflineStorageTests.m
+++ b/platform/darwin/test/MGLOfflineStorageTests.m
@@ -8,20 +8,24 @@
 
 @implementation MGLOfflineStorageTests
 
-- (void)testSharedObject {
-    XCTAssertEqual([MGLOfflineStorage sharedOfflineStorage], [MGLOfflineStorage sharedOfflineStorage], @"There should only be one shared offline storage object.");
+- (void)setUp {
+    [super setUp];
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [self keyValueObservingExpectationForObject:[MGLOfflineStorage sharedOfflineStorage] keyPath:@"packs" handler:^BOOL(id _Nonnull observedObject, NSDictionary * _Nonnull change) {
+            NSKeyValueChange changeKind = [change[NSKeyValueChangeKindKey] unsignedIntegerValue];
+            return changeKind = NSKeyValueChangeSetting;
+        }];
+        
+        [self waitForExpectationsWithTimeout:1 handler:nil];
+        
+        XCTAssertNotNil([MGLOfflineStorage sharedOfflineStorage].packs, @"Shared offline storage object should have a non-nil collection of packs by this point.");
+    });
 }
 
-// This test needs to come first so it can test the initial loading of packs.
-- (void)testAAALoadPacks {
-    [self keyValueObservingExpectationForObject:[MGLOfflineStorage sharedOfflineStorage] keyPath:@"packs" handler:^BOOL(id _Nonnull observedObject, NSDictionary * _Nonnull change) {
-        NSKeyValueChange changeKind = [change[NSKeyValueChangeKindKey] unsignedIntegerValue];
-        return changeKind = NSKeyValueChangeSetting;
-    }];
-    
-    [self waitForExpectationsWithTimeout:1 handler:nil];
-    
-    XCTAssertNotNil([MGLOfflineStorage sharedOfflineStorage].packs, @"Shared offline storage object should have a non-nil collection of packs by this point.");
+- (void)testSharedObject {
+    XCTAssertEqual([MGLOfflineStorage sharedOfflineStorage], [MGLOfflineStorage sharedOfflineStorage], @"There should only be one shared offline storage object.");
 }
 
 - (void)testAddPack {


### PR DESCRIPTION
XCTest apparently no longer executes tests in alphabetical order, so naming the test `testAAALoadPacks` doesn’t ensure it gets run first. Instead, put the pack loading test inside `-setUp`, but also put it inside a `dispatch_once()` block to ensure that it only gets run before the first offline storage test that gets run in the current process.

Fixes #6006.

/cc @friedbunny @boundsj