### PR TITLE
[core] Band-aid to prevent GeometryTile::redoLayout race condition from causing a crash

### DIFF
--- a/src/mbgl/tile/tile_worker.cpp
+++ b/src/mbgl/tile/tile_worker.cpp
@@ -136,6 +136,12 @@ void TileWorker::parseLayer(const Layer* layer) {
     if (obsolete)
         return;
 
+    // Temporary prevention for crashing due to https://github.com/mapbox/mapbox-gl-native/issues/6263.
+    // Instead, the race condition will produce a blank tile.
+    if (!tileData) {
+        return;
+    }
+
     auto geometryLayer = tileData->getLayer(layer->baseImpl->sourceLayer);
     if (!geometryLayer) {
         // The layer specified in the bucket does not exist. Do nothing.


### PR DESCRIPTION
This provides temporary prevention for crashing due to #6263, which will hopefully help stabilize our Android builds prior to stuff like #1471 landing.

Instead of a crash, the race condition will produce a blank tile. Note that the race is run only if a layout property or filter is modified. I don't see any way for it to be triggered in other scenarios. So it won't become a possible cause of "blank tiles" in general.