### PR TITLE
JumpTo style camera position

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
@@ -14,6 +14,8 @@ import com.mapbox.mapboxsdk.utils.MathUtils;
  */
 public final class CameraPosition implements Parcelable {
 
+    public final static CameraPosition DEFAULT = new CameraPosition(new LatLng(), 0, 0, 0);
+
     public static final Parcelable.Creator<CameraPosition> CREATOR
             = new Parcelable.Creator<CameraPosition>() {
         public CameraPosition createFromParcel(Parcel in) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -263,7 +263,7 @@ public class MapView extends FrameLayout {
         mapboxMap.setDebugActive(options.getDebugActive());
 
         CameraPosition position = options.getCamera();
-        if (position != null) {
+        if (position != null && !position.equals(CameraPosition.DEFAULT)) {
             mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(position));
             myLocationView.setTilt(position.tilt);
         }


### PR DESCRIPTION
WIP, closes #6129 

This PR enables loading the default camera position from a style using the following items from the [style-spec](https://www.mapbox.com/mapbox-gl-style-spec/#root-center). If the user changes the camera position while a style is being loaded, the camera position from that style will be ignored.

Currently covers Android use-cases since we only expose `jumpTo`, `easeTo` and `flyTo` as public API that could conflict with the camera position from the style. Will need to look into other bindings since they will probably expose other methods as Map::setLatLng or Map::setZoom as public API.

Would love some feedback on current approach & need to rename `setIgnoreInitialCameraOptions`.

**Question**: Would an approach hooking into MapChange events be a cleaner solution? 

cc @jfirebaugh @1ec5 @incanus 
