### PR TITLE
Remove access to gl.h for most code

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -85,6 +85,7 @@ set(MBGL_CORE_FILES
     src/mbgl/gl/object.cpp
     src/mbgl/gl/object.hpp
     src/mbgl/gl/state.hpp
+    src/mbgl/gl/types.hpp
     src/mbgl/gl/value.cpp
     src/mbgl/gl/value.hpp
 

--- a/include/mbgl/gl/gl.hpp
+++ b/include/mbgl/gl/gl.hpp
@@ -86,8 +86,3 @@ extern ExtensionFunction<void (GLsizei n, GLuint* arrays)>
 
 } // namespace gl
 } // namespace mbgl
-
-#ifdef GL_ES_VERSION_2_0
-    #define glClearDepth glClearDepthf
-    #define glDepthRange glDepthRangef
-#endif

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -45,10 +45,10 @@ enum class MapDebugOptions : EnumType {
     Collision   = 1 << 4,
     Overdraw    = 1 << 5,
 // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/5117
-#ifndef GL_ES_VERSION_2_0
+#if not MBGL_USE_GLES2
     StencilClip = 1 << 6,
     DepthBuffer = 1 << 7,
-#endif // GL_ES_VERSION_2_0
+#endif // MBGL_USE_GLES2
 };
 
 constexpr MapDebugOptions operator|(MapDebugOptions lhs, MapDebugOptions rhs) {

--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -5,7 +5,7 @@
 #include <mbgl/util/timer.hpp>
 #include <mbgl/util/geometry.hpp>
 
-#ifdef MBGL_USE_GLES2
+#if MBGL_USE_GLES2
 #define GLFW_INCLUDE_ES2
 #endif
 #define GL_GLEXT_PROTOTYPES

--- a/include/mbgl/platform/default/headless_view.hpp
+++ b/include/mbgl/platform/default/headless_view.hpp
@@ -22,6 +22,7 @@ typedef XID GLXPbuffer;
 
 #include <mbgl/mbgl.hpp>
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/types.hpp>
 
 #include <memory>
 #include <thread>
@@ -89,9 +90,9 @@ private:
 
     std::function<void(MapChange)> mapChangeCallback;
 
-    GLuint fbo = 0;
-    GLuint fboDepthStencil = 0;
-    GLuint fboColor = 0;
+    gl::FramebufferID fbo = 0;
+    gl::RenderbufferID fboDepthStencil = 0;
+    gl::RenderbufferID fboColor = 0;
 };
 
 } // namespace mbgl

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -1,3 +1,5 @@
+add_definitions(-DMBGL_USE_GLES2=1)
+
 #Include to use build specific variables
 include(${CMAKE_CURRENT_BINARY_DIR}/toolchain.cmake)
 

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -1,3 +1,5 @@
+add_definitions(-DMBGL_USE_GLES2=1)
+
 macro(mbgl_platform_core)
     set_xcode_property(mbgl-core IPHONEOS_DEPLOYMENT_TARGET "8.0")
     set_xcode_property(mbgl-core ENABLE_BITCODE "YES")

--- a/src/mbgl/geometry/buffer.hpp
+++ b/src/mbgl/geometry/buffer.hpp
@@ -70,7 +70,7 @@ public:
         }
     }
 
-    GLuint getID() const {
+    gl::BufferID getID() const {
         return buffer ? *buffer : 0;
     }
 

--- a/src/mbgl/geometry/collision_box_buffer.hpp
+++ b/src/mbgl/geometry/collision_box_buffer.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class CollisionBoxVertexBuffer : public Buffer <
     12,
-    GL_ARRAY_BUFFER,
+    gl::BufferType::Vertex,
     32768
 > {
 public:

--- a/src/mbgl/geometry/elements_buffer.hpp
+++ b/src/mbgl/geometry/elements_buffer.hpp
@@ -9,13 +9,13 @@
 
 namespace mbgl {
 
-template <GLsizei count>
+template <size_t count>
 struct ElementGroup : public util::noncopyable {
     std::array<VertexArrayObject, count> array;
-    GLsizei vertex_length;
-    GLsizei elements_length;
+    size_t vertex_length;
+    size_t elements_length;
 
-    ElementGroup(GLsizei vertex_length_ = 0, GLsizei elements_length_ = 0)
+    ElementGroup(size_t vertex_length_ = 0, size_t elements_length_ = 0)
         : vertex_length(vertex_length_)
         , elements_length(elements_length_)
     {
@@ -24,7 +24,7 @@ struct ElementGroup : public util::noncopyable {
 
 class TriangleElementsBuffer : public Buffer<
     6, // bytes per triangle (3 * unsigned short == 6 bytes)
-    GL_ELEMENT_ARRAY_BUFFER
+    gl::BufferType::Element
 > {
 public:
     typedef uint16_t element_type;
@@ -35,7 +35,7 @@ public:
 
 class LineElementsBuffer : public Buffer<
     4, // bytes per triangle (2 * unsigned short == 6 bytes)
-    GL_ELEMENT_ARRAY_BUFFER
+    gl::BufferType::Element
 > {
 public:
     typedef uint16_t element_type;

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -11,10 +11,10 @@
 
 namespace mbgl {
 
-LineAtlas::LineAtlas(GLsizei w, GLsizei h)
+LineAtlas::LineAtlas(uint16_t w, uint16_t h)
     : width(w),
       height(h),
-      data(std::make_unique<GLbyte[]>(w * h)),
+      data(std::make_unique<char[]>(w * h)),
       dirty(true) {
 }
 
@@ -120,13 +120,13 @@ LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, LinePatte
     return position;
 }
 
-void LineAtlas::upload(gl::Context& context, uint32_t unit) {
+void LineAtlas::upload(gl::Context& context, gl::TextureUnit unit) {
     if (dirty) {
         bind(context, unit);
     }
 }
 
-void LineAtlas::bind(gl::Context& context, uint32_t unit) {
+void LineAtlas::bind(gl::Context& context, gl::TextureUnit unit) {
     bool first = false;
     if (!texture) {
         texture = context.createTexture();

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/object.hpp>
 #include <mbgl/util/optional.hpp>
 
@@ -27,24 +26,24 @@ enum class LinePatternCap : bool {
 
 class LineAtlas {
 public:
-    LineAtlas(GLsizei width, GLsizei height);
+    LineAtlas(uint16_t width, uint16_t height);
     ~LineAtlas();
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind(gl::Context&, uint32_t unit);
+    void bind(gl::Context&, gl::TextureUnit unit);
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload(gl::Context&, uint32_t unit);
+    void upload(gl::Context&, gl::TextureUnit unit);
 
     LinePatternPos getDashPosition(const std::vector<float>&, LinePatternCap);
     LinePatternPos addDash(const std::vector<float>& dasharray, LinePatternCap);
 
-    const GLsizei width;
-    const GLsizei height;
+    const uint16_t width;
+    const uint16_t height;
 
 private:
-    const std::unique_ptr<GLbyte[]> data;
+    const std::unique_ptr<char[]> data;
     bool dirty;
     mbgl::optional<gl::UniqueTexture> texture;
     int nextRow = 0;

--- a/src/mbgl/geometry/line_buffer.cpp
+++ b/src/mbgl/geometry/line_buffer.cpp
@@ -1,12 +1,11 @@
 #include <mbgl/geometry/line_buffer.hpp>
-#include <mbgl/gl/gl.hpp>
 
 #include <cmath>
 
 namespace mbgl {
 
-GLsizei LineVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey, bool tx, bool ty, int8_t dir, int32_t linesofar) {
-    GLsizei idx = index();
+size_t LineVertexBuffer::add(vertex_type x, vertex_type y, float ex, float ey, bool tx, bool ty, int8_t dir, int32_t linesofar) {
+    size_t idx = index();
     void *data = addElement();
 
     int16_t *coords = static_cast<int16_t *>(data);

--- a/src/mbgl/geometry/line_buffer.hpp
+++ b/src/mbgl/geometry/line_buffer.hpp
@@ -30,7 +30,7 @@ public:
      * @param {number} ty texture normal
      * @param {number} dir direction of the line cap (-1/0/1)
      */
-    GLsizei add(vertex_type x, vertex_type y, float ex, float ey, bool tx, bool ty, int8_t dir, int32_t linesofar = 0);
+    size_t add(vertex_type x, vertex_type y, float ex, float ey, bool tx, bool ty, int8_t dir, int32_t linesofar = 0);
 };
 
 

--- a/src/mbgl/geometry/static_vertex_buffer.hpp
+++ b/src/mbgl/geometry/static_vertex_buffer.hpp
@@ -9,7 +9,7 @@ namespace mbgl {
 
 class StaticVertexBuffer : public Buffer<
     4, // bytes per vertex (2 * signed short == 4 bytes)
-    GL_ARRAY_BUFFER,
+    gl::BufferType::Vertex,
     32 // default length
 > {
 public:
@@ -19,7 +19,7 @@ public:
 
 class StaticRasterVertexBuffer : public Buffer<
     8, // bytes per vertex (4 * signed short == 8 bytes)
-    GL_ARRAY_BUFFER,
+    gl::BufferType::Vertex,
     32 // default length
 > {
 public:

--- a/src/mbgl/geometry/text_buffer.hpp
+++ b/src/mbgl/geometry/text_buffer.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class TextVertexBuffer : public Buffer <
     16,
-    GL_ARRAY_BUFFER,
+    gl::BufferType::Vertex,
     32768
 > {
 public:

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/geometry/vao.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/gl/gl.hpp>
 
 namespace mbgl {
 
@@ -31,7 +32,7 @@ void VertexArrayObject::bindVertexArrayObject(gl::Context& context) {
 void VertexArrayObject::verifyBinding(Shader& shader,
                                       gl::BufferID vertexBuffer,
                                       gl::BufferID elementsBuffer,
-                                      GLbyte* offset) {
+                                      int8_t* offset) {
     if (bound_shader != shader.getID()) {
         throw std::runtime_error(std::string("trying to rebind VAO to another shader from " +
                                              util::toString(bound_shader) + "(" + bound_shader_name + ") to " +
@@ -48,7 +49,7 @@ void VertexArrayObject::verifyBinding(Shader& shader,
 void VertexArrayObject::storeBinding(Shader& shader,
                                      gl::BufferID vertexBuffer,
                                      gl::BufferID elementsBuffer,
-                                     GLbyte* offset) {
+                                     int8_t* offset) {
     bound_shader = shader.getID();
     bound_shader_name = shader.name;
     bound_offset = offset;

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -28,8 +28,10 @@ void VertexArrayObject::bindVertexArrayObject(gl::Context& context) {
     context.vertexArrayObject = *vertexArray;
 }
 
-void VertexArrayObject::verifyBinding(Shader& shader, GLuint vertexBuffer, GLuint elementsBuffer,
-                                      GLbyte *offset) {
+void VertexArrayObject::verifyBinding(Shader& shader,
+                                      gl::BufferID vertexBuffer,
+                                      gl::BufferID elementsBuffer,
+                                      GLbyte* offset) {
     if (bound_shader != shader.getID()) {
         throw std::runtime_error(std::string("trying to rebind VAO to another shader from " +
                                              util::toString(bound_shader) + "(" + bound_shader_name + ") to " +
@@ -43,8 +45,10 @@ void VertexArrayObject::verifyBinding(Shader& shader, GLuint vertexBuffer, GLuin
     }
 }
 
-void VertexArrayObject::storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer,
-                                     GLbyte *offset) {
+void VertexArrayObject::storeBinding(Shader& shader,
+                                     gl::BufferID vertexBuffer,
+                                     gl::BufferID elementsBuffer,
+                                     GLbyte* offset) {
     bound_shader = shader.getID();
     bound_shader_name = shader.name;
     bound_offset = offset;

--- a/src/mbgl/geometry/vao.cpp
+++ b/src/mbgl/geometry/vao.cpp
@@ -19,13 +19,13 @@ void VertexArrayObject::bindVertexArrayObject(gl::Context& context) {
         return;
     }
 
-    if (!vao) {
-        vao = context.createVAO();
+    if (!vertexArray) {
+        vertexArray = context.createVertexArray();
         context.vertexBuffer.setDirty();
         context.elementBuffer.setDirty();
     }
 
-    context.vertexArrayObject = *vao;
+    context.vertexArrayObject = *vertexArray;
 }
 
 void VertexArrayObject::verifyBinding(Shader& shader, GLuint vertexBuffer, GLuint elementsBuffer,

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -24,7 +24,7 @@ public:
         if (bound_shader == 0) {
             vertexBuffer.bind(context);
             shader.bind(offset);
-            if (vao) {
+            if (vertexArray) {
                 storeBinding(shader, vertexBuffer.getID(), 0, offset);
             }
         } else {
@@ -43,7 +43,7 @@ public:
             vertexBuffer.bind(context);
             elementsBuffer.bind(context);
             shader.bind(offset);
-            if (vao) {
+            if (vertexArray) {
                 storeBinding(shader, vertexBuffer.getID(), elementsBuffer.getID(), offset);
             }
         } else {
@@ -52,7 +52,7 @@ public:
     }
 
     GLuint getID() const {
-        return *vao;
+        return *vertexArray;
     }
 
 private:
@@ -60,7 +60,7 @@ private:
     void storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
     void verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
 
-    mbgl::optional<gl::UniqueVAO> vao;
+    mbgl::optional<gl::UniqueVertexArray> vertexArray;
 
     // For debug reasons, we're storing the bind information so that we can
     // detect errors and report

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -51,23 +51,29 @@ public:
         }
     }
 
-    GLuint getID() const {
+    gl::VertexArrayID getID() const {
         return *vertexArray;
     }
 
 private:
     void bindVertexArrayObject(gl::Context&);
-    void storeBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
-    void verifyBinding(Shader &shader, GLuint vertexBuffer, GLuint elementsBuffer, GLbyte *offset);
+    void storeBinding(Shader& shader,
+                      gl::BufferID vertexBuffer,
+                      gl::BufferID elementsBuffer,
+                      GLbyte* offset);
+    void verifyBinding(Shader& shader,
+                       gl::BufferID vertexBuffer,
+                       gl::BufferID elementsBuffer,
+                       GLbyte* offset);
 
     mbgl::optional<gl::UniqueVertexArray> vertexArray;
 
     // For debug reasons, we're storing the bind information so that we can
     // detect errors and report
-    GLuint bound_shader = 0;
+    gl::ProgramID bound_shader = 0;
     const char* bound_shader_name = "";
-    GLuint bound_vertex_buffer = 0;
-    GLuint bound_elements_buffer = 0;
+    gl::BufferID bound_vertex_buffer = 0;
+    gl::BufferID bound_elements_buffer = 0;
     GLbyte *bound_offset = nullptr;
 };
 

--- a/src/mbgl/geometry/vao.hpp
+++ b/src/mbgl/geometry/vao.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mbgl/shader/shader.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/context.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/optional.hpp>
@@ -18,7 +17,7 @@ public:
     template <typename VertexBuffer>
     void bind(Shader& shader,
               VertexBuffer& vertexBuffer,
-              GLbyte* offset,
+              int8_t* offset,
               gl::Context& context) {
         bindVertexArrayObject(context);
         if (bound_shader == 0) {
@@ -36,7 +35,7 @@ public:
     void bind(Shader& shader,
               VertexBuffer& vertexBuffer,
               ElementsBuffer& elementsBuffer,
-              GLbyte* offset,
+              int8_t* offset,
               gl::Context& context) {
         bindVertexArrayObject(context);
         if (bound_shader == 0) {
@@ -60,11 +59,11 @@ private:
     void storeBinding(Shader& shader,
                       gl::BufferID vertexBuffer,
                       gl::BufferID elementsBuffer,
-                      GLbyte* offset);
+                      int8_t* offset);
     void verifyBinding(Shader& shader,
                        gl::BufferID vertexBuffer,
                        gl::BufferID elementsBuffer,
-                       GLbyte* offset);
+                       int8_t* offset);
 
     mbgl::optional<gl::UniqueVertexArray> vertexArray;
 
@@ -74,7 +73,7 @@ private:
     const char* bound_shader_name = "";
     gl::BufferID bound_vertex_buffer = 0;
     gl::BufferID bound_elements_buffer = 0;
-    GLbyte *bound_offset = nullptr;
+    int8_t *bound_offset = nullptr;
 };
 
 } // namespace mbgl

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -95,24 +95,26 @@ void Context::performCleanup() {
         abandonedTextures.clear();
     }
 
-    if (!abandonedVAOs.empty()) {
-        for (const auto id : abandonedVAOs) {
+    if (!abandonedVertexArrays.empty()) {
+        for (const auto id : abandonedVertexArrays) {
             if (vertexArrayObject == id) {
                 vertexArrayObject.setDirty();
             }
         }
-        MBGL_CHECK_ERROR(gl::DeleteVertexArrays(int(abandonedVAOs.size()), abandonedVAOs.data()));
-        abandonedVAOs.clear();
+        MBGL_CHECK_ERROR(gl::DeleteVertexArrays(int(abandonedVertexArrays.size()),
+                                                abandonedVertexArrays.data()));
+        abandonedVertexArrays.clear();
     }
 
-    if (!abandonedFBOs.empty()) {
-        for (const auto id : abandonedFBOs) {
+    if (!abandonedFramebuffers.empty()) {
+        for (const auto id : abandonedFramebuffers) {
             if (bindFramebuffer == id) {
                 bindFramebuffer.setDirty();
             }
         }
-        MBGL_CHECK_ERROR(glDeleteFramebuffers(int(abandonedFBOs.size()), abandonedFBOs.data()));
-        abandonedFBOs.clear();
+        MBGL_CHECK_ERROR(
+            glDeleteFramebuffers(int(abandonedFramebuffers.size()), abandonedFramebuffers.data()));
+        abandonedFramebuffers.clear();
     }
 }
 

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -3,6 +3,14 @@
 namespace mbgl {
 namespace gl {
 
+static_assert(std::is_same<ProgramID, GLuint>::value, "OpenGL type mismatch");
+static_assert(std::is_same<ShaderID, GLuint>::value, "OpenGL type mismatch");
+static_assert(std::is_same<BufferID, GLuint>::value, "OpenGL type mismatch");
+static_assert(std::is_same<TextureID, GLuint>::value, "OpenGL type mismatch");
+static_assert(std::is_same<VertexArrayID, GLuint>::value, "OpenGL type mismatch");
+static_assert(std::is_same<FramebufferID, GLuint>::value, "OpenGL type mismatch");
+static_assert(std::is_same<RenderbufferID, GLuint>::value, "OpenGL type mismatch");
+
 Context::~Context() {
     reset();
 }
@@ -60,7 +68,7 @@ void Context::setDirtyState() {
 }
 
 void Context::performCleanup() {
-    for (GLuint id : abandonedPrograms) {
+    for (auto id : abandonedPrograms) {
         if (program == id) {
             program.setDirty();
         }
@@ -68,7 +76,7 @@ void Context::performCleanup() {
     }
     abandonedPrograms.clear();
 
-    for (GLuint id : abandonedShaders) {
+    for (auto id : abandonedShaders) {
         MBGL_CHECK_ERROR(glDeleteShader(id));
     }
     abandonedShaders.clear();

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -1,4 +1,6 @@
 #include <mbgl/gl/context.hpp>
+#include <mbgl/gl/gl.hpp>
+#include <mbgl/util/traits.hpp>
 
 namespace mbgl {
 namespace gl {
@@ -11,8 +13,114 @@ static_assert(std::is_same<VertexArrayID, GLuint>::value, "OpenGL type mismatch"
 static_assert(std::is_same<FramebufferID, GLuint>::value, "OpenGL type mismatch");
 static_assert(std::is_same<RenderbufferID, GLuint>::value, "OpenGL type mismatch");
 
+static_assert(std::is_same<StencilValue, GLint>::value, "OpenGL type mismatch");
+static_assert(std::is_same<StencilMaskValue, GLuint>::value, "OpenGL type mismatch");
+
+static_assert(underlying_type(StencilTestFunction::Never) == GL_NEVER, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestFunction::Less) == GL_LESS, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestFunction::Equal) == GL_EQUAL, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestFunction::LessEqual) == GL_LEQUAL, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestFunction::Greater) == GL_GREATER, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestFunction::NotEqual) == GL_NOTEQUAL, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestFunction::GreaterEqual) == GL_GEQUAL, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestFunction::Always) == GL_ALWAYS, "OpenGL enum mismatch");
+
+static_assert(underlying_type(StencilTestOperation::Keep) == GL_KEEP, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestOperation::Zero) == GL_ZERO, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestOperation::Replace) == GL_REPLACE, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestOperation::Increment) == GL_INCR, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestOperation::IncrementWrap) == GL_INCR_WRAP, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestOperation::Decrement) == GL_DECR, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestOperation::DecrementWrap) == GL_DECR_WRAP, "OpenGL enum mismatch");
+static_assert(underlying_type(StencilTestOperation::Invert) == GL_INVERT, "OpenGL enum mismatch");
+
+static_assert(underlying_type(DepthTestFunction::Never) == GL_NEVER, "OpenGL enum mismatch");
+static_assert(underlying_type(DepthTestFunction::Less) == GL_LESS, "OpenGL enum mismatch");
+static_assert(underlying_type(DepthTestFunction::Equal) == GL_EQUAL, "OpenGL enum mismatch");
+static_assert(underlying_type(DepthTestFunction::LessEqual) == GL_LEQUAL, "OpenGL enum mismatch");
+static_assert(underlying_type(DepthTestFunction::Greater) == GL_GREATER, "OpenGL enum mismatch");
+static_assert(underlying_type(DepthTestFunction::NotEqual) == GL_NOTEQUAL, "OpenGL enum mismatch");
+static_assert(underlying_type(DepthTestFunction::GreaterEqual) == GL_GEQUAL, "OpenGL enum mismatch");
+static_assert(underlying_type(DepthTestFunction::Always) == GL_ALWAYS, "OpenGL enum mismatch");
+
+static_assert(underlying_type(BlendSourceFactor::Zero) == GL_ZERO, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::One) == GL_ONE, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::SrcColor) == GL_SRC_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::OneMinusSrcColor) == GL_ONE_MINUS_SRC_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::DstColor) == GL_DST_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::OneMinusDstColor) == GL_ONE_MINUS_DST_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::SrcAlpha) == GL_SRC_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::OneMinusSrcAlpha) == GL_ONE_MINUS_SRC_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::DstAlpha) == GL_DST_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::OneMinusDstAlpha) == GL_ONE_MINUS_DST_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::ConstantColor) == GL_CONSTANT_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::OneMinusConstantColor) == GL_ONE_MINUS_CONSTANT_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::ConstantAlpha) == GL_CONSTANT_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::OneMinusConstantAlpha) == GL_ONE_MINUS_CONSTANT_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendSourceFactor::SrcAlphaSaturate) == GL_SRC_ALPHA_SATURATE, "OpenGL enum mismatch");
+
+static_assert(underlying_type(BlendDestinationFactor::Zero) == GL_ZERO, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::One) == GL_ONE, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::SrcColor) == GL_SRC_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::OneMinusSrcColor) == GL_ONE_MINUS_SRC_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::DstColor) == GL_DST_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::OneMinusDstColor) == GL_ONE_MINUS_DST_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::SrcAlpha) == GL_SRC_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::OneMinusSrcAlpha) == GL_ONE_MINUS_SRC_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::DstAlpha) == GL_DST_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::OneMinusDstAlpha) == GL_ONE_MINUS_DST_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::ConstantColor) == GL_CONSTANT_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::OneMinusConstantColor) == GL_ONE_MINUS_CONSTANT_COLOR, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::ConstantAlpha) == GL_CONSTANT_ALPHA, "OpenGL enum mismatch");
+static_assert(underlying_type(BlendDestinationFactor::OneMinusConstantAlpha) == GL_ONE_MINUS_CONSTANT_ALPHA, "OpenGL enum mismatch");
+
 Context::~Context() {
     reset();
+}
+
+UniqueProgram Context::createProgram() {
+    return UniqueProgram{ MBGL_CHECK_ERROR(glCreateProgram()), { this } };
+}
+
+UniqueShader Context::createVertexShader() {
+    return UniqueShader{ MBGL_CHECK_ERROR(glCreateShader(GL_VERTEX_SHADER)), { this } };
+}
+
+UniqueShader Context::createFragmentShader() {
+    return UniqueShader{ MBGL_CHECK_ERROR(glCreateShader(GL_FRAGMENT_SHADER)), { this } };
+}
+
+UniqueBuffer Context::createBuffer() {
+    BufferID id = 0;
+    MBGL_CHECK_ERROR(glGenBuffers(1, &id));
+    return UniqueBuffer{ std::move(id), { this } };
+}
+
+UniqueTexture Context::createTexture() {
+    if (pooledTextures.empty()) {
+        pooledTextures.resize(TextureMax);
+        MBGL_CHECK_ERROR(glGenTextures(TextureMax, pooledTextures.data()));
+    }
+
+    TextureID id = pooledTextures.back();
+    pooledTextures.pop_back();
+    return UniqueTexture{ std::move(id), { this } };
+}
+
+UniqueVertexArray Context::createVertexArray() {
+    VertexArrayID id = 0;
+    MBGL_CHECK_ERROR(gl::GenVertexArrays(1, &id));
+    return UniqueVertexArray{ std::move(id), { this } };
+}
+
+UniqueFramebuffer Context::createFramebuffer() {
+    FramebufferID id = 0;
+    MBGL_CHECK_ERROR(glGenFramebuffers(1, &id));
+    return UniqueFramebuffer{ std::move(id), { this } };
+}
+
+void Context::uploadBuffer(BufferType type, size_t size, void* data) {
+    MBGL_CHECK_ERROR(glBufferData(static_cast<GLenum>(type), size, data, GL_STATIC_DRAW));
 }
 
 void Context::reset() {
@@ -45,10 +153,10 @@ void applyStateFunction(Context& context, Fn&& fn) {
     fn(context.activeTexture);
     fn(context.bindFramebuffer);
     fn(context.viewport);
-#ifndef GL_ES_VERSION_2_0
+#if not MBGL_USE_GLES2
     fn(context.pixelZoom);
     fn(context.rasterPos);
-#endif // GL_ES_VERSION_2_0
+#endif // MBGL_USE_GLES2
     for (auto& tex : context.texture) {
         fn(tex);
     }

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -21,12 +21,16 @@ public:
         return UniqueProgram { MBGL_CHECK_ERROR(glCreateProgram()), { this } };
     }
 
-    UniqueShader createShader(GLenum type) {
-        return UniqueShader { MBGL_CHECK_ERROR(glCreateShader(type)), { this } };
+    UniqueShader createVertexShader() {
+        return UniqueShader { MBGL_CHECK_ERROR(glCreateShader(GL_VERTEX_SHADER)), { this } };
+    }
+
+    UniqueShader createFragmentShader() {
+        return UniqueShader { MBGL_CHECK_ERROR(glCreateShader(GL_FRAGMENT_SHADER)), { this } };
     }
 
     UniqueBuffer createBuffer() {
-        GLuint id = 0;
+        BufferID id = 0;
         MBGL_CHECK_ERROR(glGenBuffers(1, &id));
         return UniqueBuffer { std::move(id), { this } };
     }
@@ -37,19 +41,19 @@ public:
             MBGL_CHECK_ERROR(glGenTextures(TextureMax, pooledTextures.data()));
         }
 
-        GLuint id = pooledTextures.back();
+        TextureID id = pooledTextures.back();
         pooledTextures.pop_back();
         return UniqueTexture { std::move(id), { this } };
     }
 
     UniqueVertexArray createVertexArray() {
-        GLuint id = 0;
+        VertexArrayID id = 0;
         MBGL_CHECK_ERROR(gl::GenVertexArrays(1, &id));
         return UniqueVertexArray { std::move(id), { this } };
     }
 
     UniqueFramebuffer createFramebuffer() {
-        GLuint id = 0;
+        FramebufferID id = 0;
         MBGL_CHECK_ERROR(glGenFramebuffers(1, &id));
         return UniqueFramebuffer { std::move(id), { this } };
     }
@@ -113,14 +117,14 @@ private:
     friend detail::VertexArrayDeleter;
     friend detail::FramebufferDeleter;
 
-    std::vector<GLuint> pooledTextures;
+    std::vector<TextureID> pooledTextures;
 
-    std::vector<GLuint> abandonedPrograms;
-    std::vector<GLuint> abandonedShaders;
-    std::vector<GLuint> abandonedBuffers;
-    std::vector<GLuint> abandonedTextures;
-    std::vector<GLuint> abandonedVertexArrays;
-    std::vector<GLuint> abandonedFramebuffers;
+    std::vector<ProgramID> abandonedPrograms;
+    std::vector<ShaderID> abandonedShaders;
+    std::vector<BufferID> abandonedBuffers;
+    std::vector<TextureID> abandonedTextures;
+    std::vector<VertexArrayID> abandonedVertexArrays;
+    std::vector<FramebufferID> abandonedFramebuffers;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -42,16 +42,16 @@ public:
         return UniqueTexture { std::move(id), { this } };
     }
 
-    UniqueVAO createVAO() {
+    UniqueVertexArray createVertexArray() {
         GLuint id = 0;
         MBGL_CHECK_ERROR(gl::GenVertexArrays(1, &id));
-        return UniqueVAO { std::move(id), { this } };
+        return UniqueVertexArray { std::move(id), { this } };
     }
 
-    UniqueFBO createFBO() {
+    UniqueFramebuffer createFramebuffer() {
         GLuint id = 0;
         MBGL_CHECK_ERROR(glGenFramebuffers(1, &id));
-        return UniqueFBO { std::move(id), { this } };
+        return UniqueFramebuffer { std::move(id), { this } };
     }
 
     // Actually remove the objects we marked as abandoned with the above methods.
@@ -68,8 +68,8 @@ public:
             && abandonedShaders.empty()
             && abandonedBuffers.empty()
             && abandonedTextures.empty()
-            && abandonedVAOs.empty()
-            && abandonedFBOs.empty();
+            && abandonedVertexArrays.empty()
+            && abandonedFramebuffers.empty();
     }
 
     void resetState();
@@ -103,15 +103,15 @@ public:
     std::array<State<value::BindTexture>, 2> texture;
     State<value::BindBuffer<GL_ARRAY_BUFFER>> vertexBuffer;
     State<value::BindBuffer<GL_ELEMENT_ARRAY_BUFFER>> elementBuffer;
-    State<value::BindVAO> vertexArrayObject;
+    State<value::BindVertexArray> vertexArrayObject;
 
 private:
     friend detail::ProgramDeleter;
     friend detail::ShaderDeleter;
     friend detail::BufferDeleter;
     friend detail::TextureDeleter;
-    friend detail::VAODeleter;
-    friend detail::FBODeleter;
+    friend detail::VertexArrayDeleter;
+    friend detail::FramebufferDeleter;
 
     std::vector<GLuint> pooledTextures;
 
@@ -119,8 +119,8 @@ private:
     std::vector<GLuint> abandonedShaders;
     std::vector<GLuint> abandonedBuffers;
     std::vector<GLuint> abandonedTextures;
-    std::vector<GLuint> abandonedVAOs;
-    std::vector<GLuint> abandonedFBOs;
+    std::vector<GLuint> abandonedVertexArrays;
+    std::vector<GLuint> abandonedFramebuffers;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/object.cpp
+++ b/src/mbgl/gl/object.cpp
@@ -7,22 +7,22 @@ namespace mbgl {
 namespace gl {
 namespace detail {
 
-void ProgramDeleter::operator()(GLuint id) const {
+void ProgramDeleter::operator()(ProgramID id) const {
     assert(context);
     context->abandonedPrograms.push_back(id);
 }
 
-void ShaderDeleter::operator()(GLuint id) const {
+void ShaderDeleter::operator()(ShaderID id) const {
     assert(context);
     context->abandonedShaders.push_back(id);
 }
 
-void BufferDeleter::operator()(GLuint id) const {
+void BufferDeleter::operator()(BufferID id) const {
     assert(context);
     context->abandonedBuffers.push_back(id);
 }
 
-void TextureDeleter::operator()(GLuint id) const {
+void TextureDeleter::operator()(TextureID id) const {
     assert(context);
     if (context->pooledTextures.size() >= TextureMax) {
         context->abandonedTextures.push_back(id);
@@ -31,12 +31,12 @@ void TextureDeleter::operator()(GLuint id) const {
     }
 }
 
-void VertexArrayDeleter::operator()(GLuint id) const {
+void VertexArrayDeleter::operator()(VertexArrayID id) const {
     assert(context);
     context->abandonedVertexArrays.push_back(id);
 }
 
-void FramebufferDeleter::operator()(GLuint id) const {
+void FramebufferDeleter::operator()(FramebufferID id) const {
     assert(context);
     context->abandonedFramebuffers.push_back(id);
 }

--- a/src/mbgl/gl/object.cpp
+++ b/src/mbgl/gl/object.cpp
@@ -31,14 +31,14 @@ void TextureDeleter::operator()(GLuint id) const {
     }
 }
 
-void VAODeleter::operator()(GLuint id) const {
+void VertexArrayDeleter::operator()(GLuint id) const {
     assert(context);
-    context->abandonedVAOs.push_back(id);
+    context->abandonedVertexArrays.push_back(id);
 }
 
-void FBODeleter::operator()(GLuint id) const {
+void FramebufferDeleter::operator()(GLuint id) const {
     assert(context);
-    context->abandonedFBOs.push_back(id);
+    context->abandonedFramebuffers.push_back(id);
 }
 
 } // namespace detail

--- a/src/mbgl/gl/object.hpp
+++ b/src/mbgl/gl/object.hpp
@@ -31,12 +31,12 @@ struct TextureDeleter {
     void operator()(GLuint) const;
 };
 
-struct VAODeleter {
+struct VertexArrayDeleter {
     Context* context;
     void operator()(GLuint) const;
 };
 
-struct FBODeleter {
+struct FramebufferDeleter {
     Context* context;
     void operator()(GLuint) const;
 };
@@ -47,8 +47,8 @@ using UniqueProgram = std_experimental::unique_resource<GLuint, detail::ProgramD
 using UniqueShader = std_experimental::unique_resource<GLuint, detail::ShaderDeleter>;
 using UniqueBuffer = std_experimental::unique_resource<GLuint, detail::BufferDeleter>;
 using UniqueTexture = std_experimental::unique_resource<GLuint, detail::TextureDeleter>;
-using UniqueVAO = std_experimental::unique_resource<GLuint, detail::VAODeleter>;
-using UniqueFBO = std_experimental::unique_resource<GLuint, detail::FBODeleter>;
+using UniqueVertexArray = std_experimental::unique_resource<GLuint, detail::VertexArrayDeleter>;
+using UniqueFramebuffer = std_experimental::unique_resource<GLuint, detail::FramebufferDeleter>;
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/object.hpp
+++ b/src/mbgl/gl/object.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/types.hpp>
 
 #include <unique_resource.hpp>
 
@@ -13,42 +13,42 @@ namespace detail {
 
 struct ProgramDeleter {
     Context* context;
-    void operator()(GLuint) const;
+    void operator()(ProgramID) const;
 };
 
 struct ShaderDeleter {
     Context* context;
-    void operator()(GLuint) const;
+    void operator()(ShaderID) const;
 };
 
 struct BufferDeleter {
     Context* context;
-    void operator()(GLuint) const;
+    void operator()(BufferID) const;
 };
 
 struct TextureDeleter {
     Context* context;
-    void operator()(GLuint) const;
+    void operator()(TextureID) const;
 };
 
 struct VertexArrayDeleter {
     Context* context;
-    void operator()(GLuint) const;
+    void operator()(VertexArrayID) const;
 };
 
 struct FramebufferDeleter {
     Context* context;
-    void operator()(GLuint) const;
+    void operator()(FramebufferID) const;
 };
 
 } // namespace detail
 
-using UniqueProgram = std_experimental::unique_resource<GLuint, detail::ProgramDeleter>;
-using UniqueShader = std_experimental::unique_resource<GLuint, detail::ShaderDeleter>;
-using UniqueBuffer = std_experimental::unique_resource<GLuint, detail::BufferDeleter>;
-using UniqueTexture = std_experimental::unique_resource<GLuint, detail::TextureDeleter>;
-using UniqueVertexArray = std_experimental::unique_resource<GLuint, detail::VertexArrayDeleter>;
-using UniqueFramebuffer = std_experimental::unique_resource<GLuint, detail::FramebufferDeleter>;
+using UniqueProgram = std_experimental::unique_resource<ProgramID, detail::ProgramDeleter>;
+using UniqueShader = std_experimental::unique_resource<ShaderID, detail::ShaderDeleter>;
+using UniqueBuffer = std_experimental::unique_resource<BufferID, detail::BufferDeleter>;
+using UniqueTexture = std_experimental::unique_resource<TextureID, detail::TextureDeleter>;
+using UniqueVertexArray = std_experimental::unique_resource<VertexArrayID, detail::VertexArrayDeleter>;
+using UniqueFramebuffer = std_experimental::unique_resource<FramebufferID, detail::FramebufferDeleter>;
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/types.hpp
+++ b/src/mbgl/gl/types.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace mbgl {
+namespace gl {
+
+using ProgramID = uint32_t;
+using ShaderID = uint32_t;
+using BufferID = uint32_t;
+using TextureID = uint32_t;
+using VertexArrayID = uint32_t;
+using FramebufferID = uint32_t;
+using RenderbufferID = uint32_t;
+
+} // namespace gl
+} // namespace mbgl

--- a/src/mbgl/gl/types.hpp
+++ b/src/mbgl/gl/types.hpp
@@ -5,6 +5,7 @@
 namespace mbgl {
 namespace gl {
 
+// Mapping based on https://www.opengl.org/wiki/OpenGL_Type
 using ProgramID = uint32_t;
 using ShaderID = uint32_t;
 using BufferID = uint32_t;
@@ -12,6 +13,87 @@ using TextureID = uint32_t;
 using VertexArrayID = uint32_t;
 using FramebufferID = uint32_t;
 using RenderbufferID = uint32_t;
+
+using AttributeLocation = int32_t;
+using UniformLocation = int32_t;
+using TextureUnit = uint8_t;
+
+using DepthValue = double;
+using StencilValue = int32_t;
+using StencilMaskValue = uint32_t;
+
+enum class BufferType : uint32_t {
+    Vertex = 0x8892,
+    Element = 0x8893
+};
+
+enum class StencilTestFunction : uint32_t {
+    Never = 0x0200,
+    Less = 0x0201,
+    Equal = 0x0202,
+    LessEqual = 0x0203,
+    Greater = 0x0204,
+    NotEqual = 0x0205,
+    GreaterEqual = 0x0206,
+    Always = 0x0207,
+};
+
+enum class StencilTestOperation : uint32_t {
+    Keep = 0x1E00,
+    Zero = 0x0000,
+    Replace = 0x1E01,
+    Increment = 0x1E02,
+    IncrementWrap = 0x8507,
+    Decrement = 0x1E03,
+    DecrementWrap = 0x8508,
+    Invert = 0x150A,
+};
+
+enum class DepthTestFunction : uint32_t {
+    Never = 0x0200,
+    Less = 0x0201,
+    Equal = 0x0202,
+    LessEqual = 0x0203,
+    Greater = 0x0204,
+    NotEqual = 0x0205,
+    GreaterEqual = 0x0206,
+    Always = 0x0207,
+};
+
+enum class BlendSourceFactor : uint32_t {
+    Zero = 0x0000,
+    One = 0x0001,
+    SrcColor = 0x0300,
+    OneMinusSrcColor = 0x0301,
+    DstColor = 0x0306,
+    OneMinusDstColor = 0x0307,
+    SrcAlpha = 0x0302,
+    OneMinusSrcAlpha = 0x0303,
+    DstAlpha = 0x0304,
+    OneMinusDstAlpha = 0x0305,
+    ConstantColor = 0x8001,
+    OneMinusConstantColor = 0x8002,
+    ConstantAlpha = 0x8003,
+    OneMinusConstantAlpha = 0x8004,
+    SrcAlphaSaturate = 0x0308,
+};
+
+enum class BlendDestinationFactor : uint32_t {
+    Zero = 0x0000,
+    One = 0x0001,
+    SrcColor = 0x0300,
+    OneMinusSrcColor = 0x0301,
+    DstColor = 0x0306,
+    OneMinusDstColor = 0x0307,
+    SrcAlpha = 0x0302,
+    OneMinusSrcAlpha = 0x0303,
+    DstAlpha = 0x0304,
+    OneMinusDstAlpha = 0x0305,
+    ConstantColor = 0x8001,
+    OneMinusConstantColor = 0x8002,
+    ConstantAlpha = 0x8003,
+    OneMinusConstantAlpha = 0x8004,
+};
 
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -23,7 +23,7 @@ const constexpr Program::Type Program::Default;
 const constexpr LineWidth::Type LineWidth::Default;
 const constexpr ActiveTexture::Type ActiveTexture::Default;
 const constexpr BindTexture::Type BindTexture::Default;
-const constexpr BindVAO::Type BindVAO::Default;
+const constexpr BindVertexArray::Type BindVertexArray::Default;
 
 #ifndef GL_ES_VERSION_2_0
 const constexpr PixelZoom::Type PixelZoom::Default;

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -1,34 +1,355 @@
 #include <mbgl/gl/value.hpp>
+#include <mbgl/gl/gl.hpp>
 
 namespace mbgl {
 namespace gl {
 namespace value {
 
-const constexpr StencilFunc::Type StencilFunc::Default;
-const constexpr StencilMask::Type StencilMask::Default;
-const constexpr StencilTest::Type StencilTest::Default;
-const constexpr StencilOp::Type StencilOp::Default;
-const constexpr DepthRange::Type DepthRange::Default;
-const constexpr DepthMask::Type DepthMask::Default;
-const constexpr DepthTest::Type DepthTest::Default;
-const constexpr DepthFunc::Type DepthFunc::Default;
-const constexpr Blend::Type Blend::Default;
-const constexpr BlendFunc::Type BlendFunc::Default;
-const constexpr BlendColor::Type BlendColor::Default;
-const constexpr ColorMask::Type ColorMask::Default;
 const constexpr ClearDepth::Type ClearDepth::Default;
+
+void ClearDepth::Set(const Type& value) {
+#if MBGL_USE_GLES2
+    MBGL_CHECK_ERROR(glClearDepthf(value));
+#else
+    MBGL_CHECK_ERROR(glClearDepth(value));
+#endif
+}
+
+ClearDepth::Type ClearDepth::Get() {
+    GLfloat clearDepth;
+    MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_CLEAR_VALUE, &clearDepth));
+    return clearDepth;
+}
+
 const constexpr ClearColor::Type ClearColor::Default;
+
+void ClearColor::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glClearColor(value.r, value.g, value.b, value.a));
+}
+
+ClearColor::Type ClearColor::Get() {
+    GLfloat clearColor[4];
+    MBGL_CHECK_ERROR(glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor));
+    return { clearColor[0], clearColor[1], clearColor[2], clearColor[3] };
+}
+
 const constexpr ClearStencil::Type ClearStencil::Default;
+
+void ClearStencil::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glClearStencil(value));
+}
+
+ClearStencil::Type ClearStencil::Get() {
+    GLint clearStencil;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_CLEAR_VALUE, &clearStencil));
+    return clearStencil;
+}
+
+const constexpr StencilMask::Type StencilMask::Default;
+
+void StencilMask::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glStencilMask(value));
+}
+
+StencilMask::Type StencilMask::Get() {
+    GLint stencilMask;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_WRITEMASK, &stencilMask));
+    return stencilMask;
+}
+
+const constexpr DepthMask::Type DepthMask::Default;
+
+void DepthMask::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glDepthMask(value));
+}
+
+DepthMask::Type DepthMask::Get() {
+    GLboolean depthMask;
+    MBGL_CHECK_ERROR(glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask));
+    return depthMask;
+}
+
+const constexpr ColorMask::Type ColorMask::Default;
+
+void ColorMask::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glColorMask(value.r, value.g, value.b, value.a));
+}
+
+ColorMask::Type ColorMask::Get() {
+    GLboolean bools[4];
+    MBGL_CHECK_ERROR(glGetBooleanv(GL_COLOR_WRITEMASK, bools));
+    return { static_cast<bool>(bools[0]), static_cast<bool>(bools[1]), static_cast<bool>(bools[2]),
+             static_cast<bool>(bools[3]) };
+}
+
+const constexpr StencilFunc::Type StencilFunc::Default;
+
+void StencilFunc::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glStencilFunc(static_cast<GLenum>(value.func), value.ref, value.mask));
+}
+
+StencilFunc::Type StencilFunc::Get() {
+    GLint func, ref, mask;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FUNC, &func));
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_REF, &ref));
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_VALUE_MASK, &mask));
+    return { static_cast<StencilTestFunction>(func), ref, static_cast<StencilMaskValue>(mask) };
+}
+
+const constexpr StencilTest::Type StencilTest::Default;
+
+void StencilTest::Set(const Type& value) {
+    MBGL_CHECK_ERROR(value ? glEnable(GL_STENCIL_TEST) : glDisable(GL_STENCIL_TEST));
+}
+
+StencilTest::Type StencilTest::Get() {
+    Type stencilTest;
+    MBGL_CHECK_ERROR(stencilTest = glIsEnabled(GL_STENCIL_TEST));
+    return stencilTest;
+}
+
+const constexpr StencilOp::Type StencilOp::Default;
+
+void StencilOp::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glStencilOp(static_cast<GLenum>(value.sfail),
+                                 static_cast<GLenum>(value.dpfail),
+                                 static_cast<GLenum>(value.dppass)));
+}
+
+StencilOp::Type StencilOp::Get() {
+    GLint sfail, dpfail, dppass;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FAIL, &sfail));
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_FAIL, &dpfail));
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_PASS, &dppass));
+    return { static_cast<StencilTestOperation>(sfail), static_cast<StencilTestOperation>(dpfail),
+             static_cast<StencilTestOperation>(dppass) };
+}
+
+const constexpr DepthRange::Type DepthRange::Default;
+
+void DepthRange::Set(const Type& value) {
+#if MBGL_USE_GLES2
+    MBGL_CHECK_ERROR(glDepthRangef(value.near, value.far));
+#else
+    MBGL_CHECK_ERROR(glDepthRange(value.near, value.far));
+#endif
+}
+
+DepthRange::Type DepthRange::Get() {
+    GLfloat floats[2];
+    MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_RANGE, floats));
+    return { floats[0], floats[1] };
+}
+
+const constexpr DepthTest::Type DepthTest::Default;
+
+void DepthTest::Set(const Type& value) {
+    MBGL_CHECK_ERROR(value ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST));
+}
+
+DepthTest::Type DepthTest::Get() {
+    Type depthTest;
+    MBGL_CHECK_ERROR(depthTest = glIsEnabled(GL_DEPTH_TEST));
+    return depthTest;
+}
+
+const constexpr DepthFunc::Type DepthFunc::Default;
+
+void DepthFunc::Set(const DepthFunc::Type& value) {
+    MBGL_CHECK_ERROR(glDepthFunc(static_cast<GLenum>(value)));
+}
+
+DepthFunc::Type DepthFunc::Get() {
+    GLint depthFunc;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_DEPTH_FUNC, &depthFunc));
+    return static_cast<Type>(depthFunc);
+}
+
+const constexpr Blend::Type Blend::Default;
+
+void Blend::Set(const Type& value) {
+    MBGL_CHECK_ERROR(value ? glEnable(GL_BLEND) : glDisable(GL_BLEND));
+}
+
+Blend::Type Blend::Get() {
+    Type blend;
+    MBGL_CHECK_ERROR(blend = glIsEnabled(GL_BLEND));
+    return blend;
+}
+
+const constexpr BlendFunc::Type BlendFunc::Default;
+
+void BlendFunc::Set(const Type& value) {
+    MBGL_CHECK_ERROR(
+        glBlendFunc(static_cast<GLenum>(value.sfactor), static_cast<GLenum>(value.dfactor)));
+}
+
+BlendFunc::Type BlendFunc::Get() {
+    GLint sfactor, dfactor;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_SRC_ALPHA, &sfactor));
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_DST_ALPHA, &dfactor));
+    return { static_cast<BlendSourceFactor>(sfactor),
+             static_cast<BlendDestinationFactor>(dfactor) };
+}
+
+const constexpr BlendColor::Type BlendColor::Default;
+
+void BlendColor::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glBlendColor(value.r, value.g, value.b, value.a));
+}
+
+BlendColor::Type BlendColor::Get() {
+    GLfloat floats[4];
+    MBGL_CHECK_ERROR(glGetFloatv(GL_BLEND_COLOR, floats));
+    return { floats[0], floats[1], floats[2], floats[3] };
+}
+
 const constexpr Program::Type Program::Default;
+
+void Program::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glUseProgram(value));
+}
+
+Program::Type Program::Get() {
+    GLint program;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_CURRENT_PROGRAM, &program));
+    return program;
+}
+
 const constexpr LineWidth::Type LineWidth::Default;
+
+void LineWidth::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glLineWidth(value));
+}
+
+LineWidth::Type LineWidth::Get() {
+    GLfloat lineWidth;
+    MBGL_CHECK_ERROR(glGetFloatv(GL_LINE_WIDTH, &lineWidth));
+    return lineWidth;
+}
+
 const constexpr ActiveTexture::Type ActiveTexture::Default;
+
+void ActiveTexture::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0 + value));
+}
+
+ActiveTexture::Type ActiveTexture::Get() {
+    GLint activeTexture;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture));
+    return static_cast<Type>(activeTexture - GL_TEXTURE0);
+}
+
+void Viewport::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glViewport(value.x, value.y, value.width, value.height));
+}
+
+Viewport::Type Viewport::Get() {
+    GLint viewport[4];
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_VIEWPORT, viewport));
+    return { static_cast<int32_t>(viewport[0]), static_cast<int32_t>(viewport[1]),
+             static_cast<uint16_t>(viewport[2]), static_cast<uint16_t>(viewport[3]) };
+}
+
+void BindFramebuffer::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glBindFramebuffer(GL_FRAMEBUFFER, value));
+}
+
+BindFramebuffer::Type BindFramebuffer::Get() {
+    GLint binding;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &binding));
+    return binding;
+}
+
 const constexpr BindTexture::Type BindTexture::Default;
+
+void BindTexture::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, value));
+}
+
+BindTexture::Type BindTexture::Get() {
+    GLint binding;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_TEXTURE_BINDING_2D, &binding));
+    return binding;
+}
+
+const constexpr BindVertexBuffer::Type BindVertexBuffer::Default;
+
+void BindVertexBuffer::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, value));
+}
+
+BindVertexBuffer::Type BindVertexBuffer::Get() {
+    GLint binding;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &binding));
+    return binding;
+}
+
+const constexpr BindElementBuffer::Type BindElementBuffer::Default;
+
+void BindElementBuffer::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, value));
+}
+
+BindElementBuffer::Type BindElementBuffer::Get() {
+    GLint binding;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &binding));
+    return binding;
+}
+
 const constexpr BindVertexArray::Type BindVertexArray::Default;
 
-#ifndef GL_ES_VERSION_2_0
+void BindVertexArray::Set(const Type& value) {
+    if (gl::BindVertexArray) {
+        MBGL_CHECK_ERROR(gl::BindVertexArray(value));
+    }
+}
+
+BindVertexArray::Type BindVertexArray::Get() {
+    GLint binding = 0;
+    if (gl::BindVertexArray) {
+#ifdef GL_VERTEX_ARRAY_BINDING
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &binding));
+#elif GL_VERTEX_ARRAY_BINDING_OES
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_VERTEX_ARRAY_BINDING_OES, &binding));
+#elif GL_VERTEX_ARRAY_BINDING_ARB
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_VERTEX_ARRAY_BINDING_ARB, &binding));
+#elif GLVERTEX_ARRAY_BINDING_APPLE
+        MBGL_CHECK_ERROR(glGetIntegerv(GLVERTEX_ARRAY_BINDING_APPLE, &binding));
+#endif
+    }
+    return binding;
+}
+
+#if not MBGL_USE_GLES2
+
 const constexpr PixelZoom::Type PixelZoom::Default;
+
+void PixelZoom::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glPixelZoom(value.xfactor, value.yfactor));
+}
+
+PixelZoom::Type PixelZoom::Get() {
+    GLfloat xfactor, yfactor;
+    MBGL_CHECK_ERROR(glGetFloatv(GL_ZOOM_X, &xfactor));
+    MBGL_CHECK_ERROR(glGetFloatv(GL_ZOOM_Y, &yfactor));
+    return { xfactor, yfactor };
+}
+
 const constexpr RasterPos::Type RasterPos::Default;
-#endif // GL_ES_VERSION_2_0
+
+void RasterPos::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glRasterPos4d(value.x, value.y, value.z, value.w));
+}
+
+RasterPos::Type RasterPos::Get() {
+    GLdouble pos[4];
+    MBGL_CHECK_ERROR(glGetDoublev(GL_CURRENT_RASTER_POSITION, pos));
+    return { pos[0], pos[1], pos[2], pos[3] };
+}
+
+#endif // MBGL_USE_GLES2
+
 
 } // namespace value
 } // namespace gl

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -278,9 +278,9 @@ struct BindFramebuffer {
         MBGL_CHECK_ERROR(glBindFramebuffer(GL_FRAMEBUFFER, value));
     }
     static Type Get() {
-        Type activeFBO;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &activeFBO));
-        return activeFBO;
+        Type activeFramebuffer;
+        MBGL_CHECK_ERROR(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &activeFramebuffer));
+        return activeFramebuffer;
     }
 };
 
@@ -366,7 +366,7 @@ struct BindBuffer {
 template <GLenum target>
 const typename BindBuffer<target>::Type BindBuffer<target>::Default;
 
-struct BindVAO {
+struct BindVertexArray {
     using Type = GLuint;
     static const constexpr Type Default = 0;
     static void Set(const Type& value) {

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -6,6 +6,7 @@
 #include <cassert>
 
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/types.hpp>
 #include <mbgl/util/color.hpp>
 
 namespace mbgl {
@@ -234,7 +235,7 @@ struct BlendColor {
 };
 
 struct Program {
-    using Type = GLuint;
+    using Type = gl::ProgramID;
     static const constexpr Type Default = 0;
     static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glUseProgram(value));
@@ -333,7 +334,7 @@ struct RasterPos {
 #endif // GL_ES_VERSION_2_0
 
 struct BindTexture {
-    using Type = GLuint;
+    using Type = gl::TextureID;
     static const constexpr Type Default = 0;
     static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, value));
@@ -341,7 +342,7 @@ struct BindTexture {
     static Type Get() {
         GLint texture;
         MBGL_CHECK_ERROR(glGetIntegerv(GL_TEXTURE_BINDING_2D, &texture));
-        return texture;
+        return static_cast<Type>(texture);
     }
 };
 
@@ -349,7 +350,7 @@ template <GLenum target>
 struct BindBuffer {
     static_assert(target == GL_ARRAY_BUFFER || target == GL_ELEMENT_ARRAY_BUFFER,
                   "target must be one of GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER");
-    using Type = GLuint;
+    using Type = gl::BufferID;
     static const constexpr Type Default = 0;
     static void Set(const Type& value) {
         MBGL_CHECK_ERROR(glBindBuffer(target, value));
@@ -359,7 +360,7 @@ struct BindBuffer {
         MBGL_CHECK_ERROR(glGetIntegerv(target == GL_ARRAY_BUFFER ? GL_ARRAY_BUFFER_BINDING
                                                                  : GL_ELEMENT_ARRAY_BUFFER_BINDING,
                                        &binding));
-        return binding;
+        return static_cast<Type>(binding);
     }
 };
 
@@ -367,7 +368,7 @@ template <GLenum target>
 const typename BindBuffer<target>::Type BindBuffer<target>::Default;
 
 struct BindVertexArray {
-    using Type = GLuint;
+    using Type = gl::VertexArrayID;
     static const constexpr Type Default = 0;
     static void Set(const Type& value) {
         if (gl::BindVertexArray) {

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -1,11 +1,5 @@
 #pragma once
 
-#include <cstdint>
-#include <tuple>
-#include <array>
-#include <cassert>
-
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/types.hpp>
 #include <mbgl/util/color.hpp>
 
@@ -14,82 +8,50 @@ namespace gl {
 namespace value {
 
 struct ClearDepth {
-    using Type = GLfloat;
+    using Type = float;
     static const constexpr Type Default = 1;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glClearDepth(value));
-    }
-    static Type Get() {
-        Type clearDepth;
-        MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_CLEAR_VALUE, &clearDepth));
-        return clearDepth;
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct ClearColor {
     using Type = Color;
     static const constexpr Type Default = { 0, 0, 0, 0 };
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glClearColor(value.r, value.g, value.b, value.a));
-    }
-    static Type Get() {
-        GLfloat floats[4];
-        MBGL_CHECK_ERROR(glGetFloatv(GL_COLOR_CLEAR_VALUE, floats));
-        return { floats[0], floats[1], floats[2], floats[3] };
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct ClearStencil {
-    using Type = GLint;
+    using Type = StencilValue;
     static const constexpr Type Default = 0;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glClearStencil(value));
-    }
-    static Type Get() {
-        Type clearStencil;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_CLEAR_VALUE, &clearStencil));
-        return clearStencil;
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct StencilMask {
-    using Type = GLuint;
+    using Type = StencilMaskValue;
     static const constexpr Type Default = ~0u;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glStencilMask(value));
-    }
-    static Type Get() {
-        GLint stencilMask;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_WRITEMASK, &stencilMask));
-        return stencilMask;
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct DepthMask {
-    using Type = GLboolean;
-    static const constexpr Type Default = GL_TRUE;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glDepthMask(value));
-    }
-    static Type Get() {
-        Type depthMask;
-        MBGL_CHECK_ERROR(glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask));
-        return depthMask;
-    }
+    using Type = bool;
+    static const constexpr Type Default = true;
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct ColorMask {
-    struct Type { bool r, g, b, a; };
-    static const constexpr Type Default = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glColorMask(value.r, value.g, value.b, value.a));
-    }
-    static Type Get() {
-        GLboolean bools[4];
-        MBGL_CHECK_ERROR(glGetBooleanv(GL_COLOR_WRITEMASK, bools));
-        return { static_cast<bool>(bools[0]), static_cast<bool>(bools[1]),
-                 static_cast<bool>(bools[2]), static_cast<bool>(bools[3]) };
-    }
+    struct Type {
+        bool r;
+        bool g;
+        bool b;
+        bool a;
+    };
+    static const constexpr Type Default = { true, true, true, true };
+    static void Set(const Type&);
+    static Type Get();
 };
 
 constexpr bool operator!=(const ColorMask::Type& a, const ColorMask::Type& b) {
@@ -97,18 +59,14 @@ constexpr bool operator!=(const ColorMask::Type& a, const ColorMask::Type& b) {
 }
 
 struct StencilFunc {
-    struct Type { GLenum func; GLint ref; GLuint mask; };
-    static const constexpr Type Default = { GL_ALWAYS, 0, ~0u };
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glStencilFunc(value.func, value.ref, value.mask));
-    }
-    static Type Get() {
-        GLint func, ref, mask;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FUNC, &func));
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_REF, &ref));
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_VALUE_MASK, &mask));
-        return { static_cast<GLenum>(func), ref, static_cast<GLuint>(mask) };
-    }
+    struct Type {
+        StencilTestFunction func;
+        StencilValue ref;
+        StencilMaskValue mask;
+    };
+    static const constexpr Type Default = { StencilTestFunction::Always, 0, ~0u };
+    static void Set(const Type&);
+    static Type Get();
 };
 
 constexpr bool operator!=(const StencilFunc::Type& a, const StencilFunc::Type& b) {
@@ -117,30 +75,21 @@ constexpr bool operator!=(const StencilFunc::Type& a, const StencilFunc::Type& b
 
 struct StencilTest {
     using Type = bool;
-    static const constexpr Type Default = GL_FALSE;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(value ? glEnable(GL_STENCIL_TEST) : glDisable(GL_STENCIL_TEST));
-    }
-    static Type Get() {
-        Type stencilTest;
-        MBGL_CHECK_ERROR(stencilTest = glIsEnabled(GL_STENCIL_TEST));
-        return stencilTest;
-    }
+    static const constexpr Type Default = false;
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct StencilOp {
-    struct Type { GLenum sfail, dpfail, dppass; };
-    static const constexpr Type Default = { GL_KEEP, GL_KEEP, GL_REPLACE };
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glStencilOp(value.sfail, value.dpfail, value.dppass));
-    }
-    static Type Get() {
-        GLint sfail, dpfail, dppass;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_FAIL, &sfail));
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_FAIL, &dpfail));
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_STENCIL_PASS_DEPTH_PASS, &dppass));
-        return { static_cast<GLenum>(sfail), static_cast<GLenum>(dpfail), static_cast<GLuint>(dppass) };
-    }
+    struct Type {
+        StencilTestOperation sfail;
+        StencilTestOperation dpfail;
+        StencilTestOperation dppass;
+    };
+    static const constexpr Type Default = { StencilTestOperation::Keep, StencilTestOperation::Keep,
+                                            StencilTestOperation::Keep };
+    static void Set(const Type&);
+    static Type Get();
 };
 
 constexpr bool operator!=(const StencilOp::Type& a, const StencilOp::Type& b) {
@@ -148,16 +97,13 @@ constexpr bool operator!=(const StencilOp::Type& a, const StencilOp::Type& b) {
 }
 
 struct DepthRange {
-    struct Type { GLfloat near, far; };
+    struct Type {
+        float near;
+        float far;
+    };
     static const constexpr Type Default = { 0, 1 };
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glDepthRange(value.near, value.far));
-    }
-    static Type Get() {
-        GLfloat floats[2];
-        MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_RANGE, floats));
-        return { floats[0], floats[1] };
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 constexpr bool operator!=(const DepthRange::Type& a, const DepthRange::Type& b) {
@@ -166,55 +112,33 @@ constexpr bool operator!=(const DepthRange::Type& a, const DepthRange::Type& b) 
 
 struct DepthTest {
     using Type = bool;
-    static const constexpr Type Default = GL_FALSE;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(value ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST));
-    }
-    static Type Get() {
-        Type depthTest;
-        MBGL_CHECK_ERROR(depthTest = glIsEnabled(GL_DEPTH_TEST));
-        return depthTest;
-    }
+    static const constexpr Type Default = false;
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct DepthFunc {
-    using Type = GLenum;
-    static const constexpr Type Default = GL_LEQUAL;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glDepthFunc(value));
-    }
-    static Type Get() {
-        GLint depthFunc;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_DEPTH_FUNC, &depthFunc));
-        return depthFunc;
-    }
+    using Type = DepthTestFunction;
+    static const constexpr Type Default = DepthTestFunction::Less;
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct Blend {
     using Type = bool;
-    static const constexpr Type Default = GL_TRUE;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(value ? glEnable(GL_BLEND) : glDisable(GL_BLEND));
-    }
-    static Type Get() {
-        Type blend;
-        MBGL_CHECK_ERROR(blend = glIsEnabled(GL_BLEND));
-        return blend;
-    }
+    static const constexpr Type Default = true;
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct BlendFunc {
-    struct Type { GLenum sfactor, dfactor; };
-    static const constexpr Type Default = { GL_ONE, GL_ONE_MINUS_SRC_ALPHA };
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glBlendFunc(value.sfactor, value.dfactor));
-    }
-    static Type Get() {
-        GLint sfactor, dfactor;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_SRC_ALPHA, &sfactor));
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_BLEND_DST_ALPHA, &dfactor));
-        return { static_cast<GLenum>(sfactor), static_cast<GLenum>(dfactor) };
-    }
+    struct Type {
+        BlendSourceFactor sfactor;
+        BlendDestinationFactor dfactor;
+    };
+    static const constexpr Type Default = { BlendSourceFactor::One, BlendDestinationFactor::Zero };
+    static void Set(const Type&);
+    static Type Get();
 };
 
 constexpr bool operator!=(const BlendFunc::Type& a, const BlendFunc::Type& b) {
@@ -224,94 +148,90 @@ constexpr bool operator!=(const BlendFunc::Type& a, const BlendFunc::Type& b) {
 struct BlendColor {
     using Type = Color;
     static const constexpr Type Default = { 0, 0, 0, 0 };
-    inline static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glBlendColor(value.r, value.g, value.b, value.a));
-    }
-    inline static Type Get() {
-        GLfloat floats[4];
-        MBGL_CHECK_ERROR(glGetFloatv(GL_BLEND_COLOR, floats));
-        return { floats[0], floats[1], floats[2], floats[3] };
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct Program {
     using Type = gl::ProgramID;
     static const constexpr Type Default = 0;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glUseProgram(value));
-    }
-    static Type Get() {
-        GLint program;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_CURRENT_PROGRAM, &program));
-        return program;
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct LineWidth {
-    using Type = GLfloat;
+    using Type = float;
     static const constexpr Type Default = 1;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glLineWidth(value));
-    }
-    static Type Get() {
-        Type lineWidth;
-        MBGL_CHECK_ERROR(glGetFloatv(GL_LINE_WIDTH, &lineWidth));
-        return lineWidth;
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct ActiveTexture {
-    using Type = uint8_t;
+    using Type = TextureUnit;
     static const constexpr Type Default = 0;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glActiveTexture(GL_TEXTURE0 + value));
-    }
-    static Type Get() {
-        GLint activeTexture;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture));
-        return activeTexture - GL_TEXTURE0;
-    }
-};
-
-struct BindFramebuffer {
-    using Type = GLint;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glBindFramebuffer(GL_FRAMEBUFFER, value));
-    }
-    static Type Get() {
-        Type activeFramebuffer;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &activeFramebuffer));
-        return activeFramebuffer;
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 struct Viewport {
-    using Type = std::array<GLint, 4>;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glViewport(value[0], value[1], value[2], value[3]));
-    }
-    static Type Get() {
-        Type pos;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_VIEWPORT, pos.data()));
-        return pos;
-    }
+    struct Type {
+        int32_t x;
+        int32_t y;
+        uint16_t width;
+        uint16_t height;
+    };
+    static void Set(const Type&);
+    static Type Get();
 };
 
+constexpr bool operator!=(const Viewport::Type& a, const Viewport::Type& b) {
+    return a.x != b.x || a.y != b.y || a.width != b.width || a.height != b.height;
+}
 
-#ifndef GL_ES_VERSION_2_0
+struct BindFramebuffer {
+    using Type = FramebufferID;
+    static void Set(const Type&);
+    static Type Get();
+};
+
+struct BindTexture {
+    using Type = gl::TextureID;
+    static const constexpr Type Default = 0;
+    static void Set(const Type&);
+    static Type Get();
+};
+
+struct BindVertexBuffer {
+    using Type = gl::BufferID;
+    static const constexpr Type Default = 0;
+    static void Set(const Type&);
+    static Type Get();
+};
+
+struct BindElementBuffer {
+    using Type = gl::BufferID;
+    static const constexpr Type Default = 0;
+    static void Set(const Type&);
+    static Type Get();
+};
+
+struct BindVertexArray {
+    using Type = gl::VertexArrayID;
+    static const constexpr Type Default = 0;
+    static void Set(const Type&);
+    static Type Get();
+};
+
+#if not MBGL_USE_GLES2
 
 struct PixelZoom {
-    struct Type { GLfloat xfactor; GLfloat yfactor; };
+    struct Type {
+        float xfactor;
+        float yfactor;
+    };
     static const constexpr Type Default = { 1, 1 };
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glPixelZoom(value.xfactor, value.yfactor));
-    }
-    static Type Get() {
-        Type value;
-        MBGL_CHECK_ERROR(glGetFloatv(GL_ZOOM_X, &value.xfactor));
-        MBGL_CHECK_ERROR(glGetFloatv(GL_ZOOM_Y, &value.yfactor));
-        return value;
-    }
+    static void Set(const Type&);
+    static Type Get();
 };
 
 constexpr bool operator!=(const PixelZoom::Type& a, const PixelZoom::Type& b) {
@@ -319,64 +239,22 @@ constexpr bool operator!=(const PixelZoom::Type& a, const PixelZoom::Type& b) {
 }
 
 struct RasterPos {
-    using Type = std::array<GLdouble, 4>;
-    static const constexpr Type Default = {{ 0, 0, 0, 0 }};
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glRasterPos4d(value[0], value[1], value[2], value[3]));
-    }
-    static Type Get() {
-        Type pos;
-        MBGL_CHECK_ERROR(glGetDoublev(GL_CURRENT_RASTER_POSITION, pos.data()));
-        return pos;
-    }
+    struct Type {
+        double x;
+        double y;
+        double z;
+        double w;
+    };
+    static const constexpr Type Default = { 0, 0, 0, 0 };
+    static void Set(const Type&);
+    static Type Get();
 };
 
-#endif // GL_ES_VERSION_2_0
+constexpr bool operator!=(const RasterPos::Type& a, const RasterPos::Type& b) {
+    return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
+}
 
-struct BindTexture {
-    using Type = gl::TextureID;
-    static const constexpr Type Default = 0;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glBindTexture(GL_TEXTURE_2D, value));
-    }
-    static Type Get() {
-        GLint texture;
-        MBGL_CHECK_ERROR(glGetIntegerv(GL_TEXTURE_BINDING_2D, &texture));
-        return static_cast<Type>(texture);
-    }
-};
-
-template <GLenum target>
-struct BindBuffer {
-    static_assert(target == GL_ARRAY_BUFFER || target == GL_ELEMENT_ARRAY_BUFFER,
-                  "target must be one of GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER");
-    using Type = gl::BufferID;
-    static const constexpr Type Default = 0;
-    static void Set(const Type& value) {
-        MBGL_CHECK_ERROR(glBindBuffer(target, value));
-    }
-    static Type Get() {
-        GLint binding;
-        MBGL_CHECK_ERROR(glGetIntegerv(target == GL_ARRAY_BUFFER ? GL_ARRAY_BUFFER_BINDING
-                                                                 : GL_ELEMENT_ARRAY_BUFFER_BINDING,
-                                       &binding));
-        return static_cast<Type>(binding);
-    }
-};
-
-template <GLenum target>
-const typename BindBuffer<target>::Type BindBuffer<target>::Default;
-
-struct BindVertexArray {
-    using Type = gl::VertexArrayID;
-    static const constexpr Type Default = 0;
-    static void Set(const Type& value) {
-        if (gl::BindVertexArray) {
-            MBGL_CHECK_ERROR(gl::BindVertexArray(value));
-        }
-    }
-};
-
+#endif // MBGL_USE_GLES2
 
 } // namespace value
 } // namespace gl

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -53,8 +53,8 @@ SymbolLayout::SymbolLayout(std::string bucketName_,
     auto layerName = layer.getName();
 
     // Determine and load glyph ranges
-    const GLsizei featureCount = static_cast<GLsizei>(layer.featureCount());
-    for (GLsizei i = 0; i < featureCount; i++) {
+    const size_t featureCount = static_cast<size_t>(layer.featureCount());
+    for (size_t i = 0; i < featureCount; i++) {
         auto feature = layer.getFeature(i);
         if (!filter(feature->getType(), feature->getID(), [&] (const auto& key) { return feature->getValue(key); }))
             continue;
@@ -458,7 +458,7 @@ void SymbolLayout::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float 
         // coordinate in this polygon.
         assert(buffer.groups.back());
         auto &triangleGroup = *buffer.groups.back();
-        GLsizei triangleIndex = triangleGroup.vertex_length;
+        size_t triangleIndex = triangleGroup.vertex_length;
 
         // Encode angle of glyph
         uint8_t glyphAngle = std::round((symbol.glyphAngle / (M_PI * 2)) * 256);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -888,7 +888,7 @@ void Map::setDebug(MapDebugOptions debugOptions) {
 }
 
 void Map::cycleDebugOptions() {
-#ifndef GL_ES_VERSION_2_0
+#if not MBGL_USE_GLES2
     if (impl->debugOptions & MapDebugOptions::StencilClip)
         impl->debugOptions = MapDebugOptions::NoDebug;
     else if (impl->debugOptions & MapDebugOptions::Overdraw)
@@ -896,7 +896,7 @@ void Map::cycleDebugOptions() {
 #else
     if (impl->debugOptions & MapDebugOptions::Overdraw)
         impl->debugOptions = MapDebugOptions::NoDebug;
-#endif // GL_ES_VERSION_2_0
+#endif // MBGL_USE_GLES2
     else if (impl->debugOptions & MapDebugOptions::Collision)
         impl->debugOptions = MapDebugOptions::Overdraw;
     else if (impl->debugOptions & MapDebugOptions::Timestamps)

--- a/src/mbgl/renderer/bucket.hpp
+++ b/src/mbgl/renderer/bucket.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/renderer/render_pass.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
 #include <atomic>
 
-#define BUFFER_OFFSET_0  ((GLbyte*)nullptr)
+#define BUFFER_OFFSET_0  ((int8_t*)nullptr)
 #define BUFFER_OFFSET(i) ((BUFFER_OFFSET_0) + (i))
 
 namespace mbgl {

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/renderer/circle_bucket.hpp>
 #include <mbgl/renderer/painter.hpp>
+#include <mbgl/gl/gl.hpp>
 
 #include <mbgl/shader/circle_shader.hpp>
 #include <mbgl/style/layers/circle_layer.hpp>

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -1,6 +1,7 @@
 #include <mbgl/renderer/frame_history.hpp>
 #include <mbgl/math/minmax.hpp>
 #include <mbgl/gl/context.hpp>
+#include <mbgl/gl/gl.hpp>
 
 namespace mbgl {
 
@@ -100,7 +101,7 @@ void FrameHistory::bind(gl::Context& context, uint32_t unit) {
         texture = context.createTexture();
         context.activeTexture = unit;
         context.texture[unit] = *texture;
-#ifndef GL_ES_VERSION_2_0
+#if not MBGL_USE_GLES2
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
 #endif
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -101,7 +101,7 @@ void LineBucket::addGeometry(const GeometryCoordinates& vertices) {
         nextNormal = util::perp(util::unit(convertPoint<double>(firstVertex - *currentVertex)));
     }
 
-    const GLint startVertex = vertexBuffer.index();
+    const int32_t startVertex = vertexBuffer.index();
     std::vector<TriangleElement> triangleStore;
 
     for (GLsizei i = 0; i < len; ++i) {
@@ -379,7 +379,7 @@ void LineBucket::addCurrentVertex(const GeometryCoordinate& currentVertex,
                                   double endLeft,
                                   double endRight,
                                   bool round,
-                                  GLint startVertex,
+                                  int32_t startVertex,
                                   std::vector<TriangleElement>& triangleStore) {
     int8_t tx = round ? 1 : 0;
 
@@ -419,8 +419,8 @@ void LineBucket::addPieSliceVertex(const GeometryCoordinate& currentVertex,
                                    double distance,
                                    const Point<double>& extrude,
                                    bool lineTurnsLeft,
-                                   GLint startVertex,
-                                  std::vector<TriangleElement>& triangleStore) {
+                                   int32_t startVertex,
+                                   std::vector<TriangleElement>& triangleStore) {
     int8_t ty = lineTurnsLeft;
 
     Point<double> flippedExtrude = extrude * (lineTurnsLeft ? -1.0 : 1.0);

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -43,9 +43,9 @@ private:
     };
     void addCurrentVertex(const GeometryCoordinate& currentVertex, double& distance,
             const Point<double>& normal, double endLeft, double endRight, bool round,
-            GLint startVertex, std::vector<LineBucket::TriangleElement>& triangleStore);
+            int32_t startVertex, std::vector<LineBucket::TriangleElement>& triangleStore);
     void addPieSliceVertex(const GeometryCoordinate& currentVertex, double distance,
-            const Point<double>& extrude, bool lineTurnsLeft, GLint startVertex,
+            const Point<double>& extrude, bool lineTurnsLeft, int32_t startVertex,
             std::vector<TriangleElement>& triangleStore);
 
 public:
@@ -55,9 +55,9 @@ private:
     LineVertexBuffer vertexBuffer;
     TriangleElementsBuffer triangleElementsBuffer;
 
-    GLint e1;
-    GLint e2;
-    GLint e3;
+    int32_t e1;
+    int32_t e2;
+    int32_t e3;
 
     std::vector<std::unique_ptr<TriangleGroup>> triangleGroups;
 

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -12,7 +12,6 @@
 #include <mbgl/geometry/static_vertex_buffer.hpp>
 
 #include <mbgl/gl/context.hpp>
-#include <mbgl/gl/gl.hpp>
 
 #include <mbgl/style/style.hpp>
 
@@ -114,7 +113,7 @@ private:
     void renderPass(PaintParameters&,
                     RenderPass,
                     Iterator it, Iterator end,
-                    GLsizei i, int8_t increment);
+                    uint32_t i, int8_t increment);
 
     void setClipping(const ClipID&);
 
@@ -174,7 +173,7 @@ private:
     RenderPass pass = RenderPass::Opaque;
 
     int numSublayers = 3;
-    GLsizei currentLayer;
+    uint32_t currentLayer;
     float depthRangeSize;
     const float depthEpsilon = 1.0f / (1 << 16);
 

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/gl/gl.hpp>
 
 #include <mbgl/style/layers/background_layer.hpp>
 #include <mbgl/style/layers/background_layer_impl.hpp>
@@ -55,10 +56,10 @@ void Painter::renderBackground(PaintParameters& parameters, const BackgroundLaye
         arrayBackground.bind(plainShader, tileStencilBuffer, BUFFER_OFFSET(0), context);
     }
 
-    context.stencilTest = GL_FALSE;
-    context.depthFunc.reset();
-    context.depthTest = GL_TRUE;
-    context.depthMask = GL_FALSE;
+    context.stencilTest = false;
+    context.depthFunc = gl::DepthTestFunction::LessEqual;
+    context.depthTest = true;
+    context.depthMask = false;
     setDepthSublayer(0);
 
     for (const auto& tileID : util::tileCover(state, state.getIntegerZoom())) {

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -19,10 +19,10 @@ void Painter::renderCircle(PaintParameters& parameters,
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
-    context.stencilTest = frame.mapMode == MapMode::Still ? GL_TRUE : GL_FALSE;
-    context.depthFunc.reset();
-    context.depthTest = GL_TRUE;
-    context.depthMask = GL_FALSE;
+    context.stencilTest = frame.mapMode == MapMode::Still;
+    context.depthFunc = gl::DepthTestFunction::LessEqual;
+    context.depthTest = true;
+    context.depthMask = false;
     setDepthSublayer(0);
 
     const CirclePaintProperties& properties = layer.impl->paint;

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -1,5 +1,7 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/gl/gl.hpp>
+
 #include <mbgl/style/source.hpp>
 #include <mbgl/shader/shaders.hpp>
 #include <mbgl/util/clip_id.hpp>
@@ -19,11 +21,12 @@ void Painter::drawClippingMasks(PaintParameters& parameters, const std::map<Unwr
     const GLuint mask = 0b11111111;
 
     context.program = plainShader.getID();
-    context.stencilOp.reset();
-    context.stencilTest = GL_TRUE;
-    context.depthTest = GL_FALSE;
-    context.depthMask = GL_FALSE;
-    context.colorMask = { GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
+    context.stencilOp = { gl::StencilTestOperation::Keep, gl::StencilTestOperation::Keep,
+                          gl::StencilTestOperation::Replace };
+    context.stencilTest = true;
+    context.depthTest = false;
+    context.depthMask = false;
+    context.colorMask = { false, false, false, false };
     context.stencilMask = mask;
 
     arrayCoveringPlain.bind(plainShader, tileStencilBuffer, BUFFER_OFFSET_0, context);
@@ -38,7 +41,7 @@ void Painter::drawClippingMasks(PaintParameters& parameters, const std::map<Unwr
         plainShader.u_matrix = matrix;
 
         const GLint ref = (GLint)(clip.reference.to_ulong());
-        context.stencilFunc = { GL_ALWAYS, ref, mask };
+        context.stencilFunc = { gl::StencilTestFunction::Always, ref, mask };
         MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLES, 0, (GLsizei)tileStencilBuffer.index()));
     }
 }

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -1,5 +1,7 @@
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/paint_parameters.hpp>
+#include <mbgl/gl/gl.hpp>
+
 #include <mbgl/renderer/fill_bucket.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/style/layers/fill_layer.hpp>
@@ -33,11 +35,12 @@ void Painter::renderFill(PaintParameters& parameters,
     bool outline = properties.fillAntialias && !pattern && isOutlineColorDefined;
     bool fringeline = properties.fillAntialias && !pattern && !isOutlineColorDefined;
 
-    context.stencilOp.reset();
-    context.stencilTest = GL_TRUE;
-    context.depthFunc.reset();
-    context.depthTest = GL_TRUE;
-    context.depthMask = GL_TRUE;
+    context.stencilOp = { gl::StencilTestOperation::Keep, gl::StencilTestOperation::Keep,
+                          gl::StencilTestOperation::Replace };
+    context.stencilTest = true;
+    context.depthFunc = gl::DepthTestFunction::LessEqual;
+    context.depthTest = true;
+    context.depthMask = true;
     context.lineWidth = 2.0f; // This is always fixed and does not depend on the pixelRatio!
 
     auto& outlineShader = parameters.shaders.outline;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -20,11 +20,12 @@ void Painter::renderLine(PaintParameters& parameters,
     // Abort early.
     if (pass == RenderPass::Opaque) return;
 
-    context.stencilOp.reset();
-    context.stencilTest = GL_TRUE;
-    context.depthFunc.reset();
-    context.depthTest = GL_TRUE;
-    context.depthMask = GL_FALSE;
+    context.stencilOp = { gl::StencilTestOperation::Keep, gl::StencilTestOperation::Keep,
+                          gl::StencilTestOperation::Replace };
+    context.stencilTest = true;
+    context.depthFunc = gl::DepthTestFunction::LessEqual;
+    context.depthTest = true;
+    context.depthMask = false;
 
     const auto& properties = layer.impl->paint;
     const auto& layout = bucket.layout;

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -35,16 +35,16 @@ void Painter::renderRaster(PaintParameters& parameters,
         rasterShader.u_contrast_factor = contrastFactor(properties.rasterContrast);
         rasterShader.u_spin_weights = spinWeights(properties.rasterHueRotate);
 
-        context.stencilTest = GL_FALSE;
+        context.stencilTest = false;
 
         rasterShader.u_image0 = 0; // GL_TEXTURE0
         rasterShader.u_image1 = 1; // GL_TEXTURE1
         rasterShader.u_tl_parent = {{ 0.0f, 0.0f }};
         rasterShader.u_scale_parent = 1.0f;
 
-        context.depthFunc.reset();
-        context.depthTest = GL_TRUE;
-        context.depthMask = GL_FALSE;
+        context.depthFunc = gl::DepthTestFunction::LessEqual;
+        context.depthTest = true;
+        context.depthMask = false;
         setDepthSublayer(0);
 
         bucket.drawRaster(rasterShader, rasterBoundsBuffer, rasterVAO, context);

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -119,7 +119,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
     const auto& paint = layer.impl->paint;
     const auto& layout = bucket.layout;
 
-    context.depthMask = GL_FALSE;
+    context.depthMask = false;
 
     // TODO remove the `true ||` when #1673 is implemented
     const bool drawAcrossEdges = (frame.mapMode == MapMode::Continuous) && (true || !(layout.textAllowOverlap || layout.iconAllowOverlap ||
@@ -131,20 +131,21 @@ void Painter::renderSymbol(PaintParameters& parameters,
     // layers are sorted in the y direction, and to draw the correct ordering near
     // tile edges the icons are included in both tiles and clipped when drawing.
     if (drawAcrossEdges) {
-        context.stencilTest = GL_FALSE;
+        context.stencilTest = false;
     } else {
-        context.stencilOp.reset();
-        context.stencilTest = GL_TRUE;
+        context.stencilOp = { gl::StencilTestOperation::Keep, gl::StencilTestOperation::Keep,
+                              gl::StencilTestOperation::Replace };
+        context.stencilTest = true;
     }
 
     setDepthSublayer(0);
 
     if (bucket.hasIconData()) {
         if (layout.iconRotationAlignment == AlignmentType::Map) {
-            context.depthFunc.reset();
-            context.depthTest = GL_TRUE;
+            context.depthFunc = gl::DepthTestFunction::LessEqual;
+            context.depthTest = true;
         } else {
-            context.depthTest = GL_FALSE;
+            context.depthTest = false;
         }
 
         bool sdf = bucket.sdfIcons;
@@ -222,10 +223,10 @@ void Painter::renderSymbol(PaintParameters& parameters,
 
     if (bucket.hasTextData()) {
         if (layout.textPitchAlignment == AlignmentType::Map) {
-            context.depthFunc.reset();
-            context.depthTest = GL_TRUE;
+            context.depthFunc = gl::DepthTestFunction::LessEqual;
+            context.depthTest = true;
         } else {
-            context.depthTest = GL_FALSE;
+            context.depthTest = false;
         }
 
         glyphAtlas->bind(context, 0);
@@ -250,8 +251,9 @@ void Painter::renderSymbol(PaintParameters& parameters,
     }
 
     if (bucket.hasCollisionBoxData()) {
-        context.stencilOp.reset();
-        context.stencilTest = GL_TRUE;
+        context.stencilOp = { gl::StencilTestOperation::Keep, gl::StencilTestOperation::Keep,
+                              gl::StencilTestOperation::Replace };
+        context.stencilTest = true;
 
         auto& collisionBoxShader = shaders->collisionBox;
         context.program = collisionBoxShader.getID();

--- a/src/mbgl/renderer/raster_bucket.cpp
+++ b/src/mbgl/renderer/raster_bucket.cpp
@@ -2,6 +2,8 @@
 #include <mbgl/style/layers/raster_layer.hpp>
 #include <mbgl/shader/raster_shader.hpp>
 #include <mbgl/renderer/painter.hpp>
+#include <mbgl/gl/gl.hpp>
+
 
 namespace mbgl {
 

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/shader/sdf_shader.hpp>
 #include <mbgl/shader/icon_shader.hpp>
 #include <mbgl/shader/collision_box_shader.hpp>
+#include <mbgl/gl/gl.hpp>
 
 namespace mbgl {
 

--- a/src/mbgl/shader/circle_shader.cpp
+++ b/src/mbgl/shader/circle_shader.cpp
@@ -12,7 +12,7 @@ CircleShader::CircleShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void CircleShader::bind(GLbyte* offset) {
+void CircleShader::bind(int8_t* offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 4, offset));
 }

--- a/src/mbgl/shader/circle_shader.hpp
+++ b/src/mbgl/shader/circle_shader.hpp
@@ -10,16 +10,16 @@ class CircleShader : public Shader {
 public:
     CircleShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                 u_matrix           = {"u_matrix",           *this};
-    Uniform<std::array<GLfloat, 2>>  u_extrude_scale    = {"u_extrude_scale",    *this};
-    Uniform<GLfloat>                 u_devicepixelratio = {"u_devicepixelratio", *this};
-    Uniform<Color>                   u_color            = {"u_color",            *this};
-    Uniform<GLfloat>                 u_radius           = {"u_radius",           *this};
-    Uniform<GLfloat>                 u_blur             = {"u_blur",             *this};
-    Uniform<GLfloat>                 u_opacity          = {"u_opacity",          *this};
-    Uniform<GLint>                   u_scale_with_map   = {"u_scale_with_map",   *this};
+    UniformMatrix<4>              u_matrix           = {"u_matrix",           *this};
+    Uniform<std::array<float, 2>> u_extrude_scale    = {"u_extrude_scale",    *this};
+    Uniform<float>                u_devicepixelratio = {"u_devicepixelratio", *this};
+    Uniform<Color>                u_color            = {"u_color",            *this};
+    Uniform<float>                u_radius           = {"u_radius",           *this};
+    Uniform<float>                u_blur             = {"u_blur",             *this};
+    Uniform<float>                u_opacity          = {"u_opacity",          *this};
+    Uniform<int32_t>              u_scale_with_map   = {"u_scale_with_map",   *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/collision_box_shader.hpp
+++ b/src/mbgl/shader/collision_box_shader.hpp
@@ -2,7 +2,6 @@
 
 #include <mbgl/shader/shader.hpp>
 #include <mbgl/shader/uniform.hpp>
-#include <mbgl/gl/gl.hpp>
 
 namespace mbgl {
 
@@ -10,12 +9,12 @@ class CollisionBoxShader : public Shader {
 public:
     CollisionBoxShader(gl::Context&);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>              u_matrix      = {"u_matrix",      *this};
-    Uniform<GLfloat>              u_scale       = {"u_scale",       *this};
-    Uniform<GLfloat>              u_zoom        = {"u_zoom",        *this};
-    Uniform<GLfloat>              u_maxzoom     = {"u_maxzoom",     *this};
+    UniformMatrix<4> u_matrix  = {"u_matrix",  *this};
+    Uniform<float>   u_scale   = {"u_scale",   *this};
+    Uniform<float>   u_zoom    = {"u_zoom",    *this};
+    Uniform<float>   u_maxzoom = {"u_maxzoom", *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/icon_shader.cpp
+++ b/src/mbgl/shader/icon_shader.cpp
@@ -12,7 +12,7 @@ IconShader::IconShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void IconShader::bind(GLbyte* offset) {
+void IconShader::bind(int8_t* offset) {
     const GLsizei stride = 16;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));

--- a/src/mbgl/shader/icon_shader.hpp
+++ b/src/mbgl/shader/icon_shader.hpp
@@ -9,16 +9,16 @@ class IconShader : public Shader {
 public:
     IconShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                u_matrix        = {"u_matrix",        *this};
-    Uniform<std::array<GLfloat, 2>> u_extrude_scale = {"u_extrude_scale", *this};
-    Uniform<GLfloat>                u_zoom          = {"u_zoom",          *this};
-    Uniform<GLfloat>                u_opacity       = {"u_opacity",       *this};
-    Uniform<std::array<GLfloat, 2>> u_texsize       = {"u_texsize",       *this};
-    Uniform<GLint>                  u_rotate_with_map = {"u_rotate_with_map", *this};
-    Uniform<GLint>                  u_texture       = {"u_texture",       *this};
-    Uniform<GLint>                  u_fadetexture   = {"u_fadetexture",   *this};
+    UniformMatrix<4>              u_matrix          = {"u_matrix",          *this};
+    Uniform<std::array<float, 2>> u_extrude_scale   = {"u_extrude_scale",   *this};
+    Uniform<float>                u_zoom            = {"u_zoom",            *this};
+    Uniform<float>                u_opacity         = {"u_opacity",         *this};
+    Uniform<std::array<float, 2>> u_texsize         = {"u_texsize",         *this};
+    Uniform<int32_t>              u_rotate_with_map = {"u_rotate_with_map", *this};
+    Uniform<int32_t>              u_texture         = {"u_texture",         *this};
+    Uniform<int32_t>              u_fadetexture     = {"u_fadetexture",     *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/line_shader.cpp
+++ b/src/mbgl/shader/line_shader.cpp
@@ -12,7 +12,7 @@ LineShader::LineShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void LineShader::bind(GLbyte* offset) {
+void LineShader::bind(int8_t* offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 8, offset + 0));
 

--- a/src/mbgl/shader/line_shader.hpp
+++ b/src/mbgl/shader/line_shader.hpp
@@ -10,19 +10,19 @@ class LineShader : public Shader {
 public:
     LineShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                 u_matrix    = {"u_matrix",    *this};
-    Uniform<Color>                   u_color     = {"u_color",     *this};
-    Uniform<GLfloat>                 u_opacity   = {"u_opacity",   *this};
-    Uniform<GLfloat>                 u_ratio     = {"u_ratio",     *this};
-    Uniform<GLfloat>                 u_linewidth = {"u_linewidth", *this};
-    Uniform<GLfloat>                 u_gapwidth  = {"u_gapwidth",  *this};
-    Uniform<GLfloat>                 u_antialiasing = {"u_antialiasing",  *this};
-    Uniform<GLfloat>                 u_blur      = {"u_blur",      *this};
-    Uniform<GLfloat>                 u_extra     = {"u_extra",     *this};
-    Uniform<GLfloat>                 u_offset    = {"u_offset",    *this};
-    UniformMatrix<2>                 u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
+    UniformMatrix<4> u_matrix              = {"u_matrix",             *this};
+    Uniform<Color>   u_color               = {"u_color",              *this};
+    Uniform<float>   u_opacity             = {"u_opacity",            *this};
+    Uniform<float>   u_ratio               = {"u_ratio",              *this};
+    Uniform<float>   u_linewidth           = {"u_linewidth",          *this};
+    Uniform<float>   u_gapwidth            = {"u_gapwidth",           *this};
+    Uniform<float>   u_antialiasing        = {"u_antialiasing",       *this};
+    Uniform<float>   u_blur                = {"u_blur",               *this};
+    Uniform<float>   u_extra               = {"u_extra",              *this};
+    Uniform<float>   u_offset              = {"u_offset",             *this};
+    UniformMatrix<2> u_antialiasingmatrix  = {"u_antialiasingmatrix", *this};
 };
 
 

--- a/src/mbgl/shader/linepattern_shader.cpp
+++ b/src/mbgl/shader/linepattern_shader.cpp
@@ -12,7 +12,7 @@ LinepatternShader::LinepatternShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void LinepatternShader::bind(GLbyte* offset) {
+void LinepatternShader::bind(int8_t* offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 8, offset + 0));
 

--- a/src/mbgl/shader/linepattern_shader.hpp
+++ b/src/mbgl/shader/linepattern_shader.hpp
@@ -9,27 +9,27 @@ class LinepatternShader : public Shader {
 public:
     LinepatternShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                u_matrix         = {"u_matrix",         *this};
-    Uniform<GLfloat>                u_linewidth      = {"u_linewidth",      *this};
-    Uniform<GLfloat>                u_gapwidth       = {"u_gapwidth",       *this};
-    Uniform<GLfloat>                u_antialiasing   = {"u_antialiasing",   *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_size_a = {"u_pattern_size_a", *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_tl_a   = {"u_pattern_tl_a",   *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_br_a   = {"u_pattern_br_a",   *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_size_b = {"u_pattern_size_b", *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_tl_b   = {"u_pattern_tl_b",   *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_br_b   = {"u_pattern_br_b",   *this};
-    Uniform<GLfloat>                u_ratio          = {"u_ratio",          *this};
-    Uniform<GLfloat>                u_point          = {"u_point",          *this};
-    Uniform<GLfloat>                u_blur           = {"u_blur",           *this};
-    Uniform<GLfloat>                u_fade           = {"u_fade",           *this};
-    Uniform<GLfloat>                u_opacity        = {"u_opacity",        *this};
-    Uniform<GLfloat>                u_extra          = {"u_extra",          *this};
-    Uniform<GLfloat>                u_offset         = {"u_offset",         *this};
-    Uniform<GLint>                  u_image          = {"u_image",          *this};
-    UniformMatrix<2>                u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
+    UniformMatrix<4>              u_matrix              = {"u_matrix",              *this};
+    Uniform<float>                u_linewidth           = {"u_linewidth",           *this};
+    Uniform<float>                u_gapwidth            = {"u_gapwidth",            *this};
+    Uniform<float>                u_antialiasing        = {"u_antialiasing",        *this};
+    Uniform<std::array<float, 2>> u_pattern_size_a      = {"u_pattern_size_a",      *this};
+    Uniform<std::array<float, 2>> u_pattern_tl_a        = {"u_pattern_tl_a",        *this};
+    Uniform<std::array<float, 2>> u_pattern_br_a        = {"u_pattern_br_a",        *this};
+    Uniform<std::array<float, 2>> u_pattern_size_b      = {"u_pattern_size_b",      *this};
+    Uniform<std::array<float, 2>> u_pattern_tl_b        = {"u_pattern_tl_b",        *this};
+    Uniform<std::array<float, 2>> u_pattern_br_b        = {"u_pattern_br_b",        *this};
+    Uniform<float>                u_ratio               = {"u_ratio",               *this};
+    Uniform<float>                u_point               = {"u_point",               *this};
+    Uniform<float>                u_blur                = {"u_blur",                *this};
+    Uniform<float>                u_fade                = {"u_fade",                *this};
+    Uniform<float>                u_opacity             = {"u_opacity",             *this};
+    Uniform<float>                u_extra               = {"u_extra",               *this};
+    Uniform<float>                u_offset              = {"u_offset",              *this};
+    Uniform<int32_t>              u_image               = {"u_image",               *this};
+    UniformMatrix<2>              u_antialiasingmatrix  = {"u_antialiasingmatrix",  *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/linesdf_shader.cpp
+++ b/src/mbgl/shader/linesdf_shader.cpp
@@ -12,7 +12,7 @@ LineSDFShader::LineSDFShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void LineSDFShader::bind(GLbyte* offset) {
+void LineSDFShader::bind(int8_t* offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 8, offset + 0));
 

--- a/src/mbgl/shader/linesdf_shader.hpp
+++ b/src/mbgl/shader/linesdf_shader.hpp
@@ -10,26 +10,26 @@ class LineSDFShader : public Shader {
 public:
     LineSDFShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                 u_matrix    = {"u_matrix",    *this};
-    Uniform<Color>                   u_color     = {"u_color",     *this};
-    Uniform<GLfloat>                 u_opacity   = {"u_opacity",   *this};
-    Uniform<GLfloat>                 u_linewidth = {"u_linewidth", *this};
-    Uniform<GLfloat>                 u_gapwidth  = {"u_gapwidth",  *this};
-    Uniform<GLfloat>                 u_antialiasing = {"u_antialiasing",  *this};
-    Uniform<GLfloat>                 u_ratio     = {"u_ratio",     *this};
-    Uniform<GLfloat>                 u_blur      = {"u_blur",      *this};
-    Uniform<std::array<GLfloat, 2>>  u_patternscale_a = { "u_patternscale_a", *this};
-    Uniform<GLfloat>                 u_tex_y_a   = {"u_tex_y_a",   *this};
-    Uniform<std::array<GLfloat, 2>>  u_patternscale_b = { "u_patternscale_b", *this};
-    Uniform<GLfloat>                 u_tex_y_b   = {"u_tex_y_b",   *this};
-    Uniform<GLint>                   u_image     = {"u_image",     *this};
-    Uniform<GLfloat>                 u_sdfgamma  = {"u_sdfgamma",  *this};
-    Uniform<GLfloat>                 u_mix       = {"u_mix",       *this};
-    Uniform<GLfloat>                 u_extra     = {"u_extra",     *this};
-    Uniform<GLfloat>                 u_offset    = {"u_offset",    *this};
-    UniformMatrix<2>                 u_antialiasingmatrix = {"u_antialiasingmatrix", *this};
+    UniformMatrix<4>              u_matrix             = {"u_matrix",             *this};
+    Uniform<Color>                u_color              = {"u_color",              *this};
+    Uniform<float>                u_opacity            = {"u_opacity",            *this};
+    Uniform<float>                u_linewidth          = {"u_linewidth",          *this};
+    Uniform<float>                u_gapwidth           = {"u_gapwidth",           *this};
+    Uniform<float>                u_antialiasing       = {"u_antialiasing",       *this};
+    Uniform<float>                u_ratio              = {"u_ratio",              *this};
+    Uniform<float>                u_blur               = {"u_blur",               *this};
+    Uniform<std::array<float, 2>> u_patternscale_a     = { "u_patternscale_a",    *this};
+    Uniform<float>                u_tex_y_a            = {"u_tex_y_a",            *this};
+    Uniform<std::array<float, 2>> u_patternscale_b     = { "u_patternscale_b",    *this};
+    Uniform<float>                u_tex_y_b            = {"u_tex_y_b",            *this};
+    Uniform<int32_t>              u_image              = {"u_image",              *this};
+    Uniform<float>                u_sdfgamma           = {"u_sdfgamma",           *this};
+    Uniform<float>                u_mix                = {"u_mix",                *this};
+    Uniform<float>                u_extra              = {"u_extra",              *this};
+    Uniform<float>                u_offset             = {"u_offset",             *this};
+    UniformMatrix<2>              u_antialiasingmatrix = {"u_antialiasingmatrix", *this};
 };
 
 

--- a/src/mbgl/shader/outline_shader.cpp
+++ b/src/mbgl/shader/outline_shader.cpp
@@ -12,7 +12,7 @@ OutlineShader::OutlineShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void OutlineShader::bind(GLbyte* offset) {
+void OutlineShader::bind(int8_t* offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 0, offset));
 }

--- a/src/mbgl/shader/outline_shader.hpp
+++ b/src/mbgl/shader/outline_shader.hpp
@@ -10,12 +10,12 @@ class OutlineShader : public Shader {
 public:
     OutlineShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                u_matrix         = {"u_matrix",        *this};
-    Uniform<Color>                  u_outline_color  = {"u_outline_color", *this};
-    Uniform<GLfloat>                u_opacity        = {"u_opacity",       *this};
-    Uniform<std::array<GLfloat, 2>> u_world          = {"u_world",         *this};
+    UniformMatrix<4>              u_matrix         = {"u_matrix",        *this};
+    Uniform<Color>                u_outline_color  = {"u_outline_color", *this};
+    Uniform<float>                u_opacity        = {"u_opacity",       *this};
+    Uniform<std::array<float, 2>> u_world          = {"u_world",         *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/outlinepattern_shader.hpp
+++ b/src/mbgl/shader/outlinepattern_shader.hpp
@@ -9,24 +9,24 @@ class OutlinePatternShader : public Shader {
 public:
     OutlinePatternShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                u_matrix               = {"u_matrix",               *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_tl_a         = {"u_pattern_tl_a",         *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_br_a         = {"u_pattern_br_a",         *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_tl_b         = {"u_pattern_tl_b",         *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_br_b         = {"u_pattern_br_b",         *this};
-    Uniform<GLfloat>                u_opacity              = {"u_opacity",              *this};
-    Uniform<GLfloat>                u_mix                  = {"u_mix",                  *this};
-    Uniform<GLfloat>                u_scale_a              = {"u_scale_a",              *this};
-    Uniform<GLfloat>                u_scale_b              = {"u_scale_b",              *this};
-    Uniform<GLfloat>                u_tile_units_to_pixels = {"u_tile_units_to_pixels", *this};
-    Uniform<GLint>                  u_image                = {"u_image",                *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_size_a       = {"u_pattern_size_a",       *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_size_b       = {"u_pattern_size_b",       *this};
-    Uniform<std::array<GLfloat, 2>> u_pixel_coord_upper    = {"u_pixel_coord_upper",    *this};
-    Uniform<std::array<GLfloat, 2>> u_pixel_coord_lower    = {"u_pixel_coord_lower",    *this};
-    Uniform<std::array<GLfloat, 2>> u_world                = {"u_world",                *this};
+    UniformMatrix<4>              u_matrix               = {"u_matrix",               *this};
+    Uniform<std::array<float, 2>> u_pattern_tl_a         = {"u_pattern_tl_a",         *this};
+    Uniform<std::array<float, 2>> u_pattern_br_a         = {"u_pattern_br_a",         *this};
+    Uniform<std::array<float, 2>> u_pattern_tl_b         = {"u_pattern_tl_b",         *this};
+    Uniform<std::array<float, 2>> u_pattern_br_b         = {"u_pattern_br_b",         *this};
+    Uniform<float>                u_opacity              = {"u_opacity",              *this};
+    Uniform<float>                u_mix                  = {"u_mix",                  *this};
+    Uniform<float>                u_scale_a              = {"u_scale_a",              *this};
+    Uniform<float>                u_scale_b              = {"u_scale_b",              *this};
+    Uniform<float>                u_tile_units_to_pixels = {"u_tile_units_to_pixels", *this};
+    Uniform<int32_t>              u_image                = {"u_image",                *this};
+    Uniform<std::array<float, 2>> u_pattern_size_a       = {"u_pattern_size_a",       *this};
+    Uniform<std::array<float, 2>> u_pattern_size_b       = {"u_pattern_size_b",       *this};
+    Uniform<std::array<float, 2>> u_pixel_coord_upper    = {"u_pixel_coord_upper",    *this};
+    Uniform<std::array<float, 2>> u_pixel_coord_lower    = {"u_pixel_coord_lower",    *this};
+    Uniform<std::array<float, 2>> u_world                = {"u_world",                *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/pattern_shader.hpp
+++ b/src/mbgl/shader/pattern_shader.hpp
@@ -9,23 +9,23 @@ class PatternShader : public Shader {
 public:
     PatternShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                u_matrix               = {"u_matrix",               *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_tl_a         = {"u_pattern_tl_a",         *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_br_a         = {"u_pattern_br_a",         *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_tl_b         = {"u_pattern_tl_b",         *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_br_b         = {"u_pattern_br_b",         *this};
-    Uniform<GLfloat>                u_opacity              = {"u_opacity",              *this};
-    Uniform<GLfloat>                u_mix                  = {"u_mix",                  *this};
-    Uniform<GLfloat>                u_scale_a              = {"u_scale_a",              *this};
-    Uniform<GLfloat>                u_scale_b              = {"u_scale_b",              *this};
-    Uniform<GLfloat>                u_tile_units_to_pixels = {"u_tile_units_to_pixels", *this};
-    Uniform<GLint>                  u_image                = {"u_image",                *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_size_a       = {"u_pattern_size_a",       *this};
-    Uniform<std::array<GLfloat, 2>> u_pattern_size_b       = {"u_pattern_size_b",       *this};
-    Uniform<std::array<GLfloat, 2>> u_pixel_coord_upper    = {"u_pixel_coord_upper",    *this};
-    Uniform<std::array<GLfloat, 2>> u_pixel_coord_lower    = {"u_pixel_coord_lower",    *this};
+    UniformMatrix<4>              u_matrix               = {"u_matrix",               *this};
+    Uniform<std::array<float, 2>> u_pattern_tl_a         = {"u_pattern_tl_a",         *this};
+    Uniform<std::array<float, 2>> u_pattern_br_a         = {"u_pattern_br_a",         *this};
+    Uniform<std::array<float, 2>> u_pattern_tl_b         = {"u_pattern_tl_b",         *this};
+    Uniform<std::array<float, 2>> u_pattern_br_b         = {"u_pattern_br_b",         *this};
+    Uniform<float>                u_opacity              = {"u_opacity",              *this};
+    Uniform<float>                u_mix                  = {"u_mix",                  *this};
+    Uniform<float>                u_scale_a              = {"u_scale_a",              *this};
+    Uniform<float>                u_scale_b              = {"u_scale_b",              *this};
+    Uniform<float>                u_tile_units_to_pixels = {"u_tile_units_to_pixels", *this};
+    Uniform<int32_t>              u_image                = {"u_image",                *this};
+    Uniform<std::array<float, 2>> u_pattern_size_a       = {"u_pattern_size_a",       *this};
+    Uniform<std::array<float, 2>> u_pattern_size_b       = {"u_pattern_size_b",       *this};
+    Uniform<std::array<float, 2>> u_pixel_coord_upper    = {"u_pixel_coord_upper",    *this};
+    Uniform<std::array<float, 2>> u_pixel_coord_lower    = {"u_pixel_coord_lower",    *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/plain_shader.cpp
+++ b/src/mbgl/shader/plain_shader.cpp
@@ -12,7 +12,7 @@ PlainShader::PlainShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void PlainShader::bind(GLbyte* offset) {
+void PlainShader::bind(int8_t* offset) {
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));
     MBGL_CHECK_ERROR(glVertexAttribPointer(a_pos, 2, GL_SHORT, false, 0, offset));
 }

--- a/src/mbgl/shader/plain_shader.hpp
+++ b/src/mbgl/shader/plain_shader.hpp
@@ -10,11 +10,11 @@ class PlainShader : public Shader {
 public:
     PlainShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                u_matrix   = {"u_matrix", *this};
-    Uniform<Color>                  u_color    = {"u_color",  *this};
-    Uniform<GLfloat>                u_opacity  = {"u_opacity", *this};
+    UniformMatrix<4> u_matrix   = {"u_matrix",  *this};
+    Uniform<Color>   u_color    = {"u_color",   *this};
+    Uniform<float>   u_opacity  = {"u_opacity", *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/raster_shader.cpp
+++ b/src/mbgl/shader/raster_shader.cpp
@@ -12,7 +12,7 @@ RasterShader::RasterShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void RasterShader::bind(GLbyte* offset) {
+void RasterShader::bind(int8_t* offset) {
     const GLint stride = 8;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));

--- a/src/mbgl/shader/raster_shader.hpp
+++ b/src/mbgl/shader/raster_shader.hpp
@@ -9,21 +9,21 @@ class RasterShader : public Shader {
 public:
     RasterShader(gl::Context&, Defines defines = None);
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 
-    UniformMatrix<4>                u_matrix            = {"u_matrix",            *this};
-    Uniform<GLint>                  u_image0            = {"u_image0",            *this};
-    Uniform<GLint>                  u_image1            = {"u_image1",            *this};
-    Uniform<GLfloat>                u_opacity0          = {"u_opacity0",          *this};
-    Uniform<GLfloat>                u_opacity1          = {"u_opacity1",          *this};
-    Uniform<GLfloat>                u_buffer_scale      = {"u_buffer_scale",      *this};
-    Uniform<GLfloat>                u_brightness_low    = {"u_brightness_low",    *this};
-    Uniform<GLfloat>                u_brightness_high   = {"u_brightness_high",   *this};
-    Uniform<GLfloat>                u_saturation_factor = {"u_saturation_factor", *this};
-    Uniform<GLfloat>                u_contrast_factor   = {"u_contrast_factor",   *this};
-    Uniform<std::array<GLfloat, 3>> u_spin_weights      = {"u_spin_weights",      *this};
-    Uniform<std::array<GLfloat, 2>> u_tl_parent         = {"u_tl_parent",         *this};
-    Uniform<GLfloat>                u_scale_parent      = {"u_scale_parent",      *this};
+    UniformMatrix<4>              u_matrix            = {"u_matrix",            *this};
+    Uniform<int32_t>              u_image0            = {"u_image0",            *this};
+    Uniform<int32_t>              u_image1            = {"u_image1",            *this};
+    Uniform<float>                u_opacity0          = {"u_opacity0",          *this};
+    Uniform<float>                u_opacity1          = {"u_opacity1",          *this};
+    Uniform<float>                u_buffer_scale      = {"u_buffer_scale",      *this};
+    Uniform<float>                u_brightness_low    = {"u_brightness_low",    *this};
+    Uniform<float>                u_brightness_high   = {"u_brightness_high",   *this};
+    Uniform<float>                u_saturation_factor = {"u_saturation_factor", *this};
+    Uniform<float>                u_contrast_factor   = {"u_contrast_factor",   *this};
+    Uniform<std::array<float, 3>> u_spin_weights      = {"u_spin_weights",      *this};
+    Uniform<std::array<float, 2>> u_tl_parent         = {"u_tl_parent",         *this};
+    Uniform<float>                u_scale_parent      = {"u_scale_parent",      *this};
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/sdf_shader.cpp
+++ b/src/mbgl/shader/sdf_shader.cpp
@@ -12,7 +12,7 @@ SDFShader::SDFShader(gl::Context& context, Defines defines)
              context, defines) {
 }
 
-void SDFShader::bind(GLbyte* offset) {
+void SDFShader::bind(int8_t* offset) {
     const int stride = 16;
 
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(a_pos));

--- a/src/mbgl/shader/sdf_shader.hpp
+++ b/src/mbgl/shader/sdf_shader.hpp
@@ -10,23 +10,23 @@ class SDFShader : public Shader {
 public:
     SDFShader(gl::Context&, Defines defines = None);
 
-    UniformMatrix<4>                u_matrix        = {"u_matrix",        *this};
-    Uniform<std::array<GLfloat, 2>> u_extrude_scale = {"u_extrude_scale", *this};
-    Uniform<Color>                  u_color         = {"u_color",         *this};
-    Uniform<GLfloat>                u_opacity       = {"u_opacity",       *this};
-    Uniform<std::array<GLfloat, 2>> u_texsize       = {"u_texsize",       *this};
-    Uniform<GLfloat>                u_buffer        = {"u_buffer",        *this};
-    Uniform<GLfloat>                u_gamma         = {"u_gamma",         *this};
-    Uniform<GLfloat>                u_zoom          = {"u_zoom",          *this};
-    Uniform<GLfloat>                u_pitch         = {"u_pitch",         *this};
-    Uniform<GLfloat>                u_bearing       = {"u_bearing",       *this};
-    Uniform<GLfloat>                u_aspect_ratio  = {"u_aspect_ratio",  *this};
-    Uniform<GLint>                  u_rotate_with_map = {"u_rotate_with_map",*this};
-    Uniform<GLint>                  u_pitch_with_map = {"u_pitch_with_map",*this};
-    Uniform<GLint>                  u_texture       = {"u_texture",       *this};
-    Uniform<GLint>                  u_fadetexture   = {"u_fadetexture",   *this};
+    UniformMatrix<4>              u_matrix          = {"u_matrix",          *this};
+    Uniform<std::array<float, 2>> u_extrude_scale   = {"u_extrude_scale",   *this};
+    Uniform<Color>                u_color           = {"u_color",           *this};
+    Uniform<float>                u_opacity         = {"u_opacity",         *this};
+    Uniform<std::array<float, 2>> u_texsize         = {"u_texsize",         *this};
+    Uniform<float>                u_buffer          = {"u_buffer",          *this};
+    Uniform<float>                u_gamma           = {"u_gamma",           *this};
+    Uniform<float>                u_zoom            = {"u_zoom",            *this};
+    Uniform<float>                u_pitch           = {"u_pitch",           *this};
+    Uniform<float>                u_bearing         = {"u_bearing",         *this};
+    Uniform<float>                u_aspect_ratio    = {"u_aspect_ratio",    *this};
+    Uniform<int32_t>              u_rotate_with_map = {"u_rotate_with_map", *this};
+    Uniform<int32_t>              u_pitch_with_map  = {"u_pitch_with_map",  *this};
+    Uniform<int32_t>              u_texture         = {"u_texture",         *this};
+    Uniform<int32_t>              u_fadetexture     = {"u_fadetexture",     *this};
 
-    void bind(GLbyte *offset) final;
+    void bind(int8_t* offset) final;
 };
 
 } // namespace mbgl

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -107,4 +107,8 @@ Shader::~Shader() {
     }
 }
 
+gl::UniformLocation Shader::getUniformLocation(const char* uniform) const {
+    return MBGL_CHECK_ERROR(glGetUniformLocation(program.get(), uniform));
+}
+
 } // namespace mbgl

--- a/src/mbgl/shader/shader.cpp
+++ b/src/mbgl/shader/shader.cpp
@@ -23,8 +23,8 @@ Shader::Shader(const char* name_,
                Defines defines)
     : name(name_),
       program(context.createProgram()),
-      vertexShader(context.createShader(GL_VERTEX_SHADER)),
-      fragmentShader(context.createShader(GL_FRAGMENT_SHADER)) {
+      vertexShader(context.createVertexShader()),
+      fragmentShader(context.createFragmentShader()) {
     util::stopwatch stopwatch("shader compilation", Event::Shader);
 
     if (!compileShader(vertexShader, vertexSource)) {

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
+#include <mbgl/gl/types.hpp>
 #include <mbgl/gl/object.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/optional.hpp>
@@ -20,7 +20,9 @@ public:
         return program.get();
     }
 
-    virtual void bind(GLbyte *offset) = 0;
+    gl::UniformLocation getUniformLocation(const char* uniform) const;
+
+    virtual void bind(int8_t *offset) = 0;
 
     enum Defines : bool {
         None = false,
@@ -34,14 +36,14 @@ protected:
            gl::Context&,
            Defines defines = Defines::None);
 
-    static constexpr GLint         a_pos = 0;
-    static constexpr GLint     a_extrude = 1;
-    static constexpr GLint      a_offset = 2;
-    static constexpr GLint        a_data = 3;
-    static constexpr GLint a_texture_pos = 4;
+    static constexpr gl::AttributeLocation         a_pos = 0;
+    static constexpr gl::AttributeLocation     a_extrude = 1;
+    static constexpr gl::AttributeLocation      a_offset = 2;
+    static constexpr gl::AttributeLocation        a_data = 3;
+    static constexpr gl::AttributeLocation a_texture_pos = 4;
 
 private:
-    bool compileShader(gl::UniqueShader&, const GLchar *source);
+    bool compileShader(gl::UniqueShader&, const char *source);
 
     gl::UniqueProgram program;
     gl::UniqueShader vertexShader;

--- a/src/mbgl/shader/shader.hpp
+++ b/src/mbgl/shader/shader.hpp
@@ -16,7 +16,7 @@ public:
     ~Shader();
     const char* name;
 
-    GLuint getID() const {
+    gl::ProgramID getID() const {
         return program.get();
     }
 

--- a/src/mbgl/shader/shaders.hpp
+++ b/src/mbgl/shader/shaders.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 #include <mbgl/shader/pattern_shader.hpp>
 #include <mbgl/shader/plain_shader.hpp>
 #include <mbgl/shader/outline_shader.hpp>

--- a/src/mbgl/shader/uniform.cpp
+++ b/src/mbgl/shader/uniform.cpp
@@ -1,51 +1,52 @@
 #include <mbgl/shader/uniform.hpp>
 #include <mbgl/util/color.hpp>
+#include <mbgl/gl/gl.hpp>
 
 namespace mbgl {
 
 template <>
-void Uniform<GLfloat>::bind(const GLfloat& t) {
+void Uniform<float>::bind(const float& t) {
     MBGL_CHECK_ERROR(glUniform1f(location, t));
 }
 
 template <>
-void Uniform<GLint>::bind(const GLint& t) {
+void Uniform<int32_t>::bind(const int32_t& t) {
     MBGL_CHECK_ERROR(glUniform1i(location, t));
 }
 
 template <>
-void Uniform<std::array<GLfloat, 2>>::bind(const std::array<GLfloat, 2>& t) {
+void Uniform<std::array<float, 2>>::bind(const std::array<float, 2>& t) {
     MBGL_CHECK_ERROR(glUniform2fv(location, 1, t.data()));
 }
 
 template <>
-void Uniform<std::array<GLfloat, 3>>::bind(const std::array<GLfloat, 3>& t) {
+void Uniform<std::array<float, 3>>::bind(const std::array<float, 3>& t) {
     MBGL_CHECK_ERROR(glUniform3fv(location, 1, t.data()));
 }
 
 template <>
-void Uniform<std::array<GLfloat, 4>>::bind(const std::array<GLfloat, 4>& t) {
+void Uniform<std::array<float, 4>>::bind(const std::array<float, 4>& t) {
     MBGL_CHECK_ERROR(glUniform4fv(location, 1, t.data()));
 }
 
 template <>
 void Uniform<Color>::bind(const Color& t) {
-    std::array<GLfloat, 4> a = {{ t.r, t.g, t.b, t.a }};
+    std::array<float, 4> a = {{ t.r, t.g, t.b, t.a }};
     MBGL_CHECK_ERROR(glUniform4fv(location, 1, a.data()));
 }
 
 template <>
-void UniformMatrix<2>::bind(const std::array<GLfloat, 4>& t) {
+void UniformMatrix<2>::bind(const std::array<float, 4>& t) {
     MBGL_CHECK_ERROR(glUniformMatrix2fv(location, 1, GL_FALSE, t.data()));
 }
 
 template <>
-void UniformMatrix<3>::bind(const std::array<GLfloat, 9>& t) {
+void UniformMatrix<3>::bind(const std::array<float, 9>& t) {
     MBGL_CHECK_ERROR(glUniformMatrix3fv(location, 1, GL_FALSE, t.data()));
 }
 
 template <>
-void UniformMatrix<4>::bind(const std::array<GLfloat, 16>& t) {
+void UniformMatrix<4>::bind(const std::array<float, 16>& t) {
     MBGL_CHECK_ERROR(glUniformMatrix4fv(location, 1, GL_FALSE, t.data()));
 }
 

--- a/src/mbgl/shader/uniform.hpp
+++ b/src/mbgl/shader/uniform.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mbgl/shader/shader.hpp>
-#include <mbgl/gl/gl.hpp>
 
 #include <array>
 
@@ -10,8 +9,8 @@ namespace mbgl {
 template <typename T>
 class Uniform {
 public:
-    Uniform(const GLchar* name, const Shader& shader) : current() {
-         location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.getID(), name));
+    Uniform(const char* name, const Shader& shader)
+        : current(), location(shader.getUniformLocation(name)) {
     }
 
     void operator=(const T& t) {
@@ -25,7 +24,7 @@ private:
     void bind(const T&);
 
     T current;
-    GLint location;
+    gl::UniformLocation location;
 };
 
 template <size_t C, size_t R = C>
@@ -33,8 +32,8 @@ class UniformMatrix {
 public:
     typedef std::array<float, C*R> T;
 
-    UniformMatrix(const GLchar* name, const Shader& shader) : current() {
-        location = MBGL_CHECK_ERROR(glGetUniformLocation(shader.getID(), name));
+    UniformMatrix(const char* name, const Shader& shader)
+        : current(), location(shader.getUniformLocation(name)) {
     }
 
     void operator=(const std::array<double, C*R>& t) {
@@ -54,7 +53,7 @@ private:
     void bind(const T&);
 
     T current;
-    GLint location;
+    gl::UniformLocation location;
 };
 
 } // namespace mbgl

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -282,7 +282,7 @@ void SpriteAtlas::copy(const Holder& holder, const SpritePatternMode mode) {
     dirtyFlag = true;
 }
 
-void SpriteAtlas::upload(gl::Context& context, uint32_t unit) {
+void SpriteAtlas::upload(gl::Context& context, gl::TextureUnit unit) {
     if (dirtyFlag) {
         bind(false, context, unit);
     }
@@ -316,7 +316,7 @@ void SpriteAtlas::updateDirty() {
     dirtySprites.clear();
 }
 
-void SpriteAtlas::bind(bool linear, gl::Context& context, uint32_t unit) {
+void SpriteAtlas::bind(bool linear, gl::Context& context, gl::TextureUnit unit) {
     if (!data) {
         return; // Empty atlas
     }
@@ -325,9 +325,9 @@ void SpriteAtlas::bind(bool linear, gl::Context& context, uint32_t unit) {
         texture = context.createTexture();
         context.activeTexture = unit;
         context.texture[unit] = *texture;
-#ifndef GL_ES_VERSION_2_0
+#if not MBGL_USE_GLES2
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
-#endif
+#endif // MBGL_USE_GLES2
         // We are using clamp to edge here since OpenGL ES doesn't allow GL_REPEAT on NPOT textures.
         // We use those when the pixelRatio isn't a power of two, e.g. on iPhone 6 Plus.
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
@@ -379,10 +379,10 @@ void SpriteAtlas::bind(bool linear, gl::Context& context, uint32_t unit) {
 
         dirtyFlag = false;
 
-#ifndef GL_ES_VERSION_2_0
+#if not MBGL_USE_GLES2
         // platform::showColorDebugImage("Sprite Atlas", reinterpret_cast<const char*>(data.get()),
         //                               pixelWidth, pixelHeight, pixelWidth, pixelHeight);
-#endif
+#endif // MBGL_USE_GLES2
     }
 }
 

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mbgl/geometry/binpack.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/object.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/optional.hpp>
@@ -83,14 +82,14 @@ public:
                                               SpritePatternMode mode = SpritePatternMode::Single);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind(bool linear, gl::Context&, uint32_t unit);
+    void bind(bool linear, gl::Context&, gl::TextureUnit unit);
 
     // Updates sprites in the atlas texture that may have changed.
     void updateDirty();
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload(gl::Context&, uint32_t unit);
+    void upload(gl::Context&, gl::TextureUnit unit);
 
     dimension getWidth() const { return width; }
     dimension getHeight() const { return height; }
@@ -105,7 +104,7 @@ private:
     void _setSprite(const std::string&, const std::shared_ptr<const SpriteImage>& = nullptr);
     void emitSpriteLoadedIfComplete();
 
-    const GLsizei width, height;
+    const uint16_t width, height;
     const dimension pixelWidth, pixelHeight;
     const float pixelRatio;
 

--- a/src/mbgl/text/glyph_atlas.cpp
+++ b/src/mbgl/text/glyph_atlas.cpp
@@ -203,7 +203,7 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
     }
 }
 
-void GlyphAtlas::upload(gl::Context& context, uint32_t unit) {
+void GlyphAtlas::upload(gl::Context& context, gl::TextureUnit unit) {
     if (dirty) {
         const bool first = !texture;
         bind(context, unit);
@@ -241,12 +241,12 @@ void GlyphAtlas::upload(gl::Context& context, uint32_t unit) {
     }
 }
 
-void GlyphAtlas::bind(gl::Context& context, uint32_t unit) {
+void GlyphAtlas::bind(gl::Context& context, gl::TextureUnit unit) {
     if (!texture) {
         texture = context.createTexture();
         context.activeTexture = unit;
         context.texture[unit] = *texture;
-#ifndef GL_ES_VERSION_2_0
+#if not MBGL_USE_GLES2
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
 #endif
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));

--- a/src/mbgl/text/glyph_atlas.hpp
+++ b/src/mbgl/text/glyph_atlas.hpp
@@ -8,7 +8,6 @@
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/exclusive.hpp>
 #include <mbgl/util/work_queue.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/object.hpp>
 
 #include <atomic>
@@ -61,14 +60,14 @@ public:
     void removeGlyphs(uintptr_t tileUID);
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
-    void bind(gl::Context&, uint32_t unit);
+    void bind(gl::Context&, gl::TextureUnit unit);
 
     // Uploads the texture to the GPU to be available when we need it. This is a lazy operation;
     // the texture is only bound when the data is out of date (=dirty).
-    void upload(gl::Context&, uint32_t unit);
+    void upload(gl::Context&, gl::TextureUnit unit);
 
-    const GLsizei width;
-    const GLsizei height;
+    const uint16_t width;
+    const uint16_t height;
 
 private:
     void requestGlyphRange(const FontStack&, const GlyphRange&);

--- a/src/mbgl/util/offscreen_texture.cpp
+++ b/src/mbgl/util/offscreen_texture.cpp
@@ -14,9 +14,9 @@ void OffscreenTexture::bind(gl::Context& context,
         raster.upload(context, 0);
     }
 
-    if (!fbo) {
-        fbo = context.createFBO();
-        context.bindFramebuffer = *fbo;
+    if (!framebuffer) {
+        framebuffer = context.createFramebuffer();
+        context.bindFramebuffer = *framebuffer;
         MBGL_CHECK_ERROR(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                                                 raster.getID(), 0));
 
@@ -48,7 +48,7 @@ void OffscreenTexture::bind(gl::Context& context,
             }
         }
     } else {
-        context.bindFramebuffer = *fbo;
+        context.bindFramebuffer = *framebuffer;
     }
 
     context.viewport = { { 0, 0, static_cast<GLint>(size[0]), static_cast<GLint>(size[1]) } };

--- a/src/mbgl/util/offscreen_texture.cpp
+++ b/src/mbgl/util/offscreen_texture.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/gl/context.hpp>
+#include <mbgl/gl/gl.hpp>
 #include <mbgl/util/offscreen_texture.hpp>
 
 #include <cassert>
@@ -51,7 +52,7 @@ void OffscreenTexture::bind(gl::Context& context,
         context.bindFramebuffer = *framebuffer;
     }
 
-    context.viewport = { { 0, 0, static_cast<GLint>(size[0]), static_cast<GLint>(size[1]) } };
+    context.viewport = { 0, 0, size[0], size[1] };
 }
 
 Raster& OffscreenTexture::getTexture() {

--- a/src/mbgl/util/offscreen_texture.hpp
+++ b/src/mbgl/util/offscreen_texture.hpp
@@ -16,7 +16,7 @@ public:
     std::array<uint16_t, 2> getSize() const;
 
 private:
-    mbgl::optional<gl::UniqueFBO> fbo;
+    mbgl::optional<gl::UniqueFramebuffer> framebuffer;
     Raster raster;
 };
 

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -76,9 +76,9 @@ void Raster::upload(gl::Context& context, uint32_t unit) {
         context.activeTexture = unit;
         context.texture[unit] = *texture;
         updateFilter();
-#ifndef GL_ES_VERSION_2_0
+#if not MBGL_USE_GLES2
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, images.size()));
-#endif
+#endif // MBGL_USE_GLES2
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
         MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
         GLint level = 0;

--- a/src/mbgl/util/raster.cpp
+++ b/src/mbgl/util/raster.cpp
@@ -14,7 +14,7 @@ bool Raster::isLoaded() const {
     return loaded;
 }
 
-GLuint Raster::getID() const {
+gl::TextureID Raster::getID() const {
     return texture ? *texture : 0;
 }
 

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -34,7 +34,7 @@ public:
     bool isLoaded() const;
 
     // returns the OpenGL texture ID
-    GLuint getID() const;
+    gl::TextureID getID() const;
 
     // size of uploaded image.
     std::array<uint16_t, 2> getSize() const;

--- a/src/mbgl/util/raster.hpp
+++ b/src/mbgl/util/raster.hpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <array>
+#include <vector>
 
 namespace mbgl {
 

--- a/test/gl/object.test.cpp
+++ b/test/gl/object.test.cpp
@@ -80,7 +80,7 @@ TEST(GLObject, Store) {
     context.performCleanup();
     EXPECT_TRUE(context.empty());
 
-    mbgl::gl::UniqueShader shader = context.createShader(GL_VERTEX_SHADER);
+    mbgl::gl::UniqueShader shader = context.createVertexShader();
     EXPECT_NE(shader.get(), 0u);
     shader.reset();
     EXPECT_FALSE(context.empty());

--- a/test/gl/object.test.cpp
+++ b/test/gl/object.test.cpp
@@ -103,7 +103,7 @@ TEST(GLObject, Store) {
     context.reset();
     EXPECT_TRUE(context.empty());
 
-    mbgl::gl::UniqueVAO vao = context.createVAO();
+    mbgl::gl::UniqueVertexArray vao = context.createVertexArray();
     EXPECT_NE(vao.get(), 0u);
     vao.reset();
     EXPECT_FALSE(context.empty());


### PR DESCRIPTION
We currently liberally include `gl.h`, even when we're just using a few types it defines in code that otherwise doesn't actually use any GL-related code. Instead, we should not include that file except in implementation files that actually do OpenGL calls.