### PR TITLE
[android] - remove location enabled flag from MapboxMap

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -173,7 +173,7 @@ public class MapView extends FrameLayout {
         Projection projection = new Projection(nativeMapView);
         UiSettings uiSettings = new UiSettings(projection, focalPointInvalidator, compassView, attributionsView, logoView);
         TrackingSettings trackingSettings = new TrackingSettings(myLocationView, uiSettings, focalPointInvalidator);
-        MyLocationViewSettings myLocationViewSettings = new MyLocationViewSettings(projection, myLocationView, focalPointInvalidator);
+        MyLocationViewSettings myLocationViewSettings = new MyLocationViewSettings(myLocationView, projection, focalPointInvalidator);
         MarkerViewManager markerViewManager = new MarkerViewManager(markerViewContainer);
         AnnotationManager annotationManager = new AnnotationManager(nativeMapView, this, markerViewManager);
         Transform transform = new Transform(nativeMapView, annotationManager.getMarkerViewManager(), trackingSettings);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -173,7 +173,7 @@ public class MapView extends FrameLayout {
         Projection projection = new Projection(nativeMapView);
         UiSettings uiSettings = new UiSettings(projection, focalPointInvalidator, compassView, attributionsView, logoView);
         TrackingSettings trackingSettings = new TrackingSettings(myLocationView, uiSettings, focalPointInvalidator);
-        MyLocationViewSettings myLocationViewSettings = new MyLocationViewSettings(projection, myLocationView, trackingSettings);
+        MyLocationViewSettings myLocationViewSettings = new MyLocationViewSettings(projection, myLocationView, focalPointInvalidator);
         MarkerViewManager markerViewManager = new MarkerViewManager(markerViewContainer);
         AnnotationManager annotationManager = new AnnotationManager(nativeMapView, this, markerViewManager);
         Transform transform = new Transform(nativeMapView, annotationManager.getMarkerViewManager(), trackingSettings);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -75,8 +75,6 @@ public final class MapboxMap {
 
     private MapboxMap.OnFpsChangedListener onFpsChangedListener;
 
-    private boolean myLocationEnabled;
-
     private double maxZoomLevel = -1;
     private double minZoomLevel = -1;
 
@@ -1526,7 +1524,7 @@ public final class MapboxMap {
      */
     @UiThread
     public boolean isMyLocationEnabled() {
-        return myLocationEnabled;
+        return trackingSettings.isMyLocationEnabled();
     }
 
     /**
@@ -1543,12 +1541,6 @@ public final class MapboxMap {
      */
     @UiThread
     public void setMyLocationEnabled(boolean enabled) {
-        if (!trackingSettings.isPermissionsAccepted()) {
-            Timber.e("Could not activate user location tracking: "
-                    + "user did not accept the permission or permissions were not requested.");
-            return;
-        }
-        myLocationEnabled = enabled;
         trackingSettings.setMyLocationEnabled(enabled);
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -488,6 +488,17 @@ public class MyLocationView extends View {
         invalidate();
     }
 
+    @MyLocationTracking.Mode
+    public int getMyLocationTrackingMode() {
+        return myLocationTrackingMode;
+    }
+
+
+    @MyBearingTracking.Mode
+    public int getMyBearingTrackingMode() {
+        return myBearingTrackingMode;
+    }
+
     private void setCompass(double bearing) {
         setCompass(bearing, 0 /* no animation */);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettings.java
@@ -1,11 +1,13 @@
 package com.mapbox.mapboxsdk.maps.widgets;
 
+import android.graphics.PointF;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.IntRange;
 
+import com.mapbox.mapboxsdk.constants.MyLocationTracking;
+import com.mapbox.mapboxsdk.maps.FocalPointChangeListener;
 import com.mapbox.mapboxsdk.maps.Projection;
-import com.mapbox.mapboxsdk.maps.TrackingSettings;
 
 /**
  * Settings to configure the visual appearance of the MyLocationView.
@@ -13,8 +15,8 @@ import com.mapbox.mapboxsdk.maps.TrackingSettings;
 public class MyLocationViewSettings {
 
     private Projection projection;
-    private TrackingSettings trackingSettings;
     private MyLocationView myLocationView;
+    private FocalPointChangeListener focalPointChangeListener;
 
     //
     // State
@@ -59,15 +61,17 @@ public class MyLocationViewSettings {
 
     /**
      * Creates an instance of MyLocationViewSettings
+     * <p>
      *
-     * @param projection     the MapView projection
-     * @param myLocationView the MyLocationView to apply the settings to
+     * @param myLocationView            the MyLocationView to apply the settings to
+     * @param projection                the MapView projection
+     * @param focalPointChangedListener the interface to be invoked when focal points changes
      * @see MyLocationView
      */
-    public MyLocationViewSettings(Projection projection, MyLocationView myLocationView, TrackingSettings trackingSettings) {
-        this.projection = projection;
+    public MyLocationViewSettings(MyLocationView myLocationView, Projection projection, FocalPointChangeListener focalPointChangedListener) {
         this.myLocationView = myLocationView;
-        this.trackingSettings = trackingSettings;
+        this.projection = projection;
+        this.focalPointChangeListener = focalPointChangedListener;
     }
 
     /**
@@ -212,7 +216,7 @@ public class MyLocationViewSettings {
         padding = new int[]{left, top, right, bottom};
         myLocationView.setContentPadding(padding);
         projection.invalidateContentPadding(padding);
-        trackingSettings.invalidateFocalPointForTracking(myLocationView);
+        invalidateFocalPointForTracking(myLocationView);
     }
 
     /**
@@ -265,4 +269,13 @@ public class MyLocationViewSettings {
     public void setTilt(double tilt) {
         myLocationView.setTilt(tilt);
     }
+
+    private void invalidateFocalPointForTracking(MyLocationView myLocationView) {
+        if (!(myLocationView.getMyLocationTrackingMode() == MyLocationTracking.TRACKING_NONE)) {
+            focalPointChangeListener.onFocalPointChanged(new PointF(myLocationView.getCenterX(), myLocationView.getCenterY()));
+        } else {
+            focalPointChangeListener.onFocalPointChanged(null);
+        }
+    }
+
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/TrackingSettingsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/TrackingSettingsTest.java
@@ -43,19 +43,7 @@ public class TrackingSettingsTest {
     public void testSanity() {
         assertNotNull("trackingsettings should not be null", trackingSettings);
     }
-
-    @Test
-    public void testMyLocationTrackingMode() {
-        trackingSettings.setMyLocationTrackingMode(MyLocationTracking.TRACKING_FOLLOW);
-        assertEquals("MyLocationTrackingMode should match", MyLocationTracking.TRACKING_FOLLOW, trackingSettings.getMyLocationTrackingMode());
-    }
-
-    @Test
-    public void testMyBearingTrackingMode() {
-        trackingSettings.setMyBearingTrackingMode(MyBearingTracking.COMPASS);
-        assertEquals("MyLocationTrackingMode should match", MyBearingTracking.COMPASS, trackingSettings.getMyBearingTrackingMode());
-    }
-
+    
     @Test
     public void testDismissTrackingModesOnGesture() {
         trackingSettings.setDismissTrackingOnGesture(false);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/TrackingSettingsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/TrackingSettingsTest.java
@@ -1,5 +1,9 @@
 package com.mapbox.mapboxsdk.maps;
 
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+
 import com.mapbox.mapboxsdk.constants.MyBearingTracking;
 import com.mapbox.mapboxsdk.constants.MyLocationTracking;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationView;
@@ -11,7 +15,11 @@ import org.mockito.InjectMocks;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TrackingSettingsTest {
 
@@ -27,7 +35,7 @@ public class TrackingSettingsTest {
     private TrackingSettings trackingSettings;
 
     @Before
-    public void beforeTest(){
+    public void beforeTest() {
         trackingSettings = new TrackingSettings(myLocationView, uiSettings, focalPointChangeListener);
     }
 
@@ -59,5 +67,17 @@ public class TrackingSettingsTest {
         trackingSettings.setDismissTrackingOnGesture(false);
         trackingSettings.setMyLocationTrackingMode(MyLocationTracking.TRACKING_FOLLOW);
         assertFalse("DismissTrackingOnGesture should be false", trackingSettings.isDismissTrackingOnGesture());
+    }
+
+    @Test
+    public void testMyLocationEnabled() {
+        // setup mock context to provide accepted location permission
+        Context context = mock(Context.class);
+        when(myLocationView.getContext()).thenReturn(context);
+        when(context.checkPermission(eq(Manifest.permission.ACCESS_COARSE_LOCATION), anyInt(), anyInt())).thenReturn(PackageManager.PERMISSION_GRANTED);
+
+        assertFalse("Location should be disabled by default.", trackingSettings.isMyLocationEnabled());
+        trackingSettings.setMyLocationEnabled(true);
+        assertTrue("Location should be enabled", trackingSettings.isMyLocationEnabled());
     }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettingsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettingsTest.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.maps.widgets;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 
+import com.mapbox.mapboxsdk.maps.FocalPointChangeListener;
 import com.mapbox.mapboxsdk.maps.Projection;
 import com.mapbox.mapboxsdk.maps.TrackingSettings;
 
@@ -30,11 +31,14 @@ public class MyLocationViewSettingsTest {
     @InjectMocks
     TrackingSettings trackingSettings = mock(TrackingSettings.class);
 
+    @InjectMocks
+    FocalPointChangeListener focalPointChangeListener = mock(FocalPointChangeListener.class);
+
     private MyLocationViewSettings locationViewSettings;
 
     @Before
     public void beforeTest() {
-        locationViewSettings = new MyLocationViewSettings(projection, myLocationView, trackingSettings);
+        locationViewSettings = new MyLocationViewSettings(myLocationView, projection, focalPointChangeListener);
     }
 
     @Test
@@ -83,6 +87,5 @@ public class MyLocationViewSettingsTest {
         locationViewSettings.setEnabled(true);
         assertTrue("state should be true", locationViewSettings.isEnabled());
     }
-
 }
 


### PR DESCRIPTION
remove location enabled flag from MapboxMap, decouple TrackingSettings from MyLocationViewSettings using a FocalPointChangeListener interface, Move state related to tracking modes to MyLocationView (shared object between MyLocationViewSettings and TrackingSettings).

Review @ivovandongen 