### PR TITLE
[core] Don't use depth test unless text is pitch-aligned to map

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#a6c95d33ff5ced2c0d7df995fd89eb557c0a353c",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#8ae22e5928d11fa578c17bfd734ed5377beb7bec",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#99844eaf09622b0972e740f87cd9d73487e245f5",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#a6c95d33ff5ced2c0d7df995fd89eb557c0a353c",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#e05680a27f93d7284fce31b9b42a19c80df96b13",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#8ae22e5928d11fa578c17bfd734ed5377beb7bec",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#a6c95d33ff5ced2c0d7df995fd89eb557c0a353c",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#99844eaf09622b0972e740f87cd9d73487e245f5",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#4ee7865bdcde287c1fc06e20a25c60550d37c474",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#a6c95d33ff5ced2c0d7df995fd89eb557c0a353c",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#4ee7865bdcde287c1fc06e20a25c60550d37c474",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#880c1879b29ccdb473b3888fc2134d5261efb7d3",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -224,7 +224,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
     }
 
     if (bucket.hasTextData()) {
-        if (layout.textRotationAlignment == AlignmentType::Map) {
+        if (layout.textPitchAlignment == AlignmentType::Map) {
             config.depthFunc.reset();
             config.depthTest = GL_TRUE;
         } else {

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -94,8 +94,6 @@ void Painter::renderSDF(SymbolBucket& bucket,
         sdfShader.u_color = haloColor;
         sdfShader.u_opacity = opacity;
         sdfShader.u_buffer = (haloOffset - haloWidth / fontScale) / sdfPx;
-
-        setDepthSublayer(0);
         (bucket.*drawSDF)(sdfShader, store, paintMode());
     }
 
@@ -105,8 +103,6 @@ void Painter::renderSDF(SymbolBucket& bucket,
         sdfShader.u_color = color;
         sdfShader.u_opacity = opacity;
         sdfShader.u_buffer = (256.0f - 64.0f) / 256.0f;
-
-        setDepthSublayer(1);
         (bucket.*drawSDF)(sdfShader, store, paintMode());
     }
 }
@@ -140,6 +136,8 @@ void Painter::renderSymbol(PaintParameters& parameters,
         config.stencilOp.reset();
         config.stencilTest = GL_TRUE;
     }
+
+    setDepthSublayer(0);
 
     if (bucket.hasIconData()) {
         if (layout.iconRotationAlignment == AlignmentType::Map) {
@@ -218,7 +216,6 @@ void Painter::renderSymbol(PaintParameters& parameters,
             frameHistory.bind(store, config, 1);
             iconShader.u_fadetexture = 1;
 
-            setDepthSublayer(0);
             bucket.drawIcons(iconShader, store, paintMode());
         }
     }
@@ -265,7 +262,6 @@ void Painter::renderSymbol(PaintParameters& parameters,
         collisionBoxShader.u_maxzoom = (tile.id.canonical.z + 1) * 10;
         config.lineWidth = 1.0f;
 
-        setDepthSublayer(0);
         bucket.drawCollisionBoxes(collisionBoxShader, store);
 
     }

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -67,7 +67,7 @@ void Painter::renderSDF(SymbolBucket& bucket,
     sdfShader.u_rotate_with_map = rotateWithMap;
     sdfShader.u_pitch_with_map = pitchWithMap;
     sdfShader.u_texture = 0;
-    sdfShader.u_pitch = state.getPitch() * util::DEG2RAD;
+    sdfShader.u_pitch = state.getPitch();
     sdfShader.u_bearing = -1.0f * state.getAngle();
     sdfShader.u_aspect_ratio = (state.getWidth() * 1.0f) / (state.getHeight() * 1.0f);
 


### PR DESCRIPTION
Capturing the stopgap fix for a viewport-oriented clipped text bug, similar to issue reported in https://github.com/mapbox/mapbox-gl-js/issues/2074#issuecomment-242253307 for GL JS but in the context of viewport pitched labels.

- [x] better explanation of the issue (https://github.com/mapbox/mapbox-gl-test-suite/pull/147)
- [x] render tests (https://github.com/mapbox/mapbox-gl-test-suite/pull/147)
- [x] corresponding/somewhat opposite fix on GL JS (https://github.com/mapbox/mapbox-gl-js/pull/3243)
- [x] review

cc @ansis 