### PR TITLE
Allow implicit animation of annotation views

### DIFF
--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -246,16 +246,6 @@
     return otherGestureRecognizer == _longPressRecognizer || otherGestureRecognizer == _panGestureRecognizer;
 }
 
-- (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
-{
-    // Allow mbgl to drive animation of this view’s bounds.
-    if ([event isEqualToString:@"bounds"] || [event isEqualToString:@"position"])
-    {
-        return [NSNull null];
-    }
-    return [super actionForLayer:layer forKey:event];
-}
-
 #pragma mark UIAccessibility methods
 
 - (BOOL)isAccessibilityElement {

--- a/platform/ios/src/MGLUserLocationAnnotationView.m
+++ b/platform/ios/src/MGLUserLocationAnnotationView.m
@@ -97,14 +97,4 @@
     }
 }
 
-- (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
-{
-    // Allow mbgl to drive animation of this view’s bounds.
-    if ([event isEqualToString:@"bounds"])
-    {
-        return [NSNull null];
-    }
-    return [super actionForLayer:layer forKey:event];
-}
-
 @end


### PR DESCRIPTION
We were disabling the implicit animation of `position` changes for annotation views (bb2f627 in #5550), but this meant that UIView animations were also being canceled. Once the user location annotation started inheriting from MGLAnnotationView, this meant that non-tracking changes to the user dot became unanimated.

This change shouldn’t affect the sync between map view and annotation views, as we already disable implicit animations when we update their position in [-[MGLMapView updateAnnotationViews]](https://github.com/mapbox/mapbox-gl-native/blob/c075386a984cd5de21f6201341d360a5c1039b67/platform/ios/src/MGLMapView.mm#L4548).

This also removes redundant implicit animation disabling in MGLUserLocationAnnotationView.

@incanus, I could definitely use some help confirming that this doesn’t actually regress any of our annotation view sync/performance improvements. 😁

Fixes #6203.

/cc @1ec5 