### PR TITLE
removed brew cask install android studio instruction

### DIFF
--- a/platform/android/CONTRIBUTING_MACOS.md
+++ b/platform/android/CONTRIBUTING_MACOS.md
@@ -2,11 +2,7 @@
 
 Install Oracle JDK 7+ and Android Studio:
 
-    brew tap caskroom/cask
-    brew install brew-cask
-    brew cask install java
-
-You can download the [latest version of Android Studio here](https://developer.android.com/sdk/index.html). Note that you'll still need to `brew install java` for it to work.
+Head over to [Oracles download page](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to get the Java Development Kit (JDK). Once JDK is installed and setup, you can grab the [latest version of Android Studio here](https://developer.android.com/sdk/index.html) and install it following the on screen instructions.  
 
 Once Android Studio is installed, the [first time it's run it'll ask to install the Android SDK](http://developer.android.com/sdk/installing/index.html?pkg=studio) which you should do.  While doing so in the Android SDK Manager make sure to also select and install the latest versions of "Android Support Repository" and "Android Support Library" from "Extras":
 

--- a/platform/android/CONTRIBUTING_MACOS.md
+++ b/platform/android/CONTRIBUTING_MACOS.md
@@ -1,8 +1,8 @@
 # Contributing to the Android SDK on macOS
 
-Install Oracle JDK 7+ and Android Studio:
+## Install JDK 7+ and Android Studio:
 
-Head over to [Oracles download page](http://www.oracle.com/technetwork/java/javase/downloads/index.html) to get the Java Development Kit (JDK). Once JDK is installed and setup, you can grab the [latest version of Android Studio here](https://developer.android.com/sdk/index.html) and install it following the on screen instructions.  
+ Android Studio requires the Java Development Kit (JDK) which you can [download here](http://www.oracle.com/technetwork/java/javase/downloads/index.html). Once the JDK is installed, you can grab the [latest version of Android Studio here](https://developer.android.com/sdk/index.html) and install it following the on screen instructions.  
 
 Once Android Studio is installed, the [first time it's run it'll ask to install the Android SDK](http://developer.android.com/sdk/installing/index.html?pkg=studio) which you should do.  While doing so in the Android SDK Manager make sure to also select and install the latest versions of "Android Support Repository" and "Android Support Library" from "Extras":
 

--- a/platform/android/CONTRIBUTING_MACOS.md
+++ b/platform/android/CONTRIBUTING_MACOS.md
@@ -6,10 +6,7 @@ Install Oracle JDK 7+ and Android Studio:
     brew install brew-cask
     brew cask install java
 
-    brew cask install android-studio
-
-You can [download Android Studio instead of installing it with Homebrew, but you'll still need to `brew install java`](https://developer.android.com/sdk/index.html)
-for it to work.
+You can download the [latest version of Android Studio here](https://developer.android.com/sdk/index.html). Note that you'll still need to `brew install java` for it to work.
 
 Once Android Studio is installed, the [first time it's run it'll ask to install the Android SDK](http://developer.android.com/sdk/installing/index.html?pkg=studio) which you should do.  While doing so in the Android SDK Manager make sure to also select and install the latest versions of "Android Support Repository" and "Android Support Library" from "Extras":
 


### PR DESCRIPTION
Closes #6722

I agree that the most common/easy way to install Android Studio would be simply going to their website. I made this clear in the instructions by removing the `brew` command and instead suggesting to download from site.

cc: @zugaldia for review