### PR TITLE
Use contentInset to set center coordinate for contentInset updates

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -30,6 +30,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * To customize the appearance of the user location annotation, subclass the newly added MGLUserLocationAnnotationView class and implement `-[MGLMapViewDelegate mapView:viewForAnnotation:]`. ([#5882](https://github.com/mapbox/mapbox-gl-native/pull/5882))
 * Fixed an issue causing the user dot’s accuracy ring to wobble while zooming in and out. ([#6019](https://github.com/mapbox/mapbox-gl-native/pull/6019))
 * Heading accuracy indicator sizing has been changed to appear more precise. ([#6120](https://github.com/mapbox/mapbox-gl-native/pull/6120))
+* Fixed an issue that caused the map to not update to reflect the centerOffset when the user location was tracked. ([#6216](https://github.com/mapbox/mapbox-gl-native/pull/6216))
 
 ### Annotations
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4085,7 +4085,7 @@ public:
 - (void)didUpdateLocationIncrementallyAnimated:(BOOL)animated
 {
     [self _setCenterCoordinate:self.userLocation.location.coordinate
-                   edgePadding:self.edgePaddingForFollowing
+                   edgePadding:self.contentInset
                      zoomLevel:self.zoomLevel
                      direction:self.directionByFollowingWithCourse
                       duration:animated ? MGLUserLocationAnimationDuration : 0
@@ -4112,7 +4112,7 @@ public:
     
     __weak MGLMapView *weakSelf = self;
     [self _flyToCamera:camera
-           edgePadding:self.edgePaddingForFollowing
+           edgePadding:self.contentInset
           withDuration:animated ? -1 : 0
           peakAltitude:-1
      completionHandler:^{


### PR DESCRIPTION
Fixes #3778 
Subsumes #4067 

This pulls just https://github.com/mapbox/mapbox-gl-native/pull/4067/commits/ccbdeaa451c7ec125e5b7b7af0f4eaa32ac8cce8 from https://github.com/mapbox/mapbox-gl-native/pull/4067 to fix the issue where the map did not correctly update to reflect the centerOffset when the user location was being tracked.