### PR TITLE
Add location related tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/PermissionGranter.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/PermissionGranter.java
@@ -1,0 +1,21 @@
+package com.mapbox.mapboxsdk;
+
+import android.Manifest;
+import android.os.Build;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.InstrumentationRegistry.getTargetContext;
+
+public class PermissionGranter {
+
+  private static final String PM_GRANT = "pm grant";
+  private static final String SEPARATOR = " ";
+
+  public static void grantLocation() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      getInstrumentation().getUiAutomation().executeShellCommand(
+          PM_GRANT + SEPARATOR + getTargetContext().getPackageName() +
+          SEPARATOR + Manifest.permission.ACCESS_FINE_LOCATION);
+    }
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseActivityTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/BaseActivityTest.java
@@ -4,8 +4,8 @@ import android.app.Activity;
 import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingResourceTimeoutException;
 import android.support.test.rule.ActivityTestRule;
-import timber.log.Timber;
 
+import com.mapbox.mapboxsdk.PermissionGranter;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.utils.OnMapReadyIdlingResource;
@@ -13,7 +13,10 @@ import com.mapbox.mapboxsdk.testapp.utils.ScreenshotUtil;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
+
+import timber.log.Timber;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -26,6 +29,11 @@ public abstract class BaseActivityTest {
     public ActivityTestRule<Activity> rule = new ActivityTestRule<>(getActivityClass());
     protected MapboxMap mapboxMap;
     protected OnMapReadyIdlingResource idlingResource;
+
+    @BeforeClass
+    public static void beforeClass() {
+        PermissionGranter.grantLocation();
+    }
 
     @Before
     public void beforeTest() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/widgets/MyLocationViewTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/maps/widgets/MyLocationViewTest.java
@@ -11,12 +11,9 @@ import android.support.test.espresso.ViewAction;
 import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
-import com.mapbox.mapboxsdk.camera.CameraPosition;
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.PermissionGranter;
 import com.mapbox.mapboxsdk.constants.MyBearingTracking;
 import com.mapbox.mapboxsdk.constants.MyLocationTracking;
-import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.location.LocationServices;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationView;
 import com.mapbox.mapboxsdk.testapp.R;
@@ -29,7 +26,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,6 +53,11 @@ public class MyLocationViewTest {
 
     private OnMapReadyIdlingResource idlingResource;
 
+    @BeforeClass
+    public static void beforeClass() {
+        PermissionGranter.grantLocation();
+    }
+
     @Before
     public void beforeTest() {
         idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
@@ -63,7 +65,6 @@ public class MyLocationViewTest {
     }
 
     @Test
-    @Ignore // requires runtime permissions, disabled for CI
     public void testEnabled() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
         MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -75,7 +76,6 @@ public class MyLocationViewTest {
     }
 
     @Test
-    @Ignore // requires runtime permissions, disabled for CI + issue with android.support.test.espresso.AppNotIdleException: Looped for 5049 iterations over 60 SECONDS.
     public void testTracking() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
         MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -114,18 +114,6 @@ public class MyLocationViewTest {
 
         @Override
         public void perform(UiController uiController, View view) {
-            if (isEnabled) {
-                // move camera above user location
-                mapboxMap.moveCamera(
-                        CameraUpdateFactory.newCameraPosition(
-                                new CameraPosition.Builder()
-                                        .target(new LatLng(LocationServices.getLocationServices(view.getContext()).getLastLocation()))
-                                        .build()
-                        )
-                );
-            }
-
-            // show loction on screen
             mapboxMap.setMyLocationEnabled(isEnabled);
         }
     }

--- a/platform/android/scripts/generate-test-code.js
+++ b/platform/android/scripts/generate-test-code.js
@@ -14,7 +14,7 @@ global.camelize = function (str) {
 }
 
 
-const excludeActivities = ["RealTimeGeoJsonActivity","UpdateMetadataActivity","CarDrivingActivity","MyLocationDrawableActivity","DoubleMapActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity", "MultiMapActivity", "MapInDialogActivity", "SimpleMapActivity"];
+const excludeActivities = ["MyLocationTintActivity","RealTimeGeoJsonActivity","UpdateMetadataActivity","CarDrivingActivity","MyLocationDrawableActivity","DoubleMapActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity", "MultiMapActivity", "MapInDialogActivity", "SimpleMapActivity"];
 const appBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity';
 const testBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/gen';
 const subPackages = fs.readdirSync(appBasePath);

--- a/platform/android/scripts/generate-test-code.js
+++ b/platform/android/scripts/generate-test-code.js
@@ -14,7 +14,7 @@ global.camelize = function (str) {
 }
 
 
-const excludeActivities = ["RealTimeGeoJsonActivity","UpdateMetadataActivity","CarDrivingActivity","MyLocationTrackingModeActivity","MyLocationToggleActivity","MyLocationTintActivity","MyLocationDrawableActivity","DoubleMapActivity", "LocationPickerActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity", "MultiMapActivity", "MapInDialogActivity", "SimpleMapActivity"];
+const excludeActivities = ["RealTimeGeoJsonActivity","UpdateMetadataActivity","CarDrivingActivity","MyLocationDrawableActivity","DoubleMapActivity","GeoJsonClusteringActivity","RuntimeStyleTestActivity", "AnimatedMarkerActivity", "ViewPagerActivity","MapFragmentActivity","SupportMapFragmentActivity","SnapshotActivity","NavigationDrawerActivity", "QueryRenderedFeaturesBoxHighlightActivity", "MultiMapActivity", "MapInDialogActivity", "SimpleMapActivity"];
 const appBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity';
 const testBasePath = 'platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/gen';
 const subPackages = fs.readdirSync(appBasePath);


### PR DESCRIPTION
Fixes #7159.

* Added location permission granter.
* Removed location related activities (except `MyLocationDrawableActivity` because of #7174) from being excluded.
* Removed @Ignore annotation of `testEnabled()` (`MyLocationViewTest`).

Note: Still ignoring `testTracking()` (`MyLocationViewTest`).

Cc/ @tobrun @zugaldia 
