### PR TITLE
fix bad conditional in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   - make run-test
 after_script:
   - ccache --show-stats
-  - ./platform/linux/scripts/after_script.sh ${TRAVIS_JOB_NUMBER} ${TRAVIS_TAG:-}
+  - ./platform/linux/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
 
 matrix:
   include:
@@ -63,16 +63,16 @@ matrix:
       addons: *clang35
       before_script:
         - export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-        - export PUBLISH=$([[ ${TAG} == "node-v${PACKAGE_JSON_VERSION}" ]] && echo 1 || echo 0)
-        - export BUILDTYPE=$([[ ${PUBLISH} ]] && echo "Release" || echo "Debug")
+        - export PUBLISH=$([[ "${TRAVIS_TAG:-}" == "node-v${PACKAGE_JSON_VERSION}" ]] && echo true)
+        - export BUILDTYPE=$([[ -n ${PUBLISH:-} ]] && echo "Release" || echo "Debug")
       script:
         - nvm install 4
         - nvm use 4
         - make node
-        - if [[ ! ${PUBLISH} ]]; then make test-node; fi
+        - if [[ -z ${PUBLISH} ]]; then make test-node; fi
       after_script:
         - ccache --show-stats
-        - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER} ${TRAVIS_TAG:-}
+        - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
 
     # GCC 5 - Debug - Coverage
     - os: linux

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#a6c95d33ff5ced2c0d7df995fd89eb557c0a353c",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#880c1879b29ccdb473b3888fc2134d5261efb7d3",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#694f0d0728f229d64d1639dc5ee7aff7f4b8ca41",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/platform/node/scripts/after_script.sh
+++ b/platform/node/scripts/after_script.sh
@@ -4,10 +4,9 @@ set -e
 set -o pipefail
 
 JOB=$1
-TAG=$2
 
-if [[ ${PUBLISH} ]]; then
-    if [[ "$BUILDTYPE" == "Debug" ]]; then
+if [[ -n ${PUBLISH:-} ]]; then
+    if [[ "${BUILDTYPE}" == "Debug" ]]; then
         echo "Please run this script in release mode (BUILDTYPE=Release)."
         exit 1
     else


### PR DESCRIPTION
To actually run Node.js tests, refs https://github.com/mapbox/mapbox-gl-native/pull/6226#issuecomment-248322166. Why are conditionals in bash so complicated.

@tmpsantos `npm run test-memory` is currently not included in `make test-node` - should it be? This slows downs the tests on Travis substantially, but appears to be passing.

There is currently a single failing test in `npm run test-suite` (passing locally on OS X though). Is this just an anti-aliasing difference where we could bump up the [`allowed`](https://github.com/mapbox/mapbox-gl-test-suite/blob/master/render-tests/text-font/chinese/style.json#L7) threshold slightly, or is there something wrong I'm not seeing @amyleew?

![download](https://cloud.githubusercontent.com/assets/1149913/18689686/7a6b448e-7f58-11e6-91f9-3846c2549031.png)

![download 1](https://cloud.githubusercontent.com/assets/1149913/18689685/7a64ba06-7f58-11e6-9ab9-d2e8ea106cb6.png)

- diff: 0.00057220458984375
- zoom: 11
- center: -70.751953125,43.38904828677382
- width: 512
- height: 512

/cc @tmpsantos