### PR TITLE
Make theme configurable

### DIFF
--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -32,7 +32,8 @@ mkdir -p ${OUTPUT}
 
 cp platform/ios/screenshot.png "${OUTPUT}"
 
-DEFAULT_THEME='platform/darwin/docs/theme'
+DEFAULT_THEME="platform/darwin/docs/theme"
+THEME=${JAZZY_THEME:-$DEFAULT_THEME}
 
 jazzy \
     --config platform/ios/jazzy.yml \
@@ -42,7 +43,7 @@ jazzy \
     --readme ${README} \
     --documentation="platform/ios/docs/Info.plist Keys.md" \
     --root-url https://www.mapbox.com/ios-sdk/api/${RELEASE_VERSION}/ \
-    --theme ${JAZZY_THEME:-$DEFAULT_THEME} \
+    --theme ${THEME} \
     --output ${OUTPUT}
 # https://github.com/realm/jazzy/issues/411
 find ${OUTPUT} -name *.html -exec \

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -32,6 +32,8 @@ mkdir -p ${OUTPUT}
 
 cp platform/ios/screenshot.png "${OUTPUT}"
 
+DEFAULT_THEME='platform/darwin/docs/theme'
+
 jazzy \
     --config platform/ios/jazzy.yml \
     --sdk iphonesimulator \
@@ -40,7 +42,7 @@ jazzy \
     --readme ${README} \
     --documentation="platform/ios/docs/Info.plist Keys.md" \
     --root-url https://www.mapbox.com/ios-sdk/api/${RELEASE_VERSION}/ \
-    --theme platform/darwin/docs/theme \
+    --theme ${JAZZY_THEME:-$DEFAULT_THEME} \
     --output ${OUTPUT}
 # https://github.com/realm/jazzy/issues/411
 find ${OUTPUT} -name *.html -exec \


### PR DESCRIPTION
This allows runners of `document.sh` to use their own custom, local theme. It uses the existing theme by default.