### PR TITLE
add OS_ACTIVITY_MODE=disable for Xcode 8 spew

### DIFF
--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
@@ -61,6 +61,13 @@
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
Xcode 8 introduces a lot of console crap by default. On a stock run of the `iosapp` you see this just when launching: 

```
2016-09-19 13:25:43.354235 Mapbox GL[20870:4777188] subsystem: com.apple.UIKit, category: HIDEventFiltered, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2016-09-19 13:25:43.354676 Mapbox GL[20870:4777188] subsystem: com.apple.UIKit, category: HIDEventIncoming, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2016-09-19 13:25:43.362187 Mapbox GL[20870:4777187] subsystem: com.apple.BaseBoard, category: MachPort, enable_level: 1, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 0, privacy_setting: 0, enable_private_data: 0
2016-09-19 13:25:43.370266 Mapbox GL[20870:4777109] subsystem: com.apple.UIKit, category: StatusBar, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2016-09-19 13:25:43.442904 Mapbox GL[20870:4777202] subsystem: com.apple.libsqlite3, category: logging, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2016-09-19 13:25:43.448427 Mapbox GL[20870:4777109] subsystem: com.apple.SystemConfiguration, category: SCNetworkReachability, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 0, privacy_setting: 2, enable_private_data: 0
2016-09-19 13:25:43.469302 Mapbox GL[20870:4777109] subsystem: com.apple.UIKit, category: GestureEnvironment, enable_level: 0, persist_level: 0, default_ttl: 1, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 1, privacy_setting: 2, enable_private_data: 0
2016-09-19 13:25:43.469387 Mapbox GL[20870:4777187] subsystem: com.apple.network, category: , enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 0, privacy_setting: 2, enable_private_data: 0
2016-09-19 13:25:43.470114 Mapbox GL[20870:4777179] [] nw_endpoint_handler_start [1 events.mapbox.com:443 initial path (null)]
2016-09-19 13:25:43.470384 Mapbox GL[20870:4777179] [] nw_connection_endpoint_report [1 events.mapbox.com:443 initial path (null)] reported event path:start
2016-09-19 13:25:43.470903 Mapbox GL[20870:4777179] [] nw_connection_endpoint_report [1 events.mapbox.com:443 waiting path (satisfied)] reported event path:satisfied
2016-09-19 13:25:43.471113 Mapbox GL[20870:4777179] [] nw_connection_endpoint_report [1 events.mapbox.com:443 waiting path (satisfied)] skipping state update
2016-09-19 13:25:43.471803 Mapbox GL[20870:4777179] subsystem: com.apple.SystemConfiguration, category: SCPreferences, enable_level: 0, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 0, privacy_setting: 2, enable_private_data: 0
2016-09-19 13:25:43.472568 Mapbox GL[20870:4777179] [] nw_connection_endpoint_report [1 events.mapbox.com:443 in_progress resolver (satisfied)] reported event resolver:start_dns
2016-09-19 13:25:43.543053 Mapbox GL[20870:4777195] [] nw_endpoint_resolver_update [1 events.mapbox.com:443 in_progress resolver (satisfied)] Adding endpoint handler for 52.21.13.73:443
2016-09-19 13:25:43.543330 Mapbox GL[20870:4777195] [] nw_endpoint_resolver_update [1 events.mapbox.com:443 in_progress resolver (satisfied)] Adding endpoint handler for 52.21.101.73:443
2016-09-19 13:25:43.543536 Mapbox GL[20870:4777195] [] nw_endpoint_resolver_update [1 events.mapbox.com:443 in_progress resolver (satisfied)] Adding endpoint handler for 52.71.246.84:443
2016-09-19 13:25:43.543795 Mapbox GL[20870:4777195] [] nw_connection_endpoint_report [1 events.mapbox.com:443 in_progress resolver (satisfied)] reported event resolver:receive_dns
2016-09-19 13:25:43.544029 Mapbox GL[20870:4777195] [] nw_endpoint_resolver_start_next_child [1 events.mapbox.com:443 in_progress resolver (satisfied)] starting child endpoint 52.21.13.73:443
2016-09-19 13:25:43.544336 Mapbox GL[20870:4777195] [] nw_endpoint_resolver_start_next_child [1 events.mapbox.com:443 in_progress resolver (satisfied)] starting next child endpoint in 213ms
2016-09-19 13:25:43.544583 Mapbox GL[20870:4777195] [] nw_endpoint_handler_start [1.1 52.21.13.73:443 initial path (null)]
2016-09-19 13:25:43.544766 Mapbox GL[20870:4777195] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 initial path (null)] reported event path:start
2016-09-19 13:25:43.545256 Mapbox GL[20870:4777195] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 waiting path (satisfied)] reported event path:satisfied
2016-09-19 13:25:43.546145 Mapbox GL[20870:4777195] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 in_progress socket-flow (satisfied)] reported event flow:start_connect
2016-09-19 13:25:43.549391 Mapbox GL[20870:4777109] subsystem: com.apple.BackBoardServices.fence, category: App, enable_level: 1, persist_level: 0, default_ttl: 0, info_ttl: 0, debug_ttl: 0, generate_symptoms: 0, enable_oversize: 0, privacy_setting: 0, enable_private_data: 0
2016-09-19 13:25:43.653454 Mapbox GL[20870:4777195] [] nw_endpoint_flow_protocol_connected [1.1 52.21.13.73:443 in_progress socket-flow (satisfied)] Output protocol connected
2016-09-19 13:25:43.654848 Mapbox GL[20870:4777195] [] nw_endpoint_flow_connected_path_change [1.1 52.21.13.73:443 ready socket-flow (satisfied)] Connected path is satisfied
2016-09-19 13:25:43.655202 Mapbox GL[20870:4777195] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 ready socket-flow (satisfied)] reported event flow:finish_connect
2016-09-19 13:25:43.655766 Mapbox GL[20870:4777195] [] nw_connection_endpoint_report [1 events.mapbox.com:443 ready resolver (satisfied)] reported event flow:finish_connect
2016-09-19 13:25:43.656602 Mapbox GL[20870:4777195] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 ready socket-flow (satisfied)] reported event flow:changed_viability
2016-09-19 13:25:43.657100 Mapbox GL[20870:4777195] [] nw_connection_endpoint_report [1 events.mapbox.com:443 ready resolver (satisfied)] reported event flow:changed_viability
2016-09-19 13:25:43.658042 Mapbox GL[20870:4777215] [] nw_endpoint_start_tls_while_connected [1.1 52.21.13.73:443 ready socket-flow (satisfied)]
2016-09-19 13:25:43.658974 Mapbox GL[20870:4777215] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 in_progress socket-flow (satisfied)] reported event flow:start_secondary_connect
2016-09-19 13:25:43.659282 Mapbox GL[20870:4777215] [] nw_connection_endpoint_report [1 events.mapbox.com:443 in_progress resolver (satisfied)] reported event flow:start_secondary_connect
2016-09-19 13:25:43.659492 Mapbox GL[20870:4777215] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 in_progress socket-flow (satisfied)] reported event flow:start_connect
2016-09-19 13:25:43.659716 Mapbox GL[20870:4777215] [] nw_connection_endpoint_report [1 events.mapbox.com:443 in_progress resolver (satisfied)] reported event flow:start_connect
2016-09-19 13:25:43.659941 Mapbox GL[20870:4777215] [] nw_endpoint_flow_protocol_connected [1.1 52.21.13.73:443 in_progress socket-flow (satisfied)] Transport protocol connected
2016-09-19 13:25:43.660138 Mapbox GL[20870:4777215] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 in_progress socket-flow (satisfied)] reported event flow:finish_transport
2016-09-19 13:25:43.660385 Mapbox GL[20870:4777215] [] nw_connection_endpoint_report [1 events.mapbox.com:443 in_progress resolver (satisfied)] reported event flow:finish_transport
2016-09-19 13:25:43.937734 Mapbox GL[20870:4777215] [] nw_endpoint_flow_protocol_connected [1.1 52.21.13.73:443 in_progress socket-flow (satisfied)] Output protocol connected
2016-09-19 13:25:43.938509 Mapbox GL[20870:4777215] [] nw_endpoint_flow_connected_path_change [1.1 52.21.13.73:443 ready socket-flow (satisfied)] Connected path is satisfied
2016-09-19 13:25:43.938718 Mapbox GL[20870:4777215] [] nw_connection_endpoint_report [1.1 52.21.13.73:443 ready socket-flow (satisfied)] reported event flow:finish_connect
2016-09-19 13:25:43.938934 Mapbox GL[20870:4777215] [] nw_connection_endpoint_report [1 events.mapbox.com:443 ready resolver (satisfied)] reported event flow:finish_connect
```

What is this, _Android Studio_?! 

The [trick](https://twitter.com/timonus/status/775719734981427200) is an environment variable in the scheme. This PR adds it to the shared scheme for `iosapp`. 

Apple might (will probably) get rid of this in future, but this gets ahead of some hassle until such time. 

/cc @boundsj @friedbunny @1ec5 @bleege @frederoni 