### PR TITLE
[android] - harden MapboxMapOptions, decouple fragment logic

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapFragment.java
@@ -2,17 +2,14 @@ package com.mapbox.mapboxsdk.maps;
 
 import android.app.Fragment;
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.mapbox.mapboxsdk.R;
-import com.mapbox.mapboxsdk.constants.MapboxConstants;
+import com.mapbox.mapboxsdk.utils.MapFragmentUtils;
 
 /**
  * Fragment wrapper around a map view.
@@ -34,16 +31,23 @@ public final class MapFragment extends Fragment {
   private OnMapReadyCallback onMapReadyCallback;
 
   /**
+   * Creates a default MapFragment instance
+   *
+   * @return MapFragment instantiated
+   */
+  public static MapFragment newInstance() {
+    return new MapFragment();
+  }
+
+  /**
    * Creates a MapFragment instance
    *
    * @param mapboxMapOptions The configuration options to be used.
-   * @return MapFragment created.
+   * @return MapFragment instantiated.
    */
   public static MapFragment newInstance(@Nullable MapboxMapOptions mapboxMapOptions) {
     MapFragment mapFragment = new MapFragment();
-    Bundle bundle = new Bundle();
-    bundle.putParcelable(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS, mapboxMapOptions);
-    mapFragment.setArguments(bundle);
+    mapFragment.setArguments(MapFragmentUtils.createFragmentArgs(mapboxMapOptions));
     return mapFragment;
   }
 
@@ -59,31 +63,7 @@ public final class MapFragment extends Fragment {
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     Context context = inflater.getContext();
-    MapboxMapOptions options = null;
-
-    // Get bundle
-    Bundle bundle = getArguments();
-    if (bundle != null && bundle.containsKey(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS)) {
-      options = bundle.getParcelable(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS);
-    }
-
-    Drawable foregroundDrawable = options.getMyLocationForegroundDrawable();
-    Drawable foregroundBearingDrawable = options.getMyLocationForegroundBearingDrawable();
-    if (foregroundDrawable == null || foregroundBearingDrawable == null) {
-      if (foregroundDrawable == null) {
-        foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_icon_default);
-      }
-      if (foregroundBearingDrawable == null) {
-        foregroundBearingDrawable = ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_icon_bearing);
-      }
-      options.myLocationForegroundDrawables(foregroundDrawable, foregroundBearingDrawable);
-    }
-
-    if (options.getMyLocationBackgroundDrawable() == null) {
-      options.myLocationBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_bg_shape));
-    }
-
-    return map = new MapView(inflater.getContext(), options);
+    return map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -107,7 +107,7 @@ public class MapView extends FrameLayout {
   }
 
   @UiThread
-  public MapView(@NonNull Context context, @NonNull MapboxMapOptions options) {
+  public MapView(@NonNull Context context, @Nullable MapboxMapOptions options) {
     super(context);
     initialise(context, options);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/SupportMapFragment.java
@@ -1,18 +1,15 @@
 package com.mapbox.mapboxsdk.maps;
 
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.mapbox.mapboxsdk.R;
-import com.mapbox.mapboxsdk.constants.MapboxConstants;
+import com.mapbox.mapboxsdk.utils.MapFragmentUtils;
 
 /**
  * Support Fragment wrapper around a map view.
@@ -34,7 +31,7 @@ public class SupportMapFragment extends Fragment {
   private OnMapReadyCallback onMapReadyCallback;
 
   /**
-   * Creates a MapFragment instance
+   * Creates a default MapFragment instance
    *
    * @return MapFragment created
    */
@@ -50,9 +47,7 @@ public class SupportMapFragment extends Fragment {
    */
   public static SupportMapFragment newInstance(@Nullable MapboxMapOptions mapboxMapOptions) {
     SupportMapFragment mapFragment = new SupportMapFragment();
-    Bundle bundle = new Bundle();
-    bundle.putParcelable(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS, mapboxMapOptions);
-    mapFragment.setArguments(bundle);
+    mapFragment.setArguments(MapFragmentUtils.createFragmentArgs(mapboxMapOptions));
     return mapFragment;
   }
 
@@ -68,31 +63,7 @@ public class SupportMapFragment extends Fragment {
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     Context context = inflater.getContext();
-    MapboxMapOptions options = null;
-
-    // Get bundle
-    Bundle bundle = getArguments();
-    if (bundle != null && bundle.containsKey(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS)) {
-      options = bundle.getParcelable(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS);
-    }
-
-    Drawable foregroundDrawable = options.getMyLocationForegroundDrawable();
-    Drawable foregroundBearingDrawable = options.getMyLocationForegroundBearingDrawable();
-    if (foregroundDrawable == null || foregroundBearingDrawable == null) {
-      if (foregroundDrawable == null) {
-        foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_icon_default);
-      }
-      if (foregroundBearingDrawable == null) {
-        foregroundBearingDrawable = ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_icon_bearing);
-      }
-      options.myLocationForegroundDrawables(foregroundDrawable, foregroundBearingDrawable);
-    }
-
-    if (options.getMyLocationBackgroundDrawable() == null) {
-      options.myLocationBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_bg_shape));
-    }
-
-    return map = new MapView(inflater.getContext(), options);
+    return map = new MapView(context, MapFragmentUtils.resolveArgs(context, getArguments()));
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/MapFragmentUtils.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/utils/MapFragmentUtils.java
@@ -1,0 +1,56 @@
+package com.mapbox.mapboxsdk.utils;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+
+import com.mapbox.mapboxsdk.R;
+import com.mapbox.mapboxsdk.constants.MapboxConstants;
+import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
+
+/**
+ * MapFragment utility class.
+ * <p>
+ * Used to extract duplicate code between {@link com.mapbox.mapboxsdk.maps.MapFragment} and
+ * {@link com.mapbox.mapboxsdk.maps.SupportMapFragment}.
+ * </p>
+ */
+public class MapFragmentUtils {
+
+  public static Bundle createFragmentArgs(MapboxMapOptions options) {
+    Bundle bundle = new Bundle();
+    bundle.putParcelable(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS, options);
+    return bundle;
+  }
+
+  public static MapboxMapOptions resolveArgs(Context context, Bundle args) {
+    MapboxMapOptions options;
+    if (args != null && args.containsKey(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS)) {
+      options = args.getParcelable(MapboxConstants.FRAG_ARG_MAPBOXMAPOPTIONS);
+    } else {
+      // load default options
+      options = MapboxMapOptions.createFromAttributes(context, null);
+    }
+    options = loadDefaultMyLocationViewDrawables(context, options);
+    return options;
+  }
+
+  private static MapboxMapOptions loadDefaultMyLocationViewDrawables(Context context, MapboxMapOptions options) {
+    Drawable foregroundDrawable = options.getMyLocationForegroundDrawable();
+    Drawable foregroundBearingDrawable = options.getMyLocationForegroundBearingDrawable();
+    if (foregroundDrawable == null || foregroundBearingDrawable == null) {
+      if (foregroundDrawable == null) {
+        foregroundDrawable = ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_icon_default);
+      }
+      if (foregroundBearingDrawable == null) {
+        foregroundBearingDrawable = ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_icon_bearing);
+      }
+      options.myLocationForegroundDrawables(foregroundDrawable, foregroundBearingDrawable);
+    }
+    if (options.getMyLocationBackgroundDrawable() == null) {
+      options.myLocationBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.mapbox_mylocation_bg_shape));
+    }
+    return options;
+  }
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/fragment/SupportMapFragmentActivity.java
@@ -56,7 +56,7 @@ public class SupportMapFragmentActivity extends AppCompatActivity implements OnM
         .zoom(11)
         .build());
 
-      mapFragment = SupportMapFragment.newInstance(options);
+      mapFragment = SupportMapFragment.newInstance();
 
       transaction.add(R.id.fragment_container, mapFragment, "com.mapbox.map");
       transaction.commit();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DoubleMapActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DoubleMapActivity.java
@@ -47,13 +47,10 @@ public class DoubleMapActivity extends AppCompatActivity {
       actionBar.setDisplayShowHomeEnabled(true);
     }
 
-    Fragment mapFragment;
     if (savedInstanceState == null) {
       FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-      transaction.add(R.id.fragment_container, mapFragment = new DoubleMapFragment(), TAG_FRAGMENT);
+      transaction.add(R.id.fragment_container, new DoubleMapFragment(), TAG_FRAGMENT);
       transaction.commit();
-    } else {
-      mapFragment = (DoubleMapFragment) getSupportFragmentManager().findFragmentByTag(TAG_FRAGMENT);
     }
   }
 
@@ -151,10 +148,24 @@ public class DoubleMapActivity extends AppCompatActivity {
     }
 
     @Override
+    public void onStart() {
+      super.onStart();
+      mapView.onStart();
+      mapViewMini.onStart();
+    }
+
+    @Override
     public void onPause() {
       super.onPause();
       mapView.onPause();
       mapViewMini.onPause();
+    }
+
+    @Override
+    public void onStop() {
+      super.onStop();
+      mapView.onStop();
+      mapViewMini.onStop();
     }
 
     @Override


### PR DESCRIPTION
I noticed that DoubleMapActivity in the test app wasn't working correctly, this cascaded in fixing up some fragment logic and decoupling duplicated code from it. Review @cammace 