### PR TITLE
Offsets as vectors, padding as edge insets

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -176,10 +176,10 @@ global.describeValue = function (value, property, layerType) {
                 units = ` ${units}`.replace(/pixel/, 'point');
             }
             if (property.name.indexOf('padding') !== -1) {
-                //if (value.reduce((a, b) => a + b, 0) === 0) {
-                //    return '`NSEdgeInsetsZero` or `UIEdgeInsetsZero`';
-                //}
-                return `${value[0]}${units} on the top, ${value[1]}${units} on the right, ${value[2]}${units} on the bottom, and ${value[3]}${units} on the left`;
+                if (value.reduce((a, b) => a + b, 0) === 0) {
+                    return '`NSEdgeInsetsZero` or `UIEdgeInsetsZero`';
+                }
+                return `${value[0]}${units} on the top, ${value[3]}${units} on the left, ${value[2]}${units} on the bottom, and ${value[1]}${units} on the right`;
             }
             if (property.name.indexOf('offset') !== -1 || property.name.indexOf('translate') !== -1) {
                 return `${value[0]}${units} from the left and ${value[1]}${units} from the top`;

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -98,7 +98,15 @@ global.propertyDoc = function (property, layerType) {
         }
         return '`' + symbol + '`';
     });
-    return doc;
+    if ('units' in property) {
+        if (!property.units.match(/s$/)) {
+            property.units += 's';
+        }
+        doc += `
+
+ This property is measured in ${property.units}.`;
+    }
+    return doc.replace(/(p)ixel/gi, '$1oint').replace(/(\d)px\b/g, '$1pt');
 };
 
 global.parseColor = function (str) {
@@ -140,14 +148,18 @@ global.propertyDefault = function (property, layerType) {
             }
             return 'an `NSColor` or `UIColor`' + `object whose RGB value is ${color.r}, ${color.g}, ${color.b} and whose alpha value is ${color.a}`;
         case 'array':
+            let units = property.units || '';
+            if (units) {
+                units = ` ${units}`.replace(/pixel/, 'point');
+            }
             if (property.name.indexOf('padding') !== -1) {
                 //if (property.default.reduce((a, b) => a + b, 0) === 0) {
                 //    return '`NSEdgeInsetsZero` or `UIEdgeInsetsZero`';
                 //}
-                return `${property.default[0]} on the top, ${property.default[1]} on the right, ${property.default[2]} on the bottom, and ${property.default[3]} on the left`;
+                return `${property.default[0]}${units} on the top, ${property.default[1]}${units} on the right, ${property.default[2]}${units} on the bottom, and ${property.default[3]}${units} on the left`;
             }
             if (property.name.indexOf('offset') !== -1 || property.name.indexOf('translate') !== -1) {
-                return `${property.default[0]} from the left and ${property.default[1]} from the top`;
+                return `${property.default[0]}${units} from the left and ${property.default[1]}${units} from the top`;
             }
             return '`' + property.default.join('`, `') + '`';
         default:

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -21,6 +21,10 @@ global.camelizeWithLeadingLowercase = function (str) {
 
 global.objCName = function (property) { return camelizeWithLeadingLowercase(property.name); }
 
+global.arrayType = function (property) {
+    return property.type === 'array' ? property.name.split('-').pop() : false;
+};
+
 global.testImplementation = function (property, layerType) {
     switch (property.type) {
         case 'boolean':
@@ -62,28 +66,34 @@ global.testGetterImplementation = function (property, layerType) {
 }
 
 global.testGetterArrayImplementation = function (property) {
-    switch (property.name) {
-        case 'icon-text-fit-padding':
-            return `XCTAssertEqualObjects(gLayer.${objCName(property)}, MGLRuntimeStylingHelper.testPadding);`;
-        case 'line-dasharray':
+    switch (arrayType(property)) {
+        case 'dasharray':
             return `XCTAssertEqualObjects(gLayer.${objCName(property)}, MGLRuntimeStylingHelper.testDashArray);`;
-        case 'text-font':
+        case 'font':
             return `XCTAssertEqualObjects(gLayer.${objCName(property)}, MGLRuntimeStylingHelper.testFont);`;
-        default:
+        case 'padding':
+            return `XCTAssertEqualObjects(gLayer.${objCName(property)}, MGLRuntimeStylingHelper.testPadding);`;
+        case 'offset':
+        case 'translate':
             return `XCTAssertEqualObjects(gLayer.${objCName(property)}, MGLRuntimeStylingHelper.testOffset);`; // Default offset (dx, dy)
+        default:
+            throw new Error(`unknown array type for ${property.name}`);
     }
 };
 
 global.testArrayImplementation = function (property) {
-    switch (property.name) {
-        case 'icon-text-fit-padding':
-            return `layer.${objCName(property)} = MGLRuntimeStylingHelper.testPadding;`;
-        case 'line-dasharray':
+    switch (arrayType(property)) {
+        case 'dasharray':
             return `layer.${objCName(property)} = MGLRuntimeStylingHelper.testDashArray;`;
-        case 'text-font':
+        case 'font':
             return `layer.${objCName(property)} = MGLRuntimeStylingHelper.testFont;`;
-        default:
+        case 'padding':
+            return `layer.${objCName(property)} = MGLRuntimeStylingHelper.testPadding;`;
+        case 'offset':
+        case 'translate':
             return `layer.${objCName(property)} = MGLRuntimeStylingHelper.testOffset;`; // Default offset (dx, dy)
+        default:
+            throw new Error(`unknown array type for ${property.name}`);
     }
 };
 
@@ -264,15 +274,18 @@ global.arrayGetterImplementation = function(property) {
 }
 
 global.convertedType = function(property) {
-    switch (property.name) {
-        case 'icon-text-fit-padding':
-            return "padding";
-        case 'line-dasharray':
-            return "numberArray";
-        case 'text-font':
-            return "stringArray";
+    switch (arrayType(property)) {
+        case 'dasharray':
+            return 'numberArray';
+        case 'font':
+            return 'stringArray';
+        case 'padding':
+            return 'padding';
+        case 'offset':
+        case 'translate':
+            return 'offset';
         default:
-            return "offset";
+            throw new Error(`unknown array type for ${property.name}`);
     }
 }
 

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -87,6 +87,16 @@ global.testArrayImplementation = function (property) {
     }
 };
 
+global.propertyDoc = function (property, layerType) {
+    let doc = property.doc.replace(/`(.+?)`/g, function (m, symbol, offset, str) {
+        if (!('values' in property && property.values.indexOf(symbol) !== -1) && str.substr(offset - 4, 3) !== 'CSS') {
+            symbol = camelizeWithLeadingLowercase(symbol);
+        }
+        return '`' + symbol + '`';
+    });
+    return doc;
+};
+
 global.propertyType = function (property, _private) {
     return _private ? `id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>` : `id <MGLStyleAttributeValue>`;
 };

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -176,7 +176,7 @@ global.describeValue = function (value, property, layerType) {
                 units = ` ${units}`.replace(/pixel/, 'point');
             }
             if (property.name.indexOf('padding') !== -1) {
-                if (value.reduce((a, b) => a + b, 0) === 0) {
+                if (value[0] === 0 && value[1] === 0 && value[2] === 0 && value[3] === 0) {
                     return '`NSEdgeInsetsZero` or `UIEdgeInsetsZero`';
                 }
                 return `${value[0]}${units} on the top, ${value[3]}${units} on the left, ${value[2]}${units} on the bottom, and ${value[1]}${units} on the right`;

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -265,14 +265,6 @@ global.arrayGetterImplementation = function(property) {
 
 global.convertedType = function(property) {
     switch (property.name) {
-        case 'boolean':
-            return 'bool';
-        case 'number':
-            return 'number';
-        case 'color':
-            return 'color';
-        case 'string':
-            return 'string';
         case 'icon-text-fit-padding':
             return "padding";
         case 'line-dasharray':

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -4,8 +4,8 @@ const fs = require('fs');
 const ejs = require('ejs');
 const spec = require('mapbox-gl-style-spec').latest;
 
-var prefix = 'MGL';
-var suffix = 'StyleLayer';
+const prefix = 'MGL';
+const suffix = 'StyleLayer';
 
 global.camelize = function (str) {
     return str.replace(/(?:^|-)(.)/g, function (_, x) {
@@ -30,8 +30,8 @@ global.testImplementation = function (property, layerType) {
         case 'string':
             return `layer.${objCName(property)} = MGLRuntimeStylingHelper.testString;`;
         case 'enum':
-            var objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
-            var objCEnum = `${objCType}${camelize(property.values[property.values.length-1])}`;
+            let objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
+            let objCEnum = `${objCType}${camelize(property.values[property.values.length-1])}`;
             return `layer.${objCName(property)} = [MGLRuntimeStylingHelper testEnum:${objCEnum} type:@encode(${objCType})];`;    
         case 'color':
             return `layer.${objCName(property)} = MGLRuntimeStylingHelper.testColor;`;
@@ -50,8 +50,8 @@ global.testGetterImplementation = function (property, layerType) {
         case 'string':
             return `XCTAssertEqualObjects(gLayer.${objCName(property)}, MGLRuntimeStylingHelper.testString);`;
         case 'enum':
-            var objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
-            var objCEnum = `${objCType}${camelize(property.values[property.values.length-1])}`;
+            let objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
+            let objCEnum = `${objCType}${camelize(property.values[property.values.length-1])}`;
             return `XCTAssert([(NSValue *)gLayer.${objCName(property)} objCType] == [[MGLRuntimeStylingHelper testEnum:${objCEnum} type:@encode(${objCType})] objCType]);`;
         case 'color':
             return `XCTAssertEqualObjects(gLayer.${objCName(property)}, MGLRuntimeStylingHelper.testColor);`;
@@ -100,7 +100,7 @@ global.initLayer = function (layerType) {
 }
 
 global.setterImplementation = function(property, layerType) {
-    var implementation = '';
+    let implementation = '';
     switch (property.type) {
         case 'boolean':
             implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mbgl_boolPropertyValue);`;
@@ -112,7 +112,7 @@ global.setterImplementation = function(property, layerType) {
             implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mbgl_stringPropertyValue);`;
             break;
         case 'enum':
-            var objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
+            let objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
             implementation = `MGLSetEnumProperty(${objCName(property)}, ${camelize(property.name)}, ${mbglType(property)}, ${objCType});`;
             break;
         case 'color':
@@ -128,7 +128,7 @@ global.setterImplementation = function(property, layerType) {
 }
 
 global.mbglType = function(property) {
-    var mbglType = camelize(property.name) + 'Type';
+    let mbglType = camelize(property.name) + 'Type';
     if (/-translate-anchor$/.test(property.name)) {
         mbglType = 'TranslateAnchorType';
     }
@@ -151,7 +151,7 @@ global.getterImplementation = function(property, layerType) {
         case 'string':
             return `return [MGLStyleAttribute mbgl_stringWithPropertyValueString:self.layer->get${camelize(property.name)}()];`
         case 'enum':
-            var objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
+            let objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
             return `MGLGetEnumProperty(${camelize(property.name)}, ${mbglType(property)}, ${objCType});`;
         case 'color':
             return `return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->get${camelize(property.name)}()];`

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -4,23 +4,31 @@
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MGLBackgroundStyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
 #pragma mark - Accessing the Paint Attributes
 
 /**
  The color with which the background will be drawn.
+
+ The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> backgroundColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundColor;
 
 /**
  Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
  */
-@property (nonatomic) id <MGLStyleAttributeValue> backgroundPattern;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundPattern;
 
 /**
  The opacity at which the background will be drawn.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> backgroundOpacity;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundOpacity;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -12,8 +12,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The color with which the background will be drawn.
-
+ 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `backgroundPattern` is set to `nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundColor;
 
@@ -24,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The opacity at which the background will be drawn.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundOpacity;

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -13,23 +13,23 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The color with which the background will be drawn.
  
- The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+
  This property is only applied to the style if `backgroundPattern` is set to `nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> backgroundColor;
 
 /**
  Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundPattern;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> backgroundPattern;
 
 /**
  The opacity at which the background will be drawn.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundOpacity;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> backgroundOpacity;
 
 @end
 

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The color with which the background will be drawn.
 
- The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
+ The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> backgroundColor;
 

--- a/platform/darwin/src/MGLBaseStyleLayer.h
+++ b/platform/darwin/src/MGLBaseStyleLayer.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
 
+#import "MGLTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MGLBaseStyleLayer : NSObject
 
 @property (nonatomic, assign, getter=isVisible) BOOL visible;
@@ -15,3 +19,5 @@
 @property (nonatomic, assign) float minimumZoomLevel;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -25,55 +25,55 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 
  This property is measured in points.
  
- The default value of this property is `5`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `5`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleRadius;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> circleRadius;
 
 /**
  The color of the circle.
  
- The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> circleColor;
 
 /**
  Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleBlur;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> circleBlur;
 
 /**
  The opacity at which the circle will be drawn.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleOpacity;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> circleOpacity;
 
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
  This property is measured in points.
  
- The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of 0 points from the left and 0 points from the top.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslate;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> circleTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
  
- The default value of this property is `MGLCircleStyleLayerCircleTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLCircleStyleLayerCircleTranslateAnchorMap`.
+
  This property is only applied to the style if `circleTranslate` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslateAnchor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> circleTranslateAnchor;
 
 /**
  Controls the scaling behavior of the circle when the map is pitched. The value `MGLCircleStyleLayerCirclePitchScaleMap` scales circles according to their apparent distance to the camera. The value `MGLCircleStyleLayerCirclePitchScaleViewport` results in no pitch-related scaling.
  
- The default value of this property is `MGLCircleStyleLayerCirclePitchScaleMap`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLCircleStyleLayerCirclePitchScaleMap`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circlePitchScale;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> circlePitchScale;
 
 @end
 

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -4,6 +4,8 @@
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCircleTranslateAnchor) {
     MGLCircleStyleLayerCircleTranslateAnchorMap,
     MGLCircleStyleLayerCircleTranslateAnchorViewport,
@@ -20,37 +22,53 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 
 /**
  Circle radius.
+
+ The default value of this property is `5`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> circleRadius;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleRadius;
 
 /**
  The color of the circle.
+
+ The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> circleColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleColor;
 
 /**
  Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> circleBlur;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleBlur;
 
 /**
  The opacity at which the circle will be drawn.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> circleOpacity;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleOpacity;
 
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
+
+ The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> circleTranslate;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
+
+ The default value of this property is `map`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> circleTranslateAnchor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslateAnchor;
 
 /**
  Controls the scaling behavior of the circle when the map is pitched. The value `map` scales circles according to their apparent distance to the camera. The value `viewport` results in no pitch-related scaling.
+
+ The default value of this property is `map`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> circlePitchScale;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circlePitchScale;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -24,28 +24,28 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
  Circle radius.
 
  This property is measured in points.
-
+ 
  The default value of this property is `5`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleRadius;
 
 /**
  The color of the circle.
-
+ 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleColor;
 
 /**
  Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleBlur;
 
 /**
  The opacity at which the circle will be drawn.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleOpacity;
@@ -54,21 +54,23 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
  This property is measured in points.
-
+ 
  The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
-
+ 
  The default value of this property is `MGLCircleStyleLayerCircleTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `circleTranslate` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslateAnchor;
 
 /**
  Controls the scaling behavior of the circle when the map is pitched. The value `MGLCircleStyleLayerCirclePitchScaleMap` scales circles according to their apparent distance to the camera. The value `MGLCircleStyleLayerCirclePitchScaleViewport` results in no pitch-related scaling.
-
+ 
  The default value of this property is `MGLCircleStyleLayerCirclePitchScaleMap`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circlePitchScale;

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 /**
  The color of the circle.
 
- The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
+ The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleColor;
 
@@ -51,21 +51,21 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
- The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
+ The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
 
- The default value of this property is `map`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLCircleStyleLayerCircleTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslateAnchor;
 
 /**
- Controls the scaling behavior of the circle when the map is pitched. The value `map` scales circles according to their apparent distance to the camera. The value `viewport` results in no pitch-related scaling.
+ Controls the scaling behavior of the circle when the map is pitched. The value `MGLCircleStyleLayerCirclePitchScaleMap` scales circles according to their apparent distance to the camera. The value `MGLCircleStyleLayerCirclePitchScaleViewport` results in no pitch-related scaling.
 
- The default value of this property is `map`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLCircleStyleLayerCirclePitchScaleMap`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circlePitchScale;
 

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -23,6 +23,8 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 /**
  Circle radius.
 
+ This property is measured in points.
+
  The default value of this property is `5`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleRadius;
@@ -51,7 +53,9 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
- The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
+ This property is measured in points.
+
+ The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleTranslate;
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -18,7 +18,7 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 /**
  Whether or not the fill should be antialiased.
 
- The default value of this property is `true`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `YES`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillAntialias;
 
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 /**
  The color of the filled part of this layer. This color can be specified as rgba with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.
 
- The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
+ The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillColor;
 
@@ -44,14 +44,14 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
- The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
+ The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
 
- The default value of this property is `map`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLFillStyleLayerFillTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslateAnchor;
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -17,27 +17,31 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 
 /**
  Whether or not the fill should be antialiased.
-
+ 
  The default value of this property is `YES`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillAntialias;
 
 /**
  The opacity of the entire fill layer. In contrast to the fill-color, this value will also affect the 1pt stroke around the fill, if the stroke is used.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillOpacity;
 
 /**
  The color of the filled part of this layer. This color can be specified as rgba with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
-
+ 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `fillPattern` is set to `nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillColor;
 
 /**
  The outline color of the fill. Matches the value of `fillColor` if unspecified.
+ 
+ This property is only applied to the style if `fillPattern` is set to `nil`, and `fillAntialias` is set to `YES`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillOutlineColor;
 
@@ -45,15 +49,17 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
  This property is measured in points.
-
+ 
  The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
-
+ 
  The default value of this property is `MGLFillStyleLayerFillTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `fillTranslate` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslateAnchor;
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -18,55 +18,55 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 /**
  Whether or not the fill should be antialiased.
  
- The default value of this property is `YES`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `YES`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillAntialias;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> fillAntialias;
 
 /**
  The opacity of the entire fill layer. In contrast to the fill-color, this value will also affect the 1pt stroke around the fill, if the stroke is used.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillOpacity;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> fillOpacity;
 
 /**
  The color of the filled part of this layer. This color can be specified as rgba with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
  
- The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+
  This property is only applied to the style if `fillPattern` is set to `nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> fillColor;
 
 /**
  The outline color of the fill. Matches the value of `fillColor` if unspecified.
- 
+
  This property is only applied to the style if `fillPattern` is set to `nil`, and `fillAntialias` is set to `YES`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillOutlineColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> fillOutlineColor;
 
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
  This property is measured in points.
  
- The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of 0 points from the left and 0 points from the top.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslate;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> fillTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
  
- The default value of this property is `MGLFillStyleLayerFillTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLFillStyleLayerFillTranslateAnchorMap`.
+
  This property is only applied to the style if `fillTranslate` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslateAnchor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> fillTranslateAnchor;
 
 /**
  Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillPattern;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> fillPattern;
 
 @end
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -4,6 +4,8 @@
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
     MGLFillStyleLayerFillTranslateAnchorMap,
     MGLFillStyleLayerFillTranslateAnchorViewport,
@@ -15,37 +17,49 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 
 /**
  Whether or not the fill should be antialiased.
+
+ The default value of this property is `true`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> fillAntialias;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillAntialias;
 
 /**
  The opacity of the entire fill layer. In contrast to the fill-color, this value will also affect the 1px stroke around the fill, if the stroke is used.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> fillOpacity;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillOpacity;
 
 /**
  The color of the filled part of this layer. This color can be specified as rgba with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.
+
+ The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> fillColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillColor;
 
 /**
  The outline color of the fill. Matches the value of `fillColor` if unspecified.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> fillOutlineColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillOutlineColor;
 
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
+
+ The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> fillTranslate;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
+
+ The default value of this property is `map`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> fillTranslateAnchor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslateAnchor;
 
 /**
  Name of image in sprite to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
  */
-@property (nonatomic) id <MGLStyleAttributeValue> fillPattern;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillPattern;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 @property (nonatomic) id <MGLStyleAttributeValue> fillColor;
 
 /**
- The outline color of the fill. Matches the value of `fill-color` if unspecified.
+ The outline color of the fill. Matches the value of `fillColor` if unspecified.
  */
 @property (nonatomic) id <MGLStyleAttributeValue> fillOutlineColor;
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -23,14 +23,14 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillAntialias;
 
 /**
- The opacity of the entire fill layer. In contrast to the fill-color, this value will also affect the 1px stroke around the fill, if the stroke is used.
+ The opacity of the entire fill layer. In contrast to the fill-color, this value will also affect the 1pt stroke around the fill, if the stroke is used.
 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillOpacity;
 
 /**
- The color of the filled part of this layer. This color can be specified as rgba with an alpha component and the color's opacity will not affect the opacity of the 1px stroke, if it is used.
+ The color of the filled part of this layer. This color can be specified as rgba with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
  */
@@ -44,7 +44,9 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
- The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
+ This property is measured in points.
+
+ The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> fillTranslate;
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -4,6 +4,8 @@
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineCap) {
     MGLLineStyleLayerLineCapButt,
     MGLLineStyleLayerLineCapRound,
@@ -27,74 +29,100 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 
 /**
  The display of line endings.
+
+ The default value of this property is `butt`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineCap;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineCap;
 
 /**
  The display of lines when joining.
+
+ The default value of this property is `miter`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineJoin;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineJoin;
 
 /**
  Used to automatically convert miter joins to bevel joins for sharp angles.
+
+ The default value of this property is `2`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineMiterLimit;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineMiterLimit;
 
 /**
  Used to automatically convert round joins to miter joins for shallow angles.
+
+ The default value of this property is `1.05`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineRoundLimit;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineRoundLimit;
 
 #pragma mark - Accessing the Paint Attributes
 
 /**
  The opacity at which the line will be drawn.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineOpacity;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineOpacity;
 
 /**
  The color with which the line will be drawn.
+
+ The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineColor;
 
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
+
+ The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineTranslate;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
+
+ The default value of this property is `map`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineTranslateAnchor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslateAnchor;
 
 /**
  Stroke thickness.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineWidth;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineWidth;
 
 /**
  Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineGapWidth;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineGapWidth;
 
 /**
  The line's offset perpendicular to its direction. Values may be positive or negative, where positive indicates "rightwards" (if you were moving in the direction of the line) and negative indicates "leftwards."
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineOffset;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineOffset;
 
 /**
  Blur applied to the line, in pixels.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineBlur;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineBlur;
 
 /**
  Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to pixels, multiply the length by the current line width.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> lineDasharray;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineDasharray;
 
 /**
  Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512).
  */
-@property (nonatomic) id <MGLStyleAttributeValue> linePattern;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> linePattern;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -74,7 +74,9 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
- The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
+ This property is measured in points.
+
+ The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslate;
 
@@ -88,12 +90,16 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 /**
  Stroke thickness.
 
+ This property is measured in points.
+
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineWidth;
 
 /**
  Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
+
+ This property is measured in points.
 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
@@ -102,19 +108,25 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 /**
  The line's offset perpendicular to its direction. Values may be positive or negative, where positive indicates "rightwards" (if you were moving in the direction of the line) and negative indicates "leftwards."
 
+ This property is measured in points.
+
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineOffset;
 
 /**
- Blur applied to the line, in pixels.
+ Blur applied to the line, in points.
+
+ This property is measured in points.
 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineBlur;
 
 /**
- Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to pixels, multiply the length by the current line width.
+ Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to points, multiply the length by the current line width.
+
+ This property is measured in line widths.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineDasharray;
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -29,29 +29,33 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 
 /**
  The display of line endings.
-
+ 
  The default value of this property is `MGLLineStyleLayerLineCapButt`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineCap;
 
 /**
  The display of lines when joining.
-
+ 
  The default value of this property is `MGLLineStyleLayerLineJoinMiter`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineJoin;
 
 /**
  Used to automatically convert miter joins to bevel joins for sharp angles.
-
+ 
  The default value of this property is `2`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `lineJoin` is set to `MGLLineStyleLayerLineJoinMiter`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineMiterLimit;
 
 /**
  Used to automatically convert round joins to miter joins for shallow angles.
-
+ 
  The default value of this property is `1.05`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `lineJoin` is set to `MGLLineStyleLayerLineJoinRound`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineRoundLimit;
 
@@ -59,15 +63,17 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 
 /**
  The opacity at which the line will be drawn.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineOpacity;
 
 /**
  The color with which the line will be drawn.
-
+ 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineColor;
 
@@ -75,15 +81,17 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
  This property is measured in points.
-
+ 
  The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
-
+ 
  The default value of this property is `MGLLineStyleLayerLineTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `lineTranslate` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslateAnchor;
 
@@ -91,7 +99,7 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
  Stroke thickness.
 
  This property is measured in points.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineWidth;
@@ -100,7 +108,7 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
  Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
 
  This property is measured in points.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineGapWidth;
@@ -109,7 +117,7 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
  The line's offset perpendicular to its direction. Values may be positive or negative, where positive indicates "rightwards" (if you were moving in the direction of the line) and negative indicates "leftwards."
 
  This property is measured in points.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineOffset;
@@ -118,7 +126,7 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
  Blur applied to the line, in points.
 
  This property is measured in points.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineBlur;
@@ -127,6 +135,8 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
  Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to points, multiply the length by the current line width.
 
  This property is measured in line widths.
+ 
+ This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineDasharray;
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -30,120 +30,120 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 /**
  The display of line endings.
  
- The default value of this property is `MGLLineStyleLayerLineCapButt`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLLineStyleLayerLineCapButt`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineCap;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineCap;
 
 /**
  The display of lines when joining.
  
- The default value of this property is `MGLLineStyleLayerLineJoinMiter`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLLineStyleLayerLineJoinMiter`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineJoin;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineJoin;
 
 /**
  Used to automatically convert miter joins to bevel joins for sharp angles.
  
- The default value of this property is `2`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `2`.
  
  This property is only applied to the style if `lineJoin` is set to `MGLLineStyleLayerLineJoinMiter`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineMiterLimit;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineMiterLimit;
 
 /**
  Used to automatically convert round joins to miter joins for shallow angles.
  
- The default value of this property is `1.05`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1.05`.
  
  This property is only applied to the style if `lineJoin` is set to `MGLLineStyleLayerLineJoinRound`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineRoundLimit;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineRoundLimit;
 
 #pragma mark - Accessing the Paint Attributes
 
 /**
  The opacity at which the line will be drawn.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineOpacity;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineOpacity;
 
 /**
  The color with which the line will be drawn.
  
- The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+
  This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineColor;
 
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
  This property is measured in points.
  
- The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of 0 points from the left and 0 points from the top.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslate;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
  
- The default value of this property is `MGLLineStyleLayerLineTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLLineStyleLayerLineTranslateAnchorMap`.
+
  This property is only applied to the style if `lineTranslate` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslateAnchor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineTranslateAnchor;
 
 /**
  Stroke thickness.
 
  This property is measured in points.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineWidth;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineWidth;
 
 /**
  Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.
 
  This property is measured in points.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineGapWidth;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineGapWidth;
 
 /**
  The line's offset perpendicular to its direction. Values may be positive or negative, where positive indicates "rightwards" (if you were moving in the direction of the line) and negative indicates "leftwards."
 
  This property is measured in points.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineOffset;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineOffset;
 
 /**
  Blur applied to the line, in points.
 
  This property is measured in points.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineBlur;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineBlur;
 
 /**
  Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The lengths are later scaled by the line width. To convert a dash length to points, multiply the length by the current line width.
 
  This property is measured in line widths.
- 
+
  This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineDasharray;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> lineDasharray;
 
 /**
  Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512).
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> linePattern;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> linePattern;
 
 @end
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -30,14 +30,14 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 /**
  The display of line endings.
 
- The default value of this property is `butt`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLLineStyleLayerLineCapButt`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineCap;
 
 /**
  The display of lines when joining.
 
- The default value of this property is `miter`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLLineStyleLayerLineJoinMiter`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineJoin;
 
@@ -67,21 +67,21 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 /**
  The color with which the line will be drawn.
 
- The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
+ The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineColor;
 
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
 
- The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
+ The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen)
 
- The default value of this property is `map`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLLineStyleLayerLineTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> lineTranslateAnchor;
 

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The opacity at which the image will be drawn.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterOpacity;
@@ -21,35 +21,35 @@ NS_ASSUME_NONNULL_BEGIN
  Rotates hues around the color wheel.
 
  This property is measured in degrees.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterHueRotate;
 
 /**
  Increase or reduce the brightness of the image. The value is the minimum brightness.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterBrightnessMin;
 
 /**
  Increase or reduce the brightness of the image. The value is the maximum brightness.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterBrightnessMax;
 
 /**
  Increase or reduce the saturation of the image.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterSaturation;
 
 /**
  Increase or reduce the contrast of the image.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterContrast;
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
  Fade duration when a new tile is added.
 
  This property is measured in milliseconds.
-
+ 
  The default value of this property is `300`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterFadeDuration;

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Rotates hues around the color wheel.
 
+ This property is measured in degrees.
+
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterHueRotate;
@@ -54,6 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Fade duration when a new tile is added.
+
+ This property is measured in milliseconds.
 
  The default value of this property is `300`. Set this property to `nil` to reset it to the default.
  */

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -4,43 +4,61 @@
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface MGLRasterStyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
 #pragma mark - Accessing the Paint Attributes
 
 /**
  The opacity at which the image will be drawn.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> rasterOpacity;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterOpacity;
 
 /**
  Rotates hues around the color wheel.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> rasterHueRotate;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterHueRotate;
 
 /**
  Increase or reduce the brightness of the image. The value is the minimum brightness.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> rasterBrightnessMin;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterBrightnessMin;
 
 /**
  Increase or reduce the brightness of the image. The value is the maximum brightness.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> rasterBrightnessMax;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterBrightnessMax;
 
 /**
  Increase or reduce the saturation of the image.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> rasterSaturation;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterSaturation;
 
 /**
  Increase or reduce the contrast of the image.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> rasterContrast;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterContrast;
 
 /**
  Fade duration when a new tile is added.
+
+ The default value of this property is `300`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> rasterFadeDuration;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterFadeDuration;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -13,55 +13,55 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The opacity at which the image will be drawn.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterOpacity;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> rasterOpacity;
 
 /**
  Rotates hues around the color wheel.
 
  This property is measured in degrees.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterHueRotate;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> rasterHueRotate;
 
 /**
  Increase or reduce the brightness of the image. The value is the minimum brightness.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterBrightnessMin;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> rasterBrightnessMin;
 
 /**
  Increase or reduce the brightness of the image. The value is the maximum brightness.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterBrightnessMax;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> rasterBrightnessMax;
 
 /**
  Increase or reduce the saturation of the image.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterSaturation;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> rasterSaturation;
 
 /**
  Increase or reduce the contrast of the image.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterContrast;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> rasterContrast;
 
 /**
  Fade duration when a new tile is added.
 
  This property is measured in milliseconds.
  
- The default value of this property is `300`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `300`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> rasterFadeDuration;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> rasterFadeDuration;
 
 @end
 

--- a/platform/darwin/src/MGLStyleAttribute.mm
+++ b/platform/darwin/src/MGLStyleAttribute.mm
@@ -2,8 +2,7 @@
 
 #import "MGLStyleAttributeValue_Private.h"
 #import "MGLStyleAttributeFunction_Private.h"
-
-#import "MGLTypes.h"
+#import "NSValue+MGLStyleAttributeAdditions_Private.h"
 
 @interface MGLStyleAttribute()
 @end
@@ -58,7 +57,7 @@
 {
     if (property.isConstant()) {
         auto offset = property.asConstant();
-        return @[@(offset[0]), @(offset[1])];
+        return [NSValue mgl_valueWithOffsetArray:offset];
     } else if (property.isFunction()) {
         return [MGLStyleAttributeFunction functionWithOffsetPropertyValue:property.asFunction()];
     } else {
@@ -70,7 +69,7 @@
 {
     if (property.isConstant()) {
         auto padding = property.asConstant();
-        return @[@(padding[0]), @(padding[1]), @(padding[2]), @(padding[3])];
+        return [NSValue mgl_valueWithPaddingArray:padding];
     } else if (property.isFunction()) {
         return [MGLStyleAttributeFunction functionWithPaddingPropertyValue:property.asFunction()];
     } else {

--- a/platform/darwin/src/MGLStyleAttributeFunction.h
+++ b/platform/darwin/src/MGLStyleAttributeFunction.h
@@ -10,8 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy) NS_DICTIONARY_OF(NSNumber *, id) *stops;
 
-@property (nonatomic, copy, nullable) NSString *property;
-
 @property (nonatomic, copy, nullable) NSNumber *base;
 
 @end

--- a/platform/darwin/src/MGLStyleAttributeFunction.mm
+++ b/platform/darwin/src/MGLStyleAttributeFunction.mm
@@ -93,14 +93,9 @@
 - (mbgl::style::PropertyValue<std::array<float, 4> >)mbgl_paddingPropertyValue
 {
     __block std::vector<std::pair<float, std::array<float, 4>>> stops;
-    [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSArray *  _Nonnull padding, BOOL * _Nonnull stop) {
-        NSAssert([padding isKindOfClass:[NSArray class]], @"Stops should be NSArray");
-        NSNumber *top = padding[0];
-        NSNumber *left = padding[1];
-        NSNumber *bottom = padding[2];
-        NSNumber *right = padding[2];
-        auto pad = std::array<float, 4>({{top.floatValue, left.floatValue, bottom.floatValue, right.floatValue}});
-        stops.emplace_back(zoomKey.floatValue, pad);
+    [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSValue * _Nonnull padding, BOOL * _Nonnull stop) {
+        NSAssert([padding isKindOfClass:[NSArray class]], @"Stops should be NSValue");
+        stops.emplace_back(zoomKey.floatValue, padding.mgl_paddingArrayValue);
     }];
     return mbgl::style::Function<std::array<float, 4>>({{stops}}, _base.floatValue);
 }
@@ -108,12 +103,9 @@
 - (mbgl::style::PropertyValue<std::array<float, 2> >)mbgl_offsetPropertyValue
 {
     __block std::vector<std::pair<float, std::array<float, 2>>> stops;
-    [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSArray *  _Nonnull offset, BOOL * _Nonnull stop) {
-        NSAssert([offset isKindOfClass:[NSArray class]], @"Stops should be NSArray");
-        NSNumber *dx = offset[0];
-        NSNumber *dy = offset[1];
-        auto off = std::array<float, 2>({{dx.floatValue, dy.floatValue}});
-        stops.emplace_back(zoomKey.floatValue, off);
+    [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSValue * _Nonnull offset, BOOL * _Nonnull stop) {
+        NSAssert([offset isKindOfClass:[NSValue class]], @"Stops should be NSValue");
+        stops.emplace_back(zoomKey.floatValue, offset.mgl_offsetArrayValue);
     }];
     return mbgl::style::Function<std::array<float, 2>>({{stops}}, _base.floatValue);
 }
@@ -176,7 +168,7 @@
     auto stops = property.getStops();
     NSMutableDictionary *convertedStops = [NSMutableDictionary dictionaryWithCapacity:stops.size()];
     for (auto stop : stops) {
-        convertedStops[@(stop.first)] = @[@(stop.second[0]), @(stop.second[1])];
+        convertedStops[@(stop.first)] = [NSValue mgl_valueWithOffsetArray:stop.second];
     }
     function.base = @(property.getBase());
     function.stops = convertedStops;

--- a/platform/darwin/src/MGLStyleAttributeValue_Private.h
+++ b/platform/darwin/src/MGLStyleAttributeValue_Private.h
@@ -17,7 +17,6 @@
 - (mbgl::style::PropertyValue<std::array<float, 4>>)mbgl_paddingPropertyValue;
 - (mbgl::style::PropertyValue<std::vector<std::string> >)mbgl_stringArrayPropertyValue;
 - (mbgl::style::PropertyValue<std::vector<float> >)mbgl_numberArrayPropertyValue;
-- (mbgl::style::PropertyValue<uint8_t>)mbgl_enumPropertyValue;
 
 // Convert mbgl types to darwin types
 - (id <MGLStyleAttributeValue>)mbgl_colorPropertyValueWith:(mbgl::style::PropertyValue<mbgl::Color>)color;

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 /**
  <%- propertyDoc(property, type) %><% if ('default' in property) { %>
 
- The default value of this property is `<%= property.default %>`.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %>
+ The default value of this property is <%= propertyDefault(property, type) %>.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %>
  */
 @property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 
@@ -52,7 +52,7 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 /**
  <%- propertyDoc(property, type) %><% if ('default' in property) { %>
 
- The default value of this property is `<%= property.default %>`.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %>
+ The default value of this property is <%= propertyDefault(property, type) %>.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %>
  */
 @property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -2,6 +2,8 @@
   const type = locals.type;
   const layoutProperties = locals.layoutProperties;
   const paintProperties = locals.paintProperties;
+  const layoutPropertiesByName = locals.layoutPropertiesByName;
+  const paintPropertiesByName = locals.paintPropertiesByName;
 -%>
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
@@ -39,8 +41,10 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 <% for (const property of layoutProperties) { -%>
 /**
  <%- propertyDoc(property, type) %><% if ('default' in property) { %>
-
- The default value of this property is <%= propertyDefault(property, type) %>.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %>
+ 
+ The default value of this property is <%= propertyDefault(property, type) %>.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %><% if (property.requires) { %>
+ 
+ <%= propertyReqs(property, layoutPropertiesByName, type) %><% } %>
  */
 @property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 
@@ -51,8 +55,10 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 <% for (const property of paintProperties) { -%>
 /**
  <%- propertyDoc(property, type) %><% if ('default' in property) { %>
-
- The default value of this property is <%= propertyDefault(property, type) %>.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %>
+ 
+ The default value of this property is <%= propertyDefault(property, type) %>.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %><% if (property.requires) { %>
+ 
+ <%= propertyReqs(property, paintPropertiesByName, type) %><% } %>
  */
 @property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 
 <% for (const property of layoutProperties) { -%>
 /**
- <%- property.doc %>
+ <%- propertyDoc(property, type) %>
  */
 @property (nonatomic) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 
 <% for (const property of paintProperties) { -%>
 /**
- <%- property.doc %>
+ <%- propertyDoc(property, type) %>
  */
 @property (nonatomic) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -9,6 +9,8 @@
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 <% for (const property of layoutProperties) { -%>
 <% if (property.type == "enum") { -%>
 typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(property.name) %>) {
@@ -36,9 +38,11 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 
 <% for (const property of layoutProperties) { -%>
 /**
- <%- propertyDoc(property, type) %>
+ <%- propertyDoc(property, type) %><% if ('default' in property) { %>
+
+ The default value of this property is `<%= property.default %>`.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %>
  */
-@property (nonatomic) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
+@property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 
 <% } -%>
 <% } -%>
@@ -46,9 +50,13 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 
 <% for (const property of paintProperties) { -%>
 /**
- <%- propertyDoc(property, type) %>
+ <%- propertyDoc(property, type) %><% if ('default' in property) { %>
+
+ The default value of this property is `<%= property.default %>`.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %>
  */
-@property (nonatomic) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
+@property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 
 <% } -%>
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -42,11 +42,11 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 /**
  <%- propertyDoc(property, type) %><% if ('default' in property) { %>
  
- The default value of this property is <%= propertyDefault(property, type) %>.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %><% if (property.requires) { %>
+ <% if (property.required) { %>The default value of this property is <%= propertyDefault(property, type) %>.<% } else { %>If this property is set to `nil`, the layer uses an implicit default value of <%= propertyDefault(property, type) %>.<% } %><% } %><% if (property.requires) { %>
  
  <%= propertyReqs(property, layoutPropertiesByName, type) %><% } %>
  */
-@property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
+@property (nonatomic<% if (!property.required) { %>, nullable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 
 <% } -%>
 <% } -%>
@@ -56,11 +56,11 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 /**
  <%- propertyDoc(property, type) %><% if ('default' in property) { %>
  
- The default value of this property is <%= propertyDefault(property, type) %>.<% if (!property.required) { %> Set this property to `nil` to reset it to the default.<% } %><% } %><% if (property.requires) { %>
- 
+ <% if (property.required) { %>The default value of this property is <%= propertyDefault(property, type) %>.<% } else { %>If this property is set to `nil`, the layer uses an implicit default value of <%= propertyDefault(property, type) %>.<% } %><% } %><% if (property.requires) { %>
+
  <%= propertyReqs(property, paintPropertiesByName, type) %><% } %>
  */
-@property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
+@property (nonatomic<% if (!property.required) { %>, nullable<% } %>) <%- propertyType(property, false, type) %> <%- camelizeWithLeadingLowercase(property.name) %>;
 
 <% } -%>
 @end

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 @property (nonatomic) id <MGLStyleAttributeValue> iconOffset;
 
 /**
- Aligns text to the plane of the `viewport` or the `map` when the map is pitched. Matches `text-rotation-alignment` if unspecified.
+ Aligns text to the plane of the `viewport` or the `map` when the map is pitched. Matches `textRotationAlignment` if unspecified.
  */
 @property (nonatomic) id <MGLStyleAttributeValue> textPitchAlignment;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -81,6 +81,8 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Distance between two symbol anchors.
 
+ This property is measured in points.
+
  The default value of this property is `250`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolSpacing;
@@ -137,7 +139,9 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.
 
- The default value of this property is 0 on the top, 0 on the right, 0 on the bottom, and 0 on the left. Set this property to `nil` to reset it to the default.
+ This property is measured in points.
+
+ The default value of this property is 0 points on the top, 0 points on the right, 0 points on the bottom, and 0 points on the left. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFitPadding;
 
@@ -149,12 +153,16 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Rotates the icon clockwise.
 
+ This property is measured in degrees.
+
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconRotate;
 
 /**
  Size of the additional area around the icon bounding box used for detecting symbol collisions.
+
+ This property is measured in points.
 
  The default value of this property is `2`. Set this property to `nil` to reset it to the default.
  */
@@ -203,12 +211,16 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Font size.
 
+ This property is measured in points.
+
  The default value of this property is `16`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textSize;
 
 /**
  The maximum line width for text wrapping.
+
+ This property is measured in ems.
 
  The default value of this property is `10`. Set this property to `nil` to reset it to the default.
  */
@@ -217,12 +229,16 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Text leading value for multi-line text.
 
+ This property is measured in ems.
+
  The default value of this property is `1.2`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textLineHeight;
 
 /**
  Text tracking amount.
+
+ This property is measured in ems.
 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
@@ -245,6 +261,8 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Maximum angle change between adjacent characters.
 
+ This property is measured in degrees.
+
  The default value of this property is `45`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textMaxAngle;
@@ -252,12 +270,16 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Rotates the text clockwise.
 
+ This property is measured in degrees.
+
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textRotate;
 
 /**
  Size of the additional area around the text bounding box used for detecting symbol collisions.
+
+ This property is measured in points.
 
  The default value of this property is `2`. Set this property to `nil` to reset it to the default.
  */
@@ -280,7 +302,9 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
 
- The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
+ This property is measured in ems.
+
+ The default value of this property is 0 ems from the left and 0 ems from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOffset;
 
@@ -331,12 +355,16 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Distance of halo to the icon outline.
 
+ This property is measured in points.
+
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloWidth;
 
 /**
  Fade out the halo towards the outside.
+
+ This property is measured in points.
 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
@@ -345,7 +373,9 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
 
- The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
+ This property is measured in points.
+
+ The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslate;
 
@@ -380,12 +410,16 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.
 
+ This property is measured in points.
+
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloWidth;
 
 /**
  The halo's fadeout distance towards the outside.
+
+ This property is measured in points.
 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
@@ -394,7 +428,9 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
 
- The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
+ This property is measured in points.
+
+ The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslate;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 
 /**
  Label placement relative to its geometry. `MGLSymbolStyleLayerSymbolPlacementLine` can only be used on LineStrings and Polygons.
-
+ 
  The default value of this property is `MGLSymbolStyleLayerSymbolPlacementPoint`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolPlacement;
@@ -82,57 +82,71 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Distance between two symbol anchors.
 
  This property is measured in points.
-
+ 
  The default value of this property is `250`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `symbolPlacement` is set to `MGLSymbolStyleLayerSymbolPlacementLine`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolSpacing;
 
 /**
  If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer.
-
+ 
  The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolAvoidEdges;
 
 /**
  If true, the icon will be visible even if it collides with other previously drawn symbols.
-
+ 
  The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconAllowOverlap;
 
 /**
  If true, other symbols can be visible even if they collide with the icon.
-
+ 
  The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconIgnorePlacement;
 
 /**
  If true, text will display without their corresponding icons when the icon collides with other symbols and the text does not.
-
+ 
  The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`, and `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOptional;
 
 /**
  Orientation of icon when map is rotated.
-
+ 
  The default value of this property is `MGLSymbolStyleLayerIconRotationAlignmentViewport`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconRotationAlignment;
 
 /**
  Scale factor for icon. 1 is original size, 3 triples the size.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconSize;
 
 /**
  Position and scale an icon by the its corresponding text.
-
+ 
  The default value of this property is `MGLSymbolStyleLayerIconTextFitNone`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`, and `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFit;
 
@@ -140,8 +154,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.
 
  This property is measured in points.
-
+ 
  The default value of this property is 0 points on the top, 0 points on the right, 0 points on the bottom, and 0 points on the left. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`, and `iconTextFit` is non-`nil`, and `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFitPadding;
 
@@ -154,8 +170,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Rotates the icon clockwise.
 
  This property is measured in degrees.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconRotate;
 
@@ -163,48 +181,60 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Size of the additional area around the icon bounding box used for detecting symbol collisions.
 
  This property is measured in points.
-
+ 
  The default value of this property is `2`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconPadding;
 
 /**
  If true, the icon may be flipped to prevent it from being rendered upside-down.
-
+ 
  The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`, and `iconRotationAlignment` is set to `MGLSymbolStyleLayerIconRotationAlignmentMap`, and `symbolPlacement` is set to `MGLSymbolStyleLayerSymbolPlacementLine`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconKeepUpright;
 
 /**
  Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up.
-
+ 
  The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOffset;
 
 /**
  Aligns text to the plane of the `MGLSymbolStyleLayerTextPitchAlignmentViewport` or the `MGLSymbolStyleLayerTextPitchAlignmentMap` when the map is pitched. Matches `textRotationAlignment` if unspecified.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textPitchAlignment;
 
 /**
  Orientation of text when map is rotated.
-
+ 
  The default value of this property is `MGLSymbolStyleLayerTextRotationAlignmentViewport`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textRotationAlignment;
 
 /**
  Value to use for a text label. Feature properties are specified using tokens like {field_name}.
-
+ 
  The default value of this property is ``. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textField;
 
 /**
  Font stack to use for displaying text.
-
+ 
  The default value of this property is `Open Sans Regular`, `Arial Unicode MS Regular`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textFont;
 
@@ -212,8 +242,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Font size.
 
  This property is measured in points.
-
+ 
  The default value of this property is `16`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textSize;
 
@@ -221,8 +253,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  The maximum line width for text wrapping.
 
  This property is measured in ems.
-
+ 
  The default value of this property is `10`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textMaxWidth;
 
@@ -230,8 +264,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Text leading value for multi-line text.
 
  This property is measured in ems.
-
+ 
  The default value of this property is `1.2`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textLineHeight;
 
@@ -239,22 +275,28 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Text tracking amount.
 
  This property is measured in ems.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textLetterSpacing;
 
 /**
  Text justification options.
-
+ 
  The default value of this property is `MGLSymbolStyleLayerTextJustifyCenter`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textJustify;
 
 /**
  Part of the text placed closest to the anchor.
-
+ 
  The default value of this property is `MGLSymbolStyleLayerTextAnchorCenter`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textAnchor;
 
@@ -262,8 +304,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Maximum angle change between adjacent characters.
 
  This property is measured in degrees.
-
+ 
  The default value of this property is `45`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`, and `symbolPlacement` is set to `MGLSymbolStyleLayerSymbolPlacementLine`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textMaxAngle;
 
@@ -271,8 +315,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Rotates the text clockwise.
 
  This property is measured in degrees.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textRotate;
 
@@ -280,22 +326,28 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Size of the additional area around the text bounding box used for detecting symbol collisions.
 
  This property is measured in points.
-
+ 
  The default value of this property is `2`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textPadding;
 
 /**
  If true, the text may be flipped vertically to prevent it from being rendered upside-down.
-
+ 
  The default value of this property is `YES`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`, and `textRotationAlignment` is set to `MGLSymbolStyleLayerTextRotationAlignmentMap`, and `symbolPlacement` is set to `MGLSymbolStyleLayerSymbolPlacementLine`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textKeepUpright;
 
 /**
  Specifies how to capitalize text, similar to the CSS `text-transform` property.
-
+ 
  The default value of this property is `MGLSymbolStyleLayerTextTransformNone`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTransform;
 
@@ -303,29 +355,37 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
 
  This property is measured in ems.
-
+ 
  The default value of this property is 0 ems from the left and 0 ems from the top. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOffset;
 
 /**
  If true, the text will be visible even if it collides with other previously drawn symbols.
-
+ 
  The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textAllowOverlap;
 
 /**
  If true, other symbols can be visible even if they collide with the text.
-
+ 
  The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textIgnorePlacement;
 
 /**
  If true, icons will display without their corresponding text when the text collides with other symbols and the icon does not.
-
+ 
  The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`, and `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOptional;
 
@@ -333,22 +393,28 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 
 /**
  The opacity at which the icon will be drawn.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOpacity;
 
 /**
  The color of the icon. This can only be used with sdf icons.
-
+ 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconColor;
 
 /**
  The color of the icon's halo. Icon halos can only be used with sdf icons.
-
+ 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloColor;
 
@@ -356,8 +422,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Distance of halo to the icon outline.
 
  This property is measured in points.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloWidth;
 
@@ -365,8 +433,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Fade out the halo towards the outside.
 
  This property is measured in points.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloBlur;
 
@@ -374,36 +444,46 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
 
  This property is measured in points.
-
+ 
  The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen).
-
+ 
  The default value of this property is `MGLSymbolStyleLayerIconTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `iconImage` is non-`nil`, and `iconTranslate` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslateAnchor;
 
 /**
  The opacity at which the text will be drawn.
-
+ 
  The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOpacity;
 
 /**
  The color with which the text will be drawn.
-
+ 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textColor;
 
 /**
  The color of the text's halo, which helps it stand out from backgrounds.
-
+ 
  The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloColor;
 
@@ -411,8 +491,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.
 
  This property is measured in points.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloWidth;
 
@@ -420,8 +502,10 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  The halo's fadeout distance towards the outside.
 
  This property is measured in points.
-
+ 
  The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloBlur;
 
@@ -429,15 +513,19 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
  Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
 
  This property is measured in points.
-
+ 
  The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen).
-
+ 
  The default value of this property is `MGLSymbolStyleLayerTextTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
+ 
+ This property is only applied to the style if `textField` is non-`nil`, and `textTranslate` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslateAnchor;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -155,7 +155,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 
  This property is measured in points.
  
- If this property is set to `nil`, the layer uses an implicit default value of 0 points on the top, 0 points on the right, 0 points on the bottom, and 0 points on the left.
+ If this property is set to `nil`, the layer uses an implicit default value of `NSEdgeInsetsZero` or `UIEdgeInsetsZero`.
  
  This property is only applied to the style if `iconImage` is non-`nil`, and `iconTextFit` is non-`nil`, and `textField` is non-`nil`. Otherwise, it is ignored.
  */

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -72,9 +72,9 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 #pragma mark - Accessing the Layout Attributes
 
 /**
- Label placement relative to its geometry. `line` can only be used on LineStrings and Polygons.
+ Label placement relative to its geometry. `MGLSymbolStyleLayerSymbolPlacementLine` can only be used on LineStrings and Polygons.
 
- The default value of this property is `point`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerSymbolPlacementPoint`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolPlacement;
 
@@ -88,35 +88,35 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer.
 
- The default value of this property is `false`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolAvoidEdges;
 
 /**
  If true, the icon will be visible even if it collides with other previously drawn symbols.
 
- The default value of this property is `false`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconAllowOverlap;
 
 /**
  If true, other symbols can be visible even if they collide with the icon.
 
- The default value of this property is `false`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconIgnorePlacement;
 
 /**
  If true, text will display without their corresponding icons when the icon collides with other symbols and the text does not.
 
- The default value of this property is `false`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOptional;
 
 /**
  Orientation of icon when map is rotated.
 
- The default value of this property is `viewport`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerIconRotationAlignmentViewport`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconRotationAlignment;
 
@@ -130,14 +130,14 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Position and scale an icon by the its corresponding text.
 
- The default value of this property is `none`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerIconTextFitNone`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFit;
 
 /**
  Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.
 
- The default value of this property is `0,0,0,0`. Set this property to `nil` to reset it to the default.
+ The default value of this property is 0 on the top, 0 on the right, 0 on the bottom, and 0 on the left. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFitPadding;
 
@@ -163,26 +163,26 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  If true, the icon may be flipped to prevent it from being rendered upside-down.
 
- The default value of this property is `false`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconKeepUpright;
 
 /**
  Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up.
 
- The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
+ The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOffset;
 
 /**
- Aligns text to the plane of the `viewport` or the `map` when the map is pitched. Matches `textRotationAlignment` if unspecified.
+ Aligns text to the plane of the `MGLSymbolStyleLayerTextPitchAlignmentViewport` or the `MGLSymbolStyleLayerTextPitchAlignmentMap` when the map is pitched. Matches `textRotationAlignment` if unspecified.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textPitchAlignment;
 
 /**
  Orientation of text when map is rotated.
 
- The default value of this property is `viewport`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerTextRotationAlignmentViewport`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textRotationAlignment;
 
@@ -196,7 +196,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Font stack to use for displaying text.
 
- The default value of this property is `Open Sans Regular,Arial Unicode MS Regular`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `Open Sans Regular`, `Arial Unicode MS Regular`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textFont;
 
@@ -231,14 +231,14 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Text justification options.
 
- The default value of this property is `center`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerTextJustifyCenter`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textJustify;
 
 /**
  Part of the text placed closest to the anchor.
 
- The default value of this property is `center`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerTextAnchorCenter`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textAnchor;
 
@@ -266,42 +266,42 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  If true, the text may be flipped vertically to prevent it from being rendered upside-down.
 
- The default value of this property is `true`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `YES`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textKeepUpright;
 
 /**
  Specifies how to capitalize text, similar to the CSS `text-transform` property.
 
- The default value of this property is `none`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerTextTransformNone`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTransform;
 
 /**
  Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
 
- The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
+ The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOffset;
 
 /**
  If true, the text will be visible even if it collides with other previously drawn symbols.
 
- The default value of this property is `false`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textAllowOverlap;
 
 /**
  If true, other symbols can be visible even if they collide with the text.
 
- The default value of this property is `false`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textIgnorePlacement;
 
 /**
  If true, icons will display without their corresponding text when the text collides with other symbols and the icon does not.
 
- The default value of this property is `false`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOptional;
 
@@ -317,14 +317,14 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color of the icon. This can only be used with sdf icons.
 
- The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
+ The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconColor;
 
 /**
  The color of the icon's halo. Icon halos can only be used with sdf icons.
 
- The default value of this property is `rgba(0, 0, 0, 0)`. Set this property to `nil` to reset it to the default.
+ The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloColor;
 
@@ -345,14 +345,14 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
 
- The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
+ The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen).
 
- The default value of this property is `map`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerIconTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslateAnchor;
 
@@ -366,14 +366,14 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color with which the text will be drawn.
 
- The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
+ The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textColor;
 
 /**
  The color of the text's halo, which helps it stand out from backgrounds.
 
- The default value of this property is `rgba(0, 0, 0, 0)`. Set this property to `nil` to reset it to the default.
+ The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloColor;
 
@@ -394,14 +394,14 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
 
- The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
+ The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen).
 
- The default value of this property is `map`. Set this property to `nil` to reset it to the default.
+ The default value of this property is `MGLSymbolStyleLayerTextTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslateAnchor;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -74,460 +74,460 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  Label placement relative to its geometry. `MGLSymbolStyleLayerSymbolPlacementLine` can only be used on LineStrings and Polygons.
  
- The default value of this property is `MGLSymbolStyleLayerSymbolPlacementPoint`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerSymbolPlacementPoint`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolPlacement;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> symbolPlacement;
 
 /**
  Distance between two symbol anchors.
 
  This property is measured in points.
  
- The default value of this property is `250`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `250`.
  
  This property is only applied to the style if `symbolPlacement` is set to `MGLSymbolStyleLayerSymbolPlacementLine`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolSpacing;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> symbolSpacing;
 
 /**
  If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer.
  
- The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `NO`.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolAvoidEdges;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> symbolAvoidEdges;
 
 /**
  If true, the icon will be visible even if it collides with other previously drawn symbols.
  
- The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `NO`.
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconAllowOverlap;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconAllowOverlap;
 
 /**
  If true, other symbols can be visible even if they collide with the icon.
  
- The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `NO`.
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconIgnorePlacement;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconIgnorePlacement;
 
 /**
  If true, text will display without their corresponding icons when the icon collides with other symbols and the text does not.
  
- The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `NO`.
  
  This property is only applied to the style if `iconImage` is non-`nil`, and `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOptional;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconOptional;
 
 /**
  Orientation of icon when map is rotated.
  
- The default value of this property is `MGLSymbolStyleLayerIconRotationAlignmentViewport`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerIconRotationAlignmentViewport`.
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconRotationAlignment;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconRotationAlignment;
 
 /**
  Scale factor for icon. 1 is original size, 3 triples the size.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconSize;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconSize;
 
 /**
  Position and scale an icon by the its corresponding text.
  
- The default value of this property is `MGLSymbolStyleLayerIconTextFitNone`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerIconTextFitNone`.
  
  This property is only applied to the style if `iconImage` is non-`nil`, and `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFit;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconTextFit;
 
 /**
  Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.
 
  This property is measured in points.
  
- The default value of this property is 0 points on the top, 0 points on the right, 0 points on the bottom, and 0 points on the left. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of 0 points on the top, 0 points on the right, 0 points on the bottom, and 0 points on the left.
  
  This property is only applied to the style if `iconImage` is non-`nil`, and `iconTextFit` is non-`nil`, and `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFitPadding;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconTextFitPadding;
 
 /**
  A string with {tokens} replaced, referencing the data property to pull from.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconImage;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconImage;
 
 /**
  Rotates the icon clockwise.
 
  This property is measured in degrees.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconRotate;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconRotate;
 
 /**
  Size of the additional area around the icon bounding box used for detecting symbol collisions.
 
  This property is measured in points.
  
- The default value of this property is `2`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `2`.
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconPadding;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconPadding;
 
 /**
  If true, the icon may be flipped to prevent it from being rendered upside-down.
  
- The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `NO`.
  
  This property is only applied to the style if `iconImage` is non-`nil`, and `iconRotationAlignment` is set to `MGLSymbolStyleLayerIconRotationAlignmentMap`, and `symbolPlacement` is set to `MGLSymbolStyleLayerSymbolPlacementLine`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconKeepUpright;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconKeepUpright;
 
 /**
  Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up.
  
- The default value of this property is 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of 0 from the left and 0 from the top.
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOffset;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconOffset;
 
 /**
  Aligns text to the plane of the `MGLSymbolStyleLayerTextPitchAlignmentViewport` or the `MGLSymbolStyleLayerTextPitchAlignmentMap` when the map is pitched. Matches `textRotationAlignment` if unspecified.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textPitchAlignment;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textPitchAlignment;
 
 /**
  Orientation of text when map is rotated.
  
- The default value of this property is `MGLSymbolStyleLayerTextRotationAlignmentViewport`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerTextRotationAlignmentViewport`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textRotationAlignment;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textRotationAlignment;
 
 /**
  Value to use for a text label. Feature properties are specified using tokens like {field_name}.
  
- The default value of this property is ``. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of ``.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textField;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textField;
 
 /**
  Font stack to use for displaying text.
  
- The default value of this property is `Open Sans Regular`, `Arial Unicode MS Regular`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `Open Sans Regular`, `Arial Unicode MS Regular`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textFont;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textFont;
 
 /**
  Font size.
 
  This property is measured in points.
  
- The default value of this property is `16`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `16`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textSize;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textSize;
 
 /**
  The maximum line width for text wrapping.
 
  This property is measured in ems.
  
- The default value of this property is `10`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `10`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textMaxWidth;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textMaxWidth;
 
 /**
  Text leading value for multi-line text.
 
  This property is measured in ems.
  
- The default value of this property is `1.2`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `1.2`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textLineHeight;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textLineHeight;
 
 /**
  Text tracking amount.
 
  This property is measured in ems.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textLetterSpacing;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textLetterSpacing;
 
 /**
  Text justification options.
  
- The default value of this property is `MGLSymbolStyleLayerTextJustifyCenter`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerTextJustifyCenter`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textJustify;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textJustify;
 
 /**
  Part of the text placed closest to the anchor.
  
- The default value of this property is `MGLSymbolStyleLayerTextAnchorCenter`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerTextAnchorCenter`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textAnchor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textAnchor;
 
 /**
  Maximum angle change between adjacent characters.
 
  This property is measured in degrees.
  
- The default value of this property is `45`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `45`.
  
  This property is only applied to the style if `textField` is non-`nil`, and `symbolPlacement` is set to `MGLSymbolStyleLayerSymbolPlacementLine`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textMaxAngle;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textMaxAngle;
 
 /**
  Rotates the text clockwise.
 
  This property is measured in degrees.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textRotate;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textRotate;
 
 /**
  Size of the additional area around the text bounding box used for detecting symbol collisions.
 
  This property is measured in points.
  
- The default value of this property is `2`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `2`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textPadding;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textPadding;
 
 /**
  If true, the text may be flipped vertically to prevent it from being rendered upside-down.
  
- The default value of this property is `YES`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `YES`.
  
  This property is only applied to the style if `textField` is non-`nil`, and `textRotationAlignment` is set to `MGLSymbolStyleLayerTextRotationAlignmentMap`, and `symbolPlacement` is set to `MGLSymbolStyleLayerSymbolPlacementLine`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textKeepUpright;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textKeepUpright;
 
 /**
  Specifies how to capitalize text, similar to the CSS `text-transform` property.
  
- The default value of this property is `MGLSymbolStyleLayerTextTransformNone`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerTextTransformNone`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTransform;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textTransform;
 
 /**
  Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
 
  This property is measured in ems.
  
- The default value of this property is 0 ems from the left and 0 ems from the top. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of 0 ems from the left and 0 ems from the top.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOffset;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textOffset;
 
 /**
  If true, the text will be visible even if it collides with other previously drawn symbols.
  
- The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `NO`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textAllowOverlap;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textAllowOverlap;
 
 /**
  If true, other symbols can be visible even if they collide with the text.
  
- The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `NO`.
  
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textIgnorePlacement;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textIgnorePlacement;
 
 /**
  If true, icons will display without their corresponding text when the text collides with other symbols and the icon does not.
  
- The default value of this property is `NO`. Set this property to `nil` to reset it to the default.
+ If this property is set to `nil`, the layer uses an implicit default value of `NO`.
  
  This property is only applied to the style if `textField` is non-`nil`, and `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOptional;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textOptional;
 
 #pragma mark - Accessing the Paint Attributes
 
 /**
  The opacity at which the icon will be drawn.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
+
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOpacity;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconOpacity;
 
 /**
  The color of the icon. This can only be used with sdf icons.
  
- The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconColor;
 
 /**
  The color of the icon's halo. Icon halos can only be used with sdf icons.
  
- The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0.
+
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconHaloColor;
 
 /**
  Distance of halo to the icon outline.
 
  This property is measured in points.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
+
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloWidth;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconHaloWidth;
 
 /**
  Fade out the halo towards the outside.
 
  This property is measured in points.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
+
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloBlur;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconHaloBlur;
 
 /**
  Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
 
  This property is measured in points.
  
- The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of 0 points from the left and 0 points from the top.
+
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslate;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen).
  
- The default value of this property is `MGLSymbolStyleLayerIconTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerIconTranslateAnchorMap`.
+
  This property is only applied to the style if `iconImage` is non-`nil`, and `iconTranslate` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslateAnchor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> iconTranslateAnchor;
 
 /**
  The opacity at which the text will be drawn.
  
- The default value of this property is `1`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `1`.
+
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOpacity;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textOpacity;
 
 /**
  The color with which the text will be drawn.
  
- The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textColor;
 
 /**
  The color of the text's halo, which helps it stand out from backgrounds.
  
- The default value of this property is an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0.
+
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloColor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textHaloColor;
 
 /**
  Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.
 
  This property is measured in points.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
+
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloWidth;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textHaloWidth;
 
 /**
  The halo's fadeout distance towards the outside.
 
  This property is measured in points.
  
- The default value of this property is `0`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `0`.
+
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloBlur;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textHaloBlur;
 
 /**
  Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
 
  This property is measured in points.
  
- The default value of this property is 0 points from the left and 0 points from the top. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of 0 points from the left and 0 points from the top.
+
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslate;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen).
  
- The default value of this property is `MGLSymbolStyleLayerTextTranslateAnchorMap`. Set this property to `nil` to reset it to the default.
- 
+ If this property is set to `nil`, the layer uses an implicit default value of `MGLSymbolStyleLayerTextTranslateAnchorMap`.
+
  This property is only applied to the style if `textField` is non-`nil`, and `textTranslate` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslateAnchor;
+@property (nonatomic, nullable) id <MGLStyleAttributeValue> textTranslateAnchor;
 
 @end
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -4,6 +4,8 @@
 #import "MGLStyleAttributeValue.h"
 #import "MGLBaseStyleLayer.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerSymbolPlacement) {
     MGLSymbolStyleLayerSymbolPlacementPoint,
     MGLSymbolStyleLayerSymbolPlacementLine,
@@ -71,244 +73,338 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 
 /**
  Label placement relative to its geometry. `line` can only be used on LineStrings and Polygons.
+
+ The default value of this property is `point`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> symbolPlacement;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolPlacement;
 
 /**
  Distance between two symbol anchors.
+
+ The default value of this property is `250`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> symbolSpacing;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolSpacing;
 
 /**
  If true, the symbols will not cross tile edges to avoid mutual collisions. Recommended in layers that don't have enough padding in the vector tile to prevent collisions, or if it is a point symbol layer placed after a line symbol layer.
+
+ The default value of this property is `false`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> symbolAvoidEdges;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> symbolAvoidEdges;
 
 /**
  If true, the icon will be visible even if it collides with other previously drawn symbols.
+
+ The default value of this property is `false`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconAllowOverlap;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconAllowOverlap;
 
 /**
  If true, other symbols can be visible even if they collide with the icon.
+
+ The default value of this property is `false`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconIgnorePlacement;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconIgnorePlacement;
 
 /**
  If true, text will display without their corresponding icons when the icon collides with other symbols and the text does not.
+
+ The default value of this property is `false`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconOptional;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOptional;
 
 /**
  Orientation of icon when map is rotated.
+
+ The default value of this property is `viewport`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconRotationAlignment;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconRotationAlignment;
 
 /**
  Scale factor for icon. 1 is original size, 3 triples the size.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconSize;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconSize;
 
 /**
  Position and scale an icon by the its corresponding text.
+
+ The default value of this property is `none`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconTextFit;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFit;
 
 /**
  Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.
+
+ The default value of this property is `0,0,0,0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconTextFitPadding;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFitPadding;
 
 /**
  A string with {tokens} replaced, referencing the data property to pull from.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconImage;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconImage;
 
 /**
  Rotates the icon clockwise.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconRotate;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconRotate;
 
 /**
  Size of the additional area around the icon bounding box used for detecting symbol collisions.
+
+ The default value of this property is `2`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconPadding;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconPadding;
 
 /**
  If true, the icon may be flipped to prevent it from being rendered upside-down.
+
+ The default value of this property is `false`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconKeepUpright;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconKeepUpright;
 
 /**
  Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up.
+
+ The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconOffset;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOffset;
 
 /**
  Aligns text to the plane of the `viewport` or the `map` when the map is pitched. Matches `textRotationAlignment` if unspecified.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textPitchAlignment;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textPitchAlignment;
 
 /**
  Orientation of text when map is rotated.
+
+ The default value of this property is `viewport`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textRotationAlignment;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textRotationAlignment;
 
 /**
  Value to use for a text label. Feature properties are specified using tokens like {field_name}.
+
+ The default value of this property is ``. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textField;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textField;
 
 /**
  Font stack to use for displaying text.
+
+ The default value of this property is `Open Sans Regular,Arial Unicode MS Regular`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textFont;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textFont;
 
 /**
  Font size.
+
+ The default value of this property is `16`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textSize;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textSize;
 
 /**
  The maximum line width for text wrapping.
+
+ The default value of this property is `10`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textMaxWidth;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textMaxWidth;
 
 /**
  Text leading value for multi-line text.
+
+ The default value of this property is `1.2`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textLineHeight;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textLineHeight;
 
 /**
  Text tracking amount.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textLetterSpacing;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textLetterSpacing;
 
 /**
  Text justification options.
+
+ The default value of this property is `center`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textJustify;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textJustify;
 
 /**
  Part of the text placed closest to the anchor.
+
+ The default value of this property is `center`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textAnchor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textAnchor;
 
 /**
  Maximum angle change between adjacent characters.
+
+ The default value of this property is `45`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textMaxAngle;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textMaxAngle;
 
 /**
  Rotates the text clockwise.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textRotate;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textRotate;
 
 /**
  Size of the additional area around the text bounding box used for detecting symbol collisions.
+
+ The default value of this property is `2`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textPadding;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textPadding;
 
 /**
  If true, the text may be flipped vertically to prevent it from being rendered upside-down.
+
+ The default value of this property is `true`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textKeepUpright;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textKeepUpright;
 
 /**
  Specifies how to capitalize text, similar to the CSS `text-transform` property.
+
+ The default value of this property is `none`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textTransform;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTransform;
 
 /**
  Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
+
+ The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textOffset;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOffset;
 
 /**
  If true, the text will be visible even if it collides with other previously drawn symbols.
+
+ The default value of this property is `false`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textAllowOverlap;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textAllowOverlap;
 
 /**
  If true, other symbols can be visible even if they collide with the text.
+
+ The default value of this property is `false`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textIgnorePlacement;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textIgnorePlacement;
 
 /**
  If true, icons will display without their corresponding text when the text collides with other symbols and the icon does not.
+
+ The default value of this property is `false`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textOptional;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOptional;
 
 #pragma mark - Accessing the Paint Attributes
 
 /**
  The opacity at which the icon will be drawn.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconOpacity;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOpacity;
 
 /**
  The color of the icon. This can only be used with sdf icons.
+
+ The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconColor;
 
 /**
  The color of the icon's halo. Icon halos can only be used with sdf icons.
+
+ The default value of this property is `rgba(0, 0, 0, 0)`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconHaloColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloColor;
 
 /**
  Distance of halo to the icon outline.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconHaloWidth;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloWidth;
 
 /**
  Fade out the halo towards the outside.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconHaloBlur;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconHaloBlur;
 
 /**
  Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
+
+ The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconTranslate;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen).
+
+ The default value of this property is `map`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> iconTranslateAnchor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTranslateAnchor;
 
 /**
  The opacity at which the text will be drawn.
+
+ The default value of this property is `1`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textOpacity;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textOpacity;
 
 /**
  The color with which the text will be drawn.
+
+ The default value of this property is `#000000`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textColor;
 
 /**
  The color of the text's halo, which helps it stand out from backgrounds.
+
+ The default value of this property is `rgba(0, 0, 0, 0)`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textHaloColor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloColor;
 
 /**
  Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textHaloWidth;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloWidth;
 
 /**
  The halo's fadeout distance towards the outside.
+
+ The default value of this property is `0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textHaloBlur;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textHaloBlur;
 
 /**
  Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
+
+ The default value of this property is `0,0`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textTranslate;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslate;
 
 /**
  Control whether the translation is relative to the map (north) or viewport (screen).
+
+ The default value of this property is `map`. Set this property to `nil` to reset it to the default.
  */
-@property (nonatomic) id <MGLStyleAttributeValue> textTranslateAnchor;
+@property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textTranslateAnchor;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/NSArray+MGLStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSArray+MGLStyleAttributeAdditions.mm
@@ -10,24 +10,6 @@
 
 @implementation NSArray (MGLStyleAttributeAdditions)
 
-- (mbgl::style::PropertyValue<std::array<float, 2>>)mbgl_offsetPropertyValue
-{
-    NSAssert(self.count == 2, @"Offset must contain 2 values (dx, dy)");
-    NSNumber *dx = self[0];
-    NSNumber *dy = self[1];
-    return {{dx.floatValue, dy.floatValue}};
-}
-
-- (mbgl::style::PropertyValue<std::array<float, 4> >)mbgl_paddingPropertyValue
-{
-    NSAssert(self.count == 4, @"Padding must contain 4 values (top, left, bottom & right)");
-    NSNumber *top = self[0];
-    NSNumber *left = self[1];
-    NSNumber *bottom = self[2];
-    NSNumber *right = self[3];
-    return {{top.floatValue, left.floatValue, bottom.floatValue, right.floatValue}};
-}
-
 - (mbgl::style::PropertyValue<std::vector<std::string> >)mbgl_stringArrayPropertyValue
 {
     std::vector<std::string>fonts;

--- a/platform/darwin/src/NSValue+MGLStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSValue+MGLStyleAttributeAdditions.mm
@@ -2,7 +2,35 @@
 
 #import "NSValue+MGLStyleAttributeAdditions_Private.h"
 
+#include <array>
+
+#if TARGET_OS_IPHONE
+    #import <UIKit/UIKit.h>
+    #define MGLEdgeInsets UIEdgeInsets
+#else
+    #define MGLEdgeInsets NSEdgeInsets
+#endif
+
 @implementation NSValue (MGLStyleAttributeAdditions)
+
++ (instancetype)mgl_valueWithOffsetArray:(std::array<float, 2>)offsetArray
+{
+    CGVector vector = CGVectorMake(offsetArray[0], offsetArray[1]);
+    return [NSValue value:&vector withObjCType:@encode(CGVector)];
+}
+
++ (instancetype)mgl_valueWithPaddingArray:(std::array<float, 4>)paddingArray
+{
+    // Style specification defines padding in clockwise order: top, right, bottom, left.
+    // Foundation defines padding in counterclockwise order: top, left, bottom, right.
+    MGLEdgeInsets insets = {
+        .top = paddingArray[0],
+        .right = paddingArray[1],
+        .bottom = paddingArray[2],
+        .left = paddingArray[3],
+    };
+    return [NSValue value:&insets withObjCType:@encode(MGLEdgeInsets)];
+}
 
 - (BOOL)isFunction
 {
@@ -11,9 +39,45 @@
 
 - (mbgl::style::PropertyValue<uint8_t>)mbgl_enumPropertyValue
 {
+    NSAssert(strcmp(self.objCType, @encode(uint8_t)) == 0, @"Value does not represent a uint8_t");
     uint8_t value = 0;
     [self getValue:&value];
     return mbgl::style::PropertyValue<uint8_t> { value };
+}
+
+- (mbgl::style::PropertyValue<std::array<float, 2>>)mbgl_offsetPropertyValue
+{
+    return { self.mgl_offsetArrayValue };
+}
+
+- (std::array<float, 2>)mgl_offsetArrayValue
+{
+    NSAssert(strcmp(self.objCType, @encode(CGVector)) == 0, @"Value does not represent a CGVector");
+    CGVector vector;
+    [self getValue:&vector];
+    return {
+        static_cast<float>(vector.dx),
+        static_cast<float>(vector.dy),
+    };
+}
+
+- (mbgl::style::PropertyValue<std::array<float, 4>>)mbgl_paddingPropertyValue
+{
+    return { self.mgl_paddingArrayValue };
+}
+
+- (std::array<float, 4>)mgl_paddingArrayValue
+{
+    NSAssert(strcmp(self.objCType, @encode(MGLEdgeInsets)) == 0, @"Value does not represent an NSEdgeInsets/UIEdgeInsets");
+    MGLEdgeInsets insets;
+    [self getValue:&insets];
+    // Style specification defines padding in clockwise order: top, right, bottom, left.
+    return {
+        static_cast<float>(insets.top),
+        static_cast<float>(insets.right),
+        static_cast<float>(insets.bottom),
+        static_cast<float>(insets.left),
+    };
 }
 
 @end

--- a/platform/darwin/src/NSValue+MGLStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSValue+MGLStyleAttributeAdditions.mm
@@ -37,14 +37,6 @@
     return NO;
 }
 
-- (mbgl::style::PropertyValue<uint8_t>)mbgl_enumPropertyValue
-{
-    NSAssert(strcmp(self.objCType, @encode(uint8_t)) == 0, @"Value does not represent a uint8_t");
-    uint8_t value = 0;
-    [self getValue:&value];
-    return mbgl::style::PropertyValue<uint8_t> { value };
-}
-
 - (mbgl::style::PropertyValue<std::array<float, 2>>)mbgl_offsetPropertyValue
 {
     return { self.mgl_offsetArrayValue };

--- a/platform/darwin/src/NSValue+MGLStyleAttributeAdditions_Private.h
+++ b/platform/darwin/src/NSValue+MGLStyleAttributeAdditions_Private.h
@@ -9,9 +9,6 @@
 + (instancetype)mgl_valueWithOffsetArray:(std::array<float, 2>)offsetArray;
 + (instancetype)mgl_valueWithPaddingArray:(std::array<float, 4>)paddingArray;
 
-- (mbgl::style::PropertyValue<uint8_t>)mbgl_enumPropertyValue;
-- (mbgl::style::PropertyValue<std::array<float, 2>>)mbgl_offsetPropertyValue;
-
 - (std::array<float, 2>)mgl_offsetArrayValue;
 - (std::array<float, 4>)mgl_paddingArrayValue;
 

--- a/platform/darwin/src/NSValue+MGLStyleAttributeAdditions_Private.h
+++ b/platform/darwin/src/NSValue+MGLStyleAttributeAdditions_Private.h
@@ -5,5 +5,14 @@
 #include <mbgl/style/property_value.hpp>
 
 @interface NSValue (MGLStyleAttributeAdditions_Private) <MGLStyleAttributeValue>
+
++ (instancetype)mgl_valueWithOffsetArray:(std::array<float, 2>)offsetArray;
++ (instancetype)mgl_valueWithPaddingArray:(std::array<float, 4>)paddingArray;
+
 - (mbgl::style::PropertyValue<uint8_t>)mbgl_enumPropertyValue;
+- (mbgl::style::PropertyValue<std::array<float, 2>>)mbgl_offsetPropertyValue;
+
+- (std::array<float, 2>)mgl_offsetArrayValue;
+- (std::array<float, 4>)mgl_paddingArrayValue;
+
 @end

--- a/platform/darwin/test/MGLRuntimeStylingHelper.m
+++ b/platform/darwin/test/MGLRuntimeStylingHelper.m
@@ -1,21 +1,30 @@
 #import "MGLRuntimeStylingHelper.h"
 
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
-#import <UIKit/UIKit.h>
+    #import <UIKit/UIKit.h>
+    #define MGLEdgeInsets UIEdgeInsets
 #else
-#import <Cocoa/Cocoa.h>
+    #import <Cocoa/Cocoa.h>
+    #define MGLEdgeInsets NSEdgeInsets
 #endif
 
 @implementation MGLRuntimeStylingHelper
 
-+ (NSArray *)testPadding
++ (NSValue *)testPadding
 {
-    return @[@1.0f, @1.0f, @1.0f, @1.0f];
+    MGLEdgeInsets insets = {
+        .top = 1,
+        .left = 1,
+        .bottom = 1,
+        .right = 1,
+    };
+    return [NSValue value:&insets withObjCType:@encode(MGLEdgeInsets)];
 }
 
-+ (NSArray *)testOffset
++ (NSValue *)testOffset
 {
-    return @[@1.0f, @1.0f];
+    CGVector vector = CGVectorMake(1, 1);
+    return [NSValue value:&vector withObjCType:@encode(CGVector)];
 }
 
 + (NSArray *)testFont


### PR DESCRIPTION
An offset style attribute is now exposed publicly as an NSValue representing a `CGVector` instead of an NSArray of NSNumbers. Likewise, a padding style attribute is now exposed publicly as an NSValue representing an `NSEdgeInsets` or `UIEdgeInsets` instead of an NSArray of NSNumbers.

This change also fixes round-tripping of padding values due to a difference between the style specification and Foundation regarding the order of edges around a box. It uses a designated initializer on `NSEdgeInsets`/`UIEdgeInsets` to ensure correct order when converting from C++ to Objective-C.

Fixes #5947, fixes #6065. Depends on #6076.

/cc @frederoni