### PR TITLE
[ios, macos] key-value compliant style property

### DIFF
--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -104,6 +104,14 @@ static NSURL *MGLStyleURL_emerald;
     return [NSURL URLWithString:@(self.mapView.mbglMap->getStyleURL().c_str())];
 }
 
+- (instancetype)initWithMapView:(MGLMapView *)mapView
+{
+    if (self = [super init]) {
+        _mapView = mapView;
+    }
+    return self;
+}
+
 - (MGLStyleLayer *)layerWithIdentifier:(NSString *)identifier
 {
     auto mbglLayer = self.mapView.mbglMap->getLayer(identifier.UTF8String);

--- a/platform/darwin/src/MGLStyle_Private.h
+++ b/platform/darwin/src/MGLStyle_Private.h
@@ -6,7 +6,9 @@
 #include <mbgl/mbgl.hpp>
 
 @interface MGLStyle (Private)
-@property (nonatomic, weak) MGLMapView *mapView;
+@property (nonatomic, readonly, weak) MGLMapView *mapView;
+
+- (instancetype)initWithMapView:(MGLMapView *)mapView;
 
 - (void)setStyleClasses:(NS_ARRAY_OF(NSString *) *)appliedClasses transitionDuration:(NSTimeInterval)transitionDuration;
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1077,9 +1077,13 @@ IB_DESIGNABLE
  */
 - (void)removeOverlays:(NS_ARRAY_OF(id <MGLOverlay>) *)overlays;
 
-#pragma mark - Runtime styling API
+#pragma mark Runtime styling API
 
-- (MGLStyle *)style;
+/**
+ Returns an `MGLStyle` instance that lets you manipulate layers and sources
+ in real-time.
+ */
+@property (nonatomic, readonly) MGLStyle *style;
 
 #pragma mark Accessing the Underlying Map Data
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -363,6 +363,7 @@ public:
 
     styleURL = styleURL.mgl_URLByStandardizingScheme;
     _mbglMap->setStyleURL([[styleURL absoluteString] UTF8String]);
+    _style = [[MGLStyle alloc] initWithMapView:self];
 }
 
 - (IBAction)reloadStyle:(__unused id)sender {
@@ -628,13 +629,6 @@ public:
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     return image;
-}
-
-- (MGLStyle *)style
-{
-    MGLStyle *style = [[MGLStyle alloc] init];
-    style.mapView = self;
-    return style;
 }
 
 - (void)reachabilityChanged:(NSNotification *)notification

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -928,7 +928,11 @@ IB_DESIGNABLE
 
 #pragma mark Runtime styling API
 
-- (MGLStyle *)style;
+/**
+ Returns an `MGLStyle` instance that lets you manipulate layers and sources
+ in real-time.
+ */
+@property (nonatomic, readonly) MGLStyle *style;
 
 @end
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -590,6 +590,7 @@ public:
 
     styleURL = styleURL.mgl_URLByStandardizingScheme;
     _mbglMap->setStyleURL(styleURL.absoluteString.UTF8String);
+    _style = [[MGLStyle alloc] initWithMapView:self];
 }
 
 - (IBAction)reloadStyle:(__unused id)sender {
@@ -2191,13 +2192,6 @@ public:
 }
 
 #pragma mark - Runtime styling
-
-- (MGLStyle *)style
-{
-    MGLStyle *style = [[MGLStyle alloc] init];
-    style.mapView = self;
-    return style;
-}
 
 - (mbgl::Map *)mbglMap
 {


### PR DESCRIPTION
Fixes #6096 

`MGLMapView.style` is now a key-value compliant property that the map view holds onto until the `MGLMapView.styleURL` changes.

@boundsj @1ec5 👀 