### PR TITLE
Map::setLatLng differs from Map::setLatLngZoom if zoom is same

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -422,7 +422,7 @@ void Map::moveBy(const ScreenCoordinate& point, const Duration& duration) {
 }
 
 void Map::setLatLng(const LatLng& latLng, const Duration& duration) {
-    setLatLng(latLng, ScreenCoordinate {}, duration);
+    setLatLng(latLng, optional<ScreenCoordinate> {}, duration);
 }
 
 void Map::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, const Duration& duration) {

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -26,6 +26,22 @@ struct MapTest {
     StubFileSource fileSource;
 };
 
+TEST(Map, LatLngBehavior) {
+    MapTest test;
+    Map map(test.view, test.fileSource, MapMode::Still);
+
+    map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
+
+    map.setLatLngZoom({ 1, 1 }, 0);
+    auto latLng1 = map.getLatLng();
+
+    map.setLatLng({ 1, 1 });
+    auto latLng2 = map.getLatLng();
+
+    ASSERT_DOUBLE_EQ(latLng1.latitude, latLng2.latitude);
+    ASSERT_DOUBLE_EQ(latLng1.longitude, latLng2.longitude);
+}
+
 TEST(Map, Offline) {
     MapTest test;
     DefaultFileSource fileSource(":memory:", ".");


### PR DESCRIPTION
These calls should produce the same results:
``` c++
double zoom = 0;
LatLng latLng { 1, 1 };

// call 1
mbgl::Map::setZoom(zoom);
mbgl::Map::setLatLng(latLng);

// call 2
mbgl::map::setLatLngZoom(latLng, zoom);
```

Previously part of #6553.