### PR TITLE
Sample multimap activity

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -123,6 +123,14 @@
                 android:value="@string/category_fragment" />
         </activity>
         <activity
+            android:name=".activity.fragment.MultiMapActivity"
+            android:description="@string/description_multimap"
+            android:label="@string/activity_multimap">
+            <meta-data
+                android:name="@string/category"
+                android:value="@string/category_fragment" />
+        </activity>
+        <activity
             android:name=".activity.camera.ManualZoomActivity"
             android:description="@string/description_camera_zoom"
             android:label="@string/activity_camera_zoom">
@@ -356,7 +364,6 @@
                 android:name="@string/category"
                 android:value="@string/category_style" />
         </activity>
-
         <activity
             android:name=".activity.imagegenerator.PrintActivity"
             android:description="@string/description_print"
@@ -416,7 +423,6 @@
                 android:value="@string/category_annotation" />
         </activity>
 
-
         <!-- For Unit tests -->
         <activity android:name=".activity.style.RuntimeStyleTestActivity" />
         <activity android:name=".activity.style.RuntimeStyleTimingTestActivity" />
@@ -435,7 +441,6 @@
         <!-- android:value="true" /> -->
 
         <service android:name="com.mapbox.mapboxsdk.telemetry.TelemetryService" />
-
     </application>
 
 </manifest>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MultiMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MultiMapActivity.java
@@ -1,0 +1,15 @@
+package com.mapbox.mapboxsdk.testapp.activity.fragment;
+
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+
+import com.mapbox.mapboxsdk.testapp.R;
+
+public class MultiMapActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_multi_map);
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_multi_map.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_multi_map.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/tools"
+    android:id="@+id/map_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/map_container1"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="0.5"
+        android:orientation="horizontal">
+
+        <!-- DC -->
+        <fragment
+            android:id="@+id/map1"
+            class="com.mapbox.mapboxsdk.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="0.5"
+            mapbox:center_latitude="38.913187"
+            mapbox:center_longitude="-77.032546"
+            mapbox:style_url="mapbox://styles/mapbox/streets-v9"
+            mapbox:zoom="12" />
+
+        <!-- SF -->
+        <fragment
+            android:id="@+id/map2"
+            class="com.mapbox.mapboxsdk.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="0.5"
+            mapbox:center_latitude="37.775732"
+            mapbox:center_longitude="-122.413985"
+            mapbox:style_url="mapbox://styles/mapbox/outdoors-v9"
+            mapbox:zoom="13" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/map_container2"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="0.5"
+        android:orientation="horizontal">
+
+        <!-- Bangalore -->
+        <fragment
+            android:id="@+id/map3"
+            class="com.mapbox.mapboxsdk.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="0.5"
+            mapbox:center_latitude="12.97913"
+            mapbox:center_longitude="77.59188"
+            mapbox:style_url="mapbox://styles/mapbox/light-v9"
+            mapbox:zoom="14" />
+
+        <!-- Ayacucho -->
+        <fragment
+            android:id="@+id/map4"
+            class="com.mapbox.mapboxsdk.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="0.5"
+            mapbox:center_latitude="-13.155980"
+            mapbox:center_longitude="-74.217134"
+            mapbox:style_url="mapbox://styles/mapbox/dark-v9"
+            mapbox:zoom="15" />
+    </LinearLayout>
+</LinearLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <!-- Fragment -->
     <string name="activity_map_fragment_suport">Support Map Fragment</string>
     <string name="activity_map_fragment">Map Fragment</string>
+    <string name="activity_multimap">Multiple Maps on Screen</string>
 
     <!-- Annotations -->
     <string name="activity_add_bulk_markers">Add Markers In Bulk</string>
@@ -79,6 +80,7 @@
     <string name="description_cameraposition">CameraPosition capabilities</string>
     <string name="description_map_fragment">Showcase MapFragment</string>
     <string name="description_map_fragment_support">Showcase SupportMapFragment</string>
+    <string name="description_multimap">Activity with multiple maps on screen</string>
     <string name="description_press_for_marker">Add marker to map on long press</string>
     <string name="description_camera_zoom">Different types of zoom methods</string>
     <string name="description_minmax_zoom">Configure a max and min zoomlevel</string>

--- a/platform/android/scripts/generate-test-code.js
+++ b/platform/android/scripts/generate-test-code.js
@@ -14,7 +14,7 @@ global.camelize = function (str) {
 }
 
 
-const excludeActivities = ["UpdateMetadataActivity","CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity"];
+const excludeActivities = ["UpdateMetadataActivity","CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity", "MultiMapActivity"];
 const appBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity';
 const testBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/activity/gen';
 const subPackages = fs.readdirSync(appBasePath);


### PR DESCRIPTION
Adds a new activity to the TestApp that shows multiple maps in the same activity. It uses `SupportMapFragment`.

Current iteration:

![video](https://cloud.githubusercontent.com/assets/6964/19200421/e5610044-8c96-11e6-84a0-f6dec85cc8fd.gif)

/cc: @tobrun @cammace 