### PR TITLE
Tilt results in fling moving in a reverse direction

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -56,6 +56,11 @@ public class MapboxConstants {
     public static final int ANIMATION_DURATION_SHORT = 150;
 
     /**
+     * Animation time of a fling gesture
+     */
+    public static final long ANIMATION_DURATION_FLING = 350;
+
+    /**
      * The currently supported minimum zoom level.
      */
     public static final float MINIMUM_ZOOM = 0.0f;


### PR DESCRIPTION
mitigates #5281, this PR impacts the fling gesture by
 - limiting the input for moveBy based on tilt current value (ranges from 1/2 -> 1/8)
 - lower limiting with no tilt, fling gesture shifts more
 - lower animation time, makes animation feel more natural and snappy (removes laggy ending)

@cammace can you test this out? feel free to play with the variables to get the best possible UX. 
