### PR TITLE
macOS: Depth/Stencil buffer visualization doesn't cover full screen

### DIFF
--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -116,17 +116,20 @@ NativeMapView::~NativeMapView() {
     vm = nullptr;
 }
 
+mbgl::Size NativeMapView::getFramebufferSize() const {
+    return { static_cast<uint32_t>(fbWidth), static_cast<uint32_t>(fbHeight) };
+}
+
 void NativeMapView::updateViewBinding() {
     getContext().bindFramebuffer.setCurrentValue(0);
-    getContext().viewport.setCurrentValue(
-        { 0, 0, { static_cast<uint32_t>(fbWidth), static_cast<uint32_t>(fbHeight) } });
+    assert(mbgl::gl::value::BindFramebuffer::Get() == getContext().bindFramebuffer.getCurrentValue());
+    getContext().viewport.setCurrentValue({ 0, 0, getFramebufferSize() });
+    assert(mbgl::gl::value::Viewport::Get() == getContext().viewport.getCurrentValue());
 }
 
 void NativeMapView::bind() {
     getContext().bindFramebuffer = 0;
-    getContext().viewport = { 0,
-                              0,
-                              { static_cast<uint32_t>(fbWidth), static_cast<uint32_t>(fbHeight) } };
+    getContext().viewport = { 0, 0, getFramebufferSize() };
 }
 
 void NativeMapView::activate() {

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -20,6 +20,7 @@ public:
     NativeMapView(JNIEnv *env, jobject obj, float pixelRatio, int availableProcessors, size_t totalMemory);
     virtual ~NativeMapView();
 
+    mbgl::Size getFramebufferSize() const;
     void updateViewBinding();
     void bind() override;
 

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -132,7 +132,9 @@ void GLFWView::setMap(mbgl::Map *map_) {
 
 void GLFWView::updateViewBinding() {
     getContext().bindFramebuffer.setCurrentValue(0);
+    assert(mbgl::gl::value::BindFramebuffer::Get() == getContext().bindFramebuffer.getCurrentValue());
     getContext().viewport.setCurrentValue({ 0, 0, getFramebufferSize() });
+    assert(mbgl::gl::value::Viewport::Get() == getContext().viewport.getCurrentValue());
 }
 
 void GLFWView::bind() {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -549,6 +549,12 @@ public:
              static_cast<uint32_t>(self.bounds.size.height) };
 }
 
+- (mbgl::Size)framebufferSize
+{
+    return { static_cast<uint32_t>(self.glView.drawableWidth),
+             static_cast<uint32_t>(self.glView.drawableHeight) };
+}
+
 - (void)createGLView
 {
     if (_context) return;
@@ -4953,7 +4959,7 @@ public:
     }
 
     mbgl::gl::value::Viewport::Type getViewport() const {
-        return { 0, 0, nativeView.size };
+        return { 0, 0, nativeView.framebufferSize };
     }
 
     /// This function is called before we start rendering, when iOS invokes our rendering method.
@@ -4963,6 +4969,7 @@ public:
         // We are using 0 as the placeholder value for the GLKView's framebuffer.
         getContext().bindFramebuffer.setCurrentValue(0);
         getContext().viewport.setCurrentValue(getViewport());
+        assert(mbgl::gl::value::Viewport::Get() == getContext().viewport.getCurrentValue());
     }
 
     void bind() override {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -854,6 +854,7 @@ void QMapboxGLPrivate::updateFramebufferBinding(QOpenGLFramebufferObject *fbo_)
             0, 0, { static_cast<uint32_t>(fbo->width()), static_cast<uint32_t>(fbo->height()) } };
     } else {
         getContext().bindFramebuffer.setCurrentValue(0);
+        assert(mbgl::gl::value::BindFramebuffer::Get() == getContext().bindFramebuffer.getCurrentValue());
         getContext().viewport = {
             0, 0, { static_cast<uint32_t>(fbSize.width()), static_cast<uint32_t>(fbSize.height()) } };
     }

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -183,6 +183,10 @@ constexpr bool operator!=(const Viewport::Type& a, const Viewport::Type& b) {
     return a.x != b.x || a.y != b.y || a.size != b.size;
 }
 
+constexpr bool operator==(const Viewport::Type& a, const Viewport::Type& b) {
+    return !(a != b);
+}
+
 struct BindFramebuffer {
     using Type = FramebufferID;
     static const constexpr Type Default = 0;


### PR DESCRIPTION
Reported in https://github.com/mapbox/mapbox-gl-native/issues/6799#issuecomment-257163112, when visualizing the depth/stencil buffer in the debug app, it only covers the lower left quarter of the screen on monitors that have a pixel ratio > 1.

/cc @jfirebaugh 