### PR TITLE
[ios, macos] Move debug mask options to shared header

### DIFF
--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -58,7 +58,7 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
         drawing operations appear more prominent to help diagnose overdrawing.
         @note This option does nothing in Release builds of the SDK. */
     MGLMapDebugOverdrawVisualizationMask = 1 << 5,
-#if TARGET_OS_OSX
+#if !TARGET_OS_IPHONE
     /** The stencil buffer is shown instead of the color buffer.
         @note This option does nothing in Release builds of the SDK. */
     MGLMapDebugStencilBufferMask = 1 << 6,

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -42,6 +42,30 @@ typedef NS_ENUM(NSUInteger, MGLUserTrackingMode) {
     MGLUserTrackingModeFollowWithCourse,
 };
 
+/** Options for enabling debugging features in an `MGLMapView` instance. */
+typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
+    /** Edges of tile boundaries are shown as thick, red lines to help diagnose
+        tile clipping issues. */
+    MGLMapDebugTileBoundariesMask = 1 << 1,
+    /** Each tile shows its tile coordinate (x/y/z) in the upper-left corner. */
+    MGLMapDebugTileInfoMask = 1 << 2,
+    /** Each tile shows a timestamp indicating when it was loaded. */
+    MGLMapDebugTimestampsMask = 1 << 3,
+    /** Edges of glyphs and symbols are shown as faint, green lines to help
+        diagnose collision and label placement issues. */
+    MGLMapDebugCollisionBoxesMask = 1 << 4,
+    /** Each drawing operation is replaced by a translucent fill. Overlapping
+        drawing operations appear more prominent to help diagnose overdrawing.
+        @note This option does nothing in Release builds of the SDK. */
+    MGLMapDebugOverdrawVisualizationMask = 1 << 5,
+    /** The stencil buffer is shown instead of the color buffer.
+        @note This option does nothing in Release builds of the SDK. */
+    MGLMapDebugStencilBufferMask = 1 << 6,
+    /** The depth buffer is shown instead of the color buffer.
+        @note This option does nothing in Release builds of the SDK. */
+    MGLMapDebugDepthBufferMask = 1 << 7,
+};
+
 NS_ASSUME_NONNULL_END
 
 #ifndef NS_ARRAY_OF

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -58,12 +58,14 @@ typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
         drawing operations appear more prominent to help diagnose overdrawing.
         @note This option does nothing in Release builds of the SDK. */
     MGLMapDebugOverdrawVisualizationMask = 1 << 5,
+#if TARGET_OS_OSX
     /** The stencil buffer is shown instead of the color buffer.
         @note This option does nothing in Release builds of the SDK. */
     MGLMapDebugStencilBufferMask = 1 << 6,
     /** The depth buffer is shown instead of the color buffer.
         @note This option does nothing in Release builds of the SDK. */
     MGLMapDebugDepthBufferMask = 1 << 7,
+#endif
 };
 
 NS_ASSUME_NONNULL_END

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -44,25 +44,6 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationVerticalAlignment) {
     MGLAnnotationVerticalAlignmentBottom,
 };
 
-/** Options for enabling debugging features in an `MGLMapView` instance. */
-typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
-    /** Edges of tile boundaries are shown as thick, red lines to help diagnose
-        tile clipping issues. */
-    MGLMapDebugTileBoundariesMask = 1 << 1,
-    /** Each tile shows its tile coordinate (x/y/z) in the upper-left corner. */
-    MGLMapDebugTileInfoMask = 1 << 2,
-    /** Each tile shows a timestamp indicating when it was loaded. */
-    MGLMapDebugTimestampsMask = 1 << 3,
-    /** Edges of glyphs and symbols are shown as faint, green lines to help
-        diagnose collision and label placement issues. */
-    MGLMapDebugCollisionBoxesMask = 1 << 4,
-    /** Each drawing operation is replaced by a translucent fill. Overlapping
-        drawing operations appear more prominent to help diagnose overdrawing.
-        @note This option does nothing in Release builds of the SDK.
-     */
-    MGLMapDebugOverdrawVisualizationMask = 1 << 5,
-};
-
 /**
  An interactive, customizable map view with an interface similar to the one
  provided by Apple’s MapKit.

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -6,39 +6,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** Options for enabling debugging features in an MGLMapView instance. */
-typedef NS_OPTIONS(NSUInteger, MGLMapDebugMaskOptions) {
-    /** Edges of tile boundaries are shown as thick, red lines to help diagnose
-        tile clipping issues. */
-    MGLMapDebugTileBoundariesMask = 1 << 1,
-    
-    /** Each tile shows its tile coordinate (x/y/z) in the upper-left corner. */
-    MGLMapDebugTileInfoMask = 1 << 2,
-    
-    /** Each tile shows a timestamp indicating when it was loaded. */
-    MGLMapDebugTimestampsMask = 1 << 3,
-    
-    /** Edges of glyphs and symbols are shown as faint, green lines to help
-        diagnose collision and label placement issues. */
-    MGLMapDebugCollisionBoxesMask = 1 << 4,
-    
-    /** Each drawing operation is replaced by a translucent fill. Overlapping
-        drawing operations appear more prominent to help diagnose overdrawing.
-        @note This option does nothing in Release builds of the SDK.
-     */
-    MGLMapDebugOverdrawVisualizationMask = 1 << 5,
-    
-    /** The stencil buffer is shown instead of the color buffer.
-        @note This option does nothing in Release builds of the SDK.
-     */
-    MGLMapDebugStencilBufferMask = 1 << 6,
-
-    /** The depth buffer is shown instead of the color buffer.
-        @note This option does nothing in Release builds of the SDK.
-     */
-    MGLMapDebugDepthBufferMask = 1 << 7,
-};
-
 @class MGLAnnotationImage;
 @class MGLMapCamera;
 @class MGLStyle;


### PR DESCRIPTION
~~This brings the depth buffer (#6087) and stencil buffer (#4669) debug modes to iOS~~ by moving `MGLMapDebugMaskOptions` to MGLTypes.h, which is shared between macOS and iOS targets.

~~These alternative buffer modes aren’t exposed in iosapp, but they are available in code.~~ These modes are excluded from iOS per https://github.com/mapbox/mapbox-gl-native/pull/6094#issuecomment-241101240.

The main advantage of this PR is now that we have slightly less duplicate code. 😁

/cc @kkaefer @1ec5