### PR TITLE
[android] #6077 - keep rules for Signature and Annotation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -1,13 +1,20 @@
 # By default, the flags in this file are appended to flags specified
 # in ../sdk/tools/proguard/proguard-android.txt,
 # contents of this file will be appended into proguard-android.txt
+-keepattributes Signature, *Annotation*
 
 # Square okio, ignoring warnings,
 # see https://github.com/square/okio/issues/60
 -dontwarn okio.**
 
+# Gesture package
+-keep class almeros.android.multitouch.gesturedetectors.** { *; }
+
 # Package: annotations
 -keep class com.mapbox.mapboxsdk.annotations.** { *; }
+
+# Package camera
+-keep class com.mapbox.mapboxsdk.camera.** { *; }
 
 # Package: geometry
 -keep class com.mapbox.mapboxsdk.geometry.** { *; }
@@ -18,17 +25,14 @@
 # Package maps
 -keep class com.mapbox.mapboxsdk.maps.** { *; }
 
-# Package telemetry
--keep class com.mapbox.mapboxsdk.telemetry.** { *; }
-
-# Package layers
--keep class com.mapbox.mapboxsdk.layers.** { *; }
-
-# Package camera
--keep class com.mapbox.mapboxsdk.camera.** { *; }
-
 # Package offline
 -keep class com.mapbox.mapboxsdk.offline.** { *; }
 
-# Gesture package
--keep class almeros.android.multitouch.gesturedetectors.** { *; }
+# Package style
+-keep class com.mapbox.mapboxsdk.style.layers.** { *; }
+-keep class com.mapbox.mapboxsdk.style.sources.** { *; }
+
+# Package telemetry
+-keep class com.mapbox.mapboxsdk.telemetry.** { *; }
+
+

--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -35,4 +35,7 @@
 # Package telemetry
 -keep class com.mapbox.mapboxsdk.telemetry.** { *; }
 
+# Keep external project mapbox-java,
+# Needs to be removed after https://github.com/mapbox/mapbox-java/issues/178 is resolved
+-keep class com.mapbox.services.** { *; }
 


### PR DESCRIPTION
Closes #6077 

I was able to proguard the testapp with this configuration. Would love some 👀 . 

You can retest this with adding the following in our build.gradle of the testapp:

```
    buildTypes {
        debug {
            // run code coverage reports
            testCoverageEnabled = true
            minifyEnabled true
            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
        }
```

Review @cammace, @bleege 