### PR TITLE
Link Qt tests with Mason sqlite

### DIFF
--- a/platform/qt/config.cmake
+++ b/platform/qt/config.cmake
@@ -54,6 +54,8 @@ macro(mbgl_platform_test)
         PROPERTIES COMPILE_FLAGS -DWORK_DIRECTORY="${CMAKE_SOURCE_DIR}"
     )
 
+    target_add_mason_package(mbgl-test PRIVATE sqlite)
+
     target_link_libraries(mbgl-test
         ${MBGL_QT_LIBRARIES}
     )


### PR DESCRIPTION
The Qt version of `mbgl-test` isn't linked with the Mason version of SQLite we're using. On most systems, `sqlite.h` is installed, so we haven't seen any errors from this, but it might mean that we're using headers for a SQLite version that doesn't match the one we're actually linking.