### PR TITLE
[android] - reset bearing tracking mode while panning the map

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1965,7 +1965,7 @@ public class MapView extends FrameLayout {
             requestDisallowInterceptTouchEvent(true);
 
             // reset tracking if needed
-            resetTrackingModesIfRequired(true, false);
+            resetTrackingModesIfRequired(true, true);
             // Cancel any animation
             nativeMapView.cancelTransitions();
 


### PR DESCRIPTION
It seems that #6569 has changed the business logic when it comes to disabling bearing tracking mode when you pan the map. Since upcoming release is a non-semver release, we can't change this behaviour now. I'm up to discuss this more for future releases but for now, let's disable bearing when you pan the map (FWIW users can easily override this behaviour).

Review @zugaldia / @cammace 