### PR TITLE
[core] Return source and layer ownership

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -159,12 +159,12 @@ public:
     // Sources
     style::Source* getSource(const std::string& sourceID);
     void addSource(std::unique_ptr<style::Source>);
-    void removeSource(const std::string& sourceID);
+    std::unique_ptr<style::Source> removeSource(const std::string& sourceID);
 
     // Layers
     style::Layer* getLayer(const std::string& layerID);
     void addLayer(std::unique_ptr<style::Layer>, const optional<std::string>& beforeLayerID = {});
-    void removeLayer(const std::string& layerID);
+    std::unique_ptr<style::Layer> removeLayer(const std::string& layerID);
 
     // Add image, bound to the style
     void addImage(const std::string&, std::unique_ptr<const SpriteImage>);

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -855,7 +855,7 @@ void Map::addSource(std::unique_ptr<style::Source> source) {
 std::unique_ptr<Source> Map::removeSource(const std::string& sourceID) {
     if (impl->style) {
         impl->styleMutated = true;
-        return impl->style->removeSource(sourceID);        
+        return impl->style->removeSource(sourceID);
     }
     return nullptr;
 }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -852,11 +852,12 @@ void Map::addSource(std::unique_ptr<style::Source> source) {
     }
 }
 
-void Map::removeSource(const std::string& sourceID) {
+std::unique_ptr<Source> Map::removeSource(const std::string& sourceID) {
     if (impl->style) {
         impl->styleMutated = true;
-        impl->style->removeSource(sourceID);
+        return impl->style->removeSource(sourceID);        
     }
+    return nullptr;
 }
 
 style::Layer* Map::getLayer(const std::string& layerID) {
@@ -881,18 +882,20 @@ void Map::addLayer(std::unique_ptr<Layer> layer, const optional<std::string>& be
     impl->backend.deactivate();
 }
 
-void Map::removeLayer(const std::string& id) {
+std::unique_ptr<Layer> Map::removeLayer(const std::string& id) {
     if (!impl->style) {
-        return;
+        return nullptr;
     }
 
     impl->styleMutated = true;
     impl->backend.activate();
 
-    impl->style->removeLayer(id);
+    auto removedLayer = impl->style->removeLayer(id);
     impl->onUpdate(Update::Classes);
 
     impl->backend.deactivate();
+
+    return removedLayer;
 }
 
 void Map::addImage(const std::string& name, std::unique_ptr<const SpriteImage> image) {

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -43,6 +43,11 @@ void CustomLayer::Impl::initialize() {
     initializeFn(context);
 }
 
+void CustomLayer::Impl::deinitialize() {
+    assert(deinitializeFn);
+    deinitializeFn(context);
+}
+
 void CustomLayer::Impl::render(const TransformState& state) const {
     assert(renderFn);
 

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -23,11 +23,7 @@ CustomLayer::Impl::Impl(const CustomLayer::Impl& other)
     // Don't copy anything else.
 }
 
-CustomLayer::Impl::~Impl() {
-    if (deinitializeFn) {
-        deinitializeFn(context);
-    }
-}
+CustomLayer::Impl::~Impl() = default;
 
 std::unique_ptr<Layer> CustomLayer::Impl::clone() const {
     return std::make_unique<CustomLayer>(*this);
@@ -44,8 +40,9 @@ void CustomLayer::Impl::initialize() {
 }
 
 void CustomLayer::Impl::deinitialize() {
-    assert(deinitializeFn);
-    deinitializeFn(context);
+    if (deinitializeFn) {
+        deinitializeFn(context);
+    }
 }
 
 void CustomLayer::Impl::render(const TransformState& state) const {

--- a/src/mbgl/style/layers/custom_layer_impl.hpp
+++ b/src/mbgl/style/layers/custom_layer_impl.hpp
@@ -21,6 +21,7 @@ public:
     ~Impl() final;
 
     void initialize();
+    void deinitialize();
     void render(const TransformState&) const;
 
 private:

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -51,6 +51,12 @@ Style::~Style() {
         source->baseImpl->setObserver(nullptr);
     }
 
+    for (const auto& layer : layers) {
+        if (CustomLayer* customLayer = layer->as<CustomLayer>()) {
+            customLayer->impl->deinitialize();
+        }
+    }
+
     glyphAtlas->setObserver(nullptr);
     spriteAtlas->setObserver(nullptr);
 }

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -134,7 +134,7 @@ void Style::addSource(std::unique_ptr<Source> source) {
     sources.emplace_back(std::move(source));
 }
 
-void Style::removeSource(const std::string& id) {
+std::unique_ptr<Source> Style::removeSource(const std::string& id) {
     auto it = std::find_if(sources.begin(), sources.end(), [&](const auto& source) {
         return source->getID() == id;
     });
@@ -143,8 +143,11 @@ void Style::removeSource(const std::string& id) {
         throw std::runtime_error("no such source");
     }
 
+    auto source = std::move(*it);
     sources.erase(it);
     updateBatch.sourceIDs.erase(id);
+
+    return source;
 }
 
 std::vector<const Layer*> Style::getLayers() const {
@@ -185,11 +188,17 @@ Layer* Style::addLayer(std::unique_ptr<Layer> layer, optional<std::string> befor
     return layers.emplace(before ? findLayer(*before) : layers.end(), std::move(layer))->get();
 }
 
-void Style::removeLayer(const std::string& id) {
-    auto it = findLayer(id);
+std::unique_ptr<Layer> Style::removeLayer(const std::string& id) {
+    auto it = std::find_if(layers.begin(), layers.end(), [&](const auto& layer) {
+        return layer->baseImpl->id == id;
+    });
+
     if (it == layers.end())
         throw std::runtime_error("no such layer");
+
+    auto layer = std::move(*it);
     layers.erase(it);
+    return layer;
 }
 
 std::string Style::getName() const {

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -197,6 +197,11 @@ std::unique_ptr<Layer> Style::removeLayer(const std::string& id) {
         throw std::runtime_error("no such layer");
 
     auto layer = std::move(*it);
+
+    if (CustomLayer* customLayer = layer->as<CustomLayer>()) {
+        customLayer->impl->deinitialize();
+    }
+
     layers.erase(it);
     return layer;
 }

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -66,13 +66,13 @@ public:
 
     Source* getSource(const std::string& id) const;
     void addSource(std::unique_ptr<Source>);
-    void removeSource(const std::string& sourceID);
+    std::unique_ptr<Source> removeSource(const std::string& sourceID);
 
     std::vector<const Layer*> getLayers() const;
     Layer* getLayer(const std::string& id) const;
     Layer* addLayer(std::unique_ptr<Layer>,
                     optional<std::string> beforeLayerID = {});
-    void removeLayer(const std::string& layerID);
+    std::unique_ptr<Layer> removeLayer(const std::string& layerID);
 
     std::string getName() const;
     LatLng getDefaultLatLng() const;


### PR DESCRIPTION
When a source or layer is removed transfer ownership back to the caller so it can (optionally) take it.

ref https://github.com/mapbox/mapbox-gl-native/issues/6959

cc @jfirebaugh 