### PR TITLE
Fix iosbench build

### DIFF
--- a/platform/darwin/src/MGLRasterSource.mm
+++ b/platform/darwin/src/MGLRasterSource.mm
@@ -5,6 +5,7 @@
 #import "MGLTileSource_Private.h"
 #import "NSURL+MGLAdditions.h"
 
+#include <mbgl/mbgl.hpp>
 #include <mbgl/style/sources/raster_source.hpp>
 
 const MGLTileSourceOption MGLTileSourceOptionTileSize = @"MGLTileSourceOptionTileSize";

--- a/platform/darwin/src/MGLShapeSource.mm
+++ b/platform/darwin/src/MGLShapeSource.mm
@@ -7,6 +7,7 @@
 
 #import "NSURL+MGLAdditions.h"
 
+#include <mbgl/mbgl.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
 
 const MGLShapeSourceOption MGLShapeSourceOptionClustered = @"MGLShapeSourceOptionClustered";

--- a/platform/darwin/src/MGLStyleLayer_Private.h
+++ b/platform/darwin/src/MGLStyleLayer_Private.h
@@ -3,6 +3,7 @@
 #import "MGLStyleLayer.h"
 #import "MGLStyleValue_Private.h"
 
+#include <mbgl/mbgl.hpp>
 #include <mbgl/style/layer.hpp>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platform/darwin/src/MGLVectorSource.mm
+++ b/platform/darwin/src/MGLVectorSource.mm
@@ -5,6 +5,7 @@
 #import "MGLTileSource_Private.h"
 #import "NSURL+MGLAdditions.h"
 
+#include <mbgl/mbgl.hpp>
 #include <mbgl/style/sources/vector_source.hpp>
 
 @interface MGLVectorSource ()

--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -3,7 +3,7 @@
 #import "MBXBenchAppDelegate.h"
 
 #import <Mapbox/Mapbox.h>
-#import "MGLMapView_Internal.h"
+#import "MGLMapView_Private.h"
 
 #include "locations.hpp"
 

--- a/platform/ios/src/MGLMapView_Private.h
+++ b/platform/ios/src/MGLMapView_Private.h
@@ -1,11 +1,13 @@
 #import <Mapbox/Mapbox.h>
 
-#include <mbgl/mbgl.hpp>
+namespace mbgl {
+    class Map;
+}
 
 /// Minimum size of an annotation’s accessibility element.
 extern const CGSize MGLAnnotationAccessibilityElementMinimumSize;
 
-@interface MGLMapView (Internal)
+@interface MGLMapView (Private)
 
 /// Currently shown popover representing the selected annotation.
 @property (nonatomic) UIView<MGLCalloutView> *calloutViewForSelectedAnnotation;

--- a/platform/macos/src/MGLMapView_Private.h
+++ b/platform/macos/src/MGLMapView_Private.h
@@ -1,6 +1,8 @@
 #import "MGLMapView.h"
 
-#import <mbgl/mbgl.hpp>
+namespace mbgl {
+    class Map;
+}
 
 @interface MGLMapView (Private)
 


### PR DESCRIPTION
Fixed a stale include in iosbench. MGLMapView_Private.h forward-declares `mbgl::Map` instead of including mbgl.hpp, which iosbench has no access to.