### PR TITLE
Use correct nullity annotation for convertView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -2011,7 +2011,7 @@ public class MapboxMap {
          * @return the View that is adapted to the contents of MarkerView
          */
         @Nullable
-        public abstract View getView(@NonNull U marker, @NonNull View convertView, @NonNull ViewGroup parent);
+        public abstract View getView(@NonNull U marker, @Nullable View convertView, @NonNull ViewGroup parent);
 
         /**
          * Called when an MarkerView is removed from the MapView or the View object is going to be reused.


### PR DESCRIPTION
This annotation was incorrect, causing a crash when using the adapter with Kotlin due to a null convertView argument being passed to getView().