### PR TITLE
[build] Replace 'tidy' with 'check'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,16 +112,17 @@ matrix:
       env: BUILDTYPE=Release _CXX=clang++-3.5 _CC=clang-3.5
       addons: *clang35
 
-    # Clang 3.5 - tidy
+    # Clang 3.5 - check
     - os: linux
       sudo: required
       dist: trusty
       language: cpp
-      compiler: "tidy-clang35-release"
+      compiler: "check-clang35-release"
       env: BUILDTYPE=Release _CXX=clang++-3.5 _CC=clang-3.5
       addons: *clang35
       script:
-        - make tidy
+        - git fetch origin master:refs/remotes/origin/master
+        - make check
 
     # Qt 4 - Release
     - os: linux

--- a/scripts/clang-tools.sh
+++ b/scripts/clang-tools.sh
@@ -45,17 +45,12 @@ export -f check_tidy check_format
 echo "Running clang checks... (this might take a while)"
 
 if [[ -n $2 ]] && [[ $2 == "--diff" ]]; then
-    git diff-index --quiet HEAD || {
-        echo "Your repository contains unstaged and/or uncommitted changes."
-        echo "Please commit all changes before proceeding."
-        exit 1
-    }
-    DIFF_FILES=$(for file in `git diff origin/master..HEAD --name-only | grep "pp$"`; do echo $file; done)
+    DIFF_FILES=$(for file in `git diff origin/master --name-only | grep "pp$"`; do echo $file; done)
     if [[ -n $DIFF_FILES ]]; then
         echo "${DIFF_FILES}" | xargs -I{} -P ${JOBS} bash -c 'check_tidy --fix' {}
         # XXX disabled until we run clang-format over the entire codebase.
         #echo "${DIFF_FILES}" | xargs -I{} -P ${JOBS} bash -c 'check_format' {}
-        git diff-index --quiet HEAD || {
+        git diff --quiet || {
             echo "Changes were made to source files - please review them before committing."
             exit 1
         }


### PR DESCRIPTION
The difference between `tidy` and `check` targets are that `check` only runs `clang-tidy` over the files that were modified by patches diverging from `master` branch. This is much faster than running `clang-tidy` over all files, on every Travis run.