### PR TITLE
[core] Skip duplicated IDs when querying point annotations

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -750,13 +750,15 @@ std::vector<Feature> Map::queryRenderedFeatures(const ScreenBox& box, const opti
 
 AnnotationIDs Map::queryPointAnnotations(const ScreenBox& box) {
     auto features = queryRenderedFeatures(box, {{ AnnotationManager::PointLayerID }});
-    AnnotationIDs ids;
-    ids.reserve(features.size());
+    std::set<AnnotationID> set;
     for (auto &feature : features) {
         assert(feature.id);
         assert(*feature.id <= std::numeric_limits<AnnotationID>::max());
-        ids.push_back(static_cast<AnnotationID>(feature.id->get<uint64_t>()));
+        set.insert(static_cast<AnnotationID>(feature.id->get<uint64_t>()));
     }
+    AnnotationIDs ids;
+    ids.reserve(set.size());
+    std::move(set.begin(), set.end(), std::back_inserter(ids));
     return ids;
 }
 

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -43,9 +43,19 @@ TEST(Annotations, SymbolAnnotation) {
     test.map.addAnnotation(SymbolAnnotation { Point<double>(0, 0), "default_marker" });
     test.checkRendering("point_annotation");
 
+    auto size = test.view.getSize();
+    auto screenBox = ScreenBox { {}, { double(size[0]), double(size[1]) } };
+    auto features = test.map.queryPointAnnotations(screenBox);
+    EXPECT_EQ(features.size(), 1u);
+
+    test.map.setZoom(test.map.getMaxZoom());
     // FIXME: https://github.com/mapbox/mapbox-gl-native/issues/5419
     //test.map.setZoom(test.map.getMaxZoom());
     //test.checkRendering("point_annotation");
+    test::render(test.map);
+
+    features = test.map.queryPointAnnotations(screenBox);
+    EXPECT_EQ(features.size(), 1u);
 }
 
 TEST(Annotations, LineAnnotation) {


### PR DESCRIPTION
Extracted out of https://github.com/mapbox/mapbox-gl-native/pull/3563.

/cc @ivovandongen