### PR TITLE
Fix spurious offline storage test failure

### DIFF
--- a/platform/darwin/test/MGLOfflineStorageTests.m
+++ b/platform/darwin/test/MGLOfflineStorageTests.m
@@ -19,6 +19,7 @@
         }];
         if ([MGLOfflineStorage sharedOfflineStorage].packs) {
             [expectation fulfill];
+            [self waitForExpectationsWithTimeout:0 handler:nil];
         } else {
             [self waitForExpectationsWithTimeout:2 handler:nil];
         }


### PR DESCRIPTION
This fixes the spurious offline storage unit test failure on iOS that was originally reported in #6385 and still reproduces consistently on the branch for #5999. See https://github.com/mapbox/mapbox-gl-native/pull/5999#issuecomment-263678869 for details.

I introduced this bug as part of #6397. Even if the expectation is immediately fulfilled, we still have to wait for it to be fulfilled, because the expectation only gets unregistered after waiting. The zombie expectation was fulfilling a stricter expectation in a test method.

/cc @frederoni