### PR TITLE
Call correct onfinish callback

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -1405,7 +1405,7 @@ public class MapView extends FrameLayout {
                 @Override
                 public void onMapChanged(@MapChange int change) {
                     if (change == REGION_DID_CHANGE_ANIMATED && cameraCancelableCallback != null) {
-                        cancelableCallback.onFinish();
+                        cameraCancelableCallback.onFinish();
                         cameraCancelableCallback = null;
                         // Clean up after self
                         removeOnMapChangedListener(this);


### PR DESCRIPTION
Targets release branch, some follow up work on the cancelable callback system.

While doing some testing I noticed that we weren't correctly calling the onFinish callback. This could led to situations that we recevied callbacks for the previously set callback while the current one should be invoked. 

Review @zugaldia 