### PR TITLE
Remove remaining uses of gl.hpp

### DIFF
--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -14,7 +14,6 @@
 #include <mbgl/platform/event.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/gl/extension.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/context.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/image.hpp>
@@ -34,23 +33,6 @@ void log_egl_string(EGLDisplay display, EGLint name, const char *label) {
             strncpy(buf, str + pos, 512);
             buf[512] = 0;
             mbgl::Log::Info(mbgl::Event::OpenGL, "EGL %s: %s", label, buf);
-        }
-    }
-}
-
-void log_gl_string(GLenum name, const char *label) {
-    const GLubyte *str = glGetString(name);
-    if (str == nullptr) {
-        mbgl::Log::Error(mbgl::Event::OpenGL, "glGetString(%d) returned error %d", name,
-                         glGetError());
-        throw std::runtime_error("glGetString() failed");
-    } else {
-        char buf[513];
-        for (int len = std::strlen(reinterpret_cast<const char *>(str)), pos = 0; len > 0;
-             len -= 512, pos += 512) {
-            strncpy(buf, reinterpret_cast<const char *>(str) + pos, 512);
-            buf[512] = 0;
-            mbgl::Log::Info(mbgl::Event::OpenGL, "GL %s: %s", label, buf);
         }
     }
 }
@@ -421,16 +403,6 @@ void NativeMapView::createSurface(ANativeWindow *window_) {
             throw std::runtime_error("eglMakeCurrent() failed");
         }
 
-        log_gl_string(GL_VENDOR, "Vendor");
-        log_gl_string(GL_RENDERER, "Renderer");
-        log_gl_string(GL_VERSION, "Version");
-        if (!inEmulator()) {
-            log_gl_string(GL_SHADING_LANGUAGE_VERSION,
-                        "SL Version"); // In the emulator this returns NULL with error code 0?
-                                        // https://code.google.com/p/android/issues/detail?id=78977
-        }
-
-        log_gl_string(GL_EXTENSIONS, "Extensions");
         mbgl::gl::InitializeExtensions([] (const char * name) {
              return reinterpret_cast<mbgl::gl::glProc>(eglGetProcAddress(name));
         });

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -10,8 +10,6 @@
 
 #include <sys/system_properties.h>
 
-#include <GLES2/gl2.h>
-
 #include <mbgl/platform/platform.hpp>
 #include <mbgl/platform/event.hpp>
 #include <mbgl/platform/log.hpp>
@@ -204,18 +202,7 @@ void NativeMapView::render() {
          snapshot = false;
 
          // take snapshot
-         const unsigned int w = fbWidth;
-         const unsigned int h = fbHeight;
-         mbgl::PremultipliedImage image({ w, h });
-         MBGL_CHECK_ERROR(glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image.data.get()));
-         const size_t stride = image.stride();
-         auto tmp = std::make_unique<uint8_t[]>(stride);
-         uint8_t *rgba = image.data.get();
-         for (int i = 0, j = h - 1; i < j; i++, j--) {
-            std::memcpy(tmp.get(), rgba + i * stride, stride);
-            std::memcpy(rgba + i * stride, rgba + j * stride, stride);
-            std::memcpy(rgba + j * stride, tmp.get(), stride);
-         }
+         auto image = getContext().readFramebuffer<mbgl::PremultipliedImage>(getFramebufferSize());
 
          // encode and convert to jbytes
          std::string string = encodePNG(image);

--- a/platform/default/offscreen_view.cpp
+++ b/platform/default/offscreen_view.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/platform/default/offscreen_view.hpp>
 #include <mbgl/gl/context.hpp>
-#include <mbgl/gl/gl.hpp>
 
 #include <cstring>
 #include <cassert>
@@ -25,19 +24,7 @@ void OffscreenView::bind() {
 }
 
 PremultipliedImage OffscreenView::readStillImage() {
-    PremultipliedImage image { size };
-    MBGL_CHECK_ERROR(glReadPixels(0, 0, size.width, size.height, GL_RGBA, GL_UNSIGNED_BYTE, image.data.get()));
-
-    const auto stride = image.stride();
-    auto tmp = std::make_unique<uint8_t[]>(stride);
-    uint8_t* rgba = image.data.get();
-    for (int i = 0, j = size.height - 1; i < j; i++, j--) {
-        std::memcpy(tmp.get(), rgba + i * stride, stride);
-        std::memcpy(rgba + i * stride, rgba + j * stride, stride);
-        std::memcpy(rgba + j * stride, tmp.get(), stride);
-    }
-
-    return image;
+    return context.readFramebuffer<PremultipliedImage>(size);
 }
 
 } // namespace mbgl

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -24,7 +24,6 @@
 #import <mbgl/platform/darwin/reachability.h>
 #import <mbgl/platform/default/thread_pool.hpp>
 #import <mbgl/gl/extension.hpp>
-#import <mbgl/gl/gl.hpp>
 #import <mbgl/gl/context.hpp>
 #import <mbgl/map/backend.hpp>
 #import <mbgl/sprite/sprite_image.hpp>
@@ -2608,20 +2607,7 @@ public:
     }
 
     mbgl::PremultipliedImage readStillImage() {
-        mbgl::PremultipliedImage image(nativeView.framebufferSize);
-        MBGL_CHECK_ERROR(glReadPixels(0, 0, image.size.width, image.size.height, GL_RGBA,
-                                      GL_UNSIGNED_BYTE, image.data.get()));
-
-        const size_t stride = image.stride();
-        auto tmp = std::make_unique<uint8_t[]>(stride);
-        uint8_t *rgba = image.data.get();
-        for (int i = 0, j = image.size.height - 1; i < j; i++, j--) {
-            std::memcpy(tmp.get(), rgba + i * stride, stride);
-            std::memcpy(rgba + i * stride, rgba + j * stride, stride);
-            std::memcpy(rgba + j * stride, tmp.get(), stride);
-        }
-
-        return image;
+        return getContext().readFramebuffer<mbgl::PremultipliedImage>(nativeView.framebufferSize);
     }
 
 private:

--- a/platform/macos/src/MGLOpenGLLayer.mm
+++ b/platform/macos/src/MGLOpenGLLayer.mm
@@ -2,8 +2,6 @@
 
 #import "MGLMapView_Private.h"
 
-#import <mbgl/gl/gl.hpp>
-
 @implementation MGLOpenGLLayer
 
 - (MGLMapView *)mapView {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -5,7 +5,6 @@
 #include "qt_geojson.hpp"
 
 #include <mbgl/annotation/annotation.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/context.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/map.hpp>

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -1,5 +1,4 @@
 #include <mbgl/geometry/line_atlas.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/context.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/platform/platform.hpp>

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -118,6 +118,17 @@ std::unique_ptr<uint8_t[]> Context::readFramebuffer(const Size size, const Textu
     return data;
 }
 
+#if not MBGL_USE_GLES2
+void Context::drawPixels(const Size size, const void* data, TextureFormat format) {
+    pixelStoreUnpack = { 1 };
+    if (format != TextureFormat::RGBA) {
+        format = static_cast<TextureFormat>(GL_LUMINANCE);
+    }
+    MBGL_CHECK_ERROR(glDrawPixels(size.width, size.height, static_cast<GLenum>(GL_LUMINANCE),
+                                  GL_UNSIGNED_BYTE, data));
+}
+#endif // MBGL_USE_GLES2
+
 namespace {
 
 void checkFramebuffer() {

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -285,6 +285,8 @@ void Context::setDirtyState() {
     rasterPos.setDirty();
     pixelStorePack.setDirty();
     pixelStoreUnpack.setDirty();
+    pixelTransferDepth.setDirty();
+    pixelTransferStencil.setDirty();
 #endif // MBGL_USE_GLES2
     for (auto& tex : texture) {
        tex.setDirty();

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -283,6 +283,8 @@ void Context::setDirtyState() {
     pointSize.setDirty();
     pixelZoom.setDirty();
     rasterPos.setDirty();
+    pixelStorePack.setDirty();
+    pixelStoreUnpack.setDirty();
 #endif // MBGL_USE_GLES2
     for (auto& tex : texture) {
        tex.setDirty();

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -132,6 +132,8 @@ public:
     State<value::RasterPos> rasterPos;
     State<value::PixelStorePack> pixelStorePack;
     State<value::PixelStoreUnpack> pixelStoreUnpack;
+    State<value::PixelTransferDepth> pixelTransferDepth;
+    State<value::PixelTransferStencil> pixelTransferStencil;
 #endif // MBGL_USE_GLES2
 
 private:

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -71,6 +71,14 @@ public:
         return { size, readFramebuffer(size, format, flip) };
     }
 
+#if not MBGL_USE_GLES2
+    template <typename Image>
+    void drawPixels(const Image& image) {
+        auto format = image.channels == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
+        drawPixels(image.size, image.data.get(), format);
+    }
+#endif // MBGL_USE_GLES2
+
     // Create a texture from an image with data.
     template <typename Image>
     Texture createTexture(const Image& image, TextureUnit unit = 0) {
@@ -177,6 +185,9 @@ private:
     UniqueFramebuffer createFramebuffer();
     UniqueRenderbuffer createRenderbuffer(RenderbufferType, Size size);
     std::unique_ptr<uint8_t[]> readFramebuffer(Size, TextureFormat, bool flip);
+#if not MBGL_USE_GLES2
+    void drawPixels(Size size, const void* data, TextureFormat);
+#endif // MBGL_USE_GLES2
 
     PrimitiveType operator()(const Points&);
     PrimitiveType operator()(const Lines&);

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -62,6 +62,15 @@ public:
                                   const Renderbuffer<RenderbufferType::DepthStencil>&);
     Framebuffer createFramebuffer(const Texture&);
 
+    template <typename Image,
+              TextureFormat format = Image::channels == 4 ? TextureFormat::RGBA
+                                                          : TextureFormat::Alpha>
+    Image readFramebuffer(const Size size, bool flip = true) {
+        static_assert(Image::channels == (format == TextureFormat::RGBA ? 4 : 1),
+                      "image format mismatch");
+        return { size, readFramebuffer(size, format, flip) };
+    }
+
     // Create a texture from an image with data.
     template <typename Image>
     Texture createTexture(const Image& image, TextureUnit unit = 0) {
@@ -167,6 +176,7 @@ private:
     void updateTexture(TextureID, Size size, const void* data, TextureFormat, TextureUnit);
     UniqueFramebuffer createFramebuffer();
     UniqueRenderbuffer createRenderbuffer(RenderbufferType, Size size);
+    std::unique_ptr<uint8_t[]> readFramebuffer(Size, TextureFormat, bool flip);
 
     PrimitiveType operator()(const Points&);
     PrimitiveType operator()(const Lines&);

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -130,6 +130,8 @@ public:
 #if not MBGL_USE_GLES2
     State<value::PixelZoom> pixelZoom;
     State<value::RasterPos> rasterPos;
+    State<value::PixelStorePack> pixelStorePack;
+    State<value::PixelStoreUnpack> pixelStoreUnpack;
 #endif // MBGL_USE_GLES2
 
 private:

--- a/src/mbgl/gl/extension.cpp
+++ b/src/mbgl/gl/extension.cpp
@@ -1,9 +1,11 @@
 #include <mbgl/gl/extension.hpp>
 #include <mbgl/gl/gl.hpp>
+#include <mbgl/platform/log.hpp>
 
 #include <mutex>
 #include <string>
 #include <vector>
+#include <cstring>
 
 namespace mbgl {
 namespace gl {
@@ -24,20 +26,37 @@ ExtensionFunctionBase::ExtensionFunctionBase(std::initializer_list<Probe> probes
 
 static std::once_flag initializeExtensionsOnce;
 
+const char* getGLString(GLenum name) {
+    return reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(name)));
+}
+
 void InitializeExtensions(glProc (*getProcAddress)(const char*)) {
     std::call_once(initializeExtensionsOnce, [getProcAddress] {
-        const char* extensionsPtr =
-            reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)));
+#ifndef NDEBUG
+        if (const char* vendor = getGLString(GL_VENDOR)) {
+            mbgl::Log::Info(mbgl::Event::OpenGL, "Vendor: %s", vendor);
+        }
+        if (const char* renderer = getGLString(GL_RENDERER)) {
+            mbgl::Log::Info(mbgl::Event::OpenGL, "Renderer: %s", renderer);
+        }
+        if (const char* version = getGLString(GL_VERSION)) {
+            mbgl::Log::Info(mbgl::Event::OpenGL, "Version: %s", version);
+        }
+        if (const char* shaderVersion = getGLString(GL_SHADING_LANGUAGE_VERSION)) {
+            mbgl::Log::Info(mbgl::Event::OpenGL, "Shading Language Version: %s", shaderVersion);
+        }
+#endif
 
-        if (!extensionsPtr)
-            return;
-
-        const std::string extensions = extensionsPtr;
-        for (auto fn : detail::extensionFunctions()) {
-            for (auto probe : fn.second) {
-                if (extensions.find(probe.first) != std::string::npos) {
-                    *fn.first = getProcAddress(probe.second);
-                    break;
+        if (const char* extensions = getGLString(GL_EXTENSIONS)) {
+#ifndef NDEBUG
+            mbgl::Log::Info(mbgl::Event::OpenGL, "Extensions: %s", extensions);
+#endif
+            for (auto fn : detail::extensionFunctions()) {
+                for (auto probe : fn.second) {
+                    if (strstr(extensions, probe.first) != nullptr) {
+                        *fn.first = getProcAddress(probe.second);
+                        break;
+                    }
                 }
             }
         }

--- a/src/mbgl/gl/types.hpp
+++ b/src/mbgl/gl/types.hpp
@@ -50,6 +50,10 @@ enum class TextureWrap : bool { Clamp, Repeat };
 enum class TextureFormat : uint32_t {
     RGBA = 0x1908,
     Alpha = 0x1906,
+#if not MBGL_USE_GLES2
+    Stencil = 0x1901,
+    Depth = 0x1902,
+#endif // MBGL_USE_GLES2
 };
 
 enum class PrimitiveType {

--- a/src/mbgl/gl/types.hpp
+++ b/src/mbgl/gl/types.hpp
@@ -62,5 +62,17 @@ enum class PrimitiveType {
     TriangleFan = 0x0006
 };
 
+#if not MBGL_USE_GLES2
+
+struct PixelStorageType {
+    int32_t alignment;
+};
+
+constexpr bool operator!=(const PixelStorageType& a, const PixelStorageType& b) {
+    return a.alignment != b.alignment;
+}
+
+#endif // MBGL_USE_GLES2
+
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -417,6 +417,34 @@ PixelStoreUnpack::Type PixelStoreUnpack::Get() {
     return value;
 }
 
+const constexpr PixelTransferDepth::Type PixelTransferDepth::Default;
+
+void PixelTransferDepth::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glPixelTransferf(GL_DEPTH_SCALE, value.scale));
+    MBGL_CHECK_ERROR(glPixelTransferf(GL_DEPTH_BIAS, value.bias));
+}
+
+PixelTransferDepth::Type PixelTransferDepth::Get() {
+    Type value;
+    MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_SCALE, &value.scale));
+    MBGL_CHECK_ERROR(glGetFloatv(GL_DEPTH_BIAS, &value.bias));
+    return value;
+}
+
+const constexpr PixelTransferStencil::Type PixelTransferStencil::Default;
+
+void PixelTransferStencil::Set(const Type& value) {
+    MBGL_CHECK_ERROR(glPixelTransferf(GL_INDEX_SHIFT, value.shift));
+    MBGL_CHECK_ERROR(glPixelTransferf(GL_INDEX_OFFSET, value.offset));
+}
+
+PixelTransferStencil::Type PixelTransferStencil::Get() {
+    Type value;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_INDEX_SHIFT, &value.shift));
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_INDEX_OFFSET, &value.offset));
+    return value;
+}
+
 #endif // MBGL_USE_GLES2
 
 } // namespace value

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -389,8 +389,35 @@ RasterPos::Type RasterPos::Get() {
     return { pos[0], pos[1], pos[2], pos[3] };
 }
 
-#endif // MBGL_USE_GLES2
+const constexpr PixelStorePack::Type PixelStorePack::Default;
 
+void PixelStorePack::Set(const Type& value) {
+    assert(value.alignment == 1 || value.alignment == 2 || value.alignment == 4 ||
+           value.alignment == 8);
+    MBGL_CHECK_ERROR(glPixelStorei(GL_PACK_ALIGNMENT, value.alignment));
+}
+
+PixelStorePack::Type PixelStorePack::Get() {
+    Type value;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_PACK_ALIGNMENT, &value.alignment));
+    return value;
+}
+
+const constexpr PixelStoreUnpack::Type PixelStoreUnpack::Default;
+
+void PixelStoreUnpack::Set(const Type& value) {
+    assert(value.alignment == 1 || value.alignment == 2 || value.alignment == 4 ||
+           value.alignment == 8);
+    MBGL_CHECK_ERROR(glPixelStorei(GL_UNPACK_ALIGNMENT, value.alignment));
+}
+
+PixelStoreUnpack::Type PixelStoreUnpack::Get() {
+    Type value;
+    MBGL_CHECK_ERROR(glGetIntegerv(GL_UNPACK_ALIGNMENT, &value.alignment));
+    return value;
+}
+
+#endif // MBGL_USE_GLES2
 
 } // namespace value
 } // namespace gl

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -282,6 +282,34 @@ struct PixelStoreUnpack {
     static Type Get();
 };
 
+struct PixelTransferDepth {
+    struct Type {
+        float scale;
+        float bias;
+    };
+    static const constexpr Type Default = { 1, 0 };
+    static void Set(const Type&);
+    static Type Get();
+};
+
+constexpr bool operator!=(const PixelTransferDepth::Type& a, const PixelTransferDepth::Type& b) {
+    return a.scale != b.scale || a.bias != b.bias;
+}
+
+struct PixelTransferStencil {
+    struct Type {
+        int32_t shift;
+        int32_t offset;
+    };
+    static const constexpr Type Default = { 0, 0 };
+    static void Set(const Type&);
+    static Type Get();
+};
+
+constexpr bool operator!=(const PixelTransferStencil::Type& a, const PixelTransferStencil::Type& b) {
+    return a.shift != b.shift || a.offset != b.offset;
+}
+
 #endif // MBGL_USE_GLES2
 
 } // namespace value

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -259,7 +259,7 @@ struct RasterPos {
         double z;
         double w;
     };
-    static const constexpr Type Default = { 0, 0, 0, 0 };
+    static const constexpr Type Default = { 0, 0, 0, 1 };
     static void Set(const Type&);
     static Type Get();
 };
@@ -267,6 +267,20 @@ struct RasterPos {
 constexpr bool operator!=(const RasterPos::Type& a, const RasterPos::Type& b) {
     return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
 }
+
+struct PixelStorePack {
+    using Type = PixelStorageType;
+    static const constexpr Type Default = { 4 };
+    static void Set(const Type&);
+    static Type Get();
+};
+
+struct PixelStoreUnpack {
+    using Type = PixelStorageType;
+    static const constexpr Type Default = { 4 };
+    static void Set(const Type&);
+    static Type Get();
+};
 
 #endif // MBGL_USE_GLES2
 

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -5,8 +5,6 @@
 #include <mbgl/geometry/debug_font_data.hpp>
 #include <mbgl/util/string.hpp>
 
-#include <mbgl/gl/gl.hpp>
-
 #include <cmath>
 #include <string>
 #include <vector>

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -5,7 +5,6 @@
 #include <mbgl/shader/fill_pattern_shader.hpp>
 #include <mbgl/shader/fill_outline_shader.hpp>
 #include <mbgl/shader/fill_outline_pattern_shader.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/platform/log.hpp>
 
 #include <mapbox/earcut.hpp>

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -1,7 +1,6 @@
 #include <mbgl/renderer/frame_history.hpp>
 #include <mbgl/math/minmax.hpp>
 #include <mbgl/gl/context.hpp>
-#include <mbgl/gl/gl.hpp>
 
 #include <cassert>
 

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -8,7 +8,6 @@
 #include <mbgl/map/view.hpp>
 
 #include <mbgl/platform/log.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/debugging.hpp>
 
 #include <mbgl/style/style.hpp>
@@ -197,7 +196,7 @@ void Painter::render(const Style& style, const FrameData& frame_, View& view, Sp
     renderPass(parameters,
                RenderPass::Translucent,
                order.begin(), order.end(),
-               static_cast<GLsizei>(order.size()) - 1, -1);
+               static_cast<uint32_t>(order.size()) - 1, -1);
 
     if (debug::renderTree) { Log::Info(Event::Render, "}"); indent--; }
 

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -8,7 +8,6 @@
 #include <mbgl/shader/fill_uniforms.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/gl/debugging.hpp>
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/util/color.hpp>
 
 namespace mbgl {
@@ -86,9 +85,7 @@ void Painter::renderClipMasks(PaintParameters&) {
 
     context.pixelZoom = { 1, 1 };
     context.rasterPos = { -1, -1, 0, 1 };
-    context.pixelStoreUnpack = { 1 };
-    MBGL_CHECK_ERROR(glDrawPixels(viewport.size.width, viewport.size.height, GL_LUMINANCE,
-                                  GL_UNSIGNED_BYTE, image.data.get()));
+    context.drawPixels(image);
 #endif // MBGL_USE_GLES2
 }
 
@@ -111,9 +108,7 @@ void Painter::renderDepthBuffer(PaintParameters&) {
 
     context.pixelZoom = { 1, 1 };
     context.rasterPos = { -1, -1, 0, 1 };
-    context.pixelStoreUnpack = { 1 };
-    MBGL_CHECK_ERROR(glDrawPixels(viewport.size.width, viewport.size.height, GL_LUMINANCE,
-                                  GL_UNSIGNED_BYTE, image.data.get()));
+    context.drawPixels(image);
 #endif // MBGL_USE_GLES2
 }
 #endif // NDEBUG

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -68,12 +68,10 @@ void Painter::renderClipMasks(PaintParameters&) {
     context.program = 0;
 
 #if not MBGL_USE_GLES2
-    context.pixelZoom = { 1, 1 };
-    context.rasterPos = { -1, -1, 0, 0 };
 
     // When reading data from the framebuffer, make sure that we are storing the depth values
     // tightly packed into the buffer to avoid buffer overruns. Also see unpacking adjustment below.
-    MBGL_CHECK_ERROR(glPixelStorei(GL_PACK_ALIGNMENT, 1));
+    context.pixelStorePack = { 1 };
 
     // Read the stencil buffer
     const auto viewport = context.viewport.getCurrentValue();
@@ -96,8 +94,9 @@ void Painter::renderClipMasks(PaintParameters&) {
         *it *= factor;
     }
 
-    MBGL_CHECK_ERROR(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
-    MBGL_CHECK_ERROR(glWindowPos2i(viewport.x, viewport.y));
+    context.pixelZoom = { 1, 1 };
+    context.rasterPos = { -1, -1, 0, 1 };
+    context.pixelStoreUnpack = { 1 };
     MBGL_CHECK_ERROR(glDrawPixels(viewport.size.width, viewport.size.height, GL_LUMINANCE,
                                   GL_UNSIGNED_BYTE, pixels.get()));
 #endif // MBGL_USE_GLES2
@@ -110,12 +109,10 @@ void Painter::renderDepthBuffer(PaintParameters&) {
     context.program = 0;
 
 #if not MBGL_USE_GLES2
-    context.pixelZoom = { 1, 1 };
-    context.rasterPos = { -1, -1, 0, 0 };
 
     // When reading data from the framebuffer, make sure that we are storing the depth values
     // tightly packed into the buffer to avoid buffer overruns. Also see unpacking adjustment below.
-    MBGL_CHECK_ERROR(glPixelStorei(GL_PACK_ALIGNMENT, 1));
+    context.pixelStorePack = { 1 };
 
     // Scales the values in the depth buffer so that they cover the entire grayscale range. This
     // makes it easier to spot tiny differences.
@@ -137,8 +134,9 @@ void Painter::renderDepthBuffer(PaintParameters&) {
                 pixels.get()          // GLvoid * data
                 ));
 
-    MBGL_CHECK_ERROR(glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
-    MBGL_CHECK_ERROR(glWindowPos2i(viewport.x, viewport.y));
+    context.pixelZoom = { 1, 1 };
+    context.rasterPos = { -1, -1, 0, 1 };
+    context.pixelStoreUnpack = { 1 };
     MBGL_CHECK_ERROR(glDrawPixels(viewport.size.width, viewport.size.height, GL_LUMINANCE,
                                   GL_UNSIGNED_BYTE, pixels.get()));
 #endif // MBGL_USE_GLES2

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -73,6 +73,9 @@ void Painter::renderClipMasks(PaintParameters&) {
     // tightly packed into the buffer to avoid buffer overruns. Also see unpacking adjustment below.
     context.pixelStorePack = { 1 };
 
+    // Reset the value in case someone else changed it, or it's dirty.
+    context.pixelTransferStencil = gl::value::PixelTransferStencil::Default;
+
     // Read the stencil buffer
     const auto viewport = context.viewport.getCurrentValue();
     auto pixels = std::make_unique<uint8_t[]>(viewport.size.width * viewport.size.height);
@@ -116,9 +119,8 @@ void Painter::renderDepthBuffer(PaintParameters&) {
 
     // Scales the values in the depth buffer so that they cover the entire grayscale range. This
     // makes it easier to spot tiny differences.
-    const double base = 1.0 / (1.0 - depthRangeSize);
-    MBGL_CHECK_ERROR(glPixelTransferf(GL_DEPTH_SCALE, base));
-    MBGL_CHECK_ERROR(glPixelTransferf(GL_DEPTH_BIAS, 1.0 - base));
+    const float base = 1.0f / (1.0f - depthRangeSize);
+    context.pixelTransferDepth = { base, 1.0f - base };
 
     // Read the stencil buffer
     auto viewport = context.viewport.getCurrentValue();

--- a/src/mbgl/shader/symbol_vertex.cpp
+++ b/src/mbgl/shader/symbol_vertex.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/shader/symbol_vertex.hpp>
 #include <mbgl/gl/shader.hpp>
-#include <mbgl/gl/gl.hpp>
 
 namespace mbgl {
 

--- a/src/mbgl/util/offscreen_texture.cpp
+++ b/src/mbgl/util/offscreen_texture.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/util/offscreen_texture.hpp>
 #include <mbgl/gl/context.hpp>
-#include <mbgl/gl/gl.hpp>
 
 #include <cstring>
 #include <cassert>
@@ -29,20 +28,7 @@ gl::Texture& OffscreenTexture::getTexture() {
 }
 
 PremultipliedImage OffscreenTexture::readStillImage() {
-    PremultipliedImage image { size };
-    MBGL_CHECK_ERROR(
-        glReadPixels(0, 0, size.width, size.height, GL_RGBA, GL_UNSIGNED_BYTE, image.data.get()));
-
-    const auto stride = image.stride();
-    auto tmp = std::make_unique<uint8_t[]>(stride);
-    uint8_t* rgba = image.data.get();
-    for (int i = 0, j = size.height - 1; i < j; i++, j--) {
-        std::memcpy(tmp.get(), rgba + i * stride, stride);
-        std::memcpy(rgba + i * stride, rgba + j * stride, stride);
-        std::memcpy(rgba + j * stride, tmp.get(), stride);
-    }
-
-    return image;
+    return context.readFramebuffer<PremultipliedImage>(size);
 }
 
 

--- a/test/gl/object.test.cpp
+++ b/test/gl/object.test.cpp
@@ -3,7 +3,6 @@
 #include <mbgl/platform/default/headless_backend.hpp>
 #include <mbgl/platform/default/offscreen_view.hpp>
 
-#include <mbgl/gl/gl.hpp>
 #include <mbgl/gl/context.hpp>
 
 #include <memory>


### PR DESCRIPTION
We should only use `gl.hpp` in the OpenGL bindings, and not in any other code.