### PR TITLE
[core] Fix regression in Bucket::hasData

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -23,6 +23,7 @@ set(MBGL_TEST_FILES
     test/geometry/binpack.test.cpp
 
     # gl
+    test/gl/bucket.test.cpp
     test/gl/object.test.cpp
 
     # include/mbgl

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -448,7 +448,7 @@ void SymbolLayout::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float 
             minZoom = 0;
         }
 
-        if (buffer.segments.back().vertexLength + vertexLength > std::numeric_limits<uint16_t>::max()) {
+        if (buffer.segments.empty() || buffer.segments.back().vertexLength + vertexLength > std::numeric_limits<uint16_t>::max()) {
             buffer.segments.emplace_back(buffer.vertices.size(), buffer.triangles.size());
         }
 

--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -44,7 +44,7 @@ void CircleBucket::addGeometry(const GeometryCollection& geometryCollection) {
             if ((mode != MapMode::Still) &&
                 (x < 0 || x >= util::EXTENT || y < 0 || y >= util::EXTENT)) continue;
 
-            if (segments.back().vertexLength + vertexLength > std::numeric_limits<uint16_t>::max()) {
+            if (segments.empty() || segments.back().vertexLength + vertexLength > std::numeric_limits<uint16_t>::max()) {
                 // Move to a new segments because the old one can't hold the geometry.
                 segments.emplace_back(vertices.size(), triangles.size());
             }

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -22,7 +22,7 @@ public:
 
     std::vector<CircleVertex> vertices;
     std::vector<gl::Triangle> triangles;
-    std::vector<gl::Segment> segments { { 0, 0 } };
+    std::vector<gl::Segment> segments;
 
     optional<gl::VertexBuffer<CircleVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangle>> indexBuffer;

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -51,7 +51,7 @@ void FillBucket::addGeometry(const GeometryCollection& geometry) {
             if (nVertices == 0)
                 continue;
 
-            if (lineSegments.back().vertexLength + nVertices > std::numeric_limits<uint16_t>::max()) {
+            if (lineSegments.empty() || lineSegments.back().vertexLength + nVertices > std::numeric_limits<uint16_t>::max()) {
                 lineSegments.emplace_back(vertices.size(), lines.size());
             }
 
@@ -76,7 +76,7 @@ void FillBucket::addGeometry(const GeometryCollection& geometry) {
         std::size_t nIndicies = indices.size();
         assert(nIndicies % 3 == 0);
 
-        if (triangleSegments.back().vertexLength + totalVertices > std::numeric_limits<uint16_t>::max()) {
+        if (triangleSegments.empty() || triangleSegments.back().vertexLength + totalVertices > std::numeric_limits<uint16_t>::max()) {
             triangleSegments.emplace_back(startVertices, triangles.size());
         }
 

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -22,8 +22,8 @@ public:
     std::vector<FillVertex> vertices;
     std::vector<gl::Line> lines;
     std::vector<gl::Triangle> triangles;
-    std::vector<gl::Segment> lineSegments { { 0, 0 } };
-    std::vector<gl::Segment> triangleSegments { { 0, 0 } };
+    std::vector<gl::Segment> lineSegments;
+    std::vector<gl::Segment> triangleSegments;
 
     optional<gl::VertexBuffer<FillVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Line>> lineIndexBuffer;

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -348,8 +348,7 @@ void LineBucket::addGeometry(const GeometryCoordinates& coordinates) {
     const std::size_t endVertex = vertices.size();
     const std::size_t vertexCount = endVertex - startVertex;
 
-    if (segments.back().vertexLength + vertexCount > std::numeric_limits<uint16_t>::max()) {
-        // Move to a new group because the old one can't hold the geometry.
+    if (segments.empty() || segments.back().vertexLength + vertexCount > std::numeric_limits<uint16_t>::max()) {
         segments.emplace_back(startVertex, triangles.size());
     }
 

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -28,7 +28,7 @@ public:
 
     std::vector<LineVertex> vertices;
     std::vector<gl::Triangle> triangles;
-    std::vector<gl::Segment> segments { { 0, 0 } };
+    std::vector<gl::Segment> segments;
 
     optional<gl::VertexBuffer<LineVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangle>> indexBuffer;

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -42,7 +42,7 @@ void SymbolBucket::render(Painter& painter,
 }
 
 bool SymbolBucket::hasData() const {
-    assert(false); // Should be calling SymbolLayout::hasSymbolInstances() instead.
+    assert(false); // Should be calling SymbolLayout::has{Text,Icon,CollisonBox}Data() instead.
     return false;
 }
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -36,7 +36,7 @@ public:
     struct TextBuffer {
         std::vector<SymbolVertex> vertices;
         std::vector<gl::Triangle> triangles;
-        std::vector<gl::Segment> segments { { 0, 0 } };
+        std::vector<gl::Segment> segments;
 
         optional<gl::VertexBuffer<SymbolVertex>> vertexBuffer;
         optional<gl::IndexBuffer<gl::Triangle>> indexBuffer;
@@ -45,7 +45,7 @@ public:
     struct IconBuffer {
         std::vector<SymbolVertex> vertices;
         std::vector<gl::Triangle> triangles;
-        std::vector<gl::Segment> segments { { 0, 0 } };
+        std::vector<gl::Segment> segments;
 
         optional<gl::VertexBuffer<SymbolVertex>> vertexBuffer;
         optional<gl::IndexBuffer<gl::Triangle>> indexBuffer;

--- a/test/gl/bucket.test.cpp
+++ b/test/gl/bucket.test.cpp
@@ -1,0 +1,41 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/renderer/circle_bucket.hpp>
+#include <mbgl/renderer/fill_bucket.hpp>
+#include <mbgl/renderer/line_bucket.hpp>
+#include <mbgl/renderer/symbol_bucket.hpp>
+
+#include <mbgl/style/layers/symbol_layer_properties.hpp>
+
+#include <mbgl/map/mode.hpp>
+
+TEST(Buckets, CircleBucket) {
+    mbgl::MapMode mapMode = mbgl::MapMode::Still;
+
+    mbgl::CircleBucket bucket { mapMode };
+    ASSERT_FALSE(bucket.hasData());
+}
+
+TEST(Buckets, FillBucket) {
+    mbgl::FillBucket bucket;
+    ASSERT_FALSE(bucket.hasData());
+}
+
+TEST(Buckets, LineBucket) {
+    uint32_t overscaling = 0;
+
+    mbgl::LineBucket bucket { overscaling };
+    ASSERT_FALSE(bucket.hasData());
+}
+
+TEST(Buckets, SymbolBucket) {
+    mbgl::MapMode mapMode = mbgl::MapMode::Still;
+    mbgl::style::SymbolLayoutProperties properties;
+    bool sdfIcons = false;
+    bool iconsNeedLinear = false;
+
+    mbgl::SymbolBucket bucket { mapMode, properties, sdfIcons, iconsNeedLinear };
+    ASSERT_FALSE(bucket.hasIconData());
+    ASSERT_FALSE(bucket.hasTextData());
+    ASSERT_FALSE(bucket.hasCollisionBoxData());
+}


### PR DESCRIPTION
As per @jfirebaugh review in https://github.com/mapbox/mapbox-gl-native/commit/384f1a1960c9a21039642afe9bd1df58a93fddfc#commitcomment-19656901, commit 384f1a1960c9a21039642afe9bd1df58a93fddfc introduced a regression in `{Circle,Fill,Line,Symbol}Bucket::hasData()` in a sense that an empty bucket would never return `false`.

