### PR TITLE
[core] - initialise frame_history with an out of range zoom value

### DIFF
--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -20,6 +20,7 @@ void FrameHistory::record(const TimePoint& now, float zoom, const Duration& dura
         for (int16_t z = 0; z <= zoomIndex; z++) {
             opacities[z] = 255u;
         }
+        previousTime = now;
         firstFrame = false;
     }
 

--- a/src/mbgl/renderer/frame_history.hpp
+++ b/src/mbgl/renderer/frame_history.hpp
@@ -30,7 +30,7 @@ private:
     std::array<uint8_t, 256> changeOpacities;
     std::array<uint8_t, 256> opacities;
 
-    int16_t previousZoomIndex = 0;
+    int16_t previousZoomIndex = -1;
     TimePoint previousTime = TimePoint::min();
     TimePoint time = TimePoint::min();
     bool firstFrame = true;


### PR DESCRIPTION
Closes #6667.

This PR initialises `previousZoomIndex` with -1 instead of 0 in `frame_history.cpp`. Solves the issue that `painter->needsAnimation()` keeps on returning true when a map is initialised with the default camera location. This currently results in constantly rerendering the map.

Below you can see it stops using cpu resources vs [the before screenshot](https://cloud.githubusercontent.com/assets/2151639/19302211/81c444c6-9063-11e6-8dd7-5d0236460a6f.png). 

![screen shot 2016-10-19 at 10 02 29](https://cloud.githubusercontent.com/assets/2151639/19510602/3bac2630-95e4-11e6-98a7-e513dd9f23f4.png)

More information in #6667.

Review @kkaefer
