### PR TITLE
Consistify runtime styling category prefix: mbgl_ → mgl_

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -227,20 +227,20 @@ global.setterImplementation = function(property, layerType) {
     let implementation = '';
     switch (property.type) {
         case 'boolean':
-            implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mbgl_boolPropertyValue);`;
+            implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mgl_boolPropertyValue);`;
             break;
         case 'number':
-            implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mbgl_floatPropertyValue);`;
+            implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mgl_floatPropertyValue);`;
             break;
         case 'string':
-            implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mbgl_stringPropertyValue);`;
+            implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mgl_stringPropertyValue);`;
             break;
         case 'enum':
             let objCType = global.objCType(layerType, property.name);
             implementation = `MGLSetEnumProperty(${objCName(property)}, ${camelize(property.name)}, ${mbglType(property)}, ${objCType});`;
             break;
         case 'color':
-            implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mbgl_colorPropertyValue);`;
+            implementation = `self.layer->set${camelize(property.name)}(${objCName(property)}.mgl_colorPropertyValue);`;
             break;
         case 'array':
             implementation = arraySetterImplementation(property);
@@ -262,23 +262,23 @@ global.mbglType = function(property) {
 }
 
 global.arraySetterImplementation = function(property) {
-    return `self.layer->set${camelize(property.name)}(${objCName(property)}.mbgl_${convertedType(property)}PropertyValue);`;
+    return `self.layer->set${camelize(property.name)}(${objCName(property)}.mgl_${convertedType(property)}PropertyValue);`;
 }
 
 global.styleAttributeFactory = function (property, layerType) {
     switch (property.type) {
         case 'boolean':
-            return 'mbgl_boolWithPropertyValueBool';
+            return 'mgl_boolWithPropertyValueBool';
         case 'number':
-            return 'mbgl_numberWithPropertyValueNumber';
+            return 'mgl_numberWithPropertyValueNumber';
         case 'string':
-            return 'mbgl_stringWithPropertyValueString';
+            return 'mgl_stringWithPropertyValueString';
         case 'enum':
             throw new Error('Use MGLGetEnumProperty() for enums.');
         case 'color':
-            return 'mbgl_colorWithPropertyValueColor';
+            return 'mgl_colorWithPropertyValueColor';
         case 'array':
-            return `mbgl_${convertedType(property)}WithPropertyValue${camelize(convertedType(property))}`;
+            return `mgl_${convertedType(property)}WithPropertyValue${camelize(convertedType(property))}`;
         default:
             throw new Error(`unknown type for ${property.name}`);
     }

--- a/platform/darwin/src/MGLBackgroundStyleLayer.mm
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.mm
@@ -28,27 +28,27 @@
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setBackgroundColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)backgroundColor {
-    self.layer->setBackgroundColor(backgroundColor.mbgl_colorPropertyValue);
+    self.layer->setBackgroundColor(backgroundColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)backgroundColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getBackgroundColor() ?: self.layer->getDefaultBackgroundColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getBackgroundColor() ?: self.layer->getDefaultBackgroundColor()];
 }
 
 - (void)setBackgroundPattern:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)backgroundPattern {
-    self.layer->setBackgroundPattern(backgroundPattern.mbgl_stringPropertyValue);
+    self.layer->setBackgroundPattern(backgroundPattern.mgl_stringPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)backgroundPattern {
-    return [MGLStyleAttribute mbgl_stringWithPropertyValueString:self.layer->getBackgroundPattern() ?: self.layer->getDefaultBackgroundPattern()];
+    return [MGLStyleAttribute mgl_stringWithPropertyValueString:self.layer->getBackgroundPattern() ?: self.layer->getDefaultBackgroundPattern()];
 }
 
 - (void)setBackgroundOpacity:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)backgroundOpacity {
-    self.layer->setBackgroundOpacity(backgroundOpacity.mbgl_floatPropertyValue);
+    self.layer->setBackgroundOpacity(backgroundOpacity.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)backgroundOpacity {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getBackgroundOpacity() ?: self.layer->getDefaultBackgroundOpacity()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getBackgroundOpacity() ?: self.layer->getDefaultBackgroundOpacity()];
 }
 
 @end

--- a/platform/darwin/src/MGLCircleStyleLayer.mm
+++ b/platform/darwin/src/MGLCircleStyleLayer.mm
@@ -49,43 +49,43 @@
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setCircleRadius:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)circleRadius {
-    self.layer->setCircleRadius(circleRadius.mbgl_floatPropertyValue);
+    self.layer->setCircleRadius(circleRadius.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)circleRadius {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getCircleRadius() ?: self.layer->getDefaultCircleRadius()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getCircleRadius() ?: self.layer->getDefaultCircleRadius()];
 }
 
 - (void)setCircleColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)circleColor {
-    self.layer->setCircleColor(circleColor.mbgl_colorPropertyValue);
+    self.layer->setCircleColor(circleColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)circleColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getCircleColor() ?: self.layer->getDefaultCircleColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getCircleColor() ?: self.layer->getDefaultCircleColor()];
 }
 
 - (void)setCircleBlur:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)circleBlur {
-    self.layer->setCircleBlur(circleBlur.mbgl_floatPropertyValue);
+    self.layer->setCircleBlur(circleBlur.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)circleBlur {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getCircleBlur() ?: self.layer->getDefaultCircleBlur()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getCircleBlur() ?: self.layer->getDefaultCircleBlur()];
 }
 
 - (void)setCircleOpacity:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)circleOpacity {
-    self.layer->setCircleOpacity(circleOpacity.mbgl_floatPropertyValue);
+    self.layer->setCircleOpacity(circleOpacity.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)circleOpacity {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getCircleOpacity() ?: self.layer->getDefaultCircleOpacity()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getCircleOpacity() ?: self.layer->getDefaultCircleOpacity()];
 }
 
 - (void)setCircleTranslate:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)circleTranslate {
-    self.layer->setCircleTranslate(circleTranslate.mbgl_offsetPropertyValue);
+    self.layer->setCircleTranslate(circleTranslate.mgl_offsetPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)circleTranslate {
-    return [MGLStyleAttribute mbgl_offsetWithPropertyValueOffset:self.layer->getCircleTranslate() ?: self.layer->getDefaultCircleTranslate()];
+    return [MGLStyleAttribute mgl_offsetWithPropertyValueOffset:self.layer->getCircleTranslate() ?: self.layer->getDefaultCircleTranslate()];
 }
 
 - (void)setCircleTranslateAnchor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)circleTranslateAnchor {

--- a/platform/darwin/src/MGLFillStyleLayer.mm
+++ b/platform/darwin/src/MGLFillStyleLayer.mm
@@ -49,43 +49,43 @@
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setFillAntialias:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)fillAntialias {
-    self.layer->setFillAntialias(fillAntialias.mbgl_boolPropertyValue);
+    self.layer->setFillAntialias(fillAntialias.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)fillAntialias {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getFillAntialias() ?: self.layer->getDefaultFillAntialias()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getFillAntialias() ?: self.layer->getDefaultFillAntialias()];
 }
 
 - (void)setFillOpacity:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)fillOpacity {
-    self.layer->setFillOpacity(fillOpacity.mbgl_floatPropertyValue);
+    self.layer->setFillOpacity(fillOpacity.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)fillOpacity {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getFillOpacity() ?: self.layer->getDefaultFillOpacity()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getFillOpacity() ?: self.layer->getDefaultFillOpacity()];
 }
 
 - (void)setFillColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)fillColor {
-    self.layer->setFillColor(fillColor.mbgl_colorPropertyValue);
+    self.layer->setFillColor(fillColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)fillColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getFillColor() ?: self.layer->getDefaultFillColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getFillColor() ?: self.layer->getDefaultFillColor()];
 }
 
 - (void)setFillOutlineColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)fillOutlineColor {
-    self.layer->setFillOutlineColor(fillOutlineColor.mbgl_colorPropertyValue);
+    self.layer->setFillOutlineColor(fillOutlineColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)fillOutlineColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getFillOutlineColor() ?: self.layer->getDefaultFillOutlineColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getFillOutlineColor() ?: self.layer->getDefaultFillOutlineColor()];
 }
 
 - (void)setFillTranslate:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)fillTranslate {
-    self.layer->setFillTranslate(fillTranslate.mbgl_offsetPropertyValue);
+    self.layer->setFillTranslate(fillTranslate.mgl_offsetPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)fillTranslate {
-    return [MGLStyleAttribute mbgl_offsetWithPropertyValueOffset:self.layer->getFillTranslate() ?: self.layer->getDefaultFillTranslate()];
+    return [MGLStyleAttribute mgl_offsetWithPropertyValueOffset:self.layer->getFillTranslate() ?: self.layer->getDefaultFillTranslate()];
 }
 
 - (void)setFillTranslateAnchor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)fillTranslateAnchor {
@@ -97,11 +97,11 @@
 }
 
 - (void)setFillPattern:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)fillPattern {
-    self.layer->setFillPattern(fillPattern.mbgl_stringPropertyValue);
+    self.layer->setFillPattern(fillPattern.mgl_stringPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)fillPattern {
-    return [MGLStyleAttribute mbgl_stringWithPropertyValueString:self.layer->getFillPattern() ?: self.layer->getDefaultFillPattern()];
+    return [MGLStyleAttribute mgl_stringWithPropertyValueString:self.layer->getFillPattern() ?: self.layer->getDefaultFillPattern()];
 }
 
 @end

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -65,45 +65,45 @@
 }
 
 - (void)setLineMiterLimit:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineMiterLimit {
-    self.layer->setLineMiterLimit(lineMiterLimit.mbgl_floatPropertyValue);
+    self.layer->setLineMiterLimit(lineMiterLimit.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineMiterLimit {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getLineMiterLimit() ?: self.layer->getDefaultLineMiterLimit()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getLineMiterLimit() ?: self.layer->getDefaultLineMiterLimit()];
 }
 
 - (void)setLineRoundLimit:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineRoundLimit {
-    self.layer->setLineRoundLimit(lineRoundLimit.mbgl_floatPropertyValue);
+    self.layer->setLineRoundLimit(lineRoundLimit.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineRoundLimit {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getLineRoundLimit() ?: self.layer->getDefaultLineRoundLimit()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getLineRoundLimit() ?: self.layer->getDefaultLineRoundLimit()];
 }
 
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setLineOpacity:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineOpacity {
-    self.layer->setLineOpacity(lineOpacity.mbgl_floatPropertyValue);
+    self.layer->setLineOpacity(lineOpacity.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineOpacity {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getLineOpacity() ?: self.layer->getDefaultLineOpacity()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getLineOpacity() ?: self.layer->getDefaultLineOpacity()];
 }
 
 - (void)setLineColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineColor {
-    self.layer->setLineColor(lineColor.mbgl_colorPropertyValue);
+    self.layer->setLineColor(lineColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getLineColor() ?: self.layer->getDefaultLineColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getLineColor() ?: self.layer->getDefaultLineColor()];
 }
 
 - (void)setLineTranslate:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineTranslate {
-    self.layer->setLineTranslate(lineTranslate.mbgl_offsetPropertyValue);
+    self.layer->setLineTranslate(lineTranslate.mgl_offsetPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineTranslate {
-    return [MGLStyleAttribute mbgl_offsetWithPropertyValueOffset:self.layer->getLineTranslate() ?: self.layer->getDefaultLineTranslate()];
+    return [MGLStyleAttribute mgl_offsetWithPropertyValueOffset:self.layer->getLineTranslate() ?: self.layer->getDefaultLineTranslate()];
 }
 
 - (void)setLineTranslateAnchor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineTranslateAnchor {
@@ -115,51 +115,51 @@
 }
 
 - (void)setLineWidth:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineWidth {
-    self.layer->setLineWidth(lineWidth.mbgl_floatPropertyValue);
+    self.layer->setLineWidth(lineWidth.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineWidth {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getLineWidth() ?: self.layer->getDefaultLineWidth()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getLineWidth() ?: self.layer->getDefaultLineWidth()];
 }
 
 - (void)setLineGapWidth:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineGapWidth {
-    self.layer->setLineGapWidth(lineGapWidth.mbgl_floatPropertyValue);
+    self.layer->setLineGapWidth(lineGapWidth.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineGapWidth {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getLineGapWidth() ?: self.layer->getDefaultLineGapWidth()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getLineGapWidth() ?: self.layer->getDefaultLineGapWidth()];
 }
 
 - (void)setLineOffset:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineOffset {
-    self.layer->setLineOffset(lineOffset.mbgl_floatPropertyValue);
+    self.layer->setLineOffset(lineOffset.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineOffset {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getLineOffset() ?: self.layer->getDefaultLineOffset()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getLineOffset() ?: self.layer->getDefaultLineOffset()];
 }
 
 - (void)setLineBlur:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineBlur {
-    self.layer->setLineBlur(lineBlur.mbgl_floatPropertyValue);
+    self.layer->setLineBlur(lineBlur.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineBlur {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getLineBlur() ?: self.layer->getDefaultLineBlur()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getLineBlur() ?: self.layer->getDefaultLineBlur()];
 }
 
 - (void)setLineDasharray:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)lineDasharray {
-    self.layer->setLineDasharray(lineDasharray.mbgl_numberArrayPropertyValue);
+    self.layer->setLineDasharray(lineDasharray.mgl_numberArrayPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)lineDasharray {
-    return [MGLStyleAttribute mbgl_numberArrayWithPropertyValueNumberArray:self.layer->getLineDasharray() ?: self.layer->getDefaultLineDasharray()];
+    return [MGLStyleAttribute mgl_numberArrayWithPropertyValueNumberArray:self.layer->getLineDasharray() ?: self.layer->getDefaultLineDasharray()];
 }
 
 - (void)setLinePattern:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)linePattern {
-    self.layer->setLinePattern(linePattern.mbgl_stringPropertyValue);
+    self.layer->setLinePattern(linePattern.mgl_stringPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)linePattern {
-    return [MGLStyleAttribute mbgl_stringWithPropertyValueString:self.layer->getLinePattern() ?: self.layer->getDefaultLinePattern()];
+    return [MGLStyleAttribute mgl_stringWithPropertyValueString:self.layer->getLinePattern() ?: self.layer->getDefaultLinePattern()];
 }
 
 @end

--- a/platform/darwin/src/MGLRasterStyleLayer.mm
+++ b/platform/darwin/src/MGLRasterStyleLayer.mm
@@ -28,59 +28,59 @@
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setRasterOpacity:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)rasterOpacity {
-    self.layer->setRasterOpacity(rasterOpacity.mbgl_floatPropertyValue);
+    self.layer->setRasterOpacity(rasterOpacity.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)rasterOpacity {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getRasterOpacity() ?: self.layer->getDefaultRasterOpacity()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getRasterOpacity() ?: self.layer->getDefaultRasterOpacity()];
 }
 
 - (void)setRasterHueRotate:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)rasterHueRotate {
-    self.layer->setRasterHueRotate(rasterHueRotate.mbgl_floatPropertyValue);
+    self.layer->setRasterHueRotate(rasterHueRotate.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)rasterHueRotate {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getRasterHueRotate() ?: self.layer->getDefaultRasterHueRotate()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getRasterHueRotate() ?: self.layer->getDefaultRasterHueRotate()];
 }
 
 - (void)setRasterBrightnessMin:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)rasterBrightnessMin {
-    self.layer->setRasterBrightnessMin(rasterBrightnessMin.mbgl_floatPropertyValue);
+    self.layer->setRasterBrightnessMin(rasterBrightnessMin.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)rasterBrightnessMin {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getRasterBrightnessMin() ?: self.layer->getDefaultRasterBrightnessMin()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getRasterBrightnessMin() ?: self.layer->getDefaultRasterBrightnessMin()];
 }
 
 - (void)setRasterBrightnessMax:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)rasterBrightnessMax {
-    self.layer->setRasterBrightnessMax(rasterBrightnessMax.mbgl_floatPropertyValue);
+    self.layer->setRasterBrightnessMax(rasterBrightnessMax.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)rasterBrightnessMax {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getRasterBrightnessMax() ?: self.layer->getDefaultRasterBrightnessMax()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getRasterBrightnessMax() ?: self.layer->getDefaultRasterBrightnessMax()];
 }
 
 - (void)setRasterSaturation:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)rasterSaturation {
-    self.layer->setRasterSaturation(rasterSaturation.mbgl_floatPropertyValue);
+    self.layer->setRasterSaturation(rasterSaturation.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)rasterSaturation {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getRasterSaturation() ?: self.layer->getDefaultRasterSaturation()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getRasterSaturation() ?: self.layer->getDefaultRasterSaturation()];
 }
 
 - (void)setRasterContrast:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)rasterContrast {
-    self.layer->setRasterContrast(rasterContrast.mbgl_floatPropertyValue);
+    self.layer->setRasterContrast(rasterContrast.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)rasterContrast {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getRasterContrast() ?: self.layer->getDefaultRasterContrast()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getRasterContrast() ?: self.layer->getDefaultRasterContrast()];
 }
 
 - (void)setRasterFadeDuration:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)rasterFadeDuration {
-    self.layer->setRasterFadeDuration(rasterFadeDuration.mbgl_floatPropertyValue);
+    self.layer->setRasterFadeDuration(rasterFadeDuration.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)rasterFadeDuration {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getRasterFadeDuration() ?: self.layer->getDefaultRasterFadeDuration()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getRasterFadeDuration() ?: self.layer->getDefaultRasterFadeDuration()];
 }
 
 @end

--- a/platform/darwin/src/MGLStyleAttribute.h
+++ b/platform/darwin/src/MGLStyleAttribute.h
@@ -6,20 +6,20 @@
 
 @interface MGLStyleAttribute : NSObject <MGLStyleAttributeValue>
 
-+ (id <MGLStyleAttributeValue>)mbgl_colorWithPropertyValueColor:(mbgl::style::PropertyValue<mbgl::Color>)property;
++ (id <MGLStyleAttributeValue>)mgl_colorWithPropertyValueColor:(mbgl::style::PropertyValue<mbgl::Color>)property;
 
-+ (id <MGLStyleAttributeValue>)mbgl_numberWithPropertyValueNumber:(mbgl::style::PropertyValue<float>)property;
++ (id <MGLStyleAttributeValue>)mgl_numberWithPropertyValueNumber:(mbgl::style::PropertyValue<float>)property;
 
-+ (id <MGLStyleAttributeValue>)mbgl_boolWithPropertyValueBool:(mbgl::style::PropertyValue<bool>)property;
++ (id <MGLStyleAttributeValue>)mgl_boolWithPropertyValueBool:(mbgl::style::PropertyValue<bool>)property;
 
-+ (id <MGLStyleAttributeValue>)mbgl_stringWithPropertyValueString:(mbgl::style::PropertyValue<std::string>)property;
++ (id <MGLStyleAttributeValue>)mgl_stringWithPropertyValueString:(mbgl::style::PropertyValue<std::string>)property;
 
-+ (id <MGLStyleAttributeValue>)mbgl_offsetWithPropertyValueOffset:(mbgl::style::PropertyValue<std::array<float, 2>>)property;
++ (id <MGLStyleAttributeValue>)mgl_offsetWithPropertyValueOffset:(mbgl::style::PropertyValue<std::array<float, 2>>)property;
 
-+ (id <MGLStyleAttributeValue>)mbgl_paddingWithPropertyValuePadding:(mbgl::style::PropertyValue<std::array<float, 4>>)property;
++ (id <MGLStyleAttributeValue>)mgl_paddingWithPropertyValuePadding:(mbgl::style::PropertyValue<std::array<float, 4>>)property;
 
-+ (id <MGLStyleAttributeValue>)mbgl_stringArrayWithPropertyValueStringArray:(mbgl::style::PropertyValue<std::vector<std::string>>)property;
++ (id <MGLStyleAttributeValue>)mgl_stringArrayWithPropertyValueStringArray:(mbgl::style::PropertyValue<std::vector<std::string>>)property;
 
-+ (id <MGLStyleAttributeValue>)mbgl_numberArrayWithPropertyValueNumberArray:(mbgl::style::PropertyValue<std::vector<float>>)property;
++ (id <MGLStyleAttributeValue>)mgl_numberArrayWithPropertyValueNumberArray:(mbgl::style::PropertyValue<std::vector<float>>)property;
 
 @end

--- a/platform/darwin/src/MGLStyleAttribute.mm
+++ b/platform/darwin/src/MGLStyleAttribute.mm
@@ -9,10 +9,10 @@
 
 @implementation MGLStyleAttribute
 
-+ (id<MGLStyleAttributeValue>)mbgl_colorWithPropertyValueColor:(mbgl::style::PropertyValue<mbgl::Color>)property
++ (id<MGLStyleAttributeValue>)mgl_colorWithPropertyValueColor:(mbgl::style::PropertyValue<mbgl::Color>)property
 {
     if (property.isConstant()) {
-        return [MGLColor mbgl_colorWithColor:property.asConstant()];
+        return [MGLColor mgl_colorWithColor:property.asConstant()];
     } else if (property.isFunction()) {
         return [MGLStyleAttributeFunction functionWithColorPropertyValue:property.asFunction()];
     } else {
@@ -20,7 +20,7 @@
     }
 }
 
-+ (id <MGLStyleAttributeValue>)mbgl_numberWithPropertyValueNumber:(mbgl::style::PropertyValue<float>)property
++ (id <MGLStyleAttributeValue>)mgl_numberWithPropertyValueNumber:(mbgl::style::PropertyValue<float>)property
 {
     if (property.isConstant()) {
         return @(property.asConstant());
@@ -31,7 +31,7 @@
     }
 }
 
-+ (id<MGLStyleAttributeValue>)mbgl_boolWithPropertyValueBool:(mbgl::style::PropertyValue<bool>)property
++ (id<MGLStyleAttributeValue>)mgl_boolWithPropertyValueBool:(mbgl::style::PropertyValue<bool>)property
 {
     if (property.isConstant()) {
         return @(property.asConstant());
@@ -42,7 +42,7 @@
     }
 }
 
-+ (id<MGLStyleAttributeValue>)mbgl_stringWithPropertyValueString:(mbgl::style::PropertyValue<std::string>)property
++ (id<MGLStyleAttributeValue>)mgl_stringWithPropertyValueString:(mbgl::style::PropertyValue<std::string>)property
 {
     if (property.isConstant()) {
         return @(property.asConstant().c_str());
@@ -53,7 +53,7 @@
     }
 }
 
-+ (id<MGLStyleAttributeValue>)mbgl_offsetWithPropertyValueOffset:(mbgl::style::PropertyValue<std::array<float, 2> >)property
++ (id<MGLStyleAttributeValue>)mgl_offsetWithPropertyValueOffset:(mbgl::style::PropertyValue<std::array<float, 2> >)property
 {
     if (property.isConstant()) {
         auto offset = property.asConstant();
@@ -65,7 +65,7 @@
     }
 }
 
-+ (id<MGLStyleAttributeValue>)mbgl_paddingWithPropertyValuePadding:(mbgl::style::PropertyValue<std::array<float, 4> >)property
++ (id<MGLStyleAttributeValue>)mgl_paddingWithPropertyValuePadding:(mbgl::style::PropertyValue<std::array<float, 4> >)property
 {
     if (property.isConstant()) {
         auto padding = property.asConstant();
@@ -77,7 +77,7 @@
     }
 }
 
-+ (id<MGLStyleAttributeValue>)mbgl_stringArrayWithPropertyValueStringArray:(mbgl::style::PropertyValue<std::vector<std::string> >)property
++ (id<MGLStyleAttributeValue>)mgl_stringArrayWithPropertyValueStringArray:(mbgl::style::PropertyValue<std::vector<std::string> >)property
 {
     if (property.isConstant()) {
         auto strings = property.asConstant();
@@ -93,7 +93,7 @@
     }
 }
 
-+ (id<MGLStyleAttributeValue>)mbgl_numberArrayWithPropertyValueNumberArray:(mbgl::style::PropertyValue<std::vector<float> >)property
++ (id<MGLStyleAttributeValue>)mgl_numberArrayWithPropertyValueNumberArray:(mbgl::style::PropertyValue<std::vector<float> >)property
 {
     if (property.isConstant()) {
         auto numbers = property.asConstant();

--- a/platform/darwin/src/MGLStyleAttributeFunction.mm
+++ b/platform/darwin/src/MGLStyleAttributeFunction.mm
@@ -22,17 +22,17 @@
     return YES;
 }
 
-- (mbgl::style::PropertyValue<mbgl::Color>)mbgl_colorPropertyValue
+- (mbgl::style::PropertyValue<mbgl::Color>)mgl_colorPropertyValue
 {
     __block std::vector<std::pair<float, mbgl::Color>> stops;
     [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, MGLColor * _Nonnull color, BOOL * _Nonnull stop) {
         NSAssert([color isKindOfClass:[MGLColor class]], @"Stops should be colors");
-        stops.emplace_back(zoomKey.floatValue, color.mbgl_color);
+        stops.emplace_back(zoomKey.floatValue, color.mgl_color);
     }];
     return mbgl::style::Function<mbgl::Color>({{stops}}, _base.floatValue);
 }
 
-- (mbgl::style::PropertyValue<float>)mbgl_floatPropertyValue
+- (mbgl::style::PropertyValue<float>)mgl_floatPropertyValue
 {
     __block std::vector<std::pair<float, float>> stops;
     [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSNumber * _Nonnull number, BOOL * _Nonnull stop) {
@@ -42,7 +42,7 @@
     return mbgl::style::Function<float>({{stops}}, _base.floatValue);
 }
 
-- (mbgl::style::PropertyValue<bool>)mbgl_boolPropertyValue
+- (mbgl::style::PropertyValue<bool>)mgl_boolPropertyValue
 {
     __block std::vector<std::pair<float, bool>> stops;
     [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSNumber * _Nonnull number, BOOL * _Nonnull stop) {
@@ -52,7 +52,7 @@
     return mbgl::style::Function<bool>({{stops}}, _base.floatValue);
 }
 
-- (mbgl::style::PropertyValue<std::string>)mbgl_stringPropertyValue
+- (mbgl::style::PropertyValue<std::string>)mgl_stringPropertyValue
 {
     __block std::vector<std::pair<float, std::string>> stops;
     [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSString * _Nonnull string, BOOL * _Nonnull stop) {
@@ -62,7 +62,7 @@
     return mbgl::style::Function<std::string>({{stops}}, _base.floatValue);
 }
 
-- (mbgl::style::PropertyValue<std::vector<std::string> >)mbgl_stringArrayPropertyValue
+- (mbgl::style::PropertyValue<std::vector<std::string> >)mgl_stringArrayPropertyValue
 {
     __block std::vector<std::pair<float, std::vector<std::string>>> stops;
     [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSArray *  _Nonnull strings, BOOL * _Nonnull stop) {
@@ -76,7 +76,7 @@
     return mbgl::style::Function<std::vector<std::string>>({{stops}}, _base.floatValue);
 }
 
-- (mbgl::style::PropertyValue<std::vector<float> >)mbgl_numberArrayPropertyValue
+- (mbgl::style::PropertyValue<std::vector<float> >)mgl_numberArrayPropertyValue
 {
     __block std::vector<std::pair<float, std::vector<float>>> stops;
     [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSArray *  _Nonnull numbers, BOOL * _Nonnull stop) {
@@ -90,7 +90,7 @@
     return mbgl::style::Function<std::vector<float>>({{stops}}, _base.floatValue);
 }
 
-- (mbgl::style::PropertyValue<std::array<float, 4> >)mbgl_paddingPropertyValue
+- (mbgl::style::PropertyValue<std::array<float, 4> >)mgl_paddingPropertyValue
 {
     __block std::vector<std::pair<float, std::array<float, 4>>> stops;
     [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSValue * _Nonnull padding, BOOL * _Nonnull stop) {
@@ -100,7 +100,7 @@
     return mbgl::style::Function<std::array<float, 4>>({{stops}}, _base.floatValue);
 }
 
-- (mbgl::style::PropertyValue<std::array<float, 2> >)mbgl_offsetPropertyValue
+- (mbgl::style::PropertyValue<std::array<float, 2> >)mgl_offsetPropertyValue
 {
     __block std::vector<std::pair<float, std::array<float, 2>>> stops;
     [self.stops enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull zoomKey, NSValue * _Nonnull offset, BOOL * _Nonnull stop) {
@@ -116,7 +116,7 @@
     auto stops = property.getStops();
     NSMutableDictionary *convertedStops = [NSMutableDictionary dictionaryWithCapacity:stops.size()];
     for (auto stop : stops) {
-        convertedStops[@(stop.first)] = [MGLColor mbgl_colorWithColor:stop.second];
+        convertedStops[@(stop.first)] = [MGLColor mgl_colorWithColor:stop.second];
     }
     function.base = @(property.getBase());
     function.stops = convertedStops;

--- a/platform/darwin/src/MGLStyleAttributeValue_Private.h
+++ b/platform/darwin/src/MGLStyleAttributeValue_Private.h
@@ -9,16 +9,16 @@
 @optional
 
 // Convert darwin types to mbgl types
-- (mbgl::style::PropertyValue<mbgl::Color>)mbgl_colorPropertyValue;
-- (mbgl::style::PropertyValue<float>)mbgl_floatPropertyValue;
-- (mbgl::style::PropertyValue<bool>)mbgl_boolPropertyValue;
-- (mbgl::style::PropertyValue<std::string>)mbgl_stringPropertyValue;
-- (mbgl::style::PropertyValue<std::array<float, 2>>)mbgl_offsetPropertyValue;
-- (mbgl::style::PropertyValue<std::array<float, 4>>)mbgl_paddingPropertyValue;
-- (mbgl::style::PropertyValue<std::vector<std::string> >)mbgl_stringArrayPropertyValue;
-- (mbgl::style::PropertyValue<std::vector<float> >)mbgl_numberArrayPropertyValue;
+- (mbgl::style::PropertyValue<mbgl::Color>)mgl_colorPropertyValue;
+- (mbgl::style::PropertyValue<float>)mgl_floatPropertyValue;
+- (mbgl::style::PropertyValue<bool>)mgl_boolPropertyValue;
+- (mbgl::style::PropertyValue<std::string>)mgl_stringPropertyValue;
+- (mbgl::style::PropertyValue<std::array<float, 2>>)mgl_offsetPropertyValue;
+- (mbgl::style::PropertyValue<std::array<float, 4>>)mgl_paddingPropertyValue;
+- (mbgl::style::PropertyValue<std::vector<std::string> >)mgl_stringArrayPropertyValue;
+- (mbgl::style::PropertyValue<std::vector<float> >)mgl_numberArrayPropertyValue;
 
 // Convert mbgl types to darwin types
-- (id <MGLStyleAttributeValue>)mbgl_colorPropertyValueWith:(mbgl::style::PropertyValue<mbgl::Color>)color;
+- (id <MGLStyleAttributeValue>)mgl_colorPropertyValueWith:(mbgl::style::PropertyValue<mbgl::Color>)color;
 
 @end

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -57,43 +57,43 @@
 }
 
 - (void)setSymbolSpacing:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)symbolSpacing {
-    self.layer->setSymbolSpacing(symbolSpacing.mbgl_floatPropertyValue);
+    self.layer->setSymbolSpacing(symbolSpacing.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)symbolSpacing {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getSymbolSpacing() ?: self.layer->getDefaultSymbolSpacing()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getSymbolSpacing() ?: self.layer->getDefaultSymbolSpacing()];
 }
 
 - (void)setSymbolAvoidEdges:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)symbolAvoidEdges {
-    self.layer->setSymbolAvoidEdges(symbolAvoidEdges.mbgl_boolPropertyValue);
+    self.layer->setSymbolAvoidEdges(symbolAvoidEdges.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)symbolAvoidEdges {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getSymbolAvoidEdges() ?: self.layer->getDefaultSymbolAvoidEdges()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getSymbolAvoidEdges() ?: self.layer->getDefaultSymbolAvoidEdges()];
 }
 
 - (void)setIconAllowOverlap:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconAllowOverlap {
-    self.layer->setIconAllowOverlap(iconAllowOverlap.mbgl_boolPropertyValue);
+    self.layer->setIconAllowOverlap(iconAllowOverlap.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconAllowOverlap {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getIconAllowOverlap() ?: self.layer->getDefaultIconAllowOverlap()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getIconAllowOverlap() ?: self.layer->getDefaultIconAllowOverlap()];
 }
 
 - (void)setIconIgnorePlacement:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconIgnorePlacement {
-    self.layer->setIconIgnorePlacement(iconIgnorePlacement.mbgl_boolPropertyValue);
+    self.layer->setIconIgnorePlacement(iconIgnorePlacement.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconIgnorePlacement {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getIconIgnorePlacement() ?: self.layer->getDefaultIconIgnorePlacement()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getIconIgnorePlacement() ?: self.layer->getDefaultIconIgnorePlacement()];
 }
 
 - (void)setIconOptional:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconOptional {
-    self.layer->setIconOptional(iconOptional.mbgl_boolPropertyValue);
+    self.layer->setIconOptional(iconOptional.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconOptional {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getIconOptional() ?: self.layer->getDefaultIconOptional()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getIconOptional() ?: self.layer->getDefaultIconOptional()];
 }
 
 - (void)setIconRotationAlignment:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconRotationAlignment {
@@ -105,11 +105,11 @@
 }
 
 - (void)setIconSize:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconSize {
-    self.layer->setIconSize(iconSize.mbgl_floatPropertyValue);
+    self.layer->setIconSize(iconSize.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconSize {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getIconSize() ?: self.layer->getDefaultIconSize()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getIconSize() ?: self.layer->getDefaultIconSize()];
 }
 
 - (void)setIconTextFit:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconTextFit {
@@ -121,51 +121,51 @@
 }
 
 - (void)setIconTextFitPadding:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconTextFitPadding {
-    self.layer->setIconTextFitPadding(iconTextFitPadding.mbgl_paddingPropertyValue);
+    self.layer->setIconTextFitPadding(iconTextFitPadding.mgl_paddingPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconTextFitPadding {
-    return [MGLStyleAttribute mbgl_paddingWithPropertyValuePadding:self.layer->getIconTextFitPadding() ?: self.layer->getDefaultIconTextFitPadding()];
+    return [MGLStyleAttribute mgl_paddingWithPropertyValuePadding:self.layer->getIconTextFitPadding() ?: self.layer->getDefaultIconTextFitPadding()];
 }
 
 - (void)setIconImage:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconImage {
-    self.layer->setIconImage(iconImage.mbgl_stringPropertyValue);
+    self.layer->setIconImage(iconImage.mgl_stringPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconImage {
-    return [MGLStyleAttribute mbgl_stringWithPropertyValueString:self.layer->getIconImage() ?: self.layer->getDefaultIconImage()];
+    return [MGLStyleAttribute mgl_stringWithPropertyValueString:self.layer->getIconImage() ?: self.layer->getDefaultIconImage()];
 }
 
 - (void)setIconRotate:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconRotate {
-    self.layer->setIconRotate(iconRotate.mbgl_floatPropertyValue);
+    self.layer->setIconRotate(iconRotate.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconRotate {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getIconRotate() ?: self.layer->getDefaultIconRotate()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getIconRotate() ?: self.layer->getDefaultIconRotate()];
 }
 
 - (void)setIconPadding:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconPadding {
-    self.layer->setIconPadding(iconPadding.mbgl_floatPropertyValue);
+    self.layer->setIconPadding(iconPadding.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconPadding {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getIconPadding() ?: self.layer->getDefaultIconPadding()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getIconPadding() ?: self.layer->getDefaultIconPadding()];
 }
 
 - (void)setIconKeepUpright:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconKeepUpright {
-    self.layer->setIconKeepUpright(iconKeepUpright.mbgl_boolPropertyValue);
+    self.layer->setIconKeepUpright(iconKeepUpright.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconKeepUpright {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getIconKeepUpright() ?: self.layer->getDefaultIconKeepUpright()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getIconKeepUpright() ?: self.layer->getDefaultIconKeepUpright()];
 }
 
 - (void)setIconOffset:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconOffset {
-    self.layer->setIconOffset(iconOffset.mbgl_offsetPropertyValue);
+    self.layer->setIconOffset(iconOffset.mgl_offsetPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconOffset {
-    return [MGLStyleAttribute mbgl_offsetWithPropertyValueOffset:self.layer->getIconOffset() ?: self.layer->getDefaultIconOffset()];
+    return [MGLStyleAttribute mgl_offsetWithPropertyValueOffset:self.layer->getIconOffset() ?: self.layer->getDefaultIconOffset()];
 }
 
 - (void)setTextPitchAlignment:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textPitchAlignment {
@@ -185,51 +185,51 @@
 }
 
 - (void)setTextField:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textField {
-    self.layer->setTextField(textField.mbgl_stringPropertyValue);
+    self.layer->setTextField(textField.mgl_stringPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textField {
-    return [MGLStyleAttribute mbgl_stringWithPropertyValueString:self.layer->getTextField() ?: self.layer->getDefaultTextField()];
+    return [MGLStyleAttribute mgl_stringWithPropertyValueString:self.layer->getTextField() ?: self.layer->getDefaultTextField()];
 }
 
 - (void)setTextFont:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textFont {
-    self.layer->setTextFont(textFont.mbgl_stringArrayPropertyValue);
+    self.layer->setTextFont(textFont.mgl_stringArrayPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textFont {
-    return [MGLStyleAttribute mbgl_stringArrayWithPropertyValueStringArray:self.layer->getTextFont() ?: self.layer->getDefaultTextFont()];
+    return [MGLStyleAttribute mgl_stringArrayWithPropertyValueStringArray:self.layer->getTextFont() ?: self.layer->getDefaultTextFont()];
 }
 
 - (void)setTextSize:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textSize {
-    self.layer->setTextSize(textSize.mbgl_floatPropertyValue);
+    self.layer->setTextSize(textSize.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textSize {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextSize() ?: self.layer->getDefaultTextSize()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextSize() ?: self.layer->getDefaultTextSize()];
 }
 
 - (void)setTextMaxWidth:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textMaxWidth {
-    self.layer->setTextMaxWidth(textMaxWidth.mbgl_floatPropertyValue);
+    self.layer->setTextMaxWidth(textMaxWidth.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textMaxWidth {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextMaxWidth() ?: self.layer->getDefaultTextMaxWidth()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextMaxWidth() ?: self.layer->getDefaultTextMaxWidth()];
 }
 
 - (void)setTextLineHeight:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textLineHeight {
-    self.layer->setTextLineHeight(textLineHeight.mbgl_floatPropertyValue);
+    self.layer->setTextLineHeight(textLineHeight.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textLineHeight {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextLineHeight() ?: self.layer->getDefaultTextLineHeight()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextLineHeight() ?: self.layer->getDefaultTextLineHeight()];
 }
 
 - (void)setTextLetterSpacing:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textLetterSpacing {
-    self.layer->setTextLetterSpacing(textLetterSpacing.mbgl_floatPropertyValue);
+    self.layer->setTextLetterSpacing(textLetterSpacing.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textLetterSpacing {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextLetterSpacing() ?: self.layer->getDefaultTextLetterSpacing()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextLetterSpacing() ?: self.layer->getDefaultTextLetterSpacing()];
 }
 
 - (void)setTextJustify:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textJustify {
@@ -249,35 +249,35 @@
 }
 
 - (void)setTextMaxAngle:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textMaxAngle {
-    self.layer->setTextMaxAngle(textMaxAngle.mbgl_floatPropertyValue);
+    self.layer->setTextMaxAngle(textMaxAngle.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textMaxAngle {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextMaxAngle() ?: self.layer->getDefaultTextMaxAngle()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextMaxAngle() ?: self.layer->getDefaultTextMaxAngle()];
 }
 
 - (void)setTextRotate:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textRotate {
-    self.layer->setTextRotate(textRotate.mbgl_floatPropertyValue);
+    self.layer->setTextRotate(textRotate.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textRotate {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextRotate() ?: self.layer->getDefaultTextRotate()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextRotate() ?: self.layer->getDefaultTextRotate()];
 }
 
 - (void)setTextPadding:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textPadding {
-    self.layer->setTextPadding(textPadding.mbgl_floatPropertyValue);
+    self.layer->setTextPadding(textPadding.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textPadding {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextPadding() ?: self.layer->getDefaultTextPadding()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextPadding() ?: self.layer->getDefaultTextPadding()];
 }
 
 - (void)setTextKeepUpright:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textKeepUpright {
-    self.layer->setTextKeepUpright(textKeepUpright.mbgl_boolPropertyValue);
+    self.layer->setTextKeepUpright(textKeepUpright.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textKeepUpright {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getTextKeepUpright() ?: self.layer->getDefaultTextKeepUpright()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getTextKeepUpright() ?: self.layer->getDefaultTextKeepUpright()];
 }
 
 - (void)setTextTransform:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textTransform {
@@ -289,85 +289,85 @@
 }
 
 - (void)setTextOffset:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textOffset {
-    self.layer->setTextOffset(textOffset.mbgl_offsetPropertyValue);
+    self.layer->setTextOffset(textOffset.mgl_offsetPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textOffset {
-    return [MGLStyleAttribute mbgl_offsetWithPropertyValueOffset:self.layer->getTextOffset() ?: self.layer->getDefaultTextOffset()];
+    return [MGLStyleAttribute mgl_offsetWithPropertyValueOffset:self.layer->getTextOffset() ?: self.layer->getDefaultTextOffset()];
 }
 
 - (void)setTextAllowOverlap:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textAllowOverlap {
-    self.layer->setTextAllowOverlap(textAllowOverlap.mbgl_boolPropertyValue);
+    self.layer->setTextAllowOverlap(textAllowOverlap.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textAllowOverlap {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getTextAllowOverlap() ?: self.layer->getDefaultTextAllowOverlap()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getTextAllowOverlap() ?: self.layer->getDefaultTextAllowOverlap()];
 }
 
 - (void)setTextIgnorePlacement:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textIgnorePlacement {
-    self.layer->setTextIgnorePlacement(textIgnorePlacement.mbgl_boolPropertyValue);
+    self.layer->setTextIgnorePlacement(textIgnorePlacement.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textIgnorePlacement {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getTextIgnorePlacement() ?: self.layer->getDefaultTextIgnorePlacement()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getTextIgnorePlacement() ?: self.layer->getDefaultTextIgnorePlacement()];
 }
 
 - (void)setTextOptional:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textOptional {
-    self.layer->setTextOptional(textOptional.mbgl_boolPropertyValue);
+    self.layer->setTextOptional(textOptional.mgl_boolPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textOptional {
-    return [MGLStyleAttribute mbgl_boolWithPropertyValueBool:self.layer->getTextOptional() ?: self.layer->getDefaultTextOptional()];
+    return [MGLStyleAttribute mgl_boolWithPropertyValueBool:self.layer->getTextOptional() ?: self.layer->getDefaultTextOptional()];
 }
 
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setIconOpacity:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconOpacity {
-    self.layer->setIconOpacity(iconOpacity.mbgl_floatPropertyValue);
+    self.layer->setIconOpacity(iconOpacity.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconOpacity {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getIconOpacity() ?: self.layer->getDefaultIconOpacity()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getIconOpacity() ?: self.layer->getDefaultIconOpacity()];
 }
 
 - (void)setIconColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconColor {
-    self.layer->setIconColor(iconColor.mbgl_colorPropertyValue);
+    self.layer->setIconColor(iconColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getIconColor() ?: self.layer->getDefaultIconColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getIconColor() ?: self.layer->getDefaultIconColor()];
 }
 
 - (void)setIconHaloColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconHaloColor {
-    self.layer->setIconHaloColor(iconHaloColor.mbgl_colorPropertyValue);
+    self.layer->setIconHaloColor(iconHaloColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconHaloColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getIconHaloColor() ?: self.layer->getDefaultIconHaloColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getIconHaloColor() ?: self.layer->getDefaultIconHaloColor()];
 }
 
 - (void)setIconHaloWidth:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconHaloWidth {
-    self.layer->setIconHaloWidth(iconHaloWidth.mbgl_floatPropertyValue);
+    self.layer->setIconHaloWidth(iconHaloWidth.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconHaloWidth {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getIconHaloWidth() ?: self.layer->getDefaultIconHaloWidth()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getIconHaloWidth() ?: self.layer->getDefaultIconHaloWidth()];
 }
 
 - (void)setIconHaloBlur:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconHaloBlur {
-    self.layer->setIconHaloBlur(iconHaloBlur.mbgl_floatPropertyValue);
+    self.layer->setIconHaloBlur(iconHaloBlur.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconHaloBlur {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getIconHaloBlur() ?: self.layer->getDefaultIconHaloBlur()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getIconHaloBlur() ?: self.layer->getDefaultIconHaloBlur()];
 }
 
 - (void)setIconTranslate:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconTranslate {
-    self.layer->setIconTranslate(iconTranslate.mbgl_offsetPropertyValue);
+    self.layer->setIconTranslate(iconTranslate.mgl_offsetPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)iconTranslate {
-    return [MGLStyleAttribute mbgl_offsetWithPropertyValueOffset:self.layer->getIconTranslate() ?: self.layer->getDefaultIconTranslate()];
+    return [MGLStyleAttribute mgl_offsetWithPropertyValueOffset:self.layer->getIconTranslate() ?: self.layer->getDefaultIconTranslate()];
 }
 
 - (void)setIconTranslateAnchor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)iconTranslateAnchor {
@@ -379,51 +379,51 @@
 }
 
 - (void)setTextOpacity:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textOpacity {
-    self.layer->setTextOpacity(textOpacity.mbgl_floatPropertyValue);
+    self.layer->setTextOpacity(textOpacity.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textOpacity {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextOpacity() ?: self.layer->getDefaultTextOpacity()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextOpacity() ?: self.layer->getDefaultTextOpacity()];
 }
 
 - (void)setTextColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textColor {
-    self.layer->setTextColor(textColor.mbgl_colorPropertyValue);
+    self.layer->setTextColor(textColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getTextColor() ?: self.layer->getDefaultTextColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getTextColor() ?: self.layer->getDefaultTextColor()];
 }
 
 - (void)setTextHaloColor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textHaloColor {
-    self.layer->setTextHaloColor(textHaloColor.mbgl_colorPropertyValue);
+    self.layer->setTextHaloColor(textHaloColor.mgl_colorPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textHaloColor {
-    return [MGLStyleAttribute mbgl_colorWithPropertyValueColor:self.layer->getTextHaloColor() ?: self.layer->getDefaultTextHaloColor()];
+    return [MGLStyleAttribute mgl_colorWithPropertyValueColor:self.layer->getTextHaloColor() ?: self.layer->getDefaultTextHaloColor()];
 }
 
 - (void)setTextHaloWidth:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textHaloWidth {
-    self.layer->setTextHaloWidth(textHaloWidth.mbgl_floatPropertyValue);
+    self.layer->setTextHaloWidth(textHaloWidth.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textHaloWidth {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextHaloWidth() ?: self.layer->getDefaultTextHaloWidth()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextHaloWidth() ?: self.layer->getDefaultTextHaloWidth()];
 }
 
 - (void)setTextHaloBlur:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textHaloBlur {
-    self.layer->setTextHaloBlur(textHaloBlur.mbgl_floatPropertyValue);
+    self.layer->setTextHaloBlur(textHaloBlur.mgl_floatPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textHaloBlur {
-    return [MGLStyleAttribute mbgl_numberWithPropertyValueNumber:self.layer->getTextHaloBlur() ?: self.layer->getDefaultTextHaloBlur()];
+    return [MGLStyleAttribute mgl_numberWithPropertyValueNumber:self.layer->getTextHaloBlur() ?: self.layer->getDefaultTextHaloBlur()];
 }
 
 - (void)setTextTranslate:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textTranslate {
-    self.layer->setTextTranslate(textTranslate.mbgl_offsetPropertyValue);
+    self.layer->setTextTranslate(textTranslate.mgl_offsetPropertyValue);
 }
 
 - (id <MGLStyleAttributeValue>)textTranslate {
-    return [MGLStyleAttribute mbgl_offsetWithPropertyValueOffset:self.layer->getTextTranslate() ?: self.layer->getDefaultTextTranslate()];
+    return [MGLStyleAttribute mgl_offsetWithPropertyValueOffset:self.layer->getTextTranslate() ?: self.layer->getDefaultTextTranslate()];
 }
 
 - (void)setTextTranslateAnchor:(id <MGLStyleAttributeValue, MGLStyleAttributeValue_Private>)textTranslateAnchor {

--- a/platform/darwin/src/NSArray+MGLStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSArray+MGLStyleAttributeAdditions.mm
@@ -10,7 +10,7 @@
 
 @implementation NSArray (MGLStyleAttributeAdditions)
 
-- (mbgl::style::PropertyValue<std::vector<std::string> >)mbgl_stringArrayPropertyValue
+- (mbgl::style::PropertyValue<std::vector<std::string> >)mgl_stringArrayPropertyValue
 {
     std::vector<std::string>fonts;
     
@@ -21,7 +21,7 @@
     return {{fonts}};
 }
 
-- (mbgl::style::PropertyValue<std::vector<float> >)mbgl_numberArrayPropertyValue
+- (mbgl::style::PropertyValue<std::vector<float> >)mgl_numberArrayPropertyValue
 {
     std::vector<float>values;
     

--- a/platform/darwin/src/NSNumber+MGLStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSNumber+MGLStyleAttributeAdditions.mm
@@ -9,12 +9,12 @@
     return self;
 }
 
-- (mbgl::style::PropertyValue<bool>)mbgl_boolPropertyValue
+- (mbgl::style::PropertyValue<bool>)mgl_boolPropertyValue
 {
     return mbgl::style::PropertyValue<bool> { !!self.boolValue };
 }
 
-- (mbgl::style::PropertyValue<float>)mbgl_floatPropertyValue
+- (mbgl::style::PropertyValue<float>)mgl_floatPropertyValue
 {
     return mbgl::style::PropertyValue<float> { self.floatValue };
 }

--- a/platform/darwin/src/NSNumber+MGLStyleAttributeAdditions_Private.h
+++ b/platform/darwin/src/NSNumber+MGLStyleAttributeAdditions_Private.h
@@ -6,8 +6,8 @@
 
 @interface NSNumber (MGLStyleAttributeAdditions_Private) <MGLStyleAttributeValue>
 
-- (mbgl::style::PropertyValue<bool>)mbgl_booleanPropertyValue;
+- (mbgl::style::PropertyValue<bool>)mgl_booleanPropertyValue;
 
-- (mbgl::style::PropertyValue<float>)mbgl_numberPropertyValue;
+- (mbgl::style::PropertyValue<float>)mgl_numberPropertyValue;
 
 @end

--- a/platform/darwin/src/NSString+MGLStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSString+MGLStyleAttributeAdditions.mm
@@ -9,7 +9,7 @@
     return NO;
 }
 
-- (mbgl::style::PropertyValue<std::string>)mbgl_stringPropertyValue
+- (mbgl::style::PropertyValue<std::string>)mgl_stringPropertyValue
 {
     return mbgl::style::PropertyValue<std::string> {{ self.UTF8String }};
 }

--- a/platform/darwin/src/NSString+MGLStyleAttributeAdditions_Private.h
+++ b/platform/darwin/src/NSString+MGLStyleAttributeAdditions_Private.h
@@ -6,6 +6,6 @@
 
 @interface NSString (MGLStyleAttributeAdditions_Private) <MGLStyleAttributeValue>
 
-- (mbgl::style::PropertyValue<std::string>)mbgl_stringPropertyValue;
+- (mbgl::style::PropertyValue<std::string>)mgl_stringPropertyValue;
 
 @end

--- a/platform/darwin/src/NSValue+MGLStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSValue+MGLStyleAttributeAdditions.mm
@@ -37,7 +37,7 @@
     return NO;
 }
 
-- (mbgl::style::PropertyValue<std::array<float, 2>>)mbgl_offsetPropertyValue
+- (mbgl::style::PropertyValue<std::array<float, 2>>)mgl_offsetPropertyValue
 {
     return { self.mgl_offsetArrayValue };
 }
@@ -53,7 +53,7 @@
     };
 }
 
-- (mbgl::style::PropertyValue<std::array<float, 4>>)mbgl_paddingPropertyValue
+- (mbgl::style::PropertyValue<std::array<float, 4>>)mgl_paddingPropertyValue
 {
     return { self.mgl_paddingArrayValue };
 }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3066,7 +3066,7 @@ public:
     UIColor *color = (_delegateHasStrokeColorsForShapeAnnotations
                       ? [self.delegate mapView:self strokeColorForShapeAnnotation:annotation]
                       : self.tintColor);
-    return color.mbgl_color;
+    return color.mgl_color;
 }
 
 - (mbgl::Color)fillColorForPolygonAnnotation:(MGLPolygon *)annotation
@@ -3074,7 +3074,7 @@ public:
     UIColor *color = (_delegateHasFillColorsForShapeAnnotations
                       ? [self.delegate mapView:self fillColorForPolygonAnnotation:annotation]
                       : self.tintColor);
-    return color.mbgl_color;
+    return color.mgl_color;
 }
 
 - (CGFloat)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation

--- a/platform/ios/src/UIColor+MGLAdditions.h
+++ b/platform/ios/src/UIColor+MGLAdditions.h
@@ -5,10 +5,10 @@
 
 @interface UIColor (MGLAdditions)
 
-- (mbgl::Color)mbgl_color;
+- (mbgl::Color)mgl_color;
 
-- (mbgl::style::PropertyValue<mbgl::Color>)mbgl_colorPropertyValue;
+- (mbgl::style::PropertyValue<mbgl::Color>)mgl_colorPropertyValue;
 
-+ (UIColor *)mbgl_colorWithColor:(mbgl::Color)color;
++ (UIColor *)mgl_colorWithColor:(mbgl::Color)color;
 
 @end

--- a/platform/ios/src/UIColor+MGLAdditions.mm
+++ b/platform/ios/src/UIColor+MGLAdditions.mm
@@ -5,20 +5,20 @@
 
 @implementation UIColor (MGLAdditions)
 
-- (mbgl::Color)mbgl_color
+- (mbgl::Color)mgl_color
 {
     CGFloat r, g, b, a;
     [self getRed:&r green:&g blue:&b alpha:&a];
     return { (float)r, (float)g, (float)b, (float)a };
 }
 
-- (mbgl::style::PropertyValue<mbgl::Color>)mbgl_colorPropertyValue
+- (mbgl::style::PropertyValue<mbgl::Color>)mgl_colorPropertyValue
 {
-    mbgl::Color color = self.mbgl_color;
+    mbgl::Color color = self.mgl_color;
     return {{ color.r, color.g, color.b, color.a }};
 }
 
-+ (UIColor *)mbgl_colorWithColor:(mbgl::Color)color
++ (UIColor *)mgl_colorWithColor:(mbgl::Color)color
 {
     return [UIColor colorWithRed:color.r green:color.g blue:color.b alpha:color.a];
 }

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2173,14 +2173,14 @@ public:
     NSColor *color = (_delegateHasStrokeColorsForShapeAnnotations
                       ? [self.delegate mapView:self strokeColorForShapeAnnotation:annotation]
                       : [NSColor selectedMenuItemColor]);
-    return color.mbgl_color;
+    return color.mgl_color;
 }
 
 - (mbgl::Color)fillColorForPolygonAnnotation:(MGLPolygon *)annotation {
     NSColor *color = (_delegateHasFillColorsForShapeAnnotations
                       ? [self.delegate mapView:self fillColorForPolygonAnnotation:annotation]
                       : [NSColor selectedMenuItemColor]);
-    return color.mbgl_color;
+    return color.mgl_color;
 }
 
 - (CGFloat)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation {

--- a/platform/macos/src/NSColor+MGLAdditions.h
+++ b/platform/macos/src/NSColor+MGLAdditions.h
@@ -8,13 +8,13 @@
 /**
  Converts the color into an mbgl::Color in calibrated RGB space.
  */
-- (mbgl::Color)mbgl_color;
+- (mbgl::Color)mgl_color;
 
 /**
  Instantiates `NSColor` from an `mbgl::Color`
  */
-+ (NSColor *)mbgl_colorWithColor:(mbgl::Color)color;
++ (NSColor *)mgl_colorWithColor:(mbgl::Color)color;
 
-- (mbgl::style::PropertyValue<mbgl::Color>)mbgl_colorPropertyValue;
+- (mbgl::style::PropertyValue<mbgl::Color>)mgl_colorPropertyValue;
 
 @end

--- a/platform/macos/src/NSColor+MGLAdditions.mm
+++ b/platform/macos/src/NSColor+MGLAdditions.mm
@@ -2,7 +2,7 @@
 
 @implementation NSColor (MGLAdditions)
 
-- (mbgl::Color)mbgl_color
+- (mbgl::Color)mgl_color
 {
     CGFloat r, g, b, a;
     
@@ -11,14 +11,14 @@
     return { (float)r, (float)g, (float)b, (float)a };
 }
 
-+ (NSColor *)mbgl_colorWithColor:(mbgl::Color)color
++ (NSColor *)mgl_colorWithColor:(mbgl::Color)color
 {
     return [NSColor colorWithRed:color.r green:color.g blue:color.b alpha:color.a];
 }
 
-- (mbgl::style::PropertyValue<mbgl::Color>)mbgl_colorPropertyValue
+- (mbgl::style::PropertyValue<mbgl::Color>)mgl_colorPropertyValue
 {
-    mbgl::Color color = self.mbgl_color;
+    mbgl::Color color = self.mgl_color;
     return {{ color.r, color.g, color.b, color.a }};
 }
 


### PR DESCRIPTION
Fixes #6078. This makes runtime styling category method naming consistent with the rest of the SDK.

/cc @1ec5 @frederoni