### PR TITLE
Allows for setting the user location icon to transparent

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -211,8 +211,8 @@ public class MapboxMapOptions implements Parcelable {
                     , (int) (typedArray.getDimension(R.styleable.mapbox_MapView_mapbox_uiAttributionMarginBottom, DIMENSION_SEVEN_DP * screenDensity))});
 
             mapboxMapOptions.locationEnabled(typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_myLocation, false));
-            mapboxMapOptions.myLocationForegroundTintColor(typedArray.getColor(R.styleable.mapbox_MapView_mapbox_myLocationTintColor, Color.TRANSPARENT));
-            mapboxMapOptions.myLocationBackgroundTintColor(typedArray.getColor(R.styleable.mapbox_MapView_mapbox_myLocationBackgroundTintColor, Color.TRANSPARENT));
+            mapboxMapOptions.myLocationForegroundTintColor(typedArray.getColor(R.styleable.mapbox_MapView_mapbox_myLocationTintColor, ColorUtils.getPrimaryColor(context)));
+            mapboxMapOptions.myLocationBackgroundTintColor(typedArray.getColor(R.styleable.mapbox_MapView_mapbox_myLocationBackgroundTintColor, Color.WHITE));
 
             Drawable foregroundDrawable = typedArray.getDrawable(R.styleable.mapbox_MapView_mapbox_myLocationDrawable);
             if (foregroundDrawable == null) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -173,13 +173,11 @@ public class MyLocationView extends View {
     }
 
     public final void setForegroundDrawableTint(@ColorInt int color) {
-        if (color < 1) {
-            if (foregroundDrawable != null) {
-                foregroundDrawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
-            }
-            if (foregroundBearingDrawable != null) {
-                foregroundBearingDrawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
-            }
+        if (foregroundDrawable != null) {
+            foregroundDrawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
+        }
+        if (foregroundBearingDrawable != null) {
+            foregroundBearingDrawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
         }
         invalidate();
     }
@@ -202,12 +200,10 @@ public class MyLocationView extends View {
     }
 
     public final void setShadowDrawableTint(@ColorInt int color) {
-         if (color < 1) {
-            if (backgroundDrawable == null) {
-                return;
-            }
-            backgroundDrawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
+        if (backgroundDrawable == null) {
+            return;
         }
+        backgroundDrawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
         invalidate();
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationView.java
@@ -173,7 +173,7 @@ public class MyLocationView extends View {
     }
 
     public final void setForegroundDrawableTint(@ColorInt int color) {
-        if (color != Color.TRANSPARENT) {
+        if (color < 1) {
             if (foregroundDrawable != null) {
                 foregroundDrawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
             }
@@ -202,7 +202,7 @@ public class MyLocationView extends View {
     }
 
     public final void setShadowDrawableTint(@ColorInt int color) {
-        if (color != Color.TRANSPARENT) {
+         if (color < 1) {
             if (backgroundDrawable == null) {
                 return;
             }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationTintActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationTintActivity.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxsdk.testapp.activity.userlocation;
 import android.Manifest;
 import android.app.Activity;
 import android.content.pm.PackageManager;
+import android.graphics.Color;
 import android.location.Location;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
@@ -81,6 +82,7 @@ public class MyLocationTintActivity extends AppCompatActivity implements Locatio
                             MyLocationTintActivity.this, R.color.mapbox_my_location_ring));
                         myLocationViewSettings.setForegroundTintColor(ContextCompat.getColor(
                             MyLocationTintActivity.this, R.color.mapbox_blue));
+                        myLocationViewSettings.setBackgroundTintColor(Color.WHITE);
                     }
                 });
 
@@ -95,6 +97,7 @@ public class MyLocationTintActivity extends AppCompatActivity implements Locatio
                             ContextCompat.getColor(MyLocationTintActivity.this, R.color.mapbox_green));
                         myLocationViewSettings.setForegroundTintColor(
                             ContextCompat.getColor(MyLocationTintActivity.this, R.color.mapbox_green));
+                        myLocationViewSettings.setBackgroundTintColor(Color.WHITE);
                     }
                 });
 
@@ -109,8 +112,21 @@ public class MyLocationTintActivity extends AppCompatActivity implements Locatio
                             ContextCompat.getColor(MyLocationTintActivity.this, R.color.accent));
                         myLocationViewSettings.setForegroundTintColor(
                             ContextCompat.getColor(MyLocationTintActivity.this, R.color.mapbox_blue));
+                        myLocationViewSettings.setBackgroundTintColor(Color.WHITE);
                     }
                 });
+
+                ViewUtils.attachClickListener(
+                  MyLocationTintActivity.this,
+                  R.id.user_dot_transparent_button,
+                  new View.OnClickListener() {
+                      @Override
+                      public void onClick(View view) {
+                          myLocationViewSettings.setForegroundTintColor(Color.TRANSPARENT);
+                          myLocationViewSettings.setBackgroundTintColor(Color.TRANSPARENT);
+                      }
+                  }
+                );
             }
         });
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_my_location_dot_color.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_my_location_dot_color.xml
@@ -1,50 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:mapbox="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="@color/primary"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
 
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@id/mapView"
-        android:layout_below="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:layout_below="@+id/toolbar"
+        mapbox:mapbox_uiAttribution="false"
+        mapbox:mapbox_uiLogo="false"/>
 
     <LinearLayout
+        style="?android:attr/buttonBarStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
+        android:background="@color/accent"
         android:orientation="horizontal"
-        android:weightSum="3">
+        android:weightSum="4">
 
         <Button
             android:id="@+id/default_user_dot_coloring_button"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/button_user_dot_default" />
+            android:text="@string/button_user_dot_default"
+            android:textColor="@color/white"/>
 
         <Button
             android:id="@+id/tint_user_dot_button"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/button_user_dot_tint" />
+            android:text="@string/button_user_dot_tint"
+            android:textColor="@color/white"/>
 
         <Button
             android:id="@+id/user_accuracy_ring_tint_button"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/button_user_accuracy_ring_tint" />
+            android:text="@string/button_user_accuracy_ring_tint"
+            android:textColor="@color/white"/>
 
-        </LinearLayout>
+        <Button
+            android:id="@+id/user_dot_transparent_button"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/button_user_transparent_tint"
+            android:textColor="@color/white"/>
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -169,6 +169,7 @@
     <string name="button_user_dot_default">Default</string>
     <string name="button_user_dot_tint">Tint dot</string>
     <string name="button_user_accuracy_ring_tint">Tint ring</string>
+    <string name="button_user_transparent_tint">tran</string>
     <string name="button_open_dialog">Open dialog</string>
 
     <string name="label_fps">FPS:</string>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettingsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/widgets/MyLocationViewSettingsTest.java
@@ -75,9 +75,23 @@ public class MyLocationViewSettingsTest {
     }
 
     @Test
+    public void testForegroundTransparentTint() {
+        int color = Color.TRANSPARENT;
+        locationViewSettings.setForegroundTintColor(Color.TRANSPARENT);
+        assertEquals("color should match", color, locationViewSettings.getForegroundTintColor());
+    }
+
+    @Test
     public void testBackgroundTint() {
         int color = Color.RED;
         locationViewSettings.setBackgroundTintColor(Color.RED);
+        assertEquals("color should match", color, locationViewSettings.getBackgroundTintColor());
+    }
+
+    @Test
+    public void testBackgroundTransparentTint() {
+        int color = Color.TRANSPARENT;
+        locationViewSettings.setBackgroundTintColor(Color.TRANSPARENT);
         assertEquals("color should match", color, locationViewSettings.getBackgroundTintColor());
     }
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/7116

Set the default user location color to be `mapbox_blue` and not transparent and allow for any color int value below 1 to tint user location foreground and background. We might be able to get rid of the color check `if (color < 1)`?