### PR TITLE
Loosen style doc transform regex

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -86,10 +86,10 @@ global.testHelperMessage = function (property, layerType, isFunction) {
 global.propertyDoc = function (propertyName, property, layerType) {
     // Match references to other property names & values. 
     // Requires the format 'When `foo` is set to `bar`,'.
-    let doc = property.doc.replace(/When `(.+?)` is set to `(.+?)`,/g, function (m, peerPropertyName, propertyValue, offset, str) {
+    let doc = property.doc.replace(/`([^`]+?)` is set to `([^`]+?)`/g, function (m, peerPropertyName, propertyValue, offset, str) {
         let otherProperty = camelizeWithLeadingLowercase(peerPropertyName);
         let otherValue = objCType(layerType, peerPropertyName) + camelize(propertyValue);
-        return 'When `' + `${otherProperty}` + '` is set to `' + `${otherValue}` + '`,';
+        return '`' + `${otherProperty}` + '` is set to `' + `${otherValue}` + '`';
     });
     // Match references to our own property values.
     // Requires the format 'is equivalent to `bar`'.


### PR DESCRIPTION
Mildly decoupled the transformation from the style specification to the format required for iOS/macOS documentation so it’s harder for style specification references to other properties’ values to fall through the cracks.

Fixes #6541.

/cc @incanus