### PR TITLE
[qt, macos] Remove workaround for a bug in Qt 5.7

### DIFF
--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -800,15 +800,6 @@ void QMapboxGL::setFilter(const QString& layer_, const QVariant& filter_)
 #if QT_VERSION >= 0x050000
 void QMapboxGL::render(QOpenGLFramebufferObject *fbo)
 {
-#if defined(__APPLE__)
-    // FIXME Consume one GL_INVALID_OPERATION from Qt.
-    // See https://bugreports.qt.io/browse/QTBUG-36802 for details.
-    GLenum error = glGetError();
-    if (!(error == GL_NO_ERROR || error == GL_INVALID_OPERATION)) {
-        throw std::runtime_error(std::string("glGetError() returned ") + std::to_string(error));
-    }
-#endif
-
     d_ptr->dirty = false;
     d_ptr->fbo = fbo;
     d_ptr->mapObj->render(*d_ptr);


### PR DESCRIPTION
A bug present in Qt 5.7 onwards affected macOS in a sense that it'd eventually enqueue the GL error pipeline with a `GL_INVALID_OPERATION` caused by a faulty usage of `glClearDepthf` instead of `glClearDepth` in Desktop GL - details in https://bugreports.qt.io/browse/QTBUG-57490 and https://bugreports.qt.io/browse/QTBUG-56798.

Proposed fix for Qt 5.7 in https://codereview.qt-project.org/#/c/179218/ - this is probably coming on the next patch release.

/cc @tmpsantos