### PR TITLE
[core] operator bool() must always be explicit

### DIFF
--- a/include/mbgl/util/size.hpp
+++ b/include/mbgl/util/size.hpp
@@ -13,7 +13,7 @@ public:
     constexpr Size(const uint32_t width_, const uint32_t height_) : width(width_), height(height_) {
     }
 
-    constexpr operator bool() const {
+    constexpr explicit operator bool() const {
         return width > 0 && height > 0;
     }
 

--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -14,7 +14,7 @@ namespace mbgl {
 GlyphRange getGlyphRange(char32_t glyph);
 
 struct GlyphMetrics {
-    operator bool() const {
+    explicit operator bool() const {
         return !(width == 0 && height == 0 && advance == 0);
     }
 
@@ -27,12 +27,20 @@ struct GlyphMetrics {
 
 };
 
+inline bool operator==(const GlyphMetrics& lhs, const GlyphMetrics& rhs) {
+    return lhs.width == rhs.width &&
+        lhs.height == rhs.height &&
+        lhs.left == rhs.left &&
+        lhs.top == rhs.top &&
+        lhs.advance == rhs.advance;
+}
+
 struct Glyph {
     explicit Glyph() : rect(0, 0, 0, 0), metrics() {}
     explicit Glyph(Rect<uint16_t> rect_, GlyphMetrics metrics_)
         : rect(std::move(rect_)), metrics(std::move(metrics_)) {}
 
-    operator bool() const {
+    explicit operator bool() const {
         return metrics || rect.hasArea();
     }
 
@@ -64,7 +72,7 @@ class Shaping {
     int32_t left;
     int32_t right;
 
-    operator bool() const { return !positionedGlyphs.empty(); }
+    explicit operator bool() const { return !positionedGlyphs.empty(); }
 };
 
 class SDFGlyph {

--- a/src/mbgl/text/shaping.hpp
+++ b/src/mbgl/text/shaping.hpp
@@ -26,7 +26,7 @@ class PositionedIcon {
         float left = 0;
         float right = 0;
 
-        operator bool() const { return image && (*image).pos.hasArea(); }
+        explicit operator bool() const { return image && (*image).pos.hasArea(); }
 };
 
 PositionedIcon shapeIcon(const SpriteAtlasElement& image, const style::SymbolLayoutProperties&);


### PR DESCRIPTION
Otherwise, it can participate in unexpected conversions. Case in point: GlyphSet::insert was comparing the result of GlyphMetrics::operator bool() where it wanted to use operator==.