### PR TITLE
[core] Transform{,State} cleanups

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -119,8 +119,10 @@ set(MBGL_CORE_FILES
 
     # math
     include/mbgl/math/clamp.hpp
+    include/mbgl/math/log2.hpp
     include/mbgl/math/minmax.hpp
     include/mbgl/math/wrap.hpp
+    src/mbgl/math/log2.cpp
 
     # mbgl
     include/mbgl/mbgl.hpp
@@ -481,7 +483,6 @@ set(MBGL_CORE_FILES
     src/mbgl/util/mat3.hpp
     src/mbgl/util/mat4.cpp
     src/mbgl/util/mat4.hpp
-    src/mbgl/util/math.cpp
     src/mbgl/util/math.hpp
     src/mbgl/util/offscreen_texture.cpp
     src/mbgl/util/offscreen_texture.hpp

--- a/include/mbgl/math/log2.hpp
+++ b/include/mbgl/math/log2.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+
+namespace mbgl {
+namespace util {
+
+// Computes the log2(x) rounded up to the next integer.
+// (== number of bits required to store x)
+uint32_t ceil_log2(uint64_t x);
+
+template <typename T>
+typename std::enable_if_t<std::is_floating_point<T>::value, T> log2(T x)
+{
+// log2() is producing wrong results on ARMv5 binaries
+// running on ARMv7+ CPUs.
+#if defined(__ANDROID__)
+    return std::log(x) / M_LN2;
+#else
+    return std::log2(x);
+#endif
+}
+
+} // namespace util
+} // namespace mbgl

--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -35,6 +35,8 @@ constexpr double DEGREES_MAX = 360;
 constexpr double PITCH_MAX = M_PI / 3;
 constexpr double MIN_ZOOM = 0.0;
 constexpr double MAX_ZOOM = 25.5;
+constexpr float  MIN_ZOOM_F = MIN_ZOOM;
+constexpr float  MAX_ZOOM_F = MAX_ZOOM;
 
 constexpr uint64_t DEFAULT_MAX_CACHE_SIZE = 50 * 1024 * 1024;
 

--- a/src/mbgl/algorithm/generate_clip_ids_impl.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids_impl.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <mbgl/algorithm/generate_clip_ids.hpp>
-#include <mbgl/util/math.hpp>
+#include <mbgl/math/log2.hpp>
 #include <mbgl/platform/log.hpp>
 
 namespace mbgl {

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -11,12 +11,12 @@
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/utf.hpp>
 #include <mbgl/util/token.hpp>
-#include <mbgl/util/math.hpp>
 #include <mbgl/util/std.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/math/clamp.hpp>
 #include <mbgl/math/minmax.hpp>
+#include <mbgl/math/log2.hpp>
 #include <mbgl/platform/platform.hpp>
 #include <mbgl/platform/log.hpp>
 
@@ -418,8 +418,7 @@ std::unique_ptr<SymbolBucket> SymbolLayout::place(CollisionTile& collisionTile) 
 
 template <typename Buffer>
 void SymbolLayout::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float scale, const bool keepUpright, const style::SymbolPlacementType placement, const float placementAngle) {
-
-    const float placementZoom = ::fmax(std::log(scale) / std::log(2) + zoom, 0);
+    const float placementZoom = util::max(util::log2(scale) + zoom, 0.0f);
 
     for (const auto& symbol : symbols) {
         const auto &tl = symbol.tl;
@@ -428,9 +427,8 @@ void SymbolLayout::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float 
         const auto &br = symbol.br;
         const auto &tex = symbol.tex;
 
-        float minZoom =
-            util::max(static_cast<float>(zoom + log(symbol.minScale) / log(2)), placementZoom);
-        float maxZoom = util::min(static_cast<float>(zoom + log(symbol.maxScale) / log(2)), 25.0f);
+        float minZoom = util::max(zoom + util::log2(symbol.minScale), placementZoom);
+        float maxZoom = util::min(zoom + util::log2(symbol.maxScale), util::MAX_ZOOM_F);
         const auto &anchorPoint = symbol.anchorPoint;
 
         // drop upside down versions of glyphs
@@ -510,8 +508,8 @@ void SymbolLayout::addToDebugBuffers(CollisionTile& collisionTile, SymbolBucket&
                 bl = util::matrixMultiply(collisionTile.reverseRotationMatrix, bl);
                 br = util::matrixMultiply(collisionTile.reverseRotationMatrix, br);
 
-                const float maxZoom = util::clamp(zoom + log(box.maxScale) / log(2), util::MIN_ZOOM, util::MAX_ZOOM);
-                const float placementZoom = util::clamp(zoom + log(box.placementScale) / log(2), util::MIN_ZOOM, util::MAX_ZOOM);
+                const float maxZoom = util::clamp(zoom + util::log2(box.maxScale), util::MIN_ZOOM_F, util::MAX_ZOOM_F);
+                const float placementZoom = util::clamp(zoom + util::log2(box.placementScale), util::MIN_ZOOM_F, util::MAX_ZOOM_F);
 
                 collisionBox.vertices.emplace_back(anchor.x, anchor.y, tl.x, tl.y, maxZoom, placementZoom);
                 collisionBox.vertices.emplace_back(anchor.x, anchor.y, tr.x, tr.y, maxZoom, placementZoom);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -408,7 +408,6 @@ void Map::cancelTransitions() {
 
 void Map::setGestureInProgress(bool inProgress) {
     impl->transform.setGestureInProgress(inProgress);
-    impl->onUpdate(Update::Repaint);
 }
 
 bool Map::isGestureInProgress() const {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -24,6 +24,7 @@
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/platform/log.hpp>
+#include <mbgl/math/log2.hpp>
 
 namespace mbgl {
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/interpolate.hpp>
-#include <mbgl/util/math.hpp>
+#include <mbgl/math/log2.hpp>
 #include <mbgl/math/clamp.hpp>
 
 namespace mbgl {
@@ -117,7 +117,7 @@ double TransformState::pixel_y() const {
 #pragma mark - Zoom
 
 double TransformState::getZoom() const {
-    return std::log(scale) / M_LN2;
+    return scaleZoom(scale);
 }
 
 int32_t TransformState::getIntegerZoom() const {

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -175,10 +175,6 @@ float TransformState::getPitch() const {
 
 #pragma mark - State
 
-bool TransformState::isChanging() const {
-    return rotating || scaling || panning || gestureInProgress;
-}
-
 bool TransformState::isRotating() const {
     return rotating;
 }

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -121,7 +121,7 @@ double TransformState::getZoom() const {
 }
 
 int32_t TransformState::getIntegerZoom() const {
-    return std::floor(getZoom());
+    return getZoom();
 }
 
 double TransformState::getZoomFraction() const {

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -60,7 +60,6 @@ public:
     float getPitch() const;
 
     // State
-    bool isChanging() const;
     bool isRotating() const;
     bool isScaling() const;
     bool isPanning() const;

--- a/src/mbgl/math/log2.cpp
+++ b/src/mbgl/math/log2.cpp
@@ -1,4 +1,4 @@
-#include <mbgl/util/math.hpp>
+#include <mbgl/math/log2.hpp>
 
 namespace mbgl {
 namespace util {
@@ -19,16 +19,6 @@ uint32_t ceil_log2(uint64_t x) {
     }
 
     return y;
-}
-
-double log2(double x) {
-// log2() is producing wrong results on ARMv5 binaries
-// running on ARMv7+ CPUs.
-#if defined(__ANDROID__)
-    return std::log(x) / 0.6931471805599453; // log(x) / log(2)
-#else
-    return ::log2(x);
-#endif
 }
 
 } // namespace util

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -22,7 +22,7 @@ public:
 
     std::vector<CircleVertex> vertices;
     std::vector<gl::Triangle> triangles;
-    std::vector<gl::Segment> segments;
+    std::vector<gl::Segment> segments { { 0, 0 } };
 
     optional<gl::VertexBuffer<CircleVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangle>> indexBuffer;

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -39,7 +39,7 @@ void FillBucket::addGeometry(const GeometryCollection& geometry) {
 
         for (const auto& ring : polygon) {
             totalVertices += ring.size();
-            if (totalVertices > 65535)
+            if (totalVertices > std::numeric_limits<uint16_t>::max())
                 throw GeometryTooLongException();
         }
 
@@ -51,21 +51,20 @@ void FillBucket::addGeometry(const GeometryCollection& geometry) {
             if (nVertices == 0)
                 continue;
 
-            if (lineSegments.empty() || lineSegments.back().vertexLength + nVertices > 65535) {
+            if (lineSegments.back().vertexLength + nVertices > std::numeric_limits<uint16_t>::max()) {
                 lineSegments.emplace_back(vertices.size(), lines.size());
             }
 
             auto& lineSegment = lineSegments.back();
+            assert(lineSegment.vertexLength <= std::numeric_limits<uint16_t>::max());
             uint16_t lineIndex = lineSegment.vertexLength;
 
             vertices.emplace_back(ring[0].x, ring[0].y);
-            lines.emplace_back(static_cast<uint16_t>(lineIndex + nVertices - 1),
-                               static_cast<uint16_t>(lineIndex));
+            lines.emplace_back(lineIndex + nVertices - 1, lineIndex);
 
             for (uint32_t i = 1; i < nVertices; i++) {
                 vertices.emplace_back(ring[i].x, ring[i].y);
-                lines.emplace_back(static_cast<uint16_t>(lineIndex + i - 1),
-                                   static_cast<uint16_t>(lineIndex + i));
+                lines.emplace_back(lineIndex + i - 1, lineIndex + i);
             }
 
             lineSegment.vertexLength += nVertices;
@@ -77,17 +76,18 @@ void FillBucket::addGeometry(const GeometryCollection& geometry) {
         std::size_t nIndicies = indices.size();
         assert(nIndicies % 3 == 0);
 
-        if (triangleSegments.empty() || triangleSegments.back().vertexLength + totalVertices > 65535) {
+        if (triangleSegments.back().vertexLength + totalVertices > std::numeric_limits<uint16_t>::max()) {
             triangleSegments.emplace_back(startVertices, triangles.size());
         }
 
         auto& triangleSegment = triangleSegments.back();
+        assert(triangleSegment.vertexLength <= std::numeric_limits<uint16_t>::max());
         uint16_t triangleIndex = triangleSegment.vertexLength;
 
         for (uint32_t i = 0; i < nIndicies; i += 3) {
-            triangles.emplace_back(static_cast<uint16_t>(triangleIndex + indices[i]),
-                                   static_cast<uint16_t>(triangleIndex + indices[i + 1]),
-                                   static_cast<uint16_t>(triangleIndex + indices[i + 2]));
+            triangles.emplace_back(triangleIndex + indices[i],
+                                   triangleIndex + indices[i + 1],
+                                   triangleIndex + indices[i + 2]);
         }
 
         triangleSegment.vertexLength += totalVertices;

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -22,8 +22,8 @@ public:
     std::vector<FillVertex> vertices;
     std::vector<gl::Line> lines;
     std::vector<gl::Triangle> triangles;
-    std::vector<gl::Segment> lineSegments;
-    std::vector<gl::Segment> triangleSegments;
+    std::vector<gl::Segment> lineSegments { { 0, 0 } };
+    std::vector<gl::Segment> triangleSegments { { 0, 0 } };
 
     optional<gl::VertexBuffer<FillVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Line>> lineIndexBuffer;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -348,17 +348,17 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates) {
     const std::size_t endVertex = vertices.size();
     const std::size_t vertexCount = endVertex - startVertex;
 
-    if (segments.empty() || segments.back().vertexLength + vertexCount > 65535) {
+    if (segments.back().vertexLength + vertexCount > std::numeric_limits<uint16_t>::max()) {
+        // Move to a new group because the old one can't hold the geometry.
         segments.emplace_back(startVertex, triangles.size());
     }
 
     auto& segment = segments.back();
+    assert(segment.vertexLength <= std::numeric_limits<uint16_t>::max());
     uint16_t index = segment.vertexLength;
 
     for (const auto& triangle : triangleStore) {
-        triangles.emplace_back(static_cast<uint16_t>(index + triangle.a),
-                               static_cast<uint16_t>(index + triangle.b),
-                               static_cast<uint16_t>(index + triangle.c));
+        triangles.emplace_back(index + triangle.a, index + triangle.b, index + triangle.c);
     }
 
     segment.vertexLength += vertexCount;

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -28,7 +28,7 @@ public:
 
     std::vector<LineVertex> vertices;
     std::vector<gl::Triangle> triangles;
-    std::vector<gl::Segment> segments;
+    std::vector<gl::Segment> segments { { 0, 0 } };
 
     optional<gl::VertexBuffer<LineVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangle>> indexBuffer;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -70,7 +70,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
         SpriteAtlas& atlas = *layer.impl->spriteAtlas;
         const bool iconScaled = values.paintSize != 1.0f || frame.pixelRatio != atlas.getPixelRatio() || bucket.iconsNeedLinear;
         const bool iconTransformed = values.rotationAlignment == AlignmentType::Map || state.getPitch() != 0;
-        atlas.bind(bucket.sdfIcons || state.isChanging() || iconScaled || iconTransformed, context, 0);
+        atlas.bind(bucket.sdfIcons || state.isScaling() || state.isRotating() || iconScaled || iconTransformed, context, 0);
 
         std::array<uint16_t, 2> texsize {{ atlas.getWidth(), atlas.getHeight() }};
 

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -10,6 +10,7 @@
 #include <mbgl/shader/symbol_uniforms.hpp>
 #include <mbgl/shader/collision_box_uniforms.hpp>
 #include <mbgl/util/math.hpp>
+#include <mbgl/tile/tile.hpp>
 
 #include <cmath>
 
@@ -125,7 +126,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
             shaders->collisionBox,
             CollisionBoxUniforms::values(
                 tile.matrix,
-                std::pow(2, state.getZoom() - tile.id.canonical.z),
+                std::pow(2.0f, state.getZoom() - tile.tile.id.overscaledZ),
                 state.getZoom() * 10,
                 (tile.id.canonical.z + 1) * 10
             ),

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -36,7 +36,7 @@ public:
     struct TextBuffer {
         std::vector<SymbolVertex> vertices;
         std::vector<gl::Triangle> triangles;
-        std::vector<gl::Segment> segments;
+        std::vector<gl::Segment> segments { { 0, 0 } };
 
         optional<gl::VertexBuffer<SymbolVertex>> vertexBuffer;
         optional<gl::IndexBuffer<gl::Triangle>> indexBuffer;
@@ -45,7 +45,7 @@ public:
     struct IconBuffer {
         std::vector<SymbolVertex> vertices;
         std::vector<gl::Triangle> triangles;
-        std::vector<gl::Segment> segments;
+        std::vector<gl::Segment> segments { { 0, 0 } };
 
         optional<gl::VertexBuffer<SymbolVertex>> vertexBuffer;
         optional<gl::IndexBuffer<gl::Triangle>> indexBuffer;

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -106,7 +106,7 @@ private:
     void _setSprite(const std::string&, const std::shared_ptr<const SpriteImage>& = nullptr);
     void emitSpriteLoadedIfComplete();
 
-    const uint16_t width, height;
+    const dimension width, height;
     const dimension pixelWidth, pixelHeight;
     const float pixelRatio;
 

--- a/src/mbgl/text/collision_tile.cpp
+++ b/src/mbgl/text/collision_tile.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/text/collision_tile.hpp>
 #include <mbgl/geometry/feature_index.hpp>
+#include <mbgl/math/log2.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/math/minmax.hpp>

--- a/src/mbgl/util/math.hpp
+++ b/src/mbgl/util/math.hpp
@@ -106,11 +106,5 @@ T smoothstep(T edge0, T edge1, T x) {
     return t * t * (T(3) - T(2) * t);
 }
 
-// Computes the log2(x) rounded up to the next integer.
-// (== number of bits required to store x)
-uint32_t ceil_log2(uint64_t x);
-
-double log2(double x);
-
 } // namespace util
 } // namespace mbgl

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -49,12 +49,28 @@ TEST(Annotations, SymbolAnnotation) {
     auto screenBox = ScreenBox { {}, { double(size.width), double(size.height) } };
     auto features = test.map.queryPointAnnotations(screenBox);
     EXPECT_EQ(features.size(), 1u);
+    test.checkRendering("point_annotation");
 
     test.map.setZoom(test.map.getMaxZoom());
     test.checkRendering("point_annotation");
 
     features = test.map.queryPointAnnotations(screenBox);
     EXPECT_EQ(features.size(), 1u);
+}
+
+TEST(Annotations, SymbolLinearInterpolation)
+{
+    AnnotationTest test;
+
+    test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
+    test.map.addAnnotationIcon("default_marker", namedMarker("default_marker.png"));
+    test.map.addAnnotation(SymbolAnnotation { Point<double>(0.15, 0.15), "default_marker" });
+    test.checkRendering("point_annotation");
+
+    // Should not trigger GL_LINEAR when binding the symbol shader.
+    test.map.setGestureInProgress(true);
+    test.map.moveBy({});
+    test.checkRendering("point_annotation");
 }
 
 TEST(Annotations, LineAnnotation) {

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -103,6 +103,29 @@ TEST(Transform, InvalidBearing) {
     ASSERT_DOUBLE_EQ(2, transform.getAngle());
 }
 
+TEST(Transform, IntegerZoom) {
+    Transform transform;
+
+    auto checkIntegerZoom = [&transform](uint8_t zoomInt, double zoom) {
+        double scale = transform.getState().zoomScale(zoom);
+        transform.setScale(scale);
+        ASSERT_DOUBLE_EQ(transform.getScale(), scale);
+        ASSERT_NEAR(transform.getZoom(), zoom, 0.0001);
+        ASSERT_EQ(transform.getState().getIntegerZoom(), zoomInt);
+        ASSERT_NEAR(transform.getState().getZoomFraction(), zoom - zoomInt, 0.0001);
+    };
+
+    for (uint8_t zoomInt = 0; zoomInt < 20; ++zoomInt) {
+        for (uint32_t percent = 0; percent < 100; ++percent) {
+            double zoom = zoomInt + (0.01 * percent);
+            checkIntegerZoom(zoomInt, zoom);
+        }
+    }
+
+    // Special case zoom 20.
+    checkIntegerZoom(20, 20.0);
+}
+
 TEST(Transform, PerspectiveProjection) {
     LatLng loc;
 


### PR DESCRIPTION
Reuse `TransformState::{zoomScale,scaleZoom,getZoomFraction}` and `util::log2` whenever possible.
