### PR TITLE
[ios] Reorder classes in jazzy docs sidebar

### DIFF
--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -26,10 +26,6 @@ custom_categories:
       - MGLMapViewDelegate
       - MGLStyle
       - MGLUserTrackingMode
-  - name: User Interaction
-    children:
-      - MGLCalloutView
-      - MGLCalloutViewDelegate
   - name: Protocols and Abstract Classes
     children:
       - MGLAnnotation
@@ -52,6 +48,10 @@ custom_categories:
       - MGLAnnotationView
       - MGLUserLocation
       - MGLUserLocationAnnotationView
+  - name: User Interaction
+    children:
+      - MGLCalloutView
+      - MGLCalloutViewDelegate
   - name: Style Features
     children:
       - MGLPointFeature

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -81,6 +81,10 @@ custom_categories:
       - MGLFillStyleLayer
       - MGLLineStyleLayer
       - MGLSymbolStyleLayer
+  - name: Style Values
+    children:
+      - MGLStyleValue
+      - NSValue(MGLAdditions)
   - name: Offline Maps
     children:
       - MGLOfflineRegion

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -94,6 +94,7 @@ custom_categories:
       - MGLCoordinateBounds
       - MGLCoordinateBoundsEqualToCoordinateBounds
       - MGLCoordinateBoundsGetCoordinateSpan
+      - MGLCoordinateBoundsIntersectsCoordinateBounds
       - MGLCoordinateBoundsIsEmpty
       - MGLCoordinateBoundsMake
       - MGLCoordinateBoundsOffset

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -15,6 +15,9 @@ umbrella_header: src/Mapbox.h
 framework_root: ../darwin/src
 
 custom_categories:
+  - name: Guides
+    children:
+      - Info.plist Keys
   - name: Maps
     children:
       - MGLAccountManager
@@ -23,55 +26,61 @@ custom_categories:
       - MGLMapViewDelegate
       - MGLStyle
       - MGLUserTrackingMode
-  - name: Annotations
+  - name: User Interaction
     children:
-      - MGLAnnotation
-      - MGLAnnotationImage
-      - MGLAnnotationView
       - MGLCalloutView
       - MGLCalloutViewDelegate
+  - name: Protocols and Abstract Classes
+    children:
+      - MGLAnnotation
+      - MGLOverlay
+      - MGLShape
       - MGLMultiPoint
-      - MGLMultiPolygon
-      - MGLMultiPolyline
+      - MGLFeature
+  - name: Primitive Shapes
+    children:
       - MGLPointAnnotation
       - MGLPointCollection
       - MGLPolygon
       - MGLPolyline
-      - MGLOverlay
-      - MGLShape
+      - MGLMultiPolygon
+      - MGLMultiPolyline
       - MGLShapeCollection
+  - name: Annotations
+    children:
+      - MGLAnnotationImage
+      - MGLAnnotationView
       - MGLUserLocation
       - MGLUserLocationAnnotationView
-  - name: Map Data
+  - name: Style Features
     children:
-      - MGLFeature
-      - MGLMultiPolygonFeature
-      - MGLMultiPolylineFeature
-      - MGLPointCollectionFeature
       - MGLPointFeature
       - MGLPolygonFeature
       - MGLPolylineFeature
+      - MGLMultiPolygonFeature
+      - MGLMultiPolylineFeature
+      - MGLPointCollectionFeature
       - MGLShapeCollectionFeature
+  - name: Style Sources
+    children:
+      - MGLSource
+      - MGLTileSet
+      - MGLGeoJSONSource
+      - MGLRasterSource
+      - MGLVectorSource
+  - name: Style Layers (Abstract)
+    children:
+      - MGLStyleLayer
+      - MGLForegroundStyleLayer
+      - MGLVectorStyleLayer
   - name: Style Layers
     children:
       - MGLBackgroundStyleLayer
+      - MGLRasterStyleLayer
       - MGLCircleStyleLayer
       - MGLFillStyleLayer
-      - MGLForegroundStyleLayer
       - MGLLineStyleLayer
-      - MGLRasterStyleLayer
-      - MGLStyleLayer
       - MGLSymbolStyleLayer
-      - MGLVectorStyleLayer
-  - name: Content Sources
-    children:
-      - MGLAttributionInfo
-      - MGLRasterSource
-      - MGLShapeSource
-      - MGLSource
-      - MGLTileCoordinateSystem
-      - MGLTileSource
-      - MGLVectorSource
   - name: Offline Maps
     children:
       - MGLOfflineRegion
@@ -82,15 +91,12 @@ custom_categories:
       - MGLTilePyramidOfflineRegion
   - name: Geometry
     children:
-      - MGLClockDirectionFormatter
-      - MGLCompassDirectionFormatter
       - MGLCoordinateBounds
       - MGLCoordinateBoundsEqualToCoordinateBounds
       - MGLCoordinateBoundsGetCoordinateSpan
       - MGLCoordinateBoundsIsEmpty
       - MGLCoordinateBoundsMake
       - MGLCoordinateBoundsOffset
-      - MGLCoordinateFormatter
       - MGLCoordinateInCoordinateBounds
       - MGLCoordinateSpan
       - MGLCoordinateSpanEqualToCoordinateSpan
@@ -99,3 +105,8 @@ custom_categories:
       - MGLDegreesFromRadians
       - MGLRadiansFromDegrees
       - MGLStringFromCoordinateBounds
+  - name: Formatters
+    children:
+      - MGLClockDirectionFormatter
+      - MGLCompassDirectionFormatter
+      - MGLCoordinateFormatter

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -52,7 +52,7 @@ custom_categories:
     children:
       - MGLCalloutView
       - MGLCalloutViewDelegate
-  - name: Style Features
+  - name: Style Primitives
     children:
       - MGLPointFeature
       - MGLPolygonFeature
@@ -61,22 +61,20 @@ custom_categories:
       - MGLMultiPolylineFeature
       - MGLPointCollectionFeature
       - MGLShapeCollectionFeature
-  - name: Style Sources
+  - name: Style Content
     children:
       - MGLSource
-      - MGLTileSet
-      - MGLGeoJSONSource
+      - MGLTileSource
+      - MGLShapeSource
       - MGLRasterSource
       - MGLVectorSource
-  - name: Style Layers (Abstract)
+  - name: Style Layers
     children:
       - MGLStyleLayer
       - MGLForegroundStyleLayer
-      - MGLVectorStyleLayer
-  - name: Style Layers
-    children:
       - MGLBackgroundStyleLayer
       - MGLRasterStyleLayer
+      - MGLVectorStyleLayer
       - MGLCircleStyleLayer
       - MGLFillStyleLayer
       - MGLLineStyleLayer
@@ -84,7 +82,6 @@ custom_categories:
   - name: Style Values
     children:
       - MGLStyleValue
-      - NSValue(MGLAdditions)
   - name: Offline Maps
     children:
       - MGLOfflineRegion

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -24,17 +24,13 @@ custom_categories:
       - MGLMapCamera
       - MGLMapView
       - MGLMapViewDelegate
-      - MGLStyle
       - MGLUserTrackingMode
-  - name: Protocols and Abstract Classes
+  - name: Primitive Shapes
     children:
       - MGLAnnotation
       - MGLOverlay
       - MGLShape
       - MGLMultiPoint
-      - MGLFeature
-  - name: Primitive Shapes
-    children:
       - MGLPointAnnotation
       - MGLPointCollection
       - MGLPolygon
@@ -52,8 +48,13 @@ custom_categories:
     children:
       - MGLCalloutView
       - MGLCalloutViewDelegate
+  - name: Styling the Map
+    children:
+      - MGLStyle
+      - MGLStyleValue
   - name: Style Primitives
     children:
+      - MGLFeature
       - MGLPointFeature
       - MGLPolygonFeature
       - MGLPolylineFeature
@@ -79,9 +80,6 @@ custom_categories:
       - MGLFillStyleLayer
       - MGLLineStyleLayer
       - MGLSymbolStyleLayer
-  - name: Style Values
-    children:
-      - MGLStyleValue
   - name: Offline Maps
     children:
       - MGLOfflineRegion

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -14,58 +14,62 @@ umbrella_header: src/Mapbox.h
 framework_root: ../darwin/src
 
 custom_categories:
+  - name: Guides
+    children:
+      - Info.plist Keys
   - name: Maps
     children:
       - MGLAccountManager
       - MGLMapCamera
       - MGLMapView
       - MGLMapViewDelegate
-      - MGLStyle
       - MGLUserTrackingMode
-  - name: Annotations
+  - name: Shapes and Annotations
     children:
       - MGLAnnotation
       - MGLAnnotationImage
+      - MGLOverlay
+      - MGLShape
       - MGLMultiPoint
-      - MGLMultiPolygon
-      - MGLMultiPolyline
       - MGLPointAnnotation
       - MGLPointCollection
       - MGLPolygon
       - MGLPolyline
-      - MGLOverlay
-      - MGLShape
+      - MGLMultiPolygon
+      - MGLMultiPolyline
       - MGLShapeCollection
-  - name: Map Data
+  - name: Styling the Map
+    children:
+      - MGLStyle
+      - MGLStyleValue
+  - name: Content Primitives
     children:
       - MGLFeature
-      - MGLMultiPolygonFeature
-      - MGLMultiPolylineFeature
-      - MGLPointCollectionFeature
       - MGLPointFeature
       - MGLPolygonFeature
       - MGLPolylineFeature
+      - MGLMultiPolygonFeature
+      - MGLMultiPolylineFeature
+      - MGLPointCollectionFeature
       - MGLShapeCollectionFeature
-  - name: Style Layers
-    children:
-      - MGLBackgroundStyleLayer
-      - MGLCircleStyleLayer
-      - MGLFillStyleLayer
-      - MGLForegroundStyleLayer
-      - MGLLineStyleLayer
-      - MGLRasterStyleLayer
-      - MGLStyleLayer
-      - MGLSymbolStyleLayer
-      - MGLVectorStyleLayer
   - name: Content Sources
     children:
-      - MGLAttributionInfo
-      - MGLRasterSource
-      - MGLShapeSource
       - MGLSource
-      - MGLTileCoordinateSystem
       - MGLTileSource
+      - MGLShapeSource
+      - MGLRasterSource
       - MGLVectorSource
+  - name: Style Layers
+    children:
+      - MGLStyleLayer
+      - MGLForegroundStyleLayer
+      - MGLBackgroundStyleLayer
+      - MGLRasterStyleLayer
+      - MGLVectorStyleLayer
+      - MGLCircleStyleLayer
+      - MGLFillStyleLayer
+      - MGLLineStyleLayer
+      - MGLSymbolStyleLayer
   - name: Offline Maps
     children:
       - MGLOfflineRegion
@@ -76,15 +80,13 @@ custom_categories:
       - MGLTilePyramidOfflineRegion
   - name: Geometry
     children:
-      - MGLClockDirectionFormatter
-      - MGLCompassDirectionFormatter
       - MGLCoordinateBounds
       - MGLCoordinateBoundsEqualToCoordinateBounds
       - MGLCoordinateBoundsGetCoordinateSpan
+      - MGLCoordinateBoundsIntersectsCoordinateBounds
       - MGLCoordinateBoundsIsEmpty
       - MGLCoordinateBoundsMake
       - MGLCoordinateBoundsOffset
-      - MGLCoordinateFormatter
       - MGLCoordinateInCoordinateBounds
       - MGLCoordinateSpan
       - MGLCoordinateSpanEqualToCoordinateSpan
@@ -93,3 +95,8 @@ custom_categories:
       - MGLDegreesFromRadians
       - MGLRadiansFromDegrees
       - MGLStringFromCoordinateBounds
+  - name: Formatters
+    children:
+      - MGLClockDirectionFormatter
+      - MGLCompassDirectionFormatter
+      - MGLCoordinateFormatter


### PR DESCRIPTION
* Move guides front-and-center (to be expanded out to include more guides)
* Organize shape classes heirarchically for clarity
* Clarify features, sources, and layers as related to map styling (as opposed to annotations)