### PR TITLE
[core] Corrupted resource stays in the cache until expiration

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -71,7 +71,6 @@ set(MBGL_TEST_FILES
     test/style/style_layer.cpp
     test/style/style_parser.cpp
     test/style/tile_source.cpp
-    test/style/variant.cpp
     
     # style conversion
     test/style/conversion/geojson_options.cpp

--- a/include/mbgl/storage/response.hpp
+++ b/include/mbgl/storage/response.hpp
@@ -36,6 +36,9 @@ public:
     bool isFresh() const {
         return !expires || *expires > util::now();
     }
+
+    using ReportBadCallback = std::function<void(void)>;
+    ReportBadCallback reportBad = []{};
 };
 
 class Response::Error {

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -241,7 +241,13 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const Resou
     if (!data) {
         response.noContent = true;
     } else if (stmt->get<int>(4)) {
-        response.data = std::make_shared<std::string>(util::decompress(*data));
+        try {
+            response.data = std::make_shared<std::string>(util::decompress(*data));
+        } catch (std::exception const& ex) {
+            Log::Error(Event::Database, "Error decompressing resource: %s", ex.what());
+            removeResource(resource);
+            return {};
+        }
         size = data->length();
     } else {
         response.data = std::make_shared<std::string>(*data);
@@ -410,7 +416,13 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource:
     if (!data) {
         response.noContent = true;
     } else if (stmt->get<int>(4)) {
-        response.data = std::make_shared<std::string>(util::decompress(*data));
+        try {
+            response.data = std::make_shared<std::string>(util::decompress(*data));
+        } catch (std::exception const& ex) {
+            Log::Error(Event::Database, "Error decompressing tile: %s", ex.what());
+            removeTile(tile);
+            return {};
+        }
         size = data->length();
     } else {
         response.data = std::make_shared<std::string>(*data);

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -153,6 +153,10 @@ std::pair<bool, uint64_t> OfflineDatabase::putInternal(const Resource& resource,
         return { false, 0 };
     }
 
+    if (response.noContent && resource.kind != Resource::Kind::Tile) {
+        return { false, 0 };
+    }
+
     std::string compressedData;
     bool compressed = false;
     uint64_t size = 0;

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -30,6 +30,7 @@ public:
     OfflineDatabase(std::string path, uint64_t maximumCacheSize = util::DEFAULT_MAX_CACHE_SIZE);
     ~OfflineDatabase();
 
+    void remove(const Resource&);
     optional<Response> get(const Resource&);
 
     // Return value is (inserted, stored size)
@@ -77,10 +78,12 @@ private:
 
     Statement getStatement(const char *);
 
+    void removeTile(const Resource::TileData& tile);
     optional<std::pair<Response, uint64_t>> getTile(const Resource::TileData&);
     bool putTile(const Resource::TileData&, const Response&,
                  const std::string&, bool compressed);
 
+    void removeResource(const Resource&);
     optional<std::pair<Response, uint64_t>> getResource(const Resource&);
     bool putResource(const Resource&, const Response&,
                      const std::string&, bool compressed);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -323,6 +323,7 @@ void Map::setStyleURL(const std::string& url) {
             return;
         } else {
             impl->loadStyleJSON(*res.data);
+            if (!impl->style->loaded) res.reportBad();
         }
     });
 }

--- a/src/mbgl/storage/response.cpp
+++ b/src/mbgl/storage/response.cpp
@@ -18,6 +18,7 @@ Response& Response::operator=(const Response& res) {
     modified = res.modified;
     expires = res.expires;
     etag = res.etag;
+    reportBad = res.reportBad;
     return *this;
 }
 

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -91,6 +91,7 @@ void GeoJSONSource::Impl::load(FileSource& fileSource) {
             d.Parse<0>(res.data->c_str());
 
             if (d.HasParseError()) {
+                res.reportBad();
                 std::stringstream message;
                 message << d.GetErrorOffset() << " - "
                         << rapidjson::GetParseError_En(d.GetParseError());

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -77,6 +77,7 @@ void TileSourceImpl::load(FileSource& fileSource) {
             try {
                 newTileset = parseTileJSON(*res.data, url, type, tileSize);
             } catch (...) {
+                res.reportBad();
                 observer->onSourceError(base, std::current_exception());
                 return;
             }

--- a/src/mbgl/text/glyph_pbf.cpp
+++ b/src/mbgl/text/glyph_pbf.cpp
@@ -81,6 +81,7 @@ GlyphPBF::GlyphPBF(GlyphStore* store,
             try {
                 parseGlyphPBF(**store->getGlyphSet(fontStack), *res.data);
             } catch (...) {
+                res.reportBad();
                 observer->onGlyphsError(fontStack, glyphRange, std::current_exception());
                 return;
             }

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -102,9 +102,11 @@ void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_) {
             }
 
             redoPlacement();
+            firstParseFinished(true);
             observer->onTileLoaded(*this, true);
         } else {
             availableData = DataAvailability::All;
+            firstParseFinished(false);
             observer->onTileError(*this, result.get<std::exception_ptr>());
         }
     });

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -25,9 +25,7 @@ public:
 
     void setError(std::exception_ptr err);
 
-    void setData(std::shared_ptr<const std::string> data,
-                 optional<Timestamp> modified_,
-                 optional<Timestamp> expires_);
+    void setData(const Response& response);
 
     void cancel() override;
     Bucket* getBucket(const style::Layer&) override;

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -45,6 +45,8 @@ public:
     // Mark this tile as no longer needed and cancel any pending work.
     virtual void cancel() = 0;
 
+    virtual void firstParseFinished(bool /* succeed */) {}
+
     virtual Bucket* getBucket(const style::Layer&) = 0;
 
     virtual bool parsePending() { return true; }

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -99,7 +99,7 @@ void TileLoader<T>::loadedData(const Response& res) {
         resource.priorModified = res.modified;
         resource.priorExpires = res.expires;
         resource.priorEtag = res.etag;
-        tile.setData(res.noContent ? nullptr : res.data, res.modified, res.expires);
+        tile.setData(res);
     }
 }
 

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -75,11 +75,23 @@ VectorTile::VectorTile(const OverscaledTileID& id_,
       loader(*this, id_, parameters, tileset) {
 }
 
+void VectorTile::firstParseFinished(bool succeed) {
+    assert(response);
+
+    if (!succeed) {
+        response->reportBad();
+    }
+
+    response = optional<Response>();
+}
+
 void VectorTile::setNecessity(Necessity necessity) {
     loader.setNecessity(necessity);
 }
 
 void VectorTile::setData(const Response& res) {
+    response = res;
+
     modified = res.modified;
     expires = res.expires;
 

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -79,13 +79,11 @@ void VectorTile::setNecessity(Necessity necessity) {
     loader.setNecessity(necessity);
 }
 
-void VectorTile::setData(std::shared_ptr<const std::string> data_,
-                         optional<Timestamp> modified_,
-                         optional<Timestamp> expires_) {
-    modified = modified_;
-    expires = expires_;
+void VectorTile::setData(const Response& res) {
+    modified = res.modified;
+    expires = res.expires;
 
-    GeometryTile::setData(data_ ? std::make_unique<VectorTileData>(data_) : nullptr);
+    GeometryTile::setData(res.noContent ? nullptr : std::make_unique<VectorTileData>(res.data));
 }
 
 Value parseValue(protozero::pbf_reader data) {

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -19,9 +19,7 @@ public:
                const Tileset&);
 
     void setNecessity(Necessity) final;
-    void setData(std::shared_ptr<const std::string> data,
-                 optional<Timestamp> modified,
-                 optional<Timestamp> expires);
+    void setData(const Response& response);
 
 private:
     TileLoader<VectorTile> loader;

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -18,10 +18,12 @@ public:
                const style::UpdateParameters&,
                const Tileset&);
 
+    void firstParseFinished(bool succeed) final;
     void setNecessity(Necessity) final;
     void setData(const Response& response);
 
 private:
+    optional<Response> response;
     TileLoader<VectorTile> loader;
 };
 

--- a/test/storage/offline_database.cpp
+++ b/test/storage/offline_database.cpp
@@ -224,15 +224,38 @@ TEST(OfflineDatabase, PutResourceNoContent) {
 
     OfflineDatabase db(":memory:");
 
-    Resource resource { Resource::Style, "http://example.com/" };
     Response response;
     response.noContent = true;
 
-    db.put(resource, response);
-    auto res = db.get(resource);
-    EXPECT_EQ(nullptr, res->error);
-    EXPECT_TRUE(res->noContent);
-    EXPECT_FALSE(res->data.get());
+    Resource style { Resource::Style, "http://example.com/" };
+    db.put(style, response);
+    EXPECT_FALSE(db.get(style));
+
+    Resource source { Resource::Source, "http://example.com/" };
+    db.put(source, response);
+    EXPECT_FALSE(db.get(source));
+
+    Resource glyphs { Resource::Glyphs, "http://example.com/" };
+    db.put(glyphs, response);
+    EXPECT_FALSE(db.get(glyphs));
+
+    Resource spriteImage { Resource::SpriteImage, "http://example.com/" };
+    db.put(spriteImage, response);
+    EXPECT_FALSE(db.get(spriteImage));
+
+    Resource spriteJSON { Resource::SpriteJSON, "http://example.com/" };
+    db.put(spriteJSON, response);
+    EXPECT_FALSE(db.get(spriteJSON));
+
+    Resource tile { Resource::Tile, "http://example.com/" };
+    tile.tileData = Resource::TileData { "http://example.com/", 1, 0, 0, 0 };
+
+    db.put(tile, response);
+    auto tileResponse = db.get(tile);
+
+    EXPECT_EQ(nullptr, tileResponse->error);
+    EXPECT_TRUE(tileResponse->noContent);
+    EXPECT_FALSE(tileResponse->data.get());
 }
 
 TEST(OfflineDatabase, PutTileNotFound) {
@@ -353,7 +376,7 @@ TEST(OfflineDatabase, TEST_REQUIRES_WRITE(ConcurrentUse)) {
 
     Resource resource { Resource::Style, "http://example.com/" };
     Response response;
-    response.noContent = true;
+    response.data = std::make_shared<std::string>("foobar");
 
     std::thread thread1([&] {
         for (auto i = 0; i < 100; i++) {

--- a/test/storage/offline_database.cpp
+++ b/test/storage/offline_database.cpp
@@ -185,6 +185,36 @@ TEST(OfflineDatabase, PutResource) {
     EXPECT_EQ("second", *updateGetResult->data);
 }
 
+TEST(OfflineDatabase, RemoveResource) {
+    using namespace mbgl;
+
+    OfflineDatabase db(":memory:");
+
+    Response response;
+    response.data = std::make_shared<std::string>("data");
+
+    Resource style { Resource::Style, "http://example.com/" };
+    db.put(style, response);
+    EXPECT_EQ(*db.get(style)->data, "data");
+
+    db.remove(style);
+    EXPECT_FALSE(db.get(style));
+
+    // Should not fail/crash.
+    db.remove(style);
+
+    Resource tile { Resource::Tile, "http://example.com/" };
+    tile.tileData = Resource::TileData { "http://example.com/", 1, 0, 0, 0 };
+    db.put(tile, response);
+    EXPECT_EQ(*db.get(tile)->data, "data");
+
+    db.remove(tile);
+    EXPECT_FALSE(db.get(tile));
+
+    // Should not fail/crash.
+    db.remove(tile);
+}
+
 TEST(OfflineDatabase, PutTile) {
     using namespace mbgl;
 

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -283,6 +283,7 @@ TEST(Source, VectorTileCorrupt) {
         EXPECT_EQ(source.baseImpl->type, SourceType::Vector);
         EXPECT_EQ(OverscaledTileID(0, 0, 0), tileID);
         EXPECT_EQ(util::toString(error), "unknown pbf field type exception");
+        ASSERT_TRUE(badResourceReported);
         test.end();
     };
 

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -95,16 +95,20 @@ TEST(Source, LoadingFail) {
 TEST(Source, LoadingCorrupt) {
     SourceTest test;
 
+    bool badResourceReported = false;
+
     test.fileSource.sourceResponse = [&] (const Resource& resource) {
         EXPECT_EQ("url", resource.url);
         Response response;
         response.data = std::make_unique<std::string>("CORRUPTED");
+        response.reportBad = [&]() { badResourceReported = true; };
         return response;
     };
 
     test.observer.sourceError = [&] (Source& source, std::exception_ptr error) {
         EXPECT_EQ("source", source.getID());
         EXPECT_EQ("0 - Invalid value.", util::toString(error));
+        ASSERT_TRUE(badResourceReported);
         test.end();
     };
 
@@ -234,9 +238,12 @@ TEST(Source, VectorTileFail) {
 TEST(Source, RasterTileCorrupt) {
     SourceTest test;
 
+    bool badResourceReported = false;
+
     test.fileSource.tileResponse = [&] (const Resource&) {
         Response response;
         response.data = std::make_unique<std::string>("CORRUPTED");
+        response.reportBad = [&]() { badResourceReported = true; };
         return response;
     };
 
@@ -244,6 +251,7 @@ TEST(Source, RasterTileCorrupt) {
         EXPECT_EQ(source.baseImpl->type, SourceType::Raster);
         EXPECT_EQ(OverscaledTileID(0, 0, 0), tileID);
         EXPECT_TRUE(bool(error));
+        ASSERT_TRUE(badResourceReported);
         // Not asserting on platform-specific error text.
         test.end();
     };
@@ -262,9 +270,12 @@ TEST(Source, RasterTileCorrupt) {
 TEST(Source, VectorTileCorrupt) {
     SourceTest test;
 
+    bool badResourceReported = false;
+
     test.fileSource.tileResponse = [&] (const Resource&) {
         Response response;
         response.data = std::make_unique<std::string>("CORRUPTED");
+        response.reportBad = [&]() { badResourceReported = true; };
         return response;
     };
 


### PR DESCRIPTION
Any resource that makes to the cache is only evicted when it expires or the cache runs out of space. In case of critical resources like the style or tile source, this can potentially "brick" the map.

We should evict corrupted resources as we find them.
