### PR TITLE
Fix crash on launch in iosapp

### DIFF
--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1205,7 +1205,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     NSString *bestLanguage;
 
     for (NSString *language in preferredLanguages) {
-        NSString *thisLanguage = [NSLocale localeWithLocaleIdentifier:language].languageCode;
+        NSString *thisLanguage = [[NSLocale localeWithLocaleIdentifier:language] objectForKey:NSLocaleLanguageCode];
         if ([supportedLanguages containsObject:thisLanguage]) {
             bestLanguage = thisLanguage;
             break;


### PR DESCRIPTION
Use `NSLocaleLanguageCode` instead of `-[NSLocale languageCode]`, which is newer than the minimum deployment target.

Fixes #7399.

/cc @boundsj