### PR TITLE
Introduce a setConnected method to manually set a connected flag

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
@@ -109,7 +109,7 @@ public class MapboxAccountManager {
      *
      * @return true if there is an Internet connection, false otherwise
      */
-    public boolean isConnected() {
+    public Boolean isConnected() {
         if (connected != null) {
             // Connectivity state overridden by app
             return connected;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/MapboxAccountManager.java
@@ -18,6 +18,8 @@ public class MapboxAccountManager {
     private final String accessToken;
     private final Context applicationContext;
 
+    private Boolean connected = null;
+
     /**
      * MapboxAccountManager should NOT be instantiated directly.
      * Use @see MapboxAccountManager#getInstance() instead.
@@ -90,12 +92,29 @@ public class MapboxAccountManager {
     }
 
     /**
+     * Manually sets the connectivity state of the app. This is useful for apps that control their
+     * own connectivity state and want to bypass any checks to the ConnectivityManager.
+     *
+     * @param connected flag to determine the connectivity state, true for connected, false for
+     *                  disconnected, null for ConnectivityManager to determine.
+     */
+    public void setConnected(Boolean connected) {
+        // Connectivity state overridden by app
+        this.connected = connected;
+    }
+
+    /**
      * Determines whether we have an Internet connection available. Please do not rely on this
      * method in your apps, this method is used internally by the SDK.
      *
      * @return true if there is an Internet connection, false otherwise
      */
     public boolean isConnected() {
+        if (connected != null) {
+            // Connectivity state overridden by app
+            return connected;
+        }
+
         ConnectivityManager cm = (ConnectivityManager) applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
         return (activeNetwork != null && activeNetwork.isConnected());

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/ConnectivityReceiver.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/ConnectivityReceiver.java
@@ -9,6 +9,8 @@ import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
+import com.mapbox.mapboxsdk.MapboxAccountManager;
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -80,6 +82,12 @@ public class ConnectivityReceiver extends BroadcastReceiver {
      * @return true if connected
      */
     public boolean isConnected(Context context) {
+        Boolean connected = MapboxAccountManager.getInstance().isConnected();
+        if (connected != null) {
+            // Connectivity state overridden by app
+            return connected;
+        }
+
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
         return (activeNetwork != null && activeNetwork.isConnected());

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
@@ -78,7 +78,7 @@ public class OfflineActivity extends AppCompatActivity
         // You can use MapboxAccountManager.setConnected(Boolean) to manually set the connectivity
         // state of your app. This will override any checks performed via the ConnectivityManager.
         //MapboxAccountManager.getInstance().setConnected(false);
-        boolean connected = MapboxAccountManager.getInstance().isConnected();
+        Boolean connected = MapboxAccountManager.getInstance().isConnected();
         Log.d(LOG_TAG, String.format(MapboxConstants.MAPBOX_LOCALE,
                 "MapboxAccountManager is connected: %b", connected));
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
@@ -13,8 +13,10 @@ import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
+import com.mapbox.mapboxsdk.MapboxAccountManager;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -72,6 +74,13 @@ public class OfflineActivity extends AppCompatActivity
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setDisplayShowHomeEnabled(true);
         }
+
+        // You can use MapboxAccountManager.setConnected(Boolean) to manually set the connectivity
+        // state of your app. This will override any checks performed via the ConnectivityManager.
+        //MapboxAccountManager.getInstance().setConnected(false);
+        boolean connected = MapboxAccountManager.getInstance().isConnected();
+        Log.d(LOG_TAG, String.format(MapboxConstants.MAPBOX_LOCALE,
+                "MapboxAccountManager is connected: %b", connected));
 
         // Set up map
         mapView = (MapView) findViewById(R.id.mapView);


### PR DESCRIPTION
Currently, the PR only covers the usecase where an app handles its connectivity state internally and bypasses `ConnectivityManager`.

Fixes #6617.

/cc: @danswick @mapbox/android 