### PR TITLE
Use SQLite in-memory temporary table store

### DIFF
--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -61,6 +61,9 @@ private:
     void removeExisting();
     void migrateToVersion3();
     void migrateToVersion4();
+    void migrateToVersion5();
+
+    void echoPragmas();
 
     class Statement {
     public:

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -63,8 +63,6 @@ private:
     void migrateToVersion4();
     void migrateToVersion5();
 
-    void echoPragmas();
-
     class Statement {
     public:
         explicit Statement(mapbox::sqlite::Statement& stmt_) : stmt(stmt_) {}

--- a/test/storage/offline_database.cpp
+++ b/test/storage/offline_database.cpp
@@ -559,18 +559,18 @@ TEST(OfflineDatabase, MigrateFromV2Schema) {
 
     // v2.db is a v2 database containing a single offline region with a small number of resources.
 
-    deleteFile("test/fixtures/offline_database/v4.db");
-    writeFile("test/fixtures/offline_database/v4.db", util::read_file("test/fixtures/offline_database/v2.db"));
+    deleteFile("test/fixtures/offline_database/v5.db");
+    writeFile("test/fixtures/offline_database/v5.db", util::read_file("test/fixtures/offline_database/v2.db"));
 
     {
-        OfflineDatabase db("test/fixtures/offline_database/v4.db", 0);
+        OfflineDatabase db("test/fixtures/offline_database/v5.db", 0);
         auto regions = db.listRegions();
         for (auto& region : regions) {
             db.deleteRegion(std::move(region));
         }
     }
 
-    EXPECT_EQ(4, databaseUserVersion("test/fixtures/offline_database/v4.db"));
-    EXPECT_LT(databasePageCount("test/fixtures/offline_database/v4.db"),
+    EXPECT_EQ(5, databaseUserVersion("test/fixtures/offline_database/v5.db"));
+    EXPECT_LT(databasePageCount("test/fixtures/offline_database/v5.db"),
               databasePageCount("test/fixtures/offline_database/v2.db"));
 }


### PR DESCRIPTION
Fixes #6193 — a crash on Android with `terminating with uncaught exception of type mapbox::sqlite::Exception: unable to open database file`. That crash was caused by Android’s SQLite trying to write to `./someTempFile`, which it did not have permission to do. This was brought about by the change to WAL journaling in #5796.

This pull request sets [`PRAGMA temp_store = MEMORY`](https://www.sqlite.org/pragma.html#pragma_temp_store), where previously it was the default (`FILE`). Using an in-memory temporary table store avoids the permission issue and fixes the crash. This should not affect the two WAL cache files.

[Some background](http://codificar.com.br/blog/sqlite-optimization-faq/):

>The `temp_store` values specifies the type of database back-end to use for temporary files. The choices are DEFAULT (0), FILE (1), and MEMORY (2). The use of a memory database for temporary tables can produce signifigant savings. DEFAULT specifies the compiled-in default, which is FILE unless the source has been modified.
>
>This pragma will have no effect if the sqlite library has support for in-memory databases turned off using symbol `SQLITE_OMIT_INMEMORYDB`.

### Why not change where temporary files are written?

Simply changing [`PRAGMA temp_store_directory`](https://www.sqlite.org/pragma.html#pragma_temp_store_directory) isn’t a good option: it’s deprecated and there are no guarantees we could set it to a good temp directory. We would also have to limit this to Android, because other platforms do not have this problem (and use different temp dirs).

### Benefits of `temp_store = MEMORY`
- No longer crashes on Android — under standard conditions.
- Supposedly faster.

### Risks
- Will increase memory usage by some unknown amount.
- Android is the wild-west and an OEM could have compiled SQLite with `SQLITE_OMIT_INMEMORYDB`, which means SQLite could still try to write temporary files and subsequently crash.

### To-do
- [ ] Quantify memory usage.
- [ ] Further research into when these temporary tables are created.
- [ ] Research how common `SQLITE_OMIT_INMEMORYDB` is on different plaforms.
- [ ] Get sign-off **_with testing_** for different platforms:
 - [ ] iOS
 - [ ] Android
 - [ ] Qt
 - [ ] Node
 - [ ] macOS

/cc @mapbox/gl 