### PR TITLE
[core] using 32bits (instead of 8) for the stencil masks, fixes stencil mask overflows

### DIFF
--- a/src/mbgl/algorithm/generate_clip_ids_impl.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids_impl.hpp
@@ -51,7 +51,7 @@ void ClipIDGenerator::update(Renderables& renderables) {
 
     if (size > 0) {
         const uint32_t bit_count = util::ceil_log2(size + 1);
-        const std::bitset<8> mask = uint64_t(((1ul << bit_count) - 1) << bit_offset);
+        const std::bitset<32> mask = uint64_t(((1ul << bit_count) - 1) << bit_offset);
 
         // We are starting our count with 1 since we need at least 1 bit set to distinguish between
         // areas without any tiles whatsoever and the current area.
@@ -69,7 +69,7 @@ void ClipIDGenerator::update(Renderables& renderables) {
         bit_offset += bit_count;
     }
 
-    if (bit_offset > 8) {
+    if (bit_offset > 32) {
         Log::Error(Event::OpenGL, "stencil mask overflow");
     }
 }

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -122,7 +122,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
         MBGL_DEBUG_GROUP("clear");
         config.stencilFunc.reset();
         config.stencilTest = GL_TRUE;
-        config.stencilMask = 0xFF;
+        config.stencilMask = 0xFFFFFFFF;
         config.depthTest = GL_FALSE;
         config.depthMask = GL_TRUE;
         config.colorMask = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -16,7 +16,7 @@ void Painter::drawClippingMasks(PaintParameters& parameters, const std::map<Unwr
     auto& arrayCoveringPlain = parameters.shaders.coveringPlainArray;
 
     mat4 matrix;
-    const GLuint mask = 0b11111111;
+    const GLuint mask = 0xFFFFFFFF;
 
     config.program = plainShader.getID();
     config.stencilOp.reset();

--- a/src/mbgl/util/clip_id.hpp
+++ b/src/mbgl/util/clip_id.hpp
@@ -15,8 +15,8 @@ struct ClipID {
     ClipID() {}
     ClipID(const std::string &mask_, const std::string &reference_) : mask(mask_), reference(reference_) {}
 
-    std::bitset<8> mask;
-    std::bitset<8> reference;
+    std::bitset<32> mask;
+    std::bitset<32> reference;
 
     bool operator==(const ClipID &other) const {
         return mask == other.mask && reference == other.reference;


### PR DESCRIPTION
fixes #962

OpenGL's glStencilFunc [supports](https://www.opengl.org/sdk/docs/man/html/glStencilMask.xhtml) a stencial mask in form of a GLuint -> 32 bit long mask.

Using just 8 bits as before is limiting and leads to avoidable stencil overflow errors.

Cheers!