### PR TITLE
Stop exaggerating heading accuracy indicator size

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -29,6 +29,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * To customize the appearance of the user location annotation, subclass the newly added MGLUserLocationAnnotationView class and implement `-[MGLMapViewDelegate mapView:viewForAnnotation:]`. ([#5882](https://github.com/mapbox/mapbox-gl-native/pull/5882))
 * Fixed an issue causing the user dot’s accuracy ring to wobble while zooming in and out. ([#6019](https://github.com/mapbox/mapbox-gl-native/pull/6019))
+* Heading accuracy indicator sizing has been changed to appear more precise. ([#6120](https://github.com/mapbox/mapbox-gl-native/pull/6120))
 
 ### Annotations
 

--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -459,10 +459,11 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
 
 - (CGFloat)calculateAccuracyRingSize
 {
-    CGFloat latRadians = self.userLocation.coordinate.latitude * M_PI / 180.0f;
-    CGFloat pixelRadius = self.userLocation.location.horizontalAccuracy / cos(latRadians) / [self.mapView metersPerPointAtLatitude:self.userLocation.coordinate.latitude];
+    CGFloat latitudeRadians = MGLRadiansFromDegrees(self.userLocation.coordinate.latitude);
+    CGFloat metersPerPoint = [self.mapView metersPerPointAtLatitude:self.userLocation.coordinate.latitude];
+    CGFloat pixelRadius = self.userLocation.location.horizontalAccuracy / cos(latitudeRadians) / metersPerPoint;
 
-    return pixelRadius * 2;
+    return pixelRadius * 2.0;
 }
 
 - (UIImage *)headingIndicatorTintedGradientImage
@@ -479,8 +480,11 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
     // gradient from the tint color to no-alpha tint color
     CGFloat gradientLocations[] = {0.0, 1.0};
     CGGradientRef gradient = CGGradientCreateWithColors(
-                                                        colorSpace, (__bridge CFArrayRef)@[(id)[self.mapView.tintColor CGColor],
-                                                                                           (id)[[self.mapView.tintColor colorWithAlphaComponent:0] CGColor]], gradientLocations);
+                                colorSpace,
+                                (__bridge CFArrayRef)@[
+                                    (id)[self.mapView.tintColor CGColor],
+                                    (id)[[self.mapView.tintColor colorWithAlphaComponent:0] CGColor]],
+                                gradientLocations);
 
     // draw the gradient from the center point to the edge (full halo radius)
     CGPoint centerPoint = CGPointMake(haloRadius, haloRadius);
@@ -513,8 +517,8 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
     // clip the oval to ± incoming accuracy degrees (converted to radians), from the top
     [ovalPath addArcWithCenter:CGPointMake(CGRectGetMidX(ovalRect), CGRectGetMidY(ovalRect))
                         radius:CGRectGetWidth(ovalRect) / 2.0
-                    startAngle:(-180 + clippingDegrees) * M_PI / 180
-                      endAngle:-clippingDegrees * M_PI / 180
+                    startAngle:MGLRadiansFromDegrees(-180 + clippingDegrees)
+                      endAngle:MGLRadiansFromDegrees(-clippingDegrees)
                      clockwise:YES];
 
     [ovalPath addLineToPoint:CGPointMake(CGRectGetMidX(ovalRect), CGRectGetMidY(ovalRect))];

--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -502,10 +502,10 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
 {
     CGFloat accuracy = self.userLocation.heading.headingAccuracy;
 
-    // size the mask using exagerated accuracy, but keep within a good display range
-    CGFloat clippingDegrees = 90 - (accuracy * 1.5);
-    clippingDegrees = fmin(clippingDegrees, 55);
-    clippingDegrees = fmax(clippingDegrees, 10);
+    // size the mask using accuracy, but keep within a good display range
+    CGFloat clippingDegrees = 90 - accuracy;
+    clippingDegrees = fmin(clippingDegrees, 70); // most accurate
+    clippingDegrees = fmax(clippingDegrees, 10); // least accurate
 
     CGRect ovalRect = CGRectMake(0, 0, MGLUserLocationAnnotationHaloSize, MGLUserLocationAnnotationHaloSize);
     UIBezierPath *ovalPath = UIBezierPath.bezierPath;


### PR DESCRIPTION
This change removes the 1.5× exaggeration of the user location annotation’s heading indicator.

Also cleaned up some of the heading mask calculations while I was at it.

Fixes #3718.

/cc @1ec5