### PR TITLE
[ios] Fix bad merge in iosapp

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1527,11 +1527,8 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style
 {
     // Default Mapbox styles use {name_en} as their label language, which means
-    NSUInteger queuedAnnotations = 0;
     // that a device with an English-language locale is already effectively
-    {
     // using locale-based country labels.
-    }
     _usingLocaleBasedCountryLabels = [[self bestLanguageForUser] isEqualToString:@"en"];
 }
 


### PR DESCRIPTION
Although functionality was not affected, a previous merge garbled the language test with a temporary test done for annotation view performance improvement.

cc @1ec5 