### PR TITLE
[ios] Observer that app did become active instead of will foreground

### DIFF
--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -208,7 +208,7 @@ const NSTimeInterval MGLFlushInterval = 180;
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(userDefaultsDidChange:) name:NSUserDefaultsDidChangeNotification object:nil];
        
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:UIApplicationDidEnterBackgroundNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseOrResumeMetricsCollectionIfRequired) name:UIApplicationDidBecomeActiveNotification object:nil];
 
         // Watch for Low Power Mode change events
         if (&NSProcessInfoPowerStateDidChangeNotification != NULL) {


### PR DESCRIPTION
If metrics collection was paused when the host app was previously backgrounded, metrics collection should resume if the host app becomes active. This change observes `UIApplicationDidBecomeActiveNotification` so that, when responding to that notification, the application is in the required state (active) when the method to determine if metrics should be collected is run.

cc @1ec5 @friedbunny @pveugen 