### PR TITLE
Upgraded okhttp dependency to latest version

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile "com.android.support:support-annotations:${supportLibVersion}"
     compile "com.android.support:support-v4:${supportLibVersion}"
     compile "com.android.support:design:${supportLibVersion}"
-    compile 'com.squareup.okhttp3:okhttp:3.3.0'
+    compile 'com.squareup.okhttp3:okhttp:3.4.1'
     compile 'com.mapzen.android:lost:1.1.1'
 
     // Mapbox Android Services


### PR DESCRIPTION
We were still using `3.3.0` (latest is `3.4.1`). [Changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md). 

cc: @tobrun for review