### PR TITLE
[linux] Added EGL headless backend support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,48 @@ git:
   submodules: false
 
 # Save common build configurations as shortcuts, so we can reference them later.
+addons:
+  apt:
+    sources:
+      - &common_sources [ 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
+    packages:
+      - &common_packages [ 'libllvm3.8v4', 'cmake', 'cmake-data' ]
+      - &clang38_packages [ 'clang-3.8', 'libstdc++-5-dev', 'libstdc++6' ]
+      - &gcc5_packages [ 'gcc-5', 'g++-5' ]
+      - &egl_packages [ 'libgles2-mesa-dev', 'libgbm-dev' ]
+      - &glfw_packages [ 'libxrandr-dev', 'libxcursor-dev', 'libxinerama-dev' ]
+
 addons_shortcuts:
   addons_clang38: &clang38
     apt:
-      sources:  [ 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
-      packages: [ 'clang-3.8', 'libstdc++-5-dev', 'libstdc++6', 'libllvm3.8v4', 'cmake', 'cmake-data',
-                  'libxrandr-dev', 'libxcursor-dev', 'libxinerama-dev' ]
+      sources: *common_sources
+      packages:
+        - *common_packages
+        - *clang38_packages
+        - *egl_packages
+        - *glfw_packages
   addons_gcc5: &gcc5
     apt:
-      sources:  [ 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
-      packages: [ 'g++-5', 'gcc-5', 'libllvm3.8v4', 'cmake', 'cmake-data',
-                  'libxrandr-dev', 'libxcursor-dev', 'libxinerama-dev' ]
+      sources: *common_sources
+      packages:
+        - *common_packages
+        - *gcc5_packages
+        - *egl_packages
+        - *glfw_packages
   addons_qt4: &qt4
     apt:
-      sources:  [ 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
-      packages: [ 'g++-5', 'gcc-5', 'libllvm3.8v4', 'libjemalloc-dev', 'cmake', 'cmake-data',
-                  'mesa-utils', 'qt4-default' ]
+      sources: *common_sources
+      packages:
+        - *common_packages
+        - *gcc5_packages
+        - [ 'libjemalloc-dev', 'mesa-utils', 'qt4-default' ]
   addons_qt5: &qt5
     apt:
-      sources:  [ 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
-      packages: [ 'g++-5', 'gcc-5', 'libllvm3.8v4', 'cmake', 'cmake-data',
-                  'mesa-utils', 'libc6-dbg', 'qt5-default', 'libqt5opengl5-dev', 'qtdeclarative5-dev', 'qtpositioning5-dev', 'qtlocation5-dev' ]
+      sources: *common_sources
+      packages:
+        - *common_packages
+        - *gcc5_packages
+        - [ 'mesa-utils', 'libc6-dbg', 'qt5-default', 'libqt5opengl5-dev', 'qtdeclarative5-dev', 'qtpositioning5-dev', 'qtlocation5-dev' ]
 
 env:
   global:
@@ -38,9 +59,7 @@ env:
 install:
   - source ./scripts/travis_helper.sh
   - source ./scripts/travis_setup.sh
-before_script:
   - ccache --zero-stats
-  - cmake --version
 script:
   - make linux
   - make benchmark
@@ -54,6 +73,17 @@ after_success:
 
 matrix:
   include:
+    # LLVM 3.8.0 - clang-{format,tidy}
+    - os: linux
+      sudo: false
+      dist: trusty
+      language: cpp
+      env: _CXX=c++ _CC=cc
+      compiler: "check"
+      script:
+        - git fetch origin master:refs/remotes/origin/master
+        - make check
+
     # OSMesa - Node - Clang 3.8 - Debug
     - os: linux
       sudo: required
@@ -71,98 +101,114 @@ matrix:
         - ccache --show-stats
         - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
 
+    # EGL - Node - Clang 3.8 - Debug
+    - os: linux
+      sudo: required
+      dist: trusty
+      language: node
+      compiler: "egl-node4-clang38-debug"
+      env: BUILDTYPE=Debug _CXX=clang++-3.8 _CC=clang-3.8 WITH_EGL=1
+      addons: *clang38
+      before_script:
+        - mapbox_start_xvfb
+      script:
+        - nvm install 4
+        - nvm use 4
+        - make node
+        - make test-node
+      after_script:
+        - ccache --show-stats
+        - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
+
     # GLX - Node - Clang 3.8 - Release
     - os: linux
       sudo: required
       dist: trusty
       language: node
       compiler: "glx-node4-clang38-release"
-      env: BUILDTYPE=Release _CXX=clang++-3.8 _CC=clang-3.8 RUN_XVFB=1
+      env: BUILDTYPE=Release _CXX=clang++-3.8 _CC=clang-3.8
       addons: *clang38
       before_script:
         - export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
         - export PUBLISH=$([[ "${TRAVIS_TAG:-}" == "node-v${PACKAGE_JSON_VERSION}" ]] && echo true)
+        - mapbox_start_xvfb
       script:
         - nvm install 4
         - nvm use 4
         - make node
+        - make test-node
       after_script:
         - ccache --show-stats
+        - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
       after_success:
         - ./platform/node/scripts/after_success.sh
 
-    # GCC 5 - Debug - Coverage
+    # OSMesa - GCC 5 - Debug (Coverage)
     # FIXME: https://github.com/mapbox/mapbox-gl-native/issues/6918
     - os: linux
       sudo: required
       dist: trusty
       language: cpp
-      compiler: "glfw-gcc5-debug"
+      compiler: "osmesa-gcc5-debug"
       env: BUILDTYPE=Debug _CXX=g++-5 _CC=gcc-5 WITH_COVERAGE=1 WITH_OSMESA=1
       addons: *gcc5
       after_script:
         - ccache --show-stats
         - ./platform/linux/scripts/coveralls.sh
 
-    # GCC 5 - Release
+    # OSMesa - GCC 5 - Release
     - os: linux
       sudo: required
       dist: trusty
       language: cpp
-      compiler: "glfw-gcc5-release"
+      compiler: "osmesa-gcc5-release"
       env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5 WITH_OSMESA=1
       addons: *gcc5
 
-    # Clang 3.8 - Debug
+    # OSMesa - Clang 3.8 - Debug
     - os: linux
       sudo: required
       dist: trusty
       language: cpp
-      compiler: "glfw-clang38-debug"
+      compiler: "osmesa-clang38-debug"
       env: BUILDTYPE=Debug _CXX=clang++-3.8 _CC=clang-3.8 WITH_OSMESA=1
       addons: *clang38
 
-    # Clang 3.8 - Release
+    # OSMesa - Clang 3.8 - Release
     - os: linux
       sudo: required
       dist: trusty
       language: cpp
-      compiler: "glfw-clang38-release"
+      compiler: "osmesa-clang38-release"
       env: BUILDTYPE=Release _CXX=clang++-3.8 _CC=clang-3.8 WITH_OSMESA=1
       addons: *clang38
 
-    # Clang 3.8 - check
-    - os: linux
-      sudo: required
-      dist: trusty
-      language: cpp
-      compiler: "check-clang38-release"
-      env: BUILDTYPE=Release _CXX=clang++-3.8 _CC=clang-3.8 WITH_OSMESA=1
-      addons: *clang38
-      script:
-        - git fetch origin master:refs/remotes/origin/master
-        - make check
-
-    # Qt 4 - Release
+    # Qt 4 - GCC 5 - Release
     - os: linux
       sudo: required
       dist: trusty
       language: cpp
       compiler: "qt4-gcc5-release"
-      env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5 RUN_XVFB=1 WITH_QT_4=1
+      env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5 WITH_QT_4=1
       addons: *qt4
+      before_script:
+        - mapbox_start_xvfb
+        - mapbox_export_mesa_library_path
       script:
         - make qt-app
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so make run-qt-test-Memory.*:*.Load
 
-    # Qt 5 - Release
+    # Qt 5 - GCC 5 - Release
     - os: linux
       sudo: required
       dist: trusty
       language: cpp
       compiler: "qt5-gcc5-release"
-      env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5 RUN_XVFB=1
+      env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5
       addons: *qt5
+      before_script:
+        - mapbox_start_xvfb
+        - mapbox_export_mesa_library_path
       script:
         - make qt-app
         - make qt-qml-app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,23 @@ include(.mason/mason.cmake)
 option(WITH_CXX11ABI "Use cxx11abi mason packages" OFF)
 option(WITH_COVERAGE "Enable coverage reports" OFF)
 option(WITH_OSMESA   "Use OSMesa headless backend" OFF)
+option(WITH_EGL      "Use EGL backend" OFF)
 option(IS_CI_BUILD   "Continuous integration build" OFF)
 
 if(WITH_CXX11ABI)
     set(MASON_CXXABI_SUFFIX -cxx11abi)
 endif()
 
+if(WITH_OSMESA AND WITH_EGL)
+    message(FATAL_ERROR "WITH_OSMESA and WITH_EGL are mutually exclusive.")
+endif()
+
 if(WITH_OSMESA)
     # Default mesa mason binary is OSMesa.
     set(MASON_MESA_SUFFIX "")
+elseif(WITH_EGL)
+    add_definitions(-DMBGL_USE_GLES2=1)
+    set(MASON_MESA_SUFFIX "-egl")
 else()
     set(MASON_MESA_SUFFIX "-glx")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,8 @@ $(LINUX_BUILD): $(BUILD_DEPS)
 		-DWITH_CXX11ABI=$(shell scripts/check-cxx11abi.sh) \
 		-DWITH_COVERAGE=${WITH_COVERAGE} \
 		-DIS_CI_BUILD=${CI} \
-		-DWITH_OSMESA=${WITH_OSMESA})
+		-DWITH_OSMESA=${WITH_OSMESA} \
+		-DWITH_EGL=${WITH_EGL})
 
 .PHONY: linux
 linux: glfw-app render offline

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.16.4",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#ec891ce5360e488d81f60991f95d2038b83c4e3c",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#7f62a4fc9f21e619824d68abbc4b03cbc1685572",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#2f6453e17cd3d17ab2ff677056f65b9cab70f2e8",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#7f9f6837dd8e7c595d684680c69da0880e07d7eb",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/platform/default/glfw_view.cpp
+++ b/platform/default/glfw_view.cpp
@@ -172,6 +172,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
                 }
             }
             break;
+#if not MBGL_USE_GLES2
         case GLFW_KEY_B: {
             auto debug = view->map->getDebug();
             if (debug & mbgl::MapDebugOptions::StencilClip) {
@@ -184,6 +185,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             }
             view->map->setDebug(debug);
         } break;
+#endif // MBGL_USE_GLES2
         case GLFW_KEY_N:
             if (!mods)
                 view->map->resetNorth();

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -1,5 +1,5 @@
 mason_use(glfw VERSION 3.2.1)
-if(IS_CI_BUILD)
+if(IS_CI_BUILD AND NOT WITH_EGL)
     mason_use(mesa VERSION 13.0.0${MASON_MESA_SUFFIX}${MASON_CXXABI_SUFFIX})
 endif()
 mason_use(boost_libprogram_options VERSION 1.60.0)
@@ -40,6 +40,7 @@ macro(mbgl_platform_core)
         )
         if (IS_CI_BUILD)
             target_add_mason_package(mbgl-core PUBLIC mesa)
+            target_link_libraries(mbgl-core PUBLIC -lX11)
         else()
             target_link_libraries(mbgl-core
                 PUBLIC -lGL

--- a/platform/linux/src/headless_backend_egl.cpp
+++ b/platform/linux/src/headless_backend_egl.cpp
@@ -58,11 +58,16 @@ void HeadlessBackend::createContext() {
     EGLDisplay display_ = display->attribute<EGLDisplay>();
     EGLConfig& config = display->attribute<EGLConfig&>();
 
-    if (!eglBindAPI(EGL_OPENGL_API)) {
-        throw std::runtime_error("Error setting the EGL rendering API.\n");
-    }
+    // EGL initializes the context client version to 1 by default. We want to
+    // use OpenGL ES 2.0 which has the ability to create shader and program
+    // objects and also to write vertex and fragment shaders in the OpenGL ES
+    // Shading Language.
+    const EGLint attribs[] = {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_NONE
+    };
 
-    EGLContext glContext = eglCreateContext(display_, config, EGL_NO_CONTEXT, NULL);
+    EGLContext glContext = eglCreateContext(display_, config, EGL_NO_CONTEXT, attribs);
     if (glContext == EGL_NO_CONTEXT) {
         mbgl::Log::Error(mbgl::Event::OpenGL, "eglCreateContext() returned error 0x%04x",
                          eglGetError());

--- a/platform/linux/src/headless_backend_egl.cpp
+++ b/platform/linux/src/headless_backend_egl.cpp
@@ -1,0 +1,75 @@
+#include <mbgl/platform/default/headless_backend.hpp>
+#include <mbgl/platform/default/headless_display.hpp>
+
+#include <mbgl/platform/log.hpp>
+
+#include <EGL/egl.h>
+
+#include <cassert>
+
+namespace mbgl {
+
+struct EGLImpl : public HeadlessBackend::Impl {
+    EGLImpl(EGLContext glContext_, EGLDisplay display_)
+            : glContext(glContext_),
+              display(display_) {
+    }
+
+    ~EGLImpl() {
+        if (glContext != eglGetCurrentContext()) {
+            activateContext();
+        }
+        if (!eglDestroyContext(display, glContext)) {
+            throw std::runtime_error("Failed to destroy EGL context.\n");
+        }
+    }
+
+    void activateContext() final {
+        if (!eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, glContext)) {
+            throw std::runtime_error("Switching OpenGL context failed.\n");
+        }
+    }
+
+    void deactivateContext() final {
+        if (!eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
+            throw std::runtime_error("Removing OpenGL context failed.\n");
+        }
+    }
+
+    EGLContext glContext = EGL_NO_CONTEXT;
+    EGLDisplay display = EGL_NO_DISPLAY;
+};
+
+gl::glProc HeadlessBackend::initializeExtension(const char* name) {
+    return eglGetProcAddress(name);
+}
+
+bool HeadlessBackend::hasDisplay() {
+    if (!display) {
+        display.reset(new HeadlessDisplay);
+    }
+    return bool(display);
+};
+
+void HeadlessBackend::createContext() {
+    assert(!hasContext());
+    assert(hasDisplay());
+
+    EGLDisplay display_ = display->attribute<EGLDisplay>();
+    EGLConfig& config = display->attribute<EGLConfig&>();
+
+    if (!eglBindAPI(EGL_OPENGL_API)) {
+        throw std::runtime_error("Error setting the EGL rendering API.\n");
+    }
+
+    EGLContext glContext = eglCreateContext(display_, config, EGL_NO_CONTEXT, NULL);
+    if (glContext == EGL_NO_CONTEXT) {
+        mbgl::Log::Error(mbgl::Event::OpenGL, "eglCreateContext() returned error 0x%04x",
+                         eglGetError());
+        throw std::runtime_error("Error creating the EGL context object.\n");
+    }
+
+    impl.reset(new EGLImpl(glContext, display_));
+}
+
+} // namespace mbgl

--- a/platform/linux/src/headless_display_egl.cpp
+++ b/platform/linux/src/headless_display_egl.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/platform/default/headless_display.hpp>
+#include <mbgl/platform/log.hpp>
 #include <mbgl/util/string.hpp>
 
 #include <EGL/egl.h>
@@ -23,6 +24,11 @@ HeadlessDisplay::Impl::Impl() {
     EGLint major, minor, numConfigs;
     if (!eglInitialize(display, &major, &minor)) {
         throw std::runtime_error("eglInitialize() failed.\n");
+    }
+
+    if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+        mbgl::Log::Error(mbgl::Event::OpenGL, "eglBindAPI(EGL_OPENGL_ES_API) returned error %d", eglGetError());
+        throw std::runtime_error("eglBindAPI() failed");
     }
 
     // This shouldn't matter as we're rendering to a framebuffer.

--- a/platform/linux/src/headless_display_egl.cpp
+++ b/platform/linux/src/headless_display_egl.cpp
@@ -1,0 +1,56 @@
+#include <mbgl/platform/default/headless_display.hpp>
+#include <mbgl/util/string.hpp>
+
+#include <EGL/egl.h>
+
+namespace mbgl {
+
+class HeadlessDisplay::Impl {
+public:
+    Impl();
+    ~Impl();
+
+    EGLDisplay display = EGL_NO_DISPLAY;
+    EGLConfig config = 0;
+};
+
+HeadlessDisplay::Impl::Impl() {
+    display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    if (display == EGL_NO_DISPLAY) {
+        throw std::runtime_error("Failed to obtain a valid EGL display.\n");
+    }
+
+    EGLint major, minor, numConfigs;
+    if (!eglInitialize(display, &major, &minor)) {
+        throw std::runtime_error("eglInitialize() failed.\n");
+    }
+
+    // This shouldn't matter as we're rendering to a framebuffer.
+    const EGLint attribs[] = { EGL_NONE };
+    if (!eglChooseConfig(display, attribs, &config, 1, &numConfigs) || numConfigs != 1) {
+        throw std::runtime_error("Failed to choose ARGB config.\n");
+    }
+}
+
+HeadlessDisplay::Impl::~Impl() {
+    eglTerminate(display);
+}
+
+template <>
+EGLDisplay HeadlessDisplay::attribute() const {
+    return impl->display;
+}
+
+template <>
+EGLConfig& HeadlessDisplay::attribute() const {
+    return impl->config;
+}
+
+HeadlessDisplay::HeadlessDisplay()
+    : impl(std::make_unique<Impl>()) {
+}
+
+HeadlessDisplay::~HeadlessDisplay() {
+}
+
+} // namespace mbgl

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -23,8 +23,8 @@ std::shared_ptr<SpriteImage> namedMarker(const std::string &name) {
 class AnnotationTest {
 public:
     util::RunLoop loop;
-    HeadlessBackend backend;
-    OffscreenView view{ backend.getContext() };
+    HeadlessBackend backend { test::sharedDisplay() };
+    OffscreenView view { backend.getContext() };
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };
     Map map { backend, view.size, 1, fileSource, threadPool, MapMode::Still };

--- a/test/api/api_misuse.test.cpp
+++ b/test/api/api_misuse.test.cpp
@@ -14,14 +14,15 @@
 
 using namespace mbgl;
 
+
 TEST(API, RenderWithoutCallback) {
     auto log = new FixtureLogObserver();
     Log::setObserver(std::unique_ptr<Log::Observer>(log));
 
     util::RunLoop loop;
 
-    HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), { 128, 512 });
+    HeadlessBackend backend { test::sharedDisplay() };
+    OffscreenView view { backend.getContext(), { 128, 512 } };
     StubFileSource fileSource;
     ThreadPool threadPool(4);
 
@@ -45,8 +46,8 @@ TEST(API, RenderWithoutCallback) {
 TEST(API, RenderWithoutStyle) {
     util::RunLoop loop;
 
-    HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), { 128, 512 });
+    HeadlessBackend backend { test::sharedDisplay() };
+    OffscreenView view { backend.getContext(), { 128, 512 } };
     StubFileSource fileSource;
     ThreadPool threadPool(4);
 

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -85,8 +85,8 @@ public:
 TEST(CustomLayer, Basic) {
     util::RunLoop loop;
 
-    HeadlessBackend backend;
-    OffscreenView view(backend.getContext());
+    HeadlessBackend backend { test::sharedDisplay() };
+    OffscreenView view { backend.getContext() };
 
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`

--- a/test/api/query.test.cpp
+++ b/test/api/query.test.cpp
@@ -26,7 +26,7 @@ public:
     }
 
     util::RunLoop loop;
-    HeadlessBackend backend;
+    HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext() };
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };

--- a/test/api/render_missing.test.cpp
+++ b/test/api/render_missing.test.cpp
@@ -25,8 +25,8 @@ TEST(API, TEST_REQUIRES_SERVER(RenderMissingTile)) {
 
     const auto style = util::read_file("test/fixtures/api/water_missing_tiles.json");
 
-    HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), { 256, 512 });
+    HeadlessBackend backend { test::sharedDisplay() };
+    OffscreenView view { backend.getContext(), { 256, 512 } };
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets.zip");

--- a/test/api/repeated_render.test.cpp
+++ b/test/api/repeated_render.test.cpp
@@ -12,15 +12,17 @@
 
 #include <future>
 
+using namespace mbgl;
+
+
 TEST(API, RepeatedRender) {
-    using namespace mbgl;
 
     util::RunLoop loop;
 
     const auto style = util::read_file("test/fixtures/api/water.json");
 
-    HeadlessBackend backend;
-    OffscreenView view(backend.getContext(), { 256, 512 });
+    HeadlessBackend backend { test::sharedDisplay() };
+    OffscreenView view { backend.getContext(), { 256, 512 } };
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets.zip");

--- a/test/gl/object.test.cpp
+++ b/test/gl/object.test.cpp
@@ -60,7 +60,7 @@ TEST(GLObject, Value) {
 }
 
 TEST(GLObject, Store) {
-    HeadlessBackend backend;
+    HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view(backend.getContext());
 
     gl::Context context;

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -23,7 +23,7 @@ using namespace std::literals::string_literals;
 
 struct MapTest {
     util::RunLoop runLoop;
-    HeadlessBackend backend;
+    HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext() };
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };
@@ -447,6 +447,10 @@ TEST(Map, DontLoadUnneededTiles) {
 
 class MockBackend : public HeadlessBackend {
 public:
+    MockBackend(std::shared_ptr<HeadlessDisplay> display_)
+            : HeadlessBackend(display_) {
+    }
+
     std::function<void()> callback;
     void invalidate() override {
         if (callback) {
@@ -457,7 +461,7 @@ public:
 
 TEST(Map, TEST_DISABLED_ON_CI(ContinuousRendering)) {
     util::RunLoop runLoop;
-    MockBackend backend;
+    MockBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext() };
     ThreadPool threadPool { 4 };
 

--- a/test/src/mbgl/test/util.cpp
+++ b/test/src/mbgl/test/util.cpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/map/map.hpp>
 #include <mbgl/platform/default/offscreen_view.hpp>
+#include <mbgl/platform/default/headless_display.hpp>
 #include <mbgl/platform/log.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/io.hpp>
@@ -96,6 +97,11 @@ Server::~Server() {
     if (fd > 0) {
         close(fd);
     }
+}
+
+std::shared_ptr<HeadlessDisplay> sharedDisplay() {
+    static auto display = std::make_shared<HeadlessDisplay>();
+    return display;
 }
 
 PremultipliedImage render(Map& map, OffscreenView& view) {

--- a/test/src/mbgl/test/util.hpp
+++ b/test/src/mbgl/test/util.hpp
@@ -46,6 +46,7 @@
 #include <mbgl/util/chrono.hpp>
 
 #include <cstdint>
+#include <memory>
 
 #include <gtest/gtest.h>
 
@@ -53,6 +54,7 @@ namespace mbgl {
 
 class Map;
 class OffscreenView;
+class HeadlessDisplay;
 
 namespace test {
 
@@ -64,6 +66,8 @@ public:
 private:
     int fd = -1;
 };
+
+std::shared_ptr<HeadlessDisplay> sharedDisplay();
 
 PremultipliedImage render(Map&, OffscreenView&);
 

--- a/test/util/memory.test.cpp
+++ b/test/util/memory.test.cpp
@@ -56,7 +56,7 @@ public:
     }
 
     util::RunLoop runLoop;
-    HeadlessBackend backend;
+    HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view{ backend.getContext(), { 512, 512 } };
     StubFileSource fileSource;
     ThreadPool threadPool { 4 };

--- a/test/util/offscreen_texture.test.cpp
+++ b/test/util/offscreen_texture.test.cpp
@@ -74,17 +74,26 @@ TEST(OffscreenTexture, RenderToTexture) {
     MBGL_CHECK_ERROR(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
 
     Shader paintShader(R"MBGL_SHADER(
+#ifdef GL_ES
+precision mediump float;
+#endif
 attribute vec2 a_pos;
 void main() {
     gl_Position = vec4(a_pos, 0, 1);
 }
 )MBGL_SHADER", R"MBGL_SHADER(
+#ifdef GL_ES
+precision mediump float;
+#endif
 void main() {
     gl_FragColor = vec4(0, 0.8, 0, 0.8);
 }
 )MBGL_SHADER");
 
         Shader compositeShader(R"MBGL_SHADER(
+#ifdef GL_ES
+precision mediump float;
+#endif
 attribute vec2 a_pos;
 varying vec2 v_texcoord;
 void main() {
@@ -92,6 +101,9 @@ void main() {
     v_texcoord = (a_pos + 1.0) / 2.0;
 }
 )MBGL_SHADER", R"MBGL_SHADER(
+#ifdef GL_ES
+precision mediump float;
+#endif
 uniform sampler2D u_texture;
 varying vec2 v_texcoord;
 void main() {

--- a/test/util/offscreen_texture.test.cpp
+++ b/test/util/offscreen_texture.test.cpp
@@ -10,7 +10,7 @@
 using namespace mbgl;
 
 TEST(OffscreenTexture, EmptyRed) {
-    HeadlessBackend backend;
+    HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view(backend.getContext(), { 512, 256 });
     view.bind();
 
@@ -67,7 +67,7 @@ struct Buffer {
 
 
 TEST(OffscreenTexture, RenderToTexture) {
-    HeadlessBackend backend;
+    HeadlessBackend backend { test::sharedDisplay() };
     auto& context = backend.getContext();
 
     MBGL_CHECK_ERROR(glEnable(GL_BLEND));


### PR DESCRIPTION
Follow-up to the work started by @tiagovignatti in #5843 - thanks Tiago!

This PR implements EGL headless backend, using `EGL_DEFAULT_DISPLAY` as primary display - thus no need for handling render nodes directly via [gbm](https://en.wikipedia.org/wiki/Mesa_(computer_graphics)#Generic_Buffer_Management).

Though we use software rendering via LLVMpipe, we still need a valid display for EGL to be properly initialized. On Travis CI, _like the Qt builds_, we still need to start Xvfb to obtain a valid display.

I've put some effort attempting to find a working setup for Mesa to have its EGL platform working with a native display that doesn't require a window system, but so far no success. The most promising option, though, comes from this recent [Mesa extension](https://www.khronos.org/registry/egl/extensions/MESA/EGL_MESA_platform_surfaceless.txt) - __MESA_platform_surfaceless__ - that promises to provide a native display independent of any native window system. Given this solution already works and is testable via CI, we can pursuit this as a follow-up work.