### PR TITLE
[ios] Silence MGLCalloutView related warnings in tests

### DIFF
--- a/platform/ios/test/MGLAnnotationViewTests.m
+++ b/platform/ios/test/MGLAnnotationViewTests.m
@@ -23,6 +23,10 @@ static NSString * const MGLTestAnnotationReuseIdentifer = @"MGLTestAnnotationReu
 
 @interface MGLTestCalloutView: UIView<MGLCalloutView>
 @property (nonatomic) BOOL didCallDismissCalloutAnimated;
+@property (nonatomic, strong) id <MGLAnnotation> representedObject;
+@property (nonatomic, strong) UIView *leftAccessoryView;
+@property (nonatomic, strong) UIView *rightAccessoryView;
+@property (nonatomic, weak) id<MGLCalloutViewDelegate> delegate;
 @end
 
 @implementation MGLTestCalloutView
@@ -31,6 +35,8 @@ static NSString * const MGLTestAnnotationReuseIdentifer = @"MGLTestAnnotationReu
 {
     _didCallDismissCalloutAnimated = YES;
 }
+
+- (void)presentCalloutFromRect:(CGRect)rect inView:(UIView *)view constrainedToView:(UIView *)constrainedView animated:(BOOL)animated { }
 
 @end
 


### PR DESCRIPTION
The annotation view test uses a fake MGLTestCalloutView that declares conformance to the MGLCalloutView protocol. However, several properties and a method were not implemented in the test which caused several warnings that were visible if you compiled the SDK tests. This change stubs out the properties and method so the warnings go away.

cc @frederoni @1ec5 