### PR TITLE
[android] - allow gradle to allocate more memory

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDKTestApp/gradle.properties
@@ -1,0 +1,2 @@
+# allows gradle to use more memory
+org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
This allows the test app to be compiled faster by allowing gradle to use up to 2GB of memory. We already had this configuration enabled for the SDK module, but this is not picked up when building the testapp.

Review @zugaldia / @cammace 