### PR TITLE
[core] Use geojson as a header only library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ mason_use(kdbush VERSION 0.1.1 HEADER_ONLY)
 mason_use(earcut VERSION 0.11 HEADER_ONLY)
 mason_use(protozero VERSION 1.4.2 HEADER_ONLY)
 mason_use(pixelmatch VERSION 0.9.0 HEADER_ONLY)
-mason_use(geojson VERSION 0.3.0)
+mason_use(geojson VERSION 0.3.1 HEADER_ONLY)
 
 if(WITH_COVERAGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")

--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -436,6 +436,7 @@ set(MBGL_CORE_FILES
     src/mbgl/util/exclusive.hpp
     src/mbgl/util/font_stack.cpp
     src/mbgl/util/geo.cpp
+    src/mbgl/util/geojson.cpp
     src/mbgl/util/grid_index.cpp
     src/mbgl/util/grid_index.hpp
     src/mbgl/util/http_header.cpp

--- a/src/mbgl/util/geojson.cpp
+++ b/src/mbgl/util/geojson.cpp
@@ -1,0 +1,1 @@
+#include <mapbox/geojson_impl.hpp>


### PR DESCRIPTION
Mapbox GL Native Core depends only on header-only libraries.

This increases portability as we don't need to deal with ABI breakages and getting deps pre-built to all the platforms we target.