### PR TITLE
Refactor Android CMake targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,17 +493,17 @@ build/android-$1/$(BUILDTYPE)/Makefile: build/android-$1/$(BUILDTYPE)/toolchain.
 
 .PHONY: android-test-lib-$1
 android-test-lib-$1: build/android-$1/$(BUILDTYPE)/Makefile
-	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C build/android-$1/$(BUILDTYPE) mbgl-test-stripped
+	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C build/android-$1/$(BUILDTYPE) mbgl-test
 
 .PHONY: android-lib-$1
 android-lib-$1: build/android-$1/$(BUILDTYPE)/Makefile
-	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C build/android-$1/$(BUILDTYPE) all
+	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C build/android-$1/$(BUILDTYPE) mapbox-gl example-custom-layer
 
 .PHONY: android-$1
 android-$1: android-lib-$1
 	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) assemble$(BUILDTYPE)
 
-run-android-core-test-$1: android-lib-$1 android-test-lib-$1
+run-android-core-test-$1: android-test-lib-$1
 	# Compile main sources and extract the classes (using the test app to get all transitive dependencies in one place)
 	cd platform/android && ./gradlew assembleDebug
 	unzip -o platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug.apk classes.dex -d build/android-$1/$(BUILDTYPE)


### PR DESCRIPTION
We're currently running strip operations for every invocation, and build the test cases always, which makes the Android nightly build [go over Bitrise's 45 minute limit](https://www.bitrise.io/build/1a579128dd97a6a4). We should refactor `make apackage` so that it doesn't build the `mbgl-test` library.