### PR TITLE
Improve naming in Source

### DIFF
--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -18,7 +18,7 @@ Range<uint8_t> AnnotationSource::Impl::getZoomRange() {
     return { 0, 22 };
 }
 
-void AnnotationSource::Impl::load(FileSource&) {
+void AnnotationSource::Impl::loadDescription(FileSource&) {
     loaded = true;
 }
 

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -16,7 +16,7 @@ class AnnotationSource::Impl : public style::Source::Impl {
 public:
     Impl(Source&);
 
-    void load(FileSource&) final;
+    void loadDescription(FileSource&) final;
 
 private:
     uint16_t getTileSize() const final { return util::tileSize; }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -227,7 +227,6 @@ void Map::Impl::update() {
 
     style::UpdateParameters parameters(pixelRatio,
                                        debugOptions,
-                                       timePoint,
                                        transform.getState(),
                                        style->workers,
                                        fileSource,

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -236,7 +236,7 @@ void Map::Impl::update() {
                                        *annotationManager,
                                        *style);
 
-    style->update(parameters);
+    style->updateTiles(parameters);
 
     if (mode == MapMode::Continuous) {
         view.invalidate();

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -77,11 +77,9 @@ const std::map<UnwrappedTileID, RenderTile>& Source::Impl::getRenderTiles() cons
     return renderTiles;
 }
 
-bool Source::Impl::update(const UpdateParameters& parameters) {
-    bool allTilesUpdated = true;
-
-    if (!loaded || parameters.animationTime <= updated) {
-        return allTilesUpdated;
+void Source::Impl::loadTiles(const UpdateParameters& parameters) {
+    if (!loaded) {
+        return;
     }
 
     const uint16_t tileSize = getTileSize();
@@ -163,7 +161,10 @@ bool Source::Impl::update(const UpdateParameters& parameters) {
             ++retainIt;
         }
     }
+}
 
+bool Source::Impl::parseTiles(const UpdateParameters& parameters) {
+    bool allTilesUpdated = true;
     const PlacementConfig newConfig{ parameters.transformState.getAngle(),
                                      parameters.transformState.getPitch(),
                                      parameters.debugOptions & MapDebugOptions::Collision };

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -179,8 +179,6 @@ bool Source::Impl::parseTiles(const UpdateParameters& parameters) {
         }
     }
 
-    updated = parameters.animationTime;
-
     return allTilesUpdated;
 }
 

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -88,9 +88,6 @@ private:
     virtual Range<uint8_t> getZoomRange() = 0;
     virtual std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) = 0;
 
-    // Stores the time when this source was most recently updated.
-    TimePoint updated = TimePoint::min();
-
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     std::map<UnwrappedTileID, RenderTile> renderTiles;
     TileCache cache;

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -40,14 +40,15 @@ public:
     Impl(SourceType, std::string id, Source&);
     ~Impl() override;
 
-    virtual void load(FileSource&) = 0;
+    virtual void loadDescription(FileSource&) = 0;
     bool isLoaded() const;
 
     // Request or parse all the tiles relevant for the "TransformState". This method
     // will return true if all the tiles were scheduled for updating of false if
     // they were not. shouldReparsePartialTiles must be set to "true" if there is
     // new data available that a tile in the "partial" state might be interested at.
-    bool update(const UpdateParameters&);
+    void loadTiles(const UpdateParameters&);
+    bool parseTiles(const UpdateParameters&);
 
     void startRender(algorithm::ClipIDGenerator&,
                      const mat4& projMatrix,

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -67,7 +67,7 @@ void GeoJSONSource::Impl::setGeoJSON(const GeoJSON& geoJSON) {
     }
 }
 
-void GeoJSONSource::Impl::load(FileSource& fileSource) {
+void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
     if (!url) {
         loaded = true;
         return;

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -20,7 +20,7 @@ public:
 
     void setGeoJSON(const GeoJSON&);
 
-    void load(FileSource&) final;
+    void loadDescription(FileSource&) final;
 
     uint16_t getTileSize() const final {
         return util::tileSize;

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -197,11 +197,12 @@ double Style::getDefaultPitch() const {
     return defaultPitch;
 }
 
-void Style::update(const UpdateParameters& parameters) {
+void Style::updateTiles(const UpdateParameters& parameters) {
     bool allTilesUpdated = true;
 
     for (const auto& source : sources) {
-        if (!source->baseImpl->update(parameters)) {
+        source->baseImpl->loadTiles(parameters);
+        if (!source->baseImpl->parseTiles(parameters)) {
             allTilesUpdated = false;
         }
     }
@@ -260,7 +261,7 @@ void Style::recalculate(float z, const TimePoint& timePoint, MapMode mode) {
         if (source && layer->baseImpl->needsRendering(z)) {
             source->baseImpl->enabled = true;
             if (!source->baseImpl->loaded) {
-                source->baseImpl->load(fileSource);
+                source->baseImpl->loadDescription(fileSource);
             }
         }
     }

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -48,7 +48,7 @@ public:
 
     // Fetch the tiles needed by the current viewport and emit a signal when
     // a tile is ready so observers can render the tile.
-    void update(const UpdateParameters&);
+    void updateTiles(const UpdateParameters&);
 
     void cascade(const TimePoint&, MapMode);
     void recalculate(float z, const TimePoint&, MapMode);

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -49,7 +49,7 @@ TileSourceImpl::TileSourceImpl(SourceType type_, std::string id_, Source& base_,
 
 TileSourceImpl::~TileSourceImpl() = default;
 
-void TileSourceImpl::load(FileSource& fileSource) {
+void TileSourceImpl::loadDescription(FileSource& fileSource) {
     if (urlOrTileset.is<Tileset>()) {
         tileset = urlOrTileset.get<Tileset>();
         loaded = true;

--- a/src/mbgl/style/tile_source_impl.hpp
+++ b/src/mbgl/style/tile_source_impl.hpp
@@ -24,7 +24,7 @@ public:
                    uint16_t tileSize);
     ~TileSourceImpl() override;
 
-    void load(FileSource&) final;
+    void loadDescription(FileSource&) final;
 
     uint16_t getTileSize() const final {
         return tileSize;

--- a/src/mbgl/style/update_parameters.hpp
+++ b/src/mbgl/style/update_parameters.hpp
@@ -17,7 +17,6 @@ class UpdateParameters {
 public:
     UpdateParameters(float pixelRatio_,
                           MapDebugOptions debugOptions_,
-                          TimePoint animationTime_,
                           const TransformState& transformState_,
                           Worker& worker_,
                           FileSource& fileSource_,
@@ -27,7 +26,6 @@ public:
                           Style& style_)
         : pixelRatio(pixelRatio_),
           debugOptions(debugOptions_),
-          animationTime(std::move(animationTime_)),
           transformState(transformState_),
           worker(worker_),
           fileSource(fileSource_),
@@ -38,7 +36,6 @@ public:
 
     float pixelRatio;
     MapDebugOptions debugOptions;
-    TimePoint animationTime;
     const TransformState& transformState;
     Worker& worker;
     FileSource& fileSource;

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -38,7 +38,6 @@ public:
     style::UpdateParameters updateParameters {
         1.0,
         MapDebugOptions(),
-        TimePoint(),
         transformState,
         worker,
         fileSource,

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -87,7 +87,7 @@ TEST(Source, LoadingFail) {
 
     VectorSource source("source", "url");
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
+    source.baseImpl->loadDescription(test.fileSource);
 
     test.run();
 }
@@ -110,7 +110,7 @@ TEST(Source, LoadingCorrupt) {
 
     VectorSource source("source", "url");
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
+    source.baseImpl->loadDescription(test.fileSource);
 
     test.run();
 }
@@ -138,8 +138,8 @@ TEST(Source, RasterTileEmpty) {
 
     RasterSource source("source", tileset, 512);
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
-    source.baseImpl->update(test.updateParameters);
+    source.baseImpl->loadDescription(test.fileSource);
+    source.baseImpl->loadTiles(test.updateParameters);
 
     test.run();
 }
@@ -167,8 +167,8 @@ TEST(Source, VectorTileEmpty) {
 
     VectorSource source("source", tileset);
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
-    source.baseImpl->update(test.updateParameters);
+    source.baseImpl->loadDescription(test.fileSource);
+    source.baseImpl->loadTiles(test.updateParameters);
 
     test.run();
 }
@@ -196,8 +196,8 @@ TEST(Source, RasterTileFail) {
 
     RasterSource source("source", tileset, 512);
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
-    source.baseImpl->update(test.updateParameters);
+    source.baseImpl->loadDescription(test.fileSource);
+    source.baseImpl->loadTiles(test.updateParameters);
 
     test.run();
 }
@@ -225,8 +225,8 @@ TEST(Source, VectorTileFail) {
 
     VectorSource source("source", tileset);
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
-    source.baseImpl->update(test.updateParameters);
+    source.baseImpl->loadDescription(test.fileSource);
+    source.baseImpl->loadTiles(test.updateParameters);
 
     test.run();
 }
@@ -253,8 +253,8 @@ TEST(Source, RasterTileCorrupt) {
 
     RasterSource source("source", tileset, 512);
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
-    source.baseImpl->update(test.updateParameters);
+    source.baseImpl->loadDescription(test.fileSource);
+    source.baseImpl->loadTiles(test.updateParameters);
 
     test.run();
 }
@@ -285,8 +285,8 @@ TEST(Source, VectorTileCorrupt) {
 
     VectorSource source("source", tileset);
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
-    source.baseImpl->update(test.updateParameters);
+    source.baseImpl->loadDescription(test.fileSource);
+    source.baseImpl->loadTiles(test.updateParameters);
 
     test.run();
 }
@@ -312,8 +312,8 @@ TEST(Source, RasterTileCancel) {
 
     RasterSource source("source", tileset, 512);
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
-    source.baseImpl->update(test.updateParameters);
+    source.baseImpl->loadDescription(test.fileSource);
+    source.baseImpl->loadTiles(test.updateParameters);
 
     test.run();
 }
@@ -339,8 +339,8 @@ TEST(Source, VectorTileCancel) {
 
     VectorSource source("source", tileset);
     source.baseImpl->setObserver(&test.observer);
-    source.baseImpl->load(test.fileSource);
-    source.baseImpl->update(test.updateParameters);
+    source.baseImpl->loadDescription(test.fileSource);
+    source.baseImpl->loadTiles(test.updateParameters);
 
     test.run();
 }


### PR DESCRIPTION
There are some very generic terms like `update` used in `Source` member functions names. Instead, we should explicitly name these functions after what they are updating.