### PR TITLE
[Android] Fixed readme image and links in contributing file

### DIFF
--- a/platform/android/CONTRIBUTING_MACOS.md
+++ b/platform/android/CONTRIBUTING_MACOS.md
@@ -57,11 +57,11 @@ Run:
     // Makes arm7 ABI version of Core GL
     // Can be run on most Android phones and arm emulator
     make android
-    
+
     // Make x86 version of Core GL
     // Useful for running faster Anroid x86 emulator on Macs
     make android-lib-x86
 
 Once Core GL has been built, the TestApp can be run by selecting `MapboxGLAndroidSDKTestApp` from the Run menu or toolbar in Android Studio.
 
-**Next: get your app [running on a hardware Android Device](docs/ANDROID_DEVICE.md) or [simulator](docs/ANDROID_SIMULATOR.md)**
+**Next: get your app [running on a hardware Android Device](platform/android/README.md#running-mapbox-gl-native-on-a-hardware-android-device) or [simulator](platform/android/README.md#setting-up-the-android-emulator)**

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -6,7 +6,7 @@ A library based on [Mapbox GL Native](../../README.md) for embedding interactive
 
 **To install and use the Mapbox Android SDK in an application, see the [Mapbox Android SDK website](https://www.mapbox.com/android-sdk/).**
 
-[![](https://www.mapbox.com/android-sdk/images/splash.jpg)](https://www.mapbox.com/android-sdk/)
+[![](https://www.mapbox.com/android-sdk/images/splash.png)](https://www.mapbox.com/android-sdk/)
 
 ## Contributing to the SDK
 


### PR DESCRIPTION
Closes #6297 

Fixes broken links in macOS contributing doc and image address in readme.

cc: @tobrun @zugaldia 