### PR TITLE
Fix for stepwise functions 

### DIFF
--- a/src/mbgl/util/interpolate.hpp
+++ b/src/mbgl/util/interpolate.hpp
@@ -57,8 +57,8 @@ public:
 
 struct Uninterpolated {
     template <class T>
-    T operator()(const T&, const T& b, const double) const {
-        return b;
+    T operator()(const T& a, const T&, const double) const {
+        return a;
     }
 };
 

--- a/test/style/functions.cpp
+++ b/test/style/functions.cpp
@@ -10,6 +10,9 @@ using namespace mbgl::style;
 float evaluate(PropertyValue<float> value, float zoom) {
     return PropertyValue<float>::visit(value, PropertyEvaluator<float>(CalculationParameters(zoom), 0));
 }
+std::string evaluate(PropertyValue<std::string> value, float zoom) {
+    return PropertyValue<std::string>::visit(value, PropertyEvaluator<std::string>(CalculationParameters(zoom), ""));
+}
 
 TEST(Function, Constant) {
     EXPECT_EQ(2.0f, evaluate(2, 0));
@@ -61,4 +64,12 @@ TEST(Function, Stops) {
     EXPECT_EQ(4, evaluate(slope_4, 2));
     EXPECT_EQ(4.75, evaluate(slope_4, 2.75));
     EXPECT_EQ(10, evaluate(slope_4, 8));
+
+    // discrete values
+    Function<std::string> discrete_0({{ 3, "string0"}, {6, "string1"}, {9, "string2"}}, 1);
+    EXPECT_EQ("string0", evaluate(discrete_0, 2));
+    EXPECT_EQ("string0", evaluate(discrete_0, 4));
+    EXPECT_EQ("string1", evaluate(discrete_0, 7));
+    EXPECT_EQ("string2", evaluate(discrete_0, 9));
+    EXPECT_EQ("string2", evaluate(discrete_0, 10));
 }


### PR DESCRIPTION
This change fixes the bugs reported in #6303 and #5823. It swaps the behaviour of the interpolate function for discrete values to return the value just less than the current zoom level, in accordance with the Mapbox style documentation.