### PR TITLE
[android] - update gradle command line args for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -565,7 +565,7 @@ run-android-ui-test:
 
 .PHONY: apackage
 apackage:
-	cd platform/android && ./gradlew --parallel-threads=$(JOBS) assemble$(BUILDTYPE)
+	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) assemble$(BUILDTYPE)
 
 .PHONY: test-code-android
 test-code-android:


### PR DESCRIPTION
This updates the `make apackage` command with the latest gradle `3.2.1` syntax.

cc @kkaefer 