### PR TITLE
Highlight current topic in documentation

### DIFF
--- a/platform/darwin/docs/theme/assets/css/jazzy.css.scss
+++ b/platform/darwin/docs/theme/assets/css/jazzy.css.scss
@@ -367,6 +367,11 @@ pre code {
   color: $navigation_task_color;
 }
 
+.nav-group-name > .small-heading,
+.nav-group-task-link {
+  display: block;
+}
+
 .nav-group-task-link {
    color: $color_darkblue_lighten;
 }

--- a/platform/darwin/docs/theme/templates/doc.mustache
+++ b/platform/darwin/docs/theme/templates/doc.mustache
@@ -8,6 +8,15 @@
     <script src="{{path_to_root}}js/jquery.min.js" defer></script>
     <script src="{{path_to_root}}js/jazzy.js" defer></script>
     {{{custom_head}}}
+    <style type="text/css">
+      .nav-group-name[data-name="{{name}}"] {
+        background-color: #f5f8fc;
+      }
+      .nav-group-task[data-name="{{name}}"] {
+        background-color: #f5f8fc;
+        font-weight: bold;
+      }
+    </style>
   </head>
   <body>
 

--- a/platform/darwin/docs/theme/templates/doc.mustache
+++ b/platform/darwin/docs/theme/templates/doc.mustache
@@ -9,12 +9,12 @@
     <script src="{{path_to_root}}js/jazzy.js" defer></script>
     {{{custom_head}}}
     <style type="text/css">
-      .nav-group-name[data-name="{{name}}"] {
-        background-color: #f5f8fc;
-      }
+      .nav-group-name[data-name="{{name}}"] > .small-heading,
       .nav-group-task[data-name="{{name}}"] {
         background-color: #f5f8fc;
-        font-weight: bold;
+        font-family: "Open Sans Bold";
+        border-left: 3px solid #3a68d8;
+        padding-left: 5px
       }
     </style>
   </head>

--- a/platform/darwin/docs/theme/templates/nav.mustache
+++ b/platform/darwin/docs/theme/templates/nav.mustache
@@ -1,11 +1,11 @@
 <nav class="navigation">
   <ul class="nav-groups">
     {{#structure}}
-    <li class="nav-group-name">
+    <li class="nav-group-name" data-name="{{section}}">
       <a class="small-heading" href="{{path_to_root}}{{section}}.html">{{section}}<span class="anchor-icon" /></a>
       <ul class="nav-group-tasks">
         {{#children}}
-        <li class="nav-group-task">
+        <li class="nav-group-task" data-name="{{name}}">
           <a title="{{name}}" class="nav-group-task-link" href="{{path_to_root}}{{url}}">{{name}}</a>
         </li>
         {{/children}}


### PR DESCRIPTION
On category pages, the current category is highlighted in the navigation list:

<img width="390" alt="category" src="https://cloud.githubusercontent.com/assets/1231218/21283007/4ce5d582-c3b0-11e6-8235-92911a5a572e.png">

On topic pages, the current topic is highlighted:

<img width="369" alt="topic" src="https://cloud.githubusercontent.com/assets/1231218/21283009/5029eaf8-c3b0-11e6-872f-aa7559267506.png">

This effect assumes that categories and topics are named uniquely. The only thing that would prevent that from happening would be a guide named identically to a category or topic, which we can easily avoid.

@mayagao, I just reused the navigation bar’s background color for the highlight. Feel free to improve the style.

/cc @friedbunny