### PR TITLE
[ios] Store annotation tags for MGLMultiPoint annotations in the map

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4705,13 +4705,19 @@ public:
     // Enqueue (and move if required) offscreen annotation views
     for (id<MGLAnnotation> annotation in offscreenAnnotations)
     {
-        CLLocationCoordinate2D coordinate = annotation.coordinate;
+        // Defer to the shape/polygon styling delegate methods
+        if ([annotation isKindOfClass:[MGLMultiPoint class]])
+        {
+            continue;
+        }
+
         MGLAnnotationTag annotationTag = _annotationTagsByAnnotation.at(annotation);
         MGLAnnotationContext &annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
         UIView *annotationView = annotationContext.annotationView;
         
         if (annotationView)
         {
+            CLLocationCoordinate2D coordinate = annotation.coordinate;
             // Every so often (1 out of 1000 frames?) the mbgl query mechanism fails. This logic spot checks the
             // offscreenAnnotations values -- if they are actually still on screen then the view center is
             // moved and the enqueue operation is avoided. This allows us to keep the performance benefit of

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2915,6 +2915,7 @@ public:
             MGLAnnotationContext context;
             context.annotation = annotation;
             _annotationContextsByAnnotationTag[annotationTag] = context;
+            _annotationTagsByAnnotation[annotation] = annotationTag;
 
             [(NSObject *)annotation addObserver:self forKeyPath:@"coordinates" options:0 context:(void *)(NSUInteger)annotationTag];
         }


### PR DESCRIPTION
This fixes an issue where, if a multipoint annotation was added, native annotation view update logic would crash. Adding the annotation tag for multipoints, too, avoids the out of range exception.

cc @1ec5 @incanus 