### PR TITLE
[ios, macos] Put MGLStyleLayer inits in respective classes

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -187,12 +187,24 @@ global.propertyType = function (property, _private) {
     return _private ? `id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>` : `id <MGLStyleAttributeValue>`;
 };
 
+global.initLayerIdentifierOnly = function (layerType) {
+    return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String);`
+}
+
 global.initLayer = function (layerType) {
     if (layerType == "background") {
-        return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String);`
+       return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String);` 
     } else {
-        return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String, sourceIdentifier.UTF8String);`
+        return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);`
     }
+}
+
+global.initLayerWithSourceLayer = function(layerType) {
+    return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);`  
+}
+
+global.setSourceLayer = function() {
+   return `_layer->setSourceLayer(sourceLayer.UTF8String);`
 }
 
 global.setterImplementation = function(property, layerType) {

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -8,6 +8,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MGLBackgroundStyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier;
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source;
+
+
 #pragma mark - Accessing the Paint Attributes
 
 #if TARGET_OS_IPHONE

--- a/platform/darwin/src/MGLBackgroundStyleLayer.mm
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.mm
@@ -1,6 +1,7 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
+#import "MGLSource.h"
 #import "NSPredicate+MGLAdditions.h"
 #import "MGLStyleLayer_Private.h"
 #import "MGLStyleAttributeValue.h"
@@ -13,6 +14,7 @@
 @property (nonatomic) mbgl::style::BackgroundLayer *layer;
 @property (nonatomic, readwrite) NSString *layerIdentifier;
 @property (nonatomic, readwrite) NSString *sourceIdentifier;
+@property (nonatomic, readwrite) NSString *sourceLayerIdentifier;
 
 @end
 
@@ -20,14 +22,25 @@
 
 @synthesize mapView;
 
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier {
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier
+{
     if (self = [super init]) {
         _layerIdentifier = layerIdentifier;
-        _sourceIdentifier = sourceIdentifier;
         _layer = new mbgl::style::BackgroundLayer(layerIdentifier.UTF8String);
     }
     return self;
 }
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source
+{
+    if (self = [super init]) {
+        _layerIdentifier = layerIdentifier;
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::BackgroundLayer(layerIdentifier.UTF8String);
+    }
+    return self;
+}
+
 
 #pragma mark - Accessing the Paint Attributes
 

--- a/platform/darwin/src/MGLBaseStyleLayer.mm
+++ b/platform/darwin/src/MGLBaseStyleLayer.mm
@@ -13,6 +13,32 @@
 @synthesize layerIdentifier;
 @synthesize mapView;
 @synthesize layer;
+@synthesize sourceIdentifier;
+@synthesize sourceLayerIdentifier;
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier
+{
+    [[NSException exceptionWithName:@"MGLAbstractClassException"
+                             reason:@"MGLBaseStyleLayer is an abstract class"
+                           userInfo:nil] raise];
+    return nil;
+}
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier
+{
+    [[NSException exceptionWithName:@"MGLAbstractClassException"
+                             reason:@"MGLBaseStyleLayer is an abstract class"
+                           userInfo:nil] raise];
+    return nil;
+}
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier sourceLayer:(NSString *)sourceLayer
+{
+    [[NSException exceptionWithName:@"MGLAbstractClassException"
+                             reason:@"MGLBaseStyleLayer is an abstract class"
+                           userInfo:nil] raise];
+    return nil;
+}
 
 - (void)setVisible:(BOOL)visible
 {

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -18,6 +18,11 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 
 @interface MGLCircleStyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source;
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer;
+
 /**
  A predicate that corresponds to the layer's <a href='https://www.mapbox.com/mapbox-gl-style-spec/#types-filter'>filter</a>.
  

--- a/platform/darwin/src/MGLCircleStyleLayer.mm
+++ b/platform/darwin/src/MGLCircleStyleLayer.mm
@@ -1,6 +1,7 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
+#import "MGLSource.h"
 #import "NSPredicate+MGLAdditions.h"
 #import "MGLStyleLayer_Private.h"
 #import "MGLStyleAttributeValue.h"
@@ -13,6 +14,7 @@
 @property (nonatomic) mbgl::style::CircleLayer *layer;
 @property (nonatomic, readwrite) NSString *layerIdentifier;
 @property (nonatomic, readwrite) NSString *sourceIdentifier;
+@property (nonatomic, readwrite) NSString *sourceLayerIdentifier;
 
 @end
 
@@ -20,11 +22,24 @@
 
 @synthesize mapView;
 
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier {
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source
+{
     if (self = [super init]) {
         _layerIdentifier = layerIdentifier;
-        _sourceIdentifier = sourceIdentifier;
-        _layer = new mbgl::style::CircleLayer(layerIdentifier.UTF8String, sourceIdentifier.UTF8String);
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::CircleLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
+    }
+    return self;
+}
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer
+{
+    if (self = [super init]) {
+        _layerIdentifier = layerIdentifier;
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::CircleLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
+        _layer->setSourceLayer(sourceLayer.UTF8String);
     }
     return self;
 }

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -13,6 +13,11 @@ typedef NS_ENUM(NSUInteger, MGLFillStyleLayerFillTranslateAnchor) {
 
 @interface MGLFillStyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source;
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer;
+
 /**
  A predicate that corresponds to the layer's <a href='https://www.mapbox.com/mapbox-gl-style-spec/#types-filter'>filter</a>.
  

--- a/platform/darwin/src/MGLFillStyleLayer.mm
+++ b/platform/darwin/src/MGLFillStyleLayer.mm
@@ -1,6 +1,7 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
+#import "MGLSource.h"
 #import "NSPredicate+MGLAdditions.h"
 #import "MGLStyleLayer_Private.h"
 #import "MGLStyleAttributeValue.h"
@@ -13,6 +14,7 @@
 @property (nonatomic) mbgl::style::FillLayer *layer;
 @property (nonatomic, readwrite) NSString *layerIdentifier;
 @property (nonatomic, readwrite) NSString *sourceIdentifier;
+@property (nonatomic, readwrite) NSString *sourceLayerIdentifier;
 
 @end
 
@@ -20,11 +22,24 @@
 
 @synthesize mapView;
 
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier {
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source
+{
     if (self = [super init]) {
         _layerIdentifier = layerIdentifier;
-        _sourceIdentifier = sourceIdentifier;
-        _layer = new mbgl::style::FillLayer(layerIdentifier.UTF8String, sourceIdentifier.UTF8String);
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::FillLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
+    }
+    return self;
+}
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer
+{
+    if (self = [super init]) {
+        _layerIdentifier = layerIdentifier;
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::FillLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
+        _layer->setSourceLayer(sourceLayer.UTF8String);
     }
     return self;
 }

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -25,6 +25,11 @@ typedef NS_ENUM(NSUInteger, MGLLineStyleLayerLineTranslateAnchor) {
 
 @interface MGLLineStyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source;
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer;
+
 /**
  A predicate that corresponds to the layer's <a href='https://www.mapbox.com/mapbox-gl-style-spec/#types-filter'>filter</a>.
  

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -1,6 +1,7 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
+#import "MGLSource.h"
 #import "NSPredicate+MGLAdditions.h"
 #import "MGLStyleLayer_Private.h"
 #import "MGLStyleAttributeValue.h"
@@ -13,6 +14,7 @@
 @property (nonatomic) mbgl::style::LineLayer *layer;
 @property (nonatomic, readwrite) NSString *layerIdentifier;
 @property (nonatomic, readwrite) NSString *sourceIdentifier;
+@property (nonatomic, readwrite) NSString *sourceLayerIdentifier;
 
 @end
 
@@ -20,11 +22,24 @@
 
 @synthesize mapView;
 
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier {
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source
+{
     if (self = [super init]) {
         _layerIdentifier = layerIdentifier;
-        _sourceIdentifier = sourceIdentifier;
-        _layer = new mbgl::style::LineLayer(layerIdentifier.UTF8String, sourceIdentifier.UTF8String);
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::LineLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
+    }
+    return self;
+}
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer
+{
+    if (self = [super init]) {
+        _layerIdentifier = layerIdentifier;
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::LineLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
+        _layer->setSourceLayer(sourceLayer.UTF8String);
     }
     return self;
 }

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -8,6 +8,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MGLRasterStyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source;
+
+
 #pragma mark - Accessing the Paint Attributes
 
 /**

--- a/platform/darwin/src/MGLRasterStyleLayer.mm
+++ b/platform/darwin/src/MGLRasterStyleLayer.mm
@@ -1,6 +1,7 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
+#import "MGLSource.h"
 #import "NSPredicate+MGLAdditions.h"
 #import "MGLStyleLayer_Private.h"
 #import "MGLStyleAttributeValue.h"
@@ -13,6 +14,7 @@
 @property (nonatomic) mbgl::style::RasterLayer *layer;
 @property (nonatomic, readwrite) NSString *layerIdentifier;
 @property (nonatomic, readwrite) NSString *sourceIdentifier;
+@property (nonatomic, readwrite) NSString *sourceLayerIdentifier;
 
 @end
 
@@ -20,14 +22,17 @@
 
 @synthesize mapView;
 
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier {
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source
+{
     if (self = [super init]) {
         _layerIdentifier = layerIdentifier;
-        _sourceIdentifier = sourceIdentifier;
-        _layer = new mbgl::style::RasterLayer(layerIdentifier.UTF8String, sourceIdentifier.UTF8String);
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::RasterLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
     }
     return self;
 }
+
 
 #pragma mark - Accessing the Paint Attributes
 

--- a/platform/darwin/src/MGLRuntimeStylingTests.m.ejs
+++ b/platform/darwin/src/MGLRuntimeStylingTests.m.ejs
@@ -17,7 +17,7 @@
     NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
     NSURL *url = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"sourceID" URL:url];
-    MGL<%- camelize(type) %>StyleLayer *layer = [[MGL<%- camelize(type) %>StyleLayer alloc] initWithLayerIdentifier:@"layerID" sourceIdentifier:@"sourceID"];
+MGL<%- camelize(type) %>StyleLayer *layer = [[MGL<%- camelize(type) %>StyleLayer alloc] initWithLayerIdentifier:@"layerID" source:source];
     [self.mapView.style addSource:source];
     [self.mapView.style addLayer:layer];
 

--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -6,12 +6,7 @@
 
 @property (nonatomic, weak) MGLMapView *mapView;
 @property (nonatomic, copy, readonly) NSString *layerIdentifier;
-
-@optional
-
 @property (nonatomic, readonly) NSString *sourceIdentifier;
-
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier;
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier;
+@property (nonatomic, readonly) NSString *sourceLayerIdentifier;
 
 @end

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -35,6 +35,16 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(type) %>StyleLayer<%- camelize(prope
 <% } -%>
 @interface MGL<%- camelize(type) %>StyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
+<% if (type == 'background') { -%>
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier;
+<% } -%>
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source;
+
+<% if (type !== 'background' && type !== 'raster') { -%>
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer;
+<% } -%>
+
 <% if (type !== 'background' && type !== 'raster') { -%>
 /**
  A predicate that corresponds to the layer's <a href='https://www.mapbox.com/mapbox-gl-style-spec/#types-filter'>filter</a>.

--- a/platform/darwin/src/MGLStyleLayer.mm.ejs
+++ b/platform/darwin/src/MGLStyleLayer.mm.ejs
@@ -6,6 +6,7 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
+#import "MGLSource.h"
 #import "NSPredicate+MGLAdditions.h"
 #import "MGLStyleLayer_Private.h"
 #import "MGLStyleAttributeValue.h"
@@ -18,6 +19,7 @@
 @property (nonatomic) mbgl::style::<%- camelize(type) %>Layer *layer;
 @property (nonatomic, readwrite) NSString *layerIdentifier;
 @property (nonatomic, readwrite) NSString *sourceIdentifier;
+@property (nonatomic, readwrite) NSString *sourceLayerIdentifier;
 
 @end
 
@@ -25,14 +27,39 @@
 
 @synthesize mapView;
 
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier {
+<% if (type == 'background') { -%>
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier
+{
     if (self = [super init]) {
         _layerIdentifier = layerIdentifier;
-        _sourceIdentifier = sourceIdentifier;
+        <%- initLayerIdentifierOnly(type) %>
+    }
+    return self;
+}
+<% } -%>
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source
+{
+    if (self = [super init]) {
+        _layerIdentifier = layerIdentifier;
+        _sourceIdentifier = source.sourceIdentifier;
         <%- initLayer(type) %>
     }
     return self;
 }
+
+<% if (type !== 'background' && type !== 'raster') { -%>
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer
+{
+    if (self = [super init]) {
+        _layerIdentifier = layerIdentifier;
+        _sourceIdentifier = source.sourceIdentifier;
+        <%- initLayerWithSourceLayer(type) %>
+        <%- setSourceLayer() %>
+    }
+    return self;
+}
+<% } -%>
 
 <% if (type !== 'background' && type !== 'raster') { -%>
 - (void)setPredicate:(NSPredicate *)predicate

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -69,6 +69,11 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 
 @interface MGLSymbolStyleLayer : MGLBaseStyleLayer <MGLStyleLayer>
 
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source;
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer;
+
 /**
  A predicate that corresponds to the layer's <a href='https://www.mapbox.com/mapbox-gl-style-spec/#types-filter'>filter</a>.
  

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -1,6 +1,7 @@
 // This file is generated. 
 // Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
 
+#import "MGLSource.h"
 #import "NSPredicate+MGLAdditions.h"
 #import "MGLStyleLayer_Private.h"
 #import "MGLStyleAttributeValue.h"
@@ -13,6 +14,7 @@
 @property (nonatomic) mbgl::style::SymbolLayer *layer;
 @property (nonatomic, readwrite) NSString *layerIdentifier;
 @property (nonatomic, readwrite) NSString *sourceIdentifier;
+@property (nonatomic, readwrite) NSString *sourceLayerIdentifier;
 
 @end
 
@@ -20,11 +22,24 @@
 
 @synthesize mapView;
 
-- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier sourceIdentifier:(NSString *)sourceIdentifier {
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source
+{
     if (self = [super init]) {
         _layerIdentifier = layerIdentifier;
-        _sourceIdentifier = sourceIdentifier;
-        _layer = new mbgl::style::SymbolLayer(layerIdentifier.UTF8String, sourceIdentifier.UTF8String);
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::SymbolLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
+    }
+    return self;
+}
+
+- (instancetype)initWithLayerIdentifier:(NSString *)layerIdentifier source:(MGLSource *)source sourceLayer:(NSString *)sourceLayer
+{
+    if (self = [super init]) {
+        _layerIdentifier = layerIdentifier;
+        _sourceIdentifier = source.sourceIdentifier;
+        _layer = new mbgl::style::SymbolLayer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);
+        _layer->setSourceLayer(sourceLayer.UTF8String);
     }
     return self;
 }

--- a/platform/darwin/test/MGLBackgroundStyleLayerTests.m
+++ b/platform/darwin/test/MGLBackgroundStyleLayerTests.m
@@ -12,7 +12,7 @@
     NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
     NSURL *url = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"sourceID" URL:url];
-    MGLBackgroundStyleLayer *layer = [[MGLBackgroundStyleLayer alloc] initWithLayerIdentifier:@"layerID" sourceIdentifier:@"sourceID"];
+MGLBackgroundStyleLayer *layer = [[MGLBackgroundStyleLayer alloc] initWithLayerIdentifier:@"layerID" source:source];
     [self.mapView.style addSource:source];
     [self.mapView.style addLayer:layer];
 

--- a/platform/darwin/test/MGLCircleStyleLayerTests.m
+++ b/platform/darwin/test/MGLCircleStyleLayerTests.m
@@ -12,7 +12,7 @@
     NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
     NSURL *url = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"sourceID" URL:url];
-    MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithLayerIdentifier:@"layerID" sourceIdentifier:@"sourceID"];
+MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithLayerIdentifier:@"layerID" source:source];
     [self.mapView.style addSource:source];
     [self.mapView.style addLayer:layer];
 

--- a/platform/darwin/test/MGLFillStyleLayerTests.m
+++ b/platform/darwin/test/MGLFillStyleLayerTests.m
@@ -12,7 +12,7 @@
     NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
     NSURL *url = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"sourceID" URL:url];
-    MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithLayerIdentifier:@"layerID" sourceIdentifier:@"sourceID"];
+MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithLayerIdentifier:@"layerID" source:source];
     [self.mapView.style addSource:source];
     [self.mapView.style addLayer:layer];
 

--- a/platform/darwin/test/MGLFilterTests.mm
+++ b/platform/darwin/test/MGLFilterTests.mm
@@ -19,7 +19,7 @@
     NSData *geoJSONData = [NSData dataWithContentsOfURL:url];
     source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"test-source" geoJSONData:geoJSONData];
     [self.mapView.style addSource:source];
-    layer = [[MGLLineStyleLayer alloc] initWithLayerIdentifier:@"test-layer" sourceIdentifier:@"test-source"];
+    layer = [[MGLLineStyleLayer alloc] initWithLayerIdentifier:@"test-layer" source:source];
 }
 
 - (void)tearDown

--- a/platform/darwin/test/MGLLineStyleLayerTests.m
+++ b/platform/darwin/test/MGLLineStyleLayerTests.m
@@ -12,7 +12,7 @@
     NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
     NSURL *url = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"sourceID" URL:url];
-    MGLLineStyleLayer *layer = [[MGLLineStyleLayer alloc] initWithLayerIdentifier:@"layerID" sourceIdentifier:@"sourceID"];
+MGLLineStyleLayer *layer = [[MGLLineStyleLayer alloc] initWithLayerIdentifier:@"layerID" source:source];
     [self.mapView.style addSource:source];
     [self.mapView.style addLayer:layer];
 

--- a/platform/darwin/test/MGLRasterStyleLayerTests.m
+++ b/platform/darwin/test/MGLRasterStyleLayerTests.m
@@ -12,7 +12,7 @@
     NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
     NSURL *url = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"sourceID" URL:url];
-    MGLRasterStyleLayer *layer = [[MGLRasterStyleLayer alloc] initWithLayerIdentifier:@"layerID" sourceIdentifier:@"sourceID"];
+MGLRasterStyleLayer *layer = [[MGLRasterStyleLayer alloc] initWithLayerIdentifier:@"layerID" source:source];
     [self.mapView.style addSource:source];
     [self.mapView.style addLayer:layer];
 

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.m
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.m
@@ -12,7 +12,7 @@
     NSString *filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"amsterdam" ofType:@"geojson"];
     NSURL *url = [NSURL fileURLWithPath:filePath];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"sourceID" URL:url];
-    MGLSymbolStyleLayer *layer = [[MGLSymbolStyleLayer alloc] initWithLayerIdentifier:@"layerID" sourceIdentifier:@"sourceID"];
+MGLSymbolStyleLayer *layer = [[MGLSymbolStyleLayer alloc] initWithLayerIdentifier:@"layerID" source:source];
     [self.mapView.style addSource:source];
     [self.mapView.style addLayer:layer];
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -484,7 +484,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"ams" URL:geoJSONURL];
     [self.mapView.style addSource:source];
     
-    MGLFillStyleLayer *fillLayer = [[MGLFillStyleLayer alloc] initWithLayerIdentifier:@"test" sourceIdentifier:@"ams"];
+    MGLFillStyleLayer *fillLayer = [[MGLFillStyleLayer alloc] initWithLayerIdentifier:@"test" source:source];
     fillLayer.fillColor = [UIColor purpleColor];
     [self.mapView.style addLayer:fillLayer];
 }
@@ -495,7 +495,7 @@ static NSString * const MBXViewControllerAnnotationViewReuseIdentifer = @"MBXVie
     MGLRasterSource *rasterSource = [[MGLRasterSource alloc] initWithSourceIdentifier:@"my-raster-source" URL:rasterURL tileSize:512];
     [self.mapView.style addSource:rasterSource];
     
-    MGLRasterStyleLayer *rasterLayer = [[MGLRasterStyleLayer alloc] initWithLayerIdentifier:@"my-raster-layer" sourceIdentifier:@"my-raster-source"];
+    MGLRasterStyleLayer *rasterLayer = [[MGLRasterStyleLayer alloc] initWithLayerIdentifier:@"my-raster-layer" source:rasterSource];
     MGLStyleAttributeFunction *opacityFunction = [[MGLStyleAttributeFunction alloc] init];
     opacityFunction.stops = @{@20.0f: @1.0f,
                               @5.0f: @0.0f};

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -507,7 +507,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithSourceIdentifier:@"ams" URL:geoJSONURL];
     [self.mapView.style addSource:source];
     
-    MGLFillStyleLayer *fillLayer = [[MGLFillStyleLayer alloc] initWithLayerIdentifier:@"test" sourceIdentifier:@"ams"];
+    MGLFillStyleLayer *fillLayer = [[MGLFillStyleLayer alloc] initWithLayerIdentifier:@"test" source:source];
     fillLayer.fillColor = [NSColor greenColor];
     fillLayer.predicate = [NSPredicate predicateWithFormat:@"%K == %@", @"type", @"park"];
     [self.mapView.style addLayer:fillLayer];


### PR DESCRIPTION
Previously, we declared MGLStyleLayer initializers in the MGLStyleLayer protocol as optional methods. In the generated implementation, this made it easier to opt in and out of initializers that did or or did not make sense for the subclass. However, this approach was dangerous since it was easy for an application developer to initialize an MGLStyleLayer subclass with an init method that was actually not implemented in that class causing an exception at runtime.

This commit moves the init methods that each subclass supports to each subclass so xcode (and the compiler) help the developer avoid the previously possible runtime exception.

In addition, a new init method is added that takes the source layer and passes that on to `mbgl::style:Layer` (but only on classes where this is possible in core). This allows an application developer to style a specific source layer (i.e. the contour lines of the mapbox terrain vector source).

Fixes https://github.com/mapbox/mapbox-gl-native/issues/6250
Fixes  https://github.com/mapbox/mapbox-gl-native/issues/6252

@frederoni @1ec5 do you think this approach is reasonable or did I miss a requirement that the initializers should be in the protocol and optional?

### Todo:

- [x] confirm tests work
- [x] test that contour example works
- [x] review from @1ec5 @frederoni 
- [x] clean up commented code
- [x] clean up code generation script