### PR TITLE
[ios, macos] Add back support for CONTAINS operator

### DIFF
--- a/platform/darwin/src/MGLVectorStyleLayer.h
+++ b/platform/darwin/src/MGLVectorStyleLayer.h
@@ -52,10 +52,11 @@ NS_ASSUME_NONNULL_BEGIN
  <li><code>NSNotPredicateType</code> (<code>NOT</code>, <code>!</code>)</li>
  </ul>
  
- The following aggregate operator is supported:
+ The following aggregate operators are supported:
  
  <ul>
  <li><code>NSInPredicateOperatorType</code> (<code>IN</code>)</li>
+ <li><code>NSContainsPredicateOperatorType</code> (<code>CONTAINS</code>)</li>
  </ul>
  
  To test whether a feature has or lacks a specific attribute, compare the attribute to `NULL` or `NIL`. Predicates created using the `+[NSPredicate predicateWithValue:]` method are also supported. String operators and custom operators are not supported.
@@ -118,7 +119,9 @@ NS_ASSUME_NONNULL_BEGIN
  
  Automatic type casting is not performed. Therefore, a feature only matches this
  predicate if its value for the attribute in question is of the same type as the
- value specified in the predicate.
+ value specified in the predicate. Also, operator modifiers `c`, `d`, and the
+ combined `cd` for case and diacritic insensitivity are unsupported for 
+ comparison and aggregate operators that are used in the predicate.
  */
 @property (nonatomic, nullable) NSPredicate *predicate;
 

--- a/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
+++ b/platform/darwin/src/NSComparisonPredicate+MGLAdditions.mm
@@ -68,6 +68,12 @@
             filter.values = self.rightExpression.mgl_filterValues;
             return filter;
         }
+        case NSContainsPredicateOperatorType: {
+            auto filter = mbgl::style::InFilter();
+            filter.key = [self.rightExpression.constantValue UTF8String];
+            filter.values = self.leftExpression.mgl_filterValues;
+            return filter;
+        }
         case NSBetweenPredicateOperatorType: {
             auto filter = mbgl::style::AllFilter();
             auto gteFilter = mbgl::style::GreaterThanEqualsFilter();
@@ -85,7 +91,6 @@
         case NSBeginsWithPredicateOperatorType:
         case NSEndsWithPredicateOperatorType:
         case NSCustomSelectorPredicateOperatorType:
-        case NSContainsPredicateOperatorType:
             [NSException raise:@"Unsupported operator type"
                         format:@"NSPredicateOperatorType:%lu is not supported.", (unsigned long)self.predicateOperatorType];
     }

--- a/platform/darwin/test/MGLFilterTests.mm
+++ b/platform/darwin/test/MGLFilterTests.mm
@@ -74,6 +74,18 @@
     [self.mapView.style addLayer:layer];
 }
 
+- (void)testContainsPredicate
+{
+    // core does not have a "contains" filter but we can achieve the equivalent by creating an `mbgl::style::InFilter`
+    // and searching the value for the key
+    NSPredicate *expectedPredicate = [NSPredicate predicateWithFormat:@"park IN %@", @[@"park", @"neighbourhood"]];
+    NSPredicate *containsPredicate = [NSPredicate predicateWithFormat:@"%@ CONTAINS %@", @[@"park", @"neighbourhood"], @"park"];
+    
+    layer.predicate = containsPredicate;
+    XCTAssertEqualObjects(layer.predicate, expectedPredicate);
+    [self.mapView.style addLayer:layer];
+}
+
 - (void)testBetweenPredicate
 {
     // core does not have a "between" filter but we can achieve the equivalent by creating a set of greater than or equal / less than or equal


### PR DESCRIPTION
This reverts commit 6877e3efe73fb6e103c2635f1e4b1c1866b17d5c.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/6784

cc @1ec5 