### PR TITLE
[core] Port ensure a non-zero source tile cache size

### DIFF
--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -139,8 +139,8 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
 
     if (type != SourceType::Annotations && cache.getSize() == 0) {
         size_t conservativeCacheSize =
-            ((float)parameters.transformState.getWidth() / util::tileSize) *
-            ((float)parameters.transformState.getHeight() / util::tileSize) *
+            std::max((float)parameters.transformState.getWidth() / util::tileSize, 1.0f) *
+            std::max((float)parameters.transformState.getHeight() / util::tileSize, 1.0f) *
             (parameters.transformState.getMaxZoom() - parameters.transformState.getMinZoom() + 1) *
             0.5;
         cache.setSize(conservativeCacheSize);


### PR DESCRIPTION
This ports https://github.com/mapbox/mapbox-gl-native/pull/7242/commits/2d323211af54499d5c822b8e45d7415bf92112f0 to the iOS 3.4.0 release branch.

cc @1ec5 @jfirebaugh 