### PR TITLE
Rename style spec properties

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -39,7 +39,7 @@ global.objCType = function (layerType, propertyName) {
 }
 
 global.arrayType = function (property) {
-    return property.type === 'array' ? property.name.split('-').pop() : false;
+    return property.type === 'array' ? originalPropertyName(property).split('-').pop() : false;
 };
 
 global.testImplementation = function (property, layerType, isFunction) {

--- a/platform/darwin/scripts/style-spec-cocoa-conventions-v8.json
+++ b/platform/darwin/scripts/style-spec-cocoa-conventions-v8.json
@@ -1,9 +1,13 @@
 {
   "layout_symbol": {
-    "icon-image": "icon-image-name"
+    "icon-image": "icon-image-name",
+    "icon-size": "icon-scale"
   },
   "paint_raster": {
     "raster-brightness-min": "minimum-raster-brightness",
     "raster-brightness-max": "maximum-raster-brightness"
+  },
+  "paint_line": {
+    "line-dasharray": "line-dash-pattern"
   }
 }

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -142,7 +142,7 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
 
  This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSNumber *> *> *lineDasharray;
+@property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSNumber *> *> *lineDashPattern;
 
 /**
  Draws a line casing outside of a line's actual path. Value indicates the width of the inner gap.

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -141,6 +141,8 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
  This property is measured in line widths.
 
  This property is only applied to the style if `linePattern` is set to `nil`. Otherwise, it is ignored.
+ 
+ This attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-dasharray"><code>line-dasharray</code></a> paint property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSNumber *> *> *lineDashPattern;
 

--- a/platform/darwin/src/MGLLineStyleLayer.mm
+++ b/platform/darwin/src/MGLLineStyleLayer.mm
@@ -210,14 +210,14 @@ namespace mbgl {
     return MGLStyleValueTransformer<mbgl::Color, MGLColor *>().toStyleValue(propertyValue);
 }
 
-- (void)setLineDasharray:(MGLStyleValue<NSArray<NSNumber *> *> *)lineDasharray {
+- (void)setLineDashPattern:(MGLStyleValue<NSArray<NSNumber *> *> *)lineDashPattern {
     MGLAssertStyleLayerIsValid();
 
-    auto mbglValue = MGLStyleValueTransformer<std::vector<float>, NSArray<NSNumber *> *, float>().toPropertyValue(lineDasharray);
+    auto mbglValue = MGLStyleValueTransformer<std::vector<float>, NSArray<NSNumber *> *, float>().toPropertyValue(lineDashPattern);
     _rawLayer->setLineDasharray(mbglValue);
 }
 
-- (MGLStyleValue<NSArray<NSNumber *> *> *)lineDasharray {
+- (MGLStyleValue<NSArray<NSNumber *> *> *)lineDashPattern {
     MGLAssertStyleLayerIsValid();
 
     auto propertyValue = _rawLayer->getLineDasharray() ?: _rawLayer->getDefaultLineDasharray();

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
  Increase or reduce the brightness of the image. The value is the maximum brightness.
  
  The default value of this property is an `MGLStyleValue` object containing an `NSNumber` object containing the float `1`. Set this property to `nil` to reset it to the default value.
+ 
+ This attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-max"><code>raster-brightness-max</code></a> paint property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumRasterBrightness;
 
@@ -27,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
  Increase or reduce the brightness of the image. The value is the minimum brightness.
  
  The default value of this property is an `MGLStyleValue` object containing an `NSNumber` object containing the float `0`. Set this property to `nil` to reset it to the default value.
+ 
+ This attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-min"><code>raster-brightness-min</code></a> paint property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *minimumRasterBrightness;
 

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -91,6 +91,10 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(property.name) %>) {
  
  <%- propertyReqs(property, layoutPropertiesByName, type) %>
 <% } -%>
+<% if (property.original) { -%>
+ 
+ This attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-<%- type -%>-<%- property.original -%>"><code><%- property.original -%></code></a> layout property in the Mapbox Style Specification.
+<% } -%>
  */
 @property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) MGLStyleValue<<%- propertyType(property, true) %>> *<%- camelizeWithLeadingLowercase(property.name) %>;
 
@@ -108,6 +112,10 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(property.name) %>) {
 <% } if (property.requires) { -%>
 
  <%- propertyReqs(property, paintPropertiesByName, type) %>
+<% } -%>
+<% if (property.original) { -%>
+ 
+ This attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-<%- property.original -%>"><code><%- property.original -%></code></a> paint property in the Mapbox Style Specification.
 <% } -%>
  */
 @property (nonatomic<% if (!property.required) { %>, null_resettable<% } %>) MGLStyleValue<<%- propertyType(property, true) %>> *<%- camelizeWithLeadingLowercase(property.name) %>;

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -252,6 +252,8 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
 
 /**
  A string with {tokens} replaced, referencing the data property to pull from.
+ 
+ This attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-image"><code>icon-image</code></a> layout property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *iconImageName;
 
@@ -319,6 +321,8 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
  The default value of this property is an `MGLStyleValue` object containing an `NSNumber` object containing the float `1`. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
+ 
+ This attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-size"><code>icon-size</code></a> layout property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconScale;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -320,7 +320,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
  
  This property is only applied to the style if `iconImage` is non-`nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconSize;
+@property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconScale;
 
 /**
  Scales the icon to fit around the associated text.

--- a/platform/darwin/src/MGLSymbolStyleLayer.mm
+++ b/platform/darwin/src/MGLSymbolStyleLayer.mm
@@ -297,14 +297,14 @@ namespace mbgl {
     return MGLStyleValueTransformer<mbgl::style::AlignmentType, NSValue *, mbgl::style::AlignmentType, MGLIconRotationAlignment>().toEnumStyleValue(propertyValue);
 }
 
-- (void)setIconSize:(MGLStyleValue<NSNumber *> *)iconSize {
+- (void)setIconScale:(MGLStyleValue<NSNumber *> *)iconScale {
     MGLAssertStyleLayerIsValid();
 
-    auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(iconSize);
+    auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(iconScale);
     _rawLayer->setIconSize(mbglValue);
 }
 
-- (MGLStyleValue<NSNumber *> *)iconSize {
+- (MGLStyleValue<NSNumber *> *)iconScale {
     MGLAssertStyleLayerIsValid();
 
     auto propertyValue = _rawLayer->getIconSize() ?: _rawLayer->getDefaultIconSize();

--- a/platform/darwin/test/MGLLineStyleLayerTests.m
+++ b/platform/darwin/test/MGLLineStyleLayerTests.m
@@ -22,7 +22,7 @@
     layer.lineRoundLimit = [MGLRuntimeStylingHelper testNumber];
     layer.lineBlur = [MGLRuntimeStylingHelper testNumber];
     layer.lineColor = [MGLRuntimeStylingHelper testColor];
-    layer.lineDasharray = [MGLRuntimeStylingHelper testDashArray];
+    layer.lineDashPattern = [MGLRuntimeStylingHelper testDashArray];
     layer.lineGapWidth = [MGLRuntimeStylingHelper testNumber];
     layer.lineOffset = [MGLRuntimeStylingHelper testNumber];
     layer.lineOpacity = [MGLRuntimeStylingHelper testNumber];
@@ -41,7 +41,7 @@
     XCTAssertEqualObjects(gLayer.lineRoundLimit, [MGLRuntimeStylingHelper testNumber]);
     XCTAssertEqualObjects(gLayer.lineBlur, [MGLRuntimeStylingHelper testNumber]);
     XCTAssertEqualObjects(gLayer.lineColor, [MGLRuntimeStylingHelper testColor]);
-    XCTAssertEqualObjects(gLayer.lineDasharray, [MGLRuntimeStylingHelper testDashArray]);
+    XCTAssertEqualObjects(gLayer.lineDashPattern, [MGLRuntimeStylingHelper testDashArray]);
     XCTAssertEqualObjects(gLayer.lineGapWidth, [MGLRuntimeStylingHelper testNumber]);
     XCTAssertEqualObjects(gLayer.lineOffset, [MGLRuntimeStylingHelper testNumber]);
     XCTAssertEqualObjects(gLayer.lineOpacity, [MGLRuntimeStylingHelper testNumber]);
@@ -57,7 +57,7 @@
     layer.lineRoundLimit = [MGLRuntimeStylingHelper testNumberFunction];
     layer.lineBlur = [MGLRuntimeStylingHelper testNumberFunction];
     layer.lineColor = [MGLRuntimeStylingHelper testColorFunction];
-    layer.lineDasharray = [MGLRuntimeStylingHelper testDashArrayFunction];
+    layer.lineDashPattern = [MGLRuntimeStylingHelper testDashArrayFunction];
     layer.lineGapWidth = [MGLRuntimeStylingHelper testNumberFunction];
     layer.lineOffset = [MGLRuntimeStylingHelper testNumberFunction];
     layer.lineOpacity = [MGLRuntimeStylingHelper testNumberFunction];
@@ -72,7 +72,7 @@
     XCTAssertEqualObjects(gLayer.lineRoundLimit, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.lineBlur, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.lineColor, [MGLRuntimeStylingHelper testColorFunction]);
-    XCTAssertEqualObjects(gLayer.lineDasharray, [MGLRuntimeStylingHelper testDashArrayFunction]);
+    XCTAssertEqualObjects(gLayer.lineDashPattern, [MGLRuntimeStylingHelper testDashArrayFunction]);
     XCTAssertEqualObjects(gLayer.lineGapWidth, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.lineOffset, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.lineOpacity, [MGLRuntimeStylingHelper testNumberFunction]);

--- a/platform/darwin/test/MGLSymbolStyleLayerTests.m
+++ b/platform/darwin/test/MGLSymbolStyleLayerTests.m
@@ -25,7 +25,7 @@
     layer.iconPadding = [MGLRuntimeStylingHelper testNumber];
     layer.iconRotate = [MGLRuntimeStylingHelper testNumber];
     layer.iconRotationAlignment = [MGLRuntimeStylingHelper testEnum:MGLIconRotationAlignmentAuto type:@encode(MGLIconRotationAlignment)];
-    layer.iconSize = [MGLRuntimeStylingHelper testNumber];
+    layer.iconScale = [MGLRuntimeStylingHelper testNumber];
     layer.iconTextFit = [MGLRuntimeStylingHelper testEnum:MGLIconTextFitBoth type:@encode(MGLIconTextFit)];
     layer.iconTextFitPadding = [MGLRuntimeStylingHelper testPadding];
     layer.symbolAvoidEdges = [MGLRuntimeStylingHelper testBool];
@@ -77,7 +77,7 @@
     XCTAssertEqualObjects(gLayer.iconRotate, [MGLRuntimeStylingHelper testNumber]);
     XCTAssert([gLayer.iconRotationAlignment isKindOfClass:[MGLStyleConstantValue class]]);
     XCTAssertEqualObjects(gLayer.iconRotationAlignment, [MGLRuntimeStylingHelper testEnum:MGLIconRotationAlignmentAuto type:@encode(MGLIconRotationAlignment)]);
-    XCTAssertEqualObjects(gLayer.iconSize, [MGLRuntimeStylingHelper testNumber]);
+    XCTAssertEqualObjects(gLayer.iconScale, [MGLRuntimeStylingHelper testNumber]);
     XCTAssert([gLayer.iconTextFit isKindOfClass:[MGLStyleConstantValue class]]);
     XCTAssertEqualObjects(gLayer.iconTextFit, [MGLRuntimeStylingHelper testEnum:MGLIconTextFitBoth type:@encode(MGLIconTextFit)]);
     XCTAssertEqualObjects(gLayer.iconTextFitPadding, [MGLRuntimeStylingHelper testPadding]);
@@ -135,7 +135,7 @@
     layer.iconPadding = [MGLRuntimeStylingHelper testNumberFunction];
     layer.iconRotate = [MGLRuntimeStylingHelper testNumberFunction];
     layer.iconRotationAlignment = [MGLRuntimeStylingHelper testEnumFunction:MGLIconRotationAlignmentAuto type:@encode(MGLIconRotationAlignment)];
-    layer.iconSize = [MGLRuntimeStylingHelper testNumberFunction];
+    layer.iconScale = [MGLRuntimeStylingHelper testNumberFunction];
     layer.iconTextFit = [MGLRuntimeStylingHelper testEnumFunction:MGLIconTextFitBoth type:@encode(MGLIconTextFit)];
     layer.iconTextFitPadding = [MGLRuntimeStylingHelper testPaddingFunction];
     layer.symbolAvoidEdges = [MGLRuntimeStylingHelper testBoolFunction];
@@ -184,7 +184,7 @@
     XCTAssertEqualObjects(gLayer.iconPadding, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.iconRotate, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.iconRotationAlignment, [MGLRuntimeStylingHelper testEnumFunction:MGLIconRotationAlignmentAuto type:@encode(MGLIconRotationAlignment)]);
-    XCTAssertEqualObjects(gLayer.iconSize, [MGLRuntimeStylingHelper testNumberFunction]);
+    XCTAssertEqualObjects(gLayer.iconScale, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.iconTextFit, [MGLRuntimeStylingHelper testEnumFunction:MGLIconTextFitBoth type:@encode(MGLIconTextFit)]);
     XCTAssertEqualObjects(gLayer.iconTextFitPadding, [MGLRuntimeStylingHelper testPaddingFunction]);
     XCTAssertEqualObjects(gLayer.symbolAvoidEdges, [MGLRuntimeStylingHelper testBoolFunction]);


### PR DESCRIPTION
Fixes #6098 
Renamed a couple of more style spec properties.

- line-dasharray => line-dash-pattern
- icon-size => icon-scale