### PR TITLE
[node] Revert semantics of Map#render

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.16.4",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#597115a1e1bd982944b068f8accde34eada74fc2",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#7f62a4fc9f21e619824d68abbc4b03cbc1685572",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#bd5c7a34702634bf670ef9ea03251eda8b36944a",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#87192085b3c1ebe668524511bfba28381e5eb627",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -21,15 +21,15 @@
 namespace node_mbgl {
 
 struct NodeMap::RenderOptions {
-    mbgl::optional<double> zoom;
-    mbgl::optional<double> bearing;
-    mbgl::optional<double> pitch;
-    mbgl::optional<double> latitude;
-    mbgl::optional<double> longitude;
+    double zoom = 0;
+    double bearing = 0;
+    double pitch = 0;
+    double latitude = 0;
+    double longitude = 0;
     unsigned int width = 512;
     unsigned int height = 512;
-    mbgl::optional<std::vector<std::string>> classes;
-    mbgl::optional<mbgl::MapDebugOptions> debugOptions;
+    std::vector<std::string> classes;
+    mbgl::MapDebugOptions debugOptions = mbgl::MapDebugOptions::NoDebug;
 };
 
 Nan::Persistent<v8::Function> NodeMap::constructor;
@@ -266,40 +266,37 @@ NodeMap::RenderOptions NodeMap::ParseOptions(v8::Local<v8::Object> obj) {
     if (Nan::Has(obj, Nan::New("classes").ToLocalChecked()).FromJust()) {
         auto classes = Nan::To<v8::Object>(Nan::Get(obj, Nan::New("classes").ToLocalChecked()).ToLocalChecked()).ToLocalChecked().As<v8::Array>();
         const int length = classes->Length();
-        std::vector<std::string> vector;
-        vector.reserve(length);
+        options.classes.reserve(length);
         for (int i = 0; i < length; i++) {
-            vector.push_back(std::string { *Nan::Utf8String(Nan::To<v8::String>(Nan::Get(classes, i).ToLocalChecked()).ToLocalChecked()) });
+            options.classes.push_back(std::string { *Nan::Utf8String(Nan::To<v8::String>(Nan::Get(classes, i).ToLocalChecked()).ToLocalChecked()) });
         }
-        options.classes = std::move(vector);
     }
 
     if (Nan::Has(obj, Nan::New("debug").ToLocalChecked()).FromJust()) {
         auto debug = Nan::To<v8::Object>(Nan::Get(obj, Nan::New("debug").ToLocalChecked()).ToLocalChecked()).ToLocalChecked();
-        options.debugOptions = mbgl::MapDebugOptions::NoDebug;
         if (Nan::Has(debug, Nan::New("tileBorders").ToLocalChecked()).FromJust()) {
             if (Nan::Get(debug, Nan::New("tileBorders").ToLocalChecked()).ToLocalChecked()->BooleanValue()) {
-                *options.debugOptions = *options.debugOptions | mbgl::MapDebugOptions::TileBorders;
+                options.debugOptions = options.debugOptions | mbgl::MapDebugOptions::TileBorders;
             }
         }
         if (Nan::Has(debug, Nan::New("parseStatus").ToLocalChecked()).FromJust()) {
             if (Nan::Get(debug, Nan::New("parseStatus").ToLocalChecked()).ToLocalChecked()->BooleanValue()) {
-                *options.debugOptions = *options.debugOptions | mbgl::MapDebugOptions::ParseStatus;
+                options.debugOptions = options.debugOptions | mbgl::MapDebugOptions::ParseStatus;
             }
         }
         if (Nan::Has(debug, Nan::New("timestamps").ToLocalChecked()).FromJust()) {
             if (Nan::Get(debug, Nan::New("timestamps").ToLocalChecked()).ToLocalChecked()->BooleanValue()) {
-                *options.debugOptions = *options.debugOptions | mbgl::MapDebugOptions::Timestamps;
+                options.debugOptions = options.debugOptions | mbgl::MapDebugOptions::Timestamps;
             }
         }
         if (Nan::Has(debug, Nan::New("collision").ToLocalChecked()).FromJust()) {
             if (Nan::Get(debug, Nan::New("collision").ToLocalChecked()).ToLocalChecked()->BooleanValue()) {
-                *options.debugOptions = *options.debugOptions | mbgl::MapDebugOptions::Collision;
+                options.debugOptions = options.debugOptions | mbgl::MapDebugOptions::Collision;
             }
         }
         if (Nan::Has(debug, Nan::New("overdraw").ToLocalChecked()).FromJust()) {
             if (Nan::Get(debug, Nan::New("overdraw").ToLocalChecked()).ToLocalChecked()->BooleanValue()) {
-                *options.debugOptions = mbgl::MapDebugOptions::Overdraw;
+                options.debugOptions = mbgl::MapDebugOptions::Overdraw;
             }
         }
     }
@@ -368,28 +365,29 @@ void NodeMap::startRender(NodeMap::RenderOptions options) {
         view = std::make_unique<mbgl::OffscreenView>(backend.getContext(), fbSize);
     }
 
-    if (options.classes) {
-        map->setClasses(*options.classes);
+    if (map->getClasses() != options.classes) {
+        map->setClasses(options.classes);
     }
 
-    if (options.latitude && options.longitude) {
-        map->setLatLng(mbgl::LatLng(*options.latitude, *options.longitude));
+    mbgl::LatLng latLng(options.latitude, options.longitude);
+    if (map->getLatLng() != latLng) {
+        map->setLatLng(latLng);
     }
 
-    if (options.zoom) {
-        map->setZoom(*options.zoom);
+    if (map->getZoom() != options.zoom) {
+        map->setZoom(options.zoom);
     }
 
-    if (options.bearing) {
-        map->setBearing(*options.bearing);
+    if (map->getBearing() != options.bearing) {
+        map->setBearing(options.bearing);
     }
 
-    if (options.pitch) {
-        map->setPitch(*options.pitch);
+    if (map->getPitch() != options.pitch) {
+        map->setPitch(options.pitch);
     }
 
-    if (options.debugOptions) {
-        map->setDebug(*options.debugOptions);
+    if (map->getDebug() != options.debugOptions) {
+        map->setDebug(options.debugOptions);
     }
 
     map->renderStill(*view, [this](const std::exception_ptr eptr) {

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -62,7 +62,9 @@ void NodeMap::Init(v8::Local<v8::Object> target) {
     Nan::SetPrototypeMethod(tpl, "setPaintProperty", SetPaintProperty);
     Nan::SetPrototypeMethod(tpl, "setFilter", SetFilter);
     Nan::SetPrototypeMethod(tpl, "setCenter", SetCenter);
+    Nan::SetPrototypeMethod(tpl, "setZoom", SetZoom);
     Nan::SetPrototypeMethod(tpl, "setBearing", SetBearing);
+    Nan::SetPrototypeMethod(tpl, "setPitch", SetPitch);
 
     Nan::SetPrototypeMethod(tpl, "dumpDebugLogs", DumpDebugLogs);
     Nan::SetPrototypeMethod(tpl, "queryRenderedFeatures", QueryRenderedFeatures);
@@ -725,6 +727,23 @@ void NodeMap::SetCenter(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     info.GetReturnValue().SetUndefined();
 }
 
+void NodeMap::SetZoom(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
+    if (!nodeMap->map) return Nan::ThrowError(releasedMessage());
+
+    if (info.Length() <= 0 || !info[0]->IsNumber()) {
+        return Nan::ThrowTypeError("First argument must be a number");
+    }
+
+    try {
+        nodeMap->map->setZoom(info[0]->NumberValue());
+    } catch (const std::exception &ex) {
+        return Nan::ThrowError(ex.what());
+    }
+
+    info.GetReturnValue().SetUndefined();
+}
+
 void NodeMap::SetBearing(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
     if (!nodeMap->map) return Nan::ThrowError(releasedMessage());
@@ -735,6 +754,23 @@ void NodeMap::SetBearing(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 
     try {
         nodeMap->map->setBearing(info[0]->NumberValue());
+    } catch (const std::exception &ex) {
+        return Nan::ThrowError(ex.what());
+    }
+
+    info.GetReturnValue().SetUndefined();
+}
+
+void NodeMap::SetPitch(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    auto nodeMap = Nan::ObjectWrap::Unwrap<NodeMap>(info.Holder());
+    if (!nodeMap->map) return Nan::ThrowError(releasedMessage());
+
+    if (info.Length() <= 0 || !info[0]->IsNumber()) {
+        return Nan::ThrowTypeError("First argument must be a number");
+    }
+
+    try {
+        nodeMap->map->setPitch(info[0]->NumberValue());
     } catch (const std::exception &ex) {
         return Nan::ThrowError(ex.what());
     }

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -41,7 +41,9 @@ public:
     static void SetPaintProperty(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetFilter(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetCenter(const Nan::FunctionCallbackInfo<v8::Value>&);
+    static void SetZoom(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void SetBearing(const Nan::FunctionCallbackInfo<v8::Value>&);
+    static void SetPitch(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void DumpDebugLogs(const Nan::FunctionCallbackInfo<v8::Value>&);
     static void QueryRenderedFeatures(const Nan::FunctionCallbackInfo<v8::Value>&);
 

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -115,7 +115,9 @@ test('Map', function(t) {
             'setPaintProperty',
             'setFilter',
             'setCenter',
+            'setZoom',
             'setBearing',
+            'setPitch',
             'dumpDebugLogs',
             'queryRenderedFeatures'
         ]);

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -36,6 +36,11 @@ module.exports = function (style, options, callback) {
         overdraw: options.showOverdrawInspector,
     };
 
+    options.center = style.center || [0, 0];
+    options.zoom = style.zoom || 0;
+    options.bearing = style.bearing || 0;
+    options.pitch = style.pitch || 0;
+
     map.load(style);
 
     applyOperations(options.operations, function() {
@@ -56,7 +61,7 @@ module.exports = function (style, options, callback) {
             callback();
 
         } else if (operation[0] === 'wait') {
-            var wait = function() {
+            var wait = function () {
                 if (map.loaded()) {
                     applyOperations(operations.slice(1), callback);
                 } else {
@@ -66,6 +71,13 @@ module.exports = function (style, options, callback) {
             wait();
 
         } else {
+            // Ensure that the next `map.render(options)` does not overwrite this change.
+            if (operation[0] === 'setCenter') {
+                options.center = operations[1];
+            } else if (operation[0] === 'setBearing') {
+                options.bearing = operations[1];
+            }
+
             map[operation[0]].apply(map, operation.slice(1));
             applyOperations(operations.slice(1), callback);
         }

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -74,8 +74,12 @@ module.exports = function (style, options, callback) {
             // Ensure that the next `map.render(options)` does not overwrite this change.
             if (operation[0] === 'setCenter') {
                 options.center = operations[1];
+            } else if (operation[0] === 'setZoom') {
+                options.zoom = operations[1];
             } else if (operation[0] === 'setBearing') {
                 options.bearing = operations[1];
+            } else if (operation[0] === 'setPitch') {
+                options.pitch = operations[1];
             }
 
             map[operation[0]].apply(map, operation.slice(1));


### PR DESCRIPTION
Revert node `Map#render` API to "stateless" camera semantics: the center, zoom, bearing, and pitch passed are what is used to render, with defaults for unspecified values.

For the test-suite implementation, which wants stateful semantics, track the camera options manually. Also, change the implementation of `Map#render` so that it avoids calling `setCenter`, etc. when the value is not changing. (Internally, `setCenter` does not short-circuit, so it could cause undesired updates.)

cc @mikemorris 