### PR TITLE
[android] - correct camera position

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
@@ -158,7 +158,7 @@ public final class CameraPosition implements Parcelable {
                 double lat = typedArray.getFloat(R.styleable.MapView_center_latitude, 0.0f);
                 double lng = typedArray.getFloat(R.styleable.MapView_center_longitude, 0.0f);
                 this.target = new LatLng(lat, lng);
-                this.tilt = Math.toRadians(typedArray.getFloat(R.styleable.MapView_tilt, 0.0f));
+                this.tilt = typedArray.getFloat(R.styleable.MapView_tilt, 0.0f);
                 this.zoom = typedArray.getFloat(R.styleable.MapView_zoom, 0.0f);
             }
         }
@@ -192,16 +192,19 @@ public final class CameraPosition implements Parcelable {
 
         /**
          * Create Builder from an existing array of doubles.
+         * <p>
+         * These values conform to map.ccp representation of a camera position.
+         * </p>
          *
-         * @param values Values containing target, bearing, tilt and zoom
+         * @param nativeCameraValues Values containing target, bearing, tilt and zoom
          */
-        public Builder(double[] values) {
+        public Builder(double[] nativeCameraValues) {
             super();
-            if (values != null && values.length == 5) {
-                this.target = new LatLng(values[0], values[1]);
-                this.bearing = Math.toDegrees(values[2]);
-                this.tilt = Math.toRadians(values[3]);
-                this.zoom = (float) values[4];
+            if (nativeCameraValues != null && nativeCameraValues.length == 5) {
+                target(new LatLng(nativeCameraValues[0], nativeCameraValues[1]));
+                bearing(-nativeCameraValues[2]);
+                tilt(nativeCameraValues[3]);
+                zoom((float) nativeCameraValues[4]);
             }
         }
 
@@ -212,7 +215,16 @@ public final class CameraPosition implements Parcelable {
          * @return Builder
          */
         public Builder bearing(double bearing) {
-            this.bearing = bearing;
+            double direction = bearing;
+
+            while (direction > 360) {
+                direction -= 360;
+            }
+            while (direction < 0) {
+                direction += 360;
+            }
+
+            this.bearing = direction;
             return this;
         }
 
@@ -237,13 +249,16 @@ public final class CameraPosition implements Parcelable {
         }
 
         /**
-         * Set the tilt
+         * Set the tilt in degrees
+         * <p>
+         * value is clamped to 0 and 60.
+         * <p/>
          *
          * @param tilt Tilt value
          * @return Builder
          */
         public Builder tilt(double tilt) {
-            this.tilt = (float) Math.toRadians(MathUtils.clamp(tilt, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT));
+            this.tilt = (float) MathUtils.clamp(tilt, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT);
             return this;
         }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -87,6 +87,7 @@ import com.mapbox.mapboxsdk.maps.widgets.MyLocationViewSettings;
 import com.mapbox.mapboxsdk.telemetry.MapboxEvent;
 import com.mapbox.mapboxsdk.telemetry.MapboxEventManager;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
+import com.mapbox.mapboxsdk.utils.MathUtils;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -1308,7 +1309,7 @@ public class MapView extends FrameLayout {
             return;
         }
         nativeMapView.cancelTransitions();
-        nativeMapView.jumpTo(bearing, center, pitch, zoom);
+        nativeMapView.jumpTo(Math.toRadians(bearing), center, Math.toRadians(MathUtils.clamp(pitch, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT)), zoom);
     }
 
     void easeTo(double bearing, LatLng center, long duration, double pitch, double zoom, boolean easingInterpolator, @Nullable final MapboxMap.CancelableCallback cancelableCallback) {
@@ -1332,7 +1333,7 @@ public class MapView extends FrameLayout {
             });
         }
 
-        nativeMapView.easeTo(bearing, center, duration, pitch, zoom, easingInterpolator);
+        nativeMapView.easeTo(Math.toRadians(bearing), center, duration, Math.toRadians(MathUtils.clamp(pitch, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT)), zoom, easingInterpolator);
     }
 
     void flyTo(double bearing, LatLng center, long duration, double pitch, double zoom, @Nullable final MapboxMap.CancelableCallback cancelableCallback) {
@@ -1356,7 +1357,7 @@ public class MapView extends FrameLayout {
             });
         }
 
-        nativeMapView.flyTo(bearing, center, duration, pitch, zoom);
+        nativeMapView.flyTo(Math.toRadians(bearing), center, duration, Math.toRadians(MathUtils.clamp(pitch, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT)), zoom);
     }
 
     private void adjustTopOffsetPixels() {
@@ -2496,6 +2497,7 @@ public class MapView extends FrameLayout {
                 if (mapboxMap.getUiSettings().isZoomControlsEnabled()) {
                     zoomButtonsController.setVisible(false);
                 }
+                return true;
 
             default:
                 // We are not interested in this event

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/camera/CameraPositionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/camera/CameraPositionTest.java
@@ -4,9 +4,7 @@ import android.content.res.TypedArray;
 import android.os.Parcelable;
 
 import com.mapbox.mapboxsdk.R;
-import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.utils.MathUtils;
 import com.mapbox.mapboxsdk.utils.MockParcel;
 
 import org.junit.Test;
@@ -58,7 +56,7 @@ public class CameraPositionTest {
         CameraPosition cameraPosition = new CameraPosition.Builder(typedArray).build();
         assertEquals("bearing should match", bearing, cameraPosition.bearing, DELTA);
         assertEquals("latlng should match", new LatLng(latitude, longitude), cameraPosition.target);
-        assertEquals("tilt should match", Math.toRadians(tilt), cameraPosition.tilt, DELTA);
+        assertEquals("tilt should match", tilt, cameraPosition.tilt, DELTA);
         assertEquals("zoom should match", zoom, cameraPosition.zoom, DELTA);
     }
 
@@ -72,9 +70,9 @@ public class CameraPositionTest {
 
         double[] cameraVars = new double[]{latitude, longitude, bearing, tilt, zoom};
         CameraPosition cameraPosition = new CameraPosition.Builder(cameraVars).build();
-        assertEquals("bearing should match", Math.toDegrees(bearing), cameraPosition.bearing, DELTA);
+        assertEquals("bearing should match", bearing, cameraPosition.bearing, DELTA);
         assertEquals("latlng should match", new LatLng(latitude, longitude), cameraPosition.target);
-        assertEquals("tilt should match", Math.toRadians(tilt), cameraPosition.tilt, DELTA);
+        assertEquals("tilt should match", tilt, cameraPosition.tilt, DELTA);
         assertEquals("zoom should match", zoom, cameraPosition.zoom, DELTA);
     }
 


### PR DESCRIPTION
I noticed that the android binding was not providing the correct value type to core when executing one of the CameraOptions methods (jumpTo, moveTo, flyTo). The binding was also not restoring the value correctly when requesting the camera value from core. 

Review @zugaldia 