### PR TITLE
Android: Replace libpng/libjpeg-turbo/libwebp with BitmapFactory

### DIFF
--- a/include/mbgl/util/image.hpp
+++ b/include/mbgl/util/image.hpp
@@ -10,8 +10,7 @@
 namespace mbgl {
 
 enum class ImageAlphaMode {
-    Unassociated,
-    Premultiplied,
+    Premultiplied, // Premultiplied RGBA
     Exclusive, // Alpha-channel only
 };
 
@@ -20,43 +19,44 @@ class Image : private util::noncopyable {
 public:
     Image() = default;
 
-    Image(Size size_)
-        : size(std::move(size_)),
-          data(std::make_unique<uint8_t[]>(bytes())) {}
-
-    Image(Size size_, std::unique_ptr<uint8_t[]> data_)
-        : size(std::move(size_)),
-          data(std::move(data_)) {}
-
-    Image(Image&& o)
-        : size(o.size),
-          data(std::move(o.data)) {}
-
-    Image& operator=(Image&& o) {
-        size = o.size;
-        data = std::move(o.data);
-        return *this;
-    }
-
     bool operator==(const Image& rhs) const {
         return size == rhs.size &&
-               std::equal(data.get(), data.get() + bytes(), rhs.data.get(),
-                          rhs.data.get() + rhs.bytes());
+               std::equal(data(), data() + bytes(), rhs.data(), rhs.data() + rhs.bytes());
     }
 
     bool valid() const {
-        return size && data.get() != nullptr;
+        return size && data();
     }
 
-    size_t stride() const { return channels * size.width; }
+    static constexpr size_t channels() { return Mode == ImageAlphaMode::Exclusive ? 1 : 4; }
+    size_t stride() const { return channels() * size.width; }
     size_t bytes() const { return stride() * size.height; }
 
+public:
     Size size;
-    static constexpr size_t channels = Mode == ImageAlphaMode::Exclusive ? 1 : 4;
-    std::unique_ptr<uint8_t[]> data;
+
+// Implementation-specific code.
+public:
+    Image(Size size_)
+        : size(size_),
+          blob_(std::make_unique<uint8_t[]>(bytes())) {}
+
+    Image(Image&& o)
+        : size(o.size),
+          blob_(std::move(o.blob_)) {}
+
+    Image& operator=(Image&& o) {
+        size = o.size;
+        blob_ = std::move(o.blob_);
+        return *this;
+    }
+
+    uint8_t* data() const { return blob_.get(); }
+
+private:
+    std::unique_ptr<uint8_t[]> blob_;
 };
 
-using UnassociatedImage = Image<ImageAlphaMode::Unassociated>;
 using PremultipliedImage = Image<ImageAlphaMode::Premultiplied>;
 using AlphaImage = Image<ImageAlphaMode::Exclusive>;
 

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -845,7 +845,7 @@ void nativeAddAnnotationIcon(JNIEnv *env, jni::jobject* obj, jlong nativeMapView
         throw mbgl::util::SpriteImageException("Sprite image pixel count mismatch");
     }
 
-    jni::GetArrayRegion(*env, *jpixels, 0, size, reinterpret_cast<jbyte*>(premultipliedImage.data.get()));
+    jni::GetArrayRegion(*env, *jpixels, 0, size, reinterpret_cast<jbyte*>(premultipliedImage.data()));
 
     auto iconImage = std::make_shared<mbgl::SpriteImage>(
         std::move(premultipliedImage),
@@ -1211,7 +1211,7 @@ void nativeAddImage(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jni:
         throw mbgl::util::SpriteImageException("Sprite image pixel count mismatch");
     }
 
-    jni::GetArrayRegion(*env, *data, 0, size, reinterpret_cast<jbyte*>(premultipliedImage.data.get()));
+    jni::GetArrayRegion(*env, *data, 0, size, reinterpret_cast<jbyte*>(premultipliedImage.data()));
 
     //Wrap in a SpriteImage with the correct pixel ratio
     auto spriteImage = std::make_unique<mbgl::SpriteImage>(std::move(premultipliedImage), float(pixelRatio));

--- a/platform/darwin/src/image.mm
+++ b/platform/darwin/src/image.mm
@@ -11,7 +11,7 @@
 namespace mbgl {
 
 std::string encodePNG(const PremultipliedImage& src) {
-    CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, src.data.get(), src.bytes(), NULL);
+    CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, src.data(), src.bytes(), NULL);
     if (!provider) {
         return "";
     }
@@ -93,11 +93,12 @@ PremultipliedImage decodeImage(const std::string &source_data) {
         throw std::runtime_error("CGColorSpaceCreateDeviceRGB failed");
     }
 
+    // CoreGraphics produces premultiplied images by default.
     PremultipliedImage result({ static_cast<uint32_t>(CGImageGetWidth(image)),
                                 static_cast<uint32_t>(CGImageGetHeight(image)) });
 
     CGContextRef context =
-        CGBitmapContextCreate(result.data.get(), result.size.width, result.size.height, 8,
+        CGBitmapContextCreate(result.data(), result.size.width, result.size.height, 8,
                               result.stride(), color_space, kCGImageAlphaPremultipliedLast);
     if (!context) {
         CGColorSpaceRelease(color_space);

--- a/platform/default/image.cpp
+++ b/platform/default/image.cpp
@@ -24,11 +24,11 @@ const static bool png_version_check __attribute__((unused)) = []() {
 
 namespace mbgl {
 
-std::string encodePNG(const PremultipliedImage& pre) {
-    PremultipliedImage copy(pre.size);
-    std::copy(pre.data.get(), pre.data.get() + pre.bytes(), copy.data.get());
-
-    UnassociatedImage src = util::unpremultiply(std::move(copy));
+std::string encodePNG(const PremultipliedImage& image) {
+    // Make a copy of the image data that we can premultiply.
+    auto data = std::make_unique<uint8_t[]>(image.bytes());
+    std::copy(image.data(), image.data() + image.bytes(), data.get());
+    util::unpremultiply(data.get(), image.bytes());
 
     png_voidp error_ptr = nullptr;
     png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, error_ptr, nullptr, nullptr);
@@ -42,7 +42,7 @@ std::string encodePNG(const PremultipliedImage& pre) {
         throw std::runtime_error("couldn't create info_ptr");
     }
 
-    png_set_IHDR(png_ptr, info_ptr, src.size.width, src.size.height, 8, PNG_COLOR_TYPE_RGB_ALPHA,
+    png_set_IHDR(png_ptr, info_ptr, image.size.width, image.size.height, 8, PNG_COLOR_TYPE_RGB_ALPHA,
                  PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
 
     jmp_buf *jmp_context = (jmp_buf *)png_get_error_ptr(png_ptr);
@@ -52,19 +52,19 @@ std::string encodePNG(const PremultipliedImage& pre) {
     }
 
     std::string result;
-    png_set_write_fn(png_ptr, &result, [](png_structp png_ptr_, png_bytep data, png_size_t length) {
+    png_set_write_fn(png_ptr, &result, [](png_structp png_ptr_, png_bytep data_, png_size_t length_) {
         std::string *out = static_cast<std::string *>(png_get_io_ptr(png_ptr_));
-        out->append(reinterpret_cast<char *>(data), length);
+        out->append(reinterpret_cast<char *>(data_), length_);
     }, nullptr);
 
     struct ptrs {
         ptrs(size_t count) : rows(new png_bytep[count]) {}
         ~ptrs() { delete[] rows; }
         png_bytep *rows = nullptr;
-    } pointers(src.size.height);
+    } pointers(image.size.height);
 
-    for (size_t i = 0; i < src.size.height; i++) {
-        pointers.rows[i] = src.data.get() + src.stride() * i;
+    for (size_t i = 0; i < image.size.height; i++) {
+        pointers.rows[i] = data.get() + image.stride() * i;
     }
 
     png_set_rows(png_ptr, info_ptr, pointers.rows);

--- a/platform/default/jpeg_reader.cpp
+++ b/platform/default/jpeg_reader.cpp
@@ -120,7 +120,7 @@ PremultipliedImage decodeJPEG(const uint8_t* data, size_t size) {
     size_t rowStride = components * width;
 
     PremultipliedImage image({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
-    uint8_t* dst = image.data.get();
+    uint8_t* dst = image.data();
 
     JSAMPARRAY buffer = (*cinfo.mem->alloc_sarray)((j_common_ptr) &cinfo, JPOOL_IMAGE, rowStride, 1);
 

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -271,7 +271,7 @@ GLFWView::makeSpriteImage(int width, int height, float pixelRatio) {
     const int h = std::ceil(pixelRatio * height);
 
     mbgl::PremultipliedImage image({ static_cast<uint32_t>(w), static_cast<uint32_t>(h) });
-    auto data = reinterpret_cast<uint32_t*>(image.data.get());
+    auto data = reinterpret_cast<uint32_t*>(image.data());
     const int dist = (w / 2) * (w / 2);
     for (int y = 0; y < h; y++) {
         for (int x = 0; x < w; x++) {

--- a/platform/ios/src/UIImage+MGLAdditions.mm
+++ b/platform/ios/src/UIImage+MGLAdditions.mm
@@ -13,7 +13,7 @@
     size_t bytesPerRow = bytesPerPixel * width;
     size_t bitsPerComponent = 8;
 
-    CGContextRef context = CGBitmapContextCreate(cPremultipliedImage.data.get(),
+    CGContextRef context = CGBitmapContextCreate(cPremultipliedImage.data(),
       width, height, bitsPerComponent, bytesPerRow,
       colorSpace, kCGImageAlphaPremultipliedLast);
 

--- a/platform/qt/src/image.cpp
+++ b/platform/qt/src/image.cpp
@@ -7,7 +7,7 @@
 namespace mbgl {
 
 std::string encodePNG(const PremultipliedImage& pre) {
-    QImage image(pre.data.get(), pre.size.width, pre.size.height,
+    QImage image(pre.data(), pre.size.width, pre.size.height,
         QImage::Format_ARGB32_Premultiplied);
 
     QByteArray array;
@@ -54,10 +54,9 @@ PremultipliedImage decodeImage(const std::string& string) {
         throw std::runtime_error("Unsupported image type");
     }
 
-    auto img = std::make_unique<uint8_t[]>(image.byteCount());
-    memcpy(img.get(), image.constBits(), image.byteCount());
-
-    return { { static_cast<uint32_t>(image.width()), static_cast<uint32_t>(image.height()) },
-             std::move(img) };
+    PremultipliedImage img(
+        { static_cast<uint32_t>(image.width()), static_cast<uint32_t>(image.height()) });
+    memcpy(img.data(), image.constBits(), image.byteCount());
+    return img;
 }
 }

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -119,14 +119,10 @@ std::unique_ptr<const mbgl::SpriteImage> toSpriteImage(const QImage &sprite) {
         .rgbSwapped()
         .convertToFormat(QImage::Format_ARGB32_Premultiplied);
 
-    auto img = std::make_unique<uint8_t[]>(swapped.byteCount());
-    memcpy(img.get(), swapped.constBits(), swapped.byteCount());
+    mbgl::PremultipliedImage img({ static_cast<uint32_t>(swapped.width()), static_cast<uint32_t>(swapped.height()) });
+    memcpy(img.data(), swapped.constBits(), swapped.byteCount());
 
-    return std::make_unique<mbgl::SpriteImage>(
-        mbgl::PremultipliedImage(
-            { static_cast<uint32_t>(swapped.width()), static_cast<uint32_t>(swapped.height()) },
-            std::move(img)),
-        1.0);
+    return std::make_unique<mbgl::SpriteImage>(std::move(img), 1.0);
 }
 
 } // namespace

--- a/src/mbgl/geometry/line_atlas.cpp
+++ b/src/mbgl/geometry/line_atlas.cpp
@@ -101,7 +101,7 @@ LinePatternPos LineAtlas::addDash(const std::vector<float>& dasharray, LinePatte
                 signedDistance = int((inside ? 1 : -1) * dist);
             }
 
-            image.data[index + x] = fmax(0, fmin(255, signedDistance + offset));
+            image.data()[index + x] = fmax(0, fmin(255, signedDistance + offset));
         }
     }
 

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -138,9 +138,8 @@ UniqueRenderbuffer Context::createRenderbuffer(const RenderbufferType type, cons
     return renderbuffer;
 }
 
-std::unique_ptr<uint8_t[]> Context::readFramebuffer(const Size size, const TextureFormat format, const bool flip) {
+void Context::readFramebuffer(const Size size, const TextureFormat format, const bool flip, uint8_t* data) {
     const size_t stride = size.width * (format == TextureFormat::RGBA ? 4 : 1);
-    auto data = std::make_unique<uint8_t[]>(stride * size.height);
 
 #if not MBGL_USE_GLES2
     // When reading data from the framebuffer, make sure that we are storing the values
@@ -149,19 +148,17 @@ std::unique_ptr<uint8_t[]> Context::readFramebuffer(const Size size, const Textu
 #endif // MBGL_USE_GLES2
 
     MBGL_CHECK_ERROR(glReadPixels(0, 0, size.width, size.height, static_cast<GLenum>(format),
-                                  GL_UNSIGNED_BYTE, data.get()));
+                                  GL_UNSIGNED_BYTE, data));
 
     if (flip) {
         auto tmp = std::make_unique<uint8_t[]>(stride);
-        uint8_t* rgba = data.get();
+        uint8_t* rgba = data;
         for (int i = 0, j = size.height - 1; i < j; i++, j--) {
             std::memcpy(tmp.get(), rgba + i * stride, stride);
             std::memcpy(rgba + i * stride, rgba + j * stride, stride);
             std::memcpy(rgba + j * stride, tmp.get(), stride);
         }
     }
-
-    return data;
 }
 
 #if not MBGL_USE_GLES2

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -71,33 +71,35 @@ public:
     Framebuffer createFramebuffer(const Texture&);
 
     template <typename Image,
-              TextureFormat format = Image::channels == 4 ? TextureFormat::RGBA
-                                                          : TextureFormat::Alpha>
+              TextureFormat format = Image::channels() == 4 ? TextureFormat::RGBA
+                                                            : TextureFormat::Alpha>
     Image readFramebuffer(const Size size, bool flip = true) {
-        static_assert(Image::channels == (format == TextureFormat::RGBA ? 4 : 1),
+        static_assert(Image::channels() == (format == TextureFormat::RGBA ? 4 : 1),
                       "image format mismatch");
-        return { size, readFramebuffer(size, format, flip) };
+        Image image{ size };
+        readFramebuffer(size, format, flip, image.data());
+        return image;
     }
 
 #if not MBGL_USE_GLES2
     template <typename Image>
     void drawPixels(const Image& image) {
-        auto format = image.channels == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
-        drawPixels(image.size, image.data.get(), format);
+        auto format = image.channels() == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
+        drawPixels(image.size, image.data(), format);
     }
 #endif // MBGL_USE_GLES2
 
     // Create a texture from an image with data.
     template <typename Image>
     Texture createTexture(const Image& image, TextureUnit unit = 0) {
-        auto format = image.channels == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
-        return { image.size, createTexture(image.size, image.data.get(), format, unit) };
+        auto format = image.channels() == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
+        return { image.size, createTexture(image.size, image.data(), format, unit) };
     }
 
     template <typename Image>
     void updateTexture(Texture& obj, const Image& image, TextureUnit unit = 0) {
-        auto format = image.channels == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
-        updateTexture(obj.texture.get(), image.size, image.data.get(), format, unit);
+        auto format = image.channels() == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
+        updateTexture(obj.texture.get(), image.size, image.data(), format, unit);
         obj.size = image.size;
     }
 
@@ -205,7 +207,7 @@ private:
     void updateTexture(TextureID, Size size, const void* data, TextureFormat, TextureUnit);
     UniqueFramebuffer createFramebuffer();
     UniqueRenderbuffer createRenderbuffer(RenderbufferType, Size size);
-    std::unique_ptr<uint8_t[]> readFramebuffer(Size, TextureFormat, bool flip);
+    void readFramebuffer(Size, TextureFormat, bool flip, uint8_t* data);
 #if not MBGL_USE_GLES2
     void drawPixels(Size size, const void* data, TextureFormat);
 #endif // MBGL_USE_GLES2

--- a/src/mbgl/renderer/frame_history.cpp
+++ b/src/mbgl/renderer/frame_history.cpp
@@ -8,7 +8,7 @@ namespace mbgl {
 
 FrameHistory::FrameHistory() {
     changeOpacities.fill(0);
-    std::fill(opacities.data.get(), opacities.data.get() + opacities.bytes(), 0);
+    std::fill(opacities.data(), opacities.data() + opacities.bytes(), 0);
 }
 
 void FrameHistory::record(const TimePoint& now, float zoom, const Duration& duration) {
@@ -19,7 +19,7 @@ void FrameHistory::record(const TimePoint& now, float zoom, const Duration& dura
         changeTimes.fill(now);
 
         for (int16_t z = 0; z <= zoomIndex; z++) {
-            opacities.data[z] = 255u;
+            opacities.data()[z] = 255u;
         }
         firstFrame = false;
     }
@@ -27,12 +27,12 @@ void FrameHistory::record(const TimePoint& now, float zoom, const Duration& dura
     if (zoomIndex < previousZoomIndex) {
         for (int16_t z = zoomIndex + 1; z <= previousZoomIndex; z++) {
             changeTimes[z] = now;
-            changeOpacities[z] = opacities.data[z];
+            changeOpacities[z] = opacities.data()[z];
         }
     } else {
         for (int16_t z = zoomIndex; z > previousZoomIndex; z--) {
             changeTimes[z] = now;
-            changeOpacities[z] = opacities.data[z];
+            changeOpacities[z] = opacities.data()[z];
         }
     }
 
@@ -40,9 +40,9 @@ void FrameHistory::record(const TimePoint& now, float zoom, const Duration& dura
         std::chrono::duration<float> timeDiff = now - changeTimes[z];
         int32_t opacityChange = (duration == Milliseconds(0) ? 1 : (timeDiff / duration)) * 255;
         if (z <= zoomIndex) {
-            opacities.data[z] = util::min(255, changeOpacities[z] + opacityChange);
+            opacities.data()[z] = util::min(255, changeOpacities[z] + opacityChange);
         } else {
-            opacities.data[z] = util::max(0, changeOpacities[z] - opacityChange);
+            opacities.data()[z] = util::max(0, changeOpacities[z] - opacityChange);
         }
     }
 

--- a/src/mbgl/renderer/painter_debug.cpp
+++ b/src/mbgl/renderer/painter_debug.cpp
@@ -86,7 +86,7 @@ void Painter::renderClipMasks(PaintParameters&) {
         context.readFramebuffer<AlphaImage, gl::TextureFormat::Stencil>(viewport.size, false);
 
     // Scale the Stencil buffer to cover the entire color space.
-    auto it = image.data.get();
+    auto it = image.data();
     auto end = it + viewport.size.width * viewport.size.height;
     const auto factor = 255.0f / *std::max_element(it, end);
     for (; it != end; ++it) {

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -263,13 +263,13 @@ void SpriteAtlas::copy(const Holder& holder, const SpritePatternMode mode) {
     if (!image.valid()) {
         image = PremultipliedImage({ static_cast<uint32_t>(std::ceil(size.width * pixelRatio)),
                                      static_cast<uint32_t>(std::ceil(size.height * pixelRatio)) });
-        std::fill(image.data.get(), image.data.get() + image.bytes(), 0);
+        std::fill(image.data(), image.data() + image.bytes(), 0);
     }
 
     const uint32_t* srcData =
-        reinterpret_cast<const uint32_t*>(holder.spriteImage->image.data.get());
+        reinterpret_cast<const uint32_t*>(holder.spriteImage->image.data());
     if (!srcData) return;
-    uint32_t* const dstData = reinterpret_cast<uint32_t*>(image.data.get());
+    uint32_t* const dstData = reinterpret_cast<uint32_t*>(image.data());
 
     const int padding = 1;
 

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -34,8 +34,8 @@ SpriteImagePtr createSpriteImage(const PremultipliedImage& image,
 
     PremultipliedImage dstImage({ width, height });
 
-    auto srcData = reinterpret_cast<const uint32_t*>(image.data.get());
-    auto dstData = reinterpret_cast<uint32_t*>(dstImage.data.get());
+    auto srcData = reinterpret_cast<const uint32_t*>(image.data());
+    auto dstData = reinterpret_cast<uint32_t*>(dstImage.data());
 
     // Copy from the source image into our individual sprite image
     for (uint32_t y = 0; y < height; ++y) {

--- a/src/mbgl/text/glyph_atlas.cpp
+++ b/src/mbgl/text/glyph_atlas.cpp
@@ -156,7 +156,7 @@ Rect<uint16_t> GlyphAtlas::addGlyph(uintptr_t tileUID,
         uint32_t y1 = image.size.width * (rect.y + y + padding) + rect.x + padding;
         uint32_t y2 = buffered_width * y;
         for (uint32_t x = 0; x < buffered_width; x++) {
-            image.data[y1 + x] = source[y2 + x];
+            image.data()[y1 + x] = source[y2 + x];
         }
     }
 
@@ -178,7 +178,7 @@ void GlyphAtlas::removeGlyphs(uintptr_t tileUID) {
                 const Rect<uint16_t>& rect = value.rect;
 
                 // Clear out the bitmap.
-                uint8_t *target = image.data.get();
+                uint8_t *target = image.data();
                 for (uint32_t y = 0; y < rect.h; y++) {
                     uint32_t y1 = image.size.width * (rect.y + y) + rect.x;
                     for (uint32_t x = 0; x < rect.w; x++) {

--- a/src/mbgl/util/premultiply.cpp
+++ b/src/mbgl/util/premultiply.cpp
@@ -1,18 +1,10 @@
 #include <mbgl/util/premultiply.hpp>
 
-#include <cmath>
-
 namespace mbgl {
 namespace util {
 
-PremultipliedImage premultiply(UnassociatedImage&& src) {
-    PremultipliedImage dst;
-
-    dst.size = src.size;
-    dst.data = std::move(src.data);
-
-    uint8_t* data = dst.data.get();
-    for (size_t i = 0; i < dst.bytes(); i += 4) {
+void premultiply(uint8_t* data, size_t size) {
+    for (size_t i = 0; i < size; i += 4) {
         uint8_t& r = data[i + 0];
         uint8_t& g = data[i + 1];
         uint8_t& b = data[i + 2];
@@ -21,18 +13,10 @@ PremultipliedImage premultiply(UnassociatedImage&& src) {
         g = (g * a + 127) / 255;
         b = (b * a + 127) / 255;
     }
-
-    return dst;
 }
 
-UnassociatedImage unpremultiply(PremultipliedImage&& src) {
-    UnassociatedImage dst;
-
-    dst.size = src.size;
-    dst.data = std::move(src.data);
-
-    uint8_t* data = dst.data.get();
-    for (size_t i = 0; i < dst.bytes(); i += 4) {
+void unpremultiply(uint8_t* data, size_t size) {
+    for (size_t i = 0; i < size; i += 4) {
         uint8_t& r = data[i + 0];
         uint8_t& g = data[i + 1];
         uint8_t& b = data[i + 2];
@@ -43,8 +27,6 @@ UnassociatedImage unpremultiply(PremultipliedImage&& src) {
             b = (255 * b + (a / 2)) / a;
         }
     }
-
-    return dst;
 }
 
 } // namespace util

--- a/src/mbgl/util/premultiply.hpp
+++ b/src/mbgl/util/premultiply.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <mbgl/util/image.hpp>
+#include <cstdint>
+#include <cstddef>
 
 namespace mbgl {
 namespace util {
 
-PremultipliedImage premultiply(UnassociatedImage&&);
-UnassociatedImage unpremultiply(PremultipliedImage&&);
+// (Un-)Premultiples a blob of RGBA image data with the given length.
+void premultiply(uint8_t* data, size_t size);
+void unpremultiply(uint8_t* data, size_t size);
 
 } // namespace util
 } // namespace mbgl

--- a/test/sprite/sprite_atlas.test.cpp
+++ b/test/sprite/sprite_atlas.test.cpp
@@ -137,7 +137,7 @@ TEST(SpriteAtlas, Updates) {
     // Update sprite
     PremultipliedImage image2({ 16, 12 });
     for (size_t i = 0; i < image2.bytes(); i++) {
-        image2.data.get()[i] = 255;
+        image2.data()[i] = 255;
     }
     auto newSprite = std::make_shared<SpriteImage>(std::move(image2), 1);
     atlas.setSprite("one", newSprite);

--- a/test/src/mbgl/test/util.cpp
+++ b/test/src/mbgl/test/util.cpp
@@ -147,11 +147,11 @@ void checkImage(const std::string& base,
 
     ASSERT_EQ(expected.size, actual.size);
 
-    double pixels = mapbox::pixelmatch(actual.data.get(),
-                                       expected.data.get(),
+    double pixels = mapbox::pixelmatch(actual.data(),
+                                       expected.data(),
                                        expected.size.width,
                                        expected.size.height,
-                                       diff.data.get(),
+                                       diff.data(),
                                        pixelThreshold);
 
     EXPECT_LE(pixels / (expected.size.width * expected.size.height), imageThreshold);

--- a/test/util/image.test.cpp
+++ b/test/util/image.test.cpp
@@ -8,62 +8,62 @@ using namespace mbgl;
 
 TEST(Image, PNGRoundTrip) {
     PremultipliedImage rgba({ 1, 1 });
-    rgba.data[0] = 128;
-    rgba.data[1] = 0;
-    rgba.data[2] = 0;
-    rgba.data[3] = 255;
+    rgba.data()[0] = 128;
+    rgba.data()[1] = 0;
+    rgba.data()[2] = 0;
+    rgba.data()[3] = 255;
 
     PremultipliedImage image = decodeImage(encodePNG(rgba));
-    EXPECT_EQ(128, image.data[0]);
-    EXPECT_EQ(0, image.data[1]);
-    EXPECT_EQ(0, image.data[2]);
-    EXPECT_EQ(255, image.data[3]);
+    EXPECT_EQ(128, image.data()[0]);
+    EXPECT_EQ(0, image.data()[1]);
+    EXPECT_EQ(0, image.data()[2]);
+    EXPECT_EQ(255, image.data()[3]);
 }
 
 TEST(Image, PNGRoundTripAlpha) {
     PremultipliedImage rgba({ 1, 1 });
-    rgba.data[0] = 128;
-    rgba.data[1] = 0;
-    rgba.data[2] = 0;
-    rgba.data[3] = 128;
+    rgba.data()[0] = 128;
+    rgba.data()[1] = 0;
+    rgba.data()[2] = 0;
+    rgba.data()[3] = 128;
 
     PremultipliedImage image = decodeImage(encodePNG(rgba));
-    EXPECT_EQ(128, image.data[0]);
-    EXPECT_EQ(0, image.data[1]);
-    EXPECT_EQ(0, image.data[2]);
-    EXPECT_EQ(128, image.data[3]);
+    EXPECT_EQ(128, image.data()[0]);
+    EXPECT_EQ(0, image.data()[1]);
+    EXPECT_EQ(0, image.data()[2]);
+    EXPECT_EQ(128, image.data()[3]);
 }
 
 TEST(Image, PNGReadNoProfile) {
     PremultipliedImage image = decodeImage(util::read_file("test/fixtures/image/no_profile.png"));
-    EXPECT_EQ(128, image.data[0]);
-    EXPECT_EQ(0, image.data[1]);
-    EXPECT_EQ(0, image.data[2]);
-    EXPECT_EQ(255, image.data[3]);
+    EXPECT_EQ(128, image.data()[0]);
+    EXPECT_EQ(0, image.data()[1]);
+    EXPECT_EQ(0, image.data()[2]);
+    EXPECT_EQ(255, image.data()[3]);
 }
 
 TEST(Image, PNGReadNoProfileAlpha) {
     PremultipliedImage image = decodeImage(util::read_file("test/fixtures/image/no_profile_alpha.png"));
-    EXPECT_EQ(64, image.data[0]);
-    EXPECT_EQ(0, image.data[1]);
-    EXPECT_EQ(0, image.data[2]);
-    EXPECT_EQ(128, image.data[3]);
+    EXPECT_EQ(64, image.data()[0]);
+    EXPECT_EQ(0, image.data()[1]);
+    EXPECT_EQ(0, image.data()[2]);
+    EXPECT_EQ(128, image.data()[3]);
 }
 
 TEST(Image, PNGReadProfile) {
     PremultipliedImage image = decodeImage(util::read_file("test/fixtures/image/profile.png"));
-    EXPECT_EQ(128, image.data[0]);
-    EXPECT_EQ(0, image.data[1]);
-    EXPECT_EQ(0, image.data[2]);
-    EXPECT_EQ(255, image.data[3]);
+    EXPECT_EQ(128, image.data()[0]);
+    EXPECT_EQ(0, image.data()[1]);
+    EXPECT_EQ(0, image.data()[2]);
+    EXPECT_EQ(255, image.data()[3]);
 }
 
 TEST(Image, PNGReadProfileAlpha) {
     PremultipliedImage image = decodeImage(util::read_file("test/fixtures/image/profile_alpha.png"));
-    EXPECT_EQ(64, image.data[0]);
-    EXPECT_EQ(0, image.data[1]);
-    EXPECT_EQ(0, image.data[2]);
-    EXPECT_EQ(128, image.data[3]);
+    EXPECT_EQ(64, image.data()[0]);
+    EXPECT_EQ(0, image.data()[1]);
+    EXPECT_EQ(0, image.data()[2]);
+    EXPECT_EQ(128, image.data()[3]);
 }
 
 TEST(Image, PNGTile) {
@@ -87,15 +87,12 @@ TEST(Image, WebPTile) {
 #endif // !defined(__ANDROID__) && !defined(__APPLE__) && !defined(QT_IMAGE_DECODERS)
 
 TEST(Image, Premultiply) {
-    UnassociatedImage rgba({ 1, 1 });
-    rgba.data[0] = 255;
-    rgba.data[1] = 254;
-    rgba.data[2] = 253;
-    rgba.data[3] = 128;
+    uint8_t data[4] = { 255, 254, 253, 128 };
 
-    PremultipliedImage image = util::premultiply(std::move(rgba));
-    EXPECT_EQ(128, image.data[0]);
-    EXPECT_EQ(127, image.data[1]);
-    EXPECT_EQ(127, image.data[2]);
-    EXPECT_EQ(128, image.data[3]);
+    util::premultiply(data, 4);
+
+    EXPECT_EQ(128, data[0]);
+    EXPECT_EQ(127, data[1]);
+    EXPECT_EQ(127, data[2]);
+    EXPECT_EQ(128, data[3]);
 }


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-gl-native/issues/2354, we captured that we want to replace these libs with a Java-based version. Here's how this will work:

* [x] Refactor `util::Image` to hide its implementation, in particular the `data` member
* [ ] When compiling for Android, add an additional constructor that takes `JNIEnv *env, jobject jbitmap`, and then uses [`libjnigraphics`](https://developer.android.com/ndk/reference/group___bitmap.html) to expose the bitmap information, and handle JNI object lifetime
* [ ] Create an Android-specific implementation of `util::decodeImage()` that uses the JNI to call [BitmapFactory::decodeByteArray](https://developer.android.com/reference/android/graphics/BitmapFactory.html#decodeByteArray(byte[],%20int,%20int,%20android.graphics.BitmapFactory.Options)) for decompressing + premultiplying the image
* [ ] Create an Android-specific version of `util::encodePNG()` that uses the JNI/Bitmap/BitmapFactory to create a Java Bitmap + compress it to PNG

/cc @mapbox/android