### PR TITLE
Prevent duplicate symbol placement requests

### DIFF
--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -57,11 +57,12 @@ void GeometryTile::setData(std::unique_ptr<const GeometryTileData> data_) {
 }
 
 void GeometryTile::setPlacementConfig(const PlacementConfig& desiredConfig) {
-    if (placedConfig == desiredConfig) {
+    if (requestedConfig == desiredConfig) {
         return;
     }
 
     ++correlationID;
+    requestedConfig = desiredConfig;
     worker.invoke(&GeometryTileWorker::setPlacementConfig, desiredConfig, correlationID);
 }
 
@@ -112,7 +113,6 @@ void GeometryTile::onPlacement(PlacementResult result) {
         buckets[bucket.first] = std::move(bucket.second);
     }
     featureIndex->setCollisionTile(std::move(result.collisionTile));
-    placedConfig = result.placedConfig;
     observer->onTileChanged(*this);
 }
 

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -61,7 +61,6 @@ public:
     public:
         std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
         std::unique_ptr<CollisionTile> collisionTile;
-        PlacementConfig placedConfig;
         uint64_t correlationID;
     };
     void onPlacement(PlacementResult);
@@ -79,7 +78,7 @@ private:
     Actor<GeometryTileWorker> worker;
 
     uint64_t correlationID = 0;
-    optional<PlacementConfig> placedConfig;
+    optional<PlacementConfig> requestedConfig;
 
     std::unordered_map<std::string, std::unique_ptr<Bucket>> buckets;
     std::unique_ptr<FeatureIndex> featureIndex;

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -321,7 +321,6 @@ void GeometryTileWorker::attemptPlacement() {
     parent.invoke(&GeometryTile::onPlacement, GeometryTile::PlacementResult {
         std::move(buckets),
         std::move(collisionTile),
-        *placementConfig,
         correlationID
     });
 }


### PR DESCRIPTION
In some situations, we are doing the same symbol placement request multiple times:

- placement configuration changed => triggers request
- rerender trigger update, which triggers a null change, but since the original request didn't complete yet, we are starting another placement request