### PR TITLE
Override style specification documentation in runtime styling API

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -2,8 +2,9 @@
 
 const fs = require('fs');
 const ejs = require('ejs');
-const spec = require('mapbox-gl-style-spec').latest;
+const _ = require('lodash');
 const colorParser = require('csscolorparser');
+const spec = _.merge(require('mapbox-gl-style-spec').latest, require('./style-spec-overrides-v8.json'));
 
 const prefix = 'MGL';
 const suffix = 'StyleLayer';

--- a/platform/darwin/scripts/style-spec-overrides-v8.json
+++ b/platform/darwin/scripts/style-spec-overrides-v8.json
@@ -1,0 +1,55 @@
+{
+  "layout_symbol": {
+    "icon-text-fit-padding": {
+      "doc": "Size of the additional area added to dimensions determined by `icon-text-fit`."
+    },
+    "icon-offset": {
+      "doc": "Offset distance of icon from its anchor."
+    },
+    "text-offset": {
+      "doc": "Offset distance of text from its anchor."
+    },
+    "text-transform": {
+      "doc": "Specifies how to capitalize text."
+    }
+  },
+  "paint_background": {
+    "background-pattern": {
+      "doc": "Name of image in style images to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512)."
+    }
+  },
+  "paint_fill": {
+    "fill-pattern": {
+      "doc": "Name of image in style images to use for drawing image fills. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512)."
+    }
+  },
+  "paint_line": {
+    "line-pattern": {
+      "doc": "Name of image in style images to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512)."
+    },
+    "line-translate": {
+      "doc": "The geometry's offset."
+    }
+  },
+  "paint_circle": {
+    "circle-translate": {
+      "doc": "The geometry's offset."
+    }
+  },
+  "paint_fill": {
+    "fill-translate": {
+      "doc": "The geometry's offset."
+    },
+    "fill-color": {
+      "doc": "The color of the filled part of this layer."
+    }
+  },
+  "paint_symbol": {
+    "icon-translate": {
+      "doc": "Distance that the icon's anchor is moved from its original placement."
+    },
+    "text-translate": {
+      "doc": "Distance that the text's anchor is moved from its original placement."
+    }
+  }
+}

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 /**
- Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
+ Name of image in style images to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *backgroundPattern;
 

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -88,7 +88,7 @@ typedef NS_ENUM(NSUInteger, MGLCirclePitchScale) {
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleOpacity;
 
 /**
- The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
+ The geometry's offset.
 
  This property is measured in points.
  

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslateAnchor) {
 
 #if TARGET_OS_IPHONE
 /**
- The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
+ The color of the filled part of this layer.
  
  The default value of this property is an `MGLStyleValue` object containing `UIColor.blackColor`. Set this property to `nil` to reset it to the default value.
 
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *fillColor;
 #else
 /**
- The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
+ The color of the filled part of this layer.
  
  The default value of this property is an `MGLStyleValue` object containing `NSColor.blackColor`. Set this property to `nil` to reset it to the default value.
 
@@ -74,7 +74,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *fillOutlineColor;
 
 /**
- The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
+ The geometry's offset.
 
  This property is measured in points.
  

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -134,7 +134,7 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
 #endif
 
 /**
- The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.
+ The geometry's offset.
 
  This property is measured in points.
  
@@ -197,7 +197,7 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSNumber *> *> *lineDasharray;
 
 /**
- Name of image in sprite to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512).
+ Name of image in style images to use for drawing image lines. For seamless patterns, image width must be a factor of two (2, 4, 8, ..., 512).
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *linePattern;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -171,7 +171,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
 };
 
 /**
- Specifies how to capitalize text, similar to the CSS `text-transform` property.
+ Specifies how to capitalize text.
  
  Values of this type are used in the `textTransform` property of `MGLSymbolStyleLayer`.
  */
@@ -312,7 +312,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFit;
 
 /**
- Size of the additional area added to dimensions determined by `iconTextFit`, in clockwise order: top, right, bottom, left.
+ Size of the additional area added to dimensions determined by `iconTextFit`.
 
  This property is measured in points.
  
@@ -359,7 +359,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconKeepUpright;
 
 /**
- Offset distance of icon from its anchor. Positive values indicate right and down, while negative values indicate left and up.
+ Offset distance of icon from its anchor.
  
  The default value of this property is an `MGLStyleValue` object containing an `NSValue` object containing a `CGVector` struct set to 0 from the left and 0 from the top. Set this property to `nil` to reset it to the default value.
  
@@ -506,7 +506,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textKeepUpright;
 
 /**
- Specifies how to capitalize text, similar to the CSS `text-transform` property.
+ Specifies how to capitalize text.
  
  The default value of this property is an `MGLStyleValue` object containing an `NSValue` object containing `MGLTextTransformNone`. Set this property to `nil` to reset it to the default value.
  
@@ -515,7 +515,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTransform;
 
 /**
- Offset distance of text from its anchor. Positive values indicate right and down, while negative values indicate left and up.
+ Offset distance of text from its anchor.
 
  This property is measured in ems.
  
@@ -626,7 +626,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconHaloBlur;
 
 /**
- Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
+ Distance that the icon's anchor is moved from its original placement.
 
  This property is measured in points.
  
@@ -717,7 +717,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textHaloBlur;
 
 /**
- Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.
+ Distance that the text's anchor is moved from its original placement.
 
  This property is measured in points.
  


### PR DESCRIPTION
Fixes #5954 - Override some gl-style-spec documentation to make it more idiomatic.

👀  @1ec5 @friedbunny 
