### PR TITLE
[iOS][WIP] Improve annotationsView performances

### DIFF
--- a/platform/ios/src/MGLAnnotationContainerView.m
+++ b/platform/ios/src/MGLAnnotationContainerView.m
@@ -31,8 +31,8 @@
     for (MGLAnnotationView *view in subviews)
     {
         [self addSubview:view];
-        [self.annotationViews addObject:view];
     }
+    [self.annotationViews addObjectsFromArray:subviews];
 }
 
 #pragma mark UIAccessibility methods

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -83,6 +83,9 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
 - (void)prepareForReuse;
 
 /**
+ Called when the view go into the reuse queue.
+ */
+- (void)willBeEnqueued;
  The annotation object currently associated with the view.
  
  You should not change the value of this property directly. This property

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -38,6 +38,9 @@
     // Intentionally left blank. The default implementation of this method does nothing.
 }
 
+-(void)willBeEnqueued {
+    
+}
 - (void)setCenterOffset:(CGVector)centerOffset
 {
     _centerOffset = centerOffset;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -268,7 +268,7 @@ public:
     MGLAnnotationContextMap _annotationContextsByAnnotationTag;
     /// Tag of the selected annotation. If the user location annotation is selected, this ivar is set to `MGLAnnotationTagNotFound`.
     MGLAnnotationTag _selectedAnnotationTag;
-    NS_MUTABLE_DICTIONARY_OF(NSString *, NS_MUTABLE_ARRAY_OF(MGLAnnotationView *) *) *_annotationViewReuseQueueByIdentifier;
+    NS_MUTABLE_DICTIONARY_OF(NSString *, NS_MUTABLE_SET_OF(MGLAnnotationView *) *) *_annotationViewReuseQueueByIdentifier;
 
     BOOL _userLocationAnnotationIsSelected;
     /// Size of the rectangle formed by unioning the maximum slop area around every annotation image and annotation image view.
@@ -3224,11 +3224,13 @@ public:
 
 - (nullable MGLAnnotationView *)dequeueReusableAnnotationViewWithIdentifier:(NSString *)identifier
 {
-    NSMutableArray *annotationViewReuseQueue = [self annotationViewReuseQueueForIdentifier:identifier];
-    MGLAnnotationView *reusableView = annotationViewReuseQueue.firstObject;
-    [reusableView prepareForReuse];
-    [annotationViewReuseQueue removeObject:reusableView];
-
+    NSMutableSet *annotationViewReuseQueue = [self annotationViewReuseQueueForIdentifier:identifier];
+    MGLAnnotationView *reusableView = annotationViewReuseQueue.anyObject;
+    if (reusableView) {
+        reusableView.hidden = NO;
+        [reusableView prepareForReuse];
+        [annotationViewReuseQueue removeObject:reusableView];
+    }
     return reusableView;
 }
 
@@ -4596,16 +4598,17 @@ public:
     {
         return;
     }
-
+    
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
 
+    CGRect viewPort = CGRectInset(self.bounds,
+                                  -_largestAnnotationViewSize.width / 2.0 - MGLAnnotationUpdateViewportOutset.width / 2.0,
+                                  -_largestAnnotationViewSize.height / 2.0 - MGLAnnotationUpdateViewportOutset.width);
+    MGLCoordinateBounds bounds = [self convertRect:viewPort toCoordinateBoundsFromView:self];
+
     for (auto &pair : _annotationContextsByAnnotationTag)
     {
-        CGRect viewPort = CGRectInset(self.bounds,
-                                      -_largestAnnotationViewSize.width / 2.0 - MGLAnnotationUpdateViewportOutset.width / 2.0,
-                                      -_largestAnnotationViewSize.height / 2.0 - MGLAnnotationUpdateViewportOutset.width);
-
         MGLAnnotationContext &annotationContext = pair.second;
         MGLAnnotationView *annotationView = annotationContext.annotationView;
 
@@ -4615,37 +4618,26 @@ public:
             continue;
         }
 
-        if (!annotationView)
-        {
-            MGLAnnotationView *annotationView = [self annotationViewForAnnotation:annotationContext.annotation];
-            if (annotationView)
-            {
+        bool annotationViewIsVisible = MGLCoordinateInCoordinateBounds([annotationContext.annotation coordinate], bounds);
+
+        if (annotationViewIsVisible) {
+            if (!annotationView) {
+                MGLAnnotationView *annotationView = [self annotationViewForAnnotation:annotationContext.annotation];
                 annotationView.mapView = self;
-                annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
                 annotationContext.annotationView = annotationView;
 
                 if (!annotationView.superview) {
                     [self.annotationContainerView insertSubview:annotationView atIndex:0];
                 }
             }
-            else
-            {
-                // if there is no annotationView at this point then we are dealing with a sprite backed annotation
-                continue;
+            annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
+
+        } else {
+            if (annotationContext.viewReuseIdentifier) {
+                [self enqueueAnnotationViewForAnnotationContext:annotationContext];
             }
         }
-
-        bool annotationViewIsVisible = CGRectContainsRect(viewPort, annotationView.frame);
-        if (!annotationViewIsVisible && annotationContext.viewReuseIdentifier)
-        {
-            [self enqueueAnnotationViewForAnnotationContext:annotationContext];
-        }
-        else
-        {
-            annotationView.center = [self convertCoordinate:annotationContext.annotation.coordinate toPointToView:self];
-        }
     }
-
     [CATransaction commit];
 }
 
@@ -4654,12 +4646,12 @@ public:
     MGLAnnotationView *annotationView = annotationContext.annotationView;
 
     if (!annotationView) return;
-
+    [annotationView willBeEnqueued];
     annotationView.annotation = nil;
-
+    annotationView.hidden = YES;
     if (annotationContext.viewReuseIdentifier)
     {
-        NSMutableArray *annotationViewReuseQueue = [self annotationViewReuseQueueForIdentifier:annotationContext.viewReuseIdentifier];
+        NSMutableSet *annotationViewReuseQueue = [self annotationViewReuseQueueForIdentifier:annotationContext.viewReuseIdentifier];
         if (![annotationViewReuseQueue containsObject:annotationView])
         {
             [annotationViewReuseQueue addObject:annotationView];
@@ -4716,7 +4708,6 @@ public:
         } completion:NULL];
         _userLocationAnimationCompletionDate = [NSDate dateWithTimeIntervalSinceNow:duration];
 
-        annotationView.hidden = NO;
         [annotationView update];
 
         if (_userLocationAnnotationIsSelected)
@@ -4929,10 +4920,10 @@ public:
                                                views:views]];
 }
 
-- (NS_MUTABLE_ARRAY_OF(MGLAnnotationView *) *)annotationViewReuseQueueForIdentifier:(NSString *)identifier {
+- (NS_MUTABLE_SET_OF(MGLAnnotationView *) *)annotationViewReuseQueueForIdentifier:(NSString *)identifier {
     if (!_annotationViewReuseQueueByIdentifier[identifier])
     {
-        _annotationViewReuseQueueByIdentifier[identifier] = [NSMutableArray array];
+        _annotationViewReuseQueueByIdentifier[identifier] = [NSMutableSet set];
     }
 
     return _annotationViewReuseQueueByIdentifier[identifier];


### PR DESCRIPTION
This PR adresses the following issue:
- #6173 
# What changed ?

updateAnnotationViews was not working properly. The delegate method was called on each frame even if it wasn't in the view work. As a result, performance were worse when an annotation was outside the screen (!).
The reuse queue was also an NSArray instead of a NSSet resulting in poor performance when picking inside.

This PR improve the performance of the updateAnnotationViews especially when you are using complicated views.

One possible improvement to this would be to use queryPointAnnotations, but it's too slow when there is a lot of annotations on the screen.
# Testing done

I tested with thousand views and CAAnimation spread across the world with much better performances.

cc @1ec5 
