### PR TITLE
[ios, macos] Make feature attributes and identifier writable

### DIFF
--- a/platform/darwin/src/MGLFeature.h
+++ b/platform/darwin/src/MGLFeature.h
@@ -18,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
  using `-[MGLMapView visibleFeaturesAtPoint:]` and related methods. Each feature
  object associates a shape with an identifier and attributes as specified by the
  source. Like ordinary `MGLAnnotation` objects, some kinds of `MGLFeature`
- objects can also be added to a map view using `-[MGLMapView addAnnotations:]`
- and related methods.
+ objects can also be added to a map view using an `MGLGeoJSONSource` or
+ `-[MGLMapView addAnnotations:]` and related methods.
  */
 @protocol MGLFeature <MGLAnnotation>
 
@@ -48,7 +48,11 @@ NS_ASSUME_NONNULL_BEGIN
  For details about the identifiers used in most Mapbox-provided styles, consult
  the
  <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets</a>
- layer reference.
+ layer reference. Note that while it is possible to change this value on feature 
+ instances obtained from `-[MGLMapView visibleFeaturesAtPoint:]` and related 
+ methods, there will be no effect on the map. Setting this value can be useful
+ when the feature instance is used to initialize an `MGLGeoJSONSource` and that 
+ source is added to the map and styled.
  */
 @property (nonatomic, copy, nullable) id identifier;
 
@@ -79,7 +83,11 @@ NS_ASSUME_NONNULL_BEGIN
  <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets</a>
  and
  <a href="https://www.mapbox.com/vector-tiles/mapbox-terrain/">Mapbox Terrain</a>
- layer references.
+ layer references. Note that while it is possible to change this value on feature
+ instances obtained from `-[MGLMapView visibleFeaturesAtPoint:]` and related
+ methods, there will be no effect on the map. Setting this value can be useful
+ when the feature instance is used to initialize an `MGLGeoJSONSource` and that
+ source is added to the map and styled.
  */
 @property (nonatomic, copy) NS_DICTIONARY_OF(NSString *, id) *attributes;
 

--- a/platform/darwin/src/MGLFeature.h
+++ b/platform/darwin/src/MGLFeature.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets</a>
  layer reference.
  */
-@property (nonatomic, copy, nullable, readonly) id identifier;
+@property (nonatomic, copy, nullable) id identifier;
 
 /**
  A dictionary of attributes for this feature specified by the
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
  <a href="https://www.mapbox.com/vector-tiles/mapbox-terrain/">Mapbox Terrain</a>
  layer references.
  */
-@property (nonatomic, copy, readonly) NS_DICTIONARY_OF(NSString *, id) *attributes;
+@property (nonatomic, copy) NS_DICTIONARY_OF(NSString *, id) *attributes;
 
 /**
  Returns the feature attribute for the given attribute name.

--- a/platform/darwin/src/MGLFeature_Private.h
+++ b/platform/darwin/src/MGLFeature_Private.h
@@ -26,9 +26,6 @@ NS_DICTIONARY_OF(NSString *, id) *NSDictionaryFeatureForGeometry(NSDictionary *g
 
 @protocol MGLFeaturePrivate <MGLFeature>
 
-@property (nonatomic, copy, nullable, readwrite) id identifier;
-@property (nonatomic, copy, readwrite) NS_DICTIONARY_OF(NSString *, id) *attributes;
-
 - (mbgl::Feature)mbglFeature;
 
 @end

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -31,6 +31,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * A source’s tiles are no longer rendered when the map is outside the source’s supported zoom levels. ([#6345](https://github.com/mapbox/mapbox-gl-native/pull/6345))
 * Improved style parsing performance. ([#6170](https://github.com/mapbox/mapbox-gl-native/pull/6170))
 * Improved feature querying performance. ([#6514](https://github.com/mapbox/mapbox-gl-native/pull/6514))
+* A feature's `identifier` and `attributes` properties can now be mutated. ([#6728](https://github.com/mapbox/mapbox-gl-native/pull/6728))
 
 ### User location
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -62,6 +62,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsRuntimeStylingRows) {
     MBXSettingsRuntimeStylingFilteredLines,
     MBXSettingsRuntimeStylingNumericFilteredFill,
     MBXSettingsRuntimeStylingStyleQuery,
+    MBXSettingsRuntimeStylingFeatureSource,
 };
 
 typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
@@ -306,6 +307,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                 @"Style Lines With Filter",
                 @"Style Fill With Numeric Filter",
                 @"Style Query For GeoJSON",
+                @"Style Feature",
             ]];
             break;
         case MBXSettingsMiscellaneous:
@@ -433,6 +435,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                     break;
                 case MBXSettingsRuntimeStylingStyleQuery:
                     [self styleQuery];
+                    break;
+                case MBXSettingsRuntimeStylingFeatureSource:
+                    [self styleFeature];
                     break;
                 default:
                     NSAssert(NO, @"All runtime styling setting rows should be implemented");
@@ -826,6 +831,59 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         fillLayer.fillOpacity = [MGLStyleConstantValue<NSNumber *> valueWithRawValue:@0.5];
         [self.mapView.style addLayer:fillLayer];
     });
+}
+
+- (void)styleFeature
+{
+    self.mapView.zoomLevel = 10;
+    self.mapView.centerCoordinate = CLLocationCoordinate2DMake(51.068585180672635, -114.06074523925781);
+    
+    CLLocationCoordinate2D leafCoords[] = {
+        CLLocationCoordinate2DMake(50.9683733218221,-114.07035827636719),
+        CLLocationCoordinate2DMake(51.02325750523972,-114.06967163085938),
+        CLLocationCoordinate2DMake(51.009434536947786,-114.14245605468749),
+        CLLocationCoordinate2DMake(51.030599281184124,-114.12597656249999),
+        CLLocationCoordinate2DMake(51.060386316691016,-114.21043395996094),
+        CLLocationCoordinate2DMake(51.063838646941576,-114.17816162109375),
+        CLLocationCoordinate2DMake(51.08152779888779,-114.19876098632812),
+        CLLocationCoordinate2DMake(51.08066507029602,-114.16854858398438),
+        CLLocationCoordinate2DMake(51.09662294502995,-114.17472839355469),
+        CLLocationCoordinate2DMake(51.07764539352731,-114.114990234375),
+        CLLocationCoordinate2DMake(51.13670896949613,-114.12391662597656),
+        CLLocationCoordinate2DMake(51.13369295212583,-114.09576416015624),
+        CLLocationCoordinate2DMake(51.17546878815025,-114.07585144042969),
+        CLLocationCoordinate2DMake(51.140155605265896,-114.04632568359375),
+        CLLocationCoordinate2DMake(51.15049396880196,-114.01542663574219),
+        CLLocationCoordinate2DMake(51.088860342359965,-114.00924682617186),
+        CLLocationCoordinate2DMake(51.12205789681453,-113.94813537597656),
+        CLLocationCoordinate2DMake(51.106539930027225,-113.94882202148438),
+        CLLocationCoordinate2DMake(51.117747873223344,-113.92616271972656),
+        CLLocationCoordinate2DMake(51.10093493903458,-113.92616271972656),
+        CLLocationCoordinate2DMake(51.10697105503078,-113.90625),
+        CLLocationCoordinate2DMake(51.09144802136697,-113.9117431640625),
+        CLLocationCoordinate2DMake(51.04916446529361,-113.97010803222655),
+        CLLocationCoordinate2DMake(51.045279344649146,-113.9398956298828),
+        CLLocationCoordinate2DMake(51.022825599852496,-114.06211853027344),
+        CLLocationCoordinate2DMake(51.045279344649146,-113.9398956298828),
+        CLLocationCoordinate2DMake(51.022825599852496,-114.06211853027344),
+        CLLocationCoordinate2DMake(51.022825599852496,-114.06280517578125),
+        CLLocationCoordinate2DMake(50.968805734317804,-114.06280517578125),
+        CLLocationCoordinate2DMake(50.9683733218221,-114.07035827636719),
+    };
+    NSUInteger coordsCount = sizeof(leafCoords) / sizeof(leafCoords[0]);
+    
+    MGLPolygonFeature *feature = [MGLPolygonFeature polygonWithCoordinates:leafCoords count:coordsCount];
+    feature.identifier = @"leaf-feature";
+    feature.attributes = @{@"color": @"red"};
+    
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"leaf-source" features:@[feature] options:nil];
+    [self.mapView.style addSource:source];
+    
+    MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"leaf-fill-layer" source:source];
+    layer.predicate = [NSPredicate predicateWithFormat:@"color = %@", @"red"];
+    MGLStyleValue *fillColor = [MGLStyleValue<UIColor *> valueWithRawValue:[UIColor redColor]];
+    layer.fillColor = fillColor;
+    [self.mapView.style addLayer:layer];
 }
 
 - (IBAction)startWorldTour

--- a/platform/ios/test/MGLGeoJSONSourceTests.mm
+++ b/platform/ios/test/MGLGeoJSONSourceTests.mm
@@ -10,12 +10,6 @@
 @interface MGLGeoJSONSourceTests : XCTestCase
 @end
 
-@interface MGLPolygonFeature (Test)
-
-@property (nonatomic, copy, readwrite) NS_DICTIONARY_OF(NSString *, id) *attributes;
-
-@end
-
 @implementation MGLGeoJSONSourceTests
 
 - (void)testMGLGeoJSONSourceWithOptions {

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fixed crashes that could occur when loading a malformed stylesheet. ([#5736](https://github.com/mapbox/mapbox-gl-native/pull/5736))
 * Improved style parsing performance. ([#6170](https://github.com/mapbox/mapbox-gl-native/pull/6170))
 * Improved feature querying performance. ([#6514](https://github.com/mapbox/mapbox-gl-native/pull/6514))
+* A feature's `identifier` and `attributes` properties can now be mutated. ([#6728](https://github.com/mapbox/mapbox-gl-native/pull/6728))
 
 ### Annotations
 


### PR DESCRIPTION
Instances of MGLFeature subclasses can now have their attributes and identifier properties mutated.

Follow up to https://github.com/mapbox/mapbox-gl-native/issues/6302

cc @1ec5 