### PR TITLE
[ios] Fix deploy script temp directory creation

### DIFF
--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -43,7 +43,7 @@ buildPackageStyle() {
         github-release upload \
             --tag "ios-v${PUBLISH_VERSION}" \
             --name ${file_name} \
-            --file "${BINARY_DIRECTORY}/${file_name}"
+            --file "${BINARY_DIRECTORY}/${file_name}" > /dev/null
     fi        
 }
 
@@ -57,9 +57,6 @@ PUBLISH_VERSION=
 BINARY_DIRECTORY=${BINARY_DIRECTORY:-build/ios/deploy}
 GITHUB_RELEASE=${GITHUB_RELEASE:-true}
 PUBLISH_PRE_FLAG=''
-
-rm -rf ${BINARY_DIRECTORY}
-mkdir -p ${BINARY_DIRECTORY}
 
 if [[ ${GITHUB_RELEASE} = "true" ]]; then
     GITHUB_RELEASE=true # Assign bool, not just a string
@@ -98,6 +95,7 @@ git checkout ${VERSION_TAG}
 step "Deploying version ${PUBLISH_VERSION}…"
 
 make clean && make distclean
+mkdir -p ${BINARY_DIRECTORY}
 
 if [[ "${GITHUB_RELEASE}" == true ]]; then
     step "Create GitHub release…"
@@ -116,4 +114,4 @@ buildPackageStyle "iframework" "symbols-dynamic"
 buildPackageStyle "iframework SYMBOLS=NO" "dynamic"
 buildPackageStyle "ifabric" "fabric"
 
-step "Finished deploying ${PUBLISH_VERSION}"
+step "Finished deploying ${PUBLISH_VERSION} in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"


### PR DESCRIPTION
Fixes `build/ios/deploy` directory creation. This directory was being created but then immediately blown away by `make clean`.

This PR also includes:

#### Ignore stdout from github-release uploads
Try to avoid `github-release` sometimes failing with:
```
* Uploading mapbox-ios-sdk-3.4.0-beta.1-symbols.zip to GitHub
./platform/ios/scripts/deploy-packages.sh: line 119: unexpected EOF while looking for matching `”’
```

#### Add execution time to “finished” message
```
* Finished deploying 3.4.0-beta.1 in 5 minutes and 20 seconds
```

/cc @boundsj