### PR TITLE
[ios, macos] Make Xcode 7.3 the minimum required version

### DIFF
--- a/platform/darwin/src/MGLAccountManager.h
+++ b/platform/darwin/src/MGLAccountManager.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLAnnotation.h
+++ b/platform/darwin/src/MGLAnnotation.h
@@ -2,8 +2,6 @@
 #import <CoreLocation/CoreLocation.h>
 #import <TargetConditionals.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -1,7 +1,6 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
-#import "MGLTypes.h"
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -1,7 +1,6 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
-#import "MGLTypes.h"
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 

--- a/platform/darwin/src/MGLClockDirectionFormatter.h
+++ b/platform/darwin/src/MGLClockDirectionFormatter.h
@@ -1,8 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLCompassDirectionFormatter.h
+++ b/platform/darwin/src/MGLCompassDirectionFormatter.h
@@ -1,8 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLCoordinateFormatter.h
+++ b/platform/darwin/src/MGLCoordinateFormatter.h
@@ -1,8 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLFeature.h
+++ b/platform/darwin/src/MGLFeature.h
@@ -5,8 +5,6 @@
 #import "MGLPointAnnotation.h"
 #import "MGLShapeCollection.h"
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -1,7 +1,6 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
-#import "MGLTypes.h"
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 

--- a/platform/darwin/src/MGLGeometry.h
+++ b/platform/darwin/src/MGLGeometry.h
@@ -2,8 +2,6 @@
 #import <CoreLocation/CoreLocation.h>
 #import <CoreGraphics/CGBase.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /** Defines the area spanned by an `MGLCoordinateBounds`. */

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -1,7 +1,6 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
-#import "MGLTypes.h"
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 

--- a/platform/darwin/src/MGLMapCamera.h
+++ b/platform/darwin/src/MGLMapCamera.h
@@ -2,8 +2,6 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreLocation/CoreLocation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLMultiPoint.h
+++ b/platform/darwin/src/MGLMultiPoint.h
@@ -3,8 +3,6 @@
 
 #import "MGLShape.h"
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLMultiPoint_Private.h
+++ b/platform/darwin/src/MGLMultiPoint_Private.h
@@ -1,7 +1,6 @@
 #import "MGLMultiPoint.h"
 
 #import "MGLGeometry.h"
-#import "MGLTypes.h"
 
 #import <mbgl/annotation/annotation.hpp>
 #import <vector>

--- a/platform/darwin/src/MGLOfflineRegion.h
+++ b/platform/darwin/src/MGLOfflineRegion.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLOverlay.h
+++ b/platform/darwin/src/MGLOverlay.h
@@ -4,8 +4,6 @@
 #import "MGLAnnotation.h"
 #import "MGLGeometry.h"
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLPointAnnotation.h
+++ b/platform/darwin/src/MGLPointAnnotation.h
@@ -3,8 +3,6 @@
 
 #import "MGLShape.h"
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -1,7 +1,6 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
-#import "MGLTypes.h"
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 

--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -2,8 +2,6 @@
 
 #import "MGLAnnotation.h"
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -1,8 +1,8 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 #import "MGLStyleLayer.h"
+
+#import "MGLTypes.h"
 
 @class MGLSource;
 

--- a/platform/darwin/src/MGLStyleAttribute.mm
+++ b/platform/darwin/src/MGLStyleAttribute.mm
@@ -3,6 +3,8 @@
 #import "MGLStyleAttributeValue_Private.h"
 #import "MGLStyleAttributeFunction_Private.h"
 
+#import "MGLTypes.h"
+
 @interface MGLStyleAttribute()
 @end
 

--- a/platform/darwin/src/MGLStyleAttributeValue.h
+++ b/platform/darwin/src/MGLStyleAttributeValue.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 @protocol MGLStyleAttributeValue <NSObject>
 @optional
 @end

--- a/platform/darwin/src/MGLStyleAttributeValue_Private.h
+++ b/platform/darwin/src/MGLStyleAttributeValue_Private.h
@@ -1,6 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
 #import "MGLStyleAttributeFunction_Private.h"
 
 #include <array>

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -6,7 +6,6 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
-#import "MGLTypes.h"
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 

--- a/platform/darwin/src/MGLStyleLayer.mm
+++ b/platform/darwin/src/MGLStyleLayer.mm
@@ -1,5 +1,4 @@
 #import "MGLStyleLayer.h"
 
-#import "MGLTypes.h"
 #import "MGLStyleLayer_Private.h"
 #import "MGLMapView_Private.h"

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -1,7 +1,6 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
-#import "MGLTypes.h"
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -2,16 +2,6 @@
 
 #pragma once
 
-#if !__has_feature(nullability)
-    #define NS_ASSUME_NONNULL_BEGIN
-    #define NS_ASSUME_NONNULL_END
-    #define nullable
-    #define nonnull
-    #define null_resettable
-    #define _Nullable
-    #define _Nonnull
-#endif
-
 #if TARGET_OS_IPHONE
 @class UIColor;
 #define MGLColor UIColor

--- a/platform/darwin/src/NSData+MGLAdditions.h
+++ b/platform/darwin/src/NSData+MGLAdditions.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSData (MGLAdditions)

--- a/platform/darwin/src/NSString+MGLAdditions.h
+++ b/platform/darwin/src/NSString+MGLAdditions.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSString (MGLAdditions)

--- a/platform/darwin/src/NSURL+MGLAdditions.h
+++ b/platform/darwin/src/NSURL+MGLAdditions.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSURL (MGLAdditions)

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * A new runtime styling API allows you to adjust the style and content of the base map dynamically. All the options available in [Mapbox Studio](https://www.mapbox.com/studio/) are now exposed via MGLStyle and subclasses of MGLStyleLayer and MGLSource. ([#5727](https://github.com/mapbox/mapbox-gl-native/pull/5727))
 * The user location annotation is now customizable via the newly added `MGLUserLocationAnnotationView` class. ([#5882](https://github.com/mapbox/mapbox-gl-native/pull/5882))
+* Xcode 7.3 or higher is now required to use this SDK. ([#6059](https://github.com/mapbox/mapbox-gl-native/issues/6059))
 * Simulator architecture slices are included in the included dSYM file, allowing you to symbolicate crashes that occur in the Simulator. ([#5740](https://github.com/mapbox/mapbox-gl-native/pull/5740))
 * As the user zooms in, tiles from lower zoom levels are scaled up until tiles for higher zoom levels are loaded. ([#5143](https://github.com/mapbox/mapbox-gl-native/pull/5143))
 * Fixed an issue causing the wrong annotation view to be selected when tapping an annotation view with a center offset applied. ([#5931](https://github.com/mapbox/mapbox-gl-native/pull/5931))

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -6,6 +6,8 @@ This document explains how to build the Mapbox iOS SDK from source. It is intend
 
 The Mapbox iOS SDK and iosapp demo application build against the iOS 7.0 SDK. The SDK is intended to run on iOS 7.0 and above, while iosapp is intended to run on iOS 8.0 and above due to the use of a dynamic framework. Both require Xcode on a computer running macOS.
 
+The Mapbox iOS SDK requires Xcode 7.3 or higher.
+
 ## Building the SDK
 
 Make sure that you have the [core dependencies](../../INSTALL.md) installed.
@@ -83,6 +85,7 @@ To add an Objective-C class, protocol, category, typedef, enumeration, or global
 To add an Objective-C header or implementation file to the iOS SDK:
 
 1. Add the file to the Headers or Compile Sources build phase, as appropriate, of both the “dynamic” and “static” targets. You can either use the Build Phases tab of the project editor or the Target Membership section of the File inspector.
+1. Audit new headers for nullability. Typically, you will wrap a header with `NS_ASSUME_NONNULL_BEGIN` and `NS_ASSUME_NONNULL_END`.
 1. _(Optional.)_ If it’s a public header, change its visibility from Project to Public and import it in [the iOS SDK’s umbrella header](./src/Mapbox.h).
 1. _(Optional.)_ If the file would also be used by the macOS SDK, make sure it’s in [platform/darwin/src/](../darwin/src/), then consult [the companion macOS document](../macos/DEVELOPING.md#adding-a-source-code-file) for further instructions.
 

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -4,11 +4,13 @@ This document explains how to build a development version of Mapbox iOS SDK for 
 
 ### Requirements
 
-The Mapbox iOS SDK application builds against the iOS 7.0 SDK. It is intended to run on iOS 7.0 and above on the following devices and their simulators:
+The Mapbox iOS SDK builds against the iOS 7.0 SDK. It is intended to run on iOS 7.0 and above on the following devices and their simulators:
 
 * iPhone 4S and above (5, 5c, 5s, 6, 6 Plus)
 * iPad 2 and above (3, 4, Mini, Air, Mini 2, Air 2)
 * iPod touch 5th generation and above
+
+The Mapbox iOS SDK requires Xcode 7.3 or higher.
 
 ### Building the SDK
 

--- a/platform/ios/docs/pod-README.md
+++ b/platform/ios/docs/pod-README.md
@@ -10,6 +10,8 @@ For more information, check out the [Mapbox iOS SDK homepage](https://www.mapbox
 
 The Mapbox iOS SDK may be installed as either a dynamic framework or a static framework. (To reduce the download size, the static framework is omitted from some distributions; you may need to download the full package from the [release page](https://github.com/mapbox/mapbox-gl-native/releases/).)
 
+Integrating the Mapbox iOS SDK requires Xcode 7.3 or higher.
+
 {{DYNAMIC}}
 
 ### Dynamic framework

--- a/platform/ios/src/MGLAPIClient.h
+++ b/platform/ios/src/MGLAPIClient.h
@@ -3,10 +3,14 @@
 #import "MGLMapboxEvents.h"
 #import "MGLTypes.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MGLAPIClient : NSObject <NSURLSessionDelegate>
 
-- (void)postEvents:(nonnull NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
-- (void)postEvent:(nonnull MGLMapboxEventAttributes *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
+- (void)postEvents:(NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
+- (void)postEvent:(MGLMapboxEventAttributes *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)cancelAll;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/ios/src/MGLAnnotationImage.h
+++ b/platform/ios/src/MGLAnnotationImage.h
@@ -1,7 +1,5 @@
 #import <UIKit/UIKit.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -1,7 +1,5 @@
 #import <UIKit/UIKit.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MGLAnnotation;

--- a/platform/ios/src/MGLCalloutView.h
+++ b/platform/ios/src/MGLCalloutView.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MGLCalloutViewDelegate;

--- a/platform/ios/src/MGLMapView+IBAdditions.h
+++ b/platform/ios/src/MGLMapView+IBAdditions.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 @class MGLMapView;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platform/ios/src/MGLUserLocation.h
+++ b/platform/ios/src/MGLUserLocation.h
@@ -3,8 +3,6 @@
 
 #import "MGLAnnotation.h"
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/ios/src/MGLUserLocationAnnotationView.h
+++ b/platform/ios/src/MGLUserLocationAnnotationView.h
@@ -2,8 +2,6 @@
 #import <CoreLocation/CoreLocation.h>
 #import <Mapbox/Mapbox.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class MGLMapView;

--- a/platform/macos/DEVELOPING.md
+++ b/platform/macos/DEVELOPING.md
@@ -4,7 +4,9 @@ This document explains how to build the Mapbox macOS SDK from source. It is inte
 
 ## Requirements
 
-The Mapbox macOS SDK and the macosapp demo application run on macOS 10.10.0 and above.
+The Mapbox macOS SDK and the macosapp demo application run on macOS 10.10.0 or above.
+
+The Mapbox macOS SDK requires Xcode 7.3 or above.
 
 ## Building the SDK
 
@@ -34,6 +36,7 @@ To add an Objective-C class, protocol, category, typedef, enumeration, or global
 To add an Objective-C header or implementation file to the macOS SDK:
 
 1. Add the file to the “dynamic” target’s Headers or Compile Sources build phase, as appropriate. You can either use the Build Phases tab of the project editor or the Target Membership section of the File inspector.
+1. Audit new headers for nullability. Typically, you will wrap a header with `NS_ASSUME_NONNULL_BEGIN` and `NS_ASSUME_NONNULL_END`.
 1. _(Optional.)_ If it’s a public header, change its visibility from Project to Public and import it in [the macOS SDK’s umbrella header](./src/Mapbox.h).
 1. _(Optional.)_ If the file would also be used by the iOS SDK, make sure it’s in [platform/darwin/src/](../darwin/src/), then consult [the companion iOS document](../ios/DEVELOPING.md#adding-a-source-code-file) for further instructions.
 

--- a/platform/macos/INSTALL.md
+++ b/platform/macos/INSTALL.md
@@ -4,7 +4,7 @@ This document explains how to build the Mapbox macOS SDK and integrate it into y
 
 ### Requirements
 
-The Mapbox macOS SDK requires the macOS 10.10.0 SDK or above.
+The Mapbox macOS SDK requires the macOS 10.10.0 SDK (or above) and Xcode 7.3 (or above).
 
 ### Building the SDK
 

--- a/platform/macos/src/MGLAnnotationImage.h
+++ b/platform/macos/src/MGLAnnotationImage.h
@@ -1,7 +1,5 @@
 #import <AppKit/AppKit.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -1,6 +1,7 @@
 #import <Cocoa/Cocoa.h>
 #import <CoreLocation/CoreLocation.h>
 
+#import "MGLTypes.h"
 #import "MGLGeometry.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -1,7 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class MGLMapView;

--- a/platform/macos/src/MGLOpenGLLayer.h
+++ b/platform/macos/src/MGLOpenGLLayer.h
@@ -1,7 +1,5 @@
 #import <Cocoa/Cocoa.h>
 
-#import "MGLTypes.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 /// A subclass of NSOpenGLLayer that creates the environment mbgl needs to


### PR DESCRIPTION
This commit makes Xcode 7.3 the minimum version requirement to build and integrate the iOS SDK.

This removes `#import “MGLTypes.h”` from headers where it was only being used to conditionally define `NS_ASSUME_NONNULL_*` and various nullability traits, which were necessary to support Xcode 6.

Xcode 7.3 becomes the minimum supported version because of `NS_SWIFT_NAME`, which is not fully supported by lower versions (and we were already using it).

@frederoni I also removed the MGLTypes.h import from the runtime styling generation template and regenerated.

Fixes #5472.

/cc @1ec5 @tmcw