### PR TITLE
[qt] Added copyrightsChanged() signal

### DIFF
--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -213,6 +213,7 @@ public slots:
 signals:
     void needsRendering();
     void mapChanged(QMapbox::MapChange);
+    void copyrightsChanged(const QString &copyrightsHtml);
 
 private:
     Q_DISABLE_COPY(QMapboxGL)

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -51,4 +51,5 @@ public slots:
 signals:
     void needsRendering();
     void mapChanged(QMapbox::MapChange);
+    void copyrightsChanged(const QString &copyrightsHtml);
 };


### PR DESCRIPTION
Used by `QGeoMap` to show copyrights (example below):
<img width="562" alt="screen shot 2016-12-08 at 12 31 50 pm" src="https://cloud.githubusercontent.com/assets/76133/21008882/fcb65b58-bd43-11e6-989e-9553eec4cf4c.png">
Part of #2723.
/cc @tmpsantos 