### PR TITLE
[android] - update make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,6 +491,10 @@ android-lib-$1: build/android-$1/$(BUILDTYPE)/Makefile
 android-$1: android-lib-$1
 	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) assemble$(BUILDTYPE)
 
+.PHONY: run-android-$1
+run-android-$1: android-$1
+	cd platform/android  && ./gradlew :MapboxGLAndroidSDKTestApp:installDebug && adb shell am start -n com.mapbox.mapboxsdk.testapp/.activity.FeatureOverviewActivity	
+
 apackage: android-lib-$1
 endef
 
@@ -499,21 +503,32 @@ $(foreach abi,$(ANDROID_ABIS),$(eval $(call ANDROID_RULES,$(abi))))
 .PHONY: android
 android: android-arm-v7
 
-.PHONY: android-test
-android-test:
-	cd platform/android && ./gradlew testDebugUnitTest --continue
+.PHONY: run-android
+run-android: run-android-arm-v7
+	 
+.PHONY: run-android-unit-test
+run-android-unit-test:
+	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:testDebugUnitTest --continue
 
-.PHONY: android-test-apk
-android-test-apk:
-	cd platform/android && ./gradlew assembleDebug --continue && ./gradlew assembleAndroidTest --continue
+.PHONY: android-ui-test
+android-ui-test:
+	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:assembleDebug --continue && ./gradlew :MapboxGLAndroidSDKTestApp:assembleAndroidTest --continue
+
+.PHONY: run-android-ui-test
+run-android-ui-test:
+	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:connectedAndroidTest -i	
 
 .PHONY: apackage
 apackage:
 	cd platform/android && ./gradlew --parallel-threads=$(JOBS) assemble$(BUILDTYPE)
 
-.PHONY: android-generate-test
-android-generate-test:
+.PHONY: test-code-android
+test-code-android:
 	node platform/android/scripts/generate-test-code.js
+
+.PHONY: android-ndk-stack
+android-ndk-stack:
+	adb logcat | ndk-stack -sym build/android-arm-v7/Debug	
 
 #### Miscellaneous targets #####################################################
 
@@ -526,6 +541,7 @@ clean:
 	-rm -rf ./build \
 	        ./platform/android/MapboxGLAndroidSDK/build \
 	        ./platform/android/MapboxGLAndroidSDKTestApp/build \
+	        ./platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/gen \
 	        ./platform/android/MapboxGLAndroidSDK/src/main/jniLibs \
 	        ./platform/android/MapboxGLAndroidSDKTestApp/src/main/jniLibs \
 	        ./platform/android/MapboxGLAndroidSDK/src/main/assets

--- a/platform/android/.gitignore
+++ b/platform/android/.gitignore
@@ -30,5 +30,5 @@ fabric.properties
 captures/
 
 # Generated test cases
-MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/activity/gen/
+MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/gen/
 

--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -71,7 +71,7 @@ workflows:
         - content: |-
             #!/bin/bash
             echo "Running unit tests from testapp/src/test:"
-            make android-test
+            make run-android-unit-test
     - script:
         title: Generate Espresso sanity tests
         run_if: '{{enveq "SKIPCI" "false"}}'
@@ -79,7 +79,7 @@ workflows:
         - content: |-
             #!/bin/bash
             echo "Generate these test locally by executing:"
-            make android-generate-test
+            make test-code-android
     - script:
         title: Run Firebase instrumentation tests
         run_if: '{{enveq "SKIPCI" "false"}}'
@@ -90,7 +90,7 @@ workflows:
             wget -O platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/developer-config.xml "$BITRISEIO_TEST_ACCESS_TOKEN_UI_TEST_URL"
 
             echo "Build seperate test apk:"
-            make android-test-apk
+            make android-ui-test
 
             echo "Run tests on firebase:"
             gcloud auth activate-service-account --key-file secret.json --project android-gl-native
@@ -223,7 +223,7 @@ workflows:
         - content: |-
             #!/bin/bash
             echo "Generate these test locally by executing:"
-            make android-generate-test
+            make test-code-android
     - script:
         title: Run AWS Device Farm instrumentation tests
         inputs:


### PR DESCRIPTION
closes #6697

This PR reworks the make targets for the android platform. 

### Goals
 - general cleanup, consistency naming
 - allow running application on a device from cmake
 - allow running our different types of android tests from cmake
 - provide convenience method for running ndk-stack

### Base configurations

- `make android-lib-$1` - builds core into a .so file
- `make android-$1`  - builds .so + .aar + .apk file
- `make run-android-$1` - builds .so + .aar + .apk file and runs it on a device
- `make apackage` - builds .so files for all supported ABI + .aar file

You can replace the $1 above with one of the following ABI:
 > arm-v5 arm-v7 arm-v8 x86 x86-64 mips

Alternatively we provided some convenient configurations for `arm-v7`:
- `make android `
- `make run-android`

### Test configurations

- `make run-android-unit-test` - executes unit tests on jvm of dev. machine 
- `make android-ui-test` - builds 2 .apk files for ui testing
- `make run-android-ui-test` - above + runs it on a device

### Code generation configurations

- `make style-code-android` - generates code from stylespec
- `make test-code-android` - generates sanity instrumentation tests

### Convenient configuration

- `make android-ndk-stack` - try symbolicating logcat output for `arm-v7`

Review @ivovandongen

cc @mapbox/gl @mapbox/mobile 


