### PR TITLE
[android] fixed horizontal panning going the opposite direction

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1651,20 +1651,17 @@ public class MapView extends FrameLayout {
 
             resetTrackingModesIfRequired(true, false);
 
-            // Fling the map
-            float ease = 0.25f;
-
-            velocityX = velocityX * ease;
-            velocityY = velocityY * ease;
-
-            double speed = Math.sqrt(velocityX * velocityX + velocityY * velocityY);
-            double deceleration = 2500;
-            double duration = speed / (deceleration * ease);
+            double decelerationRate = 1;
 
             // Cancel any animation
             cancelTransitions();
 
-            nativeMapView.moveBy(velocityX * duration / 2.0 / screenDensity, velocityY * duration / 2.0 / screenDensity, (long) (duration * 1000.0f));
+            double offsetX = velocityX * decelerationRate / 4 / screenDensity;
+            double offsetY = velocityY * decelerationRate / 4 / screenDensity;
+
+            nativeMapView.setGestureInProgress(true);
+            nativeMapView.moveBy(offsetX, offsetY, (long) (decelerationRate * 1000.0f));
+            nativeMapView.setGestureInProgress(false);
 
             MapboxMap.OnFlingListener listener = mapboxMap.getOnFlingListener();
             if (listener != null) {

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -471,8 +471,7 @@ void nativeMoveBy(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jdoubl
                           jlong duration) {
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    mbgl::ScreenCoordinate center(dx, dy);
-    nativeMapView->getMap().moveBy(center, mbgl::Milliseconds(duration));
+    nativeMapView->getMap().moveBy({dx, dy}, mbgl::Milliseconds(duration));
 }
 
 void nativeSetLatLng(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jdouble latitude, jdouble longitude, jlong duration) {


### PR DESCRIPTION
Fixes #7104 

The root cause was that the nativeMapView's `gestureInProgress` was false during the fling.
This resulted in mbgl map unwrapping the longitude to find the shortest path > https://github.com/mapbox/mapbox-gl-native/blob/master/src/mbgl/map/transform.cpp#L111

Without the unwrapping, the deceleration rate was way too slow as well as the duration causing a simple fling to go around the world 50 times before stopping. The new deceleration rate mimics a scrollView with fast scrolling disabled.

![horizontal_fix](https://cloud.githubusercontent.com/assets/764476/20392920/335654bc-acda-11e6-8576-35c26fcdb60f.gif)


@tobrun  👀 