### PR TITLE
Expose name and default position of current style

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -164,6 +164,13 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  */
 + (NSURL *)satelliteStreetsStyleURLWithVersion:(NSInteger)version;
 
+/**
+ The name of the style.
+ 
+ You can customize the style’s name in Mapbox Studio.
+ */
+@property (readonly, copy, nullable) NSString *name;
+
 #pragma mark Runtime Styling
 
 /**

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -88,6 +88,10 @@ static NSURL *MGLStyleURL_emerald;
     return MGLStyleURL_emerald;
 }
 
+- (NSString *)name {
+    return @(self.mapView.mbglMap->getStyleName().c_str());
+}
+
 - (mbgl::style::Layer *)mbglLayerWithIdentifier:(NSString *)identifier
 {
     return self.mapView.mbglMap->getLayer(identifier.UTF8String);

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added [quadkey](https://msdn.microsoft.com/en-us/library/bb259689.aspx) support and limited WMS support in raster tile URL templates. ([#5628](https://github.com/mapbox/mapbox-gl-native/pull/5628))
 * TileJSON manifests can now specify `"scheme": "tms"` to indicate the use of [TMS](https://en.wikipedia.org/wiki/Tile_Map_Service) coordinates. ([#2270](https://github.com/mapbox/mapbox-gl-native/pull/2270))
 * Fixed rendering artifacts and missing glyphs that occurred after viewing a large number of CJK characters on the map. ([#5908](https://github.com/mapbox/mapbox-gl-native/pull/5908))
+* `-[MGLMapView resetPosition]` now resets to the current style’s default center coordinates, zoom level, direction, and pitch, if specified. ([#6127](https://github.com/mapbox/mapbox-gl-native/pull/6127))
 * The `text-pitch-alignment` property is now supported in stylesheets for improved street label legibility on a tilted map. ([#5288](https://github.com/mapbox/mapbox-gl-native/pull/5288))
 * The `icon-text-fit` and `icon-text-fit-padding` properties are now supported in stylesheets, allowing the background of a shield to automatically resize to fit the shield’s text. ([#5334](https://github.com/mapbox/mapbox-gl-native/pull/5334))
 * The `circle-pitch-scale` property is now supported in stylesheets, allowing circle features in a tilted base map to scale or remain the same size as the viewing distance changes. ([#5576](https://github.com/mapbox/mapbox-gl-native/pull/5576))

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -559,6 +559,14 @@ IB_DESIGNABLE
 - (IBAction)resetNorth;
 
 /**
+ Resets the map to the current style’s default viewport.
+ 
+ If the style doesn’t specify a default viewport, the map resets to a minimum
+ zoom level, a center coordinate of (0, 0), and a northern heading.
+ */
+- (IBAction)resetPosition;
+
+/**
  The coordinate bounds visible in the receiver’s viewport.
  
  Changing the value of this property updates the receiver immediately. If you
@@ -1213,12 +1221,6 @@ IB_DESIGNABLE
 - (void)toggleDebug __attribute__((deprecated("Use -setDebugMask:.")));
 
 - (void)emptyMemoryCache __attribute__((deprecated));
-
-/**
-    Resets the map to the minimum zoom level, a center coordinate of (0, 0), and
-    a northern heading.
- */
-- (void)resetPosition;
 
 @end
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1899,9 +1899,13 @@ public:
 
 - (void)resetPosition
 {
-    MGLMapCamera *camera = [MGLMapCamera camera];
-    camera.altitude = MGLAltitudeForZoomLevel(0, 0, 0, self.frame.size);
-    self.camera = camera;
+    CGFloat pitch = _mbglMap->getDefaultPitch();
+    CLLocationDirection heading = mbgl::util::wrap(_mbglMap->getDefaultBearing(), 0., 360.);
+    CLLocationDistance distance = MGLAltitudeForZoomLevel(_mbglMap->getDefaultZoom(), pitch, 0, self.frame.size);
+    self.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:MGLLocationCoordinate2DFromLatLng(_mbglMap->getDefaultLatLng())
+                                                   fromDistance:distance
+                                                          pitch:pitch
+                                                        heading:heading];
 }
 
 - (void)emptyMemoryCache


### PR DESCRIPTION
This is a followup to #6002 that exposes the current style’s name and makes `-[MGLMapView resetPosition]` reset to the style’s default viewport rather than the SDK default.

/cc @friedbunny