### PR TITLE
[core] port matrix and antialiasing cleanup

### DIFF
--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -25,7 +25,7 @@ struct CustomLayerRenderParameters {
     double zoom;
     double bearing;
     double pitch;
-    double altitude;
+    double fieldOfView;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ejs": "^2.4.1",
     "express": "^4.11.1",
     "lodash": "^4.16.4",
-    "mapbox-gl": "mapbox/mapbox-gl-js#eb6c6596c6a7a61363d30356674e0002153b1d19",
+    "mapbox-gl": "mapbox/mapbox-gl-js#ef5582dd3bc5c15a3112e875ed66494dab8e9d0b",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#49e8b407bdbbe6f7c92dbcb56d3d51f425fc2653",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#da53a81453068f4c2b440f9077d6bd5e7e14ff3d",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ejs": "^2.4.1",
     "express": "^4.11.1",
     "lodash": "^4.16.4",
-    "mapbox-gl": "mapbox/mapbox-gl-js#ab836206d415ca3a74257a3066d11a54ab2838cb",
+    "mapbox-gl": "mapbox/mapbox-gl-js#c52a09639ceeeb809cd837360993df9c45b45420",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#49e8b407bdbbe6f7c92dbcb56d3d51f425fc2653",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#da53a81453068f4c2b440f9077d6bd5e7e14ff3d",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ejs": "^2.4.1",
     "express": "^4.11.1",
     "lodash": "^4.16.4",
-    "mapbox-gl": "mapbox/mapbox-gl-js#c52a09639ceeeb809cd837360993df9c45b45420",
+    "mapbox-gl": "mapbox/mapbox-gl-js#eb6c6596c6a7a61363d30356674e0002153b1d19",
     "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#49e8b407bdbbe6f7c92dbcb56d3d51f425fc2653",
     "mapbox-gl-test-suite": "mapbox/mapbox-gl-test-suite#da53a81453068f4c2b440f9077d6bd5e7e14ff3d",
     "mkdirp": "^0.5.1",

--- a/platform/darwin/src/MGLGeometry.mm
+++ b/platform/darwin/src/MGLGeometry.mm
@@ -5,8 +5,8 @@
 /** Vertical field of view, measured in degrees, for determining the altitude
     of the viewpoint.
     
-    TransformState::getProjMatrix() assumes a vertical field of view of
-    2 arctan ⅓ rad ≈ 36.9°, but MapKit uses a vertical field of view of 30°.
+    TransformState::getProjMatrix() has a variable vertical field of view that
+    defaults to 2 arctan ⅓ rad ≈ 36.9° but MapKit uses a vertical field of view of 30°.
     flyTo() assumes a field of view of 2 arctan ½ rad. */
 const CLLocationDegrees MGLAngularFieldOfView = 30;
 

--- a/platform/darwin/src/MGLOpenGLStyleLayer.h
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.h
@@ -14,7 +14,7 @@ typedef struct MGLStyleLayerDrawingContext {
     double zoomLevel;
     CLLocationDirection direction;
     CGFloat pitch;
-    CGFloat perspectiveSkew;
+    CGFloat fieldOfView;
 } MGLStyleLayerDrawingContext;
 
 @interface MGLOpenGLStyleLayer : MGLStyleLayer

--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -34,7 +34,7 @@ void MGLDrawCustomStyleLayer(void *context, const mbgl::style::CustomLayerRender
         .zoomLevel = params.zoom,
         .direction = mbgl::util::wrap(params.bearing, 0., 360.),
         .pitch = static_cast<CGFloat>(params.pitch),
-        .perspectiveSkew = static_cast<CGFloat>(params.altitude),
+        .fieldOfView = static_cast<CGFloat>(params.fieldOfView),
     };
     [layer drawInMapView:layer.mapView withContext:drawingContext];
 }

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -36,10 +36,13 @@ void TransformState::getProjMatrix(mat4& projMatrix) const {
     const double groundAngle = M_PI / 2.0 + getPitch();
     const double topHalfSurfaceDistance = std::sin(halfFov) * getCameraToCenterDistance() / std::sin(M_PI - groundAngle - halfFov);
 
-    // Calculate z value of the farthest fragment that should be rendered.
-    const double farZ = std::cos(M_PI / 2.0 - getPitch()) * topHalfSurfaceDistance + getCameraToCenterDistance();
 
-    matrix::perspective(projMatrix, getFieldOfView(), double(size.width) / size.height, 0.1, farZ);
+    // Calculate z distance of the farthest fragment that should be rendered.
+    const double furthestDistance = std::cos(M_PI / 2 - getPitch()) * topHalfSurfaceDistance + getCameraToCenterDistance();
+    // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
+    const double farZ = furthestDistance * 1.01;
+
+    matrix::perspective(projMatrix, getFieldOfView(), double(size.width) / size.height, 1, farZ);
 
     const bool flippedY = viewportMode == ViewportMode::FlippedY;
     matrix::scale(projMatrix, projMatrix, 1, flippedY ? 1 : -1, 1);

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -56,7 +56,8 @@ public:
 
     // Rotation
     float getAngle() const;
-    float getAltitude() const;
+    float getFieldOfView() const;
+    float getCameraToCenterDistance() const;
     float getPitch() const;
 
     // State
@@ -109,7 +110,11 @@ private:
     double x = 0, y = 0;
     double angle = 0;
     double scale = 1;
-    double altitude = 1.5;
+    // This fov value is somewhat arbitrary. The altitude of the camera used
+    // to be defined as 1.5 screen heights above the ground, which was an
+    // arbitrary choice. This is the fov equivalent to that value calculated with:
+    // `fov = 2 * arctan((height / 2) / (height * 1.5))`
+    double fov = 0.6435011087932844;
     double pitch = 0.0;
 
     // cache values for spherical mercator math

--- a/src/mbgl/programs/line_program.cpp
+++ b/src/mbgl/programs/line_program.cpp
@@ -25,7 +25,7 @@ Values makeValues(const LinePaintProperties::Evaluated& properties,
 
     // calculate how much longer the real world distance is at the top of the screen
     // than at the middle of the screen.
-    float topedgelength = std::sqrt(std::pow(state.getSize().height, 2.0f) / 4.0f  * (1.0f + std::pow(state.getAltitude(), 2.0f)));
+    float topedgelength = std::sqrt(std::pow(state.getSize().height, 2.0f) / 4.0f  * (1.0f + std::pow(state.getCameraToCenterDistance(), 2.0f)));
     float x = state.getSize().height / 2.0f * std::tan(state.getPitch());
 
     return Values {

--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -22,7 +22,6 @@ namespace uniforms {
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_ratio);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_width);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_gapwidth);
-MBGL_DEFINE_UNIFORM_SCALAR(float, u_extra);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_offset);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_tex_y_a);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_tex_y_b);
@@ -30,7 +29,7 @@ MBGL_DEFINE_UNIFORM_SCALAR(float, u_sdfgamma);
 MBGL_DEFINE_UNIFORM_SCALAR(float, u_fade);
 MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_patternscale_a);
 MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_patternscale_b);
-MBGL_DEFINE_UNIFORM_MATRIX(double, 2, u_antialiasingmatrix);
+MBGL_DEFINE_UNIFORM_VECTOR(float, 2, u_gl_units_to_pixels);
 } // namespace uniforms
 
 struct LineAttributes : gl::Attributes<
@@ -93,9 +92,8 @@ class LineProgram : public Program<
         uniforms::u_gapwidth,
         uniforms::u_blur,
         uniforms::u_offset,
-        uniforms::u_antialiasingmatrix,
         uniforms::u_ratio,
-        uniforms::u_extra,
+        uniforms::u_gl_units_to_pixels,
         uniforms::u_color>>
 {
 public:
@@ -103,7 +101,8 @@ public:
 
     static UniformValues uniformValues(const style::LinePaintProperties::Evaluated&,
                                        const RenderTile&,
-                                       const TransformState&);
+                                       const TransformState&,
+                                       const std::array<float, 2>& pixelsToGLUnits);
 };
 
 class LinePatternProgram : public Program<
@@ -117,9 +116,8 @@ class LinePatternProgram : public Program<
         uniforms::u_gapwidth,
         uniforms::u_blur,
         uniforms::u_offset,
-        uniforms::u_antialiasingmatrix,
         uniforms::u_ratio,
-        uniforms::u_extra,
+        uniforms::u_gl_units_to_pixels,
         uniforms::u_pattern_tl_a,
         uniforms::u_pattern_br_a,
         uniforms::u_pattern_tl_b,
@@ -135,6 +133,7 @@ public:
     static UniformValues uniformValues(const style::LinePaintProperties::Evaluated&,
                                        const RenderTile&,
                                        const TransformState&,
+                                       const std::array<float, 2>& pixelsToGLUnits,
                                        const SpriteAtlasPosition& posA,
                                        const SpriteAtlasPosition& posB);
 };
@@ -150,9 +149,8 @@ class LineSDFProgram : public Program<
         uniforms::u_gapwidth,
         uniforms::u_blur,
         uniforms::u_offset,
-        uniforms::u_antialiasingmatrix,
         uniforms::u_ratio,
-        uniforms::u_extra,
+        uniforms::u_gl_units_to_pixels,
         uniforms::u_color,
         uniforms::u_patternscale_a,
         uniforms::u_patternscale_b,
@@ -169,6 +167,7 @@ public:
                                        float pixelRatio,
                                        const RenderTile&,
                                        const TransformState&,
+                                       const std::array<float, 2>& pixelsToGLUnits,
                                        const LinePatternPos& posA,
                                        const LinePatternPos& posB,
                                        float dashLineWidth,

--- a/src/mbgl/programs/symbol_program.cpp
+++ b/src/mbgl/programs/symbol_program.cpp
@@ -23,8 +23,8 @@ Values makeValues(const style::SymbolPropertyValues& values,
         extrudeScale.fill(tile.id.pixelsToTileUnits(1, state.getZoom()) * scale);
     } else {
         extrudeScale = {{
-            pixelsToGLUnits[0] * scale * state.getAltitude(),
-            pixelsToGLUnits[1] * scale * state.getAltitude()
+            pixelsToGLUnits[0] * scale * state.getCameraToCenterDistance(),
+            pixelsToGLUnits[1] * scale * state.getCameraToCenterDistance()
         }};
     }
 
@@ -77,7 +77,7 @@ static SymbolSDFProgram::UniformValues makeSDFValues(const style::SymbolProperty
     const float gammaBase = 0.105 * values.sdfScale / values.paintSize / pixelRatio;
     const float gammaScale = (values.pitchAlignment == AlignmentType::Map
         ? 1.0 / std::cos(state.getPitch())
-        : 1.0) / state.getAltitude();
+        : 1.0) / state.getCameraToCenterDistance();
 
     return makeValues<SymbolSDFProgram::UniformValues>(
         values,

--- a/src/mbgl/programs/symbol_program.cpp
+++ b/src/mbgl/programs/symbol_program.cpp
@@ -75,9 +75,9 @@ static SymbolSDFProgram::UniformValues makeSDFValues(const style::SymbolProperty
     // The default gamma value has to be adjust for the current pixelratio so that we're not
     // drawing blurry font on retina screens.
     const float gammaBase = 0.105 * values.sdfScale / values.paintSize / pixelRatio;
-    const float gammaScale = values.pitchAlignment == AlignmentType::Map
+    const float gammaScale = (values.pitchAlignment == AlignmentType::Map
         ? 1.0 / std::cos(state.getPitch())
-        : 1.0;
+        : 1.0) / state.getAltitude();
 
     return makeValues<SymbolSDFProgram::UniformValues>(
         values,

--- a/src/mbgl/renderer/painter_circle.cpp
+++ b/src/mbgl/renderer/painter_circle.cpp
@@ -47,8 +47,8 @@ void Painter::renderCircle(PaintParameters& parameters,
             uniforms::u_scale_with_map::Value{ scaleWithMap },
             uniforms::u_extrude_scale::Value{ scaleWithMap
                 ? std::array<float, 2> {{
-                    pixelsToGLUnits[0] * state.getAltitude(),
-                    pixelsToGLUnits[1] * state.getAltitude()
+                    pixelsToGLUnits[0] * state.getCameraToCenterDistance(),
+                    pixelsToGLUnits[1] * state.getCameraToCenterDistance()
                   }}
                 : pixelsToGLUnits }
         },

--- a/src/mbgl/renderer/painter_line.cpp
+++ b/src/mbgl/renderer/painter_line.cpp
@@ -51,6 +51,7 @@ void Painter::renderLine(PaintParameters& parameters,
                  frame.pixelRatio,
                  tile,
                  state,
+                 pixelsToGLUnits,
                  posA,
                  posB,
                  layer.impl->dashLineWidth,
@@ -72,6 +73,7 @@ void Painter::renderLine(PaintParameters& parameters,
                  properties,
                  tile,
                  state,
+                 pixelsToGLUnits,
                  *posA,
                  *posB));
 
@@ -80,7 +82,8 @@ void Painter::renderLine(PaintParameters& parameters,
              LineProgram::uniformValues(
                  properties,
                  tile,
-                 state));
+                 state,
+                 pixelsToGLUnits));
     }
 }
 

--- a/src/mbgl/style/layers/custom_layer_impl.cpp
+++ b/src/mbgl/style/layers/custom_layer_impl.cpp
@@ -57,7 +57,7 @@ void CustomLayer::Impl::render(const TransformState& state) const {
     parameters.zoom = state.getZoom();
     parameters.bearing = -state.getAngle() * util::RAD2DEG;
     parameters.pitch = state.getPitch();
-    parameters.altitude = state.getAltitude();
+    parameters.fieldOfView = state.getFieldOfView();
 
     renderFn(context, parameters);
 }

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -362,7 +362,7 @@ TEST(Transform, Padding) {
     
     const LatLng shiftedCenter = transform.getLatLng(padding);
     ASSERT_NE(trueCenter.latitude, shiftedCenter.latitude);
-    ASSERT_DOUBLE_EQ(trueCenter.longitude, shiftedCenter.longitude);
+    ASSERT_NEAR(trueCenter.longitude, shiftedCenter.longitude, 1e-9);
     ASSERT_DOUBLE_EQ(manualShiftedCenter.latitude, shiftedCenter.latitude);
     ASSERT_DOUBLE_EQ(manualShiftedCenter.longitude, shiftedCenter.longitude);
 }
@@ -401,12 +401,12 @@ TEST(Transform, Antimeridian) {
 
     const LatLng coordinateSanFrancisco { 37.7833, -122.4167 };
     ScreenCoordinate pixelSF = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
-    ASSERT_DOUBLE_EQ(151.79409149185352, pixelSF.x);
-    ASSERT_DOUBLE_EQ(383.76774094913071, pixelSF.y);
+    ASSERT_NEAR(151.79409149185352, pixelSF.x, 1e-2);
+    ASSERT_NEAR(383.76774094913071, pixelSF.y, 1e-2);
 
     transform.setLatLng({ 0, -181 });
     ScreenCoordinate pixelSFBackwards = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
-    ASSERT_DOUBLE_EQ(666.63617954008976, pixelSFBackwards.x);
+    ASSERT_NEAR(666.63617954008976, pixelSFBackwards.x, 1e-2);
     ASSERT_DOUBLE_EQ(pixelSF.y, pixelSFBackwards.y);
 
     transform.setLatLng({ 0, 179 });
@@ -417,12 +417,12 @@ TEST(Transform, Antimeridian) {
     const LatLng coordinateWaikiri{ -16.9310, 179.9787 };
     transform.setLatLngZoom(coordinateWaikiri, 10);
     ScreenCoordinate pixelWaikiri = transform.latLngToScreenCoordinate(coordinateWaikiri);
-    ASSERT_DOUBLE_EQ(500.00000000007759, pixelWaikiri.x);
-    ASSERT_DOUBLE_EQ(500, pixelWaikiri.y);
+    ASSERT_NEAR(500, pixelWaikiri.x, 1e-2);
+    ASSERT_NEAR(500, pixelWaikiri.y, 1e-2);
 
     transform.setLatLng({ coordinateWaikiri.latitude, 180.0213 });
     ScreenCoordinate pixelWaikiriForwards = transform.latLngToScreenCoordinate(coordinateWaikiri);
-    ASSERT_DOUBLE_EQ(437.95953728819512, pixelWaikiriForwards.x);
+    ASSERT_NEAR(437.95953728819512, pixelWaikiriForwards.x, 1e-2);
     ASSERT_DOUBLE_EQ(pixelWaikiri.y, pixelWaikiriForwards.y);
     LatLng coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriForwards);
     ASSERT_NEAR(coordinateWaikiri.latitude, coordinateFromPixel.latitude, 0.000001);

--- a/test/util/tile_cover.test.cpp
+++ b/test/util/tile_cover.test.cpp
@@ -30,6 +30,8 @@ TEST(TileCover, WorldZ0) {
 TEST(TileCover, Pitch) {
     Transform transform;
     transform.resize({ 512, 512 });
+    // slightly offset center so that tile order is better defined
+    transform.setLatLng({ 0.01, -0.01 });
     transform.setZoom(2);
     transform.setPitch(40.0 * M_PI / 180.0);
 


### PR DESCRIPTION
fix #7439

ports https://github.com/mapbox/mapbox-gl-js/pull/3790

> This cleans up a bunch of matrix and antialiasing code.
> 
> - removes the confusing altitude and replaces it with fov
> - fixes text blurriness at non-default FOVs
> - removes the hack added in #3740 and adds a different fix
> - makes pitched line antialiasing clearer and removes lineStretch and lineAntialiasingMatrix

TODO:
I removed `altitude` from `CustomLayerRenderParameters` and added `fieldOfView`. Is this considered an external interface / breaking change? Should I remove it from the platform bindings as well? Or should I calculate it and add it? The old altitude value is just `0.5 / tan(fov / 2) * height`

@jfirebaugh 