### PR TITLE
[core] Disable stencil test when rendering collision boxes

### DIFF
--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -251,9 +251,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
     }
 
     if (bucket.hasCollisionBoxData()) {
-        context.stencilOp = { gl::StencilTestOperation::Keep, gl::StencilTestOperation::Keep,
-                              gl::StencilTestOperation::Replace };
-        context.stencilTest = true;
+        context.stencilTest = false;
 
         auto& collisionBoxShader = shaders->collisionBox;
         context.program = collisionBoxShader.getID();


### PR DESCRIPTION
Fixes #5055.

Because render tests are done in still mode - [which causes the stencil function to be properly updated](https://github.com/mapbox/mapbox-gl-native/issues/5055#issuecomment-252938666) - there is no need for a render test.

Example output:
<img width="1136" alt="screen shot 2016-10-12 at 12 11 07 pm" src="https://cloud.githubusercontent.com/assets/76133/19304367/01ffb100-9075-11e6-8d10-8c8232300b41.png">
