### PR TITLE
Update MAS dependencies to v1.3.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'com.mapzen.android:lost:1.1.0'
 
     // Mapbox Android Services
-    compile('com.mapbox.mapboxsdk:mapbox-android-services:2.0.0-SNAPSHOT@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-java-services:1.3.0@jar') {
         transitive = true
     }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
 
     // Mapbox Android Services
-    compile('com.mapbox.mapboxsdk:mapbox-android-services:2.0.0-SNAPSHOT@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-services:1.3.0@aar') {
         transitive = true
     }
 


### PR DESCRIPTION
This PR removes dependencies on MAS SNAPSHOT versions. It also brings down the SDK dependency from `mapbox-android-services` to `mapbox-java-services` as none of the Android-specific code is currently used by the SDK.

Fixes #6148.

/cc: @ivovandongen 