### PR TITLE
clarify circle color as fill

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ejs": "^2.4.1",
     "express": "^4.11.1",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747",
-    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#a6c95d33ff5ced2c0d7df995fd89eb557c0a353c",
+    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#23155c0f34e1e6833ca772dc8b19111ee6cd40e9",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#694f0d0728f229d64d1639dc5ee7aff7f4b8ca41",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CircleLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CircleLayer.java
@@ -132,7 +132,7 @@ public class CircleLayer extends Layer {
         return (PropertyValue<String>) new PropertyValue(nativeGetCircleColor());
     }
      /**
-     * The color of the circle.
+     * The fill color of the circle.
      *
      * @return int representation of a rgba string color
      * @throws RuntimeException thrown if property isn't a value

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -1282,7 +1282,7 @@ public class PropertyFactory {
     }
 
     /**
-     * Orientation of icon when map is rotated. Aligns icon to the plane of the viewport when set to `viewport` or the plane of the map when set to `map`. Selecting `auto` defaults to `map` for line placement and `viewport` for symbol placement
+     * In combination with `symbol-placement`, determines the rotation behavior of icons. The value `viewport` produces icons whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbol-placement`. When `symbol-placement` is set to `point`, the value `map` produces icons whose x-axes are aligned east-west, and the value `auto` is equivalent to `viewport`. When `symbol-placement` is set to `line`, the value `map` produces icons whose x-axes are aligned with the line, and the value `auto` is equivalent to `map`.
      *
      * @param value a String value
      * @return property wrapper around String
@@ -1292,7 +1292,7 @@ public class PropertyFactory {
     }
 
     /**
-     * Orientation of icon when map is rotated. Aligns icon to the plane of the viewport when set to `viewport` or the plane of the map when set to `map`. Selecting `auto` defaults to `map` for line placement and `viewport` for symbol placement
+     * In combination with `symbol-placement`, determines the rotation behavior of icons. The value `viewport` produces icons whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbol-placement`. When `symbol-placement` is set to `point`, the value `map` produces icons whose x-axes are aligned east-west, and the value `auto` is equivalent to `viewport`. When `symbol-placement` is set to `line`, the value `map` produces icons whose x-axes are aligned with the line, and the value `auto` is equivalent to `map`.
      *
      * @param function a wrapper function for String
      * @return property wrapper around a String function
@@ -1322,7 +1322,7 @@ public class PropertyFactory {
     }
 
     /**
-     * Position and scale an icon by the its corresponding text.
+     * Scales the icon to fit around the associated text. The value `none` performs no scaling. The values `width` and `height` scale the x- or y-dimension, respectively, to fit the text's dimensions. The value `both` scales in both dimensions.
      *
      * @param value a String value
      * @return property wrapper around String
@@ -1332,7 +1332,7 @@ public class PropertyFactory {
     }
 
     /**
-     * Position and scale an icon by the its corresponding text.
+     * Scales the icon to fit around the associated text. The value `none` performs no scaling. The values `width` and `height` scale the x- or y-dimension, respectively, to fit the text's dimensions. The value `both` scales in both dimensions.
      *
      * @param function a wrapper function for String
      * @return property wrapper around a String function
@@ -1342,7 +1342,7 @@ public class PropertyFactory {
     }
 
     /**
-     * Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.
+     * Size of the additional area added to dimensions determined by `icon-text-fix`, in clockwise order: top, right, bottom, left.
      *
      * @param value a Float[] value
      * @return property wrapper around Float[]
@@ -1352,7 +1352,7 @@ public class PropertyFactory {
     }
 
     /**
-     * Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.
+     * Size of the additional area added to dimensions determined by `icon-text-fix`, in clockwise order: top, right, bottom, left.
      *
      * @param function a wrapper function for Float[]
      * @return property wrapper around a Float[] function
@@ -1482,7 +1482,7 @@ public class PropertyFactory {
     }
 
     /**
-     * Orientation of text when map is rotated. Aligns text to the plane of the viewport when set to `viewport` or the plane of the map when set to `map`. Selecting `auto` defaults to the plane of the `map` for line placement and the `viewport` for symbol placement.
+     * In combination with `symbol-placement`, determines the rotation behavior of the individual glyphs forming the text. The value `viewport` produces glyphs whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbol-placement`. When `symbol-placement` is set to `point`, the value `map` produces glyphs whose x-axes are aligned east-west, and the value `auto` is equivalent to `viewport`. When `symbol-placement` is set to `line`, the value `map` produces glyphs whose x-axes are aligned with the line at the point where each glyph is placed, and the value `auto` is equivalent to `map`.
      *
      * @param value a String value
      * @return property wrapper around String
@@ -1492,7 +1492,7 @@ public class PropertyFactory {
     }
 
     /**
-     * Orientation of text when map is rotated. Aligns text to the plane of the viewport when set to `viewport` or the plane of the map when set to `map`. Selecting `auto` defaults to the plane of the `map` for line placement and the `viewport` for symbol placement.
+     * In combination with `symbol-placement`, determines the rotation behavior of the individual glyphs forming the text. The value `viewport` produces glyphs whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbol-placement`. When `symbol-placement` is set to `point`, the value `map` produces glyphs whose x-axes are aligned east-west, and the value `auto` is equivalent to `viewport`. When `symbol-placement` is set to `line`, the value `map` produces glyphs whose x-axes are aligned with the line at the point where each glyph is placed, and the value `auto` is equivalent to `map`.
      *
      * @param function a wrapper function for String
      * @return property wrapper around a String function

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -742,7 +742,7 @@ public class PropertyFactory {
     }
 
     /**
-     * The color of the circle.
+     * The fill color of the circle.
      *
      * @param value a int color value
      * @return property wrapper around String color
@@ -752,7 +752,7 @@ public class PropertyFactory {
     }
 
     /**
-     * The color of the circle.
+     * The fill color of the circle.
      *
      * @param value a String value
      * @return property wrapper around String
@@ -762,7 +762,7 @@ public class PropertyFactory {
     }
 
     /**
-     * The color of the circle.
+     * The fill color of the circle.
      *
      * @param function a wrapper function for String
      * @return property wrapper around a String function

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -44,14 +44,14 @@ typedef NS_ENUM(NSUInteger, MGLCircleStyleLayerCirclePitchScale) {
 
 #if TARGET_OS_IPHONE
 /**
- The color of the circle.
+ The fill color of the circle.
  
  The default value of this property is `UIColor.blackColor`. Set this property to `nil` to reset it to the default value.
  */
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> circleColor;
 #else
 /**
- The color of the circle.
+ The fill color of the circle.
  
  The default value of this property is `NSColor.blackColor`. Set this property to `nil` to reset it to the default value.
  */

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconOptional;
 
 /**
- Orientation of icon when map is rotated. Aligns icon to the plane of the viewport when set to `MGLSymbolStyleLayerIconRotationAlignmentViewport` or the plane of the map when set to `MGLSymbolStyleLayerIconRotationAlignmentMap`. Selecting `MGLSymbolStyleLayerIconRotationAlignmentAuto` defaults to `MGLSymbolStyleLayerIconRotationAlignmentMap` for line placement and `MGLSymbolStyleLayerIconRotationAlignmentViewport` for symbol placement
+ In combination with `symbolPlacement`, determines the rotation behavior of icons. The value `MGLSymbolStyleLayerIconRotationAlignmentViewport` produces icons whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbolPlacement`. When `symbolPlacement` is set to `point`, the value `MGLSymbolStyleLayerIconRotationAlignmentMap` produces icons whose x-axes are aligned east-west, and the value `MGLSymbolStyleLayerIconRotationAlignmentAuto` is equivalent to `MGLSymbolStyleLayerIconRotationAlignmentViewport`. When `symbolPlacement` is set to `line`, the value `MGLSymbolStyleLayerIconRotationAlignmentMap` produces icons whose x-axes are aligned with the line, and the value `MGLSymbolStyleLayerIconRotationAlignmentAuto` is equivalent to `MGLSymbolStyleLayerIconRotationAlignmentMap`.
  
  The default value of this property is an `NSValue` object containing `MGLSymbolStyleLayerIconRotationAlignmentAuto`. Set this property to `nil` to reset it to the default value.
  
@@ -158,7 +158,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconSize;
 
 /**
- Position and scale an icon by the its corresponding text.
+ Scales the icon to fit around the associated text. The value `MGLSymbolStyleLayerIconTextFitNone` performs no scaling. The values `MGLSymbolStyleLayerIconTextFitWidth` and `MGLSymbolStyleLayerIconTextFitHeight` scale the x- or y-dimension, respectively, to fit the text's dimensions. The value `MGLSymbolStyleLayerIconTextFitBoth` scales in both dimensions.
  
  The default value of this property is an `NSValue` object containing `MGLSymbolStyleLayerIconTextFitNone`. Set this property to `nil` to reset it to the default value.
  
@@ -167,7 +167,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> iconTextFit;
 
 /**
- Size of padding area around the text-fit size in clockwise order: top, right, bottom, left.
+ Size of the additional area added to dimensions determined by `iconTextFix`, in clockwise order: top, right, bottom, left.
 
  This property is measured in points.
  
@@ -232,7 +232,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolStyleLayerTextTranslateAnchor) {
 @property (nonatomic, null_resettable) id <MGLStyleAttributeValue> textPitchAlignment;
 
 /**
- Orientation of text when map is rotated. Aligns text to the plane of the viewport when set to `MGLSymbolStyleLayerTextRotationAlignmentViewport` or the plane of the map when set to `MGLSymbolStyleLayerTextRotationAlignmentMap`. Selecting `MGLSymbolStyleLayerTextRotationAlignmentAuto` defaults to the plane of the `MGLSymbolStyleLayerTextRotationAlignmentMap` for line placement and the `MGLSymbolStyleLayerTextRotationAlignmentViewport` for symbol placement.
+ In combination with `symbolPlacement`, determines the rotation behavior of the individual glyphs forming the text. The value `MGLSymbolStyleLayerTextRotationAlignmentViewport` produces glyphs whose x-axes are aligned with the x-axis of the viewport, regardless of the value of `symbolPlacement`. When `symbolPlacement` is set to `point`, the value `MGLSymbolStyleLayerTextRotationAlignmentMap` produces glyphs whose x-axes are aligned east-west, and the value `MGLSymbolStyleLayerTextRotationAlignmentAuto` is equivalent to `MGLSymbolStyleLayerTextRotationAlignmentViewport`. When `symbolPlacement` is set to `line`, the value `MGLSymbolStyleLayerTextRotationAlignmentMap` produces glyphs whose x-axes are aligned with the line at the point where each glyph is placed, and the value `MGLSymbolStyleLayerTextRotationAlignmentAuto` is equivalent to `MGLSymbolStyleLayerTextRotationAlignmentMap`.
  
  The default value of this property is an `NSValue` object containing `MGLSymbolStyleLayerTextRotationAlignmentAuto`. Set this property to `nil` to reset it to the default value.
  


### PR DESCRIPTION
Analog to https://github.com/mapbox/mapbox-gl-style-spec/pull/506 to clarify "circle color" as the fill color. 