### PR TITLE
[ios] Avoid updating sprite backed annotations in view update method

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3189,25 +3189,6 @@ public:
     return reusableView;
 }
 
-- (MGLAnnotationView *)annotationViewAtPoint:(CGPoint)point
-{
-    std::vector<MGLAnnotationTag> annotationTags = [self annotationTagsInRect:self.bounds];
-    
-    for(auto const& annotationTag: annotationTags)
-    {
-        auto &annotationContext = _annotationContextsByAnnotationTag[annotationTag];
-        MGLAnnotationView *annotationView = annotationContext.annotationView;
-        CGPoint convertedPoint = [self convertPoint:point toView:annotationView];
-        
-        if ([annotationView pointInside:convertedPoint withEvent:nil])
-        {
-            return annotationView;
-        }
-    }
-    
-    return nil;
-}
-
 /**
     Returns the tag of the annotation at the given point in the view.
 
@@ -4586,15 +4567,14 @@ public:
             MGLAnnotationView *annotationView = [self annotationViewForAnnotation:annotationContext.annotation];
             if (annotationView)
             {
-                // If the annotation view has no superview it means it was never used before so add it
-                if (!annotationView.superview)
-                {
-                    [self.glView addSubview:annotationView];
-                }
-                
                 annotationView.mapView = self;
                 annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
                 annotationContext.annotationView = annotationView;
+            }
+            else
+            {
+                // if there is no annotationView at this point then we are dealing with a sprite backed annotation
+                continue;
             }
         }
         


### PR DESCRIPTION
Previously, annotations backed by sprite had their frames updated by the view backed annotation update method. This guards against that by aborting an update for an annotation if an associated
view cannot be found.

In addition, some dead code is removed.

Fixes #5787 

cc @incanus 