### PR TITLE
Android: Improve core test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,6 +474,8 @@ MBGL_ANDROID_ABIS = arm-v5 arm-v7 arm-v8 x86 x86-64 mips
 MBGL_ANDROID_LOCAL_WORK_DIR = /data/local/tmp/core-tests
 MBGL_ANDROID_LIBDIR = lib$(if $(filter arm-v8 x86-64,$1),64)
 MBGL_ANDROID_DALVIKVM = dalvikvm$(if $(filter arm-v8 x86-64,$1),64,32)
+MBGL_ANDROID_APK_SUFFIX = $(if $(filter Release,$(BUILDTYPE)),release-unsigned,debug)
+MBGL_ANDROID_CORE_TEST_DIR = build/android-$1/$(BUILDTYPE)/core-tests
 
 .PHONY: android-style-code
 android-style-code:
@@ -507,40 +509,49 @@ android-lib-$1: build/android-$1/$(BUILDTYPE)/Makefile
 android-$1: android-lib-$1
 	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) :MapboxGLAndroidSDKTestApp:assemble$(BUILDTYPE)
 
-run-android-core-test-$1: android-test-lib-$1
+.PHONY: android-core-test-$1
+android-core-test-$1: android-test-lib-$1
+	mkdir -p $(MBGL_ANDROID_CORE_TEST_DIR)
 	# Compile main sources and extract the classes (using the test app to get all transitive dependencies in one place)
-	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:assembleDebug
-	unzip -o platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug.apk classes.dex -d build/android-$1/$(BUILDTYPE)
-	
-	#Compile Test runner
-	find platform/android/src/test -name "*.java" > build/android-$1/$(BUILDTYPE)/java-sources.txt
-	javac -sourcepath platform/android/src/test -d build/android-$1/$(BUILDTYPE) -source 1.7 -target 1.7 @build/android-$1/$(BUILDTYPE)/java-sources.txt
-	#Combine and dex
-	cd build/android-$1/$(BUILDTYPE) && $(ANDROID_HOME)/build-tools/25.0.0/dx --dex --output=test.jar *.class classes.dex
+	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:assemble$(BUILDTYPE)
+	unzip -o platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-$(MBGL_ANDROID_APK_SUFFIX).apk classes.dex -d $(MBGL_ANDROID_CORE_TEST_DIR)
 
-	#Ensure clean state on the device
+	# Compile Test runner
+	find platform/android/src/test -name "*.java" > $(MBGL_ANDROID_CORE_TEST_DIR)/java-sources.txt
+	javac -sourcepath platform/android/src/test -d $(MBGL_ANDROID_CORE_TEST_DIR) -source 1.7 -target 1.7 @$(MBGL_ANDROID_CORE_TEST_DIR)/java-sources.txt
+	# Combine and dex
+	cd $(MBGL_ANDROID_CORE_TEST_DIR) && $(ANDROID_HOME)/build-tools/25.0.0/dx --dex --output=test.jar *.class classes.dex
+
+run-android-core-test-$1-%: android-core-test-$1
+	# Ensure clean state on the device
 	adb shell "rm -Rf $(MBGL_ANDROID_LOCAL_WORK_DIR) && mkdir -p $(MBGL_ANDROID_LOCAL_WORK_DIR)/test"
 
 	# Generate zipped asset files
 	cd test/fixtures/api && zip -r assets.zip assets && cd -
 	cd test/fixtures/storage && zip -r assets.zip assets && cd -
 
-	#Push all needed files to the device
-	adb push build/android-$1/$(BUILDTYPE)/test.jar $(MBGL_ANDROID_LOCAL_WORK_DIR) > /dev/null 2>&1
+	# Push all needed files to the device
+	adb push $(MBGL_ANDROID_CORE_TEST_DIR)/test.jar $(MBGL_ANDROID_LOCAL_WORK_DIR) > /dev/null 2>&1
 	adb push test/fixtures $(MBGL_ANDROID_LOCAL_WORK_DIR)/test > /dev/null 2>&1
 	adb push build/android-$1/$(BUILDTYPE)/stripped/libmapbox-gl.so $(MBGL_ANDROID_LOCAL_WORK_DIR) > /dev/null 2>&1
 	adb push build/android-$1/$(BUILDTYPE)/stripped/libmbgl-test.so $(MBGL_ANDROID_LOCAL_WORK_DIR) > /dev/null 2>&1
 
-	#Kick off the tests
-	adb shell "export LD_LIBRARY_PATH=/system/$(MBGL_ANDROID_LIBDIR):$(MBGL_ANDROID_LOCAL_WORK_DIR) && cd $(MBGL_ANDROID_LOCAL_WORK_DIR) && $(MBGL_ANDROID_DALVIKVM) -cp $(MBGL_ANDROID_LOCAL_WORK_DIR)/test.jar Main"
+	# Kick off the tests
+	adb shell "export LD_LIBRARY_PATH=/system/$(MBGL_ANDROID_LIBDIR):$(MBGL_ANDROID_LOCAL_WORK_DIR) && cd $(MBGL_ANDROID_LOCAL_WORK_DIR) && $(MBGL_ANDROID_DALVIKVM) -cp $(MBGL_ANDROID_LOCAL_WORK_DIR)/test.jar Main --gtest_filter=$$*"
 
-	#Gather the results
+	# Gather the results and unpack them
 	adb shell "cd $(MBGL_ANDROID_LOCAL_WORK_DIR) && tar -cvzf results.tgz test/fixtures/*  > /dev/null 2>&1"
-	adb pull $(MBGL_ANDROID_LOCAL_WORK_DIR)/results.tgz build/android-$1/$(BUILDTYPE)/ > /dev/null 2>&1
+	adb pull $(MBGL_ANDROID_LOCAL_WORK_DIR)/results.tgz $(MBGL_ANDROID_CORE_TEST_DIR)/ > /dev/null 2>&1
+	rm -rf $(MBGL_ANDROID_CORE_TEST_DIR)/results && mkdir -p $(MBGL_ANDROID_CORE_TEST_DIR)/results
+	tar -xzf $(MBGL_ANDROID_CORE_TEST_DIR)/results.tgz --strip-components=2 -C $(MBGL_ANDROID_CORE_TEST_DIR)/results
+
+.PHONY: run-android-core-test-$1
+run-android-core-test-$1: run-android-core-test-$1-*
+	@echo "run-android-core-test-$1"
 
 .PHONY: run-android-$1
 run-android-$1: android-$1
-	cd platform/android  && ./gradlew :MapboxGLAndroidSDKTestApp:installDebug && adb shell am start -n com.mapbox.mapboxsdk.testapp/.activity.FeatureOverviewActivity	
+	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:install$(BUILDTYPE) && adb shell am start -n com.mapbox.mapboxsdk.testapp/.activity.FeatureOverviewActivity
 
 apackage: android-lib-$1
 endef

--- a/platform/android/src/test/Main.java
+++ b/platform/android/src/test/Main.java
@@ -1,13 +1,13 @@
 
 public class Main {
-    public native void runAllTests();
+    public native void runAllTests(String[] args);
 
     public static void main(String[] args) throws Exception {
         //Load the tests
         System.loadLibrary("mbgl-test");
 
         //Run the tests
-        new Main().runAllTests();
+        new Main().runAllTests(args);
 
         //Exit explicitly otherwise dalvikvm won't quit
         System.exit(0);

--- a/platform/android/src/test/main.jni.cpp
+++ b/platform/android/src/test/main.jni.cpp
@@ -2,9 +2,12 @@
 
 #include <android/log.h>
 #include <jni/jni.hpp>
+#include <jni/jni.hpp>
 
 #include <mbgl/util/logging.hpp>
 #include <mbgl/test.hpp>
+
+#include <vector>
 
 #pragma clang diagnostic ignored "-Wunused-parameter"
 
@@ -12,15 +15,38 @@
 
 namespace {
 
-/**
- * JNI Bound to Main#runAllTests()
- */
-void runAllTests(JNIEnv *env, jni::jobject* obj) {
-    mbgl::Log::Info(mbgl::Event::JNI, "Starting tests");
-    mbgl::runTests(0, nullptr);
-}
+// Main class (entry point for tests from dalvikvm)
+struct Main {
+    static constexpr auto Name() {
+        return "Main";
+    }
 
-}
+    /**
+     * JNI Bound to Main#runAllTests()
+     */
+    static void runAllTests(jni::JNIEnv& env, jni::Object<Main>, jni::Array<jni::String> args) {
+        mbgl::Log::Warning(mbgl::Event::JNI, "Starting tests");
+
+        // We need to create a copy of the argv data since Java-internals are stored in UTF-16.
+        std::vector<std::string> data;
+        // Add a fake first argument to align indices. Google Test expects the first argument to
+        // start at index 1; index 0 is the name of the executable.
+        data.push_back("main.jar");
+        const int argc = args.Length(env);
+        for (auto i = 0; i < argc; i++) {
+            data.emplace_back(jni::Make<std::string>(env, args.Get(env, i)));
+        }
+
+        // Create an array of char pointers that point back to the data array.
+        std::vector<const char*> argv;
+        for (const auto& arg : data) {
+            argv.push_back(arg.data());
+        }
+        mbgl::runTests(argv.size(), const_cast<char**>(argv.data()));
+    }
+};
+
+} // namespace
 
 // JNI Bindings to stub the android.util.Log implementation
 
@@ -47,20 +73,19 @@ static jint logger_entry_max_payload_native(JNIEnv* env, jni::jobject* clazz) {
 // Main entry point
 
 extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
-    //Load the main library jni bindings
+    // Load the main library jni bindings
     mbgl::Log::Info(mbgl::Event::JNI, "Registering main JNI Methods");
     mbgl::android::registerNatives(vm);
 
-    //Load the test library jni bindings
+    // Load the test library jni bindings
     mbgl::Log::Info(mbgl::Event::JNI, "Registering test JNI Methods");
 
     jni::JNIEnv& env = jni::GetEnv(*vm, jni::jni_version_1_6);
 
-    //Main class (entry point for tests from dalvikvm)
-    struct Main { static constexpr auto Name() { return "Main"; } };
-    jni::RegisterNatives(env, jni::Class<Main>::Find(env), MAKE_NATIVE_METHOD(runAllTests, "()V"));
+    jni::RegisterNatives(env, jni::Class<Main>::Find(env),
+                         jni::MakeNativeMethod<decltype(Main::runAllTests), &Main::runAllTests>("runAllTests"));
 
-    //Bindings for system classes
+    // Bindings for system classes
     struct Log { static constexpr auto Name() { return "android/util/Log"; } };
     try {
         jni::RegisterNatives(env, jni::Class<Log>::Find(env),


### PR DESCRIPTION
Adds the ability to selectively run tests with `make run-android-core-test-(arch)-%`, with `(arch)` being the architecture you want to run the test for. An invocation to only run `UpdateRenderables` tests on an armv8 device would look like this:

```
make run-android-core-test-arm-v8-UpdateRenderables.*
```

Also make sure that we can run the tests both as Debug and Release versions.