### PR TITLE
Track binary size over time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ script:
 after_script:
   - ccache --show-stats
   - ./platform/linux/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
+after_success:
+  - ./platform/linux/scripts/after_success.sh
 
 matrix:
   include:

--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -8,42 +8,6 @@
             "Properties": {
                 "Policies": [
                     {
-                        "PolicyName": "list-testing-old",
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "s3:ListBucket"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": [
-                                        "arn:aws:s3:::mapbox-gl-testing"
-                                    ]
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "PolicyName": "build-testing-old",
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "s3:DeleteObject",
-                                        "s3:GetObject",
-                                        "s3:GetObjectAcl",
-                                        "s3:PutObject",
-                                        "s3:PutObjectAcl"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": [
-                                        "arn:aws:s3:::mapbox-gl-testing/*"
-                                    ]
-                                }
-                            ]
-                        }
-                    },
-                    {
                         "PolicyName": "list-testing",
                         "PolicyDocument": {
                             "Statement": [
@@ -148,6 +112,24 @@
                                 }
                             ]
                         }
+                    },
+                    {
+                        "PolicyName": "cloudwatch-metrics",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "cloudwatch:PutMetricData",
+                                        "cloudwatch:GetMetricData",
+                                        "cloudwatch:GetMetricStatistics"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                }
+                            ]
+                        }
                     }
                 ]
             }
@@ -175,6 +157,24 @@
                                     "Effect": "Allow",
                                     "Resource": [
                                         "arn:aws:s3:::mapbox/android/signing-credentials/secring.gpg"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "cloudwatch-metrics",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "cloudwatch:PutMetricData",
+                                        "cloudwatch:GetMetricData",
+                                        "cloudwatch:GetMetricStatistics"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        "*"
                                     ]
                                 }
                             ]

--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -175,6 +175,13 @@ workflows:
             export BUILDTYPE=Release
             make apackage
     - script:
+        title: Log metrics
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "Log binary size metrics to AWS CloudWatch:"
+            CLOUDWATCH=true platform/android/scripts/metrics.sh
+    - script:
         title: Publish to maven
         inputs:
         - content: |-

--- a/platform/android/scripts/metrics.sh
+++ b/platform/android/scripts/metrics.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Track individual architectures
+scripts/log_binary_size.sh "platform/android/MapboxGLAndroidSDK/src/main/jniLibs/armeabi/libmapbox-gl.so"     "Platform=Android,Arch=arm-v5"
+scripts/log_binary_size.sh "platform/android/MapboxGLAndroidSDK/src/main/jniLibs/armeabi-v7a/libmapbox-gl.so" "Platform=Android,Arch=arm-v7"
+scripts/log_binary_size.sh "platform/android/MapboxGLAndroidSDK/src/main/jniLibs/arm64-v8a/libmapbox-gl.so"   "Platform=Android,Arch=arm-v8"
+scripts/log_binary_size.sh "platform/android/MapboxGLAndroidSDK/src/main/jniLibs/x86/libmapbox-gl.so"         "Platform=Android,Arch=x86"
+scripts/log_binary_size.sh "platform/android/MapboxGLAndroidSDK/src/main/jniLibs/x86_64/libmapbox-gl.so"      "Platform=Android,Arch=x86_64"
+scripts/log_binary_size.sh "platform/android/MapboxGLAndroidSDK/src/main/jniLibs/mips/libmapbox-gl.so"        "Platform=Android,Arch=mips"
+
+# Track overall library size
+scripts/log_binary_size.sh "platform/android/MapboxGLAndroidSDK/build/outputs/aar/MapboxGLAndroidSDK-release.aar" "Platform=Android,Arch=Archive"

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -2,6 +2,8 @@
 format_version: 1.0.0
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 trigger_map:
+- pattern: nightly-release
+  workflow: nightly-release
 - pattern: "*"
   is_pull_request_allowed: true
   workflow: primary
@@ -72,3 +74,32 @@ workflows:
             failed'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+  nightly-release:
+    steps:
+    - script:
+        title: Install Dependencies
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            brew install cmake
+        - is_debug: 'yes'
+    - script:
+        title: Configure AWS-CLI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            apt-get install -y python-pip python-dev build-essential
+            pip install awscli
+    - script:
+        title: Build package
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            export BUILDTYPE=Release
+            export BUILD_DEVICE=true
+            export FORMAT=dynamic
+            make ipackage-strip
+            CLOUDWATCH=true platform/ios/scripts/metrics.sh
+        - is_debug: 'yes'

--- a/platform/ios/scripts/metrics.sh
+++ b/platform/ios/scripts/metrics.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Generate stripped versions for every architecture
+xcrun bitcode_strip build/ios/pkg/dynamic/Mapbox.framework/Mapbox -r -o  build/ios/pkg/dynamic/Mapbox-stripped
+lipo build/ios/pkg/dynamic/Mapbox-stripped -extract armv7 -output build/ios/pkg/dynamic/Mapbox-stripped-armv7
+lipo build/ios/pkg/dynamic/Mapbox-stripped -extract arm64 -output build/ios/pkg/dynamic/Mapbox-stripped-arm64
+lipo build/ios/pkg/dynamic/Mapbox-stripped -extract i386 -output build/ios/pkg/dynamic/Mapbox-stripped-i386
+lipo build/ios/pkg/dynamic/Mapbox-stripped -extract x86_64 -output build/ios/pkg/dynamic/Mapbox-stripped-x86_64
+
+# Track individual architectures
+scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped-armv7"   "Platform=iOS,Arch=armv7"
+scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped-arm64"   "Platform=iOS,Arch=arm64"
+scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped-i386"    "Platform=iOS,Arch=i386"
+scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped-x86_64"  "Platform=iOS,Arch=x86_64"
+
+# Track overall library size
+scripts/log_binary_size.sh "build/ios/pkg/dynamic/Mapbox-stripped"         "Platform=iOS,Arch=Dynamic"

--- a/platform/linux/scripts/after_success.sh
+++ b/platform/linux/scripts/after_success.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+if [ "${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}" = "master" ] && [ "${BUILDTYPE}" = "Release" ]; then
+    CLOUDWATCH=true platform/linux/scripts/metrics.sh
+else
+    echo "Not logging binary size for branch or Debug build"
+fi

--- a/platform/linux/scripts/metrics.sh
+++ b/platform/linux/scripts/metrics.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Generate stripped version
+ARCH=$(uname -m)
+RENDER=build/linux-${ARCH}/Release/mbgl-render
+strip -s -x "${RENDER}" -o "${RENDER}-stripped"
+
+# Track individual architecture
+scripts/log_binary_size.sh "${RENDER}-stripped" "Platform=Linux,Compiler=${_CC},Arch=${ARCH}"

--- a/platform/macos/bitrise.yml
+++ b/platform/macos/bitrise.yml
@@ -2,6 +2,8 @@ format_version: 1.1.0
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 trigger_map:
+- pattern: nightly-release
+  workflow: nightly-release
 - pattern: "*"
   is_pull_request_allowed: true
   workflow: primary
@@ -78,3 +80,31 @@ workflows:
             failed'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+  nightly-release:
+    steps:
+    - script:
+        title: Install Dependencies
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            brew install cmake
+        - is_debug: 'yes'
+    - script:
+        title: Configure AWS-CLI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            apt-get install -y python-pip python-dev build-essential
+            pip install awscli
+    - script:
+        title: Build package
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            export BUILDTYPE=Release
+            export SYMBOLS=NO
+            make xpackage
+            CLOUDWATCH=true platform/macos/scripts/metrics.sh
+        - is_debug: 'yes'

--- a/platform/macos/scripts/metrics.sh
+++ b/platform/macos/scripts/metrics.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+# Track individual architectures
+scripts/log_binary_size.sh "build/macos/pkg/Mapbox.framework/Versions/Current/Mapbox"  "Platform=macOS,Arch=x86_64"

--- a/scripts/log_binary_size.sh
+++ b/scripts/log_binary_size.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+function filesize {
+    if [ `uname -s` = 'Darwin' ]; then
+        stat -f%z $1
+    else
+        stat --printf=%s $1
+    fi
+}
+
+# Uploads build metrics to CloudWatch
+FILE=$1
+DIMENSIONS=$2
+
+if [ -z "${DIMENSIONS}" ]; then
+    echo "* No dimensions specified for '${FILE}'"
+    exit 1
+fi
+
+if [ -f "${FILE}" ]; then
+    SIZE=`filesize ${FILE}`
+    echo "* Reporting `LC_NUMERIC=en_US printf "%'10.f\n" ${SIZE}` bytes for '${DIMENSIONS}' (${FILE})"
+    if [ ${CLOUDWATCH} ]; then
+        aws --region us-east-1 cloudwatch put-metric-data \
+            --namespace "Mapbox/GL" \
+            --metric-name "BinarySize" \
+            --unit "Bytes" \
+            --value ${SIZE} \
+            --dimensions "${DIMENSIONS}"
+    fi
+else
+    echo "* File '${FILE}' does not exist"
+    exit 1
+fi


### PR DESCRIPTION
Add logging to CloudWatch that records binary size for Linux, Android, iOS and macOS. In the case of fat binaries, the binary size is split up to individual architectures (iOS/Android) in addition to the default archive.

The idea is that we'll have nightly builds (running in EU early morning) that create a stripped release build to approximate the size of the library in a deployed setting, and record those. Using the data stored in CloudWatch, we'll be able to generate graphs of how the binary size changes over time.