### PR TITLE
Fix bad dSYM for symbol-stripped dynamic framework builds

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ### Packaging
 
 * Xcode 7.3 or above is required for using this SDK. ([#6059](https://github.com/mapbox/mapbox-gl-native/issues/6059))
+* Fixed an issue with symbols not being properly stripped from the dynamic framework. The dSYM file included with the standard dynamic framework in previous releases (e.g., `mapbox-ios-sdk-3.3.4-dynamic.zip` or the `Mapbox-iOS-SDK` pod) could not be used to symbolicate crashes. ([#6531](https://github.com/mapbox/mapbox-gl-native/pull/6531))
 * Simulator architecture slices are included in the included dSYM file, allowing you to symbolicate crashes that occur in the Simulator. ([#5740](https://github.com/mapbox/mapbox-gl-native/pull/5740))
 * Clarified that the `-ObjC` linker flag is required for linking against the static framework distribution of this SDK. ([#6213](https://github.com/mapbox/mapbox-gl-native/pull/6213))
 

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -53,7 +53,7 @@ You can customize the build output by passing the following arguments into the `
 * `BUILDTYPE=Release` will optimize for distribution. Defaults to `Debug`.
 * `BUILD_DEVICE=false` builds only for the iOS Simulator.
 * `FORMAT=dynamic` builds only a dynamic framework. `FORMAT=static` builds only a static framework, for compatibility with iOS 7.x.
-* `SYMBOLS=NO` strips the build output of any debug symbols, yielding much smaller binaries.
+* `SYMBOLS=NO` strips the build output of any debug symbols, yielding much smaller binaries. Defaults to `YES`.
 
 An example command that creates a dynamic framework suitable for eventual App Store distribution:
 

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -11,7 +11,7 @@ PRODUCTS=${DERIVED_DATA}
 
 BUILDTYPE=${BUILDTYPE:-Debug}
 BUILD_FOR_DEVICE=${BUILD_DEVICE:-true}
-GCC_GENERATE_DEBUGGING_SYMBOLS=${SYMBOLS:-YES}
+SYMBOLS=${SYMBOLS:-YES}
 
 BUILD_DYNAMIC=true
 BUILD_STATIC=true
@@ -42,7 +42,7 @@ if [[ ${BUILD_FOR_DEVICE} == true ]]; then
 fi
 IOS_SDK_VERSION=`xcrun --sdk ${SDK} --show-sdk-version`
 
-echo "Configuring ${FORMAT:-dynamic and static} ${BUILDTYPE} framework for ${SDK}; symbols: ${GCC_GENERATE_DEBUGGING_SYMBOLS}; self-contained static framework: ${SELF_CONTAINED:-NO}"
+echo "Configuring ${FORMAT:-dynamic and static} ${BUILDTYPE} framework for ${SDK}; symbols: ${SYMBOLS}; self-contained static framework: ${SELF_CONTAINED:-NO}"
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
@@ -79,7 +79,6 @@ elif [[ ${BUILD_STATIC} == true ]]; then
 fi
 
 xcodebuild \
-    GCC_GENERATE_DEBUGGING_SYMBOLS=${GCC_GENERATE_DEBUGGING_SYMBOLS} \
     CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
     CURRENT_SHORT_VERSION=${SHORT_VERSION} \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
@@ -94,7 +93,6 @@ xcodebuild \
 
 if [[ ${BUILD_FOR_DEVICE} == true ]]; then
     xcodebuild \
-        GCC_GENERATE_DEBUGGING_SYMBOLS=${GCC_GENERATE_DEBUGGING_SYMBOLS} \
         CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
         CURRENT_SHORT_VERSION=${SHORT_VERSION} \
         CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
@@ -111,7 +109,7 @@ fi
 LIBS=(Mapbox.a)
 
 # https://medium.com/@syshen/create-an-ios-universal-framework-148eb130a46c
-if [[ "${BUILD_FOR_DEVICE}" == true ]]; then
+if [[ ${BUILD_FOR_DEVICE} == true ]]; then
     if [[ ${BUILD_STATIC} == true ]]; then
         step "Assembling static framework for iOS Simulator and devices…"
         mkdir -p ${OUTPUT}/static/${NAME}.framework
@@ -179,8 +177,8 @@ else
     cp -rv ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/Settings.bundle ${STATIC_SETTINGS_DIR}
 fi
 
-if [[ "${GCC_GENERATE_DEBUGGING_SYMBOLS}" == false ]]; then
-    step "Stripping binaries…"
+if [[ ${SYMBOLS} = NO ]]; then
+    step "Stripping symbols from binaries…"
     if [[ ${BUILD_STATIC} == true ]]; then
         strip -Sx "${OUTPUT}/static/${NAME}.framework/${NAME}"
     fi

--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -178,13 +178,34 @@ else
 fi
 
 if [[ ${SYMBOLS} = NO ]]; then
-    step "Stripping symbols from binaries…"
+    step "Stripping symbols from binaries"
     if [[ ${BUILD_STATIC} == true ]]; then
         strip -Sx "${OUTPUT}/static/${NAME}.framework/${NAME}"
     fi
     if [[ ${BUILD_DYNAMIC} == true ]]; then
         strip -Sx "${OUTPUT}/dynamic/${NAME}.framework/${NAME}"
     fi
+fi
+
+function get_comparable_uuid {
+    echo $(dwarfdump --uuid ${1} | sed -n 's/.*UUID:\([^\"]*\) .*/\1/p' | sort)
+}
+
+function validate_dsym {
+    step "Validating dSYM and framework UUIDs…"
+    DSYM_UUID=$(get_comparable_uuid "${1}")
+    FRAMEWORK_UUID=$(get_comparable_uuid "${2}")
+    echo -e "${1}\n  ${DSYM_UUID}\n${2}\n  ${FRAMEWORK_UUID}"
+    if [[ ${DSYM_UUID} != ${FRAMEWORK_UUID} ]]; then
+        echo "Error: dSYM and framework UUIDs do not match."
+        exit 1
+    fi
+}
+
+if [[ ${BUILD_DYNAMIC} == true && ${BUILDTYPE} == Release ]]; then
+    validate_dsym \
+        "${OUTPUT}/dynamic/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}" \
+        "${OUTPUT}/dynamic/${NAME}.framework/${NAME}"
 fi
 
 function create_podspec {

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed an issue causing code signing failures and bloating the framework. ([#5850](https://github.com/mapbox/mapbox-gl-native/pull/5850))
 * Xcode 7.3 or higher is now required for using this SDK. ([#6059](https://github.com/mapbox/mapbox-gl-native/issues/6059))
 * A new runtime styling API allows you to adjust the style and content of the base map dynamically. All the options available in [Mapbox Studio](https://www.mapbox.com/studio/) are now exposed via MGLStyle and subclasses of MGLStyleLayer and MGLSource. ([#5727](https://github.com/mapbox/mapbox-gl-native/pull/5727))
+* Fixed an issue with symbols not being properly stripped from the dynamic framework when built with `make xpackage SYMBOLS=NO`. ([#6531](https://github.com/mapbox/mapbox-gl-native/pull/6531))
 * Added `showAnnotations:animated:` and `showAnnotations:edgePadding:animated:`, which moves the map viewport to show the specified annotations. ([#5749](https://github.com/mapbox/mapbox-gl-native/pull/5749))
 * Fixed an issue where the map view’s center would always be calculated as if the view occupied the entire window. ([#6102](https://github.com/mapbox/mapbox-gl-native/pull/6102))
 * To make an MGLPolyline or MGLPolygon span the antimeridian, specify coordinates with longitudes greater than 180° or less than −180°. ([#6088](https://github.com/mapbox/mapbox-gl-native/pull/6088))

--- a/platform/macos/DEVELOPING.md
+++ b/platform/macos/DEVELOPING.md
@@ -14,6 +14,32 @@ The Mapbox macOS SDK requires Xcode 7.3 or above.
 1. Run `make xproj`.
 1. Switch to the “dynamic” or “macosapp” scheme. The former builds just the Cocoa framework, while the latter also builds a Cocoa demo application based on it.
 
+### Packaging builds
+
+Install [jazzy](https://github.com/realm/jazzy) for generating API documentation:
+
+```bash
+[sudo] gem install jazzy
+```
+
+Build and package the SDK by using one of the following commands:
+
+* `make xpackage` builds a dynamic framework in the Debug configuration, including debug symbols.
+* `make xdocument` generates API documentation using jazzy.
+
+You can customize the build output by passing the following arguments into the `make` invocation:
+
+* `BUILDTYPE=Release` will optimize for distribution. Defaults to `Debug`.
+* `SYMBOLS=NO` strips the build output of any debug symbols, yielding much smaller binaries. Defaults to `YES`.
+
+An example command that creates a dynamic framework suitable for distribution:
+
+```bash
+make xpackage BUILDTYPE=Release SYMBOLS=NO
+```
+
+The products of these build commands can be found in the `build/macos/pkg` folder at the base of the repository.
+
 ## Contributing
 
 ### Making any symbol public

--- a/platform/macos/scripts/package.sh
+++ b/platform/macos/scripts/package.sh
@@ -10,7 +10,7 @@ DERIVED_DATA=build/macos
 PRODUCTS=${DERIVED_DATA}
 
 BUILDTYPE=${BUILDTYPE:-Release}
-GCC_GENERATE_DEBUGGING_SYMBOLS=${SYMBOLS:-YES}
+SYMBOLS=${SYMBOLS:-YES}
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
@@ -25,7 +25,6 @@ SHORT_VERSION=${SEM_VERSION%-*}
 
 step "Building targets (build ${PROJ_VERSION}, version ${SEM_VERSION})…"
 xcodebuild \
-    GCC_GENERATE_DEBUGGING_SYMBOLS=${GCC_GENERATE_DEBUGGING_SYMBOLS} \
     CURRENT_PROJECT_VERSION=${PROJ_VERSION} \
     CURRENT_SHORT_VERSION=${SHORT_VERSION} \
     CURRENT_SEMANTIC_VERSION=${SEM_VERSION} \
@@ -43,7 +42,7 @@ if [[ -e ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework.dSYM ]]; then
     cp -r ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework.dSYM "${OUTPUT}"
 fi
 
-if [[ "${GCC_GENERATE_DEBUGGING_SYMBOLS}" == false ]]; then
+if [[ ${SYMBOLS} = NO ]]; then
     step "Stripping binaries…"
     strip -Sx "${OUTPUT}/${NAME}.framework/${NAME}"
 fi

--- a/platform/macos/scripts/package.sh
+++ b/platform/macos/scripts/package.sh
@@ -43,8 +43,29 @@ if [[ -e ${PRODUCTS}/${BUILDTYPE}/${NAME}.framework.dSYM ]]; then
 fi
 
 if [[ ${SYMBOLS} = NO ]]; then
-    step "Stripping binaries…"
+    step "Stripping symbols from binaries"
     strip -Sx "${OUTPUT}/${NAME}.framework/${NAME}"
+fi
+
+function get_comparable_uuid {
+    echo $(dwarfdump --uuid ${1} | sed -n 's/.*UUID:\([^\"]*\) .*/\1/p' | sort)
+}
+
+function validate_dsym {
+    step "Validating dSYM and framework UUIDs…"
+    DSYM_UUID=$(get_comparable_uuid "${1}")
+    FRAMEWORK_UUID=$(get_comparable_uuid "${2}")
+    echo -e "${1}\n  ${DSYM_UUID}\n${2}\n  ${FRAMEWORK_UUID}"
+    if [[ ${DSYM_UUID} != ${FRAMEWORK_UUID} ]]; then
+        echo "Error: dSYM and framework UUIDs do not match."
+        exit 1
+    fi
+}
+
+if [[ ${BUILDTYPE} == Release ]]; then
+    validate_dsym \
+        "${OUTPUT}/${NAME}.framework.dSYM/Contents/Resources/DWARF/${NAME}" \
+        "${OUTPUT}/${NAME}.framework/${NAME}"
 fi
 
 step "Copying library resources…"


### PR DESCRIPTION
Fixes #6502. Stripped dynamic framework packages should now come with the correct dSYM.

Disabling `GCC_GENERATE_DEBUGGING_SYMBOLS` for `SYMBOLS=NO` builds meant that those builds had no debug symbols to strip or add to a dSYM. Running `make iframework SYMBOLS=NO` would fail to create a dSYM, but our deploy script would evidently [reuse the symbol-ful dSYM](https://github.com/mapbox/mapbox-gl-native/issues/6502#issuecomment-250605473).

With the added UUID validation, the above scenario would now fail:
```
* Stripping symbols from binaries…
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: changes being made to the file will invalidate the code signature in: /Users/jason/Documents/Mapbox/mapbox-gl-native/build/ios/pkg/dynamic/Mapbox.framework/Mapbox (for architecture i386)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: changes being made to the file will invalidate the code signature in: /Users/jason/Documents/Mapbox/mapbox-gl-native/build/ios/pkg/dynamic/Mapbox.framework/Mapbox (for architecture x86_64)
* Validating dSYM and framework UUIDs
error: unable to open 'build/ios/pkg/dynamic/Mapbox.framework.dSYM/Contents/Resources/DWARF/Mapbox': No such file or directory
Error: dSYM and framework UUIDs do not match.
build/ios/pkg/dynamic/Mapbox.framework.dSYM/Contents/Resources/DWARF/Mapbox
  
build/ios/pkg/dynamic/Mapbox.framework/Mapbox
  23F302DF-17AB-384C-879B-746C8A73511A (arm64) 2877864D-E317-3250-8756-11D94C868177 (i386) 59352B56-89D5-3E8E-B83E-9B15657B5C83 (armv7) F91C2CAC-5283-3ADF-ACFB-DD86B4BF5BFF (x86_64)
make: *** [iframework] Error 1
```

Note: `GCC_GENERATE_DEBUGGING_SYMBOLS=YES` is the default setting.

### Useful resources
- https://developer.apple.com/library/content/technotes/tn2004/tn2123.html
- `nm Mapbox.framework/Mapbox | grep MGL` helped test symbol stripping.
- Archived [Xcode build settings reference](https://web.archive.org/web/20160424060222/https://developer.apple.com/library/ios/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW53).

/cc @boundsj @1ec5