### PR TITLE
Allow Bitrise user to publish metrics

### DIFF
--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -163,6 +163,26 @@
                         }
                     },
                     {
+                        "PolicyName": "publish-metrics",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "s3:DeleteObject",
+                                        "s3:GetObject",
+                                        "s3:GetObjectAcl",
+                                        "s3:PutObject",
+                                        "s3:PutObjectAcl"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        "arn:aws:s3:::mapbox/mapbox-gl-native/metrics/*"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
                         "PolicyName": "cloudwatch-metrics",
                         "PolicyDocument": {
                             "Statement": [


### PR DESCRIPTION
The `BitriseUser` in CloudFormation currently does not have access to `s3://mapbox/mapbox-gl-native/metrics`, so publishing the metrics fails.