### PR TITLE
avoid altering annotation view transforms set by user

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -39,6 +39,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * To make an MGLPolyline or MGLPolygon span the antimeridian, specify coordinates with longitudes greater than 180° or less than −180°. ([#6088](https://github.com/mapbox/mapbox-gl-native/pull/6088))
 * Improved the performance of relocating a non-view-backed point annotation by changing its `coordinate` property. ([#5385](https://github.com/mapbox/mapbox-gl-native/pull/5385))
 * Improved the precision of annotations at zoom levels greater than 18. ([#5517](https://github.com/mapbox/mapbox-gl-native/pull/5517))
+* Fixed an issue that could reset user-added transformations on annotation views. ([#6166](https://github.com/mapbox/mapbox-gl-native/pull/6166))
 
 ### Other changes
 


### PR DESCRIPTION
I unearthed a bug where trying to set an annotation view `transform` of your own gets rapidly reset nearly every frame while annotation view `center` is changing due to the `CATransform3DIdentity` that is repeatedly set in our `setCenter:` override. 

One case this doesn't cover is when you _do_ have draggable views but still want to set a `transform`. Perhaps we could create an alternate setter called `setCenterDuringAnnotationUpdate:` which is called by `-[MGLMapView updateAnnotationViews]` to bypass any of this drag-related `transform` setting entirely? 

@1ec5 @friedbunny @boundsj 