### PR TITLE
Relayout after recalculating to ensure visibility changes are handled correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.16.4",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#b51b85ffb8c512e228c36c5405293ce51d123519",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#49e8b407bdbbe6f7c92dbcb56d3d51f425fc2653",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#9252ffc5108131704b5acf52d78258ac05687871",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#66397c8ee0426537d25e8d4cfcac134ca21a021b",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -61,14 +61,9 @@ module.exports = function (style, options, callback) {
             callback();
 
         } else if (operation[0] === 'wait') {
-            var wait = function () {
-                if (map.loaded()) {
-                    applyOperations(operations.slice(1), callback);
-                } else {
-                    map.render(options, wait);
-                }
-            };
-            wait();
+            map.render(options, function () {
+                applyOperations(operations.slice(1), callback);
+            });
 
         } else {
             // Ensure that the next `map.render(options)` does not overwrite this change.

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -253,16 +253,16 @@ void Map::Impl::update() {
         annotationManager->updateData();
     }
 
-    if (updateFlags & Update::Layout) {
-        style->relayout();
-    }
-
     if (updateFlags & Update::Classes) {
         style->cascade(timePoint, mode);
     }
 
     if (updateFlags & Update::Classes || updateFlags & Update::RecalculateStyle) {
         style->recalculate(transform.getZoom(), timePoint, mode);
+    }
+
+    if (updateFlags & Update::Layout) {
+        style->relayout();
     }
 
     style::UpdateParameters parameters(pixelRatio,

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -141,8 +141,8 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
 
     if (type != SourceType::Annotations && cache.getSize() == 0) {
         size_t conservativeCacheSize =
-            ((float)parameters.transformState.getSize().width / util::tileSize) *
-            ((float)parameters.transformState.getSize().height / util::tileSize) *
+            std::max((float)parameters.transformState.getSize().width / util::tileSize, 1.0f) *
+            std::max((float)parameters.transformState.getSize().height / util::tileSize, 1.0f) *
             (parameters.transformState.getMaxZoom() - parameters.transformState.getMinZoom() + 1) *
             0.5;
         cache.setSize(conservativeCacheSize);


### PR DESCRIPTION
Fixes #7241
Fixes #7225
Fixes #6758

Re-ordering `relayout()` after `recalculate()` ensures that sources are enabled before checking if tiles need to be reloaded on them.