### PR TITLE
Update INSTALL doc for -ObjC; use local podspec path

### DIFF
--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -1,6 +1,6 @@
-# Integrating the Mapbox iOS SDK into your application
+# Integrating custom builds of the Mapbox iOS SDK into your application
 
-This document explains how to build a development version of Mapbox iOS SDK for use in your own Cocoa Touch application. To use a production-ready version of the SDK, see the [Mapbox iOS SDK homepage](https://github.com/mapbox/ios-sdk).
+This document explains how to build a development version of Mapbox iOS SDK for use in your own Cocoa Touch application. To use a production-ready version of the SDK, see the [Mapbox iOS SDK homepage](https://mapbox.com/ios-sdk).
 
 ### Requirements
 
@@ -28,51 +28,11 @@ The Mapbox iOS SDK requires Xcode 7.3 or higher.
   - a `documentation` folder with HTML API documentation
   - an example `Settings.bundle` containing an optional Mapbox Telemetry opt-out setting
 
+See the [packaging documentation](DEVELOPING.md#packaging-builds) for other build options.
+
 ### Installation
 
-There are a few ways to install the Mapbox iOS SDK:
-
-#### CocoaPods
-
-Currently, until [#1437](https://github.com/mapbox/mapbox-gl-native/issues/1437) is completed, to install a _development version_ of Mapbox GL using CocoaPods you will need to build it from source manually per above.
-
-1. Zip up the build product.
-
-    ```bash
-    cd build/ios/pkg/
-    ZIP=mapbox-ios-sdk.zip
-    rm -f ../${ZIP}
-    zip -r ../${ZIP} *
-    ```
-
-1. Customize [`Mapbox-iOS-SDK.podspec`](../ios/Mapbox-iOS-SDK.podspec) to download this zip file.
-
-    ```rb
-    {...}
-
-    m.source = {
-        :http => "http://{...}/mapbox-ios-sdk.zip",
-        :flatten => true
-    }
-
-    {...}
-    ```
-
-1. Update your app's `Podfile` to point to the `Mapbox-iOS-SDK.podspec`.
-
-    ```rb
-    pod 'Mapbox-iOS-SDK', :podspec => 'http://{...}/Mapbox-iOS-SDK.podspec'
-    ```
-
-1. Run `pod update` to grab the newly-built library.
-
-##### Testing pre-releases with CocoaPods
-
-To test pre-releases and/or betas, you can reference the pre-release like so in your Podfile:
-
-```rb
-pod 'Mapbox-iOS-SDK', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/<insert branch or tag>/ios/Mapbox-iOS-SDK.podspec'
-```
+There are several ways to install custom builds of the Mapbox iOS SDK:
 
 #### Dynamic framework
 
@@ -112,6 +72,51 @@ If your application targets iOS 7.x, you’ll need to install the static framewo
    - libc++.tbd
    - libsqlite3.tbd
    - libz.tbd
+
+1. In the Build Settings tab, find the Other Linker Flags setting and add `-ObjC`.
+
+#### CocoaPods
+
+##### Testing pre-releases with CocoaPods
+
+To test pre-releases and/or betas, you can reference the pre-release like so in your Podfile:
+
+```rb
+pod 'Mapbox-iOS-SDK', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/<insert branch or tag>/ios/Mapbox-iOS-SDK.podspec'
+```
+
+##### Using your own build with CocoaPods
+
+To install a _development version_ of this SDK using CocoaPods you will need to build it from source manually per above, then include that build product in your Podfile.
+
+1. Zip up the build product.
+
+    ```bash
+    cd build/ios/pkg/
+    ZIP=mapbox-ios-sdk.zip
+    rm -f ../${ZIP}
+    zip -r ../${ZIP} *
+    ```
+
+1. Customize [`Mapbox-iOS-SDK.podspec`](../ios/Mapbox-iOS-SDK.podspec) to download this zip file.
+
+    ```rb
+    {...}
+
+    m.source = {
+        :path => "{...}/mapbox-ios-sdk.zip"
+    }
+
+    {...}
+    ```
+
+1. Update your app's `Podfile` to point to the `Mapbox-iOS-SDK.podspec`.
+
+    ```rb
+    pod 'Mapbox-iOS-SDK', :path => '{...}/Mapbox-iOS-SDK.podspec'
+    ```
+
+1. Run `pod update` to grab the newly-built library.
 
 ### Configuration
 

--- a/platform/ios/docs/pod-README.md
+++ b/platform/ios/docs/pod-README.md
@@ -52,6 +52,8 @@ If your application targets iOS 7.x, you’ll need to install the static framewo
    - libsqlite3.tbd
    - libz.tbd
 
+1. In the Build Settings tab, find the Other Linker Flags setting and add `-ObjC`.
+
 {{/STATIC}}
 
 ## Configuration


### PR DESCRIPTION
- Adds -ObjC flag for static lib.
- Fixes link to iOS SDK site.
- Pushes CocoaPods down the list.
- Changes CocoaPods to use local path, not HTTP.
- Emphasizes that INSTALL.md is only for custom builds.

Fixes #6195.

/cc @1ec5