### PR TITLE
Ignore progress updates after suspending

### DIFF
--- a/platform/darwin/src/MGLOfflinePack.h
+++ b/platform/darwin/src/MGLOfflinePack.h
@@ -144,11 +144,6 @@ typedef struct MGLOfflinePackProgress {
 /**
  Resumes downloading if the pack is inactive.
  
- A pack resumes asynchronously. To get notified when this pack resumes, observe
- KVO change notifications on this pack’s `state` key path. Alternatively, you
- can add an observer for `MGLOfflinePackProgressChangedNotification`s about this
- pack that come from the default notification center.
- 
  When a pack resumes after being suspended, it may begin by iterating over the
  already downloaded resources. As a result, the `progress` structure’s
  `countOfResourcesCompleted` field may revert to 0 before rapidly returning to
@@ -161,10 +156,9 @@ typedef struct MGLOfflinePackProgress {
 /**
  Temporarily stops downloading if the pack is active.
  
- A pack suspends asynchronously. To get notified when this pack resumes, observe
- KVO change notifications on this pack’s `state` key path. Alternatively, you
- can add an observer for `MGLOfflinePackProgressChangedNotification` about this
- pack that come from the default notification center.
+ A pack suspends asynchronously, so some network requests may be sent after this
+ method is called. Regardless, the `progress` property will not be updated until
+ `-resume` is called.
  
  If the pack previously reached a higher level of progress before being
  suspended, it may wait to suspend until it returns to that level.

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -49,6 +49,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed a crash that sometimes occurred when initializing an MGLMapView. ([#5932](https://github.com/mapbox/mapbox-gl-native/pull/5932))
 * As the user zooms in, tiles from lower zoom levels are scaled up until tiles for higher zoom levels are loaded. ([#5143](https://github.com/mapbox/mapbox-gl-native/pull/5143))
+* Fixed an issue causing an MGLOfflinePack’s progress to continue to update after calling `-suspend`. ([#6186](https://github.com/mapbox/mapbox-gl-native/pull/6186))
 * MGLMapDebugOverdrawVisualizationMask no longer has any effect in Release builds of the SDK. This debug mask has been disabled for performance reasons. ([#5555](https://github.com/mapbox/mapbox-gl-native/pull/5555))
 * Fixed a typo in the documentation for the MGLCompassDirectionFormatter class. ([#5879](https://github.com/mapbox/mapbox-gl-native/pull/5879))
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixed rendering artifacts and missing glyphs that occurred after viewing a large number of CJK characters on the map. ([#5908](https://github.com/mapbox/mapbox-gl-native/pull/5908))
 * Improved the precision of annotations at zoom levels greater than 18. ([#5517](https://github.com/mapbox/mapbox-gl-native/pull/5517))
 * Fixed an issue where the style zoom levels were not respected when deciding when to render a layer. ([#5811](https://github.com/mapbox/mapbox-gl-native/issues/5811))
+* Fixed an issue causing an MGLOfflinePack’s progress to continue to update after calling `-suspend`. ([#6186](https://github.com/mapbox/mapbox-gl-native/pull/6186))
 * If MGLMapView is unable to obtain or parse a style, it now calls its delegate’s `-mapViewDidFailLoadingMap:withError:` method. ([#6145](https://github.com/mapbox/mapbox-gl-native/pull/6145))
 * Fixed crashes that could occur when loading a malformed stylesheet. ([#5736](https://github.com/mapbox/mapbox-gl-native/pull/5736))
 * Fixed a typo in the documentation for the MGLCompassDirectionFormatter class. ([#5879](https://github.com/mapbox/mapbox-gl-native/pull/5879))


### PR DESCRIPTION
This is a cosmetic fix that makes an offline pack appear to stop downloading as soon as `-suspend` is called on it.

Note that this change does not address the crash in #6092, which occurs because the `MBGLOfflineRegionObserver`’s weak pointer to the MGLOfflinePack object has gone stale by the time late notifications come in from the `mbgl::OfflineRegion`. `MBGLOfflineRegionObserver` is owned by `mbgl::OfflineRegion` and MGLOfflinePack doesn’t currently have a reference to it, although that might be one future direction for improvement.

Fixes #5538.

/cc @jfirebaugh