### PR TITLE
Android: Use Identical Code Folding to reduce binary size

### DIFF
--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -179,6 +179,7 @@ macro(mbgl_platform_core)
         PUBLIC -latomic
         PUBLIC -lz
         PUBLIC -Wl,--gc-sections
+        PUBLIC -Wl,--icf=safe
     )
 endmacro()
 
@@ -202,6 +203,7 @@ target_compile_options(mapbox-gl
 target_link_libraries(mapbox-gl
     PUBLIC mbgl-core
     PUBLIC -Wl,--gc-sections
+    PUBLIC -Wl,--icf=safe
 )
 
 # Create a stripped version of the library and copy it to the JNIDIR.
@@ -288,6 +290,7 @@ target_compile_options(example-custom-layer
 target_link_libraries(example-custom-layer
     PRIVATE mapbox-gl
     PUBLIC -Wl,--gc-sections
+    PUBLIC -Wl,--icf=safe
 )
 
 add_custom_command(TARGET example-custom-layer POST_BUILD


### PR DESCRIPTION
The Android NDK uses the gold linker by default, and it includes a function called [Identical Code Folding](http://research.google.com/pubs/pub36912.html), which deduplicates identical functions. It can be enabled by adding  `--icf=safe` to the linker flags, and reduces the code in a different way from [--gc-sections](https://github.com/mapbox/mapbox-gl-native/pull/7107). Just by enabling ICF, I got a reduction from 4,916,076 bytes to 4,715,372 bytes for arm-v7.

We are currently using the gold linker for `arm-v5`, `arm-v7`, `x86`, and `x86_64`, but [we **aren't** using it currently for `arm-v8`](https://github.com/mapbox/mason/blob/master/mason.sh#L147) due to [a bug that @tmpsantos previously discovered](https://code.google.com/p/android/issues/detail?id=204151). The gold linker doesn't exist for `mips` and `mips-64` afaik.

Actions:
- [ ] Enable ICF for architectures that use gold
- [x] Check if arm-v8 can use gold with the newest NDK
- [ ] Enable ICF for arm-v8 once it works again