### PR TITLE
Fast Android rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,8 +273,10 @@ ideploy:
 idocument:
 	OUTPUT=$(OUTPUT) ./platform/ios/scripts/document.sh
 
-style-code-darwin:
+.PHONY: darwin-style-code
+darwin-style-code:
 	node platform/darwin/scripts/generate-style-code.js
+style-code: darwin-style-code
 endif
 
 #### Linux targets #####################################################
@@ -467,13 +469,14 @@ test-node: node
 ANDROID_ENV = platform/android/scripts/toolchain.sh
 ANDROID_ABIS = arm-v5 arm-v7 arm-v8 x86 x86-64 mips
 
-.PHONY: style-code-android
-style-code-android: $(BUILD_DEPS)
+.PHONY: android-style-code
+android-style-code:
 	node platform/android/scripts/generate-style-code.js
+style-code: android-style-code
 
 define ANDROID_RULES
 
-build/android-$1/$(BUILDTYPE): style-code-android
+build/android-$1/$(BUILDTYPE): $(BUILD_DEPS)
 	mkdir -p build/android-$1/$(BUILDTYPE)
 
 build/android-$1/$(BUILDTYPE)/toolchain.cmake: platform/android/scripts/toolchain.sh build/android-$1/$(BUILDTYPE)

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -6,20 +6,10 @@ const _ = require('lodash');
 const colorParser = require('csscolorparser');
 const spec = _.merge(require('mapbox-gl-style-spec').latest, require('./style-spec-overrides-v8.json'));
 
+require('../../../scripts/style-code');
+
 const prefix = 'MGL';
 const suffix = 'StyleLayer';
-
-global.camelize = function (str) {
-    return str.replace(/(?:^|-)(.)/g, function (_, x) {
-        return x.toUpperCase();
-    });
-};
-
-global.camelizeWithLeadingLowercase = function (str) {
-    return str.replace(/-(.)/g, function (_, x) {
-        return x.toUpperCase();
-    });
-};
 
 global.objCName = function (property) {
     return camelizeWithLeadingLowercase(property.name);
@@ -346,7 +336,7 @@ ${macosComment}${decl}
 }
 
 for (var layer of layers) {
-    fs.writeFileSync(`platform/darwin/src/${prefix}${camelize(layer.type)}${suffix}.h`, duplicatePlatformDecls(layerH(layer)));
-    fs.writeFileSync(`platform/darwin/src/${prefix}${camelize(layer.type)}${suffix}.mm`, layerM(layer));
-    fs.writeFileSync(`platform/darwin/test/${prefix}${camelize(layer.type)}${suffix}Tests.m`, testLayers(layer));
+    writeIfModified(`platform/darwin/src/${prefix}${camelize(layer.type)}${suffix}.h`, duplicatePlatformDecls(layerH(layer)));
+    writeIfModified(`platform/darwin/src/${prefix}${camelize(layer.type)}${suffix}.mm`, layerM(layer));
+    writeIfModified(`platform/darwin/test/${prefix}${camelize(layer.type)}${suffix}Tests.m`, testLayers(layer));
 }

--- a/scripts/style-code.js
+++ b/scripts/style-code.js
@@ -1,0 +1,36 @@
+// Global functions //
+
+const fs = require('fs');
+
+global.iff = function (condition, val) {
+  return condition() ? val : "";
+};
+
+global.camelize = function (str) {
+  return str.replace(/(?:^|-)(.)/g, function (_, x) {
+    return x.toUpperCase();
+  });
+};
+
+global.camelizeWithLeadingLowercase = function (str) {
+  return str.replace(/-(.)/g, function (_, x) {
+    return x.toUpperCase();
+  });
+};
+
+global.snakeCaseUpper = function snakeCaseUpper(str) {
+  return str.replace(/-/g, "_").toUpperCase();
+};
+
+global.writeIfModified = function(filename, newContent) {
+  try {
+    const oldContent = fs.readFileSync(filename, 'utf8');
+    if (oldContent == newContent) {
+      console.warn(`* Skipping current file '${filename}'`);
+      return;
+    }
+  } catch(err) {
+  }
+  fs.writeFileSync(filename, newContent);
+  console.warn(`* Updating outdated file '${filename}'`);
+};


### PR DESCRIPTION
Android builds currently regenerate the style code on every build, which triggers a recompile of many dependent files (~60 files), so running `make android-lib-arm-v7` twice without modifying any files in between isn't fast.