### PR TITLE
added hasRegionResource when the content are not needed by the caller

### DIFF
--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -151,6 +151,15 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getInternal(const Resou
     }
 }
 
+optional<int64_t> OfflineDatabase::hasInternal(const Resource& resource) {
+    if (resource.kind == Resource::Kind::Tile) {
+        assert(resource.tileData);
+        return hasTile(*resource.tileData);
+    } else {
+        return hasResource(resource);
+    }
+}
+
 std::pair<bool, uint64_t> OfflineDatabase::put(const Resource& resource, const Response& response) {
     return putInternal(resource, response, true);
 }
@@ -234,6 +243,20 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getResource(const Resou
     }
 
     return std::make_pair(response, size);
+}
+
+optional<int64_t> OfflineDatabase::hasResource(const Resource& resource) {
+    // clang-format off
+    Statement stmt = getStatement("SELECT length(data) FROM resources WHERE url = ?");
+    // clang-format on
+
+    stmt->bind(1, resource.url);
+    if (!stmt->run()) {
+        return {};
+    }
+
+    optional<int64_t> size = stmt->get<optional<int64_t>>(0);
+    return size;
 }
 
 bool OfflineDatabase::putResource(const Resource& resource,
@@ -384,6 +407,32 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource:
     }
 
     return std::make_pair(response, size);
+}
+
+optional<int64_t> OfflineDatabase::hasTile(const Resource::TileData& tile) {
+    // clang-format off
+    Statement stmt = getStatement(
+        "SELECT length(data) "
+        "FROM tiles "
+        "WHERE url_template = ?1 "
+        "  AND pixel_ratio  = ?2 "
+        "  AND x            = ?3 "
+        "  AND y            = ?4 "
+        "  AND z            = ?5 ");
+    // clang-format on
+
+    stmt->bind(1, tile.urlTemplate);
+    stmt->bind(2, tile.pixelRatio);
+    stmt->bind(3, tile.x);
+    stmt->bind(4, tile.y);
+    stmt->bind(5, tile.z);
+
+    if (!stmt->run()) {
+        return {};
+    }
+
+    optional<int64_t> size = stmt->get<optional<int64_t>>(0);
+    return size;
 }
 
 bool OfflineDatabase::putTile(const Resource::TileData& tile,
@@ -554,6 +603,16 @@ void OfflineDatabase::deleteRegion(OfflineRegion&& region) {
 
 optional<std::pair<Response, uint64_t>> OfflineDatabase::getRegionResource(int64_t regionID, const Resource& resource) {
     auto response = getInternal(resource);
+
+    if (response) {
+        markUsed(regionID, resource);
+    }
+
+    return response;
+}
+
+optional<int64_t> OfflineDatabase::hasRegionResource(int64_t regionID, const Resource& resource) {
+    auto response = hasInternal(resource);
 
     if (response) {
         markUsed(regionID, resource);

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -255,8 +255,7 @@ optional<int64_t> OfflineDatabase::hasResource(const Resource& resource) {
         return {};
     }
 
-    optional<int64_t> size = stmt->get<optional<int64_t>>(0);
-    return size;
+    return stmt->get<optional<int64_t>>(0);
 }
 
 bool OfflineDatabase::putResource(const Resource& resource,
@@ -431,8 +430,7 @@ optional<int64_t> OfflineDatabase::hasTile(const Resource::TileData& tile) {
         return {};
     }
 
-    optional<int64_t> size = stmt->get<optional<int64_t>>(0);
-    return size;
+    return stmt->get<optional<int64_t>>(0);
 }
 
 bool OfflineDatabase::putTile(const Resource::TileData& tile,

--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -46,6 +46,7 @@ public:
 
     // Return value is (response, stored size)
     optional<std::pair<Response, uint64_t>> getRegionResource(int64_t regionID, const Resource&);
+    optional<int64_t> hasRegionResource(int64_t regionID, const Resource&);
     uint64_t putRegionResource(int64_t regionID, const Resource&, const Response&);
 
     OfflineRegionDefinition getRegionDefinition(int64_t regionID);
@@ -80,14 +81,17 @@ private:
     Statement getStatement(const char *);
 
     optional<std::pair<Response, uint64_t>> getTile(const Resource::TileData&);
+    optional<int64_t> hasTile(const Resource::TileData&);
     bool putTile(const Resource::TileData&, const Response&,
                  const std::string&, bool compressed);
 
     optional<std::pair<Response, uint64_t>> getResource(const Resource&);
+    optional<int64_t> hasResource(const Resource&);
     bool putResource(const Resource&, const Response&,
                      const std::string&, bool compressed);
 
     optional<std::pair<Response, uint64_t>> getInternal(const Resource&);
+    optional<int64_t> hasInternal(const Resource&);
     std::pair<bool, uint64_t> putInternal(const Resource&, const Response&, bool evict);
 
     // Return value is true iff the resource was previously unused by any other regions.

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -252,41 +252,31 @@ void OfflineDownload::ensureResource(const Resource& resource,
     auto workRequestsIt = requests.insert(requests.begin(), nullptr);
     *workRequestsIt = util::RunLoop::Get()->invokeCancellable([=]() {
         requests.erase(workRequestsIt);
-
-        if (callback) {
-            optional<std::pair<Response, uint64_t>> offlineResponse =
-                offlineDatabase.getRegionResource(id, resource);
-            if (offlineResponse) {
-                if (callback) {
-                    callback(offlineResponse->first);
-                }
-
-                status.completedResourceCount++;
-                status.completedResourceSize += offlineResponse->second;
-                if (resource.kind == Resource::Kind::Tile) {
-                    status.completedTileCount += 1;
-                    status.completedTileSize += offlineResponse->second;
-                }
-
-                observer->statusChanged(status);
-                continueDownload();
-                return;
+        
+        auto getResourceSizeInDatabase = [&] () -> optional<int64_t> {
+            if (!callback) {
+                return offlineDatabase.hasRegionResource(id, resource);
             }
-        } else {
-            // without callback - only fetch if resource exist and the size of it
-            optional<int64_t> offlineResponse = offlineDatabase.hasRegionResource(id, resource);
-            if (offlineResponse) {
-                status.completedResourceCount++;
-                status.completedResourceSize += *offlineResponse;
-                if (resource.kind == Resource::Kind::Tile) {
-                    status.completedTileCount += 1;
-                    status.completedTileSize += *offlineResponse;
-                }
-
-                observer->statusChanged(status);
-                continueDownload();
-                return;
+            optional<std::pair<Response, uint64_t>> response = offlineDatabase.getRegionResource(id, resource);
+            if (!response) {
+                return {};
             }
+            callback(response->first);
+            return response->second;
+        };
+        
+        optional<int64_t> offlineResponse = getResourceSizeInDatabase();
+        if (offlineResponse) {
+            status.completedResourceCount++;
+            status.completedResourceSize += *offlineResponse;
+            if (resource.kind == Resource::Kind::Tile) {
+                status.completedTileCount += 1;
+                status.completedTileSize += *offlineResponse;
+            }
+
+            observer->statusChanged(status);
+            continueDownload();
+            return;
         }
 
         if (checkTileCountLimit(resource)) {


### PR DESCRIPTION
When a offline download continues with lots of existing tiles, it is too expensive to get the tile and even decompress it to only check if it exist. This add hasRegionResource, hasResource and hasTile to the existing get-methods. This solve one part of #6651 and is a subset of the earlier #6691.