### PR TITLE
fix android style code

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "csscolorparser": "^1.0.2",
     "ejs": "^2.4.1",
     "express": "^4.11.1",
+    "lodash": "^4.16.4",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#98a56d538b11fb331aa67a6d632d6ecd6821b007",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#7f62a4fc9f21e619824d68abbc4b03cbc1685572",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#6df3b27868cc00432197e3fc9c166fdba7067913",

--- a/platform/android/scripts/generate-style-code.js
+++ b/platform/android/scripts/generate-style-code.js
@@ -265,7 +265,7 @@ fs.writeFileSync(
 );
 
 //De-duplicate enum properties before processing jni property templates
-const enumPropertiesDeDup = _(enumProperties).uniq(global.propertyNativeType).value();
+const enumPropertiesDeDup = _(enumProperties).uniqBy(global.propertyNativeType).value();
 
 // JNI Enum property conversion templates
 const enumPropertyHppTypeStringValueTemplate = ejs.compile(fs.readFileSync('platform/android/src/style/conversion/types_string_values.hpp.ejs', 'utf8'), {strict: true});


### PR DESCRIPTION
Fixes #6705

Difference in the way uniq with iteratee is implemented between lodash [3.10.1](https://lodash.com/docs/3.10.1#uniq) and [4.17.4](https://lodash.com/docs/4.16.4#uniqBy) broke the code generation script.

review @mikemorris 