### PR TITLE
[ios, macos] Fix typo in exception name for style source identifier

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -203,7 +203,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  @note Adding the same source instance more than once will result in a 
     `MGLRedundantSourceException`. Reusing the same source identifier, even with
     different source instances, will result in a 
-    `MGLRedundantSourceIdentiferException`.
+    `MGLRedundantSourceIdentifierException`.
  
  @param source The source to add to the current style.
  */

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -187,7 +187,7 @@ static NSURL *MGLStyleURL_emerald;
     try {
         [source addToMapView:self.mapView];
     } catch (std::runtime_error & err) {
-        [NSException raise:@"MGLRedundantSourceIdentiferException" format:@"%s", err.what()];
+        [NSException raise:@"MGLRedundantSourceIdentifierException" format:@"%s", err.what()];
     }
 }
 

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -139,7 +139,7 @@
     MGLVectorSource *source2 = [[MGLVectorSource alloc] initWithIdentifier:@"my-source" URL:[NSURL URLWithString:@"mapbox://mapbox.mapbox-terrain-v2"]];
 
     [self.style addSource: source1];
-    XCTAssertThrowsSpecificNamed([self.style addSource: source2], NSException, @"MGLRedundantSourceIdentiferException");
+    XCTAssertThrowsSpecificNamed([self.style addSource: source2], NSException, @"MGLRedundantSourceIdentifierException");
 }
 
 - (void)testAddingLayersTwice {


### PR DESCRIPTION
cc @1ec5 @ivovandongen 

(sorry!)