### PR TITLE
Introduce Size type

### DIFF
--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -34,10 +34,10 @@ public:
 
     util::RunLoop loop;
     HeadlessBackend backend;
-    OffscreenView view{ backend.getContext(), {{ 1000, 1000 }} };
+    OffscreenView view{ backend.getContext(), { 1000, 1000 } };
     DefaultFileSource fileSource{ "benchmark/fixtures/api/cache.db", "." };
     ThreadPool threadPool{ 4 };
-    Map map{ backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still };
+    Map map{ backend, view.size, 1, fileSource, threadPool, MapMode::Still };
     ScreenBox box{{ 0, 0 }, { 1000, 1000 }};
 };
 

--- a/benchmark/src/mbgl/benchmark/util.cpp
+++ b/benchmark/src/mbgl/benchmark/util.cpp
@@ -15,7 +15,7 @@ void render(Map& map, OffscreenView& view) {
         result = view.readStillImage();
     });
 
-    while (!result.size()) {
+    while (!result.valid()) {
         util::RunLoop::Get()->runOnce();
     }
 }

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -27,8 +27,8 @@ int main(int argc, char *argv[]) {
     double bearing = 0;
     double pitch = 0;
 
-    int width = 512;
-    int height = 512;
+    uint32_t width = 512;
+    uint32_t height = 512;
     static std::string output = "out.png";
     std::string cache_file = "cache.sqlite";
     std::string asset_root = ".";
@@ -84,9 +84,9 @@ int main(int argc, char *argv[]) {
     }
 
     HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), {{ static_cast<uint16_t>(width), static_cast<uint16_t>(height) }});
+    OffscreenView view(backend.getContext(), { width, height });
     ThreadPool threadPool(4);
-    Map map(backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still);
+    Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
 
     map.setStyleJSON(style);
     map.setClasses(classes);

--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -420,6 +420,7 @@ set(MBGL_CORE_FILES
     include/mbgl/util/projection.hpp
     include/mbgl/util/range.hpp
     include/mbgl/util/run_loop.hpp
+    include/mbgl/util/size.hpp
     include/mbgl/util/string.hpp
     include/mbgl/util/tileset.hpp
     include/mbgl/util/timer.hpp

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/size.hpp>
 #include <mbgl/annotation/annotation.hpp>
 #include <mbgl/style/transition_options.hpp>
 
@@ -33,7 +34,7 @@ class Layer;
 class Map : private util::noncopyable {
 public:
     explicit Map(Backend&,
-                 std::array<uint16_t, 2> size,
+                 Size size,
                  float pixelRatio,
                  FileSource&,
                  Scheduler&,
@@ -136,9 +137,8 @@ public:
     ViewportMode getViewportMode() const;
 
     // Size
-    void setSize(const std::array<uint16_t, 2>&);
-    uint16_t getWidth() const;
-    uint16_t getHeight() const;
+    void setSize(Size);
+    Size getSize() const;
 
     // Projection
     double getMetersPerPixelAtLatitude(double lat, double zoom) const;

--- a/include/mbgl/platform/default/glfw_view.hpp
+++ b/include/mbgl/platform/default/glfw_view.hpp
@@ -34,8 +34,8 @@ public:
     // mbgl::View implementation
     void updateViewBinding();
     void bind() override;
-    std::array<uint16_t, 2> getSize() const;
-    std::array<uint16_t, 2> getFramebufferSize() const;
+    mbgl::Size getSize() const;
+    mbgl::Size getFramebufferSize() const;
 
     // mbgl::Backend implementation
     void activate() override;

--- a/include/mbgl/platform/default/offscreen_view.hpp
+++ b/include/mbgl/platform/default/offscreen_view.hpp
@@ -14,17 +14,17 @@ class Context;
 
 class OffscreenView : public View {
 public:
-    OffscreenView(gl::Context&, std::array<uint16_t, 2> size = {{ 256, 256 }});
+    OffscreenView(gl::Context&, Size size = { 256, 256 });
 
     void bind() override;
 
     PremultipliedImage readStillImage();
 
-    std::array<uint16_t, 2> getSize() const;
+public:
+    const Size size;
 
 private:
     gl::Context& context;
-    std::array<uint16_t, 2> size;
     optional<gl::Framebuffer> framebuffer;
     optional<gl::Renderbuffer<gl::RenderbufferType::RGBA>> color;
     optional<gl::Renderbuffer<gl::RenderbufferType::DepthStencil>> depthStencil;

--- a/include/mbgl/sprite/sprite_image.hpp
+++ b/include/mbgl/sprite/sprite_image.hpp
@@ -22,8 +22,8 @@ public:
     // Whether this image should be interpreted as a signed distance field icon.
     const bool sdf;
 
-    float getWidth() const { return image.width / pixelRatio; }
-    float getHeight() const { return image.height / pixelRatio; }
+    float getWidth() const { return image.size.width / pixelRatio; }
+    float getHeight() const { return image.size.height / pixelRatio; }
 };
 
 } // namespace mbgl

--- a/include/mbgl/util/image.hpp
+++ b/include/mbgl/util/image.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/noncopyable.hpp>
+#include <mbgl/util/size.hpp>
 
 #include <string>
 #include <memory>
@@ -18,39 +19,38 @@ class Image : private util::noncopyable {
 public:
     Image() = default;
 
-    Image(uint16_t w, uint16_t h)
-        : width(w),
-          height(h),
-          data(std::make_unique<uint8_t[]>(size())) {}
+    Image(Size size_)
+        : size(std::move(size_)),
+          data(std::make_unique<uint8_t[]>(bytes())) {}
 
-    Image(uint16_t w, uint16_t h, std::unique_ptr<uint8_t[]> data_)
-        : width(w),
-          height(h),
+    Image(Size size_, std::unique_ptr<uint8_t[]> data_)
+        : size(std::move(size_)),
           data(std::move(data_)) {}
 
     Image(Image&& o)
-        : width(o.width),
-          height(o.height),
+        : size(o.size),
           data(std::move(o.data)) {}
 
     Image& operator=(Image&& o) {
-        width = o.width;
-        height = o.height;
+        size = o.size;
         data = std::move(o.data);
         return *this;
     }
 
     bool operator==(const Image& rhs) const {
-        return width == rhs.width && height == rhs.height &&
-               std::equal(data.get(), data.get() + size(), rhs.data.get(),
-                          rhs.data.get() + rhs.size());
+        return size == rhs.size &&
+               std::equal(data.get(), data.get() + bytes(), rhs.data.get(),
+                          rhs.data.get() + rhs.bytes());
     }
 
-    size_t stride() const { return static_cast<size_t>(width) * 4; }
-    size_t size() const { return static_cast<size_t>(width) * height * 4; }
+    bool valid() const {
+        return size && data.get() != nullptr;
+    }
 
-    uint16_t width = 0;
-    uint16_t height = 0;
+    size_t stride() const { return static_cast<size_t>(size.width) * 4; }
+    size_t bytes() const { return stride() * size.height; }
+
+    Size size;
     std::unique_ptr<uint8_t[]> data;
 };
 

--- a/include/mbgl/util/size.hpp
+++ b/include/mbgl/util/size.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+#include <array>
+
+namespace mbgl {
+
+class Size {
+public:
+    constexpr Size() : width(0), height(0) {
+    }
+
+    constexpr Size(const uint32_t width_, const uint32_t height_) : width(width_), height(height_) {
+    }
+
+    constexpr operator bool() const {
+        return width > 0 && height > 0;
+    }
+
+    uint32_t width;
+    uint32_t height;
+};
+
+constexpr inline bool operator==(const Size& a, const Size& b) {
+    return a.width == b.width && a.height == b.height;
+}
+
+constexpr inline bool operator!=(const Size& a, const Size& b) {
+    return !(a == b);
+}
+
+} // namespace mbgl

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -833,9 +833,10 @@ void nativeAddAnnotationIcon(JNIEnv *env, jni::jobject* obj, jlong nativeMapView
 
     NullCheck(*env, jpixels);
     std::size_t size = jni::GetArrayLength(*env, *jpixels);
-    mbgl::PremultipliedImage premultipliedImage(width, height);
+    mbgl::PremultipliedImage premultipliedImage(
+        { static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
 
-    if (premultipliedImage.size() != uint32_t(size)) {
+    if (premultipliedImage.bytes() != uint32_t(size)) {
         throw mbgl::util::SpriteImageException("Sprite image pixel count mismatch");
     }
 
@@ -1162,9 +1163,10 @@ void nativeAddImage(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jni:
     // Create Pre-multiplied image from byte[]
     NullCheck(*env, data);
     std::size_t size = jni::GetArrayLength(*env, *data);
-    mbgl::PremultipliedImage premultipliedImage(width, height);
+    mbgl::PremultipliedImage premultipliedImage(
+        { static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
 
-    if (premultipliedImage.size() != uint32_t(size)) {
+    if (premultipliedImage.bytes() != uint32_t(size)) {
         throw mbgl::util::SpriteImageException("Sprite image pixel count mismatch");
     }
 

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -132,14 +132,12 @@ void GLFWView::setMap(mbgl::Map *map_) {
 
 void GLFWView::updateViewBinding() {
     getContext().bindFramebuffer.setCurrentValue(0);
-    getContext().viewport.setCurrentValue(
-        { 0, 0, static_cast<uint16_t>(fbWidth), static_cast<uint16_t>(fbHeight) });
+    getContext().viewport.setCurrentValue({ 0, 0, getFramebufferSize() });
 }
 
 void GLFWView::bind() {
     getContext().bindFramebuffer = 0;
-    getContext().viewport = { 0, 0, static_cast<uint16_t>(fbWidth),
-                              static_cast<uint16_t>(fbHeight) };
+    getContext().viewport = { 0, 0, getFramebufferSize() };
 }
 
 void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, int mods) {
@@ -192,7 +190,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             view->nextOrientation();
             break;
         case GLFW_KEY_Q: {
-            auto result = view->map->queryPointAnnotations({ {}, { double(view->getSize()[0]), double(view->getSize()[1]) } });
+            auto result = view->map->queryPointAnnotations({ {}, { double(view->getSize().width), double(view->getSize().height) } });
             printf("visible point annotations: %lu\n", result.size());
         } break;
         case GLFW_KEY_C:
@@ -267,7 +265,7 @@ GLFWView::makeSpriteImage(int width, int height, float pixelRatio) {
     const int w = std::ceil(pixelRatio * width);
     const int h = std::ceil(pixelRatio * height);
 
-    mbgl::PremultipliedImage image(w, h);
+    mbgl::PremultipliedImage image({ static_cast<uint32_t>(w), static_cast<uint32_t>(h) });
     auto data = reinterpret_cast<uint32_t*>(image.data.get());
     const int dist = (w / 2) * (w / 2);
     for (int y = 0; y < h; y++) {
@@ -374,8 +372,7 @@ void GLFWView::onWindowResize(GLFWwindow *window, int width, int height) {
     GLFWView *view = reinterpret_cast<GLFWView *>(glfwGetWindowUserPointer(window));
     view->width = width;
     view->height = height;
-    view->map->setSize({{ static_cast<uint16_t>(view->width),
-                          static_cast<uint16_t>(view->height) }});
+    view->map->setSize({ static_cast<uint32_t>(view->width), static_cast<uint32_t>(view->height) });
 }
 
 void GLFWView::onFramebufferResize(GLFWwindow *window, int width, int height) {
@@ -480,12 +477,12 @@ float GLFWView::getPixelRatio() const {
     return pixelRatio;
 }
 
-std::array<uint16_t, 2> GLFWView::getSize() const {
-    return {{ static_cast<uint16_t>(width), static_cast<uint16_t>(height) }};
+mbgl::Size GLFWView::getSize() const {
+    return { static_cast<uint32_t>(width), static_cast<uint32_t>(height) };
 }
 
-std::array<uint16_t, 2> GLFWView::getFramebufferSize() const {
-    return {{ static_cast<uint16_t>(fbWidth), static_cast<uint16_t>(fbHeight) }};
+mbgl::Size GLFWView::getFramebufferSize() const {
+    return { static_cast<uint32_t>(fbWidth), static_cast<uint32_t>(fbHeight) };
 }
 
 void GLFWView::activate() {

--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -25,8 +25,8 @@ const static bool png_version_check __attribute__((unused)) = []() {
 namespace mbgl {
 
 std::string encodePNG(const PremultipliedImage& pre) {
-    PremultipliedImage copy { pre.width, pre.height };
-    std::copy(pre.data.get(), pre.data.get() + pre.size(), copy.data.get());
+    PremultipliedImage copy(pre.size);
+    std::copy(pre.data.get(), pre.data.get() + pre.bytes(), copy.data.get());
 
     UnassociatedImage src = util::unpremultiply(std::move(copy));
 
@@ -42,8 +42,8 @@ std::string encodePNG(const PremultipliedImage& pre) {
         throw std::runtime_error("couldn't create info_ptr");
     }
 
-    png_set_IHDR(png_ptr, info_ptr, src.width, src.height, 8, PNG_COLOR_TYPE_RGB_ALPHA, PNG_INTERLACE_NONE,
-                 PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+    png_set_IHDR(png_ptr, info_ptr, src.size.width, src.size.height, 8, PNG_COLOR_TYPE_RGB_ALPHA,
+                 PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
 
     jmp_buf *jmp_context = (jmp_buf *)png_get_error_ptr(png_ptr);
     if (jmp_context) {
@@ -61,9 +61,9 @@ std::string encodePNG(const PremultipliedImage& pre) {
         ptrs(size_t count) : rows(new png_bytep[count]) {}
         ~ptrs() { delete[] rows; }
         png_bytep *rows = nullptr;
-    } pointers(src.height);
+    } pointers(src.size.height);
 
-    for (size_t i = 0; i < src.height; i++) {
+    for (size_t i = 0; i < src.size.height; i++) {
         pointers.rows[i] = src.data.get() + src.stride() * i;
     }
 

--- a/platform/default/jpeg_reader.cpp
+++ b/platform/default/jpeg_reader.cpp
@@ -119,7 +119,7 @@ PremultipliedImage decodeJPEG(const uint8_t* data, size_t size) {
     size_t components = cinfo.output_components;
     size_t rowStride = components * width;
 
-    PremultipliedImage image { static_cast<uint16_t>(width), static_cast<uint16_t>(height) };
+    PremultipliedImage image({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
     uint8_t* dst = image.data.get();
 
     JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr) &cinfo, JPOOL_IMAGE, rowStride, 1);

--- a/platform/default/offscreen_view.cpp
+++ b/platform/default/offscreen_view.cpp
@@ -7,9 +7,9 @@
 
 namespace mbgl {
 
-OffscreenView::OffscreenView(gl::Context& context_, std::array<uint16_t, 2> size_)
-    : context(context_), size(std::move(size_)) {
-    assert(size[0] > 0 && size[1] > 0);
+OffscreenView::OffscreenView(gl::Context& context_, const Size size_)
+    : size(std::move(size_)), context(context_) {
+    assert(size);
 }
 
 void OffscreenView::bind() {
@@ -21,27 +21,23 @@ void OffscreenView::bind() {
         context.bindFramebuffer = framebuffer->framebuffer;
     }
 
-    context.viewport = { 0, 0, size[0], size[1] };
+    context.viewport = { 0, 0, size };
 }
 
 PremultipliedImage OffscreenView::readStillImage() {
-    PremultipliedImage image { size[0], size[1] };
-    MBGL_CHECK_ERROR(glReadPixels(0, 0, size[0], size[1], GL_RGBA, GL_UNSIGNED_BYTE, image.data.get()));
+    PremultipliedImage image { size };
+    MBGL_CHECK_ERROR(glReadPixels(0, 0, size.width, size.height, GL_RGBA, GL_UNSIGNED_BYTE, image.data.get()));
 
     const auto stride = image.stride();
     auto tmp = std::make_unique<uint8_t[]>(stride);
     uint8_t* rgba = image.data.get();
-    for (int i = 0, j = size[1] - 1; i < j; i++, j--) {
+    for (int i = 0, j = size.height - 1; i < j; i++, j--) {
         std::memcpy(tmp.get(), rgba + i * stride, stride);
         std::memcpy(rgba + i * stride, rgba + j * stride, stride);
         std::memcpy(rgba + j * stride, tmp.get(), stride);
     }
 
     return image;
-}
-
-std::array<uint16_t, 2> OffscreenView::getSize() const {
-    return size;
 }
 
 } // namespace mbgl

--- a/platform/default/png_reader.cpp
+++ b/platform/default/png_reader.cpp
@@ -80,7 +80,7 @@ PremultipliedImage decodePNG(const uint8_t* data, size_t size) {
     int color_type = 0;
     png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type, nullptr, nullptr, nullptr);
 
-    UnassociatedImage image { static_cast<uint16_t>(width), static_cast<uint16_t>(height) };
+    UnassociatedImage image({ width, height });
 
     if (color_type == PNG_COLOR_TYPE_PALETTE)
         png_set_expand(png_ptr);

--- a/platform/default/webp_reader.cpp
+++ b/platform/default/webp_reader.cpp
@@ -23,8 +23,8 @@ PremultipliedImage decodeWebP(const uint8_t* data, size_t size) {
         throw std::runtime_error("failed to decode WebP data");
     }
 
-    UnassociatedImage image{ static_cast<uint16_t>(width), static_cast<uint16_t>(height),
-                             std::move(webp) };
+    UnassociatedImage image({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) },
+                            std::move(webp));
     return util::premultiply(std::move(image));
 }
 

--- a/platform/ios/src/UIImage+MGLAdditions.mm
+++ b/platform/ios/src/UIImage+MGLAdditions.mm
@@ -8,7 +8,7 @@
     size_t width = CGImageGetWidth(cgImage);
     size_t height = CGImageGetHeight(cgImage);
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    mbgl::PremultipliedImage cPremultipliedImage(width, height);
+    mbgl::PremultipliedImage cPremultipliedImage({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
     size_t bytesPerPixel = 4;
     size_t bytesPerRow = bytesPerPixel * width;
     size_t bitsPerComponent = 8;

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -266,10 +266,8 @@ public:
 
     mbgl::DefaultFileSource* mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
 
-    const std::array<uint16_t, 2> size = {{ static_cast<uint16_t>(self.bounds.size.width),
-                                            static_cast<uint16_t>(self.bounds.size.height) }};
     _mbglThreadPool = new mbgl::ThreadPool(4);
-    _mbglMap = new mbgl::Map(*_mbglView, size, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
+    _mbglMap = new mbgl::Map(*_mbglView, self.size, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
     [self validateTileCacheSize];
 
     // Install the OpenGL layer. Interface Builder’s synchronous drawing means
@@ -306,6 +304,11 @@ public:
     _mbglMap->jumpTo(options);
     _pendingLatitude = NAN;
     _pendingLongitude = NAN;
+}
+
+- (mbgl::Size)size {
+    return { static_cast<uint32_t>(self.bounds.size.width),
+             static_cast<uint32_t>(self.bounds.size.height) };
 }
 
 /// Adds zoom controls to the lower-right corner.
@@ -639,8 +642,7 @@ public:
         [self validateTileCacheSize];
     }
     if (!_isTargetingInterfaceBuilder) {
-        _mbglMap->setSize({{ static_cast<uint16_t>(self.bounds.size.width),
-                             static_cast<uint16_t>(self.bounds.size.height) }});
+        _mbglMap->setSize(self.size);
     }
 }
 
@@ -2561,8 +2563,7 @@ public:
     }
 
     mbgl::gl::value::Viewport::Type getViewport() const {
-        return { 0, 0, static_cast<uint16_t>(nativeView.bounds.size.width),
-                 static_cast<uint16_t>(nativeView.bounds.size.height) };
+        return { 0, 0, nativeView.size };
     }
 
     void updateViewBinding() {
@@ -2578,9 +2579,9 @@ public:
 
     mbgl::PremultipliedImage readStillImage() {
         NSRect bounds = [nativeView convertRectToBacking:nativeView.bounds];
-        const uint16_t width = bounds.size.width;
-        const uint16_t height = bounds.size.height;
-        mbgl::PremultipliedImage image{ width, height };
+        const uint32_t width = bounds.size.width;
+        const uint32_t height = bounds.size.height;
+        mbgl::PremultipliedImage image({ width, height });
         MBGL_CHECK_ERROR(
             glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, image.data.get()));
 

--- a/platform/macos/src/NSImage+MGLAdditions.mm
+++ b/platform/macos/src/NSImage+MGLAdditions.mm
@@ -13,8 +13,8 @@
     // Get the image’s raw pixel data as an RGBA buffer.
     std::string pixelString((const char *)rep.bitmapData, rep.pixelsWide * rep.pixelsHigh * 4 /* RGBA */);
 
-    mbgl::PremultipliedImage cPremultipliedImage(rep.pixelsWide, rep.pixelsHigh);
-    std::copy(rep.bitmapData, rep.bitmapData + cPremultipliedImage.size(), cPremultipliedImage.data.get());
+    mbgl::PremultipliedImage cPremultipliedImage({ static_cast<uint32_t>(rep.pixelsWide), static_cast<uint32_t>(rep.pixelsHigh) });
+    std::copy(rep.bitmapData, rep.bitmapData + cPremultipliedImage.bytes(), cPremultipliedImage.data.get());
     return std::make_unique<mbgl::SpriteImage>(std::move(cPremultipliedImage),
                                                (float)(rep.pixelsWide / self.size.width));
 }

--- a/platform/qt/src/image.cpp
+++ b/platform/qt/src/image.cpp
@@ -7,7 +7,7 @@
 namespace mbgl {
 
 std::string encodePNG(const PremultipliedImage& pre) {
-    QImage image(pre.data.get(), pre.width, pre.height,
+    QImage image(pre.data.get(), pre.size.width, pre.size.height,
         QImage::Format_ARGB32_Premultiplied);
 
     QByteArray array;
@@ -57,7 +57,7 @@ PremultipliedImage decodeImage(const std::string& string) {
     auto img = std::make_unique<uint8_t[]>(image.byteCount());
     memcpy(img.get(), image.constBits(), image.byteCount());
 
-    return { static_cast<uint16_t>(image.width()), static_cast<uint16_t>(image.height()),
+    return { { static_cast<uint32_t>(image.width()), static_cast<uint32_t>(image.height()) },
              std::move(img) };
 }
 }

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -232,7 +232,7 @@ void AnnotationManager::removeIcon(const std::string& name) {
 
 double AnnotationManager::getTopOffsetPixelsForIcon(const std::string& name) {
     auto sprite = spriteAtlas.getSprite(name);
-    return sprite ? -(sprite->image.height / sprite->pixelRatio) / 2 : 0;
+    return sprite ? -(sprite->image.size.height / sprite->pixelRatio) / 2 : 0;
 }
 
 } // namespace mbgl

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -143,16 +143,14 @@ UniqueFramebuffer Context::createFramebuffer() {
     return UniqueFramebuffer{ std::move(id), { this } };
 }
 
-UniqueRenderbuffer Context::createRenderbuffer(const RenderbufferType type,
-                                               const uint16_t width,
-                                               const uint16_t height) {
+UniqueRenderbuffer Context::createRenderbuffer(const RenderbufferType type, const Size size) {
     RenderbufferID id = 0;
     MBGL_CHECK_ERROR(glGenRenderbuffers(1, &id));
     UniqueRenderbuffer renderbuffer{ std::move(id), { this } };
 
     bindRenderbuffer = renderbuffer;
     MBGL_CHECK_ERROR(
-        glRenderbufferStorage(GL_RENDERBUFFER, static_cast<GLenum>(type), width, height));
+        glRenderbufferStorage(GL_RENDERBUFFER, static_cast<GLenum>(type), size.width, size.height));
     return renderbuffer;
 }
 
@@ -251,7 +249,7 @@ Framebuffer Context::createFramebuffer(const Texture& color) {
 }
 
 UniqueTexture
-Context::createTexture(uint16_t width, uint16_t height, const void* data, TextureUnit unit) {
+Context::createTexture(const Size size, const void* data, TextureUnit unit) {
     auto obj = createTexture();
     activeTexture = unit;
     texture[unit] = obj;
@@ -259,8 +257,8 @@ Context::createTexture(uint16_t width, uint16_t height, const void* data, Textur
     MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
     MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
-    MBGL_CHECK_ERROR(
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data));
+    MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, size.width, size.height, 0, GL_RGBA,
+                                  GL_UNSIGNED_BYTE, data));
     return obj;
 }
 

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -49,10 +49,10 @@ public:
     }
 
     template <RenderbufferType type>
-    Renderbuffer<type> createRenderbuffer(const std::array<uint16_t, 2>& size) {
+    Renderbuffer<type> createRenderbuffer(const Size size) {
         static_assert(type == RenderbufferType::RGBA || type == RenderbufferType::DepthStencil,
                       "invalid renderbuffer type");
-        return { size, createRenderbuffer(type, size[0], size[1]) };
+        return { size, createRenderbuffer(type, size) };
     }
 
     Framebuffer createFramebuffer(const Renderbuffer<RenderbufferType::RGBA>&,
@@ -65,13 +65,12 @@ public:
     // Create a texture from an image with data.
     template <typename Image>
     Texture createTexture(const Image& image, TextureUnit unit = 0) {
-        return { {{ image.width, image.height }},
-                 createTexture(image.width, image.height, image.data.get(), unit) };
+        return { image.size, createTexture(image.size, image.data.get(), unit) };
     }
 
     // Creates an empty texture with the specified dimensions.
-    Texture createTexture(const std::array<uint16_t, 2>& size, TextureUnit unit = 0) {
-        return { size, createTexture(size[0], size[1], nullptr, unit) };
+    Texture createTexture(const Size size, TextureUnit unit = 0) {
+        return { size, createTexture(size, nullptr, unit) };
     }
 
     void bindTexture(Texture&,
@@ -140,9 +139,9 @@ public:
 private:
     UniqueBuffer createVertexBuffer(const void* data, std::size_t size);
     UniqueBuffer createIndexBuffer(const void* data, std::size_t size);
-    UniqueTexture createTexture(uint16_t width, uint16_t height, const void* data, TextureUnit);
+    UniqueTexture createTexture(Size size, const void* data, TextureUnit);
     UniqueFramebuffer createFramebuffer();
-    UniqueRenderbuffer createRenderbuffer(RenderbufferType, uint16_t width, uint16_t height);
+    UniqueRenderbuffer createRenderbuffer(RenderbufferType, Size size);
     void bindAttribute(const AttributeBinding&, std::size_t stride, const int8_t* offset);
 
     friend detail::ProgramDeleter;

--- a/src/mbgl/gl/framebuffer.hpp
+++ b/src/mbgl/gl/framebuffer.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
 #include <mbgl/gl/object.hpp>
-
-#include <array>
+#include <mbgl/util/size.hpp>
 
 namespace mbgl {
 namespace gl {
 
 class Framebuffer {
 public:
-    std::array<uint16_t, 2> size;
+    Size size;
     gl::UniqueFramebuffer framebuffer;
 };
 

--- a/src/mbgl/gl/renderbuffer.hpp
+++ b/src/mbgl/gl/renderbuffer.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <mbgl/gl/object.hpp>
-
-#include <array>
+#include <mbgl/util/size.hpp>
 
 namespace mbgl {
 namespace gl {
@@ -11,7 +10,7 @@ template <RenderbufferType renderbufferType>
 class Renderbuffer {
 public:
     using type = std::integral_constant<RenderbufferType, renderbufferType>;
-    std::array<uint16_t, 2> size;
+    Size size;
     gl::UniqueRenderbuffer renderbuffer;
 };
 

--- a/src/mbgl/gl/texture.hpp
+++ b/src/mbgl/gl/texture.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
 #include <mbgl/gl/object.hpp>
-
-#include <array>
+#include <mbgl/util/size.hpp>
 
 namespace mbgl {
 namespace gl {
 
 class Texture {
 public:
-    std::array<uint16_t, 2> size;
+    Size size;
     UniqueTexture texture;
     TextureFilter filter = TextureFilter::Nearest;
     TextureMipMap mipmap = TextureMipMap::No;

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -244,14 +244,14 @@ ActiveTexture::Type ActiveTexture::Get() {
 const constexpr Viewport::Type Viewport::Default;
 
 void Viewport::Set(const Type& value) {
-    MBGL_CHECK_ERROR(glViewport(value.x, value.y, value.width, value.height));
+    MBGL_CHECK_ERROR(glViewport(value.x, value.y, value.size.width, value.size.height));
 }
 
 Viewport::Type Viewport::Get() {
     GLint viewport[4];
     MBGL_CHECK_ERROR(glGetIntegerv(GL_VIEWPORT, viewport));
     return { static_cast<int32_t>(viewport[0]), static_cast<int32_t>(viewport[1]),
-             static_cast<uint16_t>(viewport[2]), static_cast<uint16_t>(viewport[3]) };
+             { static_cast<uint32_t>(viewport[2]), static_cast<uint32_t>(viewport[3]) } };
 }
 
 const constexpr BindFramebuffer::Type BindFramebuffer::Default;

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/gl/types.hpp>
 #include <mbgl/util/color.hpp>
+#include <mbgl/util/size.hpp>
 
 namespace mbgl {
 namespace gl {
@@ -177,16 +178,15 @@ struct Viewport {
     struct Type {
         int32_t x;
         int32_t y;
-        uint16_t width;
-        uint16_t height;
+        Size size;
     };
-    static const constexpr Type Default = { 0, 0, 0, 0 };
+    static const constexpr Type Default = { 0, 0, { 0, 0 } };
     static void Set(const Type&);
     static Type Get();
 };
 
 constexpr bool operator!=(const Viewport::Type& a, const Viewport::Type& b) {
-    return a.x != b.x || a.y != b.y || a.width != b.width || a.height != b.height;
+    return a.x != b.x || a.y != b.y || a.size != b.size;
 }
 
 struct BindFramebuffer {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -99,7 +99,7 @@ public:
 };
 
 Map::Map(Backend& backend,
-         const std::array<uint16_t, 2> size,
+         const Size size,
          const float pixelRatio,
          FileSource& fileSource,
          Scheduler& scheduler,
@@ -541,7 +541,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
     // Calculate the bounds of the possibly rotated shape with respect to the viewport.
     ScreenCoordinate nePixel = {-INFINITY, -INFINITY};
     ScreenCoordinate swPixel = {INFINITY, INFINITY};
-    double viewportHeight = getHeight();
+    double viewportHeight = getSize().height;
     for (LatLng latLng : latLngs) {
         ScreenCoordinate pixel = pixelForLatLng(latLng);
         swPixel.x = std::min(swPixel.x, pixel.x);
@@ -555,8 +555,8 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
     // Calculate the zoom level.
     double minScale = INFINITY;
     if (width > 0 || height > 0) {
-        double scaleX = getWidth() / width;
-        double scaleY = getHeight() / height;
+        double scaleX = double(getSize().width) / width;
+        double scaleY = double(getSize().height) / height;
         if (padding && *padding) {
             scaleX -= (padding->left + padding->right) / width;
             scaleY -= (padding->top + padding->bottom) / height;
@@ -617,17 +617,13 @@ double Map::getMaxZoom() const {
 
 #pragma mark - Size
 
-void Map::setSize(const std::array<uint16_t, 2>& size) {
+void Map::setSize(const Size size) {
     impl->transform.resize(size);
     impl->onUpdate(Update::Repaint);
 }
 
-uint16_t Map::getWidth() const {
-    return impl->transform.getState().getWidth();
-}
-
-uint16_t Map::getHeight() const {
-    return impl->transform.getState().getHeight();
+Size Map::getSize() const {
+    return impl->transform.getState().getSize();
 }
 
 #pragma mark - Rotation

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -45,8 +45,8 @@ Transform::Transform(std::function<void(MapChange)> callback_,
 
 #pragma mark - Map View
 
-bool Transform::resize(const std::array<uint16_t, 2> size) {
-    if (state.width == size[0] && state.height == size[1]) {
+bool Transform::resize(const Size size) {
+    if (state.size == size) {
         return false;
     }
 
@@ -54,8 +54,7 @@ bool Transform::resize(const std::array<uint16_t, 2> size) {
         callback(MapChangeRegionWillChange);
     }
 
-    state.width = size[0];
-    state.height = size[1];
+    state.size = size;
     state.constrain(state.scale, state.x, state.y);
 
     if (callback) {
@@ -117,7 +116,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     const Point<double> endPoint = Projection::project(latLng, state.scale);
 
     ScreenCoordinate center = getScreenCoordinate(padding);
-    center.y = state.height - center.y;
+    center.y = state.size.height - center.y;
 
     // Constrain camera options.
     zoom = util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
@@ -187,7 +186,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
     const Point<double> endPoint = Projection::project(latLng, state.scale);
 
     ScreenCoordinate center = getScreenCoordinate(padding);
-    center.y = state.height - center.y;
+    center.y = state.size.height - center.y;
 
     // Constrain camera options.
     zoom = util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
@@ -203,9 +202,9 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
 
     /// w₀: Initial visible span, measured in pixels at the initial scale.
     /// Known henceforth as a <i>screenful</i>.
-    double w0 = padding ? std::max(state.width, state.height)
-                        : std::max(state.width - padding.left - padding.right,
-                                   state.height - padding.top - padding.bottom);
+    double w0 = padding ? std::max(state.size.width, state.size.height)
+                        : std::max(state.size.width - padding.left - padding.right,
+                                   state.size.height - padding.top - padding.bottom);
     /// w₁: Final visible span, measured in pixels with respect to the initial
     /// scale.
     double w1 = w0 / state.zoomScale(zoom - startZoom);
@@ -355,8 +354,8 @@ void Transform::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> ancho
         EdgeInsets padding;
         padding.top = anchor->y;
         padding.left = anchor->x;
-        padding.bottom = state.height - anchor->y;
-        padding.right = state.width - anchor->x;
+        padding.bottom = state.size.height - anchor->y;
+        padding.right = state.size.width - anchor->x;
         if (padding) camera.padding = padding;
     }
     easeTo(camera, duration);
@@ -378,7 +377,7 @@ void Transform::setLatLngZoom(const LatLng& latLng, double zoom, optional<EdgeIn
 
 LatLng Transform::getLatLng(optional<EdgeInsets> padding) const {
     if (padding && *padding) {
-        return screenCoordinateToLatLng(padding->getCenter(state.width, state.height));
+        return screenCoordinateToLatLng(padding->getCenter(state.size.width, state.size.height));
     } else {
         return state.getLatLng();
     }
@@ -386,9 +385,9 @@ LatLng Transform::getLatLng(optional<EdgeInsets> padding) const {
 
 ScreenCoordinate Transform::getScreenCoordinate(optional<EdgeInsets> padding) const {
     if (padding && *padding) {
-        return padding->getCenter(state.width, state.height);
+        return padding->getCenter(state.size.width, state.size.height);
     } else {
-        return { state.width / 2., state.height / 2. };
+        return { state.size.width / 2., state.size.height / 2. };
     }
 }
 
@@ -565,7 +564,7 @@ void Transform::startTransition(const CameraOptions& camera,
     optional<ScreenCoordinate> anchor = camera.anchor;
     LatLng anchorLatLng;
     if (anchor) {
-        anchor->y = state.getHeight() - anchor->y;
+        anchor->y = state.size.height - anchor->y;
         anchorLatLng = state.screenCoordinateToLatLng(*anchor);
     }
 
@@ -650,13 +649,13 @@ ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const
     LatLng unwrappedLatLng = latLng.wrapped();
     unwrappedLatLng.unwrapForShortestPath(getLatLng());
     ScreenCoordinate point = state.latLngToScreenCoordinate(unwrappedLatLng);
-    point.y = state.height - point.y;
+    point.y = state.size.height - point.y;
     return point;
 }
 
 LatLng Transform::screenCoordinateToLatLng(const ScreenCoordinate& point) const {
     ScreenCoordinate flippedPoint = point;
-    flippedPoint.y = state.height - flippedPoint.y;
+    flippedPoint.y = state.size.height - flippedPoint.y;
     return state.screenCoordinateToLatLng(flippedPoint).wrapped();
 }
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -23,7 +23,7 @@ public:
               ViewportMode = ViewportMode::Default);
 
     // Map view
-    bool resize(std::array<uint16_t, 2> size);
+    bool resize(Size size);
 
     // Camera
     /** Returns the current camera options. */

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -33,15 +33,16 @@ void TransformState::getProjMatrix(mat4& projMatrix) const {
     // Calculate z value of the farthest fragment that should be rendered.
     double farZ = std::cos(M_PI / 2.0f - getPitch()) * topHalfSurfaceDistance + getAltitude();
 
-    matrix::perspective(projMatrix, 2.0f * std::atan((getHeight() / 2.0f) / getAltitude()),
-            double(getWidth()) / getHeight(), 0.1, farZ);
+    matrix::perspective(projMatrix, 2.0f * std::atan((size.height / 2.0f) / getAltitude()),
+                        double(size.width) / size.height, 0.1, farZ);
 
     matrix::translate(projMatrix, projMatrix, 0, 0, -getAltitude());
 
     // After the rotateX, z values are in pixel units. Convert them to
     // altitude unites. 1 altitude unit = the screen height.
     const bool flippedY = viewportMode == ViewportMode::FlippedY;
-    matrix::scale(projMatrix, projMatrix, 1, flippedY ? 1 : -1, 1.0f / (rotatedNorth() ? getWidth() : getHeight()));
+    matrix::scale(projMatrix, projMatrix, 1, flippedY ? 1 : -1,
+                  1.0f / (rotatedNorth() ? size.width : size.height));
 
     using NO = NorthOrientation;
     switch (getNorthOrientation()) {
@@ -53,18 +54,14 @@ void TransformState::getProjMatrix(mat4& projMatrix) const {
 
     matrix::rotate_z(projMatrix, projMatrix, getAngle() + getNorthOrientationAngle());
 
-    matrix::translate(projMatrix, projMatrix, pixel_x() - getWidth() / 2.0f,
-            pixel_y() - getHeight() / 2.0f, 0);
+    matrix::translate(projMatrix, projMatrix, pixel_x() - size.width / 2.0f,
+                      pixel_y() - size.height / 2.0f, 0);
 }
 
 #pragma mark - Dimensions
 
-uint16_t TransformState::getWidth() const {
-    return width;
-}
-
-uint16_t TransformState::getHeight() const {
-    return height;
+Size TransformState::getSize() const {
+    return size;
 }
 
 #pragma mark - North Orientation
@@ -108,12 +105,12 @@ LatLng TransformState::getLatLng(LatLng::WrapMode wrapMode) const {
 }
 
 double TransformState::pixel_x() const {
-    const double center = (width - Projection::worldSize(scale)) / 2;
+    const double center = (size.width - Projection::worldSize(scale)) / 2;
     return center + x;
 }
 
 double TransformState::pixel_y() const {
-    const double center = (height - Projection::worldSize(scale)) / 2;
+    const double center = (size.height - Projection::worldSize(scale)) / 2;
     return center + y;
 }
 
@@ -210,7 +207,7 @@ double TransformState::scaleZoom(double s) const {
 }
 
 ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) const {
-    if (width == 0 || height == 0) {
+    if (!size) {
         return {};
     }
 
@@ -219,11 +216,11 @@ ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) 
     Point<double> pt = Projection::project(latLng, scale) / double(util::tileSize);
     vec4 c = {{ pt.x, pt.y, 0, 1 }};
     matrix::transformMat4(p, c, mat);
-    return { p[0] / p[3], height - p[1] / p[3] };
+    return { p[0] / p[3], size.height - p[1] / p[3] };
 }
 
 LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng::WrapMode wrapMode) const {
-    if (width == 0 || height == 0) {
+    if (!size) {
         return {};
     }
 
@@ -235,7 +232,7 @@ LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point, L
 
     if (err) throw std::runtime_error("failed to invert coordinatePointMatrix");
 
-    double flippedY = height - point.y;
+    double flippedY = size.height - point.y;
 
     // since we don't know the correct projected z value for the point,
     // unproject two points to get a line and then find the point on that
@@ -273,7 +270,8 @@ mat4 TransformState::coordinatePointMatrix(double z) const {
 mat4 TransformState::getPixelMatrix() const {
     mat4 m;
     matrix::identity(m);
-    matrix::scale(m, m, width / 2.0f, -height / 2.0f, 1);
+    matrix::scale(m, m,
+                  static_cast<double>(size.width) / 2, -static_cast<double>(size.height) / 2, 1);
     matrix::translate(m, m, 1, -1, 0);
     return m;
 }
@@ -289,17 +287,17 @@ bool TransformState::rotatedNorth() const {
 void TransformState::constrain(double& scale_, double& x_, double& y_) const {
     // Constrain minimum scale to avoid zooming out far enough to show off-world areas.
     scale_ = util::max(scale_,
-                       static_cast<double>((rotatedNorth() ? height : width) / util::tileSize),
-                       static_cast<double>((rotatedNorth() ? width : height) / util::tileSize));
+                       static_cast<double>(rotatedNorth() ? size.height : size.width) / util::tileSize,
+                       static_cast<double>(rotatedNorth() ? size.width : size.height) / util::tileSize);
 
     // Constrain min/max pan to avoid showing off-world areas.
     if (constrainMode == ConstrainMode::WidthAndHeight) {
-        double max_x = (scale_ * util::tileSize - (rotatedNorth() ? height : width)) / 2;
+        double max_x = (scale_ * util::tileSize - (rotatedNorth() ? size.height : size.width)) / 2;
         x_ = std::max(-max_x, std::min(x_, max_x));
     }
 
     if (constrainMode != ConstrainMode::None) {
-        double max_y = (scale_ * util::tileSize - (rotatedNorth() ? width : height)) / 2;
+        double max_y = (scale_ * util::tileSize - (rotatedNorth() ? size.width : size.height)) / 2;
         y_ = std::max(-max_y, std::min(y_, max_y));
     }
 }

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/mat4.hpp>
+#include <mbgl/util/size.hpp>
 
 #include <cstdint>
 #include <array>
@@ -26,8 +27,7 @@ public:
     void getProjMatrix(mat4& matrix) const;
 
     // Dimensions
-    uint16_t getWidth() const;
-    uint16_t getHeight() const;
+    Size getSize() const;
 
     // North Orientation
     NorthOrientation getNorthOrientation() const;
@@ -84,7 +84,7 @@ private:
     NorthOrientation orientation = NorthOrientation::Upwards;
 
     // logical dimensions
-    uint16_t width = 0, height = 0;
+    Size size;
 
     mat4 coordinatePointMatrix(double z) const;
     mat4 getPixelMatrix() const;

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -119,7 +119,7 @@ void Painter::render(const Style& style, const FrameData& frame_, View& view, Sp
     // Update the default matrices to the current viewport dimensions.
     state.getProjMatrix(projMatrix);
 
-    pixelsToGLUnits = {{ 2.0f  / state.getWidth(), -2.0f / state.getHeight() }};
+    pixelsToGLUnits = {{ 2.0f  / state.getSize().width, -2.0f / state.getSize().height }};
     if (state.getViewportMode() == ViewportMode::FlippedY) {
         pixelsToGLUnits[1] *= -1;
     }

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -85,7 +85,8 @@ void Painter::renderDebugFrame(const mat4 &matrix) {
     tileBorderArray.bind(plainShader, tileLineStripVertexBuffer, BUFFER_OFFSET_0, context);
     plainShader.u_color = { 1.0f, 0.0f, 0.0f, 1.0f };
     context.lineWidth = 4.0f * frame.pixelRatio;
-    MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0, static_cast<GLsizei>(tileLineStripVertexBuffer.vertexCount)));
+    MBGL_CHECK_ERROR(glDrawArrays(GL_LINE_STRIP, 0,
+                                  static_cast<GLsizei>(tileLineStripVertexBuffer.vertexCount)));
 }
 
 #ifndef NDEBUG
@@ -101,28 +102,28 @@ void Painter::renderClipMasks(PaintParameters&) {
 
     // Read the stencil buffer
     const auto viewport = context.viewport.getCurrentValue();
-    auto pixels = std::make_unique<uint8_t[]>(viewport.width * viewport.height);
+    auto pixels = std::make_unique<uint8_t[]>(viewport.size.width * viewport.size.height);
     MBGL_CHECK_ERROR(glReadPixels(
-                viewport.x,         // GLint x
-                viewport.y,         // GLint y
-                viewport.width,   // GLsizei width
-                viewport.height,  // GLsizei height
-                GL_STENCIL_INDEX, // GLenum format
-                GL_UNSIGNED_BYTE, // GLenum type
-                pixels.get()      // GLvoid * data
+                viewport.x,           // GLint x
+                viewport.y,           // GLint y
+                viewport.size.width,  // GLsizei width
+                viewport.size.height, // GLsizei height
+                GL_STENCIL_INDEX,     // GLenum format
+                GL_UNSIGNED_BYTE,     // GLenum type
+                pixels.get()          // GLvoid * data
                 ));
 
     // Scale the Stencil buffer to cover the entire color space.
     auto it = pixels.get();
-    auto end = it + viewport.width * viewport.height;
+    auto end = it + viewport.size.width * viewport.size.height;
     const auto factor = 255.0f / *std::max_element(it, end);
     for (; it != end; ++it) {
         *it *= factor;
     }
 
     MBGL_CHECK_ERROR(glWindowPos2i(viewport.x, viewport.y));
-    MBGL_CHECK_ERROR(glDrawPixels(viewport.width, viewport.height, GL_LUMINANCE, GL_UNSIGNED_BYTE,
-                                  pixels.get()));
+    MBGL_CHECK_ERROR(glDrawPixels(viewport.size.width, viewport.size.height, GL_LUMINANCE,
+                                  GL_UNSIGNED_BYTE, pixels.get()));
 #endif // MBGL_USE_GLES2
 }
 #endif // NDEBUG
@@ -140,25 +141,25 @@ void Painter::renderDepthBuffer(PaintParameters&) {
 
     // Read the stencil buffer
     const auto viewport = context.viewport.getCurrentValue();
-    auto pixels = std::make_unique<uint8_t[]>(viewport.width * viewport.height);
+    auto pixels = std::make_unique<uint8_t[]>(viewport.size.width * viewport.size.height);
 
     const double base = 1.0 / (1.0 - depthRangeSize);
     glPixelTransferf(GL_DEPTH_SCALE, base);
     glPixelTransferf(GL_DEPTH_BIAS, 1.0 - base);
 
     MBGL_CHECK_ERROR(glReadPixels(
-                viewport.x,         // GLint x
-                viewport.y,         // GLint y
-                viewport.width,     // GLsizei width
-                viewport.height,    // GLsizei height
-                GL_DEPTH_COMPONENT, // GLenum format
-                GL_UNSIGNED_BYTE,   // GLenum type
-                pixels.get()        // GLvoid * data
+                viewport.x,           // GLint x
+                viewport.y,           // GLint y
+                viewport.size.width,  // GLsizei width
+                viewport.size.height, // GLsizei height
+                GL_DEPTH_COMPONENT,   // GLenum format
+                GL_UNSIGNED_BYTE,     // GLenum type
+                pixels.get()          // GLvoid * data
                 ));
 
     MBGL_CHECK_ERROR(glWindowPos2i(viewport.x, viewport.y));
-    MBGL_CHECK_ERROR(glDrawPixels(viewport.width, viewport.height, GL_LUMINANCE, GL_UNSIGNED_BYTE,
-                                  pixels.get()));
+    MBGL_CHECK_ERROR(glDrawPixels(viewport.size.width, viewport.size.height, GL_LUMINANCE,
+                                  GL_UNSIGNED_BYTE, pixels.get()));
 #endif // MBGL_USE_GLES2
 }
 #endif // NDEBUG

--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -31,8 +31,8 @@ void Painter::renderFill(PaintParameters& parameters,
     Color strokeColor = isOutlineColorDefined? properties.fillOutlineColor : fillColor;
 
     const auto viewport = context.viewport.getCurrentValue();
-    const std::array<GLfloat, 2> worldSize{ { static_cast<GLfloat>(viewport.width),
-                                              static_cast<GLfloat>(viewport.height) } };
+    const std::array<GLfloat, 2> worldSize{{ static_cast<GLfloat>(viewport.size.width),
+                                             static_cast<GLfloat>(viewport.size.height) }};
 
     bool pattern = !properties.fillPattern.value.from.empty();
     bool outline = properties.fillAntialias && !pattern && isOutlineColorDefined;

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -47,8 +47,8 @@ void Painter::renderLine(PaintParameters& parameters,
 
     // calculate how much longer the real world distance is at the top of the screen
     // than at the middle of the screen.
-    float topedgelength = std::sqrt(std::pow(state.getHeight(), 2.0f) / 4.0f  * (1.0f + std::pow(state.getAltitude(), 2.0f)));
-    float x = state.getHeight() / 2.0f * std::tan(state.getPitch());
+    float topedgelength = std::sqrt(std::pow(state.getSize().height, 2.0f) / 4.0f  * (1.0f + std::pow(state.getAltitude(), 2.0f)));
+    float x = state.getSize().height / 2.0f * std::tan(state.getPitch());
     float extra = (topedgelength + x) / topedgelength - 1.0f;
 
     mat4 vtxMatrix = tile.translatedMatrix(properties.lineTranslate,

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -69,7 +69,7 @@ void Painter::renderSDF(SymbolBucket& bucket,
     sdfShader.u_texture = 0;
     sdfShader.u_pitch = state.getPitch();
     sdfShader.u_bearing = -1.0f * state.getAngle();
-    sdfShader.u_aspect_ratio = (state.getWidth() * 1.0f) / (state.getHeight() * 1.0f);
+    sdfShader.u_aspect_ratio = double(state.getSize().width) / state.getSize().height;
 
     // adjust min/max zooms for variable font sies
     float zoomAdjust = std::log(fontSize / layoutSize) / std::log(2);

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -128,7 +128,7 @@ void SpriteAtlas::_setSprite(const std::string& name,
         auto it = sprites.find(name);
         if (it != sprites.end()) {
             // There is already a sprite with that name in our store.
-            if ((it->second->image.width != sprite->image.width || it->second->image.height != sprite->image.height)) {
+            if (it->second->image.size != sprite->image.size) {
                 Log::Warning(Event::Sprite, "Can't change sprite dimensions for '%s'", name.c_str());
                 return;
             }
@@ -164,8 +164,8 @@ std::shared_ptr<const SpriteImage> SpriteAtlas::getSprite(const std::string& nam
 
 Rect<SpriteAtlas::dimension> SpriteAtlas::allocateImage(const SpriteImage& spriteImage) {
 
-    const uint16_t pixel_width = std::ceil(spriteImage.image.width / pixelRatio);
-    const uint16_t pixel_height = std::ceil(spriteImage.image.height / pixelRatio);
+    const uint16_t pixel_width = std::ceil(spriteImage.image.size.width / pixelRatio);
+    const uint16_t pixel_height = std::ceil(spriteImage.image.size.height / pixelRatio);
 
     // Increase to next number divisible by 4, but at least 1.
     // This is so we can scale down the texture coordinates and pack them
@@ -275,9 +275,10 @@ void SpriteAtlas::copy(const Holder& holder, const SpritePatternMode mode) {
 
     const int padding = 1;
 
-    copyBitmap(srcData, uint32_t(holder.spriteImage->image.width), 0, 0,
-            dstData, pixelWidth, (holder.pos.x + padding) * pixelRatio, (holder.pos.y + padding) * pixelRatio, pixelWidth * pixelHeight,
-            uint32_t(holder.spriteImage->image.width), uint32_t(holder.spriteImage->image.height), mode);
+    copyBitmap(srcData, holder.spriteImage->image.size.width, 0, 0, dstData, pixelWidth,
+               (holder.pos.x + padding) * pixelRatio, (holder.pos.y + padding) * pixelRatio,
+               pixelWidth * pixelHeight, holder.spriteImage->image.size.width,
+               holder.spriteImage->image.size.height, mode);
 
     dirtyFlag = true;
 }

--- a/src/mbgl/sprite/sprite_image.cpp
+++ b/src/mbgl/sprite/sprite_image.cpp
@@ -13,7 +13,7 @@ SpriteImage::SpriteImage(PremultipliedImage&& image_,
       pixelRatio(pixelRatio_),
       sdf(sdf_) {
 
-    if (image.size() == 0) {
+    if (!image.valid()) {
         throw util::SpriteImageException("Sprite image dimensions may not be zero");
     } else if (pixelRatio <= 0) {
         throw util::SpriteImageException("Sprite pixelRatio may not be <= 0");

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -13,30 +13,31 @@
 namespace mbgl {
 
 SpriteImagePtr createSpriteImage(const PremultipliedImage& image,
-                                 const uint16_t srcX,
-                                 const uint16_t srcY,
-                                 const uint16_t width,
-                                 const uint16_t height,
+                                 const uint32_t srcX,
+                                 const uint32_t srcY,
+                                 const uint32_t width,
+                                 const uint32_t height,
                                  const double ratio,
                                  const bool sdf) {
     // Disallow invalid parameter configurations.
     if (width <= 0 || height <= 0 || width > 1024 || height > 1024 ||
         ratio <= 0 || ratio > 10 ||
-        srcX + width > image.width || srcY + height > image.height) {
+        srcX >= image.size.width || srcY >= image.size.height ||
+        srcX + width > image.size.width || srcY + height > image.size.height) {
         Log::Error(Event::Sprite, "Can't create sprite with invalid metrics");
         return nullptr;
     }
 
-    PremultipliedImage dstImage(width, height);
+    PremultipliedImage dstImage({ width, height });
 
     auto srcData = reinterpret_cast<const uint32_t*>(image.data.get());
     auto dstData = reinterpret_cast<uint32_t*>(dstImage.data.get());
 
     // Copy from the source image into our individual sprite image
-    for (uint16_t y = 0; y < height; ++y) {
+    for (uint32_t y = 0; y < height; ++y) {
         const auto dstRow = y * width;
-        const auto srcRow = (y + srcY) * image.width + srcX;
-        for (uint16_t x = 0; x < width; ++x) {
+        const auto srcRow = (y + srcY) * image.size.width + srcX;
+        for (uint32_t x = 0; x < width; ++x) {
             dstData[dstRow + x] = srcData[srcRow + x];
         }
     }

--- a/src/mbgl/sprite/sprite_parser.hpp
+++ b/src/mbgl/sprite/sprite_parser.hpp
@@ -17,10 +17,10 @@ using SpriteImagePtr = std::shared_ptr<const SpriteImage>;
 
 // Extracts an individual image from a spritesheet from the given location.
 SpriteImagePtr createSpriteImage(const PremultipliedImage&,
-                                 uint16_t srcX,
-                                 uint16_t srcY,
-                                 uint16_t srcWidth,
-                                 uint16_t srcHeight,
+                                 uint32_t srcX,
+                                 uint32_t srcY,
+                                 uint32_t srcWidth,
+                                 uint32_t srcHeight,
                                  double ratio,
                                  bool sdf);
 

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -48,8 +48,8 @@ void CustomLayer::Impl::render(const TransformState& state) const {
 
     CustomLayerRenderParameters parameters;
 
-    parameters.width = state.getWidth();
-    parameters.height = state.getHeight();
+    parameters.width = state.getSize().width;
+    parameters.height = state.getSize().height;
     parameters.latitude = state.getLatLng().latitude;
     parameters.longitude = state.getLatLng().longitude;
     parameters.zoom = state.getZoom();

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -139,8 +139,8 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
 
     if (type != SourceType::Raster && type != SourceType::Annotations && cache.getSize() == 0) {
         size_t conservativeCacheSize =
-            ((float)parameters.transformState.getWidth() / util::tileSize) *
-            ((float)parameters.transformState.getHeight() / util::tileSize) *
+            ((float)parameters.transformState.getSize().width / util::tileSize) *
+            ((float)parameters.transformState.getSize().height / util::tileSize) *
             (parameters.transformState.getMaxZoom() - parameters.transformState.getMinZoom() + 1) *
             0.5;
         cache.setSize(conservativeCacheSize);
@@ -202,7 +202,7 @@ std::unordered_map<std::string, std::vector<Feature>> Source::Impl::queryRendere
 
     for (const auto& p : parameters.geometry) {
         queryGeometry.push_back(TileCoordinate::fromScreenCoordinate(
-            parameters.transformState, 0, { p.x, parameters.transformState.getHeight() - p.y }).p);
+            parameters.transformState, 0, { p.x, parameters.transformState.getSize().height - p.y }).p);
     }
 
     mapbox::geometry::box<double> box = mapbox::geometry::envelope(queryGeometry);

--- a/src/mbgl/util/offscreen_texture.hpp
+++ b/src/mbgl/util/offscreen_texture.hpp
@@ -14,7 +14,7 @@ class Context;
 
 class OffscreenTexture : public View {
 public:
-    OffscreenTexture(gl::Context&, std::array<uint16_t, 2> size = {{ 256, 256 }});
+    OffscreenTexture(gl::Context&, Size size = { 256, 256 });
 
     void bind() override;
 
@@ -22,9 +22,11 @@ public:
 
     gl::Texture& getTexture();
 
+public:
+    const Size size;
+
 private:
     gl::Context& context;
-    std::array<uint16_t, 2> size;
     optional<gl::Framebuffer> framebuffer;
     optional<gl::Texture> texture;
 };

--- a/src/mbgl/util/premultiply.cpp
+++ b/src/mbgl/util/premultiply.cpp
@@ -8,12 +8,11 @@ namespace util {
 PremultipliedImage premultiply(UnassociatedImage&& src) {
     PremultipliedImage dst;
 
-    dst.width = src.width;
-    dst.height = src.height;
+    dst.size = src.size;
     dst.data = std::move(src.data);
 
     uint8_t* data = dst.data.get();
-    for (size_t i = 0; i < dst.size(); i += 4) {
+    for (size_t i = 0; i < dst.bytes(); i += 4) {
         uint8_t& r = data[i + 0];
         uint8_t& g = data[i + 1];
         uint8_t& b = data[i + 2];
@@ -29,12 +28,11 @@ PremultipliedImage premultiply(UnassociatedImage&& src) {
 UnassociatedImage unpremultiply(PremultipliedImage&& src) {
     UnassociatedImage dst;
 
-    dst.width = src.width;
-    dst.height = src.height;
+    dst.size = src.size;
     dst.data = std::move(src.data);
 
     uint8_t* data = dst.data.get();
-    for (size_t i = 0; i < dst.size(); i += 4) {
+    for (size_t i = 0; i < dst.bytes(); i += 4) {
         uint8_t& r = data[i + 0];
         uint8_t& g = data[i + 1];
         uint8_t& b = data[i + 2];

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -157,8 +157,8 @@ std::vector<UnwrappedTileID> tileCover(const LatLngBounds& bounds_, int32_t z) {
 }
 
 std::vector<UnwrappedTileID> tileCover(const TransformState& state, int32_t z) {
-    const double w = state.getWidth();
-    const double h = state.getHeight();
+    const double w = state.getSize().width;
+    const double h = state.getSize().height;
     return tileCover(
         TileCoordinate::fromScreenCoordinate(state, z, { 0,   0   }).p,
         TileCoordinate::fromScreenCoordinate(state, z, { w,   0   }).p,

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -27,7 +27,7 @@ public:
     OffscreenView view{ backend.getContext() };
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };
-    Map map { backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still };
+    Map map { backend, view.size, 1, fileSource, threadPool, MapMode::Still };
 
     void checkRendering(const char * name) {
         test::checkImage(std::string("test/fixtures/annotations/") + name,
@@ -45,8 +45,8 @@ TEST(Annotations, SymbolAnnotation) {
     test.map.addAnnotation(SymbolAnnotation { Point<double>(0, 0), "default_marker" });
     test.checkRendering("point_annotation");
 
-    auto size = test.view.getSize();
-    auto screenBox = ScreenBox { {}, { double(size[0]), double(size[1]) } };
+    auto size = test.view.size;
+    auto screenBox = ScreenBox { {}, { double(size.width), double(size.height) } };
     auto features = test.map.queryPointAnnotations(screenBox);
     EXPECT_EQ(features.size(), 1u);
 
@@ -354,8 +354,8 @@ TEST(Annotations, QueryRenderedFeatures) {
 TEST(Annotations, QueryFractionalZoomLevels) {
     AnnotationTest test;
 
-    auto viewSize = test.view.getSize();
-    auto box = ScreenBox { {}, { double(viewSize[0]), double(viewSize[1]) } };
+    auto viewSize = test.view.size;
+    auto box = ScreenBox { {}, { double(viewSize.width), double(viewSize.height) } };
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotationIcon("default_marker", namedMarker("default_marker.png"));
@@ -386,8 +386,8 @@ TEST(Annotations, QueryFractionalZoomLevels) {
 TEST(Annotations, VisibleFeatures) {
     AnnotationTest test;
 
-    auto viewSize = test.view.getSize();
-    auto box = ScreenBox { {}, { double(viewSize[0]), double(viewSize[1]) } };
+    auto viewSize = test.view.size;
+    auto box = ScreenBox { {}, { double(viewSize.width), double(viewSize.height) } };
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotationIcon("default_marker", namedMarker("default_marker.png"));

--- a/test/api/api_misuse.test.cpp
+++ b/test/api/api_misuse.test.cpp
@@ -21,12 +21,12 @@ TEST(API, RenderWithoutCallback) {
     util::RunLoop loop;
 
     HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), {{ 128, 512 }});
+    OffscreenView view(backend.getContext(), { 128, 512 });
     StubFileSource fileSource;
     ThreadPool threadPool(4);
 
     std::unique_ptr<Map> map =
-        std::make_unique<Map>(backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still);
+        std::make_unique<Map>(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
     map->renderStill(view, nullptr);
 
     // Force Map thread to join.
@@ -46,11 +46,11 @@ TEST(API, RenderWithoutStyle) {
     util::RunLoop loop;
 
     HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), {{ 128, 512 }});
+    OffscreenView view(backend.getContext(), { 128, 512 });
     StubFileSource fileSource;
     ThreadPool threadPool(4);
 
-    Map map(backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still);
+    Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
 
     std::exception_ptr error;
     map.renderStill(view, [&](std::exception_ptr error_) {

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -97,7 +97,7 @@ TEST(CustomLayer, Basic) {
 
     ThreadPool threadPool(4);
 
-    Map map(backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still);
+    Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/water.json"));
     map.setLatLngZoom({ 37.8, -122.5 }, 10);
     map.addLayer(std::make_unique<CustomLayer>(

--- a/test/api/query.test.cpp
+++ b/test/api/query.test.cpp
@@ -30,7 +30,7 @@ public:
     OffscreenView view { backend.getContext() };
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };
-    Map map { backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still };
+    Map map { backend, view.size, 1, fileSource, threadPool, MapMode::Still };
 };
 
 } // end namespace

--- a/test/api/render_missing.test.cpp
+++ b/test/api/render_missing.test.cpp
@@ -26,7 +26,7 @@ TEST(API, TEST_REQUIRES_SERVER(RenderMissingTile)) {
     const auto style = util::read_file("test/fixtures/api/water_missing_tiles.json");
 
     HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), {{ 256, 512 }});
+    OffscreenView view(backend.getContext(), { 256, 512 });
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets.zip");
@@ -38,7 +38,7 @@ TEST(API, TEST_REQUIRES_SERVER(RenderMissingTile)) {
 
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 
-    Map map(backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still);
+    Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
 
     std::string message;
 

--- a/test/api/repeated_render.test.cpp
+++ b/test/api/repeated_render.test.cpp
@@ -20,7 +20,7 @@ TEST(API, RepeatedRender) {
     const auto style = util::read_file("test/fixtures/api/water.json");
 
     HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), {{ 256, 512 }});
+    OffscreenView view(backend.getContext(), { 256, 512 });
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets.zip");
@@ -32,7 +32,7 @@ TEST(API, RepeatedRender) {
 
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 
-    Map map(backend, view.getSize(), 1, fileSource, threadPool, MapMode::Still);
+    Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
 
     {
         map.setStyleJSON(style);
@@ -41,12 +41,12 @@ TEST(API, RepeatedRender) {
             result = view.readStillImage();
         });
 
-        while (!result.size()) {
+        while (!result.valid()) {
             loop.runOnce();
         }
 
-        ASSERT_EQ(256u, result.width);
-        ASSERT_EQ(512u, result.height);
+        ASSERT_EQ(256u, result.size.width);
+        ASSERT_EQ(512u, result.size.height);
 #if !TEST_READ_ONLY
         util::write_file("test/fixtures/api/1.png", encodePNG(result));
 #endif
@@ -59,12 +59,12 @@ TEST(API, RepeatedRender) {
             result = view.readStillImage();
         });
 
-        while (!result.size()) {
+        while (!result.valid()) {
             loop.runOnce();
         }
 
-        ASSERT_EQ(256u, result.width);
-        ASSERT_EQ(512u, result.height);
+        ASSERT_EQ(256u, result.size.width);
+        ASSERT_EQ(512u, result.size.height);
 #if !TEST_READ_ONLY
         util::write_file("test/fixtures/api/2.png", encodePNG(result));
 #endif

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -30,7 +30,7 @@ struct MapTest {
 
 TEST(Map, LatLngBehavior) {
     MapTest test;
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
 
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
 
@@ -64,7 +64,7 @@ TEST(Map, Offline) {
     fileSource.put(Resource::glyphs(prefix + "{fontstack}/{range}.pbf", {{"Helvetica"}}, {0, 255}), expiredItem("glyph.pbf"));
     NetworkStatus::Set(NetworkStatus::Status::Offline);
 
-    Map map(test.backend, test.view.getSize(), 1, fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, fileSource, test.threadPool, MapMode::Still);
     map.setStyleURL(prefix + "style.json");
 
     test::checkImage("test/fixtures/map/offline",
@@ -88,7 +88,7 @@ TEST(Map, SetStyleInvalidJSON) {
     });
 
     {
-        Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool,
+        Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool,
                 MapMode::Still);
         map.setStyleJSON("invalid");
     }
@@ -120,7 +120,7 @@ TEST(Map, SetStyleInvalidURL) {
         }
     });
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     map.setStyleURL("mapbox://bar");
 
     test.runLoop.run();
@@ -129,7 +129,7 @@ TEST(Map, SetStyleInvalidURL) {
 TEST(Map, DoubleStyleLoad) {
     MapTest test;
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     map.setStyleJSON("");
     map.setStyleJSON("");
 }
@@ -140,7 +140,7 @@ TEST(Map, StyleFresh) {
     MapTest test;
     FakeFileSource fileSource;
 
-    Map map(test.backend, test.view.getSize(), 1, fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, fileSource, test.threadPool, MapMode::Still);
     map.setStyleURL("mapbox://styles/test");
     EXPECT_EQ(1u, fileSource.requests.size());
 
@@ -160,7 +160,7 @@ TEST(Map, StyleExpired) {
     MapTest test;
     FakeFileSource fileSource;
 
-    Map map(test.backend, test.view.getSize(), 1, fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, fileSource, test.threadPool, MapMode::Still);
     map.setStyleURL("mapbox://styles/test");
     EXPECT_EQ(1u, fileSource.requests.size());
 
@@ -187,7 +187,7 @@ TEST(Map, StyleExpiredWithAnnotations) {
     MapTest test;
     FakeFileSource fileSource;
 
-    Map map(test.backend, test.view.getSize(), 1, fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, fileSource, test.threadPool, MapMode::Still);
     map.setStyleURL("mapbox://styles/test");
     EXPECT_EQ(1u, fileSource.requests.size());
 
@@ -211,7 +211,7 @@ TEST(Map, StyleEarlyMutation) {
     MapTest test;
     FakeFileSource fileSource;
 
-    Map map(test.backend, test.view.getSize(), 1, fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, fileSource, test.threadPool, MapMode::Still);
     map.setStyleURL("mapbox://styles/test");
     map.addLayer(std::make_unique<style::BackgroundLayer>("bg"));
 
@@ -225,7 +225,7 @@ TEST(Map, StyleEarlyMutation) {
 
 TEST(Map, StyleLoadedSignal) {
     MapTest test;
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
 
     // The map should emit a signal on style loaded
     bool emitted = false;
@@ -246,7 +246,7 @@ TEST(Map, StyleLoadedSignal) {
 TEST(Map, AddLayer) {
     MapTest test;
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
 
     auto layer = std::make_unique<BackgroundLayer>("background");
@@ -259,7 +259,7 @@ TEST(Map, AddLayer) {
 TEST(Map, RemoveLayer) {
     MapTest test;
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
 
     auto layer = std::make_unique<BackgroundLayer>("background");
@@ -284,7 +284,7 @@ TEST(Map, DisabledSources) {
         return {};
     };
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     map.setZoom(1);
 
     // This stylesheet has two raster layers, one that starts at zoom 1, the other at zoom 0.
@@ -334,7 +334,7 @@ TEST(Map, DisabledSources) {
 TEST(Map, Classes) {
     MapTest test;
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
 
     EXPECT_FALSE(map.getTransitionOptions().duration);
@@ -368,7 +368,7 @@ TEST(Map, Classes) {
 TEST(Map, AddImage) {
     MapTest test;
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     auto decoded1 = decodeImage(util::read_file("test/fixtures/sprites/default_marker.png"));
     auto decoded2 = decodeImage(util::read_file("test/fixtures/sprites/default_marker.png"));
     auto image1 = std::make_unique<SpriteImage>(std::move(decoded1), 1.0);
@@ -385,7 +385,7 @@ TEST(Map, AddImage) {
 TEST(Map, RemoveImage) {
     MapTest test;
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     auto decoded = decodeImage(util::read_file("test/fixtures/sprites/default_marker.png"));
     auto image = std::make_unique<SpriteImage>(std::move(decoded), 1.0);
 
@@ -398,7 +398,7 @@ TEST(Map, RemoveImage) {
 TEST(Map, DontLoadUnneededTiles) {
     MapTest test;
 
-    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, test.view.size, 1, test.fileSource, test.threadPool, MapMode::Still);
     map.setStyleJSON(R"STYLE({
   "sources": {
     "a": { "type": "vector", "tiles": [ "a/{z}/{x}/{y}" ] }

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -107,7 +107,7 @@ TEST(Transform, PerspectiveProjection) {
     LatLng loc;
 
     Transform transform;
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
     transform.setScale(2 << 9);
     transform.setPitch(0.9);
     transform.setLatLng(LatLng(38, -77));
@@ -137,7 +137,7 @@ TEST(Transform, PerspectiveProjection) {
 
 TEST(Transform, UnwrappedLatLng) {
     Transform transform;
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
     transform.setScale(2 << 9);
     transform.setPitch(0.9);
     transform.setLatLng(LatLng(38, -77));
@@ -169,7 +169,7 @@ TEST(Transform, ConstrainHeightOnly) {
     LatLng loc;
 
     Transform transform;
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
     transform.setScale(std::pow(2, util::MAX_ZOOM));
 
     transform.setLatLng(LatLngBounds::world().southwest());
@@ -187,7 +187,7 @@ TEST(Transform, ConstrainWidthAndHeight) {
     LatLng loc;
 
     Transform transform(nullptr, ConstrainMode::WidthAndHeight);
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
     transform.setScale(std::pow(2, util::MAX_ZOOM));
 
     transform.setLatLng(LatLngBounds::world().southwest());
@@ -203,7 +203,7 @@ TEST(Transform, ConstrainWidthAndHeight) {
 
 TEST(Transform, Anchor) {
     Transform transform;
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
 
     const LatLng latLng { 10, -100 };
     transform.setLatLngZoom(latLng, 10);
@@ -303,7 +303,7 @@ TEST(Transform, Anchor) {
 
 TEST(Transform, Padding) {
     Transform transform;
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
 
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().latitude);
     ASSERT_DOUBLE_EQ(0, transform.getLatLng().longitude);
@@ -340,7 +340,7 @@ TEST(Transform, Padding) {
 
 TEST(Transform, MoveBy) {
     Transform transform;
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
     transform.setLatLngZoom({ 0, 0 }, 10);
 
     LatLng trueCenter = transform.getLatLng();
@@ -367,7 +367,7 @@ TEST(Transform, MoveBy) {
 
 TEST(Transform, Antimeridian) {
     Transform transform;
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
     transform.setLatLngZoom({ 0, 0 }, 1);
 
     const LatLng coordinateSanFrancisco { 37.7833, -122.4167 };
@@ -410,7 +410,7 @@ TEST(Transform, Antimeridian) {
 
 TEST(Transform, Camera) {
     Transform transform;
-    transform.resize({{ 1000, 1000 }});
+    transform.resize({ 1000, 1000 });
 
     const LatLng latLng1 { 45, 135 };
     CameraOptions cameraOptions1;
@@ -481,8 +481,8 @@ TEST(Transform, DefaultTransform) {
 
     LatLng nullIsland, latLng = {};
     ScreenCoordinate center, point = {};
-    const uint16_t min = std::numeric_limits<uint16_t>::min();
-    const uint16_t max = std::numeric_limits<uint16_t>::max();
+    const uint32_t min = 0;
+    const uint32_t max = 65535;
 
     auto testConversions = [&](const LatLng& coord, const ScreenCoordinate& screenCoord) {
         latLng = state.screenCoordinateToLatLng(center);
@@ -496,21 +496,21 @@ TEST(Transform, DefaultTransform) {
     testConversions(nullIsland, center);
 
     // Cannot assign the current size.
-    ASSERT_FALSE(transform.resize({{}}));
+    ASSERT_FALSE(transform.resize({}));
 
-    ASSERT_TRUE(transform.resize({{ min, max }}));
+    ASSERT_TRUE(transform.resize({ min, max }));
     testConversions(nullIsland, center);
 
-    ASSERT_TRUE(transform.resize({{ max, min }}));
+    ASSERT_TRUE(transform.resize({ max, min }));
     testConversions(nullIsland, center);
 
-    ASSERT_TRUE(transform.resize({{ min, min }}));
+    ASSERT_TRUE(transform.resize({ min, min }));
     testConversions(nullIsland, center);
 
     center = { max / 2., max / 2. };
 
-    // -1 evaluates to UINT_MAX.
-    ASSERT_TRUE(transform.resize({{ static_cast<uint16_t>(-1), static_cast<uint16_t>(-1) }}));
-    ASSERT_FALSE(transform.resize({{ max, max }}));
+    // Double resize
+    ASSERT_TRUE(transform.resize({ max, max }));
+    ASSERT_FALSE(transform.resize({ max, max }));
     testConversions(nullIsland, center);
 }

--- a/test/sprite/sprite_atlas.test.cpp
+++ b/test/sprite/sprite_atlas.test.cpp
@@ -26,7 +26,7 @@ auto imageFromAtlas(const SpriteAtlas& atlas) {
     auto data = std::make_unique<uint8_t[]>(bytes);
     const auto src = reinterpret_cast<const uint8_t*>(atlas.getData());
     std::copy(src, src + bytes, data.get());
-    return PremultipliedImage{ atlas.getTextureWidth(), atlas.getTextureHeight(), std::move(data) };
+    return PremultipliedImage{ { atlas.getTextureWidth(), atlas.getTextureHeight() }, std::move(data) };
 }
 
 } // namespace
@@ -56,8 +56,8 @@ TEST(SpriteAtlas, Basic) {
     EXPECT_EQ(20, metro.pos.h);
     EXPECT_EQ(18, metro.spriteImage->getWidth());
     EXPECT_EQ(18, metro.spriteImage->getHeight());
-    EXPECT_EQ(18u, metro.spriteImage->image.width);
-    EXPECT_EQ(18u, metro.spriteImage->image.height);
+    EXPECT_EQ(18u, metro.spriteImage->image.size.width);
+    EXPECT_EQ(18u, metro.spriteImage->image.size.height);
     EXPECT_EQ(1.0f, metro.spriteImage->pixelRatio);
 
     EXPECT_TRUE(atlas.getData());
@@ -110,8 +110,8 @@ TEST(SpriteAtlas, Size) {
     EXPECT_EQ(16, metro.pos.h);
     EXPECT_EQ(18, metro.spriteImage->getWidth());
     EXPECT_EQ(18, metro.spriteImage->getHeight());
-    EXPECT_EQ(18u, metro.spriteImage->image.width);
-    EXPECT_EQ(18u, metro.spriteImage->image.height);
+    EXPECT_EQ(18u, metro.spriteImage->image.size.width);
+    EXPECT_EQ(18u, metro.spriteImage->image.size.height);
     EXPECT_EQ(1.0f, metro.spriteImage->pixelRatio);
 
     EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteatlassize.png"),
@@ -127,7 +127,7 @@ TEST(SpriteAtlas, Updates) {
     EXPECT_EQ(32, atlas.getTextureWidth());
     EXPECT_EQ(32, atlas.getTextureHeight());
 
-    atlas.setSprite("one", std::make_shared<SpriteImage>(PremultipliedImage(16, 12), 1));
+    atlas.setSprite("one", std::make_shared<SpriteImage>(PremultipliedImage({ 16, 12 }), 1));
     auto one = *atlas.getImage("one", SpritePatternMode::Single);
     EXPECT_EQ(0, one.pos.x);
     EXPECT_EQ(0, one.pos.y);
@@ -135,16 +135,16 @@ TEST(SpriteAtlas, Updates) {
     EXPECT_EQ(16, one.pos.h);
     EXPECT_EQ(16, one.spriteImage->getWidth());
     EXPECT_EQ(12, one.spriteImage->getHeight());
-    EXPECT_EQ(16u, one.spriteImage->image.width);
-    EXPECT_EQ(12u, one.spriteImage->image.height);
+    EXPECT_EQ(16u, one.spriteImage->image.size.width);
+    EXPECT_EQ(12u, one.spriteImage->image.size.height);
     EXPECT_EQ(1.0f, one.spriteImage->pixelRatio);
 
     EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteatlas-empty.png"),
               imageFromAtlas(atlas));
 
     // Update sprite
-    PremultipliedImage image2(16, 12);
-    for (size_t i = 0; i < image2.size(); i++) {
+    PremultipliedImage image2({ 16, 12 });
+    for (size_t i = 0; i < image2.bytes(); i++) {
         image2.data.get()[i] = 255;
     }
     auto newSprite = std::make_shared<SpriteImage>(std::move(image2), 1);
@@ -165,9 +165,9 @@ TEST(SpriteAtlas, Updates) {
 TEST(SpriteAtlas, AddRemove) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
-    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
-    const auto sprite3 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage({ 16, 16 }), 2);
+    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage({ 16, 16 }), 2);
+    const auto sprite3 = std::make_shared<SpriteImage>(PremultipliedImage({ 16, 16 }), 2);
 
     SpriteAtlas atlas(32, 32, 1);
 
@@ -210,7 +210,7 @@ TEST(SpriteAtlas, AddRemove) {
 TEST(SpriteAtlas, OtherPixelRatio) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(8, 8), 1);
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage({ 8, 8 }), 1);
 
     SpriteAtlas atlas(32, 32, 1);
 
@@ -219,8 +219,8 @@ TEST(SpriteAtlas, OtherPixelRatio) {
 }
 
 TEST(SpriteAtlas, Multiple) {
-    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
-    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage({ 16, 16 }), 2);
+    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage({ 16, 16 }), 2);
 
     SpriteAtlas atlas(32, 32, 1);
 
@@ -232,8 +232,8 @@ TEST(SpriteAtlas, Multiple) {
 TEST(SpriteAtlas, Replace) {
     FixtureLog log;
 
-    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
-    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage({ 16, 16 }), 2);
+    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage({ 16, 16 }), 2);
 
     SpriteAtlas atlas(32, 32, 1);
 
@@ -246,10 +246,10 @@ TEST(SpriteAtlas, Replace) {
 TEST(SpriteAtlas, ReplaceWithDifferentDimensions) {
     FixtureLog log;
 
-    PremultipliedImage image(16, 16);
-    PremultipliedImage image2(18, 18);
-    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage(16, 16), 2);
-    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage(18, 18), 2);
+    PremultipliedImage image({ 16, 16 });
+    PremultipliedImage image2({ 18, 18 });
+    const auto sprite1 = std::make_shared<SpriteImage>(PremultipliedImage({ 16, 16 }), 2);
+    const auto sprite2 = std::make_shared<SpriteImage>(PremultipliedImage({ 18, 18 }), 2);
 
     SpriteAtlas atlas(32, 32, 1);
 

--- a/test/sprite/sprite_image.test.cpp
+++ b/test/sprite/sprite_image.test.cpp
@@ -7,7 +7,7 @@
 using namespace mbgl;
 
 TEST(Sprite, SpriteImageZeroWidth) {
-    PremultipliedImage image(0, 16);
+    PremultipliedImage image({ 0, 16 });
     try {
         SpriteImage(std::move(image), 2.0);
         FAIL() << "Expected exception";
@@ -17,7 +17,7 @@ TEST(Sprite, SpriteImageZeroWidth) {
 }
 
 TEST(Sprite, SpriteImageZeroHeight) {
-    PremultipliedImage image(16, 0);
+    PremultipliedImage image({ 16, 0 });
     try {
         SpriteImage(std::move(image), 2.0);
         FAIL() << "Expected exception";
@@ -27,7 +27,7 @@ TEST(Sprite, SpriteImageZeroHeight) {
 }
 
 TEST(Sprite, SpriteImageZeroRatio) {
-    PremultipliedImage image(16, 16);
+    PremultipliedImage image({ 16, 16 });
     try {
         SpriteImage(std::move(image), 0.0);
         FAIL() << "Expected exception";
@@ -37,21 +37,21 @@ TEST(Sprite, SpriteImageZeroRatio) {
 }
 
 TEST(Sprite, SpriteImage) {
-    PremultipliedImage image(32, 24);
+    PremultipliedImage image({ 32, 24 });
     SpriteImage sprite(std::move(image), 2.0);
     EXPECT_EQ(16, sprite.getWidth());
-    EXPECT_EQ(32u, sprite.image.width);
+    EXPECT_EQ(32u, sprite.image.size.width);
     EXPECT_EQ(12, sprite.getHeight());
-    EXPECT_EQ(24u, sprite.image.height);
+    EXPECT_EQ(24u, sprite.image.size.height);
     EXPECT_EQ(2, sprite.pixelRatio);
 }
 
 TEST(Sprite, SpriteImageFractionalRatio) {
-    PremultipliedImage image(20, 12);
+    PremultipliedImage image({ 20, 12 });
     SpriteImage sprite(std::move(image), 1.5);
     EXPECT_EQ(float(20.0 / 1.5), sprite.getWidth());
-    EXPECT_EQ(20u, sprite.image.width);
+    EXPECT_EQ(20u, sprite.image.size.width);
     EXPECT_EQ(float(12.0 / 1.5), sprite.getHeight());
-    EXPECT_EQ(12u, sprite.image.height);
+    EXPECT_EQ(12u, sprite.image.size.height);
     EXPECT_EQ(1.5, sprite.pixelRatio);
 }

--- a/test/sprite/sprite_parser.test.cpp
+++ b/test/sprite/sprite_parser.test.cpp
@@ -24,8 +24,8 @@ TEST(Sprite, SpriteImageCreationInvalid) {
 
     const PremultipliedImage image_1x = decodeImage(util::read_file("test/fixtures/annotations/emerald.png"));
 
-    ASSERT_EQ(200u, image_1x.width);
-    ASSERT_EQ(299u, image_1x.height);
+    ASSERT_EQ(200u, image_1x.size.width);
+    ASSERT_EQ(299u, image_1x.size.height);
 
     ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, 0, 16, 1, false));    // width == 0
     ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, 16, 0, 1, false));    // height == 0
@@ -38,8 +38,8 @@ TEST(Sprite, SpriteImageCreationInvalid) {
     ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, 16, 1025, 1, false)); // too tall
     ASSERT_EQ(nullptr, createSpriteImage(image_1x, -1, 0, 16, 16, 1, false));  // srcX < 0
     ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, -1, 16, 16, 1, false));  // srcY < 0
-    ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, image_1x.width + 1, 16, 1, false));   // right edge out of bounds
-    ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, 16, image_1x.height + 1, 1, false));  // bottom edge out of bounds
+    ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, image_1x.size.width + 1, 16, 1, false));   // right edge out of bounds
+    ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, 16, image_1x.size.height + 1, 1, false));  // bottom edge out of bounds
 
     EXPECT_EQ(13u, log.count({
                       EventSeverity::Error,
@@ -52,16 +52,16 @@ TEST(Sprite, SpriteImageCreationInvalid) {
 TEST(Sprite, SpriteImageCreation1x) {
     const PremultipliedImage image_1x = decodeImage(util::read_file("test/fixtures/annotations/emerald.png"));
 
-    ASSERT_EQ(200u, image_1x.width);
-    ASSERT_EQ(299u, image_1x.height);
+    ASSERT_EQ(200u, image_1x.size.width);
+    ASSERT_EQ(299u, image_1x.size.height);
 
     { // "museum_icon":{"x":177,"y":187,"width":18,"height":18,"pixelRatio":1,"sdf":false}
         const auto sprite = createSpriteImage(image_1x, 177, 187, 18, 18, 1, false);
         ASSERT_TRUE(sprite.get());
         EXPECT_EQ(18, sprite->getWidth());
         EXPECT_EQ(18, sprite->getHeight());
-        EXPECT_EQ(18u, sprite->image.width);
-        EXPECT_EQ(18u, sprite->image.height);
+        EXPECT_EQ(18u, sprite->image.size.width);
+        EXPECT_EQ(18u, sprite->image.size.height);
         EXPECT_EQ(1, sprite->pixelRatio);
         EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteimagecreation1x-museum.png"),
                   sprite->image);
@@ -76,8 +76,8 @@ TEST(Sprite, SpriteImageCreation2x) {
     ASSERT_TRUE(sprite.get());
     EXPECT_EQ(18, sprite->getWidth());
     EXPECT_EQ(18, sprite->getHeight());
-    EXPECT_EQ(36u, sprite->image.width);
-    EXPECT_EQ(36u, sprite->image.height);
+    EXPECT_EQ(36u, sprite->image.size.width);
+    EXPECT_EQ(36u, sprite->image.size.height);
     EXPECT_EQ(2, sprite->pixelRatio);
     EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteimagecreation2x.png"),
               sprite->image);
@@ -91,8 +91,8 @@ TEST(Sprite, SpriteImageCreation1_5x) {
     ASSERT_TRUE(sprite.get());
     EXPECT_EQ(24, sprite->getWidth());
     EXPECT_EQ(24, sprite->getHeight());
-    EXPECT_EQ(36u, sprite->image.width);
-    EXPECT_EQ(36u, sprite->image.height);
+    EXPECT_EQ(36u, sprite->image.size.width);
+    EXPECT_EQ(36u, sprite->image.size.height);
     EXPECT_EQ(1.5, sprite->pixelRatio);
     EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteimagecreation1_5x-museum.png"),
               sprite->image);
@@ -102,8 +102,8 @@ TEST(Sprite, SpriteImageCreation1_5x) {
     ASSERT_TRUE(sprite2.get());
     EXPECT_EQ(float(35 / 1.5), sprite2->getWidth());
     EXPECT_EQ(float(35 / 1.5), sprite2->getHeight());
-    EXPECT_EQ(35u, sprite2->image.width);
-    EXPECT_EQ(35u, sprite2->image.height);
+    EXPECT_EQ(35u, sprite2->image.size.width);
+    EXPECT_EQ(35u, sprite2->image.size.height);
     EXPECT_EQ(1.5, sprite2->pixelRatio);
     EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteimagecreation1_5x-hospital.png"),
               sprite2->image);
@@ -198,8 +198,8 @@ TEST(Sprite, SpriteParsing) {
         auto sprite = images.find("generic-metro")->second;
         EXPECT_EQ(18, sprite->getWidth());
         EXPECT_EQ(18, sprite->getHeight());
-        EXPECT_EQ(18u, sprite->image.width);
-        EXPECT_EQ(18u, sprite->image.height);
+        EXPECT_EQ(18u, sprite->image.size.width);
+        EXPECT_EQ(18u, sprite->image.size.height);
         EXPECT_EQ(1, sprite->pixelRatio);
         EXPECT_EQ(readImage("test/fixtures/annotations/result-spriteparsing.png"), sprite->image);
     }

--- a/test/src/mbgl/test/util.cpp
+++ b/test/src/mbgl/test/util.cpp
@@ -104,7 +104,7 @@ PremultipliedImage render(Map& map, OffscreenView& view) {
         result = view.readStillImage();
     });
 
-    while (!result.size()) {
+    while (!result.valid()) {
         util::RunLoop::Get()->runOnce();
     }
 
@@ -132,24 +132,23 @@ void checkImage(const std::string& base,
     }
 
     PremultipliedImage expected = decodeImage(expected_image);
-    PremultipliedImage diff { expected.width, expected.height };
+    PremultipliedImage diff { expected.size };
 
 
 #if !TEST_READ_ONLY
     util::write_file(base + "/actual.png", encodePNG(actual));
 #endif
 
-    ASSERT_EQ(expected.width, actual.width);
-    ASSERT_EQ(expected.height, actual.height);
+    ASSERT_EQ(expected.size, actual.size);
 
     double pixels = mapbox::pixelmatch(actual.data.get(),
                                        expected.data.get(),
-                                       expected.width,
-                                       expected.height,
+                                       expected.size.width,
+                                       expected.size.height,
                                        diff.data.get(),
                                        pixelThreshold);
 
-    EXPECT_LE(pixels / (expected.width * expected.height), imageThreshold);
+    EXPECT_LE(pixels / (expected.size.width * expected.size.height), imageThreshold);
 
 #if !TEST_READ_ONLY
     util::write_file(base + "/diff.png", encodePNG(diff));

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -50,7 +50,7 @@ public:
         // Squelch logging.
         Log::setObserver(std::make_unique<Log::NullObserver>());
 
-        transform.resize({{ 512, 512 }});
+        transform.resize({ 512, 512 });
         transform.setLatLngZoom({0, 0}, 0);
 
         transformState = transform.getState();

--- a/test/tile/tile_coordinate.test.cpp
+++ b/test/tile/tile_coordinate.test.cpp
@@ -26,8 +26,7 @@ TEST(TileCoordinate, FromLatLng) {
     Transform transform(onMapChange);
 
     const double max = util::tileSize;
-    const std::array<uint16_t, 2> size { { uint16_t(max), uint16_t(max) } };
-    transform.resize(size);
+    transform.resize({ static_cast<uint32_t>(max), static_cast<uint32_t>(max) });
 
     // Center, top-left, bottom-left, bottom-right, top-right edges.
     std::vector<std::pair<LatLng, ScreenCoordinate>> edges {

--- a/test/util/image.test.cpp
+++ b/test/util/image.test.cpp
@@ -7,7 +7,7 @@
 using namespace mbgl;
 
 TEST(Image, PNGRoundTrip) {
-    PremultipliedImage rgba { 1, 1 };
+    PremultipliedImage rgba({ 1, 1 });
     rgba.data[0] = 128;
     rgba.data[1] = 0;
     rgba.data[2] = 0;
@@ -21,7 +21,7 @@ TEST(Image, PNGRoundTrip) {
 }
 
 TEST(Image, PNGRoundTripAlpha) {
-    PremultipliedImage rgba { 1, 1 };
+    PremultipliedImage rgba({ 1, 1 });
     rgba.data[0] = 128;
     rgba.data[1] = 0;
     rgba.data[2] = 0;
@@ -68,26 +68,26 @@ TEST(Image, PNGReadProfileAlpha) {
 
 TEST(Image, PNGTile) {
     PremultipliedImage image = decodeImage(util::read_file("test/fixtures/image/tile.png"));
-    EXPECT_EQ(256u, image.width);
-    EXPECT_EQ(256u, image.height);
+    EXPECT_EQ(256u, image.size.width);
+    EXPECT_EQ(256u, image.size.height);
 }
 
 TEST(Image, JPEGTile) {
     PremultipliedImage image = decodeImage(util::read_file("test/fixtures/image/tile.jpeg"));
-    EXPECT_EQ(256u, image.width);
-    EXPECT_EQ(256u, image.height);
+    EXPECT_EQ(256u, image.size.width);
+    EXPECT_EQ(256u, image.size.height);
 }
 
 #if !defined(__ANDROID__) && !defined(__APPLE__) && !defined(QT_IMAGE_DECODERS)
 TEST(Image, WebPTile) {
     PremultipliedImage image = decodeImage(util::read_file("test/fixtures/image/tile.webp"));
-    EXPECT_EQ(256u, image.width);
-    EXPECT_EQ(256u, image.height);
+    EXPECT_EQ(256u, image.size.width);
+    EXPECT_EQ(256u, image.size.height);
 }
 #endif // !defined(__ANDROID__) && !defined(__APPLE__) && !defined(QT_IMAGE_DECODERS)
 
 TEST(Image, Premultiply) {
-    UnassociatedImage rgba { 1, 1 };
+    UnassociatedImage rgba({ 1, 1 });
     rgba.data[0] = 255;
     rgba.data[1] = 254;
     rgba.data[2] = 253;

--- a/test/util/memory.test.cpp
+++ b/test/util/memory.test.cpp
@@ -57,7 +57,7 @@ public:
 
     util::RunLoop runLoop;
     HeadlessBackend backend;
-    OffscreenView view{ backend.getContext(), {{ 512, 512 }} };
+    OffscreenView view{ backend.getContext(), { 512, 512 } };
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };
 
@@ -93,7 +93,7 @@ private:
 TEST(Memory, Vector) {
     MemoryTest test;
 
-    Map map(test.backend, { { 256, 256 } }, 2, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, { 256, 256 }, 2, test.fileSource, test.threadPool, MapMode::Still);
     map.setZoom(16); // more map features
     map.setStyleURL("mapbox://streets");
 
@@ -103,7 +103,7 @@ TEST(Memory, Vector) {
 TEST(Memory, Raster) {
     MemoryTest test;
 
-    Map map(test.backend, { { 256, 256 } }, 2, test.fileSource, test.threadPool, MapMode::Still);
+    Map map(test.backend, { 256, 256 }, 2, test.fileSource, test.threadPool, MapMode::Still);
     map.setStyleURL("mapbox://satellite");
 
     test::render(map, test.view);
@@ -129,7 +129,7 @@ TEST(Memory, Footprint) {
 
     // Warm up buffers and cache.
     for (unsigned i = 0; i < 10; ++i) {
-        Map map(test.backend, {{ 256, 256 }}, 2, test.fileSource, test.threadPool, MapMode::Still);
+        Map map(test.backend, { 256, 256 }, 2, test.fileSource, test.threadPool, MapMode::Still);
         renderMap(map, "mapbox://streets");
         renderMap(map, "mapbox://satellite");
     };
@@ -143,8 +143,8 @@ TEST(Memory, Footprint) {
 
     long vectorInitialRSS = getRSS();
     for (unsigned i = 0; i < runs; ++i) {
-        auto vector = std::make_unique<Map>(test.backend, std::array<uint16_t, 2>{ { 256, 256 } },
-                                            2, test.fileSource, test.threadPool, MapMode::Still);
+        auto vector = std::make_unique<Map>(test.backend, Size{ 256, 256 }, 2, test.fileSource,
+                                            test.threadPool, MapMode::Still);
         renderMap(*vector, "mapbox://streets");
         maps.push_back(std::move(vector));
     };
@@ -153,8 +153,8 @@ TEST(Memory, Footprint) {
 
     long rasterInitialRSS = getRSS();
     for (unsigned i = 0; i < runs; ++i) {
-        auto raster = std::make_unique<Map>(test.backend, std::array<uint16_t, 2>{ { 256, 256 } },
-                                            2, test.fileSource, test.threadPool, MapMode::Still);
+        auto raster = std::make_unique<Map>(test.backend, Size{ 256, 256 }, 2, test.fileSource,
+                                            test.threadPool, MapMode::Still);
         renderMap(*raster, "mapbox://satellite");
         maps.push_back(std::move(raster));
     };

--- a/test/util/offscreen_texture.test.cpp
+++ b/test/util/offscreen_texture.test.cpp
@@ -11,7 +11,7 @@ using namespace mbgl;
 
 TEST(OffscreenTexture, EmptyRed) {
     HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), {{ 512, 256 }});
+    OffscreenView view(backend.getContext(), { 512, 256 });
     view.bind();
 
     MBGL_CHECK_ERROR(glClearColor(1.0f, 0.0f, 0.0f, 1.0f));
@@ -106,7 +106,7 @@ void main() {
 
     // Make sure the texture gets destructed before we call context.reset();
     {
-        OffscreenView view(context, {{ 512, 256 }});
+        OffscreenView view(context, { 512, 256 });
 
         // First, draw red to the bound FBO.
         context.clearColor = { 1, 0, 0, 1 };
@@ -115,7 +115,7 @@ void main() {
 
         // Then, create a texture, bind it, and render yellow to that texture. This should not
         // affect the originally bound FBO.
-        OffscreenTexture texture(context, {{ 128, 128 }});
+        OffscreenTexture texture(context, { 128, 128 });
         texture.bind();
 
         context.clearColor = { 0, 0, 0, 0 };

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -29,7 +29,7 @@ TEST(TileCover, WorldZ0) {
 
 TEST(TileCover, Pitch) {
     Transform transform;
-    transform.resize({ { 512, 512 } });
+    transform.resize({ 512, 512 });
     transform.setZoom(2);
     transform.setPitch(40.0 * M_PI / 180.0);
 


### PR DESCRIPTION
We frequently specify sizes that have a width and a height and should introduce a size type that encodes this instead of using `std::array<uint16_t, 2>` in those places.

/cc @jfirebaugh 