### PR TITLE
[ios]] Remove transaction in callout view update

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4815,8 +4815,6 @@ public:
 
 - (void)updateCalloutView
 {
-    [CATransaction begin];
-    
     UIView <MGLCalloutView> *calloutView = self.calloutViewForSelectedAnnotation;
     id <MGLAnnotation> annotation = calloutView.representedObject;
     
@@ -4839,8 +4837,6 @@ public:
             calloutView.center = point;
         }
     }
-    
-    [CATransaction commit];
 }
 
 - (void)enqueueAnnotationViewForAnnotationContext:(MGLAnnotationContext &)annotationContext


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/7424

I'm not sure why we used a CATransaction for the callout view update. It does seem like, when it is called from a path initiated by CADisplayLink, there view is constantly hidden and shown again. If the transaction is removed, that does not occur.

cc @frederoni @1ec5 