### PR TITLE
Fix pixelated icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ejs": "^2.4.1",
     "express": "^4.11.1",
     "lodash": "^4.16.4",
-    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#b51b85ffb8c512e228c36c5405293ce51d123519",
+    "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#cfb36126be74a303c6a5fe640a17c5e0d79b2035",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#49e8b407bdbbe6f7c92dbcb56d3d51f425fc2653",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#9252ffc5108131704b5acf52d78258ac05687871",
     "mkdirp": "^0.5.1",

--- a/src/mbgl/programs/fill_program.hpp
+++ b/src/mbgl/programs/fill_program.hpp
@@ -9,7 +9,6 @@
 #include <mbgl/shader/fill_outline_pattern.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/mat4.hpp>
-#include <mbgl/util/size.hpp>
 
 #include <string>
 
@@ -24,7 +23,6 @@ template <class> class Faded;
 } // namespace style
 
 namespace uniforms {
-MBGL_DEFINE_UNIFORM_SCALAR(Size,     u_world);
 MBGL_DEFINE_UNIFORM_SCALAR(Color,    u_outline_color);
 MBGL_DEFINE_UNIFORM_SCALAR(float,    u_scale_a);
 MBGL_DEFINE_UNIFORM_SCALAR(float,    u_scale_b);

--- a/src/mbgl/programs/symbol_program.cpp
+++ b/src/mbgl/programs/symbol_program.cpp
@@ -51,14 +51,18 @@ SymbolIconProgram::uniformValues(const style::SymbolPropertyValues& values,
                                  const Size& texsize,
                                  const std::array<float, 2>& pixelsToGLUnits,
                                  const RenderTile& tile,
-                                 const TransformState& state)
+                                 const TransformState& state,
+                                 const bool interpolate,
+                                 const Size framebufferSize)
 {
     return makeValues<SymbolIconProgram::UniformValues>(
         values,
         texsize,
         pixelsToGLUnits,
         tile,
-        state
+        state,
+        uniforms::u_interpolate::Value{ interpolate },
+        uniforms::u_world::Value{ framebufferSize }
     );
 }
 

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -22,6 +22,7 @@ class TransformState;
 
 namespace uniforms {
 MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_texsize);
+MBGL_DEFINE_UNIFORM_SCALAR(bool, u_interpolate);
 MBGL_DEFINE_UNIFORM_SCALAR(bool, u_rotate_with_map);
 MBGL_DEFINE_UNIFORM_SCALAR(bool, u_pitch_with_map);
 MBGL_DEFINE_UNIFORM_SCALAR(gl::TextureUnit, u_texture);
@@ -82,7 +83,9 @@ class SymbolIconProgram : public Program<
         uniforms::u_zoom,
         uniforms::u_rotate_with_map,
         uniforms::u_texture,
-        uniforms::u_fadetexture>>
+        uniforms::u_fadetexture,
+        uniforms::u_interpolate,
+        uniforms::u_world>>
 {
 public:
     using Program::Program;
@@ -91,7 +94,9 @@ public:
                                        const Size& texsize,
                                        const std::array<float, 2>& pixelsToGLUnits,
                                        const RenderTile&,
-                                       const TransformState&);
+                                       const TransformState&,
+                                       const bool interpolate,
+                                       const Size framebufferSize);
 };
 
 class SymbolSDFProgram : public Program<

--- a/src/mbgl/programs/uniforms.hpp
+++ b/src/mbgl/programs/uniforms.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/gl/uniform.hpp>
 #include <mbgl/util/color.hpp>
+#include <mbgl/util/size.hpp>
 
 namespace mbgl {
 namespace uniforms {
@@ -26,6 +27,7 @@ MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_pattern_br_b);
 MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_pattern_size_a);
 MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_pattern_size_b);
 
+MBGL_DEFINE_UNIFORM_SCALAR(Size, u_world);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_mix);
 MBGL_DEFINE_UNIFORM_SCALAR(gl::TextureUnit, u_image);
 

--- a/src/mbgl/renderer/painter_symbol.cpp
+++ b/src/mbgl/renderer/painter_symbol.cpp
@@ -61,7 +61,9 @@ void Painter::renderSymbol(PaintParameters& parameters,
         SpriteAtlas& atlas = *layer.impl->spriteAtlas;
         const bool iconScaled = values.paintSize != 1.0f || frame.pixelRatio != atlas.getPixelRatio() || bucket.iconsNeedLinear;
         const bool iconTransformed = values.rotationAlignment == AlignmentType::Map || state.getPitch() != 0;
-        atlas.bind(bucket.sdfIcons || state.isChanging() || iconScaled || iconTransformed, context, 0);
+        const bool interpolate =
+            bucket.sdfIcons || state.isChanging() || iconScaled || iconTransformed;
+        atlas.bind(interpolate, context, 0);
 
         const Size texsize = atlas.getSize();
 
@@ -81,9 +83,10 @@ void Painter::renderSymbol(PaintParameters& parameters,
             }
         } else {
             draw(parameters.programs.symbolIcon,
-                 SymbolIconProgram::uniformValues(values, texsize, pixelsToGLUnits, tile, state),
-                 bucket.icon,
-                 values);
+                 SymbolIconProgram::uniformValues(values, texsize, pixelsToGLUnits, tile, state,
+                                                  interpolate,
+                                                  context.viewport.getCurrentValue().size),
+                 bucket.icon, values);
         }
     }
 


### PR DESCRIPTION
This is a fix for #6863, which seems very elusive. It's highly dependent on the actual coordinates, the GPU in use (I could only replicate it with my discrete nVidia GPU, but not with the Intel integrated GPU), but even then repeated renders produce different results. My assumption is that the floating point implementation in the nVidia GPU is behaves in an undefined way when doing non-interpolated texture lookups at fringe locations (.5). I tried creating a test case, but given it's highly random behavior, I don't think adding a test case makes much sense.

The fix itself is close to what @jfirebaugh described in #6863 in that we are rounding the texture lookup coordinates when we aren't using linear interpolation.