### PR TITLE
Default Style Camera on Android

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
@@ -16,6 +16,8 @@ import static com.mapbox.mapboxsdk.utils.MathUtils.convertNativeBearing;
  */
 public final class CameraPosition implements Parcelable {
 
+    public static final CameraPosition DEFAULT = new CameraPosition(new LatLng(), 0, 0, 0);
+
     public static final Parcelable.Creator<CameraPosition> CREATOR
             = new Parcelable.Creator<CameraPosition>() {
         public CameraPosition createFromParcel(Parcel in) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -263,7 +263,7 @@ public class MapView extends FrameLayout {
         mapboxMap.setDebugActive(options.getDebugActive());
 
         CameraPosition position = options.getCamera();
-        if (position != null) {
+        if (!position.equals(CameraPosition.DEFAULT)) {
             mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(position));
             myLocationView.setTilt(position.tilt);
         }

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -492,7 +492,6 @@ void Map::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, con
 }
 
 LatLng Map::getLatLng(optional<EdgeInsets> padding) const {
-    impl->cameraMutated = true;
     return impl->transform.getLatLng(padding);
 }
 


### PR DESCRIPTION
Follow up from https://github.com/mapbox/mapbox-gl-native/pull/6989. When trying to make it work on android I noticed that `getLatLng` also set cameraMutated to true. This PR fixes this up + corrects the check in java code to validate if no camera position was provided.

```cpp
LatLng Map::getLatLng(optional<EdgeInsets> padding) const {
    impl->cameraMutated = true;
    return impl->transform.getLatLng(padding);
}
```

Review @jfirebaugh 