### PR TITLE
Remove debug spew

### DIFF
--- a/src/mbgl/gl/extension.cpp
+++ b/src/mbgl/gl/extension.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/gl/extension.hpp>
 #include <mbgl/gl/gl.hpp>
-#include <mbgl/platform/log.hpp>
 
 #include <mutex>
 #include <string>
@@ -26,31 +25,10 @@ ExtensionFunctionBase::ExtensionFunctionBase(std::initializer_list<Probe> probes
 
 static std::once_flag initializeExtensionsOnce;
 
-const char* getGLString(GLenum name) {
-    return reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(name)));
-}
-
 void InitializeExtensions(glProc (*getProcAddress)(const char*)) {
     std::call_once(initializeExtensionsOnce, [getProcAddress] {
-#ifndef NDEBUG
-        if (const char* vendor = getGLString(GL_VENDOR)) {
-            mbgl::Log::Info(mbgl::Event::OpenGL, "Vendor: %s", vendor);
-        }
-        if (const char* renderer = getGLString(GL_RENDERER)) {
-            mbgl::Log::Info(mbgl::Event::OpenGL, "Renderer: %s", renderer);
-        }
-        if (const char* version = getGLString(GL_VERSION)) {
-            mbgl::Log::Info(mbgl::Event::OpenGL, "Version: %s", version);
-        }
-        if (const char* shaderVersion = getGLString(GL_SHADING_LANGUAGE_VERSION)) {
-            mbgl::Log::Info(mbgl::Event::OpenGL, "Shading Language Version: %s", shaderVersion);
-        }
-#endif
-
-        if (const char* extensions = getGLString(GL_EXTENSIONS)) {
-#ifndef NDEBUG
-            mbgl::Log::Info(mbgl::Event::OpenGL, "Extensions: %s", extensions);
-#endif
+        if (const char* extensions =
+                reinterpret_cast<const char*>(MBGL_CHECK_ERROR(glGetString(GL_EXTENSIONS)))) {
             for (auto fn : detail::extensionFunctions()) {
                 for (auto probe : fn.second) {
                     if (strstr(extensions, probe.first) != nullptr) {


### PR DESCRIPTION
When running any application or test binary, the following is printed at startup:

<blockquote>
2016-11-08 09:03:35.915 mbgl-test[48917:6215380] [INFO] {}[OpenGL]: Vendor: Intel Inc.
2016-11-08 09:03:35.916 mbgl-test[48917:6215380] [INFO] {}[OpenGL]: Renderer: Intel(R) Iris(TM) Graphics 6100
2016-11-08 09:03:35.916 mbgl-test[48917:6215380] [INFO] {}[OpenGL]: Version: 2.1 INTEL-10.14.73
2016-11-08 09:03:35.916 mbgl-test[48917:6215380] [INFO] {}[OpenGL]: Shading Language Version: 1.20
2016-11-08 09:03:35.916 mbgl-test[48917:6215380] [INFO] {}[OpenGL]: Extensions: GL_ARB_color_buffer_float GL_ARB_depth_buffer_float GL_ARB_depth_clamp GL_ARB_depth_texture GL_ARB_draw_buffers GL_ARB_draw_elements_base_vertex GL_ARB_draw_instanced GL_ARB_fragment_program GL_ARB_fragment_program_shadow GL_ARB_fragment_shader GL_ARB_framebuffer_object GL_ARB_framebuffer_sRGB GL_ARB_half_float_pixel GL_ARB_half_float_vertex GL_ARB_instanced_arrays GL_ARB_multisample GL_ARB_multitexture GL_ARB_occlusion_query GL_ARB_pixel_buffer_object GL_ARB_point_parameters GL_ARB_point_sprite GL_ARB_provoking_vertex GL_ARB_seamless_cube_map GL_ARB_shader_objects GL_ARB_shader_texture_lod GL_ARB_shading_language_100 GL_ARB_shadow GL_ARB_sync GL_ARB_texture_border_clamp GL_ARB_texture_compression GL_ARB_texture_compression_rgtc GL_ARB_texture_cube_map GL_ARB_texture_env_add GL_ARB_texture_env_combine GL_ARB_texture_env_crossbar GL_ARB_texture_env_dot3 GL_ARB_texture_float GL_ARB_texture_mirrored_repeat GL_ARB_texture_non_power_of_two GL_ARB_texture_rectangle GL_ARB_texture_rg GL_ARB_transpose_matrix GL_ARB_vertex_array_bgra GL_ARB_vertex_blend GL_ARB_vertex_buffer_object GL_ARB_vertex_program GL_ARB_vertex_shader GL_ARB_window_pos GL_EXT_abgr GL_EXT_bgra GL_EXT_blend_color GL_EXT_blend_equation_separate GL_EXT_blend_func_separate GL_EXT_blend_minmax GL_EXT_blend_subtract GL_EXT_clip_volume_hint GL_EXT_debug_label GL_EXT_debug_marker GL_EXT_draw_buffers2 GL_EXT_draw_range_elements GL_EXT_fog_coord GL_EXT_framebuffer_blit GL_EXT_framebuffer_multisample GL_EXT_framebuffer_multisample_blit_scaled GL_EXT_framebuffer_object GL_EXT_framebuffer_sRGB GL_EXT_geometry_shader4 GL_EXT_gpu_program_parameters GL_EXT_gpu_shader4 GL_EXT_multi_draw_arrays GL_EXT_packed_depth_stencil GL_EXT_packed_float GL_EXT_provoking_vertex GL_EXT_rescale_normal GL_EXT_secondary_color GL_EXT_separate_specular_color GL_EXT_shadow_funcs GL_EXT_stencil_two_side GL_EXT_stencil_wrap GL_EXT_texture_array GL_EXT_texture_compression_dxt1 GL_EXT_texture_compression_s3tc GL_EXT_texture_env_add GL_EXT_texture_filter_anisotropic GL_EXT_texture_integer GL_EXT_texture_lod_bias GL_EXT_texture_rectangle GL_EXT_texture_shared_exponent GL_EXT_texture_sRGB GL_EXT_texture_sRGB_decode GL_EXT_timer_query GL_EXT_transform_feedback GL_EXT_vertex_array_bgra GL_APPLE_aux_depth_stencil GL_APPLE_client_storage GL_APPLE_element_array GL_APPLE_fence GL_APPLE_float_pixels GL_APPLE_flush_buffer_range GL_APPLE_flush_render GL_APPLE_object_purgeable GL_APPLE_packed_pixels GL_APPLE_pixel_buffer GL_APPLE_rgb_422 GL_APPLE_row_bytes GL_APPLE_specular_vector GL_APPLE_texture_range GL_APPLE_transform_hint GL_APPLE_vertex_array_object GL_APPLE_vertex_array_range GL_APPLE_vertex_point_size GL_APPLE_vertex_program_evaluators GL_APPLE_ycbcr_422 GL_ATI_separate_stencil GL_ATI_texture_env_combine3 GL_ATI_texture_float GL_ATI_texture_mirror_once GL_IBM_rasterpos_clip GL_NV_blend_square GL_NV_conditional_render GL_NV_depth_clamp GL_NV_fog_distance GL_NV_light_max_exponent GL_NV_texgen_reflection GL_NV_texture_barrier GL_SGIS_generate_mipmap GL_SGIS_texture_edge_clamp GL_SGIS_texture_lod 
</blockquote>

This obscures the actually relevant and interesting output, like test results. Let's nix it.

cc @kkaefer 