### PR TITLE
Deprecate -[MGLMapViewDelegate mapView:alphaForShapeAnnotation:]

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -51,6 +51,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Improved the precision of annotations at zoom levels greater than 18. ([#5517](https://github.com/mapbox/mapbox-gl-native/pull/5517))
 * Fixed an issue that could reset user-added transformations on annotation views. ([#6166](https://github.com/mapbox/mapbox-gl-native/pull/6166))
 * Fixed an issue that caused an annotation view to disappear if it isn’t created using the annotation view reuse queue. ([#6485](https://github.com/mapbox/mapbox-gl-native/pull/6485))
+* Deprecated `-[MGLMapViewDelegate mapView:alphaForShapeAnnotation:]` in favor of specifying an alpha component via `-[MGLMapViewDelegate mapView:strokeColorForShapeAnnotation:]` or `-[MGLMapViewDelegate mapView:fillColorForPolygonAnnotation:]`. ([#6706](https://github.com/mapbox/mapbox-gl-native/pull/6706))
 
 ### Networking and offline maps
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1084,11 +1084,6 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     return YES;
 }
 
-- (CGFloat)mapView:(__unused MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation
-{
-    return ([annotation isKindOfClass:[MGLPolygon class]] ? 0.5 : 1.0);
-}
-
 - (UIColor *)mapView:(__unused MGLMapView *)mapView strokeColorForShapeAnnotation:(MGLShape *)annotation
 {
     return ([annotation isKindOfClass:[MGLPolyline class]] ? [UIColor purpleColor] : [UIColor blackColor]);
@@ -1096,7 +1091,8 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 
 - (UIColor *)mapView:(__unused MGLMapView *)mapView fillColorForPolygonAnnotation:(__unused MGLPolygon *)annotation
 {
-    return (annotation.pointCount > 3 ? [UIColor greenColor] : [UIColor redColor]);
+    UIColor *color = annotation.pointCount > 3 ? [UIColor greenColor] : [UIColor redColor];
+    return [color colorWithAlphaComponent:0.5];
 }
 
 - (void)mapView:(__unused MGLMapView *)mapView didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(__unused BOOL)animated

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3054,9 +3054,23 @@ public:
 
 - (double)alphaForShapeAnnotation:(MGLShape *)annotation
 {
+    // The explicit -mapView:alphaForShapeAnnotation: delegate method is deprecated
+    // but still used, if implemented. When not implemented, call the stroke or
+    // fill color delegate methods and pull the alpha from the returned color.
     if (_delegateHasAlphasForShapeAnnotations)
     {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return [self.delegate mapView:self alphaForShapeAnnotation:annotation];
+#pragma clang diagnostic pop
+    }
+    else if ([annotation isKindOfClass:[MGLPolygon class]])
+    {
+        return [self fillColorForPolygonAnnotation:(MGLPolygon *)annotation].a ?: 1.0;
+    }
+    else if ([annotation isKindOfClass:[MGLShape class]])
+    {
+        return [self strokeColorForShapeAnnotation:annotation].a ?: 1.0;
     }
     return 1.0;
 }

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -240,7 +240,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param annotation The annotation being rendered.
  @return An alpha value between `0` and `1.0`.
  */
-- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation __attribute__((deprecated("Use -mapView:strokeColorForShapeAnnotation:.")));
+- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation __attribute__((deprecated("Use -mapView:strokeColorForShapeAnnotation: or -mapView:fillColorForPolygonAnnotation:.")));
 
 /**
  Returns the color to use when rendering the outline of a shape annotation.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -228,26 +228,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable MGLAnnotationImage *)mapView:(MGLMapView *)mapView imageForAnnotation:(id <MGLAnnotation>)annotation;
 
-/**
- Returns the alpha value to use when rendering a shape annotation.
- 
- A value of `0.0` results in a completely transparent shape. A value of `1.0`,
- the default, results in a completely opaque shape.
- 
- @deprecated Use `-mapView:strokeColorForShapeAnnotation:`.
-
- @param mapView The map view rendering the shape annotation.
- @param annotation The annotation being rendered.
- @return An alpha value between `0` and `1.0`.
- */
 - (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation __attribute__((deprecated("Use -mapView:strokeColorForShapeAnnotation: or -mapView:fillColorForPolygonAnnotation:.")));
 
 /**
  Returns the color to use when rendering the outline of a shape annotation.
  
  The default stroke color is the map view’s tint color. If a pattern color is
- specified, the result is undefined. Opacity may be set by specifying an alpha
- component.
+ specified, the result is undefined.
+ 
+ Opacity may be set by specifying an alpha component. The default alpha value is
+ `1.0` and results in a completely opaque shape.
  
  @param mapView The map view rendering the shape annotation.
  @param annotation The annotation being rendered.
@@ -259,8 +249,10 @@ NS_ASSUME_NONNULL_BEGIN
  Returns the color to use when rendering the fill of a polygon annotation.
  
  The default fill color is the map view’s tint color. If a pattern color is
- specified, the result is undefined. Opacity may be set by specifying an alpha
- component.
+ specified, the result is undefined.
+ 
+ Opacity may be set by specifying an alpha component. The default alpha value is
+ `1.0` and results in a completely opaque shape.
  
  @param mapView The map view rendering the polygon annotation.
  @param annotation The annotation being rendered.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -237,7 +237,7 @@ NS_ASSUME_NONNULL_BEGIN
  specified, the result is undefined.
  
  Opacity may be set by specifying an alpha component. The default alpha value is
- `1.0` and results in a completely opaque shape.
+ `1.0` and results in a completely opaque stroke.
  
  @param mapView The map view rendering the shape annotation.
  @param annotation The annotation being rendered.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -234,17 +234,20 @@ NS_ASSUME_NONNULL_BEGIN
  A value of `0.0` results in a completely transparent shape. A value of `1.0`,
  the default, results in a completely opaque shape.
  
+ @deprecated Use `-mapView:strokeColorForShapeAnnotation:`.
+
  @param mapView The map view rendering the shape annotation.
  @param annotation The annotation being rendered.
  @return An alpha value between `0` and `1.0`.
  */
-- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation;
+- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation __attribute__((deprecated("Use -mapView:strokeColorForShapeAnnotation:.")));
 
 /**
  Returns the color to use when rendering the outline of a shape annotation.
  
  The default stroke color is the map view’s tint color. If a pattern color is
- specified, the result is undefined.
+ specified, the result is undefined. Opacity may be set by specifying an alpha
+ component.
  
  @param mapView The map view rendering the shape annotation.
  @param annotation The annotation being rendered.
@@ -256,7 +259,8 @@ NS_ASSUME_NONNULL_BEGIN
  Returns the color to use when rendering the fill of a polygon annotation.
  
  The default fill color is the map view’s tint color. If a pattern color is
- specified, the result is undefined.
+ specified, the result is undefined. Opacity may be set by specifying an alpha
+ component.
  
  @param mapView The map view rendering the polygon annotation.
  @param annotation The annotation being rendered.

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Database errors are now logged to the console. ([#6291](https://github.com/mapbox/mapbox-gl-native/pull/6291))
 * Improved style parsing performance. ([#6170](https://github.com/mapbox/mapbox-gl-native/pull/6170))
 * Fixed a typo in the documentation for the MGLCompassDirectionFormatter class. ([#5879](https://github.com/mapbox/mapbox-gl-native/pull/5879))
+* Deprecated `-[MGLMapViewDelegate mapView:alphaForShapeAnnotation:]` in favor of specifying an alpha component via `-[MGLMapViewDelegate mapView:strokeColorForShapeAnnotation:]` or `-[MGLMapViewDelegate mapView:fillColorForPolygonAnnotation:]`. ([#6706](https://github.com/mapbox/mapbox-gl-native/pull/6706))
 
 ## 0.2.1 - July 19, 2016
 

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -826,8 +826,8 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     }
 }
 
-- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation {
-    return 0.8;
+- (NSColor *)mapView:(MGLMapView *)mapView fillColorForPolygonAnnotation:(MGLPolygon *)annotation {
+    return [NSColor colorWithWhite:0 alpha:0.8];
 }
 
 @end

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -827,7 +827,8 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
 }
 
 - (NSColor *)mapView:(MGLMapView *)mapView fillColorForPolygonAnnotation:(MGLPolygon *)annotation {
-    return [NSColor colorWithWhite:0 alpha:0.8];
+    NSColor *color = [[NSColor selectedMenuItemColor] colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+    return [color colorWithAlphaComponent:0.8];
 }
 
 @end

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2163,8 +2163,18 @@ public:
 #pragma mark MGLMultiPointDelegate methods
 
 - (double)alphaForShapeAnnotation:(MGLShape *)annotation {
+    // The explicit -mapView:alphaForShapeAnnotation: delegate method is deprecated
+    // but still used, if implemented. When not implemented, call the stroke or
+    // fill color delegate methods and pull the alpha from the returned color.
     if (_delegateHasAlphasForShapeAnnotations) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return [self.delegate mapView:self alphaForShapeAnnotation:annotation];
+#pragma clang diagnostic pop
+    } else if ([annotation isKindOfClass:[MGLPolygon class]]) {
+        return [self fillColorForPolygonAnnotation:(MGLPolygon *)annotation].a ?: 1.0;
+    } else if ([annotation isKindOfClass:[MGLShape class]]) {
+        return [self strokeColorForShapeAnnotation:annotation].a ?: 1.0;
     }
     return 1.0;
 }

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -165,7 +165,7 @@ NS_ASSUME_NONNULL_BEGIN
  specified, the result is undefined.
  
  Opacity may be set by specifying an alpha component. The default alpha value is
- `1.0` and results in a completely opaque shape.
+ `1.0` and results in a completely opaque stroke.
  
  @param mapView The map view rendering the shape annotation.
  @param annotation The annotation being rendered.

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -156,16 +156,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable MGLAnnotationImage *)mapView:(MGLMapView *)mapView imageForAnnotation:(id <MGLAnnotation>)annotation;
 
-/**
- Returns the alpha value to use when rendering a shape annotation.
- 
- A value of 0.0 results in a completely transparent shape. A value of 1.0, the
- default, results in a completely opaque shape.
- 
- @param mapView The map view rendering the shape annotation.
- @param annotation The annotation being rendered.
- @return An alpha value between 0 and 1.0.
- */
 - (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation __attribute__((deprecated("Use -mapView:strokeColorForShapeAnnotation: or -mapView:fillColorForPolygonAnnotation:.")));
 
 /**
@@ -173,6 +163,9 @@ NS_ASSUME_NONNULL_BEGIN
  
  The default stroke color is the selected menu item color. If a pattern color is
  specified, the result is undefined.
+ 
+ Opacity may be set by specifying an alpha component. The default alpha value is
+ `1.0` and results in a completely opaque shape.
  
  @param mapView The map view rendering the shape annotation.
  @param annotation The annotation being rendered.
@@ -185,6 +178,9 @@ NS_ASSUME_NONNULL_BEGIN
  
  The default fill color is the selected menu item color. If a pattern color is
  specified, the result is undefined.
+ 
+ Opacity may be set by specifying an alpha component. The default alpha value is
+ `1.0` and results in a completely opaque shape.
  
  @param mapView The map view rendering the polygon annotation.
  @param annotation The annotation being rendered.

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param annotation The annotation being rendered.
  @return An alpha value between 0 and 1.0.
  */
-- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation __attribute__((deprecated("Use -mapView:strokeColorForShapeAnnotation:.")));
+- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation __attribute__((deprecated("Use -mapView:strokeColorForShapeAnnotation: or -mapView:fillColorForPolygonAnnotation:.")));
 
 /**
  Returns the color to use when rendering the outline of a shape annotation.

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param annotation The annotation being rendered.
  @return An alpha value between 0 and 1.0.
  */
-- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation;
+- (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation __attribute__((deprecated("Use -mapView:strokeColorForShapeAnnotation:.")));
 
 /**
  Returns the color to use when rendering the outline of a shape annotation.


### PR DESCRIPTION
This replaces `-[MGLMapViewDelegate mapView:alphaForShapeAnnotation:]` with the alpha component already provided in `-[MGLMapViewDelegate mapView:strokeColorForShapeAnnotation:]` or `-[MGLMapViewDelegate mapView:fillColorForPolygonAnnotation:]`.

This should better meet developer expectations and simplify our annotation delegate API situation a tiny bit.

/cc @1ec5 @incanus @boundsj