### PR TITLE
[android] - increase firebase test timeout to 15 minutes

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
             sudo apt-get update && sudo apt-get install google-cloud-sdk
             gcloud auth activate-service-account --key-file secret.json --project android-gl-native
             gcloud beta test android devices list
-            gcloud beta test android run --type instrumentation --app platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug.apk --test platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug-androidTest-unaligned.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
+            gcloud beta test android run --type instrumentation --app platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug.apk --test platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug-androidTest-unaligned.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 15m
     - script:
         title: Download test results
         is_always_run: true


### PR DESCRIPTION
Increases timeout on the firebase tests to 15 minutes.

cc @ivovandongen 