### PR TITLE
Ignore non-conforming user location annotation views

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -732,15 +732,17 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
         annotationView = [[MBXAnnotationView alloc] initWithReuseIdentifier:MBXViewControllerAnnotationViewReuseIdentifer];
         annotationView.frame = CGRectMake(0, 0, 10, 10);
         annotationView.backgroundColor = [UIColor whiteColor];
-        
-        // uncomment to make the annotation view draggable
-        // also note that having two long press gesture recognizers on overlapping views (`self.view` & `annotationView`) will cause weird behaviour
-        // comment out the pin dropping functionality in the handleLongPress: method in this class to make draggable annotation views play nice
+
+        // Note that having two long press gesture recognizers on overlapping
+        // views (`self.view` & `annotationView`) will cause weird behaviour.
+        // Comment out the pin dropping functionality in the handleLongPress:
+        // method in this class to make draggable annotation views play nice.
         annotationView.draggable = YES;
         
-        // uncomment to force annotation view to maintain a constant size when the map is tilted
-        // by default, annotation views will shrink and grow as the move towards and away from the
-        // horizon. Relatedly, annotations backed by GL sprites ONLY scale with viewing distance currently.
+        // Uncomment to force annotation view to maintain a constant size when
+        // the map is tilted. By default, annotation views will shrink and grow
+        // as they move towards and away from the horizon. Relatedly, annotations
+        // backed by GL sprites currently ONLY scale with viewing distance.
         // annotationView.scalesWithViewingDistance = NO;
     } else {
         // orange indicates that the annotation view was reused

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3824,10 +3824,14 @@ public:
         if ([self.delegate respondsToSelector:@selector(mapView:viewForAnnotation:)])
         {
             userLocationAnnotationView = (MGLUserLocationAnnotationView *)[self.delegate mapView:self viewForAnnotation:self.userLocation];
-            if (userLocationAnnotationView)
+            if (userLocationAnnotationView && ! [userLocationAnnotationView isKindOfClass:MGLUserLocationAnnotationView.class])
             {
-                NSAssert([userLocationAnnotationView.class isSubclassOfClass:MGLUserLocationAnnotationView.class],
-                         @"User location annotation view must be a subclass of MGLUserLocationAnnotationView");
+                static dispatch_once_t onceToken;
+                dispatch_once(&onceToken, ^{
+                    NSLog(@"Ignoring user location annotation view with type %@. User location annotation view must be a kind of MGLUserLocationAnnotationView. This warning is only shown once and will become an error in a future version.", NSStringFromClass(userLocationAnnotationView.class));
+                });
+
+                userLocationAnnotationView = nil;
             }
         }
         

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -273,6 +273,11 @@ NS_ASSUME_NONNULL_BEGIN
  Touch frameworks. On the other hand, static annotation images use less memory
  and draw more quickly than annotation views.
  
+ The user location annotation view can also be customized via this method. When
+ `annotation` is an instance of `MGLUserLocation` (or equal to the map view’s
+ `userLocation` property), return an instance of `MGLUserLocationAnnotationView`
+ (or a subclass thereof).
+
  @param mapView The map view that requested the annotation view.
  @param annotation The object representing the annotation that is about to be
     displayed.


### PR DESCRIPTION
Prior to v3.4.0, a developer could indiscriminately return any UIView-conforming object in `mapView:viewForAnnotation:` and everything would be fine. With custom user location annotation views, we now also pass in a `MGLUserLocation` annotation, which requires a view that conforms to `MGLUserLocationAnnotationView`.

This pull request ignores views that the developer nominated for the user location annotation view that are not actually a kind of `MGLUserLocationAnnotationView`. This changes the alpha.2 behavior of asserting when the inheritance was wrong. When we ignore a view, the default user dot is used in its stead.

I’ve also documented that `mapView:viewForAnnotation:` can be used to customize the user location annotation view, because this is a somewhat unexpected new behavior.

Fixes #6100.

/cc @1ec5 @frederoni