### PR TITLE
Fix crash getting annotation view

### DIFF
--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1667,16 +1667,11 @@ public:
 
 /// Returns the annotation tag assigned to the given annotation. Relatively expensive.
 - (MGLAnnotationTag)annotationTagForAnnotation:(id <MGLAnnotation>)annotation {
-    if (!annotation) {
+    if (!annotation || _annotationTagsByAnnotation.count(annotation) == 0) {
         return MGLAnnotationTagNotFound;
     }
 
-    for (auto &pair : _annotationContextsByAnnotationTag) {
-        if (pair.second.annotation == annotation) {
-            return pair.first;
-        }
-    }
-    return MGLAnnotationTagNotFound;
+    return  _annotationTagsByAnnotation.at(annotation);
 }
 
 - (void)addAnnotation:(id <MGLAnnotation>)annotation {


### PR DESCRIPTION
Streamlined `-[MGLMapView annotationTagForAnnotation:]` to use the `std::map` added in #5987 on iOS. Added the same `map` to the macOS implementation.

Replaced unsafe calls to `std::map::at()` – which throws an exception when the given element isn’t found – with calls to the newly streamlined `-annotationTagForAnnotation:`. One of these unsafe calls was added in #5987 and is reverted by this PR in favor of returning `nil`.

Return the user location annotation view when given the user location annotation.

Fixes #6953.

/cc @boundsj