### PR TITLE
[android] - revert making bearing and tilt to radiants

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -87,7 +87,6 @@ import com.mapbox.mapboxsdk.maps.widgets.MyLocationViewSettings;
 import com.mapbox.mapboxsdk.telemetry.MapboxEvent;
 import com.mapbox.mapboxsdk.telemetry.MapboxEventManager;
 import com.mapbox.mapboxsdk.utils.ColorUtils;
-import com.mapbox.mapboxsdk.utils.MathUtils;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -1315,7 +1314,7 @@ public class MapView extends FrameLayout {
             return;
         }
         nativeMapView.cancelTransitions();
-        nativeMapView.jumpTo(Math.toRadians(bearing), center, Math.toRadians(MathUtils.clamp(pitch, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT)), zoom);
+        nativeMapView.jumpTo(bearing, center, pitch, zoom);
     }
 
     void easeTo(double bearing, LatLng center, long duration, double pitch, double zoom, boolean easingInterpolator, @Nullable final MapboxMap.CancelableCallback cancelableCallback) {
@@ -1339,7 +1338,7 @@ public class MapView extends FrameLayout {
             });
         }
 
-        nativeMapView.easeTo(Math.toRadians(bearing), center, duration, Math.toRadians(MathUtils.clamp(pitch, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT)), zoom, easingInterpolator);
+        nativeMapView.easeTo(bearing, center, duration, pitch, zoom, easingInterpolator);
     }
 
     void flyTo(double bearing, LatLng center, long duration, double pitch, double zoom, @Nullable final MapboxMap.CancelableCallback cancelableCallback) {
@@ -1363,7 +1362,7 @@ public class MapView extends FrameLayout {
             });
         }
 
-        nativeMapView.flyTo(Math.toRadians(bearing), center, duration, Math.toRadians(MathUtils.clamp(pitch, MapboxConstants.MINIMUM_TILT, MapboxConstants.MAXIMUM_TILT)), zoom);
+        nativeMapView.flyTo(bearing, center, duration, pitch, zoom);
     }
 
     private void adjustTopOffsetPixels() {


### PR DESCRIPTION
Regression from https://github.com/mapbox/mapbox-gl-native/pull/6641. 

I based those changes on the specification of `CameraOptions`:

```
struct CameraOptions {
   
   ...

    /** Bearing, measured in radians counterclockwise from true north. Wrapped
        to [−π rad, π rad). */
    optional<double> angle;

    /** Pitch toward the horizon measured in radians, with 0 rad resulting in a
        two-dimensional map. */
    optional<double> pitch;
};
```

This is the core model object that is used by moveTo, easeTo and flyTo. This PR reverts using degrees instead of the noted radiants above. Not sure why this is now working correctly by passing in degrees. 

Review @zugaldia 