### PR TITLE
node-v3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-native",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.4.1 - Novmeber 10, 2016
+
+- Skips assigning clip IDs to tiles that won't be rendered, mitigating a `stencil mask overflow` error ([#6871](https://github.com/mapbox/mapbox-gl-native/pull/6871))
+- Fixes camera logic to avoid unnecessary or redundant setting of camera options ([#6990](https://github.com/mapbox/mapbox-gl-native/pull/6990))
+
 # 3.4.0 - Novmeber 2, 2016
 
 - Fixes Bitrise configuration to automatically publish macOS binaries ([#6789](https://github.com/mapbox/mapbox-gl-native/pull/6789))


### PR DESCRIPTION
Publishing a patch release to get the `stencil mask overflow` fix from #6871 out before a (semver-major?) change removing ClipperLib from published binaries in #6965.