### PR TITLE
[android] add spoon gradle plugin

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
+    androidTestCompile 'com.squareup.spoon:spoon-client:1.6.2'
 }
 
 checkstyle {
@@ -160,3 +161,7 @@ android.applicationVariants.all { variant ->
     checkstyle.exclude('**/R.java')
     project.tasks.getByName("check").dependsOn checkstyle
 }
+
+
+apply from: 'gradle-spoon.gradle'
+

--- a/platform/android/MapboxGLAndroidSDKTestApp/gradle-spoon.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/gradle-spoon.gradle
@@ -1,0 +1,8 @@
+println "configuring spoon"
+apply plugin: 'spoon'
+spoon {
+    // Spoon: distributes instrumentation tests to all your Androids
+    // for more  options see https://github.com/stanfy/spoon-gradle-plugin
+    grantAllPermissions = true
+    debug = true
+}

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.github.JakeWharton:sdk-manager-plugin:220bf7a88a7072df3ed16dc8466fb144f2817070'
         classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.2'
+        classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.1'
     }
 }
 


### PR DESCRIPTION
This PR adds the spoon gradle plugin to the project. We now have a separate gradle command for executing instrumentation tests on multiple devices at once. This is handy if you have a setup as:

![img_20160819_141953](https://cloud.githubusercontent.com/assets/2151639/17810151/b1b2baa4-661b-11e6-9a94-7c1fc93a0745.jpg)

This new gradle configuration conforms to the guidelines set in https://github.com/mapbox/mapbox-gl-native/issues/6009.

Review @zugaldia