### PR TITLE
Fix Identical Code Folding on Android

### DIFF
--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -11,6 +11,13 @@ set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> cruT <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> ruT <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_C_ARCHIVE_APPEND "<CMAKE_AR> ruT <TARGET> <LINK_FLAGS> <OBJECTS>")
 
+if ((ANDROID_ABI STREQUAL "armeabi") OR (ANDROID_ABI STREQUAL "armeabi-v7a") OR (ANDROID_ABI STREQUAL "arm64-v8a") OR
+    (ANDROID_ABI STREQUAL "x86") OR (ANDROID_ABI STREQUAL "x86_64"))
+    # Use Identical Code Folding on platforms that support the gold linker.
+    set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=gold -Wl,--icf=safe ${CMAKE_EXE_LINKER_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=gold -Wl,--icf=safe ${CMAKE_SHARED_LINKER_FLAGS}")
+endif()
+
 mason_use(jni.hpp VERSION 2.0.0 HEADER_ONLY)
 mason_use(libjpeg-turbo VERSION 1.5.0)
 mason_use(libpng VERSION 1.6.25)
@@ -173,7 +180,6 @@ macro(mbgl_platform_core)
         PUBLIC -latomic
         PUBLIC -lz
         PUBLIC -Wl,--gc-sections
-        PUBLIC -Wl,--icf=safe
     )
 endmacro()
 
@@ -197,7 +203,6 @@ target_compile_options(mapbox-gl
 target_link_libraries(mapbox-gl
     PUBLIC mbgl-core
     PUBLIC -Wl,--gc-sections
-    PUBLIC -Wl,--icf=safe
 )
 
 # Create a stripped version of the library and copy it to the JNIDIR.
@@ -284,7 +289,6 @@ target_compile_options(example-custom-layer
 target_link_libraries(example-custom-layer
     PRIVATE mapbox-gl
     PUBLIC -Wl,--gc-sections
-    PUBLIC -Wl,--icf=safe
 )
 
 add_custom_command(TARGET example-custom-layer POST_BUILD


### PR DESCRIPTION
#7109 mistakenly added ICF to all architectures, but it is not supported on mips. Additionally, arm64 doesn't seem to use the gold linker by default.