### PR TITLE
[glfw] add map change callback methods to glfw_view

### DIFF
--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -42,6 +42,9 @@ public:
 
     void run();
     void report(float duration);
+    
+    void setMapChangeCallback(std::function<void(mbgl::MapChange)> callback);
+    void notifyMapChange(mbgl::MapChange change) override;
 
 private:
     mbgl::Color makeRandomColor() const;
@@ -61,6 +64,8 @@ private:
 
     mbgl::AnnotationIDs annotationIDs;
     std::vector<std::string> spriteIDs;
+
+    std::function<void(mbgl::MapChange)> mapChangeCallback;
 
 private:
     bool fullscreen = false;

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -508,6 +508,16 @@ void GLFWView::setWindowTitle(const std::string& title) {
     glfwSetWindowTitle(window, (std::string { "Mapbox GL: " } + title).c_str());
 }
 
+void GLFWView::setMapChangeCallback(std::function<void(mbgl::MapChange)> callback) {
+    this->mapChangeCallback = callback;
+}
+
+void GLFWView::notifyMapChange(mbgl::MapChange change) {
+    if (mapChangeCallback) {
+        mapChangeCallback(change);
+    }
+}
+
 namespace mbgl {
 namespace platform {
 


### PR DESCRIPTION
Adds (registration of) a mapchange callback handler.

cc @brunoabinader 