### PR TITLE
[android] - update components  with latest camera values

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -157,7 +157,7 @@ public final class MapboxMap {
    * Called when the user
    */
   void onUpdate() {
-    CameraPosition cameraPosition = transform.getCameraPosition();
+    CameraPosition cameraPosition = transform.invalidateCameraPosition();
     uiSettings.update(cameraPosition);
     // FIXME introduce update method with camera position
     trackingSettings.update();


### PR DESCRIPTION
A call to `getCameraPosition` automatically resulted in invalidating the camera position before https://github.com/mapbox/mapbox-gl-native/pull/7189 . To limit jni calls we removed this but didn't update the part in code where we actually needed to invalidate the position. This PR solves that. 