### PR TITLE
Correct formatting and typos in MGLStyleValue documentation

### DIFF
--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -16,14 +16,12 @@ NS_ASSUME_NONNULL_BEGIN
  
  The `MGLStyleValue` class takes a generic parameter `T` that indicates the
  Foundation class being wrapped by this class. Common values for `T` include:
- 
- <ul>
- <li>`NSNumber` (for Boolean values, floating-point numbers, and enumerations)</li>
- <li>`NSValue` (for `CGVector`, `NSEdgeInset`, and `UIEdgeInset`s)</li>
- <li>`NSString`</li>
- <li>`NSColor` or `UIColor`</li>
- <li>`NSArray`</li>
- </ul>
+
+   - `NSNumber` (for Boolean values and floating-point numbers)
+   - `NSValue` (for `CGVector`, `NSEdgeInsets`, `UIEdgeInsets`, and enumerations)
+   - `NSString`
+   - `NSColor` or `UIColor`
+   - `NSArray`
  */
 @interface MGLStyleValue<T> : NSObject
 

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -17,11 +17,13 @@ NS_ASSUME_NONNULL_BEGIN
  The `MGLStyleValue` class takes a generic parameter `T` that indicates the
  Foundation class being wrapped by this class. Common values for `T` include:
 
-   - `NSNumber` (for Boolean values and floating-point numbers)
-   - `NSValue` (for `CGVector`, `NSEdgeInsets`, `UIEdgeInsets`, and enumerations)
-   - `NSString`
-   - `NSColor` or `UIColor`
-   - `NSArray`
+ <ul>
+ <li><code>NSNumber</code> (for Boolean values and floating-point numbers)</li>
+ <li><code>NSValue</code> (for <code>CGVector</code>, <code>NSEdgeInsets</code>, <code>UIEdgeInsets</code>, and enumerations)</li>
+ <li><code>NSString</code></li>
+ <li><code>NSColor</code> or <code>UIColor</code></li>
+ <li><code>NSArray</code></li>
+ </ul>
  */
 @interface MGLStyleValue<T> : NSObject
 


### PR DESCRIPTION
Corrected several issues with `MGLStyleValue`’s inline docs:

- Moved the enumerations responsibility to `NSValue` (from `NSNumber`).
- Corrected the names of `NSEdgeInsets` and `UIEdgeInsets`.
- ~~Changed list formatting to Markdown, as jazzy wasn’t parsing code ticks inside HTML tags.~~
- Changed the backticks to `<code>` blocks, which parse correctly in jazzy and are the same in appearance as the Markdown version.

Now in jazzy:

![screen shot 2016-12-21 at 6 30 04 pm](https://cloud.githubusercontent.com/assets/1198851/21410065/19895678-c7ac-11e6-8436-1e89656da946.png)

Note that Xcode’s Quick Help now fails to add linebreaks to this list:

![screen shot 2016-12-21 at 6 30 19 pm](https://cloud.githubusercontent.com/assets/1198851/21410073/217eec3a-c7ac-11e6-8e51-064b70ee5f15.png)