### PR TITLE
[ios] Add inline examples in documentation

### DIFF
--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -71,8 +71,8 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslateAnchor) {
     22: MGLStyleValue(rawValue: 180)
  ])
  layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
- layer.predicate = NSPredicate(format: "%K == %@", "ethnicity", "ewok")
- mapView.style().add(layer)
+ layer.predicate = NSPredicate(format: "%K == %@", "marital-status", "married")
+ mapView.style.addLayer(layer)
  ```
  */
 @interface MGLCircleStyleLayer : MGLVectorStyleLayer

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -59,6 +59,21 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslateAnchor) {
  otherwise, find it using the `MGLStyle.layers` property. You can also create a
  new circle style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
+
+ ### Example ###
+
+ ```swift
+ let layer = MGLCircleStyleLayer(identifier: "circles", source: population)
+ layer.sourceLayerIdentifier = "population"
+ layer.circleColor = MGLStyleValue(rawValue: UIColor.green)
+ layer.circleRadius = MGLStyleValue(base: 1.75, stops: [
+    12: MGLStyleValue(rawValue: 2),
+    22: MGLStyleValue(rawValue: 180)
+ ])
+ layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
+ layer.predicate = NSPredicate(format: "%K == %@", "ethnicity", "ewok")
+ mapView.style().add(layer)
+ ```
  */
 @interface MGLCircleStyleLayer : MGLVectorStyleLayer
 

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslateAnchor) {
  let layer = MGLCircleStyleLayer(identifier: "circles", source: population)
  layer.sourceLayerIdentifier = "population"
  layer.circleColor = MGLStyleValue(rawValue: UIColor.green)
- layer.circleRadius = MGLStyleValue(base: 1.75, stops: [
+ layer.circleRadius = MGLStyleValue(interpolationBase: 1.75, stops: [
     12: MGLStyleValue(rawValue: 2),
     22: MGLStyleValue(rawValue: 180)
  ])

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -60,20 +60,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslateAnchor) {
  new circle style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
 
- ### Example ###
-
- ```swift
- let layer = MGLCircleStyleLayer(identifier: "circles", source: population)
- layer.sourceLayerIdentifier = "population"
- layer.circleColor = MGLStyleValue(rawValue: UIColor.green)
- layer.circleRadius = MGLStyleValue(interpolationBase: 1.75, stops: [
-    12: MGLStyleValue(rawValue: 2),
-    22: MGLStyleValue(rawValue: 180)
- ])
- layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
- layer.predicate = NSPredicate(format: "%K == %@", "marital-status", "married")
- mapView.style.addLayer(layer)
- ```
+ <!--EXAMPLE: MGLCircleStyleLayer-->
  */
 @interface MGLCircleStyleLayer : MGLVectorStyleLayer
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -38,15 +38,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslateAnchor) {
  new fill style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
 
- ### Example ###
-
- ```swift
- let layer = MGLFillStyleLayer(identifier: "parks", source: parks)
- layer.sourceLayerIdentifier = "parks"
- layer.fillColor = MGLStyleValue(rawValue: UIColor.green)
- layer.predicate = NSPredicate(format: "type == %@", "national-park")
- mapView.style.addLayer(layer)
- ```
+ <!--EXAMPLE: MGLFillStyleLayer-->
  */
 @interface MGLFillStyleLayer : MGLVectorStyleLayer
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslateAnchor) {
  layer.sourceLayerIdentifier = "parks"
  layer.fillColor = MGLStyleValue(rawValue: UIColor.green)
  layer.predicate = NSPredicate(format: "type == %@", "national-park")
- mapView.style().add(layer)
+ mapView.style.addLayer(layer)
  ```
  */
 @interface MGLFillStyleLayer : MGLVectorStyleLayer

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -37,6 +37,16 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslateAnchor) {
  otherwise, find it using the `MGLStyle.layers` property. You can also create a
  new fill style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
+
+ ### Example ###
+
+ ```swift
+ let layer = MGLFillStyleLayer(identifier: "parks", source: parks)
+ layer.sourceLayerIdentifier = "parks"
+ layer.fillColor = MGLStyleValue(rawValue: UIColor.green)
+ layer.predicate = NSPredicate(format: "type == %@", "national-park")
+ mapView.style().add(layer)
+ ```
  */
 @interface MGLFillStyleLayer : MGLVectorStyleLayer
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -94,13 +94,13 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
  let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
  layer.sourceLayerIdentifier = "trails"
  layer.lineWidth = MGLStyleValue(base: 1.5, stops: [
-    14: MGLStyleValue(rawValue: 2),
-    18: MGLStyleValue(rawValue: 20),
+ 14: MGLStyleValue(rawValue: 2),
+ 18: MGLStyleValue(rawValue: 20),
  ])
  layer.lineColor = MGLStyleValue(rawValue: UIColor.brown)
  layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
- layer.predicate = NSPredicate(format: "%K == %@", "trail-type" "mountain-biking")
- mapView.style().add(layer)
+ layer.predicate = NSPredicate(format: "%K == %@", "trail-type", "mountain-biking")
+ mapView.style.addLayer(layer)
  ```
  */
 @interface MGLLineStyleLayer : MGLVectorStyleLayer

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -87,6 +87,21 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
  otherwise, find it using the `MGLStyle.layers` property. You can also create a
  new line style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
+
+ ### Example ###
+
+ ```swift
+ let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
+ layer.sourceLayerIdentifier = "trails"
+ layer.lineWidth = MGLStyleValue(base: 1.5, stops: [
+    14: MGLStyleValue(rawValue: 2),
+    18: MGLStyleValue(rawValue: 20),
+ ])
+ layer.lineColor = MGLStyleValue(rawValue: UIColor.brown)
+ layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
+ layer.predicate = NSPredicate(format: "%K == %@", "trail-type" "mountain-biking")
+ mapView.style().add(layer)
+ ```
  */
 @interface MGLLineStyleLayer : MGLVectorStyleLayer
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -93,9 +93,9 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
  ```swift
  let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
  layer.sourceLayerIdentifier = "trails"
- layer.lineWidth = MGLStyleValue(base: 1.5, stops: [
- 14: MGLStyleValue(rawValue: 2),
- 18: MGLStyleValue(rawValue: 20),
+ layer.lineWidth = MGLStyleValue(interpolationBase: 1.5, stops: [
+    14: MGLStyleValue(rawValue: 2),
+    18: MGLStyleValue(rawValue: 20),
  ])
  layer.lineColor = MGLStyleValue(rawValue: UIColor.brown)
  layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -88,20 +88,7 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslateAnchor) {
  new line style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
 
- ### Example ###
-
- ```swift
- let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
- layer.sourceLayerIdentifier = "trails"
- layer.lineWidth = MGLStyleValue(interpolationBase: 1.5, stops: [
-    14: MGLStyleValue(rawValue: 2),
-    18: MGLStyleValue(rawValue: 20),
- ])
- layer.lineColor = MGLStyleValue(rawValue: UIColor.brown)
- layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
- layer.predicate = NSPredicate(format: "%K == %@", "trail-type", "mountain-biking")
- mapView.style.addLayer(layer)
- ```
+ <!--EXAMPLE: MGLLineStyleLayer-->
  */
 @interface MGLLineStyleLayer : MGLVectorStyleLayer
 

--- a/platform/darwin/src/MGLRasterSource.h
+++ b/platform/darwin/src/MGLRasterSource.h
@@ -17,19 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
  
  This option is only applicable to `MGLRasterSource` objects; it is ignored when
  initializing `MGLVectorSource` objects.
-
- ### Example ###
-
- ```swift
- // Define tileset
- let tileset = MGLTileSet(tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"])
- tileset.minimumZoomLevel = 9
- tileset.maximumZoomLevel = 16
- tileset.attribution = "© Mapbox"
- // Add source to map
- let source = MGLRasterSource(identifier: "clouds", tileSet: tileset, tileSize: 512)
- mapView.style.addSource(source)
- ```
  */
 extern const MGLTileSourceOption MGLTileSourceOptionTileSize;
 
@@ -48,6 +35,20 @@ extern const MGLTileSourceOption MGLTileSourceOptionTileSize;
  `MGLRasterSource` object that you can use to initialize new style layers. You
  can also add and remove sources dynamically using methods such as
  `-[MGLStyle addSource:]` and `-[MGLStyle sourceWithIdentifier:]`.
+
+ ### Example ###
+
+ ```swift
+ let source = MGLRasterSource(identifier: "clouds", tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"], options: [
+    .minimumZoomLevel: 9,
+    .maximumZoomLevel: 16,
+    .tileSize: 512,
+    .attributionInfos: [
+	MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+    ]
+ ])
+ mapView.style.addSource(source)
+ ```
  */
 @interface MGLRasterSource : MGLTileSource
 

--- a/platform/darwin/src/MGLRasterSource.h
+++ b/platform/darwin/src/MGLRasterSource.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  tileset.attribution = "© Mapbox"
  // Add source to map
  let source = MGLRasterSource(identifier: "clouds", tileSet: tileset, tileSize: 512)
- mapView.style().add(source)
+ mapView.style.addSource(source)
  ```
  */
 extern const MGLTileSourceOption MGLTileSourceOptionTileSize;

--- a/platform/darwin/src/MGLRasterSource.h
+++ b/platform/darwin/src/MGLRasterSource.h
@@ -36,18 +36,7 @@ extern const MGLTileSourceOption MGLTileSourceOptionTileSize;
  can also add and remove sources dynamically using methods such as
  `-[MGLStyle addSource:]` and `-[MGLStyle sourceWithIdentifier:]`.
 
- ### Example ###
-
- ```swift
- let source = MGLRasterSource(identifier: "clouds", tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"], options: [
-    .minimumZoomLevel: 9,
-    .maximumZoomLevel: 16,
-    .tileSize: 512,
-    .attributionInfos: [
-	MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
-    ]
- ])
- mapView.style.addSource(source)
+ <!--EXAMPLE: MGLRasterSource-->
  ```
  */
 @interface MGLRasterSource : MGLTileSource

--- a/platform/darwin/src/MGLRasterSource.h
+++ b/platform/darwin/src/MGLRasterSource.h
@@ -17,6 +17,19 @@ NS_ASSUME_NONNULL_BEGIN
  
  This option is only applicable to `MGLRasterSource` objects; it is ignored when
  initializing `MGLVectorSource` objects.
+
+ ### Example ###
+
+ ```swift
+ // Define tileset
+ let tileset = MGLTileSet(tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"])
+ tileset.minimumZoomLevel = 9
+ tileset.maximumZoomLevel = 16
+ tileset.attribution = "© Mapbox"
+ // Add source to map
+ let source = MGLRasterSource(identifier: "clouds", tileSet: tileset, tileSize: 512)
+ mapView.style().add(source)
+ ```
  */
 extern const MGLTileSourceOption MGLTileSourceOptionTileSize;
 

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
  otherwise, find it using the `MGLStyle.layers` property. You can also create a
  new raster style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
+
+ <!--EXAMPLE: MGLRasterStyleLayer-->
  */
 @interface MGLRasterStyleLayer : MGLForegroundStyleLayer
 

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -74,6 +74,22 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
  
  Any vector style layer initialized with a shape source should have a `nil`
  value in its `sourceLayerIdentifier` property.
+
+ ### Example ###
+
+ ```swift
+ var coordinates: [CLLocationCoordinate2D] = [
+    CLLocationCoordinate2D(latitude: 37.77, longitude: -122.42),
+    CLLocationCoordinate2D(latitude: 38.91, longitude: -77.04),
+ ]
+ let polyline = MGLPolylineFeature(coordinates: &coordinates, count: UInt(coordinates.count))
+ let shape = MGLShapeCollectionFeature(shapes: [polyline])
+ let source = MGLShapeSource(identifier: "lines", shape: shape, options: nil)
+ mapView.style.addSource(source)
+ ```
+
+ @see <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson">The
+    style specification.</a>
  */
 @interface MGLShapeSource : MGLSource
 

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -75,17 +75,7 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
  Any vector style layer initialized with a shape source should have a `nil`
  value in its `sourceLayerIdentifier` property.
 
- ### Example ###
-
- ```swift
- var coordinates: [CLLocationCoordinate2D] = [
-    CLLocationCoordinate2D(latitude: 37.77, longitude: -122.42),
-    CLLocationCoordinate2D(latitude: 38.91, longitude: -77.04),
- ]
- let polyline = MGLPolylineFeature(coordinates: &coordinates, count: UInt(coordinates.count))
- let shape = MGLShapeCollectionFeature(shapes: [polyline])
- let source = MGLShapeSource(identifier: "lines", shape: shape, options: nil)
- mapView.style.addSource(source)
+ <!--EXAMPLE: MGLShapeSource-->
  ```
  */
 @interface MGLShapeSource : MGLSource

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -87,9 +87,6 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
  let source = MGLShapeSource(identifier: "lines", shape: shape, options: nil)
  mapView.style.addSource(source)
  ```
-
- @see <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson">The
-    style specification.</a>
  */
 @interface MGLShapeSource : MGLSource
 

--- a/platform/darwin/src/MGLSource.h
+++ b/platform/darwin/src/MGLSource.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  Do not create instances of this class directly, and do not create your own
  subclasses of this class. Instead, create instances of `MGLShapeSource` and the
- concrete subclasses of `MGLTileSource`.
+ concrete subclasses of `MGLTileSource`, `MGLVectorSource` and `MGLRasterSource`.
  */
 @interface MGLSource : NSObject
 

--- a/platform/darwin/src/MGLStyleLayer.h.ejs
+++ b/platform/darwin/src/MGLStyleLayer.h.ejs
@@ -67,6 +67,8 @@ typedef NS_ENUM(NSUInteger, MGL<%- camelize(property.name) %>) {
  otherwise, find it using the `MGLStyle.layers` property. You can also create a
  new <%- type %> style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
+
+ <!--EXAMPLE: MGL<%- camelize(type) %>StyleLayer-->
  */
 <% } -%>
 @interface MGL<%- camelize(type) %>StyleLayer : MGL<%-

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -260,6 +260,21 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
  otherwise, find it using the `MGLStyle.layers` property. You can also create a
  new symbol style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
+
+ ### Example ###
+
+ ```swift
+ let layer = MGLSymbolStyleLayer(identifier: "coffeeshops", source: pois)
+ layer.sourceLayerIdentifier = "pois"
+ layer.iconImage = MGLStyleValue(rawValue: "coffee")
+ layer.iconSize = MGLStyleValue(rawValue: 0.5)
+ layer.textField = MGLStyleValue(rawValue: "{name}")
+ layer.textTranslate = MGLStyleValue(rawValue: NSValue(cgVector: CGVector(dx: 10, dy: 0)))
+ layer.textJustify = MGLStyleValue(rawValue: NSValue(mglTextJustify: .left))
+ layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
+ layer.predicate = NSPredicate(format: "%K == %@", "venue-type" "coffee")
+ mapView.style().add(layer)
+ ```
  */
 @interface MGLSymbolStyleLayer : MGLVectorStyleLayer
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -266,14 +266,14 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
  ```swift
  let layer = MGLSymbolStyleLayer(identifier: "coffeeshops", source: pois)
  layer.sourceLayerIdentifier = "pois"
- layer.iconImage = MGLStyleValue(rawValue: "coffee")
- layer.iconSize = MGLStyleValue(rawValue: 0.5)
+ layer.iconImageName = MGLStyleValue(rawValue: "coffee")
+ layer.iconScale = MGLStyleValue(rawValue: 0.5)
  layer.textField = MGLStyleValue(rawValue: "{name}")
  layer.textTranslate = MGLStyleValue(rawValue: NSValue(cgVector: CGVector(dx: 10, dy: 0)))
  layer.textJustify = MGLStyleValue(rawValue: NSValue(mglTextJustify: .left))
  layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
- layer.predicate = NSPredicate(format: "%K == %@", "venue-type" "coffee")
- mapView.style().add(layer)
+ layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
+ mapView.style.addLayer(layer)
  ```
  */
 @interface MGLSymbolStyleLayer : MGLVectorStyleLayer

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -261,20 +261,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
  new symbol style layer and add it to the style using a method such as
  `-[MGLStyle addLayer:]`.
 
- ### Example ###
-
- ```swift
- let layer = MGLSymbolStyleLayer(identifier: "coffeeshops", source: pois)
- layer.sourceLayerIdentifier = "pois"
- layer.iconImageName = MGLStyleValue(rawValue: "coffee")
- layer.iconScale = MGLStyleValue(rawValue: 0.5)
- layer.textField = MGLStyleValue(rawValue: "{name}")
- layer.textTranslate = MGLStyleValue(rawValue: NSValue(cgVector: CGVector(dx: 10, dy: 0)))
- layer.textJustification = MGLStyleValue(rawValue: NSValue(mglTextJustification: .left))
- layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
- layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
- mapView.style.addLayer(layer)
- ```
+ <!--EXAMPLE: MGLSymbolStyleLayer-->
  */
 @interface MGLSymbolStyleLayer : MGLVectorStyleLayer
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -270,7 +270,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslateAnchor) {
  layer.iconScale = MGLStyleValue(rawValue: 0.5)
  layer.textField = MGLStyleValue(rawValue: "{name}")
  layer.textTranslate = MGLStyleValue(rawValue: NSValue(cgVector: CGVector(dx: 10, dy: 0)))
- layer.textJustify = MGLStyleValue(rawValue: NSValue(mglTextJustify: .left))
+ layer.textJustification = MGLStyleValue(rawValue: NSValue(mglTextJustification: .left))
  layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
  layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
  mapView.style.addLayer(layer)

--- a/platform/darwin/src/MGLVectorSource.h
+++ b/platform/darwin/src/MGLVectorSource.h
@@ -26,7 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
  `sourceLayerIdentifier` property.
 
  <!--EXAMPLE: MGLVectorSource-->
- ```
  */
 @interface MGLVectorSource : MGLTileSource
 

--- a/platform/darwin/src/MGLVectorSource.h
+++ b/platform/darwin/src/MGLVectorSource.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  tileset.attribution = "© Mapbox"
  // Add source to map
  let source = MGLVectorSource(identifier: "pois", tileSet: tileset)
- mapView.style().add(source)
+ mapView.style.addSource(source)
  ```
  */
 @interface MGLVectorSource : MGLTileSource

--- a/platform/darwin/src/MGLVectorSource.h
+++ b/platform/darwin/src/MGLVectorSource.h
@@ -28,13 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
  ### Example ###
 
  ```swift
- // Define tileset
- let tileset = MGLTileSet(tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"])
- tileset.minimumZoomLevel = 9
- tileset.maximumZoomLevel = 16
- tileset.attribution = "© Mapbox"
- // Add source to map
- let source = MGLVectorSource(identifier: "pois", tileSet: tileset)
+ let source = MGLVectorSource(identifier: "pois", tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"], options: [
+    .minimumZoomLevel: 9,
+    .maximumZoomLevel: 16,
+    .attributionInfos: [
+	MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+    ]
+ ])
  mapView.style.addSource(source)
  ```
  */

--- a/platform/darwin/src/MGLVectorSource.h
+++ b/platform/darwin/src/MGLVectorSource.h
@@ -25,17 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  layer initialized with a vector source must have a non-`nil` value in its
  `sourceLayerIdentifier` property.
 
- ### Example ###
-
- ```swift
- let source = MGLVectorSource(identifier: "pois", tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"], options: [
-    .minimumZoomLevel: 9,
-    .maximumZoomLevel: 16,
-    .attributionInfos: [
-	MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
-    ]
- ])
- mapView.style.addSource(source)
+ <!--EXAMPLE: MGLVectorSource-->
  ```
  */
 @interface MGLVectorSource : MGLTileSource

--- a/platform/darwin/src/MGLVectorSource.h
+++ b/platform/darwin/src/MGLVectorSource.h
@@ -24,6 +24,19 @@ NS_ASSUME_NONNULL_BEGIN
  (<var>extent</var>&nbsp;×&nbsp;2)&nbsp;−&nbsp;1, inclusive. Any vector style
  layer initialized with a vector source must have a non-`nil` value in its
  `sourceLayerIdentifier` property.
+
+ ### Example ###
+
+ ```swift
+ // Define tileset
+ let tileset = MGLTileSet(tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"])
+ tileset.minimumZoomLevel = 9
+ tileset.maximumZoomLevel = 16
+ tileset.attribution = "© Mapbox"
+ // Add source to map
+ let source = MGLVectorSource(identifier: "pois", tileSet: tileset)
+ mapView.style().add(source)
+ ```
  */
 @interface MGLVectorSource : MGLTileSource
 

--- a/platform/darwin/src/MGLVectorStyleLayer.h
+++ b/platform/darwin/src/MGLVectorStyleLayer.h
@@ -128,6 +128,22 @@ NS_ASSUME_NONNULL_BEGIN
  style attributes and also `hyphen-minus` and `tag:subtag`. However, you must use
  `%K` in the format string to represent these variables:
  `@"%K == 'LineString'", @"$type"`.
+
+ ### Example ###
+ To create a filter with the logic `(index == 10 || index == 5) && ele >= 200`,
+ you could create a predicate using `NSCompoundPredicate` along these lines:
+
+ ```swift
+ let meters = 1500.0
+ let layer = MGLLineStyleLayer(identifier: "contour", source: contours)
+ layer.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+    NSCompoundPredicate(orPredicateWithSubpredicates: [
+	NSPredicate(format: "%K == 10", "contour-index"),
+	NSPredicate(format: "%K == 5", "contour-index"),
+    ]),
+    NSPredicate(format: "ele >= \(meters)"),
+ ])
+ ```
  */
 @property (nonatomic, nullable) NSPredicate *predicate;
 

--- a/platform/darwin/src/MGLVectorStyleLayer.h
+++ b/platform/darwin/src/MGLVectorStyleLayer.h
@@ -129,16 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
  `%K` in the format string to represent these variables:
  `@"%K == 'LineString'", @"$type"`.
 
- ### Example ###
- To create a filter with the logic `(index == 10 || index == 5) && ele >= 200`,
- you could create a predicate using `NSCompoundPredicate` along these lines:
-
- ```swift
- let layer = MGLLineStyleLayer(identifier: "contour", source: terrain)
- layer.sourceLayerIdentifier = "contours"
- layer.predicate = NSPredicate(format: "(index == 10 || index == 5) && ele >= 1500.0")
- mapView.style.addLayer(layer)
- ```
+ <!--EXAMPLE: MGLVectorStyleLayer.predicate-->
  */
 @property (nonatomic, nullable) NSPredicate *predicate;
 

--- a/platform/darwin/src/MGLVectorStyleLayer.h
+++ b/platform/darwin/src/MGLVectorStyleLayer.h
@@ -134,15 +134,10 @@ NS_ASSUME_NONNULL_BEGIN
  you could create a predicate using `NSCompoundPredicate` along these lines:
 
  ```swift
- let meters = 1500.0
- let layer = MGLLineStyleLayer(identifier: "contour", source: contours)
- layer.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-    NSCompoundPredicate(orPredicateWithSubpredicates: [
-	NSPredicate(format: "%K == 10", "contour-index"),
-	NSPredicate(format: "%K == 5", "contour-index"),
-    ]),
-    NSPredicate(format: "ele >= \(meters)"),
- ])
+ let layer = MGLLineStyleLayer(identifier: "contour", source: terrain)
+ layer.sourceLayerIdentifier = "contours"
+ layer.predicate = NSPredicate(format: "(index == 10 || index == 5) && ele >= 1500.0")
+ mapView.style.addLayer(layer)
  ```
  */
 @property (nonatomic, nullable) NSPredicate *predicate;

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -1693,6 +1693,7 @@
 				DA8847CE1CBAF91600AB86E3 /* Frameworks */,
 				DA8847CF1CBAF91600AB86E3 /* Headers */,
 				DA8847D01CBAF91600AB86E3 /* Resources */,
+				64E5BF321E09D729005223F7 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1727,6 +1728,7 @@
 				DAA4E4101CBB71D400178DFB /* Frameworks */,
 				DAA4E4111CBB71D400178DFB /* CopyFiles */,
 				DABFB85C1CBE99DE00D62B32 /* Headers */,
+				6421B07A1E09EA4B00AF169B /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1917,6 +1919,35 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		6421B07A1E09EA4B00AF169B /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "node \"${SRCROOT}/scripts/add-examples-to-docs.js\"";
+		};
+		64E5BF321E09D729005223F7 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "node \"${SRCROOT}/scripts/add-examples-to-docs.js\"";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DA1DC9461CB6C1C2006E619F /* Sources */ = {

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -164,7 +164,7 @@
 		40FDA76B1CCAAA6800442548 /* MBXAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FDA76A1CCAAA6800442548 /* MBXAnnotationView.m */; };
 		554180421D2E97DE00012372 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 554180411D2E97DE00012372 /* OpenGLES.framework */; };
 		55D8C9961D0F18CE00F42F10 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D8C9951D0F18CE00F42F10 /* libsqlite3.tbd */; };
-		6407D6701E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6407D66F1E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift */; };
+		6407D6701E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6407D66F1E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift */; };
 		7E016D7E1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */; };
 		7E016D7F1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */; };
 		7E016D801D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E016D7D1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m */; };
@@ -609,7 +609,7 @@
 		554180411D2E97DE00012372 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		55D8C9941D0F133500F42F10 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = ../../build/ios/config.xcconfig; sourceTree = "<group>"; };
 		55D8C9951D0F18CE00F42F10 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
-		6407D66F1E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBLDocumentationExampleTests.swift; sourceTree = "<group>"; };
+		6407D66F1E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MGLDocumentationExampleTests.swift; sourceTree = "<group>"; };
 		7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolyline+MGLAdditions.h"; sourceTree = "<group>"; };
 		7E016D7D1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolyline+MGLAdditions.m"; sourceTree = "<group>"; };
 		7E016D821D9E890300A29A21 /* MGLPolygon+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolygon+MGLAdditions.h"; sourceTree = "<group>"; };
@@ -1086,7 +1086,7 @@
 				DA35A2C31CCA9F8300E826B2 /* MGLClockDirectionFormatterTests.m */,
 				DA35A2C41CCA9F8300E826B2 /* MGLCompassDirectionFormatterTests.m */,
 				DA35A2A91CCA058D00E826B2 /* MGLCoordinateFormatterTests.m */,
-				6407D66F1E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift */,
+				6407D66F1E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift */,
 				DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */,
 				DA2E885C1CC0382C00F24E7B /* MGLGeometryTests.mm */,
 				DA2DBBCC1D51E80400D38FF9 /* MGLStyleLayerTests.h */,
@@ -1770,16 +1770,18 @@
 				TargetAttributes = {
 					DA1DC9491CB6C1C2006E619F = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0820;
 					};
 					DA25D5B81CCD9EDE00607828 = {
 						CreatedOnToolsVersion = 7.3;
 					};
 					DA2E88501CC036F400F24E7B = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 0820;
 					};
 					DA8847D11CBAF91600AB86E3 = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0820;
 					};
 					DA8933D41CCD306400E68420 = {
 						CreatedOnToolsVersion = 7.3;
@@ -1935,7 +1937,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6407D6701E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift in Sources */,
+				6407D6701E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift in Sources */,
 				DA2E88631CC0382C00F24E7B /* MGLOfflineRegionTests.m in Sources */,
 				3599A3E61DF708BC00E77FB2 /* MGLStyleValueTests.m in Sources */,
 				DA2E88651CC0382C00F24E7B /* MGLStyleTests.mm in Sources */,
@@ -2318,6 +2320,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -2330,6 +2333,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGL;
 				PRODUCT_NAME = "Mapbox GL";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -2372,7 +2376,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -2394,7 +2398,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -2426,6 +2430,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.sdk.ios;
 				PRODUCT_NAME = Mapbox;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2459,6 +2464,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.sdk.ios;
 				PRODUCT_NAME = Mapbox;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -1693,7 +1693,7 @@
 				DA8847CE1CBAF91600AB86E3 /* Frameworks */,
 				DA8847CF1CBAF91600AB86E3 /* Headers */,
 				DA8847D01CBAF91600AB86E3 /* Resources */,
-				64E5BF321E09D729005223F7 /* ShellScript */,
+				64E5BF321E09D729005223F7 /* Add Examples to Documentation */,
 			);
 			buildRules = (
 			);
@@ -1728,7 +1728,7 @@
 				DAA4E4101CBB71D400178DFB /* Frameworks */,
 				DAA4E4111CBB71D400178DFB /* CopyFiles */,
 				DABFB85C1CBE99DE00D62B32 /* Headers */,
-				6421B07A1E09EA4B00AF169B /* ShellScript */,
+				6421B07A1E09EA4B00AF169B /* Add Examples to Documentation */,
 			);
 			buildRules = (
 			);
@@ -1921,26 +1921,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		6421B07A1E09EA4B00AF169B /* ShellScript */ = {
+		6421B07A1E09EA4B00AF169B /* Add Examples to Documentation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Add Examples to Documentation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "node \"${SRCROOT}/scripts/add-examples-to-docs.js\"";
 		};
-		64E5BF321E09D729005223F7 /* ShellScript */ = {
+		64E5BF321E09D729005223F7 /* Add Examples to Documentation */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Add Examples to Documentation";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		40FDA76B1CCAAA6800442548 /* MBXAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FDA76A1CCAAA6800442548 /* MBXAnnotationView.m */; };
 		554180421D2E97DE00012372 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 554180411D2E97DE00012372 /* OpenGLES.framework */; };
 		55D8C9961D0F18CE00F42F10 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D8C9951D0F18CE00F42F10 /* libsqlite3.tbd */; };
+		6407D6701E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6407D66F1E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift */; };
 		7E016D7E1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */; };
 		7E016D7F1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */; };
 		7E016D801D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E016D7D1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m */; };
@@ -608,6 +609,7 @@
 		554180411D2E97DE00012372 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		55D8C9941D0F133500F42F10 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = ../../build/ios/config.xcconfig; sourceTree = "<group>"; };
 		55D8C9951D0F18CE00F42F10 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
+		6407D66F1E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBLDocumentationExampleTests.swift; sourceTree = "<group>"; };
 		7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolyline+MGLAdditions.h"; sourceTree = "<group>"; };
 		7E016D7D1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolyline+MGLAdditions.m"; sourceTree = "<group>"; };
 		7E016D821D9E890300A29A21 /* MGLPolygon+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolygon+MGLAdditions.h"; sourceTree = "<group>"; };
@@ -1084,6 +1086,7 @@
 				DA35A2C31CCA9F8300E826B2 /* MGLClockDirectionFormatterTests.m */,
 				DA35A2C41CCA9F8300E826B2 /* MGLCompassDirectionFormatterTests.m */,
 				DA35A2A91CCA058D00E826B2 /* MGLCoordinateFormatterTests.m */,
+				6407D66F1E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift */,
 				DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */,
 				DA2E885C1CC0382C00F24E7B /* MGLGeometryTests.mm */,
 				DA2DBBCC1D51E80400D38FF9 /* MGLStyleLayerTests.h */,
@@ -1773,7 +1776,7 @@
 					};
 					DA2E88501CC036F400F24E7B = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0810;
 					};
 					DA8847D11CBAF91600AB86E3 = {
 						CreatedOnToolsVersion = 7.3;
@@ -1932,6 +1935,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6407D6701E0085FD00F6A9C3 /* MBLDocumentationExampleTests.swift in Sources */,
 				DA2E88631CC0382C00F24E7B /* MGLOfflineRegionTests.m in Sources */,
 				3599A3E61DF708BC00E77FB2 /* MGLStyleValueTests.m in Sources */,
 				DA2E88651CC0382C00F24E7B /* MGLStyleTests.mm in Sources */,
@@ -2368,7 +2372,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Debug;
 		};
@@ -2390,7 +2394,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.test;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "../darwin/test/test-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 3.0.1;
 			};
 			name = Release;
 		};

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -11,8 +11,6 @@ head: |
 objc: Yes
 skip_undocumented: Yes
 hide_documentation_coverage: Yes
-umbrella_header: src/Mapbox.h
-framework_root: ../darwin/src
 
 custom_categories:
   - name: Maps

--- a/platform/ios/scripts/add-examples-to-docs.js
+++ b/platform/ios/scripts/add-examples-to-docs.js
@@ -18,6 +18,8 @@ const exampleRegex = /\/\*---BEGIN EXAMPLE:(.*)---\*\/\s*(\/\*+[\s\S]*?\*+\/)?([
 
 var path = `${process.env.TARGET_BUILD_DIR}/${process.env.PUBLIC_HEADERS_FOLDER_PATH}`;
 
+console.log("Installing examples...");
+
 var match;
 while ((match = exampleRegex.exec(examples)) !== null) {
   const token = match[1].trim();
@@ -50,8 +52,14 @@ while ((match = exampleRegex.exec(examples)) !== null) {
     const file = fs.readFileSync(filename, 'utf8');
     // Check for example placeholder in file & update file if found
     if (placeholderRegex.test(file)) {
-      console.log("Updating examples:", filename);
+      console.log("Updating example:", filename);
       fs.writeFileSync(filename, file.replace(placeholderRegex, exampleText));
+    } else if (file.indexOf(exampleText) === -1) {
+      console.log(`Placeholder "${token}" missing:`, filename);
+    } else {
+      console.log(`Example "${token}" already replaced.`);
     }
+  } else if (token !== "ExampleToken") {
+    console.log("Error file doesn't exist:", filename);
   }
 }

--- a/platform/ios/scripts/add-examples-to-docs.js
+++ b/platform/ios/scripts/add-examples-to-docs.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const fs = require('fs');
+
+const examples = fs.readFileSync(`${__dirname}/../test/MGLDocumentationExampleTests.swift`, 'utf8');
+
+// Regex extracts the following block
+// /*---BEGIN EXAMPLE: MGLStyleSource---*/
+// /* Frontmatter to describe the example */
+// let sampleCode: String?
+// /*---END EXAMPLE---*/
+//
+// into the following regex groups:
+// 1 (token): " MGLStyleSource"
+// 2 (frontmatter): "/* Frontmatter to describe the example */"
+// 3 (sample code): "let sampleCode: String?"
+const exampleRegex = /\/\*---BEGIN EXAMPLE:(.*)---\*\/\s*(\/\*+[\s\S]*?\*+\/)?([\s\S]*?)\/\*---END EXAMPLE---\*\//gm;
+
+var path = `${process.env.TARGET_BUILD_DIR}/${process.env.PUBLIC_HEADERS_FOLDER_PATH}`;
+
+var match;
+while ((match = exampleRegex.exec(examples)) !== null) {
+  const token = match[1].trim();
+  const className = token.split('.')[0];
+
+  const frontmatter = (match[2] || '')
+    .replace(/\/\*+/g, '') // Remove block comment /**
+    .replace(/\*+\//g, '') // Remove block comment end */
+    .trim()
+    .replace(/\n {8,9}/g, '\n'); // Remove leading whitespace (8-9 spaces incl block comment)
+
+  const exampleCode = match[3]
+    .trim()
+    .replace(/\n {8}/g, '\n'); // Remove leading whitespace (8 spaces)
+
+  // Generate example text
+  var exampleText = "### Example\n\n";
+  if (frontmatter.length > 0) {
+    exampleText += `${frontmatter}\n\n`;
+  }
+  exampleText += "```swift\n" + exampleCode + "\n```";
+  exampleText = exampleText.replace(/\n/g, '\n ');
+
+  const placeholderRegex = new RegExp(`<!--EXAMPLE: ${token}-->`);
+
+  // check if file exists at path
+  const filename = `${path}/${className}.h`;
+
+  if (fs.existsSync(filename)) {
+    const file = fs.readFileSync(filename, 'utf8');
+    // Check for example placeholder in file & update file if found
+    if (placeholderRegex.test(file)) {
+      console.log("Updating examples:", filename);
+      fs.writeFileSync(filename, file.replace(placeholderRegex, exampleText));
+    }
+  }
+}

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -35,11 +35,15 @@ cp platform/ios/screenshot.png "${OUTPUT}"
 DEFAULT_THEME="platform/darwin/docs/theme"
 THEME=${JAZZY_THEME:-$DEFAULT_THEME}
 
+FRAMEWORK_PATH="build/ios/pkg/dynamic/Mapbox.framework"
+
 jazzy \
     --config platform/ios/jazzy.yml \
     --sdk iphonesimulator \
     --github-file-prefix https://github.com/mapbox/mapbox-gl-native/tree/${BRANCH} \
     --module-version ${SHORT_VERSION} \
+    --framework-root ${FRAMEWORK_PATH} \
+    --umbrella-header "${FRAMEWORK_PATH}/Headers/Mapbox.h" \
     --readme ${README} \
     --documentation="platform/ios/docs/Info.plist Keys.md" \
     --root-url https://www.mapbox.com/ios-sdk/api/${RELEASE_VERSION}/ \

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -35,7 +35,8 @@ cp platform/ios/screenshot.png "${OUTPUT}"
 DEFAULT_THEME="platform/darwin/docs/theme"
 THEME=${JAZZY_THEME:-$DEFAULT_THEME}
 
-FRAMEWORK_PATH="build/ios/pkg/dynamic/Mapbox.framework"
+DEFAULT_FRAMEWORK_PATH="build/ios/pkg/dynamic/Mapbox.framework"
+FRAMEWORK_PATH=${FRAMEWORK_PATH:-$DEFAULT_FRAMEWORK_PATH}
 
 jazzy \
     --config platform/ios/jazzy.yml \

--- a/platform/ios/test/MBLDocumentationExampleTests.swift
+++ b/platform/ios/test/MBLDocumentationExampleTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+import Mapbox
+
+/**
+ Test cases that ensure the inline examples in the project documentation
+ compile. If any of these need to be changed, update the corresponding header
+ documentation accordingly.
+ */
+class MBLDocumentationExampleTests: XCTestCase {
+    var mapView: MGLMapView!
+
+    override func setUp() {
+	super.setUp()
+	self.mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: 256, height: 256))
+    }
+
+    override func tearDown() {
+	self.mapView = nil
+	super.tearDown()
+    }
+
+    // Example code in MGLShapeSource.h
+    func testMGLShapeSourceExample() {
+	var coordinates: [CLLocationCoordinate2D] = [
+	    CLLocationCoordinate2D(latitude: 37.77, longitude: -122.42),
+	    CLLocationCoordinate2D(latitude: 38.91, longitude: -77.04),
+	    ]
+	let polyline = MGLPolylineFeature(coordinates: &coordinates, count: UInt(coordinates.count))
+	let shape = MGLShapeCollectionFeature(shapes: [polyline])
+	let source = MGLShapeSource(identifier: "lines", shape: shape, options: nil)
+	mapView.style.addSource(source)
+
+	XCTAssertNotNil(mapView.style.source(withIdentifier: "lines"))
+    }
+
+    // Example code in MGLRasterSource.h
+    func testMGLRasterSourceExample() {
+	// Define tileset
+	let tileset = MGLTileSet(tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"])
+	tileset.minimumZoomLevel = 9
+	tileset.maximumZoomLevel = 16
+	tileset.attribution = "© Mapbox"
+	// Add source to map
+	let source = MGLRasterSource(identifier: "clouds", tileSet: tileset, tileSize: 512)
+	mapView.style.addSource(source)
+
+	XCTAssertNotNil(mapView.style.source(withIdentifier: "clouds"))
+    }
+
+    // Example code in MGLVectorSource.h
+    func testMGLVectorSource() {
+	// Define tileset
+	let tileset = MGLTileSet(tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"])
+	tileset.minimumZoomLevel = 9
+	tileset.maximumZoomLevel = 16
+	tileset.attribution = "© Mapbox"
+	// Add source to map
+	let source = MGLVectorSource(identifier: "pois", tileSet: tileset)
+	mapView.style.addSource(source)
+
+	XCTAssertNotNil(mapView.style.source(withIdentifier: "pois"))
+    }
+
+    // Example code in MGLCircleStyleLayer.h
+    func testMGLCircleStyleLayerExample() {
+	let population = MGLVectorSource(identifier: "population", url: URL(string: "https://example.com")!)
+	mapView.style.addSource(population)
+
+	let layer = MGLCircleStyleLayer(identifier: "circles", source: population)
+	layer.sourceLayerIdentifier = "population"
+	layer.circleColor = MGLStyleValue(rawValue: UIColor.green)
+	layer.circleRadius = MGLStyleValue(base: 1.75, stops: [
+	    12: MGLStyleValue(rawValue: 2),
+	    22: MGLStyleValue(rawValue: 180)
+	    ])
+	layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
+	layer.predicate = NSPredicate(format: "%K == %@", "marital-status", "married")
+	mapView.style.addLayer(layer)
+
+	XCTAssertNotNil(mapView.style.layer(withIdentifier: "circles"))
+    }
+
+    // Example code in MGLLineStyleLayer.h
+    func testMGLLineStyleLayerExample() {
+	let trails = MGLVectorSource(identifier: "trails", url: URL(string: "https://example.com")!)
+	mapView.style.addSource(trails)
+
+	let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
+	layer.sourceLayerIdentifier = "trails"
+	layer.lineWidth = MGLStyleValue(base: 1.5, stops: [
+	    14: MGLStyleValue(rawValue: 2),
+	    18: MGLStyleValue(rawValue: 20),
+	    ])
+	layer.lineColor = MGLStyleValue(rawValue: UIColor.brown)
+	layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
+	layer.predicate = NSPredicate(format: "%K == %@", "trail-type", "mountain-biking")
+	mapView.style.addLayer(layer)
+
+	XCTAssertNotNil(mapView.style.layer(withIdentifier: "trails-path"))
+    }
+
+    // Example code in MGLFillStyleLayer.h
+    func testMGLFillStyleLayerExample() {
+	let parks = MGLVectorSource(identifier: "parks", url: URL(string: "https://example.com")!)
+	mapView.style.addSource(parks)
+
+	let layer = MGLFillStyleLayer(identifier: "parks", source: parks)
+	layer.sourceLayerIdentifier = "parks"
+	layer.fillColor = MGLStyleValue(rawValue: UIColor.green)
+	layer.predicate = NSPredicate(format: "type == %@", "national-park")
+	mapView.style.addLayer(layer)
+
+	XCTAssertNotNil(mapView.style.layer(withIdentifier: "parks"))
+    }
+
+    // Example code in MGLSymbolStyleLayer.h
+    func testMGLSymbolStyleLayerExample() {
+	let pois = MGLVectorSource(identifier: "pois", url: URL(string: "https://example.com")!)
+	mapView.style.addSource(pois)
+
+	let layer = MGLSymbolStyleLayer(identifier: "coffeeshops", source: pois)
+	layer.sourceLayerIdentifier = "pois"
+	layer.iconImageName = MGLStyleValue(rawValue: "coffee")
+	layer.iconScale = MGLStyleValue(rawValue: 0.5)
+	layer.textField = MGLStyleValue(rawValue: "{name}")
+	layer.textTranslate = MGLStyleValue(rawValue: NSValue(cgVector: CGVector(dx: 10, dy: 0)))
+	layer.textJustify = MGLStyleValue(rawValue: NSValue(mglTextJustify: .left))
+	layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
+	layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
+	mapView.style.addLayer(layer)
+
+	XCTAssertNotNil(mapView.style.layer(withIdentifier: "coffeeshops"))
+    }
+
+    // Example code in MGLVectorStyleLayer.h
+    func testMGLVectorStyleLayer() {
+	let terrain = MGLVectorSource(identifier: "terrain", url: URL(string: "https://example.com")!)
+	mapView.style.addSource(terrain)
+
+	let layer = MGLLineStyleLayer(identifier: "contour", source: terrain)
+	layer.sourceLayerIdentifier = "contours"
+	layer.predicate = NSPredicate(format: "(index == 10 || index == 5) && ele >= 1500.0")
+	mapView.style.addLayer(layer)
+
+	XCTAssertNotNil(mapView.style.layer(withIdentifier: "contour"))
+    }
+}

--- a/platform/ios/test/MGLDocumentationExampleTests.swift
+++ b/platform/ios/test/MGLDocumentationExampleTests.swift
@@ -6,7 +6,7 @@ import Mapbox
  compile. If any of these need to be changed, update the corresponding header
  documentation accordingly.
  */
-class MBLDocumentationExampleTests: XCTestCase {
+class MGLDocumentationExampleTests: XCTestCase {
     var mapView: MGLMapView!
 
     override func setUp() {
@@ -19,7 +19,7 @@ class MBLDocumentationExampleTests: XCTestCase {
 	super.tearDown()
     }
 
-    // Example code in MGLShapeSource.h
+    // Example code in MGLShapeSource
     func testMGLShapeSourceExample() {
 	var coordinates: [CLLocationCoordinate2D] = [
 	    CLLocationCoordinate2D(latitude: 37.77, longitude: -122.42),
@@ -33,46 +33,49 @@ class MBLDocumentationExampleTests: XCTestCase {
 	XCTAssertNotNil(mapView.style.source(withIdentifier: "lines"))
     }
 
-    // Example code in MGLRasterSource.h
+    // Example code in MGLRasterSource
     func testMGLRasterSourceExample() {
-	// Define tileset
-	let tileset = MGLTileSet(tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"])
-	tileset.minimumZoomLevel = 9
-	tileset.maximumZoomLevel = 16
-	tileset.attribution = "© Mapbox"
-	// Add source to map
-	let source = MGLRasterSource(identifier: "clouds", tileSet: tileset, tileSize: 512)
+	let source = MGLRasterSource(identifier: "clouds", tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"], options: [
+	    .minimumZoomLevel: 9,
+	    .maximumZoomLevel: 16,
+	    .tileSize: 512,
+	    .attributionInfos: [
+		MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+	    ]
+	])
 	mapView.style.addSource(source)
 
 	XCTAssertNotNil(mapView.style.source(withIdentifier: "clouds"))
     }
 
-    // Example code in MGLVectorSource.h
+    // Example code in MGLVectorSource
     func testMGLVectorSource() {
-	// Define tileset
-	let tileset = MGLTileSet(tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"])
-	tileset.minimumZoomLevel = 9
-	tileset.maximumZoomLevel = 16
-	tileset.attribution = "© Mapbox"
-	// Add source to map
-	let source = MGLVectorSource(identifier: "pois", tileSet: tileset)
+	let source = MGLVectorSource(identifier: "pois", tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"], options: [
+	    .minimumZoomLevel: 9,
+	    .maximumZoomLevel: 16,
+	    .attributionInfos: [
+		MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+	    ]
+	])
 	mapView.style.addSource(source)
 
 	XCTAssertNotNil(mapView.style.source(withIdentifier: "pois"))
     }
 
-    // Example code in MGLCircleStyleLayer.h
+    // Example code in MGLCircleStyleLayer
     func testMGLCircleStyleLayerExample() {
-	let population = MGLVectorSource(identifier: "population", url: URL(string: "https://example.com")!)
+	// Don't bother with the source setup in the header docs
+	let population = MGLVectorSource(identifier: "population", configurationURL: URL(string: "https://example.com/style.json")!)
 	mapView.style.addSource(population)
 
+	// Start documentation here
 	let layer = MGLCircleStyleLayer(identifier: "circles", source: population)
 	layer.sourceLayerIdentifier = "population"
 	layer.circleColor = MGLStyleValue(rawValue: UIColor.green)
-	layer.circleRadius = MGLStyleValue(base: 1.75, stops: [
+	layer.circleRadius = MGLStyleValue(interpolationBase: 1.75, stops: [
 	    12: MGLStyleValue(rawValue: 2),
 	    22: MGLStyleValue(rawValue: 180)
-	    ])
+	])
 	layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
 	layer.predicate = NSPredicate(format: "%K == %@", "marital-status", "married")
 	mapView.style.addLayer(layer)
@@ -80,17 +83,17 @@ class MBLDocumentationExampleTests: XCTestCase {
 	XCTAssertNotNil(mapView.style.layer(withIdentifier: "circles"))
     }
 
-    // Example code in MGLLineStyleLayer.h
+    // Example code in MGLLineStyleLayer
     func testMGLLineStyleLayerExample() {
-	let trails = MGLVectorSource(identifier: "trails", url: URL(string: "https://example.com")!)
+	let trails = MGLVectorSource(identifier: "trails", configurationURL: URL(string: "https://example.com/style.json")!)
 	mapView.style.addSource(trails)
 
 	let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
 	layer.sourceLayerIdentifier = "trails"
-	layer.lineWidth = MGLStyleValue(base: 1.5, stops: [
+	layer.lineWidth = MGLStyleValue(interpolationBase: 1.5, stops: [
 	    14: MGLStyleValue(rawValue: 2),
 	    18: MGLStyleValue(rawValue: 20),
-	    ])
+	])
 	layer.lineColor = MGLStyleValue(rawValue: UIColor.brown)
 	layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
 	layer.predicate = NSPredicate(format: "%K == %@", "trail-type", "mountain-biking")
@@ -99,9 +102,9 @@ class MBLDocumentationExampleTests: XCTestCase {
 	XCTAssertNotNil(mapView.style.layer(withIdentifier: "trails-path"))
     }
 
-    // Example code in MGLFillStyleLayer.h
+    // Example code in MGLFillStyleLayer
     func testMGLFillStyleLayerExample() {
-	let parks = MGLVectorSource(identifier: "parks", url: URL(string: "https://example.com")!)
+	let parks = MGLVectorSource(identifier: "parks", configurationURL: URL(string: "https://example.com/style.json")!)
 	mapView.style.addSource(parks)
 
 	let layer = MGLFillStyleLayer(identifier: "parks", source: parks)
@@ -113,9 +116,9 @@ class MBLDocumentationExampleTests: XCTestCase {
 	XCTAssertNotNil(mapView.style.layer(withIdentifier: "parks"))
     }
 
-    // Example code in MGLSymbolStyleLayer.h
+    // Example code in MGLSymbolStyleLayer
     func testMGLSymbolStyleLayerExample() {
-	let pois = MGLVectorSource(identifier: "pois", url: URL(string: "https://example.com")!)
+	let pois = MGLVectorSource(identifier: "pois", configurationURL: URL(string: "https://example.com/style.json")!)
 	mapView.style.addSource(pois)
 
 	let layer = MGLSymbolStyleLayer(identifier: "coffeeshops", source: pois)
@@ -124,7 +127,7 @@ class MBLDocumentationExampleTests: XCTestCase {
 	layer.iconScale = MGLStyleValue(rawValue: 0.5)
 	layer.textField = MGLStyleValue(rawValue: "{name}")
 	layer.textTranslate = MGLStyleValue(rawValue: NSValue(cgVector: CGVector(dx: 10, dy: 0)))
-	layer.textJustify = MGLStyleValue(rawValue: NSValue(mglTextJustify: .left))
+	layer.textJustification = MGLStyleValue(rawValue: NSValue(mglTextJustification: .left))
 	layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
 	layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
 	mapView.style.addLayer(layer)
@@ -132,9 +135,9 @@ class MBLDocumentationExampleTests: XCTestCase {
 	XCTAssertNotNil(mapView.style.layer(withIdentifier: "coffeeshops"))
     }
 
-    // Example code in MGLVectorStyleLayer.h
+    // Example code in MGLVectorStyleLayer.predicate
     func testMGLVectorStyleLayer() {
-	let terrain = MGLVectorSource(identifier: "terrain", url: URL(string: "https://example.com")!)
+	let terrain = MGLVectorSource(identifier: "terrain", configurationURL: URL(string: "https://example.com/style.json")!)
 	mapView.style.addSource(terrain)
 
 	let layer = MGLLineStyleLayer(identifier: "contour", source: terrain)

--- a/platform/ios/test/MGLDocumentationExampleTests.swift
+++ b/platform/ios/test/MGLDocumentationExampleTests.swift
@@ -1,150 +1,204 @@
 import XCTest
 import Mapbox
+import UIKit
 
 /**
  Test cases that ensure the inline examples in the project documentation
- compile. If any of these need to be changed, update the corresponding header
- documentation accordingly.
+ compile.
+
+ There is a run script build phase for the dynamic & static iOS targets
+ that invokes `/platform/ios/scrips/add-examples-to-docs.js`. This script
+ will pull example code out of this test file and replace the corresponding
+ placeholder comment in the built header files.
+
+ Adding examples:
+ 1. Add a test case below
+ 2. Wrap the code you'd like to appear in the documentation within the
+    following comment blocks:
+    `/*---BEGIN EXAMPLE: ExampleToken---*/`
+    ...
+    `/*---END EXAMPLE---*/`
+ 3. Insert a comment `<!--EXAMPLE: ExampleToken-->` inside the header file
+    where you'd like the example code to be inserted
  */
 class MGLDocumentationExampleTests: XCTestCase {
     var mapView: MGLMapView!
 
     override func setUp() {
-	super.setUp()
-	self.mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: 256, height: 256))
+        super.setUp()
+        self.mapView = MGLMapView(frame: CGRect(x: 0, y: 0, width: 256, height: 256))
     }
 
     override func tearDown() {
-	self.mapView = nil
-	super.tearDown()
+        self.mapView = nil
+        super.tearDown()
     }
 
-    // Example code in MGLShapeSource
+    // MGLShapeSource
     func testMGLShapeSourceExample() {
-	var coordinates: [CLLocationCoordinate2D] = [
-	    CLLocationCoordinate2D(latitude: 37.77, longitude: -122.42),
-	    CLLocationCoordinate2D(latitude: 38.91, longitude: -77.04),
-	    ]
-	let polyline = MGLPolylineFeature(coordinates: &coordinates, count: UInt(coordinates.count))
-	let shape = MGLShapeCollectionFeature(shapes: [polyline])
-	let source = MGLShapeSource(identifier: "lines", shape: shape, options: nil)
-	mapView.style.addSource(source)
+        /*---BEGIN EXAMPLE: MGLShapeSource---*/
+        var coordinates: [CLLocationCoordinate2D] = [
+            CLLocationCoordinate2D(latitude: 37.77, longitude: -122.42),
+            CLLocationCoordinate2D(latitude: 38.91, longitude: -77.04),
+        ]
+        let polyline = MGLPolylineFeature(coordinates: &coordinates, count: UInt(coordinates.count))
+        let shape = MGLShapeCollectionFeature(shapes: [polyline])
+        let source = MGLShapeSource(identifier: "lines", shape: shape, options: nil)
+        mapView.style.addSource(source)
+        /*---END EXAMPLE---*/
 
-	XCTAssertNotNil(mapView.style.source(withIdentifier: "lines"))
+        XCTAssertNotNil(mapView.style.source(withIdentifier: "lines"))
     }
 
-    // Example code in MGLRasterSource
+    // MGLRasterSource
     func testMGLRasterSourceExample() {
-	let source = MGLRasterSource(identifier: "clouds", tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"], options: [
-	    .minimumZoomLevel: 9,
-	    .maximumZoomLevel: 16,
-	    .tileSize: 512,
-	    .attributionInfos: [
-		MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
-	    ]
-	])
-	mapView.style.addSource(source)
+        /*---BEGIN EXAMPLE: MGLRasterSource---*/
+        let source = MGLRasterSource(identifier: "clouds", tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"], options: [
+            .minimumZoomLevel: 9,
+            .maximumZoomLevel: 16,
+            .tileSize: 512,
+            .attributionInfos: [
+                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+            ]
+        ])
+        mapView.style.addSource(source)
+        /*---END EXAMPLE---*/
 
-	XCTAssertNotNil(mapView.style.source(withIdentifier: "clouds"))
+        XCTAssertNotNil(mapView.style.source(withIdentifier: "clouds"))
     }
 
-    // Example code in MGLVectorSource
+    // MGLVectorSource
     func testMGLVectorSource() {
-	let source = MGLVectorSource(identifier: "pois", tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"], options: [
-	    .minimumZoomLevel: 9,
-	    .maximumZoomLevel: 16,
-	    .attributionInfos: [
-		MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
-	    ]
-	])
-	mapView.style.addSource(source)
+        /*---BEGIN EXAMPLE: MGLVectorSource---*/
+        let source = MGLVectorSource(identifier: "pois", tileURLTemplates: ["https://example.com/vector-tiles/{z}/{x}/{y}.mvt"], options: [
+            .minimumZoomLevel: 9,
+            .maximumZoomLevel: 16,
+            .attributionInfos: [
+                MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+            ]
+        ])
+        mapView.style.addSource(source)
+        /*---END EXAMPLE---*/
 
-	XCTAssertNotNil(mapView.style.source(withIdentifier: "pois"))
+        XCTAssertNotNil(mapView.style.source(withIdentifier: "pois"))
     }
 
-    // Example code in MGLCircleStyleLayer
+    // MGLCircleStyleLayer
     func testMGLCircleStyleLayerExample() {
-	// Don't bother with the source setup in the header docs
-	let population = MGLVectorSource(identifier: "population", configurationURL: URL(string: "https://example.com/style.json")!)
-	mapView.style.addSource(population)
+        let population = MGLVectorSource(identifier: "population", configurationURL: URL(string: "https://example.com/style.json")!)
+        mapView.style.addSource(population)
+        
+        /*---BEGIN EXAMPLE: MGLCircleStyleLayer---*/
+        let layer = MGLCircleStyleLayer(identifier: "circles", source: population)
+        layer.sourceLayerIdentifier = "population"
+        layer.circleColor = MGLStyleValue(rawValue: UIColor.green)
+        layer.circleRadius = MGLStyleValue(interpolationBase: 1.75, stops: [
+            12: MGLStyleValue(rawValue: 2),
+            22: MGLStyleValue(rawValue: 180)
+        ])
+        layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
+        layer.predicate = NSPredicate(format: "%K == %@", "marital-status", "married")
+        mapView.style.addLayer(layer)
+        /*---END EXAMPLE---*/
 
-	// Start documentation here
-	let layer = MGLCircleStyleLayer(identifier: "circles", source: population)
-	layer.sourceLayerIdentifier = "population"
-	layer.circleColor = MGLStyleValue(rawValue: UIColor.green)
-	layer.circleRadius = MGLStyleValue(interpolationBase: 1.75, stops: [
-	    12: MGLStyleValue(rawValue: 2),
-	    22: MGLStyleValue(rawValue: 180)
-	])
-	layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
-	layer.predicate = NSPredicate(format: "%K == %@", "marital-status", "married")
-	mapView.style.addLayer(layer)
-
-	XCTAssertNotNil(mapView.style.layer(withIdentifier: "circles"))
+        XCTAssertNotNil(mapView.style.layer(withIdentifier: "circles"))
     }
 
-    // Example code in MGLLineStyleLayer
+    // MGLLineStyleLayer
     func testMGLLineStyleLayerExample() {
-	let trails = MGLVectorSource(identifier: "trails", configurationURL: URL(string: "https://example.com/style.json")!)
-	mapView.style.addSource(trails)
+        let trails = MGLVectorSource(identifier: "trails", configurationURL: URL(string: "https://example.com/style.json")!)
+        mapView.style.addSource(trails)
 
-	let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
-	layer.sourceLayerIdentifier = "trails"
-	layer.lineWidth = MGLStyleValue(interpolationBase: 1.5, stops: [
-	    14: MGLStyleValue(rawValue: 2),
-	    18: MGLStyleValue(rawValue: 20),
-	])
-	layer.lineColor = MGLStyleValue(rawValue: UIColor.brown)
-	layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
-	layer.predicate = NSPredicate(format: "%K == %@", "trail-type", "mountain-biking")
-	mapView.style.addLayer(layer)
+        /*---BEGIN EXAMPLE: MGLLineStyleLayer---*/
+        let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
+        layer.sourceLayerIdentifier = "trails"
+        layer.lineWidth = MGLStyleValue(interpolationBase: 1.5, stops: [
+            14: MGLStyleValue(rawValue: 2),
+            18: MGLStyleValue(rawValue: 20),
+        ])
+        layer.lineColor = MGLStyleValue(rawValue: UIColor.brown)
+        layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
+        layer.predicate = NSPredicate(format: "%K == %@", "trail-type", "mountain-biking")
+        mapView.style.addLayer(layer)
+        /*---END EXAMPLE---*/
 
-	XCTAssertNotNil(mapView.style.layer(withIdentifier: "trails-path"))
+        XCTAssertNotNil(mapView.style.layer(withIdentifier: "trails-path"))
     }
 
-    // Example code in MGLFillStyleLayer
+    // MGLFillStyleLayer
     func testMGLFillStyleLayerExample() {
-	let parks = MGLVectorSource(identifier: "parks", configurationURL: URL(string: "https://example.com/style.json")!)
-	mapView.style.addSource(parks)
+        let parks = MGLVectorSource(identifier: "parks", configurationURL: URL(string: "https://example.com/style.json")!)
+        mapView.style.addSource(parks)
 
-	let layer = MGLFillStyleLayer(identifier: "parks", source: parks)
-	layer.sourceLayerIdentifier = "parks"
-	layer.fillColor = MGLStyleValue(rawValue: UIColor.green)
-	layer.predicate = NSPredicate(format: "type == %@", "national-park")
-	mapView.style.addLayer(layer)
+        /*---BEGIN EXAMPLE: MGLFillStyleLayer---*/
+        let layer = MGLFillStyleLayer(identifier: "parks", source: parks)
+        layer.sourceLayerIdentifier = "parks"
+        layer.fillColor = MGLStyleValue(rawValue: UIColor.green)
+        layer.predicate = NSPredicate(format: "type == %@", "national-park")
+        mapView.style.addLayer(layer)
+        /*---END EXAMPLE---*/
 
-	XCTAssertNotNil(mapView.style.layer(withIdentifier: "parks"))
+        XCTAssertNotNil(mapView.style.layer(withIdentifier: "parks"))
     }
 
-    // Example code in MGLSymbolStyleLayer
+    // MGLSymbolStyleLayer
     func testMGLSymbolStyleLayerExample() {
-	let pois = MGLVectorSource(identifier: "pois", configurationURL: URL(string: "https://example.com/style.json")!)
-	mapView.style.addSource(pois)
+        let pois = MGLVectorSource(identifier: "pois", configurationURL: URL(string: "https://example.com/style.json")!)
+        mapView.style.addSource(pois)
 
-	let layer = MGLSymbolStyleLayer(identifier: "coffeeshops", source: pois)
-	layer.sourceLayerIdentifier = "pois"
-	layer.iconImageName = MGLStyleValue(rawValue: "coffee")
-	layer.iconScale = MGLStyleValue(rawValue: 0.5)
-	layer.textField = MGLStyleValue(rawValue: "{name}")
-	layer.textTranslate = MGLStyleValue(rawValue: NSValue(cgVector: CGVector(dx: 10, dy: 0)))
-	layer.textJustification = MGLStyleValue(rawValue: NSValue(mglTextJustification: .left))
-	layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
-	layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
-	mapView.style.addLayer(layer)
+        /*---BEGIN EXAMPLE: MGLSymbolStyleLayer---*/
+        let layer = MGLSymbolStyleLayer(identifier: "coffeeshops", source: pois)
+        layer.sourceLayerIdentifier = "pois"
+        layer.iconImageName = MGLStyleValue(rawValue: "coffee")
+        layer.iconScale = MGLStyleValue(rawValue: 0.5)
+        layer.textField = MGLStyleValue(rawValue: "{name}")
+        layer.textTranslate = MGLStyleValue(rawValue: NSValue(cgVector: CGVector(dx: 10, dy: 0)))
+        layer.textJustification = MGLStyleValue(rawValue: NSValue(mglTextJustification: .left))
+        layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
+        layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
+        mapView.style.addLayer(layer)
+        /*---END EXAMPLE---*/
 
-	XCTAssertNotNil(mapView.style.layer(withIdentifier: "coffeeshops"))
+        XCTAssertNotNil(mapView.style.layer(withIdentifier: "coffeeshops"))
     }
 
-    // Example code in MGLVectorStyleLayer.predicate
+    // MGLRasterStyleLayer
+    func testMGLRasterStyleLayer() {
+        let source = MGLRasterSource(identifier: "clouds", tileURLTemplates: ["https://example.com/raster-tiles/{z}/{x}/{y}.png"], options: [
+            .minimumZoomLevel: 9,
+            .maximumZoomLevel: 16,
+            .tileSize: 512,
+            .attributionInfos: [
+            MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
+            ]
+        ])
+        mapView.style.addSource(source)
+
+        /*---BEGIN EXAMPLE: MGLRasterStyleLayer---*/
+        let layer = MGLRasterStyleLayer(identifier: "clouds", source: source)
+        layer.rasterOpacity = MGLStyleValue(rawValue: 0.5)
+        mapView.style.addLayer(layer)
+        /*---END EXAMPLE---*/
+
+        XCTAssertNotNil(mapView.style.layer(withIdentifier: "clouds"))
+    }
+
+    // MGLVectorStyleLayer.predicate
     func testMGLVectorStyleLayer() {
-	let terrain = MGLVectorSource(identifier: "terrain", configurationURL: URL(string: "https://example.com/style.json")!)
-	mapView.style.addSource(terrain)
+        let terrain = MGLVectorSource(identifier: "terrain", configurationURL: URL(string: "https://example.com/style.json")!)
+        mapView.style.addSource(terrain)
 
-	let layer = MGLLineStyleLayer(identifier: "contour", source: terrain)
-	layer.sourceLayerIdentifier = "contours"
-	layer.predicate = NSPredicate(format: "(index == 10 || index == 5) && ele >= 1500.0")
-	mapView.style.addLayer(layer)
+        /*---BEGIN EXAMPLE: MGLVectorStyleLayer.predicate---*/
+        /**
+         To create a filter with the logic `(index == 10 || index == 5) && ele >= 200`,
+         you could create a predicate using `NSCompoundPredicate` along these lines:
+         */
+        let layer = MGLLineStyleLayer(identifier: "contour", source: terrain)
+        layer.sourceLayerIdentifier = "contours"
+        layer.predicate = NSPredicate(format: "(index == 10 || index == 5) && ele >= 1500.0")
+        mapView.style.addLayer(layer)
+        /*---END EXAMPLE---*/
 
-	XCTAssertNotNil(mapView.style.layer(withIdentifier: "contour"))
+        XCTAssertNotNil(mapView.style.layer(withIdentifier: "contour"))
     }
 }


### PR DESCRIPTION
Examples for:
* Sources
  * `MGLGeoJSONSource`
  * `MGLVectorSource`
  * `MGLRasterSource`
* Layers
  * `MGLCircleStyleLayer`
  * `MGLFillStyleLayer`
  * `MGLLineStyleLayer`
  * `MGLSymbolStyleLayer`
* `MGLVectorStyleLayer.predicate`

Swift 3 for now. We can add Objective-C inline or a link to the respective examples on http://mapbox.com/ios-sdk/examples later.