### PR TITLE
Color interpolation with configurable color spaces

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -95,6 +95,7 @@ set(MBGL_TEST_FILES
 
     # util
     test/util/async_task.test.cpp
+    test/util/color.cpp
     test/util/geo.test.cpp
     test/util/http_timeout.test.cpp
     test/util/image.test.cpp

--- a/include/mbgl/style/function.hpp
+++ b/include/mbgl/style/function.hpp
@@ -23,14 +23,17 @@ public:
     explicit Function(Stops stops_, float base_)
         : base(base_), stops(std::move(stops_)) {}
 
+    explicit Function(Stops stops_, float base_, ColorSpace colorSpace_)
+        : base(base_), stops(std::move(stops_)), colorSpace(colorSpace_) {}
+
     float getBase() const { return base; }
     ColorSpace getColorSpace() const { return colorSpace; }
     const std::vector<std::pair<float, T>>& getStops() const { return stops; }
 
 private:
     float base = 1;
-    ColorSpace colorSpace = ColorSpace::RGB;
     std::vector<std::pair<float, T>> stops;
+    ColorSpace colorSpace = ColorSpace::RGB;
 
     template <class S> friend bool operator==(const Function<S>&, const Function<S>&);
 };

--- a/include/mbgl/style/function.hpp
+++ b/include/mbgl/style/function.hpp
@@ -3,6 +3,14 @@
 #include <vector>
 #include <utility>
 
+using EnumType = uint32_t;
+
+enum class ColorSpace : EnumType {
+    RGB,
+    LAB,
+    HCL
+};
+
 namespace mbgl {
 namespace style {
 
@@ -16,10 +24,12 @@ public:
         : base(base_), stops(std::move(stops_)) {}
 
     float getBase() const { return base; }
+    ColorSpace getColorSpace() const { return colorSpace; }
     const std::vector<std::pair<float, T>>& getStops() const { return stops; }
 
 private:
     float base = 1;
+    ColorSpace colorSpace = ColorSpace::RGB;
     std::vector<std::pair<float, T>> stops;
 
     template <class S> friend bool operator==(const Function<S>&, const Function<S>&);
@@ -27,7 +37,9 @@ private:
 
 template <class T>
 bool operator==(const Function<T>& lhs, const Function<T>& rhs) {
-    return lhs.base == rhs.base && lhs.stops == rhs.stops;
+    return lhs.base == rhs.base &&
+        lhs.stops == rhs.stops &&
+        lhs.colorSpace == rhs.colorSpace;
 }
 
 template <class T>

--- a/include/mbgl/style/function.hpp
+++ b/include/mbgl/style/function.hpp
@@ -3,9 +3,7 @@
 #include <vector>
 #include <utility>
 
-using EnumType = uint32_t;
-
-enum class ColorSpace : EnumType {
+enum class ColorSpace {
     RGB,
     LAB,
     HCL
@@ -20,10 +18,7 @@ public:
     using Stop = std::pair<float, T>;
     using Stops = std::vector<Stop>;
 
-    explicit Function(Stops stops_, float base_)
-        : base(base_), stops(std::move(stops_)) {}
-
-    explicit Function(Stops stops_, float base_, ColorSpace colorSpace_)
+    explicit Function(Stops stops_, float base_, ColorSpace colorSpace_ = ColorSpace::RGB)
         : base(base_), stops(std::move(stops_)), colorSpace(colorSpace_) {}
 
     float getBase() const { return base; }

--- a/include/mbgl/util/color.hpp
+++ b/include/mbgl/util/color.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/color_lab.hpp>
 
 #include <string>
 
@@ -13,6 +14,8 @@ public:
     float g = 0.0f;
     float b = 0.0f;
     float a = 0.0f;
+
+    optional<ColorLAB> to_lab();
 
     static constexpr Color black() { return { 0.0f, 0.0f, 0.0f, 1.0f }; };
     static constexpr Color white() { return { 1.0f, 1.0f, 1.0f, 1.0f }; };

--- a/include/mbgl/util/color.hpp
+++ b/include/mbgl/util/color.hpp
@@ -16,12 +16,14 @@ public:
     float b = 0.0f;
     float a = 0.0f;
 
-    optional<ColorLAB> to_lab();
-    optional<ColorHCL> to_hcl();
+    ColorLAB to_lab();
+    ColorHCL to_hcl();
 
     static constexpr Color black() { return { 0.0f, 0.0f, 0.0f, 1.0f }; };
     static constexpr Color white() { return { 1.0f, 1.0f, 1.0f, 1.0f }; };
 
+    static Color from_lab(const ColorLAB);
+    static Color from_hcl(const ColorHCL);
     static optional<Color> parse(const std::string&);
 };
 

--- a/include/mbgl/util/color.hpp
+++ b/include/mbgl/util/color.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/color_lab.hpp>
+#include <mbgl/util/color_hcl.hpp>
 
 #include <string>
 
@@ -16,6 +17,7 @@ public:
     float a = 0.0f;
 
     optional<ColorLAB> to_lab();
+    optional<ColorHCL> to_hcl();
 
     static constexpr Color black() { return { 0.0f, 0.0f, 0.0f, 1.0f }; };
     static constexpr Color white() { return { 1.0f, 1.0f, 1.0f, 1.0f }; };

--- a/include/mbgl/util/color.hpp
+++ b/include/mbgl/util/color.hpp
@@ -16,14 +16,14 @@ public:
     float b = 0.0f;
     float a = 0.0f;
 
-    ColorLAB to_lab();
-    ColorHCL to_hcl();
+    ColorLAB toLAB();
+    ColorHCL toHCL();
 
     static constexpr Color black() { return { 0.0f, 0.0f, 0.0f, 1.0f }; };
     static constexpr Color white() { return { 1.0f, 1.0f, 1.0f, 1.0f }; };
 
-    static Color from_lab(const ColorLAB);
-    static Color from_hcl(const ColorHCL);
+    static Color fromLAB(const ColorLAB&);
+    static Color fromHCL(const ColorHCL&);
     static optional<Color> parse(const std::string&);
 };
 

--- a/include/mbgl/util/color_hcl.hpp
+++ b/include/mbgl/util/color_hcl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/color.hpp>
 #include <string>
 
 namespace mbgl {

--- a/include/mbgl/util/color_hcl.hpp
+++ b/include/mbgl/util/color_hcl.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <mbgl/util/optional.hpp>
+#include <string>
+
+namespace mbgl {
+
+// Stores a HCL color, with all four channels ranging from 0..1
+class ColorHCL {
+public:
+    float h = 0.0f;
+    float c = 0.0f;
+    float l = 0.0f;
+    float A = 0.0f;
+};
+
+constexpr bool operator==(const ColorHCL& colorA, const ColorHCL& colorB) {
+    return colorA.h == colorB.h &&
+        colorA.c == colorB.c &&
+        colorA.l == colorB.l &&
+        colorA.A == colorB.A;
+}
+
+constexpr bool operator!=(const ColorHCL& colorA, const ColorHCL& colorB) {
+    return !(colorA == colorB);
+}
+
+} // namespace mbgl

--- a/include/mbgl/util/color_lab.hpp
+++ b/include/mbgl/util/color_lab.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <mbgl/util/optional.hpp>
+#include <string>
+
+namespace mbgl {
+
+// Stores a LAB color, with all four channels ranging from 0..1
+class ColorLAB {
+public:
+    float l = 0.0f;
+    float a = 0.0f;
+    float b = 0.0f;
+    float A = 0.0f;
+};
+
+constexpr bool operator==(const ColorLAB& colorA, const ColorLAB& colorB) {
+    return colorA.l == colorB.l && colorA.a == colorB.a && colorA.b == colorB.b && colorA.A == colorB.A;
+}
+
+constexpr bool operator!=(const ColorLAB& colorA, const ColorLAB& colorB) {
+    return !(colorA == colorB);
+}
+
+} // namespace mbgl

--- a/include/mbgl/util/color_lab.hpp
+++ b/include/mbgl/util/color_lab.hpp
@@ -13,7 +13,6 @@ public:
     float a = 0.0f;
     float b = 0.0f;
     float A = 0.0f;
-    optional<Color> to_rgb();
 };
 
 constexpr bool operator==(const ColorLAB& colorA, const ColorLAB& colorB) {

--- a/include/mbgl/util/color_lab.hpp
+++ b/include/mbgl/util/color_lab.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/color.hpp>
 #include <string>
 
 namespace mbgl {
@@ -12,6 +13,7 @@ public:
     float a = 0.0f;
     float b = 0.0f;
     float A = 0.0f;
+    optional<Color> to_rgb();
 };
 
 constexpr bool operator==(const ColorLAB& colorA, const ColorLAB& colorB) {

--- a/src/mbgl/style/property_evaluator.cpp
+++ b/src/mbgl/style/property_evaluator.cpp
@@ -124,9 +124,11 @@ Color PropertyEvaluator<Color>::operator()(const Function<Color>& fn) const {
             (std::pow(base, zoomProgress) - 1) / (std::pow(base, zoomDiff) - 1);
 
         if (colorSpace == ColorSpace::LAB) {
-            return util::interpolate(smaller_val.to_lab(), larger_val.to_lab(), t).to_rgb();
+            return Color::from_lab(util::interpolate(smaller_val.to_lab(), larger_val.to_lab(), t));
         } else if (colorSpace == ColorSpace::HCL) {
-            return util::interpolate(smaller_val.to_hcl(), larger_val.to_hcl(), t).to_rgb();
+            return Color::from_hcl(util::interpolate(smaller_val.to_hcl(), larger_val.to_hcl(), t));
+        } else {
+            return util::interpolate(smaller_val, larger_val, t);
         }
 
     } else if (larger) {

--- a/src/mbgl/style/property_evaluator.cpp
+++ b/src/mbgl/style/property_evaluator.cpp
@@ -124,9 +124,9 @@ Color PropertyEvaluator<Color>::operator()(const Function<Color>& fn) const {
             (std::pow(base, zoomProgress) - 1) / (std::pow(base, zoomDiff) - 1);
 
         if (colorSpace == ColorSpace::LAB) {
-            return Color::from_lab(util::interpolate(smaller_val.to_lab(), larger_val.to_lab(), t));
+            return Color::fromLAB(util::interpolate(smaller_val.toLAB(), larger_val.toLAB(), t));
         } else if (colorSpace == ColorSpace::HCL) {
-            return Color::from_hcl(util::interpolate(smaller_val.to_hcl(), larger_val.to_hcl(), t));
+            return Color::fromHCL(util::interpolate(smaller_val.toHCL(), larger_val.toHCL(), t));
         } else {
             return util::interpolate(smaller_val, larger_val, t);
         }

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -77,4 +77,13 @@ optional<ColorHCL> Color::to_hcl() {
     };
 }
 
+optional<Color> ColorHCL::to_rgb() {
+    return Color{
+        h < 0 ? h + 360 : h,
+        std::sqrt(labColor->a * labColor->a + labColor->b * labColor->b),
+        labColor->l,
+        labColor->A
+    };
+}
+
 } // namespace mbgl

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -1,6 +1,35 @@
+#include <cmath>
 #include <mbgl/util/color.hpp>
+#include <mbgl/util/color_lab.hpp>
 
 #include <csscolorparser/csscolorparser.hpp>
+
+const float Kn = 18;
+const float Xn = 0.950470; // D65 standard referent
+const float Yn = 1;
+const float Zn = 1.088830;
+const float t0 = 4 / 29;
+const float t1 = 6 / 29;
+const float t2 = 3 * t1 * t1;
+const float t3 = t1 * t1 * t1;
+// const float deg2rad = M_PI / 180;
+// const float rad2deg = 180 / M_PI;
+
+float xyz2lab(float t) {
+    return t > t3 ? std::pow(t, 1 / 3) : t / t2 + t0;
+}
+
+float lab2xyz(float t) {
+    return t > t1 ? t * t * t : t2 * (t - t0);
+}
+
+float xyz2rgb(float x) {
+    return 255 * (x <= 0.0031308 ? 12.92 * x : 1.055 * std::pow(x, 1 / 2.4) - 0.055);
+}
+
+float rgb2xyz(float x) {
+    return (x /= 255) <= 0.04045 ? x / 12.92 : std::pow((x + 0.055) / 1.055, 2.4);
+}
 
 namespace mbgl {
 
@@ -15,6 +44,23 @@ optional<Color> Color::parse(const std::string& s) {
         css_color.b * factor,
         css_color.a
     }};
+}
+
+optional<ColorLAB> Color::to_lab() {
+
+    const float rawB = rgb2xyz(r);
+    const float rawA = rgb2xyz(g);
+    const float rawL = rgb2xyz(b);
+    const float x = xyz2lab((0.4124564 * rawB + 0.3575761 * rawA + 0.1804375 * rawL) / Xn);
+    const float y = xyz2lab((0.2126729 * rawB + 0.7151522 * rawA + 0.0721750 * rawL) / Yn);
+    const float z = xyz2lab((0.0193339 * rawB + 0.1191920 * rawA + 0.9503041 * rawL) / Zn);
+
+    return ColorLAB{
+        116 * y - 16,
+        500 * (x - y),
+        200 * (y - z),
+        a
+    };
 }
 
 } // namespace mbgl

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -13,7 +13,7 @@ const float t0 = 4 / 29;
 const float t1 = 6 / 29;
 const float t2 = 3 * t1 * t1;
 const float t3 = t1 * t1 * t1;
-// const float deg2rad = M_PI / 180;
+const float deg2rad = M_PI / 180;
 const float rad2deg = 180.0 / M_PI;
 
 float xyz2lab(float t) {
@@ -35,21 +35,27 @@ float rgb2xyz(float x) {
 namespace mbgl {
 
 Color Color::from_lab(const ColorLAB labColor) {
+    float y = (labColor.l + 16) / 116;
+    float x = y + labColor.a / 500;
+    float z = y - labColor.b / 200;
+    y = Yn * lab2xyz(y);
+    x = Xn * lab2xyz(x);
+    z = Zn * lab2xyz(z);
     return {
-        labColor.l,
-        labColor.a,
-        labColor.b,
+        xyz2rgb(3.2404542 * x - 1.5371385 * y - 0.4985314 * z), // D65 -> sRGB
+        xyz2rgb(-0.9692660 * x + 1.8760108 * y + 0.0415560 * z),
+        xyz2rgb(0.0556434 * x - 0.2040259 * y + 1.0572252 * z),
         labColor.A
     };
 }
 
 Color Color::from_hcl(const ColorHCL hclColor) {
-    return {
-        hclColor.h,
-        hclColor.c,
+    return Color::from_lab(ColorLAB{
         hclColor.l,
+        std::cos(hclColor.h * deg2rad) * hclColor.c,
+        std::sin(hclColor.h * deg2rad) * hclColor.c,
         hclColor.A
-    };
+    });
 }
 
 optional<Color> Color::parse(const std::string& s) {

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -34,6 +34,24 @@ float rgb2xyz(float x) {
 
 namespace mbgl {
 
+Color Color::from_lab(const ColorLAB labColor) {
+    return {
+        labColor.l,
+        labColor.a,
+        labColor.b,
+        labColor.A
+    };
+}
+
+Color Color::from_hcl(const ColorHCL hclColor) {
+    return {
+        hclColor.h,
+        hclColor.c,
+        hclColor.l,
+        hclColor.A
+    };
+}
+
 optional<Color> Color::parse(const std::string& s) {
     CSSColorParser::Color css_color = CSSColorParser::parse(s);
 
@@ -47,7 +65,7 @@ optional<Color> Color::parse(const std::string& s) {
     }};
 }
 
-optional<ColorLAB> Color::to_lab() {
+ColorLAB Color::to_lab() {
 
     const float rawB = rgb2xyz(r);
     const float rawA = rgb2xyz(g);
@@ -64,21 +82,12 @@ optional<ColorLAB> Color::to_lab() {
     };
 }
 
-optional<ColorHCL> Color::to_hcl() {
+ColorHCL Color::to_hcl() {
 
     const optional<ColorLAB> labColor = to_lab();
     const float h = std::atan2(labColor->b, labColor->a) * rad2deg;
 
     return ColorHCL{
-        h < 0 ? h + 360 : h,
-        std::sqrt(labColor->a * labColor->a + labColor->b * labColor->b),
-        labColor->l,
-        labColor->A
-    };
-}
-
-optional<Color> ColorHCL::to_rgb() {
-    return Color{
         h < 0 ? h + 360 : h,
         std::sqrt(labColor->a * labColor->a + labColor->b * labColor->b),
         labColor->l,

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -1,10 +1,11 @@
 #include <cmath>
 #include <mbgl/util/color.hpp>
 #include <mbgl/util/color_lab.hpp>
+#include <mbgl/util/color_hcl.hpp>
 
 #include <csscolorparser/csscolorparser.hpp>
 
-const float Kn = 18;
+// const float Kn = 18;
 const float Xn = 0.950470; // D65 standard referent
 const float Yn = 1;
 const float Zn = 1.088830;
@@ -13,7 +14,7 @@ const float t1 = 6 / 29;
 const float t2 = 3 * t1 * t1;
 const float t3 = t1 * t1 * t1;
 // const float deg2rad = M_PI / 180;
-// const float rad2deg = 180 / M_PI;
+const float rad2deg = 180.0 / M_PI;
 
 float xyz2lab(float t) {
     return t > t3 ? std::pow(t, 1 / 3) : t / t2 + t0;
@@ -60,6 +61,19 @@ optional<ColorLAB> Color::to_lab() {
         500 * (x - y),
         200 * (y - z),
         a
+    };
+}
+
+optional<ColorHCL> Color::to_hcl() {
+
+    const optional<ColorLAB> labColor = to_lab();
+    const float h = std::atan2(labColor->b, labColor->a) * rad2deg;
+
+    return ColorHCL{
+        h < 0 ? h + 360 : h,
+        std::sqrt(labColor->a * labColor->a + labColor->b * labColor->b),
+        labColor->l,
+        labColor->A
     };
 }
 

--- a/src/mbgl/util/color.cpp
+++ b/src/mbgl/util/color.cpp
@@ -34,7 +34,7 @@ float rgb2xyz(float x) {
 
 namespace mbgl {
 
-Color Color::from_lab(const ColorLAB labColor) {
+Color Color::fromLAB(const ColorLAB& labColor) {
     float y = (labColor.l + 16) / 116;
     float x = y + labColor.a / 500;
     float z = y - labColor.b / 200;
@@ -49,8 +49,8 @@ Color Color::from_lab(const ColorLAB labColor) {
     };
 }
 
-Color Color::from_hcl(const ColorHCL hclColor) {
-    return Color::from_lab(ColorLAB{
+Color Color::fromHCL(const ColorHCL& hclColor) {
+    return Color::fromLAB(ColorLAB{
         hclColor.l,
         std::cos(hclColor.h * deg2rad) * hclColor.c,
         std::sin(hclColor.h * deg2rad) * hclColor.c,
@@ -71,7 +71,7 @@ optional<Color> Color::parse(const std::string& s) {
     }};
 }
 
-ColorLAB Color::to_lab() {
+ColorLAB Color::toLAB() {
 
     const float rawB = rgb2xyz(r);
     const float rawA = rgb2xyz(g);
@@ -88,9 +88,9 @@ ColorLAB Color::to_lab() {
     };
 }
 
-ColorHCL Color::to_hcl() {
+ColorHCL Color::toHCL() {
 
-    const optional<ColorLAB> labColor = to_lab();
+    const optional<ColorLAB> labColor = toLAB();
     const float h = std::atan2(labColor->b, labColor->a) * rad2deg;
 
     return ColorHCL{

--- a/src/mbgl/util/interpolate.hpp
+++ b/src/mbgl/util/interpolate.hpp
@@ -55,6 +55,32 @@ public:
     }
 };
 
+template <>
+struct Interpolator<ColorLAB> {
+public:
+    ColorLAB operator()(const ColorLAB& a, const ColorLAB& b, const double t) {
+        return {
+            interpolate(a.l, b.l, t),
+            interpolate(a.a, b.a, t),
+            interpolate(a.b, b.b, t),
+            interpolate(a.A, b.A, t)
+        };
+    }
+};
+
+template <>
+struct Interpolator<ColorHCL> {
+public:
+    ColorHCL operator()(const ColorHCL& a, const ColorHCL& b, const double t) {
+        return {
+            interpolate(a.h, b.h, t),
+            interpolate(a.c, b.c, t),
+            interpolate(a.l, b.l, t),
+            interpolate(a.A, b.A, t)
+        };
+    }
+};
+
 struct Uninterpolated {
     template <class T>
     T operator()(const T& a, const T&, const double) const {

--- a/test/style/functions.test.cpp
+++ b/test/style/functions.test.cpp
@@ -3,6 +3,7 @@
 
 #include <mbgl/style/property_evaluator.hpp>
 #include <mbgl/style/calculation_parameters.hpp>
+#include <mbgl/util/color.hpp>
 
 using namespace mbgl;
 using namespace mbgl::style;
@@ -12,6 +13,10 @@ float evaluate(PropertyValue<float> value, float zoom) {
 }
 std::string evaluate(PropertyValue<std::string> value, float zoom) {
     return PropertyValue<std::string>::visit(value, PropertyEvaluator<std::string>(CalculationParameters(zoom), ""));
+}
+Color evaluate(PropertyValue<Color> value, float zoom) {
+    return PropertyValue<Color>::visit(value,
+        PropertyEvaluator<Color>(CalculationParameters(zoom), Color()));
 }
 
 TEST(Function, Constant) {
@@ -72,4 +77,19 @@ TEST(Function, Stops) {
     EXPECT_EQ("string1", evaluate(discrete_0, 7));
     EXPECT_EQ("string2", evaluate(discrete_0, 9));
     EXPECT_EQ("string2", evaluate(discrete_0, 10));
+}
+
+TEST(Function, Colors) {
+    // Explicit constant slope in fringe regions.
+    Function<Color> slope_1({
+            { 0, Color{ 0.0, 1.0, 0.0, 1.0 } },
+            { 10, Color{ 0.0, 1.0, 0.0, 1.0 } } }, 1.75);
+    Color expectation = Color{ 0.0, 1.0, 0.0, 1.0 };
+    EXPECT_EQ(expectation, evaluate(slope_1, 0));
+
+    Function<Color> slope_2({
+            { 0, Color{ 0.0, 1.0, 0.0, 1.0 } },
+            { 10, Color{ 0.0, 1.0, 0.0, 1.0 } } }, 1.75, ColorSpace::HCL);
+    Color expectation2 = Color{ 0.0, 1.0, 0.0, 1.0 };
+    EXPECT_EQ(expectation2, evaluate(slope_2, 0));
 }

--- a/test/util/color.cpp
+++ b/test/util/color.cpp
@@ -1,0 +1,31 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/util/constants.hpp>
+#include <mbgl/util/color.hpp>
+#include <mbgl/util/color_lab.hpp>
+
+using namespace mbgl;
+
+TEST(Color, CanParse) {
+    optional<Color> result = Color::parse("#00ff00");
+    ASSERT_DOUBLE_EQ( result->r, 0);
+    ASSERT_DOUBLE_EQ( result->g, 1);
+    ASSERT_DOUBLE_EQ( result->b, 0);
+}
+
+TEST(Color, InvalidColor) {
+    optional<Color> result = Color::parse(" not a color value");
+
+    ASSERT_DOUBLE_EQ( result->r, 0);
+    ASSERT_DOUBLE_EQ( result->g, 0);
+    ASSERT_DOUBLE_EQ( result->b, 0);
+}
+
+TEST(Color, ColorLAB) {
+    optional<Color> result = Color::parse("#00ff00");
+    optional<ColorLAB> labColor = result->to_lab();
+
+    ASSERT_DOUBLE_EQ( labColor->l, 100);
+    ASSERT_DOUBLE_EQ( labColor->a, 0);
+    ASSERT_DOUBLE_EQ( labColor->b, 0);
+}

--- a/test/util/color.cpp
+++ b/test/util/color.cpp
@@ -29,3 +29,12 @@ TEST(Color, ColorLAB) {
     ASSERT_DOUBLE_EQ( labColor->a, 0);
     ASSERT_DOUBLE_EQ( labColor->b, 0);
 }
+
+TEST(Color, ColorHCL) {
+    optional<Color> result = Color::parse("#00ff00");
+    optional<ColorHCL> hclColor = result->to_hcl();
+
+    ASSERT_DOUBLE_EQ( hclColor->h, 0);
+    ASSERT_DOUBLE_EQ( hclColor->c, 0);
+    ASSERT_DOUBLE_EQ( hclColor->l, 100);
+}

--- a/test/util/color.cpp
+++ b/test/util/color.cpp
@@ -23,7 +23,7 @@ TEST(Color, InvalidColor) {
 
 TEST(Color, ColorLAB) {
     optional<Color> result = Color::parse("#00ff00");
-    optional<ColorLAB> labColor = result->to_lab();
+    optional<ColorLAB> labColor = result->toLAB();
 
     ASSERT_DOUBLE_EQ( labColor->l, 100);
     ASSERT_DOUBLE_EQ( labColor->a, 0);
@@ -32,7 +32,7 @@ TEST(Color, ColorLAB) {
 
 TEST(Color, ColorHCL) {
     optional<Color> result = Color::parse("#00ff00");
-    optional<ColorHCL> hclColor = result->to_hcl();
+    optional<ColorHCL> hclColor = result->toHCL();
 
     ASSERT_DOUBLE_EQ( hclColor->h, 0);
     ASSERT_DOUBLE_EQ( hclColor->c, 0);


### PR DESCRIPTION
This is just a start so I can get an idea from the C++ illuminati
about whether it's the right direction. Approach here is
- Since colors are arrays in JS and objects in C++, instead of a
  rgbToLab() method, there's a to_lab() method on the color object

---

Connected to https://github.com/mapbox/mapbox-gl-js/pull/3245 - the GL JS side
