### PR TITLE
[iOS, macOS] Add support for dash patterns for Polyline Annotations

### DIFF
--- a/include/mbgl/annotation/annotation.hpp
+++ b/include/mbgl/annotation/annotation.hpp
@@ -32,6 +32,7 @@ public:
     style::PropertyValue<float> opacity { 1.0f };
     style::PropertyValue<float> width { 1.0f };
     style::PropertyValue<Color> color { Color::black() };
+    style::PropertyValue<std::vector<float>> dasharray { { 1 } };
 };
 
 class FillAnnotation {

--- a/platform/darwin/src/MGLMultiPoint_Private.h
+++ b/platform/darwin/src/MGLMultiPoint_Private.h
@@ -41,6 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** Returns the stroke width object for the given annotation. */
 - (CGFloat)lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
 
+/** Returns the dasharray object for the given annotation. */
+- (NSArray<NSNumber *> *)lineDasharrayForPolylineAnnotation:(MGLPolyline *)annotation;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLPolyline.mm
+++ b/platform/darwin/src/MGLPolyline.mm
@@ -2,6 +2,7 @@
 
 #import "MGLMultiPoint_Private.h"
 #import "MGLGeometry_Private.h"
+#import "MGLStyleValue_Private.h"
 
 #import "MGLPolyline+MGLAdditions.h"
 
@@ -33,7 +34,11 @@
     annotation.opacity = { static_cast<float>([delegate alphaForShapeAnnotation:self]) };
     annotation.color = { [delegate strokeColorForShapeAnnotation:self] };
     annotation.width = { static_cast<float>([delegate lineWidthForPolylineAnnotation:self]) };
-
+    NSArray<NSNumber*> *dashArray = [delegate lineDasharrayForPolylineAnnotation:self];
+    if(!dashArray) {
+        dashArray = @[@1];
+    }
+    annotation.dasharray = MGLStyleValueTransformer<std::vector<float>, NSArray<NSNumber *> *, float>().toPropertyValue([MGLStyleValue valueWithRawValue:dashArray]);
     return annotation;
 }
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Labels written in Arabic, Hebrew, and other scripts are written right-to-left. Arabic characters are correctly shaped. ([#6984](https://github.com/mapbox/mapbox-gl-native/pull/6984), [#7123](https://github.com/mapbox/mapbox-gl-native/pull/7123))
 * Improved the line wrapping behavior of point-placed labels written in Chinese, Japanese, and Yi. ([#6828](https://github.com/mapbox/mapbox-gl-native/pull/6828))
 * Fixed an issue where translucent, non-view-backed point annotations along tile boundaries would be drawn darker than expected. ([#6832](https://github.com/mapbox/mapbox-gl-native/pull/6832))
+* Polyline annotations now support dash patterns, with the `mapView:lineDasharrayForPolylineAnnotation:` delegate method.
 
 ## 3.4.0
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1504,6 +1504,11 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     return ([annotation isKindOfClass:[MGLPolyline class]] ? [UIColor purpleColor] : [UIColor blackColor]);
 }
 
+- (NSArray<NSNumber*>*)mapView:(MGLMapView *)mapView lineDasharrayForPolylineAnnotation:(MGLPolyline *)annotation
+{
+    return @[@0.3, @0.3];
+}
+
 - (UIColor *)mapView:(__unused MGLMapView *)mapView fillColorForPolygonAnnotation:(__unused MGLPolygon *)annotation
 {
     UIColor *color = annotation.pointCount > 3 ? [UIColor greenColor] : [UIColor redColor];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -308,6 +308,7 @@ public:
     BOOL _delegateHasStrokeColorsForShapeAnnotations;
     BOOL _delegateHasFillColorsForShapeAnnotations;
     BOOL _delegateHasLineWidthsForShapeAnnotations;
+    BOOL _delegateHasDasharrayForShapeAnnotations;
 
     MGLCompassDirectionFormatter *_accessibilityCompassFormatter;
 }
@@ -702,6 +703,7 @@ public:
     _delegateHasStrokeColorsForShapeAnnotations = [_delegate respondsToSelector:@selector(mapView:strokeColorForShapeAnnotation:)];
     _delegateHasFillColorsForShapeAnnotations = [_delegate respondsToSelector:@selector(mapView:fillColorForPolygonAnnotation:)];
     _delegateHasLineWidthsForShapeAnnotations = [_delegate respondsToSelector:@selector(mapView:lineWidthForPolylineAnnotation:)];
+    _delegateHasDasharrayForShapeAnnotations = [_delegate respondsToSelector:@selector(mapView:lineDasharrayForPolylineAnnotation:)];
 }
 
 - (void)didReceiveMemoryWarning
@@ -3177,6 +3179,15 @@ public:
         return [self.delegate mapView:self lineWidthForPolylineAnnotation:(MGLPolyline *)annotation];
     }
     return 3.0;
+}
+
+- (NSArray<NSNumber *> *)lineDasharrayForPolylineAnnotation:(MGLPolyline *)annotation
+{
+    if(_delegateHasDasharrayForShapeAnnotations)
+    {
+        return [self.delegate mapView:self lineDasharrayForPolylineAnnotation:annotation];
+    }
+    return nil;
 }
 
 - (void)installAnnotationImage:(MGLAnnotationImage *)annotationImage

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -272,6 +272,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (CGFloat)mapView:(MGLMapView *)mapView lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
 
+/**
+ Returns the lengths of the alternating dashes and gaps that form the dash pattern of a polyline annotation.
+ 
+ This property is measured in line widths.
+ 
+ @param mapView The map view rendering the polygon annotation.
+ @param annotation The annotation being rendered.
+ @return The pattern of dashes.
+ */
+- (nullable NSArray<NSNumber *> *)mapView:(MGLMapView *)mapView lineDasharrayForPolylineAnnotation:(MGLPolyline *)annotation;
+
 #pragma mark Managing Annotation Views
 
 /**

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Labels written in Arabic, Hebrew, and other scripts are written right-to-left. Arabic characters are correctly shaped. ([#6984](https://github.com/mapbox/mapbox-gl-native/pull/6984), [#7123](https://github.com/mapbox/mapbox-gl-native/pull/7123))
 * Improved the line wrapping behavior of point-placed labels written in Chinese, Japanese, and Yi. ([#6828](https://github.com/mapbox/mapbox-gl-native/pull/6828))
 * Fixed an issue where translucent point annotations along tile boundaries would be drawn darker than expected. ([#6832](https://github.com/mapbox/mapbox-gl-native/pull/6832))
+* Polyline annotations now support dash patterns, with the `mapView:lineDasharrayForPolylineAnnotation:` delegate method.
 
 ## 0.3.0
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -198,6 +198,7 @@ public:
     BOOL _delegateHasStrokeColorsForShapeAnnotations;
     BOOL _delegateHasFillColorsForShapeAnnotations;
     BOOL _delegateHasLineWidthsForShapeAnnotations;
+    BOOL _delegateHasDasharrayForShapeAnnotations;
 
     /// True if the current process is the Interface Builder designable
     /// renderer. When drawing the designable, the map is paused, so any call to
@@ -557,6 +558,7 @@ public:
     _delegateHasStrokeColorsForShapeAnnotations = [_delegate respondsToSelector:@selector(mapView:strokeColorForShapeAnnotation:)];
     _delegateHasFillColorsForShapeAnnotations = [_delegate respondsToSelector:@selector(mapView:fillColorForPolygonAnnotation:)];
     _delegateHasLineWidthsForShapeAnnotations = [_delegate respondsToSelector:@selector(mapView:lineWidthForPolylineAnnotation:)];
+    _delegateHasDasharrayForShapeAnnotations = [_delegate respondsToSelector:@selector(mapView:lineDasharrayForPolylineAnnotation:)];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
@@ -2293,6 +2295,13 @@ public:
         return [self.delegate mapView:self lineWidthForPolylineAnnotation:(MGLPolyline *)annotation];
     }
     return 3.0;
+}
+
+- (NSArray<NSNumber *> *)lineDasharrayForPolylineAnnotation:(MGLPolyline *)annotation {
+    if(_delegateHasDasharrayForShapeAnnotations) {
+        return [self.delegate mapView:self lineDasharrayForPolylineAnnotation:annotation];
+    }
+    return nil;
 }
 
 #pragma mark MGLPopoverDelegate methods

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -200,6 +200,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (CGFloat)mapView:(MGLMapView *)mapView lineWidthForPolylineAnnotation:(MGLPolyline *)annotation;
 
+/**
+ Returns the lengths of the alternating dashes and gaps that form the dash pattern of a polyline annotation.
+ 
+ This property is measured in line widths.
+ 
+ @param mapView The map view rendering the polygon annotation.
+ @param annotation The annotation being rendered.
+ @return The pattern of dashes.
+ */
+- (nullable NSArray<NSNumber *> *)mapView:(MGLMapView *)mapView lineDasharrayForPolylineAnnotation:(MGLPolyline *)annotation;
+
 #pragma mark Selecting Annotations
 
 /**

--- a/src/mbgl/annotation/line_annotation_impl.cpp
+++ b/src/mbgl/annotation/line_annotation_impl.cpp
@@ -9,7 +9,7 @@ using namespace style;
 
 LineAnnotationImpl::LineAnnotationImpl(AnnotationID id_, LineAnnotation annotation_, uint8_t maxZoom_)
     : ShapeAnnotationImpl(id_, maxZoom_),
-      annotation({ ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.width, annotation_.color }) {
+      annotation({ ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.width, annotation_.color, annotation_.dasharray }) {
 }
 
 void LineAnnotationImpl::updateStyle(Style& style) const {
@@ -26,6 +26,7 @@ void LineAnnotationImpl::updateStyle(Style& style) const {
     lineLayer->setLineOpacity(annotation.opacity);
     lineLayer->setLineWidth(annotation.width);
     lineLayer->setLineColor(annotation.color);
+    lineLayer->setLineDasharray(annotation.dasharray);
 }
 
 const ShapeAnnotationGeometry& LineAnnotationImpl::geometry() const {


### PR DESCRIPTION
This adds a new method to MGLMapViewDelegate -mapView:lineDasharrayForPolylineAnnotation: to enable proving dash patterns for Polyline annotations.
