### PR TITLE
Remove support for CONTAINS operator

### DIFF
--- a/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
@@ -68,12 +68,6 @@
             filter.values = self.rightExpression.mgl_filterValues;
             return filter;
         }
-        case NSContainsPredicateOperatorType: {
-            auto filter = mbgl::style::InFilter();
-            filter.key = [self.rightExpression.constantValue UTF8String];
-            filter.values = self.leftExpression.mgl_filterValues;
-            return filter;
-        }
         case NSBetweenPredicateOperatorType: {
             auto filter = mbgl::style::AllFilter();
             auto gteFilter = mbgl::style::GreaterThanEqualsFilter();
@@ -91,6 +85,7 @@
         case NSBeginsWithPredicateOperatorType:
         case NSEndsWithPredicateOperatorType:
         case NSCustomSelectorPredicateOperatorType:
+        case NSContainsPredicateOperatorType:
             [NSException raise:@"Unsupported operator type"
                         format:@"NSPredicateOperatorType:%lu is not supported.", (unsigned long)self.predicateOperatorType];
     }

--- a/platform/darwin/test/MGLFilterTests.mm
+++ b/platform/darwin/test/MGLFilterTests.mm
@@ -74,18 +74,6 @@
     [self.mapView.style addLayer:layer];
 }
 
-- (void)testContainsPredicate
-{
-    // core does not have a "contains" filter but we can achieve the equivalent by creating an `mbgl::style::InFilter`
-    // and searching the value for the key
-    NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"park IN %@", @[@"park", @"neighbourhood"]];
-    NSPredicate *containsPredicate = [NSPredicate predicateWithFormat:@"%@ CONTAINS %@", @[@"park", @"neighbourhood"], @"park"];
-    
-    layer.predicate = containsPredicate;
-    XCTAssertEqualObjects(layer.predicate, expectedPredicate);
-    [self.mapView.style addLayer:layer];
-}
-
 - (void)testBetweenPredicate
 {
     // core does not have a "between" filter but we can achieve the equivalent by creating a set of greater than or equal / less than or equal


### PR DESCRIPTION
Removed support for the `CONTAINS` operator, which was incorrectly interpreted to mean a transposed `IN` rather than a find-substring operation. A proper implementation would be blocked by mapbox/mapbox-gl-style-spec#233.

Fixes #6586.

/cc @boundsj