### PR TITLE
Explicitly initialize default runloop on Darwin

### DIFF
--- a/platform/darwin/src/run_loop.cpp
+++ b/platform/darwin/src/run_loop.cpp
@@ -8,7 +8,6 @@ namespace mbgl {
 namespace util {
 
 static ThreadLocal<RunLoop>& current = *new ThreadLocal<RunLoop>;
-static RunLoop mainRunLoop;
 
 class RunLoop::Impl {
 public:
@@ -22,6 +21,7 @@ RunLoop* RunLoop::Get() {
 
 RunLoop::RunLoop(Type)
   : impl(std::make_unique<Impl>()) {
+    assert(!current.get());
     current.set(this);
     impl->async = std::make_unique<AsyncTask>(std::bind(&RunLoop::process, this));
 }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -24,6 +24,7 @@
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/default_styles.hpp>
 #include <mbgl/util/chrono.hpp>
+#import <mbgl/util/run_loop.hpp>
 
 #import "Mapbox.h"
 #import "MGLFeature_Private.h"
@@ -125,6 +126,11 @@ enum { MGLAnnotationTagNotFound = UINT32_MAX };
 /// Mapping from an annotation tag to metadata about that annotation, including
 /// the annotation itself.
 typedef std::map<MGLAnnotationTag, MGLAnnotationContext> MGLAnnotationContextMap;
+
+/// Initializes the run loop shim that lives on the main thread.
+void MGLinitializeRunLoop() {
+    static mbgl::util::RunLoop mainRunLoop;
+}
 
 mbgl::util::UnitBezier MGLUnitBezierForMediaTimingFunction(CAMediaTimingFunction *function)
 {
@@ -357,6 +363,8 @@ public:
 
 - (void)commonInit
 {
+    MGLinitializeRunLoop();
+
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
     _opaque = YES;
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -30,6 +30,7 @@
 #import <mbgl/math/wrap.hpp>
 #import <mbgl/util/constants.hpp>
 #import <mbgl/util/chrono.hpp>
+#import <mbgl/util/run_loop.hpp>
 
 #import <unordered_map>
 #import <unordered_set>
@@ -110,6 +111,11 @@ NSImage *MGLDefaultMarkerImage() {
     NSString *path = [[NSBundle mgl_frameworkBundle] pathForResource:MGLDefaultStyleMarkerSymbolName
                                                               ofType:@"pdf"];
     return [[NSImage alloc] initWithContentsOfFile:path];
+}
+
+/// Initializes the run loop shim that lives on the main thread.
+void MGLinitializeRunLoop() {
+    static mbgl::util::RunLoop mainRunLoop;
 }
 
 /// Converts a media timing function into a unit bezier object usable in mbgl.
@@ -234,6 +240,8 @@ public:
 }
 
 - (void)commonInit {
+    MGLinitializeRunLoop();
+
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
     
     // Set up cross-platform controllers and resources.

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/tile/tile_loader_impl.hpp>
 
 #include <mbgl/actor/thread_pool.hpp>
+#include <mbgl/util/run_loop.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/update_parameters.hpp>
@@ -15,6 +16,7 @@ class RasterTileTest {
 public:
     FakeFileSource fileSource;
     TransformState transformState;
+    util::RunLoop loop;
     ThreadPool threadPool { 1 };
     AnnotationManager annotationManager { 1.0 };
     style::Style style { fileSource, 1.0 };

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/tile/tile_loader_impl.hpp>
 
 #include <mbgl/actor/thread_pool.hpp>
+#include <mbgl/util/run_loop.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/update_parameters.hpp>
@@ -15,6 +16,7 @@ class VectorTileTest {
 public:
     FakeFileSource fileSource;
     TransformState transformState;
+    util::RunLoop loop;
     ThreadPool threadPool { 1 };
     AnnotationManager annotationManager { 1.0 };
     style::Style style { fileSource, 1.0 };


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/pull/6579 introduced a unit test crash on macOS that exposed a larger issue: In the Darwin `RunLoop` implementation, we are statically initializing a `RunLoop` object for the main thread. However, this object is overwritten, and subsequently destructed/nulled by most unit tests that use their own `RunLoop`. This moves the static initialization to the macOS and iOS SDK. The GLFW implementation which also runs on macOS already creates its own `RunLoop`.

/cc @jfirebaugh 