### PR TITLE
Annotation symbols should ignore icon placement

### DIFF
--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -185,6 +185,7 @@ void AnnotationManager::updateStyle(Style& style) {
         layer->setSourceLayer(PointLayerID);
         layer->setIconImage({"{sprite}"});
         layer->setIconAllowOverlap(true);
+        layer->setIconIgnorePlacement(true);
 
         layer->impl->spriteAtlas = &spriteAtlas;
 

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -341,3 +341,28 @@ TEST(Annotations, QueryRenderedFeatures) {
     EXPECT_TRUE(!!features2[0].id);
     EXPECT_EQ(*features2[0].id, 1);
 }
+
+TEST(Annotations, QueryFractionalZoomLevels) {
+    AnnotationTest test;
+
+    auto viewSize = test.view.getSize();
+    auto box = ScreenBox { {}, { double(viewSize[0]), double(viewSize[1]) } };
+
+    test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
+    test.map.addAnnotationIcon("default_marker", namedMarker("default_marker.png"));
+
+    std::vector<mbgl::AnnotationID> ids;
+    for (int longitude = 0; longitude < 10; ++longitude) {
+        for (int latitude = 0; latitude < 10; ++latitude) {
+            ids.push_back(test.map.addAnnotation(SymbolAnnotation { { double(latitude), double(longitude) }, "default_marker" }));
+        }
+    }
+
+    test.map.setLatLngZoom({ 5, 5 }, 0);
+    for (uint16_t zoomSteps = 0; zoomSteps <= 20; ++zoomSteps) {
+        test.map.setZoom(zoomSteps / 10.0);
+        test::render(test.map);
+        auto features = test.map.queryRenderedFeatures(box);
+        EXPECT_EQ(features.size(), ids.size());
+    }
+}


### PR DESCRIPTION
We currently set `icon-allow-overlap` to `true` [when creating the annotation symbol layer](https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/annotation/annotation_manager.cpp#L187) but we also need `icon-ignore-placement` set to `true`.

Ignoring icon placements causes symbol annotations to skip calculating the placement scale - which is currently broken (see #6628) and thus returning the correct values for rendered features.