### PR TITLE
Cherry pick 7257 into iOS 3.4.0 release branch

### DIFF
--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -190,7 +190,7 @@ void NativeMapView::invalidate() {
 }
 
 void NativeMapView::render() {
-    activate();
+    BackendScope guard(*this);
 
     updateViewBinding();
     map->render(*this);
@@ -235,8 +235,6 @@ void NativeMapView::render() {
     } else {
         mbgl::Log::Info(mbgl::Event::Android, "Not swapping as we are not ready");
     }
-
-    deactivate();
 }
 
 mbgl::Map &NativeMapView::getMap() { return *map; }
@@ -421,7 +419,7 @@ void NativeMapView::createSurface(ANativeWindow *window_) {
     if (!firstTime) {
         firstTime = true;
 
-        activate();
+        BackendScope guard(*this);
 
         if (!eglMakeCurrent(display, surface, surface, context)) {
             mbgl::Log::Error(mbgl::Event::OpenGL, "eglMakeCurrent() returned error %d",
@@ -442,8 +440,6 @@ void NativeMapView::createSurface(ANativeWindow *window_) {
         mbgl::gl::InitializeExtensions([] (const char * name) {
              return reinterpret_cast<mbgl::gl::glProc>(eglGetProcAddress(name));
         });
-
-        deactivate();
     }
 }
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -23,8 +23,6 @@ public:
     void updateViewBinding();
     void bind() override;
 
-    void activate() override;
-    void deactivate() override;
     void invalidate() override;
 
     void notifyMapChange(mbgl::MapChange) override;
@@ -52,6 +50,10 @@ public:
     void setInsets(mbgl::EdgeInsets insets_);
 
     void scheduleTakeSnapshot();
+
+protected:
+    void activate() override;
+    void deactivate() override;
 
 private:
     EGLConfig chooseConfig(const EGLConfig configs[], EGLint numConfigs);

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -287,10 +287,18 @@ static NSURL *MGLStyleURL_emerald;
         [NSException raise:NSRangeException
                     format:@"Cannot insert style layer at out-of-bounds index %lu.", (unsigned long)index];
     } else if (index == 0) {
-        [styleLayer addToMapView:self.mapView belowLayer:nil];
+        try {
+            [styleLayer addToMapView:self.mapView belowLayer:nil];
+        } catch (const std::runtime_error & err) {
+            [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+        }
     } else {
-        MGLStyleLayer *sibling = [self layerFromMBGLLayer:layers.at(layers.size() - index)];
-        [styleLayer addToMapView:self.mapView belowLayer:sibling];
+        try {
+            MGLStyleLayer *sibling = [self layerFromMBGLLayer:layers.at(layers.size() - index)];
+            [styleLayer addToMapView:self.mapView belowLayer:sibling];
+        } catch (std::runtime_error & err) {
+            [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+        }
     }
 }
 
@@ -374,7 +382,11 @@ static NSURL *MGLStyleURL_emerald;
          layer];
     }
     [self willChangeValueForKey:@"layers"];
-    [layer addToMapView:self.mapView belowLayer:nil];
+    try {
+        [layer addToMapView:self.mapView belowLayer:nil];
+    } catch (std::runtime_error & err) {
+        [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+    }
     [self didChangeValueForKey:@"layers"];
 }
 
@@ -399,7 +411,11 @@ static NSURL *MGLStyleURL_emerald;
          sibling];
     }
     [self willChangeValueForKey:@"layers"];
-    [layer addToMapView:self.mapView belowLayer:sibling];
+    try {
+        [layer addToMapView:self.mapView belowLayer:sibling];
+    } catch (std::runtime_error & err) {
+        [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+    }
     [self didChangeValueForKey:@"layers"];
 }
 
@@ -437,10 +453,18 @@ static NSURL *MGLStyleURL_emerald;
          @"Make sure sibling was obtained using -[MGLStyle layerWithIdentifier:].",
          sibling];
     } else if (index + 1 == layers.size()) {
-        [layer addToMapView:self.mapView belowLayer:nil];
+        try {
+            [layer addToMapView:self.mapView belowLayer:nil];
+        } catch (std::runtime_error & err) {
+            [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+        }
     } else {
         MGLStyleLayer *sibling = [self layerFromMBGLLayer:layers.at(index + 1)];
-        [layer addToMapView:self.mapView belowLayer:sibling];
+        try {
+            [layer addToMapView:self.mapView belowLayer:sibling];
+        } catch (std::runtime_error & err) {
+            [NSException raise:@"MGLRedundantLayerIdentifierException" format:@"%s", err.what()];
+        }
     }
     [self didChangeValueForKey:@"layers"];
 }

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -1,5 +1,6 @@
 #import "MGLMapView.h"
 #import "MGLStyle_Private.h"
+#import "MGLOpenGLStyleLayer.h"
 
 #import "MGLShapeSource.h"
 #import "MGLRasterSource.h"
@@ -168,6 +169,23 @@
     MGLSymbolStyleLayer *symbolLayer = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"symbolLayer" source:source];
     [self.style addLayer:symbolLayer];
     XCTAssertThrowsSpecificNamed([self.style addLayer:symbolLayer], NSException, @"MGLRedundantLayerException");
+}
+
+- (void)testAddingLayersWithDuplicateIdentifiers {
+    //Just some source
+    MGLVectorSource *source = [[MGLVectorSource alloc] initWithIdentifier:@"my-source" URL:[NSURL URLWithString:@"mapbox://mapbox.mapbox-terrain-v2"]];
+    [self.mapView.style addSource: source];
+    
+    //Add initial layer
+    MGLFillStyleLayer *initial = [[MGLFillStyleLayer alloc] initWithIdentifier:@"my-layer" source:source];
+    [self.mapView.style addLayer:initial];
+    
+    //Try to add the duplicate
+    XCTAssertThrowsSpecificNamed([self.mapView.style addLayer:[[MGLFillStyleLayer alloc] initWithIdentifier:@"my-layer" source:source]], NSException, @"MGLRedundantLayerIdentifierException");
+    XCTAssertThrowsSpecificNamed([self.mapView.style insertLayer:[[MGLFillStyleLayer alloc] initWithIdentifier:@"my-layer" source:source] belowLayer:initial],NSException, @"MGLRedundantLayerIdentifierException");
+    XCTAssertThrowsSpecificNamed([self.mapView.style insertLayer:[[MGLFillStyleLayer alloc] initWithIdentifier:@"my-layer" source:source] aboveLayer:initial], NSException, @"MGLRedundantLayerIdentifierException");
+    XCTAssertThrowsSpecificNamed([self.mapView.style insertLayer:[[MGLFillStyleLayer alloc] initWithIdentifier:@"my-layer" source:source] atIndex:0], NSException, @"MGLRedundantLayerIdentifierException");
+    XCTAssertThrowsSpecificNamed([self.mapView.style insertLayer:[[MGLOpenGLStyleLayer alloc] initWithIdentifier:@"my-layer"] atIndex:0], NSException, @"MGLRedundantLayerIdentifierException");
 }
 
 - (NSString *)stringWithContentsOfStyleHeader {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -140,7 +140,7 @@ Map::Impl::Impl(Backend& backend_,
 }
 
 Map::~Map() {
-    impl->backend.activate();
+    BackendScope guard(impl->backend);
 
     impl->styleRequest = nullptr;
 
@@ -149,8 +149,6 @@ Map::~Map() {
     impl->style.reset();
     impl->annotationManager.reset();
     impl->painter.reset();
-
-    impl->backend.deactivate();
 }
 
 void Map::renderStill(View& view, StillImageCallback callback) {
@@ -275,9 +273,8 @@ void Map::Impl::update() {
         backend.invalidate();
     } else if (stillImageRequest && style->isLoaded()) {
         // TODO: determine whether we need activate/deactivate
-        backend.activate();
+        BackendScope guard(backend);
         render(stillImageRequest->view);
-        backend.deactivate();
     }
 
     updateFlags = Update::Nothing;
@@ -848,12 +845,10 @@ void Map::addLayer(std::unique_ptr<Layer> layer, const optional<std::string>& be
     }
 
     impl->styleMutated = true;
-    impl->backend.activate();
+    BackendScope guard(impl->backend);
 
     impl->style->addLayer(std::move(layer), before);
     impl->onUpdate(Update::Classes);
-
-    impl->backend.deactivate();
 }
 
 std::unique_ptr<Layer> Map::removeLayer(const std::string& id) {
@@ -862,12 +857,10 @@ std::unique_ptr<Layer> Map::removeLayer(const std::string& id) {
     }
 
     impl->styleMutated = true;
-    impl->backend.activate();
+    BackendScope guard(impl->backend);
 
     auto removedLayer = impl->style->removeLayer(id);
     impl->onUpdate(Update::Classes);
-
-    impl->backend.deactivate();
 
     return removedLayer;
 }
@@ -1033,9 +1026,8 @@ void Map::setSourceTileCacheSize(size_t size) {
 
 void Map::onLowMemory() {
     if (impl->painter) {
-        impl->backend.activate();
+        BackendScope guard(impl->backend);
         impl->painter->cleanup();
-        impl->backend.deactivate();
     }
     if (impl->style) {
         impl->style->onLowMemory();

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -198,6 +198,15 @@ Layer* Style::getLayer(const std::string& id) const {
 Layer* Style::addLayer(std::unique_ptr<Layer> layer, optional<std::string> before) {
     // TODO: verify source
 
+    // Guard against duplicate layer ids
+    auto it = std::find_if(layers.begin(), layers.end(), [&](const auto& existing) {
+        return existing->getID() == layer->getID();
+    });
+
+    if (it != layers.end()) {
+        throw std::runtime_error(std::string{"Layer "} + layer->getID() + " already exists");
+    }
+
     if (SymbolLayer* symbolLayer = layer->as<SymbolLayer>()) {
         if (!symbolLayer->impl->spriteAtlas) {
             symbolLayer->impl->spriteAtlas = spriteAtlas.get();


### PR DESCRIPTION
This brings in:

- [core] use raii to guard backend deactivation https://github.com/mapbox/mapbox-gl-native/commit/c76a933514e4e1514a58ac0e668b13eebab37794
- [core] guard against duplicate layer ids https://github.com/mapbox/mapbox-gl-native/commit/028db7febacf7d40598aff32653ae89599d0d0d2
- [ios, macos] handle duplicate layer error https://github.com/mapbox/mapbox-gl-native/commit/e9f101a52f626744991ee73c3ced9c48bc013a51

But not:

- [android] test duplicate layer id exception handling https://github.com/mapbox/mapbox-gl-native/commit/a32e62cb0f3a6d9654712ab93380b15db7b337aa

from https://github.com/mapbox/mapbox-gl-native/pull/7257 which landed in `master`

cc @1ec5 fyi @ivovandongen 