### PR TITLE
[android] Update GLSL + ensure binding to OpenGL ES 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ejs": "^2.4.1",
     "express": "^4.11.1",
     "lodash": "^4.16.4",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#7f1c3bef3692f1d044035a22e65c8758b7630333",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#ec891ce5360e488d81f60991f95d2038b83c4e3c",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#7f62a4fc9f21e619824d68abbc4b03cbc1685572",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#af9ee275f19e81f839a2733e6906c3fac272620e",
     "mkdirp": "^0.5.1",

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -57,8 +57,6 @@ public:
 private:
     EGLConfig chooseConfig(const EGLConfig configs[], EGLint numConfigs);
 
-    bool inEmulator();
-
 private:
     JavaVM *vm = nullptr;
     JNIEnv *env = nullptr;


### PR DESCRIPTION
Thanks to @masterjefferson [logcat](https://github.com/mapbox/mapbox-gl-native/issues/6400#issuecomment-250237354), we've found the root cause for the crashes using Android emulator Hardware OpenGL ES 2.0 support - in particular:
```
ERROR: 0:6: error(#101) Macro redefined: lowp
ERROR: 0:7: error(#101) Macro redefined: mediump
ERROR: 0:8: error(#101) Macro redefined: highp
```

This means that the shader compiler was already defining those macros for non-GLSL ES shader code. I have a PR in https://github.com/mapbox/mapbox-gl-shaders/pull/36 that checks if those macros are already defined, and also ensure NativeMapView that we're binding to the [EGL's OpenGL ES 2.0 API](https://www.khronos.org/registry/egl/sdk/docs/man/html/eglBindAPI.xhtml).

Fixes the issues mentioned in #2995 and #6400.

/cc @kkaefer @mapbox/android 