### PR TITLE
[6749] fix annotation tap detection (smaller area for annotation imag…

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -53,6 +53,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that could reset user-added transformations on annotation views. ([#6166](https://github.com/mapbox/mapbox-gl-native/pull/6166))
 * Fixed an issue that caused an annotation view to disappear if it isn’t created using the annotation view reuse queue. ([#6485](https://github.com/mapbox/mapbox-gl-native/pull/6485))
 * Deprecated `-[MGLMapViewDelegate mapView:alphaForShapeAnnotation:]` in favor of specifying an alpha component via `-[MGLMapViewDelegate mapView:strokeColorForShapeAnnotation:]` or `-[MGLMapViewDelegate mapView:fillColorForPolygonAnnotation:]`. ([#6706](https://github.com/mapbox/mapbox-gl-native/pull/6706))
+* Fixed annotation tap detection (native touch detection on annotation views). ([#6749](https://github.com/mapbox/mapbox-gl-native/issues/6749))
 
 ### Networking and offline maps
 


### PR DESCRIPTION
I know tap detection is quite sensitive, my tests show it works well on different annotation images and views sizes, with offsets.