### PR TITLE
macOS minimum deployment target excludes OS X 10.10.0

### DIFF
--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.11)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
 
 mason_use(glfw VERSION 3.1.2)
 mason_use(boost_libprogram_options VERSION 1.60.0)


### PR DESCRIPTION
#5359 [increased](https://github.com/mapbox/mapbox-gl-native/blob/112789a76111d4dd38e50c73ae1e81e5c53dd59c/platform/macos/config.cmake#L1) the minimum deployment target for mbgl libraries from OS X 10.10.0 to OS X 10.11. The SDK targets’ minimum deployment target [remains](https://github.com/mapbox/mapbox-gl-native/blob/112789a76111d4dd38e50c73ae1e81e5c53dd59c/platform/macos/macos.xcodeproj/project.pbxproj#L1228) at OS X 10.10.0. For consistency, if not for compatibility, the mbgl libraries’ minimum deployment targets should be reduced back to OS X 10.10.0.

/cc @kkaefer