### PR TITLE
Fix syntax error in documentation comment

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -152,6 +152,9 @@ global.describeValue = function (value, property, layerType) {
         case 'number':
             return 'an `NSNumber` object containing the float `' + value + '`';
         case 'string':
+            if (value === '') {
+                return 'the empty string';
+            }
             return 'the string `' + value + '`';
         case 'enum':
             let displayValue;

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -388,7 +388,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
 /**
  Value to use for a text label. Feature properties are specified using tokens like {field_name}.
  
- The default value of this property is an `MGLStyleValue` object containing the string ``. Set this property to `nil` to reset it to the default value.
+ The default value of this property is an `MGLStyleValue` object containing the empty string. Set this property to `nil` to reset it to the default value.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *textField;
 


### PR DESCRIPTION
![empty](https://cloud.githubusercontent.com/assets/1231218/19714620/83bacd1c-9b04-11e6-9d4f-ea2eee78b7e1.png)

Fixes #6821.

/cc @friedbunny