### PR TITLE
Guides for style and GeoJSON authors

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md
+++ b/platform/darwin/docs/guides/For Style Authors.md
@@ -1,0 +1,234 @@
+<!--
+  This file is generated.
+  Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
+-->
+# Information for Style Authors
+
+A _style_ defines a map view’s content and appearance. If you’ve authored a
+style using
+[Mapbox Studio’s Styles editor](https://www.mapbox.com/studio/styles/) or as
+JSON in a text editor, you can use that style in this SDK and manipulate it
+afterwards in code. This document provides information you can use to ensure a
+seamless transition from Mapbox Studio to your application.
+
+## Designing for the platform
+
+When designing your style, consider the context in which your application shows
+the style. There are a number of considerations specific to iOS and macOS that
+may not be obvious when designing your style in Mapbox Studio on the Web. A map
+view is essentially a graphical user interface element, so many of same issues
+in user interface design also apply when designing a map style.
+
+### Color
+
+Ensure sufficient contrast in your application’s user interface when your map
+style is present. Standard user interface elements such as toolbars and sidebars
+often overlap the map view with a translucent, blurred background, so make sure
+the contents of these elements remain legible with the map view underneath. On
+iOS, the user location annotation view, the attribution button, any buttons in
+callout views, and any items in the navigation bar are influenced by your
+application’s tint color, so choose a tint color that constrasts well with your
+map style. If you intend your style to be used in the dark, consider the impact
+that the Night Shift mode on iOS may have on your style’s colors.
+
+### Typography and graphics
+
+Choose font and icon sizes appropriate to the device: iOS devices have smaller
+screens than the typical browser window in which you would use Mapbox Studio,
+and your user’s viewing distance may be shorter than on a desktop computer. Some
+of your users may use the Dynamic Type and Accessibility Text features on iOS
+and macOS to increase the size of all text on the device. You can use the
+[runtime styling API](#manipulating-the-style-at-runtime) to adjust your style’s
+font and icon sizes accordingly.
+
+Design sprite images and choose font weights that look crisp on both
+standard-resolution displays and Retina displays. This SDK supports the same
+resolutions as the operating system it runs on. On iOS, standard-resolution
+displays are limited to older devices that your application may or may not
+support, depending on its minimum deployment target. On macOS,
+standard-resolution displays are often found on external monitors.
+
+### Interactivity
+
+Pay attention to whether elements of your style appear to be interactive. An
+icon with a shadow or shading effect may appear to be clickable on macOS.
+Likewise, a text label may look like a tappable button on iOS merely due to
+matching your application’s tint color or the default blue tint color. You can
+actually make an icon or text label interactive by installing a gesture
+recognizer and performing feature querying (e.g.,
+`-[MGLMapView visibleFeaturesAtPoint:]`) to get details about the selected
+feature.
+
+Make sure your users can easily distinguish any interactive elements from the
+surrounding map, such as pins, the user location annotation view, or a route
+line. On iOS, avoid relying on hover effects to indicate interactive elements,
+and leave enough room between interactive elements to accommodate imprecise
+tapping gestures.
+
+For more information about user interface design, consult Apple’s
+_Human Interface Guidelines_ document for
+[iOS](https://developer.apple.com/ios/human-interface-guidelines/) or
+[macOS](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/).
+
+## Setting the style
+
+You set an `MGLMapView` object’s style either in code, by setting the
+`MGLMapView.styleURL` property, or in Interface Builder, by setting the “Style
+URL” inspectable. The URL must point to a local or remote style JSON file. The
+style JSON file format is defined by the
+[Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/). This
+SDK supports the functionality defined by version 8 of the specification unless
+otherwise noted in the
+[style specification documentation](https://www.mapbox.com/mapbox-gl-style-spec/).
+
+## Manipulating the style at runtime
+
+The _runtime styling API_ enables you to modify every aspect of a style
+dynamically as a user interacts with your application. The style itself is
+represented at runtime by an `MGLStyle` object, which provides access to various
+`MGLSource` and `MGLStyleLayer` objects that represent content sources and style
+layers, respectively.
+
+The names of runtime styling classes and properties on iOS and macOS are
+generally consistent with the style specification and Mapbox Studio’s Styles
+editor. Any exceptions are listed in this document.
+
+To avoid conflicts with Objective-C keywords or Cocoa terminology, this SDK uses
+the following terms for concepts defined in the style specification:
+
+In the style specification | In the SDK
+---------------------------|---------
+class                      | style class
+filter                     | predicate
+id                         | identifier
+image                      | style image
+layer                      | style layer
+property                   | attribute
+SDF icon                   | template image
+source                     | content source
+
+## Specifying the map’s content
+
+Each source defined by a style JSON file is represented at runtime by a content
+source object that you can use to initialize new style layers. The content
+source object is a member of one of the following subclasses of `MGLSource`:
+
+In style JSON | In the SDK
+--------------|-----------
+`geojson`     | `MGLShapeSource`
+`raster`      | `MGLRasterSource`
+`vector`      | `MGLVectorSource`
+
+`image` and `video` sources are not supported.
+
+## Configuring the map content’s appearance
+
+Each layer defined by the style JSON file is represented at runtime by a style
+layer object, which you can use to refine the map’s appearance. The style layer
+object is a member of one of the following subclasses of `MGLStyleLayer`:
+
+In style JSON | In the SDK
+--------------|-----------
+`fill` | `MGLFillStyleLayer`
+`line` | `MGLLineStyleLayer`
+`symbol` | `MGLSymbolStyleLayer`
+`circle` | `MGLCircleStyleLayer`
+`raster` | `MGLRasterStyleLayer`
+`background` | `MGLBackgroundStyleLayer`
+
+You configure layout and paint attributes by setting properties on these style
+layer objects. The property names generally correspond to the style JSON
+properties, except for the use of camelCase instead of kebab-case. Properties
+whose names differ from the style specification are listed below:
+
+### Fill style layers
+
+In style JSON | In Objective-C | In Swift
+--------------|----------------|---------
+`fill-antialias` | `MGLFillStyleLayer.fillAntialiased` | `MGLFillStyleLayer.isFillAntialiased`
+
+### Line style layers
+
+In style JSON | In Objective-C | In Swift
+--------------|----------------|---------
+`line-dasharray` | `MGLLineStyleLayer.lineDashPattern` | `MGLLineStyleLayer.lineDashPattern`
+
+### Symbol style layers
+
+In style JSON | In Objective-C | In Swift
+--------------|----------------|---------
+`icon-allow-overlap` | `MGLSymbolStyleLayer.iconAllowsOverlap` | `MGLSymbolStyleLayer.iconAllowsOverlap`
+`icon-ignore-placement` | `MGLSymbolStyleLayer.iconIgnoresPlacement` | `MGLSymbolStyleLayer.iconIgnoresPlacement`
+`icon-image` | `MGLSymbolStyleLayer.iconImageName` | `MGLSymbolStyleLayer.iconImageName`
+`icon-optional` | `MGLSymbolStyleLayer.iconOptional` | `MGLSymbolStyleLayer.isIconOptional`
+`icon-rotate` | `MGLSymbolStyleLayer.iconRotation` | `MGLSymbolStyleLayer.iconRotation`
+`icon-size` | `MGLSymbolStyleLayer.iconScale` | `MGLSymbolStyleLayer.iconScale`
+`icon-keep-upright` | `MGLSymbolStyleLayer.keepsIconUpright` | `MGLSymbolStyleLayer.keepsIconUpright`
+`text-keep-upright` | `MGLSymbolStyleLayer.keepsTextUpright` | `MGLSymbolStyleLayer.keepsTextUpright`
+`text-max-angle` | `MGLSymbolStyleLayer.maximumTextAngle` | `MGLSymbolStyleLayer.maximumTextAngle`
+`text-max-width` | `MGLSymbolStyleLayer.maximumTextWidth` | `MGLSymbolStyleLayer.maximumTextWidth`
+`symbol-avoid-edges` | `MGLSymbolStyleLayer.symbolAvoidsEdges` | `MGLSymbolStyleLayer.symbolAvoidsEdges`
+`text-allow-overlap` | `MGLSymbolStyleLayer.textAllowsOverlap` | `MGLSymbolStyleLayer.textAllowsOverlap`
+`text-ignore-placement` | `MGLSymbolStyleLayer.textIgnoresPlacement` | `MGLSymbolStyleLayer.textIgnoresPlacement`
+`text-justify` | `MGLSymbolStyleLayer.textJustification` | `MGLSymbolStyleLayer.textJustification`
+`text-optional` | `MGLSymbolStyleLayer.textOptional` | `MGLSymbolStyleLayer.isTextOptional`
+`text-rotate` | `MGLSymbolStyleLayer.textRotation` | `MGLSymbolStyleLayer.textRotation`
+
+### Raster style layers
+
+In style JSON | In Objective-C | In Swift
+--------------|----------------|---------
+`raster-brightness-max` | `MGLRasterStyleLayer.maximumRasterBrightness` | `MGLRasterStyleLayer.maximumRasterBrightness`
+`raster-brightness-min` | `MGLRasterStyleLayer.minimumRasterBrightness` | `MGLRasterStyleLayer.minimumRasterBrightness`
+`raster-hue-rotate` | `MGLRasterStyleLayer.rasterHueRotation` | `MGLRasterStyleLayer.rasterHueRotation`
+
+## Setting attribute values
+
+Each property representing a layout or paint attribute is set to an
+`MGLStyleValue` object, which is either an `MGLStyleConstantValue` object (for
+constant values) or an `MGLStyleFunction` object (for zoom level functions). The
+style value object is a container for the raw value or function parameters that
+you want the attribute to be set to.
+
+In contrast to the JSON type that the style specification defines for each
+layout or paint property, the style value object often contains a more specific
+Foundation or Cocoa type. General rules for attribute types are listed below.
+Pay close attention to the SDK documentation for the attribute you want to set.
+
+In style JSON | In Objective-C        | In Swift
+--------------|-----------------------|---------
+Color         | `NSColor` (macOS)<br>`UIColor` (iOS) | `NSColor` (macOS)<br>`UIColor` (iOS)
+Enum          | `NSValue` (see `NSValue(MGLAdditions)`) | `NSValue` (see `NSValue(MGLAdditions)`)
+String        | `NSString`            | `String`
+Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
+Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
+Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
+Array (`-font`) | `NSArray<NSString>` | `[String]`
+Array (`-offset`, `-translate`) | `CGVector` | `CGVector`
+Array (`-padding`) | `NSEdgeInsets` (macOS)<br>`UIEdgeInsets` (iOS) | `NSEdgeInsets` (macOS)<br>`UIEdgeInsets` (iOS)
+
+## Filtering sources
+
+You can filter a shape or vector source by setting the
+`MGLVectorStyleLayer.predicate` property to an `NSPredicate` object. Below is a
+table of style JSON operators and the corresponding operators used in the
+predicate format string:
+
+In style JSON             | In the format string
+--------------------------|---------------------
+`["has", key]`            | `key != nil`
+`["!has", key]`           | `key == nil`
+`["==", key, value]`      | `key == value`
+`["!=", key, value]`      | `key != value`
+`[">", key, value]`       | `key > value`
+`[">=", key, value]`      | `key >= value`
+`["<", key, value]`       | `key < value`
+`["<=", key, value]`      | `key <= value`
+`["in", key, v0, …, vn]`  | `key IN {v0, …, vn}`
+`["!in", key, v0, …, vn]` | `NOT key IN {v0, …, vn}`
+`["all", f0, …, fn]`      | `p0 AND … AND pn`
+`["any", f0, …, fn]`      | `p0 OR … OR pn`
+`["none", f0, …, fn]`     | `NOT (p0 OR … OR pn)`
+
+See the `MGLVectorStyleLayer.predicate` documentation for a full description of
+the supported operators and operand types.

--- a/platform/darwin/docs/guides/For Style Authors.md
+++ b/platform/darwin/docs/guides/For Style Authors.md
@@ -70,7 +70,7 @@ _Human Interface Guidelines_ document for
 [iOS](https://developer.apple.com/ios/human-interface-guidelines/) or
 [macOS](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/).
 
-## Setting the style
+## Applying your style
 
 You set an `MGLMapView` object’s style either in code, by setting the
 `MGLMapView.styleURL` property, or in Interface Builder, by setting the “Style
@@ -120,6 +120,45 @@ In style JSON | In the SDK
 `vector`      | `MGLVectorSource`
 
 `image` and `video` sources are not supported.
+
+### Tile sources
+
+Raster and vector sources may be defined in TileJSON configuration files. This
+SDK supports the properties defined in the style specification, which are a
+subset of the keys defined in version 2.1.0 of the
+[TileJSON](https://github.com/mapbox/tilejson-spec/tree/master/2.1.0)
+specification. As an alternative to authoring a custom TileJSON file, you may
+supply various tile source options when creating a raster or vector source.
+These options are detailed in the `MGLTileSourceOption` documentation:
+
+In style JSON | In TileJSON   | In the SDK
+--------------|---------------|-----------
+`url`         | —             | `configurationURL` parameter in `-[MGLTileSource initWithIdentifier:configurationURL:]`
+`tiles`       | `tiles`       | `tileURLTemplates` parameter in `-[MGLTileSource initWithIdentifier:tileURLTemplates:options:]`
+`minzoom`     | `minzoom`     | `MGLTileSourceOptionMinimumZoomLevel`
+`maxzoom`     | `maxzoom`     | `MGLTileSourceOptionMaximumZoomLevel`
+`tileSize`    | —             | `MGLTileSourceOptionTileSize`
+`attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
+`scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`
+
+### Shape sources
+
+Shape sources also accept various options. These options are detailed in the
+`MGLShapeSourceOption` documentation:
+
+In style JSON    | In the SDK
+-----------------|-----------
+`data`           | `url` parameter in `-[MGLShapeSource initWithIdentifier:URL:options:]`
+`maxzoom`        | `MGLShapeSourceOptionMaximumZoomLevel`
+`buffer`         | `MGLShapeSourceOptionBuffer`
+`tolerance`      | `MGLShapeSourceOptionSimplificationTolerance`
+`cluster`        | `MGLShapeSourceOptionClustered`
+`clusterRadius`  | `MGLShapeSourceOptionClusterRadius`
+`clusterMaxZoom` | `MGLShapeSourceOptionMaximumZoomLevelForClustering`
+
+To create a shape source from local GeoJSON data, first
+[convert the GeoJSON data into a shape](working-with-geojson-data.html#converting-geojson-data-into-shape-objects),
+then use the `-[MGLShapeSource initWithIdentifier:shape:options:]` method.
 
 ## Configuring the map content’s appearance
 

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -1,0 +1,208 @@
+<%
+  const types = locals.types;
+  const renamedProperties = locals.renamedProperties;
+-%>
+<!--
+  This file is generated.
+  Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
+-->
+# Information for Style Authors
+
+A _style_ defines a map view’s content and appearance. If you’ve authored a
+style using
+[Mapbox Studio’s Styles editor](https://www.mapbox.com/studio/styles/) or as
+JSON in a text editor, you can use that style in this SDK and manipulate it
+afterwards in code. This document provides information you can use to ensure a
+seamless transition from Mapbox Studio to your application.
+
+## Designing for the platform
+
+When designing your style, consider the context in which your application shows
+the style. There are a number of considerations specific to iOS and macOS that
+may not be obvious when designing your style in Mapbox Studio on the Web. A map
+view is essentially a graphical user interface element, so many of same issues
+in user interface design also apply when designing a map style.
+
+### Color
+
+Ensure sufficient contrast in your application’s user interface when your map
+style is present. Standard user interface elements such as toolbars and sidebars
+often overlap the map view with a translucent, blurred background, so make sure
+the contents of these elements remain legible with the map view underneath. On
+iOS, the user location annotation view, the attribution button, any buttons in
+callout views, and any items in the navigation bar are influenced by your
+application’s tint color, so choose a tint color that constrasts well with your
+map style. If you intend your style to be used in the dark, consider the impact
+that the Night Shift mode on iOS may have on your style’s colors.
+
+### Typography and graphics
+
+Choose font and icon sizes appropriate to the device: iOS devices have smaller
+screens than the typical browser window in which you would use Mapbox Studio,
+and your user’s viewing distance may be shorter than on a desktop computer. Some
+of your users may use the Dynamic Type and Accessibility Text features on iOS
+and macOS to increase the size of all text on the device. You can use the
+[runtime styling API](#manipulating-the-style-at-runtime) to adjust your style’s
+font and icon sizes accordingly.
+
+Design sprite images and choose font weights that look crisp on both
+standard-resolution displays and Retina displays. This SDK supports the same
+resolutions as the operating system it runs on. On iOS, standard-resolution
+displays are limited to older devices that your application may or may not
+support, depending on its minimum deployment target. On macOS,
+standard-resolution displays are often found on external monitors.
+
+### Interactivity
+
+Pay attention to whether elements of your style appear to be interactive. An
+icon with a shadow or shading effect may appear to be clickable on macOS.
+Likewise, a text label may look like a tappable button on iOS merely due to
+matching your application’s tint color or the default blue tint color. You can
+actually make an icon or text label interactive by installing a gesture
+recognizer and performing feature querying (e.g.,
+`-[MGLMapView visibleFeaturesAtPoint:]`) to get details about the selected
+feature.
+
+Make sure your users can easily distinguish any interactive elements from the
+surrounding map, such as pins, the user location annotation view, or a route
+line. On iOS, avoid relying on hover effects to indicate interactive elements,
+and leave enough room between interactive elements to accommodate imprecise
+tapping gestures.
+
+For more information about user interface design, consult Apple’s
+_Human Interface Guidelines_ document for
+[iOS](https://developer.apple.com/ios/human-interface-guidelines/) or
+[macOS](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/).
+
+## Setting the style
+
+You set an `MGLMapView` object’s style either in code, by setting the
+`MGLMapView.styleURL` property, or in Interface Builder, by setting the “Style
+URL” inspectable. The URL must point to a local or remote style JSON file. The
+style JSON file format is defined by the
+[Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/). This
+SDK supports the functionality defined by version 8 of the specification unless
+otherwise noted in the
+[style specification documentation](https://www.mapbox.com/mapbox-gl-style-spec/).
+
+## Manipulating the style at runtime
+
+The _runtime styling API_ enables you to modify every aspect of a style
+dynamically as a user interacts with your application. The style itself is
+represented at runtime by an `MGLStyle` object, which provides access to various
+`MGLSource` and `MGLStyleLayer` objects that represent content sources and style
+layers, respectively.
+
+The names of runtime styling classes and properties on iOS and macOS are
+generally consistent with the style specification and Mapbox Studio’s Styles
+editor. Any exceptions are listed in this document.
+
+To avoid conflicts with Objective-C keywords or Cocoa terminology, this SDK uses
+the following terms for concepts defined in the style specification:
+
+In the style specification | In the SDK
+---------------------------|---------
+class                      | style class
+filter                     | predicate
+id                         | identifier
+image                      | style image
+layer                      | style layer
+property                   | attribute
+SDF icon                   | template image
+source                     | content source
+
+## Specifying the map’s content
+
+Each source defined by a style JSON file is represented at runtime by a content
+source object that you can use to initialize new style layers. The content
+source object is a member of one of the following subclasses of `MGLSource`:
+
+In style JSON | In the SDK
+--------------|-----------
+`geojson`     | `MGLShapeSource`
+`raster`      | `MGLRasterSource`
+`vector`      | `MGLVectorSource`
+
+`image` and `video` sources are not supported.
+
+## Configuring the map content’s appearance
+
+Each layer defined by the style JSON file is represented at runtime by a style
+layer object, which you can use to refine the map’s appearance. The style layer
+object is a member of one of the following subclasses of `MGLStyleLayer`:
+
+In style JSON | In the SDK
+--------------|-----------
+<% for (const type of types) { -%>
+`<%- type %>` | `MGL<%- camelize(type) %>StyleLayer`
+<% } -%>
+
+You configure layout and paint attributes by setting properties on these style
+layer objects. The property names generally correspond to the style JSON
+properties, except for the use of camelCase instead of kebab-case. Properties
+whose names differ from the style specification are listed below:
+<% for (const type in renamedProperties) { -%>
+<% if (renamedProperties.hasOwnProperty(type)) { -%>
+
+### <%- camelize(type) %> style layers
+
+In style JSON | In Objective-C | In Swift
+--------------|----------------|---------
+<% for (const name in renamedProperties[type]) { -%>
+<% if (renamedProperties[type].hasOwnProperty(name)) { -%>
+`<%- originalPropertyName(renamedProperties[type][name]) %>` | `MGL<%- camelize(type) %>StyleLayer.<%- objCName(renamedProperties[type][name]) %>` | `MGL<%- camelize(type) %>StyleLayer.<%- objCGetter(renamedProperties[type][name]) %>`
+<% } -%>
+<% } -%>
+<% } -%>
+<% } -%>
+
+## Setting attribute values
+
+Each property representing a layout or paint attribute is set to an
+`MGLStyleValue` object, which is either an `MGLStyleConstantValue` object (for
+constant values) or an `MGLStyleFunction` object (for zoom level functions). The
+style value object is a container for the raw value or function parameters that
+you want the attribute to be set to.
+
+In contrast to the JSON type that the style specification defines for each
+layout or paint property, the style value object often contains a more specific
+Foundation or Cocoa type. General rules for attribute types are listed below.
+Pay close attention to the SDK documentation for the attribute you want to set.
+
+In style JSON | In Objective-C        | In Swift
+--------------|-----------------------|---------
+Color         | `NSColor` (macOS)<br>`UIColor` (iOS) | `NSColor` (macOS)<br>`UIColor` (iOS)
+Enum          | `NSValue` (see `NSValue(MGLAdditions)`) | `NSValue` (see `NSValue(MGLAdditions)`)
+String        | `NSString`            | `String`
+Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
+Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
+Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
+Array (`-font`) | `NSArray<NSString>` | `[String]`
+Array (`-offset`, `-translate`) | `CGVector` | `CGVector`
+Array (`-padding`) | `NSEdgeInsets` (macOS)<br>`UIEdgeInsets` (iOS) | `NSEdgeInsets` (macOS)<br>`UIEdgeInsets` (iOS)
+
+## Filtering sources
+
+You can filter a shape or vector source by setting the
+`MGLVectorStyleLayer.predicate` property to an `NSPredicate` object. Below is a
+table of style JSON operators and the corresponding operators used in the
+predicate format string:
+
+In style JSON             | In the format string
+--------------------------|---------------------
+`["has", key]`            | `key != nil`
+`["!has", key]`           | `key == nil`
+`["==", key, value]`      | `key == value`
+`["!=", key, value]`      | `key != value`
+`[">", key, value]`       | `key > value`
+`[">=", key, value]`      | `key >= value`
+`["<", key, value]`       | `key < value`
+`["<=", key, value]`      | `key <= value`
+`["in", key, v0, …, vn]`  | `key IN {v0, …, vn}`
+`["!in", key, v0, …, vn]` | `NOT key IN {v0, …, vn}`
+`["all", f0, …, fn]`      | `p0 AND … AND pn`
+`["any", f0, …, fn]`      | `p0 OR … OR pn`
+`["none", f0, …, fn]`     | `NOT (p0 OR … OR pn)`
+
+See the `MGLVectorStyleLayer.predicate` documentation for a full description of
+the supported operators and operand types.

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -143,6 +143,10 @@ dynamically as a user interacts with your application. The style itself is
 represented at runtime by an `MGLStyle` object, which provides access to various
 `MGLSource` and `MGLStyleLayer` objects that represent content sources and style
 layers, respectively.
+<% if (iOS) { -%>
+For more information about the capabilities exposed by the runtime styling API,
+see “[Runtime Styling](runtime-styling.html)”.
+<% } -%>
 
 The names of runtime styling classes and properties on <%- os %> are generally
 consistent with the style specification and Mapbox Studio’s Styles editor. Any

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -74,7 +74,7 @@ _Human Interface Guidelines_ document for
 [iOS](https://developer.apple.com/ios/human-interface-guidelines/) or
 [macOS](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/).
 
-## Setting the style
+## Applying your style
 
 You set an `MGLMapView` object’s style either in code, by setting the
 `MGLMapView.styleURL` property, or in Interface Builder, by setting the “Style
@@ -124,6 +124,45 @@ In style JSON | In the SDK
 `vector`      | `MGLVectorSource`
 
 `image` and `video` sources are not supported.
+
+### Tile sources
+
+Raster and vector sources may be defined in TileJSON configuration files. This
+SDK supports the properties defined in the style specification, which are a
+subset of the keys defined in version 2.1.0 of the
+[TileJSON](https://github.com/mapbox/tilejson-spec/tree/master/2.1.0)
+specification. As an alternative to authoring a custom TileJSON file, you may
+supply various tile source options when creating a raster or vector source.
+These options are detailed in the `MGLTileSourceOption` documentation:
+
+In style JSON | In TileJSON   | In the SDK
+--------------|---------------|-----------
+`url`         | —             | `configurationURL` parameter in `-[MGLTileSource initWithIdentifier:configurationURL:]`
+`tiles`       | `tiles`       | `tileURLTemplates` parameter in `-[MGLTileSource initWithIdentifier:tileURLTemplates:options:]`
+`minzoom`     | `minzoom`     | `MGLTileSourceOptionMinimumZoomLevel`
+`maxzoom`     | `maxzoom`     | `MGLTileSourceOptionMaximumZoomLevel`
+`tileSize`    | —             | `MGLTileSourceOptionTileSize`
+`attribution` | `attribution` | `MGLTileSourceOptionAttributionHTMLString` (but consider specifying `MGLTileSourceOptionAttributionInfos` instead for improved security)
+`scheme`      | `scheme`      | `MGLTileSourceOptionTileCoordinateSystem`
+
+### Shape sources
+
+Shape sources also accept various options. These options are detailed in the
+`MGLShapeSourceOption` documentation:
+
+In style JSON    | In the SDK
+-----------------|-----------
+`data`           | `url` parameter in `-[MGLShapeSource initWithIdentifier:URL:options:]`
+`maxzoom`        | `MGLShapeSourceOptionMaximumZoomLevel`
+`buffer`         | `MGLShapeSourceOptionBuffer`
+`tolerance`      | `MGLShapeSourceOptionSimplificationTolerance`
+`cluster`        | `MGLShapeSourceOptionClustered`
+`clusterRadius`  | `MGLShapeSourceOptionClusterRadius`
+`clusterMaxZoom` | `MGLShapeSourceOptionMaximumZoomLevelForClustering`
+
+To create a shape source from local GeoJSON data, first
+[convert the GeoJSON data into a shape](working-with-geojson-data.html#converting-geojson-data-into-shape-objects),
+then use the `-[MGLShapeSource initWithIdentifier:shape:options:]` method.
 
 ## Configuring the map content’s appearance
 

--- a/platform/darwin/docs/guides/Working with GeoJSON Data.md
+++ b/platform/darwin/docs/guides/Working with GeoJSON Data.md
@@ -1,0 +1,89 @@
+# Working with GeoJSON Data
+
+This SDK offers several ways to work with [GeoJSON](http://geojson.org/) files.
+GeoJSON is a standard file format for representing geographic data.
+
+## Adding a GeoJSON file to the map
+
+You can use
+[Mapbox Studio’s Datasets editor](https://www.mapbox.com/studio/datasets/) to
+upload a GeoJSON file and include it in your custom map style. The GeoJSON data
+will be hosted on Mapbox servers. When a user loads your style, the SDK
+automatically loads the GeoJSON data for display.
+
+Alternatively, if you need to host the GeoJSON file elsewhere or bundle it with
+your application, you can use a GeoJSON file as the basis of an `MGLShapeSource`
+object. Pass the file’s URL into the
+`-[MGLShapeSource initWithIdentifier:URL:options:]` initializer and add the
+shape source to the map using the `-[MGLStyle addSource:]` method. The URL may
+be a local file URL, an HTTP URL, or an HTTPS URL.
+
+Once you’ve added the GeoJSON file to the map via an `MGLShapeSource` object,
+you can configure the appearance of its data and control what data is visible
+using `MGLStyleLayer` objects, you can
+[access the data programmatically](#Extracting GeoJSON data from the map).
+
+## Converting GeoJSON data into shape objects
+
+If you have GeoJSON data in the form of source code (also known as “GeoJSON
+text”), you can convert it into an `MGLShape`, `MGLFeature`, or
+`MGLShapeCollectionFeature` object that the `MGLShapeSource` class understands
+natively. First, create an `NSData` object out of the source code string or file
+contents, then pass that data object into the
+`+[MGLShape shapeWithData:encoding:error:]` method. Finally, you can pass the
+resulting shape or feature object into the
+`-[MGLShapeSource initWithIdentifier:shape:options:]` initializer and add it to
+the map, or you can use the object and its properties to power non-map-related
+functionality in your application.
+
+## Extracting GeoJSON data from the map
+
+Any `MGLShape`, `MGLFeature`, or `MGLShapeCollectionFeature` object has an
+`-[MGLShape geoJSONDataUsingEncoding:]` method that you can use to create a
+GeoJSON source code representation of the object. You can extract a feature
+object from the map using a method such as
+`-[MGLMapView visibleFeaturesAtPoint:]`.
+
+## About GeoJSON deserialization
+
+The process of converting GeoJSON text into `MGLShape`, `MGLFeature`, or
+`MGLShapeCollectionFeature` objects is known as “GeoJSON deserialization”.
+GeoJSON geometries, features, and feature collections are known in this SDK as
+shapes, features, and shape collection features, respectively.
+
+Each GeoJSON object type corresponds to a type provided by either this SDK or
+the Core Location framework:
+
+GeoJSON object type | SDK type
+--------------------|---------
+`Position` (longitude, latitude) | `CLLocationCoordinate2D` (latitude, longitude)
+`Point`             | `MGLPointAnnotation`
+`MultiPoint`        | `MGLPointCollection`
+`LineString`        | `MGLPolyline`
+`MultiLineString`   | `MGLMultiPolyline`
+`Polygon`           | `MGLPolygon`
+Linear ring         | `MGLPolygon.coordinates`, `MGLPolygon.interiorPolygons`
+`MultiPolygon`      | `MGLMultiPolygon`
+`GeometryCollection` | `MGLShapeCollection`
+`Feature`           | `MGLFeature`
+`FeatureCollection` | `MGLShapeCollectionFeature`
+
+A `Feature` object in GeoJSON corresponds to an instance of an `MGLShape`
+subclass conforming to the `MGLFeature` protocol. There is a distinct
+`MGLFeature`-conforming class for each type of geometry that a GeoJSON feature
+can contain. This allows features to be used as shapes where convenient. For
+example, some features can be added to a map view as annotations.
+
+In contrast to the GeoJSON standard, it is possible for `MGLShape` subclasses
+other than `MGLPointAnnotation` to straddle the antimeridian.
+
+The following GeoJSON data types correspond straightforwardly to Foundation data
+types when they occur as feature identifiers or property values:
+
+GeoJSON data type  | Objective-C representation | Swift representation
+-------------------|----------------------------|---------------------
+`null`             | `NSNull`                   | `NSNull`
+`true`, `false`    | `NSNumber.boolValue`       | `NSNumber.boolValue`
+Integer            | `NSNumber.unsignedLongLongValue`, `NSNumber.longLongValue` | `NSNumber.uint64Value`, `NSNumber.int64Value`
+Floating-point number | `NSNumber.doubleValue`  | `NSNumber.doubleValue`
+String             | `NSString`                 | `String`

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -447,7 +447,13 @@ fs.writeFileSync(`platform/darwin/src/NSValue+MGLStyleEnumAttributeAdditions.mm`
     paintProperties: _.flatten(allPaintProperties)
 }));
 
-fs.writeFileSync(`platform/darwin/docs/guides/For Style Authors.md`, guideMD({
+fs.writeFileSync(`platform/ios/docs/guides/For Style Authors.md`, guideMD({
+    os: 'iOS',
+    renamedProperties: allRenamedProperties,
+    types: allTypes,
+}));
+fs.writeFileSync(`platform/macos/docs/guides/For Style Authors.md`, guideMD({
+    os: 'macOS',
     renamedProperties: allRenamedProperties,
     types: allTypes,
 }));

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -16,6 +16,10 @@ typedef NSString *MGLShapeSourceOption NS_STRING_ENUM;
  An `NSNumber` object containing a Boolean enabling or disabling clustering.
  If the `shape` property contains point shapes, setting this option to
  `YES` clusters the points by radius into groups. The default value is `NO`.
+
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-cluster"><code>cluster</code></a>
+ source property in the Mapbox Style Specification.
  */
 extern const MGLShapeSourceOption MGLShapeSourceOptionClustered;
 
@@ -31,6 +35,10 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionClusterRadius;
  which to cluster points if clustering is enabled. Defaults to one zoom level 
  less than the value of `MGLShapeSourceOptionMaximumZoomLevel` so that, at the
  maximum zoom level, the shapes are not clustered.
+
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-clusterMaxZoom"><code>clusterMaxZoom</code></a>
+ source property in the Mapbox Style Specification.
  */
 extern const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering;
 
@@ -38,6 +46,10 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForCluster
  An `NSNumber` object containing an integer; specifies the maximum zoom level at
  which to create vector tiles. A greater value produces greater detail at high
  zoom levels. The default value is 18.
+
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-maxzoom"><code>maxzoom</code></a>
+ source property in the Mapbox Style Specification.
  */
 extern const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel;
 
@@ -46,6 +58,10 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel;
  buffer on each side. A value of 0 produces no buffer. A value of 512 produces a 
  buffer as wide as the tile itself. Larger values produce fewer rendering 
  artifacts near tile edges and slower performance. The default value is 128.
+
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-buffer"><code>buffer</code></a>
+ source property in the Mapbox Style Specification.
  */
 extern const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
 
@@ -53,6 +69,10 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
  An `NSNumber` object containing a double; specifies the Douglas-Peucker
  simplification tolerance. A greater value produces simpler geometries and
  improves performance. The default value is 0.375.
+
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-tolerance"><code>tolerance</code></a>
+ source property in the Mapbox Style Specification.
  */
 extern const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
 

--- a/platform/darwin/src/MGLTileSource.h
+++ b/platform/darwin/src/MGLTileSource.h
@@ -19,6 +19,10 @@ typedef NSString *MGLTileSourceOption NS_STRING_ENUM;
  The value should be between 0 and 22, inclusive, and less than
  `MGLTileSourceOptionMaximumZoomLevel`, if specified. The default value for this
  option is 0.
+
+ This option corresponds to the `minzoom` key in the
+ <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
+ specification.
  */
 extern const MGLTileSourceOption MGLTileSourceOptionMinimumZoomLevel;
 
@@ -29,6 +33,10 @@ extern const MGLTileSourceOption MGLTileSourceOptionMinimumZoomLevel;
  The value should be between 0 and 22, inclusive, and less than
  `MGLTileSourceOptionMinimumZoomLevel`, if specified. The default value for this
  option is 22.
+
+ This option corresponds to the `maxzoom` key in the
+ <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
+ specification.
  */
 extern const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel;
 
@@ -41,6 +49,10 @@ extern const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel;
  By default, no attribution statements are displayed. If the
  `MGLTileSourceOptionAttributionInfos` option is specified, this option is
  ignored.
+
+ This option corresponds to the `attribution` key in the
+ <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
+ specification.
  */
 extern const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString;
 
@@ -60,6 +72,10 @@ extern const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
  By default, no attribution statements are displayed. If the
  `MGLTileSourceOptionAttributionInfos` option is specified, this option is
  ignored.
+
+ This option corresponds to the `attribution` key in the
+ <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
+ specification.
  */
 extern const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString;
 
@@ -79,6 +95,10 @@ extern const MGLTileSourceOption MGLTileSourceOptionAttributionInfos;
  the constants described in `MGLTileCoordinateSystem`.
  
  The default value for this option is `MGLTileCoordinateSystemXYZ`.
+
+ This option corresponds to the `scheme` key in the
+ <a href="https://github.com/mapbox/tilejson-spec/tree/master/2.1.0">TileJSON</a>
+ specification.
  */
 extern const MGLTileSourceOption MGLTileSourceOptionTileCoordinateSystem;
 

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -11,64 +11,70 @@ JSON in a text editor, you can use that style in this SDK and manipulate it
 afterwards in code. This document provides information you can use to ensure a
 seamless transition from Mapbox Studio to your application.
 
-## Designing for the platform
+## Designing for iOS
 
 When designing your style, consider the context in which your application shows
-the style. There are a number of considerations specific to iOS and macOS that
-may not be obvious when designing your style in Mapbox Studio on the Web. A map
-view is essentially a graphical user interface element, so many of same issues
-in user interface design also apply when designing a map style.
+the style. There are a number of considerations specific to iOS that may
+not be obvious when designing your style in Mapbox Studio on the Web. A map view
+is essentially a graphical user interface element, so many of same issues in
+user interface design also apply when designing a map style.
 
 ### Color
 
 Ensure sufficient contrast in your application’s user interface when your map
-style is present. Standard user interface elements such as toolbars and sidebars
-often overlap the map view with a translucent, blurred background, so make sure
-the contents of these elements remain legible with the map view underneath. On
-iOS, the user location annotation view, the attribution button, any buttons in
+style is present. Standard user interface elements such as toolbars, sidebars,
+and sheets often overlap the map view with a translucent, blurred background, so
+make sure the contents of these elements remain legible with the map view
+underneath.
+The user location annotation view, the attribution button, any buttons in
 callout views, and any items in the navigation bar are influenced by your
 application’s tint color, so choose a tint color that constrasts well with your
 map style. If you intend your style to be used in the dark, consider the impact
-that the Night Shift mode on iOS may have on your style’s colors.
+that Night Shift may have on your style’s colors.
 
 ### Typography and graphics
 
-Choose font and icon sizes appropriate to the device: iOS devices have smaller
-screens than the typical browser window in which you would use Mapbox Studio,
-and your user’s viewing distance may be shorter than on a desktop computer. Some
-of your users may use the Dynamic Type and Accessibility Text features on iOS
-and macOS to increase the size of all text on the device. You can use the
+Choose font and icon sizes appropriate to iOS devices. iPhones and iPads have
+smaller screens than the typical browser window in which you would use Mapbox
+Studio, especially when multitasking is enabled. Your user’s viewing distance
+may be shorter than on a desktop computer. Some of your users may use the Larger
+Dynamic Type and Accessibility Text features to increase the size of all text on
+the device. You can use the
 [runtime styling API](#manipulating-the-style-at-runtime) to adjust your style’s
 font and icon sizes accordingly.
 
 Design sprite images and choose font weights that look crisp on both
 standard-resolution displays and Retina displays. This SDK supports the same
-resolutions as the operating system it runs on. On iOS, standard-resolution
-displays are limited to older devices that your application may or may not
-support, depending on its minimum deployment target. On macOS,
-standard-resolution displays are often found on external monitors.
+resolutions as iOS.
+Standard-resolution displays are limited to older devices that your application
+may or may not support, depending on its minimum deployment target.
+
+Icon and text labels should be legible regardless of the map’s orientation.
+By default, this SDK makes it easy for your users to rotate or tilt the map
+using multitouch gestures.
+If you do not intend your design to accommodate rotation and tilting, disable
+these gestures using the `MGLMapView.rotateEnabled` and
+`MGLMapView.pitchEnabled` properties, respectively, or the corresponding
+inspectables in Interface Builder.
 
 ### Interactivity
 
-Pay attention to whether elements of your style appear to be interactive. An
-icon with a shadow or shading effect may appear to be clickable on macOS.
-Likewise, a text label may look like a tappable button on iOS merely due to
-matching your application’s tint color or the default blue tint color. You can
-actually make an icon or text label interactive by installing a gesture
+Pay attention to whether elements of your style appear to be interactive.
+A text label may look like a tappable button merely due to matching your
+application’s tint color or the default blue tint color.
+You can make an icon or text label interactive by installing a gesture
 recognizer and performing feature querying (e.g.,
 `-[MGLMapView visibleFeaturesAtPoint:]`) to get details about the selected
 feature.
 
 Make sure your users can easily distinguish any interactive elements from the
 surrounding map, such as pins, the user location annotation view, or a route
-line. On iOS, avoid relying on hover effects to indicate interactive elements,
-and leave enough room between interactive elements to accommodate imprecise
-tapping gestures.
+line. Avoid relying on hover effects to indicate interactive elements. Leave
+enough room between interactive elements to accommodate imprecise tapping
+gestures.
 
 For more information about user interface design, consult Apple’s
-_Human Interface Guidelines_ document for
-[iOS](https://developer.apple.com/ios/human-interface-guidelines/) or
-[macOS](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/).
+[_iOS Human Interface Guidelines_](https://developer.apple.com/ios/human-interface-guidelines/).
 
 ## Applying your style
 
@@ -89,9 +95,9 @@ represented at runtime by an `MGLStyle` object, which provides access to various
 `MGLSource` and `MGLStyleLayer` objects that represent content sources and style
 layers, respectively.
 
-The names of runtime styling classes and properties on iOS and macOS are
-generally consistent with the style specification and Mapbox Studio’s Styles
-editor. Any exceptions are listed in this document.
+The names of runtime styling classes and properties on iOS are generally
+consistent with the style specification and Mapbox Studio’s Styles editor. Any
+exceptions are listed in this document.
 
 To avoid conflicts with Objective-C keywords or Cocoa terminology, this SDK uses
 the following terms for concepts defined in the style specification:
@@ -236,7 +242,7 @@ Pay close attention to the SDK documentation for the attribute you want to set.
 
 In style JSON | In Objective-C        | In Swift
 --------------|-----------------------|---------
-Color         | `NSColor` (macOS)<br>`UIColor` (iOS) | `NSColor` (macOS)<br>`UIColor` (iOS)
+Color         | `UIColor` | `UIColor`
 Enum          | `NSValue` (see `NSValue(MGLAdditions)`) | `NSValue` (see `NSValue(MGLAdditions)`)
 String        | `NSString`            | `String`
 Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
@@ -244,7 +250,7 @@ Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
 Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
 Array (`-font`) | `NSArray<NSString>` | `[String]`
 Array (`-offset`, `-translate`) | `CGVector` | `CGVector`
-Array (`-padding`) | `NSEdgeInsets` (macOS)<br>`UIEdgeInsets` (iOS) | `NSEdgeInsets` (macOS)<br>`UIEdgeInsets` (iOS)
+Array (`-padding`) | `UIEdgeInsets` | `UIEdgeInsets`
 
 ## Filtering sources
 

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -94,6 +94,8 @@ dynamically as a user interacts with your application. The style itself is
 represented at runtime by an `MGLStyle` object, which provides access to various
 `MGLSource` and `MGLStyleLayer` objects that represent content sources and style
 layers, respectively.
+For more information about the capabilities exposed by the runtime styling API,
+see “[Runtime Styling](runtime-styling.html)”.
 
 The names of runtime styling classes and properties on iOS are generally
 consistent with the style specification and Mapbox Studio’s Styles editor. Any

--- a/platform/ios/docs/guides/Runtime Styling.md
+++ b/platform/ios/docs/guides/Runtime Styling.md
@@ -46,6 +46,8 @@ Draw custom shapes on the map the same way you would a custom `UIView` or `CALay
 
 ## Resources
 
+* [Information for style authors](for-style-authors.html)
+* [Mapbox Streets source reference](https://www.mapbox.com/vector-tiles/mapbox-streets-v7/)
 * [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/)
 * [Mapbox Studio](https://www.mapbox.com/mapbox-studio/)
 * [iOS code examples](https://www.mapbox.com/ios-sdk/examples/)

--- a/platform/ios/docs/guides/Runtime Styling.md
+++ b/platform/ios/docs/guides/Runtime Styling.md
@@ -1,6 +1,6 @@
 # Runtime Styling
 
-Mapbox's runtime styling features allow you direct control over every layer in your maps with code. It's now possible create dynamic maps and visualizations that aren't possible with other mobile maps SDKs.
+Mapbox's runtime styling features allow you direct control over every layer in your maps with code. It's now possible to create dynamic maps and visualizations that aren't possible with other mobile maps SDKs.
 
 Runtime styling expands upon the design power of [Mapbox Studio](https://www.mapbox.com/mapbox-studio/) and exposes all of the same properties and attributes directly to mobile developers in our SDK.
 
@@ -43,10 +43,6 @@ The Mapbox SDK gives you access to all of the same tools we use to render our de
 ### Custom shapes
 
 Draw custom shapes on the map the same way you would a custom `UIView` or `CALayer`. These shapes keep their geographic scale and are perfect for visualizing everything from indoor floor plans to metro systems to hurricane tracks.
-
-<!-- TODO: custom storm tracks -->
-<!-- TODO: metro system -->
-<!-- TODO: indoor maps -->
 
 ## Resources
 

--- a/platform/ios/docs/guides/Working with Mapbox Studio.md
+++ b/platform/ios/docs/guides/Working with Mapbox Studio.md
@@ -1,6 +1,6 @@
 # Working with Mapbox Studio
 
-[Mapbox Studio](http://mapbox.com/studio) is Mapbox's tool for creating custom map styles. It also serves as an excellent tool for rapidly prototyping dynamic maps and runtime styling interactions for iOS.
+[Mapbox Studio’s Styles editor](http://mapbox.com/studio) is Mapbox's tool for creating custom map styles. It also serves as an excellent tool for rapidly prototyping dynamic maps and [runtime styling](runtime-styling.html) interactions for iOS.
 
 ## Creating a base style
 
@@ -38,7 +38,7 @@ Next, add data properties you'd like to use to drive your style. Consider catego
 * Text along a line: add line with a text property
 * Text at specific points on a line or polygon: in addition to the line, create points at the specific points you'd like with text properties
 * If you want circles where scale doesn't matter relative to the geography (e.g. always 20 pixels), you can add as a point and style with a circle layer or a symbol
-* If you want circles or arcs where the scale matters (e.g. 10 mile radius), you'll need to approximately freehand a polygon, and you can create more precisely later in code.
+* If you want circles or arcs where the scale matters (e.g. 10 mile radius), you'll need to approximately freehand a polygon that you can create more precisely later in code.
 
 When you're done, save your dataset and export as a tileset. When that's complete, add your tileset to your style.
 
@@ -74,18 +74,18 @@ Once you're happy with the styles you've created, it's time to [get setup with M
 
 To implement your prototypes with runtime styling:
 
-1. Implement `MGLMapViewDelegate` `-mapView:didFinishLoadingStyle:`
-2. Add your real data as a source
+1. Implement `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]`.
+2. Add your real data as a source:
     * This can be done using vector data from tileset editor ([example](https://www.mapbox.com/ios-sdk/examples/runtime-circle-styles)), custom vector tiles, added as GeoJSON ([example](https://www.mapbox.com/ios-sdk/examples/runtime-add-line), or added manually through the app via `MGLShapeSource` ([example](https://www.mapbox.com/ios-sdk/examples/runtime-multiple-annotations))
-3. For each layer you've prototyped in studio, add it's corresponding `MGLStyleLayer` subclass: `MGLSymbolStyleLayer`, `MGLLineStyleLayer`, `MGLFillStyleLayer`, or `MGLCircleStyleLayer`.
+3. For each layer you've prototyped in Studio, add its corresponding `MGLStyleLayer` subclass. See [“Configuring the map content’s appearance”](for-style-authors.html#configuring-the-map-content-s-appearance) for the available style layer classes.
 
 **Translating style attributes from Studio**
-For each property you've edited in Studio, you can hover over the property name to find it's corresponding property in the iOS SDK. They're generally the camelCased version of the Property ID.
+For each property you've edited in Studio, you can hover over the property name to find the corresponding property in the iOS SDK. It’ll generally be the camelCased version of the Property ID, but see [“Configuring the map content’s appearance”](for-style-authors.html#configuring-the-map-content-s-appearance) for a table of properties that differ between Mapbox Studio and the iOS SDK.
 
 ![property values](img/studio-workflow/property-values.png)
 
 **Translating stop functions**
-It's possible to use stop functions in Mapbox Studio to transition the style of a layer by it's zoom level (e.g. a line that gets wider as you zoom in). These can be translated in the mobile SDKs using `+[MGLSyleValue valueWithInterpolationBase:stops:]`. The rate of change between stops in studio is represented by `interpolationBase`.
+It's possible to use stop functions in Mapbox Studio to transition the style of a layer by its zoom level (e.g. a line that gets wider as you zoom in). These can be translated in the mobile SDKs using `+[MGLSyleValue valueWithInterpolationBase:stops:]`. The rate of change between stops in Studio is represented by `interpolationBase`.
 
 ![Stop functions](img/studio-workflow/stop-functions.png)
 
@@ -94,4 +94,3 @@ It's possible to use stop functions in Mapbox Studio to transition the style of 
 * [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/)
 * [Mapbox Studio](https://www.mapbox.com/mapbox-studio/)
 * [iOS code examples](https://www.mapbox.com/ios-sdk/examples/)
-

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -21,6 +21,7 @@ custom_categories:
       - Runtime Styling
       - Working with Mapbox Studio
       - Info.plist Keys
+      - Working with GeoJSON Data
   - name: Maps
     children:
       - MGLAccountManager

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -22,6 +22,7 @@ custom_categories:
       - Working with Mapbox Studio
       - Info.plist Keys
       - Working with GeoJSON Data
+      - For Style Authors
   - name: Maps
     children:
       - MGLAccountManager

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -20,9 +20,9 @@ custom_categories:
       - Adding Points to a Map
       - Runtime Styling
       - Working with Mapbox Studio
-      - Info.plist Keys
       - Working with GeoJSON Data
       - For Style Authors
+      - Info.plist Keys
   - name: Maps
     children:
       - MGLAccountManager

--- a/platform/ios/scripts/document.sh
+++ b/platform/ios/scripts/document.sh
@@ -41,7 +41,7 @@ jazzy \
     --github-file-prefix https://github.com/mapbox/mapbox-gl-native/tree/${BRANCH} \
     --module-version ${SHORT_VERSION} \
     --readme ${README} \
-    --documentation="platform/ios/docs/guides/*.md" \
+    --documentation="platform/{darwin,ios}/docs/guides/*.md" \
     --root-url https://www.mapbox.com/ios-sdk/api/${RELEASE_VERSION}/ \
     --theme ${THEME} \
     --output ${OUTPUT}

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -1,11 +1,3 @@
-<%
-  const os = locals.os;
-  const iOS = os === 'iOS';
-  const macOS = os === 'macOS';
-  const cocoaPrefix = iOS ? 'UI' : 'NS';
-  const types = locals.types;
-  const renamedProperties = locals.renamedProperties;
--%>
 <!--
   This file is generated.
   Edit platform/darwin/scripts/generate-style-code.js, then run `make style-code-darwin`.
@@ -19,14 +11,10 @@ JSON in a text editor, you can use that style in this SDK and manipulate it
 afterwards in code. This document provides information you can use to ensure a
 seamless transition from Mapbox Studio to your application.
 
-<% if (iOS) { -%>
-## Designing for iOS
-<% } else { -%>
 ## Designing for macOS
-<% } -%>
 
 When designing your style, consider the context in which your application shows
-the style. There are a number of considerations specific to <%- os %> that may
+the style. There are a number of considerations specific to macOS that may
 not be obvious when designing your style in Mapbox Studio on the Web. A map view
 is essentially a graphical user interface element, so many of same issues in
 user interface design also apply when designing a map style.
@@ -38,48 +26,21 @@ style is present. Standard user interface elements such as toolbars, sidebars,
 and sheets often overlap the map view with a translucent, blurred background, so
 make sure the contents of these elements remain legible with the map view
 underneath.
-<% if (iOS) { -%>
-The user location annotation view, the attribution button, any buttons in
-callout views, and any items in the navigation bar are influenced by your
-application’s tint color, so choose a tint color that constrasts well with your
-map style. If you intend your style to be used in the dark, consider the impact
-that Night Shift may have on your style’s colors.
-<% } -%>
 
 ### Typography and graphics
 
-<% if (iOS) { -%>
-Choose font and icon sizes appropriate to iOS devices. iPhones and iPads have
-smaller screens than the typical browser window in which you would use Mapbox
-Studio, especially when multitasking is enabled. Your user’s viewing distance
-may be shorter than on a desktop computer. Some of your users may use the Larger
-Dynamic Type and Accessibility Text features to increase the size of all text on
-the device. You can use the
-[runtime styling API](#manipulating-the-style-at-runtime) to adjust your style’s
-font and icon sizes accordingly.
-<% } -%>
 
 Design sprite images and choose font weights that look crisp on both
 standard-resolution displays and Retina displays. This SDK supports the same
-resolutions as <%- os %>.
-<% if (iOS) { -%>
-Standard-resolution displays are limited to older devices that your application
-may or may not support, depending on its minimum deployment target.
-<% } else { -%>
+resolutions as macOS.
 Standard-resolution displays are often found on external monitors. Even with
 built-in screens, some of your users may use the Larger Text option in Display
 Preferences, which is essentially standard resolution, to make text easier to
 read.
-<% } -%>
 
 Icon and text labels should be legible regardless of the map’s orientation.
-<% if (iOS) { -%>
-By default, this SDK makes it easy for your users to rotate or tilt the map
-using multitouch gestures.
-<% } else { -%>
 By default, this SDK makes it easy for your users to rotate or tilt the map
 using multitouch trackpad gestures or keyboard shortcuts.
-<% } -%>
 If you do not intend your design to accommodate rotation and tilting, disable
 these gestures using the `MGLMapView.rotateEnabled` and
 `MGLMapView.pitchEnabled` properties, respectively, or the corresponding
@@ -88,42 +49,22 @@ inspectables in Interface Builder.
 ### Interactivity
 
 Pay attention to whether elements of your style appear to be interactive.
-<% if (iOS) { -%>
-A text label may look like a tappable button merely due to matching your
-application’s tint color or the default blue tint color.
-<% } else { -%>
 An icon with a shadow or shading effect may appear to be clickable.
-<% } -%>
 You can make an icon or text label interactive by installing a gesture
 recognizer and performing feature querying (e.g.,
 `-[MGLMapView visibleFeaturesAtPoint:]`) to get details about the selected
 feature.
-<% if (macOS) { -%>
 You can install cursor or tooltip tracking rectangles to indicate interactive
 features as an alternative to prominent hover effects.
-<% } -%>
 
-<% if (iOS) { -%>
-Make sure your users can easily distinguish any interactive elements from the
-surrounding map, such as pins, the user location annotation view, or a route
-line. Avoid relying on hover effects to indicate interactive elements. Leave
-enough room between interactive elements to accommodate imprecise tapping
-gestures.
-<% } else { -%>
 Make sure your users can easily distinguish any interactive elements from the
 surrounding map, such as pins or a route line. If your application supports
 printing, consider using the
 [runtime styling API](#manipulating-the-style-at-runtime) to optimize your style
 for ink economy before printing the map view.
-<% } -%>
 
-<% if (iOS) { -%>
-For more information about user interface design, consult Apple’s
-[_iOS Human Interface Guidelines_](https://developer.apple.com/ios/human-interface-guidelines/).
-<% } else { -%>
 For more information about user interface design, consult Apple’s
 [_macOS Human Interface Guidelines_](https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/).
-<% } -%>
 
 ## Applying your style
 
@@ -144,7 +85,7 @@ represented at runtime by an `MGLStyle` object, which provides access to various
 `MGLSource` and `MGLStyleLayer` objects that represent content sources and style
 layers, respectively.
 
-The names of runtime styling classes and properties on <%- os %> are generally
+The names of runtime styling classes and properties on macOS are generally
 consistent with the style specification and Mapbox Studio’s Styles editor. Any
 exceptions are listed in this document.
 
@@ -223,28 +164,58 @@ object is a member of one of the following subclasses of `MGLStyleLayer`:
 
 In style JSON | In the SDK
 --------------|-----------
-<% for (const type of types) { -%>
-`<%- type %>` | `MGL<%- camelize(type) %>StyleLayer`
-<% } -%>
+`fill` | `MGLFillStyleLayer`
+`line` | `MGLLineStyleLayer`
+`symbol` | `MGLSymbolStyleLayer`
+`circle` | `MGLCircleStyleLayer`
+`raster` | `MGLRasterStyleLayer`
+`background` | `MGLBackgroundStyleLayer`
 
 You configure layout and paint attributes by setting properties on these style
 layer objects. The property names generally correspond to the style JSON
 properties, except for the use of camelCase instead of kebab-case. Properties
 whose names differ from the style specification are listed below:
-<% for (const type in renamedProperties) { -%>
-<% if (renamedProperties.hasOwnProperty(type)) { -%>
 
-### <%- camelize(type) %> style layers
+### Fill style layers
 
 In style JSON | In Objective-C | In Swift
 --------------|----------------|---------
-<% for (const name in renamedProperties[type]) { -%>
-<% if (renamedProperties[type].hasOwnProperty(name)) { -%>
-`<%- originalPropertyName(renamedProperties[type][name]) %>` | `MGL<%- camelize(type) %>StyleLayer.<%- objCName(renamedProperties[type][name]) %>` | `MGL<%- camelize(type) %>StyleLayer.<%- objCGetter(renamedProperties[type][name]) %>`
-<% } -%>
-<% } -%>
-<% } -%>
-<% } -%>
+`fill-antialias` | `MGLFillStyleLayer.fillAntialiased` | `MGLFillStyleLayer.isFillAntialiased`
+
+### Line style layers
+
+In style JSON | In Objective-C | In Swift
+--------------|----------------|---------
+`line-dasharray` | `MGLLineStyleLayer.lineDashPattern` | `MGLLineStyleLayer.lineDashPattern`
+
+### Symbol style layers
+
+In style JSON | In Objective-C | In Swift
+--------------|----------------|---------
+`icon-allow-overlap` | `MGLSymbolStyleLayer.iconAllowsOverlap` | `MGLSymbolStyleLayer.iconAllowsOverlap`
+`icon-ignore-placement` | `MGLSymbolStyleLayer.iconIgnoresPlacement` | `MGLSymbolStyleLayer.iconIgnoresPlacement`
+`icon-image` | `MGLSymbolStyleLayer.iconImageName` | `MGLSymbolStyleLayer.iconImageName`
+`icon-optional` | `MGLSymbolStyleLayer.iconOptional` | `MGLSymbolStyleLayer.isIconOptional`
+`icon-rotate` | `MGLSymbolStyleLayer.iconRotation` | `MGLSymbolStyleLayer.iconRotation`
+`icon-size` | `MGLSymbolStyleLayer.iconScale` | `MGLSymbolStyleLayer.iconScale`
+`icon-keep-upright` | `MGLSymbolStyleLayer.keepsIconUpright` | `MGLSymbolStyleLayer.keepsIconUpright`
+`text-keep-upright` | `MGLSymbolStyleLayer.keepsTextUpright` | `MGLSymbolStyleLayer.keepsTextUpright`
+`text-max-angle` | `MGLSymbolStyleLayer.maximumTextAngle` | `MGLSymbolStyleLayer.maximumTextAngle`
+`text-max-width` | `MGLSymbolStyleLayer.maximumTextWidth` | `MGLSymbolStyleLayer.maximumTextWidth`
+`symbol-avoid-edges` | `MGLSymbolStyleLayer.symbolAvoidsEdges` | `MGLSymbolStyleLayer.symbolAvoidsEdges`
+`text-allow-overlap` | `MGLSymbolStyleLayer.textAllowsOverlap` | `MGLSymbolStyleLayer.textAllowsOverlap`
+`text-ignore-placement` | `MGLSymbolStyleLayer.textIgnoresPlacement` | `MGLSymbolStyleLayer.textIgnoresPlacement`
+`text-justify` | `MGLSymbolStyleLayer.textJustification` | `MGLSymbolStyleLayer.textJustification`
+`text-optional` | `MGLSymbolStyleLayer.textOptional` | `MGLSymbolStyleLayer.isTextOptional`
+`text-rotate` | `MGLSymbolStyleLayer.textRotation` | `MGLSymbolStyleLayer.textRotation`
+
+### Raster style layers
+
+In style JSON | In Objective-C | In Swift
+--------------|----------------|---------
+`raster-brightness-max` | `MGLRasterStyleLayer.maximumRasterBrightness` | `MGLRasterStyleLayer.maximumRasterBrightness`
+`raster-brightness-min` | `MGLRasterStyleLayer.minimumRasterBrightness` | `MGLRasterStyleLayer.minimumRasterBrightness`
+`raster-hue-rotate` | `MGLRasterStyleLayer.rasterHueRotation` | `MGLRasterStyleLayer.rasterHueRotation`
 
 ## Setting attribute values
 
@@ -261,7 +232,7 @@ Pay close attention to the SDK documentation for the attribute you want to set.
 
 In style JSON | In Objective-C        | In Swift
 --------------|-----------------------|---------
-Color         | `<%- cocoaPrefix %>Color` | `<%- cocoaPrefix %>Color`
+Color         | `NSColor` | `NSColor`
 Enum          | `NSValue` (see `NSValue(MGLAdditions)`) | `NSValue` (see `NSValue(MGLAdditions)`)
 String        | `NSString`            | `String`
 Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
@@ -269,7 +240,7 @@ Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
 Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
 Array (`-font`) | `NSArray<NSString>` | `[String]`
 Array (`-offset`, `-translate`) | `CGVector` | `CGVector`
-Array (`-padding`) | `<%- cocoaPrefix %>EdgeInsets` | `<%- cocoaPrefix %>EdgeInsets`
+Array (`-padding`) | `NSEdgeInsets` | `NSEdgeInsets`
 
 ## Filtering sources
 

--- a/platform/macos/docs/guides/Info.plist Keys.md
+++ b/platform/macos/docs/guides/Info.plist Keys.md
@@ -1,6 +1,6 @@
 # Info.plist Keys
 
-The Mapbox macOS SDK supports custom `Info.plist` keys in your application in order to configure various settings. 
+The Mapbox macOS SDK supports custom `Info.plist` keys in your application in order to configure various settings.
 
 ## MGLMapboxAccessToken
 
@@ -8,10 +8,10 @@ Set the [Mapbox access token](https://www.mapbox.com/help/define-access-token/) 
 
 Mapbox-hosted vector tiles and styles require an API access token, which you can obtain from the [Mapbox account page](https://www.mapbox.com/studio/account/tokens/). Access tokens associate requests to Mapbox’s vector tile and style APIs with your Mapbox account. They also deter other developers from using your styles without your permission.
 
-As an alternative, you can use `+[MGLAccountManager setAccessToken:]` to set a token in code. See [our guide](https://www.mapbox.com/help/ios-private-access-token/) for some tips on keeping access tokens in open source code private. 
+As an alternative, you can use `+[MGLAccountManager setAccessToken:]` to set a token in code. See [our guide](https://www.mapbox.com/help/ios-private-access-token/) for some tips on keeping access tokens in open source code private.
 
 ## MGLMapboxAPIBaseURL
 
-Use this key if you need to customize the API base URL used throughout the SDK. If unset, the default Mapbox API is used. 
+Use this key if you need to customize the API base URL used throughout the SDK. If unset, the default Mapbox API is used.
 
-The default value is `https://api.mapbox.com`. 
+The default value is `https://api.mapbox.com`.

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -17,6 +17,7 @@ custom_categories:
   - name: Guides
     children:
       - Info.plist Keys
+      - Working with GeoJSON Data
   - name: Maps
     children:
       - MGLAccountManager

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -16,9 +16,9 @@ framework_root: ../darwin/src
 custom_categories:
   - name: Guides
     children:
-      - Info.plist Keys
       - Working with GeoJSON Data
       - For Style Authors
+      - Info.plist Keys
   - name: Maps
     children:
       - MGLAccountManager

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -18,6 +18,7 @@ custom_categories:
     children:
       - Info.plist Keys
       - Working with GeoJSON Data
+      - For Style Authors
   - name: Maps
     children:
       - MGLAccountManager

--- a/platform/macos/scripts/document.sh
+++ b/platform/macos/scripts/document.sh
@@ -38,7 +38,7 @@ jazzy \
     --github-file-prefix https://github.com/mapbox/mapbox-gl-native/tree/${BRANCH} \
     --module-version ${SHORT_VERSION} \
     --readme ${README} \
-    --documentation="platform/macos/docs/Info.plist Keys.md" \
+    --documentation="platform/{darwin,macos}/docs/guides/*.md" \
     --theme platform/darwin/docs/theme \
     --output ${OUTPUT}
 # https://github.com/realm/jazzy/issues/411


### PR DESCRIPTION
Added two guides to the jazzy documentation:

* “Working with GeoJSON Data” maps GeoJSON concepts and types to the runtime styling API.
* “Information for Style Authors” points out a number of tips for designing a style appropriate for an iOS or macOS application and also maps style JSON types to the runtime styling API to help Mapbox Studio users. This document is generated by `make style-code-darwin` just like the rest of the runtime styling API. I avoided talking in great detail about Studio or the runtime styling API to avoid overlapping with #7488.

~~These two guides are shared between the iOS and macOS docsets. This means the iOS SDK documentation will include some language specific to macOS and vice versa. I think this is fine, given that Apple’s own guides do the same thing.~~ The two guides are now separate but generated from the same template.

Fixes #7530.

/cc @friedbunny @ericrwolfe @mapbox/copycop