### PR TITLE
Fixed proguard rules

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -2,9 +2,11 @@
 # in ../sdk/tools/proguard/proguard-android.txt,
 # contents of this file will be appended into proguard-android.txt
 -keepattributes Signature, *Annotation*, EnclosingMethod
+-dontobfuscate
 
 # Square okio, ignoring warnings,
 # see https://github.com/square/okio/issues/60
+-dontwarn okhttp3.**
 -dontwarn okio.**
 
 # Gesture package
@@ -38,7 +40,48 @@
 # Package telemetry
 -keep class com.mapbox.mapboxsdk.telemetry.** { *; }
 
-# Keep external project mapbox-java,
-# Needs to be removed after https://github.com/mapbox/mapbox-java/issues/178 is resolved
--keep class com.mapbox.services.** { *; }
+#
+# Mapbox-java Proguard rules
+# We include these rules since libjava is a Jar file not AAR
+#
 
+# Retrofit 2
+# Platform calls Class.forName on types which do not exist on Android to determine platform.
+-dontnote retrofit2.Platform
+# Platform used when running on RoboVM on iOS. Will not be used at runtime.
+-dontnote retrofit2.Platform$IOS$MainThreadExecutor
+# Platform used when running on Java 8 VMs. Will not be used at runtime.
+-dontwarn retrofit2.Platform$Java8
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
+# Retain declared checked exceptions for use by a Proxy instance.
+-keepattributes Exceptions
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+# Gson specific classes
+-dontwarn sun.misc.**
+
+# Prevent proguard from stripping interface information from TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+# MAS Data Models
+-keep class com.mapbox.services.commons.geojson.** { *; }
+-keep class com.mapbox.services.mapmatching.v4.models.** { *; }
+-keep class com.mapbox.services.distance.v1.models.** { *; }
+-keep class com.mapbox.services.directions.v4.models.** { *; }
+-keep class com.mapbox.services.directions.v5.models.** { *; }
+-keep class com.mapbox.services.geocoding.v5.models.** { *; }
+
+-dontwarn javax.annotation.**
+
+-keepclassmembers class rx.internal.util.unsafe.** {
+    long producerIndex;
+    long consumerIndex;
+}
+
+-keep class com.google.**
+-dontwarn com.google.**

--- a/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
+++ b/platform/android/MapboxGLAndroidSDK/proguard-rules.pro
@@ -2,7 +2,6 @@
 # in ../sdk/tools/proguard/proguard-android.txt,
 # contents of this file will be appended into proguard-android.txt
 -keepattributes Signature, *Annotation*, EnclosingMethod
--dontobfuscate
 
 # Square okio, ignoring warnings,
 # see https://github.com/square/okio/issues/60
@@ -83,5 +82,5 @@
     long consumerIndex;
 }
 
--keep class com.google.**
+-keep class com.google.** { *; }
 -dontwarn com.google.**

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -43,6 +43,8 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled = true
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
             minifyEnabled false

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -43,7 +43,7 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled = true
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/7378
Closes #7313

There seemed to be an issue with obfuscation and JNI bindings, adding `-dontobfuscate` resolved #7378. I also added `-dontwarn okhttp3.**` which was being required in both testapp and demo app. Lastly I ported over the `mapbox-java` proguard rules. 