### PR TITLE
render to a single static context in HeadlessView

### DIFF
--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -66,25 +66,24 @@ private:
 
     bool needsResize = false;
     bool extensionsLoaded = false;
-    bool active = false;
 
 #if MBGL_USE_QT
-    QGLWidget* glContext = nullptr;
+    static QGLWidget* glContext;
 #endif
 
 #if MBGL_USE_CGL
-    CGLContextObj glContext = nullptr;
+    static CGLContextObj glContext;
 #endif
 
 #if MBGL_USE_EAGL
-    void *glContext = nullptr;
+    static void *glContext;
 #endif
 
 #if MBGL_USE_GLX
-    Display *xDisplay = nullptr;
-    GLXFBConfig *fbConfigs = nullptr;
-    GLXContext glContext = nullptr;
-    GLXPbuffer glxPbuffer = 0;
+    static Display *xDisplay;
+    static GLXFBConfig *fbConfigs;
+    static GLXContext glContext;
+    static GLXPbuffer glxPbuffer;
 #endif
 
     std::function<void(MapChange)> mapChangeCallback;

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -34,7 +34,6 @@ class HeadlessView : public View {
 public:
     HeadlessView(float pixelRatio, uint16_t width = 256, uint16_t height = 256);
     HeadlessView(std::shared_ptr<HeadlessDisplay> display, float pixelRatio, uint16_t width = 256, uint16_t height = 256);
-    ~HeadlessView() override;
 
     float getPixelRatio() const override;
     std::array<uint16_t, 2> getSize() const override;

--- a/platform/darwin/src/headless_view_cgl.cpp
+++ b/platform/darwin/src/headless_view_cgl.cpp
@@ -76,8 +76,6 @@ void HeadlessView::resizeFramebuffer() {
 }
 
 void HeadlessView::clearBuffers() {
-    assert(active);
-
     MBGL_CHECK_ERROR(glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0));
 
     if (fbo) {

--- a/platform/darwin/src/headless_view_eagl.mm
+++ b/platform/darwin/src/headless_view_eagl.mm
@@ -72,8 +72,6 @@ void HeadlessView::resizeFramebuffer() {
 }
 
 void HeadlessView::clearBuffers() {
-    assert(active);
-
     MBGL_CHECK_ERROR(glBindFramebuffer(GL_FRAMEBUFFER, 0));
 
     if (fbo) {

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -21,15 +21,22 @@ HeadlessView::HeadlessView(std::shared_ptr<HeadlessDisplay> display_,
     , pixelRatio(pixelRatio_)
     , dimensions({{ width, height }})
     , needsResize(true) {
+    if (!glContext) {
+        if (!display) {
+            throw std::runtime_error("Display is not set");
+        }
+
+        createContext();
+        activateContext();
+
+        if (!extensionsLoaded) {
+            gl::InitializeExtensions(initializeExtension);
+            extensionsLoaded = true;
+        }
+    }
 }
 
-HeadlessView::~HeadlessView() {
-    activate();
-    clearBuffers();
-    deactivate();
-
-    destroyContext();
-}
+HeadlessView::~HeadlessView() {}
 
 void HeadlessView::resize(const uint16_t width, const uint16_t height) {
     if(dimensions[0] == width &&
@@ -41,8 +48,6 @@ void HeadlessView::resize(const uint16_t width, const uint16_t height) {
 }
 
 PremultipliedImage HeadlessView::readStillImage() {
-    assert(active);
-
     const unsigned int w = dimensions[0] * pixelRatio;
     const unsigned int h = dimensions[1] * pixelRatio;
 
@@ -75,22 +80,6 @@ std::array<uint16_t, 2> HeadlessView::getFramebufferSize() const {
 }
 
 void HeadlessView::activate() {
-    active = true;
-
-    if (!glContext) {
-        if (!display) {
-            throw std::runtime_error("Display is not set");
-        }
-        createContext();
-    }
-
-    activateContext();
-
-    if (!extensionsLoaded) {
-        gl::InitializeExtensions(initializeExtension);
-        extensionsLoaded = true;
-    }
-
     if (needsResize) {
         clearBuffers();
         resizeFramebuffer();
@@ -99,8 +88,7 @@ void HeadlessView::activate() {
 }
 
 void HeadlessView::deactivate() {
-    deactivateContext();
-    active = false;
+    // no-op
 }
 
 void HeadlessView::invalidate() {
@@ -112,5 +100,24 @@ void HeadlessView::notifyMapChange(MapChange change) {
         mapChangeCallback(change);
     }
 }
+
+#if MBGL_USE_QT
+    QGLWidget* HeadlessView::glContext = nullptr;
+#endif
+
+#if MBGL_USE_CGL
+    CGLContextObj HeadlessView::glContext = nullptr;
+#endif
+
+#if MBGL_USE_EAGL
+    void* HeadlessView::glContext = nullptr;
+#endif
+
+#if MBGL_USE_GLX
+    Display* HeadlessView::xDisplay = nullptr;
+    GLXFBConfig* HeadlessView::fbConfigs = nullptr;
+    GLXContext HeadlessView::glContext = nullptr;
+    GLXPbuffer HeadlessView::glxPbuffer = 0;
+#endif
 
 } // namespace mbgl

--- a/platform/default/headless_view.cpp
+++ b/platform/default/headless_view.cpp
@@ -36,8 +36,6 @@ HeadlessView::HeadlessView(std::shared_ptr<HeadlessDisplay> display_,
     }
 }
 
-HeadlessView::~HeadlessView() {}
-
 void HeadlessView::resize(const uint16_t width, const uint16_t height) {
     if(dimensions[0] == width &&
        dimensions[1] == height) {
@@ -114,8 +112,8 @@ void HeadlessView::notifyMapChange(MapChange change) {
 #endif
 
 #if MBGL_USE_GLX
-    Display* HeadlessView::xDisplay = nullptr;
-    GLXFBConfig* HeadlessView::fbConfigs = nullptr;
+    Display *HeadlessView::xDisplay = nullptr;
+    GLXFBConfig *HeadlessView::fbConfigs = nullptr;
     GLXContext HeadlessView::glContext = nullptr;
     GLXPbuffer HeadlessView::glxPbuffer = 0;
 #endif

--- a/platform/default/headless_view_glx.cpp
+++ b/platform/default/headless_view_glx.cpp
@@ -93,8 +93,6 @@ void HeadlessView::resizeFramebuffer() {
 }
 
 void HeadlessView::clearBuffers() {
-    assert(active);
-
     MBGL_CHECK_ERROR(glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0));
 
     if (fbo) {


### PR DESCRIPTION
Fixes #6212

This is a first draft. It would be worth investigating whether `needsResize` can be refactored into `HeadlessView::resize`, eliminating the need for `HeadlessView::activate` - if possible we could completely remove that method and `HeadlessView::deactivate`, which is just a no-op for now.

Is it necessary to deactivate and destroy the `glContext` anywhere now that it's `static` and shared across all instances of `HeadlessView`?

/cc @tmpsantos
