### PR TITLE
[ios, macos] Take back source and layer ownership on removal

### DIFF
--- a/platform/darwin/src/MGLBackgroundStyleLayer.mm
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.mm
@@ -32,6 +32,31 @@
 }
 
 
+
+#pragma mark -  Adding to and removing from a map view
+
+- (void)addToMapView:(MGLMapView *)mapView
+{
+    [self addToMapView:mapView belowLayer:nil];
+}
+
+- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
+{
+    if (otherLayer) {
+        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
+        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
+    } else {
+        mapView.mbglMap->addLayer(std::move(_pendingLayer));
+    }
+}
+
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
+    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::BackgroundLayer> &>(removedLayer));
+    self.rawLayer = _pendingLayer.get();
+}
+
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setBackgroundColor:(MGLStyleValue<MGLColor *> *)backgroundColor {
@@ -64,22 +89,5 @@
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
-
-#pragma mark - Add style layer to map
-
-- (void)addToMapView:(MGLMapView *)mapView
-{
-    [self addToMapView:mapView belowLayer:nil];
-}
-
-- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
-{
-    if (otherLayer) {
-        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
-        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
-    } else {
-        mapView.mbglMap->addLayer(std::move(_pendingLayer));
-    }
-}
 
 @end

--- a/platform/darwin/src/MGLCircleStyleLayer.mm
+++ b/platform/darwin/src/MGLCircleStyleLayer.mm
@@ -53,6 +53,31 @@
     return [NSPredicate mgl_predicateWithFilter:self.rawLayer->getFilter()];
 }
 
+
+#pragma mark -  Adding to and removing from a map view
+
+- (void)addToMapView:(MGLMapView *)mapView
+{
+    [self addToMapView:mapView belowLayer:nil];
+}
+
+- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
+{
+    if (otherLayer) {
+        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
+        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
+    } else {
+        mapView.mbglMap->addLayer(std::move(_pendingLayer));
+    }
+}
+
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
+    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::CircleLayer> &>(removedLayer));
+    self.rawLayer = _pendingLayer.get();
+}
+
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setCircleRadius:(MGLStyleValue<NSNumber *> *)circleRadius {
@@ -125,22 +150,5 @@
     return MGLStyleValueTransformer<mbgl::style::CirclePitchScaleType, NSValue *>().toStyleValue(propertyValue);
 }
 
-
-#pragma mark - Add style layer to map
-
-- (void)addToMapView:(MGLMapView *)mapView
-{
-    [self addToMapView:mapView belowLayer:nil];
-}
-
-- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
-{
-    if (otherLayer) {
-        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
-        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
-    } else {
-        mapView.mbglMap->addLayer(std::move(_pendingLayer));
-    }
-}
 
 @end

--- a/platform/darwin/src/MGLGeoJSONSource.mm
+++ b/platform/darwin/src/MGLGeoJSONSource.mm
@@ -64,6 +64,14 @@ const MGLGeoJSONSourceOption MGLGeoJSONSourceOptionSimplificationTolerance = @"M
     mapView.mbglMap->addSource(std::move(_pendingSource));
 }
 
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedSource = mapView.mbglMap->removeSource(self.identifier.UTF8String);
+
+    _pendingSource = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::GeoJSONSource> &>(removedSource));
+    self.rawSource = _pendingSource.get();
+}
+
 - (void)commonInit
 {
     auto source = std::make_unique<mbgl::style::GeoJSONSource>(self.identifier.UTF8String, self.geoJSONOptions);

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -53,6 +53,31 @@
     return [NSPredicate mgl_predicateWithFilter:self.rawLayer->getFilter()];
 }
 
+
+#pragma mark -  Adding to and removing from a map view
+
+- (void)addToMapView:(MGLMapView *)mapView
+{
+    [self addToMapView:mapView belowLayer:nil];
+}
+
+- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
+{
+    if (otherLayer) {
+        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
+        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
+    } else {
+        mapView.mbglMap->addLayer(std::move(_pendingLayer));
+    }
+}
+
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
+    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::LineLayer> &>(removedLayer));
+    self.rawLayer = _pendingLayer.get();
+}
+
 #pragma mark - Accessing the Layout Attributes
 
 - (void)setLineCap:(MGLStyleValue<NSValue *> *)lineCap {
@@ -197,22 +222,5 @@
     return MGLStyleValueTransformer<std::string, NSString *>().toStyleValue(propertyValue);
 }
 
-
-#pragma mark - Add style layer to map
-
-- (void)addToMapView:(MGLMapView *)mapView
-{
-    [self addToMapView:mapView belowLayer:nil];
-}
-
-- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
-{
-    if (otherLayer) {
-        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
-        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
-    } else {
-        mapView.mbglMap->addLayer(std::move(_pendingLayer));
-    }
-}
 
 @end

--- a/platform/darwin/src/MGLRasterSource.mm
+++ b/platform/darwin/src/MGLRasterSource.mm
@@ -65,4 +65,12 @@
     mapView.mbglMap->addSource(std::move(_pendingSource));
 }
 
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedSource = mapView.mbglMap->removeSource(self.identifier.UTF8String);
+
+    _pendingSource = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::RasterSource> &>(removedSource));
+    self.rawSource = _pendingSource.get();
+}
+
 @end

--- a/platform/darwin/src/MGLRasterStyleLayer.mm
+++ b/platform/darwin/src/MGLRasterStyleLayer.mm
@@ -32,6 +32,31 @@
 }
 
 
+
+#pragma mark -  Adding to and removing from a map view
+
+- (void)addToMapView:(MGLMapView *)mapView
+{
+    [self addToMapView:mapView belowLayer:nil];
+}
+
+- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
+{
+    if (otherLayer) {
+        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
+        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
+    } else {
+        mapView.mbglMap->addLayer(std::move(_pendingLayer));
+    }
+}
+
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
+    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::RasterLayer> &>(removedLayer));
+    self.rawLayer = _pendingLayer.get();
+}
+
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setRasterOpacity:(MGLStyleValue<NSNumber *> *)rasterOpacity {
@@ -104,22 +129,5 @@
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
-
-#pragma mark - Add style layer to map
-
-- (void)addToMapView:(MGLMapView *)mapView
-{
-    [self addToMapView:mapView belowLayer:nil];
-}
-
-- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
-{
-    if (otherLayer) {
-        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
-        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
-    } else {
-        mapView.mbglMap->addLayer(std::move(_pendingLayer));
-    }
-}
 
 @end

--- a/platform/darwin/src/MGLSource_Private.h
+++ b/platform/darwin/src/MGLSource_Private.h
@@ -28,4 +28,13 @@
  */
 - (void)addToMapView:(MGLMapView *)mapView;
 
+/**
+ Removes the mbgl source that this object represents from the mbgl map.
+ 
+ When a mbgl source is removed, ownership of the object is transferred back
+ to the `MGLSource` instance and the unique_ptr reference is valid again. It is
+ safe to add the source back to the style after it is removed.
+ */
+- (void)removeFromMapView:(MGLMapView *)mapView;
+
 @end

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -168,7 +168,7 @@ static NSURL *MGLStyleURL_emerald;
 
 - (void)removeLayer:(MGLStyleLayer *)layer
 {
-    self.mapView.mbglMap->removeLayer(layer.identifier.UTF8String);
+    [layer removeFromMapView:self.mapView];    
 }
 
 - (void)addLayer:(MGLStyleLayer *)layer
@@ -209,12 +209,7 @@ static NSURL *MGLStyleURL_emerald;
 
 - (void)removeSource:(MGLSource *)source
 {
-    self.mapView.mbglMap->removeSource(source.identifier.UTF8String);
-    
-    // Once a mbgl source is removed from the map, ownership does not return
-    // to the MGL source. Therefore, the rawSource pointer is set to NULL
-    // so that the implementation of MGL source can avoid using it again.
-    source.rawSource = NULL;
+    [source removeFromMapView:self.mapView];
 }
 
 - (NS_ARRAY_OF(NSString *) *)styleClasses

--- a/platform/darwin/src/MGLStyleLayer.mm.ejs
+++ b/platform/darwin/src/MGLStyleLayer.mm.ejs
@@ -73,6 +73,31 @@
 }
 
 <% } -%>
+
+#pragma mark -  Adding to and removing from a map view
+
+- (void)addToMapView:(MGLMapView *)mapView
+{
+    [self addToMapView:mapView belowLayer:nil];
+}
+
+- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
+{
+    if (otherLayer) {
+        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
+        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
+    } else {
+        mapView.mbglMap->addLayer(std::move(_pendingLayer));
+    }
+}
+
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
+    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::<%- camelize(type) %>Layer> &>(removedLayer));
+    self.rawLayer = _pendingLayer.get();
+}
+
 <% if (layoutProperties.length) { -%>
 #pragma mark - Accessing the Layout Attributes
 
@@ -105,22 +130,5 @@
 
 <% } -%>
 <% } -%>
-
-#pragma mark - Add style layer to map
-
-- (void)addToMapView:(MGLMapView *)mapView
-{
-    [self addToMapView:mapView belowLayer:nil];
-}
-
-- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
-{
-    if (otherLayer) {
-        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
-        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
-    } else {
-        mapView.mbglMap->addLayer(std::move(_pendingLayer));
-    }
-}
 
 @end

--- a/platform/darwin/src/MGLStyleLayer_Private.h
+++ b/platform/darwin/src/MGLStyleLayer_Private.h
@@ -29,11 +29,18 @@
  */
 - (void)addToMapView:(MGLMapView *)mapView;
 
-
+/**
+ Removes the mbgl style layer that this object represents from the mbgl map.
+ 
+ When a mbgl style layer is removed, ownership of the object is transferred back
+ to the `MGLStyleLayer` instance and the unique_ptr reference is valid again. It 
+ is safe to add the layer back to the style after it is removed.
+ */
+- (void)removeFromMapView:(MGLMapView *)mapView;
 
 /**
  Adds the mbgl style layer that this object represents to the mbgl map below the specified `otherLayer`.
- 
+
  Once a mbgl style layer is added, ownership of the object is transferred to the
  `mbgl::Map` and this object no longer has an active unique_ptr reference to the
  `mbgl::style::Layer`.

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -53,6 +53,31 @@
     return [NSPredicate mgl_predicateWithFilter:self.rawLayer->getFilter()];
 }
 
+
+#pragma mark -  Adding to and removing from a map view
+
+- (void)addToMapView:(MGLMapView *)mapView
+{
+    [self addToMapView:mapView belowLayer:nil];
+}
+
+- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
+{
+    if (otherLayer) {
+        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
+        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
+    } else {
+        mapView.mbglMap->addLayer(std::move(_pendingLayer));
+    }
+}
+
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
+    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::SymbolLayer> &>(removedLayer));
+    self.rawLayer = _pendingLayer.get();
+}
+
 #pragma mark - Accessing the Layout Attributes
 
 - (void)setSymbolPlacement:(MGLStyleValue<NSValue *> *)symbolPlacement {
@@ -537,22 +562,5 @@
     return MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *>().toStyleValue(propertyValue);
 }
 
-
-#pragma mark - Add style layer to map
-
-- (void)addToMapView:(MGLMapView *)mapView
-{
-    [self addToMapView:mapView belowLayer:nil];
-}
-
-- (void)addToMapView:(MGLMapView *)mapView belowLayer:(MGLStyleLayer *)otherLayer
-{
-    if (otherLayer) {
-        const mbgl::optional<std::string> belowLayerId{otherLayer.identifier.UTF8String};
-        mapView.mbglMap->addLayer(std::move(_pendingLayer), belowLayerId);
-    } else {
-        mapView.mbglMap->addLayer(std::move(_pendingLayer));
-    }
-}
 
 @end

--- a/platform/darwin/src/MGLVectorSource.mm
+++ b/platform/darwin/src/MGLVectorSource.mm
@@ -64,4 +64,12 @@ static NSString *MGLVectorSourceType   = @"vector";
     mapView.mbglMap->addSource(std::move(_pendingSource));
 }
 
+- (void)removeFromMapView:(MGLMapView *)mapView
+{
+    auto removedSource = mapView.mbglMap->removeSource(self.identifier.UTF8String);
+
+    _pendingSource = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::VectorSource> &>(removedSource));
+    self.rawSource = _pendingSource.get();
+}
+
 @end


### PR DESCRIPTION
If a source or layer is removed from the style, recapture the unique pointer ownership. This makes it safe to add back sources and layers after they have been removed.

Fixes iOS and macOS portion of https://github.com/mapbox/mapbox-gl-native/issues/6959

cc @1ec5 @frederoni @incanus 