### PR TITLE
Viewport getCurrentValue failed assertion error

### DIFF
--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -177,6 +177,11 @@ void NativeMapView::invalidate() {
 void NativeMapView::render() {
     activate();
 
+    if (framebufferSizeChanged) {
+        getContext().viewport = { 0, 0, getFramebufferSize() };
+        framebufferSizeChanged = false;
+    }
+
     updateViewBinding();
     map->render(*this);
 
@@ -688,6 +693,7 @@ void NativeMapView::resizeView(int w, int h) {
 void NativeMapView::resizeFramebuffer(int w, int h) {
     fbWidth = w;
     fbHeight = h;
+    framebufferSizeChanged = true;
     invalidate();
 }
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -90,6 +90,7 @@ private:
     int height = 0;
     int fbWidth = 0;
     int fbHeight = 0;
+    bool framebufferSizeChanged = true;
 
     int availableProcessors = 0;
     size_t totalMemory = 0;


### PR DESCRIPTION
Getting a crash in the testapp when opening the soft keyboard and attempting to resize the map.

![ezgif com-video-to-gif 22](https://cloud.githubusercontent.com/assets/5652865/20019436/af51f02c-a2a2-11e6-93da-bc1d34b4d6ff.gif)

```
11-04 15:18:19.860 24581-24581/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
11-04 15:18:19.860 24581-24581/? A/DEBUG: Build fingerprint: 'google/sailfish/sailfish:7.1/NDE63L/3273814:user/release-keys'
11-04 15:18:19.860 24581-24581/? A/DEBUG: Revision: '0'
11-04 15:18:19.860 24581-24581/? A/DEBUG: ABI: 'arm'
11-04 15:18:19.860 24581-24581/? A/DEBUG: pid: 24520, tid: 24520, name: pboxsdk.testapp  >>> com.mapbox.mapboxsdk.testapp <<<
11-04 15:18:19.861 24581-24581/? A/DEBUG: signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
11-04 15:18:19.864 24581-24581/? A/DEBUG: Abort message: '../../../platform/android/src/native_map_view.cpp:127: void mbgl::android::NativeMapView::updateViewBinding(): assertion "mbgl::gl::value::Viewport::Get() == getContext().viewport.getCurrentValue()" failed'
11-04 15:18:19.864 24581-24581/? A/DEBUG:     r0 00000000  r1 00005fc8  r2 00000006  r3 00000008
11-04 15:18:19.864 24581-24581/? A/DEBUG:     r4 ee0b858c  r5 00000006  r6 ee0b8534  r7 0000010c
11-04 15:18:19.864 24581-24581/? A/DEBUG:     r8 d05dae00  r9 eb405400  sl d05dae00  fp 00000000
11-04 15:18:19.864 24581-24581/? A/DEBUG:     ip 00000009  sp ffa08070  lr ecc60537  pc ecc62da0  cpsr 60070010
11-04 15:18:19.871 24581-24581/? A/DEBUG: backtrace:
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #00 pc 00049da0  /system/lib/libc.so (tgkill+12)
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #01 pc 00047533  /system/lib/libc.so (pthread_kill+34)
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #02 pc 0001d635  /system/lib/libc.so (raise+10)
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #03 pc 00019181  /system/lib/libc.so (__libc_android_abort+34)
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #04 pc 00017048  /system/lib/libc.so (abort+4)
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #05 pc 0001b633  /system/lib/libc.so (__libc_fatal+22)
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #06 pc 0001937b  /system/lib/libc.so (__assert2+18)
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #07 pc 000aca64  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #08 pc 000ad080  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #09 pc 000b4a9c  /data/app/com.mapbox.mapboxsdk.testapp-1/lib/arm/libmapbox-gl.so
11-04 15:18:19.872 24581-24581/? A/DEBUG:     #10 pc 0003d677  /data/data/com.mapbox.mapboxsdk.testapp/cache/slice-slice_6-classes.dex (offset 0xec000)
```

cc: @mapbox/android @kkaefer 