### PR TITLE
Rename raster hue rotate

### DIFF
--- a/platform/darwin/scripts/style-spec-cocoa-conventions-v8.json
+++ b/platform/darwin/scripts/style-spec-cocoa-conventions-v8.json
@@ -5,7 +5,8 @@
   },
   "paint_raster": {
     "raster-brightness-min": "minimum-raster-brightness",
-    "raster-brightness-max": "maximum-raster-brightness"
+    "raster-brightness-max": "maximum-raster-brightness",
+    "raster-hue-rotate": "raster-hue-rotation"
   },
   "paint_line": {
     "line-dasharray": "line-dash-pattern"

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -56,8 +56,10 @@ NS_ASSUME_NONNULL_BEGIN
  This property is measured in degrees.
  
  The default value of this property is an `MGLStyleValue` object containing an `NSNumber` object containing the float `0`. Set this property to `nil` to reset it to the default value.
+ 
+ This attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-hue-rotate"><code>raster-hue-rotate</code></a> paint property in the Mapbox Style Specification.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterHueRotate;
+@property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterHueRotation;
 
 /**
  The opacity at which the image will be drawn.

--- a/platform/darwin/src/MGLRasterStyleLayer.mm
+++ b/platform/darwin/src/MGLRasterStyleLayer.mm
@@ -127,14 +127,14 @@
     return MGLStyleValueTransformer<float, NSNumber *>().toStyleValue(propertyValue);
 }
 
-- (void)setRasterHueRotate:(MGLStyleValue<NSNumber *> *)rasterHueRotate {
+- (void)setRasterHueRotation:(MGLStyleValue<NSNumber *> *)rasterHueRotation {
     MGLAssertStyleLayerIsValid();
 
-    auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(rasterHueRotate);
+    auto mbglValue = MGLStyleValueTransformer<float, NSNumber *>().toPropertyValue(rasterHueRotation);
     _rawLayer->setRasterHueRotate(mbglValue);
 }
 
-- (MGLStyleValue<NSNumber *> *)rasterHueRotate {
+- (MGLStyleValue<NSNumber *> *)rasterHueRotation {
     MGLAssertStyleLayerIsValid();
 
     auto propertyValue = _rawLayer->getRasterHueRotate() ?: _rawLayer->getDefaultRasterHueRotate();

--- a/platform/darwin/test/MGLRasterStyleLayerTests.m
+++ b/platform/darwin/test/MGLRasterStyleLayerTests.m
@@ -20,7 +20,7 @@
     layer.minimumRasterBrightness = [MGLRuntimeStylingHelper testNumber];
     layer.rasterContrast = [MGLRuntimeStylingHelper testNumber];
     layer.rasterFadeDuration = [MGLRuntimeStylingHelper testNumber];
-    layer.rasterHueRotate = [MGLRuntimeStylingHelper testNumber];
+    layer.rasterHueRotation = [MGLRuntimeStylingHelper testNumber];
     layer.rasterOpacity = [MGLRuntimeStylingHelper testNumber];
     layer.rasterSaturation = [MGLRuntimeStylingHelper testNumber];
 
@@ -30,7 +30,7 @@
     XCTAssertEqualObjects(gLayer.minimumRasterBrightness, [MGLRuntimeStylingHelper testNumber]);
     XCTAssertEqualObjects(gLayer.rasterContrast, [MGLRuntimeStylingHelper testNumber]);
     XCTAssertEqualObjects(gLayer.rasterFadeDuration, [MGLRuntimeStylingHelper testNumber]);
-    XCTAssertEqualObjects(gLayer.rasterHueRotate, [MGLRuntimeStylingHelper testNumber]);
+    XCTAssertEqualObjects(gLayer.rasterHueRotation, [MGLRuntimeStylingHelper testNumber]);
     XCTAssertEqualObjects(gLayer.rasterOpacity, [MGLRuntimeStylingHelper testNumber]);
     XCTAssertEqualObjects(gLayer.rasterSaturation, [MGLRuntimeStylingHelper testNumber]);
 
@@ -38,7 +38,7 @@
     layer.minimumRasterBrightness = [MGLRuntimeStylingHelper testNumberFunction];
     layer.rasterContrast = [MGLRuntimeStylingHelper testNumberFunction];
     layer.rasterFadeDuration = [MGLRuntimeStylingHelper testNumberFunction];
-    layer.rasterHueRotate = [MGLRuntimeStylingHelper testNumberFunction];
+    layer.rasterHueRotation = [MGLRuntimeStylingHelper testNumberFunction];
     layer.rasterOpacity = [MGLRuntimeStylingHelper testNumberFunction];
     layer.rasterSaturation = [MGLRuntimeStylingHelper testNumberFunction];
 
@@ -46,7 +46,7 @@
     XCTAssertEqualObjects(gLayer.minimumRasterBrightness, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.rasterContrast, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.rasterFadeDuration, [MGLRuntimeStylingHelper testNumberFunction]);
-    XCTAssertEqualObjects(gLayer.rasterHueRotate, [MGLRuntimeStylingHelper testNumberFunction]);
+    XCTAssertEqualObjects(gLayer.rasterHueRotation, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.rasterOpacity, [MGLRuntimeStylingHelper testNumberFunction]);
     XCTAssertEqualObjects(gLayer.rasterSaturation, [MGLRuntimeStylingHelper testNumberFunction]);
 }


### PR DESCRIPTION
Properties shouldn't be verbs.
This PR renames `raster-hue-rotate` to `raster-hue-rotation`