### PR TITLE
[ios, macos] Use the rawLayer pointer to access the mbgl layer

### DIFF
--- a/platform/darwin/src/MGLStyleLayer.mm
+++ b/platform/darwin/src/MGLStyleLayer.mm
@@ -5,8 +5,6 @@
 
 @interface MGLStyleLayer ()
 
-@property (nonatomic) mbgl::style::Layer *layer;
-
 @end
 
 @implementation MGLStyleLayer
@@ -24,33 +22,33 @@
     mbgl::style::VisibilityType v = visible
     ? mbgl::style::VisibilityType::Visible
     : mbgl::style::VisibilityType::None;
-    self.layer->setVisibility(v);
+    self.rawLayer->setVisibility(v);
 }
 
 - (BOOL)isVisible
 {
-    mbgl::style::VisibilityType v = self.layer->getVisibility();
+    mbgl::style::VisibilityType v = self.rawLayer->getVisibility();
     return (v == mbgl::style::VisibilityType::Visible);
 }
 
 - (void)setMaximumZoomLevel:(float)maximumZoomLevel
 {
-    self.layer->setMaxZoom(maximumZoomLevel);
+    self.rawLayer->setMaxZoom(maximumZoomLevel);
 }
 
 - (float)maximumZoomLevel
 {
-    return self.layer->getMaxZoom();
+    return self.rawLayer->getMaxZoom();
 }
 
 - (void)setMinimumZoomLevel:(float)minimumZoomLevel
 {
-    self.layer->setMinZoom(minimumZoomLevel);
+    self.rawLayer->setMinZoom(minimumZoomLevel);
 }
 
 - (float)minimumZoomLevel
 {
-    return self.layer->getMinZoom();
+    return self.rawLayer->getMinZoom();
 }
 
 @end


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/pull/6904 renamed the `layer` property to `rawLayer`. The subclasses of `MGLStyleLayer` were all updated to use `rawLayer` but the
`MGLStyleLayer` itself was not. So, common functionality like setting visibility caused a crash.
This removes the `layer` property in `MGLStyleLayer` itself and uses the `rawLayer` property that actually points to the mbgl layer.

cc @1ec5 