### PR TITLE
Core support for source-driven attribution

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -155,6 +155,7 @@ public:
     style::Source* getSource(const std::string& sourceID);
     void addSource(std::unique_ptr<style::Source>);
     void removeSource(const std::string& sourceID);
+    std::vector<std::string> getAttributions() const;
 
     // Layers
     style::Layer* getLayer(const std::string& layerID);

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -45,7 +45,8 @@ enum MapChange {
     MapChangeWillStartRenderingMap,
     MapChangeDidFinishRenderingMap,
     MapChangeDidFinishRenderingMapFullyRendered,
-    MapChangeDidFinishLoadingStyle
+    MapChangeDidFinishLoadingStyle,
+    MapChangeSourceAttributionDidChange
 };
 
 struct Q_DECL_EXPORT CameraOptions {

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -95,7 +95,6 @@ public:
         NorthLeftwards,
     };
 
-
     QMapboxGL(QObject *parent = 0, const QMapboxGLSettings& = QMapboxGLSettings());
     virtual ~QMapboxGL();
 

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -32,6 +32,7 @@ static_assert(mbgl::underlying_type(QMapbox::MapChangeWillStartRenderingMap) == 
 static_assert(mbgl::underlying_type(QMapbox::MapChangeDidFinishRenderingMap) == mbgl::underlying_type(mbgl::MapChangeDidFinishRenderingMap), "error");
 static_assert(mbgl::underlying_type(QMapbox::MapChangeDidFinishRenderingMapFullyRendered) == mbgl::underlying_type(mbgl::MapChangeDidFinishRenderingMapFullyRendered), "error");
 static_assert(mbgl::underlying_type(QMapbox::MapChangeDidFinishLoadingStyle) == mbgl::underlying_type(mbgl::MapChangeDidFinishLoadingStyle), "error");
+static_assert(mbgl::underlying_type(QMapbox::MapChangeSourceAttributionDidChange) == mbgl::underlying_type(mbgl::MapChangeSourceAttributionDidChange), "error");
 
 namespace QMapbox {
 

--- a/src/mbgl/map/change.hpp
+++ b/src/mbgl/map/change.hpp
@@ -19,7 +19,8 @@ enum MapChange : uint8_t {
     MapChangeWillStartRenderingMap = 11,
     MapChangeDidFinishRenderingMap = 12,
     MapChangeDidFinishRenderingMapFullyRendered = 13,
-    MapChangeDidFinishLoadingStyle = 14
+    MapChangeDidFinishLoadingStyle = 14,
+    MapChangeSourceAttributionDidChange = 15
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -38,6 +38,7 @@ class Map::Impl : public style::Observer {
 public:
     Impl(View&, FileSource&, MapMode, GLContextMode, ConstrainMode, ViewportMode);
 
+    void onSourceAttributionChanged(style::Source&, const std::string&) override;
     void onUpdate(Update) override;
     void onStyleLoaded() override;
     void onStyleError() override;
@@ -785,6 +786,10 @@ void Map::removeSource(const std::string& sourceID) {
     }
 }
 
+std::vector<std::string> Map::getAttributions() const {
+    return impl->style ? impl->style->getAttributions() : std::vector<std::string>();
+}
+
 style::Layer* Map::getLayer(const std::string& layerID) {
     if (impl->style) {
         impl->styleMutated = true;
@@ -978,6 +983,10 @@ void Map::onLowMemory() {
     if (!impl->style) return;
     impl->style->onLowMemory();
     impl->view.invalidate();
+}
+
+void Map::Impl::onSourceAttributionChanged(style::Source&, const std::string&) {
+    view.notifyMapChange(MapChangeSourceAttributionDidChange);
 }
 
 void Map::Impl::onUpdate(Update flags) {

--- a/src/mbgl/style/source_observer.hpp
+++ b/src/mbgl/style/source_observer.hpp
@@ -17,6 +17,7 @@ public:
     virtual ~SourceObserver() = default;
 
     virtual void onSourceLoaded(Source&) {}
+    virtual void onSourceAttributionChanged(Source&, const std::string&) {}
     virtual void onSourceError(Source&, std::exception_ptr) {}
 
     virtual void onTileChanged(Source&, const OverscaledTileID&) {}

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -67,6 +67,7 @@ public:
     Source* getSource(const std::string& id) const;
     void addSource(std::unique_ptr<Source>);
     void removeSource(const std::string& sourceID);
+    std::vector<std::string> getAttributions() const;
 
     std::vector<const Layer*> getLayers() const;
     Layer* getLayer(const std::string& id) const;
@@ -132,6 +133,7 @@ private:
 
     // SourceObserver implementation.
     void onSourceLoaded(Source&) override;
+    void onSourceAttributionChanged(Source&, const std::string&) override;
     void onSourceError(Source&, std::exception_ptr) override;
     void onTileChanged(Source&, const OverscaledTileID&) override;
     void onTileError(Source&, const OverscaledTileID&, std::exception_ptr) override;

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -82,6 +82,7 @@ void TileSourceImpl::loadDescription(FileSource& fileSource) {
             }
 
             // Check whether previous information specifies different tile
+            bool attributionChanged = false;
             if (tileset.tiles != newTileset.tiles) {
                 // Tile URLs changed: force tiles to be reloaded.
                 invalidateTiles();
@@ -95,8 +96,8 @@ void TileSourceImpl::loadDescription(FileSource& fileSource) {
                 // This is done automatically when we trigger the onSourceLoaded observer below.
 
                 // Attribution changed: We need to notify the embedding application that this
-                // changed. See https://github.com/mapbox/mapbox-gl-native/issues/2723
-                // This is not yet implemented.
+                // changed.
+                attributionChanged = true;
 
                 // Center/bounds changed: We're not using these values currently
             }
@@ -105,6 +106,9 @@ void TileSourceImpl::loadDescription(FileSource& fileSource) {
             loaded = true;
 
             observer->onSourceLoaded(base);
+            if (attributionChanged) {
+                observer->onSourceAttributionChanged(base, newTileset.attribution);
+            }
         }
     });
 }
@@ -112,6 +116,10 @@ void TileSourceImpl::loadDescription(FileSource& fileSource) {
 Range<uint8_t> TileSourceImpl::getZoomRange() {
     assert(loaded);
     return tileset.zoomRange;
+}
+
+std::string TileSourceImpl::getAttribution() const {
+    return loaded ? tileset.attribution : "";
 }
 
 } // namespace style

--- a/src/mbgl/style/tile_source_impl.hpp
+++ b/src/mbgl/style/tile_source_impl.hpp
@@ -33,6 +33,8 @@ public:
     const variant<std::string, Tileset>& getURLOrTileset() const {
         return urlOrTileset;
     }
+    
+    std::string getAttribution() const;
 
 protected:
     Range<uint8_t> getZoomRange() final;

--- a/test/src/mbgl/test/stub_style_observer.hpp
+++ b/test/src/mbgl/test/stub_style_observer.hpp
@@ -6,7 +6,7 @@ using namespace mbgl;
 using namespace mbgl::style;
 
 /**
- * An implementation of style::Observer that forwards all methods to dynamically-settable lambas.
+ * An implementation of style::Observer that forwards all methods to dynamically-settable lambdas.
  */
 class StubStyleObserver : public style::Observer {
 public:
@@ -28,6 +28,10 @@ public:
 
     void onSourceLoaded(Source& source) override {
         if (sourceLoaded) sourceLoaded(source);
+    }
+
+    void onSourceAttributionChanged(Source& source, const std::string& attribution) override {
+        if (sourceAttributionChanged) sourceAttributionChanged(source, attribution);
     }
 
     void onSourceError(Source& source, std::exception_ptr error) override {
@@ -52,6 +56,7 @@ public:
     std::function<void ()> spriteLoaded;
     std::function<void (std::exception_ptr)> spriteError;
     std::function<void (Source&)> sourceLoaded;
+    std::function<void (Source&, std::string)> sourceAttributionChanged;
     std::function<void (Source&, std::exception_ptr)> sourceError;
     std::function<void (Source&, const OverscaledTileID&)> tileChanged;
     std::function<void (Source&, const OverscaledTileID&, std::exception_ptr)> tileError;


### PR DESCRIPTION
Implemented observer callbacks so the style knows when the source’s attribution changes and the map knows when the style’s attribution changes. Also implemented a getter for a tile source’s attribution.

Working towards #2723. Blocks #5999.

/cc @tmpsantos