### PR TITLE
Don't force-update tiles when setting GeoJSON data

### DIFF
--- a/platform/android/src/style/sources/geojson_source.cpp
+++ b/platform/android/src/style/sources/geojson_source.cpp
@@ -36,17 +36,11 @@ namespace android {
 
         //Update the core source
         source.as<mbgl::style::GeoJSONSource>()->GeoJSONSource::setGeoJSON(*converted);
-
-        //Repaint
-        updateStyle(false);
     }
 
     void GeoJSONSource::setURL(jni::JNIEnv& env, jni::String url) {
         //Update the core source
         source.as<mbgl::style::GeoJSONSource>()->GeoJSONSource::setURL(jni::Make<std::string>(env, url));
-
-        //Repaint
-        updateStyle(false);
     }
 
     jni::Class<GeoJSONSource> GeoJSONSource::javaClass;

--- a/platform/android/src/style/sources/source.cpp
+++ b/platform/android/src/style/sources/source.cpp
@@ -35,19 +35,6 @@ namespace android {
         return jni::Make<jni::String>(env, source.getID());
     }
 
-    void Source::updateStyle(jni::jboolean updateClasses) {
-        //Update the style only if attached
-        if (ownedSource == nullptr) {
-            Update flags = mbgl::Update::RecalculateStyle;
-            if(updateClasses) {
-                flags = flags | mbgl::Update::Classes;
-            }
-            map->update(flags);
-        } else {
-            mbgl::Log::Debug(mbgl::Event::JNI, "Not updating as source is not attached to map (yet)");
-        }
-    }
-
     std::unique_ptr<mbgl::style::Source> Source::releaseCoreSource() {
         assert(ownedSource != nullptr);
         return std::move(ownedSource);

--- a/platform/android/src/style/sources/source.hpp
+++ b/platform/android/src/style/sources/source.hpp
@@ -40,8 +40,6 @@ public:
     std::unique_ptr<mbgl::style::Source> releaseCoreSource();
 
 protected:
-    void updateStyle(jni::jboolean);
-
     std::unique_ptr<mbgl::style::Source> ownedSource;
     mbgl::style::Source& source;
     mbgl::Map* map;

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -65,24 +65,10 @@ void GeoJSONSource::Impl::setGeoJSON(const GeoJSON& geoJSON) {
         geoJSONOrSupercluster =
             std::make_unique<mapbox::supercluster::Supercluster>(features, clusterOptions);
     }
-    
-    for (auto const &item : tiles) {
-        GeoJSONTile* geoJSONTile = static_cast<GeoJSONTile*>(item.second.get());
-        setTileData(*geoJSONTile, geoJSONTile->id);
-    }
-}
 
-void GeoJSONSource::Impl::setTileData(GeoJSONTile& tile, const OverscaledTileID& tileID) {
-    if (geoJSONOrSupercluster.is<GeoJSONVTPointer>()) {
-        tile.updateData(geoJSONOrSupercluster.get<GeoJSONVTPointer>()->getTile(tileID.canonical.z,
-                                                                               tileID.canonical.x,
-                                                                               tileID.canonical.y).features);
-    } else {
-        assert(geoJSONOrSupercluster.is<SuperclusterPointer>());
-        tile.updateData(geoJSONOrSupercluster.get<SuperclusterPointer>()->getTile(tileID.canonical.z,
-                                                                                  tileID.canonical.x,
-                                                                                  tileID.canonical.y));
-    }
+    invalidateTiles();
+    loaded = true;
+    observer->onSourceLoaded(base);
 }
 
 void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
@@ -129,9 +115,6 @@ void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
             } else {
                 setGeoJSON(*geoJSON);
             }
-
-            loaded = true;
-            observer->onSourceLoaded(base);
         }
     });
 }
@@ -144,9 +127,27 @@ Range<uint8_t> GeoJSONSource::Impl::getZoomRange() {
 std::unique_ptr<Tile> GeoJSONSource::Impl::createTile(const OverscaledTileID& tileID,
                                                       const UpdateParameters& parameters) {
     assert(loaded);
-    auto tilePointer = std::make_unique<GeoJSONTile>(tileID, base.getID(), parameters);
-    setTileData(*tilePointer.get(), tileID);
-    return std::move(tilePointer);
+    auto tile = std::make_unique<GeoJSONTile>(tileID, base.getID(), parameters);
+    if (geoJSONOrSupercluster.is<GeoJSONVTPointer>()) {
+        if (auto& geojsonvt = geoJSONOrSupercluster.get<GeoJSONVTPointer>()) {
+            tile->updateData(
+                geojsonvt->getTile(tileID.canonical.z, tileID.canonical.x, tileID.canonical.y)
+                    .features);
+        } else {
+            Log::Error(Event::ParseStyle, "GeoJSON source does not have data");
+            tile->updateData({});
+        }
+    } else {
+        assert(geoJSONOrSupercluster.is<SuperclusterPointer>());
+        if (auto& supercluster = geoJSONOrSupercluster.get<SuperclusterPointer>()) {
+            tile->updateData(
+                supercluster->getTile(tileID.canonical.z, tileID.canonical.x, tileID.canonical.y));
+        } else {
+            Log::Error(Event::ParseStyle, "GeoJSON source does not have data");
+            tile->updateData({});
+        }
+    }
+    return std::move(tile);
 }
 
 } // namespace style

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -20,7 +20,6 @@ public:
     optional<std::string> getURL();
 
     void setGeoJSON(const GeoJSON&);
-    void setTileData(GeoJSONTile&, const OverscaledTileID& tileID);
 
     void loadDescription(FileSource&) final;
 

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -12,8 +12,12 @@
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/style/sources/geojson_source.hpp>
 #include <mbgl/style/layers/background_layer.hpp>
+#include <mbgl/style/layers/line_layer.hpp>
 #include <mbgl/util/color.hpp>
+
+#include <mapbox/geojson.hpp>
 
 using namespace mbgl;
 using namespace mbgl::style;
@@ -392,3 +396,21 @@ TEST(Map, RemoveImage) {
     test::checkImage("test/fixtures/map/remove_icon", test::render(map));
 }
 
+TEST(Map, GeoJSONSourceInline) {
+    MapTest test;
+
+    Map map(test.view, test.fileSource, MapMode::Still);
+
+    map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
+
+    map.addSource(std::make_unique<GeoJSONSource>("geojson"));
+    map.addLayer(std::make_unique<LineLayer>("line", "geojson"));
+
+    test::checkImage("test/fixtures/map/empty", test::render(map));
+
+    auto geojson = mapbox::geojson::parse(
+        R"GEOJSON({"type": "LineString", "coordinates": [[-10, 10], [10, 10], [-10, -10], [10, -10]]})GEOJSON");
+    map.getSource("geojson")->as<GeoJSONSource>()->setGeoJSON(geojson);
+
+    test::checkImage("test/fixtures/map/geojson", test::render(map));
+}


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/commit/7df9a21f415aa269e7ae435d1500f4a3c7d607e1 introduced a loop that updates all existing tiles when changing the GeoJSON source. This could break in a few ways:

- doing too much on the main thread
- the source could have tiles in the cache, which are not updated
- the source is unused, but still update its tiles

Instead, we should just invalidate all tiles and have our mechanism for querying tiles automatically generate new ones when they are needed.