### PR TITLE
Updating mapbox-gl-shaders doesn't trigger build-shaders.js

### DIFF
--- a/cmake/shaders.cmake
+++ b/cmake/shaders.cmake
@@ -6,6 +6,7 @@ function(add_shader VAR name)
     add_custom_command(
        OUTPUT ${shader_source_prefix}/${name}.hpp
        COMMAND ${shader_build_cmd} ${name} ${shader_file_prefix} ${shader_source_prefix}
+       DEPENDS ${CMAKE_SOURCE_DIR}/scripts/build-shaders.js
        DEPENDS ${shader_file_prefix}/${name}.vertex.glsl
        DEPENDS ${shader_file_prefix}/${name}.fragment.glsl
        DEPENDS ${shader_file_prefix}/_prelude.vertex.glsl


### PR DESCRIPTION
If you update the commit hash of mapbox-gl-shaders in package.json, run `make xproj`, and build, it should run `build-shaders.js` for each of the modified shaders. But it doesn't -- the old output is used.

cc @kkaefer 