### PR TITLE
Fix spelling on month in node.js changelog

### DIFF
--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,13 +1,13 @@
-# 3.4.2 - Novmeber 15, 2016
+# 3.4.2 - November 15, 2016
 
 - Switches back to publishing Linux binaries with GLX, to eliminate a runtime dependency on `libOSMesa.so.8` and enable dynamically linking against `libGL.so` provided by an alternate implementation, such as the NVIDIA proproetary drivers ([#7503](https://github.com/mapbox/mapbox-gl-native/pull/7053))
 
-# 3.4.1 - Novmeber 10, 2016
+# 3.4.1 - November 10, 2016
 
 - Skips assigning clip IDs to tiles that won't be rendered, mitigating a `stencil mask overflow` error ([#6871](https://github.com/mapbox/mapbox-gl-native/pull/6871))
 - Fixes camera logic to avoid unnecessary or redundant setting of camera options ([#6990](https://github.com/mapbox/mapbox-gl-native/pull/6990))
 
-# 3.4.0 - Novmeber 2, 2016
+# 3.4.0 - November 2, 2016
 
 - Fixes Bitrise configuration to automatically publish macOS binaries ([#6789](https://github.com/mapbox/mapbox-gl-native/pull/6789))
 - Switches from using individual thread pools for each `mbgl::Map` object to sharing the built-in Node.js thread pool for NodeMap implementations ([#6687](https://github.com/mapbox/mapbox-gl-native/pull/6687))


### PR DESCRIPTION
Rebase of #7110