### PR TITLE
Fix tilt ClassCastException in myLocationView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -401,7 +401,7 @@ public class MyLocationView extends View {
     public void onRestoreInstanceState(Parcelable state) {
         if (state instanceof Bundle) {
             Bundle bundle = (Bundle) state;
-            tilt = bundle.getFloat("tilt");
+            tilt = bundle.getDouble("tilt");
             state = bundle.getParcelable("superState");
         }
         super.onRestoreInstanceState(state);


### PR DESCRIPTION
Got this after I moved from 4.2.0 beta3 to beta5
```
W/Bundle: Attempt to cast generated internal exception:
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Float
at android.os.BaseBundle.getFloat(BaseBundle.java:868)
at android.os.Bundle.getFloat(Bundle.java:654)
at android.os.BaseBundle.getFloat(BaseBundle.java:850)
at android.os.Bundle.getFloat(Bundle.java:641)
at com.mapbox.mapboxsdk.maps.widgets.MyLocationView.onRestoreInstanceState(MyLocationView.java:404)
at android.view.View.dispatchRestoreInstanceState(View.java:13758)
at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:2895)
at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:2895)
at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:2895)
at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:2895)
at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:2895)
at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:2895)
at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:2895)
at android.view.View.restoreHierarchyState(View.java:13736)
at com.android.internal.policy.impl.PhoneWindow.restoreHierarchyState(PhoneWindow.java:2009)
at android.app.Activity.onRestoreInstanceState(Activity.java:1033)
at android.app.Activity.performRestoreInstanceState(Activity.java:988)
at android.app.Instrumentation.callActivityOnRestoreInstanceState(Instrumentation.java:1185)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2312)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2413)
at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4032)
at android.app.ActivityThread.access$900(ActivityThread.java:155)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1323)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5343)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:905)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:700)
```