### PR TITLE
proper use of nullability for source & layer querying

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -187,7 +187,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  
  @return source An instance of an `MGLSource` subclass.
  */
-- (MGLSource *)sourceWithIdentifier:(NSString *)identifier;
+- (nullable MGLSource *)sourceWithIdentifier:(NSString *)identifier;
 
 /**
  Adds a new layer on top of existing layers.

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -92,19 +92,11 @@ static NSURL *MGLStyleURL_emerald;
     return @(self.mapView.mbglMap->getStyleName().c_str());
 }
 
-- (mbgl::style::Layer *)mbglLayerWithIdentifier:(NSString *)identifier
-{
-    return self.mapView.mbglMap->getLayer(identifier.UTF8String);
-}
-
-- (mbgl::style::Source *)mbglSourceWithIdentifier:(NSString *)identifier
-{
-    return self.mapView.mbglMap->getSource(identifier.UTF8String);
-}
-
 - (id <MGLStyleLayer>)layerWithIdentifier:(NSString *)identifier
 {
     auto layer = self.mapView.mbglMap->getLayer(identifier.UTF8String);
+
+    if (!layer) return nil;
     
     Class clazz = [self classFromLayer:layer];
     
@@ -119,6 +111,8 @@ static NSURL *MGLStyleURL_emerald;
 - (MGLSource *)sourceWithIdentifier:(NSString *)identifier
 {
     auto s = self.mapView.mbglMap->getSource(identifier.UTF8String);
+
+    if (!s) return nil;
     
     Class clazz = [self classFromSource:s];
     


### PR DESCRIPTION
The core functions here can return `nullptr` if queries aren't found, yet we proceed merrily until the user gets a runtime crash. We should instead follow Cocoa convention and return `nil` early. 

This also touches up source querying to also support `nullable`. 

Also curious about the background of the dead code. 

/cc @1ec5 @frederoni 