### PR TITLE
[android] user agent string

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -41,6 +41,9 @@ android {
     defaultConfig {
         minSdkVersion Integer.parseInt(project.ANDROID_MIN_SDK)
         targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
+        buildConfigField "String", "MAPBOX_EVENTS_USER_AGENT_BASE", String.format("\"MapboxEventsAndroid/%s\"", project.VERSION_NAME)
+        buildConfigField "String", "MAPBOX_VERSION_STRING", String.format("\"Mapbox/%s\"", project.VERSION_NAME)
+        buildConfigField "String", "GIT_REVISION_SHORT", String.format("\"%s\"", getGitRevision())
     }
 
     sourceSets {
@@ -64,12 +67,10 @@ android {
     buildTypes {
         debug {
             jniDebuggable true
-            buildConfigField "String", "MAPBOX_EVENTS_USER_AGENT_BASE", new StringBuilder().append("\"").append("MapboxEventsAndroid/").append(project.VERSION_NAME).append("\"").toString()
         }
 
         release {
             jniDebuggable false
-            buildConfigField "String", "MAPBOX_EVENTS_USER_AGENT_BASE", new StringBuilder().append("\"").append("MapboxEventsAndroid/").append(project.VERSION_NAME).append("\"").toString()
             consumerProguardFiles 'proguard-rules.pro'
         }
     }
@@ -157,6 +158,12 @@ def getRepositoryPassword() {
             (hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : "")
 }
 
+def getGitRevision() {
+    def cmd = "git rev-parse --short HEAD"
+    def proc = cmd.execute()
+    def ref = proc.text.trim()
+    return ref
+}
 
 task apklib(type: Zip) {
     appendix = extension = 'apklib'

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
@@ -101,4 +101,12 @@ public class MapboxAccountManager {
         return (activeNetwork != null && activeNetwork.isConnected());
     }
 
+    /**
+     * Not public API
+     * @return the Application Context
+     */
+    public Context getApplicationContext() {
+        return applicationContext;
+    }
+
 }

--- a/platform/android/src/http_file_source.cpp
+++ b/platform/android/src/http_file_source.cpp
@@ -83,12 +83,11 @@ HTTPRequest::HTTPRequest(jni::JNIEnv& env, const Resource& resource_, FileSource
     jni::UniqueLocalFrame frame = jni::PushLocalFrame(env, 10);
 
     static auto constructor =
-        javaClass.GetConstructor<jni::jlong, jni::String, jni::String, jni::String, jni::String>(env);
+        javaClass.GetConstructor<jni::jlong, jni::String, jni::String, jni::String>(env);
 
     javaRequest = javaClass.New(env, constructor,
         reinterpret_cast<jlong>(this),
         jni::Make<jni::String>(env, resource.url),
-        jni::Make<jni::String>(env, "MapboxGL/1.0"),
         jni::Make<jni::String>(env, etagStr),
         jni::Make<jni::String>(env, modifiedStr)).NewGlobalRef(env);
 }


### PR DESCRIPTION
Fixes #1993 

Example user agent string:

```
com.mapbox.mapboxsdk.testapp/4.1.0 (9) Mapbox/4.2.0-SNAPSHOT (0c25615) Android/24 (armeabi-v7a)
```
eg: 

```
<app packagename>/<app version string> (<app version code>) Mapbox/<SDK version> (<git revision>) Android/<API level> (ABI)
```

cc @mick 