### PR TITLE
Upgrade okhttp to 3.5.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile "com.android.support:support-annotations:${supportLibVersion}"
     compile "com.android.support:support-v4:${supportLibVersion}"
     compile "com.android.support:design:${supportLibVersion}"
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    compile 'com.squareup.okhttp3:okhttp:3.5.0'
     compile 'com.mapzen.android:lost:1.1.1'
     compile 'com.jakewharton.timber:timber:4.3.1'
 


### PR DESCRIPTION
Upgrade okhttp from 3.4.1 to 3.5.0 (released december the 1st, 2016)