### PR TITLE
Fix null expression crash

### DIFF
--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -55,9 +55,10 @@
             // We use long long here to avoid any truncation.
             return { (int64_t)number.longLongValue };
         }
+    } else if (value != [NSNull null]) {
+        [NSException raise:@"Value not handled"
+                    format:@"Can’t convert %s:%@ to mbgl::Value", [value objCType], value];
     }
-    [NSException raise:@"Value not handled"
-                format:@"Can’t convert %s:%@ to mbgl::Value", [value objCType], value];
     return { };
 }
 

--- a/platform/darwin/test/MGLExpressionTests.mm
+++ b/platform/darwin/test/MGLExpressionTests.mm
@@ -197,4 +197,13 @@
     }
 }
 
+#pragma mark - Null Tests
+
+- (void)testExpressionConversionNull
+{
+    NSComparisonPredicate *predicate = [self equalityComparisonPredicateWithRightConstantValue:[NSNull null]];
+    mbgl::Value convertedValue = predicate.rightExpression.mgl_filterValue;
+    XCTAssertTrue(convertedValue.is<mbgl::NullValue>());
+}
+
 @end


### PR DESCRIPTION
Convert NSNull into an `mbgl::NullValue`. This latent bug was exposed by #7377, which sent MGLShapeSource through the same code path used to convert MGLVectorSource predicates into mbgl style filters.

Fixes #7467.