### PR TITLE
Remove tiles from source when source is disabled

### DIFF
--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -146,6 +146,19 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
         cache.setSize(conservativeCacheSize);
     }
 
+    removeStaleTiles(retain);
+
+    const PlacementConfig config { parameters.transformState.getAngle(),
+                                   parameters.transformState.getPitch(),
+                                   parameters.debugOptions & MapDebugOptions::Collision };
+
+    for (auto& pair : tiles) {
+        pair.second->setPlacementConfig(config);
+    }
+}
+
+// Moves all tiles to the cache except for those specified in the retain set.
+void Source::Impl::removeStaleTiles(const std::set<OverscaledTileID>& retain) {
     // Remove stale tiles. This goes through the (sorted!) tiles map and retain set in lockstep
     // and removes items from tiles that don't have the corresponding key in the retain set.
     auto tilesIt = tiles.begin();
@@ -162,13 +175,12 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
             ++retainIt;
         }
     }
+}
 
-    const PlacementConfig config { parameters.transformState.getAngle(),
-                                   parameters.transformState.getPitch(),
-                                   parameters.debugOptions & MapDebugOptions::Collision };
-
-    for (auto& pair : tiles) {
-        pair.second->setPlacementConfig(config);
+void Source::Impl::removeTiles() {
+    renderTiles.clear();
+    if (!tiles.empty()) {
+        removeStaleTiles({});
     }
 }
 

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -48,6 +48,9 @@ public:
     // re-placement of existing complete tiles.
     void updateTiles(const UpdateParameters&);
 
+    // Removes all tiles (by putting them into the cache).
+    void removeTiles();
+
     // Request that all loaded tiles re-run the layout operation on the existing source
     // data with fresh style information.
     void reloadTiles();
@@ -82,6 +85,7 @@ public:
 
 protected:
     void invalidateTiles();
+    void removeStaleTiles(const std::set<OverscaledTileID>&);
 
     Source& base;
     SourceObserver* observer = nullptr;

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -251,6 +251,8 @@ void Style::cascade(const TimePoint& timePoint, MapMode mode) {
 }
 
 void Style::recalculate(float z, const TimePoint& timePoint, MapMode mode) {
+    // Disable all sources first. If we find an enabled layer that uses this source, we will
+    // re-enable it later.
     for (const auto& source : sources) {
         source->baseImpl->enabled = false;
     }
@@ -282,6 +284,13 @@ void Style::recalculate(float z, const TimePoint& timePoint, MapMode mode) {
             if (!source->baseImpl->loaded) {
                 source->baseImpl->loadDescription(fileSource);
             }
+        }
+    }
+
+    // Remove the existing tiles if we didn't end up re-enabling the source.
+    for (const auto& source : sources) {
+        if (!source->baseImpl->enabled) {
+            source->baseImpl->removeTiles();
         }
     }
 }


### PR DESCRIPTION
As a followup to #6345: When no layer of a source is visible anymore, we are currently disabling the source, but we don't evict tiles that are still stored in that source.