### PR TITLE
[core] Avoid clipping symbols in continuous mode

### DIFF
--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -262,8 +262,6 @@ void SymbolLayout::addFeature(const GeometryCollection &lines,
     const SymbolPlacementType iconPlacement = layout.get<IconRotationAlignment>() != AlignmentType::Map
                                                   ? SymbolPlacementType::Point
                                                   : layout.get<SymbolPlacement>();
-    const bool mayOverlap = layout.get<TextAllowOverlap>() || layout.get<IconAllowOverlap>() ||
-        layout.get<TextIgnorePlacement>() || layout.get<IconIgnorePlacement>();
     const bool isLine = layout.get<SymbolPlacement>() == SymbolPlacementType::Line;
     const float textRepeatDistance = symbolSpacing / 2;
 
@@ -289,22 +287,25 @@ void SymbolLayout::addFeature(const GeometryCollection &lines,
                 }
             }
 
-            const bool inside = !(anchor.point.x < 0 || anchor.point.x > util::EXTENT || anchor.point.y < 0 || anchor.point.y > util::EXTENT);
+            // https://github.com/mapbox/vector-tile-spec/tree/master/2.1#41-layers
+            // +-------------------+ Symbols with anchors located on tile edges
+            // |(0,0)             || are duplicated on neighbor tiles.
+            // |                  ||
+            // |                  || In continuous mode, to avoid overdraw we
+            // |                  || skip symbols located on the extent edges.
+            // |       Tile       || In still mode, we include the features in
+            // |                  || the buffers for both tiles and clip them
+            // |                  || at draw time.
+            // |                  ||
+            // +-------------------| In this scenario, the inner bounding box
+            // +-------------------+ is called 'withinPlus0', and the outer
+            //       (extent,extent) is called 'inside'.
+            const bool withinPlus0 = anchor.point.x >= 0 && anchor.point.x < util::EXTENT && anchor.point.y >= 0 && anchor.point.y < util::EXTENT;
+            const bool inside = withinPlus0 || anchor.point.x == util::EXTENT || anchor.point.y == util::EXTENT;
 
             if (avoidEdges && !inside) continue;
 
-            // Normally symbol layers are drawn across tile boundaries. Only symbols
-            // with their anchors within the tile boundaries are added to the buffers
-            // to prevent symbols from being drawn twice.
-            //
-            // Symbols in layers with overlap are sorted in the y direction so that
-            // symbols lower on the canvas are drawn on top of symbols near the top.
-            // To preserve this order across tile boundaries these symbols can't
-            // be drawn across tile boundaries. Instead they need to be included in
-            // the buffers for both tiles and clipped to tile boundaries at draw time.
-            //
-            // TODO remove the `&& false` when is #1673 implemented
-            const bool addToBuffers = (mode == MapMode::Still) || inside || (mayOverlap && false);
+            const bool addToBuffers = mode == MapMode::Still || withinPlus0;
 
             symbolInstances.emplace_back(anchor, line, shapedText, shapedIcon, layout, addToBuffers, symbolInstances.size(),
                     textBoxScale, textPadding, textPlacement,

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -125,7 +125,7 @@ void Painter::render(const Style& style, const FrameData& frame_, View& view, Sp
     spriteAtlas = style.spriteAtlas.get();
     lineAtlas = style.lineAtlas.get();
 
-    RenderData renderData = style.getRenderData(frame.debugOptions);
+    RenderData renderData = style.getRenderData(frame.debugOptions, state.getAngle());
     const std::vector<RenderItem>& order = renderData.order;
     const std::unordered_set<Source*>& sources = renderData.sources;
 

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -90,7 +90,7 @@ public:
     bool hasClass(const std::string&) const;
     std::vector<std::string> getClasses() const;
 
-    RenderData getRenderData(MapDebugOptions) const;
+    RenderData getRenderData(MapDebugOptions, float angle) const;
 
     std::vector<Feature> queryRenderedFeatures(const QueryParameters&) const;
 

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -47,14 +47,11 @@ TEST(Annotations, SymbolAnnotation) {
 
     auto size = test.view.size;
     auto screenBox = ScreenBox { {}, { double(size.width), double(size.height) } };
-    auto features = test.map.queryPointAnnotations(screenBox);
-    EXPECT_EQ(features.size(), 1u);
-
-    test.map.setZoom(test.map.getMaxZoom());
-    test.checkRendering("point_annotation");
-
-    features = test.map.queryPointAnnotations(screenBox);
-    EXPECT_EQ(features.size(), 1u);
+    for (uint8_t zoom = test.map.getMinZoom(); zoom <= test.map.getMaxZoom(); ++zoom) {
+        test.map.setZoom(zoom);
+        test.checkRendering("point_annotation");
+        EXPECT_EQ(test.map.queryPointAnnotations(screenBox).size(), 1u);
+    }
 }
 
 TEST(Annotations, LineAnnotation) {


### PR DESCRIPTION
~~Re-enable symbol clipping based on layout property settings, cleaning up workarounds and adds padding to symbol annotation tiles.~~

Avoid clipping symbols in continuous mode - preserving clipping behavior in still mode. To avoid overdrawing symbols on tile edges, we avoid inserting symbol features with anchors located among the tile extent edges.

Fixes #1673 and #6670.

/cc @jfirebaugh @ansis
