### PR TITLE
Use animated rotation value for MarkerView.setRotate

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
@@ -265,17 +265,9 @@ public class MarkerView extends Marker {
             newRotation += 360;
         }
 
-        // calculate new direction
-        float diff = newRotation - this.rotation;
-        if (diff > 180.0f) {
-            diff -= 360.0f;
-        } else if (diff < -180.0f) {
-            diff += 360.f;
-        }
-
         this.rotation = newRotation;
         if (markerViewManager != null) {
-            markerViewManager.animateRotationBy(this, diff);
+            markerViewManager.animateRotationBy(this, newRotation);
         }
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -74,12 +74,20 @@ public class MarkerViewManager {
      * Animate a MarkerView with a given rotation.
      *
      * @param marker   the MarkerView to rotate by
-     * @param rotation the rotation by value
+     * @param rotation the rotation by value, limited to 0 - 360 degrees
      */
     public void animateRotationBy(@NonNull MarkerView marker, float rotation) {
         View convertView = markerViewMap.get(marker);
         if (convertView != null) {
-            AnimatorUtils.rotateBy(convertView, rotation);
+            convertView.animate().cancel();
+            // calculate new direction
+            float diff = rotation - convertView.getRotation();
+            if (diff > 180.0f) {
+                diff -= 360.0f;
+            } else if (diff < -180.0f) {
+                diff += 360.f;
+            }
+            AnimatorUtils.rotateBy(convertView, diff);
         }
     }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/annotations/MarkerViewTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/annotations/MarkerViewTest.java
@@ -146,7 +146,6 @@ public class MarkerViewTest {
     public void testRotationUpdatePositive() {
         float startRotation = 45;
         float endRotation = 180;
-        float animationValue = 135;
 
         // allow calls to our mock
         when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
@@ -156,14 +155,13 @@ public class MarkerViewTest {
         marker.setMapboxMap(mapboxMap);
 
         marker.setRotation(endRotation);
-        verify(markerViewManager, times(1)).animateRotationBy(marker, animationValue);
+        verify(markerViewManager, times(1)).animateRotationBy(marker, endRotation);
     }
 
     @Test
     public void testRotationUpdateNegative() {
         float startRotation = 10;
         float endRotation = 270;
-        float animationValue = -100;
 
         // allow calls to our mock
         when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
@@ -173,14 +171,13 @@ public class MarkerViewTest {
         marker.setMapboxMap(mapboxMap);
 
         marker.setRotation(endRotation);
-        verify(markerViewManager, times(1)).animateRotationBy(marker, animationValue);
+        verify(markerViewManager, times(1)).animateRotationBy(marker, endRotation);
     }
 
     @Test
     public void testRotationUpdateMax() {
         float startRotation = 359;
         float endRotation = 0;
-        float animationValue = 1;
 
         // allow calls to our mock
         when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
@@ -190,14 +187,13 @@ public class MarkerViewTest {
         marker.setMapboxMap(mapboxMap);
 
         marker.setRotation(endRotation);
-        verify(markerViewManager, times(1)).animateRotationBy(marker, animationValue);
+        verify(markerViewManager, times(1)).animateRotationBy(marker, 0);
     }
 
     @Test
     public void testRotationUpdateMin() {
         float startRotation = 0;
         float endRotation = 359;
-        float animationValue = -1;
 
         // allow calls to our mock
         when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
@@ -207,7 +203,7 @@ public class MarkerViewTest {
         marker.setMapboxMap(mapboxMap);
 
         marker.setRotation(endRotation);
-        verify(markerViewManager, times(1)).animateRotationBy(marker, animationValue);
+        verify(markerViewManager, times(1)).animateRotationBy(marker, endRotation);
     }
 
     @Test


### PR DESCRIPTION
closes #6816, targeting `release-android-v4.2.0`. This PR cancels ongoing rotation animations and uses the current animated value instead of using the previous set rotation. If you would call `MarkerView#setRotate` while an animation was ongoing you would end up with a wrong rotation value. 

Review @ivovandongen