### PR TITLE
[Qt] Connect to finished() and error() signals from QNetworkReply

### DIFF
--- a/platform/qt/src/http_file_source.hpp
+++ b/platform/qt/src/http_file_source.hpp
@@ -28,7 +28,7 @@ public:
     void cancel(HTTPRequest *);
 
 public slots:
-    void replyFinish(QNetworkReply *);
+    void onReplyFinished();
 
 private:
     QMap<QUrl, QPair<QNetworkReply *, QVector<HTTPRequest *>>> m_pending;


### PR DESCRIPTION
Qt macOS network manage implementation differs from linux in a sense that some requests do not generate a `finished()` signal, but an `error()` instead - that is not caught up by the network access manager. This made QMapboxGL.styleURL utest hang for macOS.

/cc @ivovandongen @tmpsantos 