### PR TITLE
[android] - max/min refactor

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraUpdateFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraUpdateFactory.java
@@ -258,7 +258,7 @@ public final class CameraUpdateFactory {
                 float scaleY = (uiSettings.getHeight() - padding.top - padding.bottom) / height;
                 minScale = scaleX < scaleY ? scaleX : scaleY;
                 zoom = calculateZoom(mapboxMap, minScale);
-                zoom = MathUtils.clamp(zoom, mapboxMap.getMinZoom(), mapboxMap.getMaxZoom());
+                zoom = MathUtils.clamp(zoom, mapboxMap.getMinZoomLevel(), mapboxMap.getMaxZoomLevel());
             }
 
             // Calculate the center point

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -68,7 +68,7 @@ public class MapboxConstants {
     /**
      * The currently supported maximum zoom level.
      */
-    public static final float MAXIMUM_ZOOM = 21.0f;
+    public static final float MAXIMUM_ZOOM = 20.0f;
 
     /**
      * The currently supported maximum tilt value.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -70,9 +70,6 @@ public final class MapboxMap {
 
     private MapboxMap.OnFpsChangedListener onFpsChangedListener;
 
-    private double maxZoomLevel = -1;
-    private double minZoomLevel = -1;
-
     MapboxMap(NativeMapView map, Transform transform, UiSettings ui, TrackingSettings tracking, MyLocationViewSettings myLocationView,
               Projection projection, OnRegisterTouchListener listener, AnnotationManager annotations) {
         this.nativeMapView = map;
@@ -89,17 +86,13 @@ public final class MapboxMap {
         transform.initialise(this, options);
         uiSettings.initialise(context, options);
         myLocationViewSettings.initialise(options);
+        setMyLocationEnabled(options.getLocationEnabled());
 
         // api base url
         setDebugActive(options.getDebugActive());
         setApiBaseUrl(options);
         setAccessToken(options);
         setStyleUrl(options);
-
-        // todo migrate with other PR
-        setMyLocationEnabled(options.getLocationEnabled());
-        setMaxZoom(options.getMaxZoom());
-        setMinZoom(options.getMinZoom());
     }
 
     // Style
@@ -262,14 +255,9 @@ public final class MapboxMap {
      * @param minZoom The new minimum zoom level.
      */
     @UiThread
-    public void setMinZoom(
+    public void setMinZoomPreference(
             @FloatRange(from = MapboxConstants.MINIMUM_ZOOM, to = MapboxConstants.MAXIMUM_ZOOM) double minZoom) {
-        if ((minZoom < MapboxConstants.MINIMUM_ZOOM) || (minZoom > MapboxConstants.MAXIMUM_ZOOM)) {
-            Timber.e("Not setting minZoom, value is in unsupported range: " + minZoom);
-            return;
-        }
-        minZoomLevel = minZoom;
-        nativeMapView.setMinZoom(minZoom);
+        transform.setMinZoom(minZoom);
     }
 
     /**
@@ -280,11 +268,8 @@ public final class MapboxMap {
      * @return The minimum zoom level.
      */
     @UiThread
-    public double getMinZoom() {
-        if (minZoomLevel == -1) {
-            return minZoomLevel = nativeMapView.getMinZoom();
-        }
-        return minZoomLevel;
+    public double getMinZoomLevel() {
+        return transform.getMinZoom();
     }
 
     //
@@ -299,14 +284,8 @@ public final class MapboxMap {
      * @param maxZoom The new maximum zoom level.
      */
     @UiThread
-    public void setMaxZoom(
-            @FloatRange(from = MapboxConstants.MINIMUM_ZOOM, to = MapboxConstants.MAXIMUM_ZOOM) double maxZoom) {
-        if ((maxZoom < MapboxConstants.MINIMUM_ZOOM) || (maxZoom > MapboxConstants.MAXIMUM_ZOOM)) {
-            Timber.e("Not setting maxZoom, value is in unsupported range: " + maxZoom);
-            return;
-        }
-        maxZoomLevel = maxZoom;
-        nativeMapView.setMaxZoom(maxZoom);
+    public void setMaxZoomPreference(@FloatRange(from = MapboxConstants.MINIMUM_ZOOM, to = MapboxConstants.MAXIMUM_ZOOM) double maxZoom) {
+        transform.setMaxZoom(maxZoom);
     }
 
     /**
@@ -317,11 +296,8 @@ public final class MapboxMap {
      * @return The maximum zoom level.
      */
     @UiThread
-    public double getMaxZoom() {
-        if (maxZoomLevel == -1) {
-            return maxZoomLevel = nativeMapView.getMaxZoom();
-        }
-        return maxZoomLevel;
+    public double getMaxZoomLevel() {
+        return transform.getMaxZoom();
     }
 
     //

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -58,8 +58,8 @@ public class MapboxMapOptions implements Parcelable {
     private int attributionGravity = Gravity.BOTTOM;
     private int[] attributionMargins;
 
-    private float minZoom = MapboxConstants.MINIMUM_ZOOM;
-    private float maxZoom = MapboxConstants.MAXIMUM_ZOOM;
+    private double minZoom = MapboxConstants.MINIMUM_ZOOM;
+    private double maxZoom = MapboxConstants.MAXIMUM_ZOOM;
 
     private boolean rotateGesturesEnabled = true;
     private boolean scrollGesturesEnabled = true;
@@ -110,8 +110,8 @@ public class MapboxMapOptions implements Parcelable {
         attributionMargins = in.createIntArray();
         attributionTintColor = in.readInt();
 
-        minZoom = in.readFloat();
-        maxZoom = in.readFloat();
+        minZoom = in.readDouble();
+        maxZoom = in.readDouble();
 
         rotateGesturesEnabled = in.readByte() != 0;
         scrollGesturesEnabled = in.readByte() != 0;
@@ -184,8 +184,8 @@ public class MapboxMapOptions implements Parcelable {
             mapboxMapOptions.tiltGesturesEnabled(typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_uiTiltGestures, true));
             mapboxMapOptions.zoomControlsEnabled(typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_uiZoomControls, false));
 
-            mapboxMapOptions.maxZoom(typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_cameraZoomMax, MapboxConstants.MAXIMUM_ZOOM));
-            mapboxMapOptions.minZoom(typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_cameraZoomMin, MapboxConstants.MINIMUM_ZOOM));
+            mapboxMapOptions.maxZoomPreference(typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_cameraZoomMax, MapboxConstants.MAXIMUM_ZOOM));
+            mapboxMapOptions.minZoomPreference(typedArray.getFloat(R.styleable.mapbox_MapView_mapbox_cameraZoomMin, MapboxConstants.MINIMUM_ZOOM));
 
             mapboxMapOptions.compassEnabled(typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_uiCompass, true));
             mapboxMapOptions.compassGravity(typedArray.getInt(R.styleable.mapbox_MapView_mapbox_uiCompassGravity, Gravity.TOP | Gravity.END));
@@ -310,7 +310,7 @@ public class MapboxMapOptions implements Parcelable {
      * @param minZoom Zoom level to be used
      * @return This
      */
-    public MapboxMapOptions minZoom(float minZoom) {
+    public MapboxMapOptions minZoomPreference(double minZoom) {
         this.minZoom = minZoom;
         return this;
     }
@@ -321,7 +321,7 @@ public class MapboxMapOptions implements Parcelable {
      * @param maxZoom Zoom level to be used
      * @return This
      */
-    public MapboxMapOptions maxZoom(float maxZoom) {
+    public MapboxMapOptions maxZoomPreference(double maxZoom) {
         this.maxZoom = maxZoom;
         return this;
     }
@@ -654,7 +654,7 @@ public class MapboxMapOptions implements Parcelable {
      *
      * @return Mininum zoom level to be used.
      */
-    public float getMinZoom() {
+    public double getMinZoomPreference() {
         return minZoom;
     }
 
@@ -663,7 +663,7 @@ public class MapboxMapOptions implements Parcelable {
      *
      * @return Maximum zoom to be used.
      */
-    public float getMaxZoom() {
+    public double getMaxZoomPreference() {
         return maxZoom;
     }
 
@@ -969,8 +969,8 @@ public class MapboxMapOptions implements Parcelable {
         dest.writeIntArray(attributionMargins);
         dest.writeInt(attributionTintColor);
 
-        dest.writeFloat(minZoom);
-        dest.writeFloat(maxZoom);
+        dest.writeDouble(minZoom);
+        dest.writeDouble(maxZoom);
 
         dest.writeByte((byte) (rotateGesturesEnabled ? 1 : 0));
         dest.writeByte((byte) (scrollGesturesEnabled ? 1 : 0));
@@ -1011,8 +1011,8 @@ public class MapboxMapOptions implements Parcelable {
         if (attributionTintColor != options.attributionTintColor) return false;
         if (attributionEnabled != options.attributionEnabled) return false;
         if (attributionGravity != options.attributionGravity) return false;
-        if (Float.compare(options.minZoom, minZoom) != 0) return false;
-        if (Float.compare(options.maxZoom, maxZoom) != 0) return false;
+        if (Double.compare(options.minZoom, minZoom) != 0) return false;
+        if (Double.compare(options.maxZoom, maxZoom) != 0) return false;
         if (rotateGesturesEnabled != options.rotateGesturesEnabled) return false;
         if (scrollGesturesEnabled != options.scrollGesturesEnabled) return false;
         if (tiltGesturesEnabled != options.tiltGesturesEnabled) return false;
@@ -1045,7 +1045,9 @@ public class MapboxMapOptions implements Parcelable {
 
     @Override
     public int hashCode() {
-        int result = cameraPosition != null ? cameraPosition.hashCode() : 0;
+        int result;
+        long temp;
+        result = cameraPosition != null ? cameraPosition.hashCode() : 0;
         result = 31 * result + (debugActive ? 1 : 0);
         result = 31 * result + (compassEnabled ? 1 : 0);
         result = 31 * result + (fadeCompassFacingNorth ? 1 : 0);
@@ -1058,8 +1060,10 @@ public class MapboxMapOptions implements Parcelable {
         result = 31 * result + (attributionEnabled ? 1 : 0);
         result = 31 * result + attributionGravity;
         result = 31 * result + Arrays.hashCode(attributionMargins);
-        result = 31 * result + (minZoom != +0.0f ? Float.floatToIntBits(minZoom) : 0);
-        result = 31 * result + (maxZoom != +0.0f ? Float.floatToIntBits(maxZoom) : 0);
+        temp = Double.doubleToLongBits(minZoom);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(maxZoom);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
         result = 31 * result + (rotateGesturesEnabled ? 1 : 0);
         result = 31 * result + (scrollGesturesEnabled ? 1 : 0);
         result = 31 * result + (tiltGesturesEnabled ? 1 : 0);
@@ -1074,9 +1078,10 @@ public class MapboxMapOptions implements Parcelable {
         result = 31 * result + Arrays.hashCode(myLocationBackgroundPadding);
         result = 31 * result + myLocationAccuracyTintColor;
         result = 31 * result + myLocationAccuracyAlpha;
+        result = 31 * result + (apiBaseUrl != null ? apiBaseUrl.hashCode() : 0);
+        result = 31 * result + (textureMode ? 1 : 0);
         result = 31 * result + (style != null ? style.hashCode() : 0);
         result = 31 * result + (accessToken != null ? accessToken.hashCode() : 0);
-        result = 31 * result + (apiBaseUrl != null ? apiBaseUrl.hashCode() : 0);
         return result;
     }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -14,6 +14,8 @@ import com.mapbox.mapboxsdk.maps.widgets.MyLocationView;
 
 import java.util.concurrent.TimeUnit;
 
+import timber.log.Timber;
+
 import static com.mapbox.mapboxsdk.maps.MapView.REGION_DID_CHANGE_ANIMATED;
 
 /**
@@ -261,5 +263,33 @@ final class Transform implements MapView.OnMapChangedListener {
 
     void moveBy(double offsetX, double offsetY, long duration) {
         mapView.moveBy(offsetX, offsetY, duration);
+    }
+
+    //
+    // Min & Max ZoomLevel
+    //
+
+    void setMinZoom(double minZoom) {
+        if ((minZoom < MapboxConstants.MINIMUM_ZOOM) || (minZoom > MapboxConstants.MAXIMUM_ZOOM)) {
+            Timber.e("Not setting minZoomPreference, value is in unsupported range: " + minZoom);
+            return;
+        }
+        mapView.setMinZoom(minZoom);
+    }
+
+    double getMinZoom() {
+        return mapView.getMinZoom();
+    }
+
+    void setMaxZoom(double maxZoom) {
+        if ((maxZoom < MapboxConstants.MINIMUM_ZOOM) || (maxZoom > MapboxConstants.MAXIMUM_ZOOM)) {
+            Timber.e("Not setting maxZoomPreference, value is in unsupported range: " + maxZoom);
+            return;
+        }
+        mapView.setMaxZoom(maxZoom);
+    }
+
+    double getMaxZoom() {
+        return mapView.getMaxZoom();
     }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
@@ -9,7 +9,6 @@ import android.support.test.espresso.ViewAction;
 import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 
-import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerOptions;
 import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
@@ -23,6 +22,7 @@ import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.mapboxsdk.testapp.activity.espresso.EspressoTestActivity;
 import com.mapbox.mapboxsdk.testapp.utils.OnMapReadyIdlingResource;
+import com.mapbox.mapboxsdk.testapp.utils.TestConstants;
 import com.mapbox.mapboxsdk.testapp.utils.ViewUtils;
 
 import org.hamcrest.Matcher;
@@ -39,7 +39,6 @@ import timber.log.Timber;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withChild;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
@@ -87,8 +86,8 @@ public class MapboxMapTest {
         onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
             @Override
             public void onViewAction(UiController uiController, View view) {
-                mapboxMap.setMinZoom(10);
-                assertEquals("MinZoom should match", 10, mapboxMap.getMinZoom(), 10);
+                mapboxMap.setMinZoomPreference(10);
+                assertEquals("MinZoom should match", 10, mapboxMap.getMinZoomLevel(), 10);
             }
         }));
     }
@@ -101,8 +100,8 @@ public class MapboxMapTest {
         onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
             @Override
             public void onViewAction(UiController uiController, View view) {
-                mapboxMap.setMaxZoom(zoom);
-                assertEquals("MaxZoom should match", zoom, mapboxMap.getMaxZoom(), 10);
+                mapboxMap.setMaxZoomPreference(zoom);
+                assertEquals("MaxZoom should match", zoom, mapboxMap.getMaxZoomLevel(), 10);
             }
         }));
     }
@@ -110,9 +109,14 @@ public class MapboxMapTest {
     @Test
     public void testInitialZoomLevels() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        assertEquals("MaxZoom should match", MapboxConstants.MAXIMUM_ZOOM, mapboxMap.getMaxZoom(), 0);
-        assertEquals("MinZoom should match", MapboxConstants.MINIMUM_ZOOM, mapboxMap.getMinZoom(), 0);
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                assertEquals("MaxZoom should match", MapboxConstants.MAXIMUM_ZOOM, mapboxMap.getMaxZoomLevel(), TestConstants.ZOOM_DELTA);
+                assertEquals("MinZoom should match", MapboxConstants.MINIMUM_ZOOM, mapboxMap.getMinZoomLevel(), TestConstants.ZOOM_DELTA);
+            }
+        }));
     }
 
     //

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/TestConstants.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/utils/TestConstants.java
@@ -10,7 +10,7 @@ public class TestConstants {
     public static final double LAT_LNG_DELTA = 0.01;
     public static final double BEARING_DELTA = 0.1;
     public static final double TILT_DELTA = 0.1;
-    public static final double ZOOM_DELTA = 0.1;
+    public static final double ZOOM_DELTA = 0.3;
 
     public static final String TEXT_MARKER_TEXT = "Text";
     public static final String TEXT_MARKER_TITLE = "Marker";

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/MaxMinZoomActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/MaxMinZoomActivity.java
@@ -39,8 +39,8 @@ public class MaxMinZoomActivity extends AppCompatActivity implements OnMapReadyC
     @Override
     public void onMapReady(MapboxMap map) {
         mapboxMap = map;
-        mapboxMap.setMinZoom(3);
-        mapboxMap.setMaxZoom(5);
+        mapboxMap.setMinZoomPreference(3);
+        mapboxMap.setMaxZoomPreference(5);
     }
 
     @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/MapFragmentActivity.java
@@ -51,8 +51,8 @@ public class MapFragmentActivity extends AppCompatActivity implements OnMapReady
 
             LatLng dc = new LatLng(38.90252, -77.02291);
 
-            options.minZoom(9);
-            options.maxZoom(11);
+            options.minZoomPreference(9);
+            options.maxZoomPreference(11);
             options.camera(new CameraPosition.Builder()
                     .target(dc)
                     .zoom(11)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
@@ -54,8 +54,8 @@ public class SupportMapFragmentActivity extends AppCompatActivity implements OnM
 
             LatLng dc = new LatLng(38.90252, -77.02291);
 
-            options.minZoom(9);
-            options.maxZoom(11);
+            options.minZoomPreference(9);
+            options.maxZoomPreference(11);
             options.camera(new CameraPosition.Builder()
                     .target(dc)
                     .zoom(11)

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
@@ -247,7 +247,7 @@ public class OfflineActivity extends AppCompatActivity
         // Definition
         LatLngBounds bounds = mapboxMap.getProjection().getVisibleRegion().latLngBounds;
         double minZoom = mapboxMap.getCameraPosition().zoom;
-        double maxZoom = mapboxMap.getMaxZoom();
+        double maxZoom = mapboxMap.getMaxZoomLevel();
         float pixelRatio = this.getResources().getDisplayMetrics().density;
         OfflineTilePyramidRegionDefinition definition = new OfflineTilePyramidRegionDefinition(
                 STYLE_URL, bounds, minZoom, maxZoom, pixelRatio);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/MapboxMapOptionsTest.java
@@ -7,7 +7,6 @@ import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.utils.MockParcel;
 
 import org.junit.Test;
 
@@ -21,6 +20,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class MapboxMapOptionsTest {
+
+    private static final double DELTA = 1e-15;
 
     @Test
     public void testSanity() {
@@ -99,16 +100,16 @@ public class MapboxMapOptionsTest {
 
     @Test
     public void testMinZoom() {
-        assertEquals(MapboxConstants.MINIMUM_ZOOM, new MapboxMapOptions().getMinZoom());
-        assertEquals(5.0f, new MapboxMapOptions().minZoom(5.0f).getMinZoom());
-        assertNotEquals(2.0f, new MapboxMapOptions().minZoom(5.0f).getMinZoom());
+        assertEquals(MapboxConstants.MINIMUM_ZOOM, new MapboxMapOptions().getMinZoomPreference(), DELTA);
+        assertEquals(5.0f, new MapboxMapOptions().minZoomPreference(5.0f).getMinZoomPreference(), DELTA);
+        assertNotEquals(2.0f, new MapboxMapOptions().minZoomPreference(5.0f).getMinZoomPreference(), DELTA);
     }
 
     @Test
     public void testMaxZoom() {
-        assertEquals(MapboxConstants.MAXIMUM_ZOOM, new MapboxMapOptions().getMaxZoom());
-        assertEquals(5.0f, new MapboxMapOptions().maxZoom(5.0f).getMaxZoom());
-        assertNotEquals(2.0f, new MapboxMapOptions().maxZoom(5.0f).getMaxZoom());
+        assertEquals(MapboxConstants.MAXIMUM_ZOOM, new MapboxMapOptions().getMaxZoomPreference(), DELTA);
+        assertEquals(5.0f, new MapboxMapOptions().maxZoomPreference(5.0f).getMaxZoomPreference(), DELTA);
+        assertNotEquals(2.0f, new MapboxMapOptions().maxZoomPreference(5.0f).getMaxZoomPreference(), DELTA);
     }
 
     @Test


### PR DESCRIPTION
This PR changes the following items:
 - move max/min zoom code from `MapboxMap.java` to `Transform.java`
 - cleanup usage of double vs float
 - renamed public API methods for parity reasons

Review @ivovandongen 