### PR TITLE
Only build active architecture in Xcode

### DIFF
--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -4,6 +4,7 @@ macro(mbgl_platform_core)
     set_xcode_property(mbgl-core IPHONEOS_DEPLOYMENT_TARGET "8.0")
     set_xcode_property(mbgl-core ENABLE_BITCODE "YES")
     set_xcode_property(mbgl-core BITCODE_GENERATION_MODE bitcode)
+    set_xcode_property(mbgl-core ONLY_ACTIVE_ARCH $<$<CONFIG:Debug>:YES>)
 
     target_sources(mbgl-core
         # Loop


### PR DESCRIPTION
Trying to land #7131 as separate PRs to make the changes easier to reason about.

This changes the *default* setting to only build the active architecture (i.e. they for the device you connected to your Mac). This cuts build time in half since we don't need to build the other architecture when iterating.

On CI, and for `make ipackage/iframework`, we are using the `package.sh` script which already forces `ONLY_ACTIVE_ARCH=NO` and ensures that both architectures get built, so we can discover build-time issues for different architectures. Similarly, running other iOS-related make targets that build for Simluator already force `ONLY_ACTIVE_ARCH=YES`. This means that this change *only* affects what is being built when you use Xcode to manually compile apps; automated builds are unaffected by this change.