### PR TITLE
Upgrade to protozero 1.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ mason_use(geojsonvt VERSION 6.1.3 HEADER_ONLY)
 mason_use(supercluster VERSION 0.2.0 HEADER_ONLY)
 mason_use(kdbush VERSION 0.1.1 HEADER_ONLY)
 mason_use(earcut VERSION 0.11 HEADER_ONLY)
-mason_use(protozero VERSION 1.4.0 HEADER_ONLY)
+mason_use(protozero VERSION 1.4.2 HEADER_ONLY)
 mason_use(pixelmatch VERSION 0.9.0 HEADER_ONLY)
 mason_use(geojson VERSION 0.1.4${MASON_CXXABI_SUFFIX})
 


### PR DESCRIPTION
Upgrades to latest protozero release. This ensures that upcoming PRs do not need to suppress extra warnings (when we start using new headers inside protozero for `protozero::dataview`).