### PR TITLE
Use content inset to calculate edge padding

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4085,7 +4085,7 @@ public:
 - (void)didUpdateLocationIncrementallyAnimated:(BOOL)animated
 {
     [self _setCenterCoordinate:self.userLocation.location.coordinate
-                   edgePadding:self.contentInset
+                   edgePadding:self.edgePaddingForFollowing
                      zoomLevel:self.zoomLevel
                      direction:self.directionByFollowingWithCourse
                       duration:animated ? MGLUserLocationAnimationDuration : 0
@@ -4112,7 +4112,7 @@ public:
     
     __weak MGLMapView *weakSelf = self;
     [self _flyToCamera:camera
-           edgePadding:self.contentInset
+           edgePadding:self.edgePaddingForFollowing
           withDuration:animated ? -1 : 0
           peakAltitude:-1
      completionHandler:^{
@@ -4173,8 +4173,10 @@ public:
     CGRect boundsAroundCorrectPoint = CGRectOffset(bounds,
                                                    correctPoint.x - CGRectGetMidX(bounds),
                                                    correctPoint.y - CGRectGetMidY(bounds));
-    return UIEdgeInsetsMake(CGRectGetMinY(boundsAroundCorrectPoint) - CGRectGetMinY(bounds), 0,
-                            CGRectGetMaxY(bounds) - CGRectGetMaxY(boundsAroundCorrectPoint), 0);
+    return UIEdgeInsetsMake(CGRectGetMinY(boundsAroundCorrectPoint) - CGRectGetMinY(bounds) + self.contentInset.top,
+                            self.contentInset.left,
+                            CGRectGetMaxY(bounds) - CGRectGetMaxY(boundsAroundCorrectPoint) + self.contentInset.bottom,
+                            self.contentInset.right);
 }
 
 /// Returns the edge padding to apply during bifocal course tracking.


### PR DESCRIPTION
This reverts a previous change that used only the `contentInset` when setting the center coordinate of the map view. Instead of `contentInset`, `edgePaddingForFollowing` is now used again. This fixes
the regression introduced in https://github.com/mapbox/mapbox-gl-native/pull/6216 that caused the user dot annotation to be misplaced when the map was configured to show the annotation in any place other than in the center of the map.

In addition, `edgePaddingForFollowing` is updated to account for `contentInset` when it calculates its `UIEdgeInsets`. This fixes a bug where the user dot would move to the center of the content frame
(when it was adjusted for content insets) but the map would not scroll along with it yielding the effect of the user dot being misplaced.

Fixes #6257 
Reverts #6216

cc @1ec5 