### PR TITLE
[core] Emit MapChangeDidFailLoadingMap when the style cannot be loaded or parsed

### DIFF
--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -43,10 +43,12 @@ public:
     void invalidate() override;
     void activate() override;
     void deactivate() override;
+    void notifyMapChange(MapChange) override;
 
     PremultipliedImage readStillImage() override;
 
     void resize(uint16_t width, uint16_t height);
+    void setMapChangeCallback(std::function<void(MapChange)>&& cb) { mapChangeCallback = std::move(cb); }
 
 private:
     // Implementation specific functions
@@ -84,6 +86,8 @@ private:
     GLXContext glContext = nullptr;
     GLXPbuffer glxPbuffer = 0;
 #endif
+
+    std::function<void(MapChange)> mapChangeCallback;
 
     GLuint fbo = 0;
     GLuint fboDepthStencil = 0;

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -107,4 +107,10 @@ void HeadlessView::invalidate() {
     assert(false);
 }
 
+void HeadlessView::notifyMapChange(MapChange change) {
+    if (mapChangeCallback) {
+        mapChangeCallback(change);
+    }
+}
+
 } // namespace mbgl

--- a/src/mbgl/style/observer.hpp
+++ b/src/mbgl/style/observer.hpp
@@ -18,6 +18,7 @@ public:
      * and `onNeedsRepaint` will be called.
      */
     void onNeedsRepaint() override {}
+    virtual void onStyleError() {}
     virtual void onResourceError(std::exception_ptr) {}
 };
 

--- a/src/mbgl/style/parser.hpp
+++ b/src/mbgl/style/parser.hpp
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <forward_list>
@@ -16,11 +17,13 @@
 namespace mbgl {
 namespace style {
 
+using StyleParseResult = std::exception_ptr;
+
 class Parser {
 public:
     ~Parser();
 
-    void parse(const std::string&);
+    StyleParseResult parse(const std::string&);
 
     std::string spriteURL;
     std::string glyphURL;

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -90,7 +90,15 @@ void Style::setJSON(const std::string& json) {
     classes.clear();
 
     Parser parser;
-    parser.parse(json);
+    auto error = parser.parse(json);
+
+    if (error) {
+        Log::Error(Event::ParseStyle, "Failed to parse style: %s", util::toString(error).c_str());
+        observer->onStyleError();
+        observer->onResourceError(error);
+
+        return;
+    }
 
     for (auto& source : parser.sources) {
         addSource(std::move(source));

--- a/test/fixtures/style_parser/non-object.info.json
+++ b/test/fixtures/style_parser/non-object.info.json
@@ -1,7 +1,7 @@
 {
     "default": {
         "log": [
-            [1, "ERROR", "ParseStyle", "Style JSON must be an object"]
+            [1, "ERROR", "ParseStyle", "Failed to parse style: style must be an object"]
         ]
     }
 }

--- a/test/map/map.cpp
+++ b/test/map/map.cpp
@@ -68,7 +68,7 @@ TEST(Map, SetStyleInvalidJSON) {
     auto observer = Log::removeObserver();
     auto flo = dynamic_cast<FixtureLogObserver*>(observer.get());
     EXPECT_EQ(1u, flo->count({ EventSeverity::Error, Event::ParseStyle, -1,
-        "Error parsing style JSON at 0: Invalid value." }));
+        "Failed to parse style: 0 - Invalid value." }));
     auto unchecked = flo->unchecked();
     EXPECT_TRUE(unchecked.empty()) << unchecked;
 }

--- a/test/src/mbgl/test/util.hpp
+++ b/test/src/mbgl/test/util.hpp
@@ -43,14 +43,6 @@
 
 #include <gtest/gtest.h>
 
-#define SCOPED_TEST(name) \
-    static class name { \
-        bool completed = false; \
-    public: \
-        void finish() { EXPECT_FALSE(completed) << #name " was already completed."; completed = true; } \
-        ~name() { if (!completed) ADD_FAILURE() << #name " didn't complete."; } \
-    } name;
-
 namespace mbgl {
 
 class Map;

--- a/test/style/style_parser.cpp
+++ b/test/style/style_parser.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/style/parser.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/enum.hpp>
+#include <mbgl/util/string.hpp>
 #include <mbgl/util/tileset.hpp>
 
 #include <rapidjson/document.h>
@@ -32,7 +33,11 @@ TEST_P(StyleParserTest, ParseStyle) {
     Log::setObserver(std::unique_ptr<Log::Observer>(observer));
 
     style::Parser parser;
-    parser.parse(util::read_file(base + ".style.json"));
+    auto error = parser.parse(util::read_file(base + ".style.json"));
+
+    if (error) {
+        Log::Error(Event::ParseStyle, "Failed to parse style: %s", util::toString(error).c_str());
+    }
 
     for (auto it = infoDoc.MemberBegin(), end = infoDoc.MemberEnd(); it != end; it++) {
         const std::string name { it->name.GetString(), it->name.GetStringLength() };


### PR DESCRIPTION
Currently this signal is never emitted, which can cause the Still mode to starve in case of an invalid style or failed request.