### PR TITLE
Fix broken compile on GCC

### DIFF
--- a/src/mbgl/style/class_dictionary.hpp
+++ b/src/mbgl/style/class_dictionary.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <unordered_map>
+#include <functional>
 
 namespace mbgl {
 namespace style {
@@ -34,3 +35,19 @@ private:
 
 } // namespace style
 } // namespace mbgl
+
+namespace std {
+
+// Explicitly define std::hash<style::ClassID> because GCC doesn't automatically use std::hash<> of
+// the underlying enum type.
+
+template <>
+struct hash<mbgl::style::ClassID> {
+public:
+    size_t operator()(const mbgl::style::ClassID id) const {
+        using T = std::underlying_type_t<mbgl::style::ClassID>;
+        return std::hash<T>()(static_cast<T>(id));
+    }
+};
+
+} // namespace std

--- a/test/src/mbgl/test/conversion_stubs.hpp
+++ b/test/src/mbgl/test/conversion_stubs.hpp
@@ -15,8 +15,12 @@ namespace conversion {
 class Value;
 using ValueMap = std::unordered_map<std::string, Value>;
 using ValueVector = std::vector<Value>;
-class Value : public mbgl::variant<std::string, float, bool, ValueMap, ValueVector> {
-     using variant::variant;
+class Value : public mbgl::variant<std::string,
+                                   float,
+                                   bool,
+                                   mapbox::util::recursive_wrapper<ValueMap>,
+                                   mapbox::util::recursive_wrapper<ValueVector>> {
+    using variant::variant;
 };
 
 inline bool isUndefined(const Value&) {
@@ -25,19 +29,19 @@ inline bool isUndefined(const Value&) {
 }
 
 inline bool isArray(const Value& value) {
-    return value.is<ValueVector>();
+    return value.is<mapbox::util::recursive_wrapper<ValueVector>>();
 }
 
 inline std::size_t arrayLength(const Value& value) {
-    return value.get<ValueVector>().size();
+    return value.get<mapbox::util::recursive_wrapper<ValueVector>>().get().size();
 }
 
 inline Value arrayMember(const Value& value, std::size_t i) {
-    return value.get<ValueVector>()[i];
+    return value.get<mapbox::util::recursive_wrapper<ValueVector>>().get()[i];
 }
 
 inline bool isObject(const Value& value) {
-    return value.is<ValueMap>();
+    return value.is<mapbox::util::recursive_wrapper<ValueMap>>();
 }
 
 inline optional<Value> objectMember(const Value& value, const char* key) {


### PR DESCRIPTION
The build is currently broken in GCC 5 after https://github.com/mapbox/mapbox-gl-native/pull/6324 due to a missing `std::hash` specialization for `mbgl::style::ClassID`, which doesn't automatically use the underlying enum type's `hash` implementation.

/cc @bleege 