### PR TITLE
Doc gen handles arrays as required property values

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -107,7 +107,7 @@ global.propertyReqs = function (property, layoutPropertiesByName, type) {
             return '`' + camelizeWithLeadingLowercase(req['!']) + '` is set to `nil`';
         } else {
             let name = Object.keys(req)[0];
-            return '`' + camelizeWithLeadingLowercase(name) + '` is set to ' + describeValue(req[Object.keys(req)[0]], layoutPropertiesByName[name], type);
+            return '`' + camelizeWithLeadingLowercase(name) + '` is set to ' + describeValue(req[name], layoutPropertiesByName[name], type);
         }
     }).join(', and ') + '. Otherwise, it is ignored.';
 };
@@ -131,8 +131,21 @@ global.describeValue = function (value, property, layerType) {
         case 'string':
             return 'the string `' + value + '`';
         case 'enum':
-            let objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
-            return 'an `NSValue` object containing `' + `${objCType}${camelize(value)}` + '`';
+            let displayValue;
+            if (Array.isArray(value)) {
+              let separator = (value.length === 2) ? ' ' : ', ';
+              displayValue = value.map((possibleValue, i) => {
+                let conjunction = '';
+                if (value.length === 2 && i === 0) conjunction = 'either ';
+                if (i === value.length - 1) conjunction = 'or ';
+                let objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
+                return `${conjunction}\`${objCType}${camelize(possibleValue)}\``;
+              }).join(separator);
+            } else {
+              let objCType = `${prefix}${camelize(layerType)}${suffix}${camelize(property.name)}`;
+              displayValue = `\`${objCType}${camelize(value)}\``;
+            }
+            return `an \`NSValue\` object containing ${displayValue}`;
         case 'color':
             let color = parseColor(value);
             if (!color) {
@@ -182,14 +195,14 @@ global.initLayerIdentifierOnly = function (layerType) {
 
 global.initLayer = function (layerType) {
     if (layerType == "background") {
-       return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String);` 
+       return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String);`
     } else {
         return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);`
     }
 }
 
 global.initLayerWithSourceLayer = function(layerType) {
-    return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);`  
+    return `_layer = new mbgl::style::${camelize(layerType)}Layer(layerIdentifier.UTF8String, source.sourceIdentifier.UTF8String);`
 }
 
 global.setSourceLayer = function() {


### PR DESCRIPTION
Ref https://github.com/mapbox/mapbox-gl-style-spec/issues/504.

Modifies the style documentation generation code to allow for an array as the required property value. An array means that the property must have one of multiple possible values.

I tried to match the sentence-style syntax and punctuation I saw elsewhere. Here's what we end up with in a few scenarios:

```
"requires": [ 
  {
    "icon-text-fit": ["both", "width", "height"]
  },
],
``` 
> This property is only applied to the style if `iconTextFit` is set to either an `NSValue` object containing `MGLSymbolStyleLayerIconTextFitBoth`, or an `NSValue` object containing `MGLSymbolStyleLayerIconTextFitWidth`, or an `NSValue` object containing `MGLSymbolStyleLayerIconTextFitHeight`. Otherwise, it is ignored.

```
"requires": [
  {
    "icon-text-fit": [
      "both",
      "width"
    ]
  }
],
```

> This property is only applied to the style if `iconTextFit` is set to either an `NSValue` object containing `MGLSymbolStyleLayerIconTextFitBoth` or an `NSValue` object containing `MGLSymbolStyleLayerIconTextFitWidth`. Otherwise, it is ignored.

```
"requires": [
  {
    "icon-text-fit": "both"
  }
],
```

> This property is only applied to the style if `iconTextFit` is set to an `NSValue` object containing `MGLSymbolStyleLayerIconTextFitBoth`. Otherwise, it is ignored.

(Looks like I also stripped some superfluous end-of-line whitespace.)

cc @1ec5 