### PR TITLE
iOS deploy script enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,10 @@ ifabric: $(IOS_PROJ_PATH)
 	FORMAT=static BUILD_DEVICE=$(BUILD_DEVICE) SYMBOLS=NO SELF_CONTAINED=YES \
 	./platform/ios/scripts/package.sh
 
+.PHONY: ideploy
+ideploy:
+	caffeinate -i ./platform/ios/scripts/deploy-packages.sh
+
 .PHONY: idocument
 idocument:
 	OUTPUT=$(OUTPUT) ./platform/ios/scripts/document.sh

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -38,11 +38,10 @@ buildPackageStyle() {
     wget -O ${BINARY_DIRECTORY}/${file_name} http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/${file_name}
     if [[ "${GITHUB_RELEASE}" == true ]]; then
         step "Uploading ${file_name} to GitHub"
-        github-release --verbose upload \
+        github-release upload \
             --tag "ios-v${PUBLISH_VERSION}" \
             --name ${file_name} \
             --file "${BINARY_DIRECTORY}/${file_name}"
-            # | sed '/^BODY/d'
     fi        
 }
 
@@ -60,7 +59,7 @@ rm -rf ${BINARY_DIRECTORY}
 mkdir -p ${BINARY_DIRECTORY}
 
 if [[ ${GITHUB_RELEASE} = "true" ]]; then
-    GITHUB_RELEASE=true # Assign bool, not just a word
+    GITHUB_RELEASE=true # Assign bool, not just a string
 fi
 
 if [[ -z ${PUBLISH_VERSION} ]]; then
@@ -78,11 +77,10 @@ if [[ "${GITHUB_RELEASE}" == true ]]; then
     if [[ $( echo ${PUBLISH_VERSION} | awk '/[0-9]-/' ) ]]; then
         PUBLISH_PRE_FLAG='--pre-release'
     fi
-    github-release --verbose release \
+    github-release release \
         --tag "ios-v${PUBLISH_VERSION}" \
         --name "ios-v${PUBLISH_VERSION}" \
         --draft ${PUBLISH_PRE_FLAG}
-        #| sed '/^BODY/d; /^GET/d'
 fi
 
 buildPackageStyle "ipackage" "symbols"
@@ -90,3 +88,5 @@ buildPackageStyle "ipackage-strip"
 buildPackageStyle "iframework" "symbols-dynamic"
 buildPackageStyle "iframework SYMBOLS=NO" "dynamic"
 buildPackageStyle "ifabric" "fabric"
+
+step "Finished deploying ${PUBLISH_VERSION}"

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -59,7 +59,7 @@ GITHUB_RELEASE=${GITHUB_RELEASE:-true}
 rm -rf ${BINARY_DIRECTORY}
 mkdir -p ${BINARY_DIRECTORY}
 
-if [[ ${GITHUB_RELEASE} = true ]]; then
+if [[ ${GITHUB_RELEASE} = "true" ]]; then
     GITHUB_RELEASE=true # Assign bool, not just a word
 fi
 
@@ -70,7 +70,7 @@ if [[ -z ${PUBLISH_VERSION} ]]; then
 fi
 
 step "Deploying version ${PUBLISH_VERSION}…"
- 
+
 make clean && make distclean
 
 if [[ "${GITHUB_RELEASE}" == true ]]; then

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -41,7 +41,8 @@ buildPackageStyle() {
         github-release --verbose upload \
             --tag "ios-v${PUBLISH_VERSION}" \
             --name ${file_name} \
-            --file "${BINARY_DIRECTORY}/${file_name}" | sed '/^BODY/d; /^GET/d'
+            --file "${BINARY_DIRECTORY}/${file_name}"
+            # | sed '/^BODY/d'
     fi        
 }
 
@@ -80,8 +81,8 @@ if [[ "${GITHUB_RELEASE}" == true ]]; then
     github-release --verbose release \
         --tag "ios-v${PUBLISH_VERSION}" \
         --name "ios-v${PUBLISH_VERSION}" \
-        --draft ${PUBLISH_PRE_FLAG} \
-        | sed '/^BODY/d; /^GET/d'
+        --draft ${PUBLISH_PRE_FLAG}
+        #| sed '/^BODY/d; /^GET/d'
 fi
 
 buildPackageStyle "ipackage" "symbols"

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -80,8 +80,15 @@ if [[ -z ${VERSION_TAG} ]]; then
     echo "Found tag: ${VERSION_TAG}"
 fi
 
-if [[ $( echo ${VERSION_TAG} | grep -v ios-v ) ]]; then
-    echo "${VERSION_TAG} is not a valid iOS version tag"
+if [[ $( echo ${VERSION_TAG} | grep --invert-match ios-v ) ]]; then
+    echo "Error: ${VERSION_TAG} is not a valid iOS version tag"
+    echo "VERSION_TAG should be in format: ios-vX.X.X-pre.X"
+    exit 1
+fi
+
+if [[ $( wget --spider -O- https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/tags/${VERSION_TAG} 2>&1 | grep -c "404 Not Found" ) == 0 ]]; then
+    echo "Error: ${VERSION_TAG} has already been published on GitHub"
+    echo "See: https://github.com/${GITHUB_USER}/${GITHUB_REPO}/releases/tag/${VERSION_TAG}"
     exit 1
 fi
 
@@ -89,8 +96,6 @@ PUBLISH_VERSION=$( echo ${VERSION_TAG} | sed 's/^ios-v//' )
 git checkout ${VERSION_TAG}
 
 step "Deploying version ${PUBLISH_VERSION}…"
-
-exit 1
 
 make clean && make distclean
 

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -6,10 +6,9 @@ set -u
 
 usage() {
 cat <<EOF
-# Usage: sh $0 version target_directory [argument]
+# Usage: sh $0 version [argument]
 
 # version: The semver version plus optional alpha beta distinction (i.e. {major.minor.patch}{-alpha.N})
-# target_directory: The directory where build output should be placed
 
 # argument:
 #     -g: Upload to github
@@ -44,7 +43,7 @@ buildPackageStyle() {
         file_name=mapbox-ios-sdk-${PUBLISH_VERSION}-${style}.zip        
     fi
     step "Downloading ${file_name} from s3 to ${BINARY_DIRECTORY}"
-    wget -P ${BINARY_DIRECTORY} http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/${file_name}
+    wget -P ${BINARY_DIRECTORY} -O ${file_name} http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/${file_name}
     if [[ "${GITHUB_RELEASE}" == true ]]; then
         step "Publishing ${file_name} to GitHub"
         github-release --verbose upload \
@@ -65,7 +64,7 @@ export GITHUB_USER=mapbox
 export GITHUB_REPO=mapbox-gl-native
 export BUILDTYPE=Release
 
-BINARY_DIRECTORY=$2
+BINARY_DIRECTORY='./build/ios/deploy'
 PUBLISH_PRE_FLAG=''
 GITHUB_RELEASE=false
 

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -5,7 +5,9 @@ set -o pipefail
 set -u
 
 # dynamic environment variables:
+#     PUBLISH_VERSION={determined from tag}: Version string
 #     GITHUB_RELEASE=true: Upload to github
+#     BINARY_DIRECTORY=build/ios/deploy: Directory in which to save test packages
 
 # environment variables and dependencies: 
 #     - You must run "mbx auth ..." before running
@@ -50,10 +52,10 @@ export GITHUB_USER=mapbox
 export GITHUB_REPO=mapbox-gl-native
 export BUILDTYPE=Release
 
-PUBLISH_VERSION=
-BINARY_DIRECTORY='build/ios/deploy'
-PUBLISH_PRE_FLAG=''
+PUBLISH_VERSION=${PUBLISH_VERSION:-''}
+BINARY_DIRECTORY=${BINARY_DIRECTORY:-build/ios/deploy}
 GITHUB_RELEASE=${GITHUB_RELEASE:-true}
+PUBLISH_PRE_FLAG=''
 
 rm -rf ${BINARY_DIRECTORY}
 mkdir -p ${BINARY_DIRECTORY}

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -43,7 +43,10 @@ buildPackageStyle() {
     wget -P ${BINARY_DIRECTORY} http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/${file_name}
     if [[ "${GITHUB_RELEASE}" == true ]]; then
         echo "publish ${file_name} to GitHub"
-        github-release --verbose upload --tag "ios-v${PUBLISH_VERSION}" --name ${file_name} --file "${BINARY_DIRECTORY}/${file_name}"
+        github-release --verbose upload \
+            --tag "ios-v${PUBLISH_VERSION}" \
+            --name ${file_name} --file "${BINARY_DIRECTORY}/${file_name}" \
+            | sed '/^BODY/d; /^GET/d' # Omit overly verbose HTTP logging
     fi        
 }
 
@@ -75,7 +78,11 @@ if [[ "${GITHUB_RELEASE}" == true ]]; then
     if [[ $( echo ${PUBLISH_VERSION} | awk '/[0-9]-/' ) ]]; then
         PUBLISH_PRE_FLAG='--pre-release'
     fi
-    github-release --verbose release --tag "ios-v${PUBLISH_VERSION}" --name "ios-v${PUBLISH_VERSION}" --draft ${PUBLISH_PRE_FLAG}
+    github-release --verbose release \
+        --tag "ios-v${PUBLISH_VERSION}" \
+        --name "ios-v${PUBLISH_VERSION}" \
+        --draft ${PUBLISH_PRE_FLAG} \
+        | sed '/^BODY/d; /^GET/d' # Omit overly verbose HTTP logging
 fi
 
 buildPackageStyle "ipackage" "symbols"

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -11,7 +11,7 @@ set -u
 #     - You must run "mbx auth ..." before running
 #     - Set GITHUB_TOKEN to a GitHub API access token in your environment to use GITHUB_RELEASE
 #     - "wget" is required for downloading the zip files from s3
-#     - The "github-release" gem is required to use GITHUB_RELEASE
+#     - The "github-release" command is required to use GITHUB_RELEASE
 
 function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
 function finish { >&2 echo -en "\033[0m"; }
@@ -60,6 +60,15 @@ mkdir -p ${BINARY_DIRECTORY}
 
 if [[ ${GITHUB_RELEASE} = "true" ]]; then
     GITHUB_RELEASE=true # Assign bool, not just a string
+
+    if [[ -z `which github-release` ]]; then
+        step "Installing github-release…"
+        brew install github-release
+        if [ -z `which github-release` ]; then
+            echo "Unable to install github-release. See: https://github.com/aktau/github-release"
+            exit 1
+        fi
+    fi
 fi
 
 if [[ -z ${PUBLISH_VERSION} ]]; then

--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -22,14 +22,18 @@ cat <<EOF
 EOF
 }
 
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
 buildPackageStyle() {
     local package=$1 style=""     
     if [[ ${#} -eq 2 ]]; then
         style="$2"
     fi            
-    echo "make ${package} ${style}"
+    step "Building: make ${package} ${style}"
     make ${package}
-    echo "publish ${package} with ${style}"
+    step "Publishing ${package} with ${style}"
     local file_name=""
     if [ -z ${style} ] 
     then
@@ -39,10 +43,10 @@ buildPackageStyle() {
         ./platform/ios/scripts/publish.sh "${PUBLISH_VERSION}" ${style}
         file_name=mapbox-ios-sdk-${PUBLISH_VERSION}-${style}.zip        
     fi
-    echo "Downloading ${file_name} from s3... to ${BINARY_DIRECTORY}"
+    step "Downloading ${file_name} from s3 to ${BINARY_DIRECTORY}"
     wget -P ${BINARY_DIRECTORY} http://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/${file_name}
     if [[ "${GITHUB_RELEASE}" == true ]]; then
-        echo "publish ${file_name} to GitHub"
+        step "Publishing ${file_name} to GitHub"
         github-release --verbose upload \
             --tag "ios-v${PUBLISH_VERSION}" \
             --name ${file_name} --file "${BINARY_DIRECTORY}/${file_name}" \
@@ -65,7 +69,7 @@ BINARY_DIRECTORY=$2
 PUBLISH_PRE_FLAG=''
 GITHUB_RELEASE=false
 
-echo "Deploying version ${PUBLISH_VERSION}..."
+step "Deploying version ${PUBLISH_VERSION}..."
 
 if [[ ${#} -eq 3 &&  $3 == "-g" ]]; then
     GITHUB_RELEASE=true

--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -32,7 +32,7 @@ zip -r ../${ZIP} *
 #
 # upload
 #
-step "Uploading to s3…"
+step "Uploading ${ZIP} to s3…"
 REPO_NAME=$(basename $TRAVIS_REPO_SLUG)
 aws s3 cp ../${ZIP} s3://mapbox/$REPO_NAME/ios/builds/ --acl public-read
 echo http://mapbox.s3.amazonaws.com/$REPO_NAME/ios/builds/${ZIP}

--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -34,5 +34,5 @@ zip -r ../${ZIP} *
 #
 step "Uploading to s3…"
 REPO_NAME=$(basename $TRAVIS_REPO_SLUG)
-aws s3 cp ../${ZIP} s3://mapbox/$REPO_NAME/ios/builds/ --acl public-read > /dev/null
+aws s3 cp ../${ZIP} s3://mapbox/$REPO_NAME/ios/builds/ --acl public-read
 echo http://mapbox.s3.amazonaws.com/$REPO_NAME/ios/builds/${ZIP}

--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -4,6 +4,10 @@ set -e
 set -o pipefail
 set -u
 
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
 #
 # iOS release tag format is `vX.Y.Z`; `X.Y.Z` gets passed in
 # In the case of symbolicated builds, we also append the `-symbols`.
@@ -21,11 +25,14 @@ fi
 #
 cd build/ios/pkg
 ZIP=mapbox-ios-sdk-${PUBLISH_VERSION}${PUBLISH_STYLE}.zip
+step "Compressing ${ZIP}…"
 rm -f ../${ZIP}
 zip -r ../${ZIP} *
+
 #
 # upload
 #
+step "Uploading to s3…"
 REPO_NAME=$(basename $TRAVIS_REPO_SLUG)
 aws s3 cp ../${ZIP} s3://mapbox/$REPO_NAME/ios/builds/ --acl public-read > /dev/null
 echo http://mapbox.s3.amazonaws.com/$REPO_NAME/ios/builds/${ZIP}


### PR DESCRIPTION
Spent some time converting @boundsj’s `deploy-packages.sh` into a more automated `make` command:

- **`make ideploy` is now the one-stop shop for deploying releases.**
 - Automatically detects latest `ios-vX.X.X-pre.X` tag.
 - Fails if version has already been published on GitHub.
 - Fails if tag does not exist, checks it out if it does.
 - Specify a version and skip GitHub publishing: `make ideploy VERSION_TAG=ios-v9.8.7 GITHUB_RELEASE=false`
- Does not allow your computer to go to sleep (`caffeinate`), which would ruin the deploy.
- Adds more informative steps, formatted like the build `make` commands.
- Shows upload progress for s3.
- Removes overly-verbose `github-release` output.
 - Tried to filter this instead, but `sed` would occasionally kill the entire process.
- Installs `github-release` from homebrew.
- Re-downloaded packages are now stored in `build/ios/deploy`.
 - Can override this via: `make ideploy BINARY_DIRECTORY='~/Desktop'`

Another future enhancement would be to check if you have `aws s3` push privileges.

/cc @boundsj @1ec5 @incanus @frederoni