### PR TITLE
[core] Tiles that error on load are not renderable

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -60,9 +60,9 @@ set(MBGL_TEST_FILES
     # storage
     test/storage/asset_file_source.test.cpp
     test/storage/default_file_source.test.cpp
-    test/storage/local_file_source.test.cpp
     test/storage/headers.test.cpp
     test/storage/http_file_source.test.cpp
+    test/storage/local_file_source.test.cpp
     test/storage/offline.test.cpp
     test/storage/offline_database.test.cpp
     test/storage/offline_download.test.cpp
@@ -87,7 +87,9 @@ set(MBGL_TEST_FILES
 
     # tile
     test/tile/geometry_tile_data.test.cpp
+    test/tile/raster_tile.test.cpp
     test/tile/tile_id.test.cpp
+    test/tile/vector_tile.test.cpp
 
     # util
     test/util/async_task.test.cpp

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -41,7 +41,6 @@ void GeometryTile::cancel() {
 }
 
 void GeometryTile::setError(std::exception_ptr err) {
-    availableData = DataAvailability::All;
     observer->onTileError(*this, err);
 }
 
@@ -111,6 +110,11 @@ void GeometryTile::onPlacement(PlacementResult result) {
     featureIndex->setCollisionTile(std::move(result.collisionTile));
     placedConfig = result.placedConfig;
     observer->onTileChanged(*this);
+}
+
+void GeometryTile::onError(std::exception_ptr err) {
+    availableData = DataAvailability::All;
+    observer->onTileError(*this, err);
 }
 
 Bucket* GeometryTile::getBucket(const Layer& layer) {

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -31,8 +31,9 @@ public:
 
     ~GeometryTile() override;
 
-    void setError(std::exception_ptr err);
+    void setError(std::exception_ptr);
     void setData(std::unique_ptr<const GeometryTileData>);
+
     void setPlacementConfig(const PlacementConfig&) override;
     void redoLayout() override;
 
@@ -63,6 +64,8 @@ public:
         uint64_t correlationID;
     };
     void onPlacement(PlacementResult);
+
+    void onError(std::exception_ptr);
 
 private:
     const std::string sourceID;

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -88,7 +88,7 @@ void GeometryTileWorker::setData(std::unique_ptr<const GeometryTileData> data_, 
             break;
         }
     } catch (...) {
-        parent.invoke(&GeometryTile::setError, std::current_exception());
+        parent.invoke(&GeometryTile::onError, std::current_exception());
     }
 }
 
@@ -112,7 +112,7 @@ void GeometryTileWorker::setLayers(std::vector<std::unique_ptr<Layer>> layers_, 
             break;
         }
     } catch (...) {
-        parent.invoke(&GeometryTile::setError, std::current_exception());
+        parent.invoke(&GeometryTile::onError, std::current_exception());
     }
 }
 
@@ -136,7 +136,7 @@ void GeometryTileWorker::setPlacementConfig(PlacementConfig placementConfig_, ui
             break;
         }
     } catch (...) {
-        parent.invoke(&GeometryTile::setError, std::current_exception());
+        parent.invoke(&GeometryTile::onError, std::current_exception());
     }
 }
 
@@ -162,7 +162,7 @@ void GeometryTileWorker::coalesced() {
             break;
         }
     } catch (...) {
-        parent.invoke(&GeometryTile::setError, std::current_exception());
+        parent.invoke(&GeometryTile::onError, std::current_exception());
     }
 }
 

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -28,8 +28,6 @@ void RasterTile::cancel() {
 }
 
 void RasterTile::setError(std::exception_ptr err) {
-    bucket.reset();
-    availableData = DataAvailability::All;
     observer->onTileError(*this, err);
 }
 
@@ -45,6 +43,12 @@ void RasterTile::onParsed(std::unique_ptr<Bucket> result) {
     bucket = std::move(result);
     availableData = DataAvailability::All;
     observer->onTileChanged(*this);
+}
+
+void RasterTile::onError(std::exception_ptr err) {
+    bucket.reset();
+    availableData = DataAvailability::All;
+    observer->onTileError(*this, err);
 }
 
 Bucket* RasterTile::getBucket(const style::Layer&) {

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -23,8 +23,7 @@ public:
 
     void setNecessity(Necessity) final;
 
-    void setError(std::exception_ptr err);
-
+    void setError(std::exception_ptr);
     void setData(std::shared_ptr<const std::string> data,
                  optional<Timestamp> modified_,
                  optional<Timestamp> expires_);
@@ -33,6 +32,7 @@ public:
     Bucket* getBucket(const style::Layer&) override;
 
     void onParsed(std::unique_ptr<Bucket> result);
+    void onError(std::exception_ptr);
 
 private:
     TileLoader<RasterTile> loader;

--- a/src/mbgl/tile/raster_tile_worker.cpp
+++ b/src/mbgl/tile/raster_tile_worker.cpp
@@ -19,7 +19,7 @@ void RasterTileWorker::parse(std::shared_ptr<const std::string> data) {
         auto bucket = std::make_unique<RasterBucket>(decodeImage(*data));
         parent.invoke(&RasterTile::onParsed, std::move(bucket));
     } catch (...) {
-        parent.invoke(&RasterTile::setError, std::current_exception());
+        parent.invoke(&RasterTile::onError, std::current_exception());
     }
 }
 

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -1,0 +1,47 @@
+#include <mbgl/test/util.hpp>
+#include <mbgl/test/fake_file_source.hpp>
+#include <mbgl/tile/raster_tile.hpp>
+#include <mbgl/tile/tile_loader_impl.hpp>
+
+#include <mbgl/actor/thread_pool.hpp>
+#include <mbgl/map/transform.hpp>
+#include <mbgl/style/style.hpp>
+#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/annotation/annotation_manager.hpp>
+
+using namespace mbgl;
+
+class RasterTileTest {
+public:
+    FakeFileSource fileSource;
+    TransformState transformState;
+    ThreadPool threadPool { 1 };
+    AnnotationManager annotationManager { 1.0 };
+    style::Style style { fileSource, 1.0 };
+    Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
+
+    style::UpdateParameters updateParameters {
+        1.0,
+        MapDebugOptions(),
+        transformState,
+        threadPool,
+        fileSource,
+        MapMode::Continuous,
+        annotationManager,
+        style
+    };
+};
+
+TEST(RasterTile, setError) {
+    RasterTileTest test;
+    RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
+    tile.setError(std::make_exception_ptr(std::runtime_error("test")));
+    EXPECT_FALSE(tile.isRenderable());
+}
+
+TEST(RasterTile, onError) {
+    RasterTileTest test;
+    RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
+    tile.onError(std::make_exception_ptr(std::runtime_error("test")));
+    EXPECT_TRUE(tile.isRenderable());
+}

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -1,0 +1,47 @@
+#include <mbgl/test/util.hpp>
+#include <mbgl/test/fake_file_source.hpp>
+#include <mbgl/tile/vector_tile.hpp>
+#include <mbgl/tile/tile_loader_impl.hpp>
+
+#include <mbgl/actor/thread_pool.hpp>
+#include <mbgl/map/transform.hpp>
+#include <mbgl/style/style.hpp>
+#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/annotation/annotation_manager.hpp>
+
+using namespace mbgl;
+
+class VectorTileTest {
+public:
+    FakeFileSource fileSource;
+    TransformState transformState;
+    ThreadPool threadPool { 1 };
+    AnnotationManager annotationManager { 1.0 };
+    style::Style style { fileSource, 1.0 };
+    Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
+
+    style::UpdateParameters updateParameters {
+        1.0,
+        MapDebugOptions(),
+        transformState,
+        threadPool,
+        fileSource,
+        MapMode::Continuous,
+        annotationManager,
+        style
+    };
+};
+
+TEST(VectorTile, setError) {
+    VectorTileTest test;
+    VectorTile tile(OverscaledTileID(0, 0, 0), "source", test.updateParameters, test.tileset);
+    tile.setError(std::make_exception_ptr(std::runtime_error("test")));
+    EXPECT_FALSE(tile.isRenderable());
+}
+
+TEST(VectorTile, onError) {
+    VectorTileTest test;
+    VectorTile tile(OverscaledTileID(0, 0, 0), "source", test.updateParameters, test.tileset);
+    tile.onError(std::make_exception_ptr(std::runtime_error("test")));
+    EXPECT_TRUE(tile.isRenderable());
+}


### PR DESCRIPTION
In 41bbd4e4f7d66465433e370ca024ab0239fcace3 I merged two error pathways that need to be distinct:

* If an error occurs while loading a tile, the tile should not be treated as renderable
* If an error occurs while creating the tile layout, the tile can be considered renderable (there might be partial data, or the data from a prior layout may still be used)

Fixes #6506
Fixes #6547

@halset, thanks for locating the offending commit, it made the cause of this regression easy to find.