### PR TITLE
Move class handling to Style

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -51,9 +51,12 @@ public:
     void update(Update update);
 
     // Styling
-    void addClass(const std::string&, const style::TransitionOptions& = {});
-    void removeClass(const std::string&, const style::TransitionOptions& = {});
-    void setClasses(const std::vector<std::string>&, const style::TransitionOptions& = {});
+    void addClass(const std::string&);
+    void removeClass(const std::string&);
+    void setClasses(const std::vector<std::string>&);
+
+    style::TransitionOptions getTransitionOptions() const;
+    void setTransitionOptions(const style::TransitionOptions&);
 
     bool hasClass(const std::string&) const;
     std::vector<std::string> getClasses() const;

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -217,7 +217,8 @@ static NSURL *MGLStyleURL_emerald;
     }
     
     mbgl::style::TransitionOptions transition { { MGLDurationInSeconds(transitionDuration) } };
-    self.mapView.mbglMap->setClasses(newAppliedClasses, transition);
+    self.mapView.mbglMap->setTransitionOptions(transition);
+    self.mapView.mbglMap->setClasses(newAppliedClasses);
 }
 
 - (BOOL)hasStyleClass:(NSString *)styleClass

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -149,10 +149,11 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
         case GLFW_KEY_R:
             if (!mods) {
                 static const mbgl::style::TransitionOptions transition { { mbgl::Milliseconds(300) } };
+                view->map->setTransitionOptions(transition);
                 if (view->map->hasClass("night")) {
-                    view->map->removeClass("night", transition);
+                    view->map->removeClass("night");
                 } else {
-                    view->map->addClass("night", transition);
+                    view->map->addClass("night");
                 }
             }
             break;

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -105,13 +105,14 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
     case Qt::Key_Tab:
         m_map.cycleDebugOptions();
         break;
-    case Qt::Key_R:
+    case Qt::Key_R: {
+        m_map.setTransitionOptions(transition);
         if (m_map.hasClass("night")) {
-            m_map.removeClass("night", transition);
+            m_map.removeClass("night");
         } else {
-            m_map.addClass("night", transition);
+            m_map.addClass("night");
         }
-        break;
+    } break;
     default:
         break;
     }

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -159,13 +159,13 @@ public:
     void setGestureInProgress(bool inProgress);
 
     void addClass(const QString &);
-    void addClass(const QString &, const QMapbox::TransitionOptions &);
     void removeClass(const QString &);
-    void removeClass(const QString &, const QMapbox::TransitionOptions &);
     bool hasClass(const QString &) const;
     void setClasses(const QStringList &);
-    void setClasses(const QStringList &, const QMapbox::TransitionOptions &);
     QStringList getClasses() const;
+
+    QMapbox::TransitionOptions getTransitionOptions() const;
+    void setTransitionOptions(const QMapbox::TransitionOptions&);
 
     QMapbox::AnnotationID addPointAnnotation(const QMapbox::PointAnnotation &);
     QMapbox::AnnotationID addShapeAnnotation(const QMapbox::ShapeAnnotation &);

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -107,6 +107,16 @@ auto fromQMapboxTransitionOptions(const QMapbox::TransitionOptions &options) {
     return mbgl::style::TransitionOptions { convert(options.duration), convert(options.delay) };
 }
 
+auto toQMapboxTransitionOptions(const mbgl::style::TransitionOptions &options) {
+    auto convert = [](auto& value) -> QVariant {
+        if (value) {
+            return qint64(std::chrono::duration_cast<mbgl::Milliseconds>(*value).count());
+        }
+        return {};
+    };
+    return QMapbox::TransitionOptions { convert(options.duration), convert(options.delay) };
+}
+
 auto fromQStringList(const QStringList &list)
 {
     std::vector<std::string> strings(list.size());
@@ -462,19 +472,9 @@ void QMapboxGL::addClass(const QString &className)
     d_ptr->mapObj->addClass(className.toStdString());
 }
 
-void QMapboxGL::addClass(const QString &className, const QMapbox::TransitionOptions &options)
-{
-    d_ptr->mapObj->addClass(className.toStdString(), fromQMapboxTransitionOptions(options));
-}
-
 void QMapboxGL::removeClass(const QString &className)
 {
     d_ptr->mapObj->removeClass(className.toStdString());
-}
-
-void QMapboxGL::removeClass(const QString &className, const QMapbox::TransitionOptions &options)
-{
-    d_ptr->mapObj->removeClass(className.toStdString(), fromQMapboxTransitionOptions(options));
 }
 
 bool QMapboxGL::hasClass(const QString &className) const
@@ -487,11 +487,6 @@ void QMapboxGL::setClasses(const QStringList &classNames)
     d_ptr->mapObj->setClasses(fromQStringList(classNames));
 }
 
-void QMapboxGL::setClasses(const QStringList &classNames, const QMapbox::TransitionOptions &options)
-{
-    d_ptr->mapObj->setClasses(fromQStringList(classNames), fromQMapboxTransitionOptions(options));
-}
-
 QStringList QMapboxGL::getClasses() const
 {
     QStringList classNames;
@@ -499,6 +494,14 @@ QStringList QMapboxGL::getClasses() const
         classNames << QString::fromStdString(mbglClass);
     }
     return classNames;
+}
+
+QMapbox::TransitionOptions QMapboxGL::getTransitionOptions() const {
+    return toQMapboxTransitionOptions(d_ptr->mapObj->getTransitionOptions());
+}
+
+void QMapboxGL::setTransitionOptions(const QMapbox::TransitionOptions &options) {
+    d_ptr->mapObj->setTransitionOptions(fromQMapboxTransitionOptions(options));
 }
 
 mbgl::Annotation fromPointAnnotation(const PointAnnotation &pointAnnotation) {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -119,9 +119,10 @@ auto toQMapboxTransitionOptions(const mbgl::style::TransitionOptions &options) {
 
 auto fromQStringList(const QStringList &list)
 {
-    std::vector<std::string> strings(list.size());
+    std::vector<std::string> strings;
+    strings.reserve(list.size());
     for (const QString &string : list) {
-        strings.emplace_back(string.toStdString());
+        strings.push_back(string.toStdString());
     }
     return strings;
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -896,22 +896,35 @@ bool Map::isFullyLoaded() const {
     return impl->style ? impl->style->isLoaded() : false;
 }
 
-void Map::addClass(const std::string& className, const TransitionOptions& properties) {
-    if (impl->style && impl->style->addClass(className, properties)) {
+void Map::addClass(const std::string& className) {
+    if (impl->style && impl->style->addClass(className)) {
         update(Update::Classes);
     }
 }
 
-void Map::removeClass(const std::string& className, const TransitionOptions& properties) {
-    if (impl->style && impl->style->removeClass(className, properties)) {
+void Map::removeClass(const std::string& className) {
+    if (impl->style && impl->style->removeClass(className)) {
         update(Update::Classes);
     }
 }
 
-void Map::setClasses(const std::vector<std::string>& classNames, const TransitionOptions& properties) {
+void Map::setClasses(const std::vector<std::string>& classNames) {
     if (impl->style) {
-        impl->style->setClasses(classNames, properties);
+        impl->style->setClasses(classNames);
         update(Update::Classes);
+    }
+}
+
+style::TransitionOptions Map::getTransitionOptions() const {
+    if (impl->style) {
+        return impl->style->getTransitionOptions();
+    }
+    return {};
+}
+
+void Map::setTransitionOptions(const style::TransitionOptions& options) {
+    if (impl->style) {
+        impl->style->setTransitionOptions(options);
     }
 }
 

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -761,26 +761,40 @@ AnnotationIDs Map::queryPointAnnotations(const ScreenBox& box) {
 #pragma mark - Style API
 
 style::Source* Map::getSource(const std::string& sourceID) {
-    impl->styleMutated = true;
-    return impl->style ? impl->style->getSource(sourceID) : nullptr;
+    if (impl->style) {
+        impl->styleMutated = true;
+        return impl->style->getSource(sourceID);
+    }
+    return nullptr;
 }
 
 void Map::addSource(std::unique_ptr<style::Source> source) {
-    impl->styleMutated = true;
-    impl->style->addSource(std::move(source));
+    if (impl->style) {
+        impl->styleMutated = true;
+        impl->style->addSource(std::move(source));
+    }
 }
 
 void Map::removeSource(const std::string& sourceID) {
-    impl->styleMutated = true;
-    impl->style->removeSource(sourceID);
+    if (impl->style) {
+        impl->styleMutated = true;
+        impl->style->removeSource(sourceID);
+    }
 }
 
 style::Layer* Map::getLayer(const std::string& layerID) {
-    impl->styleMutated = true;
-    return impl->style ? impl->style->getLayer(layerID) : nullptr;
+    if (impl->style) {
+        impl->styleMutated = true;
+        return impl->style->getLayer(layerID);
+    }
+    return nullptr;
 }
 
 void Map::addLayer(std::unique_ptr<Layer> layer, const optional<std::string>& before) {
+    if (!impl->style) {
+        return;
+    }
+
     impl->styleMutated = true;
     impl->view.activate();
 
@@ -792,6 +806,10 @@ void Map::addLayer(std::unique_ptr<Layer> layer, const optional<std::string>& be
 }
 
 void Map::removeLayer(const std::string& id) {
+    if (!impl->style) {
+        return;
+    }
+
     impl->styleMutated = true;
     impl->view.activate();
 
@@ -805,23 +823,38 @@ void Map::removeLayer(const std::string& id) {
 #pragma mark - Defaults
 
 std::string Map::getStyleName() const {
-    return impl->style->getName();
+    if (impl->style) {
+        return impl->style->getName();
+    }
+    return {};
 }
 
 LatLng Map::getDefaultLatLng() const {
-    return impl->style->getDefaultLatLng();
+    if (impl->style) {
+        return impl->style->getDefaultLatLng();
+    }
+    return {};
 }
 
 double Map::getDefaultZoom() const {
-    return impl->style->getDefaultZoom();
+    if (impl->style) {
+        return impl->style->getDefaultZoom();
+    }
+    return {};
 }
 
 double Map::getDefaultBearing() const {
-    return impl->style->getDefaultBearing();
+    if (impl->style) {
+        return impl->style->getDefaultBearing();
+    }
+    return {};
 }
 
 double Map::getDefaultPitch() const {
-    return impl->style->getDefaultPitch();
+    if (impl->style) {
+        return impl->style->getDefaultPitch();
+    }
+    return {};
 }
 
 #pragma mark - Toggles
@@ -860,32 +893,37 @@ MapDebugOptions Map::getDebug() const {
 }
 
 bool Map::isFullyLoaded() const {
-    return impl->style->isLoaded();
+    return impl->style ? impl->style->isLoaded() : false;
 }
 
 void Map::addClass(const std::string& className, const TransitionOptions& properties) {
-    if (impl->style->addClass(className, properties)) {
+    if (impl->style && impl->style->addClass(className, properties)) {
         update(Update::Classes);
     }
 }
 
 void Map::removeClass(const std::string& className, const TransitionOptions& properties) {
-    if (impl->style->removeClass(className, properties)) {
+    if (impl->style && impl->style->removeClass(className, properties)) {
         update(Update::Classes);
     }
 }
 
 void Map::setClasses(const std::vector<std::string>& classNames, const TransitionOptions& properties) {
-    impl->style->setClasses(classNames, properties);
-    update(Update::Classes);
+    if (impl->style) {
+        impl->style->setClasses(classNames, properties);
+        update(Update::Classes);
+    }
 }
 
 bool Map::hasClass(const std::string& className) const {
-    return impl->style->hasClass(className);
+    return impl->style ? impl->style->hasClass(className) : false;
 }
 
 std::vector<std::string> Map::getClasses() const {
-    return impl->style->getClasses();
+    if (impl->style) {
+        return impl->style->getClasses();
+    }
+    return {};
 }
 
 void Map::setSourceTileCacheSize(size_t size) {

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -58,10 +58,9 @@ Style::~Style() {
     spriteStore->setObserver(nullptr);
 }
 
-bool Style::addClass(const std::string& className, const TransitionOptions& properties) {
+bool Style::addClass(const std::string& className) {
     if (hasClass(className)) return false;
     classes.push_back(className);
-    transitionProperties = properties;
     return true;
 }
 
@@ -69,29 +68,36 @@ bool Style::hasClass(const std::string& className) const {
     return std::find(classes.begin(), classes.end(), className) != classes.end();
 }
 
-bool Style::removeClass(const std::string& className, const TransitionOptions& properties) {
+bool Style::removeClass(const std::string& className) {
     const auto it = std::find(classes.begin(), classes.end(), className);
     if (it != classes.end()) {
         classes.erase(it);
-        transitionProperties = properties;
         return true;
     }
     return false;
 }
 
-void Style::setClasses(const std::vector<std::string>& classNames, const TransitionOptions& properties) {
+void Style::setClasses(const std::vector<std::string>& classNames) {
     classes = classNames;
-    transitionProperties = properties;
 }
 
 std::vector<std::string> Style::getClasses() const {
     return classes;
 }
 
+void Style::setTransitionOptions(const TransitionOptions& options) {
+    transitionOptions = options;
+}
+
+TransitionOptions Style::getTransitionOptions() const {
+    return transitionOptions;
+}
+
 void Style::setJSON(const std::string& json) {
     sources.clear();
     layers.clear();
     classes.clear();
+    transitionOptions = {};
     updateBatch = {};
 
     Parser parser;
@@ -249,10 +255,8 @@ void Style::cascade(const TimePoint& timePoint, MapMode mode) {
     const CascadeParameters parameters {
         classIDs,
         mode == MapMode::Continuous ? timePoint : Clock::time_point::max(),
-        mode == MapMode::Continuous ? transitionProperties.value_or(immediateTransition) : immediateTransition
+        mode == MapMode::Continuous ? transitionOptions : immediateTransition
     };
-
-    transitionProperties = {};
 
     for (const auto& layer : layers) {
         layer->baseImpl->cascade(parameters);

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -79,10 +79,14 @@ public:
     double getDefaultBearing() const;
     double getDefaultPitch() const;
 
-    bool addClass(const std::string&, const TransitionOptions& = {});
-    bool removeClass(const std::string&, const TransitionOptions& = {});
+    bool addClass(const std::string&);
+    bool removeClass(const std::string&);
+    void setClasses(const std::vector<std::string>&);
+
+    TransitionOptions getTransitionOptions() const;
+    void setTransitionOptions(const TransitionOptions&);
+
     bool hasClass(const std::string&) const;
-    void setClasses(const std::vector<std::string>&, const TransitionOptions& = {});
     std::vector<std::string> getClasses() const;
 
     RenderData getRenderData(MapDebugOptions) const;
@@ -107,7 +111,7 @@ private:
     std::vector<std::unique_ptr<Source>> sources;
     std::vector<std::unique_ptr<Layer>> layers;
     std::vector<std::string> classes;
-    optional<TransitionOptions> transitionProperties;
+    TransitionOptions transitionOptions;
 
     // Defaults
     std::string name;

--- a/test/map/map.cpp
+++ b/test/map/map.cpp
@@ -228,3 +228,37 @@ TEST(Map, RemoveLayer) {
 
     test::checkImage("test/fixtures/map/remove_layer", test::render(map));
 }
+
+TEST(Map, Classes) {
+    MapTest test;
+
+    Map map(test.view, test.fileSource, MapMode::Still);
+    map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
+
+    EXPECT_FALSE(map.getTransitionOptions().duration);
+
+    auto duration = mbgl::Duration(mbgl::Milliseconds(300));
+    map.setTransitionOptions({ duration });
+    EXPECT_EQ(map.getTransitionOptions().duration, duration);
+
+    map.addClass("test");
+    EXPECT_TRUE(map.hasClass("test"));
+
+    map.removeClass("test");
+    EXPECT_TRUE(map.getClasses().empty());
+
+    std::vector<std::string> classes = { "foo", "bar" };
+    map.setClasses(classes);
+    EXPECT_FALSE(map.hasClass("test"));
+    EXPECT_TRUE(map.hasClass("foo"));
+    EXPECT_TRUE(map.hasClass("bar"));
+
+    // Does nothing - same style JSON.
+    map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
+    EXPECT_TRUE(map.hasClass("foo"));
+    EXPECT_EQ(map.getTransitionOptions().duration, duration);
+
+    map.setStyleJSON(util::read_file("test/fixtures/api/water.json"));
+    EXPECT_TRUE(map.getClasses().empty());
+    EXPECT_FALSE(map.getTransitionOptions().duration);
+}


### PR DESCRIPTION
Fixes #6118.

- [x] Map::Impl now owns class data.
- [x] This prevents class state being reset upon `mbgl::Style` state changes.
- [x] Adds new `mbgl::setClassTransition` to cleanup class API.
 - Updated GLFW and darwin API usage accordingly
- [x] Update Qt QML: `classes` property now belongs to `QQuickMapboxGL` (map) instead of `QQuickMapboxGLStyle` (style)