### PR TITLE
Rotate markerview

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BaseMarkerViewOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BaseMarkerViewOptions.java
@@ -126,6 +126,12 @@ public abstract class BaseMarkerViewOptions<U extends MarkerView, T extends Base
      */
     public T rotation(float rotation) {
         this.rotation = rotation;
+        while (this.rotation > 360) {
+            this.rotation -= 360;
+        }
+        while (this.rotation < 0) {
+            this.rotation += 360;
+        }
         return getThis();
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
@@ -1,18 +1,12 @@
 package com.mapbox.mapboxsdk.annotations;
 
-import android.animation.AnimatorSet;
 import android.graphics.Bitmap;
-import android.graphics.PointF;
 import android.support.annotation.FloatRange;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.view.View;
-import android.view.animation.AnimationUtils;
 
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.utils.AnimatorUtils;
 
 /**
  * MarkerView is an annotation that shows an View at a geographical location.
@@ -231,7 +225,10 @@ public class MarkerView extends Marker {
     }
 
     /**
-     * Set the rotation value of the MarkerView.
+     * Set the rotation value of the MarkerView in degrees.
+     * <p>
+     * Input will be limited to 0 - 360 degrees
+     * </p>
      * <p>
      * This will result in animating the rotation of the MarkerView using an rotation animator
      * from current value to the provided parameter value.
@@ -240,9 +237,26 @@ public class MarkerView extends Marker {
      * @param rotation the rotation value to animate to
      */
     public void setRotation(float rotation) {
-        this.rotation = rotation;
+        // limit to 0 - 360 degrees
+        float newRotation = rotation;
+        while (newRotation > 360) {
+            newRotation -= 360;
+        }
+        while (newRotation < 0) {
+            newRotation += 360;
+        }
+
+        // calculate new direction
+        float diff = newRotation - this.rotation;
+        if (diff > 180.0f) {
+            diff -= 360.0f;
+        } else if (diff < -180.0f) {
+            diff += 360.f;
+        }
+
+        this.rotation = newRotation;
         if (markerViewManager != null) {
-            markerViewManager.animateRotation(this, rotation);
+            markerViewManager.animateRotationBy(this, diff);
         }
     }
 
@@ -339,7 +353,7 @@ public class MarkerView extends Marker {
     public void setMapboxMap(MapboxMap mapboxMap) {
         super.setMapboxMap(mapboxMap);
 
-        if(isFlat()) {
+        if (isFlat()) {
             // initial tilt value if MapboxMap is started with a tilt attribute
             tiltValue = (float) mapboxMap.getCameraPosition().tilt;
         }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -15,7 +15,6 @@ import com.mapbox.mapboxsdk.R;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.Projection;
 import com.mapbox.mapboxsdk.utils.AnimatorUtils;
 
 import java.util.ArrayList;
@@ -68,6 +67,19 @@ public class MarkerViewManager {
         View convertView = markerViewMap.get(marker);
         if (convertView != null) {
             AnimatorUtils.rotate(convertView, rotation);
+        }
+    }
+
+    /**
+     * Animate a MarkerView with a given rotation.
+     *
+     * @param marker   the MarkerView to rotate by
+     * @param rotation the rotation by value
+     */
+    public void animateRotationBy(@NonNull MarkerView marker, float rotation) {
+        View convertView = markerViewMap.get(marker);
+        if (convertView != null) {
+            AnimatorUtils.rotateBy(convertView, rotation);
         }
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AnimatorUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/AnimatorUtils.java
@@ -7,6 +7,7 @@ import android.animation.ObjectAnimator;
 import android.support.annotation.AnimatorRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.view.View;
 
 public class AnimatorUtils {
@@ -59,6 +60,17 @@ public class AnimatorUtils {
             }
         });
         rotateAnimator.start();
+    }
+
+    public static void rotateBy(@NonNull final View view, float rotationBy) {
+        view.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+        view.animate().rotationBy(rotationBy).setInterpolator(new FastOutSlowInInterpolator()).setListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                super.onAnimationEnd(animation);
+                view.setLayerType(View.LAYER_TYPE_NONE, null);
+            }
+        });
     }
 
     public static void alpha(@NonNull final View convertView, float alpha, @Nullable final OnAnimationEndListener listener) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/annotations/MarkerViewTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/annotations/MarkerViewTest.java
@@ -4,17 +4,35 @@ import android.os.Parcelable;
 
 import com.mapbox.mapboxsdk.exceptions.InvalidMarkerPositionException;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.utils.MockParcel;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MarkerViewTest {
+
+    @Mock
+    MapboxMap mapboxMap;
+
+    @Mock
+    MarkerViewManager markerViewManager;
+
+    @Before
+    public void beforeTest() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     public void testSanity() {
@@ -29,7 +47,7 @@ public class MarkerViewTest {
     }
 
     @Test(expected = InvalidMarkerPositionException.class)
-    public void testInvalidMarker(){
+    public void testInvalidMarker() {
         new MarkerViewOptions().getMarker();
     }
 
@@ -108,6 +126,88 @@ public class MarkerViewTest {
         MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(rotation);
         MarkerView marker = markerOptions.getMarker();
         assertEquals("rotation should match ", rotation, marker.getRotation(), 0);
+    }
+
+    @Test
+    public void testRotationAboveMax() {
+        MarkerViewOptions markerOptions = new MarkerViewOptions().rotation(390).position(new LatLng());
+        MarkerView marker = markerOptions.getMarker();
+        assertEquals(marker.getRotation(), 30, 0);
+    }
+
+    @Test
+    public void testRotationBelowMin() {
+        MarkerViewOptions markerOptions = new MarkerViewOptions().rotation(-10).position(new LatLng());
+        MarkerView marker = markerOptions.getMarker();
+        assertEquals(marker.getRotation(), 350, 0);
+    }
+
+    @Test
+    public void testRotationUpdatePositive() {
+        float startRotation = 45;
+        float endRotation = 180;
+        float animationValue = 135;
+
+        // allow calls to our mock
+        when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
+
+        MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(startRotation);
+        MarkerView marker = markerOptions.getMarker();
+        marker.setMapboxMap(mapboxMap);
+
+        marker.setRotation(endRotation);
+        verify(markerViewManager, times(1)).animateRotationBy(marker, animationValue);
+    }
+
+    @Test
+    public void testRotationUpdateNegative() {
+        float startRotation = 10;
+        float endRotation = 270;
+        float animationValue = -100;
+
+        // allow calls to our mock
+        when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
+
+        MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(startRotation);
+        MarkerView marker = markerOptions.getMarker();
+        marker.setMapboxMap(mapboxMap);
+
+        marker.setRotation(endRotation);
+        verify(markerViewManager, times(1)).animateRotationBy(marker, animationValue);
+    }
+
+    @Test
+    public void testRotationUpdateMax() {
+        float startRotation = 359;
+        float endRotation = 0;
+        float animationValue = 1;
+
+        // allow calls to our mock
+        when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
+
+        MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(startRotation);
+        MarkerView marker = markerOptions.getMarker();
+        marker.setMapboxMap(mapboxMap);
+
+        marker.setRotation(endRotation);
+        verify(markerViewManager, times(1)).animateRotationBy(marker, animationValue);
+    }
+
+    @Test
+    public void testRotationUpdateMin() {
+        float startRotation = 0;
+        float endRotation = 359;
+        float animationValue = -1;
+
+        // allow calls to our mock
+        when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
+
+        MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(startRotation);
+        MarkerView marker = markerOptions.getMarker();
+        marker.setMapboxMap(mapboxMap);
+
+        marker.setRotation(endRotation);
+        verify(markerViewManager, times(1)).animateRotationBy(marker, animationValue);
     }
 
     @Test


### PR DESCRIPTION
Customer reached out about following use-case:

> 
When we update our MarkerView rotation from 359 to 0, the rotation is executed counterclockwise with a value of 359 degrees instead of rotating with value 1.

This PR constrains input to 0 - 359 degrees and manages calculating the rotation value ourselves. This resulted in introducing an new `AnimatorUtils#animateRotateBy`. To validate the changes I added some test cases to MarkerViewTest.

Review @zugaldia 
 