### PR TITLE
Create separate Android nightly build

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -6,6 +6,8 @@ trigger_map:
   workflow: devicefarmUpload
 - pattern: scheduled
   workflow: scheduled
+- pattern: nightly-release
+  workflow: nightly-release
 - pattern: "*"
   workflow: primary
 workflows:
@@ -175,13 +177,6 @@ workflows:
             export BUILDTYPE=Release
             make apackage
     - script:
-        title: Log metrics
-        inputs:
-        - content: |-
-            #!/bin/bash
-            echo "Log binary size metrics to AWS CloudWatch:"
-            CLOUDWATCH=true platform/android/scripts/metrics.sh
-    - script:
         title: Publish to maven
         inputs:
         - content: |-
@@ -249,3 +244,35 @@ workflows:
         - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}> for devicefarmUpload failed'
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+  nightly-release:
+    steps:
+    - script:
+        title: Configure GL-native build environement
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+            sudo apt-get install -y pkg-config nodejs cmake
+    - script:
+        title: Configure AWS-CLI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            apt-get install -y python-pip python-dev build-essential
+            pip install awscli
+    - script:
+        title: Build release
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "Compile libmapbox-gl.so for all supportd abi's:"
+            export BUILDTYPE=Release
+            make apackage
+    - script:
+        title: Log metrics
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "Log binary size metrics to AWS CloudWatch:"
+            CLOUDWATCH=true platform/android/scripts/metrics.sh

--- a/scripts/log_binary_size.sh
+++ b/scripts/log_binary_size.sh
@@ -33,5 +33,4 @@ if [ -f "${FILE}" ]; then
     fi
 else
     echo "* File '${FILE}' does not exist"
-    exit 1
 fi


### PR DESCRIPTION
I piggy-backed on the scheduled Bitirse build that already exists, but it turned out that it is not building master but the current release branch. That means we need to add a second scheduled build that runs master.