### PR TITLE
Add CMake source groups for the rest of the targets

### DIFF
--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -32,3 +32,5 @@ add_custom_command(
 target_add_mason_package(mbgl-glfw PRIVATE glfw)
 
 mbgl_platform_glfw()
+
+create_source_groups(mbgl-glfw)

--- a/cmake/node.cmake
+++ b/cmake/node.cmake
@@ -42,3 +42,5 @@ add_custom_command(
 )
 
 mbgl_platform_node()
+
+create_source_groups(mbgl-node)

--- a/cmake/offline.cmake
+++ b/cmake/offline.cmake
@@ -19,3 +19,5 @@ target_add_mason_package(mbgl-offline PRIVATE boost)
 target_add_mason_package(mbgl-offline PRIVATE boost_libprogram_options)
 
 mbgl_platform_offline()
+
+create_source_groups(mbgl-offline)

--- a/cmake/render.cmake
+++ b/cmake/render.cmake
@@ -19,3 +19,5 @@ target_add_mason_package(mbgl-render PRIVATE boost)
 target_add_mason_package(mbgl-render PRIVATE boost_libprogram_options)
 
 mbgl_platform_render()
+
+create_source_groups(mbgl-render)

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -31,3 +31,5 @@ target_add_mason_package(mbgl-test PRIVATE geojson)
 target_add_mason_package(mbgl-test PRIVATE geojsonvt)
 
 mbgl_platform_test()
+
+create_source_groups(mbgl-test)


### PR DESCRIPTION
Currently, only `mbgl-core` and `mbgl-loop` have calls to `create_source_groups`, which files all of the source files into the correct groups so they appear as a folder structure in Xcode. This patch adds those calls to all other targets that have source files as well.