### PR TITLE
Add option to show depth buffer

### DIFF
--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -47,6 +47,7 @@ enum class MapDebugOptions : EnumType {
 // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/5117
 #ifndef GL_ES_VERSION_2_0
     StencilClip = 1 << 6,
+    DepthBuffer = 1 << 7,
 #endif // GL_ES_VERSION_2_0
 };
 
@@ -55,11 +56,19 @@ constexpr MapDebugOptions operator|(MapDebugOptions lhs, MapDebugOptions rhs) {
 }
 
 constexpr MapDebugOptions& operator|=(MapDebugOptions& lhs, MapDebugOptions rhs) {
-    return (lhs = lhs | rhs);
+    return (lhs = MapDebugOptions(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs)));
 }
 
 constexpr bool operator&(MapDebugOptions lhs, MapDebugOptions rhs) {
     return mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs);
+}
+
+constexpr MapDebugOptions& operator&=(MapDebugOptions& lhs, MapDebugOptions rhs) {
+    return (lhs = MapDebugOptions(mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs)));
+}
+
+constexpr MapDebugOptions operator~(MapDebugOptions value) {
+    return MapDebugOptions(~mbgl::underlying_type(value));
 }
 
 } // namespace mbgl

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -97,6 +97,7 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     printf("- Press `Z` to cycle through north orientations\n");
     printf("- Prezz `X` to cycle through the viewport modes\n");
     printf("- Press `A` to cycle through Mapbox offices in the world + dateline monument\n");
+    printf("- Press `B` to cycle through the color, stencil, and depth buffer\n");
     printf("\n");
     printf("- Press `1` through `6` to add increasing numbers of point annotations for testing\n");
     printf("- Press `7` through `0` to add increasing numbers of shape annotations for testing\n");
@@ -155,6 +156,18 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                 }
             }
             break;
+        case GLFW_KEY_B: {
+            auto debug = view->map->getDebug();
+            if (debug & mbgl::MapDebugOptions::StencilClip) {
+                debug &= ~mbgl::MapDebugOptions::StencilClip;
+                debug |= mbgl::MapDebugOptions::DepthBuffer;
+            } else if (debug & mbgl::MapDebugOptions::DepthBuffer) {
+                debug &= ~mbgl::MapDebugOptions::DepthBuffer;
+            } else {
+                debug |= mbgl::MapDebugOptions::StencilClip;
+            }
+            view->map->setDebug(debug);
+        } break;
         case GLFW_KEY_N:
             if (!mods)
                 view->map->resetNorth();

--- a/platform/macos/app/Base.lproj/MainMenu.xib
+++ b/platform/macos/app/Base.lproj/MainMenu.xib
@@ -474,6 +474,12 @@
                                     <action selector="showStencilBuffer:" target="-1" id="WkN-t9-Mpv"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Depth Buffer" keyEquivalent="d" id="CDq-70-oPa">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="showDepthBuffer:" target="-1" id="h7r-eM-ZEu"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="dYw-bb-tr1"/>
                             <menuItem title="Show Tooltips on Dropped Pins" id="uir-Rx-zmw">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -283,10 +283,17 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
 
 - (IBAction)showColorBuffer:(id)sender {
     self.mapView.debugMask &= ~MGLMapDebugStencilBufferMask;
+    self.mapView.debugMask &= ~MGLMapDebugDepthBufferMask;
 }
 
 - (IBAction)showStencilBuffer:(id)sender {
+    self.mapView.debugMask &= ~MGLMapDebugDepthBufferMask;
     self.mapView.debugMask |= MGLMapDebugStencilBufferMask;
+}
+
+- (IBAction)showDepthBuffer:(id)sender {
+    self.mapView.debugMask &= ~MGLMapDebugStencilBufferMask;
+    self.mapView.debugMask |= MGLMapDebugDepthBufferMask;
 }
 
 - (IBAction)toggleShowsToolTipsOnDroppedPins:(id)sender {
@@ -642,12 +649,17 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
         return YES;
     }
     if (menuItem.action == @selector(showColorBuffer:)) {
-        BOOL enabled = self.mapView.debugMask & MGLMapDebugStencilBufferMask;
+        BOOL enabled = self.mapView.debugMask & (MGLMapDebugStencilBufferMask | MGLMapDebugDepthBufferMask);
         menuItem.state = enabled ? NSOffState : NSOnState;
         return YES;
     }
     if (menuItem.action == @selector(showStencilBuffer:)) {
         BOOL enabled = self.mapView.debugMask & MGLMapDebugStencilBufferMask;
+        menuItem.state = enabled ? NSOnState : NSOffState;
+        return YES;
+    }
+    if (menuItem.action == @selector(showDepthBuffer:)) {
+        BOOL enabled = self.mapView.debugMask & MGLMapDebugDepthBufferMask;
         menuItem.state = enabled ? NSOnState : NSOffState;
         return YES;
     }

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -32,6 +32,11 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
         @note This option does nothing in Release builds of the SDK.
      */
     MGLMapDebugStencilBufferMask = 1 << 6,
+
+    /** The depth buffer is shown instead of the color buffer.
+        @note This option does nothing in Release builds of the SDK.
+     */
+    MGLMapDebugDepthBufferMask = 1 << 7,
 };
 
 @class MGLAnnotationImage;

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2450,6 +2450,9 @@ public:
     if (options & mbgl::MapDebugOptions::StencilClip) {
         mask |= MGLMapDebugStencilBufferMask;
     }
+    if (options & mbgl::MapDebugOptions::DepthBuffer) {
+        mask |= MGLMapDebugDepthBufferMask;
+    }
     return mask;
 }
 
@@ -2472,6 +2475,9 @@ public:
     }
     if (debugMask & MGLMapDebugStencilBufferMask) {
         options |= mbgl::MapDebugOptions::StencilClip;
+    }
+    if (debugMask & MGLMapDebugDepthBufferMask) {
+        options |= mbgl::MapDebugOptions::DepthBuffer;
     }
     _mbglMap->setDebug(options);
 }

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -198,6 +198,12 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         }
     }
 
+#ifndef NDEBUG
+    if (frame.debugOptions & MapDebugOptions::DepthBuffer) {
+        renderDepthBuffer();
+    }
+#endif
+
     // TODO: Find a better way to unbind VAOs after we're done with them without introducing
     // unnecessary bind(0)/bind(N) sequences.
     {

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -89,6 +89,8 @@ public:
 #ifndef NDEBUG
     // Renders tile clip boundaries, using stencil buffer to calculate fill color.
     void renderClipMasks();
+    // Renders the depth buffer.
+    void renderDepthBuffer();
 #endif
 
     void renderDebugText(Tile&, const mat4&);


### PR DESCRIPTION
We are [showing the stencil buffer](https://github.com/mapbox/mapbox-gl-native/pull/4669) in the debug app, but there's no way to show the depth buffer.