### PR TITLE
Allow setting URL scheme templates

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -36,6 +36,9 @@ public:
     void setAccessToken(const std::string&);
     std::string getAccessToken() const;
 
+    void setURLSchemeTemplate(const std::string& scheme, const std::string& tpl);
+    std::string getURLSchemeTemplate(const std::string& scheme) const;
+
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
     /*

--- a/include/mbgl/storage/online_file_source.hpp
+++ b/include/mbgl/storage/online_file_source.hpp
@@ -3,6 +3,8 @@
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/util/constants.hpp>
 
+#include <map>
+
 namespace mbgl {
 
 class OnlineFileSource : public FileSource {
@@ -16,6 +18,9 @@ public:
     void setAccessToken(const std::string& t) { accessToken = t; }
     std::string getAccessToken() const { return accessToken; }
 
+    void setURLSchemeTemplate(const std::string& scheme, const std::string& tpl);
+    std::string getURLSchemeTemplate(const std::string& scheme) const;
+
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
 private:
@@ -25,6 +30,7 @@ private:
     const std::unique_ptr<Impl> impl;
     std::string accessToken;
     std::string apiBaseURL = mbgl::util::API_BASE_URL;
+    std::map<std::string, std::string> urlSchemeTemplates;
 };
 
 } // namespace mbgl

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -373,6 +373,34 @@ public class MapView extends FrameLayout {
   }
 
   /**
+   * <p>Sets a URL template for the given scheme.</p>
+   * <p>Any URLs encountered in styles and subsequently loaded sources will be fed through a URL
+   *   replacement mechanism that e.g. transforms {@code mapbox://} URLs into regular
+   *   {@code https://} URLs. You can provide URL replacement patterns for your own scheme, e.g.
+   *   {@code example://}.</p>
+   * <p>Any query string will be preserved from the original URL and merged with a query string of
+   *   the template URL, if any.</p>
+   *
+   * @param scheme scheme The scheme that this template should be used for. Specify the scheme
+   * without trailing {@code ://}, e.g. just {@code example}. You may use arbitrary alphanumeric
+   * schemes, with the exception of the protected scheme {@code mapbox}.
+   * @param tpl A templated URL. it may contain these brace-enclosed replacement tokens, e.g. for
+   *   {@code &quot;http://example.com/foo/bar/baz.png&quot;}, valid tokens are:
+   *   <ul>
+   *   <li>{@code {scheme}}: {@code &quot;http&quot;}</li>
+   *   <li>{@code {domain}}: {@code &quot;example.com&quot;}</li>
+   *   <li>{@code {path}}: {@code &quot;foo/bar/baz.png&quot;} (without leading {@code /})</li>
+   *   <li>{@code {directory}}: {@code &quot;foo/bar/&quot;} (with trailing {@code /})</li>
+   *   <li>{@code {filename}}: {@code &quot;baz&quot;} (without file extension)</li>
+   *   <li>{@code {extension}}: {@code &quot;.png&quot;} (optionally with a preceding {@code @2x}
+   *   ratio specifier)</li>
+   *   </ul>
+   */
+  public void setURLSchemeTemplate(String scheme, String tpl) {
+    nativeMapView.setURLSchemeTemplate(scheme, tpl);
+  }
+
+  /**
    * <p>
    * Loads a new map style from the specified URL.
    * </p>

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -238,6 +238,14 @@ final class NativeMapView {
     return nativeGetAccessToken(nativeMapViewPtr);
   }
 
+  public void setURLSchemeTemplate(String scheme, String tpl) {
+    nativeSetURLTemplate(nativeMapViewPtr, scheme, tpl);
+  }
+
+  public String getURLSchemeTemplate(String scheme) {
+    return nativeGetURLTemplate(nativeMapViewPtr, scheme);
+  }
+
   public void cancelTransitions() {
     nativeCancelTransitions(nativeMapViewPtr);
   }
@@ -685,6 +693,10 @@ final class NativeMapView {
   private native void nativeSetAccessToken(long nativeMapViewPtr, String accessToken);
 
   private native String nativeGetAccessToken(long nativeMapViewPtr);
+
+  private native void nativeSetURLTemplate(long nativeMapViewPtr, String scheme, String tpl);
+
+  private native String nativeGetURLTemplate(long nativeMapViewPtr, String scheme);
 
   private native void nativeCancelTransitions(long nativeMapViewPtr);
 

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -461,6 +461,18 @@ jni::jstring* nativeGetAccessToken(JNIEnv *env, jni::jobject* obj, jlong nativeM
     return std_string_to_jstring(env, nativeMapView->getFileSource().getAccessToken());
 }
 
+void nativeSetURLTemplate(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jni::jstring* scheme, jni::jstring* tpl) {
+    assert(nativeMapViewPtr != 0);
+    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
+    nativeMapView->getFileSource().setURLSchemeTemplate(std_string_from_jstring(env, scheme), std_string_from_jstring(env, tpl));
+}
+
+jni::jstring* nativeGetURLTemplate(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jni::jstring* scheme) {
+    assert(nativeMapViewPtr != 0);
+    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
+    return std_string_to_jstring(env, nativeMapView->getFileSource().getURLSchemeTemplate(std_string_from_jstring(env, scheme)));
+}
+
 void nativeCancelTransitions(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr) {
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
@@ -1827,6 +1839,8 @@ void registerNatives(JavaVM *vm) {
         MAKE_NATIVE_METHOD(nativeGetStyleJson, "(J)Ljava/lang/String;"),
         MAKE_NATIVE_METHOD(nativeSetAccessToken, "(JLjava/lang/String;)V"),
         MAKE_NATIVE_METHOD(nativeGetAccessToken, "(J)Ljava/lang/String;"),
+        MAKE_NATIVE_METHOD(nativeSetURLTemplate, "(JLjava/lang/String;Ljava/lang/String;)V"),
+        MAKE_NATIVE_METHOD(nativeGetURLTemplate, "(JLjava/lang/String;)Ljava/lang/String;"),
         MAKE_NATIVE_METHOD(nativeCancelTransitions, "(J)V"),
         MAKE_NATIVE_METHOD(nativeSetGestureInProgress, "(JZ)V"),
         MAKE_NATIVE_METHOD(nativeMoveBy, "(JDDJ)V"),

--- a/platform/darwin/src/MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h
+++ b/platform/darwin/src/MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h
@@ -1,0 +1,11 @@
+#import "MGLOfflineStorage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MGLOfflineStorage (MGLURLSchemeTemplateAdditions)
+
+- (void)setURLTemplate:(nullable NSString *)tpl forScheme:(NSString *)scheme;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm
+++ b/platform/darwin/src/MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm
@@ -1,0 +1,33 @@
+#import "MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h"
+#import "MGLOfflineStorage_Private.h"
+
+@implementation MGLOfflineStorage (MGLURLSchemeTemplateAdditions)
+
+/**
+ Sets a URL template for the given scheme.
+
+ Any URLs encountered in styles and subsequently loaded sources will be fed through
+ a URL replacement mechanism that e.g. transforms `mapbox://` URLs into regular
+ `https://` URLs. You can provide URL replacement patterns for your own scheme,
+ e.g. `example://`.
+
+ Any query string will be preserved from the original URL and merged with a
+ query string of the template URL, if any.
+
+ @param tpl A templated URL. it may contain these brace-enclosed replacement
+    tokens, e.g. for `"http://example.com/foo/bar/baz.png"`, valid tokens are:
+    * `{scheme}`: `"http"`
+    * `{domain}`: `"example.com"`
+    * `{path}`: `"foo/bar/baz.png"` (without leading `/`)
+    * `{directory}`: `"foo/bar/"` (with trailing `/`)
+    * `{filename}`: `"baz"` (without file extension)
+    * `{extension}`: `".png"` (optionally with a preceding `@2x` ratio specifier)
+ @param scheme The scheme that this template should be used for. Specify the
+    scheme without trailing `://`, e.g. just `example`. You may use arbitrary
+    alphanumeric schemes, with the exception of the protected scheme `mapbox`.
+ */
+- (void)setURLTemplate:(nullable NSString *)tpl forScheme:(NSString *)scheme {
+    self.mbglFileSource->setURLSchemeTemplate(scheme.UTF8String, tpl.UTF8String);
+}
+
+@end

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -46,6 +46,14 @@ public:
         return onlineFileSource.getAccessToken();
     }
 
+    void setURLSchemeTemplate(const std::string& scheme, const std::string& tpl) {
+        onlineFileSource.setURLSchemeTemplate(scheme, tpl);
+    }
+
+    std::string getURLSchemeTemplate(const std::string& scheme) const {
+        return onlineFileSource.getURLSchemeTemplate(scheme);
+    }
+
     void listRegions(std::function<void (std::exception_ptr, optional<std::vector<OfflineRegion>>)> callback) {
         try {
             callback({}, offlineDatabase.listRegions());
@@ -185,6 +193,14 @@ void DefaultFileSource::setAccessToken(const std::string& accessToken) {
 
 std::string DefaultFileSource::getAccessToken() const {
     return thread->invokeSync(&Impl::getAccessToken);
+}
+
+void DefaultFileSource::setURLSchemeTemplate(const std::string& scheme, const std::string& tpl) {
+    thread->invokeSync(&Impl::setURLSchemeTemplate, scheme, tpl);
+}
+
+std::string DefaultFileSource::getURLSchemeTemplate(const std::string& scheme) const {
+    return thread->invokeSync(&Impl::getURLSchemeTemplate, scheme);
 }
 
 std::unique_ptr<AsyncRequest> DefaultFileSource::request(const Resource& resource, Callback callback) {

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -166,6 +166,10 @@
 		556660CA1E1BF3A900E2C41B /* MGLFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 556660C91E1BF3A900E2C41B /* MGLFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		556660D81E1D085500E2C41B /* MGLVersionNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = 556660D71E1D085500E2C41B /* MGLVersionNumber.m */; };
 		556660DB1E1D8E8D00E2C41B /* MGLFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 556660C91E1BF3A900E2C41B /* MGLFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		559B96C81E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 559B96C61E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		559B96C91E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 559B96C61E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		559B96CA1E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 559B96C71E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm */; };
+		559B96CB1E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 559B96C71E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm */; };
 		55D8C9961D0F18CE00F42F10 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D8C9951D0F18CE00F42F10 /* libsqlite3.tbd */; };
 		7E016D7E1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */; };
 		7E016D7F1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */; };
@@ -614,6 +618,8 @@
 		554180411D2E97DE00012372 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		556660C91E1BF3A900E2C41B /* MGLFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLFoundation.h; sourceTree = "<group>"; };
 		556660D71E1D085500E2C41B /* MGLVersionNumber.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLVersionNumber.m; path = ../../darwin/test/MGLVersionNumber.m; sourceTree = "<group>"; };
+		559B96C61E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h"; sourceTree = "<group>"; };
+		559B96C71E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm"; sourceTree = "<group>"; };
 		55D8C9941D0F133500F42F10 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = ../../build/ios/config.xcconfig; sourceTree = "<group>"; };
 		55D8C9951D0F18CE00F42F10 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLPolyline+MGLAdditions.h"; sourceTree = "<group>"; };
@@ -1367,6 +1373,8 @@
 		DAD165831CF4CFED001FF4B9 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				559B96C61E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h */,
+				559B96C71E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm */,
 				7E016D821D9E890300A29A21 /* MGLPolygon+MGLAdditions.h */,
 				7E016D831D9E890300A29A21 /* MGLPolygon+MGLAdditions.m */,
 				7E016D7C1D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.h */,
@@ -1449,9 +1457,11 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA8847F61CBAFA5100AB86E3 /* MGLOfflineStorage.h in Headers */,
 				556660DB1E1D8E8D00E2C41B /* MGLFoundation.h in Headers */,
 				35D13AC31D3D19DD00AFB4E0 /* MGLFillStyleLayer.h in Headers */,
 				DA88483A1CBAFB8500AB86E3 /* MGLAnnotationImage.h in Headers */,
+				559B96C81E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h in Headers */,
 				DA35A2BB1CCA9A6900E826B2 /* MGLClockDirectionFormatter.h in Headers */,
 				353933FE1D3FB7DD003F57D7 /* MGLSymbolStyleLayer.h in Headers */,
 				DA8848861CBB033F00AB86E3 /* Fabric+FABKits.h in Headers */,
@@ -1553,7 +1563,6 @@
 				DA8848601CBAFC2E00AB86E3 /* Mapbox.h in Headers */,
 				DAF0D8101DFE0EA000B28378 /* MGLRasterSource_Private.h in Headers */,
 				350098BB1D480108004B2AF0 /* MGLVectorSource.h in Headers */,
-				DA8847F61CBAFA5100AB86E3 /* MGLOfflineStorage.h in Headers */,
 				DAD1656E1CF41981001FF4B9 /* MGLFeature_Private.h in Headers */,
 				DA88483C1CBAFB8500AB86E3 /* MGLMapView.h in Headers */,
 			);
@@ -1563,7 +1572,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DABFB8641CBE99E500D62B32 /* MGLOfflineStorage.h in Headers */,
 				556660CA1E1BF3A900E2C41B /* MGLFoundation.h in Headers */,
+				559B96C91E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h in Headers */,
 				4032C5C01DE1FC780062E8BD /* NSValue+MGLStyleEnumAttributeAdditions.h in Headers */,
 				35B82BF91D6C5F8400B1B721 /* NSPredicate+MGLAdditions.h in Headers */,
 				DA35A2CA1CCAAAD200E826B2 /* NSValue+MGLAdditions.h in Headers */,
@@ -1572,7 +1583,6 @@
 				3566C76D1D4A8DFA008152BC /* MGLRasterSource.h in Headers */,
 				DAED38641D62D0FC00D7640F /* NSURL+MGLAdditions.h in Headers */,
 				DABFB85E1CBE99E500D62B32 /* MGLAnnotation.h in Headers */,
-				DABFB8641CBE99E500D62B32 /* MGLOfflineStorage.h in Headers */,
 				DAD165791CF4CDFF001FF4B9 /* MGLShapeCollection.h in Headers */,
 				4049C29E1DB6CD6C00B3F799 /* MGLPointCollection.h in Headers */,
 				3566C7671D4A77BA008152BC /* MGLShapeSource.h in Headers */,
@@ -1982,6 +1992,7 @@
 				35136D391D42271A00C20EFD /* MGLBackgroundStyleLayer.mm in Sources */,
 				3510FFEC1D6D9C7A00F413B2 /* NSComparisonPredicate+MGLAdditions.mm in Sources */,
 				7E016D801D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m in Sources */,
+				559B96CA1E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm in Sources */,
 				DAED38651D62D0FC00D7640F /* NSURL+MGLAdditions.m in Sources */,
 				354B83981D2E873E005D9406 /* MGLUserLocationAnnotationView.m in Sources */,
 				DA88485D1CBAFB9800AB86E3 /* MGLFaux3DUserLocationAnnotationView.m in Sources */,
@@ -2057,6 +2068,7 @@
 				35136D3A1D42271A00C20EFD /* MGLBackgroundStyleLayer.mm in Sources */,
 				3510FFED1D6D9C7A00F413B2 /* NSComparisonPredicate+MGLAdditions.mm in Sources */,
 				7E016D811D9E86BE00A29A21 /* MGLPolyline+MGLAdditions.m in Sources */,
+				559B96CB1E27A22F005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm in Sources */,
 				354B83991D2E873E005D9406 /* MGLUserLocationAnnotationView.m in Sources */,
 				DAA4E4221CBB730400178DFB /* MGLPointAnnotation.mm in Sources */,
 				DAED38661D62D0FC00D7640F /* NSURL+MGLAdditions.m in Sources */,

--- a/platform/ios/src/Mapbox.h
+++ b/platform/ios/src/Mapbox.h
@@ -26,6 +26,7 @@ FOUNDATION_EXPORT MGL_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLOfflinePack.h"
 #import "MGLOfflineRegion.h"
 #import "MGLOfflineStorage.h"
+#import "MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h"
 #import "MGLOverlay.h"
 #import "MGLPointAnnotation.h"
 #import "MGLPointCollection.h"

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		556660C61E1BEA0100E2C41B /* MGLFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 556660C51E1BEA0100E2C41B /* MGLFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		556660D61E1D07E400E2C41B /* MGLVersionNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = 556660D51E1D07E400E2C41B /* MGLVersionNumber.m */; };
 		558F18221D0B13B100123F46 /* libmbgl-loop.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 558F18211D0B13B000123F46 /* libmbgl-loop.a */; };
+		559B96C21E279D13005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 559B96C01E279D13005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		559B96C51E279ED6005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 559B96C41E279ED6005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm */; };
 		55D9B4B11D005D3900C1CCE2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 55D9B4B01D005D3900C1CCE2 /* libz.tbd */; };
 		DA00FC8A1D5EEAC3009AABC8 /* MGLAttributionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DA00FC881D5EEAC3009AABC8 /* MGLAttributionInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA00FC8B1D5EEAC3009AABC8 /* MGLAttributionInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA00FC891D5EEAC3009AABC8 /* MGLAttributionInfo.mm */; };
@@ -310,6 +312,8 @@
 		556660C51E1BEA0100E2C41B /* MGLFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLFoundation.h; sourceTree = "<group>"; };
 		556660D51E1D07E400E2C41B /* MGLVersionNumber.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLVersionNumber.m; path = ../../darwin/test/MGLVersionNumber.m; sourceTree = "<group>"; };
 		558F18211D0B13B000123F46 /* libmbgl-loop.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-loop.a"; path = "../../build/osx/Debug/libmbgl-loop.a"; sourceTree = "<group>"; };
+		559B96C01E279D13005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h"; sourceTree = "<group>"; };
+		559B96C41E279ED6005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm"; sourceTree = "<group>"; };
 		55D9B4B01D005D3900C1CCE2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		55FE0E8D1D100A0900FD240B /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = ../../build/macos/config.xcconfig; sourceTree = "<group>"; };
 		DA00FC881D5EEAC3009AABC8 /* MGLAttributionInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAttributionInfo.h; sourceTree = "<group>"; };
@@ -807,6 +811,8 @@
 		DAD1657F1CF4CF50001FF4B9 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				559B96C01E279D13005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h */,
+				559B96C41E279ED6005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm */,
 				408AA8601DAEED3300022900 /* MGLPolygon+MGLAdditions.h */,
 				408AA85C1DAEED3300022900 /* MGLPolygon+MGLAdditions.m */,
 				408AA8611DAEED3300022900 /* MGLPolyline+MGLAdditions.h */,
@@ -963,7 +969,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAE6C3611CC31E0400DB3429 /* MGLOfflineStorage.h in Headers */,
 				556660C61E1BEA0100E2C41B /* MGLFoundation.h in Headers */,
+				559B96C21E279D13005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h in Headers */,
 				DA8F258F1D51CA600010E6B5 /* MGLRasterStyleLayer.h in Headers */,
 				3508EC641D749D39009B0EE4 /* NSExpression+MGLAdditions.h in Headers */,
 				DAE6C38D1CC31E2A00DB3429 /* MGLOfflineRegion_Private.h in Headers */,
@@ -980,7 +988,6 @@
 				DAE6C3A31CC31E9400DB3429 /* MGLAnnotationImage.h in Headers */,
 				DAE6C3A41CC31E9400DB3429 /* MGLMapView.h in Headers */,
 				355BA4ED1D41633E00CCC6D5 /* NSColor+MGLAdditions.h in Headers */,
-				DAE6C3611CC31E0400DB3429 /* MGLOfflineStorage.h in Headers */,
 				352742781D4C220900A1ECE6 /* MGLStyleValue.h in Headers */,
 				DAE6C35E1CC31E0400DB3429 /* MGLMultiPoint.h in Headers */,
 				35602BFF1D3EA9B40050646F /* MGLStyleLayer_Private.h in Headers */,
@@ -1283,6 +1290,7 @@
 				35C5D84A1D6DD66D00E95907 /* NSCompoundPredicate+MGLAdditions.mm in Sources */,
 				408AA8681DAEEE5200022900 /* MGLPolygon+MGLAdditions.m in Sources */,
 				DAE6C3951CC31E2A00DB3429 /* MGLTilePyramidOfflineRegion.mm in Sources */,
+				559B96C51E279ED6005D4D26 /* MGLOfflineStorage+MGLURLSchemeTemplateAdditions.mm in Sources */,
 				DAE6C3851CC31E2A00DB3429 /* MGLAccountManager.m in Sources */,
 				DA00FC8B1D5EEAC3009AABC8 /* MGLAttributionInfo.mm in Sources */,
 				DAE6C3921CC31E2A00DB3429 /* MGLPolyline.mm in Sources */,

--- a/platform/macos/src/Mapbox.h
+++ b/platform/macos/src/Mapbox.h
@@ -24,6 +24,7 @@ FOUNDATION_EXPORT MGL_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLOfflinePack.h"
 #import "MGLOfflineRegion.h"
 #import "MGLOfflineStorage.h"
+#import "MGLOfflineStorage+MGLURLSchemeTemplateAdditions.h"
 #import "MGLOverlay.h"
 #import "MGLPointAnnotation.h"
 #import "MGLPointCollection.h"

--- a/src/mbgl/util/mapbox.hpp
+++ b/src/mbgl/util/mapbox.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <mbgl/style/types.hpp>
+#include <mbgl/storage/resource.hpp>
 
 namespace mbgl {
 namespace util {


### PR DESCRIPTION
We are currently using `mapbox://` URLs, but they're hardcoded into the system. This PR adds a generic `setURLSchemeTemplate` to `OnlineFileSource` and `DefaultFileSource` that allows you to specify templates for your own URL schemes.