### PR TITLE
[core] add template instances for Source.is<>().

### DIFF
--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -50,5 +50,10 @@ public:
     Impl* const impl;
 };
 
+template <>
+inline bool Source::is<GeoJSONSource>() const {
+    return type == SourceType::GeoJSON;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/sources/raster_source.hpp
+++ b/include/mbgl/style/sources/raster_source.hpp
@@ -16,5 +16,10 @@ public:
     class Impl;
 };
 
+template <>
+inline bool Source::is<RasterSource>() const {
+    return type == SourceType::Raster;
+}
+
 } // namespace style
 } // namespace mbgl

--- a/include/mbgl/style/sources/vector_source.hpp
+++ b/include/mbgl/style/sources/vector_source.hpp
@@ -16,5 +16,10 @@ public:
     class Impl;
 };
 
+template <>
+inline bool Source::is<VectorSource>() const {
+    return type == SourceType::Vector;
+}
+
 } // namespace style
 } // namespace mbgl


### PR DESCRIPTION
Adds some template instances to use with `Source.is()`

