### PR TITLE
Fix return type of MGLShape factory method

### DIFF
--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
     not be parsed as valid GeoJSON source code. If `nil`, `outError` contains an
     `NSError` object describing the problem.
  */
-+ (nullable instancetype)shapeWithData:(NSData *)data encoding:(NSStringEncoding)encoding error:(NSError * _Nullable *)outError;
++ (nullable MGLShape *)shapeWithData:(NSData *)data encoding:(NSStringEncoding)encoding error:(NSError * _Nullable *)outError;
 
 #pragma mark Accessing the Shape Attributes
 

--- a/platform/darwin/src/MGLShape.mm
+++ b/platform/darwin/src/MGLShape.mm
@@ -4,7 +4,7 @@
 
 @implementation MGLShape
 
-+ (nullable instancetype)shapeWithData:(NSData *)data encoding:(NSStringEncoding)encoding error:(NSError * _Nullable *)outError {
++ (nullable MGLShape *)shapeWithData:(NSData *)data encoding:(NSStringEncoding)encoding error:(NSError * _Nullable *)outError {
     NSString *string = [[NSString alloc] initWithData:data encoding:encoding];
     if (!string) {
         if (outError) {


### PR DESCRIPTION
This change ensures that `-shapeWithData:encoding:error:` is only available on MGLShape in Swift.

Fixes #7456.