### PR TITLE
[ios, macos] Use NSNumber in exception strings

### DIFF
--- a/platform/darwin/src/MGLMultiPoint.mm
+++ b/platform/darwin/src/MGLMultiPoint.mm
@@ -58,8 +58,8 @@ mbgl::Color MGLColorObjectFromCGColorRef(CGColorRef cgColor)
     if (range.location + range.length > [self pointCount])
     {
         [NSException raise:NSRangeException
-                    format:@"Invalid coordinate range %@ extends beyond current coordinate count of %zu",
-                        NSStringFromRange(range), [self pointCount]];
+                    format:@"Invalid coordinate range %@ extends beyond current coordinate count of %@",
+                        NSStringFromRange(range), @([self pointCount])];
     }
 
     std::copy(_coordinates.begin() + range.location, _coordinates.begin() + NSMaxRange(range), coords);
@@ -83,8 +83,8 @@ mbgl::Color MGLColorObjectFromCGColorRef(CGColorRef cgColor)
     if (NSMaxRange(range) > _coordinates.size())
     {
         [NSException raise:NSRangeException
-                    format:@"Invalid range %@ for existing coordinate count %zu",
-         NSStringFromRange(range), [self pointCount]];
+                    format:@"Invalid range %@ for existing coordinate count %@",
+         NSStringFromRange(range), @([self pointCount])];
     }
 
     [self willChangeValueForKey:@"coordinates"];

--- a/platform/darwin/src/MGLPointCollection.mm
+++ b/platform/darwin/src/MGLPointCollection.mm
@@ -54,8 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
     if (range.location + range.length > [self pointCount])
     {
         [NSException raise:NSRangeException
-                    format:@"Invalid coordinate range %@ extends beyond current coordinate count of %zu",
-         NSStringFromRange(range), [self pointCount]];
+                    format:@"Invalid coordinate range %@ extends beyond current coordinate count of %@",
+         NSStringFromRange(range), @([self pointCount])];
     }
 
     std::copy(_coordinates.begin() + range.location, _coordinates.begin() + NSMaxRange(range), coords);


### PR DESCRIPTION
Avoid precision loss / cast warnings.

cc @incanus @1ec5 