### PR TITLE
[qt] Fix Qt5 bitrise bot

### DIFF
--- a/platform/qt/bitrise-qt5.yml
+++ b/platform/qt/bitrise-qt5.yml
@@ -34,8 +34,9 @@ workflows:
             brew install qt5
             brew link qt5 --force
             brew linkapps qt5
-            ln -s /usr/local/Cellar/qt5/5.6.1-1/mkspecs /usr/local/mkspecs
-            ln -s /usr/local/Cellar/qt5/5.6.1-1/plugins /usr/local/plugins
+            export HOMEBREW_QT5_VERSION=$(brew list --versions qt5 | rev | cut -d' ' -f1 | rev)
+            ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
+            ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
             export BUILDTYPE=Debug
             make qt-app
             make qt-qml-app


### PR DESCRIPTION
Always get the latest installed Qt5 version from Homebrew when creating the `mkspec` and `plugin` symlinks.

Fixes #6712.