### PR TITLE
add NodeMap reference to req paramter passed to request function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-native",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.0 - October 6, 2016
+
+- Adds a `NodeMap` reference to the `req` paramter passed to the `request` function to give resource requests visibility into the `NodeMap` object that triggered them ([#6614](https://github.com/mapbox/mapbox-gl-native/pull/6614))
+
 # 3.3.3 - September 6, 2016
 
 - Switches to using a NodeRequest member function (with a JavaScript shim in front to preserve the API) instead of a new `v8::Context` to avoid a memory leak ([#5704](https://github.com/mapbox/mapbox-gl-native/pull/5704))

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -769,6 +769,7 @@ std::unique_ptr<mbgl::AsyncRequest> NodeMap::request(const mbgl::Resource& resou
 
     Nan::Set(instance, Nan::New("url").ToLocalChecked(), Nan::New(resource.url).ToLocalChecked());
     Nan::Set(instance, Nan::New("kind").ToLocalChecked(), Nan::New<v8::Integer>(resource.kind));
+    Nan::Set(instance, Nan::New("map").ToLocalChecked(), this->handle());
 
     auto request = Nan::ObjectWrap::Unwrap<NodeRequest>(instance);
     request->Execute();

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -393,10 +393,39 @@ test('Map', function(t) {
                     callback();
                 },
             });
+            map.id = 'foo';
             map.load(style);
             map.render({ zoom: 1 }, function(err, data) {
                 map.release();
                 t.ok(data, 'no error');
+                t.end();
+            });
+        });
+
+        t.test('req.map passed to request is a ref to map', function(t) {
+            var bar;
+
+            var map = new mbgl.Map({
+                request: function(req, callback) {
+                    req.map.foo = 'bar';
+                    bar = req.map.bar;
+                    callback();
+                },
+            });
+
+            map.bar = 'foo';
+
+            map.load(style);
+            map.render({}, function(err, data) {
+                map.release();
+
+                t.error(err);
+
+                // Safe because map.release only releases the underlying
+                // C++ resources, not the JavaScript shell
+                t.equal(map.foo, 'bar');
+                t.equal(bar, 'foo');
+
                 t.end();
             });
         });


### PR DESCRIPTION
To give resource requests visibility into the `NodeMap` object that triggered them.