### PR TITLE
Move SQLite logging setup to before database initialization

### DIFF
--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -9,6 +9,12 @@
 
 #include <mbgl/platform/log.hpp>
 
+namespace mapbox {
+namespace sqlite {
+
+template <typename T>
+using optional = std::experimental::optional<T>;
+
 const static bool sqliteVersionCheck __attribute__((unused)) = []() {
     if (sqlite3_libversion_number() / 1000000 != SQLITE_VERSION_NUMBER / 1000000) {
         char message[96];
@@ -18,17 +24,13 @@ const static bool sqliteVersionCheck __attribute__((unused)) = []() {
         throw std::runtime_error(message);
     }
 
+    // Enable SQLite logging before initializing the database.
+    sqlite3_config(SQLITE_CONFIG_LOG, Database::errorLogCallback, nullptr);
+
     return true;
 }();
 
-namespace mapbox {
-namespace sqlite {
-
-template <typename T>
-using optional = std::experimental::optional<T>;
-
 Database::Database(const std::string &filename, int flags) {
-    sqlite3_config(SQLITE_CONFIG_LOG, errorLogCallback, nullptr);
     const int err = sqlite3_open_v2(filename.c_str(), &db, flags, nullptr);
     if (err != SQLITE_OK) {
         const auto message = sqlite3_errmsg(db);

--- a/platform/default/sqlite3.hpp
+++ b/platform/default/sqlite3.hpp
@@ -42,6 +42,7 @@ public:
 
     explicit operator bool() const;
 
+    static void errorLogCallback(void *arg, const int err, const char *msg);
     void setBusyTimeout(std::chrono::milliseconds);
     void exec(const std::string &sql);
     Statement prepare(const char *query);
@@ -51,7 +52,6 @@ public:
 
 private:
     sqlite3 *db = nullptr;
-    static void errorLogCallback(void *arg, const int err, const char *msg);
 };
 
 class Statement {


### PR DESCRIPTION
Fixes the `SQLITE_MISUSE` warning on the first launch of an app — half of #6295.

Follows-up on the initial SQLite logging implementation in #6291.

/cc @jfirebaugh