### PR TITLE
Template images as style images

### DIFF
--- a/platform/ios/src/UIImage+MGLAdditions.mm
+++ b/platform/ios/src/UIImage+MGLAdditions.mm
@@ -6,7 +6,14 @@
 {
     std::string png = encodePNG(spriteImage->image);
     NSData *data = [[NSData alloc] initWithBytes:png.data() length:png.size()];
-    return [self initWithData:data scale:spriteImage->pixelRatio];
+    if (self = [self initWithData:data scale:spriteImage->pixelRatio])
+    {
+        if (spriteImage->sdf)
+        {
+            self = [self imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        }
+    }
+    return self;
 }
 
 - (std::unique_ptr<mbgl::SpriteImage>)mgl_spriteImage
@@ -28,7 +35,8 @@
     CGContextRelease(context);
     CGColorSpaceRelease(colorSpace);
 
-    return std::make_unique<mbgl::SpriteImage>(std::move(cPremultipliedImage), float(self.scale));
+    BOOL isTemplate = self.renderingMode == UIImageRenderingModeAlwaysTemplate;
+    return std::make_unique<mbgl::SpriteImage>(std::move(cPremultipliedImage), float(self.scale), isTemplate);
 }
 
 @end

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -675,6 +675,22 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     fillLayer.fillColor = [MGLStyleValue<NSColor *> valueWithRawValue:[NSColor greenColor]];
     fillLayer.predicate = [NSPredicate predicateWithFormat:@"%K == %@", @"type", @"park"];
     [self.mapView.style addLayer:fillLayer];
+    
+    NSImage *image = [NSImage imageNamed:NSImageNameIChatTheaterTemplate];
+    [self.mapView.style setImage:image forName:NSImageNameIChatTheaterTemplate];
+    
+    MGLSource *streetsSource = [self.mapView.style sourceWithIdentifier:@"composite"];
+    MGLSymbolStyleLayer *theaterLayer = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"theaters" source:streetsSource];
+    theaterLayer.sourceLayerIdentifier = @"poi_label";
+    theaterLayer.predicate = [NSPredicate predicateWithFormat:@"maki == 'theatre'"];
+    theaterLayer.iconImageName = [MGLStyleValue valueWithRawValue:NSImageNameIChatTheaterTemplate];
+    theaterLayer.iconSize = [MGLStyleValue valueWithRawValue:@2];
+    theaterLayer.iconColor = [MGLStyleValue valueWithStops:@{
+        @16.0: [MGLStyleValue valueWithRawValue:[NSColor redColor]],
+        @18.0: [MGLStyleValue valueWithRawValue:[NSColor yellowColor]],
+        @20.0: [MGLStyleValue valueWithRawValue:[NSColor blackColor]],
+    }];
+    [self.mapView.style addLayer:theaterLayer];
 }
 
 - (IBAction)dropPin:(NSMenuItem *)sender {

--- a/platform/macos/src/NSImage+MGLAdditions.mm
+++ b/platform/macos/src/NSImage+MGLAdditions.mm
@@ -8,6 +8,7 @@
     NSBitmapImageRep *rep = [NSBitmapImageRep imageRepWithData:data];
     if ([self initWithSize:NSMakeSize(spriteImage->getWidth(), spriteImage->getHeight())]) {
         [self addRepresentation:rep];
+        [self setTemplate:spriteImage->sdf];
     }
     return self;
 }
@@ -23,7 +24,8 @@
     mbgl::PremultipliedImage cPremultipliedImage(rep.pixelsWide, rep.pixelsHigh);
     std::copy(rep.bitmapData, rep.bitmapData + cPremultipliedImage.size(), cPremultipliedImage.data.get());
     return std::make_unique<mbgl::SpriteImage>(std::move(cPremultipliedImage),
-                                               (float)(rep.pixelsWide / self.size.width));
+                                               (float)(rep.pixelsWide / self.size.width),
+                                               [self isTemplate]);
 }
 
 @end


### PR DESCRIPTION
This is a followup to #7096 that converts template images to SDF icons and back when storing them as style images. It turns out that template images and SDF icons are exactly the same format ([source](https://github.com/mapbox/maki/blob/cb5d8516eb4d0fcbe38f69dd285268f43c3d6a4e/sdf-render.js#L70-L75)).

Also extended the Manipulate Style command in macosapp to replace theater POIs with AppKit’s built-in `NSImageNameIChatTheaterTemplate` template image:

![theater](https://cloud.githubusercontent.com/assets/1231218/20918329/50edfa78-bb4b-11e6-8ffe-1c8e05f67060.gif)

Fixes #7291.

/cc @incanus @friedbunny