### PR TITLE
Add -mapView:didFinishLoadingStyle: delegate methods

### DIFF
--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -34,6 +34,7 @@
 
 @interface MGLStyle()
 @property (nonatomic, weak) MGLMapView *mapView;
+@property (readonly, copy, nullable) NSURL *URL;
 @end
 
 @implementation MGLStyle
@@ -90,6 +91,10 @@ static NSURL *MGLStyleURL_emerald;
 
 - (NSString *)name {
     return @(self.mapView.mbglMap->getStyleName().c_str());
+}
+
+- (NSURL *)URL {
+    return [NSURL URLWithString:@(self.mapView.mbglMap->getStyleURL().c_str())];
 }
 
 - (MGLStyleLayer *)layerWithIdentifier:(NSString *)identifier
@@ -254,5 +259,12 @@ static NSURL *MGLStyleURL_emerald;
     }
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; name = %@, URL = %@>",
+            NSStringFromClass([self class]), (void *)self,
+            self.name ? [NSString stringWithFormat:@"\"%@\"", self.name] : self.name,
+            self.URL ? [NSString stringWithFormat:@"\"%@\"", self.URL] : self.URL];
+}
 
 @end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -25,6 +25,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * The `circle-pitch-scale` property is now supported in stylesheets, allowing circle features in a tilted base map to scale or remain the same size as the viewing distance changes. ([#5576](https://github.com/mapbox/mapbox-gl-native/pull/5576))
 * The `identifier` property of an MGLFeature may now be either a number or string. ([#5514](https://github.com/mapbox/mapbox-gl-native/pull/5514))
 * If MGLMapView is unable to obtain or parse a style, it now calls its delegate’s `-mapViewDidFailLoadingMap:withError:` method. ([#6145](https://github.com/mapbox/mapbox-gl-native/pull/6145))
+* Added the `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` delegate method, which offers the earliest opportunity to modify the layout or appearance of the current style before the map view is displayed to the user. ([#6636](https://github.com/mapbox/mapbox-gl-native/pull/6636))
 * Fixed crashes that could occur when loading a malformed stylesheet. ([#5736](https://github.com/mapbox/mapbox-gl-native/pull/5736))
 * Fixed an issue causing stepwise zoom functions to be misinterpreted. ([#6328](https://github.com/mapbox/mapbox-gl-native/pull/6328))
 * A source’s tiles are no longer rendered when the map is outside the source’s supported zoom levels. ([#6345](https://github.com/mapbox/mapbox-gl-native/pull/6345))

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4566,6 +4566,14 @@ public:
             }
             break;
         }
+        case mbgl::MapChangeDidFinishLoadingStyle:
+        {
+            if ([self.delegate respondsToSelector:@selector(mapView:didFinishLoadingStyle:)])
+            {
+                [self.delegate mapView:self didFinishLoadingStyle:self.style];
+            }
+            break;
+        }
     }
 }
 

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -126,6 +126,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapViewDidFinishRenderingFrame:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered;
 
+/**
+ Tells the delegate that the map has just finished loading a style.
+ 
+ This method is called during the initialization of the map view and after any
+ subsequent loading of a new style. This method is called between the
+ `-mapViewWillStartRenderingMap:` and `-mapViewDidFinishRenderingMap:` delegate
+ methods. Changes to sources or layers of the current style do not cause this
+ method to be called.
+ 
+ This method is the earliest opportunity to modify the layout or appearance of
+ the current style before the map view is displayed to the user.
+
+ @param mapView The map view that has just loaded a style.
+ @param style The style that was loaded.
+ */
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style;
+
 #pragma mark Tracking User Location
 
 /**

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fixed an issue causing an MGLOfflinePack’s progress to continue to update after calling `-suspend`. ([#6186](https://github.com/mapbox/mapbox-gl-native/pull/6186))
 * Fixed an issue preventing cached annotation images from displaying while the device is offline. ([#6358](https://github.com/mapbox/mapbox-gl-native/pull/6358))
 * If MGLMapView is unable to obtain or parse a style, it now calls its delegate’s `-mapViewDidFailLoadingMap:withError:` method. ([#6145](https://github.com/mapbox/mapbox-gl-native/pull/6145))
+* Added the `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` delegate method, which offers the earliest opportunity to modify the layout or appearance of the current style before the map view is displayed to the user. ([#6636](https://github.com/mapbox/mapbox-gl-native/pull/6636))
 * Fixed an issue causing stepwise zoom functions to be misinterpreted. ([#6328](https://github.com/mapbox/mapbox-gl-native/pull/6328))
 * A source’s tiles are no longer rendered when the map is outside the source’s supported zoom levels. ([#6345](https://github.com/mapbox/mapbox-gl-native/pull/6345))
 * Fixed a crash that could occur when the device is disconnected while downloading an offline pack. ([#6293](https://github.com/mapbox/mapbox-gl-native/pull/6293))

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -873,6 +873,14 @@ public:
             }
             break;
         }
+        case mbgl::MapChangeDidFinishLoadingStyle:
+        {
+            if ([self.delegate respondsToSelector:@selector(mapView:didFinishLoadingStyle:)])
+            {
+                [self.delegate mapView:self didFinishLoadingStyle:self.style];
+            }
+            break;
+        }
     }
 }
 

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -125,6 +125,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapViewDidFinishRenderingFrame:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered;
 
+/**
+ Tells the delegate that the map has just finished loading a style.
+
+ This method is called during the initialization of the map view and after any
+ subsequent loading of a new style. This method is called between the
+ `-mapViewWillStartRenderingMap:` and `-mapViewDidFinishRenderingMap:` delegate
+ methods. Changes to sources or layers of the current style do not cause this
+ method to be called.
+
+ This method is the earliest opportunity to modify the layout or appearance of
+ the current style before the map view is displayed to the user.
+
+ @param mapView The map view that has just loaded a style.
+ @param style The style that was loaded.
+ */
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style;
+
 #pragma mark Managing the Appearance of Annotations
 
 /**


### PR DESCRIPTION
Fixes #6412 by implementing `-mapView:didFinishLoadingStyle:` delegate methods, made possible at the core level by #6371.

Also adds `MGLStyle.description` and a private `MGLStyle.URL` property, which are useful when debugging:

```
<MGLStyle: 0x60800001e0a0; name = "Mapbox Dark", URL = "mapbox://styles/mapbox/dark-v9”>
```

/cc @1ec5