### PR TITLE
Omit perspectiveSkew from drawing context struct

### DIFF
--- a/platform/darwin/src/MGLOpenGLStyleLayer.h
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.h
@@ -14,7 +14,6 @@ typedef struct MGLStyleLayerDrawingContext {
     double zoomLevel;
     CLLocationDirection direction;
     CGFloat pitch;
-    CGFloat perspectiveSkew;
 } MGLStyleLayerDrawingContext;
 
 @interface MGLOpenGLStyleLayer : MGLStyleLayer

--- a/platform/darwin/src/MGLOpenGLStyleLayer.mm
+++ b/platform/darwin/src/MGLOpenGLStyleLayer.mm
@@ -34,7 +34,6 @@ void MGLDrawCustomStyleLayer(void *context, const mbgl::style::CustomLayerRender
         .zoomLevel = params.zoom,
         .direction = mbgl::util::wrap(params.bearing, 0., 360.),
         .pitch = static_cast<CGFloat>(params.pitch),
-        .perspectiveSkew = static_cast<CGFloat>(params.altitude),
     };
     [layer drawInMapView:layer.mapView withContext:drawingContext];
 }


### PR DESCRIPTION
Removed the `perspectiveSkew` field from the `MGLStyleLayerDrawingContext` struct in anticipation of #7444. It was always set to 1.5, so I don’t think anyone would’ve been using it anyways.

/cc @jfirebaugh