### PR TITLE
More verbose errors on invalid sprite metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-native",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.4.0 - Novmeber 2, 2016
+
+- Fixes Bitrise configuration to automatically publish macOS binaries ([#6789](https://github.com/mapbox/mapbox-gl-native/pull/6789))
+- Switches from using individual thread pools for each `mbgl::Map` object to sharing the built-in Node.js thread pool for NodeMap implementations ([#6687](https://github.com/mapbox/mapbox-gl-native/pull/6687))
+
 # 3.3.3 - September 6, 2016
 
 - Switches to using a NodeRequest member function (with a JavaScript shim in front to preserve the API) instead of a new `v8::Context` to avoid a memory leak ([#5704](https://github.com/mapbox/mapbox-gl-native/pull/5704))

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -5,6 +5,7 @@
 
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/rapidjson.hpp>
+#include <mbgl/util/string.hpp>
 
 #include <cmath>
 #include <limits>
@@ -24,7 +25,10 @@ SpriteImagePtr createSpriteImage(const PremultipliedImage& image,
         ratio <= 0 || ratio > 10 ||
         srcX >= image.size.width || srcY >= image.size.height ||
         srcX + width > image.size.width || srcY + height > image.size.height) {
-        Log::Error(Event::Sprite, "Can't create sprite with invalid metrics");
+        Log::Error(Event::Sprite, "Can't create sprite with invalid metrics: %ux%u@%u,%u in %ux%u@%sx sprite",
+            width, height, srcX, srcY,
+            image.size.width, image.size.height,
+            util::toString(ratio).c_str());
         return nullptr;
     }
 

--- a/test/sprite/sprite_parser.test.cpp
+++ b/test/sprite/sprite_parser.test.cpp
@@ -41,12 +41,97 @@ TEST(Sprite, SpriteImageCreationInvalid) {
     ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, image_1x.size.width + 1, 16, 1, false));   // right edge out of bounds
     ASSERT_EQ(nullptr, createSpriteImage(image_1x, 0, 0, 16, image_1x.size.height + 1, 1, false));  // bottom edge out of bounds
 
-    EXPECT_EQ(13u, log.count({
+    EXPECT_EQ(1u, log.count({
                       EventSeverity::Error,
                       Event::Sprite,
                       int64_t(-1),
-                      "Can't create sprite with invalid metrics",
+                      "Can't create sprite with invalid metrics: 0x16@0,0 in 200x299@1x sprite",
                   }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 16x0@0,0 in 200x299@1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 4294967295x16@0,0 in 200x299@1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 16x4294967295@0,0 in 200x299@1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 1x1@0,0 in 200x299@0x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 1x1@0,0 in 200x299@-1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 1x1@0,0 in 200x299@23x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 2048x16@0,0 in 200x299@1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 16x1025@0,0 in 200x299@1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 16x16@4294967295,0 in 200x299@1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 16x16@0,4294967295 in 200x299@1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 201x16@0,0 in 200x299@1x sprite",
+                  }));
+
+    EXPECT_EQ(1u, log.count({
+                      EventSeverity::Error,
+                      Event::Sprite,
+                      int64_t(-1),
+                      "Can't create sprite with invalid metrics: 16x300@0,0 in 200x299@1x sprite",
+                  }));
+
 }
 
 TEST(Sprite, SpriteImageCreation1x) {
@@ -228,7 +313,7 @@ TEST(Sprite, SpriteParsingEmptyImage) {
                       EventSeverity::Error,
                       Event::Sprite,
                       int64_t(-1),
-                      "Can't create sprite with invalid metrics",
+                      "Can't create sprite with invalid metrics: 0x0@0,0 in 200x299@1x sprite",
                   }));
 }
 
@@ -261,7 +346,7 @@ TEST(Sprite, SpriteParsingWidthTooBig) {
                       EventSeverity::Error,
                       Event::Sprite,
                       int64_t(-1),
-                      "Can't create sprite with invalid metrics",
+                      "Can't create sprite with invalid metrics: 0x32@0,0 in 200x299@1x sprite",
                   }));
 }
 
@@ -284,7 +369,7 @@ TEST(Sprite, SpriteParsingNegativeWidth) {
                       EventSeverity::Error,
                       Event::Sprite,
                       int64_t(-1),
-                      "Can't create sprite with invalid metrics",
+                      "Can't create sprite with invalid metrics: 0x32@0,0 in 200x299@1x sprite",
                   }));
 }
 
@@ -301,6 +386,6 @@ TEST(Sprite, SpriteParsingNullRatio) {
                       EventSeverity::Error,
                       Event::Sprite,
                       int64_t(-1),
-                      "Can't create sprite with invalid metrics",
+                      "Can't create sprite with invalid metrics: 32x32@0,0 in 200x299@0x sprite",
                   }));
 }


### PR DESCRIPTION
This breaks the `Can't create sprite with invalid metrics` catchall into individual verbose error cases. I'm pretty sure this should be tweaked slightly to avoid allocating the `std::stringstream` in non-error cases.