### PR TITLE
More MGLGeoJSONSource options

### DIFF
--- a/platform/darwin/src/MGLGeoJSONSource.h
+++ b/platform/darwin/src/MGLGeoJSONSource.h
@@ -1,9 +1,60 @@
 #import "MGLSource.h"
 
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MGLFeature;
+
 @interface MGLGeoJSONSource : MGLSource
 
-@property (nonatomic, readonly, copy) NSString *data;
+/**
+ The contents of the source.
+ 
+ If the receiver was initialized using `-initWithSourceIdentifier:URL:`, this
+ property is set to `nil`. This property is unavailable until the receiver is
+ passed into `-[MGLStyle addSource]`.
+ */
+@property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLFeature>) *features;
 
+/**
+ A GeoJSON representation of the contents of the source.
+ 
+ Use the `features` property instead to get an object representation of the
+ contents. Alternatively, use NSJSONSerialization with the value of this
+ property to transform it into Foundation types.
+ 
+ If the receiver was initialized using `-initWithSourceIdentifier:URL:`, this
+ property is set to `nil`. This property is unavailable until the receiver is
+ passed into `-[MGLStyle addSource]`.
+ */
+@property (nonatomic, readonly, nullable, copy) NSData *geoJSONData;
+
+/**
+ The URL to the GeoJSON document that specifies the contents of the source.
+ 
+ If the receiver was initialized using `-initWithSourceIdentifier:geoJSONData:`,
+ this property is set to `nil`.
+ */
+@property (nonatomic, readonly, nullable) NSURL *URL;
+
+/**
+ Initializes a source with the given identifier and GeoJSON data.
+ 
+ @param sourceIdentifier A string that uniquely identifies the source.
+ @param geoJSONData An NSData object representing GeoJSON source code.
+ */
+- (instancetype)initWithSourceIdentifier:(NSString *)sourceIdentifier geoJSONData:(NSData *)data NS_DESIGNATED_INITIALIZER;
+
+/**
+ Initializes a source with the given identifier and URL.
+ 
+ @param sourceIdentifier A string that uniquely identifies the source.
+ @param URL An HTTP(S) URL, absolute file URL, or local file URL relative to the
+    current application’s resource bundle.
+ */
 - (instancetype)initWithSourceIdentifier:(NSString *)sourceIdentifier URL:(NSURL *)url NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLGeoJSONSource.mm
+++ b/platform/darwin/src/MGLGeoJSONSource.mm
@@ -1,26 +1,24 @@
 #import "MGLGeoJSONSource.h"
 
 #import "MGLSource_Private.h"
+#import "MGLFeature_Private.h"
+
+#import "NSURL+MGLAdditions.h"
 
 #include <mbgl/style/sources/geojson_source.hpp>
 
-@interface MGLGeoJSONSource ()
-
-@property (nonatomic, copy) NSURL *URL;
-
-@end
-
 @implementation MGLGeoJSONSource
 
-- (instancetype)initWithSourceIdentifier:(NSString *)sourceIdentifier URL:(NSURL *)url
-{
+- (instancetype)initWithSourceIdentifier:(NSString *)sourceIdentifier geoJSONData:(NSData *)data {
+    if (self = [super initWithSourceIdentifier:sourceIdentifier]) {
+        _geoJSONData = data;
+    }
+    return self;
+}
+
+- (instancetype)initWithSourceIdentifier:(NSString *)sourceIdentifier URL:(NSURL *)url {
     if (self = [super initWithSourceIdentifier:sourceIdentifier]) {
         _URL = url;
-        if (url.isFileURL) {
-            _data = [[NSString alloc] initWithContentsOfURL:url encoding:NSUTF8StringEncoding error:NULL];
-        } else {
-            _data = url.absoluteString;
-        }
     }
     return self;
 }
@@ -28,11 +26,14 @@
 - (std::unique_ptr<mbgl::style::Source>)mbgl_source
 {
     auto source = std::make_unique<mbgl::style::GeoJSONSource>(self.sourceIdentifier.UTF8String);
-    if (_URL.isFileURL) {
-        const auto geojson = mapbox::geojson::parse(self.data.UTF8String).get<mapbox::geojson::feature_collection>();
-        source->setGeoJSON(geojson);
+    if (self.URL) {
+        NSURL *url = self.URL.mgl_URLByStandardizingScheme;
+        source->setURL(url.absoluteString.UTF8String);
     } else {
-        source->setURL(self.data.UTF8String);
+        NSString *string = [[NSString alloc] initWithData:self.geoJSONData encoding:NSUTF8StringEncoding];
+        const auto geojson = mapbox::geojson::parse(string.UTF8String).get<mapbox::geojson::feature_collection>();
+        source->setGeoJSON(geojson);
+        _features = MGLFeaturesFromMBGLFeatures(geojson);
     }
     return std::move(source);
 }

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -203,7 +203,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         @"Start World Tour",
         @"Add Custom Callout Point",
         @"Remove Annotations",
-        @"Runtime Styling",
+        @"Manipulate Style",
         ((_customUserLocationAnnnotationEnabled)
          ? @"Disable Custom User Dot"
          : @"Enable Custom User Dot"),
@@ -479,7 +479,8 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
 
 - (void)styleGeoJSONSource
 {
-    NSURL *geoJSONURL = [NSURL URLWithString:@"https://dl.dropboxusercontent.com/u/5285447/amsterdam.geojson"];
+    NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
+    NSURL *geoJSONURL = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"ams" URL:geoJSONURL];
     [self.mapView.style addSource:source];
     

--- a/platform/macos/app/Base.lproj/MainMenu.xib
+++ b/platform/macos/app/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G26a" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11191" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11191"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -520,6 +520,13 @@ CA
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="wQq-Mx-QY0"/>
+                            <menuItem title="Manipulate Style" id="Zli-T5-cTQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="manipulateStyle:" target="-1" id="9Np-3n-FXK"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="vMh-WE-Frt"/>
                             <menuItem title="Start World Tour" id="VFo-Jh-2sw">
                                 <modifierMask key="keyEquivalentModifierMask" option="YES"/>
                                 <connections>

--- a/platform/macos/app/Base.lproj/MapDocument.xib
+++ b/platform/macos/app/Base.lproj/MapDocument.xib
@@ -129,7 +129,7 @@
                         <action selector="selectFeatures:" target="-1" id="ikt-CZ-yZT"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Runtime styling" id="qZJ-mM-bLj">
+                <menuItem title="Manipulate Style" id="qZJ-mM-bLj">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="runtimeStyling:" target="-1" id="gN9-lw-fG8"/>

--- a/platform/macos/app/Base.lproj/MapDocument.xib
+++ b/platform/macos/app/Base.lproj/MapDocument.xib
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="16A254g" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11191" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11191"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="MapDocument">
@@ -17,7 +17,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="388" y="211" width="512" height="480"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <view key="contentView" id="TuG-C5-zLS">
                 <rect key="frame" x="0.0" y="0.0" width="512" height="480"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -127,12 +127,6 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="selectFeatures:" target="-1" id="ikt-CZ-yZT"/>
-                    </connections>
-                </menuItem>
-                <menuItem title="Manipulate Style" id="qZJ-mM-bLj">
-                    <modifierMask key="keyEquivalentModifierMask"/>
-                    <connections>
-                        <action selector="runtimeStyling:" target="-1" id="gN9-lw-fG8"/>
                     </connections>
                 </menuItem>
             </items>

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -495,7 +495,8 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     };
     fillStyleLayer.fillColor = colorFunction;
     
-    NSURL *geoJSONURL = [NSURL URLWithString:@"https://dl.dropboxusercontent.com/u/5285447/amsterdam.geojson"];
+    NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
+    NSURL *geoJSONURL = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"ams" URL:geoJSONURL];
     [self.mapView.style addSource:source];
     

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -484,7 +484,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     }
 }
 
-- (IBAction)runtimeStyling:(id)sender {
+- (IBAction)manipulateStyle:(id)sender {
     MGLFillStyleLayer *fillStyleLayer = (MGLFillStyleLayer *)[self.mapView.style layerWithIdentifier:@"water"];
     
     MGLStyleAttributeFunction *colorFunction = [[MGLStyleAttributeFunction alloc] init];
@@ -600,7 +600,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     if (menuItem.action == @selector(reload:)) {
         return YES;
     }
-    if (menuItem.action == @selector(runtimeStyling:)) {
+    if (menuItem.action == @selector(manipulateStyle:)) {
         return YES;
     }
     if (menuItem.action == @selector(dropPin:)) {


### PR DESCRIPTION
MGLGeoJSONSource can now be initialized with GeoJSON data. Replaced the `data` property with a `geoJSONData` property and added `features` and `URL` properties alongside it. Each property may be set or unset based on how the object was initialized.

Along the way, this change replaces the Dropbox-hosted fixture with a local GeoJSON document for the runtime styling demos in iosapp and macosapp. The runtime styling demo has been renamed “Manipulate Style”, and in macosapp it has been moved from the context menu to the Debug menu.

Fixes #5965, fixes #5966, fixes #6021, fixes #6022, fixes #6024. Depends on #6026.

/cc @frederoni