### PR TITLE
[core] Functions must have at least one stop

### DIFF
--- a/include/mbgl/style/conversion/function.hpp
+++ b/include/mbgl/style/conversion/function.hpp
@@ -25,6 +25,10 @@ struct Converter<Function<T>> {
             return Error { "function stops must be an array" };
         }
 
+        if (arrayLength(*stopsValue) == 0) {
+            return Error { "function must have at least one stop" };
+        }
+
         std::vector<std::pair<float, T>> stops;
         for (std::size_t i = 0; i < arrayLength(*stopsValue); ++i) {
             const auto& stopValue = arrayMember(*stopsValue, i);

--- a/include/mbgl/style/function.hpp
+++ b/include/mbgl/style/function.hpp
@@ -12,8 +12,10 @@ public:
     using Stop = std::pair<float, T>;
     using Stops = std::vector<Stop>;
 
-    explicit Function(Stops stops_, float base_)
-        : base(base_), stops(std::move(stops_)) {}
+    Function(Stops stops_, float base_)
+        : base(base_), stops(std::move(stops_)) {
+        assert(stops.size() > 0);
+    }
 
     float getBase() const { return base; }
     const std::vector<std::pair<float, T>>& getStops() const { return stops; }

--- a/src/mbgl/style/property_evaluator.cpp
+++ b/src/mbgl/style/property_evaluator.cpp
@@ -11,30 +11,6 @@ namespace mbgl {
 namespace style {
 
 template <typename T>
-T defaultStopsValue();
-
-template <> bool defaultStopsValue() { return true; }
-template <> float defaultStopsValue() { return 1.0f; }
-template <> Color defaultStopsValue() { return { 0, 0, 0, 1 }; }
-template <> std::vector<float> defaultStopsValue() { return {{ 1, 0 }}; }
-template <> std::vector<std::string> defaultStopsValue() { return {{}}; }
-template <> std::array<float, 2> defaultStopsValue() { return {{ 0, 0 }}; }
-template <> std::array<float, 4> defaultStopsValue() { return {{ 0, 0, 0, 0 }}; }
-
-template <> std::string defaultStopsValue() { return {}; }
-template <> TranslateAnchorType defaultStopsValue() { return {}; }
-template <> RotateAnchorType defaultStopsValue() { return {}; }
-template <> CirclePitchScaleType defaultStopsValue() { return {}; }
-template <> LineCapType defaultStopsValue() { return {}; }
-template <> LineJoinType defaultStopsValue() { return {}; }
-template <> SymbolPlacementType defaultStopsValue() { return {}; }
-template <> TextAnchorType defaultStopsValue() { return {}; }
-template <> TextJustifyType defaultStopsValue() { return {}; }
-template <> TextTransformType defaultStopsValue() { return {}; }
-template <> AlignmentType defaultStopsValue() { return {}; }
-template <> IconTextFitType defaultStopsValue() { return {}; };
-
-template <typename T>
 T PropertyEvaluator<T>::operator()(const Function<T>& fn) const {
     float base = fn.getBase();
     const std::vector<std::pair<float, T>>& stops = fn.getStops();
@@ -80,7 +56,8 @@ T PropertyEvaluator<T>::operator()(const Function<T>& fn) const {
         return smaller_val;
     } else {
         // No stop defined.
-        return defaultStopsValue<T>();
+        assert(false);
+        return T();
     }
 }
 

--- a/test/fixtures/style_parser/stop-zoom-value.info.json
+++ b/test/fixtures/style_parser/stop-zoom-value.info.json
@@ -1,6 +1,7 @@
 {
     "default": {
         "log": [
+            [1, "WARNING", "ParseStyle", "function must have at least one stop"],
             [1, "WARNING", "ParseStyle", "function stop must have two elements"]
         ]
     }

--- a/test/style/functions.test.cpp
+++ b/test/style/functions.test.cpp
@@ -50,12 +50,6 @@ TEST(Function, Stops) {
     EXPECT_EQ(3.0, evaluate(slope_2, 15));
     EXPECT_EQ(3.0, evaluate(slope_2, 22));
 
-    // Test no values.
-    Function<float> slope_3({}, 1.75);
-    EXPECT_EQ(1, evaluate(slope_3, 2));
-    EXPECT_EQ(1, evaluate(slope_3, 6));
-    EXPECT_EQ(1, evaluate(slope_3, 12));
-
 
     // Explicit constant slope in fringe regions.
     Function<float> slope_4({ { 0, 2 }, { 8, 10 } }, 1);


### PR DESCRIPTION
This is already enforced by the style validator in mapbox-gl-style-spec. Enforce it here too.

@1ec5 @frederoni Do we need to add an equivalent validation in the SDK bindings for `Function`?