### PR TITLE
Switch Node Linux binary builds back to GLX/xvfb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,26 +54,42 @@ after_success:
 
 matrix:
   include:
-    # Clang 3.8 - Debug - Node
+    # OSMesa - Node - Clang 3.8 - Debug
     - os: linux
       sudo: required
       dist: trusty
       language: node
-      compiler: "node4-clang38-debug"
-      env: _CXX=clang++-3.8 _CC=clang-3.8 WITH_OSMESA=1
+      compiler: "osmesa-node4-clang38-debug"
+      env: BUILDTYPE=Debug _CXX=clang++-3.8 _CC=clang-3.8 WITH_OSMESA=1
       addons: *clang38
-      before_script:
-        - export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-        - export PUBLISH=$([[ "${TRAVIS_TAG:-}" == "node-v${PACKAGE_JSON_VERSION}" ]] && echo true)
-        - export BUILDTYPE=$([[ -n ${PUBLISH:-} ]] && echo "Release" || echo "Debug")
       script:
         - nvm install 4
         - nvm use 4
         - make node
-        - if [[ -z ${PUBLISH} ]]; then make test-node; fi
+        - make test-node
       after_script:
         - ccache --show-stats
         - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
+
+    # GLX - Node - Clang 3.8 - Release
+    - os: linux
+      sudo: required
+      dist: trusty
+      language: node
+      compiler: "glx-node4-clang38-release"
+      env: BUILDTYPE=Release _CXX=clang++-3.8 _CC=clang-3.8 RUN_XVFB=1
+      addons: *clang38
+      before_script:
+        - export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
+        - export PUBLISH=$([[ "${TRAVIS_TAG:-}" == "node-v${PACKAGE_JSON_VERSION}" ]] && echo true)
+      script:
+        - nvm install 4
+        - nvm use 4
+        - make node
+      after_script:
+        - ccache --show-stats
+      after_success:
+        - ./platform/node/scripts/after_success.sh
 
     # GCC 5 - Debug - Coverage
     # FIXME: https://github.com/mapbox/mapbox-gl-native/issues/6918

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-native",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.2 - Novmeber 15, 2016
+
+- Switches back to publishing Linux binaries with GLX, to eliminate a runtime dependency on `libOSMesa.so.8` and enable dynamically linking against `libGL.so` provided by an alternate implementation, such as the NVIDIA proproetary drivers ([#7503](https://github.com/mapbox/mapbox-gl-native/pull/7053))
+
 # 3.4.1 - Novmeber 10, 2016
 
 - Skips assigning clip IDs to tiles that won't be rendered, mitigating a `stencil mask overflow` error ([#6871](https://github.com/mapbox/mapbox-gl-native/pull/6871))

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -56,6 +56,7 @@ workflows:
             #!/bin/bash
             set -eu -o pipefail
             make test-node || envman add --key RESULT --value $?
+            ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
     - script:
         title: Run publish script
         run_if: '{{enveq "SKIPCI" "false"}}'
@@ -63,7 +64,7 @@ workflows:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
-            ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
+            ./platform/node/scripts/after_success.sh
             exit ${RESULT:-0}
     - slack:
         title: Post to Slack

--- a/platform/node/scripts/after_script.sh
+++ b/platform/node/scripts/after_script.sh
@@ -5,19 +5,10 @@ set -o pipefail
 
 JOB=$1
 
-if [[ -n ${PUBLISH:-} ]]; then
-    if [[ "${BUILDTYPE}" == "Debug" ]]; then
-        echo "Please run this script in release mode (BUILDTYPE=Release)."
-        exit 1
-    else
-        ./node_modules/.bin/node-pre-gyp package publish info
-    fi
-else
-    if [ ! -z "${AWS_ACCESS_KEY_ID}" ] && [ ! -z "${AWS_SECRET_ACCESS_KEY}" ] ; then
-        gzip --stdout node_modules/mapbox-gl-test-suite/render-tests/index.html | \
-            aws s3 cp --acl public-read --content-encoding gzip --content-type text/html \
-                - s3://mapbox/mapbox-gl-native/render-tests/$JOB/index.html
+if [ ! -z "${AWS_ACCESS_KEY_ID}" ] && [ ! -z "${AWS_SECRET_ACCESS_KEY}" ] ; then
+    gzip --stdout node_modules/mapbox-gl-test-suite/render-tests/index.html | \
+        aws s3 cp --acl public-read --content-encoding gzip --content-type text/html \
+            - s3://mapbox/mapbox-gl-native/render-tests/$JOB/index.html
 
-        echo http://mapbox.s3.amazonaws.com/mapbox-gl-native/render-tests/$JOB/index.html
-    fi
+    echo http://mapbox.s3.amazonaws.com/mapbox-gl-native/render-tests/$JOB/index.html
 fi

--- a/platform/node/scripts/after_success.sh
+++ b/platform/node/scripts/after_success.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+if [[ -n ${PUBLISH:-} ]]; then
+    if [[ "${BUILDTYPE}" == "Debug" ]]; then
+        echo "Please run this script in release mode (BUILDTYPE=Release)."
+        exit 1
+    else
+        ./node_modules/.bin/node-pre-gyp package publish info
+    fi
+fi


### PR DESCRIPTION
Switches Node.js Linux binary builds from OSMesa back to GLX/xvfb to remove a runtime dependency on `libOSMesa.so.8` and allow `libGL.so` to be supplied at runtime by alternate implementations, like the NVIDIA proprietary drivers for rendering on hardware GPUs.

/cc @brunoabinader @springmeyer