### PR TITLE
Restore -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,10 @@ mason_use(boost VERSION 1.60.0 HEADER_ONLY)
 mason_use(geojsonvt VERSION 6.1.3 HEADER_ONLY)
 mason_use(supercluster VERSION 0.2.0 HEADER_ONLY)
 mason_use(kdbush VERSION 0.1.1 HEADER_ONLY)
-mason_use(earcut VERSION 0.11 HEADER_ONLY)
+mason_use(earcut VERSION 0.12.1 HEADER_ONLY)
 mason_use(protozero VERSION 1.4.2 HEADER_ONLY)
-mason_use(pixelmatch VERSION 0.9.0 HEADER_ONLY)
-mason_use(geojson VERSION 0.3.1 HEADER_ONLY)
+mason_use(pixelmatch VERSION 0.10.0 HEADER_ONLY)
+mason_use(geojson VERSION 0.3.2 HEADER_ONLY)
 
 if(WITH_COVERAGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
@@ -37,7 +37,12 @@ if(WITH_COVERAGE)
 endif(WITH_COVERAGE)
 
 set(CMAKE_CONFIGURATION_TYPES Debug Release)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wshadow -Wno-variadic-macros -Wno-unknown-pragmas")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wshadow -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
+if(APPLE)
+    # -Wno-error=unused-command-line-argument is required due to https://llvm.org/bugs/show_bug.cgi?id=7798
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument")
+endif()
 
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/platform/${MBGL_PLATFORM}/config.cmake)
     message(ERROR "Can't find config.cmake file for platform ${MBGL_PLATFORM}")

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -12,9 +12,9 @@
 
 namespace mbgl {
 
-template <size_t item_size,
+template <uint32_t item_size,
           gl::BufferType target = gl::BufferType::Vertex,
-          size_t defaultLength = 8192,
+          uint32_t defaultLength = 8192,
           bool retainAfterUpload = false>
 class Buffer : private util::noncopyable {
     static_assert(target == gl::BufferType::Vertex || target == gl::BufferType::Element,
@@ -27,8 +27,8 @@ public:
 
     // Returns the number of elements in this buffer. This is not the number of
     // bytes, but rather the number of coordinates with associated information.
-    size_t index() const {
-        return static_cast<size_t>(pos / itemSize);
+    uint32_t index() const {
+        return pos / itemSize;
     }
 
     bool empty() const {
@@ -96,17 +96,17 @@ protected:
     }
 
 public:
-    static const size_t itemSize = item_size;
+    static constexpr const uint32_t itemSize = item_size;
 
 private:
     // CPU buffer
     void* array = nullptr;
 
     // Byte position where we are writing.
-    size_t pos = 0;
+    uint32_t pos = 0;
 
     // Number of bytes that are valid in this buffer.
-    size_t length = 0;
+    uint32_t length = 0;
 
     // GL buffer object handle.
     mbgl::optional<gl::UniqueBuffer> buffer;

--- a/src/mbgl/geometry/collision_box_buffer.cpp
+++ b/src/mbgl/geometry/collision_box_buffer.cpp
@@ -6,8 +6,8 @@
 
 namespace mbgl {
 
-size_t CollisionBoxVertexBuffer::add(int16_t x, int16_t y, float ox, float oy, float maxzoom, float placementZoom) {
-    const size_t idx = index();
+uint32_t CollisionBoxVertexBuffer::add(int16_t x, int16_t y, float ox, float oy, float maxzoom, float placementZoom) {
+    const uint32_t idx = index();
     void *data = addElement();
 
     int16_t *shorts = static_cast<int16_t *>(data);

--- a/src/mbgl/geometry/collision_box_buffer.hpp
+++ b/src/mbgl/geometry/collision_box_buffer.hpp
@@ -13,7 +13,7 @@ class CollisionBoxVertexBuffer : public Buffer <
 public:
     typedef int16_t vertex_type;
 
-    size_t add(int16_t x, int16_t y, float ex, float ey, float maxzoom, float placementZoom);
+    uint32_t add(int16_t x, int16_t y, float ex, float ey, float maxzoom, float placementZoom);
 };
 
 

--- a/src/mbgl/geometry/elements_buffer.hpp
+++ b/src/mbgl/geometry/elements_buffer.hpp
@@ -9,13 +9,13 @@
 
 namespace mbgl {
 
-template <size_t count>
+template <uint8_t count>
 struct ElementGroup : public util::noncopyable {
     std::array<VertexArrayObject, count> array;
-    size_t vertex_length;
-    size_t elements_length;
+    uint32_t vertex_length;
+    uint32_t elements_length;
 
-    ElementGroup(size_t vertex_length_ = 0, size_t elements_length_ = 0)
+    ElementGroup(uint32_t vertex_length_ = 0, uint32_t elements_length_ = 0)
         : vertex_length(vertex_length_)
         , elements_length(elements_length_)
     {

--- a/src/mbgl/geometry/icon_buffer.cpp
+++ b/src/mbgl/geometry/icon_buffer.cpp
@@ -6,8 +6,8 @@
 
 namespace mbgl {
 
-size_t IconVertexBuffer::add(int16_t x, int16_t y, float ox, float oy, int16_t tx, int16_t ty, float minzoom, float maxzoom, float labelminzoom, uint8_t labelangle) {
-    const size_t idx = index();
+uint32_t IconVertexBuffer::add(int16_t x, int16_t y, float ox, float oy, int16_t tx, int16_t ty, float minzoom, float maxzoom, float labelminzoom, uint8_t labelangle) {
+    const uint32_t idx = index();
     void *data = addElement();
 
     int16_t *shorts = static_cast<int16_t *>(data);

--- a/src/mbgl/geometry/icon_buffer.hpp
+++ b/src/mbgl/geometry/icon_buffer.hpp
@@ -10,7 +10,7 @@ namespace mbgl {
     16
     > {
     public:
-        size_t add(int16_t x, int16_t y, float ox, float oy, int16_t tx, int16_t ty, float minzoom, float maxzoom, float labelminzoom, uint8_t labelangle);
+        uint32_t add(int16_t x, int16_t y, float ox, float oy, int16_t tx, int16_t ty, float minzoom, float maxzoom, float labelminzoom, uint8_t labelangle);
 
     };
 

--- a/src/mbgl/geometry/line_buffer.cpp
+++ b/src/mbgl/geometry/line_buffer.cpp
@@ -4,8 +4,8 @@
 
 namespace mbgl {
 
-size_t LineVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey, bool tx, bool ty, int8_t dir, int32_t linesofar) {
-    size_t idx = index();
+uint32_t LineVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey, bool tx, bool ty, int8_t dir, int32_t linesofar) {
+    uint32_t idx = index();
     void *data = addElement();
 
     int16_t *coords = static_cast<int16_t *>(data);

--- a/src/mbgl/geometry/line_buffer.hpp
+++ b/src/mbgl/geometry/line_buffer.hpp
@@ -30,7 +30,7 @@ public:
      * @param {number} ty texture normal
      * @param {number} dir direction of the line cap (-1/0/1)
      */
-    size_t add(vertex_type x, vertex_type y, float ex, float ey, bool tx, bool ty, int8_t dir, int32_t linesofar = 0);
+    uint32_t add(vertex_type x, vertex_type y, float ex, float ey, bool tx, bool ty, int8_t dir, int32_t linesofar = 0);
 };
 
 

--- a/src/mbgl/geometry/text_buffer.cpp
+++ b/src/mbgl/geometry/text_buffer.cpp
@@ -6,8 +6,8 @@
 
 namespace mbgl {
 
-size_t TextVertexBuffer::add(int16_t x, int16_t y, float ox, float oy, uint16_t tx, uint16_t ty, float minzoom, float maxzoom, float labelminzoom, uint8_t labelangle) {
-    const size_t idx = index();
+uint32_t TextVertexBuffer::add(int16_t x, int16_t y, float ox, float oy, uint16_t tx, uint16_t ty, float minzoom, float maxzoom, float labelminzoom, uint8_t labelangle) {
+    const uint32_t idx = index();
     void *data = addElement();
 
     int16_t *shorts = static_cast<int16_t *>(data);

--- a/src/mbgl/geometry/text_buffer.hpp
+++ b/src/mbgl/geometry/text_buffer.hpp
@@ -13,7 +13,7 @@ class TextVertexBuffer : public Buffer <
 public:
     typedef int16_t vertex_type;
 
-    size_t add(int16_t x, int16_t y, float ox, float oy, uint16_t tx, uint16_t ty, float minzoom, float maxzoom, float labelminzoom, uint8_t labelangle);
+    uint32_t add(int16_t x, int16_t y, float ox, float oy, uint16_t tx, uint16_t ty, float minzoom, float maxzoom, float labelminzoom, uint8_t labelangle);
 };
 
 

--- a/test/storage/online_file_source.test.cpp
+++ b/test/storage/online_file_source.test.cpp
@@ -398,7 +398,7 @@ TEST(OnlineFileSource, TEST_REQUIRES_SERVER(RateLimitDefault)) {
     auto req = fs.request({ Resource::Unknown, "http://127.0.0.1:3000/rate-limit" }, [&](Response res) {
         ASSERT_NE(nullptr, res.error);
         EXPECT_EQ(Response::Error::Reason::RateLimit, res.error->reason);
-        ASSERT_EQ(false, bool(res.error->retryAfter));
+        ASSERT_FALSE(res.error->retryAfter);
         loop.stop();
     });
     


### PR DESCRIPTION
We used to treat all warnings as errors with `-Werror`. I think this was lost with the switch to CMake; we should restore it.