### PR TITLE
Custom head markup in generated documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ xpackage: $(MACOS_PROJ_PATH)
 
 .PHONY: xdocument
 xdocument:
-	OUTPUT=$(OUTPUT) ./platform/macos/scripts/document.sh
+	OUTPUT=$(OUTPUT) HTMLHEAD=$(HTMLHEAD) ./platform/macos/scripts/document.sh
 
 .PHONY: genstrings
 genstrings:
@@ -271,7 +271,7 @@ ideploy:
 
 .PHONY: idocument
 idocument:
-	OUTPUT=$(OUTPUT) ./platform/ios/scripts/document.sh
+	OUTPUT=$(OUTPUT) HTMLHEAD=$(HTMLHEAD) ./platform/ios/scripts/document.sh
 
 style-code-darwin:
 	node platform/darwin/scripts/generate-style-code.js

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -5,9 +5,6 @@ github_url: https://github.com/mapbox/mapbox-gl-native
 dash_url: https://www.mapbox.com/ios-sdk/docsets/Mapbox.xml
 copyright: '© 2014–2016 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native/blob/master/LICENSE.md) for more details.'
 
-head: |
-  <link rel='shortcut icon' href='https://www.mapbox.com/img/favicon.ico' type='image/x-icon' />
-
 objc: Yes
 skip_undocumented: Yes
 hide_documentation_coverage: Yes

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -19,6 +19,14 @@ BRANCH=$( git describe --tags --match=ios-v*.*.* --abbrev=0 )
 SHORT_VERSION=$( echo ${BRANCH} | sed 's/^ios-v//' )
 RELEASE_VERSION=$( echo ${SHORT_VERSION} | sed -e 's/^ios-v//' -e 's/-.*//' )
 
+FAVICON='<link rel="shortcut icon" href="https://www.mapbox.com/img/favicon.ico" type="image/x-icon" />'
+if [ -a ${HTMLHEAD} ]; then
+    HTMLHEAD="${FAVICON}
+$(cat ${HTMLHEAD})"
+else
+    HTMLHEAD="${FAVICON}"
+fi
+
 rm -rf /tmp/mbgl
 mkdir -p /tmp/mbgl/
 README=/tmp/mbgl/README.md
@@ -41,6 +49,7 @@ jazzy \
     --documentation="platform/ios/docs/Info.plist Keys.md" \
     --root-url https://www.mapbox.com/ios-sdk/api/${RELEASE_VERSION}/ \
     --theme platform/darwin/docs/theme \
+    --head "${HTMLHEAD}" \
     --output ${OUTPUT}
 # https://github.com/realm/jazzy/issues/411
 find ${OUTPUT} -name *.html -exec \

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -4,9 +4,6 @@ author_url: https://www.mapbox.com/
 github_url: https://github.com/mapbox/mapbox-gl-native
 copyright: '© 2014–2016 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/mapbox-gl-native/blob/master/LICENSE.md) for more details.'
 
-head: |
-  <link rel='shortcut icon' href='https://www.mapbox.com/img/favicon.ico' type='image/x-icon' />
-
 objc: Yes
 skip_undocumented: Yes
 hide_documentation_coverage: Yes

--- a/platform/macos/scripts/document.sh
+++ b/platform/macos/scripts/document.sh
@@ -19,6 +19,14 @@ BRANCH=$( git describe --tags --match=macos-v*.*.* --abbrev=0 )
 SHORT_VERSION=$( echo ${BRANCH} | sed 's/^macos-v//' )
 RELEASE_VERSION=$( echo ${SHORT_VERSION} | sed -e 's/^macos-v//' -e 's/-.*//' )
 
+FAVICON='<link rel="shortcut icon" href="https://www.mapbox.com/img/favicon.ico" type="image/x-icon" />'
+if [ -a ${HTMLHEAD} ]; then
+    HTMLHEAD="${FAVICON}
+$(cat ${HTMLHEAD})"
+else
+    HTMLHEAD="${FAVICON}"
+fi
+
 rm -rf /tmp/mbgl
 mkdir -p /tmp/mbgl/
 README=/tmp/mbgl/README.md
@@ -40,6 +48,7 @@ jazzy \
     --readme ${README} \
     --documentation="platform/macos/docs/Info.plist Keys.md" \
     --theme platform/darwin/docs/theme \
+    --head "${HTMLHEAD}" \
     --output ${OUTPUT}
 # https://github.com/realm/jazzy/issues/411
 find ${OUTPUT} -name *.html -exec \


### PR DESCRIPTION
The `idocument` and `xdocument` make rules now accept an `HTMLHEAD` variable that specifies a file to be included after the favicon in the `<head>` of every page in the generated documentation.

This is an alternative to #7392 that avoids hard-coding specific markup in the templates. Instead, the site script that pulls in this generated docset can specify its own markup.