### PR TITLE
[android] - disable closable strictmode

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/MapboxApplication.java
@@ -21,7 +21,6 @@ public class MapboxApplication extends Application {
                 .build());
         StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
                 .detectLeakedSqlLiteObjects()
-                .detectLeakedClosableObjects()
                 .penaltyLog()
                 .penaltyDeath()
                 .build());


### PR DESCRIPTION
Disabling closable strictmode since they make our [tests flaky](https://github.com/mapbox/mapbox-gl-native/issues/6286#issuecomment-246362353).
We aren't able to resolve this issue from our end since it's coming from OKHttp dependency.

Review @ivovandongen 