### PR TITLE
[ios] Remove double counting of content inset top and bottom

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4173,9 +4173,9 @@ public:
     CGRect boundsAroundCorrectPoint = CGRectOffset(bounds,
                                                    correctPoint.x - CGRectGetMidX(bounds),
                                                    correctPoint.y - CGRectGetMidY(bounds));
-    return UIEdgeInsetsMake(CGRectGetMinY(boundsAroundCorrectPoint) - CGRectGetMinY(bounds) + self.contentInset.top,
+    return UIEdgeInsetsMake(CGRectGetMinY(boundsAroundCorrectPoint) - CGRectGetMinY(bounds),
                             self.contentInset.left,
-                            CGRectGetMaxY(bounds) - CGRectGetMaxY(boundsAroundCorrectPoint) + self.contentInset.bottom,
+                            CGRectGetMaxY(bounds) - CGRectGetMaxY(boundsAroundCorrectPoint),
                             self.contentInset.right);
 }
 


### PR DESCRIPTION
This removes the calls to top and bottom for content inset of the map view when calculating the edge padding for following. https://github.com/mapbox/mapbox-gl-native/pull/6313 added this along with the left and right values. 

The correction in this PR eliminates a bug where the map did not scroll to the correct location for the user dot (it was several points off on the y axis) and also a bug in `didUpdateLocationWithUserTrackingAnimated:` where the map panning operations would always occur because the current and correct points never matched up even if a stream of location values that were the same were processed.

cc @1ec5 @friedbunny 