### PR TITLE
Allow initializing MGLGeoJSONSource from a shape

### DIFF
--- a/platform/darwin/src/MGLFeature_Private.h
+++ b/platform/darwin/src/MGLFeature_Private.h
@@ -3,6 +3,7 @@
 
 #import <mbgl/util/geo.hpp>
 #import <mbgl/util/feature.hpp>
+#import <mbgl/style/conversion/geojson.hpp>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,6 +12,17 @@ NS_ASSUME_NONNULL_BEGIN
  vector tile features.
  */
 NS_ARRAY_OF(MGLShape <MGLFeature> *) *MGLFeaturesFromMBGLFeatures(const std::vector<mbgl::Feature> &features);
+
+/**
+ Returns an `MGLFeature` object converted from the given mbgl::Feature
+ */
+id <MGLFeature> MGLFeatureFromMBGLFeature(const mbgl::Feature &feature);
+
+/**
+ Returns an `MGLShape` representing the given geojson. The shape can be
+ a feature, a collection of features, or a geometry.
+ */
+MGLShape* MGLShapeFromGeoJSON(const mapbox::geojson::geojson &geojson);
 
 /**
  Takes an `mbgl::Feature` object, an identifer, and attributes dictionary and

--- a/platform/darwin/src/MGLGeoJSONSource.h
+++ b/platform/darwin/src/MGLGeoJSONSource.h
@@ -1,6 +1,7 @@
 #import "MGLSource.h"
 
 #import "MGLTypes.h"
+#import "MGLShape.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -93,28 +94,29 @@ extern const MGLGeoJSONSourceOption MGLGeoJSONSourceOptionSimplificationToleranc
 - (instancetype)initWithIdentifier:(NSString *)identifier URL:(NSURL *)url options:(nullable NS_DICTIONARY_OF(MGLGeoJSONSourceOption, id) *)options NS_DESIGNATED_INITIALIZER;
 
 /**
- Returns a GeoJSON source with an identifier, features dictionary, and dictionary 
+ Returns a GeoJSON source with an identifier, features dictionary, and dictionary
  of options for the source according to the
  <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson">style
  specification</a>.
  
  @param identifier A string that uniquely identifies the source.
- @param features An array of features that conform to the `MGLFeature` protocol.
+ @param shape A concrete subclass of `MGLShape`
  @param options An `NSDictionary` of options for this source.
  @return An initialized GeoJSON source.
  */
-- (instancetype)initWithIdentifier:(NSString *)identifier features:(NSArray<id<MGLFeature>> *)features options:(nullable NS_DICTIONARY_OF(MGLGeoJSONSourceOption, id) *)options NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithIdentifier:(NSString *)identifier shape:(nullable MGLShape *)shape options:(nullable NS_DICTIONARY_OF(MGLGeoJSONSourceOption, id) *)options NS_DESIGNATED_INITIALIZER;
 
 #pragma mark Accessing a Source’s Content
 
 /**
- The contents of the source.
+ The contents of the source. A shape can represent a GeoJSON geometry, a feature, 
+ or a collection of features.
 
  If the receiver was initialized using `-initWithIdentifier:URL:options:`, this property
  is set to `nil`. This property is unavailable until the receiver is passed into
  `-[MGLStyle addSource]`.
  */
-@property (nonatomic, nullable) NS_ARRAY_OF(id <MGLFeature>) *features;
+@property (nonatomic, nullable) MGLShape *shape;
 
 /**
  A GeoJSON representation of the contents of the source.
@@ -137,7 +139,6 @@ extern const MGLGeoJSONSourceOption MGLGeoJSONSourceOptionSimplificationToleranc
  property is set to `nil`.
  */
 @property (nonatomic, nullable) NSURL *URL;
-
 
 @end
 

--- a/platform/darwin/src/MGLPointAnnotation.mm
+++ b/platform/darwin/src/MGLPointAnnotation.mm
@@ -24,10 +24,10 @@
              @"coordinates": @[@(self.coordinate.longitude), @(self.coordinate.latitude)]};
 }
 
-- (mbgl::Feature)featureObject
+- (mbgl::Geometry<double>)geometryObject
 {
     mbgl::Point<double> point = { self.coordinate.longitude, self.coordinate.latitude };
-    return mbgl::Feature {point};
+    return point;
 }
 
 @end

--- a/platform/darwin/src/MGLPointCollection.mm
+++ b/platform/darwin/src/MGLPointCollection.mm
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
     return MGLLatLngBoundsFromCoordinateBounds(_bounds).intersects(MGLLatLngBoundsFromCoordinateBounds(overlayBounds));
 }
 
-- (mbgl::Feature)featureObject
+- (mbgl::Geometry<double>)geometryObject
 {
     mbgl::MultiPoint<double> multiPoint;
     multiPoint.reserve(self.pointCount);
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
     {
         multiPoint.push_back(mbgl::Point<double>(self.coordinates[i].longitude, self.coordinates[i].latitude));
     }
-    return mbgl::Feature {multiPoint};
+    return multiPoint;
 }
 
 - (NSDictionary *)geoJSONDictionary

--- a/platform/darwin/src/MGLPolygon.mm
+++ b/platform/darwin/src/MGLPolygon.mm
@@ -38,23 +38,22 @@
     return result;
 }
 
-- (mbgl::Feature)featureObject {
+- (mbgl::Polygon<double>)polygon {
     mbgl::Polygon<double> geometry;
     geometry.push_back(self.ring);
     for (MGLPolygon *polygon in self.interiorPolygons) {
         geometry.push_back(polygon.ring);
     }
-    return mbgl::Feature{geometry};
+    return geometry;
+}
+
+- (mbgl::Geometry<double>)geometryObject {
+    return [self polygon];
 }
 
 - (mbgl::Annotation)annotationObjectWithDelegate:(id <MGLMultiPointDelegate>)delegate {
-    mbgl::Polygon<double> geometry;
-    geometry.push_back(self.ring);
-    for (MGLPolygon *polygon in self.interiorPolygons) {
-        geometry.push_back(polygon.ring);
-    }
-
-    mbgl::FillAnnotation annotation { geometry };
+    
+    mbgl::FillAnnotation annotation { [self polygon] };
     annotation.opacity = { static_cast<float>([delegate alphaForShapeAnnotation:self]) };
     annotation.outlineColor = { [delegate strokeColorForShapeAnnotation:self] };
     annotation.color = { [delegate fillColorForPolygonAnnotation:self] };
@@ -103,7 +102,7 @@
     return MGLLatLngBoundsFromCoordinateBounds(_overlayBounds).intersects(MGLLatLngBoundsFromCoordinateBounds(overlayBounds));
 }
 
-- (mbgl::Feature)featureObject {
+- (mbgl::Geometry<double>)geometryObject {
     mbgl::MultiPolygon<double> multiPolygon;
     multiPolygon.reserve(self.polygons.count);
     for (MGLPolygon *polygon in self.polygons) {
@@ -114,7 +113,7 @@
         }
         multiPolygon.push_back(geometry);
     }
-    return mbgl::Feature {multiPolygon};
+    return multiPolygon;
 }
 
 - (NSDictionary *)geoJSONDictionary {

--- a/platform/darwin/src/MGLPolyline.mm
+++ b/platform/darwin/src/MGLPolyline.mm
@@ -37,8 +37,8 @@
     return annotation;
 }
 
-- (mbgl::Feature)featureObject {
-    return mbgl::Feature {[self lineString]};    
+- (mbgl::Geometry<double>)geometryObject {
+    return [self lineString];
 }
 
 - (NSDictionary *)geoJSONDictionary {
@@ -82,13 +82,13 @@
     return MGLLatLngBoundsFromCoordinateBounds(_overlayBounds).intersects(MGLLatLngBoundsFromCoordinateBounds(overlayBounds));
 }
 
-- (mbgl::Feature)featureObject {
+- (mbgl::Geometry<double>)geometryObject {
     mbgl::MultiLineString<double> multiLineString;
     multiLineString.reserve(self.polylines.count);
     for (MGLPolyline *polyline in self.polylines) {
         multiLineString.push_back([polyline lineString]);
     }
-    return mbgl::Feature {multiLineString};
+    return multiLineString;
 }
 
 - (NSDictionary *)geoJSONDictionary {

--- a/platform/darwin/src/MGLShapeCollection.mm
+++ b/platform/darwin/src/MGLShapeCollection.mm
@@ -1,5 +1,9 @@
 #import "MGLShapeCollection.h"
 
+#import "MGLShape_Private.h"
+
+#import <mbgl/style/conversion/geojson.hpp>
+
 @implementation MGLShapeCollection
 
 + (instancetype)shapeCollectionWithShapes:(NS_ARRAY_OF(MGLShape *) *)shapes {
@@ -30,6 +34,15 @@
         [geometries addObject:geometry];
     }
     return [geometries copy];
+}
+
+- (mbgl::Geometry<double>)geometryObject {
+    mapbox::geojson::geometry_collection collection;
+    collection.reserve(self.shapes.count);
+    for (MGLShape *shape in self.shapes) {
+        collection.push_back([shape geometryObject]);
+    }
+    return collection;
 }
 
 @end

--- a/platform/darwin/src/MGLShape_Private.h
+++ b/platform/darwin/src/MGLShape_Private.h
@@ -1,13 +1,13 @@
 #import "MGLShape.h"
 
-#import <mbgl/util/feature.hpp>
+#import <mbgl/util/geometry.hpp>
 
 @interface MGLShape (Private)
 
 /**
- Returns an `mbgl::Feature` representation of the `MGLShape`.
+ Returns an `mbgl::Geometry<double>` representation of the `MGLShape`.
  */
-- (mbgl::Feature)featureObject;
+- (mbgl::Geometry<double>)geometryObject;
 
 /**
  Returns a dictionary with the GeoJSON geometry member object.

--- a/platform/darwin/test/MGLGeoJSONSourceTests.mm
+++ b/platform/darwin/test/MGLGeoJSONSourceTests.mm
@@ -35,27 +35,40 @@
     XCTAssertThrows([[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" URL:url options:options]);
 }
 
-- (void)testMGLGeoJSONSourceWithData {
+- (void)testNilShape {
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"id" shape:nil options:nil];
+    XCTAssertNil(source.shape);
+}
+
+- (void)testMGLGeoJSONSourceWithDataMultipleFeatures {
     
     NSString *geoJSON = @"{\"type\": \"FeatureCollection\",\"features\": [{\"type\": \"Feature\",\"properties\": {},\"geometry\": {\"type\": \"LineString\",\"coordinates\": [[-107.75390625,40.329795743702064],[-104.34814453125,37.64903402157866]]}}]}";
     
     NSData *data = [geoJSON dataUsingEncoding:NSUTF8StringEncoding];
     MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" geoJSONData:data options:nil];
     
-    XCTAssertNotNil(source.features);
-    XCTAssertEqual(source.features.count, 1);
-    XCTAssertTrue([source.features.firstObject isMemberOfClass:[MGLPolylineFeature class]]);
+    MGLShapeCollection *collection = source.shape;
+    XCTAssertNotNil(collection);
+    XCTAssertEqual(collection.shapes.count, 1);
+    XCTAssertTrue([collection.shapes.firstObject isMemberOfClass:[MGLPolylineFeature class]]);
+}
+
+- (void)testMGLGeoJSONSourceWithSingleFeature {
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"geojson"
+                                                                geoJSONData:[@"{\"type\": \"Point\", \"coordinates\": [0, 0]}" dataUsingEncoding:NSUTF8StringEncoding]
+                                                                    options:nil];
+    XCTAssertNotNil(source.shape);
+    XCTAssert([source.shape isKindOfClass:[MGLPointFeature class]]);
 }
 
 - (void)testMGLGeoJSONSourceWithPolylineFeatures {
     CLLocationCoordinate2D coordinates[] = { CLLocationCoordinate2DMake(0, 0), CLLocationCoordinate2DMake(10, 10)};
     MGLPolylineFeature *polylineFeature = [MGLPolylineFeature polylineWithCoordinates:coordinates count:2];
     
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" features:@[polylineFeature] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" shape:polylineFeature options:nil];
     
-    XCTAssertNotNil(source.features);
-    XCTAssertEqual(source.features.count, 1);
-    XCTAssertTrue([source.features.firstObject isMemberOfClass:[MGLPolylineFeature class]]);
+    XCTAssertNotNil(source.shape);
+    XCTAssertTrue([source.shape isMemberOfClass:[MGLPolylineFeature class]]);
 }
 
 - (void)testMGLGeoJSONSourceWithPolygonFeatures {
@@ -88,11 +101,11 @@
                                   @"array-of-array-attribute": arrayOfArrays,
                                   @"array-of-dictionary-attribute": arrayOfDictionaries};
     
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" features:@[polygonFeature] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" shape:polygonFeature options:nil];
     
-    XCTAssertNotNil(source.features);
-    XCTAssertEqual(source.features.count, 1);
-    MGLPolygonFeature *expectedPolygonFeature = (MGLPolygonFeature *)source.features.firstObject;
+    XCTAssertNotNil(source.shape);
+    MGLPolygonFeature *expectedPolygonFeature = (MGLPolygonFeature *)source.shape;
+    XCTAssertEqualObjects(expectedPolygonFeature.identifier, polygonFeature.identifier);
     XCTAssertTrue([expectedPolygonFeature isMemberOfClass:[MGLPolygonFeature class]]);
     XCTAssertEqualObjects(expectedPolygonFeature.identifier, polygonFeature.identifier);
     XCTAssertEqualObjects(expectedPolygonFeature.attributes[@"name"], stringAttribute);
@@ -123,12 +136,10 @@
     
     MGLPolygonFeature *polygonFeature = [MGLPolygonFeature polygonWithCoordinates:coordinates count:5 interiorPolygons:@[polygon]];
     
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" features:@[polygonFeature] options:nil];
-   
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" shape:polygonFeature options:nil];
     
-    XCTAssertNotNil(source.features);
-    XCTAssertEqual(source.features.count, 1);
-    XCTAssertTrue([source.features.firstObject isMemberOfClass:[MGLPolygonFeature class]]);
+    XCTAssertNotNil(source.shape);
+    XCTAssertTrue([source.shape isMemberOfClass:[MGLPolygonFeature class]]);
 }
 
 - (void)testMGLGeoJSONSourceWithMultiPolylineFeatures {
@@ -138,11 +149,10 @@
     MGLPolylineFeature *secondPolylineFeature = [MGLPolylineFeature polylineWithCoordinates:secondCoordinates count:2];
     MGLMultiPolylineFeature *multiPolylineFeature = [MGLMultiPolylineFeature multiPolylineWithPolylines:@[firstPolylineFeature, secondPolylineFeature]];
     
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" features:@[multiPolylineFeature] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" shape:multiPolylineFeature options:nil];
     
-    XCTAssertNotNil(source.features);
-    XCTAssertEqual(source.features.count, 1);
-    XCTAssertTrue([source.features.firstObject isMemberOfClass:[MGLMultiPolylineFeature class]]);
+    XCTAssertNotNil(source.shape);
+    XCTAssertTrue([source.shape isMemberOfClass:[MGLMultiPolylineFeature class]]);
 }
 
 - (void)testMGLGeoJSONSourceWithMultiPolygonFeatures {
@@ -167,23 +177,20 @@
     
     MGLMultiPolygonFeature *multiPolygonFeature = [MGLMultiPolygonFeature multiPolygonWithPolygons:@[firstPolygon, secondPolygon]];
     
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" features:@[multiPolygonFeature] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" shape:multiPolygonFeature options:nil];
     
-    XCTAssertNotNil(source.features);
-    XCTAssertEqual(source.features.count, 1);
-    XCTAssertTrue([source.features.firstObject isMemberOfClass:[MGLMultiPolygonFeature class]]);
-
+    XCTAssertNotNil(source.shape);
+    XCTAssertTrue([source.shape isMemberOfClass:[MGLMultiPolygonFeature class]]);
 }
 
 - (void)testMGLGeoJSONSourceWithPointFeature {
     MGLPointFeature *pointFeature = [MGLPointFeature new];
     pointFeature.coordinate = CLLocationCoordinate2DMake(100.2, 0.2);
     
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"souce-id" features:@[pointFeature] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"souce-id" shape:pointFeature options:nil];
     
-    XCTAssertNotNil(source.features);
-    XCTAssertEqual(source.features.count, 1);
-    XCTAssertTrue([source.features.firstObject isMemberOfClass:[MGLPointFeature class]]);
+    XCTAssertNotNil(source.shape);
+    XCTAssertTrue([source.shape isMemberOfClass:[MGLPointFeature class]]);
 }
 
 - (void)testMGLGeoJSONSourceWithPointCollectionFeature {
@@ -194,11 +201,10 @@
         CLLocationCoordinate2DMake(100.0, 1.0),
         CLLocationCoordinate2DMake(100.0, 0.0)};
     MGLPointCollectionFeature *pointCollectionFeature = [MGLPointCollectionFeature pointCollectionWithCoordinates:coordinates count:5];
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"souce-id" features:@[pointCollectionFeature] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"souce-id" shape:pointCollectionFeature options:nil];
 
-    XCTAssertNotNil(source.features);
-    XCTAssertEqual(source.features.count, 1);
-    XCTAssertTrue([source.features.firstObject isMemberOfClass:[MGLPointCollectionFeature class]]);
+    XCTAssertNotNil(source.shape);
+    XCTAssertTrue([source.shape isMemberOfClass:[MGLPointCollectionFeature class]]);
 }
 
 - (void)testMGLGeoJSONSourceWithShapeCollectionFeatures {
@@ -236,7 +242,13 @@
 
     MGLShapeCollectionFeature *shapeCollectionFeature_1 = [MGLShapeCollectionFeature shapeCollectionWithShapes:@[polygonFeature, polylineFeature, multiPolygonFeature, multiPolylineFeature, pointCollectionFeature, pointFeature, shapeCollectionFeature]];
 
-    XCTAssertThrowsSpecificNamed([[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" features:@[shapeCollectionFeature_1] options:nil], NSException, @"Method unavailable");
+    
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"source-id" shape:shapeCollectionFeature_1 options:nil];
+    
+    MGLShapeCollectionFeature *shape = source.shape;
+    
+    XCTAssertNotNil(shape);
+    XCTAssert(shape.shapes.count == 7, @"Shape collection should contain 7 shapes");
 }
 
 @end

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -121,7 +121,7 @@
 }
 
 - (void)testAddingSourcesTwice {
-    MGLGeoJSONSource *geoJSONSource = [[MGLGeoJSONSource alloc] initWithIdentifier:@"geoJSONSource" features:@[] options:nil];
+    MGLGeoJSONSource *geoJSONSource = [[MGLGeoJSONSource alloc] initWithIdentifier:@"geoJSONSource" shape:nil options:nil];
     [self.style addSource:geoJSONSource];
     XCTAssertThrowsSpecificNamed([self.style addSource:geoJSONSource], NSException, @"MGLRedundantSourceException");
 
@@ -143,7 +143,7 @@
 }
 
 - (void)testAddingLayersTwice {
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"geoJSONSource" features:@[] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"geoJSONSource" shape:nil options:nil];
 
     MGLBackgroundStyleLayer *backgroundLayer = [[MGLBackgroundStyleLayer alloc] initWithIdentifier:@"backgroundLayer"];
     [self.style addLayer:backgroundLayer];

--- a/platform/darwin/test/MGLStyleValueTests.swift
+++ b/platform/darwin/test/MGLStyleValueTests.swift
@@ -3,7 +3,7 @@ import Mapbox
 
 class MGLStyleValueTests: XCTestCase {
     func testConstantValues() {
-        let geoJSONSource = MGLGeoJSONSource(identifier: "test", features: [], options: nil)
+        let geoJSONSource = MGLGeoJSONSource(identifier: "test", shape: nil, options: nil)
         let symbolStyleLayer = MGLSymbolStyleLayer(identifier: "test", source: geoJSONSource)
         
         // Boolean
@@ -20,7 +20,7 @@ class MGLStyleValueTests: XCTestCase {
     }
     
     func testFunctions() {
-        let geoJSONSource = MGLGeoJSONSource(identifier: "test", features: [], options: nil)
+        let geoJSONSource = MGLGeoJSONSource(identifier: "test", shape: nil, options: nil)
         let symbolStyleLayer = MGLSymbolStyleLayer(identifier: "test", source: geoJSONSource)
         
         // Boolean

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -877,7 +877,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 - (void)styleQuery
 {
     CGRect queryRect = CGRectInset(self.mapView.bounds, 100, 200);
-    NSArray *features = [self.mapView visibleFeaturesInRect:queryRect];
+    NSArray *visibleFeatures = [self.mapView visibleFeaturesInRect:queryRect];
     
     NSString *querySourceID = @"query-source-id";
     NSString *queryLayerID = @"query-layer-id";
@@ -895,9 +895,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         [self.mapView.style removeSource:source];
     }
     
-    
     dispatch_async(dispatch_get_main_queue(), ^{
-        MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:querySourceID features:features options:nil];
+        MGLShapeCollectionFeature *features = [MGLShapeCollectionFeature shapeCollectionWithShapes:visibleFeatures];
+        MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:querySourceID shape:features options:nil];
         [self.mapView.style addSource:source];
         
         MGLFillStyleLayer *fillLayer = [[MGLFillStyleLayer alloc] initWithIdentifier:queryLayerID source:source];
@@ -950,7 +950,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     feature.identifier = @"leaf-feature";
     feature.attributes = @{@"color": @"red"};
     
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"leaf-source" features:@[feature] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"leaf-source" shape:feature options:nil];
     [self.mapView.style addSource:source];
     
     MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"leaf-fill-layer" source:source];
@@ -1026,7 +1026,10 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     MGLPolygonFeature *smallBoxFeature = [MGLPolygonFeature polygonWithCoordinates:smallBox count:sizeof(smallBox)/sizeof(smallBox[0])];
     MGLPolygonFeature *largeBoxFeature = [MGLPolygonFeature polygonWithCoordinates:largeBox count:sizeof(largeBox)/sizeof(largeBox[0])];
 
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"mutable-data-source-features-id" features:@[smallBoxFeature] options:nil];
+    MGLShapeCollectionFeature *collection = [MGLShapeCollectionFeature shapeCollectionWithShapes:@[smallBoxFeature]];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"mutable-data-source-features-id"
+                                                                    shape:collection
+                                                                    options:nil];
     [self.mapView.style addSource:source];
     
     MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"mutable-data-layer-features-id" source:source];
@@ -1035,7 +1038,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     [self.mapView.style addLayer:layer];
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        source.features = @[largeBoxFeature];
+        source.shape = largeBoxFeature;
     });
 }
 
@@ -1049,7 +1052,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         {36.99508088541243, -109.04007911682129},
     };
     MGLPointCollectionFeature *feature = [MGLPointCollectionFeature pointCollectionWithCoordinates:coordinates count:4];
-    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"wiggle-source" features:@[feature] options:nil];
+    MGLGeoJSONSource *source = [[MGLGeoJSONSource alloc] initWithIdentifier:@"wiggle-source" shape:feature options:nil];
     [self.mapView.style addSource:source];
     
     MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithIdentifier:@"wiggle-layer" source:source];
@@ -1116,7 +1119,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 
     MGLPolylineFeature *routeLine = [MGLPolylineFeature polylineWithCoordinates:coords count:count];
 
-    MGLGeoJSONSource *routeSource = [[MGLGeoJSONSource alloc] initWithIdentifier:@"style-route-source" features:@[routeLine] options:nil];
+    MGLGeoJSONSource *routeSource = [[MGLGeoJSONSource alloc] initWithIdentifier:@"style-route-source" shape:routeLine options:nil];
     [self.mapView.style addSource:routeSource];
 
     MGLLineStyleLayer *baseRouteLayer = [[MGLLineStyleLayer alloc] initWithIdentifier:@"style-base-route-layer" source:routeSource];

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -398,8 +398,8 @@
 		DAD165711CF41981001FF4B9 /* MGLFeature.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAD1656B1CF41981001FF4B9 /* MGLFeature.mm */; };
 		DAD165781CF4CDFF001FF4B9 /* MGLShapeCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = DAD165761CF4CDFF001FF4B9 /* MGLShapeCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAD165791CF4CDFF001FF4B9 /* MGLShapeCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = DAD165761CF4CDFF001FF4B9 /* MGLShapeCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DAD1657A1CF4CDFF001FF4B9 /* MGLShapeCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.m */; };
-		DAD1657B1CF4CDFF001FF4B9 /* MGLShapeCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.m */; };
+		DAD1657A1CF4CDFF001FF4B9 /* MGLShapeCollection.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.mm */; };
+		DAD1657B1CF4CDFF001FF4B9 /* MGLShapeCollection.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.mm */; };
 		DAED38631D62D0FC00D7640F /* NSURL+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED38611D62D0FC00D7640F /* NSURL+MGLAdditions.h */; };
 		DAED38641D62D0FC00D7640F /* NSURL+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = DAED38611D62D0FC00D7640F /* NSURL+MGLAdditions.h */; };
 		DAED38651D62D0FC00D7640F /* NSURL+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DAED38621D62D0FC00D7640F /* NSURL+MGLAdditions.m */; };
@@ -767,7 +767,7 @@
 		DAD1656A1CF41981001FF4B9 /* MGLFeature_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLFeature_Private.h; sourceTree = "<group>"; };
 		DAD1656B1CF41981001FF4B9 /* MGLFeature.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLFeature.mm; sourceTree = "<group>"; };
 		DAD165761CF4CDFF001FF4B9 /* MGLShapeCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLShapeCollection.h; sourceTree = "<group>"; };
-		DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLShapeCollection.m; sourceTree = "<group>"; };
+		DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLShapeCollection.mm; sourceTree = "<group>"; };
 		DAED38611D62D0FC00D7640F /* NSURL+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+MGLAdditions.h"; sourceTree = "<group>"; };
 		DAED38621D62D0FC00D7640F /* NSURL+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+MGLAdditions.m"; sourceTree = "<group>"; };
 		DD0902A21DB18DE700C5BDCE /* MGLNetworkConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfiguration.m; sourceTree = "<group>"; };
@@ -1302,7 +1302,7 @@
 				40CF6DBA1DAC3C1800A4D18B /* MGLShape_Private.h */,
 				DA88480E1CBAFA6200AB86E3 /* MGLShape.mm */,
 				DAD165761CF4CDFF001FF4B9 /* MGLShapeCollection.h */,
-				DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.m */,
+				DAD165771CF4CDFF001FF4B9 /* MGLShapeCollection.mm */,
 			);
 			name = Geometry;
 			sourceTree = "<group>";
@@ -1950,7 +1950,7 @@
 				DA88488C1CBB037E00AB86E3 /* SMCalloutView.m in Sources */,
 				35136D4E1D4277FC00C20EFD /* MGLSource.mm in Sources */,
 				DA35A2B81CCA9A5D00E826B2 /* MGLClockDirectionFormatter.m in Sources */,
-				DAD1657A1CF4CDFF001FF4B9 /* MGLShapeCollection.m in Sources */,
+				DAD1657A1CF4CDFF001FF4B9 /* MGLShapeCollection.mm in Sources */,
 				35136D451D42275100C20EFD /* MGLSymbolStyleLayer.mm in Sources */,
 				35599DED1D46F14E0048254D /* MGLStyleValue.mm in Sources */,
 				DA8848211CBAFA6200AB86E3 /* MGLOfflinePack.mm in Sources */,
@@ -2023,7 +2023,7 @@
 				DAA4E4351CBB730400178DFB /* SMCalloutView.m in Sources */,
 				35136D4F1D4277FC00C20EFD /* MGLSource.mm in Sources */,
 				DA35A2B91CCA9A5D00E826B2 /* MGLClockDirectionFormatter.m in Sources */,
-				DAD1657B1CF4CDFF001FF4B9 /* MGLShapeCollection.m in Sources */,
+				DAD1657B1CF4CDFF001FF4B9 /* MGLShapeCollection.mm in Sources */,
 				DAA4E4251CBB730400178DFB /* MGLShape.mm in Sources */,
 				35136D461D42275100C20EFD /* MGLSymbolStyleLayer.mm in Sources */,
 				35599DEE1D46F14E0048254D /* MGLStyleValue.mm in Sources */,

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -122,7 +122,7 @@
 		DACC22151CF3D3E200D220D9 /* MGLFeature.mm in Sources */ = {isa = PBXBuildFile; fileRef = DACC22131CF3D3E200D220D9 /* MGLFeature.mm */; };
 		DACC22181CF3D4F700D220D9 /* MGLFeature_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DACC22171CF3D4F700D220D9 /* MGLFeature_Private.h */; };
 		DAD165741CF4CD7A001FF4B9 /* MGLShapeCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = DAD165721CF4CD7A001FF4B9 /* MGLShapeCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DAD165751CF4CD7A001FF4B9 /* MGLShapeCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = DAD165731CF4CD7A001FF4B9 /* MGLShapeCollection.m */; };
+		DAD165751CF4CD7A001FF4B9 /* MGLShapeCollection.mm in Sources */ = {isa = PBXBuildFile; fileRef = DAD165731CF4CD7A001FF4B9 /* MGLShapeCollection.mm */; };
 		DAE0DD7A1D5F015A005A6BB1 /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE6C3451CC31D1200DB3429 /* libmbgl-core.a */; };
 		DAE6C2E21CC304F900DB3429 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = DAE6C2E11CC304F900DB3429 /* Credits.rtf */; };
 		DAE6C2ED1CC3050F00DB3429 /* DroppedPinAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE6C2E41CC3050F00DB3429 /* DroppedPinAnnotation.m */; };
@@ -366,7 +366,7 @@
 		DACC22131CF3D3E200D220D9 /* MGLFeature.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLFeature.mm; sourceTree = "<group>"; };
 		DACC22171CF3D4F700D220D9 /* MGLFeature_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLFeature_Private.h; sourceTree = "<group>"; };
 		DAD165721CF4CD7A001FF4B9 /* MGLShapeCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLShapeCollection.h; sourceTree = "<group>"; };
-		DAD165731CF4CD7A001FF4B9 /* MGLShapeCollection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLShapeCollection.m; sourceTree = "<group>"; };
+		DAD165731CF4CD7A001FF4B9 /* MGLShapeCollection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLShapeCollection.mm; sourceTree = "<group>"; };
 		DAE6C2E11CC304F900DB3429 /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		DAE6C2E31CC3050F00DB3429 /* DroppedPinAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DroppedPinAnnotation.h; sourceTree = "<group>"; };
 		DAE6C2E41CC3050F00DB3429 /* DroppedPinAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DroppedPinAnnotation.m; sourceTree = "<group>"; };
@@ -741,7 +741,7 @@
 				DAE6C3561CC31E0400DB3429 /* MGLShape.h */,
 				DAE6C3791CC31E2A00DB3429 /* MGLShape.mm */,
 				DAD165721CF4CD7A001FF4B9 /* MGLShapeCollection.h */,
-				DAD165731CF4CD7A001FF4B9 /* MGLShapeCollection.m */,
+				DAD165731CF4CD7A001FF4B9 /* MGLShapeCollection.mm */,
 			);
 			name = Geometry;
 			sourceTree = "<group>";
@@ -1230,7 +1230,7 @@
 				3527428A1D4C245800A1ECE6 /* MGLGeoJSONSource.mm in Sources */,
 				DAE6C3B51CC31EF300DB3429 /* MGLCompassCell.m in Sources */,
 				DA8F25901D51CA600010E6B5 /* MGLRasterStyleLayer.mm in Sources */,
-				DAD165751CF4CD7A001FF4B9 /* MGLShapeCollection.m in Sources */,
+				DAD165751CF4CD7A001FF4B9 /* MGLShapeCollection.mm in Sources */,
 				35C5D8481D6DD66D00E95907 /* NSComparisonPredicate+MGLAdditions.mm in Sources */,
 				DA35A2AE1CCA091800E826B2 /* MGLCompassDirectionFormatter.m in Sources */,
 				DA8F258C1D51CA540010E6B5 /* MGLLineStyleLayer.mm in Sources */,


### PR DESCRIPTION
First stab at #6986 

I'm slightly hesitant about replacing `-[MGLGeoJSONSource initWithIdentifier:features:options:]` with `feature` because of the additional initialization of MGLShapeCollectionFeature devs has to do now compared to a concise array literal prior to this change.

@1ec5 👀 