### PR TITLE
[ios] Always show annotation view even when view reuse is not used

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -44,6 +44,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Improved the performance of relocating a non-view-backed point annotation by changing its `coordinate` property. ([#5385](https://github.com/mapbox/mapbox-gl-native/pull/5385))
 * Improved the precision of annotations at zoom levels greater than 18. ([#5517](https://github.com/mapbox/mapbox-gl-native/pull/5517))
 * Fixed an issue that could reset user-added transformations on annotation views. ([#6166](https://github.com/mapbox/mapbox-gl-native/pull/6166))
+* Fixed an issue that caused annotation views to be dropped if they did not fully participate in the view reuse queue system. ([#6485](https://github.com/mapbox/mapbox-gl-native/pull/6485))
 
 ### Other changes
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4572,6 +4572,10 @@ public:
                 annotationView.mapView = self;
                 annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
                 annotationContext.annotationView = annotationView;
+                
+                if (!annotationView.superview) {
+                    [self.annotationContainerView insertSubview:annotationView atIndex:0];
+                }
             }
             else
             {
@@ -4581,7 +4585,7 @@ public:
         }
         
         bool annotationViewIsVisible = CGRectContainsRect(viewPort, annotationView.frame);
-        if (!annotationViewIsVisible)
+        if (!annotationViewIsVisible && annotationContext.viewReuseIdentifier)
         {
             [self enqueueAnnotationViewForAnnotationContext:annotationContext];
         }


### PR DESCRIPTION
This fixes an issue noted in https://github.com/mapbox/mapbox-gl-native/issues/6458#issuecomment-249808011 where the map view would drop annotation views
if the developer did not make full use of the reuse queue. 

The fixes are:

- Guard against enqueuing a view for reuse if it does not have a `viewReuseIdentifier`. Previously, if the app developer created a new annotation view with no reuse id each time `[MGLMapViewDelegate mapView:viewForAnnotation:]` was called and then the view was scrolled offscreen, we  attempted to add the view to the reuse queue (for no good reason) and  did not update the views center ever again.  This change avoids the reuse queue and just updates the
center always.

- Add any annotation view that should be displayed but is not in the annotation container view to the annotation container view. Previously, if the app developer created a new annotation view with a reuse id each time `[MGLMapViewDelegate mapView:viewForAnnotation:]` was called,
and then if the annotation was scrolled off and then on screen again, we did not add the new view to the container view because it was not happening in the normal `addAnnotation` cycle. This adds add logic to catch that case and add annotation views created in this way to the view.

Nonte that it is still advisable to use the resuse queue as shown in our [annotation view example](https://www.mapbox.com/ios-sdk/examples/annotation-views). Also, once https://github.com/mapbox/mapbox-gl-native/issues/6055 lands, we will be able to clean this up even more. But, for now, this restores the unoptimized annotation view functionality that I think we were unintentionally not supporting.

cc @incanus @1ec5 @frederoni 