### PR TITLE
[android] - correct android to core conversion of camera options.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
@@ -171,10 +171,10 @@ public final class CameraPosition implements Parcelable {
         public Builder(CameraUpdateFactory.CameraPositionUpdate update) {
             super();
             if (update != null) {
-                this.bearing = update.getBearing();
-                this.target = update.getTarget();
-                this.tilt = update.getTilt();
-                this.zoom = update.getZoom();
+                bearing(update.getBearing());
+                target(update.getTarget());
+                tilt(update.getTilt());
+                zoom(update.getZoom());
             }
         }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraUpdateFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraUpdateFactory.java
@@ -185,7 +185,7 @@ public final class CameraUpdateFactory {
             CameraPosition previousPosition = mapboxMap.getCameraPosition();
             if (target == null) {
                 return new CameraPosition.Builder()
-                        .tilt(Math.toDegrees(tilt))
+                        .tilt(tilt)
                         .zoom(zoom)
                         .bearing(bearing)
                         .target(previousPosition.target)
@@ -302,21 +302,12 @@ public final class CameraUpdateFactory {
             LatLng latLng = projection.fromScreenLocation(targetPoint);
 
             CameraPosition previousPosition = mapboxMap.getCameraPosition();
-            if (latLng != null) {
-                return new CameraPosition.Builder()
-                        .target(latLng)
-                        .zoom(previousPosition.zoom)
-                        .tilt(previousPosition.tilt)
-                        .bearing(previousPosition.bearing)
-                        .build();
-            } else {
-                return new CameraPosition.Builder()
-                        .tilt(Math.toDegrees(previousPosition.tilt))
-                        .zoom(previousPosition.zoom)
-                        .bearing(previousPosition.bearing)
-                        .target(previousPosition.target)
-                        .build();
-            }
+            return new CameraPosition.Builder()
+                    .target(latLng != null ? latLng : previousPosition.target)
+                    .zoom(previousPosition.zoom)
+                    .tilt(previousPosition.tilt)
+                    .bearing(previousPosition.bearing)
+                    .build();
         }
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1539,7 +1539,7 @@ public class MapView extends FrameLayout {
         }
         CameraPosition position = new CameraPosition.Builder(nativeMapView.getCameraValues()).build();
         myLocationView.setCameraPosition(position);
-        mapboxMap.getMarkerViewManager().setTilt((float) Math.toDegrees(position.tilt));
+        mapboxMap.getMarkerViewManager().setTilt((float) position.tilt);
         return position;
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1314,7 +1314,7 @@ public class MapView extends FrameLayout {
             return;
         }
         nativeMapView.cancelTransitions();
-        nativeMapView.jumpTo(bearing, center, pitch, zoom);
+        nativeMapView.jumpTo(Math.toRadians(-bearing), center, Math.toRadians(pitch), zoom);
     }
 
     void easeTo(double bearing, LatLng center, long duration, double pitch, double zoom, boolean easingInterpolator, @Nullable final MapboxMap.CancelableCallback cancelableCallback) {
@@ -1338,7 +1338,7 @@ public class MapView extends FrameLayout {
             });
         }
 
-        nativeMapView.easeTo(bearing, center, duration, pitch, zoom, easingInterpolator);
+        nativeMapView.easeTo(Math.toRadians(-bearing), center, duration, Math.toRadians(pitch), zoom, easingInterpolator);
     }
 
     void flyTo(double bearing, LatLng center, long duration, double pitch, double zoom, @Nullable final MapboxMap.CancelableCallback cancelableCallback) {
@@ -1362,7 +1362,7 @@ public class MapView extends FrameLayout {
             });
         }
 
-        nativeMapView.flyTo(bearing, center, duration, pitch, zoom);
+        nativeMapView.flyTo(Math.toRadians(-bearing), center, duration, Math.toRadians(pitch), zoom);
     }
 
     private void adjustTopOffsetPixels() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -36,7 +36,6 @@ import com.mapbox.mapboxsdk.location.LocationListener;
 import com.mapbox.mapboxsdk.location.LocationServices;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Projection;
-import com.mapbox.mapboxsdk.utils.MathUtils;
 
 import java.lang.ref.WeakReference;
 
@@ -322,7 +321,7 @@ public class MyLocationView extends View {
     }
 
     public void setCameraPosition(CameraPosition position) {
-        setTilt(MathUtils.clamp(Math.toDegrees(position.tilt), 0.0, 60.0));
+        setTilt(position.tilt);
         setBearing(position.bearing);
     }
 


### PR DESCRIPTION
Fixes issue of Android not correctly converting the android camera position to the core CameraOptions equivalent as mentioned in https://github.com/mapbox/mapbox-gl-native/pull/6656.

Review @cammace 