### PR TITLE
Qt macOS fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(mbgl LANGUAGES CXX C)
+set(CMAKE_CXX_STANDARD 14)
 
 include(cmake/mbgl.cmake)
 
@@ -42,6 +43,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wshadow -Werro
 if(APPLE)
     # -Wno-error=unused-command-line-argument is required due to https://llvm.org/bugs/show_bug.cgi?id=7798
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument")
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+    # https://svn.boost.org/trac/boost/ticket/9240
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fext-numeric-literals")
 endif()
 
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/platform/${MBGL_PLATFORM}/config.cmake)

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -297,5 +297,15 @@ void MapWindow::resizeGL(int w, int h)
 void MapWindow::paintGL()
 {
     m_frameDraws++;
+
+#if QT_VERSION < 0x050400 && defined(__APPLE__)
+    // XXX GL framebuffer is valid only after first attempt of painting on
+    // older versions of Qt on macOS.
+    // See https://bugreports.qt.io/browse/QTBUG-36802 for details.
+    static bool first = true;
+    if (!first) m_map.render();
+    first = false;
+#else
     m_map.render();
+#endif
 }


### PR DESCRIPTION
On this PR:
- Added a workaround fix for an issue [with older Qt versions](https://bugreports.qt.io/browse/QTBUG-36802) preventing the QMapboxGL demo application from running.
- Enforce C++14 as default standard on CMake to satisfy latest Qt builds.

Fixes #6794.