### PR TITLE
[tests] Disable "ContinuousRendering" test; causing spurious CI failures

### DIFF
--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -455,7 +455,7 @@ public:
     }
 };
 
-TEST(Map, ContinuousRendering) {
+TEST(Map, TEST_DISABLED_ON_CI(ContinuousRendering)) {
     util::RunLoop runLoop;
     MockBackend backend;
     OffscreenView view { backend.getContext() };


### PR DESCRIPTION
Refs #7035.

cc @kkaefer 