### PR TITLE
Don't initialize timestamps to TimePoint::min()

### DIFF
--- a/src/mbgl/renderer/frame_history.hpp
+++ b/src/mbgl/renderer/frame_history.hpp
@@ -29,8 +29,8 @@ private:
     const AlphaImage opacities{ { 256, 1 } };
 
     int16_t previousZoomIndex = 0;
-    TimePoint previousTime = TimePoint::min();
-    TimePoint time = TimePoint::min();
+    TimePoint previousTime;
+    TimePoint time;
     bool firstFrame = true;
     bool dirty = true;
 


### PR DESCRIPTION
An alternative fix to #6747/#6667: In `FrameHistory::needsAnimation`, we are computing `time - previousTime`, but since `previousTime` was initialized to `TimePoint::min()`, we got a integer overflow, which produced invalid values and made the map render continuously.

/cc @tobrun