### PR TITLE
Indicate protocols, abstract classes in documentation navigation

### DIFF
--- a/platform/darwin/docs/theme/assets/css/jazzy.css.scss
+++ b/platform/darwin/docs/theme/assets/css/jazzy.css.scss
@@ -367,6 +367,17 @@ pre code {
   color: $navigation_task_color;
 }
 
+.nav-group-task[data-url^="Protocols/"],
+.nav-group-task[data-name="MGLForegroundStyleLayer"],
+.nav-group-task[data-name="MGLMultiPoint"],
+.nav-group-task[data-name="MGLShape"],
+.nav-group-task[data-name="MGLSource"],
+.nav-group-task[data-name="MGLStyleLayer"],
+.nav-group-task[data-name="MGLTileSource"],
+.nav-group-task[data-name="MGLVectorStyleLayer"] {
+  font-style: italic;
+}
+
 .nav-group-name > .small-heading,
 .nav-group-task-link {
   display: block;

--- a/platform/darwin/docs/theme/assets/css/jazzy.css.scss
+++ b/platform/darwin/docs/theme/assets/css/jazzy.css.scss
@@ -51,6 +51,7 @@ $navigation_bg_color: #fbfbfb;
 $navigation_task_color: $link_color;
 
 $section_name_color: $color_darkblue;
+$navigation_gloss_color: #999;
 
 // ----- Content
 
@@ -367,7 +368,17 @@ pre code {
   color: $navigation_task_color;
 }
 
-.nav-group-task[data-url^="Protocols/"],
+%nav-group-task-gloss {
+  color: $navigation_gloss_color;
+  font-size: 90%;
+  margin-left: 0.5em;
+}
+
+.nav-group-task[data-url^="Protocols/"] > .nav-group-task-link::after {
+  @extend %nav-group-task-gloss;
+  content: "(Protocol)";
+}
+
 .nav-group-task[data-name="MGLForegroundStyleLayer"],
 .nav-group-task[data-name="MGLMultiPoint"],
 .nav-group-task[data-name="MGLShape"],
@@ -375,7 +386,10 @@ pre code {
 .nav-group-task[data-name="MGLStyleLayer"],
 .nav-group-task[data-name="MGLTileSource"],
 .nav-group-task[data-name="MGLVectorStyleLayer"] {
-  font-style: italic;
+  .nav-group-task-link::after {
+    @extend %nav-group-task-gloss;
+    content: "(Abstract Class)";
+  }
 }
 
 .nav-group-name > .small-heading,

--- a/platform/darwin/docs/theme/templates/nav.mustache
+++ b/platform/darwin/docs/theme/templates/nav.mustache
@@ -5,7 +5,7 @@
       <a class="small-heading" href="{{path_to_root}}{{section}}.html">{{section}}<span class="anchor-icon" /></a>
       <ul class="nav-group-tasks">
         {{#children}}
-        <li class="nav-group-task" data-name="{{name}}">
+        <li class="nav-group-task" data-name="{{name}}" data-url="{{url}}">
           <a title="{{name}}" class="nav-group-task-link" href="{{path_to_root}}{{url}}">{{name}}</a>
         </li>
         {{/children}}


### PR DESCRIPTION
Italicize protocols and abstract classes in the generated documentation’s navigation sidebar. This treatment hopefully gives the concrete classes more prominence while keeping concrete classes together with their abstract superclasses:

<img width="342" alt="abstract" src="https://cloud.githubusercontent.com/assets/1231218/21298196/21c34e82-c542-11e6-9288-247fbe24f8d2.png">

This visual distinction doesn’t necessarily preclude the “Protocols and Abstract Classes” and “Style Layers (Abstract)” categories being added in #7338, although it may make them less necessary. (I do agree that we need to reorganize the categories regardless.) I think keeping concrete classes together with their abstract superclasses in navigation is important, because classes very often inherit initializers and properties from their superclasses. Until realm/jazzy#708 lands, it’s a bit difficult otherwise to navigate from a class to its superclass.

I didn’t bother to pull in Open Sans Italic for just a handful of links, although that’s certainly a possibility. Alternatively, we could denote protocols and abstract classes with faint “(Protocol)” and “(Abstract Class)” glosses or perhaps [P] and [A] icons. Or we could even surround the protocol and abstract class names with parentheses.

Unfortunately, since there’s nothing in Objective-C that would distinguish an abstract class from a concrete class, we have to maintain a hard-coded list of abstract classes in jazzy.css.scss. Ideally we’d list these classes in jazzy.yml or something, I guess.

/cc @mayagao @ericrwolfe