### PR TITLE
[Qt] Copy headers to build path in 'qt-lib' target

### DIFF
--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -92,3 +92,11 @@ else()
         PRIVATE -lGL
     )
 endif()
+
+add_custom_command(
+    TARGET qmapboxgl
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/platform/qt/include
+            ${CMAKE_CURRENT_BINARY_DIR}/platform/qt/include
+)


### PR DESCRIPTION
This post-build step for `qmapboxgl` target copies the `platform/qt/include` folder into build path.

/cc @assanegu