### PR TITLE
[android] - wrap mapbox map test in ViewActions

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
@@ -39,6 +39,7 @@ import timber.log.Timber;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withChild;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
@@ -47,6 +48,10 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * This test is responsible for testing the public API.
+ * <p>
+ * Methods executed on MapboxMap are called from a ViewAction to ensure correct synchronisation
+ * with the application UI-thread.
+ * </p>
  */
 public class MapboxMapTest {
 
@@ -78,18 +83,28 @@ public class MapboxMapTest {
     @Test
     public void testMinZoom() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        onView(withId(R.id.mapView)).perform(new MinZoomAction(mapboxMap));
-        assertEquals("MinZoom should match", 10, mapboxMap.getMinZoom(), 0);
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                mapboxMap.setMinZoom(10);
+                assertEquals("MinZoom should match", 10, mapboxMap.getMinZoom(), 10);
+            }
+        }));
     }
 
     @Test
     public void testMaxZoom() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        double zoom = 10;
-        mapboxMap.setMaxZoom(zoom);
-        assertEquals("MaxZoom should match", zoom, mapboxMap.getMaxZoom(), 0);
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        final double zoom = 10;
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                mapboxMap.setMaxZoom(zoom);
+                assertEquals("MaxZoom should match", zoom, mapboxMap.getMaxZoom(), 10);
+            }
+        }));
     }
 
     @Test
@@ -118,32 +133,47 @@ public class MapboxMapTest {
     @Test
     public void testConcurrentInfoWindowEnabled() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        mapboxMap.setAllowConcurrentMultipleOpenInfoWindows(true);
-        assertTrue("ConcurrentWindows should be true", mapboxMap.isAllowConcurrentMultipleOpenInfoWindows());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                mapboxMap.setAllowConcurrentMultipleOpenInfoWindows(true);
+                assertTrue("ConcurrentWindows should be true", mapboxMap.isAllowConcurrentMultipleOpenInfoWindows());
+            }
+        }));
     }
 
     @Test
     public void testConcurrentInfoWindowDisabled() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        mapboxMap.setAllowConcurrentMultipleOpenInfoWindows(false);
-        assertFalse("ConcurrentWindows should be false", mapboxMap.isAllowConcurrentMultipleOpenInfoWindows());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                mapboxMap.setAllowConcurrentMultipleOpenInfoWindows(false);
+                assertFalse("ConcurrentWindows should be false", mapboxMap.isAllowConcurrentMultipleOpenInfoWindows());
+            }
+        }));
     }
 
     @Test
     public void testInfoWindowAdapter() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MapboxMap.InfoWindowAdapter infoWindowAdapter = new MapboxMap.InfoWindowAdapter() {
-            @Nullable
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
             @Override
-            public View getInfoWindow(@NonNull Marker marker) {
-                return null;
+            public void onViewAction(UiController uiController, View view) {
+                MapboxMap.InfoWindowAdapter infoWindowAdapter = new MapboxMap.InfoWindowAdapter() {
+                    @Nullable
+                    @Override
+                    public View getInfoWindow(@NonNull Marker marker) {
+                        return null;
+                    }
+                };
+                mapboxMap.setInfoWindowAdapter(infoWindowAdapter);
+                assertEquals("InfoWindowAdpter should be the same", infoWindowAdapter, mapboxMap.getInfoWindowAdapter());
             }
-        };
-        mapboxMap.setInfoWindowAdapter(infoWindowAdapter);
-        assertEquals("InfoWindowAdpter should be the same", infoWindowAdapter, mapboxMap.getInfoWindowAdapter());
+        }));
     }
 
     //
@@ -154,18 +184,28 @@ public class MapboxMapTest {
     @Ignore /* disabled due to enabling permissions during test #7177 */
     public void testMyLocationEnabled() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        mapboxMap.setMyLocationEnabled(true);
-        assertTrue("MyLocationEnabled should be true", mapboxMap.isMyLocationEnabled());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                mapboxMap.setMyLocationEnabled(true);
+                assertTrue("MyLocationEnabled should be true", mapboxMap.isMyLocationEnabled());
+            }
+        }));
     }
 
     @Test
     @Ignore /* can't create handler inside thread that not called Looper.prepare() */
     public void testMyLocationDisabled() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        mapboxMap.setMyLocationEnabled(false);
-        assertFalse("MyLocationEnabled should be false", mapboxMap.isMyLocationEnabled());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                mapboxMap.setMyLocationEnabled(false);
+                assertFalse("MyLocationEnabled should be false", mapboxMap.isMyLocationEnabled());
+            }
+        }));
     }
 
     //
@@ -175,57 +215,77 @@ public class MapboxMapTest {
     @Test
     public void testFpsListener() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MapboxMap.OnFpsChangedListener fpsChangedListener = new MapboxMap.OnFpsChangedListener() {
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
             @Override
-            public void onFpsChanged(double fps) {
+            public void onViewAction(UiController uiController, View view) {
+                MapboxMap.OnFpsChangedListener fpsChangedListener = new MapboxMap.OnFpsChangedListener() {
+                    @Override
+                    public void onFpsChanged(double fps) {
 
+                    }
+                };
+                mapboxMap.setOnFpsChangedListener(fpsChangedListener);
+                assertEquals("FpsListener should match", fpsChangedListener, mapboxMap.getOnFpsChangedListener());
             }
-        };
-        mapboxMap.setOnFpsChangedListener(fpsChangedListener);
-        assertEquals("FpsListener should match", fpsChangedListener, mapboxMap.getOnFpsChangedListener());
+        }));
     }
 
     @Test
     public void testInfoWindowClickListener() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MapboxMap.OnInfoWindowClickListener clickListener = new MapboxMap.OnInfoWindowClickListener() {
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
             @Override
-            public boolean onInfoWindowClick(@NonNull Marker marker) {
-                return false;
+            public void onViewAction(UiController uiController, View view) {
+                MapboxMap.OnInfoWindowClickListener clickListener = new MapboxMap.OnInfoWindowClickListener() {
+                    @Override
+                    public boolean onInfoWindowClick(@NonNull Marker marker) {
+                        return false;
+                    }
+                };
+                mapboxMap.setOnInfoWindowClickListener(clickListener);
+                assertEquals("InfoWidowClickListener should match", clickListener, mapboxMap.getOnInfoWindowClickListener());
             }
-        };
-        mapboxMap.setOnInfoWindowClickListener(clickListener);
-        assertEquals("InfoWidowClickListener should match", clickListener, mapboxMap.getOnInfoWindowClickListener());
+        }));
     }
 
     @Test
     public void testInfoWindowCloseListener() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MapboxMap.OnInfoWindowCloseListener listener = new MapboxMap.OnInfoWindowCloseListener() {
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
             @Override
-            public void onInfoWindowClose(Marker marker) {
+            public void onViewAction(UiController uiController, View view) {
+                MapboxMap.OnInfoWindowCloseListener listener = new MapboxMap.OnInfoWindowCloseListener() {
+                    @Override
+                    public void onInfoWindowClose(Marker marker) {
 
+                    }
+                };
+                mapboxMap.setOnInfoWindowCloseListener(listener);
+                assertEquals("InfoWindowCloseListener should match", listener, mapboxMap.getOnInfoWindowCloseListener());
             }
-        };
-        mapboxMap.setOnInfoWindowCloseListener(listener);
-        assertEquals("InfoWindowCloseListener should match", listener, mapboxMap.getOnInfoWindowCloseListener());
+        }));
     }
 
     @Test
     public void testInfoWindowLongClickListener() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MapboxMap.OnInfoWindowLongClickListener listener = new MapboxMap.OnInfoWindowLongClickListener() {
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
             @Override
-            public void onInfoWindowLongClick(Marker marker) {
+            public void onViewAction(UiController uiController, View view) {
+                MapboxMap.OnInfoWindowLongClickListener listener = new MapboxMap.OnInfoWindowLongClickListener() {
+                    @Override
+                    public void onInfoWindowLongClick(Marker marker) {
 
+                    }
+                };
+                mapboxMap.setOnInfoWindowLongClickListener(listener);
+                assertEquals("InfoWindowLongClickListener should match", listener, mapboxMap.getOnInfoWindowLongClickListener());
             }
-        };
-        mapboxMap.setOnInfoWindowLongClickListener(listener);
-        assertEquals("InfoWindowLongClickListener should match", listener, mapboxMap.getOnInfoWindowLongClickListener());
+        }));
     }
 
     //
@@ -235,10 +295,15 @@ public class MapboxMapTest {
     @Test
     public void testAddMarker() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
-        Marker marker = mapboxMap.addMarker(markerOptions);
-        assertTrue("Marker should be contained", mapboxMap.getMarkers().contains(marker));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
+                Marker marker = mapboxMap.addMarker(markerOptions);
+                assertTrue("Marker should be contained", mapboxMap.getMarkers().contains(marker));
+            }
+        }));
     }
 
     @Test(expected = InvalidMarkerPositionException.class)
@@ -249,323 +314,473 @@ public class MapboxMapTest {
     @Test
     public void testAddMarkers() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<BaseMarkerOptions> markerList = new ArrayList<>();
-        MarkerOptions markerOptions1 = new MarkerOptions().position(new LatLng()).title("a");
-        MarkerOptions markerOptions2 = new MarkerOptions().position(new LatLng()).title("b");
-        markerList.add(markerOptions1);
-        markerList.add(markerOptions2);
-        List<Marker> markers = mapboxMap.addMarkers(markerList);
-        assertEquals("Markers size should be 2", 2, mapboxMap.getMarkers().size());
-        assertTrue(mapboxMap.getMarkers().contains(markers.get(0)));
-        assertTrue(mapboxMap.getMarkers().contains(markers.get(1)));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<BaseMarkerOptions> markerList = new ArrayList<>();
+                MarkerOptions markerOptions1 = new MarkerOptions().position(new LatLng()).title("a");
+                MarkerOptions markerOptions2 = new MarkerOptions().position(new LatLng()).title("b");
+                markerList.add(markerOptions1);
+                markerList.add(markerOptions2);
+                List<Marker> markers = mapboxMap.addMarkers(markerList);
+                assertEquals("Markers size should be 2", 2, mapboxMap.getMarkers().size());
+                assertTrue(mapboxMap.getMarkers().contains(markers.get(0)));
+                assertTrue(mapboxMap.getMarkers().contains(markers.get(1)));
+            }
+        }));
     }
 
     @Test
     public void testAddMarkersEmpty() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<BaseMarkerOptions> markerList = new ArrayList<>();
-        mapboxMap.addMarkers(markerList);
-        assertEquals("Markers size should be 0", 0, mapboxMap.getMarkers().size());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<BaseMarkerOptions> markerList = new ArrayList<>();
+                mapboxMap.addMarkers(markerList);
+                assertEquals("Markers size should be 0", 0, mapboxMap.getMarkers().size());
+            }
+        }));
     }
 
     @Test
     public void testAddMarkersSingleMarker() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<BaseMarkerOptions> markerList = new ArrayList<>();
-        MarkerOptions markerOptions = new MarkerOptions().title("a").position(new LatLng());
-        markerList.add(markerOptions);
-        List<Marker> markers = mapboxMap.addMarkers(markerList);
-        assertEquals("Markers size should be 1", 1, mapboxMap.getMarkers().size());
-        assertTrue(mapboxMap.getMarkers().contains(markers.get(0)));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<BaseMarkerOptions> markerList = new ArrayList<>();
+                MarkerOptions markerOptions = new MarkerOptions().title("a").position(new LatLng());
+                markerList.add(markerOptions);
+                List<Marker> markers = mapboxMap.addMarkers(markerList);
+                assertEquals("Markers size should be 1", 1, mapboxMap.getMarkers().size());
+                assertTrue(mapboxMap.getMarkers().contains(markers.get(0)));
+            }
+        }));
     }
 
     @Test
     public void testAddPolygon() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        PolygonOptions polygonOptions = new PolygonOptions().add(new LatLng());
-        Polygon polygon = mapboxMap.addPolygon(polygonOptions);
-        assertTrue("Polygon should be contained", mapboxMap.getPolygons().contains(polygon));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                PolygonOptions polygonOptions = new PolygonOptions().add(new LatLng());
+                Polygon polygon = mapboxMap.addPolygon(polygonOptions);
+                assertTrue("Polygon should be contained", mapboxMap.getPolygons().contains(polygon));
+            }
+        }));
     }
 
     @Test
     public void testAddEmptyPolygon() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        PolygonOptions polygonOptions = new PolygonOptions();
-        Polygon polygon = mapboxMap.addPolygon(polygonOptions);
-        assertTrue("Polygon should be ignored", !mapboxMap.getPolygons().contains(polygon));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                PolygonOptions polygonOptions = new PolygonOptions();
+                Polygon polygon = mapboxMap.addPolygon(polygonOptions);
+                assertTrue("Polygon should be ignored", !mapboxMap.getPolygons().contains(polygon));
+            }
+        }));
     }
 
     @Test
     public void testAddPolygons() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<PolygonOptions> polygonList = new ArrayList<>();
-        PolygonOptions polygonOptions1 = new PolygonOptions().fillColor(Color.BLACK).add(new LatLng());
-        PolygonOptions polygonOptions2 = new PolygonOptions().fillColor(Color.WHITE).add(new LatLng());
-        PolygonOptions polygonOptions3 = new PolygonOptions();
-        polygonList.add(polygonOptions1);
-        polygonList.add(polygonOptions2);
-        polygonList.add(polygonOptions3);
-        mapboxMap.addPolygons(polygonList);
-        assertEquals("Polygons size should be 2", 2, mapboxMap.getPolygons().size());
-        assertTrue(mapboxMap.getPolygons().contains(polygonOptions1.getPolygon()));
-        assertTrue(mapboxMap.getPolygons().contains(polygonOptions2.getPolygon()));
-        assertTrue("Polygon should be ignored", !mapboxMap.getPolygons().contains(polygonOptions3.getPolygon()));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<PolygonOptions> polygonList = new ArrayList<>();
+                PolygonOptions polygonOptions1 = new PolygonOptions().fillColor(Color.BLACK).add(new LatLng());
+                PolygonOptions polygonOptions2 = new PolygonOptions().fillColor(Color.WHITE).add(new LatLng());
+                PolygonOptions polygonOptions3 = new PolygonOptions();
+                polygonList.add(polygonOptions1);
+                polygonList.add(polygonOptions2);
+                polygonList.add(polygonOptions3);
+                mapboxMap.addPolygons(polygonList);
+                assertEquals("Polygons size should be 2", 2, mapboxMap.getPolygons().size());
+                assertTrue(mapboxMap.getPolygons().contains(polygonOptions1.getPolygon()));
+                assertTrue(mapboxMap.getPolygons().contains(polygonOptions2.getPolygon()));
+                assertTrue("Polygon should be ignored", !mapboxMap.getPolygons().contains(polygonOptions3.getPolygon()));
+            }
+        }));
     }
 
     @Test
     public void addPolygonsEmpty() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        mapboxMap.addPolygons(new ArrayList<PolygonOptions>());
-        assertEquals("Polygons size should be 0", 0, mapboxMap.getPolygons().size());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                mapboxMap.addPolygons(new ArrayList<PolygonOptions>());
+                assertEquals("Polygons size should be 0", 0, mapboxMap.getPolygons().size());
+            }
+        }));
     }
 
     @Test
     public void addPolygonsSingle() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<PolygonOptions> polygonList = new ArrayList<>();
-        PolygonOptions polygonOptions = new PolygonOptions().fillColor(Color.BLACK).add(new LatLng());
-        polygonList.add(polygonOptions);
-        mapboxMap.addPolygons(polygonList);
-        assertEquals("Polygons size should be 1", 1, mapboxMap.getPolygons().size());
-        assertTrue(mapboxMap.getPolygons().contains(polygonOptions.getPolygon()));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<PolygonOptions> polygonList = new ArrayList<>();
+                PolygonOptions polygonOptions = new PolygonOptions().fillColor(Color.BLACK).add(new LatLng());
+                polygonList.add(polygonOptions);
+                mapboxMap.addPolygons(polygonList);
+                assertEquals("Polygons size should be 1", 1, mapboxMap.getPolygons().size());
+                assertTrue(mapboxMap.getPolygons().contains(polygonOptions.getPolygon()));
+            }
+        }));
     }
 
     @Test
     public void testAddPolyline() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        PolylineOptions polylineOptions = new PolylineOptions().add(new LatLng());
-        Polyline polyline = mapboxMap.addPolyline(polylineOptions);
-        assertTrue("Polyline should be contained", mapboxMap.getPolylines().contains(polyline));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                PolylineOptions polylineOptions = new PolylineOptions().add(new LatLng());
+                Polyline polyline = mapboxMap.addPolyline(polylineOptions);
+                assertTrue("Polyline should be contained", mapboxMap.getPolylines().contains(polyline));
+            }
+        }));
     }
 
     @Test
     public void testAddEmptyPolyline() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        PolylineOptions polylineOptions = new PolylineOptions();
-        Polyline polyline = mapboxMap.addPolyline(polylineOptions);
-        assertTrue("Polyline should be ignored", !mapboxMap.getPolylines().contains(polyline));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                PolylineOptions polylineOptions = new PolylineOptions();
+                Polyline polyline = mapboxMap.addPolyline(polylineOptions);
+                assertTrue("Polyline should be ignored", !mapboxMap.getPolylines().contains(polyline));
+            }
+        }));
     }
 
     @Test
     public void testAddPolylines() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<PolylineOptions> polylineList = new ArrayList<>();
-        PolylineOptions polygonOptions1 = new PolylineOptions().color(Color.BLACK).add(new LatLng());
-        PolylineOptions polygonOptions2 = new PolylineOptions().color(Color.WHITE).add(new LatLng());
-        PolylineOptions polygonOptions3 = new PolylineOptions();
-        polylineList.add(polygonOptions1);
-        polylineList.add(polygonOptions2);
-        polylineList.add(polygonOptions3);
-        mapboxMap.addPolylines(polylineList);
-        assertEquals("Polygons size should be 2", 2, mapboxMap.getPolylines().size());
-        assertTrue(mapboxMap.getPolylines().contains(polygonOptions1.getPolyline()));
-        assertTrue(mapboxMap.getPolylines().contains(polygonOptions2.getPolyline()));
-        assertTrue("Polyline should be ignored", !mapboxMap.getPolylines().contains(polygonOptions3.getPolyline()));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<PolylineOptions> polylineList = new ArrayList<>();
+                PolylineOptions polygonOptions1 = new PolylineOptions().color(Color.BLACK).add(new LatLng());
+                PolylineOptions polygonOptions2 = new PolylineOptions().color(Color.WHITE).add(new LatLng());
+                PolylineOptions polygonOptions3 = new PolylineOptions();
+                polylineList.add(polygonOptions1);
+                polylineList.add(polygonOptions2);
+                polylineList.add(polygonOptions3);
+                mapboxMap.addPolylines(polylineList);
+                assertEquals("Polygons size should be 2", 2, mapboxMap.getPolylines().size());
+                assertTrue(mapboxMap.getPolylines().contains(polygonOptions1.getPolyline()));
+                assertTrue(mapboxMap.getPolylines().contains(polygonOptions2.getPolyline()));
+                assertTrue("Polyline should be ignored", !mapboxMap.getPolylines().contains(polygonOptions3.getPolyline()));
+            }
+        }));
     }
 
     @Test
     public void testAddPolylinesEmpty() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        mapboxMap.addPolylines(new ArrayList<PolylineOptions>());
-        assertEquals("Polygons size should be 0", 0, mapboxMap.getPolylines().size());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                mapboxMap.addPolylines(new ArrayList<PolylineOptions>());
+                assertEquals("Polygons size should be 0", 0, mapboxMap.getPolylines().size());
+            }
+        }));
     }
 
     @Test
     public void testAddPolylinesSingle() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<PolylineOptions> polylineList = new ArrayList<>();
-        PolylineOptions polygonOptions = new PolylineOptions().color(Color.BLACK).add(new LatLng());
-        polylineList.add(polygonOptions);
-        mapboxMap.addPolylines(polylineList);
-        assertEquals("Polygons size should be 1", 1, mapboxMap.getPolylines().size());
-        assertTrue(mapboxMap.getPolylines().contains(polygonOptions.getPolyline()));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<PolylineOptions> polylineList = new ArrayList<>();
+                PolylineOptions polygonOptions = new PolylineOptions().color(Color.BLACK).add(new LatLng());
+                polylineList.add(polygonOptions);
+                mapboxMap.addPolylines(polylineList);
+                assertEquals("Polygons size should be 1", 1, mapboxMap.getPolylines().size());
+                assertTrue(mapboxMap.getPolylines().contains(polygonOptions.getPolyline()));
+            }
+        }));
     }
 
     @Test
     public void testRemoveMarker() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
-        Marker marker = mapboxMap.addMarker(markerOptions);
-        mapboxMap.removeMarker(marker);
-        assertTrue("Markers should be empty", mapboxMap.getMarkers().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
+                Marker marker = mapboxMap.addMarker(markerOptions);
+                mapboxMap.removeMarker(marker);
+                assertTrue("Markers should be empty", mapboxMap.getMarkers().isEmpty());
+            }
+        }));
     }
 
     @Test
     public void testRemovePolygon() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        PolygonOptions polygonOptions = new PolygonOptions();
-        Polygon polygon = mapboxMap.addPolygon(polygonOptions);
-        mapboxMap.removePolygon(polygon);
-        assertTrue("Polygons should be empty", mapboxMap.getPolylines().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                PolygonOptions polygonOptions = new PolygonOptions();
+                Polygon polygon = mapboxMap.addPolygon(polygonOptions);
+                mapboxMap.removePolygon(polygon);
+                assertTrue("Polygons should be empty", mapboxMap.getPolylines().isEmpty());
+            }
+        }));
     }
 
     @Test
     public void testRemovePolyline() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        PolylineOptions polylineOptions = new PolylineOptions();
-        Polyline polyline = mapboxMap.addPolyline(polylineOptions);
-        mapboxMap.removePolyline(polyline);
-        assertTrue("Polylines should be empty", mapboxMap.getPolylines().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                PolylineOptions polylineOptions = new PolylineOptions();
+                Polyline polyline = mapboxMap.addPolyline(polylineOptions);
+                mapboxMap.removePolyline(polyline);
+                assertTrue("Polylines should be empty", mapboxMap.getPolylines().isEmpty());
+            }
+        }));
     }
 
     @Test
     public void testRemoveAnnotation() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
-        Marker marker = mapboxMap.addMarker(markerOptions);
-        onView(withId(R.id.mapView)).perform(new RemoveAnnotationAction(marker, mapboxMap));
-        assertTrue("Annotations should be empty", mapboxMap.getAnnotations().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
+                Marker marker = mapboxMap.addMarker(markerOptions);
+                mapboxMap.removeAnnotation(marker);
+                assertTrue("Annotations should be empty", mapboxMap.getAnnotations().isEmpty());
+            }
+        }));
     }
 
     @Test
     public void testRemoveAnnotationById() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
-        mapboxMap.addMarker(markerOptions);
-        // id will always be 0 in unit tests
-        mapboxMap.removeAnnotation(0);
-        assertTrue("Annotations should be empty", mapboxMap.getAnnotations().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
+                mapboxMap.addMarker(markerOptions);
+                // id will always be 0 in unit tests
+                mapboxMap.removeAnnotation(0);
+                assertTrue("Annotations should be empty", mapboxMap.getAnnotations().isEmpty());
+            }
+        }));
     }
 
     @Test
     public void testRemoveAnnotations() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<BaseMarkerOptions> markerList = new ArrayList<>();
-        MarkerOptions markerOptions1 = new MarkerOptions().title("a").position(new LatLng());
-        MarkerOptions markerOptions2 = new MarkerOptions().title("b").position(new LatLng());
-        markerList.add(markerOptions1);
-        markerList.add(markerOptions2);
-        mapboxMap.addMarkers(markerList);
-        mapboxMap.removeAnnotations();
-        assertTrue("Annotations should be empty", mapboxMap.getAnnotations().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<BaseMarkerOptions> markerList = new ArrayList<>();
+                MarkerOptions markerOptions1 = new MarkerOptions().title("a").position(new LatLng());
+                MarkerOptions markerOptions2 = new MarkerOptions().title("b").position(new LatLng());
+                markerList.add(markerOptions1);
+                markerList.add(markerOptions2);
+                mapboxMap.addMarkers(markerList);
+                mapboxMap.removeAnnotations();
+                assertTrue("Annotations should be empty", mapboxMap.getAnnotations().isEmpty());
+            }
+        }));
     }
 
     @Test
     public void testClear() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<BaseMarkerOptions> markerList = new ArrayList<>();
-        MarkerOptions markerOptions1 = new MarkerOptions().title("a").position(new LatLng());
-        MarkerOptions markerOptions2 = new MarkerOptions().title("b").position(new LatLng());
-        markerList.add(markerOptions1);
-        markerList.add(markerOptions2);
-        mapboxMap.addMarkers(markerList);
-        mapboxMap.clear();
-        assertTrue("Annotations should be empty", mapboxMap.getAnnotations().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<BaseMarkerOptions> markerList = new ArrayList<>();
+                MarkerOptions markerOptions1 = new MarkerOptions().title("a").position(new LatLng());
+                MarkerOptions markerOptions2 = new MarkerOptions().title("b").position(new LatLng());
+                markerList.add(markerOptions1);
+                markerList.add(markerOptions2);
+                mapboxMap.addMarkers(markerList);
+                mapboxMap.clear();
+                assertTrue("Annotations should be empty", mapboxMap.getAnnotations().isEmpty());
+            }
+        }));
     }
 
     @Test
     public void testRemoveAnnotationsByList() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        List<BaseMarkerOptions> markerList = new ArrayList<>();
-        MarkerOptions markerOptions1 = new MarkerOptions().title("a").position(new LatLng());
-        MarkerOptions markerOptions2 = new MarkerOptions().title("b").position(new LatLng());
-        markerList.add(markerOptions1);
-        markerList.add(markerOptions2);
-        List<Marker> markers = mapboxMap.addMarkers(markerList);
-        Marker marker = mapboxMap.addMarker(new MarkerOptions().position(new LatLng()).title("c"));
-        mapboxMap.removeAnnotations(markers);
-        assertTrue("Annotations should not be empty", mapboxMap.getAnnotations().size() == 1);
-        assertTrue("Marker should be contained", mapboxMap.getAnnotations().contains(marker));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                List<BaseMarkerOptions> markerList = new ArrayList<>();
+                MarkerOptions markerOptions1 = new MarkerOptions().title("a").position(new LatLng());
+                MarkerOptions markerOptions2 = new MarkerOptions().title("b").position(new LatLng());
+                markerList.add(markerOptions1);
+                markerList.add(markerOptions2);
+                List<Marker> markers = mapboxMap.addMarkers(markerList);
+                Marker marker = mapboxMap.addMarker(new MarkerOptions().position(new LatLng()).title("c"));
+                mapboxMap.removeAnnotations(markers);
+                assertTrue("Annotations should not be empty", mapboxMap.getAnnotations().size() == 1);
+                assertTrue("Marker should be contained", mapboxMap.getAnnotations().contains(marker));
+            }
+        }));
     }
 
     @Test
     public void testGetAnnotationById() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
-        Marker initialMarker = mapboxMap.addMarker(markerOptions);
-        Marker retrievedMarker = (Marker) mapboxMap.getAnnotation(0);
-        assertEquals("Markers should match", initialMarker, retrievedMarker);
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
+                Marker initialMarker = mapboxMap.addMarker(markerOptions);
+                Marker retrievedMarker = (Marker) mapboxMap.getAnnotation(0);
+                assertEquals("Markers should match", initialMarker, retrievedMarker);
+            }
+        }));
     }
 
     @Test
     public void testGetAnnotations() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        assertNotNull("Annotations should be non null", mapboxMap.getAnnotations());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                assertNotNull("Annotations should be non null", mapboxMap.getAnnotations());
+            }
+        }));
     }
 
     @Test
     public void testGetMarkers() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        assertNotNull("Markers should be non null", mapboxMap.getMarkers());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                assertNotNull("Markers should be non null", mapboxMap.getMarkers());
+            }
+        }));
     }
 
     @Test
     public void testGetPolygons() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        assertNotNull("Polygons should be non null", mapboxMap.getPolygons());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                assertNotNull("Polygons should be non null", mapboxMap.getPolygons());
+            }
+        }));
     }
 
     @Test
     public void testGetPolylines() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        assertNotNull("Polylines should be non null", mapboxMap.getPolylines());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                assertNotNull("Polylines should be non null", mapboxMap.getPolylines());
+            }
+        }));
     }
 
     @Test
     public void testGetSelectedMarkers() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        assertNotNull("Selected markers should be non null", mapboxMap.getSelectedMarkers());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                assertNotNull("Selected markers should be non null", mapboxMap.getSelectedMarkers());
+            }
+        }));
     }
 
     @Test
     public void testSelectMarker() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
-        Marker marker = mapboxMap.addMarker(markerOptions);
-        mapboxMap.selectMarker(marker);
-        assertTrue("Marker should be contained", mapboxMap.getSelectedMarkers().contains(marker));
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
+                Marker marker = mapboxMap.addMarker(markerOptions);
+                mapboxMap.selectMarker(marker);
+                assertTrue("Marker should be contained", mapboxMap.getSelectedMarkers().contains(marker));
+            }
+        }));
     }
 
     @Test
     public void testDeselectMarker() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
-        Marker marker = mapboxMap.addMarker(markerOptions);
-        mapboxMap.selectMarker(marker);
-        mapboxMap.deselectMarker(marker);
-        assertTrue("Selected markers should be empty", mapboxMap.getSelectedMarkers().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
+                Marker marker = mapboxMap.addMarker(markerOptions);
+                mapboxMap.selectMarker(marker);
+                mapboxMap.deselectMarker(marker);
+                assertTrue("Selected markers should be empty", mapboxMap.getSelectedMarkers().isEmpty());
+            }
+        }));
     }
 
     @Test
     public void testDeselectMarkers() {
         ViewUtils.checkViewIsDisplayed(R.id.mapView);
-        MapboxMap mapboxMap = activity.getMapboxMap();
-        MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
-        Marker marker1 = mapboxMap.addMarker(markerOptions);
-        Marker marker2 = mapboxMap.addMarker(markerOptions);
-        mapboxMap.selectMarker(marker1);
-        mapboxMap.selectMarker(marker2);
-        mapboxMap.deselectMarkers();
-        assertTrue("Selected markers should be empty", mapboxMap.getSelectedMarkers().isEmpty());
+        final MapboxMap mapboxMap = activity.getMapboxMap();
+        onView(withId(R.id.mapView)).perform(new MapboxMapAction(new InvokeViewAction() {
+            @Override
+            public void onViewAction(UiController uiController, View view) {
+                MarkerOptions markerOptions = new MarkerOptions().position(new LatLng());
+                Marker marker1 = mapboxMap.addMarker(markerOptions);
+                Marker marker2 = mapboxMap.addMarker(markerOptions);
+                mapboxMap.selectMarker(marker1);
+                mapboxMap.selectMarker(marker2);
+                mapboxMap.deselectMarkers();
+                assertTrue("Selected markers should be empty", mapboxMap.getSelectedMarkers().isEmpty());
+            }
+        }));
     }
 
     @After
@@ -574,12 +789,12 @@ public class MapboxMapTest {
         Espresso.unregisterIdlingResources(idlingResource);
     }
 
-    private class MinZoomAction implements ViewAction {
+   private class MapboxMapAction implements ViewAction{
 
-        private MapboxMap mapboxMap;
+        private InvokeViewAction invokeViewAction;
 
-        MinZoomAction(MapboxMap map) {
-            mapboxMap = map;
+        MapboxMapAction(InvokeViewAction invokeViewAction) {
+            this.invokeViewAction = invokeViewAction;
         }
 
         @Override
@@ -594,34 +809,11 @@ public class MapboxMapTest {
 
         @Override
         public void perform(UiController uiController, View view) {
-            mapboxMap.setMinZoom(10);
+            invokeViewAction.onViewAction(uiController, view);
         }
     }
 
-    private class RemoveAnnotationAction implements ViewAction {
-
-        private Annotation annotation;
-        private MapboxMap mapboxMap;
-
-        RemoveAnnotationAction(Annotation annotation, MapboxMap mapboxMap) {
-            this.annotation = annotation;
-            this.mapboxMap = mapboxMap;
-        }
-
-        @Override
-        public Matcher<View> getConstraints() {
-            return isDisplayed();
-        }
-
-        @Override
-        public String getDescription() {
-            return getClass().getSimpleName();
-        }
-
-        @Override
-        public void perform(UiController uiController, View view) {
-            mapboxMap.removeAnnotation(annotation);
-        }
+    interface InvokeViewAction {
+        void onViewAction(UiController uiController, View view);
     }
-
 }


### PR DESCRIPTION
Refs #6546, Closes #7447, this PR attempts to make our MapboxMap tests more robust by wrapping the executed code in a ViewAction. This ensures that we are calling MapboxMap methods from the application UI thread. I have done ~20 tests locally without seeing the exception from #7447, will setup some additional tests on CI to be :100: that this change fixes the issue.

Review @cammace 
cc @mapbox/android @jfirebaugh 

