### PR TITLE
Mutable geojson source

### DIFF
--- a/platform/darwin/src/MGLGeoJSONSource.h
+++ b/platform/darwin/src/MGLGeoJSONSource.h
@@ -109,7 +109,7 @@ extern NSString * const MGLGeoJSONToleranceOption;
  is set to `nil`. This property is unavailable until the receiver is passed into
  `-[MGLStyle addSource]`.
  */
-@property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLFeature>) *features;
+@property (nonatomic, nullable) NS_ARRAY_OF(id <MGLFeature>) *features;
 
 /**
  A GeoJSON representation of the contents of the source.

--- a/platform/darwin/src/MGLGeoJSONSource.h
+++ b/platform/darwin/src/MGLGeoJSONSource.h
@@ -123,7 +123,7 @@ extern NSString * const MGLGeoJSONToleranceOption;
  This property is unavailable until the receiver is passed 
  into `-[MGLStyle addSource]`.
  */
-@property (nonatomic, readonly, nullable, copy) NSData *geoJSONData;
+@property (nonatomic, nullable, copy) NSData *geoJSONData;
 
 /**
  The URL to the GeoJSON document that specifies the contents of the source.
@@ -131,7 +131,7 @@ extern NSString * const MGLGeoJSONToleranceOption;
  If the receiver was initialized using `-initWithIdentifier:geoJSONData:options`, this
  property is set to `nil`.
  */
-@property (nonatomic, readonly, nullable) NSURL *URL;
+@property (nonatomic, nullable) NSURL *URL;
 
 
 @end

--- a/platform/darwin/src/MGLGeoJSONSource.mm
+++ b/platform/darwin/src/MGLGeoJSONSource.mm
@@ -7,6 +7,7 @@
 
 #include <mbgl/style/sources/geojson_source.hpp>
 
+
 NSString * const MGLGeoJSONClusterOption = @"MGLGeoJSONCluster";
 NSString * const MGLGeoJSONClusterRadiusOption = @"MGLGeoJSONClusterRadius";
 NSString * const MGLGeoJSONClusterMaximumZoomLevelOption = @"MGLGeoJSONClusterMaximumZoomLevel";
@@ -100,6 +101,28 @@ NSString * const MGLGeoJSONToleranceOption = @"MGLGeoJSONOptionsClusterTolerance
     {
         [NSException raise:@"Value not handled" format:@"%@ is not an NSNumber", value];
     }
+}
+
+- (void)setGeoJSONData:(NSData *)geoJSONData
+{
+    _geoJSONData = geoJSONData;
+    
+    NSString *string = [[NSString alloc] initWithData:_geoJSONData encoding:NSUTF8StringEncoding];
+    const auto geojson = mapbox::geojson::parse(string.UTF8String).get<mapbox::geojson::feature_collection>();
+    
+    const auto geoJSONSource = reinterpret_cast<mbgl::style::GeoJSONSource *>(self.source);
+    geoJSONSource->setGeoJSON(geojson);
+    
+    _features = MGLFeaturesFromMBGLFeatures(geojson);
+}
+
+- (void)setURL:(NSURL *)URL
+{
+    _URL = URL;
+    
+    NSURL *url = self.URL.mgl_URLByStandardizingScheme;
+    const auto geoJSONSource = reinterpret_cast<mbgl::style::GeoJSONSource *>(self.source);
+    geoJSONSource->setURL(url.absoluteString.UTF8String);
 }
 
 - (std::unique_ptr<mbgl::style::Source>)mbglSource

--- a/platform/darwin/src/MGLGeoJSONSource.mm
+++ b/platform/darwin/src/MGLGeoJSONSource.mm
@@ -125,6 +125,20 @@ NSString * const MGLGeoJSONToleranceOption = @"MGLGeoJSONOptionsClusterTolerance
     geoJSONSource->setURL(url.absoluteString.UTF8String);
 }
 
+- (void)setFeatures:(NSArray *)features
+{
+    mbgl::FeatureCollection featureCollection;
+    featureCollection.reserve(features.count);
+    for (id <MGLFeaturePrivate> feature in features) {
+        featureCollection.push_back([feature mbglFeature]);
+    }
+    const auto geojson = mbgl::GeoJSON{featureCollection};
+    const auto geoJSONSource = reinterpret_cast<mbgl::style::GeoJSONSource *>(self.source);
+    geoJSONSource->setGeoJSON(geojson);
+    
+    _features = MGLFeaturesFromMBGLFeatures(featureCollection);
+}
+
 - (std::unique_ptr<mbgl::style::Source>)mbglSource
 {
     auto source = std::make_unique<mbgl::style::GeoJSONSource>(self.identifier.UTF8String, self.geoJSONOptions);

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -65,6 +65,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsRuntimeStylingRows) {
     MBXSettingsRuntimeStylingFeatureSource,
     MBXSettingsRuntimeStylingUpdateGeoJSONSourceData,
     MBXSettingsRuntimeStylingUpdateGeoJSONSourceURL,
+    MBXSettingsRuntimeStylingUpdateGeoJSONSourceFeatures,
 };
 
 typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
@@ -312,6 +313,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                 @"Style Feature",
                 @"Update GeoJSON Source: Data",
                 @"Update GeoJSON Source: URL",
+                @"Update GeoJSON Source: Features",
             ]];
             break;
         case MBXSettingsMiscellaneous:
@@ -448,6 +450,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                     break;
                 case MBXSettingsRuntimeStylingUpdateGeoJSONSourceURL:
                     [self updateGeoJSONSourceURL];
+                    break;
+                case MBXSettingsRuntimeStylingUpdateGeoJSONSourceFeatures:
+                    [self updateGeoJSONSourceFeatures];
                     break;
                 default:
                     NSAssert(NO, @"All runtime styling setting rows should be implemented");
@@ -937,6 +942,43 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         NSURL *geoJSONURL = [NSURL fileURLWithPath:filePath];
         MGLGeoJSONSource *source = (MGLGeoJSONSource *)[self.mapView.style sourceWithIdentifier:@"mutable-data-source-url-id"];
         source.URL = geoJSONURL;
+    });
+}
+
+- (void)updateGeoJSONSourceFeatures
+{
+    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(-41.1520, 288.6592) zoomLevel:10 animated:NO];
+    
+    CLLocationCoordinate2D smallBox[] = {
+        {-41.14763798539186, 288.68019104003906},
+        {-41.140915920129665, 288.68019104003906},
+        {-41.140915920129665, 288.6887741088867},
+        {-41.14763798539186, 288.6887741088867},
+        {-41.14763798539186, 288.68019104003906}
+    };
+    
+    CLLocationCoordinate2D largeBox[] = {
+        {-41.17710352162799, 288.67298126220703},
+        {-41.13962313627545, 288.67298126220703},
+        {-41.13962313627545, 288.7261962890625},
+        {-41.17710352162799, 288.7261962890625},
+        {-41.17710352162799, 288.67298126220703}
+    };
+    
+    MGLPolygonFeature *smallBoxFeature = [MGLPolygonFeature polygonWithCoordinates:smallBox count:sizeof(smallBox)/sizeof(smallBox[0])];
+    MGLPolygonFeature *largeBoxFeature = [MGLPolygonFeature polygonWithCoordinates:largeBox count:sizeof(largeBox)/sizeof(largeBox[0])];
+
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"mutable-data-source-features-id" features:@[smallBoxFeature] options:nil];
+    [self.mapView.style addSource:source];
+    
+    MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"mutable-data-layer-features-id" source:source];
+    MGLStyleValue *fillColor = [MGLStyleValue<UIColor *> valueWithRawValue:[UIColor redColor]];
+    layer.fillColor = fillColor;
+    [self.mapView.style addLayer:layer];
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        MGLGeoJSONSource *source = (MGLGeoJSONSource *)[self.mapView.style sourceWithIdentifier:@"mutable-data-source-features-id"];
+        source.features = @[largeBoxFeature];
     });
 }
 

--- a/src/mbgl/style/source_observer.hpp
+++ b/src/mbgl/style/source_observer.hpp
@@ -20,6 +20,9 @@ public:
     virtual void onSourceAttributionChanged(Source&, const std::string&) {}
     virtual void onSourceError(Source&, std::exception_ptr) {}
 
+    //Source description needs to be reloaded
+    virtual void onSourceDescriptionChanged(Source&) {}
+
     virtual void onTileChanged(Source&, const OverscaledTileID&) {}
     virtual void onTileError(Source&, const OverscaledTileID&, std::exception_ptr) {}
 };

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -38,6 +38,12 @@ GeoJSONSource::Impl::~Impl() = default;
 
 void GeoJSONSource::Impl::setURL(std::string url_) {
     url = std::move(url_);
+
+    //Signal that the source description needs a reload
+    if (loaded) {
+        loaded = false;
+        observer->onSourceDescriptionChanged(base);
+    }
 }
 
 optional<std::string> GeoJSONSource::Impl::getURL() {
@@ -132,6 +138,7 @@ void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
 
             loaded = true;
             observer->onSourceLoaded(base);
+            req.reset();
         }
     });
 }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -491,6 +491,13 @@ void Style::onSourceError(Source& source, std::exception_ptr error) {
     observer->onResourceError(error);
 }
 
+void Style::onSourceDescriptionChanged(Source& source) {
+    observer->onSourceDescriptionChanged(source);
+    if (!source.baseImpl->loaded) {
+	   source.baseImpl->loadDescription(fileSource);
+   } 
+}
+
 void Style::onTileChanged(Source& source, const OverscaledTileID& tileID) {
     observer->onTileChanged(source, tileID);
     observer->onUpdate(Update::Repaint);

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -494,8 +494,8 @@ void Style::onSourceError(Source& source, std::exception_ptr error) {
 void Style::onSourceDescriptionChanged(Source& source) {
     observer->onSourceDescriptionChanged(source);
     if (!source.baseImpl->loaded) {
-	   source.baseImpl->loadDescription(fileSource);
-   } 
+        source.baseImpl->loadDescription(fileSource);
+    }
 }
 
 void Style::onTileChanged(Source& source, const OverscaledTileID& tileID) {

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -134,6 +134,7 @@ private:
     void onSourceLoaded(Source&) override;
     void onSourceAttributionChanged(Source&, const std::string&) override;
     void onSourceError(Source&, std::exception_ptr) override;
+    void onSourceDescriptionChanged(Source&) override;
     void onTileChanged(Source&, const OverscaledTileID&) override;
     void onTileError(Source&, const OverscaledTileID&, std::exception_ptr) override;
 

--- a/test/src/mbgl/test/stub_style_observer.hpp
+++ b/test/src/mbgl/test/stub_style_observer.hpp
@@ -38,6 +38,10 @@ public:
         if (sourceError) sourceError(source, error);
     }
 
+    void onSourceDescriptionChanged(Source& source) override {
+        if (sourceDescriptionChanged) sourceDescriptionChanged(source);
+    }
+
     void onTileChanged(Source& source, const OverscaledTileID& tileID) override {
         if (tileChanged) tileChanged(source, tileID);
     };
@@ -58,6 +62,7 @@ public:
     std::function<void (Source&)> sourceLoaded;
     std::function<void (Source&, std::string)> sourceAttributionChanged;
     std::function<void (Source&, std::exception_ptr)> sourceError;
+    std::function<void (Source&)> sourceDescriptionChanged;
     std::function<void (Source&, const OverscaledTileID&)> tileChanged;
     std::function<void (Source&, const OverscaledTileID&, std::exception_ptr)> tileError;
     std::function<void (std::exception_ptr)> resourceError;

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -384,7 +384,7 @@ TEST(Source, RasterTileAttribution) {
 
 TEST(Source, GeoJSonSourceUrlUpdate) {
     SourceTest test;
-    
+
     test.fileSource.sourceResponse = [&] (const Resource& resource) {
         EXPECT_EQ("url", resource.url);
         Response response;
@@ -394,7 +394,7 @@ TEST(Source, GeoJSonSourceUrlUpdate) {
 
     test.observer.sourceDescriptionChanged = [&] (Source&) {
         //Should be called (test will hang if it doesn't)
-		test.end();
+        test.end();
     };
 
     test.observer.tileError = [&] (Source&, const OverscaledTileID&, std::exception_ptr) {
@@ -403,15 +403,15 @@ TEST(Source, GeoJSonSourceUrlUpdate) {
 
     GeoJSONSource source("source");
     source.baseImpl->setObserver(&test.observer);
-    
-	//Load initial, so the source state will be loaded=true
-	source.baseImpl->loadDescription(test.fileSource);
-	
-	//Schedule an update
-	test.loop.invoke([&] () {
-		//Update the url
-		source.setURL(std::string("http://source-url.ext"));	
-	});	
+
+    //Load initial, so the source state will be loaded=true
+    source.baseImpl->loadDescription(test.fileSource);
+
+    //Schedule an update
+    test.loop.invoke([&] () {
+        //Update the url
+        source.setURL(std::string("http://source-url.ext"));
+    });
 
     test.run();
 }


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/6159

This adds support for updating a `MGLGeoJSONSource`'s `geoJSONData`, `URL`, and `features` properties and having that update trigger a refresh of the map with the new source data.