### PR TITLE
[ios, macos] Use swift_name for MGLMultiPoint and subclasses

### DIFF
--- a/platform/darwin/src/MGLMultiPoint.h
+++ b/platform/darwin/src/MGLMultiPoint.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param count The number of items in the `coords` array.
  @return A new multipoint object.
  */
-+ (instancetype)multiPointWithCoordinates:(CLLocationCoordinate2D *)coords count:(NSUInteger)count;
++ (instancetype)multiPointWithCoordinates:(CLLocationCoordinate2D *)coords count:(NSUInteger)count NS_SWIFT_NAME(multiPoint(coordinates:count:));
 
 /**
  The array of coordinates associated with the shape.

--- a/platform/darwin/src/MGLPolygon.h
+++ b/platform/darwin/src/MGLPolygon.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param count The number of items in the `coords` array.
  @return A new polygon object.
  */
-+ (instancetype)polygonWithCoordinates:(CLLocationCoordinate2D *)coords count:(NSUInteger)count;
++ (instancetype)polygonWithCoordinates:(CLLocationCoordinate2D *)coords count:(NSUInteger)count NS_SWIFT_NAME(polygon(coordinates:count:));
 
 /**
  Creates and returns an `MGLPolygon` object from the specified set of

--- a/platform/darwin/src/MGLPolyline.h
+++ b/platform/darwin/src/MGLPolyline.h
@@ -25,8 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param count The number of items in the `coords` array.
  @return A new polyline object.
  */
-+ (instancetype)polylineWithCoordinates:(CLLocationCoordinate2D *)coords
-                                  count:(NSUInteger)count;
++ (instancetype)polylineWithCoordinates:(CLLocationCoordinate2D *)coords count:(NSUInteger)count NS_SWIFT_NAME(polyline(coordinates:count:));
 
 @end
 


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-gl-native/pull/6524 we added a class factory method to `MGLMultiPoint`. Since `MGLMultiPoint` is a superclass of `MGLPolyline` and `MGLPolygon`, when [modern Swift 3 translation rules](https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md) are applied, the result is ambiguous class factory method names for MultiPoint -> PolyLine and Polygon.

This change decorates the class factory methods with `NS_SWIFT_NAME({shape_name}(coordinates:count:))` so that, at the call site in a modern Swift app, we can write:

```Swift
MGLPolyline.polyline(coordinates: &coordinates, count: UInt(coordinates.count))
```

cc @friedbunny @1ec5