### PR TITLE
[macos] Merge mbgl-{test,benchmark} in CI scheme

### DIFF
--- a/platform/macos/bitrise.yml
+++ b/platform/macos/bitrise.yml
@@ -43,28 +43,7 @@ workflows:
             make xproj
         - is_debug: 'yes'
     - script:
-        title: Build Benchmark Tests
-        run_if: '{{enveq "SKIPCI" "false"}}'
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            export BUILDTYPE=Debug
-            make benchmark
-        - is_debug: 'yes'
-    - script:
-        title: Run Core Tests
-        run_if: '{{enveq "SKIPCI" "false"}}'
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            export BUILDTYPE=Debug
-            make test
-            make run-test
-        - is_debug: 'yes'
-    - script:
-        title: Run SDK Unit Tests
+        title: Run Core and SDK Unit Tests
         run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
@@ -72,7 +51,7 @@ workflows:
             set -eu -o pipefail
             export BUILDTYPE=Debug
             export XCPRETTY="| tee ${BITRISE_DEPLOY_DIR}/raw-xcodebuild-output.txt | xcpretty --color --report html --output ${BITRISE_DEPLOY_DIR}/xcode-test-results.html"
-            make macos-test
+            make run-test
         - is_debug: 'yes'
     - deploy-to-bitrise-io:
         title: Deploy to Bitrise.io

--- a/platform/macos/macos.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
+++ b/platform/macos/macos.xcodeproj/xcshareddata/xcschemes/CI.xcscheme
@@ -48,6 +48,34 @@
                ReferencedContainer = "container:macos.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8E8A234D3E364CDFA2918983"
+               BuildableName = "mbgl-test"
+               BlueprintName = "mbgl-test"
+               ReferencedContainer = "container:../../build/macos/mbgl.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "11FCEF1E29744645907C1E4B"
+               BuildableName = "mbgl-benchmark"
+               BlueprintName = "mbgl-benchmark"
+               ReferencedContainer = "container:../../build/macos/mbgl.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
Fixes #6615.

Adds `mbgl-test` and `mbgl-benchmark` as part of CI scheme.