### PR TITLE
Adjust logging level for failed OkHttp requests

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.exceptions.InvalidAccessTokenException;
@@ -94,7 +93,6 @@ public class MapboxAccountManager {
         ConnectivityManager cm = (ConnectivityManager) applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
         boolean result = (activeNetwork != null && activeNetwork.isConnected());
-        Log.v("IOUtils", "isConnected result = " + result);
         return result;
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/http/HTTPRequest.java
@@ -138,8 +138,6 @@ class HTTPRequest implements Callback {
     }
 
     private void onFailure(Exception e) {
-        Log.w(LOG_TAG, String.format("[HTTP] Request could not be executed: %s", e.getMessage()));
-
         int type = PERMANENT_ERROR;
         if ((e instanceof NoRouteToHostException) || (e instanceof UnknownHostException) || (e instanceof SocketException) || (e instanceof ProtocolException) || (e instanceof SSLException)) {
             type = CONNECTION_ERROR;
@@ -148,6 +146,18 @@ class HTTPRequest implements Callback {
         }
 
         String errorMessage = e.getMessage() != null ? e.getMessage() : "Error processing the request";
+
+        if (type == TEMPORARY_ERROR) {
+            Log.d(LOG_TAG, String.format(MapboxConstants.MAPBOX_LOCALE,
+                "Request failed due to a temporary error: %s", errorMessage));
+        } else if (type == CONNECTION_ERROR) {
+            Log.i(LOG_TAG, String.format(MapboxConstants.MAPBOX_LOCALE,
+                "Request failed due to a connection error: %s", errorMessage));
+        } else {
+            // PERMANENT_ERROR
+            Log.w(LOG_TAG, String.format(MapboxConstants.MAPBOX_LOCALE,
+                "Request failed due to a permanent error: %s", errorMessage));
+        }
 
         mLock.lock();
         if (mNativePtr != 0) {


### PR DESCRIPTION
This PR does two things:

1. Adjust logging levels for failed OkHttp requests as described in #6356.
2. Remove an unnecessary `Log` in `MapboxAccountManager` (when `isConnected` is false an exception is thrown and logged separately).

/cc: @bleege for review.

Fixes #6356.