### PR TITLE
[android] - add package-info.java for net package

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/package-info.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/net/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains the Mapbox Maps Android Network API classes.
+ */
+package com.mapbox.mapboxsdk.net;


### PR DESCRIPTION
Adds package-info.java for the net package. 
Needed for javadoc table overview on `/index.html`.

![screen shot 2016-10-18 at 14 58 41](https://cloud.githubusercontent.com/assets/2151639/19478813/4712865e-9544-11e6-9f83-50d22ec0a05b.png)

Review @cammace 