### PR TITLE
Add admonition about hub pull-request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ If you want to contribute code:
   * [Mapbox iOS SDK](platform/ios/CHANGELOG.md)
   * [Mapbox macOS SDK](platform/macos/CHANGELOG.md)
   * [node-mapbox-gl-native](platform/node/CHANGELOG.md)
+ 
+ If you must use the `hub pull-request` command, please use it only on issues that you have opened yourself, preferably on issues that you opened with a fix in hand.
 
 1. Prefix your commit messages with the platform(s) your changes affect: `[core]`, `[android]`, `[ios]`, `[macos]`, `[node]`, or `[qt]`.
 


### PR DESCRIPTION
`hub pull-request` is a nifty tool, but it must be used with care. Commandeering an older issue opened by another contributor creates confusion about who fixed the issue and when. It can be especially problematic if the pull request is declined or fails to fix the original issue. Other contributors are then forced to redo the original issue report, and visitors must follow a trail of derailed issues-turned-PRs.

/ref https://github.com/mapbox/mapbox-gl-native/pull/1749#issuecomment-118731547 https://github.com/mapbox/mapbox-gl-native/pull/3563#issuecomment-252282525