### PR TITLE
[ios, macos] Refcount view activations

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5068,16 +5068,28 @@ public:
 
     void activate() override
     {
+        if (activationCount++)
+        {
+            return;
+        }
+
         [EAGLContext setCurrentContext:nativeView.context];
     }
 
     void deactivate() override
     {
+        if (--activationCount)
+        {
+            return;
+        }
+
         [EAGLContext setCurrentContext:nil];
     }
 
 private:
     __weak MGLMapView *nativeView = nullptr;
+
+    NSUInteger activationCount = 0;
 };
 
 @end

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2590,11 +2590,19 @@ public:
     }
 
     void activate() override {
+        if (activationCount++) {
+            return;
+        }
+
         MGLOpenGLLayer *layer = (MGLOpenGLLayer *)nativeView.layer;
         [layer.openGLContext makeCurrentContext];
     }
 
     void deactivate() override {
+        if (--activationCount) {
+            return;
+        }
+
         [NSOpenGLContext clearCurrentContext];
     }
 
@@ -2640,6 +2648,9 @@ private:
 
     /// The current framebuffer of the NSOpenGLLayer we are painting to.
     GLint fbo = 0;
+
+    /// The reference counted count of activation calls
+    NSUInteger activationCount = 0;
 };
 
 @end


### PR DESCRIPTION
This adds a ref count to guard against calling activate after it has already been called. This can happen when a layer is added during certain map lifecycle methods like MapChangeWillStartRenderingFrame that also triggers activation. This also protects against issues related to a deactivation of the context happening in an inner scope while an outer scope is still expecting to be able to use the context.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/7163

cc @1ec5 @incanus @jfirebaugh 