### PR TITLE
Use thin archives when building Android

### DIFF
--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -3,6 +3,12 @@ add_definitions(-DMBGL_USE_GLES2=1)
 #Include to use build specific variables
 include(${CMAKE_CURRENT_BINARY_DIR}/toolchain.cmake)
 
+# Build thin archives.
+set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> cruT <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> cruT <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> ruT <TARGET> <LINK_FLAGS> <OBJECTS>")
+set(CMAKE_C_ARCHIVE_APPEND "<CMAKE_AR> ruT <TARGET> <LINK_FLAGS> <OBJECTS>")
+
 mason_use(jni.hpp VERSION 2.0.0 HEADER_ONLY)
 mason_use(libjpeg-turbo VERSION 1.5.0)
 mason_use(libpng VERSION 1.6.25)


### PR DESCRIPTION
We're currently first assembling all object files into a `libmbgl-core.a`, then linking that into the actual shared object. However, the archive file is > 200MB in size, so assembling it takes a while and requires some disk I/O. Since we're using a recent clang version, we can just create thin archives using the `T` flag to avoid all of that.