### PR TITLE
[core] cache offline resources in memory

### DIFF
--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -8,6 +8,7 @@
 #include <mbgl/util/mapbox.hpp>
 
 #include <unordered_map>
+#include <list>
 #include <memory>
 #include <string>
 
@@ -89,6 +90,8 @@ private:
     optional<int64_t> hasResource(const Resource&);
     bool putResource(const Resource&, const Response&,
                      const std::string&, bool compressed);
+    std::unordered_map<std::string, Response> resourceCache;
+    std::list<std::string> resourceCacheKeys;
 
     optional<std::pair<Response, uint64_t>> getInternal(const Resource&);
     optional<int64_t> hasInternal(const Resource&);


### PR DESCRIPTION
When working with lots of offline packs, OfflineDatabase::getResource is a bottleneck. The same resources are requested a lot of times. This solve one part of #6651.

I tried a similar pull-request before in #6691, but it did not have a limit on the memory usage and it was coupled with some other performance improvements. I hope this one is a bit better, @jfirebaugh.