### PR TITLE
Don't load tiles if no layer requires them

### DIFF
--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -214,15 +214,18 @@ double Style::getDefaultPitch() const {
 
 void Style::updateTiles(const UpdateParameters& parameters) {
     for (const auto& source : sources) {
-        source->baseImpl->updateTiles(parameters);
+        if (source->baseImpl->enabled) {
+            source->baseImpl->updateTiles(parameters);
+        }
     }
 }
 
 void Style::relayout() {
     for (const auto& sourceID : updateBatch.sourceIDs) {
         Source* source = getSource(sourceID);
-        if (!source) continue;
-        source->baseImpl->reloadTiles();
+        if (source && source->baseImpl->enabled) {
+            source->baseImpl->reloadTiles();
+        }
     }
     updateBatch.sourceIDs.clear();
 }


### PR DESCRIPTION
As a follow-up to #6373, this change stops our renderer from requesting tiles from sources that don't have a layer that actually requires it. Currently, if a source has been loaded before, but no layer is enabled due to the current zoom level, we are still happily loading all of the tiles even thought they are never used.