### PR TITLE
[core] Use GL_LINEAR on sprite texture if panning

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -409,6 +409,7 @@ void Map::cancelTransitions() {
 
 void Map::setGestureInProgress(bool inProgress) {
     impl->transform.setGestureInProgress(inProgress);
+    impl->onUpdate(Update::Repaint);
 }
 
 bool Map::isGestureInProgress() const {

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -175,6 +175,10 @@ float TransformState::getPitch() const {
 
 #pragma mark - State
 
+bool TransformState::isChanging() const {
+    return rotating || scaling || panning || gestureInProgress;
+}
+
 bool TransformState::isRotating() const {
     return rotating;
 }

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -60,6 +60,7 @@ public:
     float getPitch() const;
 
     // State
+    bool isChanging() const;
     bool isRotating() const;
     bool isScaling() const;
     bool isPanning() const;

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -70,7 +70,7 @@ void Painter::renderSymbol(PaintParameters& parameters,
         SpriteAtlas& atlas = *layer.impl->spriteAtlas;
         const bool iconScaled = values.paintSize != 1.0f || frame.pixelRatio != atlas.getPixelRatio() || bucket.iconsNeedLinear;
         const bool iconTransformed = values.rotationAlignment == AlignmentType::Map || state.getPitch() != 0;
-        atlas.bind(bucket.sdfIcons || state.isScaling() || state.isRotating() || iconScaled || iconTransformed, context, 0);
+        atlas.bind(bucket.sdfIcons || state.isChanging() || iconScaled || iconTransformed, context, 0);
 
         std::array<uint16_t, 2> texsize {{ atlas.getWidth(), atlas.getHeight() }};
 

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -49,28 +49,12 @@ TEST(Annotations, SymbolAnnotation) {
     auto screenBox = ScreenBox { {}, { double(size.width), double(size.height) } };
     auto features = test.map.queryPointAnnotations(screenBox);
     EXPECT_EQ(features.size(), 1u);
-    test.checkRendering("point_annotation");
 
     test.map.setZoom(test.map.getMaxZoom());
     test.checkRendering("point_annotation");
 
     features = test.map.queryPointAnnotations(screenBox);
     EXPECT_EQ(features.size(), 1u);
-}
-
-TEST(Annotations, SymbolLinearInterpolation)
-{
-    AnnotationTest test;
-
-    test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
-    test.map.addAnnotationIcon("default_marker", namedMarker("default_marker.png"));
-    test.map.addAnnotation(SymbolAnnotation { Point<double>(0.15, 0.15), "default_marker" });
-    test.checkRendering("point_annotation");
-
-    // Should not trigger GL_LINEAR when binding the symbol shader.
-    test.map.setGestureInProgress(true);
-    test.map.moveBy({});
-    test.checkRendering("point_annotation");
 }
 
 TEST(Annotations, LineAnnotation) {


### PR DESCRIPTION
Partially reverts #6790.

As per https://github.com/mapbox/mapbox-gl-native/pull/6790#issuecomment-257331524.

/cc @jfirebaugh 