### PR TITLE
[Qt] Use QOpenGLWidget instead of QGLWidget from Qt 5.4 onwards

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -17,38 +17,24 @@ int kAnimationDuration = 10000;
 
 
 MapWindow::MapWindow(const QMapboxGLSettings &settings)
-    : m_map(nullptr, settings, size(), pixelRatio())
-    , m_bearingAnimation(&m_map, "bearing")
-    , m_zoomAnimation(&m_map, "zoom")
+    : m_settings(settings)
 {
-    connect(&m_map, SIGNAL(needsRendering()), this, SLOT(updateGL()));
-
-    // Set default location to Helsinki.
-    m_map.setCoordinateZoom(QMapbox::Coordinate(60.170448, 24.942046), 14);
-
-    QString styleUrl = qgetenv("MAPBOX_STYLE_URL");
-    if (styleUrl.isEmpty()) {
-        changeStyle();
-    } else {
-        m_map.setStyleUrl(styleUrl);
-        setWindowTitle(QString("Mapbox GL: ") + styleUrl);
-    }
-
-    connect(&m_zoomAnimation, SIGNAL(finished()), this, SLOT(animationFinished()));
-    connect(&m_zoomAnimation, SIGNAL(valueChanged(const QVariant&)), this, SLOT(animationValueChanged()));
-
     setWindowIcon(QIcon(":icon.png"));
 }
 
 void MapWindow::selfTest()
 {
-    m_bearingAnimation.setDuration(kAnimationDuration);
-    m_bearingAnimation.setEndValue(m_map.bearing() + 360 * 4);
-    m_bearingAnimation.start();
+    if (m_bearingAnimation) {
+        m_bearingAnimation->setDuration(kAnimationDuration);
+        m_bearingAnimation->setEndValue(m_map->bearing() + 360 * 4);
+        m_bearingAnimation->start();
+    }
 
-    m_zoomAnimation.setDuration(kAnimationDuration);
-    m_zoomAnimation.setEndValue(m_map.zoom() + 3);
-    m_zoomAnimation.start();
+    if (m_zoomAnimation) {
+        m_zoomAnimation->setDuration(kAnimationDuration);
+        m_zoomAnimation->setEndValue(m_map->zoom() + 3);
+        m_zoomAnimation->start();
+    }
 }
 
 qreal MapWindow::pixelRatio() {
@@ -81,7 +67,7 @@ void MapWindow::changeStyle()
 
     auto& styles = QMapbox::defaultStyles();
 
-    m_map.setStyleUrl(styles[currentStyleIndex].first);
+    m_map->setStyleUrl(styles[currentStyleIndex].first);
     setWindowTitle(QString("Mapbox GL: ") + styles[currentStyleIndex].second);
 
     if (++currentStyleIndex == styles.size()) {
@@ -113,81 +99,81 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
             QVariantMap routeSource;
             routeSource["type"] = "geojson";
             routeSource["data"] = geojson.readAll();
-            m_map.addSource("routeSource", routeSource);
+            m_map->addSource("routeSource", routeSource);
 
             // The route case, painted before the route
             QVariantMap routeCase;
             routeCase["id"] = "routeCase";
             routeCase["type"] = "line";
             routeCase["source"] = "routeSource";
-            m_map.addLayer(routeCase);
+            m_map->addLayer(routeCase);
 
-            m_map.setPaintProperty("routeCase", "line-color", QColor("white"));
-            m_map.setPaintProperty("routeCase", "line-width", 20.0);
-            m_map.setLayoutProperty("routeCase", "line-join", "round");
-            m_map.setLayoutProperty("routeCase", "line-cap", "round");
+            m_map->setPaintProperty("routeCase", "line-color", QColor("white"));
+            m_map->setPaintProperty("routeCase", "line-width", 20.0);
+            m_map->setLayoutProperty("routeCase", "line-join", "round");
+            m_map->setLayoutProperty("routeCase", "line-cap", "round");
 
             // The route, painted on top of the route case
             QVariantMap route;
             route["id"] = "route";
             route["type"] = "line";
             route["source"] = "routeSource";
-            m_map.addLayer(route);
+            m_map->addLayer(route);
 
-            m_map.setPaintProperty("route", "line-color", QColor("blue"));
-            m_map.setPaintProperty("route", "line-width", 8.0);
-            m_map.setLayoutProperty("route", "line-join", "round");
-            m_map.setLayoutProperty("route", "line-cap", "round");
+            m_map->setPaintProperty("route", "line-color", QColor("blue"));
+            m_map->setPaintProperty("route", "line-width", 8.0);
+            m_map->setLayoutProperty("route", "line-join", "round");
+            m_map->setLayoutProperty("route", "line-cap", "round");
 
             // Markers at the beginning and end of the route
-            m_map.addImage("label-arrow", QImage(":label-arrow.svg"));
-            m_map.addImage("label-background", QImage(":label-background.svg"));
+            m_map->addImage("label-arrow", QImage(":label-arrow.svg"));
+            m_map->addImage("label-background", QImage(":label-background.svg"));
 
             QVariantMap makerArrow;
             makerArrow["id"] = "makerArrow";
             makerArrow["type"] = "symbol";
             makerArrow["source"] = "routeSource";
-            m_map.addLayer(makerArrow);
+            m_map->addLayer(makerArrow);
 
-            m_map.setLayoutProperty("makerArrow", "icon-image", "label-arrow");
-            m_map.setLayoutProperty("makerArrow", "icon-size", 0.5);
-            m_map.setLayoutProperty("makerArrow", "icon-ignore-placement", true);
+            m_map->setLayoutProperty("makerArrow", "icon-image", "label-arrow");
+            m_map->setLayoutProperty("makerArrow", "icon-size", 0.5);
+            m_map->setLayoutProperty("makerArrow", "icon-ignore-placement", true);
 
             QVariantList arrowOffset;
             arrowOffset.append(0.0);
             arrowOffset.append(-15.0);
-            m_map.setLayoutProperty("makerArrow", "icon-offset", arrowOffset);
+            m_map->setLayoutProperty("makerArrow", "icon-offset", arrowOffset);
 
             QVariantMap makerBackground;
             makerBackground["id"] = "makerBackground";
             makerBackground["type"] = "symbol";
             makerBackground["source"] = "routeSource";
-            m_map.addLayer(makerBackground);
+            m_map->addLayer(makerBackground);
 
-            m_map.setLayoutProperty("makerBackground", "icon-image", "label-background");
-            m_map.setLayoutProperty("makerBackground", "text-field", "{name}");
-            m_map.setLayoutProperty("makerBackground", "icon-text-fit", "both");
-            m_map.setLayoutProperty("makerBackground", "icon-ignore-placement", true);
-            m_map.setLayoutProperty("makerBackground", "text-ignore-placement", true);
-            m_map.setLayoutProperty("makerBackground", "text-anchor", "left");
-            m_map.setLayoutProperty("makerBackground", "text-size", 16.0);
-            m_map.setLayoutProperty("makerBackground", "text-padding", 0.0);
-            m_map.setLayoutProperty("makerBackground", "text-line-height", 1.0);
-            m_map.setLayoutProperty("makerBackground", "text-max-width", 8.0);
+            m_map->setLayoutProperty("makerBackground", "icon-image", "label-background");
+            m_map->setLayoutProperty("makerBackground", "text-field", "{name}");
+            m_map->setLayoutProperty("makerBackground", "icon-text-fit", "both");
+            m_map->setLayoutProperty("makerBackground", "icon-ignore-placement", true);
+            m_map->setLayoutProperty("makerBackground", "text-ignore-placement", true);
+            m_map->setLayoutProperty("makerBackground", "text-anchor", "left");
+            m_map->setLayoutProperty("makerBackground", "text-size", 16.0);
+            m_map->setLayoutProperty("makerBackground", "text-padding", 0.0);
+            m_map->setLayoutProperty("makerBackground", "text-line-height", 1.0);
+            m_map->setLayoutProperty("makerBackground", "text-max-width", 8.0);
 
             QVariantList iconTextFitPadding;
             iconTextFitPadding.append(15.0);
             iconTextFitPadding.append(10.0);
             iconTextFitPadding.append(15.0);
             iconTextFitPadding.append(10.0);
-            m_map.setLayoutProperty("makerBackground", "icon-text-fit-padding", iconTextFitPadding);
+            m_map->setLayoutProperty("makerBackground", "icon-text-fit-padding", iconTextFitPadding);
 
             QVariantList backgroundOffset;
             backgroundOffset.append(-0.5);
             backgroundOffset.append(-1.5);
-            m_map.setLayoutProperty("makerBackground", "text-offset", backgroundOffset);
+            m_map->setLayoutProperty("makerBackground", "text-offset", backgroundOffset);
 
-            m_map.setPaintProperty("makerBackground", "text-color", QColor("white"));
+            m_map->setPaintProperty("makerBackground", "text-color", QColor("white"));
 
             QVariantList filterExpression;
             filterExpression.append("==");
@@ -197,29 +183,29 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
             QVariantList filter;
             filter.append(filterExpression);
 
-            m_map.setFilter("makerArrow", filter);
-            m_map.setFilter("makerBackground", filter);
+            m_map->setFilter("makerArrow", filter);
+            m_map->setFilter("makerBackground", filter);
 
             // Tilt the labels when tilting the map and make them larger
-            m_map.setLayoutProperty("road-label-large", "text-size", 30.0);
-            m_map.setLayoutProperty("road-label-large", "text-pitch-alignment", "viewport");
+            m_map->setLayoutProperty("road-label-large", "text-size", 30.0);
+            m_map->setLayoutProperty("road-label-large", "text-pitch-alignment", "viewport");
 
-            m_map.setLayoutProperty("road-label-medium", "text-size", 30.0);
-            m_map.setLayoutProperty("road-label-medium", "text-pitch-alignment", "viewport");
+            m_map->setLayoutProperty("road-label-medium", "text-size", 30.0);
+            m_map->setLayoutProperty("road-label-medium", "text-pitch-alignment", "viewport");
 
-            m_map.setLayoutProperty("road-label-small", "text-pitch-alignment", "viewport");
-            m_map.setLayoutProperty("road-label-small", "text-size", 30.0);
+            m_map->setLayoutProperty("road-label-small", "text-pitch-alignment", "viewport");
+            m_map->setLayoutProperty("road-label-small", "text-size", 30.0);
         }
         break;
     case Qt::Key_Tab:
-        m_map.cycleDebugOptions();
+        m_map->cycleDebugOptions();
         break;
     case Qt::Key_R: {
-        m_map.setTransitionOptions(transition);
-        if (m_map.hasClass("night")) {
-            m_map.removeClass("night");
+        m_map->setTransitionOptions(transition);
+        if (m_map->hasClass("night")) {
+            m_map->removeClass("night");
         } else {
-            m_map.addClass("night");
+            m_map->addClass("night");
         }
     } break;
     default:
@@ -245,9 +231,9 @@ void MapWindow::mousePressEvent(QMouseEvent *ev)
 
     if (ev->type() == QEvent::MouseButtonDblClick) {
         if (ev->buttons() == Qt::LeftButton) {
-            m_map.scaleBy(2.0, m_lastPos);
+            m_map->scaleBy(2.0, m_lastPos);
         } else if (ev->buttons() == Qt::RightButton) {
-            m_map.scaleBy(0.5, m_lastPos);
+            m_map->scaleBy(0.5, m_lastPos);
         }
     }
 
@@ -264,14 +250,14 @@ void MapWindow::mouseMoveEvent(QMouseEvent *ev)
 
     if (!delta.isNull()) {
         if (ev->buttons() == Qt::LeftButton && ev->modifiers() & Qt::ShiftModifier) {
-            m_map.setPitch(m_map.pitch() - delta.y());
+            m_map->setPitch(m_map->pitch() - delta.y());
         } else if (ev->buttons() == Qt::LeftButton) {
-            m_map.moveBy(delta);
+            m_map->moveBy(delta);
         } else if (ev->buttons() == Qt::RightButton) {
 #if QT_VERSION < 0x050000
-            m_map.rotateBy(m_lastPos, ev->posF());
+            m_map->rotateBy(m_lastPos, ev->posF());
 #else
-            m_map.rotateBy(m_lastPos, ev->localPos());
+            m_map->rotateBy(m_lastPos, ev->localPos());
 #endif
         }
     }
@@ -295,20 +281,38 @@ void MapWindow::wheelEvent(QWheelEvent *ev)
         factor = factor > -1 ? factor : 1 / factor;
     }
 
-    m_map.scaleBy(1 + factor, ev->pos());
+    m_map->scaleBy(1 + factor, ev->pos());
     ev->accept();
 }
 
 void MapWindow::initializeGL()
 {
     QMapbox::initializeGLExtensions();
+
+    m_map.reset(new QMapboxGL(nullptr, m_settings, size(), pixelRatio()));
+    connect(m_map.data(), SIGNAL(needsRendering()), this, SLOT(update()));
+
+    // Set default location to Helsinki.
+    m_map->setCoordinateZoom(QMapbox::Coordinate(60.170448, 24.942046), 14);
+
+    QString styleUrl = qgetenv("MAPBOX_STYLE_URL");
+    if (styleUrl.isEmpty()) {
+        changeStyle();
+    } else {
+        m_map->setStyleUrl(styleUrl);
+        setWindowTitle(QString("Mapbox GL: ") + styleUrl);
+    }
+
+    m_bearingAnimation = new QPropertyAnimation(m_map.data(), "bearing");
+    m_zoomAnimation = new QPropertyAnimation(m_map.data(), "zoom");
+
+    connect(m_zoomAnimation, SIGNAL(finished()), this, SLOT(animationFinished()));
+    connect(m_zoomAnimation, SIGNAL(valueChanged(const QVariant&)), this, SLOT(animationValueChanged()));
 }
 
 void MapWindow::paintGL()
 {
     m_frameDraws++;
-
-    m_map.resize(size(), size() * pixelRatio());
-
-    m_map.render();
+    m_map->resize(size(), size() * pixelRatio());
+    m_map->render();
 }

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -38,9 +38,9 @@ void MapWindow::selfTest()
 }
 
 qreal MapWindow::pixelRatio() {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if QT_VERSION >= 0x050600
     return devicePixelRatioF();
-#elif (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#elif QT_VERSION >= 0x050000
     return devicePixelRatio();
 #else
     return 1;

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -310,14 +310,5 @@ void MapWindow::paintGL()
 
     m_map.resize(size(), size() * pixelRatio());
 
-#if QT_VERSION < 0x050400 && defined(__APPLE__)
-    // XXX GL framebuffer is valid only after first attempt of painting on
-    // older versions of Qt on macOS.
-    // See https://bugreports.qt.io/browse/QTBUG-36802 for details.
-    static bool first = true;
-    if (!first) m_map.render();
-    first = false;
-#else
     m_map.render();
-#endif
 }

--- a/platform/qt/app/mapwindow.hpp
+++ b/platform/qt/app/mapwindow.hpp
@@ -1,15 +1,29 @@
 #ifndef MAPWINDOW_H
 #define MAPWINDOW_H
 
-#include <QGLWidget>
 #include <QMapboxGL>
+
+#include <QtGlobal>
+
+// XXX http://stackoverflow.com/questions/24899558/how-to-check-qt-version-to-include-different-header#comment59591604_29887388
+#if QT_VERSION >= 0x050400
+#include <QOpenGLWidget>
+#else
+#include <QGLWidget>
+#endif // QT_VERSION
+
 #include <QPropertyAnimation>
+#include <QScopedPointer>
 
 class QKeyEvent;
 class QMouseEvent;
 class QWheelEvent;
 
+#if QT_VERSION >= 0x050400
+class MapWindow : public QOpenGLWidget
+#else
 class MapWindow : public QGLWidget
+#endif // QT_VERSION
 {
     Q_OBJECT
 

--- a/platform/qt/app/mapwindow.hpp
+++ b/platform/qt/app/mapwindow.hpp
@@ -26,21 +26,23 @@ private:
     void changeStyle();
     qreal pixelRatio();
 
-    // QGLWidget implementation.
+    // QWidget implementation.
     void keyPressEvent(QKeyEvent *ev) final;
     void mousePressEvent(QMouseEvent *ev) final;
     void mouseMoveEvent(QMouseEvent *ev) final;
     void wheelEvent(QWheelEvent *ev) final;
 
+    // Q{,Open}GLWidget implementation.
     void initializeGL() final;
     void paintGL() final;
 
     QPointF m_lastPos;
 
-    QMapboxGL m_map;
+    QMapboxGLSettings m_settings;
+    QScopedPointer<QMapboxGL> m_map;
 
-    QPropertyAnimation m_bearingAnimation;
-    QPropertyAnimation m_zoomAnimation;
+    QPropertyAnimation *m_bearingAnimation;
+    QPropertyAnimation *m_zoomAnimation;
 
     unsigned m_animationTicks = 0;
     unsigned m_frameDraws = 0;

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -25,6 +25,7 @@
 #include <QGuiApplication>
 #include <QWindow>
 #include <QOpenGLFramebufferObject>
+#include <QOpenGLContext>
 #else
 #include <QCoreApplication>
 #endif

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -31,10 +31,6 @@ public:
     void invalidate() final;
     void notifyMapChange(mbgl::MapChange) final;
 
-#if QT_VERSION >= 0x050000
-    void updateFramebufferBinding(QOpenGLFramebufferObject *);
-#endif
-
     mbgl::EdgeInsets margins;
     QSize size { 0, 0 };
     QSize fbSize { 0, 0 };


### PR DESCRIPTION
This PR:
- Workarounds two different bugs in Qt for macOS:
 - Qt 4.x provides an incomplete FBO on first paint: http://lists.qt-project.org/pipermail/qt-interest-old/2011-August/035466.html
 - Consume GL_INVALID_OPERATION from Qt 5.x render calls: https://bugreports.qt.io/browse/QTBUG-36802
 - The latter causes the Qt QML example and the upcoming Mapbox GL plugin for Qt framework to work again on Qt 5.7 onwards.
 - Lazy load QMapboxGL in the Q{,Open}GLWidget MapWindow example to avoid OpenGL initialization issues.
 - Use QOpenGLWidget instead of QGLWidget for the MapWindow example from Qt 5.4 onwards.

Fixes the root cause of #6849. (/cc @assanegu)