### PR TITLE
Add instrumentation tests for query rendered features

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedFeaturesBoxCountTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedFeaturesBoxCountTest.java
@@ -1,0 +1,58 @@
+package com.mapbox.mapboxsdk.testapp.feature;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.rule.ActivityTestRule;
+
+import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.activity.feature.QueryRenderedFeaturesBoxCountActivity;
+import com.mapbox.mapboxsdk.testapp.utils.OnMapReadyIdlingResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.withDecorView;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Instrumentation test to validate if clicking on the blue rectangle from
+ * QueryRenderedFeaturesBoxSymbolCountActivity shows a Toast that 149 features were found.
+ */
+public class QueryRenderedFeaturesBoxCountTest {
+
+    @Rule
+    public final ActivityTestRule<QueryRenderedFeaturesBoxCountActivity> rule = new ActivityTestRule<>(QueryRenderedFeaturesBoxCountActivity.class);
+
+    private OnMapReadyIdlingResource idlingResource;
+
+    @Before
+    public void registerIdlingResource() {
+        idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
+        Espresso.registerIdlingResources(idlingResource);
+    }
+
+    @Test
+    public void testCountFeatures() {
+        // click on box to query map
+        onView(withId(R.id.selection_box)).perform(click());
+
+        // validate if toast is shown
+        onView(withText("149 features in box"))
+                .inRoot(withDecorView(not(is(rule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+    }
+
+    @After
+    public void unregisterIdlingResource() {
+        Espresso.unregisterIdlingResources(idlingResource);
+    }
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedFeaturesHighlightTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedFeaturesHighlightTest.java
@@ -1,0 +1,78 @@
+package com.mapbox.mapboxsdk.testapp.feature;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewAction;
+import android.support.test.espresso.action.CoordinatesProvider;
+import android.support.test.espresso.action.GeneralClickAction;
+import android.support.test.espresso.action.Press;
+import android.support.test.espresso.action.Tap;
+import android.support.test.rule.ActivityTestRule;
+import android.view.View;
+
+import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.activity.feature.QueryRenderedFeaturesBoxHighlightActivity;
+import com.mapbox.mapboxsdk.testapp.utils.OnMapReadyIdlingResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.withDecorView;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Instrumentation test to validate if clicking box on screen highlights features.
+ */
+public class QueryRenderedFeaturesHighlightTest {
+
+    @Rule
+    public final ActivityTestRule<QueryRenderedFeaturesBoxHighlightActivity> rule = new ActivityTestRule<>(QueryRenderedFeaturesBoxHighlightActivity.class);
+
+    private OnMapReadyIdlingResource idlingResource;
+
+    @Before
+    public void registerIdlingResource() {
+        idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
+        Espresso.registerIdlingResources(idlingResource);
+    }
+
+    @Test
+    public void testCountFeatures() {
+        // click on box to query map
+        onView(withId(R.id.selection_box)).perform(click());
+
+        // validate if toast is shown
+        onView(withText("50 features in box"))
+                .inRoot(withDecorView(not(is(rule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+    }
+
+    @After
+    public void unregisterIdlingResource() {
+        Espresso.unregisterIdlingResources(idlingResource);
+    }
+
+    private static ViewAction clickXY(final float x, final float y) {
+        return new GeneralClickAction(
+                Tap.SINGLE,
+                new CoordinatesProvider() {
+                    @Override
+                    public float[] calculateCoordinates(View view) {
+                        final int[] screenPos = new int[2];
+                        view.getLocationOnScreen(screenPos);
+                        final float screenX = screenPos[0] + x;
+                        final float screenY = screenPos[1] + y;
+                        return new float[]{screenX, screenY};
+                    }
+                },
+                Press.FINGER);
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedFeaturesPropertiesTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedFeaturesPropertiesTest.java
@@ -1,0 +1,75 @@
+package com.mapbox.mapboxsdk.testapp.feature;
+
+import android.graphics.PointF;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewAction;
+import android.support.test.espresso.action.CoordinatesProvider;
+import android.support.test.espresso.action.GeneralClickAction;
+import android.support.test.espresso.action.Press;
+import android.support.test.espresso.action.Tap;
+import android.support.test.rule.ActivityTestRule;
+import android.view.View;
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.activity.feature.QueryRenderedFeaturesPropertiesActivity;
+import com.mapbox.mapboxsdk.testapp.utils.OnMapReadyIdlingResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+/**
+ * Instrumentation test to validate if clicking center of screen returns the correct features.
+ */
+public class QueryRenderedFeaturesPropertiesTest {
+
+    @Rule
+    public final ActivityTestRule<QueryRenderedFeaturesPropertiesActivity> rule = new ActivityTestRule<>(QueryRenderedFeaturesPropertiesActivity.class);
+
+    private OnMapReadyIdlingResource idlingResource;
+
+    @Before
+    public void registerIdlingResource() {
+        idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
+        Espresso.registerIdlingResources(idlingResource);
+    }
+
+    @Test
+    public void testCountFeatures() {
+        MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
+        LatLng centerScreen = mapboxMap.getCameraPosition().target;
+        PointF centerPixel = mapboxMap.getProjection().toScreenLocation(centerScreen);
+        onView(withId(R.id.mapView)).perform(clickXY(centerPixel.x, centerPixel.y));
+        onView(withText("Found 4 features")).check(matches(isDisplayed()));
+    }
+
+    @After
+    public void unregisterIdlingResource() {
+        Espresso.unregisterIdlingResources(idlingResource);
+    }
+
+    private static ViewAction clickXY(final float x, final float y) {
+        return new GeneralClickAction(
+                Tap.SINGLE,
+                new CoordinatesProvider() {
+                    @Override
+                    public float[] calculateCoordinates(View view) {
+                        final int[] screenPos = new int[2];
+                        view.getLocationOnScreen(screenPos);
+                        final float screenX = screenPos[0] + x;
+                        final float screenY = screenPos[1] + y;
+                        return new float[]{screenX, screenY};
+                    }
+                },
+                Press.FINGER);
+    }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedSymbolBoxCountTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/feature/QueryRenderedSymbolBoxCountTest.java
@@ -1,0 +1,59 @@
+package com.mapbox.mapboxsdk.testapp.feature;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.rule.ActivityTestRule;
+
+import com.mapbox.mapboxsdk.testapp.R;
+import com.mapbox.mapboxsdk.testapp.activity.feature.QueryRenderedFeaturesBoxSymbolCountActivity;
+import com.mapbox.mapboxsdk.testapp.utils.OnMapReadyIdlingResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.withDecorView;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Instrumentation test to validate if clicking on the blue rectangle from
+ * QueryRenderedFeaturesBoxSymbolCountActivity shows a Toast that 2 symbols were found.
+ */
+public class QueryRenderedSymbolBoxCountTest {
+
+    @Rule
+    public final ActivityTestRule<QueryRenderedFeaturesBoxSymbolCountActivity> rule = new ActivityTestRule<>(QueryRenderedFeaturesBoxSymbolCountActivity.class);
+
+    private OnMapReadyIdlingResource idlingResource;
+
+    @Before
+    public void registerIdlingResource() {
+        idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
+        Espresso.registerIdlingResources(idlingResource);
+    }
+
+    @Test
+    public void testCountSymbols() {
+        // click on box to query map
+        onView(withId(R.id.selection_box)).perform(click());
+
+        // validate if toast is shown
+        onView(withText("2 features in box"))
+                .inRoot(withDecorView(not(is(rule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+    }
+
+    @After
+    public void unregisterIdlingResource() {
+        Espresso.unregisterIdlingResources(idlingResource);
+    }
+
+}
+

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxCountActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxCountActivity.java
@@ -50,8 +50,6 @@ public class QueryRenderedFeaturesBoxCountActivity extends AppCompatActivity {
             @Override
             public void onMapReady(final MapboxMap mapboxMap) {
                 QueryRenderedFeaturesBoxCountActivity.this.mapboxMap = mapboxMap;
-
-
                 selectionBox.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -72,12 +70,8 @@ public class QueryRenderedFeaturesBoxCountActivity extends AppCompatActivity {
                         debugOutput(features);
                     }
                 });
-
-                //Little taste of home
-                mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(52.0907, 5.1214), 16));
             }
         });
-
     }
 
     private void debugOutput(List<Feature> features) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxHighlightActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxHighlightActivity.java
@@ -52,9 +52,6 @@ public class QueryRenderedFeaturesBoxHighlightActivity extends AppCompatActivity
             @Override
             public void onMapReady(final MapboxMap mapboxMap) {
                 QueryRenderedFeaturesBoxHighlightActivity.this.mapboxMap = mapboxMap;
-
-                //Add a fill layer to display stuff on
-
                 selectionBox.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -85,9 +82,6 @@ public class QueryRenderedFeaturesBoxHighlightActivity extends AppCompatActivity
                             .withProperties(fillColor(Color.RED)));
                     }
                 });
-
-                //Little taste of home
-                mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(52.0907, 5.1214), 16));
             }
         });
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxSymbolCountActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesBoxSymbolCountActivity.java
@@ -12,8 +12,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
@@ -73,7 +71,6 @@ public class QueryRenderedFeaturesBoxSymbolCountActivity extends AppCompatActivi
                 mapboxMap.addImage("test-icon", BitmapFactory.decodeResource(getResources(), R.drawable.mapbox_marker_icon_default));
                 mapboxMap.addLayer(new SymbolLayer("symbols-layer", "symbols-source").withProperties(iconImage("test-icon")));
 
-
                 selectionBox.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -93,15 +90,10 @@ public class QueryRenderedFeaturesBoxSymbolCountActivity extends AppCompatActivi
                                 String.format("%s features in box", features.size()),
                                 Toast.LENGTH_SHORT);
                         toast.show();
-
                     }
                 });
-
-                //Little taste of home
-                mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(52.0907, 5.1214), 16));
             }
         });
-
     }
 
     private String readRawResource(@RawRes int rawResource) throws IOException {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesPropertiesActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/feature/QueryRenderedFeaturesPropertiesActivity.java
@@ -18,7 +18,6 @@ import android.widget.TextView;
 import com.google.gson.JsonElement;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerOptions;
 import com.mapbox.mapboxsdk.annotations.Marker;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -83,9 +82,6 @@ public class QueryRenderedFeaturesPropertiesActivity extends AppCompatActivity {
                         mapboxMap.selectMarker(marker);
                     }
                 });
-
-                //Little taste of home
-                mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(52.0907, 5.1214), 16));
             }
         });
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_query_features_box.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_query_features_box.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -14,7 +15,10 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar" />
+        android:layout_below="@id/toolbar"
+        app:mapbox_cameraTargetLat="52.0907"
+        app:mapbox_cameraTargetLng="5.1214"
+        app:mapbox_cameraZoom="16" />
 
     <FrameLayout
         android:id="@+id/selection_box"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_query_features_point.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_query_features_point.xml
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="@color/primary"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"/>
+        android:layout_below="@id/toolbar"
+        app:mapbox_cameraTargetLat="52.0907"
+        app:mapbox_cameraTargetLng="5.1214"
+        app:mapbox_cameraZoom="16" />
 
 </RelativeLayout>


### PR DESCRIPTION
This PR contains a couple of tests that validate if query rendered features has regressed. It currently covers the 4 testapp activities related to query rendered features. The tests executes the default user action and validates if the expected result is shown in a Toast message/InfoWindow. 

Related to f4b91fe, there is an issue on master that doesn't seem to load the map without moving it to xml, looking into this issue as part of #6532. **update**: the PR following #6532 is not showing this issue.

Review @ivovandongen 