### PR TITLE
Copyedit default color property documentation

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -169,7 +169,7 @@ global.describeValue = function (value, property, layerType) {
             if (!color) {
                 throw new Error(`unrecognized color format in default value of ${property.name}`);
             }
-            return 'an `NSColor` or `UIColor`' + `object whose RGB value is ${color.r}, ${color.g}, ${color.b} and whose alpha value is ${color.a}`;
+            return 'an `NSColor` or `UIColor`' + ` object whose RGB value is ${color.r}, ${color.g}, ${color.b} and whose alpha value is ${color.a}`;
         case 'array':
             let units = property.units || '';
             if (units) {

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -169,6 +169,12 @@ global.describeValue = function (value, property, layerType) {
             if (!color) {
                 throw new Error(`unrecognized color format in default value of ${property.name}`);
             }
+            if (color.r === 0 && color.g === 0 && color.b === 0) {
+                return '`blackColor`' + ` with an alpha value of ${color.a}`;
+            }
+            if (color.r === 1 && color.g === 1 && color.b === 1) {
+                return '`whiteColor`' + ` with an alpha value of ${color.a}`;
+            }
             return 'an `NSColor` or `UIColor`' + ` object whose RGB value is ${color.r}, ${color.g}, ${color.b} and whose alpha value is ${color.a}`;
         case 'array':
             let units = property.units || '';

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The color with which the background will be drawn.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of `blackColor` with an alpha value of 1.
 
  This property is only applied to the style if `backgroundPattern` is set to `nil`. Otherwise, it is ignored.
  */

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The color with which the background will be drawn.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
 
  This property is only applied to the style if `backgroundPattern` is set to `nil`. Otherwise, it is ignored.
  */

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 /**
  The color of the circle.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
  */
 @property (nonatomic, nullable) id <MGLStyleAttributeValue> circleColor;
 

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 /**
  The color of the circle.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of `blackColor` with an alpha value of 1.
  */
 @property (nonatomic, nullable) id <MGLStyleAttributeValue> circleColor;
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 /**
  The color of the filled part of this layer. This color can be specified as rgba with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
 
  This property is only applied to the style if `fillPattern` is set to `nil`. Otherwise, it is ignored.
  */

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 /**
  The color of the filled part of this layer. This color can be specified as rgba with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of `blackColor` with an alpha value of 1.
 
  This property is only applied to the style if `fillPattern` is set to `nil`. Otherwise, it is ignored.
  */

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 /**
  The color with which the line will be drawn.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
 
  This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
  */

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 /**
  The color with which the line will be drawn.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of `blackColor` with an alpha value of 1.
 
  This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
  */

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -403,7 +403,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color of the icon. This can only be used with sdf icons.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
 
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
@@ -412,7 +412,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color of the icon's halo. Icon halos can only be used with sdf icons.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 0.
 
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
@@ -472,7 +472,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color with which the text will be drawn.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
 
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
@@ -481,7 +481,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color of the text's halo, which helps it stand out from backgrounds.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor`object whose RGB value is 0, 0, 0 and whose alpha value is 0.
+ If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 0.
 
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -403,7 +403,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color of the icon. This can only be used with sdf icons.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of `blackColor` with an alpha value of 1.
 
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
@@ -412,7 +412,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color of the icon's halo. Icon halos can only be used with sdf icons.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 0.
+ If this property is set to `nil`, the layer uses an implicit default value of `blackColor` with an alpha value of 0.
 
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
@@ -472,7 +472,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color with which the text will be drawn.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 1.
+ If this property is set to `nil`, the layer uses an implicit default value of `blackColor` with an alpha value of 1.
 
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
@@ -481,7 +481,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 /**
  The color of the text's halo, which helps it stand out from backgrounds.
  
- If this property is set to `nil`, the layer uses an implicit default value of an `NSColor` or `UIColor` object whose RGB value is 0, 0, 0 and whose alpha value is 0.
+ If this property is set to `nil`, the layer uses an implicit default value of `blackColor` with an alpha value of 0.
 
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */


### PR DESCRIPTION
This PR fixes a typo in the generated documentation for color properties in the runtime styling API. It also aliases RGB 0, 0, 0 to `+[NSColor blackColor]` / `+[UIColor blackColor]`.

/cc @frederoni