### PR TITLE
Avoid unsafe cast when removing style layers

### DIFF
--- a/platform/darwin/src/MGLBackgroundStyleLayer.mm
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.mm
@@ -50,42 +50,65 @@
 
 - (void)removeFromMapView:(MGLMapView *)mapView
 {
+    _pendingLayer = nullptr;
+    _rawLayer = nullptr;
+
     auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
     if (!removedLayer) {
         return;
     }
-    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::BackgroundLayer> &>(removedLayer));
+
+    mbgl::style::BackgroundLayer *layer = dynamic_cast<mbgl::style::BackgroundLayer *>(removedLayer.get());
+    if (!layer) {
+        return;
+    }
+
+    removedLayer.release();
+
+    _pendingLayer = std::unique_ptr<mbgl::style::BackgroundLayer>(layer);
     _rawLayer = _pendingLayer.get();
 }
 
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setBackgroundColor:(MGLStyleValue<MGLColor *> *)backgroundColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(backgroundColor);
     _rawLayer->setBackgroundColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)backgroundColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getBackgroundColor() ?: _rawLayer->getDefaultBackgroundColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setBackgroundOpacity:(MGLStyleValue<NSNumber *> *)backgroundOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(backgroundOpacity);
     _rawLayer->setBackgroundOpacity(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)backgroundOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getBackgroundOpacity() ?: _rawLayer->getDefaultBackgroundOpacity();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setBackgroundPattern:(MGLStyleValue<NSString *> *)backgroundPattern {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue(backgroundPattern);
     _rawLayer->setBackgroundPattern(mbglValue);
 }
 
 - (MGLStyleValue<NSString *> *)backgroundPattern {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getBackgroundPattern() ?: _rawLayer->getDefaultBackgroundPattern();
     return MGLStyleValueTransformer<std::string, NSString *>().toStyleValue(propertyValue);
 }

--- a/platform/darwin/src/MGLCircleStyleLayer.mm
+++ b/platform/darwin/src/MGLCircleStyleLayer.mm
@@ -45,22 +45,30 @@ namespace mbgl {
 }
 - (NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     auto layerID = _rawLayer->getSourceLayer();
     return layerID.empty() ? nil : @(layerID.c_str());
 }
 
 - (void)setSourceLayerIdentifier:(NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setSourceLayer(sourceLayerIdentifier.UTF8String ?: "");
 }
 
 - (void)setPredicate:(NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setFilter(predicate.mgl_filter);
 }
 
 - (NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     return [NSPredicate mgl_predicateWithFilter:_rawLayer->getFilter()];
 }
 #pragma mark -  Adding to and removing from a map view
@@ -82,82 +90,121 @@ namespace mbgl {
 
 - (void)removeFromMapView:(MGLMapView *)mapView
 {
+    _pendingLayer = nullptr;
+    _rawLayer = nullptr;
+
     auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
     if (!removedLayer) {
         return;
     }
-    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::CircleLayer> &>(removedLayer));
+
+    mbgl::style::CircleLayer *layer = dynamic_cast<mbgl::style::CircleLayer *>(removedLayer.get());
+    if (!layer) {
+        return;
+    }
+
+    removedLayer.release();
+
+    _pendingLayer = std::unique_ptr<mbgl::style::CircleLayer>(layer);
     _rawLayer = _pendingLayer.get();
 }
 
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setCircleBlur:(MGLStyleValue<NSNumber *> *)circleBlur {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(circleBlur);
     _rawLayer->setCircleBlur(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)circleBlur {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getCircleBlur() ?: _rawLayer->getDefaultCircleBlur();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setCircleColor:(MGLStyleValue<MGLColor *> *)circleColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(circleColor);
     _rawLayer->setCircleColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)circleColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getCircleColor() ?: _rawLayer->getDefaultCircleColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setCircleOpacity:(MGLStyleValue<NSNumber *> *)circleOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(circleOpacity);
     _rawLayer->setCircleOpacity(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)circleOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getCircleOpacity() ?: _rawLayer->getDefaultCircleOpacity();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setCirclePitchScale:(MGLStyleValue<NSValue *> *)circlePitchScale {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::CirclePitchScaleType, NSValue *, mbgl::style::CirclePitchScaleType, MGLCirclePitchScale>().toEnumPropertyValue(circlePitchScale);
     _rawLayer->setCirclePitchScale(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)circlePitchScale {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getCirclePitchScale() ?: _rawLayer->getDefaultCirclePitchScale();
     return MGLStyleValueTransformer<mbgl::style::CirclePitchScaleType, NSValue *, mbgl::style::CirclePitchScaleType, MGLCirclePitchScale>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setCircleRadius:(MGLStyleValue<NSNumber *> *)circleRadius {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(circleRadius);
     _rawLayer->setCircleRadius(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)circleRadius {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getCircleRadius() ?: _rawLayer->getDefaultCircleRadius();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setCircleTranslate:(MGLStyleValue<NSValue *> *)circleTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toPropertyValue(circleTranslate);
     _rawLayer->setCircleTranslate(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)circleTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getCircleTranslate() ?: _rawLayer->getDefaultCircleTranslate();
     return MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toStyleValue(propertyValue);
 }
 
 - (void)setCircleTranslateAnchor:(MGLStyleValue<NSValue *> *)circleTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLCircleTranslateAnchor>().toEnumPropertyValue(circleTranslateAnchor);
     _rawLayer->setCircleTranslateAnchor(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)circleTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getCircleTranslateAnchor() ?: _rawLayer->getDefaultCircleTranslateAnchor();
     return MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLCircleTranslateAnchor>().toEnumStyleValue(propertyValue);
 }

--- a/platform/darwin/src/MGLFillStyleLayer.mm
+++ b/platform/darwin/src/MGLFillStyleLayer.mm
@@ -40,22 +40,30 @@ namespace mbgl {
 }
 - (NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     auto layerID = _rawLayer->getSourceLayer();
     return layerID.empty() ? nil : @(layerID.c_str());
 }
 
 - (void)setSourceLayerIdentifier:(NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setSourceLayer(sourceLayerIdentifier.UTF8String ?: "");
 }
 
 - (void)setPredicate:(NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setFilter(predicate.mgl_filter);
 }
 
 - (NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     return [NSPredicate mgl_predicateWithFilter:_rawLayer->getFilter()];
 }
 #pragma mark -  Adding to and removing from a map view
@@ -77,82 +85,121 @@ namespace mbgl {
 
 - (void)removeFromMapView:(MGLMapView *)mapView
 {
+    _pendingLayer = nullptr;
+    _rawLayer = nullptr;
+
     auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
     if (!removedLayer) {
         return;
     }
-    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::FillLayer> &>(removedLayer));
+
+    mbgl::style::FillLayer *layer = dynamic_cast<mbgl::style::FillLayer *>(removedLayer.get());
+    if (!layer) {
+        return;
+    }
+
+    removedLayer.release();
+
+    _pendingLayer = std::unique_ptr<mbgl::style::FillLayer>(layer);
     _rawLayer = _pendingLayer.get();
 }
 
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setFillAntialias:(MGLStyleValue<NSNumber *> *)fillAntialias {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(fillAntialias);
     _rawLayer->setFillAntialias(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)fillAntialias {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getFillAntialias() ?: _rawLayer->getDefaultFillAntialias();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setFillColor:(MGLStyleValue<MGLColor *> *)fillColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(fillColor);
     _rawLayer->setFillColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)fillColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getFillColor() ?: _rawLayer->getDefaultFillColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setFillOpacity:(MGLStyleValue<NSNumber *> *)fillOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(fillOpacity);
     _rawLayer->setFillOpacity(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)fillOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getFillOpacity() ?: _rawLayer->getDefaultFillOpacity();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setFillOutlineColor:(MGLStyleValue<MGLColor *> *)fillOutlineColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(fillOutlineColor);
     _rawLayer->setFillOutlineColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)fillOutlineColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getFillOutlineColor() ?: _rawLayer->getDefaultFillOutlineColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setFillPattern:(MGLStyleValue<NSString *> *)fillPattern {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue(fillPattern);
     _rawLayer->setFillPattern(mbglValue);
 }
 
 - (MGLStyleValue<NSString *> *)fillPattern {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getFillPattern() ?: _rawLayer->getDefaultFillPattern();
     return MGLStyleValueTransformer<std::string, NSString *>().toStyleValue(propertyValue);
 }
 
 - (void)setFillTranslate:(MGLStyleValue<NSValue *> *)fillTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toPropertyValue(fillTranslate);
     _rawLayer->setFillTranslate(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)fillTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getFillTranslate() ?: _rawLayer->getDefaultFillTranslate();
     return MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toStyleValue(propertyValue);
 }
 
 - (void)setFillTranslateAnchor:(MGLStyleValue<NSValue *> *)fillTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLFillTranslateAnchor>().toEnumPropertyValue(fillTranslateAnchor);
     _rawLayer->setFillTranslateAnchor(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)fillTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getFillTranslateAnchor() ?: _rawLayer->getDefaultFillTranslateAnchor();
     return MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLFillTranslateAnchor>().toEnumStyleValue(propertyValue);
 }

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -52,22 +52,30 @@ namespace mbgl {
 }
 - (NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     auto layerID = _rawLayer->getSourceLayer();
     return layerID.empty() ? nil : @(layerID.c_str());
 }
 
 - (void)setSourceLayerIdentifier:(NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setSourceLayer(sourceLayerIdentifier.UTF8String ?: "");
 }
 
 - (void)setPredicate:(NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setFilter(predicate.mgl_filter);
 }
 
 - (NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     return [NSPredicate mgl_predicateWithFilter:_rawLayer->getFilter()];
 }
 #pragma mark -  Adding to and removing from a map view
@@ -89,52 +97,79 @@ namespace mbgl {
 
 - (void)removeFromMapView:(MGLMapView *)mapView
 {
+    _pendingLayer = nullptr;
+    _rawLayer = nullptr;
+
     auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
     if (!removedLayer) {
         return;
     }
-    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::LineLayer> &>(removedLayer));
+
+    mbgl::style::LineLayer *layer = dynamic_cast<mbgl::style::LineLayer *>(removedLayer.get());
+    if (!layer) {
+        return;
+    }
+
+    removedLayer.release();
+
+    _pendingLayer = std::unique_ptr<mbgl::style::LineLayer>(layer);
     _rawLayer = _pendingLayer.get();
 }
 
 #pragma mark - Accessing the Layout Attributes
 
 - (void)setLineCap:(MGLStyleValue<NSValue *> *)lineCap {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::LineCapType, NSValue *, mbgl::style::LineCapType, MGLLineCap>().toEnumPropertyValue(lineCap);
     _rawLayer->setLineCap(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)lineCap {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineCap() ?: _rawLayer->getDefaultLineCap();
     return MGLStyleValueTransformer<mbgl::style::LineCapType, NSValue *, mbgl::style::LineCapType, MGLLineCap>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setLineJoin:(MGLStyleValue<NSValue *> *)lineJoin {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::LineJoinType, NSValue *, mbgl::style::LineJoinType, MGLLineJoin>().toEnumPropertyValue(lineJoin);
     _rawLayer->setLineJoin(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)lineJoin {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineJoin() ?: _rawLayer->getDefaultLineJoin();
     return MGLStyleValueTransformer<mbgl::style::LineJoinType, NSValue *, mbgl::style::LineJoinType, MGLLineJoin>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setLineMiterLimit:(MGLStyleValue<NSNumber *> *)lineMiterLimit {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(lineMiterLimit);
     _rawLayer->setLineMiterLimit(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)lineMiterLimit {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineMiterLimit() ?: _rawLayer->getDefaultLineMiterLimit();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setLineRoundLimit:(MGLStyleValue<NSNumber *> *)lineRoundLimit {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(lineRoundLimit);
     _rawLayer->setLineRoundLimit(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)lineRoundLimit {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineRoundLimit() ?: _rawLayer->getDefaultLineRoundLimit();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
@@ -142,101 +177,141 @@ namespace mbgl {
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setLineBlur:(MGLStyleValue<NSNumber *> *)lineBlur {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(lineBlur);
     _rawLayer->setLineBlur(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)lineBlur {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineBlur() ?: _rawLayer->getDefaultLineBlur();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setLineColor:(MGLStyleValue<MGLColor *> *)lineColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(lineColor);
     _rawLayer->setLineColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)lineColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineColor() ?: _rawLayer->getDefaultLineColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setLineDasharray:(MGLStyleValue<NSArray<NSNumber *> *> *)lineDasharray {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::vector<float>, NSArray<NSNumber *> *, float>().toPropertyValue(lineDasharray);
     _rawLayer->setLineDasharray(mbglValue);
 }
 
 - (MGLStyleValue<NSArray<NSNumber *> *> *)lineDasharray {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineDasharray() ?: _rawLayer->getDefaultLineDasharray();
     return MGLStyleValueTransformer<std::vector<float>, NSArray<NSNumber *> *, float>().toStyleValue(propertyValue);
 }
 
 - (void)setLineGapWidth:(MGLStyleValue<NSNumber *> *)lineGapWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(lineGapWidth);
     _rawLayer->setLineGapWidth(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)lineGapWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineGapWidth() ?: _rawLayer->getDefaultLineGapWidth();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setLineOffset:(MGLStyleValue<NSNumber *> *)lineOffset {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(lineOffset);
     _rawLayer->setLineOffset(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)lineOffset {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineOffset() ?: _rawLayer->getDefaultLineOffset();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setLineOpacity:(MGLStyleValue<NSNumber *> *)lineOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(lineOpacity);
     _rawLayer->setLineOpacity(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)lineOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineOpacity() ?: _rawLayer->getDefaultLineOpacity();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setLinePattern:(MGLStyleValue<NSString *> *)linePattern {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue(linePattern);
     _rawLayer->setLinePattern(mbglValue);
 }
 
 - (MGLStyleValue<NSString *> *)linePattern {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLinePattern() ?: _rawLayer->getDefaultLinePattern();
     return MGLStyleValueTransformer<std::string, NSString *>().toStyleValue(propertyValue);
 }
 
 - (void)setLineTranslate:(MGLStyleValue<NSValue *> *)lineTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toPropertyValue(lineTranslate);
     _rawLayer->setLineTranslate(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)lineTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineTranslate() ?: _rawLayer->getDefaultLineTranslate();
     return MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toStyleValue(propertyValue);
 }
 
 - (void)setLineTranslateAnchor:(MGLStyleValue<NSValue *> *)lineTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLLineTranslateAnchor>().toEnumPropertyValue(lineTranslateAnchor);
     _rawLayer->setLineTranslateAnchor(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)lineTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineTranslateAnchor() ?: _rawLayer->getDefaultLineTranslateAnchor();
     return MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLLineTranslateAnchor>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setLineWidth:(MGLStyleValue<NSNumber *> *)lineWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(lineWidth);
     _rawLayer->setLineWidth(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)lineWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getLineWidth() ?: _rawLayer->getDefaultLineWidth();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }

--- a/platform/darwin/src/MGLRasterStyleLayer.mm
+++ b/platform/darwin/src/MGLRasterStyleLayer.mm
@@ -49,82 +49,121 @@
 
 - (void)removeFromMapView:(MGLMapView *)mapView
 {
+    _pendingLayer = nullptr;
+    _rawLayer = nullptr;
+
     auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
     if (!removedLayer) {
         return;
     }
-    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::RasterLayer> &>(removedLayer));
+
+    mbgl::style::RasterLayer *layer = dynamic_cast<mbgl::style::RasterLayer *>(removedLayer.get());
+    if (!layer) {
+        return;
+    }
+
+    removedLayer.release();
+
+    _pendingLayer = std::unique_ptr<mbgl::style::RasterLayer>(layer);
     _rawLayer = _pendingLayer.get();
 }
 
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setMaximumRasterBrightness:(MGLStyleValue<NSNumber *> *)maximumRasterBrightness {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(maximumRasterBrightness);
     _rawLayer->setRasterBrightnessMax(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)maximumRasterBrightness {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getRasterBrightnessMax() ?: _rawLayer->getDefaultRasterBrightnessMax();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setMinimumRasterBrightness:(MGLStyleValue<NSNumber *> *)minimumRasterBrightness {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(minimumRasterBrightness);
     _rawLayer->setRasterBrightnessMin(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)minimumRasterBrightness {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getRasterBrightnessMin() ?: _rawLayer->getDefaultRasterBrightnessMin();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setRasterContrast:(MGLStyleValue<NSNumber *> *)rasterContrast {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(rasterContrast);
     _rawLayer->setRasterContrast(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)rasterContrast {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getRasterContrast() ?: _rawLayer->getDefaultRasterContrast();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setRasterFadeDuration:(MGLStyleValue<NSNumber *> *)rasterFadeDuration {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(rasterFadeDuration);
     _rawLayer->setRasterFadeDuration(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)rasterFadeDuration {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getRasterFadeDuration() ?: _rawLayer->getDefaultRasterFadeDuration();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setRasterHueRotate:(MGLStyleValue<NSNumber *> *)rasterHueRotate {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(rasterHueRotate);
     _rawLayer->setRasterHueRotate(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)rasterHueRotate {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getRasterHueRotate() ?: _rawLayer->getDefaultRasterHueRotate();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setRasterOpacity:(MGLStyleValue<NSNumber *> *)rasterOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(rasterOpacity);
     _rawLayer->setRasterOpacity(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)rasterOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getRasterOpacity() ?: _rawLayer->getDefaultRasterOpacity();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setRasterSaturation:(MGLStyleValue<NSNumber *> *)rasterSaturation {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(rasterSaturation);
     _rawLayer->setRasterSaturation(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)rasterSaturation {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getRasterSaturation() ?: _rawLayer->getDefaultRasterSaturation();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }

--- a/platform/darwin/src/MGLStyleLayer.mm
+++ b/platform/darwin/src/MGLStyleLayer.mm
@@ -3,10 +3,6 @@
 
 #include <mbgl/style/layer.hpp>
 
-@interface MGLStyleLayer ()
-
-@end
-
 @implementation MGLStyleLayer
 
 - (instancetype)initWithIdentifier:(NSString *)identifier
@@ -19,6 +15,8 @@
 
 - (void)setVisible:(BOOL)visible
 {
+    MGLAssertStyleLayerIsValid();
+
     mbgl::style::VisibilityType v = visible
     ? mbgl::style::VisibilityType::Visible
     : mbgl::style::VisibilityType::None;
@@ -27,27 +25,37 @@
 
 - (BOOL)isVisible
 {
+    MGLAssertStyleLayerIsValid();
+
     mbgl::style::VisibilityType v = self.rawLayer->getVisibility();
     return (v == mbgl::style::VisibilityType::Visible);
 }
 
 - (void)setMaximumZoomLevel:(float)maximumZoomLevel
 {
+    MGLAssertStyleLayerIsValid();
+
     self.rawLayer->setMaxZoom(maximumZoomLevel);
 }
 
 - (float)maximumZoomLevel
 {
+    MGLAssertStyleLayerIsValid();
+
     return self.rawLayer->getMaxZoom();
 }
 
 - (void)setMinimumZoomLevel:(float)minimumZoomLevel
 {
+    MGLAssertStyleLayerIsValid();
+
     self.rawLayer->setMinZoom(minimumZoomLevel);
 }
 
 - (float)minimumZoomLevel
 {
+    MGLAssertStyleLayerIsValid();
+    
     return self.rawLayer->getMinZoom();
 }
 

--- a/platform/darwin/src/MGLStyleLayer.mm.ejs
+++ b/platform/darwin/src/MGLStyleLayer.mm.ejs
@@ -81,22 +81,30 @@ namespace mbgl {
 <% if (type !== 'background' && type !== 'raster') { -%>
 - (NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     auto layerID = _rawLayer->getSourceLayer();
     return layerID.empty() ? nil : @(layerID.c_str());
 }
 
 - (void)setSourceLayerIdentifier:(NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setSourceLayer(sourceLayerIdentifier.UTF8String ?: "");
 }
 
 - (void)setPredicate:(NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setFilter(predicate.mgl_filter);
 }
 
 - (NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     return [NSPredicate mgl_predicateWithFilter:_rawLayer->getFilter()];
 }
 <% } -%>
@@ -119,11 +127,22 @@ namespace mbgl {
 
 - (void)removeFromMapView:(MGLMapView *)mapView
 {
+    _pendingLayer = nullptr;
+    _rawLayer = nullptr;
+
     auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
     if (!removedLayer) {
         return;
     }
-    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::<%- camelize(type) %>Layer> &>(removedLayer));
+
+    mbgl::style::<%- camelize(type) %>Layer *layer = dynamic_cast<mbgl::style::<%- camelize(type) %>Layer *>(removedLayer.get());
+    if (!layer) {
+        return;
+    }
+
+    removedLayer.release();
+
+    _pendingLayer = std::unique_ptr<mbgl::style::<%- camelize(type) %>Layer>(layer);
     _rawLayer = _pendingLayer.get();
 }
 
@@ -132,6 +151,8 @@ namespace mbgl {
 
 <% for (const property of layoutProperties) { -%>
 - (void)set<%- camelize(property.name) %>:(MGLStyleValue<<%- propertyType(property, true) %>> *)<%- objCName(property) %> {
+    MGLAssertStyleLayerIsValid();
+
 <% if (property.type == "enum") { -%>
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::<%- mbglType(property) %>, NSValue *, mbgl::style::<%- mbglType(property) %>, MGL<%- camelize(originalPropertyName(property)) %>>().toEnumPropertyValue(<%- objCName(property) %>);
     _rawLayer->set<%- camelize(originalPropertyName(property)) %>(mbglValue);
@@ -142,6 +163,8 @@ namespace mbgl {
 }
 
 - (MGLStyleValue<<%- propertyType(property, true) %>> *)<%- objCName(property) %> {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->get<%- camelize(originalPropertyName(property)) %>() ?: _rawLayer->getDefault<%- camelize(originalPropertyName(property)) %>();
 <% if (property.type == "enum") { -%>
     return MGLStyleValueTransformer<mbgl::style::<%- mbglType(property) %>, NSValue *, mbgl::style::<%- mbglType(property) %>, MGL<%- camelize(originalPropertyName(property)) %>>().toEnumStyleValue(propertyValue);
@@ -157,6 +180,8 @@ namespace mbgl {
 
 <% for (const property of paintProperties) { -%>
 - (void)set<%- camelize(property.name) %>:(MGLStyleValue<<%- propertyType(property, true) %>> *)<%- objCName(property) %> {
+    MGLAssertStyleLayerIsValid();
+
 <% if (property.type == "enum") { -%>
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::<%- mbglType(property) %>, NSValue *, mbgl::style::<%- mbglType(property) %>, MGL<%- camelize(originalPropertyName(property)) %>>().toEnumPropertyValue(<%- objCName(property) %>);
     _rawLayer->set<%- camelize(originalPropertyName(property)) %>(mbglValue);
@@ -167,6 +192,8 @@ namespace mbgl {
 }
 
 - (MGLStyleValue<<%- propertyType(property, true) %>> *)<%- objCName(property) %> {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->get<%- camelize(originalPropertyName(property)) %>() ?: _rawLayer->getDefault<%- camelize(originalPropertyName(property)) %>();
 <% if (property.type == "enum") { -%>
     return MGLStyleValueTransformer<mbgl::style::<%- mbglType(property) %>, NSValue *, mbgl::style::<%- mbglType(property) %>, MGL<%- camelize(originalPropertyName(property)) %>>().toEnumStyleValue(propertyValue);

--- a/platform/darwin/src/MGLStyleLayer_Private.h
+++ b/platform/darwin/src/MGLStyleLayer_Private.h
@@ -5,6 +5,25 @@
 
 #include <mbgl/style/layer.hpp>
 
+/**
+ Assert that the style layer is valid.
+
+ This macro should be used at the beginning of any public-facing instance method
+ of `MGLStyleLayer` and its subclasses. For private methods, an assertion is more appropriate.
+ */
+#define MGLAssertStyleLayerIsValid() \
+    do { \
+        if (!self.rawLayer) { \
+            [NSException raise:@"Invalid style layer" \
+                        format: \
+            @"-[MGLStyle removeLayer:] has been called " \
+            @"with this instance but another style layer instance was added with the same identifer. It is an " \
+            @"error to send any message to this layer since it cannot be recovered after removal due to the " \
+            @"identifer collision. Use unique identifiers for all layer instances including layers of " \
+            @"different types."]; \
+        } \
+    } while (NO);
+
 @class MGLMapView;
 
 @interface MGLStyleLayer (Private)

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -99,22 +99,30 @@ namespace mbgl {
 }
 - (NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     auto layerID = _rawLayer->getSourceLayer();
     return layerID.empty() ? nil : @(layerID.c_str());
 }
 
 - (void)setSourceLayerIdentifier:(NSString *)sourceLayerIdentifier
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setSourceLayer(sourceLayerIdentifier.UTF8String ?: "");
 }
 
 - (void)setPredicate:(NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     _rawLayer->setFilter(predicate.mgl_filter);
 }
 
 - (NSPredicate *)predicate
 {
+    MGLAssertStyleLayerIsValid();
+
     return [NSPredicate mgl_predicateWithFilter:_rawLayer->getFilter()];
 }
 #pragma mark -  Adding to and removing from a map view
@@ -136,352 +144,499 @@ namespace mbgl {
 
 - (void)removeFromMapView:(MGLMapView *)mapView
 {
+    _pendingLayer = nullptr;
+    _rawLayer = nullptr;
+
     auto removedLayer = mapView.mbglMap->removeLayer(self.identifier.UTF8String);
     if (!removedLayer) {
         return;
     }
-    _pendingLayer = std::move(reinterpret_cast<std::unique_ptr<mbgl::style::SymbolLayer> &>(removedLayer));
+
+    mbgl::style::SymbolLayer *layer = dynamic_cast<mbgl::style::SymbolLayer *>(removedLayer.get());
+    if (!layer) {
+        return;
+    }
+
+    removedLayer.release();
+
+    _pendingLayer = std::unique_ptr<mbgl::style::SymbolLayer>(layer);
     _rawLayer = _pendingLayer.get();
 }
 
 #pragma mark - Accessing the Layout Attributes
 
 - (void)setIconAllowOverlap:(MGLStyleValue<NSNumber *> *)iconAllowOverlap {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(iconAllowOverlap);
     _rawLayer->setIconAllowOverlap(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconAllowOverlap {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconAllowOverlap() ?: _rawLayer->getDefaultIconAllowOverlap();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconIgnorePlacement:(MGLStyleValue<NSNumber *> *)iconIgnorePlacement {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(iconIgnorePlacement);
     _rawLayer->setIconIgnorePlacement(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconIgnorePlacement {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconIgnorePlacement() ?: _rawLayer->getDefaultIconIgnorePlacement();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconImageName:(MGLStyleValue<NSString *> *)iconImageName {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue(iconImageName);
     _rawLayer->setIconImage(mbglValue);
 }
 
 - (MGLStyleValue<NSString *> *)iconImageName {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconImage() ?: _rawLayer->getDefaultIconImage();
     return MGLStyleValueTransformer<std::string, NSString *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconKeepUpright:(MGLStyleValue<NSNumber *> *)iconKeepUpright {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(iconKeepUpright);
     _rawLayer->setIconKeepUpright(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconKeepUpright {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconKeepUpright() ?: _rawLayer->getDefaultIconKeepUpright();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconOffset:(MGLStyleValue<NSValue *> *)iconOffset {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toPropertyValue(iconOffset);
     _rawLayer->setIconOffset(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)iconOffset {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconOffset() ?: _rawLayer->getDefaultIconOffset();
     return MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconOptional:(MGLStyleValue<NSNumber *> *)iconOptional {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(iconOptional);
     _rawLayer->setIconOptional(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconOptional {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconOptional() ?: _rawLayer->getDefaultIconOptional();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconPadding:(MGLStyleValue<NSNumber *> *)iconPadding {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(iconPadding);
     _rawLayer->setIconPadding(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconPadding {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconPadding() ?: _rawLayer->getDefaultIconPadding();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconRotate:(MGLStyleValue<NSNumber *> *)iconRotate {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(iconRotate);
     _rawLayer->setIconRotate(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconRotate {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconRotate() ?: _rawLayer->getDefaultIconRotate();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconRotationAlignment:(MGLStyleValue<NSValue *> *)iconRotationAlignment {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::AlignmentType, NSValue *, mbgl::style::AlignmentType, MGLIconRotationAlignment>().toEnumPropertyValue(iconRotationAlignment);
     _rawLayer->setIconRotationAlignment(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)iconRotationAlignment {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconRotationAlignment() ?: _rawLayer->getDefaultIconRotationAlignment();
     return MGLStyleValueTransformer<mbgl::style::AlignmentType, NSValue *, mbgl::style::AlignmentType, MGLIconRotationAlignment>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setIconSize:(MGLStyleValue<NSNumber *> *)iconSize {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(iconSize);
     _rawLayer->setIconSize(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconSize {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconSize() ?: _rawLayer->getDefaultIconSize();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconTextFit:(MGLStyleValue<NSValue *> *)iconTextFit {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::IconTextFitType, NSValue *, mbgl::style::IconTextFitType, MGLIconTextFit>().toEnumPropertyValue(iconTextFit);
     _rawLayer->setIconTextFit(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)iconTextFit {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconTextFit() ?: _rawLayer->getDefaultIconTextFit();
     return MGLStyleValueTransformer<mbgl::style::IconTextFitType, NSValue *, mbgl::style::IconTextFitType, MGLIconTextFit>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setIconTextFitPadding:(MGLStyleValue<NSValue *> *)iconTextFitPadding {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::array<float, 4>, NSValue *>().toPropertyValue(iconTextFitPadding);
     _rawLayer->setIconTextFitPadding(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)iconTextFitPadding {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconTextFitPadding() ?: _rawLayer->getDefaultIconTextFitPadding();
     return MGLStyleValueTransformer<std::array<float, 4>, NSValue *>().toStyleValue(propertyValue);
 }
 
 - (void)setSymbolAvoidEdges:(MGLStyleValue<NSNumber *> *)symbolAvoidEdges {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(symbolAvoidEdges);
     _rawLayer->setSymbolAvoidEdges(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)symbolAvoidEdges {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getSymbolAvoidEdges() ?: _rawLayer->getDefaultSymbolAvoidEdges();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setSymbolPlacement:(MGLStyleValue<NSValue *> *)symbolPlacement {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::SymbolPlacementType, NSValue *, mbgl::style::SymbolPlacementType, MGLSymbolPlacement>().toEnumPropertyValue(symbolPlacement);
     _rawLayer->setSymbolPlacement(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)symbolPlacement {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getSymbolPlacement() ?: _rawLayer->getDefaultSymbolPlacement();
     return MGLStyleValueTransformer<mbgl::style::SymbolPlacementType, NSValue *, mbgl::style::SymbolPlacementType, MGLSymbolPlacement>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setSymbolSpacing:(MGLStyleValue<NSNumber *> *)symbolSpacing {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(symbolSpacing);
     _rawLayer->setSymbolSpacing(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)symbolSpacing {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getSymbolSpacing() ?: _rawLayer->getDefaultSymbolSpacing();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextAllowOverlap:(MGLStyleValue<NSNumber *> *)textAllowOverlap {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(textAllowOverlap);
     _rawLayer->setTextAllowOverlap(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textAllowOverlap {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextAllowOverlap() ?: _rawLayer->getDefaultTextAllowOverlap();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextAnchor:(MGLStyleValue<NSValue *> *)textAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::TextAnchorType, NSValue *, mbgl::style::TextAnchorType, MGLTextAnchor>().toEnumPropertyValue(textAnchor);
     _rawLayer->setTextAnchor(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)textAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextAnchor() ?: _rawLayer->getDefaultTextAnchor();
     return MGLStyleValueTransformer<mbgl::style::TextAnchorType, NSValue *, mbgl::style::TextAnchorType, MGLTextAnchor>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setTextField:(MGLStyleValue<NSString *> *)textField {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::string, NSString *>().toPropertyValue(textField);
     _rawLayer->setTextField(mbglValue);
 }
 
 - (MGLStyleValue<NSString *> *)textField {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextField() ?: _rawLayer->getDefaultTextField();
     return MGLStyleValueTransformer<std::string, NSString *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextFont:(MGLStyleValue<NSArray<NSString *> *> *)textFont {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::vector<std::string>, NSArray<NSString *> *, std::string>().toPropertyValue(textFont);
     _rawLayer->setTextFont(mbglValue);
 }
 
 - (MGLStyleValue<NSArray<NSString *> *> *)textFont {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextFont() ?: _rawLayer->getDefaultTextFont();
     return MGLStyleValueTransformer<std::vector<std::string>, NSArray<NSString *> *, std::string>().toStyleValue(propertyValue);
 }
 
 - (void)setTextIgnorePlacement:(MGLStyleValue<NSNumber *> *)textIgnorePlacement {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(textIgnorePlacement);
     _rawLayer->setTextIgnorePlacement(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textIgnorePlacement {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextIgnorePlacement() ?: _rawLayer->getDefaultTextIgnorePlacement();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextJustify:(MGLStyleValue<NSValue *> *)textJustify {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::TextJustifyType, NSValue *, mbgl::style::TextJustifyType, MGLTextJustify>().toEnumPropertyValue(textJustify);
     _rawLayer->setTextJustify(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)textJustify {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextJustify() ?: _rawLayer->getDefaultTextJustify();
     return MGLStyleValueTransformer<mbgl::style::TextJustifyType, NSValue *, mbgl::style::TextJustifyType, MGLTextJustify>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setTextKeepUpright:(MGLStyleValue<NSNumber *> *)textKeepUpright {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(textKeepUpright);
     _rawLayer->setTextKeepUpright(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textKeepUpright {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextKeepUpright() ?: _rawLayer->getDefaultTextKeepUpright();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextLetterSpacing:(MGLStyleValue<NSNumber *> *)textLetterSpacing {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textLetterSpacing);
     _rawLayer->setTextLetterSpacing(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textLetterSpacing {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextLetterSpacing() ?: _rawLayer->getDefaultTextLetterSpacing();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextLineHeight:(MGLStyleValue<NSNumber *> *)textLineHeight {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textLineHeight);
     _rawLayer->setTextLineHeight(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textLineHeight {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextLineHeight() ?: _rawLayer->getDefaultTextLineHeight();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextMaxAngle:(MGLStyleValue<NSNumber *> *)textMaxAngle {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textMaxAngle);
     _rawLayer->setTextMaxAngle(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textMaxAngle {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextMaxAngle() ?: _rawLayer->getDefaultTextMaxAngle();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextMaxWidth:(MGLStyleValue<NSNumber *> *)textMaxWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textMaxWidth);
     _rawLayer->setTextMaxWidth(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textMaxWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextMaxWidth() ?: _rawLayer->getDefaultTextMaxWidth();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextOffset:(MGLStyleValue<NSValue *> *)textOffset {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toPropertyValue(textOffset);
     _rawLayer->setTextOffset(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)textOffset {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextOffset() ?: _rawLayer->getDefaultTextOffset();
     return MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextOptional:(MGLStyleValue<NSNumber *> *)textOptional {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<bool, NSNumber *>().toPropertyValue(textOptional);
     _rawLayer->setTextOptional(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textOptional {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextOptional() ?: _rawLayer->getDefaultTextOptional();
     return MGLStyleValueTransformer<bool, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextPadding:(MGLStyleValue<NSNumber *> *)textPadding {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textPadding);
     _rawLayer->setTextPadding(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textPadding {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextPadding() ?: _rawLayer->getDefaultTextPadding();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextPitchAlignment:(MGLStyleValue<NSValue *> *)textPitchAlignment {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::AlignmentType, NSValue *, mbgl::style::AlignmentType, MGLTextPitchAlignment>().toEnumPropertyValue(textPitchAlignment);
     _rawLayer->setTextPitchAlignment(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)textPitchAlignment {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextPitchAlignment() ?: _rawLayer->getDefaultTextPitchAlignment();
     return MGLStyleValueTransformer<mbgl::style::AlignmentType, NSValue *, mbgl::style::AlignmentType, MGLTextPitchAlignment>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setTextRotate:(MGLStyleValue<NSNumber *> *)textRotate {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textRotate);
     _rawLayer->setTextRotate(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textRotate {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextRotate() ?: _rawLayer->getDefaultTextRotate();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextRotationAlignment:(MGLStyleValue<NSValue *> *)textRotationAlignment {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::AlignmentType, NSValue *, mbgl::style::AlignmentType, MGLTextRotationAlignment>().toEnumPropertyValue(textRotationAlignment);
     _rawLayer->setTextRotationAlignment(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)textRotationAlignment {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextRotationAlignment() ?: _rawLayer->getDefaultTextRotationAlignment();
     return MGLStyleValueTransformer<mbgl::style::AlignmentType, NSValue *, mbgl::style::AlignmentType, MGLTextRotationAlignment>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setTextSize:(MGLStyleValue<NSNumber *> *)textSize {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textSize);
     _rawLayer->setTextSize(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textSize {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextSize() ?: _rawLayer->getDefaultTextSize();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextTransform:(MGLStyleValue<NSValue *> *)textTransform {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::TextTransformType, NSValue *, mbgl::style::TextTransformType, MGLTextTransform>().toEnumPropertyValue(textTransform);
     _rawLayer->setTextTransform(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)textTransform {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextTransform() ?: _rawLayer->getDefaultTextTransform();
     return MGLStyleValueTransformer<mbgl::style::TextTransformType, NSValue *, mbgl::style::TextTransformType, MGLTextTransform>().toEnumStyleValue(propertyValue);
 }
@@ -489,141 +644,197 @@ namespace mbgl {
 #pragma mark - Accessing the Paint Attributes
 
 - (void)setIconColor:(MGLStyleValue<MGLColor *> *)iconColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(iconColor);
     _rawLayer->setIconColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)iconColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconColor() ?: _rawLayer->getDefaultIconColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconHaloBlur:(MGLStyleValue<NSNumber *> *)iconHaloBlur {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(iconHaloBlur);
     _rawLayer->setIconHaloBlur(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconHaloBlur {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconHaloBlur() ?: _rawLayer->getDefaultIconHaloBlur();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconHaloColor:(MGLStyleValue<MGLColor *> *)iconHaloColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(iconHaloColor);
     _rawLayer->setIconHaloColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)iconHaloColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconHaloColor() ?: _rawLayer->getDefaultIconHaloColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconHaloWidth:(MGLStyleValue<NSNumber *> *)iconHaloWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(iconHaloWidth);
     _rawLayer->setIconHaloWidth(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconHaloWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconHaloWidth() ?: _rawLayer->getDefaultIconHaloWidth();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconOpacity:(MGLStyleValue<NSNumber *> *)iconOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(iconOpacity);
     _rawLayer->setIconOpacity(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)iconOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconOpacity() ?: _rawLayer->getDefaultIconOpacity();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconTranslate:(MGLStyleValue<NSValue *> *)iconTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toPropertyValue(iconTranslate);
     _rawLayer->setIconTranslate(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)iconTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconTranslate() ?: _rawLayer->getDefaultIconTranslate();
     return MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toStyleValue(propertyValue);
 }
 
 - (void)setIconTranslateAnchor:(MGLStyleValue<NSValue *> *)iconTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLIconTranslateAnchor>().toEnumPropertyValue(iconTranslateAnchor);
     _rawLayer->setIconTranslateAnchor(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)iconTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getIconTranslateAnchor() ?: _rawLayer->getDefaultIconTranslateAnchor();
     return MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLIconTranslateAnchor>().toEnumStyleValue(propertyValue);
 }
 
 - (void)setTextColor:(MGLStyleValue<MGLColor *> *)textColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(textColor);
     _rawLayer->setTextColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)textColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextColor() ?: _rawLayer->getDefaultTextColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextHaloBlur:(MGLStyleValue<NSNumber *> *)textHaloBlur {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textHaloBlur);
     _rawLayer->setTextHaloBlur(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textHaloBlur {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextHaloBlur() ?: _rawLayer->getDefaultTextHaloBlur();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextHaloColor:(MGLStyleValue<MGLColor *> *)textHaloColor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toPropertyValue(textHaloColor);
     _rawLayer->setTextHaloColor(mbglValue);
 }
 
 - (MGLStyleValue<MGLColor *> *)textHaloColor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextHaloColor() ?: _rawLayer->getDefaultTextHaloColor();
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextHaloWidth:(MGLStyleValue<NSNumber *> *)textHaloWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textHaloWidth);
     _rawLayer->setTextHaloWidth(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textHaloWidth {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextHaloWidth() ?: _rawLayer->getDefaultTextHaloWidth();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextOpacity:(MGLStyleValue<NSNumber *> *)textOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(textOpacity);
     _rawLayer->setTextOpacity(mbglValue);
 }
 
 - (MGLStyleValue<NSNumber *> *)textOpacity {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextOpacity() ?: _rawLayer->getDefaultTextOpacity();
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextTranslate:(MGLStyleValue<NSValue *> *)textTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toPropertyValue(textTranslate);
     _rawLayer->setTextTranslate(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)textTranslate {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextTranslate() ?: _rawLayer->getDefaultTextTranslate();
     return MGLStyleValueTransformer<std::array<float, 2>, NSValue *>().toStyleValue(propertyValue);
 }
 
 - (void)setTextTranslateAnchor:(MGLStyleValue<NSValue *> *)textTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto mbglValue = MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLTextTranslateAnchor>().toEnumPropertyValue(textTranslateAnchor);
     _rawLayer->setTextTranslateAnchor(mbglValue);
 }
 
 - (MGLStyleValue<NSValue *> *)textTranslateAnchor {
+    MGLAssertStyleLayerIsValid();
+
     auto propertyValue = _rawLayer->getTextTranslateAnchor() ?: _rawLayer->getDefaultTextTranslateAnchor();
     return MGLStyleValueTransformer<mbgl::style::TranslateAnchorType, NSValue *, mbgl::style::TranslateAnchorType, MGLTextTranslateAnchor>().toEnumStyleValue(propertyValue);
 }


### PR DESCRIPTION
This updates the code generation for style layers to add a test to check that the style object returned from mbgl can be safely cast into the expected type so ownership can be returned to the caller when removing layers.

Previously a crash occurred if a layer of type T was added before a layer of type U but both layers shared the same identifier. In that case, if the pointer to the second layer of type U
was used to remove that layer, a runtime exception would occur since mbgl returns the layer with type T (the first one added) and the unsafe cast was triggered.

Now, even though the unsafe cast is avoided, an exception will still occur if layers with the same identifier are manipulated as described above but this is done as part of a validation check for all public style layer methods at the Darwin platform level. The raised `NSException` attempts to warn developers about reusing style identifiers to avoid this issue in the first place.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/7211

cc @1ec5 @jfirebaugh 