### PR TITLE
Update docs on gradle configuration

### DIFF
--- a/platform/android/CONTRIBUTING_MACOS.md
+++ b/platform/android/CONTRIBUTING_MACOS.md
@@ -46,6 +46,15 @@ export ANDROID_HOME=/<installation location>/android-sdk-macosx
 This environment variable configuration should go into a file that's read on
 your shell's startup, like `~/.profile`.
 
+## Speeding up gradle builds
+
+To optimise you development machine for faster gradle builds create the following `/Users/name/.gradle/gradle.properties`  file:
+
+```
+org.gradle.daemon=true
+org.gradle.jvmargs=-Xmx3072M
+```
+
 ## Running The TestApp
 
 In order to run the TestApp on an emulator or device the Core GL portion needs to built first.  Core GL is the common C++ based OpenGL engine that powers the maps for iOS, Android, and Qt in the project.  To build it, open Terminal and run the following commands from the root of the `mapbox-gl-native` source code

--- a/platform/android/MapboxGLAndroidSDK/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDK/gradle.properties
@@ -20,6 +20,3 @@ ANDROID_BUILD_SDK_VERSION=23
 POM_NAME=Mapbox Android SDK
 POM_ARTIFACT_ID=mapbox-android-sdk
 POM_PACKAGING=aar
-
-# allows gradle to use more memory
-org.gradle.jvmargs=-Xmx2048M

--- a/platform/android/MapboxGLAndroidSDKTestApp/gradle.properties
+++ b/platform/android/MapboxGLAndroidSDKTestApp/gradle.properties
@@ -1,2 +1,0 @@
-# allows gradle to use more memory
-org.gradle.jvmargs=-Xmx2048M

--- a/platform/android/MapboxGLAndroidSDKWearTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKWearTestApp/build.gradle
@@ -30,6 +30,7 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
CI doesn't apply heap size configuration from gradle.properties, setting in build.gradle instead.

eg. still seeing:

> To run dex in process, the Gradle daemon needs a larger heap.
It currently has approximately 1662 MB.
For faster builds, increase the maximum heap size for the Gradle daemon to more than 2048 MB.
To do this set org.gradle.jvmargs=-Xmx2048M in the project gradle.properties.
For more information see https://docs.gradle.org/current/userguide/build_environment.html

Even though we applied the suggestion here in #6678.

Review @ivovandongen 