### PR TITLE
[core] Fix initialization race on util::mapbox::isMapboxURL

### DIFF
--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -6,15 +6,19 @@
 #include <vector>
 #include <iostream>
 
+namespace {
+
+const char* protocol = "mapbox://";
+const std::size_t protocolLength = 9;
+
+} // namespace
+
 namespace mbgl {
 namespace util {
 namespace mapbox {
 
-const std::string protocol = "mapbox://";
-const std::size_t protocolLength = protocol.length();
-
 bool isMapboxURL(const std::string& url) {
-    return std::equal(protocol.begin(), protocol.end(), url.begin());
+    return url.compare(0, protocolLength, protocol) == 0;
 }
 
 static std::vector<std::string> getMapboxURLPathname(const std::string& url) {


### PR DESCRIPTION
This function can be called from different threads and was depending on a global `std::string protocol` which can do heap allocations.

The first thread to use it would initialized it which is not exactly safe, so this patch moves it to a `char *` that is just a pointer to
the data segment, so no races.

Valgrind detected it on #6431.

```
==9874== Conditional jump or move depends on uninitialised value(s)
==9874==    at 0x4C307C2: __memcmp_sse4_1 (in /home/travis/build/mapbox/mapbox-gl-native/mason_packages/linux-x86_64/valgrind/latest/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9874==    by 0x79896E: mbgl::util::mapbox::isMapboxURL(std::string const&) (in /home/travis/build/mapbox/mapbox-gl-native/build/qt-linux-x86_64/Release/mbgl-test)
==9874==    by 0x6DC756: mbgl::style::TileSourceImpl::parseTileJSON(std::string const&, std::string const&, mbgl::SourceType, unsigned short) (in /home/travis/build/mapbox/mapbox-gl-native/build/qt-linux-x86_64/Release/mbgl-test)
==9874==    by 0x6DDA6A: std::_Function_handler<void (mbgl::Response), mbgl::style::TileSourceImpl::loadDescription(mbgl::FileSource&)::{lambda(mbgl::Response)#1}>::_M_invoke(std::_Any_data const&, mbgl::Response&&) (in /home/travis/build/mapbox/mapbox-gl-native/build/qt-linux-x86_64/Release/mbgl-test)
==9874==    by 0x50BE80: std::_Function_handler<void (), mbgl::StubFileSource::StubFileSource()::{lambda()#1}>::_M_invoke(std::_Any_data const&) (in /home/travis/build/mapbox/mapbox-gl-native/build/qt-linux-x86_64/Release/mbgl-test)
==9874==    by 0x70972A5: QMetaObject::activate(QObject*, int, int, void**) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.2.1)
==9874==    by 0x70A3621: QTimer::timerEvent(QTimerEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.2.1)
==9874==    by 0x7098053: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.2.1)
==9874==    by 0x60CCC8B: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.2.1)
==9874==    by 0x60D1E55: QApplication::notify(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.2.1)
==9874==    by 0x706FC2C: QCoreApplication::notifyInternal(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.2.1)
==9874==    by 0x70BC1AC: QTimerInfoList::activateTimers() (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.2.1)
==9874==
```