### PR TITLE
[ios] Work around annotation race condition

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2836,7 +2836,11 @@ public:
         
         for (auto const& annotationTag: annotationTags)
         {
-            MGLAnnotationContext annotationContext = _annotationContextsByAnnotationTag[annotationTag];
+            if (!_annotationContextsByAnnotationTag.count(annotationTag))
+            {
+                continue;
+            }
+            MGLAnnotationContext annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
             [annotations addObject:annotationContext.annotation];
         }
         
@@ -2902,6 +2906,12 @@ public:
     for (id <MGLAnnotation> annotation in annotations)
     {
         NSAssert([annotation conformsToProtocol:@protocol(MGLAnnotation)], @"annotation should conform to MGLAnnotation");
+
+        // adding the same annotation object twice is a no-op
+        if ([self.annotations containsObject:annotation])
+        {
+            continue;
+        }
 
         if ([annotation isKindOfClass:[MGLMultiPoint class]])
         {

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1691,6 +1691,12 @@ public:
     for (id <MGLAnnotation> annotation in annotations) {
         NSAssert([annotation conformsToProtocol:@protocol(MGLAnnotation)], @"Annotation does not conform to MGLAnnotation");
 
+        // adding the same annotation object twice is a no-op
+        if ([self.annotations containsObject:annotation])
+        {
+            continue;
+        }
+
         if ([annotation isKindOfClass:[MGLMultiPoint class]]) {
             // The multipoint knows how to style itself (with the map view’s help).
             MGLMultiPoint *multiPoint = (MGLMultiPoint *)annotation;

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1635,7 +1635,11 @@ public:
         
         for (auto const& annotationTag: annotationTags)
         {
-            MGLAnnotationContext annotationContext = _annotationContextsByAnnotationTag[annotationTag];
+            if (!_annotationContextsByAnnotationTag.count(annotationTag))
+            {
+                continue;
+            }
+            MGLAnnotationContext annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
             [annotations addObject:annotationContext.annotation];
         }
         


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/6901

When annotations are removed concurrently with being updated because of a map redraw, it is possible that mbgl will still consider an annotation to exist depending on what part of the map lifecycle the call update annotations happens. However, the annotation context by
tag map in MGLMapView (on the main thread) will always be up to date.
This adds a guard that uses that map to avoid considering annotations that have actually been removed as visible.

Another issue was that adding the same annotation object twice has always been allowed and has worked, visually. However, a recent refactor to make the reuse queue work correctly is not tolerant of the a single view representing two annotation instances that are the same.
The effect is that a new UIView will be generated for each (clone) annotation that is added and only the last view will move with the map. The other views become detached and float around in the view as the map is panned. This commit adds a guard to make adding an annotation instance a no-op if it has already been added before.

cc @1ec5 @incanus @bsudekum 