### PR TITLE
[core] MapChangeDidFinishLoadingStyle - Ensure style is loaded

### DIFF
--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -103,10 +103,7 @@ void Style::setJSON(const std::string& json) {
         Log::Error(Event::ParseStyle, "Failed to parse style: %s", util::toString(error).c_str());
         observer->onStyleError();
         observer->onResourceError(error);
-
         return;
-    } else {
-        observer->onStyleLoaded();
     }
 
     for (auto& source : parser.sources) {
@@ -127,6 +124,8 @@ void Style::setJSON(const std::string& json) {
     spriteAtlas->load(parser.spriteURL, fileSource);
 
     loaded = true;
+    
+    observer->onStyleLoaded();
 }
 
 void Style::addSource(std::unique_ptr<Source> source) {


### PR DESCRIPTION
In reworking the fix in #6371 the `MapChangeDidFinishLoadingStyle` signal is now sent a little too early. This results in style manipulations in the form of layer additions not showing up correctly as the layers/sources from the style itself are not added yet. This change fixes that.

@tmpsantos Could you please review this change as you also looked at #6371?