### PR TITLE
[POC] Naïve right-to-left labeling

### DIFF
--- a/src/mbgl/text/glyph_set.cpp
+++ b/src/mbgl/text/glyph_set.cpp
@@ -70,21 +70,81 @@ void align(Shaping &shaping, const float justify, const float horizontalAlign,
         glyph.y += shiftY;
     }
 }
-    
-void reverse(std::vector<PositionedGlyph> &positionedGlyphs, const std::map<uint32_t, SDFGlyph> &sdfs, const float horizontalAlign, const uint32_t maxLineLength) {
-    auto first = positionedGlyphs.begin()->glyph;
-    auto last = positionedGlyphs.end()->glyph;
-    if ((first >= 0x600 && first <= 0x6ff) /* Arabic */
-        || (first >= 0x750 && first <= 0x77f) /* Arabic Supplement */
-        || (first >= 0x8a0 && first <= 0x8ff) /* Arabic Extended-A */
-        || (first >= 0x590 && first <= 0x5ff) /* Hebrew */
-        || (first >= 0x700 && first <= 0x74f) /* Syriac */
-        || (first >= 0x780 && first <= 0x7bf) /* Thaana */) {
+
+// Returns true if the glyph is a strong right-to-left glyph.
+bool isRTL(uint32_t glyph) {
+    // Use the major RTL Unicode code blocks as a rough approximation.
+    return ((glyph >= 0x600 && glyph <= 0x6ff) /* Arabic */
+            || (glyph >= 0x750 && glyph <= 0x77f) /* Arabic Supplement */
+            || (glyph >= 0x8a0 && glyph <= 0x8ff) /* Arabic Extended-A */
+            || (glyph >= 0x590 && glyph <= 0x5ff) /* Hebrew */
+            || (glyph >= 0x700 && glyph <= 0x74f) /* Syriac */
+            || (glyph >= 0x780 && glyph <= 0x7bf) /* Thaana */);
+}
+
+// Reverse the string to right-to-left orientation if necessary.
+void reverse(std::vector<PositionedGlyph> &positionedGlyphs, const std::map<uint32_t, SDFGlyph> &sdfs) {
+    size_t numRTLChars = 0;
+    for (auto& positionedGlyph : positionedGlyphs) {
+        auto glyph = positionedGlyph.glyph;
+        if (isRTL(glyph)) {
+            numRTLChars++;
+        }
+    }
+    // Treat the entire string as right-to-left if most characters are strong right-to-left characters.
+    bool isMostlyRTL = numRTLChars >= static_cast<float>(positionedGlyphs.size()) / 2.0f;
+    if (isMostlyRTL) {
+        // Reverse the entire string.
         for (auto& glyph : positionedGlyphs) {
             glyph.x *= -1;
             auto it = sdfs.find(glyph.glyph);
             if (it != sdfs.end()) {
                 glyph.x -= it->second.metrics.advance;
+            }
+        }
+        // For bilingual labels, unreverse short spans of LTR text in predominantly RTL strings.
+        for (auto start = positionedGlyphs.begin(), end = start; end != positionedGlyphs.end(); ++end) {
+            if (start != end && (isRTL(end->glyph) || end->y != (end - 1)->y)) {
+                // End of LTR run or line wrap.
+                auto left = (end - 1)->x;
+                auto right = start->x;
+                auto leftSDF = sdfs.find((end - 1)->glyph);
+                if (leftSDF != sdfs.end()) {
+                    right -= leftSDF->second.metrics.advance;
+                }
+                for (; start != end; ++start) {
+                    start->x = left + right - start->x;
+                    auto sdf = sdfs.find(start->glyph);
+                    if (sdf != sdfs.end()) {
+                        start->x += sdf->second.metrics.advance;
+                    }
+                }
+                ++start;
+            } else if (isRTL(end->glyph)) {
+                ++start;
+            }
+        }
+    } else {
+        // For bilingual labels, reverse short spans of RTL text in predominantly LTR strings.
+        for (auto start = positionedGlyphs.begin(), end = start; end != positionedGlyphs.end(); ++end) {
+            if (start != end && (!isRTL(end->glyph) || end->y != (end - 1)->y)) {
+                // End of RTL run or line wrap.
+                auto left = start->x;
+                auto right = (end - 1)->x;
+                auto rightSDF = sdfs.find((end - 1)->glyph);
+                if (rightSDF != sdfs.end()) {
+                    right += rightSDF->second.metrics.advance;
+                }
+                for (; start != end; ++start) {
+                    start->x = left + right - start->x;
+                    auto sdf = sdfs.find(start->glyph);
+                    if (sdf != sdfs.end()) {
+                        start->x -= sdf->second.metrics.advance;
+                    }
+                }
+                ++start;
+            } else if (!isRTL(end->glyph)) {
+                ++start;
             }
         }
     }
@@ -178,7 +238,7 @@ void GlyphSet::lineWrap(Shaping &shaping, const float lineHeight, const float ma
 
     justifyLine(positionedGlyphs, sdfs, lineStartIndex, uint32_t(positionedGlyphs.size()) - 1, justify);
     align(shaping, justify, horizontalAlign, verticalAlign, maxLineLength, lineHeight, line, translate);
-    reverse(positionedGlyphs, sdfs, horizontalAlign, maxLineLength);
+    reverse(positionedGlyphs, sdfs);
 
     // Calculate the bounding box
     shaping.top += -verticalAlign * height;

--- a/src/mbgl/text/glyph_set.cpp
+++ b/src/mbgl/text/glyph_set.cpp
@@ -74,7 +74,7 @@ void align(Shaping &shaping, const float justify, const float horizontalAlign,
 // Returns true if the glyph is a strong right-to-left glyph.
 bool isRTL(uint32_t glyph) {
     // Use the major RTL Unicode code blocks as a rough approximation.
-    return ((glyph >= 0x600 && glyph <= 0x6ff) /* Arabic */
+    return ((glyph >= 0x600 && glyph <= 0x6ff && (glyph < 0x660 || glyph > 0x669) && glyph != 0x66b && glyph != 0x66c && (glyph < 0x6f0 || glyph > 0x6f9)) /* Arabic */
             || (glyph >= 0x750 && glyph <= 0x77f) /* Arabic Supplement */
             || (glyph >= 0x8a0 && glyph <= 0x8ff) /* Arabic Extended-A */
             || (glyph >= 0x590 && glyph <= 0x5ff) /* Hebrew */


### PR DESCRIPTION
This PR is a proof of concept for right-to-left support in core. Labels are mirrored based on the presence of strongly right-to-left characters.

![tel-aviv](https://cloud.githubusercontent.com/assets/1231218/17748952/88c5f6f8-6470-11e6-8e31-3ad68f16b3ad.png)
&nbsp;&nbsp;&nbsp;&nbsp;_Compare the Hebrew label to the text in the popover. The popover is displaying the same string but rendered by Core Text, which fully supports right-to-left text and complex text shaping._

For bilingual or diglossic labels, which are common in some countries on OpenStreetMap, runs of right-to-left text inside predominantly left-to-right text and vice versa are reversed back to logical order.

![karachi](https://cloud.githubusercontent.com/assets/1231218/17748993/cae3a468-6470-11e6-87b3-82c8513e7a30.png)

As you can see in the above screenshot, complex text shaping remains unimplemented. It’s a much larger technical challenge that affects not only layout but also font glyph selection (mapbox/mapbox-gl#4). Regardless, can a native speaker of Arabic, Persian, Urdu, etc. comment on whether mirroring alone at least improves readability compared to what we have currently? I realize that a lack of contextual forms and ligatures would continue to make labels unpresentable, but I’m hopeful we can still make small progress while we work towards full support for these languages.

In practice, mirroring alone does appear to get us complete Hebrew support in styles derived from Mapbox Streets source. Final letter forms are encoded separately in Unicode, rather like in Greek, so they’re already being displayed correctly in master. Meanwhile, _niqqud_ are [nearly nonexistent](http://overpass-turbo.eu/s/hUG) in `name` tags in OpenStreetMap: two short road segments and a building in all of Israel.

On this branch, strong right-to-left characters are defined as those characters that belong to the Arabic, Arabic Supplement, Arabic Extended-A, Hebrew, Syriac, and Thaana code blocks in Unicode. There is currently no support for weak directionality, so spaces and generic punctuation are treated as left-to-right text.

We could address directionality limitations by replacing my hand-rolled algorithm with minimal usage of ICU, which is available on Android, iOS, and macOS. ICU is unavailable on the Web, which is why mapbox/mapbox-gl-js#1841 would require a large dependency. Even if we can’t get intelligent directionality support into GL JS, I don’t think that should block support in the native codebase, because no one is ever going to complain that Hebrew text looks “too correct” on one platform. 😉

This is merely a proof of concept, but the following work would need to take place in order for it to land as a stopgap solution:
- [x] Exclude Eastern Arabic numerals from strong right-to-left blocks
- [x] Mirror labels that have line placement
- [ ] Use ICU to determine (bi)directionality
- [ ] Add rendering tests

/cc @mikemorris @kkaefer @planemad
