### PR TITLE
Use enum bool classes for better readability

### DIFF
--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -21,8 +21,10 @@ LineAtlas::LineAtlas(GLsizei w, GLsizei h)
 
 LineAtlas::~LineAtlas() = default;
 
-LinePatternPos LineAtlas::getDashPosition(const std::vector<float>& dasharray, bool round) {
-    size_t key = round ? std::numeric_limits<size_t>::min() : std::numeric_limits<size_t>::max();
+LinePatternPos LineAtlas::getDashPosition(const std::vector<float>& dasharray,
+                                          LinePatternCap patternCap) {
+    size_t key = patternCap == LinePatternCap::Round ? std::numeric_limits<size_t>::min()
+                                                     : std::numeric_limits<size_t>::max();
     for (const float part : dasharray) {
         boost::hash_combine<float>(key, part);
     }
@@ -30,7 +32,7 @@ LinePatternPos LineAtlas::getDashPosition(const std::vector<float>& dasharray, b
     // Note: We're not handling hash collisions here.
     const auto it = positions.find(key);
     if (it == positions.end()) {
-        auto inserted = positions.emplace(key, addDash(dasharray, round));
+        auto inserted = positions.emplace(key, addDash(dasharray, patternCap));
         assert(inserted.second);
         return inserted.first->second;
     } else {
@@ -38,8 +40,8 @@ LinePatternPos LineAtlas::getDashPosition(const std::vector<float>& dasharray, b
     }
 }
 
-LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, bool round) {
-    int n = round ? 7 : 0;
+LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, LinePatternCap patternCap) {
+    int n = patternCap == LinePatternCap::Round ? 7 : 0;
     int dashheight = 2 * n + 1;
     const uint8_t offset = 128;
 
@@ -90,7 +92,7 @@ LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, bool roun
             bool inside = (partIndex % 2) == 1;
             int signedDistance;
 
-            if (round) {
+            if (patternCap == LinePatternCap::Round) {
                 float distMiddle = n ? (float)y / n * (halfWidth + 1) : 0;
                 if (inside) {
                     float distEdge = halfWidth - fabs(distMiddle);

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -19,6 +19,11 @@ typedef struct {
     float y;
 } LinePatternPos;
 
+enum class LinePatternCap : bool {
+    Square = false,
+    Round = true,
+};
+
 class LineAtlas {
 public:
     LineAtlas(GLsizei width, GLsizei height);
@@ -31,8 +36,8 @@ public:
     // the texture is only bound when the data is out of date (=dirty).
     void upload(gl::ObjectStore&, gl::Config&, uint32_t unit);
 
-    LinePatternPos getDashPosition(const std::vector<float>&, bool);
-    LinePatternPos addDash(const std::vector<float>& dasharray, bool round);
+    LinePatternPos getDashPosition(const std::vector<float>&, LinePatternCap);
+    LinePatternPos addDash(const std::vector<float>& dasharray, LinePatternCap);
 
     const GLsizei width;
     const GLsizei height;

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -119,49 +119,57 @@ bool FillBucket::needsClipping() const {
     return true;
 }
 
-void FillBucket::drawElements(PlainShader& shader, gl::ObjectStore& store, bool overdraw) {
+void FillBucket::drawElements(PlainShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
-        group->array[overdraw ? 1 : 0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
+        group->array[paintMode == PaintMode::Overdraw ? 1 : 0].bind(
+            shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
+                                        elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * triangleElementsBuffer.itemSize;
     }
 }
 
-void FillBucket::drawElements(PatternShader& shader, gl::ObjectStore& store, bool overdraw) {
+void FillBucket::drawElements(PatternShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
         assert(group);
-        group->array[overdraw ? 3 : 2].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
+        group->array[paintMode == PaintMode::Overdraw ? 3 : 2].bind(
+            shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
+                                        elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * triangleElementsBuffer.itemSize;
     }
 }
 
-void FillBucket::drawVertices(OutlineShader& shader, gl::ObjectStore& store, bool overdraw) {
+void FillBucket::drawVertices(OutlineShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : lineGroups) {
         assert(group);
-        group->array[overdraw ? 1 : 0].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT, elements_index));
+        group->array[paintMode == PaintMode::Overdraw ? 1 : 0].bind(
+            shader, vertexBuffer, lineElementsBuffer, vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT,
+                                        elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * lineElementsBuffer.itemSize;
     }
 }
 
-void FillBucket::drawVertices(OutlinePatternShader& shader, gl::ObjectStore& store, bool overdraw) {
+void FillBucket::drawVertices(OutlinePatternShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : lineGroups) {
         assert(group);
-        group->array[overdraw? 3 : 2].bind(shader, vertexBuffer, lineElementsBuffer, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT, elements_index));
+        group->array[paintMode == PaintMode::Overdraw ? 3 : 2].bind(
+            shader, vertexBuffer, lineElementsBuffer, vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_LINES, group->elements_length * 2, GL_UNSIGNED_SHORT,
+                                        elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
         elements_index += group->elements_length * lineElementsBuffer.itemSize;
     }

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -27,10 +27,10 @@ public:
 
     void addGeometry(const GeometryCollection&);
 
-    void drawElements(PlainShader&, gl::ObjectStore&, bool overdraw);
-    void drawElements(PatternShader&, gl::ObjectStore&, bool overdraw);
-    void drawVertices(OutlineShader&, gl::ObjectStore&, bool overdraw);
-    void drawVertices(OutlinePatternShader&, gl::ObjectStore&, bool overdraw);
+    void drawElements(PlainShader&, gl::ObjectStore&, PaintMode);
+    void drawElements(PatternShader&, gl::ObjectStore&, PaintMode);
+    void drawVertices(OutlineShader&, gl::ObjectStore&, PaintMode);
+    void drawVertices(OutlinePatternShader&, gl::ObjectStore&, PaintMode);
 
 private:
     FillVertexBuffer vertexBuffer;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -460,7 +460,7 @@ bool LineBucket::needsClipping() const {
     return true;
 }
 
-void LineBucket::drawLines(LineShader& shader, gl::ObjectStore& store, bool overdraw) {
+void LineBucket::drawLines(LineShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -468,7 +468,8 @@ void LineBucket::drawLines(LineShader& shader, gl::ObjectStore& store, bool over
         if (!group->elements_length) {
             continue;
         }
-        group->array[overdraw ? 1 : 0].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        group->array[paintMode == PaintMode::Overdraw ? 1 : 0].bind(
+            shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
@@ -476,7 +477,7 @@ void LineBucket::drawLines(LineShader& shader, gl::ObjectStore& store, bool over
     }
 }
 
-void LineBucket::drawLineSDF(LineSDFShader& shader, gl::ObjectStore& store, bool overdraw) {
+void LineBucket::drawLineSDF(LineSDFShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -484,7 +485,8 @@ void LineBucket::drawLineSDF(LineSDFShader& shader, gl::ObjectStore& store, bool
         if (!group->elements_length) {
             continue;
         }
-        group->array[overdraw ? 3 : 2].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        group->array[paintMode == PaintMode::Overdraw ? 3 : 2].bind(
+            shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;
@@ -492,7 +494,7 @@ void LineBucket::drawLineSDF(LineSDFShader& shader, gl::ObjectStore& store, bool
     }
 }
 
-void LineBucket::drawLinePatterns(LinepatternShader& shader, gl::ObjectStore& store, bool overdraw) {
+void LineBucket::drawLinePatterns(LinepatternShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte* vertex_index = BUFFER_OFFSET(0);
     GLbyte* elements_index = BUFFER_OFFSET(0);
     for (auto& group : triangleGroups) {
@@ -500,7 +502,8 @@ void LineBucket::drawLinePatterns(LinepatternShader& shader, gl::ObjectStore& st
         if (!group->elements_length) {
             continue;
         }
-        group->array[overdraw ? 5 : 4].bind(shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
+        group->array[paintMode == PaintMode::Overdraw ? 5 : 4].bind(
+            shader, vertexBuffer, triangleElementsBuffer, vertex_index, store);
         MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
                                         elements_index));
         vertex_index += group->vertex_length * vertexBuffer.itemSize;

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -32,9 +32,9 @@ public:
     void addGeometry(const GeometryCollection&);
     void addGeometry(const GeometryCoordinates& line);
 
-    void drawLines(LineShader&, gl::ObjectStore&, bool overdraw);
-    void drawLineSDF(LineSDFShader&, gl::ObjectStore&, bool overdraw);
-    void drawLinePatterns(LinepatternShader&, gl::ObjectStore&, bool overdraw);
+    void drawLines(LineShader&, gl::ObjectStore&, PaintMode);
+    void drawLineSDF(LineSDFShader&, gl::ObjectStore&, PaintMode);
+    void drawLinePatterns(LinepatternShader&, gl::ObjectStore&, PaintMode);
 
 private:
     struct TriangleElement {

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -68,7 +68,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
 
     PaintParameters parameters {
 #ifndef NDEBUG
-        isOverdraw() ? *overdrawShaders : *shaders
+        paintMode() == PaintMode::Overdraw ? *overdrawShaders : *shaders
 #else
         *shaders
 #endif
@@ -127,7 +127,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         config.depthMask = GL_TRUE;
         config.colorMask = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
 
-        if (isOverdraw()) {
+        if (paintMode() == PaintMode::Overdraw) {
             config.blend = GL_TRUE;
             config.blendFunc = { GL_CONSTANT_COLOR, GL_ONE };
             const float overdraw = 1.0f / 8.0f;
@@ -245,7 +245,7 @@ void Painter::renderPass(PaintParameters& parameters,
         if (!layer.baseImpl->hasRenderPass(pass))
             continue;
 
-        if (isOverdraw()) {
+        if (paintMode() == PaintMode::Overdraw) {
             config.blend = GL_TRUE;
         } else if (pass == RenderPass::Translucent) {
             config.blendFunc.reset();

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -125,7 +125,7 @@ private:
                    float scaleDivisor,
                    std::array<float, 2> texsize,
                    SDFShader& sdfShader,
-                   void (SymbolBucket::*drawSDF)(SDFShader&, gl::ObjectStore&, bool),
+                   void (SymbolBucket::*drawSDF)(SDFShader&, gl::ObjectStore&, PaintMode),
 
                    // Layout
                    style::AlignmentType rotationAlignment,
@@ -145,9 +145,14 @@ private:
     void setDepthSublayer(int n);
 
 #ifndef NDEBUG
-    bool isOverdraw() const { return frame.debugOptions & MapDebugOptions::Overdraw; }
+    PaintMode paintMode() const {
+        return frame.debugOptions & MapDebugOptions::Overdraw ? PaintMode::Overdraw
+                                                              : PaintMode::Regular;
+    }
 #else
-    bool isOverdraw() const { return false; }
+    PaintMode paintMode() const {
+        return PaintMode::Regular;
+    }
 #endif
 
     mat4 projMatrix;

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -27,8 +27,10 @@ void Painter::renderBackground(PaintParameters& parameters, const BackgroundLaye
     auto& arrayBackground = parameters.shaders.backgroundArray;
 
     if (isPatterned) {
-        imagePosA = spriteAtlas->getPosition(properties.backgroundPattern.value.from, true);
-        imagePosB = spriteAtlas->getPosition(properties.backgroundPattern.value.to, true);
+        imagePosA = spriteAtlas->getPosition(properties.backgroundPattern.value.from,
+                                             SpritePatternMode::Repeating);
+        imagePosB = spriteAtlas->getPosition(properties.backgroundPattern.value.to,
+                                             SpritePatternMode::Repeating);
 
         if (!imagePosA || !imagePosB)
             return;

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -69,7 +69,7 @@ void Painter::renderFill(PaintParameters& parameters,
             // the (non-antialiased) fill.
             setDepthSublayer(0); // OK
         }
-        bucket.drawVertices(outlineShader, store, isOverdraw());
+        bucket.drawVertices(outlineShader, store, paintMode());
     }
 
     if (pattern) {
@@ -105,7 +105,7 @@ void Painter::renderFill(PaintParameters& parameters,
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(0);
-            bucket.drawElements(patternShader, store, isOverdraw());
+            bucket.drawElements(patternShader, store, paintMode());
 
             if (properties.fillAntialias && !isOutlineColorDefined) {
                 config.program = outlinePatternShader.getID();
@@ -132,7 +132,7 @@ void Painter::renderFill(PaintParameters& parameters,
                 spriteAtlas->bind(true, store, config, 0);
 
                 setDepthSublayer(2);
-                bucket.drawVertices(outlinePatternShader, store, isOverdraw());
+                bucket.drawVertices(outlinePatternShader, store, paintMode());
             }
         }
     } else {
@@ -149,7 +149,7 @@ void Painter::renderFill(PaintParameters& parameters,
 
             // Draw the actual triangles into the color & stencil buffer.
             setDepthSublayer(1);
-            bucket.drawElements(plainShader, store, isOverdraw());
+            bucket.drawElements(plainShader, store, paintMode());
         }
     }
 
@@ -166,7 +166,7 @@ void Painter::renderFill(PaintParameters& parameters,
         outlineShader.u_world = worldSize;
 
         setDepthSublayer(2);
-        bucket.drawVertices(outlineShader, store, isOverdraw());
+        bucket.drawVertices(outlineShader, store, paintMode());
     }
 }
 

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -73,8 +73,10 @@ void Painter::renderFill(PaintParameters& parameters,
     }
 
     if (pattern) {
-        optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(properties.fillPattern.value.from, true);
-        optional<SpriteAtlasPosition> imagePosB = spriteAtlas->getPosition(properties.fillPattern.value.to, true);
+        optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(
+            properties.fillPattern.value.from, SpritePatternMode::Repeating);
+        optional<SpriteAtlasPosition> imagePosB =
+            spriteAtlas->getPosition(properties.fillPattern.value.to, SpritePatternMode::Repeating);
 
         // Image fill.
         if (pass == RenderPass::Translucent && imagePosA && imagePosB) {

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -96,7 +96,7 @@ void Painter::renderLine(PaintParameters& parameters,
         linesdfShader.u_image = 0;
         lineAtlas->bind(store, config, 0);
 
-        bucket.drawLineSDF(linesdfShader, store, isOverdraw());
+        bucket.drawLineSDF(linesdfShader, store, paintMode());
 
     } else if (!properties.linePattern.value.from.empty()) {
         optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(
@@ -139,7 +139,7 @@ void Painter::renderLine(PaintParameters& parameters,
         linepatternShader.u_image = 0;
         spriteAtlas->bind(true, store, config, 0);
 
-        bucket.drawLinePatterns(linepatternShader, store, isOverdraw());
+        bucket.drawLinePatterns(linepatternShader, store, paintMode());
 
     } else {
         config.program = lineShader.getID();
@@ -157,7 +157,7 @@ void Painter::renderLine(PaintParameters& parameters,
         lineShader.u_color = color;
         lineShader.u_opacity = opacity;
 
-        bucket.drawLines(lineShader, store, isOverdraw());
+        bucket.drawLines(lineShader, store, paintMode());
     }
 }
 

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -99,8 +99,10 @@ void Painter::renderLine(PaintParameters& parameters,
         bucket.drawLineSDF(linesdfShader, store, isOverdraw());
 
     } else if (!properties.linePattern.value.from.empty()) {
-        optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(properties.linePattern.value.from, true);
-        optional<SpriteAtlasPosition> imagePosB = spriteAtlas->getPosition(properties.linePattern.value.to, true);
+        optional<SpriteAtlasPosition> imagePosA = spriteAtlas->getPosition(
+            properties.linePattern.value.from, SpritePatternMode::Repeating);
+        optional<SpriteAtlasPosition> imagePosB =
+            spriteAtlas->getPosition(properties.linePattern.value.to, SpritePatternMode::Repeating);
 
         if (!imagePosA || !imagePosB)
             return;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -72,8 +72,10 @@ void Painter::renderLine(PaintParameters& parameters,
         linesdfShader.u_color = color;
         linesdfShader.u_opacity = opacity;
 
-        LinePatternPos posA = lineAtlas->getDashPosition(properties.lineDasharray.value.from, layout.lineCap == LineCapType::Round);
-        LinePatternPos posB = lineAtlas->getDashPosition(properties.lineDasharray.value.to, layout.lineCap == LineCapType::Round);
+        const LinePatternCap cap =
+            layout.lineCap == LineCapType::Round ? LinePatternCap::Round : LinePatternCap::Square;
+        LinePatternPos posA = lineAtlas->getDashPosition(properties.lineDasharray.value.from, cap);
+        LinePatternPos posB = lineAtlas->getDashPosition(properties.lineDasharray.value.to, cap);
 
         const float widthA = posA.width * properties.lineDasharray.value.fromScale * layer.impl->dashLineWidth;
         const float widthB = posB.width * properties.lineDasharray.value.toScale * layer.impl->dashLineWidth;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -20,7 +20,7 @@ void Painter::renderSDF(SymbolBucket& bucket,
                         float sdfFontSize,
                         std::array<float, 2> texsize,
                         SDFShader& sdfShader,
-                        void (SymbolBucket::*drawSDF)(SDFShader&, gl::ObjectStore&, bool),
+                        void (SymbolBucket::*drawSDF)(SDFShader&, gl::ObjectStore&, PaintMode),
 
                         // Layout
                         AlignmentType rotationAlignment,
@@ -96,7 +96,7 @@ void Painter::renderSDF(SymbolBucket& bucket,
         sdfShader.u_buffer = (haloOffset - haloWidth / fontScale) / sdfPx;
 
         setDepthSublayer(0);
-        (bucket.*drawSDF)(sdfShader, store, isOverdraw());
+        (bucket.*drawSDF)(sdfShader, store, paintMode());
     }
 
     // Then, we draw the text/icon over the halo
@@ -107,7 +107,7 @@ void Painter::renderSDF(SymbolBucket& bucket,
         sdfShader.u_buffer = (256.0f - 64.0f) / 256.0f;
 
         setDepthSublayer(1);
-        (bucket.*drawSDF)(sdfShader, store, isOverdraw());
+        (bucket.*drawSDF)(sdfShader, store, paintMode());
     }
 }
 
@@ -219,7 +219,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
             iconShader.u_fadetexture = 1;
 
             setDepthSublayer(0);
-            bucket.drawIcons(iconShader, store, isOverdraw());
+            bucket.drawIcons(iconShader, store, paintMode());
         }
     }
 

--- a/src/mbgl/renderer/render_pass.hpp
+++ b/src/mbgl/renderer/render_pass.hpp
@@ -24,4 +24,10 @@ constexpr RenderPass operator&(RenderPass a, RenderPass b) {
     return RenderPass(mbgl::underlying_type(a) & mbgl::underlying_type(b));
 }
 
+// Defines whether the overdraw shaders should be used instead of the regular shaders.
+enum class PaintMode : bool {
+    Regular = false,
+    Overdraw = true,
+};
+
 } // namespace mbgl

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -36,8 +36,8 @@ using namespace style;
 SymbolInstance::SymbolInstance(Anchor& anchor, const GeometryCoordinates& line,
         const Shaping& shapedText, const PositionedIcon& shapedIcon,
         const SymbolLayoutProperties& layout, const bool addToBuffers, const uint32_t index_,
-        const float textBoxScale, const float textPadding, const float textAlongLine,
-        const float iconBoxScale, const float iconPadding, const float iconAlongLine,
+        const float textBoxScale, const float textPadding, const SymbolPlacementType textPlacement,
+        const float iconBoxScale, const float iconPadding, const SymbolPlacementType iconPlacement,
         const GlyphPositions& face, const IndexedSubfeature& indexedFeature) :
     point(anchor.point),
     index(index_),
@@ -46,17 +46,17 @@ SymbolInstance::SymbolInstance(Anchor& anchor, const GeometryCoordinates& line,
 
     // Create the quads used for rendering the glyphs.
     glyphQuads(addToBuffers && shapedText ?
-            getGlyphQuads(anchor, shapedText, textBoxScale, line, layout, textAlongLine, face) :
+            getGlyphQuads(anchor, shapedText, textBoxScale, line, layout, textPlacement, face) :
             SymbolQuads()),
 
     // Create the quad used for rendering the icon.
     iconQuads(addToBuffers && shapedIcon ?
-            getIconQuads(anchor, shapedIcon, line, layout, iconAlongLine, shapedText) :
+            getIconQuads(anchor, shapedIcon, line, layout, iconPlacement, shapedText) :
             SymbolQuads()),
 
     // Create the collision features that will be used to check whether this symbol instance can be placed
-    textCollisionFeature(line, anchor, shapedText, textBoxScale, textPadding, textAlongLine, indexedFeature),
-    iconCollisionFeature(line, anchor, shapedIcon, iconBoxScale, iconPadding, iconAlongLine, indexedFeature)
+    textCollisionFeature(line, anchor, shapedText, textBoxScale, textPadding, textPlacement, indexedFeature),
+    iconCollisionFeature(line, anchor, shapedIcon, iconBoxScale, iconPadding, iconPlacement, indexedFeature)
     {}
 
 
@@ -313,12 +313,12 @@ void SymbolBucket::addFeature(const GeometryCollection &lines,
     const float textPadding = layout.textPadding * tilePixelRatio;
     const float iconPadding = layout.iconPadding * tilePixelRatio;
     const float textMaxAngle = layout.textMaxAngle * util::DEG2RAD;
-    const bool textAlongLine =
-        layout.textRotationAlignment == AlignmentType::Map &&
-        layout.symbolPlacement == SymbolPlacementType::Line;
-    const bool iconAlongLine =
-        layout.iconRotationAlignment == AlignmentType::Map &&
-        layout.symbolPlacement == SymbolPlacementType::Line;
+    const SymbolPlacementType textPlacement = layout.textRotationAlignment != AlignmentType::Map
+                                                  ? SymbolPlacementType::Point
+                                                  : layout.symbolPlacement;
+    const SymbolPlacementType iconPlacement = layout.iconRotationAlignment != AlignmentType::Map
+                                                  ? SymbolPlacementType::Point
+                                                  : layout.symbolPlacement;
     const bool mayOverlap = layout.textAllowOverlap || layout.iconAllowOverlap ||
         layout.textIgnorePlacement || layout.iconIgnorePlacement;
     const bool isLine = layout.symbolPlacement == SymbolPlacementType::Line;
@@ -364,8 +364,8 @@ void SymbolBucket::addFeature(const GeometryCollection &lines,
             const bool addToBuffers = (mode == MapMode::Still) || inside || (mayOverlap && false);
 
             symbolInstances.emplace_back(anchor, line, shapedText, shapedIcon, layout, addToBuffers, symbolInstances.size(),
-                    textBoxScale, textPadding, textAlongLine,
-                    iconBoxScale, iconPadding, iconAlongLine,
+                    textBoxScale, textPadding, textPlacement,
+                    iconBoxScale, iconPadding, iconPlacement,
                     face, indexedFeature);
         }
     }
@@ -393,12 +393,12 @@ void SymbolBucket::placeFeatures(CollisionTile& collisionTile) {
     // Calculate which labels can be shown and when they can be shown and
     // create the bufers used for rendering.
 
-    const bool textAlongLine =
-        layout.textRotationAlignment == AlignmentType::Map &&
-        layout.symbolPlacement == SymbolPlacementType::Line;
-    const bool iconAlongLine =
-        layout.iconRotationAlignment == AlignmentType::Map &&
-        layout.symbolPlacement == SymbolPlacementType::Line;
+    const SymbolPlacementType textPlacement = layout.textRotationAlignment != AlignmentType::Map
+                                                  ? SymbolPlacementType::Point
+                                                  : layout.symbolPlacement;
+    const SymbolPlacementType iconPlacement = layout.iconRotationAlignment != AlignmentType::Map
+                                                  ? SymbolPlacementType::Point
+                                                  : layout.symbolPlacement;
 
     const bool mayOverlap = layout.textAllowOverlap || layout.iconAllowOverlap ||
         layout.textIgnorePlacement || layout.iconIgnorePlacement;
@@ -458,7 +458,7 @@ void SymbolBucket::placeFeatures(CollisionTile& collisionTile) {
             if (glyphScale < collisionTile.maxScale) {
                 addSymbols<SymbolRenderData::TextBuffer, TextElementGroup>(
                     renderDataInProgress->text, symbolInstance.glyphQuads, glyphScale,
-                    layout.textKeepUpright, textAlongLine, collisionTile.config.angle);
+                    layout.textKeepUpright, textPlacement, collisionTile.config.angle);
             }
         }
 
@@ -467,7 +467,7 @@ void SymbolBucket::placeFeatures(CollisionTile& collisionTile) {
             if (iconScale < collisionTile.maxScale) {
                 addSymbols<SymbolRenderData::IconBuffer, IconElementGroup>(
                     renderDataInProgress->icon, symbolInstance.iconQuads, iconScale,
-                    layout.iconKeepUpright, iconAlongLine, collisionTile.config.angle);
+                    layout.iconKeepUpright, iconPlacement, collisionTile.config.angle);
             }
         }
     }
@@ -478,7 +478,7 @@ void SymbolBucket::placeFeatures(CollisionTile& collisionTile) {
 }
 
 template <typename Buffer, typename GroupType>
-void SymbolBucket::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float scale, const bool keepUpright, const bool alongLine, const float placementAngle) {
+void SymbolBucket::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float scale, const bool keepUpright, const style::SymbolPlacementType placement, const float placementAngle) {
 
     const float placementZoom = ::fmax(std::log(scale) / std::log(2) + zoom, 0);
 
@@ -496,8 +496,10 @@ void SymbolBucket::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float 
 
         // drop upside down versions of glyphs
         const float a = std::fmod(symbol.anchorAngle + placementAngle + M_PI, M_PI * 2);
-        if (keepUpright && alongLine && (a <= M_PI / 2 || a > M_PI * 3 / 2)) continue;
-
+        if (keepUpright && placement == style::SymbolPlacementType::Line &&
+            (a <= M_PI / 2 || a > M_PI * 3 / 2)) {
+            continue;
+        }
 
         if (maxZoom <= minZoom)
             continue;

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -273,7 +273,7 @@ void SymbolBucket::addFeatures(uintptr_t tileUID,
 
         // if feature has icon, get sprite atlas position
         if (feature.sprite.length()) {
-            auto image = spriteAtlas.getImage(feature.sprite, false);
+            auto image = spriteAtlas.getImage(feature.sprite, SpritePatternMode::Single);
             if (image) {
                 shapedIcon = shapeIcon(*image, layout);
                 assert((*image).spriteImage);

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -601,40 +601,46 @@ void SymbolBucket::swapRenderData() {
     }
 }
 
-void SymbolBucket::drawGlyphs(SDFShader& shader, gl::ObjectStore& store, bool overdraw) {
+void SymbolBucket::drawGlyphs(SDFShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& text = renderData->text;
     for (auto &group : text.groups) {
         assert(group);
-        group->array[overdraw ? 1 : 0].bind(shader, text.vertices, text.triangles, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
+        group->array[paintMode == PaintMode::Overdraw ? 1 : 0].bind(
+            shader, text.vertices, text.triangles, vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
+                                        elements_index));
         vertex_index += group->vertex_length * text.vertices.itemSize;
         elements_index += group->elements_length * text.triangles.itemSize;
     }
 }
 
-void SymbolBucket::drawIcons(SDFShader& shader, gl::ObjectStore& store, bool overdraw) {
+void SymbolBucket::drawIcons(SDFShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& icon = renderData->icon;
     for (auto &group : icon.groups) {
         assert(group);
-        group->array[overdraw ? 1 : 0].bind(shader, icon.vertices, icon.triangles, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
+        group->array[paintMode == PaintMode::Overdraw ? 1 : 0].bind(
+            shader, icon.vertices, icon.triangles, vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
+                                        elements_index));
         vertex_index += group->vertex_length * icon.vertices.itemSize;
         elements_index += group->elements_length * icon.triangles.itemSize;
     }
 }
 
-void SymbolBucket::drawIcons(IconShader& shader, gl::ObjectStore& store, bool overdraw) {
+void SymbolBucket::drawIcons(IconShader& shader, gl::ObjectStore& store, PaintMode paintMode) {
     GLbyte *vertex_index = BUFFER_OFFSET_0;
     GLbyte *elements_index = BUFFER_OFFSET_0;
     auto& icon = renderData->icon;
     for (auto &group : icon.groups) {
         assert(group);
-        group->array[overdraw ? 3 : 2].bind(shader, icon.vertices, icon.triangles, vertex_index, store);
-        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT, elements_index));
+        group->array[paintMode == PaintMode::Overdraw ? 3 : 2].bind(
+            shader, icon.vertices, icon.triangles, vertex_index, store);
+        MBGL_CHECK_ERROR(glDrawElements(GL_TRIANGLES, group->elements_length * 3, GL_UNSIGNED_SHORT,
+                                        elements_index));
         vertex_index += group->vertex_length * icon.vertices.itemSize;
         elements_index += group->elements_length * icon.triangles.itemSize;
     }

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -82,9 +82,9 @@ public:
                      GlyphAtlas&,
                      GlyphStore&);
 
-    void drawGlyphs(SDFShader&, gl::ObjectStore&, bool overdraw);
-    void drawIcons(SDFShader&, gl::ObjectStore&, bool overdraw);
-    void drawIcons(IconShader&, gl::ObjectStore&, bool overdraw);
+    void drawGlyphs(SDFShader&, gl::ObjectStore&, PaintMode);
+    void drawIcons(SDFShader&, gl::ObjectStore&, PaintMode);
+    void drawIcons(IconShader&, gl::ObjectStore&, PaintMode);
     void drawCollisionBoxes(CollisionBoxShader&, gl::ObjectStore&);
 
     void parseFeatures(const GeometryTileLayer&, const style::Filter&);

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -47,8 +47,8 @@ class SymbolInstance {
         explicit SymbolInstance(Anchor& anchor, const GeometryCoordinates& line,
                 const Shaping& shapedText, const PositionedIcon& shapedIcon,
                 const style::SymbolLayoutProperties&, const bool inside, const uint32_t index,
-                const float textBoxScale, const float textPadding, const float textAlongLine,
-                const float iconBoxScale, const float iconPadding, const float iconAlongLine,
+                const float textBoxScale, const float textPadding, style::SymbolPlacementType textPlacement,
+                const float iconBoxScale, const float iconPadding, style::SymbolPlacementType iconPlacement,
                 const GlyphPositions& face, const IndexedSubfeature& indexedfeature);
         Point<float> point;
         uint32_t index;
@@ -106,7 +106,7 @@ private:
     // Adds placed items to the buffer.
     template <typename Buffer, typename GroupType>
     void addSymbols(Buffer &buffer, const SymbolQuads &symbols, float scale,
-            const bool keepUpright, const bool alongLine, const float placementAngle);
+            const bool keepUpright, const style::SymbolPlacementType placement, const float placementAngle);
 
 public:
     style::SymbolLayoutProperties layout;

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -35,6 +35,11 @@ struct SpriteAtlasElement {
     float relativePixelRatio;
 };
 
+enum class SpritePatternMode : bool {
+    Single = false,
+    Repeating = true,
+};
+
 class SpriteAtlas : public util::noncopyable {
 public:
     typedef uint16_t dimension;
@@ -44,10 +49,11 @@ public:
 
     // If the sprite is loaded, copies the requsted image from it into the atlas and returns
     // the resulting icon measurements. If not, returns an empty optional.
-    optional<SpriteAtlasElement> getImage(const std::string& name, const bool wrap);
+    optional<SpriteAtlasElement> getImage(const std::string& name, SpritePatternMode mode);
 
     // This function is used for getting the position during render time.
-    optional<SpriteAtlasPosition> getPosition(const std::string& name, bool repeating = false);
+    optional<SpriteAtlasPosition> getPosition(const std::string& name,
+                                              SpritePatternMode mode = SpritePatternMode::Single);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
     void bind(bool linear, gl::ObjectStore&, gl::Config&, uint32_t unit);
@@ -80,10 +86,10 @@ private:
         const Rect<dimension> pos;
     };
 
-    using Key = std::pair<std::string, bool>;
+    using Key = std::pair<std::string, SpritePatternMode>;
 
     Rect<SpriteAtlas::dimension> allocateImage(const SpriteImage&);
-    void copy(const Holder& holder, const bool wrap);
+    void copy(const Holder& holder, SpritePatternMode mode);
 
     std::recursive_mutex mtx;
     SpriteStore& store;

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -258,8 +258,8 @@ void Source::Impl::setObserver(SourceObserver* observer_) {
     observer = observer_;
 }
 
-void Source::Impl::onTileLoaded(Tile& tile, bool isNewTile) {
-    observer->onTileLoaded(base, tile.id, isNewTile);
+void Source::Impl::onTileLoaded(Tile& tile, TileLoadState loadState) {
+    observer->onTileLoaded(base, tile.id, loadState);
 }
 
 void Source::Impl::onTileError(Tile& tile, std::exception_ptr error) {

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -88,7 +88,7 @@ protected:
 
 private:
     // TileObserver implementation.
-    void onTileLoaded(Tile&, bool isNewTile) override;
+    void onTileLoaded(Tile&, TileLoadState) override;
     void onTileError(Tile&, std::exception_ptr) override;
     void onTileUpdated(Tile&) override;
 

--- a/src/mbgl/style/source_observer.hpp
+++ b/src/mbgl/style/source_observer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mbgl/tile/tile_observer.hpp>
+
 #include <exception>
 
 namespace mbgl {
@@ -17,7 +19,7 @@ public:
     virtual void onSourceLoaded(Source&) {}
     virtual void onSourceError(Source&, std::exception_ptr) {}
 
-    virtual void onTileLoaded(Source&, const OverscaledTileID&, bool /* isNewTile */) {}
+    virtual void onTileLoaded(Source&, const OverscaledTileID&, TileLoadState) {}
     virtual void onTileError(Source&, const OverscaledTileID&, std::exception_ptr) {}
     virtual void onTileUpdated(Source&, const OverscaledTileID&) {}
 };

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -469,12 +469,12 @@ void Style::onSourceError(Source& source, std::exception_ptr error) {
     observer->onResourceError(error);
 }
 
-void Style::onTileLoaded(Source& source, const OverscaledTileID& tileID, bool isNewTile) {
-    if (isNewTile) {
+void Style::onTileLoaded(Source& source, const OverscaledTileID& tileID, TileLoadState loadState) {
+    if (loadState == TileLoadState::First) {
         shouldReparsePartialTiles = true;
     }
 
-    observer->onTileLoaded(source, tileID, isNewTile);
+    observer->onTileLoaded(source, tileID, loadState);
     observer->onUpdate(Update::Repaint);
 }
 

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -130,7 +130,7 @@ private:
     // SourceObserver implementation.
     void onSourceLoaded(Source&) override;
     void onSourceError(Source&, std::exception_ptr) override;
-    void onTileLoaded(Source&, const OverscaledTileID&, bool isNewTile) override;
+    void onTileLoaded(Source&, const OverscaledTileID&, TileLoadState) override;
     void onTileError(Source&, const OverscaledTileID&, std::exception_ptr) override;
     void onTileUpdated(Source&, const OverscaledTileID&) override;
 

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -5,7 +5,7 @@ namespace mbgl {
 
 CollisionFeature::CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
         const float top, const float bottom, const float left, const float right,
-        const float boxScale, const float padding, const bool alongLine, IndexedSubfeature indexedFeature_,
+        const float boxScale, const float padding, const style::SymbolPlacementType placement, IndexedSubfeature indexedFeature_,
         const bool straight)
         : indexedFeature(std::move(indexedFeature_)) {
 
@@ -16,7 +16,7 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates &line, const Anchor
     const float x1 = left * boxScale - padding;
     const float x2 = right * boxScale + padding;
 
-    if (alongLine) {
+    if (placement == style::SymbolPlacementType::Line) {
         float height = y2 - y1;
         const double length = x2 - x1;
 

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -35,22 +35,22 @@ namespace mbgl {
             // for text
             explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const Shaping &shapedText,
-                    const float boxScale, const float padding, const bool alongLine, const IndexedSubfeature& indexedFeature_)
+                    const float boxScale, const float padding, const style::SymbolPlacementType placement, const IndexedSubfeature& indexedFeature_)
                 : CollisionFeature(line, anchor,
                         shapedText.top, shapedText.bottom, shapedText.left, shapedText.right,
-                        boxScale, padding, alongLine, indexedFeature_, false) {}
+                        boxScale, padding, placement, indexedFeature_, false) {}
 
             // for icons
             explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const PositionedIcon &shapedIcon,
-                    const float boxScale, const float padding, const bool alongLine, const IndexedSubfeature& indexedFeature_)
+                    const float boxScale, const float padding, const style::SymbolPlacementType placement, const IndexedSubfeature& indexedFeature_)
                 : CollisionFeature(line, anchor,
                         shapedIcon.top, shapedIcon.bottom, shapedIcon.left, shapedIcon.right,
-                        boxScale, padding, alongLine, indexedFeature_, true) {}
+                        boxScale, padding, placement, indexedFeature_, true) {}
 
             explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
                     const float top, const float bottom, const float left, const float right,
-                    const float boxScale, const float padding, const bool alongLine,
+                    const float boxScale, const float padding, const style::SymbolPlacementType placement,
                     IndexedSubfeature, const bool straight);
 
 

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -15,7 +15,7 @@ const float globalMinScale = 0.5f; // underscale by 1 zoom level
 
 SymbolQuads getIconQuads(Anchor& anchor, const PositionedIcon& shapedIcon,
         const GeometryCoordinates& line, const SymbolLayoutProperties& layout,
-        const bool alongLine, const Shaping& shapedText) {
+        const style::SymbolPlacementType placement, const Shaping& shapedText) {
 
     auto image = *(shapedIcon.image);
 
@@ -63,7 +63,7 @@ SymbolQuads getIconQuads(Anchor& anchor, const PositionedIcon& shapedIcon,
     }
 
     float angle = layout.iconRotate * util::DEG2RAD;
-    if (alongLine) {
+    if (placement == style::SymbolPlacementType::Line) {
         assert(static_cast<unsigned int>(anchor.segment) < line.size());
         const GeometryCoordinate &prev= line[anchor.segment];
         if (anchor.point.y == prev.y && anchor.point.x == prev.x &&
@@ -166,7 +166,7 @@ void getSegmentGlyphs(std::back_insert_iterator<GlyphInstances> glyphs, Anchor &
 
 SymbolQuads getGlyphQuads(Anchor& anchor, const Shaping& shapedText,
         const float boxScale, const GeometryCoordinates& line, const SymbolLayoutProperties& layout,
-        const bool alongLine, const GlyphPositions& face) {
+        const style::SymbolPlacementType placement, const GlyphPositions& face) {
 
     const float textRotate = layout.textRotate * util::DEG2RAD;
     const bool keepUpright = layout.textKeepUpright;
@@ -189,7 +189,7 @@ SymbolQuads getGlyphQuads(Anchor& anchor, const Shaping& shapedText,
         const float centerX = (positionedGlyph.x + glyph.metrics.advance / 2.0f) * boxScale;
 
         GlyphInstances glyphInstances;
-        if (alongLine) {
+        if (placement == style::SymbolPlacementType::Line) {
             getSegmentGlyphs(std::back_inserter(glyphInstances), anchor, centerX, line, anchor.segment, true);
             if (keepUpright)
                 getSegmentGlyphs(std::back_inserter(glyphInstances), anchor, centerX, line, anchor.segment, false);

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/text/glyph.hpp>
+#include <mbgl/style/types.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
 
 #include <vector>
@@ -40,10 +41,10 @@ typedef std::vector<SymbolQuad> SymbolQuads;
 
 SymbolQuads getIconQuads(Anchor& anchor, const PositionedIcon& shapedIcon,
         const GeometryCoordinates& line, const style::SymbolLayoutProperties&,
-        const bool alongLine, const Shaping& shapedText);
+        style::SymbolPlacementType placement, const Shaping& shapedText);
 
 SymbolQuads getGlyphQuads(Anchor& anchor, const Shaping& shapedText,
         const float boxScale, const GeometryCoordinates& line, const style::SymbolLayoutProperties&,
-        const bool alongLine, const GlyphPositions& face);
+        style::SymbolPlacementType placement, const GlyphPositions& face);
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -69,7 +69,7 @@ void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_) {
         featureIndex.reset();
         data.reset();
         redoPlacement();
-        observer->onTileLoaded(*this, true);
+        observer->onTileLoaded(*this, TileLoadState::First);
         return;
     }
 
@@ -124,7 +124,7 @@ void GeometryTile::tileLoaded(TileParseResult result, PlacementConfig config) {
         }
 
         redoPlacement();
-        observer->onTileLoaded(*this, true);
+        observer->onTileLoaded(*this, TileLoadState::First);
     } else {
         availableData = DataAvailability::All;
         observer->onTileError(*this, result.get<std::exception_ptr>());
@@ -161,7 +161,7 @@ bool GeometryTile::parsePending() {
             }
 
             redoPlacement();
-            observer->onTileLoaded(*this, false);
+            observer->onTileLoaded(*this, TileLoadState::Subsequent);
         } else {
             availableData = DataAvailability::All;
             observer->onTileError(*this, result.get<std::exception_ptr>());

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -36,7 +36,7 @@ void RasterTile::setData(std::shared_ptr<const std::string> data,
         workRequest.reset();
         availableData = DataAvailability::All;
         bucket.reset();
-        observer->onTileLoaded(*this, true);
+        observer->onTileLoaded(*this, TileLoadState::First);
         return;
     }
 
@@ -48,7 +48,7 @@ void RasterTile::setData(std::shared_ptr<const std::string> data,
 
         if (result.is<std::unique_ptr<Bucket>>()) {
             bucket = std::move(result.get<std::unique_ptr<Bucket>>());
-            observer->onTileLoaded(*this, true);
+            observer->onTileLoaded(*this, TileLoadState::First);
         } else {
             bucket.reset();
             observer->onTileError(*this, result.get<std::exception_ptr>());

--- a/src/mbgl/tile/tile_observer.hpp
+++ b/src/mbgl/tile/tile_observer.hpp
@@ -6,11 +6,16 @@ namespace mbgl {
 
 class Tile;
 
+enum class TileLoadState : bool {
+    First = true,
+    Subsequent = false,
+};
+
 class TileObserver {
 public:
     virtual ~TileObserver() = default;
 
-    virtual void onTileLoaded(Tile&, bool /*isNewTile*/) {}
+    virtual void onTileLoaded(Tile&, TileLoadState) {}
     virtual void onTileError(Tile&, std::exception_ptr) {}
     virtual void onTileUpdated(Tile&) {}
 };

--- a/src/mbgl/util/merge_lines.cpp
+++ b/src/mbgl/util/merge_lines.cpp
@@ -40,9 +40,14 @@ unsigned int mergeFromLeft(std::vector<SymbolFeature> &features,
     return index;
 }
 
+enum class Side {
+    Left = false,
+    Right = true,
+};
+
 size_t
-getKey(const std::u32string& text, const GeometryCollection& geom, bool onRight) {
-    const GeometryCoordinate& coord = onRight ? geom[0].back() : geom[0].front();
+getKey(const std::u32string& text, const GeometryCollection& geom, Side side) {
+    const GeometryCoordinate& coord = side == Side::Right ? geom[0].back() : geom[0].front();
 
     auto hash = std::hash<std::u32string>()(text);
     boost::hash_combine(hash, coord.x);
@@ -63,8 +68,8 @@ void mergeLines(std::vector<SymbolFeature> &features) {
             continue;
         }
 
-        const auto leftKey = getKey(feature.label, geometry, false);
-        const auto rightKey = getKey(feature.label, geometry, true);
+        const auto leftKey = getKey(feature.label, geometry, Side::Left);
+        const auto rightKey = getKey(feature.label, geometry, Side::Right);
 
         const auto left = rightIndex.find(leftKey);
         const auto right = leftIndex.find(rightKey);
@@ -79,7 +84,7 @@ void mergeLines(std::vector<SymbolFeature> &features) {
 
             leftIndex.erase(leftKey);
             rightIndex.erase(rightKey);
-            rightIndex[getKey(feature.label, features[i].geometry, true)] = i;
+            rightIndex[getKey(feature.label, features[i].geometry, Side::Right)] = i;
 
         } else if (left != rightIndex.end()) {
             // found mergeable line adjacent to the start of the current line, merge

--- a/test/sprite/sprite_atlas.cpp
+++ b/test/sprite/sprite_atlas.cpp
@@ -45,7 +45,7 @@ TEST(Sprite, SpriteAtlas) {
     // Image hasn't been created yet.
     EXPECT_FALSE(atlas.getData());
 
-    auto metro = *atlas.getImage("metro", false);
+    auto metro = *atlas.getImage("metro", SpritePatternMode::Single);
     EXPECT_EQ(0, metro.pos.x);
     EXPECT_EQ(0, metro.pos.y);
     EXPECT_EQ(20, metro.pos.w);
@@ -58,7 +58,7 @@ TEST(Sprite, SpriteAtlas) {
 
     EXPECT_TRUE(atlas.getData());
 
-    auto pos = *atlas.getPosition("metro", false);
+    auto pos = *atlas.getPosition("metro", SpritePatternMode::Single);
     EXPECT_DOUBLE_EQ(18, pos.size[0]);
     EXPECT_DOUBLE_EQ(18, pos.size[1]);
     EXPECT_DOUBLE_EQ(1.0f / 63, pos.tl[0]);
@@ -66,7 +66,7 @@ TEST(Sprite, SpriteAtlas) {
     EXPECT_DOUBLE_EQ(19.0f / 63, pos.br[0]);
     EXPECT_DOUBLE_EQ(19.0f / 112, pos.br[1]);
 
-    auto missing = atlas.getImage("doesnotexist", false);
+    auto missing = atlas.getImage("doesnotexist", SpritePatternMode::Single);
     EXPECT_FALSE(missing);
 
     EXPECT_EQ(1u, log.count({
@@ -77,7 +77,7 @@ TEST(Sprite, SpriteAtlas) {
                   }));
 
     // Different wrapping mode produces different image.
-    auto metro2 = *atlas.getImage("metro", true);
+    auto metro2 = *atlas.getImage("metro", SpritePatternMode::Repeating);
     EXPECT_EQ(20, metro2.pos.x);
     EXPECT_EQ(0, metro2.pos.y);
     EXPECT_EQ(20, metro2.pos.w);
@@ -101,7 +101,7 @@ TEST(Sprite, SpriteAtlasSize) {
     EXPECT_EQ(89, atlas.getTextureWidth());
     EXPECT_EQ(157, atlas.getTextureHeight());
 
-    auto metro = *atlas.getImage("metro", false);
+    auto metro = *atlas.getImage("metro", SpritePatternMode::Single);
     EXPECT_EQ(0, metro.pos.x);
     EXPECT_EQ(0, metro.pos.y);
     EXPECT_EQ(16, metro.pos.w);
@@ -128,7 +128,7 @@ TEST(Sprite, SpriteAtlasUpdates) {
     EXPECT_EQ(32, atlas.getTextureHeight());
 
     store.setSprite("one", std::make_shared<SpriteImage>(PremultipliedImage(16, 12), 1));
-    auto one = *atlas.getImage("one", false);
+    auto one = *atlas.getImage("one", SpritePatternMode::Single);
     EXPECT_EQ(0, one.pos.x);
     EXPECT_EQ(0, one.pos.y);
     EXPECT_EQ(20, one.pos.w);

--- a/test/src/mbgl/test/stub_style_observer.hpp
+++ b/test/src/mbgl/test/stub_style_observer.hpp
@@ -34,8 +34,8 @@ public:
         if (sourceError) sourceError(source, error);
     }
 
-    void onTileLoaded(Source& source, const OverscaledTileID& tileID, bool isNewTile) override {
-        if (tileLoaded) tileLoaded(source, tileID, isNewTile);
+    void onTileLoaded(Source& source, const OverscaledTileID& tileID, TileLoadState loadState) override {
+        if (tileLoaded) tileLoaded(source, tileID, loadState);
     }
 
     void
@@ -57,7 +57,7 @@ public:
     std::function<void (std::exception_ptr)> spriteError;
     std::function<void (Source&)> sourceLoaded;
     std::function<void (Source&, std::exception_ptr)> sourceError;
-    std::function<void (Source&, const OverscaledTileID&, bool isNewTile)> tileLoaded;
+    std::function<void (Source&, const OverscaledTileID&, TileLoadState)> tileLoaded;
     std::function<void (Source&, const OverscaledTileID&, std::exception_ptr)> tileError;
     std::function<void (Source&, const OverscaledTileID&)> tileUpdated;
     std::function<void (std::exception_ptr)> resourceError;

--- a/test/style/source.cpp
+++ b/test/style/source.cpp
@@ -123,7 +123,7 @@ TEST(Source, RasterTileEmpty) {
         return response;
     };
 
-    test.observer.tileLoaded = [&] (Source& source, const OverscaledTileID&, bool) {
+    test.observer.tileLoaded = [&] (Source& source, const OverscaledTileID&, TileLoadState) {
         EXPECT_EQ("source", source.getID());
         test.end();
     };
@@ -152,7 +152,7 @@ TEST(Source, VectorTileEmpty) {
         return response;
     };
 
-    test.observer.tileLoaded = [&] (Source& source, const OverscaledTileID&, bool) {
+    test.observer.tileLoaded = [&] (Source& source, const OverscaledTileID&, TileLoadState) {
         EXPECT_EQ("source", source.getID());
         test.end();
     };
@@ -298,7 +298,7 @@ TEST(Source, RasterTileCancel) {
         return optional<Response>();
     };
 
-    test.observer.tileLoaded = [&] (Source&, const OverscaledTileID&, bool) {
+    test.observer.tileLoaded = [&] (Source&, const OverscaledTileID&, TileLoadState) {
         FAIL() << "Should never be called";
     };
 
@@ -325,7 +325,7 @@ TEST(Source, VectorTileCancel) {
         return optional<Response>();
     };
 
-    test.observer.tileLoaded = [&] (Source&, const OverscaledTileID&, bool) {
+    test.observer.tileLoaded = [&] (Source&, const OverscaledTileID&, TileLoadState) {
         FAIL() << "Should never be called";
     };
 

--- a/test/text/quads.cpp
+++ b/test/text/quads.cpp
@@ -21,8 +21,9 @@ TEST(getIconQuads, normal) {
     GeometryCoordinates line;
     Shaping shapedText;
 
-    SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
-    
+    SymbolQuads quads =
+        getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
+
     ASSERT_EQ(quads.size(), 1u);
     ASSERT_EQ(quads[0].anchorPoint.x, 2);
     ASSERT_EQ(quads[0].anchorPoint.y, 3);
@@ -58,7 +59,8 @@ TEST(getIconQuads, style) {
     // none
     {
         SymbolLayoutProperties layout;
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads.size(), 1u);
         ASSERT_EQ(quads[0].anchorPoint.x, 0);
@@ -81,7 +83,8 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties layout;
         layout.textSize = LayoutProperty<float>(24.0f);
         layout.iconTextFit = LayoutProperty<IconTextFitType>(IconTextFitType::Width);
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -60);
         ASSERT_EQ(quads[0].tl.y, 0);
@@ -98,7 +101,8 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties layout;
         layout.textSize = LayoutProperty<float>(12.0f);
         layout.iconTextFit = LayoutProperty<IconTextFitType>(IconTextFitType::Width);
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -30);
         ASSERT_EQ(quads[0].tl.y, -5);
@@ -119,7 +123,8 @@ TEST(getIconQuads, style) {
         layout.iconTextFitPadding.value[1] = 10.0f;
         layout.iconTextFitPadding.value[2] = 5.0f;
         layout.iconTextFitPadding.value[3] = 10.0f;
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -40);
         ASSERT_EQ(quads[0].tl.y, -10);
@@ -136,7 +141,8 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties layout;
         layout.textSize = LayoutProperty<float>(24.0f);
         layout.iconTextFit = LayoutProperty<IconTextFitType>(IconTextFitType::Height);
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -30);
         ASSERT_EQ(quads[0].tl.y, -10);
@@ -153,7 +159,8 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties layout;
         layout.textSize = LayoutProperty<float>(12.0f);
         layout.iconTextFit = LayoutProperty<IconTextFitType>(IconTextFitType::Height);
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -20);
         ASSERT_EQ(quads[0].tl.y, -5);
@@ -174,7 +181,8 @@ TEST(getIconQuads, style) {
         layout.iconTextFitPadding.value[1] = 10.0f;
         layout.iconTextFitPadding.value[2] = 5.0f;
         layout.iconTextFitPadding.value[3] = 10.0f;
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -30);
         ASSERT_EQ(quads[0].tl.y, -10);
@@ -191,7 +199,8 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties layout;
         layout.textSize = LayoutProperty<float>(24.0f);
         layout.iconTextFit = LayoutProperty<IconTextFitType>(IconTextFitType::Both);
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -60);
         ASSERT_EQ(quads[0].tl.y, -10);
@@ -208,7 +217,8 @@ TEST(getIconQuads, style) {
         SymbolLayoutProperties layout;
         layout.textSize = LayoutProperty<float>(12.0f);
         layout.iconTextFit = LayoutProperty<IconTextFitType>(IconTextFitType::Both);
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -30);
         ASSERT_EQ(quads[0].tl.y, -5);
@@ -229,7 +239,8 @@ TEST(getIconQuads, style) {
         layout.iconTextFitPadding.value[1] = 10.0f;
         layout.iconTextFitPadding.value[2] = 5.0f;
         layout.iconTextFitPadding.value[3] = 10.0f;
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -40);
         ASSERT_EQ(quads[0].tl.y, -10);
@@ -250,7 +261,8 @@ TEST(getIconQuads, style) {
         layout.iconTextFitPadding.value[1] = 5.0f;
         layout.iconTextFitPadding.value[2] = 10.0f;
         layout.iconTextFitPadding.value[3] = 15.0f;
-        SymbolQuads quads = getIconQuads(anchor, shapedIcon, line, layout, false, shapedText);
+        SymbolQuads quads =
+            getIconQuads(anchor, shapedIcon, line, layout, SymbolPlacementType::Point, shapedText);
 
         ASSERT_EQ(quads[0].tl.x, -45);
         ASSERT_EQ(quads[0].tl.y, -5);


### PR DESCRIPTION
In a few places, we are using `bool` to denote flags, but it's often hard to guess what true/false actually means, in particular at the call site. Instead, we should move to explicit enums in the style of 

```cpp
enum class TileLoadState : bool {
    First = true,
    Subsequent = false,
};
```

This makes the meaning and intent a lot clearer.