### PR TITLE
Remove n^2 iteration over programs when deleting

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -61,10 +61,8 @@ void Context::setDirtyState() {
 
 void Context::performCleanup() {
     for (GLuint id : abandonedPrograms) {
-        for (const auto& p : abandonedPrograms) {
-            if (program == p) {
-                program.setDirty();
-            }
+        if (program == id) {
+            program.setDirty();
         }
         MBGL_CHECK_ERROR(glDeleteProgram(id));
     }

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -74,10 +74,10 @@ void Context::performCleanup() {
     abandonedShaders.clear();
 
     if (!abandonedBuffers.empty()) {
-        for (const auto& b : abandonedBuffers) {
-            if (vertexBuffer == b) {
+        for (const auto id : abandonedBuffers) {
+            if (vertexBuffer == id) {
                 vertexBuffer.setDirty();
-            } else if (elementBuffer == b) {
+            } else if (elementBuffer == id) {
                 elementBuffer.setDirty();
             }
         }
@@ -86,8 +86,8 @@ void Context::performCleanup() {
     }
 
     if (!abandonedTextures.empty()) {
-        for (const auto& t : abandonedTextures) {
-            if (activeTexture == t) {
+        for (const auto id : abandonedTextures) {
+            if (activeTexture == id) {
                 activeTexture.setDirty();
             }
         }
@@ -96,8 +96,8 @@ void Context::performCleanup() {
     }
 
     if (!abandonedVAOs.empty()) {
-        for (const auto& v : abandonedVAOs) {
-            if (vertexArrayObject == v) {
+        for (const auto id : abandonedVAOs) {
+            if (vertexArrayObject == id) {
                 vertexArrayObject.setDirty();
             }
         }
@@ -106,8 +106,8 @@ void Context::performCleanup() {
     }
 
     if (!abandonedFBOs.empty()) {
-        for (const auto& f : abandonedFBOs) {
-            if (bindFramebuffer == f) {
+        for (const auto id : abandonedFBOs) {
+            if (bindFramebuffer == id) {
                 bindFramebuffer.setDirty();
             }
         }


### PR DESCRIPTION
An oversight in #6486 means that we're iterating way too often over all of the programs we are about to delete.