### PR TITLE
Return to static, per-segment approach to VAOs

### DIFF
--- a/src/mbgl/gl/attribute.cpp
+++ b/src/mbgl/gl/attribute.cpp
@@ -4,8 +4,9 @@
 namespace mbgl {
 namespace gl {
 
-AttributeLocation attributeLocation(ProgramID id, const char* name) {
-    return MBGL_CHECK_ERROR(glGetAttribLocation(id, name));
+AttributeLocation bindAttributeLocation(ProgramID id, AttributeLocation location, const char* name) {
+    MBGL_CHECK_ERROR(glBindAttribLocation(id, location, name));
+    return location;
 }
 
 void bindAttribute(AttributeLocation location,

--- a/src/mbgl/gl/attribute.hpp
+++ b/src/mbgl/gl/attribute.hpp
@@ -17,6 +17,9 @@ public:
 
     class State {
     public:
+        explicit State(AttributeLocation location_)
+            : location(location_) {}
+
         AttributeLocation location;
         static constexpr std::size_t count = N;
         static constexpr DataType type = DataTypeOf<T>::value;
@@ -130,7 +133,7 @@ const std::size_t Vertex<A1, A2, A3, A4, A5>::attributeOffsets[5] = {
 
 } // namespace detail
 
-AttributeLocation attributeLocation(ProgramID, const char * name);
+AttributeLocation bindAttributeLocation(ProgramID, AttributeLocation, const char * name);
 
 void bindAttribute(AttributeLocation location,
                    std::size_t count,
@@ -149,7 +152,7 @@ public:
     static constexpr std::size_t Index = TypeIndex<A, As...>::value;
 
     static State state(const ProgramID& id) {
-        return State { { attributeLocation(id, As::name) }... };
+        return State { typename As::State(bindAttributeLocation(id, Index<As>, As::name))... };
     }
 
     static std::function<void (std::size_t)> binder(const State& state) {

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -6,7 +6,7 @@
 #include <mbgl/util/std.hpp>
 #include <mbgl/platform/log.hpp>
 
-#include <boost/functional/hash.hpp>
+#include <cstring>
 
 namespace mbgl {
 namespace gl {
@@ -434,15 +434,6 @@ PrimitiveType Context::operator()(const TriangleStrip&) {
     return PrimitiveType::TriangleStrip;
 }
 
-std::size_t Context::VertexArrayObjectHash::operator()(const VertexArrayObjectKey& key) const {
-    std::size_t seed = 0;
-    boost::hash_combine(seed, std::get<0>(key));
-    boost::hash_combine(seed, std::get<1>(key));
-    boost::hash_combine(seed, std::get<2>(key));
-    boost::hash_combine(seed, std::get<3>(key));
-    return seed;
-}
-
 void Context::setDepthMode(const DepthMode& depth) {
     if (depth.func == DepthMode::Always && !depth.mask) {
         depthTest = false;
@@ -503,23 +494,15 @@ void Context::draw(const Drawable& drawable) {
                 return true;
             }
 
-            VertexArrayObjectKey vaoKey {
-                drawable.program,
-                drawable.vertexBuffer,
-                drawable.indexBuffer,
-                segment.vertexOffset
-            };
-
-            auto it = vaos.find(vaoKey);
-            if (it != vaos.end()) {
-                vertexArrayObject = it->second;
+            if (segment.vao) {
+                vertexArrayObject = *segment.vao;
                 return false;
             }
 
             VertexArrayID id = 0;
             MBGL_CHECK_ERROR(gl::GenVertexArrays(1, &id));
             vertexArrayObject = id;
-            vaos.emplace(vaoKey, UniqueVertexArray(std::move(id), { this }));
+            segment.vao = UniqueVertexArray(std::move(id), { this });
 
             // If we are initializing a new VAO, we need to force the buffers
             // to be rebound. VAOs don't inherit the existing buffer bindings.
@@ -555,9 +538,6 @@ void Context::performCleanup() {
         if (program == id) {
             program.setDirty();
         }
-        mbgl::util::erase_if(vaos, [&] (const VertexArrayObjectMap::value_type& kv) {
-            return std::get<0>(kv.first) == id;
-        });
         MBGL_CHECK_ERROR(glDeleteProgram(id));
     }
     abandonedPrograms.clear();
@@ -574,10 +554,6 @@ void Context::performCleanup() {
             } else if (elementBuffer == id) {
                 elementBuffer.setDirty();
             }
-            mbgl::util::erase_if(vaos, [&] (const VertexArrayObjectMap::value_type& kv) {
-                return std::get<1>(kv.first) == id
-                    || std::get<2>(kv.first) == id;
-            });
         }
         MBGL_CHECK_ERROR(glDeleteBuffers(int(abandonedBuffers.size()), abandonedBuffers.data()));
         abandonedBuffers.clear();

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -68,19 +68,24 @@ UniqueProgram Context::createProgram(ShaderID vertexShader, ShaderID fragmentSha
 
     MBGL_CHECK_ERROR(glAttachShader(result, vertexShader));
     MBGL_CHECK_ERROR(glAttachShader(result, fragmentShader));
-    MBGL_CHECK_ERROR(glLinkProgram(result));
+
+    return result;
+}
+
+void Context::linkProgram(ProgramID program_) {
+    MBGL_CHECK_ERROR(glLinkProgram(program_));
 
     GLint status;
-    MBGL_CHECK_ERROR(glGetProgramiv(result, GL_LINK_STATUS, &status));
-    if (status != 0) {
-        return result;
+    MBGL_CHECK_ERROR(glGetProgramiv(program_, GL_LINK_STATUS, &status));
+    if (status == GL_TRUE) {
+        return;
     }
 
     GLint logLength;
-    MBGL_CHECK_ERROR(glGetProgramiv(result, GL_INFO_LOG_LENGTH, &logLength));
+    MBGL_CHECK_ERROR(glGetProgramiv(program_, GL_INFO_LOG_LENGTH, &logLength));
     const auto log = std::make_unique<GLchar[]>(logLength);
     if (logLength > 0) {
-        MBGL_CHECK_ERROR(glGetProgramInfoLog(result, logLength, &logLength, log.get()));
+        MBGL_CHECK_ERROR(glGetProgramInfoLog(program_, logLength, &logLength, log.get()));
         Log::Error(Event::Shader, "Program failed to link: %s", log.get());
     }
 

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -38,6 +38,7 @@ public:
 
     UniqueShader createShader(ShaderType type, const std::string& source);
     UniqueProgram createProgram(ShaderID vertexShader, ShaderID fragmentShader);
+    void linkProgram(ProgramID);
     UniqueTexture createTexture();
 
     template <class Vertex, class DrawMode>

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -233,20 +233,6 @@ private:
     std::vector<VertexArrayID> abandonedVertexArrays;
     std::vector<FramebufferID> abandonedFramebuffers;
     std::vector<RenderbufferID> abandonedRenderbuffers;
-
-    using VertexArrayObjectKey = std::tuple<
-        ProgramID,  // Program
-        BufferID,   // Vertex buffer
-        BufferID,   // Index buffer
-        std::size_t // Vertex buffer offset
-    >;
-
-    struct VertexArrayObjectHash {
-        std::size_t operator()(const VertexArrayObjectKey&) const;
-    };
-
-    using VertexArrayObjectMap = std::unordered_map<VertexArrayObjectKey, UniqueVertexArray, VertexArrayObjectHash>;
-    VertexArrayObjectMap vaos;
 };
 
 } // namespace gl

--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -30,7 +30,7 @@ public:
           fragmentShader(context.createShader(ShaderType::Fragment, fragmentSource)),
           program(context.createProgram(vertexShader, fragmentShader)),
           attributesState(Attributes::state(program)),
-          uniformsState(Uniforms::state(program)) {}
+          uniformsState((context.linkProgram(program), Uniforms::state(program))) {}
 
     // Indexed drawing.
     template <class DrawMode>

--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -42,7 +42,7 @@ public:
               UniformValues&& uniformValues,
               const VertexBuffer<Vertex>& vertexBuffer,
               const IndexBuffer<DrawMode>& indexBuffer,
-              const std::vector<Segment>& segments) {
+              const SegmentVector<Attributes>& segments) {
         static_assert(std::is_same<Primitive, typename DrawMode::Primitive>::value, "incompatible draw mode");
         context.draw({
             std::move(drawMode),
@@ -66,7 +66,8 @@ public:
               StencilMode stencilMode,
               ColorMode colorMode,
               UniformValues&& uniformValues,
-              const VertexBuffer<Vertex, DrawMode>& vertexBuffer) {
+              const VertexBuffer<Vertex, DrawMode>& vertexBuffer,
+              const SegmentVector<Attributes>& segments) {
         static_assert(std::is_same<Primitive, typename DrawMode::Primitive>::value, "incompatible draw mode");
         context.draw({
             std::move(drawMode),
@@ -76,7 +77,7 @@ public:
             program,
             vertexBuffer.buffer,
             0,
-            {{ 0, 0, vertexBuffer.vertexCount, 0 }},
+            segments,
             Uniforms::binder(uniformsState, std::move(uniformValues)),
             Attributes::binder(attributesState)
         });

--- a/src/mbgl/gl/segment.hpp
+++ b/src/mbgl/gl/segment.hpp
@@ -23,5 +23,18 @@ public:
     std::size_t indexLength;
 };
 
+template <class Attributes>
+class SegmentVector : public std::vector<Segment> {
+public:
+    SegmentVector() = default;
+
+    // This constructor is for unindexed rendering. It creates a SegmentVector with a
+    // single segment having 0 indexes.
+    template <class DrawMode>
+    SegmentVector(const VertexBuffer<typename Attributes::Vertex, DrawMode>& buffer) {
+        emplace_back(0, 0, buffer.vertexCount, 0);
+    }
+};
+
 } // namespace gl
 } // namespace mbgl

--- a/src/mbgl/gl/segment.hpp
+++ b/src/mbgl/gl/segment.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mbgl/util/optional.hpp>
+
 #include <cstddef>
 
 namespace mbgl {
@@ -21,6 +23,10 @@ public:
 
     std::size_t vertexLength;
     std::size_t indexLength;
+
+private:
+    friend class Context;
+    mutable optional<UniqueVertexArray> vao;
 };
 
 template <class Attributes>

--- a/src/mbgl/programs/circle_program.hpp
+++ b/src/mbgl/programs/circle_program.hpp
@@ -14,11 +14,13 @@ MBGL_DEFINE_UNIFORM_SCALAR(bool, u_scale_with_map);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_devicepixelratio);
 } // namespace uniforms
 
+using CircleAttributes = gl::Attributes<
+    attributes::a_pos>;
+
 class CircleProgram : public Program<
     shaders::circle,
     gl::Triangle,
-    gl::Attributes<
-        attributes::a_pos>,
+    CircleAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
         uniforms::u_opacity,

--- a/src/mbgl/programs/collision_box_program.hpp
+++ b/src/mbgl/programs/collision_box_program.hpp
@@ -15,13 +15,15 @@ MBGL_DEFINE_UNIFORM_SCALAR(float, u_scale);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_maxzoom);
 } // namespace uniforms
 
+using CollisionBoxAttributes = gl::Attributes<
+    attributes::a_pos,
+    attributes::a_extrude,
+    attributes::a_data<2>>;
+
 class CollisionBoxProgram : public Program<
     shaders::collision_box,
     gl::Line,
-    gl::Attributes<
-        attributes::a_pos,
-        attributes::a_extrude,
-        attributes::a_data<2>>,
+    CollisionBoxAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
         uniforms::u_scale,

--- a/src/mbgl/programs/debug_program.hpp
+++ b/src/mbgl/programs/debug_program.hpp
@@ -7,11 +7,13 @@
 
 namespace mbgl {
 
+using DebugAttributes = gl::Attributes<
+    attributes::a_pos>;
+
 class DebugProgram : public Program<
     shaders::debug,
     gl::Line,
-    gl::Attributes<
-        attributes::a_pos>,
+    DebugAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
         uniforms::u_color>>
@@ -19,5 +21,7 @@ class DebugProgram : public Program<
 public:
     using Program::Program;
 };
+
+using DebugVertex = DebugProgram::Vertex;
 
 } // namespace mbgl

--- a/src/mbgl/programs/raster_program.hpp
+++ b/src/mbgl/programs/raster_program.hpp
@@ -23,12 +23,14 @@ MBGL_DEFINE_UNIFORM_VECTOR(float, 3, u_spin_weights);
 MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_tl_parent);
 } // namespace uniforms
 
+using RasterAttributes = gl::Attributes<
+    attributes::a_pos,
+    attributes::a_texture_pos>;
+
 class RasterProgram : public Program<
     shaders::raster,
     gl::Triangle,
-    gl::Attributes<
-        attributes::a_pos,
-        attributes::a_texture_pos>,
+    RasterAttributes,
     gl::Uniforms<
         uniforms::u_matrix,
         uniforms::u_image0,

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -22,7 +22,7 @@ public:
 
     gl::VertexVector<CircleVertex> vertices;
     gl::IndexVector<gl::Triangles> triangles;
-    std::vector<gl::Segment> segments;
+    gl::SegmentVector<CircleAttributes> segments;
 
     optional<gl::VertexBuffer<CircleVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -80,7 +80,8 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
       modified(std::move(modified_)),
       expires(std::move(expires_)),
       debugMode(debugMode_),
-      vertexBuffer(context.createVertexBuffer(buildTextVertices(id, renderable_, complete_, modified_, expires_, debugMode_))) {
+      vertexBuffer(context.createVertexBuffer(buildTextVertices(id, renderable_, complete_, modified_, expires_, debugMode_))),
+      segments(vertexBuffer) {
 }
 
 } // namespace mbgl

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -6,7 +6,7 @@
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/gl/vertex_buffer.hpp>
-#include <mbgl/programs/fill_program.hpp>
+#include <mbgl/programs/debug_program.hpp>
 
 namespace mbgl {
 
@@ -32,7 +32,8 @@ public:
     const optional<Timestamp> expires;
     const MapDebugOptions debugMode;
 
-    gl::VertexBuffer<FillVertex, gl::Lines> vertexBuffer;
+    gl::VertexBuffer<DebugVertex, gl::Lines> vertexBuffer;
+    gl::SegmentVector<DebugAttributes> segments;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -22,8 +22,8 @@ public:
     gl::VertexVector<FillVertex> vertices;
     gl::IndexVector<gl::Lines> lines;
     gl::IndexVector<gl::Triangles> triangles;
-    std::vector<gl::Segment> lineSegments;
-    std::vector<gl::Segment> triangleSegments;
+    gl::SegmentVector<FillAttributes> lineSegments;
+    gl::SegmentVector<FillAttributes> triangleSegments;
 
     optional<gl::VertexBuffer<FillVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Lines>> lineIndexBuffer;

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -28,7 +28,7 @@ public:
 
     gl::VertexVector<LineVertex> vertices;
     gl::IndexVector<gl::Triangles> triangles;
-    std::vector<gl::Segment> segments;
+    gl::SegmentVector<LineAttributes> segments;
 
     optional<gl::VertexBuffer<LineVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -77,8 +77,11 @@ Painter::Painter(gl::Context& context_, const TransformState& state_)
     : context(context_),
       state(state_),
       tileTriangleVertexBuffer(context.createVertexBuffer(tileTriangles())),
-      tileLineStripVertexBuffer(context.createVertexBuffer(tileLineStrip())),
-      rasterVertexBuffer(context.createVertexBuffer(rasterTriangleStrip())) {
+      tileTriangleSegments(tileTriangleVertexBuffer),
+      tileBorderVertexBuffer(context.createVertexBuffer(tileLineStrip())),
+      tileBorderSegments(tileBorderVertexBuffer),
+      rasterVertexBuffer(context.createVertexBuffer(rasterTriangleStrip())),
+      rasterSegments(rasterVertexBuffer) {
 #ifndef NDEBUG
     gl::debugging::enable();
 #endif

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -9,6 +9,7 @@
 #include <mbgl/renderer/bucket.hpp>
 
 #include <mbgl/gl/context.hpp>
+#include <mbgl/programs/debug_program.hpp>
 #include <mbgl/programs/fill_program.hpp>
 #include <mbgl/programs/raster_program.hpp>
 
@@ -157,8 +158,13 @@ private:
 #endif
 
     gl::VertexBuffer<FillVertex, gl::Triangles> tileTriangleVertexBuffer;
-    gl::VertexBuffer<FillVertex, gl::LineStrip> tileLineStripVertexBuffer;
+    gl::SegmentVector<FillAttributes> tileTriangleSegments;
+
+    gl::VertexBuffer<DebugVertex, gl::LineStrip> tileBorderVertexBuffer;
+    gl::SegmentVector<DebugAttributes> tileBorderSegments;
+
     gl::VertexBuffer<RasterVertex, gl::TriangleStrip> rasterVertexBuffer;
+    gl::SegmentVector<RasterAttributes> rasterSegments;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -44,7 +44,8 @@ void Painter::renderBackground(PaintParameters& parameters, const BackgroundLaye
                     tileID,
                     state
                 ),
-                tileTriangleVertexBuffer
+                tileTriangleVertexBuffer,
+                tileTriangleSegments
             );
         }
     } else {
@@ -62,7 +63,8 @@ void Painter::renderBackground(PaintParameters& parameters, const BackgroundLaye
                     uniforms::u_outline_color::Value{ properties.backgroundColor.value },
                     uniforms::u_world::Value{ context.viewport.getCurrentValue().size },
                 },
-                tileTriangleVertexBuffer
+                tileTriangleVertexBuffer,
+                tileTriangleSegments
             );
         }
     }

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -26,7 +26,8 @@ void Painter::renderClippingMask(const UnwrappedTileID& tileID, const ClipID& cl
             uniforms::u_outline_color::Value{ Color {} },
             uniforms::u_world::Value{ context.viewport.getCurrentValue().size },
         },
-        tileTriangleVertexBuffer
+        tileTriangleVertexBuffer,
+        tileTriangleSegments
     );
 }
 

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -18,7 +18,7 @@ void Painter::renderTileDebug(const RenderTile& renderTile) {
 
     MBGL_DEBUG_GROUP(std::string { "debug " } + util::toString(renderTile.id));
 
-    auto draw = [&] (Color color, const auto& vertexBuffer, auto drawMode) {
+    auto draw = [&] (Color color, const auto& vertexBuffer, const auto& segments, auto drawMode) {
         programs->debug.draw(
             context,
             drawMode,
@@ -29,7 +29,8 @@ void Painter::renderTileDebug(const RenderTile& renderTile) {
                 uniforms::u_matrix::Value{ renderTile.matrix },
                 uniforms::u_color::Value{ color }
             },
-            vertexBuffer
+            vertexBuffer,
+            segments
         );
     };
 
@@ -45,12 +46,22 @@ void Painter::renderTileDebug(const RenderTile& renderTile) {
                 tile.expires, frame.debugOptions, context);
         }
 
-        draw(Color::white(), tile.debugBucket->vertexBuffer, gl::Lines { 4.0f * frame.pixelRatio });
-        draw(Color::black(), tile.debugBucket->vertexBuffer, gl::Lines { 2.0f * frame.pixelRatio });
+        draw(Color::white(),
+             tile.debugBucket->vertexBuffer,
+             tile.debugBucket->segments,
+             gl::Lines { 4.0f * frame.pixelRatio });
+
+        draw(Color::black(),
+             tile.debugBucket->vertexBuffer,
+             tile.debugBucket->segments,
+             gl::Lines { 2.0f * frame.pixelRatio });
     }
 
     if (frame.debugOptions & MapDebugOptions::TileBorders) {
-        draw(Color::red(), tileLineStripVertexBuffer, gl::LineStrip { 4.0f * frame.pixelRatio });
+        draw(Color::red(),
+             tileBorderVertexBuffer,
+             tileBorderSegments,
+             gl::LineStrip { 4.0f * frame.pixelRatio });
     }
 }
 

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -75,7 +75,8 @@ void Painter::renderRaster(PaintParameters& parameters,
             uniforms::u_scale_parent::Value{ 1.0f },
             uniforms::u_tl_parent::Value{ std::array<float, 2> {{ 0.0f, 0.0f }} },
         },
-        rasterVertexBuffer
+        rasterVertexBuffer,
+        rasterSegments
     );
 }
 

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -36,7 +36,7 @@ public:
     struct TextBuffer {
         gl::VertexVector<SymbolVertex> vertices;
         gl::IndexVector<gl::Triangles> triangles;
-        std::vector<gl::Segment> segments;
+        gl::SegmentVector<SymbolAttributes> segments;
 
         optional<gl::VertexBuffer<SymbolVertex>> vertexBuffer;
         optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
@@ -45,7 +45,7 @@ public:
     struct IconBuffer {
         gl::VertexVector<SymbolVertex> vertices;
         gl::IndexVector<gl::Triangles> triangles;
-        std::vector<gl::Segment> segments;
+        gl::SegmentVector<SymbolAttributes> segments;
 
         optional<gl::VertexBuffer<SymbolVertex>> vertexBuffer;
         optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
@@ -54,7 +54,7 @@ public:
     struct CollisionBoxBuffer {
         gl::VertexVector<CollisionBoxVertex> vertices;
         gl::IndexVector<gl::Lines> lines;
-        std::vector<gl::Segment> segments;
+        gl::SegmentVector<CollisionBoxAttributes> segments;
 
         optional<gl::VertexBuffer<CollisionBoxVertex>> vertexBuffer;
         optional<gl::IndexBuffer<gl::Lines>> indexBuffer;


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-gl-native/pull/6468#discussion_r85182731

This is safer now -- it can be an implementation detail of Segment/Context. And the typing of SegmentVector now ensures that the attributes and program match.

Also, we've determined the cause of #5731.

cc @kkaefer 