### PR TITLE
Fix tile debug rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "^4.16.4",
     "mapbox-gl-shaders": "mapbox/mapbox-gl-shaders#b51b85ffb8c512e228c36c5405293ce51d123519",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#49e8b407bdbbe6f7c92dbcb56d3d51f425fc2653",
-    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#9252ffc5108131704b5acf52d78258ac05687871",
+    "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#e13c4860ce5809b517ed0cdbdd46751c1130719e",
     "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "request": "^2.72.0",

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -32,6 +32,7 @@ module.exports = function (style, options, callback) {
 
     options.debug = {
         tileBorders: options.debug,
+        parseStatus: options.debug,
         collision: options.collisionDebug,
         overdraw: options.showOverdrawInspector,
     };

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -105,6 +105,7 @@ UniqueBuffer Context::createIndexBuffer(const void* data, std::size_t size) {
     BufferID id = 0;
     MBGL_CHECK_ERROR(glGenBuffers(1, &id));
     UniqueBuffer result { std::move(id), { this } };
+    vertexArrayObject = 0;
     elementBuffer = result;
     MBGL_CHECK_ERROR(glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, data, GL_STATIC_DRAW));
     return result;

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -46,8 +46,8 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
                     vertices.emplace_back(FillAttributes::vertex(p));
 
                     if (prev) {
-                        indices.emplace_back(vertices.vertexSize() - 1,
-                                             vertices.vertexSize());
+                        indices.emplace_back(vertices.vertexSize() - 2,
+                                             vertices.vertexSize() - 1);
                     }
 
                     prev = p;

--- a/src/mbgl/renderer/debug_bucket.cpp
+++ b/src/mbgl/renderer/debug_bucket.cpp
@@ -60,8 +60,8 @@ DebugBucket::DebugBucket(const OverscaledTileID& id,
 
     double baseline = 200;
     if (debugMode & MapDebugOptions::ParseStatus) {
-        const std::string text = util::toString(id) + " - " +
-                                 (complete ? "complete" : renderable ? "renderable" : "pending");
+        const std::string text = util::toString(id.canonical) + " - " +
+                                 (complete ? "loaded" : renderable ? "renderable" : "pending");
         addText(text, 50, baseline, 5);
         baseline += 200;
     }

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -51,13 +51,13 @@ void Painter::renderTileDebug(const RenderTile& renderTile) {
              *tile.debugBucket->vertexBuffer,
              *tile.debugBucket->indexBuffer,
              tile.debugBucket->segments,
-             gl::Lines { 4.0f * frame.pixelRatio });
+             gl::Lines { 1.0f * frame.pixelRatio });
 
         draw(Color::black(),
              *tile.debugBucket->vertexBuffer,
              *tile.debugBucket->indexBuffer,
              tile.debugBucket->segments,
-             gl::Lines { 2.0f * frame.pixelRatio });
+             gl::Lines { 1.0f * frame.pixelRatio });
     }
 
     if (frame.debugOptions & MapDebugOptions::TileBorders) {
@@ -65,7 +65,7 @@ void Painter::renderTileDebug(const RenderTile& renderTile) {
              tileVertexBuffer,
              tileBorderIndexBuffer,
              tileBorderSegments,
-             gl::LineStrip { 4.0f * frame.pixelRatio });
+             gl::LineStrip { 1.0f * frame.pixelRatio });
     }
 }
 


### PR DESCRIPTION
* Off-by-one in DebugBucket indexing
* Must unbind VAO before binding index buffer in Context::createIndexBuffer
* Get test-suite test passing so we catch this sort of regression