### PR TITLE
6067 annotation manager

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -400,7 +400,7 @@ public class MarkerViewManager {
      */
     public void invalidateViewMarkersInVisibleRegion() {
         RectF mapViewRect = new RectF(0, 0, mapView.getWidth(), mapView.getHeight());
-        List<MarkerView> markers = mapView.getMarkerViewsInRect(mapViewRect);
+        List<MarkerView> markers = mapboxMap.getMarkerViewsInRect(mapViewRect);
         View convertView;
 
         // remove old markers

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -65,12 +65,16 @@ class AnnotationManager {
             }
         }
         long id = annotation.getId();
-        nativeMapView.removeAnnotation(id);
+        if (nativeMapView != null) {
+            nativeMapView.removeAnnotation(id);
+        }
         annotations.remove(id);
     }
 
     void removeAnnotation(long id) {
-        nativeMapView.removeAnnotation(id);
+        if (nativeMapView != null) {
+            nativeMapView.removeAnnotation(id);
+        }
         annotations.remove(id);
     }
 
@@ -88,7 +92,11 @@ class AnnotationManager {
             }
             ids[i] = annotationList.get(i).getId();
         }
-        nativeMapView.removeAnnotations(ids);
+
+        if (nativeMapView != null) {
+            nativeMapView.removeAnnotations(ids);
+        }
+
         for (long id : ids) {
             annotations.remove(id);
         }
@@ -109,7 +117,11 @@ class AnnotationManager {
                 }
             }
         }
-        nativeMapView.removeAnnotations(ids);
+
+        if (nativeMapView != null) {
+            nativeMapView.removeAnnotations(ids);
+        }
+
         annotations.clear();
     }
 
@@ -119,7 +131,7 @@ class AnnotationManager {
 
     Marker addMarker(@NonNull BaseMarkerOptions markerOptions, @NonNull MapboxMap mapboxMap) {
         Marker marker = prepareMarker(markerOptions);
-        long id = nativeMapView.addMarker(marker);
+        long id = nativeMapView != null ? nativeMapView.addMarker(marker) : 0;
         marker.setMapboxMap(mapboxMap);
         marker.setId(id);
         annotations.put(id, marker);
@@ -139,25 +151,26 @@ class AnnotationManager {
             }
 
             if (markers.size() > 0) {
-                long[] ids = nativeMapView.addMarkers(markers);
-
-                // if unittests or markers are correctly added to map
-                if (ids == null || ids.length == markers.size()) {
-                    long id = 0;
-                    Marker m;
-                    for (int i = 0; i < markers.size(); i++) {
-                        m = markers.get(i);
-                        m.setMapboxMap(mapboxMap);
-                        if (ids != null) {
-                            id = ids[i];
-                        } else {
-                            //unit test
-                            id++;
-                        }
-                        m.setId(id);
-                        annotations.put(id, m);
-                    }
+                long[] ids = null;
+                if (nativeMapView != null) {
+                    ids = nativeMapView.addMarkers(markers);
                 }
+
+                long id = 0;
+                Marker m;
+                for (int i = 0; i < markers.size(); i++) {
+                    m = markers.get(i);
+                    m.setMapboxMap(mapboxMap);
+                    if (ids != null) {
+                        id = ids[i];
+                    } else {
+                        //unit test
+                        id++;
+                    }
+                    m.setId(id);
+                    annotations.put(id, m);
+                }
+
             }
         }
         return markers;
@@ -355,7 +368,7 @@ class AnnotationManager {
     Polygon addPolygon(@NonNull PolygonOptions polygonOptions, @NonNull MapboxMap mapboxMap) {
         Polygon polygon = polygonOptions.getPolygon();
         if (!polygon.getPoints().isEmpty()) {
-            long id = nativeMapView.addPolygon(polygon);
+            long id = nativeMapView != null ? nativeMapView.addPolygon(polygon) : 0;
             polygon.setId(id);
             polygon.setMapboxMap(mapboxMap);
             annotations.put(id, polygon);
@@ -376,23 +389,23 @@ class AnnotationManager {
                 }
             }
 
-            long[] ids = nativeMapView.addPolygons(polygons);
+            long[] ids = null;
+            if (nativeMapView != null) {
+                ids = nativeMapView.addPolygons(polygons);
+            }
 
-            // if unit tests or polygons correctly added to map
-            if (ids == null || ids.length == polygons.size()) {
-                long id = 0;
-                for (int i = 0; i < polygons.size(); i++) {
-                    polygon = polygons.get(i);
-                    polygon.setMapboxMap(mapboxMap);
-                    if (ids != null) {
-                        id = ids[i];
-                    } else {
-                        // unit test
-                        id++;
-                    }
-                    polygon.setId(id);
-                    annotations.put(id, polygon);
+            long id = 0;
+            for (int i = 0; i < polygons.size(); i++) {
+                polygon = polygons.get(i);
+                polygon.setMapboxMap(mapboxMap);
+                if (ids != null) {
+                    id = ids[i];
+                } else {
+                    // unit test
+                    id++;
                 }
+                polygon.setId(id);
+                annotations.put(id, polygon);
             }
         }
         return polygons;
@@ -434,7 +447,7 @@ class AnnotationManager {
     Polyline addPolyline(@NonNull PolylineOptions polylineOptions, @NonNull MapboxMap mapboxMap) {
         Polyline polyline = polylineOptions.getPolyline();
         if (!polyline.getPoints().isEmpty()) {
-            long id = nativeMapView.addPolyline(polyline);
+            long id = nativeMapView != null ? nativeMapView.addPolyline(polyline) : 0;
             polyline.setMapboxMap(mapboxMap);
             polyline.setId(id);
             annotations.put(id, polyline);
@@ -455,25 +468,25 @@ class AnnotationManager {
                 }
             }
 
-            long[] ids = nativeMapView.addPolylines(polylines);
+            long[] ids = null;
+            if (nativeMapView != null) {
+                ids = nativeMapView.addPolylines(polylines);
+            }
 
-            // if unit tests or polylines are correctly added to map
-            if (ids == null || ids.length == polylines.size()) {
-                long id = 0;
-                Polyline p;
+            long id = 0;
+            Polyline p;
 
-                for (int i = 0; i < polylines.size(); i++) {
-                    p = polylines.get(i);
-                    p.setMapboxMap(mapboxMap);
-                    if (ids != null) {
-                        id = ids[i];
-                    } else {
-                        // unit test
-                        id++;
-                    }
-                    p.setId(id);
-                    annotations.put(id, p);
+            for (int i = 0; i < polylines.size(); i++) {
+                p = polylines.get(i);
+                p.setMapboxMap(mapboxMap);
+                if (ids != null) {
+                    id = ids[i];
+                } else {
+                    // unit test
+                    id++;
                 }
+                p.setId(id);
+                annotations.put(id, p);
             }
         }
         return polylines;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -1,0 +1,449 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.util.LongSparseArray;
+
+import com.mapbox.mapboxsdk.annotations.Annotation;
+import com.mapbox.mapboxsdk.annotations.BaseMarkerOptions;
+import com.mapbox.mapboxsdk.annotations.BaseMarkerViewOptions;
+import com.mapbox.mapboxsdk.annotations.Icon;
+import com.mapbox.mapboxsdk.annotations.Marker;
+import com.mapbox.mapboxsdk.annotations.MarkerView;
+import com.mapbox.mapboxsdk.annotations.MarkerViewManager;
+import com.mapbox.mapboxsdk.annotations.Polygon;
+import com.mapbox.mapboxsdk.annotations.PolygonOptions;
+import com.mapbox.mapboxsdk.annotations.Polyline;
+import com.mapbox.mapboxsdk.annotations.PolylineOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class AnnotationManager {
+
+    private MapboxMap mapboxMap;
+    private MapView mapView;
+    private InfoWindowManager infoWindowManager;
+
+    private LongSparseArray<Annotation> annotations;
+    private List<Marker> selectedMarkers;
+    private MarkerViewManager markerViewManager;
+
+    private MapboxMap.OnMarkerClickListener onMarkerClickListener;
+
+    AnnotationManager(MapboxMap map, MapView view, InfoWindowManager manager) {
+        mapView = view;
+        mapboxMap = map;
+        infoWindowManager = manager;
+        markerViewManager = new MarkerViewManager(map, view);
+        selectedMarkers = new ArrayList<>();
+        annotations = new LongSparseArray<>();
+    }
+
+    //
+    // Annotations
+    //
+
+    Annotation getAnnotation(long id) {
+        return annotations.get(id);
+    }
+
+    List<Annotation> getAnnotations() {
+        List<Annotation> annotations = new ArrayList<>();
+        for (int i = 0; i < this.annotations.size(); i++) {
+            annotations.add(this.annotations.get(this.annotations.keyAt(i)));
+        }
+        return annotations;
+    }
+
+    void removeAnnotation(@NonNull Annotation annotation) {
+        if (annotation instanceof Marker) {
+            Marker marker = (Marker) annotation;
+            marker.hideInfoWindow();
+            if (marker instanceof MarkerView) {
+                markerViewManager.removeMarkerView((MarkerView) marker);
+            }
+        }
+        long id = annotation.getId();
+        mapView.removeAnnotation(id);
+        annotations.remove(id);
+    }
+
+    void removeAnnotation(long id) {
+        mapView.removeAnnotation(id);
+        annotations.remove(id);
+    }
+
+    void removeAnnotations(@NonNull List<? extends Annotation> annotationList) {
+        int count = annotationList.size();
+        long[] ids = new long[count];
+        for (int i = 0; i < count; i++) {
+            Annotation annotation = annotationList.get(i);
+            if (annotation instanceof Marker) {
+                Marker marker = (Marker) annotation;
+                marker.hideInfoWindow();
+                if (marker instanceof MarkerView) {
+                    markerViewManager.removeMarkerView((MarkerView) marker);
+                }
+            }
+            ids[i] = annotationList.get(i).getId();
+        }
+        mapView.removeAnnotations(ids);
+        for (long id : ids) {
+            annotations.remove(id);
+        }
+    }
+
+    void removeAnnotations() {
+        Annotation annotation;
+        int count = annotations.size();
+        long[] ids = new long[count];
+        for (int i = 0; i < count; i++) {
+            ids[i] = annotations.keyAt(i);
+            annotation = annotations.get(ids[i]);
+            if (annotation instanceof Marker) {
+                Marker marker = (Marker) annotation;
+                marker.hideInfoWindow();
+                if (marker instanceof MarkerView) {
+                    markerViewManager.removeMarkerView((MarkerView) marker);
+                }
+            }
+        }
+        mapView.removeAnnotations(ids);
+        annotations.clear();
+    }
+
+    //
+    // Markers
+    //
+
+    Marker addMarker(@NonNull BaseMarkerOptions markerOptions) {
+        Marker marker = prepareMarker(markerOptions);
+        long id = mapView.addMarker(marker);
+        marker.setMapboxMap(mapboxMap);
+        marker.setId(id);
+        annotations.put(id, marker);
+        return marker;
+    }
+
+    List<Marker> addMarkers(@NonNull List<? extends BaseMarkerOptions> markerOptionsList) {
+        int count = markerOptionsList.size();
+        List<Marker> markers = new ArrayList<>(count);
+        if (count > 0) {
+            BaseMarkerOptions markerOptions;
+            Marker marker;
+            for (int i = 0; i < count; i++) {
+                markerOptions = markerOptionsList.get(i);
+                marker = prepareMarker(markerOptions);
+                markers.add(marker);
+            }
+
+            if (markers.size() > 0) {
+                long[] ids = mapView.addMarkers(markers);
+
+                // if unittests or markers are correctly added to map
+                if (ids == null || ids.length == markers.size()) {
+                    long id = 0;
+                    Marker m;
+                    for (int i = 0; i < markers.size(); i++) {
+                        m = markers.get(i);
+                        m.setMapboxMap(mapboxMap);
+                        if (ids != null) {
+                            id = ids[i];
+                        } else {
+                            //unit test
+                            id++;
+                        }
+                        m.setId(id);
+                        annotations.put(id, m);
+                    }
+                }
+            }
+        }
+        return markers;
+    }
+
+    private Marker prepareMarker(BaseMarkerOptions markerOptions) {
+        Marker marker = markerOptions.getMarker();
+        Icon icon = mapView.loadIconForMarker(marker);
+        marker.setTopOffsetPixels(mapView.getTopOffsetPixelsForIcon(icon));
+        return marker;
+    }
+
+    MarkerView addMarker(@NonNull BaseMarkerViewOptions markerOptions) {
+        MarkerView marker = prepareViewMarker(markerOptions);
+        marker.setMapboxMap(mapboxMap);
+        long id = mapView.addMarker(marker);
+        marker.setId(id);
+        annotations.put(id, marker);
+        markerViewManager.invalidateViewMarkersInVisibleRegion();
+        return marker;
+    }
+
+    List<MarkerView> addMarkerViews(@NonNull List<? extends BaseMarkerViewOptions> markerViewOptions) {
+        List<MarkerView> markers = new ArrayList<>();
+        for (BaseMarkerViewOptions markerViewOption : markerViewOptions) {
+            MarkerView marker = prepareViewMarker(markerViewOption);
+            marker.setMapboxMap(mapboxMap);
+            long id = mapView.addMarker(marker);
+            marker.setId(id);
+            annotations.put(id, marker);
+            markers.add(marker);
+        }
+        markerViewManager.invalidateViewMarkersInVisibleRegion();
+        return markers;
+    }
+
+    private MarkerView prepareViewMarker(BaseMarkerViewOptions markerViewOptions) {
+        MarkerView marker = markerViewOptions.getMarker();
+        mapView.loadIconForMarkerView(marker);
+        return marker;
+    }
+
+    void updateMarker(@NonNull Marker updatedMarker) {
+        mapView.updateMarker(updatedMarker);
+
+        int index = annotations.indexOfKey(updatedMarker.getId());
+        if (index > -1) {
+            annotations.setValueAt(index, updatedMarker);
+        }
+    }
+
+    List<Marker> getMarkers() {
+        List<Marker> markers = new ArrayList<>();
+        Annotation annotation;
+        for (int i = 0; i < annotations.size(); i++) {
+            annotation = annotations.get(annotations.keyAt(i));
+            if (annotation instanceof Marker) {
+                markers.add((Marker) annotation);
+            }
+        }
+        return markers;
+    }
+
+    void setOnMarkerClickListener(@Nullable MapboxMap.OnMarkerClickListener listener) {
+        onMarkerClickListener = listener;
+    }
+
+    void selectMarker(@NonNull Marker marker) {
+        if (selectedMarkers.contains(marker)) {
+            return;
+        }
+
+        // Need to deselect any currently selected annotation first
+        if (!infoWindowManager.isAllowConcurrentMultipleOpenInfoWindows()) {
+            deselectMarkers();
+        }
+
+        boolean handledDefaultClick = false;
+        if (onMarkerClickListener != null) {
+            // end developer has provided a custom click listener
+            handledDefaultClick = onMarkerClickListener.onMarkerClick(marker);
+        }
+
+        if (!handledDefaultClick) {
+            if (marker instanceof MarkerView) {
+                markerViewManager.select((MarkerView) marker, false);
+                markerViewManager.ensureInfoWindowOffset((MarkerView) marker);
+            }
+
+            if (infoWindowManager.isInfoWindowValidForMarker(marker) || infoWindowManager.getInfoWindowAdapter() != null) {
+                infoWindowManager.getInfoWindows().add(marker.showInfoWindow(mapboxMap, mapView));
+            }
+        }
+
+        selectedMarkers.add(marker);
+    }
+
+    void deselectMarkers() {
+        if (selectedMarkers.isEmpty()) {
+            return;
+        }
+
+        for (Marker marker : selectedMarkers) {
+            if (marker.isInfoWindowShown()) {
+                marker.hideInfoWindow();
+            }
+
+            if (marker instanceof MarkerView) {
+                markerViewManager.deselect((MarkerView) marker, false);
+            }
+        }
+
+        // Removes all selected markers from the list
+        selectedMarkers.clear();
+    }
+
+    void deselectMarker(@NonNull Marker marker) {
+        if (!selectedMarkers.contains(marker)) {
+            return;
+        }
+
+        if (marker.isInfoWindowShown()) {
+            marker.hideInfoWindow();
+        }
+
+        if (marker instanceof MarkerView) {
+            markerViewManager.deselect((MarkerView) marker, false);
+        }
+
+        selectedMarkers.remove(marker);
+    }
+
+    List<Marker> getSelectedMarkers() {
+        return selectedMarkers;
+    }
+
+    //
+    // Polygons
+    //
+
+    Polygon addPolygon(@NonNull PolygonOptions polygonOptions) {
+        Polygon polygon = polygonOptions.getPolygon();
+        if (!polygon.getPoints().isEmpty()) {
+            long id = mapView.addPolygon(polygon);
+            polygon.setId(id);
+            polygon.setMapboxMap(mapboxMap);
+            annotations.put(id, polygon);
+        }
+        return polygon;
+    }
+
+    List<Polygon> addPolygons(@NonNull List<PolygonOptions> polygonOptionsList) {
+        int count = polygonOptionsList.size();
+
+        Polygon polygon;
+        List<Polygon> polygons = new ArrayList<>(count);
+        if (count > 0) {
+            for (PolygonOptions polygonOptions : polygonOptionsList) {
+                polygon = polygonOptions.getPolygon();
+                if (!polygon.getPoints().isEmpty()) {
+                    polygons.add(polygon);
+                }
+            }
+
+            long[] ids = mapView.addPolygons(polygons);
+
+            // if unit tests or polygons correctly added to map
+            if (ids == null || ids.length == polygons.size()) {
+                long id = 0;
+                for (int i = 0; i < polygons.size(); i++) {
+                    polygon = polygons.get(i);
+                    polygon.setMapboxMap(mapboxMap);
+                    if (ids != null) {
+                        id = ids[i];
+                    } else {
+                        // unit test
+                        id++;
+                    }
+                    polygon.setId(id);
+                    annotations.put(id, polygon);
+                }
+            }
+        }
+        return polygons;
+    }
+
+    void updatePolygon(Polygon polygon) {
+        mapView.updatePolygon(polygon);
+
+        int index = annotations.indexOfKey(polygon.getId());
+        if (index > -1) {
+            annotations.setValueAt(index, polygon);
+        }
+    }
+
+    List<Polygon> getPolygons() {
+        List<Polygon> polygons = new ArrayList<>();
+        Annotation annotation;
+        for (int i = 0; i < annotations.size(); i++) {
+            annotation = annotations.get(annotations.keyAt(i));
+            if (annotation instanceof Polygon) {
+                polygons.add((Polygon) annotation);
+            }
+        }
+        return polygons;
+    }
+
+    //
+    // Polylines
+    //
+
+    Polyline addPolyline(@NonNull PolylineOptions polylineOptions) {
+        Polyline polyline = polylineOptions.getPolyline();
+        if (!polyline.getPoints().isEmpty()) {
+            long id = mapView.addPolyline(polyline);
+            polyline.setMapboxMap(mapboxMap);
+            polyline.setId(id);
+            annotations.put(id, polyline);
+        }
+        return polyline;
+    }
+
+    List<Polyline> addPolylines(@NonNull List<PolylineOptions> polylineOptionsList) {
+        int count = polylineOptionsList.size();
+        Polyline polyline;
+        List<Polyline> polylines = new ArrayList<>(count);
+
+        if (count > 0) {
+            for (PolylineOptions options : polylineOptionsList) {
+                polyline = options.getPolyline();
+                if (!polyline.getPoints().isEmpty()) {
+                    polylines.add(polyline);
+                }
+            }
+
+            long[] ids = mapView.addPolylines(polylines);
+
+            // if unit tests or polylines are correctly added to map
+            if (ids == null || ids.length == polylines.size()) {
+                long id = 0;
+                Polyline p;
+
+                for (int i = 0; i < polylines.size(); i++) {
+                    p = polylines.get(i);
+                    p.setMapboxMap(mapboxMap);
+                    if (ids != null) {
+                        id = ids[i];
+                    } else {
+                        // unit test
+                        id++;
+                    }
+                    p.setId(id);
+                    annotations.put(id, p);
+                }
+            }
+        }
+        return polylines;
+    }
+
+    void updatePolyline(Polyline polyline) {
+        mapView.updatePolyline(polyline);
+
+        int index = annotations.indexOfKey(polyline.getId());
+        if (index > -1) {
+            annotations.setValueAt(index, polyline);
+        }
+    }
+
+    List<Polyline> getPolylines() {
+        List<Polyline> polylines = new ArrayList<>();
+        Annotation annotation;
+        for (int i = 0; i < annotations.size(); i++) {
+            annotation = annotations.get(annotations.keyAt(i));
+            if (annotation instanceof Polyline) {
+                polylines.add((Polyline) annotation);
+            }
+        }
+        return polylines;
+    }
+
+    //
+    // MarkerViewManager
+    //
+
+    MarkerViewManager getMarkerViewManager() {
+        return markerViewManager;
+    }
+
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -20,6 +20,16 @@ import com.mapbox.mapboxsdk.annotations.PolylineOptions;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Responsible for managing and tracking state of Annotations linked to Map. All events related to
+ * annotations that occur on {@link MapboxMap} are forwarded to this class.
+ * <p>
+ * Responsible for referencing {@link InfoWindowManager} and {@link MarkerViewManager}.
+ * </p>
+ * <p>
+ * Exposes convenience methods to add/remove/update all subtypes of annotations found in com.mapbox.mapboxsdk.annotations.
+ * </p>
+ */
 class AnnotationManager {
 
     private NativeMapView nativeMapView;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
@@ -1,0 +1,147 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.graphics.Bitmap;
+import android.util.DisplayMetrics;
+
+import com.mapbox.mapboxsdk.annotations.Icon;
+import com.mapbox.mapboxsdk.annotations.IconFactory;
+import com.mapbox.mapboxsdk.annotations.Marker;
+import com.mapbox.mapboxsdk.annotations.MarkerView;
+import com.mapbox.mapboxsdk.exceptions.IconBitmapChangedException;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+class IconManager {
+
+    private NativeMapView nativeMapView;
+    private List<Icon> icons;
+
+    private int averageIconHeight;
+    private int averageIconWidth;
+
+    IconManager(NativeMapView nativeMapView) {
+        this.nativeMapView = nativeMapView;
+        this.icons = new ArrayList<>();
+        // load transparent icon for MarkerView to trace actual markers, see #6352
+        loadIcon(IconFactory.recreate(IconFactory.ICON_MARKERVIEW_ID, IconFactory.ICON_MARKERVIEW_BITMAP));
+    }
+
+    Icon loadIconForMarker(Marker marker) {
+        Icon icon = marker.getIcon();
+
+        // calculating average before adding
+        int iconSize = icons.size() + 1;
+
+        // TODO replace former if case with anchor implementation,
+        // current workaround for having extra pixels is diving height by 2
+        if (icon == null) {
+            icon = IconFactory.getInstance(nativeMapView.getContext()).defaultMarker();
+            Bitmap bitmap = icon.getBitmap();
+            averageIconHeight = averageIconHeight + (bitmap.getHeight() / 2 - averageIconHeight) / iconSize;
+            averageIconWidth = averageIconWidth + (bitmap.getWidth() - averageIconWidth) / iconSize;
+            marker.setIcon(icon);
+        } else {
+            Bitmap bitmap = icon.getBitmap();
+            averageIconHeight = averageIconHeight + (bitmap.getHeight() - averageIconHeight) / iconSize;
+            averageIconWidth = averageIconWidth + (bitmap.getWidth() - averageIconWidth) / iconSize;
+        }
+
+        if (!icons.contains(icon)) {
+            icons.add(icon);
+            loadIcon(icon);
+        } else {
+            Icon oldIcon = icons.get(icons.indexOf(icon));
+            if (!oldIcon.getBitmap().sameAs(icon.getBitmap())) {
+                throw new IconBitmapChangedException();
+            }
+        }
+        return icon;
+    }
+
+    Icon loadIconForMarkerView(MarkerView marker) {
+        Icon icon = marker.getIcon();
+        int iconSize = icons.size() + 1;
+        if (icon == null) {
+            icon = IconFactory.getInstance(nativeMapView.getContext()).defaultMarkerView();
+            marker.setIcon(icon);
+        }
+        Bitmap bitmap = icon.getBitmap();
+        averageIconHeight = averageIconHeight + (bitmap.getHeight() - averageIconHeight) / iconSize;
+        averageIconWidth = averageIconWidth + (bitmap.getWidth() - averageIconWidth) / iconSize;
+        if (!icons.contains(icon)) {
+            icons.add(icon);
+        } else {
+            Icon oldIcon = icons.get(icons.indexOf(icon));
+            if (!oldIcon.getBitmap().sameAs(icon.getBitmap())) {
+                throw new IconBitmapChangedException();
+            }
+        }
+        return icon;
+    }
+
+    int getTopOffsetPixelsForIcon(Icon icon) {
+        return (int) (nativeMapView.getTopOffsetPixelsForAnnotationSymbol(icon.getId()) * nativeMapView.getPixelRatio());
+    }
+
+    void loadIcon(Icon icon) {
+        Bitmap bitmap = icon.getBitmap();
+        String id = icon.getId();
+        if (bitmap.getConfig() != Bitmap.Config.ARGB_8888) {
+            bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, false);
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(bitmap.getRowBytes() * bitmap.getHeight());
+        bitmap.copyPixelsToBuffer(buffer);
+
+        float density = bitmap.getDensity();
+        if (density == Bitmap.DENSITY_NONE) {
+            density = DisplayMetrics.DENSITY_DEFAULT;
+        }
+        float scale = density / DisplayMetrics.DENSITY_DEFAULT;
+        nativeMapView.addAnnotationIcon(
+                id,
+                bitmap.getWidth(),
+                bitmap.getHeight(),
+                scale, buffer.array());
+    }
+
+    void reloadIcons() {
+        int count = icons.size();
+        for (int i = 0; i < count; i++) {
+            Icon icon = icons.get(i);
+            loadIcon(icon);
+        }
+    }
+
+    void ensureIconLoaded(Marker marker, MapboxMap mapboxMap) {
+        Icon icon = marker.getIcon();
+        if (icon == null) {
+            icon = IconFactory.getInstance(nativeMapView.getContext()).defaultMarker();
+            marker.setIcon(icon);
+        }
+        if (!icons.contains(icon)) {
+            icons.add(icon);
+            loadIcon(icon);
+        } else {
+            Icon oldIcon = icons.get(icons.indexOf(icon));
+            if (!oldIcon.getBitmap().sameAs(icon.getBitmap())) {
+                throw new IconBitmapChangedException();
+            }
+        }
+
+        // this seems to be a costly operation according to the profiler so I'm trying to save some calls
+        Marker previousMarker = marker.getId() != -1 ? (Marker) mapboxMap.getAnnotation(marker.getId()) : null;
+        if (previousMarker == null || previousMarker.getIcon() == null || previousMarker.getIcon() != marker.getIcon()) {
+            marker.setTopOffsetPixels(getTopOffsetPixelsForIcon(icon));
+        }
+    }
+
+    public int getAverageIconHeight() {
+        return averageIconHeight;
+    }
+
+    public int getAverageIconWidth() {
+        return averageIconWidth;
+    }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
@@ -13,6 +13,17 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Responsible for managing icons added to the Map.
+ * <p>
+ * Maintains a {@link List} of {@link Icon} and  is responsible for initialising default markers and
+ * setting up {@link MarkerView} annotation ghosting.
+ * </p>
+ * <p>
+ * Keep track of icons added and the resulting average icon size. This is used internally by our
+ * gestures detection to calculate the size of a touch target.
+ * </p>
+ */
 class IconManager {
 
     private NativeMapView nativeMapView;
@@ -137,11 +148,11 @@ class IconManager {
         }
     }
 
-    public int getAverageIconHeight() {
+    int getAverageIconHeight() {
         return averageIconHeight;
     }
 
-    public int getAverageIconWidth() {
+    int getAverageIconWidth() {
         return averageIconWidth;
     }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
@@ -1,0 +1,74 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import com.mapbox.mapboxsdk.annotations.InfoWindow;
+import com.mapbox.mapboxsdk.annotations.Marker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class InfoWindowManager {
+
+    private List<InfoWindow> infoWindows;
+    private MapboxMap.InfoWindowAdapter infoWindowAdapter;
+    private boolean allowConcurrentMultipleInfoWindows;
+
+    private MapboxMap.OnInfoWindowClickListener onInfoWindowClickListener;
+    private MapboxMap.OnInfoWindowLongClickListener onInfoWindowLongClickListener;
+    private MapboxMap.OnInfoWindowCloseListener onInfoWindowCloseListener;
+
+    InfoWindowManager() {
+        this.infoWindows = new ArrayList<>();
+    }
+
+    void setInfoWindowAdapter(@Nullable MapboxMap.InfoWindowAdapter infoWindowAdapter) {
+        this.infoWindowAdapter = infoWindowAdapter;
+    }
+
+    MapboxMap.InfoWindowAdapter getInfoWindowAdapter() {
+        return infoWindowAdapter;
+    }
+
+    void setAllowConcurrentMultipleOpenInfoWindows(boolean allow) {
+        allowConcurrentMultipleInfoWindows = allow;
+    }
+
+    boolean isAllowConcurrentMultipleOpenInfoWindows() {
+        return allowConcurrentMultipleInfoWindows;
+    }
+
+    List<InfoWindow> getInfoWindows() {
+        return infoWindows;
+    }
+
+    boolean isInfoWindowValidForMarker(@NonNull Marker marker) {
+        return !TextUtils.isEmpty(marker.getTitle()) || !TextUtils.isEmpty(marker.getSnippet());
+    }
+
+    void setOnInfoWindowClickListener(@Nullable MapboxMap.OnInfoWindowClickListener listener) {
+        onInfoWindowClickListener = listener;
+    }
+
+    MapboxMap.OnInfoWindowClickListener getOnInfoWindowClickListener() {
+        return onInfoWindowClickListener;
+    }
+
+    void setOnInfoWindowLongClickListener(@Nullable MapboxMap.OnInfoWindowLongClickListener listener) {
+        onInfoWindowLongClickListener = listener;
+    }
+
+    MapboxMap.OnInfoWindowLongClickListener getOnInfoWindowLongClickListener() {
+        return onInfoWindowLongClickListener;
+    }
+
+    void setOnInfoWindowCloseListener(@Nullable MapboxMap.OnInfoWindowCloseListener listener) {
+        onInfoWindowCloseListener = listener;
+    }
+
+    MapboxMap.OnInfoWindowCloseListener getOnInfoWindowCloseListener() {
+        return onInfoWindowCloseListener;
+    }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/InfoWindowManager.java
@@ -10,6 +10,15 @@ import com.mapbox.mapboxsdk.annotations.Marker;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Responsible for managing InfoWindows shown on the Map.
+ * <p>
+ * Maintains a {@link List} of opened {@link InfoWindow} and tracks configurations as
+ * allowConcurrentMultipleInfoWindows which allows to have multiple {@link InfoWindow} open at the
+ * same time. Responsible for managing listeners as {@link com.mapbox.mapboxsdk.maps.MapboxMap.OnInfoWindowClickListener}
+ * and {@link com.mapbox.mapboxsdk.maps.MapboxMap.OnInfoWindowLongClickListener}.
+ * </p>
+ */
 class InfoWindowManager {
 
     private List<InfoWindow> infoWindows;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -86,14 +86,14 @@ public class MapboxMap {
     private double maxZoomLevel = -1;
     private double minZoomLevel = -1;
 
-    MapboxMap(@NonNull MapView mapView) {
+    MapboxMap(@NonNull MapView mapView, IconManager iconManager) {
         this.mapView = mapView;
         this.mapView.addOnMapChangedListener(new MapChangeCameraPositionListener());
         uiSettings = new UiSettings(mapView);
         trackingSettings = new TrackingSettings(this.mapView, uiSettings);
         projection = new Projection(mapView);
         infoWindowManager = new InfoWindowManager();
-        annotationManager = new AnnotationManager(this, mapView, infoWindowManager);
+        annotationManager = new AnnotationManager(mapView.getNativeMapView(), iconManager, infoWindowManager);
     }
 
     // Style
@@ -788,7 +788,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public Marker addMarker(@NonNull MarkerOptions markerOptions) {
-        return annotationManager.addMarker(markerOptions);
+        return annotationManager.addMarker(markerOptions, this);
     }
 
     /**
@@ -804,7 +804,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public Marker addMarker(@NonNull BaseMarkerOptions markerOptions) {
-        return annotationManager.addMarker(markerOptions);
+        return annotationManager.addMarker(markerOptions, this);
     }
 
     /**
@@ -820,13 +820,19 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public MarkerView addMarker(@NonNull BaseMarkerViewOptions markerOptions) {
-        return annotationManager.addMarker(markerOptions);
+        return annotationManager.addMarker(markerOptions, this);
     }
 
     @UiThread
     @NonNull
     public List<MarkerView> addMarkerViews(@NonNull List<? extends BaseMarkerViewOptions> markerViewOptions) {
-        return annotationManager.addMarkerViews(markerViewOptions);
+        return annotationManager.addMarkerViews(markerViewOptions, this);
+    }
+
+    @UiThread
+    @NonNull
+    public List<MarkerView> getMarkerViewsInRect(@NonNull RectF rect) {
+        return annotationManager.getMarkerViewsInRect(rect);
     }
 
     /**
@@ -842,7 +848,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public List<Marker> addMarkers(@NonNull List<? extends BaseMarkerOptions> markerOptionsList) {
-        return annotationManager.addMarkers(markerOptionsList);
+        return annotationManager.addMarkers(markerOptionsList, this);
     }
 
     /**
@@ -854,7 +860,7 @@ public class MapboxMap {
      */
     @UiThread
     public void updateMarker(@NonNull Marker updatedMarker) {
-        annotationManager.updateMarker(updatedMarker);
+        annotationManager.updateMarker(updatedMarker, this);
     }
 
     /**
@@ -866,7 +872,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public Polyline addPolyline(@NonNull PolylineOptions polylineOptions) {
-        return annotationManager.addPolyline(polylineOptions);
+        return annotationManager.addPolyline(polylineOptions, this);
     }
 
     /**
@@ -878,7 +884,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public List<Polyline> addPolylines(@NonNull List<PolylineOptions> polylineOptionsList) {
-        return annotationManager.addPolylines(polylineOptionsList);
+        return annotationManager.addPolylines(polylineOptionsList, this);
     }
 
     /**
@@ -900,7 +906,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public Polygon addPolygon(@NonNull PolygonOptions polygonOptions) {
-        return annotationManager.addPolygon(polygonOptions);
+        return annotationManager.addPolygon(polygonOptions, this);
     }
 
     /**
@@ -912,7 +918,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public List<Polygon> addPolygons(@NonNull List<PolygonOptions> polygonOptionsList) {
-        return annotationManager.addPolygons(polygonOptionsList);
+        return annotationManager.addPolygons(polygonOptionsList, this);
     }
 
 
@@ -1093,7 +1099,7 @@ public class MapboxMap {
             Log.w(MapboxConstants.TAG, "marker was null, so just returning");
             return;
         }
-        annotationManager.selectMarker(marker);
+        annotationManager.selectMarker(marker, this);
     }
 
     /**
@@ -1130,7 +1136,7 @@ public class MapboxMap {
      * @return the associated MarkerViewManager
      */
     public MarkerViewManager getMarkerViewManager() {
-        return annotationManager.getMarkerViewManager();
+        return annotationManager.getMarkerViewManager(this);
     }
 
     //
@@ -1186,6 +1192,10 @@ public class MapboxMap {
     // used by MapView
     List<InfoWindow> getInfoWindows() {
         return infoWindowManager.getInfoWindows();
+    }
+
+    AnnotationManager getAnnotationManager() {
+        return annotationManager;
     }
 
     //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -10,9 +10,7 @@ import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
-import android.support.v4.util.LongSparseArray;
 import android.support.v4.util.Pools;
-import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,7 +19,6 @@ import com.mapbox.mapboxsdk.MapboxAccountManager;
 import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerOptions;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerViewOptions;
-import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.InfoWindow;
 import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
@@ -47,7 +44,6 @@ import com.mapbox.mapboxsdk.style.sources.Source;
 import com.mapbox.services.commons.geojson.Feature;
 
 import java.lang.reflect.ParameterizedType;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -70,29 +66,22 @@ public class MapboxMap {
     private Projection projection;
     private CameraPosition cameraPosition;
     private boolean invalidCameraPosition;
-    private LongSparseArray<Annotation> annotations;
-
-    private List<Marker> selectedMarkers;
-    private MarkerViewManager markerViewManager;
-
-    private List<InfoWindow> infoWindows;
-    private MapboxMap.InfoWindowAdapter infoWindowAdapter;
 
     private boolean myLocationEnabled;
-    private boolean allowConcurrentMultipleInfoWindows;
 
     private MapboxMap.OnMapClickListener onMapClickListener;
     private MapboxMap.OnMapLongClickListener onMapLongClickListener;
-    private MapboxMap.OnMarkerClickListener onMarkerClickListener;
-    private MapboxMap.OnInfoWindowClickListener onInfoWindowClickListener;
-    private MapboxMap.OnInfoWindowLongClickListener onInfoWindowLongClickListener;
-    private MapboxMap.OnInfoWindowCloseListener onInfoWindowCloseListener;
+
+
     private MapboxMap.OnFlingListener onFlingListener;
     private MapboxMap.OnScrollListener onScrollListener;
     private MapboxMap.OnMyLocationTrackingModeChangeListener onMyLocationTrackingModeChangeListener;
     private MapboxMap.OnMyBearingTrackingModeChangeListener onMyBearingTrackingModeChangeListener;
     private MapboxMap.OnFpsChangedListener onFpsChangedListener;
     private MapboxMap.OnCameraChangeListener onCameraChangeListener;
+
+    private AnnotationManager annotationManager;
+    private InfoWindowManager infoWindowManager;
 
     private double maxZoomLevel = -1;
     private double minZoomLevel = -1;
@@ -103,10 +92,8 @@ public class MapboxMap {
         uiSettings = new UiSettings(mapView);
         trackingSettings = new TrackingSettings(this.mapView, uiSettings);
         projection = new Projection(mapView);
-        annotations = new LongSparseArray<>();
-        selectedMarkers = new ArrayList<>();
-        infoWindows = new ArrayList<>();
-        markerViewManager = new MarkerViewManager(this, mapView);
+        infoWindowManager = new InfoWindowManager();
+        annotationManager = new AnnotationManager(this, mapView, infoWindowManager);
     }
 
     // Style
@@ -220,7 +207,7 @@ public class MapboxMap {
      */
     @UiThread
     public void setMinZoom(
-      @FloatRange(from = MapboxConstants.MINIMUM_ZOOM, to = MapboxConstants.MAXIMUM_ZOOM) double minZoom) {
+            @FloatRange(from = MapboxConstants.MINIMUM_ZOOM, to = MapboxConstants.MAXIMUM_ZOOM) double minZoom) {
         if ((minZoom < MapboxConstants.MINIMUM_ZOOM) || (minZoom > MapboxConstants.MAXIMUM_ZOOM)) {
             Log.e(MapboxConstants.TAG, "Not setting minZoom, value is in unsupported range: " + minZoom);
             return;
@@ -257,7 +244,7 @@ public class MapboxMap {
      */
     @UiThread
     public void setMaxZoom(
-      @FloatRange(from = MapboxConstants.MINIMUM_ZOOM, to = MapboxConstants.MAXIMUM_ZOOM) double maxZoom) {
+            @FloatRange(from = MapboxConstants.MINIMUM_ZOOM, to = MapboxConstants.MAXIMUM_ZOOM) double maxZoom) {
         if ((maxZoom < MapboxConstants.MINIMUM_ZOOM) || (maxZoom > MapboxConstants.MAXIMUM_ZOOM)) {
             Log.e(MapboxConstants.TAG, "Not setting maxZoom, value is in unsupported range: " + maxZoom);
             return;
@@ -600,7 +587,7 @@ public class MapboxMap {
      * Invalidates the current camera position by reconstructing it from mbgl
      */
     private void invalidateCameraPosition() {
-        if(invalidCameraPosition) {
+        if (invalidCameraPosition) {
             invalidCameraPosition = false;
 
             CameraPosition cameraPosition = mapView.invalidateCameraPosition();
@@ -801,7 +788,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public Marker addMarker(@NonNull MarkerOptions markerOptions) {
-        return addMarker((BaseMarkerOptions) markerOptions);
+        return annotationManager.addMarker(markerOptions);
     }
 
     /**
@@ -817,12 +804,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public Marker addMarker(@NonNull BaseMarkerOptions markerOptions) {
-        Marker marker = prepareMarker(markerOptions);
-        long id = mapView.addMarker(marker);
-        marker.setMapboxMap(this);
-        marker.setId(id);
-        annotations.put(id, marker);
-        return marker;
+        return annotationManager.addMarker(markerOptions);
     }
 
     /**
@@ -838,29 +820,13 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public MarkerView addMarker(@NonNull BaseMarkerViewOptions markerOptions) {
-        MarkerView marker = prepareViewMarker(markerOptions);
-        marker.setMapboxMap(this);
-        long id = mapView.addMarker(marker);
-        marker.setId(id);
-        annotations.put(id, marker);
-        markerViewManager.invalidateViewMarkersInVisibleRegion();
-        return marker;
+        return annotationManager.addMarker(markerOptions);
     }
 
     @UiThread
     @NonNull
     public List<MarkerView> addMarkerViews(@NonNull List<? extends BaseMarkerViewOptions> markerViewOptions) {
-        List<MarkerView> markers = new ArrayList<>();
-        for (BaseMarkerViewOptions markerViewOption : markerViewOptions) {
-            MarkerView marker = prepareViewMarker(markerViewOption);
-            marker.setMapboxMap(this);
-            long id = mapView.addMarker(marker);
-            marker.setId(id);
-            annotations.put(id, marker);
-            markers.add(marker);
-        }
-        markerViewManager.invalidateViewMarkersInVisibleRegion();
-        return markers;
+        return annotationManager.addMarkerViews(markerViewOptions);
     }
 
     /**
@@ -876,40 +842,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public List<Marker> addMarkers(@NonNull List<? extends BaseMarkerOptions> markerOptionsList) {
-        int count = markerOptionsList.size();
-        List<Marker> markers = new ArrayList<>(count);
-        if (count > 0) {
-            BaseMarkerOptions markerOptions;
-            Marker marker;
-            for (int i = 0; i < count; i++) {
-                markerOptions = markerOptionsList.get(i);
-                marker = prepareMarker(markerOptions);
-                markers.add(marker);
-            }
-
-            if (markers.size() > 0) {
-                long[] ids = mapView.addMarkers(markers);
-
-                // if unittests or markers are correctly added to map
-                if (ids == null || ids.length == markers.size()) {
-                    long id = 0;
-                    Marker m;
-                    for (int i = 0; i < markers.size(); i++) {
-                        m = markers.get(i);
-                        m.setMapboxMap(this);
-                        if (ids != null) {
-                            id = ids[i];
-                        } else {
-                            //unit test
-                            id++;
-                        }
-                        m.setId(id);
-                        annotations.put(id, m);
-                    }
-                }
-            }
-        }
-        return markers;
+        return annotationManager.addMarkers(markerOptionsList);
     }
 
     /**
@@ -921,42 +854,7 @@ public class MapboxMap {
      */
     @UiThread
     public void updateMarker(@NonNull Marker updatedMarker) {
-        mapView.updateMarker(updatedMarker);
-
-        int index = annotations.indexOfKey(updatedMarker.getId());
-        if (index > -1) {
-            annotations.setValueAt(index, updatedMarker);
-        }
-    }
-
-    /**
-     * Update a polygon on this map.
-     *
-     * @param polygon An updated polygon object.
-     */
-    @UiThread
-    public void updatePolygon(Polygon polygon) {
-        mapView.updatePolygon(polygon);
-
-        int index = annotations.indexOfKey(polygon.getId());
-        if (index > -1) {
-            annotations.setValueAt(index, polygon);
-        }
-    }
-
-    /**
-     * Update a polyline on this map.
-     *
-     * @param polyline An updated polyline object.
-     */
-    @UiThread
-    public void updatePolyline(Polyline polyline) {
-        mapView.updatePolyline(polyline);
-
-        int index = annotations.indexOfKey(polyline.getId());
-        if (index > -1) {
-            annotations.setValueAt(index, polyline);
-        }
+        annotationManager.updateMarker(updatedMarker);
     }
 
     /**
@@ -968,14 +866,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public Polyline addPolyline(@NonNull PolylineOptions polylineOptions) {
-        Polyline polyline = polylineOptions.getPolyline();
-        if (!polyline.getPoints().isEmpty()) {
-            long id = mapView.addPolyline(polyline);
-            polyline.setMapboxMap(this);
-            polyline.setId(id);
-            annotations.put(id, polyline);
-        }
-        return polyline;
+        return annotationManager.addPolyline(polylineOptions);
     }
 
     /**
@@ -987,40 +878,17 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public List<Polyline> addPolylines(@NonNull List<PolylineOptions> polylineOptionsList) {
-        int count = polylineOptionsList.size();
-        Polyline polyline;
-        List<Polyline> polylines = new ArrayList<>(count);
+        return annotationManager.addPolylines(polylineOptionsList);
+    }
 
-        if (count > 0) {
-            for (PolylineOptions options : polylineOptionsList) {
-                polyline = options.getPolyline();
-                if (!polyline.getPoints().isEmpty()) {
-                    polylines.add(polyline);
-                }
-            }
-
-            long[] ids = mapView.addPolylines(polylines);
-
-            // if unit tests or polylines are correctly added to map
-            if (ids == null || ids.length == polylines.size()) {
-                long id = 0;
-                Polyline p;
-
-                for (int i = 0; i < polylines.size(); i++) {
-                    p = polylines.get(i);
-                    p.setMapboxMap(this);
-                    if (ids != null) {
-                        id = ids[i];
-                    } else {
-                        // unit test
-                        id++;
-                    }
-                    p.setId(id);
-                    annotations.put(id, p);
-                }
-            }
-        }
-        return polylines;
+    /**
+     * Update a polyline on this map.
+     *
+     * @param polyline An updated polyline object.
+     */
+    @UiThread
+    public void updatePolyline(Polyline polyline) {
+        annotationManager.updatePolyline(polyline);
     }
 
     /**
@@ -1032,14 +900,7 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public Polygon addPolygon(@NonNull PolygonOptions polygonOptions) {
-        Polygon polygon = polygonOptions.getPolygon();
-        if (!polygon.getPoints().isEmpty()) {
-            long id = mapView.addPolygon(polygon);
-            polygon.setId(id);
-            polygon.setMapboxMap(this);
-            annotations.put(id, polygon);
-        }
-        return polygon;
+        return annotationManager.addPolygon(polygonOptions);
     }
 
     /**
@@ -1051,38 +912,18 @@ public class MapboxMap {
     @UiThread
     @NonNull
     public List<Polygon> addPolygons(@NonNull List<PolygonOptions> polygonOptionsList) {
-        int count = polygonOptionsList.size();
+        return annotationManager.addPolygons(polygonOptionsList);
+    }
 
-        Polygon polygon;
-        List<Polygon> polygons = new ArrayList<>(count);
-        if (count > 0) {
-            for (PolygonOptions polygonOptions : polygonOptionsList) {
-                polygon = polygonOptions.getPolygon();
-                if (!polygon.getPoints().isEmpty()) {
-                    polygons.add(polygon);
-                }
-            }
 
-            long[] ids = mapView.addPolygons(polygons);
-
-            // if unit tests or polygons correctly added to map
-            if (ids == null || ids.length == polygons.size()) {
-                long id = 0;
-                for (int i = 0; i < polygons.size(); i++) {
-                    polygon = polygons.get(i);
-                    polygon.setMapboxMap(this);
-                    if (ids != null) {
-                        id = ids[i];
-                    } else {
-                        // unit test
-                        id++;
-                    }
-                    polygon.setId(id);
-                    annotations.put(id, polygon);
-                }
-            }
-        }
-        return polygons;
+    /**
+     * Update a polygon on this map.
+     *
+     * @param polygon An updated polygon object.
+     */
+    @UiThread
+    public void updatePolygon(Polygon polygon) {
+        annotationManager.updatePolygon(polygon);
     }
 
     /**
@@ -1095,7 +936,7 @@ public class MapboxMap {
      */
     @UiThread
     public void removeMarker(@NonNull Marker marker) {
-        removeAnnotation(marker);
+        annotationManager.removeAnnotation(marker);
     }
 
     /**
@@ -1108,7 +949,7 @@ public class MapboxMap {
      */
     @UiThread
     public void removePolyline(@NonNull Polyline polyline) {
-        removeAnnotation(polyline);
+        annotationManager.removeAnnotation(polyline);
     }
 
     /**
@@ -1121,7 +962,7 @@ public class MapboxMap {
      */
     @UiThread
     public void removePolygon(@NonNull Polygon polygon) {
-        removeAnnotation(polygon);
+        annotationManager.removeAnnotation(polygon);
     }
 
     /**
@@ -1131,16 +972,7 @@ public class MapboxMap {
      */
     @UiThread
     public void removeAnnotation(@NonNull Annotation annotation) {
-        if (annotation instanceof Marker) {
-            Marker marker = (Marker) annotation;
-            marker.hideInfoWindow();
-            if (marker instanceof MarkerView) {
-                markerViewManager.removeMarkerView((MarkerView) marker);
-            }
-        }
-        long id = annotation.getId();
-        mapView.removeAnnotation(id);
-        annotations.remove(id);
+        annotationManager.removeAnnotation(annotation);
     }
 
     /**
@@ -1150,8 +982,7 @@ public class MapboxMap {
      */
     @UiThread
     public void removeAnnotation(long id) {
-        mapView.removeAnnotation(id);
-        annotations.remove(id);
+        annotationManager.removeAnnotation(id);
     }
 
     /**
@@ -1161,23 +992,7 @@ public class MapboxMap {
      */
     @UiThread
     public void removeAnnotations(@NonNull List<? extends Annotation> annotationList) {
-        int count = annotationList.size();
-        long[] ids = new long[count];
-        for (int i = 0; i < count; i++) {
-            Annotation annotation = annotationList.get(i);
-            if (annotation instanceof Marker) {
-                Marker marker = (Marker) annotation;
-                marker.hideInfoWindow();
-                if (marker instanceof MarkerView) {
-                    markerViewManager.removeMarkerView((MarkerView) marker);
-                }
-            }
-            ids[i] = annotationList.get(i).getId();
-        }
-        mapView.removeAnnotations(ids);
-        for (long id : ids) {
-            annotations.remove(id);
-        }
+        annotationManager.removeAnnotations(annotationList);
     }
 
     /**
@@ -1185,22 +1000,7 @@ public class MapboxMap {
      */
     @UiThread
     public void removeAnnotations() {
-        Annotation annotation;
-        int count = annotations.size();
-        long[] ids = new long[count];
-        for (int i = 0; i < count; i++) {
-            ids[i] = annotations.keyAt(i);
-            annotation = annotations.get(ids[i]);
-            if (annotation instanceof Marker) {
-                Marker marker = (Marker) annotation;
-                marker.hideInfoWindow();
-                if (marker instanceof MarkerView) {
-                    markerViewManager.removeMarkerView((MarkerView) marker);
-                }
-            }
-        }
-        mapView.removeAnnotations(ids);
-        annotations.clear();
+        annotationManager.removeAnnotations();
     }
 
     /**
@@ -1208,7 +1008,7 @@ public class MapboxMap {
      */
     @UiThread
     public void clear() {
-        removeAnnotations();
+        annotationManager.removeAnnotations();
     }
 
     /**
@@ -1219,7 +1019,7 @@ public class MapboxMap {
      */
     @Nullable
     public Annotation getAnnotation(long id) {
-        return annotations.get(id);
+        return annotationManager.getAnnotation(id);
     }
 
     /**
@@ -1230,11 +1030,7 @@ public class MapboxMap {
      */
     @NonNull
     public List<Annotation> getAnnotations() {
-        List<Annotation> annotations = new ArrayList<>();
-        for (int i = 0; i < this.annotations.size(); i++) {
-            annotations.add(this.annotations.get(this.annotations.keyAt(i)));
-        }
-        return annotations;
+        return annotationManager.getAnnotations();
     }
 
     /**
@@ -1245,15 +1041,7 @@ public class MapboxMap {
      */
     @NonNull
     public List<Marker> getMarkers() {
-        List<Marker> markers = new ArrayList<>();
-        Annotation annotation;
-        for (int i = 0; i < annotations.size(); i++) {
-            annotation = annotations.get(annotations.keyAt(i));
-            if (annotation instanceof Marker) {
-                markers.add((Marker) annotation);
-            }
-        }
-        return markers;
+        return annotationManager.getMarkers();
     }
 
     /**
@@ -1264,15 +1052,7 @@ public class MapboxMap {
      */
     @NonNull
     public List<Polygon> getPolygons() {
-        List<Polygon> polygons = new ArrayList<>();
-        Annotation annotation;
-        for (int i = 0; i < annotations.size(); i++) {
-            annotation = annotations.get(annotations.keyAt(i));
-            if (annotation instanceof Polygon) {
-                polygons.add((Polygon) annotation);
-            }
-        }
-        return polygons;
+        return annotationManager.getPolygons();
     }
 
     /**
@@ -1283,15 +1063,18 @@ public class MapboxMap {
      */
     @NonNull
     public List<Polyline> getPolylines() {
-        List<Polyline> polylines = new ArrayList<>();
-        Annotation annotation;
-        for (int i = 0; i < annotations.size(); i++) {
-            annotation = annotations.get(annotations.keyAt(i));
-            if (annotation instanceof Polyline) {
-                polylines.add((Polyline) annotation);
-            }
-        }
-        return polylines;
+        return annotationManager.getPolylines();
+    }
+
+    /**
+     * Sets a callback that's invoked when the user clicks on a marker.
+     *
+     * @param listener The callback that's invoked when the user clicks on a marker.
+     *                 To unset the callback, use null.
+     */
+    @UiThread
+    public void setOnMarkerClickListener(@Nullable OnMarkerClickListener listener) {
+        annotationManager.setOnMarkerClickListener(listener);
     }
 
     /**
@@ -1310,34 +1093,7 @@ public class MapboxMap {
             Log.w(MapboxConstants.TAG, "marker was null, so just returning");
             return;
         }
-
-        if (selectedMarkers.contains(marker)) {
-            return;
-        }
-
-        // Need to deselect any currently selected annotation first
-        if (!isAllowConcurrentMultipleOpenInfoWindows()) {
-            deselectMarkers();
-        }
-
-        boolean handledDefaultClick = false;
-        if (onMarkerClickListener != null) {
-            // end developer has provided a custom click listener
-            handledDefaultClick = onMarkerClickListener.onMarkerClick(marker);
-        }
-
-        if (!handledDefaultClick) {
-            if (marker instanceof MarkerView) {
-                markerViewManager.select((MarkerView) marker, false);
-                markerViewManager.ensureInfoWindowOffset((MarkerView) marker);
-            }
-
-            if (isInfoWindowValidForMarker(marker) || getInfoWindowAdapter() != null) {
-                infoWindows.add(marker.showInfoWindow(this, mapView));
-            }
-        }
-
-        selectedMarkers.add(marker);
+        annotationManager.selectMarker(marker);
     }
 
     /**
@@ -1345,22 +1101,7 @@ public class MapboxMap {
      */
     @UiThread
     public void deselectMarkers() {
-        if (selectedMarkers.isEmpty()) {
-            return;
-        }
-
-        for (Marker marker : selectedMarkers) {
-            if (marker.isInfoWindowShown()) {
-                marker.hideInfoWindow();
-            }
-
-            if (marker instanceof MarkerView) {
-                markerViewManager.deselect((MarkerView) marker, false);
-            }
-        }
-
-        // Removes all selected markers from the list
-        selectedMarkers.clear();
+        annotationManager.deselectMarkers();
     }
 
     /**
@@ -1370,19 +1111,7 @@ public class MapboxMap {
      */
     @UiThread
     public void deselectMarker(@NonNull Marker marker) {
-        if (!selectedMarkers.contains(marker)) {
-            return;
-        }
-
-        if (marker.isInfoWindowShown()) {
-            marker.hideInfoWindow();
-        }
-
-        if (marker instanceof MarkerView) {
-            markerViewManager.deselect((MarkerView) marker, false);
-        }
-
-        selectedMarkers.remove(marker);
+        annotationManager.deselectMarker(marker);
     }
 
     /**
@@ -1392,20 +1121,7 @@ public class MapboxMap {
      */
     @UiThread
     public List<Marker> getSelectedMarkers() {
-        return selectedMarkers;
-    }
-
-    private Marker prepareMarker(BaseMarkerOptions markerOptions) {
-        Marker marker = markerOptions.getMarker();
-        Icon icon = mapView.loadIconForMarker(marker);
-        marker.setTopOffsetPixels(mapView.getTopOffsetPixelsForIcon(icon));
-        return marker;
-    }
-
-    private MarkerView prepareViewMarker(BaseMarkerViewOptions markerViewOptions) {
-        MarkerView marker = markerViewOptions.getMarker();
-        mapView.loadIconForMarkerView(marker);
-        return marker;
+        return annotationManager.getSelectedMarkers();
     }
 
     /**
@@ -1414,7 +1130,7 @@ public class MapboxMap {
      * @return the associated MarkerViewManager
      */
     public MarkerViewManager getMarkerViewManager() {
-        return markerViewManager;
+        return annotationManager.getMarkerViewManager();
     }
 
     //
@@ -1433,7 +1149,7 @@ public class MapboxMap {
      */
     @UiThread
     public void setInfoWindowAdapter(@Nullable InfoWindowAdapter infoWindowAdapter) {
-        this.infoWindowAdapter = infoWindowAdapter;
+        infoWindowManager.setInfoWindowAdapter(infoWindowAdapter);
     }
 
     /**
@@ -1444,7 +1160,7 @@ public class MapboxMap {
     @UiThread
     @Nullable
     public InfoWindowAdapter getInfoWindowAdapter() {
-        return infoWindowAdapter;
+        return infoWindowManager.getInfoWindowAdapter();
     }
 
     /**
@@ -1454,7 +1170,7 @@ public class MapboxMap {
      */
     @UiThread
     public void setAllowConcurrentMultipleOpenInfoWindows(boolean allow) {
-        allowConcurrentMultipleInfoWindows = allow;
+        infoWindowManager.setAllowConcurrentMultipleOpenInfoWindows(allow);
     }
 
     /**
@@ -1464,16 +1180,12 @@ public class MapboxMap {
      */
     @UiThread
     public boolean isAllowConcurrentMultipleOpenInfoWindows() {
-        return allowConcurrentMultipleInfoWindows;
+        return infoWindowManager.isAllowConcurrentMultipleOpenInfoWindows();
     }
 
     // used by MapView
     List<InfoWindow> getInfoWindows() {
-        return infoWindows;
-    }
-
-    private boolean isInfoWindowValidForMarker(@NonNull Marker marker) {
-        return !TextUtils.isEmpty(marker.getTitle()) || !TextUtils.isEmpty(marker.getSnippet());
+        return infoWindowManager.getInfoWindows();
     }
 
     //
@@ -1611,17 +1323,6 @@ public class MapboxMap {
     }
 
     /**
-     * Sets a callback that's invoked when the user clicks on a marker.
-     *
-     * @param listener The callback that's invoked when the user clicks on a marker.
-     *                 To unset the callback, use null.
-     */
-    @UiThread
-    public void setOnMarkerClickListener(@Nullable OnMarkerClickListener listener) {
-        onMarkerClickListener = listener;
-    }
-
-    /**
      * Sets a callback that's invoked when the user clicks on an info window.
      *
      * @param listener The callback that's invoked when the user clicks on an info window.
@@ -1629,7 +1330,7 @@ public class MapboxMap {
      */
     @UiThread
     public void setOnInfoWindowClickListener(@Nullable OnInfoWindowClickListener listener) {
-        onInfoWindowClickListener = listener;
+        infoWindowManager.setOnInfoWindowClickListener(listener);
     }
 
     /**
@@ -1639,7 +1340,7 @@ public class MapboxMap {
      */
     @UiThread
     public OnInfoWindowClickListener getOnInfoWindowClickListener() {
-        return onInfoWindowClickListener;
+        return infoWindowManager.getOnInfoWindowClickListener();
     }
 
     /**
@@ -1650,7 +1351,7 @@ public class MapboxMap {
      */
     @UiThread
     public void setOnInfoWindowLongClickListener(@Nullable OnInfoWindowLongClickListener listener) {
-        onInfoWindowLongClickListener = listener;
+        infoWindowManager.setOnInfoWindowLongClickListener(listener);
     }
 
     /**
@@ -1659,11 +1360,11 @@ public class MapboxMap {
      * @return Current active InfoWindow long Click Listener
      */
     public OnInfoWindowLongClickListener getOnInfoWindowLongClickListener() {
-        return onInfoWindowLongClickListener;
+        return infoWindowManager.getOnInfoWindowLongClickListener();
     }
 
     public void setOnInfoWindowCloseListener(@Nullable OnInfoWindowCloseListener listener) {
-        onInfoWindowCloseListener = listener;
+        infoWindowManager.setOnInfoWindowCloseListener(listener);
     }
 
     /**
@@ -1673,7 +1374,7 @@ public class MapboxMap {
      */
     @UiThread
     public OnInfoWindowCloseListener getOnInfoWindowCloseListener() {
-        return onInfoWindowCloseListener;
+        return infoWindowManager.getOnInfoWindowCloseListener();
     }
 
     //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -34,14 +34,6 @@ import java.util.List;
 // Class that wraps the native methods for convenience
 final class NativeMapView {
 
-    //
-    // Static members
-    //
-
-    //
-    // Instance members
-    //
-
     boolean destroyed = false;
 
     // Holds the pointer to JNI NativeMapView
@@ -547,7 +539,7 @@ final class NativeMapView {
     @NonNull
     public List<Feature> queryRenderedFeatures(RectF coordinates, String... layerIds) {
         Feature[] features = nativeQueryRenderedFeaturesForBox(
-          nativeMapViewPtr,
+                nativeMapViewPtr,
                 coordinates.left / pixelRatio,
                 coordinates.top / pixelRatio,
                 coordinates.right / pixelRatio,
@@ -562,6 +554,14 @@ final class NativeMapView {
 
     public void setApiBaseUrl(String baseUrl) {
         nativeSetAPIBaseURL(nativeMapViewPtr, baseUrl);
+    }
+
+    public float getPixelRatio() {
+        return pixelRatio;
+    }
+
+    public Context getContext() {
+        return mapView.getContext();
     }
 
     //

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
@@ -79,10 +79,13 @@ public class MapboxMapTest {
     @Mock
     MapboxMap.OnMyBearingTrackingModeChangeListener mMyBearingTrackingModeChangeListener;
 
+    @Mock
+    IconManager iconManager;
+
     @Before
     public void beforeTest() {
         MockitoAnnotations.initMocks(this);
-        mMapboxMap = new MapboxMap(mMapView);
+        mMapboxMap = new MapboxMap(mMapView, iconManager);
     }
 
     @Test


### PR DESCRIPTION
Closes #6067, 
This refactor introduces the concept of AnnotationManager. This class is responsible for everything related to annotations. Mains goals for this refactor are:
 - [x] AnnotationManager talks directly to NativeMapView for JNI calls (remove mapview overhead)
 - [x] AnnotationManager has no reference to Mapview/MapboxMap
 - [x] public API remains the same for end users
 - [x] ~~unit tests~~* / instrumentation tests pass without adjustment

Note: the requirement of having no reference to Mapview/MapboxMap directly has resulted in passing Mapbox in some methods. This is going to be resolved when we pick up https://github.com/mapbox/mapbox-gl-native/issues/6912. 

* =  I had to change a couple of things due to mocking out classes, logic remained the same.

Review @ivovandongen