### PR TITLE
Always use a dot as a decimal point in string, independent of locale

### DIFF
--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/gl/program.hpp>
 #include <mbgl/programs/program_parameters.hpp>
 
+#include <sstream>
 #include <cassert>
 
 namespace mbgl {
@@ -17,7 +18,11 @@ public:
         {}
     
     static std::string pixelRatioDefine(const ProgramParameters& parameters) {
-        return std::string("#define DEVICE_PIXEL_RATIO ") + std::to_string(parameters.pixelRatio) + "\n";
+        std::ostringstream pixelRatioSS;
+        pixelRatioSS.imbue(std::locale("C"));
+        pixelRatioSS.setf(std::ios_base::showpoint);
+        pixelRatioSS << parameters.pixelRatio;
+        return std::string("#define DEVICE_PIXEL_RATIO ") + pixelRatioSS.str() + "\n";
     }
 
     static std::string fragmentSource(const ProgramParameters& parameters) {


### PR DESCRIPTION
On my environment the std::to_string() call inserted a comma (,) as a decimal point into the string. Obviously this caused compilation errors in shaders. The generated string should always use a dot (.) as the delimiter. 

Now the code proposed in this PR is probably not the best implementation (in terms of effectiveness), as it uses stringstreams and plays with locales. If anybody has a better idea how to do this, I'm very willing to change this.