### PR TITLE
[core] Use indexed rendering everywhere

### DIFF
--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -518,18 +518,11 @@ void Context::draw(const Drawable& drawable) {
             drawable.bindAttributes(segment.vertexOffset);
         }
 
-        if (drawable.indexBuffer) {
-            MBGL_CHECK_ERROR(glDrawElements(
-                static_cast<GLenum>(primitiveType),
-                static_cast<GLsizei>(segment.indexLength),
-                GL_UNSIGNED_SHORT,
-                reinterpret_cast<GLvoid*>(sizeof(uint16_t) * segment.indexOffset)));
-        } else {
-            MBGL_CHECK_ERROR(glDrawArrays(
-                static_cast<GLenum>(primitiveType),
-                static_cast<GLint>(segment.vertexOffset),
-                static_cast<GLsizei>(segment.vertexLength)));
-        }
+        MBGL_CHECK_ERROR(glDrawElements(
+            static_cast<GLenum>(primitiveType),
+            static_cast<GLsizei>(segment.indexLength),
+            GL_UNSIGNED_SHORT,
+            reinterpret_cast<GLvoid*>(sizeof(uint16_t) * segment.indexOffset)));
     }
 }
 

--- a/src/mbgl/gl/program.hpp
+++ b/src/mbgl/gl/program.hpp
@@ -32,7 +32,6 @@ public:
           attributesState(Attributes::state(program)),
           uniformsState((context.linkProgram(program), Uniforms::state(program))) {}
 
-    // Indexed drawing.
     template <class DrawMode>
     void draw(Context& context,
               DrawMode drawMode,
@@ -52,31 +51,6 @@ public:
             program,
             vertexBuffer.buffer,
             indexBuffer.buffer,
-            segments,
-            Uniforms::binder(uniformsState, std::move(uniformValues)),
-            Attributes::binder(attributesState)
-        });
-    }
-
-    // Unindexed drawing.
-    template <class DrawMode>
-    void draw(Context& context,
-              DrawMode drawMode,
-              DepthMode depthMode,
-              StencilMode stencilMode,
-              ColorMode colorMode,
-              UniformValues&& uniformValues,
-              const VertexBuffer<Vertex, DrawMode>& vertexBuffer,
-              const SegmentVector<Attributes>& segments) {
-        static_assert(std::is_same<Primitive, typename DrawMode::Primitive>::value, "incompatible draw mode");
-        context.draw({
-            std::move(drawMode),
-            std::move(depthMode),
-            std::move(stencilMode),
-            std::move(colorMode),
-            program,
-            vertexBuffer.buffer,
-            0,
             segments,
             Uniforms::binder(uniformsState, std::move(uniformValues)),
             Attributes::binder(attributesState)

--- a/src/mbgl/gl/segment.hpp
+++ b/src/mbgl/gl/segment.hpp
@@ -33,13 +33,6 @@ template <class Attributes>
 class SegmentVector : public std::vector<Segment> {
 public:
     SegmentVector() = default;
-
-    // This constructor is for unindexed rendering. It creates a SegmentVector with a
-    // single segment having 0 indexes.
-    template <class DrawMode>
-    SegmentVector(const VertexBuffer<typename Attributes::Vertex, DrawMode>& buffer) {
-        emplace_back(0, 0, buffer.vertexCount, 0);
-    }
 };
 
 } // namespace gl

--- a/src/mbgl/renderer/debug_bucket.hpp
+++ b/src/mbgl/renderer/debug_bucket.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/gl/vertex_buffer.hpp>
+#include <mbgl/gl/index_buffer.hpp>
 #include <mbgl/programs/debug_program.hpp>
 
 namespace mbgl {
@@ -32,8 +33,9 @@ public:
     const optional<Timestamp> expires;
     const MapDebugOptions debugMode;
 
-    gl::VertexBuffer<DebugVertex, gl::Lines> vertexBuffer;
     gl::SegmentVector<DebugAttributes> segments;
+    optional<gl::VertexBuffer<DebugVertex>> vertexBuffer;
+    optional<gl::IndexBuffer<gl::Lines>> indexBuffer;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/painter.cpp
+++ b/src/mbgl/renderer/painter.cpp
@@ -42,31 +42,34 @@ namespace mbgl {
 
 using namespace style;
 
-static gl::VertexVector<FillVertex, gl::Triangles> tileTriangles() {
-    gl::VertexVector<FillVertex, gl::Triangles> result;
-    result.emplace_back(
-            FillAttributes::vertex({ 0,            0 }),
-            FillAttributes::vertex({ util::EXTENT, 0 }),
-            FillAttributes::vertex({ 0, util::EXTENT }));
-    result.emplace_back(
-            FillAttributes::vertex({ util::EXTENT, 0 }),
-            FillAttributes::vertex({ 0, util::EXTENT }),
-            FillAttributes::vertex({ util::EXTENT, util::EXTENT }));
-    return result;
-}
-
-static gl::VertexVector<FillVertex, gl::LineStrip> tileLineStrip() {
-    gl::VertexVector<FillVertex, gl::LineStrip> result;
-    result.emplace_back(FillAttributes::vertex({ 0, 0 }));
+static gl::VertexVector<FillVertex> tileVertices() {
+    gl::VertexVector<FillVertex> result;
+    result.emplace_back(FillAttributes::vertex({ 0,            0 }));
     result.emplace_back(FillAttributes::vertex({ util::EXTENT, 0 }));
-    result.emplace_back(FillAttributes::vertex({ util::EXTENT, util::EXTENT }));
     result.emplace_back(FillAttributes::vertex({ 0, util::EXTENT }));
-    result.emplace_back(FillAttributes::vertex({ 0, 0 }));
+    result.emplace_back(FillAttributes::vertex({ util::EXTENT, util::EXTENT }));
     return result;
 }
 
-static gl::VertexVector<RasterVertex, gl::TriangleStrip> rasterTriangleStrip() {
-    gl::VertexVector<RasterVertex, gl::TriangleStrip> result;
+static gl::IndexVector<gl::Triangles> tileTriangleIndices() {
+    gl::IndexVector<gl::Triangles> result;
+    result.emplace_back(0, 1, 2);
+    result.emplace_back(1, 2, 3);
+    return result;
+}
+
+static gl::IndexVector<gl::LineStrip> tileLineStripIndices() {
+    gl::IndexVector<gl::LineStrip> result;
+    result.emplace_back(0);
+    result.emplace_back(1);
+    result.emplace_back(3);
+    result.emplace_back(2);
+    result.emplace_back(0);
+    return result;
+}
+
+static gl::VertexVector<RasterVertex> rasterVertices() {
+    gl::VertexVector<RasterVertex> result;
     result.emplace_back(RasterProgram::vertex({ 0, 0 }, { 0, 0 }));
     result.emplace_back(RasterProgram::vertex({ util::EXTENT, 0 }, { 32767, 0 }));
     result.emplace_back(RasterProgram::vertex({ 0, util::EXTENT }, { 0, 32767 }));
@@ -77,12 +80,15 @@ static gl::VertexVector<RasterVertex, gl::TriangleStrip> rasterTriangleStrip() {
 Painter::Painter(gl::Context& context_, const TransformState& state_, float pixelRatio)
     : context(context_),
       state(state_),
-      tileTriangleVertexBuffer(context.createVertexBuffer(tileTriangles())),
-      tileTriangleSegments(tileTriangleVertexBuffer),
-      tileBorderVertexBuffer(context.createVertexBuffer(tileLineStrip())),
-      tileBorderSegments(tileBorderVertexBuffer),
-      rasterVertexBuffer(context.createVertexBuffer(rasterTriangleStrip())),
-      rasterSegments(rasterVertexBuffer) {
+      tileVertexBuffer(context.createVertexBuffer(tileVertices())),
+      rasterVertexBuffer(context.createVertexBuffer(rasterVertices())),
+      tileTriangleIndexBuffer(context.createIndexBuffer(tileTriangleIndices())),
+      tileBorderIndexBuffer(context.createIndexBuffer(tileLineStripIndices())) {
+
+    tileTriangleSegments.emplace_back(0, 0, 4, 6);
+    tileBorderSegments.emplace_back(0, 0, 4, 5);
+    rasterSegments.emplace_back(0, 0, 4, 6);
+
 #ifndef NDEBUG
     gl::debugging::enable();
 #endif

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -158,13 +158,14 @@ private:
     std::unique_ptr<Programs> overdrawPrograms;
 #endif
 
-    gl::VertexBuffer<FillVertex, gl::Triangles> tileTriangleVertexBuffer;
+    gl::VertexBuffer<FillVertex> tileVertexBuffer;
+    gl::VertexBuffer<RasterVertex> rasterVertexBuffer;
+
+    gl::IndexBuffer<gl::Triangles> tileTriangleIndexBuffer;
+    gl::IndexBuffer<gl::LineStrip> tileBorderIndexBuffer;
+
     gl::SegmentVector<FillAttributes> tileTriangleSegments;
-
-    gl::VertexBuffer<DebugVertex, gl::LineStrip> tileBorderVertexBuffer;
     gl::SegmentVector<DebugAttributes> tileBorderSegments;
-
-    gl::VertexBuffer<RasterVertex, gl::TriangleStrip> rasterVertexBuffer;
     gl::SegmentVector<RasterAttributes> rasterSegments;
 };
 

--- a/src/mbgl/renderer/painter_background.cpp
+++ b/src/mbgl/renderer/painter_background.cpp
@@ -44,7 +44,8 @@ void Painter::renderBackground(PaintParameters& parameters, const BackgroundLaye
                     tileID,
                     state
                 ),
-                tileTriangleVertexBuffer,
+                tileVertexBuffer,
+                tileTriangleIndexBuffer,
                 tileTriangleSegments
             );
         }
@@ -63,7 +64,8 @@ void Painter::renderBackground(PaintParameters& parameters, const BackgroundLaye
                     uniforms::u_outline_color::Value{ properties.get<BackgroundColor>() },
                     uniforms::u_world::Value{ context.viewport.getCurrentValue().size },
                 },
-                tileTriangleVertexBuffer,
+                tileVertexBuffer,
+                tileTriangleIndexBuffer,
                 tileTriangleSegments
             );
         }

--- a/src/mbgl/renderer/painter_clipping.cpp
+++ b/src/mbgl/renderer/painter_clipping.cpp
@@ -26,7 +26,8 @@ void Painter::renderClippingMask(const UnwrappedTileID& tileID, const ClipID& cl
             uniforms::u_outline_color::Value{ Color {} },
             uniforms::u_world::Value{ context.viewport.getCurrentValue().size },
         },
-        tileTriangleVertexBuffer,
+        tileVertexBuffer,
+        tileTriangleIndexBuffer,
         tileTriangleSegments
     );
 }

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -18,7 +18,7 @@ void Painter::renderTileDebug(const RenderTile& renderTile) {
 
     MBGL_DEBUG_GROUP(std::string { "debug " } + util::toString(renderTile.id));
 
-    auto draw = [&] (Color color, const auto& vertexBuffer, const auto& segments, auto drawMode) {
+    auto draw = [&] (Color color, const auto& vertexBuffer, const auto& indexBuffer, const auto& segments, auto drawMode) {
         programs->debug.draw(
             context,
             drawMode,
@@ -30,6 +30,7 @@ void Painter::renderTileDebug(const RenderTile& renderTile) {
                 uniforms::u_color::Value{ color }
             },
             vertexBuffer,
+            indexBuffer,
             segments
         );
     };
@@ -47,19 +48,22 @@ void Painter::renderTileDebug(const RenderTile& renderTile) {
         }
 
         draw(Color::white(),
-             tile.debugBucket->vertexBuffer,
+             *tile.debugBucket->vertexBuffer,
+             *tile.debugBucket->indexBuffer,
              tile.debugBucket->segments,
              gl::Lines { 4.0f * frame.pixelRatio });
 
         draw(Color::black(),
-             tile.debugBucket->vertexBuffer,
+             *tile.debugBucket->vertexBuffer,
+             *tile.debugBucket->indexBuffer,
              tile.debugBucket->segments,
              gl::Lines { 2.0f * frame.pixelRatio });
     }
 
     if (frame.debugOptions & MapDebugOptions::TileBorders) {
         draw(Color::red(),
-             tileBorderVertexBuffer,
+             tileVertexBuffer,
+             tileBorderIndexBuffer,
              tileBorderSegments,
              gl::LineStrip { 4.0f * frame.pixelRatio });
     }

--- a/src/mbgl/renderer/painter_raster.cpp
+++ b/src/mbgl/renderer/painter_raster.cpp
@@ -56,7 +56,7 @@ void Painter::renderRaster(PaintParameters& parameters,
 
     parameters.programs.raster.draw(
         context,
-        gl::TriangleStrip(),
+        gl::Triangles(),
         depthModeForSublayer(0, gl::DepthMode::ReadOnly),
         gl::StencilMode::disabled(),
         colorModeForRenderPass(),
@@ -76,6 +76,7 @@ void Painter::renderRaster(PaintParameters& parameters,
             uniforms::u_tl_parent::Value{ std::array<float, 2> {{ 0.0f, 0.0f }} },
         },
         rasterVertexBuffer,
+        tileTriangleIndexBuffer,
         rasterSegments
     );
 }


### PR DESCRIPTION
I found that maintaining both pathways was a drag on work towards #4860. It's easier to use indexed rendering consistently.

cc @kkaefer 