### PR TITLE
[core] Inherit from mapbox::geometry::point<double> in {LatLng,ProjectedMeters}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(WITH_CXX11ABI)
     set(MASON_CXXABI_SUFFIX -cxx11abi)
 endif()
 
-mason_use(geometry VERSION 0.8.0 HEADER_ONLY)
+mason_use(geometry VERSION 0.8.1 HEADER_ONLY)
 mason_use(variant VERSION 1.1.0 HEADER_ONLY)
 mason_use(unique_resource VERSION dev HEADER_ONLY)
 mason_use(rapidjson VERSION 1.1.0 HEADER_ONLY)

--- a/src/mbgl/util/geo.cpp
+++ b/src/mbgl/util/geo.cpp
@@ -19,13 +19,11 @@ double lon(const uint8_t z, const int64_t x) {
 
 } // end namespace
 
-LatLng::LatLng(const CanonicalTileID& id) : latitude(lat(id.z, id.y)), longitude(lon(id.z, id.x)) {
-}
+LatLng::LatLng(const CanonicalTileID& id) : Coordinate(lon(id.z, id.x), lat(id.z, id.y)) {}
 
 LatLng::LatLng(const UnwrappedTileID& id)
-    : latitude(lat(id.canonical.z, id.canonical.y)),
-      longitude(lon(id.canonical.z, id.canonical.x) + id.wrap * util::DEGREES_MAX) {
-}
+    : Coordinate(lon(id.canonical.z, id.canonical.x) + id.wrap * util::DEGREES_MAX,
+                 lat(id.canonical.z, id.canonical.y)) {}
 
 LatLngBounds::LatLngBounds(const CanonicalTileID& id)
     : sw({ lat(id.z, id.y + 1), lon(id.z, id.x) }),

--- a/test/util/geo.test.cpp
+++ b/test/util/geo.test.cpp
@@ -6,6 +6,11 @@
 
 using namespace mbgl;
 
+TEST(LatLng, MixedCoordinateTypes) {
+    static_assert(std::is_assignable<LatLng, ScreenCoordinate>::value == false, "LatLng and ScreenCoordinate cannot be interchangeable.");
+    static_assert(std::is_assignable<LatLng, ProjectedMeters>::value == false, "LatLng and ProjectedMeters cannot be interchangeable.");
+}
+
 TEST(LatLngBounds, World) {
     auto result = LatLngBounds::world();
     ASSERT_DOUBLE_EQ(-90,  result.south());


### PR DESCRIPTION
Inherit from `mapbox::geometry::point<double>` makes it possible for `mbgl::utill::{LatLng,ProjectedMeters}` to reuse the arithmetic and logic operators.