### PR TITLE
[core] geojson source - reset req on setURL

### DIFF
--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -40,8 +40,9 @@ void GeoJSONSource::Impl::setURL(std::string url_) {
     url = std::move(url_);
 
     //Signal that the source description needs a reload
-    if (loaded) {
+    if (loaded || req) {
         loaded = false;
+        req.reset();
         observer->onSourceDescriptionChanged(base);
     }
 }
@@ -138,7 +139,6 @@ void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
 
             loaded = true;
             observer->onSourceLoaded(base);
-            req.reset();
         }
     });
 }


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/pull/6770#discussion_r84544664

@jfirebaugh added a check on an existing request in `setURL` as well so that any pending request is canceled when changing the url, not only when it was previously done loading.