### PR TITLE
Document -mapViewDidFailLoadingMap:withError:

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -22,6 +22,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The `icon-text-fit` and `icon-text-fit-padding` properties are now supported in stylesheets, allowing the background of a shield to automatically resize to fit the shield’s text. ([#5334](https://github.com/mapbox/mapbox-gl-native/pull/5334))
 * The `circle-pitch-scale` property is now supported in stylesheets, allowing circle features in a tilted base map to scale or remain the same size as the viewing distance changes. ([#5576](https://github.com/mapbox/mapbox-gl-native/pull/5576))
 * The `identifier` property of an MGLFeature may now be either a number or string. ([#5514](https://github.com/mapbox/mapbox-gl-native/pull/5514))
+* If MGLMapView is unable to obtain or parse a style, it now calls its delegate’s `-mapViewDidFailLoadingMap:withError:` method. ([#6145](https://github.com/mapbox/mapbox-gl-native/pull/6145))
 * Fixed crashes that could occur when loading a malformed stylesheet. ([#5736](https://github.com/mapbox/mapbox-gl-native/pull/5736))
 
 ### User location

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -81,7 +81,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapViewDidFinishLoadingMap:(MGLMapView *)mapView;
 
-// TODO
+/**
+ Tells the delegate that the map view was unable to load data needed for
+ displaying the map.
+ 
+ This method may be called for a variety of reasons, including a network
+ connection failure or a failure to fetch the style from the server. You can use
+ the given error message to notify the user that map data is unavailable.
+ 
+ @param mapView The map view that is unable to load the data.
+ @param error The reason the data could not be loaded.
+ */
 - (void)mapViewDidFailLoadingMap:(MGLMapView *)mapView withError:(NSError *)error;
 
 // TODO

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed rendering artifacts and missing glyphs that occurred after viewing a large number of CJK characters on the map. ([#5908](https://github.com/mapbox/mapbox-gl-native/pull/5908))
 * Improved the precision of annotations at zoom levels greater than 18. ([#5517](https://github.com/mapbox/mapbox-gl-native/pull/5517))
 * Fixed an issue where the style zoom levels were not respected when deciding when to render a layer. ([#5811](https://github.com/mapbox/mapbox-gl-native/issues/5811))
+* If MGLMapView is unable to obtain or parse a style, it now calls its delegate’s `-mapViewDidFailLoadingMap:withError:` method. ([#6145](https://github.com/mapbox/mapbox-gl-native/pull/6145))
 * Fixed crashes that could occur when loading a malformed stylesheet. ([#5736](https://github.com/mapbox/mapbox-gl-native/pull/5736))
 * Fixed a typo in the documentation for the MGLCompassDirectionFormatter class. ([#5879](https://github.com/mapbox/mapbox-gl-native/pull/5879))
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -807,7 +807,10 @@ public:
         }
         case mbgl::MapChangeDidFailLoadingMap:
         {
-            // Not yet implemented.
+            if ([self.delegate respondsToSelector:@selector(mapViewDidFailLoadingMap:withError:)]) {
+                NSError *error = [NSError errorWithDomain:MGLErrorDomain code:0 userInfo:nil];
+                [self.delegate mapViewDidFailLoadingMap:self withError:error];
+            }
             break;
         }
         case mbgl::MapChangeWillStartRenderingMap:

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -83,6 +83,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapViewDidFinishLoadingMap:(MGLMapView *)mapView;
 
+/**
+ Tells the delegate that the map view was unable to load data needed for
+ displaying the map.
+ 
+ This method may be called for a variety of reasons, including a network
+ connection failure or a failure to fetch the style from the server. You can use
+ the given error message to notify the user that map data is unavailable.
+ 
+ @param mapView The map view that is unable to load the data.
+ @param error The reason the data could not be loaded.
+ */
+- (void)mapViewDidFailLoadingMap:(MGLMapView *)mapView withError:(NSError *)error;
+
 - (void)mapViewWillStartRenderingMap:(MGLMapView *)mapView;
 - (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered;
 


### PR DESCRIPTION
Documented `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` on iOS and ported the declaration and call site over to macOS. Also mentioned the sudden new use of this API in the changelogs.

/cc @friedbunny