### PR TITLE
reduce public header code for shared color type

### DIFF
--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -18,25 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Accessing the Paint Attributes
 
-#if TARGET_OS_IPHONE
 /**
  The color with which the background will be drawn.
  
- The default value of this property is an `MGLStyleValue` object containing `UIColor.blackColor`. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the color black. Set this property to `nil` to reset it to the default value.
 
  This property is only applied to the style if `backgroundPattern` is set to `nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *backgroundColor;
-#else
-/**
- The color with which the background will be drawn.
- 
- The default value of this property is an `MGLStyleValue` object containing `NSColor.blackColor`. Set this property to `nil` to reset it to the default value.
-
- This property is only applied to the style if `backgroundPattern` is set to `nil`. Otherwise, it is ignored.
- */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *backgroundColor;
-#endif
 
 /**
  Name of image in sprite to use for drawing an image background. For seamless patterns, image width and height must be a factor of two (2, 4, 8, ..., 512).

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -57,21 +57,12 @@ typedef NS_ENUM(NSUInteger, MGLCirclePitchScale) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleRadius;
 
-#if TARGET_OS_IPHONE
 /**
  The fill color of the circle.
  
- The default value of this property is an `MGLStyleValue` object containing `UIColor.blackColor`. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the color black. Set this property to `nil` to reset it to the default value.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *circleColor;
-#else
-/**
- The fill color of the circle.
- 
- The default value of this property is an `MGLStyleValue` object containing `NSColor.blackColor`. Set this property to `nil` to reset it to the default value.
- */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *circleColor;
-#endif
 
 /**
  Amount to blur the circle. 1 blurs the circle such that only the centerpoint is full opacity.

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -46,25 +46,14 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslateAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *fillOpacity;
 
-#if TARGET_OS_IPHONE
 /**
  The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
  
- The default value of this property is an `MGLStyleValue` object containing `UIColor.blackColor`. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the color black. Set this property to `nil` to reset it to the default value.
 
  This property is only applied to the style if `fillPattern` is set to `nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *fillColor;
-#else
-/**
- The color of the filled part of this layer. This color can be specified as `rgba` with an alpha component and the color's opacity will not affect the opacity of the 1pt stroke, if it is used.
- 
- The default value of this property is an `MGLStyleValue` object containing `NSColor.blackColor`. Set this property to `nil` to reset it to the default value.
-
- This property is only applied to the style if `fillPattern` is set to `nil`. Otherwise, it is ignored.
- */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *fillColor;
-#endif
 
 /**
  The outline color of the fill. Matches the value of `fillColor` if unspecified.

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -113,25 +113,14 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineOpacity;
 
-#if TARGET_OS_IPHONE
 /**
  The color with which the line will be drawn.
  
- The default value of this property is an `MGLStyleValue` object containing `UIColor.blackColor`. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the color black. Set this property to `nil` to reset it to the default value.
 
  This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *lineColor;
-#else
-/**
- The color with which the line will be drawn.
- 
- The default value of this property is an `MGLStyleValue` object containing `NSColor.blackColor`. Set this property to `nil` to reset it to the default value.
-
- This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
- */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *lineColor;
-#endif
 
 /**
  The geometry's offset. Values are [x, y] where negatives indicate left and up, respectively.

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -563,45 +563,23 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconOpacity;
 
-#if TARGET_OS_IPHONE
 /**
  The color of the icon. This can only be used with sdf icons.
  
- The default value of this property is an `MGLStyleValue` object containing `UIColor.blackColor`. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the color black. Set this property to `nil` to reset it to the default value.
 
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *iconColor;
-#else
-/**
- The color of the icon. This can only be used with sdf icons.
- 
- The default value of this property is an `MGLStyleValue` object containing `NSColor.blackColor`. Set this property to `nil` to reset it to the default value.
 
- This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
- */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *iconColor;
-#endif
-
-#if TARGET_OS_IPHONE
 /**
  The color of the icon's halo. Icon halos can only be used with SDF icons.
  
- The default value of this property is an `MGLStyleValue` object containing `UIColor.clearColor`. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the clear color. Set this property to `nil` to reset it to the default value.
 
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *iconHaloColor;
-#else
-/**
- The color of the icon's halo. Icon halos can only be used with SDF icons.
- 
- The default value of this property is an `MGLStyleValue` object containing `NSColor.clearColor`. Set this property to `nil` to reset it to the default value.
-
- This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
- */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *iconHaloColor;
-#endif
 
 /**
  Distance of halo to the icon outline.
@@ -654,45 +632,23 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textOpacity;
 
-#if TARGET_OS_IPHONE
 /**
  The color with which the text will be drawn.
  
- The default value of this property is an `MGLStyleValue` object containing `UIColor.blackColor`. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the color black. Set this property to `nil` to reset it to the default value.
 
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *textColor;
-#else
-/**
- The color with which the text will be drawn.
- 
- The default value of this property is an `MGLStyleValue` object containing `NSColor.blackColor`. Set this property to `nil` to reset it to the default value.
 
- This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
- */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *textColor;
-#endif
-
-#if TARGET_OS_IPHONE
 /**
  The color of the text's halo, which helps it stand out from backgrounds.
  
- The default value of this property is an `MGLStyleValue` object containing `UIColor.clearColor`. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the clear color. Set this property to `nil` to reset it to the default value.
 
  This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *textHaloColor;
-#else
-/**
- The color of the text's halo, which helps it stand out from backgrounds.
- 
- The default value of this property is an `MGLStyleValue` object containing `NSColor.clearColor`. Set this property to `nil` to reset it to the default value.
-
- This property is only applied to the style if `textField` is non-`nil`. Otherwise, it is ignored.
- */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *textHaloColor;
-#endif
 
 /**
  Distance of halo to the font outline. Max text halo width is 1/4 of the font-size.


### PR DESCRIPTION
I don't feel super strongly about this, but we could cut down some public API code by merging things like this, leveraging the work in https://github.com/mapbox/mapbox-gl-native/pull/6637. 

Similarly, we could do the same for `UIEdgeInsets` and `NSEdgeInsets`. Speaking of, we call it `MGLEdgeInsetsFromNSEdgeInsets` on both platforms despite taking a `UIEdgeInsets` argument on iOS. 

/cc @1ec5 @friedbunny 
