### PR TITLE
Raster tiles are not cached

### DIFF
--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -139,7 +139,7 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
     algorithm::updateRenderables(getTileFn, createTileFn, retainTileFn, renderTileFn,
                                  idealTiles, zoomRange, tileZoom);
 
-    if (type != SourceType::Raster && type != SourceType::Annotations && cache.getSize() == 0) {
+    if (type != SourceType::Annotations && cache.getSize() == 0) {
         size_t conservativeCacheSize =
             ((float)parameters.transformState.getSize().width / util::tileSize) *
             ((float)parameters.transformState.getSize().height / util::tileSize) *


### PR DESCRIPTION
When abandoning geometry (vector) tiles, we're putting them into a [cache](https://github.com/mapbox/mapbox-gl-native/blob/5479b75c9fa971332aadfede6b380267eebbd566/src/mbgl/style/source_impl.cpp#L163-L180), but [for raster sources, that cache is of size 0](https://github.com/mapbox/mapbox-gl-native/blob/5479b75c9fa971332aadfede6b380267eebbd566/src/mbgl/style/source_impl.cpp#L142), so raster tiles get immediately deleted when they are moving outside of the viewport.

We should hold on to raster tiles as well to avoid flickering when they are getting moved out and back into the viewport.