### PR TITLE
Raise correct style layer misuse exception

### DIFF
--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -176,7 +176,7 @@ static NSURL *MGLStyleURL_emerald;
         [NSException raise:NSInvalidArgumentException format:
          @"The style layer %@ cannot be added to the style. "
          @"Make sure the style layer was created as a member of a concrete subclass of MGLStyleLayer.",
-         NSStringFromClass(self)];
+         layer];
     }
 
     self.mapView.mbglMap->addLayer(std::unique_ptr<mbgl::style::Layer>(layer.layer));
@@ -189,14 +189,14 @@ static NSURL *MGLStyleURL_emerald;
                     format:
          @"The style layer %@ cannot be added to the style. "
          @"Make sure the style layer was created as a member of a concrete subclass of MGLStyleLayer.",
-         NSStringFromClass(layer)];
+         layer];
     }
     if (!otherLayer.layer) {
         [NSException raise:NSInvalidArgumentException
                     format:
          @"A style layer cannot be placed before %@ in the style. "
-         @"Make sure the style layer was created as a member of a concrete subclass of MGLStyleLayer.",
-         NSStringFromClass(otherLayer)];
+         @"Make sure otherLayer was obtained using -[MGLStyle layerWithIdentifier:].",
+         otherLayer];
     }
 
     const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};

--- a/platform/darwin/src/MGLStyleLayer.mm
+++ b/platform/darwin/src/MGLStyleLayer.mm
@@ -3,6 +3,12 @@
 
 #include <mbgl/style/layer.hpp>
 
+@interface MGLStyleLayer ()
+
+@property (nonatomic) mbgl::style::Layer *layer;
+
+@end
+
 @implementation MGLStyleLayer
 
 - (instancetype)initWithIdentifier:(NSString *)identifier


### PR DESCRIPTION
Implement the layer property on MGLStyleLayer itself, where it’s declared, so that the check for an abstract style layer doesn’t itself raise an exception. The concrete style layer classes still declare their own layers as covariant properties, although those properties aren’t actually used anywhere.

Fixes #6736.

/cc @boundsj @bsudekum