### PR TITLE
Fix SDK compilation in Xcode 7.3

### DIFF
--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -20,6 +20,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#ifndef NS_STRING_ENUM
+    #define NS_STRING_ENUM
+    #define NS_EXTENSIBLE_STRING_ENUM
+    typedef NSString *NSErrorDomain;
+    typedef NSString *NSNotificationName;
+#endif
+
 /** Indicates an error occurred in the Mapbox SDK. */
 extern NSErrorDomain const MGLErrorDomain;
 
@@ -96,10 +103,4 @@ NS_ASSUME_NONNULL_END
         #define NS_DICTIONARY_OF(ObjectClass...)            NSDictionary
         #define NS_MUTABLE_DICTIONARY_OF(ObjectClass...)    NSMutableDictionary
     #endif
-#endif
-
-#if !defined(FOUNDATION_SWIFT_SDK_EPOCH_LESS_THAN) || FOUNDATION_SWIFT_SDK_EPOCH_LESS_THAN(8)
-    #define NS_STRING_ENUM
-    #define NS_EXTENSIBLE_STRING_ENUM
-    #define NSNotificationName NSString *
 #endif


### PR DESCRIPTION
Define `NSErrorDomain` before its first use. Define `NSNotificationName` as a typedef instead of a `#define`. Guard these shims on the existence of `NS_STRING_ENUM` rather than another macro that’s new to Xcode 8.

Fixes #6906.

/cc @boundsj