### PR TITLE
Install pkg-config on Bitrise

### DIFF
--- a/platform/macos/bitrise.yml
+++ b/platform/macos/bitrise.yml
@@ -29,7 +29,7 @@ workflows:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
-            brew install cmake
+            brew install cmake pkg-config
             gem install xcpretty --no-rdoc --no-ri
             export BUILDTYPE=Debug
             make macos

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -29,7 +29,7 @@ workflows:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
-            brew install cmake
+            brew install cmake pkg-config
             brew unlink node
             brew install awscli homebrew/versions/node4-lts
             brew link homebrew/versions/node4-lts

--- a/platform/qt/bitrise-qt4.yml
+++ b/platform/qt/bitrise-qt4.yml
@@ -29,7 +29,7 @@ workflows:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
-            brew install cmake
+            brew install cmake pkg-config
             brew install qt
             brew link qt
             brew linkapps qt

--- a/platform/qt/bitrise-qt5.yml
+++ b/platform/qt/bitrise-qt5.yml
@@ -33,6 +33,7 @@ workflows:
             brew install qt5
             brew link qt5 --force
             brew linkapps qt5
+            sudo chown -R $USER /usr/local
             ln -s /usr/local/Cellar/qt5/5.6.1-1/mkspecs /usr/local/mkspecs
             ln -s /usr/local/Cellar/qt5/5.6.1-1/plugins /usr/local/plugins
             export BUILDTYPE=Debug

--- a/platform/qt/bitrise-qt5.yml
+++ b/platform/qt/bitrise-qt5.yml
@@ -29,7 +29,7 @@ workflows:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
-            brew install cmake
+            brew install cmake pkg-config
             brew install qt5
             brew link qt5 --force
             brew linkapps qt5


### PR DESCRIPTION
Bitrise’s Xcode 8 stack doesn’t have pkg-config installed, causing Mason to fail with:

```
CMake Error at .mason/mason.cmake:149 (message):
  [Mason] Could not get configuration for package glfw 3.1.2:
  /Users/vagrant/git/.mason/mason.sh: line 584: pkg-config: command not found

Call Stack (most recent call first):
  platform/macos/config.cmake:3 (mason_use)
  CMakeLists.txt:46 (include)
```

This change installs pkg-config it via Homebrew. I didn’t add it to the iOS build bot’s configuration because the iOS targets don’t appear to need it.

/cc @jfirebaugh @brunoabinader