### PR TITLE
[core] Convert uses of std::set to std::unordered_set

### DIFF
--- a/include/mbgl/storage/network_status.hpp
+++ b/include/mbgl/storage/network_status.hpp
@@ -2,7 +2,7 @@
 
 #include <atomic>
 #include <mutex>
-#include <set>
+#include <unordered_set>
 
 namespace mbgl {
 
@@ -28,7 +28,7 @@ public:
 private:
     static std::atomic<bool> online;
     static std::mutex mtx;
-    static std::set<util::AsyncTask*> observers;
+    static std::unordered_set<util::AsyncTask*> observers;
 };
 
 } // namespace mbgl

--- a/platform/default/mbgl/storage/offline_download.hpp
+++ b/platform/default/mbgl/storage/offline_download.hpp
@@ -3,7 +3,7 @@
 #include <mbgl/storage/offline.hpp>
 
 #include <list>
-#include <set>
+#include <unordered_set>
 #include <memory>
 
 namespace mbgl {
@@ -58,7 +58,7 @@ private:
     OfflineRegionStatus status;
     std::unique_ptr<OfflineRegionObserver> observer;
     std::list<std::unique_ptr<AsyncRequest>> requests;
-    std::set<std::string> requiredSourceURLs;
+    std::unordered_set<std::string> requiredSourceURLs;
 };
 
 } // namespace mbgl

--- a/src/mbgl/algorithm/update_renderables.hpp
+++ b/src/mbgl/algorithm/update_renderables.hpp
@@ -4,7 +4,7 @@
 #include <mbgl/util/range.hpp>
 #include <mbgl/storage/resource.hpp>
 
-#include <set>
+#include <unordered_set>
 
 namespace mbgl {
 namespace algorithm {
@@ -21,7 +21,7 @@ void updateRenderables(GetTileFn getTile,
                        const IdealTileIDs& idealTileIDs,
                        const Range<uint8_t>& zoomRange,
                        const uint8_t dataTileZoom) {
-    std::set<UnwrappedTileID> checked;
+    std::unordered_set<UnwrappedTileID> checked;
     bool covered;
     int32_t overscaledZ;
 

--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -8,7 +8,7 @@
 
 #include <string>
 #include <vector>
-#include <set>
+#include <unordered_set>
 #include <unordered_map>
 
 namespace mbgl {
@@ -72,8 +72,8 @@ private:
     SymbolAnnotationTree symbolTree;
     SymbolAnnotationMap symbolAnnotations;
     ShapeAnnotationMap shapeAnnotations;
-    std::set<std::string> obsoleteShapeAnnotationLayers;
-    std::set<AnnotationTile*> tiles;
+    std::unordered_set<std::string> obsoleteShapeAnnotationLayers;
+    std::unordered_set<AnnotationTile*> tiles;
     SpriteAtlas spriteAtlas;
 };
 

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -88,7 +88,7 @@ private:
     bool sdfIcons = false;
     bool iconsNeedLinear = false;
 
-    std::unordered_set<GlyphRange, GlyphRangeHash> ranges;
+    GlyphRangeSet ranges;
     std::vector<SymbolInstance> symbolInstances;
     std::vector<SymbolFeature> features;
 };

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -7,7 +7,7 @@
 
 #include <memory>
 #include <map>
-#include <set>
+#include <unordered_set>
 #include <vector>
 
 namespace mbgl {
@@ -88,7 +88,7 @@ private:
     bool sdfIcons = false;
     bool iconsNeedLinear = false;
 
-    std::set<GlyphRange> ranges;
+    std::unordered_set<GlyphRange, GlyphRangeHash> ranges;
     std::vector<SymbolInstance> symbolInstances;
     std::vector<SymbolFeature> features;
 };

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -31,6 +31,7 @@
 #include <cassert>
 #include <algorithm>
 #include <iostream>
+#include <unordered_set>
 
 namespace mbgl {
 
@@ -80,7 +81,7 @@ void Painter::render(const Style& style, const FrameData& frame_, SpriteAtlas& a
 
     RenderData renderData = style.getRenderData(frame.debugOptions);
     const std::vector<RenderItem>& order = renderData.order;
-    const std::set<Source*>& sources = renderData.sources;
+    const std::unordered_set<Source*>& sources = renderData.sources;
     const Color& background = renderData.backgroundColor;
 
     // Update the default matrices to the current viewport dimensions.

--- a/src/mbgl/renderer/render_item.hpp
+++ b/src/mbgl/renderer/render_item.hpp
@@ -2,7 +2,7 @@
 
 #include <mbgl/util/color.hpp>
 
-#include <set>
+#include <unordered_set>
 #include <vector>
 
 namespace mbgl {
@@ -31,7 +31,7 @@ public:
 class RenderData {
 public:
     Color backgroundColor;
-    std::set<style::Source*> sources;
+    std::unordered_set<style::Source*> sources;
     std::vector<RenderItem> order;
 };
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -10,7 +10,6 @@
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
 
 #include <memory>
-#include <set>
 #include <vector>
 
 namespace mbgl {

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <map>
 #include <mutex>
-#include <set>
+#include <unordered_set>
 #include <array>
 #include <memory>
 
@@ -140,7 +140,7 @@ private:
     std::recursive_mutex mtx;
     BinPack<dimension> bin;
     std::map<Key, Holder> images;
-    std::set<std::string> uninitialized;
+    std::unordered_set<std::string> uninitialized;
     std::unique_ptr<uint32_t[]> data;
     std::atomic<bool> dirtyFlag;
     bool fullUploadRequired = true;

--- a/src/mbgl/storage/network_status.cpp
+++ b/src/mbgl/storage/network_status.cpp
@@ -11,7 +11,7 @@ namespace mbgl {
 
 std::atomic<bool> NetworkStatus::online(true);
 std::mutex NetworkStatus::mtx;
-std::set<util::AsyncTask *> NetworkStatus::observers;
+std::unordered_set<util::AsyncTask *> NetworkStatus::observers;
 
 NetworkStatus::Status NetworkStatus::Get() {
     if (online) {

--- a/src/mbgl/style/update_batch.hpp
+++ b/src/mbgl/style/update_batch.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <set>
+#include <unordered_set>
 #include <string>
 
 namespace mbgl {
@@ -8,7 +8,7 @@ namespace style {
 
 class UpdateBatch {
 public:
-    std::set<std::string> sourceIDs;
+    std::unordered_set<std::string> sourceIDs;
 };
 
 } // namespace style

--- a/src/mbgl/text/collision_tile.cpp
+++ b/src/mbgl/text/collision_tile.cpp
@@ -156,7 +156,7 @@ Box CollisionTile::getTreeBox(const Point<float>& anchor, const CollisionBox& bo
 std::vector<IndexedSubfeature> CollisionTile::queryRenderedSymbols(const mapbox::geometry::box<int16_t>& box, const float scale) {
 
     std::vector<IndexedSubfeature> result;
-    std::unordered_map<std::string, std::set<std::size_t>> sourceLayerFeatures;
+    std::unordered_map<std::string, std::unordered_set<std::size_t>> sourceLayerFeatures;
 
     auto anchor = util::matrixMultiply(rotationMatrix, convertPoint<float>(box.min));
     CollisionBox queryBox(anchor, 0, 0, box.max.x - box.min.x, box.max.y - box.min.y, scale);

--- a/src/mbgl/text/glyph_atlas.cpp
+++ b/src/mbgl/text/glyph_atlas.cpp
@@ -39,7 +39,7 @@ void GlyphAtlas::requestGlyphRange(const FontStack& fontStack, const GlyphRange&
         std::make_unique<GlyphPBF>(this, fontStack, range, observer, fileSource));
 }
 
-bool GlyphAtlas::hasGlyphRanges(const FontStack& fontStack, const std::unordered_set<GlyphRange>& glyphRanges) {
+bool GlyphAtlas::hasGlyphRanges(const FontStack& fontStack, const GlyphRangeSet& glyphRanges) {
     if (glyphRanges.empty()) {
         return true;
     }

--- a/src/mbgl/text/glyph_atlas.cpp
+++ b/src/mbgl/text/glyph_atlas.cpp
@@ -39,7 +39,7 @@ void GlyphAtlas::requestGlyphRange(const FontStack& fontStack, const GlyphRange&
         std::make_unique<GlyphPBF>(this, fontStack, range, observer, fileSource));
 }
 
-bool GlyphAtlas::hasGlyphRanges(const FontStack& fontStack, const std::set<GlyphRange>& glyphRanges) {
+bool GlyphAtlas::hasGlyphRanges(const FontStack& fontStack, const std::unordered_set<GlyphRange>& glyphRanges) {
     if (glyphRanges.empty()) {
         return true;
     }

--- a/src/mbgl/text/glyph_atlas.hpp
+++ b/src/mbgl/text/glyph_atlas.hpp
@@ -41,7 +41,7 @@ public:
     // made and when the glyph if finally parsed, it gets added to the respective
     // GlyphSet and a signal is emitted to notify the observers. This method
     // can be called from any thread.
-    bool hasGlyphRanges(const FontStack&, const std::set<GlyphRange>&);
+    bool hasGlyphRanges(const FontStack&, const std::unordered_set<GlyphRange>&);
 
     void setURL(const std::string &url) {
         glyphURL = url;

--- a/src/mbgl/text/glyph_atlas.hpp
+++ b/src/mbgl/text/glyph_atlas.hpp
@@ -13,7 +13,7 @@
 
 #include <atomic>
 #include <string>
-#include <set>
+#include <unordered_set>
 #include <unordered_map>
 #include <mutex>
 #include <exception>
@@ -95,7 +95,7 @@ private:
         GlyphValue(Rect<uint16_t> rect_, uintptr_t id)
             : rect(std::move(rect_)), ids({ id }) {}
         Rect<uint16_t> rect;
-        std::set<uintptr_t> ids;
+        std::unordered_set<uintptr_t> ids;
     };
 
     std::mutex mtx;

--- a/src/mbgl/text/glyph_atlas.hpp
+++ b/src/mbgl/text/glyph_atlas.hpp
@@ -41,7 +41,7 @@ public:
     // made and when the glyph if finally parsed, it gets added to the respective
     // GlyphSet and a signal is emitted to notify the observers. This method
     // can be called from any thread.
-    bool hasGlyphRanges(const FontStack&, const std::unordered_set<GlyphRange>&);
+    bool hasGlyphRanges(const FontStack&, const GlyphRangeSet&);
 
     void setURL(const std::string &url) {
         glyphURL = url;

--- a/src/mbgl/text/glyph_range.hpp
+++ b/src/mbgl/text/glyph_range.hpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 #include <cstdint>
+#include <unordered_set>
 #include <boost/functional/hash.hpp>
 
 namespace mbgl {
@@ -13,6 +14,8 @@ struct GlyphRangeHash {
         return boost::hash_value(glyphRange);
     }
 };
+
+typedef std::unordered_set<GlyphRange, GlyphRangeHash> GlyphRangeSet;
     
 } // end namespace mbgl
 

--- a/src/mbgl/text/glyph_range.hpp
+++ b/src/mbgl/text/glyph_range.hpp
@@ -16,6 +16,5 @@ struct GlyphRangeHash {
 };
 
 typedef std::unordered_set<GlyphRange, GlyphRangeHash> GlyphRangeSet;
-    
-} // end namespace mbgl
 
+} // end namespace mbgl

--- a/src/mbgl/text/glyph_range.hpp
+++ b/src/mbgl/text/glyph_range.hpp
@@ -2,9 +2,17 @@
 
 #include <utility>
 #include <cstdint>
+#include <boost/functional/hash.hpp>
 
 namespace mbgl {
 
 typedef std::pair<uint16_t, uint16_t> GlyphRange;
 
+struct GlyphRangeHash {
+    std::size_t operator()(const GlyphRange& glyphRange) const {
+        return boost::hash_value(glyphRange);
+    }
+};
+    
 } // end namespace mbgl
+

--- a/test/text/glyph_atlas.cpp
+++ b/test/text/glyph_atlas.cpp
@@ -18,7 +18,7 @@ public:
     StubStyleObserver observer;
     GlyphAtlas glyphAtlas { 32, 32, fileSource };
 
-    void run(const std::string& url, const FontStack& fontStack, const std::set<GlyphRange>& glyphRanges) {
+    void run(const std::string& url, const FontStack& fontStack, const std::unordered_set<GlyphRange, GlyphRangeHash>& glyphRanges) {
         // Squelch logging.
         Log::setObserver(std::make_unique<Log::NullObserver>());
 

--- a/test/text/glyph_atlas.cpp
+++ b/test/text/glyph_atlas.cpp
@@ -18,7 +18,7 @@ public:
     StubStyleObserver observer;
     GlyphAtlas glyphAtlas { 32, 32, fileSource };
 
-    void run(const std::string& url, const FontStack& fontStack, const std::unordered_set<GlyphRange, GlyphRangeHash>& glyphRanges) {
+    void run(const std::string& url, const FontStack& fontStack, const GlyphRangeSet& glyphRanges) {
         // Squelch logging.
         Log::setObserver(std::make_unique<Log::NullObserver>());
 


### PR DESCRIPTION
The `std::set` collection is ordered. It is less efficient than its `std::unordered_set` counterpart. This PR converts as many uses of `std::set` into `std::unordered_set` as possible. 

see https://github.com/mapbox/mapbox-gl-native/issues/3980

# Todo

 - [x] address all uses of `std::set` in the "Needs More work 🚧 " section
 - [x] create a `GlyphRangeSet` typedef
 - [x] wait for https://github.com/mapbox/mapbox-gl-native/pull/6322 to merge
 - [x] wait for https://github.com/mapbox/mapbox-gl-native/pull/6327 to merge
 - [ ] get CI 🍏 
 - [ ] get a PR review

# Uses of `std::set`

Below is a list of all uses of `std::set`. We will check of each as it is switched to `std::unordered_set` or we confirm that it cannot be switched. 

## Changed ✅

 - `./include/mbgl/storage/network_status.hpp:31:    static std::set<util::AsyncTask*> observers;` done in ac000d10a301d7e2a7c4dc66d84222e7d319d244
 - `./src/mbgl/algorithm/generate_clip_ids.hpp:20:        std::set<CanonicalTileID> children;` done in a289d58e346cfb2ef4ffcfe160734d59222fb013
 - `./src/mbgl/algorithm/update_renderables.hpp:24:    std::set<UnwrappedTileID> checked;` done in de20cd0a8da4edfc899020f24de288339ca4e947
 - `./src/mbgl/annotation/annotation_manager.hpp:76:    std::set<std::string> obsoleteShapeAnnotationLayers;` done in f1f73f42349
 - `./src/mbgl/annotation/annotation_manager.hpp:77:    std::set<AnnotationTile*> tiles;` f1f73f42349
 - `./src/mbgl/geometry/glyph_atlas.hpp:49:        std::set<uintptr_t> ids;` done in abce9d0
 - `./src/mbgl/renderer/painter.cpp:83:    const std::set<Source*>& sources = renderData.sources;` done in 0d9b495e8042c27816d52034a9709dba33fbd564
 - `./src/mbgl/renderer/render_item.hpp:34:    std::set<style::Source*> sources;` done in 0d9b495e8042c27816d52034a9709dba33fbd564
 - `./src/mbgl/renderer/symbol_bucket.hpp:130:    std::set<GlyphRange> ranges;` done in 55bafc5ca55e7c1364e79955a9e8fc60552b6a56
 - `./src/mbgl/sprite/sprite_atlas.hpp:92:    std::set<std::string> uninitialized;` done in 2b40808a818ef46a0b7bf06863fa424c4ca0e9de
 - `./src/mbgl/storage/network_status.cpp:14:std::set<util::AsyncTask *> NetworkStatus::observers;` done in ac000d10a301d7e2a7c4dc66d84222e7d319d244
 - `./src/mbgl/text/collision_tile.cpp:159:    std::unordered_map<std::string, std::set<std::size_t>> sourceLayerFeatures;` done in 11e109599d947420e2fa8e1a9249bd29341773ff
 - `./src/mbgl/text/glyph_store.cpp:31:bool GlyphStore::hasGlyphRanges(const FontStack& fontStack, const std::set<GlyphRange>& glyphRanges) {` done in 55bafc5ca55e7c1364e79955a9e8fc60552b6a56
 - `./src/mbgl/text/glyph_store.hpp:37:    bool hasGlyphRanges(const FontStack&, const std::set<GlyphRange>&);` done in 55bafc5
 - `./src/mbgl/tile/tile_worker.cpp:58:    std::set<std::string> parsed;` done in ecbb4b26e11a204de46be1cf638dc6ba505fad4c
 - `./src/mbgl/style/update_batch.hpp:11:    std::set<std::string> sourceIDs;` done in 3f0a3752410cca620ee92528e2690b6086ddcb9a
 - `./platform/default/mbgl/storage/offline_download.hpp` done in 0ca2c61
 -  `./src/mbgl/style/source_impl.cpp:108:    std::set<OverscaledTileID> retain;` done in 3a65ea3 

## Won't Change 🙅 

 - ~~`./src/clipper/clipper.cpp:4707:                                std::set<int> & visited,`~~ see https://github.com/mapbox/mapbox-gl-native/issues/3980#issuecomment-246523695
 - ~~`./src/clipper/clipper.cpp:4830:        std::set<int> visited;`~~ see https://github.com/mapbox/mapbox-gl-native/issues/3980#issuecomment-246523695
 - ~~`./src/clipper/clipper.hpp:387:                         std::set<int> & visited,`~~ see https://github.com/mapbox/mapbox-gl-native/issues/3980#issuecomment-246523695
 - ~~`./src/mbgl/util/url.cpp:23:            encoded << '%' << std::setw(2) << int(c);`~~ https://github.com/mapbox/mapbox-gl-native/issues/3980#issuecomment-246523695
 - ~~`./src/mbgl/style/parser.cpp:237:    std::set<FontStack> result;`~~ this is a legitimate use of an ordered set 
