### PR TITLE
Improve user location annotation performance

### DIFF
--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -148,6 +148,7 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
         _puckDot.backgroundColor = [[UIColor whiteColor] CGColor];
         _puckDot.shadowColor = [[UIColor blackColor] CGColor];
         _puckDot.shadowOpacity = 0.25;
+        _puckDot.shadowPath = [[UIBezierPath bezierPathWithOvalInRect:_puckDot.bounds] CGPath];
 
         if (self.mapView.camera.pitch)
         {
@@ -374,6 +375,7 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
         _dotBorderLayer.backgroundColor = [[UIColor whiteColor] CGColor];
         _dotBorderLayer.shadowColor = [[UIColor blackColor] CGColor];
         _dotBorderLayer.shadowOpacity = 0.25;
+        _dotBorderLayer.shadowPath = [[UIBezierPath bezierPathWithOvalInRect:_dotBorderLayer.bounds] CGPath];
 
         if (self.mapView.camera.pitch)
         {

--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -396,7 +396,6 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
     {
         _dotLayer = [self circleLayerWithSize:MGLUserLocationAnnotationDotSize * 0.75];
         _dotLayer.backgroundColor = [self.mapView.tintColor CGColor];
-        _dotLayer.shouldRasterize = NO;
 
         // set defaults for the animations
         CAAnimationGroup *animationGroup = [self loopingAnimationGroupWithDuration:1.5];

--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -291,6 +291,13 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
         if (accuracyRingSize > MGLUserLocationAnnotationDotSize + 15)
         {
             _accuracyRingLayer.hidden = NO;
+
+            // disable implicit animation of the accuracy ring, unless triggered by a change in accuracy
+            id shouldDisableActions = (_oldHorizontalAccuracy == self.userLocation.location.horizontalAccuracy) ? (id)kCFBooleanTrue : (id)kCFBooleanFalse;
+
+            [CATransaction begin];
+            [CATransaction setValue:shouldDisableActions forKey:kCATransactionDisableActions];
+
             _accuracyRingLayer.bounds = CGRectMake(0, 0, accuracyRingSize, accuracyRingSize);
             _accuracyRingLayer.cornerRadius = accuracyRingSize / 2;
 
@@ -298,6 +305,8 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
             _haloLayer.bounds = _accuracyRingLayer.bounds;
             _haloLayer.cornerRadius = _accuracyRingLayer.cornerRadius;
             _haloLayer.shouldRasterize = NO;
+
+            [CATransaction commit];
         }
         else
         {


### PR DESCRIPTION
User location annotation performance wasn’t bad previously, but there are some small tweaks we can make to improve both perceived and actual performance.

This PR is proposed against `5039-MGLUserLocationAnnotationView-refactor` until #5882 lands. We can now [change the base branch of existing pull requests](https://github.com/blog/2224-change-the-base-branch-of-a-pull-request), so I’ll try that out before merging this.

### Accuracy ring
The biggest improvement is to the accuracy ring: instead of queueing up implicit animations while zooming, now we only animate changes to the ring’s size (i.e., when the horizontal accuracy changes). This fixes the wobbling effect you could see at the edges of the ring when zooming.

We’re able to disable the implicit animation during zooms because we already update the user dot ourselves in `-[MGLMapView updateUserLocationAnnotationViewAnimatedWithDuration:]` — sometimes almost every frame.

### Shadow paths
Per [Apple](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/CoreAnimation_guide/ImprovingAnimationPerformance/ImprovingAnimationPerformance.html), pre-calculating the paths of shadows can provide better performance.

### Rasterize pulsating inner dot
This stops the dot from being rendered off-screen and smoothes its edges (which could at times appear squarish).

/cc @1ec5 @boundsj @frederoni @incanus