### PR TITLE
Clean up source-driven attribution

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -155,7 +155,6 @@ public:
     style::Source* getSource(const std::string& sourceID);
     void addSource(std::unique_ptr<style::Source>);
     void removeSource(const std::string& sourceID);
-    std::vector<std::string> getAttributions() const;
 
     // Layers
     style::Layer* getLayer(const std::string& layerID);

--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/optional.hpp>
 #include <mbgl/style/types.hpp>
 
 #include <memory>
@@ -49,6 +50,8 @@ public:
     // Create a new source with the specified `id`. All other properties
     // are copied from this source.
     std::unique_ptr<Source> copy(const std::string& id) const;
+
+    optional<std::string> getAttribution() const;
 
     // Private implementation
     class Impl;

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -46,7 +46,7 @@ enum MapChange {
     MapChangeDidFinishRenderingMap,
     MapChangeDidFinishRenderingMapFullyRendered,
     MapChangeDidFinishLoadingStyle,
-    MapChangeSourceAttributionDidChange
+    MapChangeSourceDidChange
 };
 
 struct Q_DECL_EXPORT CameraOptions {

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -32,7 +32,7 @@ static_assert(mbgl::underlying_type(QMapbox::MapChangeWillStartRenderingMap) == 
 static_assert(mbgl::underlying_type(QMapbox::MapChangeDidFinishRenderingMap) == mbgl::underlying_type(mbgl::MapChangeDidFinishRenderingMap), "error");
 static_assert(mbgl::underlying_type(QMapbox::MapChangeDidFinishRenderingMapFullyRendered) == mbgl::underlying_type(mbgl::MapChangeDidFinishRenderingMapFullyRendered), "error");
 static_assert(mbgl::underlying_type(QMapbox::MapChangeDidFinishLoadingStyle) == mbgl::underlying_type(mbgl::MapChangeDidFinishLoadingStyle), "error");
-static_assert(mbgl::underlying_type(QMapbox::MapChangeSourceAttributionDidChange) == mbgl::underlying_type(mbgl::MapChangeSourceAttributionDidChange), "error");
+static_assert(mbgl::underlying_type(QMapbox::MapChangeSourceDidChange) == mbgl::underlying_type(mbgl::MapChangeSourceDidChange), "error");
 
 namespace QMapbox {
 

--- a/src/mbgl/map/change.hpp
+++ b/src/mbgl/map/change.hpp
@@ -20,7 +20,7 @@ enum MapChange : uint8_t {
     MapChangeDidFinishRenderingMap = 12,
     MapChangeDidFinishRenderingMapFullyRendered = 13,
     MapChangeDidFinishLoadingStyle = 14,
-    MapChangeSourceAttributionDidChange = 15
+    MapChangeSourceDidChange = 15
 };
 
 } // namespace mbgl

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -786,10 +786,6 @@ void Map::removeSource(const std::string& sourceID) {
     }
 }
 
-std::vector<std::string> Map::getAttributions() const {
-    return impl->style ? impl->style->getAttributions() : std::vector<std::string>();
-}
-
 style::Layer* Map::getLayer(const std::string& layerID) {
     if (impl->style) {
         impl->styleMutated = true;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -982,7 +982,7 @@ void Map::onLowMemory() {
 }
 
 void Map::Impl::onSourceAttributionChanged(style::Source&, const std::string&) {
-    view.notifyMapChange(MapChangeSourceAttributionDidChange);
+    view.notifyMapChange(MapChangeSourceDidChange);
 }
 
 void Map::Impl::onUpdate(Update flags) {

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -14,5 +14,9 @@ const std::string& Source::getID() const {
     return baseImpl->id;
 }
 
+optional<std::string> Source::getAttribution() const {
+    return baseImpl->getAttribution();
+}
+
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -71,6 +71,8 @@ public:
     const SourceType type;
     const std::string id;
 
+    virtual optional<std::string> getAttribution() const { return {}; };
+
     bool loaded = false;
 
     // Tracks whether the source is used by any layers visible at the current zoom level. Must

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -18,7 +18,6 @@
 #include <mbgl/style/update_parameters.hpp>
 #include <mbgl/style/cascade_parameters.hpp>
 #include <mbgl/style/calculation_parameters.hpp>
-#include <mbgl/style/tile_source_impl.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
 #include <mbgl/text/glyph_atlas.hpp>
 #include <mbgl/geometry/line_atlas.hpp>
@@ -26,7 +25,6 @@
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/string.hpp>
-#include <mbgl/util/tileset.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/math/minmax.hpp>
 
@@ -293,28 +291,6 @@ Source* Style::getSource(const std::string& id) const {
     });
 
     return it != sources.end() ? it->get() : nullptr;
-}
-
-std::vector<std::string> Style::getAttributions() const {
-    std::vector<std::string> result;
-    for (const auto& source : sources) {
-        switch (source->baseImpl->type) {
-        case SourceType::Vector:
-        case SourceType::Raster: {
-            style::TileSourceImpl* tileSource = static_cast<style::TileSourceImpl*>(source->baseImpl.get());
-            auto attribution = tileSource->getAttribution();
-            if (!attribution.empty()) {
-                result.push_back(std::move(attribution));
-            }
-        }
-
-        case SourceType::GeoJSON:
-        case SourceType::Video:
-        case SourceType::Annotations:
-            break;
-        }
-    }
-    return result;
 }
 
 bool Style::hasTransitions() const {

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -67,7 +67,6 @@ public:
     Source* getSource(const std::string& id) const;
     void addSource(std::unique_ptr<Source>);
     void removeSource(const std::string& sourceID);
-    std::vector<std::string> getAttributions() const;
 
     std::vector<const Layer*> getLayers() const;
     Layer* getLayer(const std::string& id) const;

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -118,8 +118,12 @@ Range<uint8_t> TileSourceImpl::getZoomRange() {
     return tileset.zoomRange;
 }
 
-std::string TileSourceImpl::getAttribution() const {
-    return loaded ? tileset.attribution : "";
+optional<std::string> TileSourceImpl::getAttribution() const {
+    if (loaded && !tileset.attribution.empty()) {
+        return tileset.attribution;
+    } else {
+        return {};
+    }
 }
 
 } // namespace style

--- a/src/mbgl/style/tile_source_impl.hpp
+++ b/src/mbgl/style/tile_source_impl.hpp
@@ -34,7 +34,7 @@ public:
         return urlOrTileset;
     }
     
-    std::string getAttribution() const;
+    optional<std::string> getAttribution() const override;
 
 protected:
     Range<uint8_t> getZoomRange() final;


### PR DESCRIPTION
This is a followup to #6431 that addresses the feedback in https://github.com/mapbox/mapbox-gl-native/pull/6431#pullrequestreview-1184531. SDK code that wishes to display the style’s full attribution, such as MGLMapView in #5999, is now responsible for iterating over the style’s sources. The source attribution change notification has been generalized so that it can be reused in the future for other source changes.

/cc @jfirebaugh @tmpsantos