### PR TITLE
[android] - only build phone module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,11 +505,11 @@ android-lib-$1: build/android-$1/$(BUILDTYPE)/Makefile
 
 .PHONY: android-$1
 android-$1: android-lib-$1
-	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) assemble$(BUILDTYPE)
+	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) :MapboxGLAndroidSDKTestApp:assemble$(BUILDTYPE)
 
 run-android-core-test-$1: android-test-lib-$1
 	# Compile main sources and extract the classes (using the test app to get all transitive dependencies in one place)
-	cd platform/android && ./gradlew assembleDebug
+	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:assembleDebug
 	unzip -o platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug.apk classes.dex -d build/android-$1/$(BUILDTYPE)
 	
 	#Compile Test runner


### PR DESCRIPTION
When building the core tests or calling `make android`, we are building both the wear module as the phone module. Only the phone module is required in normal situations and building them both is unnecessary.

cc @cammace @kkaefer 