### PR TITLE
[node] Cannot build from source

### DIFF
--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -114,5 +114,6 @@ endmacro()
 macro(mbgl_platform_node)
     target_link_libraries(mbgl-node
         PRIVATE "-framework Foundation"
+        PRIVATE "-framework OpenGL"
     )
 endmacro()


### PR DESCRIPTION
<!--
Hello and thanks for contributing! To help us diagnose your problem quickly, please:

 - Include a minimal demonstration of the bug, including code, logs, and screenshots.
 - Ensure you can reproduce the bug using the latest release.
 - Only post to report a bug or request a feature; direct all other questions to: https://stackoverflow.com/questions/tagged/mapbox
-->

**Platform: node**
**Mapbox SDK version: master**

### Steps to trigger behavior

 1. `git clone mapbox-gl-native...`
 2. `cd mapbo-gl-native`
 3. `npm install --build-from-source`

### Expected behavior

Building `node-mapbox-gl-native`

### Actual behavior

Errors on gyp:

```
bobby mapbox-gl-native (master) $ npm install --build-from-source

> mapbox-gl-native@3.3.2 preinstall /path/mapbox-gl-native
> npm install node-pre-gyp

node-pre-gyp@0.6.29 node_modules/node-pre-gyp
├── semver@5.2.0
├── nopt@3.0.6 (abbrev@1.0.9)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── tar@2.2.1 (block-stream@0.0.9, inherits@2.0.1, fstream@1.0.10)
├── rc@1.1.6 (ini@1.3.4, deep-extend@0.4.1, strip-json-comments@1.0.4, minimist@1.2.0)
├── tar-pack@3.1.4 (uid-number@0.0.6, once@1.3.3, readable-stream@2.1.4, fstream@1.0.10, debug@2.2.0, fstream-ignore@1.0.5)
├── rimraf@2.5.4 (glob@7.0.5)
├── npmlog@3.1.2 (set-blocking@2.0.0, console-control-strings@1.1.0, are-we-there-yet@1.1.2, gauge@2.6.0)
└── request@2.74.0 (tunnel-agent@0.4.3, aws-sign2@0.6.0, forever-agent@0.6.1, oauth-sign@0.8.2, is-typedarray@1.0.0, caseless@0.11.0, stringstream@0.0.5, aws4@1.4.1, isstream@0.1.2, json-stringify-safe@5.0.1, extend@3.0.0, tough-cookie@2.3.1, qs@6.2.1, node-uuid@1.4.7, combined-stream@1.0.5, mime-types@2.1.11, form-data@1.0.0-rc4, bl@1.1.2, hawk@3.1.3, http-signature@1.1.1, har-validator@2.0.6)
-
> mapbox-gl-native@3.3.2 install /path/mapbox-gl-native
> node-pre-gyp install --fallback-to-build=false || make node

gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp: binding.gyp not found (cwd: /path/mapbox-gl-native) while trying to load binding.gyp
gyp ERR! configure error
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/path/.nvm/versions/node/v4.4.7/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:305:16)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Darwin 16.0.0
gyp ERR! command "/path/.nvm/versions/node/v4.4.7/bin/node" "/path/.nvm/versions/node/v4.4.7/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "configure" "--fallback-to-build=false" "--module=/path/mapbox-gl-native/lib/mapbox-gl-native.node" "--module_name=mapbox-gl-native" "--module_path=/path/mapbox-gl-native/lib"
gyp ERR! cwd /path/mapbox-gl-native
gyp ERR! node -v v4.4.7
gyp ERR! node-gyp -v v3.3.1
gyp ERR! not ok
node-pre-gyp ERR! build error
node-pre-gyp ERR! stack Error: Failed to execute '/path/.nvm/versions/node/v4.4.7/bin/node /path/.nvm/versions/node/v4.4.7/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build=false --module=/path/mapbox-gl-native/lib/mapbox-gl-native.node --module_name=mapbox-gl-native --module_path=/path/mapbox-gl-native/lib' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/path/mapbox-gl-native/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
node-pre-gyp ERR! stack     at emitTwo (events.js:87:13)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:827:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
node-pre-gyp ERR! System Darwin 16.0.0
node-pre-gyp ERR! command "/path/.nvm/versions/node/v4.4.7/bin/node" "/path/mapbox-gl-native/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build=false"
node-pre-gyp ERR! cwd /path/mapbox-gl-native
node-pre-gyp ERR! node -v v4.4.7
node-pre-gyp ERR! node-pre-gyp -v v0.6.29
node-pre-gyp ERR! not ok
Failed to execute '/path/.nvm/versions/node/v4.4.7/bin/node /path/.nvm/versions/node/v4.4.7/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build=false --module=/path/mapbox-gl-native/lib/mapbox-gl-native.node --module_name=mapbox-gl-native --module_path=/path/mapbox-gl-native/lib' (1)
git submodule update --init

... continues on with normal build
```

/cc @mikemorris @springmeyer @kkaefer 