### PR TITLE
Refactor Atlases+FrameHistory to use wrapped texture objects

### DIFF
--- a/include/mbgl/util/image.hpp
+++ b/include/mbgl/util/image.hpp
@@ -9,9 +9,10 @@
 
 namespace mbgl {
 
-enum ImageAlphaMode {
+enum class ImageAlphaMode {
     Unassociated,
-    Premultiplied
+    Premultiplied,
+    Exclusive, // Alpha-channel only
 };
 
 template <ImageAlphaMode Mode>
@@ -47,15 +48,17 @@ public:
         return size && data.get() != nullptr;
     }
 
-    size_t stride() const { return static_cast<size_t>(size.width) * 4; }
+    size_t stride() const { return channels * size.width; }
     size_t bytes() const { return stride() * size.height; }
 
     Size size;
+    static constexpr size_t channels = Mode == ImageAlphaMode::Exclusive ? 1 : 4;
     std::unique_ptr<uint8_t[]> data;
 };
 
 using UnassociatedImage = Image<ImageAlphaMode::Unassociated>;
 using PremultipliedImage = Image<ImageAlphaMode::Premultiplied>;
+using AlphaImage = Image<ImageAlphaMode::Exclusive>;
 
 // TODO: don't use std::string for binary data.
 PremultipliedImage decodeImage(const std::string&);

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -20,7 +20,7 @@ const std::string AnnotationManager::SourceID = "com.mapbox.annotations";
 const std::string AnnotationManager::PointLayerID = "com.mapbox.annotations.points";
 
 AnnotationManager::AnnotationManager(float pixelRatio)
-    : spriteAtlas(1024, 1024, pixelRatio) {
+    : spriteAtlas({ 1024, 1024 }, pixelRatio) {
 
     struct NullFileSource : public FileSource {
         std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override {

--- a/src/mbgl/geometry/line_atlas.hpp
+++ b/src/mbgl/geometry/line_atlas.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <mbgl/gl/texture.hpp>
 #include <mbgl/gl/object.hpp>
+#include <mbgl/util/image.hpp>
 #include <mbgl/util/optional.hpp>
 
 #include <vector>
@@ -27,7 +29,7 @@ enum class LinePatternCap : bool {
 
 class LineAtlas {
 public:
-    LineAtlas(uint16_t width, uint16_t height);
+    LineAtlas(Size);
     ~LineAtlas();
 
     // Binds the atlas texture to the GPU, and uploads data if it is out of date.
@@ -40,14 +42,13 @@ public:
     LinePatternPos getDashPosition(const std::vector<float>&, LinePatternCap);
     LinePatternPos addDash(const std::vector<float>& dasharray, LinePatternCap);
 
-    const uint16_t width;
-    const uint16_t height;
+    Size getSize() const;
 
 private:
-    const std::unique_ptr<char[]> data;
+    const AlphaImage image;
     bool dirty;
-    mbgl::optional<gl::UniqueTexture> texture;
-    int nextRow = 0;
+    mbgl::optional<gl::Texture> texture;
+    uint32_t nextRow = 0;
     std::unordered_map<size_t, LinePatternPos> positions;
 };
 

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -211,19 +211,38 @@ void Context::updateTexture(
 void Context::bindTexture(Texture& obj,
                           TextureUnit unit,
                           TextureFilter filter,
-                          TextureMipMap mipmap) {
-    if (filter != obj.filter || mipmap != obj.mipmap) {
+                          TextureMipMap mipmap,
+                          TextureWrap wrapX,
+                          TextureWrap wrapY) {
+    if (filter != obj.filter || mipmap != obj.mipmap || wrapX != obj.wrapX || wrapY != obj.wrapY) {
         activeTexture = unit;
         texture[unit] = obj.texture;
-        MBGL_CHECK_ERROR(glTexParameteri(
-            GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
-            filter == TextureFilter::Linear
-                ? (mipmap == TextureMipMap::Yes ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR)
-                : (mipmap == TextureMipMap::Yes ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST)));
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
-                                         filter == TextureFilter::Linear ? GL_LINEAR : GL_NEAREST));
-        obj.filter = filter;
-        obj.mipmap = mipmap;
+
+        if (filter != obj.filter || mipmap != obj.mipmap) {
+            MBGL_CHECK_ERROR(glTexParameteri(
+                GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                filter == TextureFilter::Linear
+                    ? (mipmap == TextureMipMap::Yes ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR)
+                    : (mipmap == TextureMipMap::Yes ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST)));
+            MBGL_CHECK_ERROR(
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+                                filter == TextureFilter::Linear ? GL_LINEAR : GL_NEAREST));
+            obj.filter = filter;
+            obj.mipmap = mipmap;
+        }
+        if (wrapX != obj.wrapX) {
+
+            MBGL_CHECK_ERROR(
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S,
+                                wrapX == TextureWrap::Clamp ? GL_CLAMP_TO_EDGE : GL_REPEAT));
+            obj.wrapX = wrapX;
+        }
+        if (wrapY != obj.wrapY) {
+            MBGL_CHECK_ERROR(
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T,
+                                wrapY == TextureWrap::Clamp ? GL_CLAMP_TO_EDGE : GL_REPEAT));
+            obj.wrapY = wrapY;
+        }
     } else if (texture[unit] != obj.texture) {
         // We are checking first to avoid setting the active texture without a subsequent
         // texture bind.

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -185,15 +185,21 @@ Framebuffer Context::createFramebuffer(const Texture& color) {
 UniqueTexture
 Context::createTexture(const Size size, const void* data, TextureUnit unit) {
     auto obj = createTexture();
-    activeTexture = unit;
-    texture[unit] = obj;
+    updateTexture(obj, size, data, unit);
+    // We are using clamp to edge here since OpenGL ES doesn't allow GL_REPEAT on NPOT textures.
+    // We use those when the pixelRatio isn't a power of two, e.g. on iPhone 6 Plus.
     MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
     MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
     MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+    return obj;
+}
+
+void Context::updateTexture(TextureID id, const Size size, const void* data, TextureUnit unit) {
+    activeTexture = unit;
+    texture[unit] = id;
     MBGL_CHECK_ERROR(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, size.width, size.height, 0, GL_RGBA,
                                   GL_UNSIGNED_BYTE, data));
-    return obj;
 }
 
 void Context::bindTexture(Texture& obj,

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -68,6 +68,12 @@ public:
         return { image.size, createTexture(image.size, image.data.get(), unit) };
     }
 
+    template <typename Image>
+    void updateTexture(Texture& obj, const Image& image, TextureUnit unit = 0) {
+        updateTexture(obj.texture.get(), image.size, image.data.get(), unit);
+        obj.size = image.size;
+    }
+
     // Creates an empty texture with the specified dimensions.
     Texture createTexture(const Size size, TextureUnit unit = 0) {
         return { size, createTexture(size, nullptr, unit) };
@@ -148,6 +154,7 @@ private:
     UniqueBuffer createVertexBuffer(const void* data, std::size_t size);
     UniqueBuffer createIndexBuffer(const void* data, std::size_t size);
     UniqueTexture createTexture(Size size, const void* data, TextureUnit);
+    void updateTexture(TextureID, Size size, const void* data, TextureUnit);
     UniqueFramebuffer createFramebuffer();
     UniqueRenderbuffer createRenderbuffer(RenderbufferType, Size size);
 

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -65,18 +65,22 @@ public:
     // Create a texture from an image with data.
     template <typename Image>
     Texture createTexture(const Image& image, TextureUnit unit = 0) {
-        return { image.size, createTexture(image.size, image.data.get(), unit) };
+        auto format = image.channels == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
+        return { image.size, createTexture(image.size, image.data.get(), format, unit) };
     }
 
     template <typename Image>
     void updateTexture(Texture& obj, const Image& image, TextureUnit unit = 0) {
-        updateTexture(obj.texture.get(), image.size, image.data.get(), unit);
+        auto format = image.channels == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
+        updateTexture(obj.texture.get(), image.size, image.data.get(), format, unit);
         obj.size = image.size;
     }
 
     // Creates an empty texture with the specified dimensions.
-    Texture createTexture(const Size size, TextureUnit unit = 0) {
-        return { size, createTexture(size, nullptr, unit) };
+    Texture createTexture(const Size size,
+                          TextureFormat format = TextureFormat::RGBA,
+                          TextureUnit unit = 0) {
+        return { size, createTexture(size, nullptr, format, unit) };
     }
 
     void bindTexture(Texture&,
@@ -153,8 +157,8 @@ private:
 
     UniqueBuffer createVertexBuffer(const void* data, std::size_t size);
     UniqueBuffer createIndexBuffer(const void* data, std::size_t size);
-    UniqueTexture createTexture(Size size, const void* data, TextureUnit);
-    void updateTexture(TextureID, Size size, const void* data, TextureUnit);
+    UniqueTexture createTexture(Size size, const void* data, TextureFormat, TextureUnit);
+    void updateTexture(TextureID, Size size, const void* data, TextureFormat, TextureUnit);
     UniqueFramebuffer createFramebuffer();
     UniqueRenderbuffer createRenderbuffer(RenderbufferType, Size size);
 

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -86,7 +86,9 @@ public:
     void bindTexture(Texture&,
                      TextureUnit = 0,
                      TextureFilter = TextureFilter::Nearest,
-                     TextureMipMap = TextureMipMap::No);
+                     TextureMipMap = TextureMipMap::No,
+                     TextureWrap wrapX = TextureWrap::Clamp,
+                     TextureWrap wrapY = TextureWrap::Clamp);
 
     void clear(optional<mbgl::Color> color,
                optional<float> depth,

--- a/src/mbgl/gl/texture.hpp
+++ b/src/mbgl/gl/texture.hpp
@@ -12,6 +12,8 @@ public:
     UniqueTexture texture;
     TextureFilter filter = TextureFilter::Nearest;
     TextureMipMap mipmap = TextureMipMap::No;
+    TextureWrap wrapX = TextureWrap::Clamp;
+    TextureWrap wrapY = TextureWrap::Clamp;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/types.hpp
+++ b/src/mbgl/gl/types.hpp
@@ -46,6 +46,10 @@ enum class RenderbufferType : uint32_t {
 
 enum class TextureMipMap : bool { No = false, Yes = true };
 enum class TextureFilter : bool { Nearest = false, Linear = true };
+enum class TextureFormat : uint32_t {
+    RGBA = 0x1908,
+    Alpha = 0x1906,
+};
 
 enum class PrimitiveType {
     Points = 0x0000,

--- a/src/mbgl/gl/types.hpp
+++ b/src/mbgl/gl/types.hpp
@@ -46,6 +46,7 @@ enum class RenderbufferType : uint32_t {
 
 enum class TextureMipMap : bool { No = false, Yes = true };
 enum class TextureFilter : bool { Nearest = false, Linear = true };
+enum class TextureWrap : bool { Clamp, Repeat };
 enum class TextureFormat : uint32_t {
     RGBA = 0x1908,
     Alpha = 0x1906,

--- a/src/mbgl/renderer/frame_history.hpp
+++ b/src/mbgl/renderer/frame_history.hpp
@@ -3,8 +3,9 @@
 #include <array>
 
 #include <mbgl/platform/platform.hpp>
-#include <mbgl/gl/object.hpp>
+#include <mbgl/gl/texture.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/util/image.hpp>
 #include <mbgl/util/optional.hpp>
 
 namespace mbgl {
@@ -23,20 +24,17 @@ public:
     void upload(gl::Context&, uint32_t);
 
 private:
-    const int width = 256;
-    const int height = 1;
-
     std::array<TimePoint, 256> changeTimes;
     std::array<uint8_t, 256> changeOpacities;
-    std::array<uint8_t, 256> opacities;
+    const AlphaImage opacities{ { 256, 1 } };
 
     int16_t previousZoomIndex = 0;
     TimePoint previousTime = TimePoint::min();
     TimePoint time = TimePoint::min();
     bool firstFrame = true;
-    bool changed = true;
+    bool dirty = true;
 
-    mbgl::optional<gl::UniqueTexture> texture;
+    mbgl::optional<gl::Texture> texture;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -55,7 +55,7 @@ void Painter::renderLine(PaintParameters& parameters,
                  posA,
                  posB,
                  layer.impl->dashLineWidth,
-                 lineAtlas->width));
+                 lineAtlas->getSize().width));
 
     } else if (!properties.linePattern.value.from.empty()) {
         optional<SpriteAtlasPosition> posA = spriteAtlas->getPosition(

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -72,7 +72,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
         const bool iconTransformed = values.rotationAlignment == AlignmentType::Map || state.getPitch() != 0;
         atlas.bind(bucket.sdfIcons || state.isChanging() || iconScaled || iconTransformed, context, 0);
 
-        std::array<uint16_t, 2> texsize {{ atlas.getWidth(), atlas.getHeight() }};
+        const Size texsize = atlas.getSize();
 
         if (bucket.sdfIcons) {
             if (values.hasHalo()) {
@@ -101,7 +101,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
 
         auto values = layer.impl->textPropertyValues(layout);
 
-        std::array<uint16_t, 2> texsize {{ glyphAtlas->width, glyphAtlas->height }};
+        const Size texsize { glyphAtlas->width, glyphAtlas->height };
 
         if (values.hasHalo()) {
             draw(parameters.shaders.symbolGlyph,

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -101,7 +101,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
 
         auto values = layer.impl->textPropertyValues(layout);
 
-        const Size texsize { glyphAtlas->width, glyphAtlas->height };
+        const Size texsize = glyphAtlas->getSize()x§;
 
         if (values.hasHalo()) {
             draw(parameters.shaders.symbolGlyph,

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -101,7 +101,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
 
         auto values = layer.impl->textPropertyValues(layout);
 
-        const Size texsize = glyphAtlas->getSize()x§;
+        const Size texsize = glyphAtlas->getSize();
 
         if (values.hasHalo()) {
             draw(parameters.shaders.symbolGlyph,

--- a/src/mbgl/shader/symbol_uniforms.cpp
+++ b/src/mbgl/shader/symbol_uniforms.cpp
@@ -9,7 +9,7 @@ using namespace style;
 
 template <class Values, class...Args>
 Values makeValues(const style::SymbolPropertyValues& values,
-                  const std::array<uint16_t, 2>& texsize,
+                  const Size& texsize,
                   const std::array<float, 2>& pixelsToGLUnits,
                   const RenderTile& tile,
                   const TransformState& state,
@@ -35,7 +35,7 @@ Values makeValues(const style::SymbolPropertyValues& values,
                               state),
         values.opacity,
         extrudeScale,
-        std::array<float, 2> {{ texsize[0] / 4.0f, texsize[1] / 4.0f }},
+        std::array<float, 2> {{ float(texsize.width) / 4, float(texsize.height) / 4 }},
         (state.getZoom() - zoomAdjust) * 10.0f,
         values.rotationAlignment == AlignmentType::Map,
         0,
@@ -46,7 +46,7 @@ Values makeValues(const style::SymbolPropertyValues& values,
 
 SymbolIconUniforms::Values
 SymbolIconUniforms::values(const style::SymbolPropertyValues& values,
-                           const std::array<uint16_t, 2>& texsize,
+                           const Size& texsize,
                            const std::array<float, 2>& pixelsToGLUnits,
                            const RenderTile& tile,
                            const TransformState& state)
@@ -61,7 +61,7 @@ SymbolIconUniforms::values(const style::SymbolPropertyValues& values,
 }
 
 static SymbolSDFUniforms::Values makeSDFValues(const style::SymbolPropertyValues& values,
-                                               const std::array<uint16_t, 2>& texsize,
+                                               const Size& texsize,
                                                const std::array<float, 2>& pixelsToGLUnits,
                                                const RenderTile& tile,
                                                const TransformState& state,
@@ -95,7 +95,7 @@ static SymbolSDFUniforms::Values makeSDFValues(const style::SymbolPropertyValues
 
 SymbolSDFUniforms::Values
 SymbolSDFUniforms::haloValues(const style::SymbolPropertyValues& values,
-                              const std::array<uint16_t, 2>& texsize,
+                              const Size& texsize,
                               const std::array<float, 2>& pixelsToGLUnits,
                               const RenderTile& tile,
                               const TransformState& state,
@@ -121,7 +121,7 @@ SymbolSDFUniforms::haloValues(const style::SymbolPropertyValues& values,
 
 SymbolSDFUniforms::Values
 SymbolSDFUniforms::foregroundValues(const style::SymbolPropertyValues& values,
-                                    const std::array<uint16_t, 2>& texsize,
+                                    const Size& texsize,
                                     const std::array<float, 2>& pixelsToGLUnits,
                                     const RenderTile& tile,
                                     const TransformState& state,

--- a/src/mbgl/shader/symbol_uniforms.hpp
+++ b/src/mbgl/shader/symbol_uniforms.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/shader/uniforms.hpp>
+#include <mbgl/util/size.hpp>
 
 #include <array>
 
@@ -35,7 +36,7 @@ struct SymbolIconUniforms : gl::Uniforms<
     uniforms::u_fadetexture>
 {
     static Values values(const style::SymbolPropertyValues&,
-                         const std::array<uint16_t, 2>& texsize,
+                         const Size& texsize,
                          const std::array<float, 2>& pixelsToGLUnits,
                          const RenderTile&,
                          const TransformState&);
@@ -59,14 +60,14 @@ struct SymbolSDFUniforms : gl::Uniforms<
     uniforms::u_pitch_with_map>
 {
     static Values haloValues(const style::SymbolPropertyValues&,
-                              const std::array<uint16_t, 2>& texsize,
+                              const Size& texsize,
                               const std::array<float, 2>& pixelsToGLUnits,
                               const RenderTile&,
                               const TransformState&,
                               float pixelRatio);
 
     static Values foregroundValues(const style::SymbolPropertyValues&,
-                              const std::array<uint16_t, 2>& texsize,
+                              const Size& texsize,
                               const std::array<float, 2>& pixelsToGLUnits,
                               const RenderTile&,
                               const TransformState&,

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -40,7 +40,7 @@ Style::Style(FileSource& fileSource_, float pixelRatio)
     : fileSource(fileSource_),
       glyphAtlas(std::make_unique<GlyphAtlas>(Size{ 2048, 2048 }, fileSource)),
       spriteAtlas(std::make_unique<SpriteAtlas>(Size{ 1024, 1024 }, pixelRatio)),
-      lineAtlas(std::make_unique<LineAtlas>(256, 512)),
+      lineAtlas(std::make_unique<LineAtlas>(Size{ 256, 512 })),
       observer(&nullObserver) {
     glyphAtlas->setObserver(this);
     spriteAtlas->setObserver(this);

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -39,7 +39,7 @@ static Observer nullObserver;
 Style::Style(FileSource& fileSource_, float pixelRatio)
     : fileSource(fileSource_),
       glyphAtlas(std::make_unique<GlyphAtlas>(2048, 2048, fileSource)),
-      spriteAtlas(std::make_unique<SpriteAtlas>(1024, 1024, pixelRatio)),
+      spriteAtlas(std::make_unique<SpriteAtlas>(Size{ 1024, 1024 }, pixelRatio)),
       lineAtlas(std::make_unique<LineAtlas>(256, 512)),
       observer(&nullObserver) {
     glyphAtlas->setObserver(this);

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -38,7 +38,7 @@ static Observer nullObserver;
 
 Style::Style(FileSource& fileSource_, float pixelRatio)
     : fileSource(fileSource_),
-      glyphAtlas(std::make_unique<GlyphAtlas>(2048, 2048, fileSource)),
+      glyphAtlas(std::make_unique<GlyphAtlas>(Size{ 2048, 2048 }, fileSource)),
       spriteAtlas(std::make_unique<SpriteAtlas>(Size{ 1024, 1024 }, pixelRatio)),
       lineAtlas(std::make_unique<LineAtlas>(256, 512)),
       observer(&nullObserver) {

--- a/src/mbgl/text/glyph_atlas.cpp
+++ b/src/mbgl/text/glyph_atlas.cpp
@@ -1,7 +1,6 @@
 #include <mbgl/text/glyph_atlas.hpp>
 #include <mbgl/text/glyph_atlas_observer.hpp>
 #include <mbgl/text/glyph_pbf.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/context.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>
@@ -13,13 +12,11 @@ namespace mbgl {
 
 static GlyphAtlasObserver nullObserver;
 
-GlyphAtlas::GlyphAtlas(uint16_t width_, uint16_t height_, FileSource& fileSource_)
-    : width(width_),
-      height(height_),
-      fileSource(fileSource_),
+GlyphAtlas::GlyphAtlas(const Size size, FileSource& fileSource_)
+    : fileSource(fileSource_),
       observer(&nullObserver),
-      bin(width_, height_),
-      data(std::make_unique<uint8_t[]>(width_ * height_)),
+      bin(size.width, size.height),
+      image(size),
       dirty(true) {
 }
 
@@ -148,18 +145,18 @@ Rect<uint16_t> GlyphAtlas::addGlyph(uintptr_t tileUID,
         return rect;
     }
 
-    assert(rect.x + rect.w <= width);
-    assert(rect.y + rect.h <= height);
+    assert(rect.x + rect.w <= image.size.width);
+    assert(rect.y + rect.h <= image.size.height);
 
     face.emplace(glyph.id, GlyphValue { rect, tileUID });
 
     // Copy the bitmap
     const uint8_t* source = reinterpret_cast<const uint8_t*>(glyph.bitmap.data());
     for (uint32_t y = 0; y < buffered_height; y++) {
-        uint32_t y1 = width * (rect.y + y + padding) + rect.x + padding;
+        uint32_t y1 = image.size.width * (rect.y + y + padding) + rect.x + padding;
         uint32_t y2 = buffered_width * y;
         for (uint32_t x = 0; x < buffered_width; x++) {
-            data[y1 + x] = source[y2 + x];
+            image.data[y1 + x] = source[y2 + x];
         }
     }
 
@@ -181,9 +178,9 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
                 const Rect<uint16_t>& rect = value.rect;
 
                 // Clear out the bitmap.
-                uint8_t *target = data.get();
+                uint8_t *target = image.data.get();
                 for (uint32_t y = 0; y < rect.h; y++) {
-                    uint32_t y1 = width * (rect.y + y) + rect.x;
+                    uint32_t y1 = image.size.width * (rect.y + y) + rect.x;
                     for (uint32_t x = 0; x < rect.w; x++) {
                         target[y1 + x] = 0;
                     }
@@ -203,60 +200,25 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
     }
 }
 
+Size GlyphAtlas::getSize() const {
+    return image.size;
+}
+
 void GlyphAtlas::upload(gl::Context& context, gl::TextureUnit unit) {
-    if (dirty) {
-        const bool first = !texture;
-        bind(context, unit);
+    std::lock_guard<std::mutex> lock(mtx);
 
-        std::lock_guard<std::mutex> lock(mtx);
-
-        context.activeTexture = unit;
-        if (first) {
-            MBGL_CHECK_ERROR(glTexImage2D(
-                GL_TEXTURE_2D, // GLenum target
-                0, // GLint level
-                GL_ALPHA, // GLint internalformat
-                width, // GLsizei width
-                height, // GLsizei height
-                0, // GLint border
-                GL_ALPHA, // GLenum format
-                GL_UNSIGNED_BYTE, // GLenum type
-                data.get() // const GLvoid* data
-            ));
-        } else {
-            MBGL_CHECK_ERROR(glTexSubImage2D(
-                GL_TEXTURE_2D, // GLenum target
-                0, // GLint level
-                0, // GLint xoffset
-                0, // GLint yoffset
-                width, // GLsizei width
-                height, // GLsizei height
-                GL_ALPHA, // GLenum format
-                GL_UNSIGNED_BYTE, // GLenum type
-                data.get() // const GLvoid* data
-            ));
-        }
-
-        dirty = false;
+    if (!texture) {
+        texture = context.createTexture(image, unit);
+    } else if (dirty) {
+        context.updateTexture(*texture, image, unit);
     }
+
+    dirty = false;
 }
 
 void GlyphAtlas::bind(gl::Context& context, gl::TextureUnit unit) {
-    if (!texture) {
-        texture = context.createTexture();
-        context.activeTexture = unit;
-        context.texture[unit] = *texture;
-#if not MBGL_USE_GLES2
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0));
-#endif
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-        MBGL_CHECK_ERROR(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-    } else if (context.texture[unit] != *texture) {
-        context.activeTexture = unit;
-        context.texture[unit] = *texture;
-    }
+    upload(context, unit);
+    context.bindTexture(*texture, unit, gl::TextureFilter::Linear);
 }
 
 } // namespace mbgl

--- a/src/mbgl/text/glyph_atlas.hpp
+++ b/src/mbgl/text/glyph_atlas.hpp
@@ -8,6 +8,8 @@
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/exclusive.hpp>
 #include <mbgl/util/work_queue.hpp>
+#include <mbgl/util/image.hpp>
+#include <mbgl/gl/texture.hpp>
 #include <mbgl/gl/object.hpp>
 
 #include <atomic>
@@ -30,7 +32,7 @@ class Context;
 
 class GlyphAtlas : public util::noncopyable {
 public:
-    GlyphAtlas(uint16_t width, uint16_t height, FileSource&);
+    GlyphAtlas(Size, FileSource&);
     ~GlyphAtlas();
 
     util::exclusive<GlyphSet> getGlyphSet(const FontStack&);
@@ -66,8 +68,7 @@ public:
     // the texture is only bound when the data is out of date (=dirty).
     void upload(gl::Context&, gl::TextureUnit unit);
 
-    const uint16_t width;
-    const uint16_t height;
+    Size getSize() const;
 
 private:
     void requestGlyphRange(const FontStack&, const GlyphRange&);
@@ -100,9 +101,9 @@ private:
     std::mutex mtx;
     BinPack<uint16_t> bin;
     std::unordered_map<FontStack, std::map<uint32_t, GlyphValue>, FontStackHash> index;
-    const std::unique_ptr<uint8_t[]> data;
+    const AlphaImage image;
     std::atomic<bool> dirty;
-    mbgl::optional<gl::UniqueTexture> texture;
+    mbgl::optional<gl::Texture> texture;
 };
 
 } // namespace mbgl

--- a/test/text/glyph_atlas.test.cpp
+++ b/test/text/glyph_atlas.test.cpp
@@ -16,7 +16,7 @@ public:
     util::RunLoop loop;
     StubFileSource fileSource;
     StubStyleObserver observer;
-    GlyphAtlas glyphAtlas { 32, 32, fileSource };
+    GlyphAtlas glyphAtlas{ { 32, 32 }, fileSource };
 
     void run(const std::string& url, const FontStack& fontStack, const GlyphRangeSet& glyphRanges) {
         // Squelch logging.


### PR DESCRIPTION
Currently, the `*Atlas` objects, as well as the `FrameHistory` object are directly using OpenGL commands to manage their texture. We should change this to use the default-provided texture management logic in `gl::Context`.

A small roadblock is the fact that we currently only support RGBA textures, but the `GlyphAtlas`, `LineAtlas`, and `FrameHistory` use mono-channel (`GL_ALPHA`) textures.

Note that all of these are currently using `glTexSubImage2D` for subsequent uploads. However, internally most drivers will create a copy of the existing data and patch up that data, so there is very little advantage of subimage patching over full texture uploads.
