### PR TITLE
[Qt] Fix viewport size for Linux on Qt5

### DIFF
--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -850,16 +850,12 @@ void QMapboxGLPrivate::updateFramebufferBinding(QOpenGLFramebufferObject *fbo_)
     fbo = fbo_;
     if (fbo) {
         getContext().bindFramebuffer.setDirty();
-        getContext().viewport.setCurrentValue(
-            { 0,
-              0,
-              { static_cast<uint32_t>(fbo->width()), static_cast<uint32_t>(fbo->height()) } });
+        getContext().viewport = {
+            0, 0, { static_cast<uint32_t>(fbo->width()), static_cast<uint32_t>(fbo->height()) } };
     } else {
         getContext().bindFramebuffer.setCurrentValue(0);
-        getContext().viewport.setCurrentValue(
-            { 0,
-              0,
-              { static_cast<uint32_t>(fbSize.width()), static_cast<uint32_t>(fbSize.height()) } });
+        getContext().viewport = {
+            0, 0, { static_cast<uint32_t>(fbSize.width()), static_cast<uint32_t>(fbSize.height()) } };
     }
 }
 


### PR DESCRIPTION
Qt 5.x for Linux platform implements a different behavior for `QGLWidget` when compared to the macOS - the viewport size is not initially set. Thus, we need to account for this by using the assignment operator that eventually calls for the viewport OpenGL setter function.

Fixes #6827.

/cc @kkaefer @tmpsantos 