### PR TITLE
6264 mutable geojson

### DIFF
--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -83,6 +83,7 @@ protected:
 
     Source& base;
     SourceObserver* observer = nullptr;
+    std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
 
 private:
     // TileObserver implementation.
@@ -93,7 +94,6 @@ private:
     virtual Range<uint8_t> getZoomRange() = 0;
     virtual std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) = 0;
 
-    std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
     std::map<UnwrappedTileID, RenderTile> renderTiles;
     TileCache cache;
 };

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/style/source_impl.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/util/variant.hpp>
+#include <mbgl/tile/geojson_tile.hpp>
 
 namespace mbgl {
 
@@ -19,6 +20,7 @@ public:
     optional<std::string> getURL();
 
     void setGeoJSON(const GeoJSON&);
+    void setTileData(GeoJSONTile&, const OverscaledTileID& tileID);
 
     void loadDescription(FileSource&) final;
 

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -77,9 +77,11 @@ public:
 
 GeoJSONTile::GeoJSONTile(const OverscaledTileID& overscaledTileID,
                          std::string sourceID_,
-                         const style::UpdateParameters& parameters,
-                         const mapbox::geometry::feature_collection<int16_t>& features)
+                         const style::UpdateParameters& parameters)
     : GeometryTile(overscaledTileID, sourceID_, parameters) {
+}
+    
+void GeoJSONTile::updateData(const mapbox::geometry::feature_collection<int16_t>& features) {
     setData(std::make_unique<GeoJSONTileData>(features));
 }
 

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -13,9 +13,10 @@ class GeoJSONTile : public GeometryTile {
 public:
     GeoJSONTile(const OverscaledTileID&,
                 std::string sourceID,
-                const style::UpdateParameters&,
-                const mapbox::geometry::feature_collection<int16_t>&);
+                const style::UpdateParameters&);
 
+    void updateData(const mapbox::geometry::feature_collection<int16_t>&);
+    
     void setNecessity(Necessity) final;
 };
 


### PR DESCRIPTION
References #6264, this PR follows approach as documented in OP:

>  For GeoJSON data changes, maybe we can get away without batching, and instead just add a loop over tiles in GeoJSONSource::Impl::setGeoJSON, calling GeometryTile::setData on each one with the new data.

cc @mollymerp 

