### PR TITLE
Immutable source and style layer collections

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -189,7 +189,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 /**
  A set containing the style’s sources.
  */
-@property (nonatomic, strong) NS_MUTABLE_SET_OF(MGLSource *) *sources;
+@property (nonatomic, strong) NS_SET_OF(MGLSource *) *sources;
 
 /**
  Returns a source with the given identifier in the current style.
@@ -240,7 +240,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  The layers included in the style, arranged according to their back-to-front
  ordering on the screen.
  */
-@property (nonatomic, strong) NS_MUTABLE_ARRAY_OF(MGLStyleLayer *) *layers;
+@property (nonatomic, strong) NS_ARRAY_OF(MGLStyleLayer *) *layers;
 
 /**
  Returns a style layer with the given identifier in the current style.

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -189,7 +189,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 /**
  A set containing the style’s sources.
  */
-@property (nonatomic, strong) NS_SET_OF(MGLSource *) *sources;
+@property (nonatomic, strong) NS_SET_OF(__kindof MGLSource *) *sources;
 
 /**
  Returns a source with the given identifier in the current style.
@@ -240,7 +240,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  The layers included in the style, arranged according to their back-to-front
  ordering on the screen.
  */
-@property (nonatomic, strong) NS_ARRAY_OF(MGLStyleLayer *) *layers;
+@property (nonatomic, strong) NS_ARRAY_OF(__kindof MGLStyleLayer *) *layers;
 
 /**
  Returns a style layer with the given identifier in the current style.

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -127,9 +127,9 @@ static NSURL *MGLStyleURL_emerald;
 
 #pragma mark Sources
 
-- (NS_SET_OF(MGLSource *) *)sources {
+- (NS_SET_OF(__kindof MGLSource *) *)sources {
     auto rawSources = self.mapView.mbglMap->getSources();
-    NSMutableSet *sources = [NSMutableSet setWithCapacity:rawSources.size()];
+    NS_MUTABLE_SET_OF(__kindof MGLSource *) *sources = [NSMutableSet setWithCapacity:rawSources.size()];
     for (auto rawSource = rawSources.begin(); rawSource != rawSources.end(); ++rawSource) {
         MGLSource *source = [self sourceFromMBGLSource:*rawSource];
         [sources addObject:source];
@@ -137,7 +137,7 @@ static NSURL *MGLStyleURL_emerald;
     return sources;
 }
 
-- (void)setSources:(NS_SET_OF(MGLSource *) *)sources {
+- (void)setSources:(NS_SET_OF(__kindof MGLSource *) *)sources {
     for (MGLSource *source in self.sources) {
         [self removeSource:source];
     }
@@ -222,10 +222,10 @@ static NSURL *MGLStyleURL_emerald;
 
 #pragma mark Style layers
 
-- (NS_ARRAY_OF(MGLStyleLayer *) *)layers
+- (NS_ARRAY_OF(__kindof MGLStyleLayer *) *)layers
 {
     auto layers = self.mapView.mbglMap->getLayers();
-    NSMutableArray *styleLayers = [NSMutableArray arrayWithCapacity:layers.size()];
+    NS_MUTABLE_ARRAY_OF(__kindof MGLStyleLayer *) *styleLayers = [NSMutableArray arrayWithCapacity:layers.size()];
     for (auto layer : layers) {
         MGLStyleLayer *styleLayer = [self layerFromMBGLLayer:layer];
         [styleLayers addObject:styleLayer];
@@ -233,7 +233,7 @@ static NSURL *MGLStyleURL_emerald;
     return styleLayers;
 }
 
-- (void)setLayers:(NS_ARRAY_OF(MGLStyleLayer *) *)layers {
+- (void)setLayers:(NS_ARRAY_OF(__kindof MGLStyleLayer *) *)layers {
     for (MGLStyleLayer *layer in self.layers) {
         [self removeLayer:layer];
     }

--- a/platform/darwin/src/MGLStyle.mm
+++ b/platform/darwin/src/MGLStyle.mm
@@ -127,7 +127,7 @@ static NSURL *MGLStyleURL_emerald;
 
 #pragma mark Sources
 
-- (NS_MUTABLE_SET_OF(MGLSource *) *)sources {
+- (NS_SET_OF(MGLSource *) *)sources {
     auto rawSources = self.mapView.mbglMap->getSources();
     NSMutableSet *sources = [NSMutableSet setWithCapacity:rawSources.size()];
     for (auto rawSource = rawSources.begin(); rawSource != rawSources.end(); ++rawSource) {
@@ -137,7 +137,7 @@ static NSURL *MGLStyleURL_emerald;
     return sources;
 }
 
-- (void)setSources:(NS_MUTABLE_SET_OF(MGLSource *) *)sources {
+- (void)setSources:(NS_SET_OF(MGLSource *) *)sources {
     for (MGLSource *source in self.sources) {
         [self removeSource:source];
     }
@@ -222,7 +222,7 @@ static NSURL *MGLStyleURL_emerald;
 
 #pragma mark Style layers
 
-- (NS_MUTABLE_ARRAY_OF(MGLStyleLayer *) *)layers
+- (NS_ARRAY_OF(MGLStyleLayer *) *)layers
 {
     auto layers = self.mapView.mbglMap->getLayers();
     NSMutableArray *styleLayers = [NSMutableArray arrayWithCapacity:layers.size()];
@@ -233,7 +233,7 @@ static NSURL *MGLStyleURL_emerald;
     return styleLayers;
 }
 
-- (void)setLayers:(NS_MUTABLE_ARRAY_OF(MGLStyleLayer *) *)layers {
+- (void)setLayers:(NS_ARRAY_OF(MGLStyleLayer *) *)layers {
     for (MGLStyleLayer *layer in self.layers) {
         [self removeLayer:layer];
     }


### PR DESCRIPTION
MGLStyle’s `sources` and `layers` properties are now immutable collections but remain writable. Now Swift developers will see `layers`’ type as `[MGLStyleLayer]`, not `NSMutableArray`. If you need a mutable array of layers, use `-mutableArrayValueForKey:`.

Fixes #7459.

/cc @bsudekum