### PR TITLE
Fix problems with map view UI layout constraints

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -757,7 +757,7 @@ public:
     [self.compassViewConstraints addObject:
      [NSLayoutConstraint constraintWithItem:compassContainer
                                   attribute:NSLayoutAttributeTop
-                                  relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                  relatedBy:NSLayoutRelationEqual
                                      toItem:self
                                   attribute:NSLayoutAttributeTop
                                  multiplier:1
@@ -800,7 +800,7 @@ public:
     [self.logoViewConstraints addObject:
      [NSLayoutConstraint constraintWithItem:self
                                   attribute:NSLayoutAttributeBottom
-                                  relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                  relatedBy:NSLayoutRelationEqual
                                      toItem:self.logoView
                                   attribute:NSLayoutAttributeBaseline
                                  multiplier:1
@@ -824,7 +824,7 @@ public:
     [self.attributionButtonConstraints addObject:
      [NSLayoutConstraint constraintWithItem:self
                                   attribute:NSLayoutAttributeBottom
-                                  relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                  relatedBy:NSLayoutRelationEqual
                                      toItem:self.attributionButton
                                   attribute:NSLayoutAttributeBaseline
                                  multiplier:1

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -754,14 +754,18 @@ public:
     [constraintParentView removeConstraints:self.compassViewConstraints];
     [self.compassViewConstraints removeAllObjects];
 
+    // Work around an apparent iOS 10 bug where the top layout guide isn't always updated
+    // unless there's an active constraint against it. This means we cannot constrain
+    // directly to the top of self — instead, we must constrain to the top layout guide's
+    // bottom offset, then subtract that value from contentInset.
     [self.compassViewConstraints addObject:
      [NSLayoutConstraint constraintWithItem:compassContainer
                                   attribute:NSLayoutAttributeTop
                                   relatedBy:NSLayoutRelationEqual
-                                     toItem:self
-                                  attribute:NSLayoutAttributeTop
+                                     toItem:viewController.topLayoutGuide
+                                  attribute:NSLayoutAttributeBottom
                                  multiplier:1
-                                   constant:5 + self.contentInset.top]];
+                                   constant:5 + self.contentInset.top - viewController.topLayoutGuide.length]];
 
     [self.compassViewConstraints addObject:
      [NSLayoutConstraint constraintWithItem:self


### PR DESCRIPTION
This addresses two problems with the map view’s UI elements (compass, attribution button, logo):

### Fixes ambiguous constraints

Fixes #5549.

By declaring that the vertical constraint relationships were `NSLayoutRelationGreaterThanOrEqual`, this meant that there were many positions that could potentially satisfy the constraints. This is not what we want (and not what was being shown) — the vertical placement of these views should be `NSLayoutRelationEqual` to the exact values we calculate.

### Fixes iOS 10 giving us incorrect `topLayoutGuide` values

Fixes #6755, where the vertical offset of the compass would be incorrect after device rotation.

Compared to iOS 9, iOS 10 is giving incorrect values for `topLayoutGuide` when the device is rotated. For reasons I don’t understand, re-adding a direct constraint against `topLayoutGuide` fixes the issue. This walks back a small part of #5671, where our accounting for layout guides moved entirely to `-adjustContentInset`.

This fix isn’t great, but it’s backwards compatible and it works.

/cc @frederoni @1ec5
