### PR TITLE
Initial style from MAPBOX_STYLE_URL if set

### DIFF
--- a/bin/glfw.cpp
+++ b/bin/glfw.cpp
@@ -148,9 +148,15 @@ int main(int argc, char *argv[]) {
 
     // Load style
     if (style.empty()) {
-        mbgl::util::default_styles::DefaultStyle newStyle = mbgl::util::default_styles::orderedStyles[0];
-        style = newStyle.url;
-        view->setWindowTitle(newStyle.name);
+        const char *url = getenv("MAPBOX_STYLE_URL");
+        if (url == nullptr) {
+            mbgl::util::default_styles::DefaultStyle newStyle = mbgl::util::default_styles::orderedStyles[0];
+            style = newStyle.url;
+            view->setWindowTitle(newStyle.name);
+        } else {
+            style = url;
+            view->setWindowTitle(url);
+        }
     }
 
     map.setStyleURL(style);

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -21,7 +21,13 @@ MapWindow::MapWindow(const QMapboxGLSettings &settings)
     // Set default location to Helsinki.
     m_map.setCoordinateZoom(QMapbox::Coordinate(60.170448, 24.942046), 14);
 
-    changeStyle();
+    QString styleUrl = qgetenv("MAPBOX_STYLE_URL");
+    if (styleUrl.isEmpty()) {
+        changeStyle();
+    } else {
+        m_map.setStyleUrl(styleUrl);
+        setWindowTitle(QString("Mapbox GL: ") + styleUrl);
+    }
 
     connect(&m_zoomAnimation, SIGNAL(finished()), this, SLOT(animationFinished()));
     connect(&m_zoomAnimation, SIGNAL(valueChanged(const QVariant&)), this, SLOT(animationValueChanged()));


### PR DESCRIPTION
There is no quick and easy way of setting a custom style in our demo applications - current process involves e.g. replacing one of the default styles with the custom style. I've been using these patches for my own debugging and thought it could be a good addition for GL native developers that frequently needs to test/debug non-default styles.

__Usage__: Export your custom style URL as a `MAPBOX_STYLE_URL` environment variable prior to running the demo application. Once the application starts, it'll use the url given by the envvar if set, otherwise use default styles.

Currently supports GLFW and Qt apps.