### PR TITLE
Annotating Null Island also annotates its antipode

### DIFF
--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -2,9 +2,9 @@
 
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/geo.hpp>
+#include <mbgl/util/geometry.hpp>
 #include <mbgl/math/clamp.hpp>
 
-#include <cmath>
 
 namespace mbgl {
 

--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -46,6 +46,22 @@ public:
 
         return LatLng(latitude, longitude);
     }
+
+    static Point<double> project(const LatLng& latLng, double scale) {
+        return Point<double> {
+            util::LONGITUDE_MAX + latLng.longitude,
+            util::LONGITUDE_MAX - util::RAD2DEG * std::log(std::tan(M_PI / 4 + latLng.latitude * M_PI / util::DEGREES_MAX))
+        } * worldSize(scale) / util::DEGREES_MAX;
+    }
+
+    static LatLng unproject(const Point<double>& p, double scale, LatLng::WrapMode wrapMode = LatLng::Unwrapped) {
+        auto p2 = p * util::DEGREES_MAX / worldSize(scale);
+        return LatLng {
+            util::DEGREES_MAX / M_PI * std::atan(std::exp((util::LONGITUDE_MAX - p2.y) * util::DEG2RAD)) - 90.0,
+            p2.x - util::LONGITUDE_MAX,
+            wrapMode
+        };
+    }
 };
 
 } // namespace mbgl

--- a/include/mbgl/util/projection.hpp
+++ b/include/mbgl/util/projection.hpp
@@ -8,14 +8,20 @@
 
 namespace mbgl {
 
+// Spherical Mercator projection
+// http://docs.openlayers.org/library/spherical_mercator.html
 class Projection {
-
 public:
+    // Map pixel width at given scale.
+    static double worldSize(double scale) {
+        return scale * util::tileSize;
+    }
+
     static double getMetersPerPixelAtLatitude(double lat, double zoom) {
         const double constrainedZoom = util::clamp(zoom, util::MIN_ZOOM, util::MAX_ZOOM);
-        const double mapPixelWidthAtZoom = std::pow(2.0, constrainedZoom) * util::tileSize;
+        const double constrainedScale = std::pow(2.0, constrainedZoom);
         const double constrainedLatitude = util::clamp(lat, -util::LATITUDE_MAX, util::LATITUDE_MAX);
-        return std::cos(constrainedLatitude * util::DEG2RAD) * util::M2PI * util::EARTH_RADIUS_M / mapPixelWidthAtZoom;
+        return std::cos(constrainedLatitude * util::DEG2RAD) * util::M2PI * util::EARTH_RADIUS_M / worldSize(constrainedScale);
     }
 
     static ProjectedMeters projectedMetersForLatLng(const LatLng& latLng) {
@@ -32,7 +38,7 @@ public:
     }
 
     static LatLng latLngForProjectedMeters(const ProjectedMeters& projectedMeters) {
-        double latitude = (2 * std::atan(std::exp(projectedMeters.northing / util::EARTH_RADIUS_M)) - (M_PI / 2)) * util::RAD2DEG;
+        double latitude = (2 * std::atan(std::exp(projectedMeters.northing / util::EARTH_RADIUS_M)) - (M_PI / 2.0)) * util::RAD2DEG;
         double longitude = projectedMeters.easting * util::RAD2DEG / util::EARTH_RADIUS_M;
 
         latitude = util::clamp(latitude, -util::LATITUDE_MAX, util::LATITUDE_MAX);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -132,9 +132,6 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     Duration duration = animation.duration ? *animation.duration : Duration::zero();
 
     const double startWorldSize = state.worldSize();
-    state.Bc = startWorldSize / util::DEGREES_MAX;
-    state.Cc = startWorldSize / util::M2PI;
-
     const double startScale = state.scale;
     const double startAngle = state.angle;
     const double startPitch = state.pitch;
@@ -292,8 +289,6 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
     }
 
     const double startWorldSize = state.worldSize();
-    state.Bc = startWorldSize / util::DEGREES_MAX;
-    state.Cc = startWorldSize / util::M2PI;
 
     state.panning = true;
     state.scaling = true;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/util/unitbezier.hpp>
 #include <mbgl/util/interpolate.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/projection.hpp>
 #include <mbgl/math/clamp.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
@@ -131,8 +132,8 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
 
     Duration duration = animation.duration ? *animation.duration : Duration::zero();
 
-    const double startWorldSize = state.worldSize();
     const double startScale = state.scale;
+    const double startWorldSize = Projection::worldSize(startScale);
     const double startAngle = state.angle;
     const double startPitch = state.pitch;
     state.panning = latLng != startLatLng;
@@ -288,8 +289,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
         return;
     }
 
-    const double startWorldSize = state.worldSize();
-
+    const double startWorldSize = Projection::worldSize(state.scale);
     state.panning = true;
     state.scaling = true;
     state.rotating = angle != startAngle;

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -113,8 +113,8 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     // Find the shortest path otherwise.
     else startLatLng.unwrapForShortestPath(latLng);
 
-    const Point<double> startPoint = state.project(startLatLng);
-    const Point<double> endPoint = state.project(latLng);
+    const Point<double> startPoint = Projection::project(startLatLng, state.scale);
+    const Point<double> endPoint = Projection::project(latLng, state.scale);
 
     ScreenCoordinate center = getScreenCoordinate(padding);
     center.y = state.height - center.y;
@@ -133,7 +133,6 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     Duration duration = animation.duration ? *animation.duration : Duration::zero();
 
     const double startScale = state.scale;
-    const double startWorldSize = Projection::worldSize(startScale);
     const double startAngle = state.angle;
     const double startPitch = state.pitch;
     state.panning = latLng != startLatLng;
@@ -142,7 +141,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
 
     startTransition(camera, animation, [=](double t) {
         Point<double> framePoint = util::interpolate(startPoint, endPoint, t);
-        LatLng frameLatLng = state.unproject(framePoint, startWorldSize);
+        LatLng frameLatLng = Projection::unproject(framePoint, startScale);
         double frameScale = util::interpolate(startScale, scale, t);
         state.setLatLngZoom(frameLatLng, state.scaleZoom(frameScale));
 
@@ -184,8 +183,8 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
     LatLng startLatLng = getLatLng(padding).wrapped();
     startLatLng.unwrapForShortestPath(latLng);
 
-    const Point<double> startPoint = state.project(startLatLng);
-    const Point<double> endPoint = state.project(latLng);
+    const Point<double> startPoint = Projection::project(startLatLng, state.scale);
+    const Point<double> endPoint = Projection::project(latLng, state.scale);
 
     ScreenCoordinate center = getScreenCoordinate(padding);
     center.y = state.height - center.y;
@@ -289,7 +288,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
         return;
     }
 
-    const double startWorldSize = Projection::worldSize(state.scale);
+    const double startScale = state.scale;
     state.panning = true;
     state.scaling = true;
     state.rotating = angle != startAngle;
@@ -305,7 +304,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
         double frameZoom = startZoom + state.scaleZoom(1 / w(s));
 
         // Convert to geographic coordinates and set the new viewpoint.
-        LatLng frameLatLng = state.unproject(framePoint, startWorldSize);
+        LatLng frameLatLng = Projection::unproject(framePoint, startScale);
         state.setLatLngZoom(frameLatLng, frameZoom);
 
         if (angle != startAngle) {

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -66,12 +66,9 @@ public:
     bool isPanning() const;
     bool isGestureInProgress() const;
 
-    // Conversion and projection
+    // Conversion
     ScreenCoordinate latLngToScreenCoordinate(const LatLng&) const;
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&, LatLng::WrapMode = LatLng::Unwrapped) const;
-
-    Point<double> project(const LatLng&) const;
-    LatLng unproject(const Point<double>&, double worldSize, LatLng::WrapMode = LatLng::Unwrapped) const;
 
     double zoomScale(double zoom) const;
     double scaleZoom(double scale) const;

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/projection.hpp>
 #include <mbgl/util/mat4.hpp>
 
 #include <cstdint>
@@ -88,8 +89,6 @@ private:
     // logical dimensions
     uint16_t width = 0, height = 0;
 
-    double worldSize() const;
-
     mat4 coordinatePointMatrix(double z) const;
     mat4 getPixelMatrix() const;
 
@@ -117,8 +116,8 @@ private:
     double pitch = 0.0;
 
     // cache values for spherical mercator math
-    double Bc = worldSize() / util::DEGREES_MAX;
-    double Cc = worldSize() / util::M2PI;
+    double Bc = Projection::worldSize(scale) / util::DEGREES_MAX;
+    double Cc = Projection::worldSize(scale) / util::M2PI;
 };
 
 } // namespace mbgl

--- a/src/mbgl/util/tile_coordinate.hpp
+++ b/src/mbgl/util/tile_coordinate.hpp
@@ -5,6 +5,7 @@
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/geometry.hpp>
+#include <mbgl/util/projection.hpp>
 
 namespace mbgl {
 
@@ -19,7 +20,7 @@ public:
 
     static TileCoordinate fromLatLng(const TransformState& state, double zoom, const LatLng& latLng) {
         const double scale = std::pow(2, zoom - state.getZoom());
-        return { state.project(latLng) * scale / double(util::tileSize), zoom };
+        return { Projection::project(latLng, state.getScale()) * scale / double(util::tileSize), zoom };
     }
 
     static TileCoordinate fromScreenCoordinate(const TransformState& state, double zoom, const ScreenCoordinate& screenCoordinate) {

--- a/src/mbgl/util/tile_coordinate.hpp
+++ b/src/mbgl/util/tile_coordinate.hpp
@@ -18,23 +18,25 @@ public:
     TileCoordinatePoint p;
     double z;
 
-    static TileCoordinate fromLatLng(const TransformState& state, double zoom, const LatLng& latLng) {
-        const double scale = std::pow(2, zoom - state.getZoom());
-        return { Projection::project(latLng, state.getScale()) * scale / double(util::tileSize), zoom };
+    static TileCoordinate fromLatLng(double zoom, const LatLng& latLng) {
+        const double scale = std::pow(2.0, zoom);
+        return { Projection::project(latLng, scale) / double(util::tileSize), zoom };
     }
 
     static TileCoordinate fromScreenCoordinate(const TransformState& state, double zoom, const ScreenCoordinate& screenCoordinate) {
-        return fromLatLng(state, zoom, state.screenCoordinateToLatLng(screenCoordinate));
+        return fromLatLng(zoom, state.screenCoordinateToLatLng(screenCoordinate));
     }
 
     TileCoordinate zoomTo(double zoom) const {
-        return { p * std::pow(2, zoom - z), zoom };
+        const double scaleDiff = std::pow(2.0, zoom - z);
+        return { p * scaleDiff, zoom };
     }
 
     static GeometryCoordinate toGeometryCoordinate(const UnwrappedTileID& tileID, const TileCoordinatePoint& point) {
+        const double scale = std::pow(2.0, tileID.canonical.z);
         auto zoomed = TileCoordinate { point, 0 }.zoomTo(tileID.canonical.z);
         return {
-            int16_t(util::clamp<int64_t>((zoomed.p.x - tileID.canonical.x - tileID.wrap * std::pow(2.0, tileID.canonical.z)) * util::EXTENT,
+            int16_t(util::clamp<int64_t>((zoomed.p.x - tileID.canonical.x - tileID.wrap * scale) * util::EXTENT,
                         std::numeric_limits<int16_t>::min(),
                         std::numeric_limits<int16_t>::max())),
             int16_t(util::clamp<int64_t>((zoomed.p.y - tileID.canonical.y) * util::EXTENT,

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -147,13 +147,12 @@ std::vector<UnwrappedTileID> tileCover(const LatLngBounds& bounds_, int32_t z) {
         { std::max(bounds_.south(), -util::LATITUDE_MAX), bounds_.west() },
         { std::min(bounds_.north(),  util::LATITUDE_MAX), bounds_.east() });
 
-    const TransformState state;
     return tileCover(
-        TileCoordinate::fromLatLng(state, z, bounds.northwest()).p,
-        TileCoordinate::fromLatLng(state, z, bounds.northeast()).p,
-        TileCoordinate::fromLatLng(state, z, bounds.southeast()).p,
-        TileCoordinate::fromLatLng(state, z, bounds.southwest()).p,
-        TileCoordinate::fromLatLng(state, z, bounds.center()).p,
+        TileCoordinate::fromLatLng(z, bounds.northwest()).p,
+        TileCoordinate::fromLatLng(z, bounds.northeast()).p,
+        TileCoordinate::fromLatLng(z, bounds.southeast()).p,
+        TileCoordinate::fromLatLng(z, bounds.southwest()).p,
+        TileCoordinate::fromLatLng(z, bounds.center()).p,
         z);
 }
 

--- a/test/tile/tile_coordinate.test.cpp
+++ b/test/tile/tile_coordinate.test.cpp
@@ -41,7 +41,7 @@ TEST(TileCoordinate, FromLatLng) {
     for (const auto& pair : edges) {
         const auto& latLng = pair.first;
         const auto& screenCoordinate = pair.second;
-        const auto base = TileCoordinate::fromLatLng(transform.getState(), 0, latLng);
+        const auto base = TileCoordinate::fromLatLng(0, latLng);
 
         // 16 is the maximum zoom level where we actually compute placements.
         for (uint8_t integerZoom = 0; integerZoom <= 16; ++integerZoom) {
@@ -52,7 +52,7 @@ TEST(TileCoordinate, FromLatLng) {
                 latLng.latitude  == 0 ? 0.5 : latLng.latitude  == -util::LATITUDE_MAX  ? 1.0 : 0,
             };
 
-            const auto fromLatLng = TileCoordinate::fromLatLng(transform.getState(), zoom, latLng);
+            const auto fromLatLng = TileCoordinate::fromLatLng(zoom, latLng);
             ASSERT_DOUBLE_EQ(fromLatLng.z, zoom);
             ASSERT_DOUBLE_EQ(fromLatLng.p.x, tilePoint.x * maxTilesPerAxis);
             ASSERT_NEAR(fromLatLng.p.y, tilePoint.y * maxTilesPerAxis, 1.0e-7);


### PR DESCRIPTION
If I add an annotation at the coordinates 0°, 0°, an annotation also appears at the coordinates 0°, 180°, but only at z1.

![antipodes](https://cloud.githubusercontent.com/assets/1231218/12346047/7159f754-bb05-11e5-8322-45078ac03ec8.png)