### PR TITLE
[ios] Don't specify Swift version for jazzy doc generation

### DIFF
--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -19,8 +19,6 @@ BRANCH=$( git describe --tags --match=ios-v*.*.* --abbrev=0 )
 SHORT_VERSION=$( echo ${BRANCH} | sed 's/^ios-v//' )
 RELEASE_VERSION=$( echo ${SHORT_VERSION} | sed -e 's/^ios-v//' -e 's/-.*//' )
 
-SWIFT_VERSION=$(xcrun swift -version | head -n 1 | sed -e 's/^Apple Swift version //' -e 's/ .*$//')
-
 rm -rf /tmp/mbgl
 mkdir -p /tmp/mbgl/
 README=/tmp/mbgl/README.md
@@ -37,7 +35,6 @@ cp platform/ios/screenshot.png "${OUTPUT}"
 jazzy \
     --config platform/ios/jazzy.yml \
     --sdk iphonesimulator \
-    --swift-version $SWIFT_VERSION \
     --github-file-prefix https://github.com/mapbox/mapbox-gl-native/tree/${BRANCH} \
     --module-version ${SHORT_VERSION} \
     --readme ${README} \


### PR DESCRIPTION
Fixes #6360 by reverting #4470.

This works when using [jazzy 0.7.2](https://github.com/realm/jazzy/releases/tag/v0.7.2) with Xcode 8.0 or Xcode 7.3.1 (via `xcode-select`).

/cc @1ec5