### PR TITLE
[ios, macos] Add new method to MGLMapViewDelegate for tapOnMap

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1544,4 +1544,10 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     }
 }
 
+
+- (void)mapView:(MGLMapView *)mapView tapAtCoordinate:(CLLocationCoordinate2D)coordinate
+{
+  NSLog(@"Did tap: %f,%f", coordinate.latitude, coordinate.longitude);
+}
+
 @end

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1477,6 +1477,10 @@ public:
     else
     {
         [self deselectAnnotation:self.selectedAnnotation animated:YES];
+        if ([self.delegate respondsToSelector:@selector(mapView:tapAtCoordinate:)])
+        {
+            [self.delegate mapView:self tapAtCoordinate:[self convertPoint:tapPoint toCoordinateFromView:self]];
+        }
     }
 }
 

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -514,6 +514,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id <MGLAnnotation>)annotation;
 
+/**
+ Tells the delegate that the user tapped on the map, but not on an annotation.
+ 
+ This method is called when then user taps on the map, but the tap does not select an annotation.
+ It is called if an annotation was previously selected, and this tap causes it to be deselected.
+ 
+ @param mapView The map view containing the specified annotation.
+ @param coordinate The coordinate of the point on the map that was tapped.
+ */
+- (void)mapView:(MGLMapView *)mapView tapAtCoordinate:(CLLocationCoordinate2D)coordinate;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This adds a new method to `MGLMapViewDelegate` `mapView:tapAtCoordinate:` that is called when the map is tapped, but an annotation was not selected.