### PR TITLE
Geojsonsource fixes

### DIFF
--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -86,6 +86,7 @@ protected:
     Source& base;
     SourceObserver* observer = nullptr;
     std::map<OverscaledTileID, std::unique_ptr<Tile>> tiles;
+    TileCache cache;
 
 private:
     // TileObserver implementation.
@@ -97,7 +98,6 @@ private:
     virtual std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) = 0;
 
     std::map<UnwrappedTileID, RenderTile> renderTiles;
-    TileCache cache;
 };
 
 } // namespace style

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -54,6 +54,8 @@ optional<std::string> GeoJSONSource::Impl::getURL() {
 void GeoJSONSource::Impl::setGeoJSON(const GeoJSON& geoJSON) {
     double scale = util::EXTENT / util::tileSize;
 
+    cache.clear();
+
     if (!options.cluster) {
         mapbox::geojsonvt::Options vtOptions;
         vtOptions.maxZoom = options.maxzoom;

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -51,7 +51,14 @@ optional<std::string> GeoJSONSource::Impl::getURL() {
     return url;
 }
 
+
 void GeoJSONSource::Impl::setGeoJSON(const GeoJSON& geoJSON) {
+    req.reset();
+    _setGeoJSON(geoJSON);
+}
+
+//Private implementation
+void GeoJSONSource::Impl::_setGeoJSON(const GeoJSON& geoJSON) {
     double scale = util::EXTENT / util::tileSize;
 
     cache.clear();
@@ -74,7 +81,7 @@ void GeoJSONSource::Impl::setGeoJSON(const GeoJSON& geoJSON) {
         geoJSONOrSupercluster =
             std::make_unique<mapbox::supercluster::Supercluster>(features, clusterOptions);
     }
-    
+
     for (auto const &item : tiles) {
         GeoJSONTile* geoJSONTile = static_cast<GeoJSONTile*>(item.second.get());
         setTileData(*geoJSONTile, geoJSONTile->id);
@@ -134,9 +141,9 @@ void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
                            geoJSON.error().message.c_str());
                 // Create an empty GeoJSON VT object to make sure we're not infinitely waiting for
                 // tiles to load.
-                setGeoJSON(GeoJSON{ FeatureCollection{} });
+                _setGeoJSON(GeoJSON{ FeatureCollection{} });
             } else {
-                setGeoJSON(*geoJSON);
+                _setGeoJSON(*geoJSON);
             }
 
             loaded = true;

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -29,6 +29,8 @@ public:
     }
 
 private:
+    void _setGeoJSON(const GeoJSON&);
+
     Range<uint8_t> getZoomRange() final;
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 


### PR DESCRIPTION
Fixes #6801

Clears the tile cache on `GeoJSONSource#setGeoJSON` to avoid stale shapes and cancels any pending requests to avoid pending requests overwriting the content that is set(https://github.com/mapbox/mapbox-gl-native/pull/6798#issuecomment-255583033)
