### PR TITLE
Disable implicit animation of user annotation pitch changes

### DIFF
--- a/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLFaux3DUserLocationAnnotationView.m
@@ -77,10 +77,16 @@ const CGFloat MGLUserLocationAnnotationArrowSize = MGLUserLocationAnnotationPuck
 {
     if (self.mapView.camera.pitch != _oldPitch)
     {
+        // disable implicit animation
+        [CATransaction begin];
+        [CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
+
         CATransform3D t = CATransform3DRotate(CATransform3DIdentity, MGLRadiansFromDegrees(self.mapView.camera.pitch), 1.0, 0, 0);
         self.layer.sublayerTransform = t;
 
         [self updateFaux3DEffect];
+
+        [CATransaction commit];
 
         _oldPitch = self.mapView.camera.pitch;
     }


### PR DESCRIPTION
Subtly improves the performance of the dot/puck’s shadow by disabling its implicit animation — it no longer lags behind when you’re executing the pitch gesture.

Follows on from #6019.

/cc @1ec5