### PR TITLE
[android] - get firebase test lab results with gsutil

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -31,6 +31,10 @@ workflows:
         inputs:
         - content: |-
             #!/bin/bash
+            sudo apt-get install -y gcc python-dev python-setuptools
+            sudo easy_install -U pip
+            sudo pip uninstall crcmod
+            sudo pip install -U crcmod
             set -eu -o pipefail
             curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
             sudo apt-get install -y pkg-config nodejs cmake
@@ -49,6 +53,23 @@ workflows:
             gcloud auth activate-service-account --key-file secret.json --project android-gl-native
             gcloud beta test android devices list
             gcloud beta test android run --type instrumentation --app MapboxGLAndroidSDKTestApp-debug.apk --test MapboxGLAndroidSDKTestApp-debug-androidTest-unaligned.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
+    - script:
+        title: Download test results
+        is_always_run: true
+        inputs:
+        - content: |-
+            #!/bin/bash
+            cd platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk
+            rm -f secret.json
+            testUri="gs://test-lab-wrrntqk05p31w-h3y1qk44vuunw/"
+            testUri=$(gsutil ls $testUri | tail -n1)
+            echo "Downloading from : "$testUri
+            gsutil -m cp -R -Z $testUri .
+    - deploy-to-bitrise-io@1.2.3:
+        inputs:
+        - deploy_path: "platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk"
+        - notify_user_groups: none
+        - is_compress: 'true'
     - slack:
         title: Post to Slack
         run_if: '{{enveq "SKIPCI" "false"}}'

--- a/platform/android/scripts/generate-test-code.js
+++ b/platform/android/scripts/generate-test-code.js
@@ -14,7 +14,7 @@ global.camelize = function (str) {
 }
 
 
-const excludeActivities = ["CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity"];
+const excludeActivities = ["CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivityTest"];
 const appBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity';
 const testBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/activity/gen';
 const subPackages = fs.readdirSync(appBasePath);

--- a/platform/android/scripts/generate-test-code.js
+++ b/platform/android/scripts/generate-test-code.js
@@ -14,7 +14,7 @@ global.camelize = function (str) {
 }
 
 
-const excludeActivities = ["CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivityTest"];
+const excludeActivities = ["CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity"];
 const appBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity';
 const testBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/activity/gen';
 const subPackages = fs.readdirSync(appBasePath);


### PR DESCRIPTION
Closes #6218: adds the test results from Firebase test lab as an artefact to the Android Bitrise job.

