### PR TITLE
Parse and expose more style JSON root properties

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -158,6 +158,13 @@ public:
     void addLayer(std::unique_ptr<style::Layer>, const optional<std::string>& beforeLayerID = {});
     void removeLayer(const std::string& layerID);
 
+    // Defaults
+    std::string getStyleName() const;
+    LatLng getDefaultLatLng() const;
+    double getDefaultZoom() const;
+    double getDefaultBearing() const;
+    double getDefaultPitch() const;
+
     // Feature queries
     std::vector<Feature> queryRenderedFeatures(const ScreenCoordinate&, const optional<std::vector<std::string>>& layerIDs = {});
     std::vector<Feature> queryRenderedFeatures(const ScreenBox&,        const optional<std::vector<std::string>>& layerIDs = {});

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -781,6 +781,28 @@ void Map::removeLayer(const std::string& id) {
     impl->view.deactivate();
 }
 
+#pragma mark - Defaults
+
+std::string Map::getStyleName() const {
+    return impl->style->getName();
+}
+
+LatLng Map::getDefaultLatLng() const {
+    return impl->style->getDefaultLatLng();
+}
+
+double Map::getDefaultZoom() const {
+    return impl->style->getDefaultZoom();
+}
+
+double Map::getDefaultBearing() const {
+    return impl->style->getDefaultBearing();
+}
+
+double Map::getDefaultPitch() const {
+    return impl->style->getDefaultPitch();
+}
+
 #pragma mark - Toggles
 
 void Map::setDebug(MapDebugOptions debugOptions) {

--- a/src/mbgl/style/parser.cpp
+++ b/src/mbgl/style/parser.cpp
@@ -42,6 +42,43 @@ void Parser::parse(const std::string& json) {
         }
     }
 
+    if (document.HasMember("name")) {
+        const JSValue& value = document["name"];
+        if (value.IsString()) {
+            name = { value.GetString(), value.GetStringLength() };
+        }
+    }
+
+    if (document.HasMember("center")) {
+        const JSValue& value = document["center"];
+        if (value.IsArray() && value.Size() >= 2) {
+            // Style spec uses lon/lat order
+            latLng.longitude = value[0].IsNumber() ? value[0].GetDouble() : 0;
+            latLng.latitude = value[1].IsNumber() ? value[1].GetDouble() : 0;
+        }
+    }
+
+    if (document.HasMember("zoom")) {
+        const JSValue& value = document["zoom"];
+        if (value.IsNumber()) {
+            zoom = value.GetDouble();
+        }
+    }
+
+    if (document.HasMember("bearing")) {
+        const JSValue& value = document["bearing"];
+        if (value.IsNumber()) {
+            bearing = value.GetDouble();
+        }
+    }
+
+    if (document.HasMember("pitch")) {
+        const JSValue& value = document["pitch"];
+        if (value.IsNumber()) {
+            pitch = value.GetDouble();
+        }
+    }
+
     if (document.HasMember("sources")) {
         parseSources(document["sources"]);
     }

--- a/src/mbgl/style/parser.hpp
+++ b/src/mbgl/style/parser.hpp
@@ -5,6 +5,7 @@
 
 #include <mbgl/util/rapidjson.hpp>
 #include <mbgl/util/font_stack.hpp>
+#include <mbgl/util/geo.hpp>
 
 #include <vector>
 #include <memory>
@@ -26,6 +27,12 @@ public:
 
     std::vector<std::unique_ptr<Source>> sources;
     std::vector<std::unique_ptr<Layer>> layers;
+
+    std::string name;
+    LatLng latLng;
+    double zoom = 0;
+    double bearing = 0;
+    double pitch = 0;
 
     // Statically evaluate layer properties to determine what font stacks are used.
     std::vector<FontStack> fontStacks() const;

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -100,6 +100,12 @@ void Style::setJSON(const std::string& json) {
         addLayer(std::move(layer));
     }
 
+    name = parser.name;
+    defaultLatLng = parser.latLng;
+    defaultZoom = parser.zoom;
+    defaultBearing = parser.bearing;
+    defaultPitch = parser.pitch;
+
     glyphStore->setURL(parser.glyphURL);
     spriteStore->load(parser.spriteURL, fileSource);
 
@@ -161,6 +167,26 @@ void Style::removeLayer(const std::string& id) {
     if (it == layers.end())
         throw std::runtime_error("no such layer");
     layers.erase(it);
+}
+
+std::string Style::getName() const {
+    return name;
+}
+
+LatLng Style::getDefaultLatLng() const {
+    return defaultLatLng;
+}
+
+double Style::getDefaultZoom() const {
+    return defaultZoom;
+}
+
+double Style::getDefaultBearing() const {
+    return defaultBearing;
+}
+
+double Style::getDefaultPitch() const {
+    return defaultPitch;
 }
 
 void Style::update(const UpdateParameters& parameters) {

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -13,6 +13,7 @@
 #include <mbgl/util/worker.hpp>
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/feature.hpp>
+#include <mbgl/util/geo.hpp>
 
 #include <cstdint>
 #include <string>
@@ -68,6 +69,12 @@ public:
                   optional<std::string> beforeLayerID = {});
     void removeLayer(const std::string& layerID);
 
+    std::string getName() const;
+    LatLng getDefaultLatLng() const;
+    double getDefaultZoom() const;
+    double getDefaultBearing() const;
+    double getDefaultPitch() const;
+
     bool addClass(const std::string&, const TransitionOptions& = {});
     bool removeClass(const std::string&, const TransitionOptions& = {});
     bool hasClass(const std::string&) const;
@@ -97,6 +104,13 @@ private:
     std::vector<std::unique_ptr<Layer>> layers;
     std::vector<std::string> classes;
     optional<TransitionOptions> transitionProperties;
+
+    // Defaults
+    std::string name;
+    LatLng defaultLatLng;
+    double defaultZoom;
+    double defaultBearing;
+    double defaultPitch;
 
     std::vector<std::unique_ptr<Layer>>::const_iterator findLayer(const std::string& layerID) const;
 

--- a/test/style/style.cpp
+++ b/test/style/style.cpp
@@ -61,3 +61,37 @@ TEST(Style, UnusedSourceActiveViaClassUpdate) {
     EXPECT_TRUE(unusedSource);
     EXPECT_FALSE(unusedSource->baseImpl->isLoaded());
 }
+
+TEST(Style, Properties) {
+    util::RunLoop loop;
+
+    StubFileSource fileSource;
+    Style style { fileSource, 1.0 };
+
+    style.setJSON(R"STYLE({"name": "Test"})STYLE");
+    ASSERT_EQ("Test", style.getName());
+
+    style.setJSON(R"STYLE({"center": [10, 20]})STYLE");
+    ASSERT_EQ("", style.getName());
+    ASSERT_EQ((LatLng{20, 10}), style.getDefaultLatLng());
+
+    style.setJSON(R"STYLE({"bearing": 24})STYLE");
+    ASSERT_EQ("", style.getName());
+    ASSERT_EQ((LatLng{0, 0}), style.getDefaultLatLng());
+    ASSERT_EQ(24, style.getDefaultBearing());
+
+    style.setJSON(R"STYLE({"zoom": 13.3})STYLE");
+    ASSERT_EQ("", style.getName());
+    ASSERT_EQ(13.3, style.getDefaultZoom());
+
+    style.setJSON(R"STYLE({"pitch": 60})STYLE");
+    ASSERT_EQ("", style.getName());
+    ASSERT_EQ(60, style.getDefaultPitch());
+
+    style.setJSON(R"STYLE({"name": 23, "center": {}, "bearing": "north", "zoom": null, "pitch": "wide"})STYLE");
+    ASSERT_EQ("", style.getName());
+    ASSERT_EQ((LatLng{0, 0}), style.getDefaultLatLng());
+    ASSERT_EQ(0, style.getDefaultBearing());
+    ASSERT_EQ(0, style.getDefaultZoom());
+    ASSERT_EQ(0, style.getDefaultPitch());
+}


### PR DESCRIPTION
[`mbgl::style::Parser::parse()`](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/style/parser.cpp#L23) should parse the [`name`](https://www.mapbox.com/mapbox-gl-style-spec/#root-name) and [`metadata`](https://www.mapbox.com/mapbox-gl-style-spec/#root-metadata) root properties out of the style JSON and expose them with accessors on the `mbgl::style::Style` class. The SDK could read the name of the style aloud in accessibility contexts.

Similarly, root properties such as [`center`](https://www.mapbox.com/mapbox-gl-style-spec/#root-center) and [`zoom`](https://www.mapbox.com/mapbox-gl-style-spec/#root-zoom) may be useful for establishing a default viewport for the style other than the Null Island default used in the SDK currently. This would enable the developer to set the default viewport once, in Mapbox Studio, and not have to set it again programmatically or in a storyboard.

/cc @jfirebaugh @kkaefer