### PR TITLE
Fixing some compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ endif(WITH_COVERAGE)
 set(CMAKE_CONFIGURATION_TYPES Debug Release)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=1024 -Wall -Wextra -Wshadow -Werror -Wno-variadic-macros -Wno-unknown-pragmas")
-if(APPLE)
+if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     # -Wno-error=unused-command-line-argument is required due to https://llvm.org/bugs/show_bug.cgi?id=7798
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=unused-command-line-argument")
 endif()

--- a/include/mbgl/annotation/annotation.hpp
+++ b/include/mbgl/annotation/annotation.hpp
@@ -28,6 +28,10 @@ using ShapeAnnotationGeometry = variant<
 
 class LineAnnotation {
 public:
+    LineAnnotation(const ShapeAnnotationGeometry &geometry_, const style::PropertyValue<float> &opacity_,
+            const style::PropertyValue<float> &width_, const style::PropertyValue<Color> &color_) :
+        geometry(geometry_), opacity(opacity_), width(width_), color(color_) {}
+
     ShapeAnnotationGeometry geometry;
     style::PropertyValue<float> opacity { 1.0f };
     style::PropertyValue<float> width { 1.0f };
@@ -36,6 +40,10 @@ public:
 
 class FillAnnotation {
 public:
+    FillAnnotation(const ShapeAnnotationGeometry &geometry_, const style::PropertyValue<float> &opacity_,
+            const style::PropertyValue<Color> &color_, const style::PropertyValue<Color> &outlineColor_) :
+        geometry(geometry_), opacity(opacity_), color(color_), outlineColor(outlineColor_) {}
+
     ShapeAnnotationGeometry geometry;
     style::PropertyValue<float> opacity { 1.0f };
     style::PropertyValue<Color> color { Color::black() };

--- a/include/mbgl/map/mode.hpp
+++ b/include/mbgl/map/mode.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/util/util.hpp>
 #include <mbgl/util/traits.hpp>
 
 #include <cstdint>
@@ -51,23 +52,23 @@ enum class MapDebugOptions : EnumType {
 #endif // MBGL_USE_GLES2
 };
 
-constexpr MapDebugOptions operator|(MapDebugOptions lhs, MapDebugOptions rhs) {
+MBGL_CONSTEXPR MapDebugOptions operator|(MapDebugOptions lhs, MapDebugOptions rhs) {
     return MapDebugOptions(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs));
 }
 
-constexpr MapDebugOptions& operator|=(MapDebugOptions& lhs, MapDebugOptions rhs) {
+MBGL_CONSTEXPR MapDebugOptions& operator|=(MapDebugOptions& lhs, MapDebugOptions rhs) {
     return (lhs = MapDebugOptions(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs)));
 }
 
-constexpr bool operator&(MapDebugOptions lhs, MapDebugOptions rhs) {
+MBGL_CONSTEXPR bool operator&(MapDebugOptions lhs, MapDebugOptions rhs) {
     return mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs);
 }
 
-constexpr MapDebugOptions& operator&=(MapDebugOptions& lhs, MapDebugOptions rhs) {
+MBGL_CONSTEXPR MapDebugOptions& operator&=(MapDebugOptions& lhs, MapDebugOptions rhs) {
     return (lhs = MapDebugOptions(mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs)));
 }
 
-constexpr MapDebugOptions operator~(MapDebugOptions value) {
+MBGL_CONSTEXPR MapDebugOptions operator~(MapDebugOptions value) {
     return MapDebugOptions(~mbgl::underlying_type(value));
 }
 

--- a/include/mbgl/style/transition_options.hpp
+++ b/include/mbgl/style/transition_options.hpp
@@ -12,10 +12,12 @@ public:
     optional<Duration> delay = {};
 
     TransitionOptions reverseMerge(const TransitionOptions& defaults) const {
-        return {
-            duration ? duration : defaults.duration,
-            delay ? delay : defaults.delay
-        };
+        TransitionOptions options;
+
+        options.duration = duration ? duration : defaults.duration;
+        options.delay = delay ? delay : defaults.delay;
+
+        return options;
     }
 
     explicit operator bool() const {

--- a/include/mbgl/util/color.hpp
+++ b/include/mbgl/util/color.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <cassert>
 #include <string>
@@ -10,8 +11,8 @@ namespace mbgl {
 // Stores a premultiplied color, with all four channels ranging from 0..1
 class Color {
 public:
-    constexpr Color() = default;
-    constexpr Color(float r_, float g_, float b_, float a_)
+    MBGL_CONSTEXPR Color() = default;
+    MBGL_CONSTEXPR Color(float r_, float g_, float b_, float a_)
         : r(r_), g(g_), b(b_), a(a_) {
         assert(r_ >= 0.0f);
         assert(r_ <= 1.0f);
@@ -28,25 +29,25 @@ public:
     float b = 0.0f;
     float a = 0.0f;
 
-    static constexpr Color black() { return { 0.0f, 0.0f, 0.0f, 1.0f }; };
-    static constexpr Color white() { return { 1.0f, 1.0f, 1.0f, 1.0f }; };
+    static MBGL_CONSTEXPR Color black() { return { 0.0f, 0.0f, 0.0f, 1.0f }; };
+    static MBGL_CONSTEXPR Color white() { return { 1.0f, 1.0f, 1.0f, 1.0f }; };
 
-    static constexpr Color red()   { return { 1.0f, 0.0f, 0.0f, 1.0f }; };
-    static constexpr Color green() { return { 0.0f, 1.0f, 0.0f, 1.0f }; };
-    static constexpr Color blue()  { return { 0.0f, 0.0f, 1.0f, 1.0f }; };
+    static MBGL_CONSTEXPR Color red()   { return { 1.0f, 0.0f, 0.0f, 1.0f }; };
+    static MBGL_CONSTEXPR Color green() { return { 0.0f, 1.0f, 0.0f, 1.0f }; };
+    static MBGL_CONSTEXPR Color blue()  { return { 0.0f, 0.0f, 1.0f, 1.0f }; };
 
     static optional<Color> parse(const std::string&);
 };
 
-constexpr bool operator==(const Color& colorA, const Color& colorB) {
+MBGL_CONSTEXPR bool operator==(const Color& colorA, const Color& colorB) {
     return colorA.r == colorB.r && colorA.g == colorB.g && colorA.b == colorB.b && colorA.a == colorB.a;
 }
 
-constexpr bool operator!=(const Color& colorA, const Color& colorB) {
+MBGL_CONSTEXPR bool operator!=(const Color& colorA, const Color& colorB) {
     return !(colorA == colorB);
 }
 
-constexpr Color operator*(const Color& color, float alpha) {
+MBGL_CONSTEXPR Color operator*(const Color& color, float alpha) {
     assert(alpha >= 0.0f);
     assert(alpha <= 1.0f);
     return {

--- a/include/mbgl/util/constants.hpp
+++ b/include/mbgl/util/constants.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/unitbezier.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <cmath>
 #include <string>
@@ -43,7 +44,7 @@ constexpr uint64_t DEFAULT_MAX_CACHE_SIZE = 50 * 1024 * 1024;
 constexpr Duration DEFAULT_FADE_DURATION = Milliseconds(300);
 constexpr Seconds CLOCK_SKEW_RETRY_TIMEOUT { 30 };
 
-constexpr UnitBezier DEFAULT_TRANSITION_EASE = { 0, 0, 0.25, 1 };
+const UnitBezier DEFAULT_TRANSITION_EASE = { 0, 0, 0.25, 1 };
     
 constexpr int DEFAULT_RATE_LIMIT_TIMEOUT = 5;
 

--- a/include/mbgl/util/convert.hpp
+++ b/include/mbgl/util/convert.hpp
@@ -1,3 +1,5 @@
+#include <mbgl/util/util.hpp>
+
 #include <array>
 #include <type_traits>
 #include <utility>
@@ -7,7 +9,7 @@ namespace util {
 
 template<typename To, typename From, std::size_t Size,
          typename = std::enable_if_t<std::is_convertible<From, To>::value>>
-constexpr std::array<To, Size> convert(const std::array<From, Size>&from) {
+MBGL_CONSTEXPR std::array<To, Size> convert(const std::array<From, Size>&from) {
     std::array<To, Size> to {};
     std::copy(std::begin(from), std::end(from), std::begin(to));
     return to;

--- a/include/mbgl/util/unitbezier.hpp
+++ b/include/mbgl/util/unitbezier.hpp
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <mbgl/util/util.hpp>
+
 #include <cmath>
 
 namespace mbgl {
@@ -32,7 +34,7 @@ namespace util {
 
 struct UnitBezier {
     // Calculate the polynomial coefficients, implicit first and last control points are (0,0) and (1,1).
-    constexpr UnitBezier(double p1x, double p1y, double p2x, double p2y)
+    MBGL_CONSTEXPR UnitBezier(double p1x, double p1y, double p2x, double p2y)
         : cx(3.0 * p1x)
         , bx(3.0 * (p2x - p1x) - cx)
         , ax(1.0 - cx - bx)

--- a/include/mbgl/util/util.hpp
+++ b/include/mbgl/util/util.hpp
@@ -12,3 +12,10 @@
 #define MBGL_VERIFY_THREAD(tid)
 
 #endif
+
+// GCC 4.9 compatibility
+#if !defined(__GNUC__) || __GNUC__ >= 5
+#define MBGL_CONSTEXPR constexpr
+#else
+#define MBGL_CONSTEXPR inline
+#endif

--- a/platform/qt/qt.pro
+++ b/platform/qt/qt.pro
@@ -437,7 +437,8 @@ QMAKE_CXXFLAGS += \
     -DNDEBUG \
     -DQT_IMAGE_DECODERS \
     -D__QT__ \
-    -fvisibility=hidden
+    -fvisibility=hidden \
+    -ftemplate-depth=512
 
 LIBS += \
     -lz

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -92,7 +92,12 @@ auto fromQMapboxTransitionOptions(const QMapbox::TransitionOptions &options) {
         };
         return {};
     };
-    return mbgl::style::TransitionOptions { convert(options.duration), convert(options.delay) };
+
+    mbgl::style::TransitionOptions transitionOptions;
+    transitionOptions.duration = convert(options.duration);
+    transitionOptions.delay = convert(options.delay);
+
+    return transitionOptions;
 }
 
 auto toQMapboxTransitionOptions(const mbgl::style::TransitionOptions &options) {

--- a/platform/qt/src/thread_local.cpp
+++ b/platform/qt/src/thread_local.cpp
@@ -9,10 +9,6 @@
 namespace mbgl {
 namespace util {
 
-template class ThreadLocal<RunLoop>;
-template class ThreadLocal<int>;
-template class ThreadLocal<style::ClassDictionary>;
-
 template <class T>
 class ThreadLocal<T>::Impl {
 public:
@@ -38,6 +34,10 @@ template <class T>
 void ThreadLocal<T>::set(T* ptr) {
    impl->local.localData()[0] = ptr;
 }
+
+template class ThreadLocal<RunLoop>;
+template class ThreadLocal<int>;
+template class ThreadLocal<style::ClassDictionary>;
 
 } // namespace util
 } // namespace mbgl

--- a/src/3rd_party/geojson-cpp/include/mapbox/geojson_impl.hpp
+++ b/src/3rd_party/geojson-cpp/include/mapbox/geojson_impl.hpp
@@ -162,7 +162,12 @@ feature convert<feature>(const rapidjson_value &json) {
     if (geom_itr == json_end)
         throw error("Feature must have a geometry property");
 
+#if !defined(__GNUC__) || __GNUC__ >= 5
     feature result{ convert<geometry>(geom_itr->value) };
+#else
+    feature result;
+    result.geometry = convert<geometry>(geom_itr->value);
+#endif
 
     auto const &id_itr = json.FindMember("id");
     if (id_itr != json_end) {

--- a/src/3rd_party/geojson-vt-cpp/include/mapbox/geojsonvt.hpp
+++ b/src/3rd_party/geojson-vt-cpp/include/mapbox/geojsonvt.hpp
@@ -27,7 +27,17 @@ struct ToFeatureCollection {
         return { value };
     }
     feature_collection operator()(const geometry& value) const {
+#if !defined(__GNUC__) || __GNUC__ >= 5
         return { { value } };
+#else
+        feature feat;
+        feat.geometry = value;
+
+        feature_collection collec;
+        collec.push_back(std::move(feat));
+
+        return collec;
+#endif
     }
 };
 

--- a/src/3rd_party/geojson-vt-cpp/include/mapbox/geojsonvt/tile.hpp
+++ b/src/3rd_party/geojson-vt-cpp/include/mapbox/geojsonvt/tile.hpp
@@ -95,19 +95,42 @@ private:
     }
 
     void addFeature(const vt_point& point, const property_map& props) {
+#if !defined(__GNUC__) || __GNUC__ >= 5
         tile.features.push_back({ transform(point), props });
+#else
+        mapbox::geometry::feature<int16_t> feature;
+        feature.geometry = transform(point);
+        feature.properties = props;
+        tile.features.push_back(std::move(feature));
+#endif
     }
 
     void addFeature(const vt_line_string& line, const property_map& props) {
         const auto new_line = transform(line);
-        if (!new_line.empty())
+        if (!new_line.empty()) {
+#if !defined(__GNUC__) || __GNUC__ >= 5
             tile.features.push_back({ std::move(new_line), props });
+#else
+            mapbox::geometry::feature<int16_t> feature;
+            feature.geometry = std::move(new_line);
+            feature.properties = props;
+            tile.features.push_back(std::move(feature));
+#endif
+        }
     }
 
     void addFeature(const vt_polygon& polygon, const property_map& props) {
         const auto new_polygon = transform(polygon);
-        if (!new_polygon.empty())
+        if (!new_polygon.empty()) {
+#if !defined(__GNUC__) || __GNUC__ >= 5
             tile.features.push_back({ std::move(new_polygon), props });
+#else
+            mapbox::geometry::feature<int16_t> feature;
+            feature.geometry = std::move(new_polygon);
+            feature.properties = props;
+            tile.features.push_back(std::move(feature));
+#endif
+        }
     }
 
     void addFeature(const vt_geometry_collection& collection, const property_map& props) {
@@ -127,18 +150,36 @@ private:
         case 0:
             break;
         case 1:
+#if !defined(__GNUC__) || __GNUC__ >= 5
             tile.features.push_back({ std::move(new_multi[0]), props });
+#else
+            {
+                mapbox::geometry::feature<int16_t> feature;
+                feature.geometry = std::move(new_multi[0]);
+                feature.properties = props;
+                tile.features.push_back(std::move(feature));
+            }
+#endif
             break;
         default:
+#if !defined(__GNUC__) || __GNUC__ >= 5
             tile.features.push_back({ std::move(new_multi), props });
+#else
+            {
+                mapbox::geometry::feature<int16_t> feature;
+                feature.geometry = std::move(new_multi);
+                feature.properties = props;
+                tile.features.push_back(std::move(feature));
+            }
+#endif
             break;
         }
     }
 
     mapbox::geometry::point<int16_t> transform(const vt_point& p) {
         ++tile.num_simplified;
-        return { static_cast<int16_t>(std::round((p.x * z2 - x) * extent)),
-                 static_cast<int16_t>(std::round((p.y * z2 - y) * extent)) };
+        return { static_cast<int16_t>(::round((p.x * z2 - x) * extent)),
+                 static_cast<int16_t>(::round((p.y * z2 - y) * extent)) };
     }
 
     mapbox::geometry::multi_point<int16_t> transform(const vt_multi_point& points) {

--- a/src/3rd_party/geometry.hpp/include/mapbox/geometry/geometry.hpp
+++ b/src/3rd_party/geometry.hpp/include/mapbox/geometry/geometry.hpp
@@ -37,7 +37,9 @@ struct geometry : geometry_base<T>
      * The default constructor would create a point geometry with default-constructed coordinates;
      * i.e. (0, 0). Since this is not particularly useful, and could hide bugs, it is disabled.
      */
+#if !defined(__GNUC__) || __GNUC__ >= 5
     geometry() = delete;
+#endif
 };
 
 template <typename T, template <typename...> class Cont>

--- a/src/3rd_party/geometry.hpp/include/mapbox/geometry/point_arithmetic.hpp
+++ b/src/3rd_party/geometry.hpp/include/mapbox/geometry/point_arithmetic.hpp
@@ -1,58 +1,65 @@
 #pragma once
 
+// GCC 4.9 compatibility
+#if !defined(__GNUC__) || __GNUC__ >= 5
+#define GEOMETRYHPP_CONSTEXPR constexpr
+#else
+#define GEOMETRYHPP_CONSTEXPR inline
+#endif
+
 namespace mapbox {
 namespace geometry {
 
 template <typename T>
-constexpr point<T> operator+(point<T> const& lhs, point<T> const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T> operator+(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x + rhs.x, lhs.y + rhs.y);
 }
 
 template <typename T>
-constexpr point<T> operator+(point<T> const& lhs, T const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T> operator+(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x + rhs, lhs.y + rhs);
 }
 
 template <typename T>
-constexpr point<T> operator-(point<T> const& lhs, point<T> const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T> operator-(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x - rhs.x, lhs.y - rhs.y);
 }
 
 template <typename T>
-constexpr point<T> operator-(point<T> const& lhs, T const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T> operator-(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x - rhs, lhs.y - rhs);
 }
 
 template <typename T>
-constexpr point<T> operator*(point<T> const& lhs, point<T> const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T> operator*(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x * rhs.x, lhs.y * rhs.y);
 }
 
 template <typename T>
-constexpr point<T> operator*(point<T> const& lhs, T const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T> operator*(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x * rhs, lhs.y * rhs);
 }
 
 template <typename T>
-constexpr point<T> operator/(point<T> const& lhs, point<T> const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T> operator/(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x / rhs.x, lhs.y / rhs.y);
 }
 
 template <typename T>
-constexpr point<T> operator/(point<T> const& lhs, T const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T> operator/(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x / rhs, lhs.y / rhs);
 }
 
 template <typename T>
-constexpr point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x += rhs.x;
     lhs.y += rhs.y;
@@ -60,7 +67,7 @@ constexpr point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator+=(point<T>& lhs, T const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T>& operator+=(point<T>& lhs, T const& rhs)
 {
     lhs.x += rhs;
     lhs.y += rhs;
@@ -68,7 +75,7 @@ constexpr point<T>& operator+=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x -= rhs.x;
     lhs.y -= rhs.y;
@@ -76,7 +83,7 @@ constexpr point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator-=(point<T>& lhs, T const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T>& operator-=(point<T>& lhs, T const& rhs)
 {
     lhs.x -= rhs;
     lhs.y -= rhs;
@@ -84,7 +91,7 @@ constexpr point<T>& operator-=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x *= rhs.x;
     lhs.y *= rhs.y;
@@ -92,7 +99,7 @@ constexpr point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator*=(point<T>& lhs, T const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T>& operator*=(point<T>& lhs, T const& rhs)
 {
     lhs.x *= rhs;
     lhs.y *= rhs;
@@ -100,7 +107,7 @@ constexpr point<T>& operator*=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x /= rhs.x;
     lhs.y /= rhs.y;
@@ -108,7 +115,7 @@ constexpr point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator/=(point<T>& lhs, T const& rhs)
+GEOMETRYHPP_CONSTEXPR point<T>& operator/=(point<T>& lhs, T const& rhs)
 {
     lhs.x /= rhs;
     lhs.y /= rhs;

--- a/src/mbgl/annotation/fill_annotation_impl.cpp
+++ b/src/mbgl/annotation/fill_annotation_impl.cpp
@@ -9,7 +9,7 @@ using namespace style;
 
 FillAnnotationImpl::FillAnnotationImpl(AnnotationID id_, FillAnnotation annotation_, uint8_t maxZoom_)
     : ShapeAnnotationImpl(id_, maxZoom_),
-      annotation({ ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.color, annotation_.outlineColor }) {
+      annotation(ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.color, annotation_.outlineColor) {
 }
 
 void FillAnnotationImpl::updateStyle(Style& style) const {

--- a/src/mbgl/annotation/line_annotation_impl.cpp
+++ b/src/mbgl/annotation/line_annotation_impl.cpp
@@ -9,7 +9,7 @@ using namespace style;
 
 LineAnnotationImpl::LineAnnotationImpl(AnnotationID id_, LineAnnotation annotation_, uint8_t maxZoom_)
     : ShapeAnnotationImpl(id_, maxZoom_),
-      annotation({ ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.width, annotation_.color }) {
+      annotation(ShapeAnnotationGeometry::visit(annotation_.geometry, CloseShapeAnnotation{}), annotation_.opacity, annotation_.width, annotation_.color) {
 }
 
 void LineAnnotationImpl::updateStyle(Style& style) const {

--- a/src/mbgl/annotation/shape_annotation_impl.cpp
+++ b/src/mbgl/annotation/shape_annotation_impl.cpp
@@ -24,7 +24,14 @@ void ShapeAnnotationImpl::updateTileData(const CanonicalTileID& tileID, Annotati
     if (!shapeTiler) {
         mapbox::geometry::feature_collection<double> features;
         features.emplace_back(ShapeAnnotationGeometry::visit(geometry(), [] (auto&& geom) {
+#if !defined(__GNUC__) || __GNUC__ >= 5
             return Feature { std::move(geom) };
+#else
+            Feature feature;
+            feature.geometry = std::move(geom);
+
+            return feature;
+#endif
         }));
         mapbox::geojsonvt::Options options;
         options.maxZoom = maxZoom;

--- a/src/mbgl/gl/attribute.hpp
+++ b/src/mbgl/gl/attribute.hpp
@@ -148,11 +148,8 @@ public:
     using State = IndexedTuple<TypeList<As...>, TypeList<typename As::State...>>;
     using Vertex = detail::Vertex<As...>;
 
-    template <class A>
-    static constexpr std::size_t Index = TypeIndex<A, As...>::value;
-
     static State state(const ProgramID& id) {
-        return State { typename As::State(bindAttributeLocation(id, Index<As>, As::name))... };
+        return State { typename As::State(bindAttributeLocation(id, TypeIndex<As, As...>::value, As::name))... };
     }
 
     static std::function<void (std::size_t)> binder(const State& state) {
@@ -162,7 +159,7 @@ public:
                                           state.template get<As>().type,
                                           sizeof(Vertex),
                                           vertexOffset,
-                                          Vertex::attributeOffsets[Index<As>]), 0)... });
+                                          Vertex::attributeOffsets[TypeIndex<As, As...>::value]), 0)... });
         };
     }
 };

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -91,7 +91,7 @@ public:
     template <typename Image>
     Texture createTexture(const Image& image, TextureUnit unit = 0) {
         auto format = image.channels == 4 ? TextureFormat::RGBA : TextureFormat::Alpha;
-        return { image.size, createTexture(image.size, image.data.get(), format, unit) };
+        return Texture(image.size, [&] { return createTexture(image.size, image.data.get(), format, unit); });
     }
 
     template <typename Image>
@@ -105,7 +105,7 @@ public:
     Texture createTexture(const Size size,
                           TextureFormat format = TextureFormat::RGBA,
                           TextureUnit unit = 0) {
-        return { size, createTexture(size, nullptr, format, unit) };
+        return Texture(size, [&] { return createTexture(size, nullptr, format, unit); });
     }
 
     void bindTexture(Texture&,

--- a/src/mbgl/gl/gl.cpp
+++ b/src/mbgl/gl/gl.cpp
@@ -1,12 +1,13 @@
 #include <mbgl/gl/gl.hpp>
 #include <mbgl/util/string.hpp>
+#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 namespace gl {
 
 namespace {
 
-constexpr const char* stringFromError(GLenum err) {
+MBGL_CONSTEXPR const char* stringFromError(GLenum err) {
     switch (err) {
     case GL_INVALID_ENUM:
         return "GL_INVALID_ENUM";

--- a/src/mbgl/gl/texture.hpp
+++ b/src/mbgl/gl/texture.hpp
@@ -3,11 +3,15 @@
 #include <mbgl/gl/object.hpp>
 #include <mbgl/util/size.hpp>
 
+#include <functional>
+
 namespace mbgl {
 namespace gl {
 
 class Texture {
 public:
+    Texture(Size size_, std::function<UniqueTexture()> getTexture) : size(size_), texture(getTexture()) {}
+
     Size size;
     UniqueTexture texture;
     TextureFilter filter = TextureFilter::Nearest;

--- a/src/mbgl/gl/uniform.hpp
+++ b/src/mbgl/gl/uniform.hpp
@@ -28,6 +28,8 @@ public:
 
     class State {
     public:
+        State(UniformLocation location_) : location(std::move(location_)) {}
+
         void operator=(const Value& value) {
             if (!current || *current != value.t) {
                 current = value.t;
@@ -67,7 +69,7 @@ public:
     using Values = IndexedTuple<TypeList<Us...>, TypeList<typename Us::Value...>>;
 
     static State state(const ProgramID& id) {
-        return State { { uniformLocation(id, Us::name) }... };
+        return State(typename Us::State(uniformLocation(id, Us::name))...);
     }
 
     static std::function<void ()> binder(State& state, Values&& values_) {

--- a/src/mbgl/gl/value.cpp
+++ b/src/mbgl/gl/value.cpp
@@ -22,7 +22,7 @@ ClearDepth::Type ClearDepth::Get() {
     return clearDepth;
 }
 
-const constexpr ClearColor::Type ClearColor::Default;
+const ClearColor::Type ClearColor::Default = { 0, 0, 0, 0 };
 
 void ClearColor::Set(const Type& value) {
     MBGL_CHECK_ERROR(glClearColor(value.r, value.g, value.b, value.a));
@@ -205,7 +205,7 @@ BlendFunc::Type BlendFunc::Get() {
              static_cast<ColorMode::BlendFactor>(dfactor) };
 }
 
-const constexpr BlendColor::Type BlendColor::Default;
+const BlendColor::Type BlendColor::Default = { 0, 0, 0, 0 };
 
 void BlendColor::Set(const Type& value) {
     MBGL_CHECK_ERROR(glBlendColor(value.r, value.g, value.b, value.a));

--- a/src/mbgl/gl/value.hpp
+++ b/src/mbgl/gl/value.hpp
@@ -21,7 +21,7 @@ struct ClearDepth {
 
 struct ClearColor {
     using Type = Color;
-    static const constexpr Type Default = { 0, 0, 0, 0 };
+    static const Type Default;
     static void Set(const Type&);
     static Type Get();
 };
@@ -142,7 +142,7 @@ constexpr bool operator!=(const BlendFunc::Type& a, const BlendFunc::Type& b) {
 
 struct BlendColor {
     using Type = Color;
-    static const constexpr Type Default = { 0, 0, 0, 0 };
+    static const Type Default;
     static void Set(const Type&);
     static Type Get();
 };

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -483,7 +483,7 @@ void SymbolLayout::addSymbols(Buffer &buffer, const SymbolQuads &symbols, float 
         uint16_t index = segment.vertexLength;
 
         // Encode angle of glyph
-        uint8_t glyphAngle = std::round((symbol.glyphAngle / (M_PI * 2)) * 256);
+        uint8_t glyphAngle = ::round((symbol.glyphAngle / (M_PI * 2)) * 256);
 
         // coordinates (2 triangles)
         buffer.vertices.emplace_back(SymbolAttributes::vertex(anchorPoint, tl, tex.x, tex.y,

--- a/src/mbgl/map/update.hpp
+++ b/src/mbgl/map/update.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/traits.hpp>
+#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 
@@ -15,15 +16,15 @@ enum class Update {
     Layout                    = 1 << 8
 };
 
-constexpr Update operator|(Update lhs, Update rhs) {
+MBGL_CONSTEXPR Update operator|(Update lhs, Update rhs) {
     return Update(mbgl::underlying_type(lhs) | mbgl::underlying_type(rhs));
 }
 
-constexpr Update& operator|=(Update& lhs, const Update& rhs) {
+MBGL_CONSTEXPR Update& operator|=(Update& lhs, const Update& rhs) {
     return (lhs = lhs | rhs);
 }
 
-constexpr bool operator& (Update lhs, Update rhs) {
+MBGL_CONSTEXPR bool operator& (Update lhs, Update rhs) {
     return mbgl::underlying_type(lhs) & mbgl::underlying_type(rhs);
 }
 

--- a/src/mbgl/renderer/render_pass.hpp
+++ b/src/mbgl/renderer/render_pass.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/util/traits.hpp>
+#include <mbgl/util/util.hpp>
 
 #include <cstdint>
 
@@ -12,15 +13,15 @@ enum class RenderPass : uint8_t {
     Translucent = 1 << 1,
 };
 
-constexpr RenderPass operator|(RenderPass a, RenderPass b) {
+MBGL_CONSTEXPR RenderPass operator|(RenderPass a, RenderPass b) {
     return RenderPass(mbgl::underlying_type(a) | mbgl::underlying_type(b));
 }
 
-constexpr RenderPass& operator|=(RenderPass& a, RenderPass b) {
+MBGL_CONSTEXPR RenderPass& operator|=(RenderPass& a, RenderPass b) {
     return (a = a | b);
 }
 
-constexpr RenderPass operator&(RenderPass a, RenderPass b) {
+MBGL_CONSTEXPR RenderPass operator&(RenderPass a, RenderPass b) {
     return RenderPass(mbgl::underlying_type(a) & mbgl::underlying_type(b));
 }
 

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -224,11 +224,11 @@ optional<SpriteAtlasPosition> SpriteAtlas::getPosition(const std::string& name,
     const float w = spriteImage->getWidth() * (*img).relativePixelRatio;
     const float h = spriteImage->getHeight() * (*img).relativePixelRatio;
 
-    return SpriteAtlasPosition {
-        {{ float(spriteImage->getWidth()), spriteImage->getHeight() }},
-        {{ float(rect.x + padding)     / size.width, float(rect.y + padding)     / size.height }},
-        {{ float(rect.x + padding + w) / size.width, float(rect.y + padding + h) / size.height }}
-    };
+    return SpriteAtlasPosition(
+        std::array<float, 2> {{ float(spriteImage->getWidth()), float(spriteImage->getHeight()) }},
+        std::array<float, 2> {{ float(rect.x + padding) / size.width, float(rect.y + padding) / size.height }},
+        std::array<float, 2> {{ float(rect.x + padding + w) / size.width, float(rect.y + padding + h) / size.height }}
+        );
 }
 
 void copyBitmap(const uint32_t *src, const uint32_t srcStride, const uint32_t srcX, const uint32_t srcY,

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -28,6 +28,7 @@ class SpritePosition;
 
 class SpriteAtlasPosition {
 public:
+    SpriteAtlasPosition(std::array<float, 2> size_, std::array<float, 2> tl_, std::array<float, 2> br_) : size(std::move(size_)), tl(std::move(tl_)), br(std::move(br_)) {}
     std::array<float, 2> size = {{ 0, 0 }};
     std::array<float, 2> tl = {{ 0, 0 }};
     std::array<float, 2> br = {{ 0, 0 }};

--- a/src/mbgl/style/property_parsing.cpp
+++ b/src/mbgl/style/property_parsing.cpp
@@ -22,7 +22,11 @@ optional<TransitionOptions> parseTransitionOptions(const char *, const JSValue& 
         return {};
     }
 
-    return TransitionOptions { duration, delay };
+    TransitionOptions options;
+    options.duration = std::move(duration);
+    options.delay = std::move(delay);
+
+    return options;
 }
 
 } // namespace style

--- a/src/mbgl/tile/geometry_tile_data.cpp
+++ b/src/mbgl/tile/geometry_tile_data.cpp
@@ -208,7 +208,12 @@ static Feature::geometry_type convertGeometry(const GeometryTileFeature& geometr
 }
 
 Feature convertFeature(const GeometryTileFeature& geometryTileFeature, const CanonicalTileID& tileID) {
+#if !defined(__GNUC__) || __GNUC__ >= 5
     Feature feature { convertGeometry(geometryTileFeature, tileID) };
+#else
+    Feature feature;
+    feature.geometry = convertGeometry(geometryTileFeature, tileID);
+#endif
     feature.properties = geometryTileFeature.getProperties();
     feature.id = geometryTileFeature.getID();
     return feature;

--- a/src/mbgl/util/indexed_tuple.hpp
+++ b/src/mbgl/util/indexed_tuple.hpp
@@ -31,16 +31,13 @@ public:
     using std::tuple<Ts...>::tuple;
 
     template <class I>
-    static constexpr std::size_t Index = TypeIndex<I, Is...>::value;
-
-    template <class I>
     auto& get() {
-        return std::get<Index<I>>(*this);
+        return std::get<TypeIndex<I, Is...>::value>(*this);
     }
 
     template <class I>
     const auto& get() const {
-        return std::get<Index<I>>(*this);
+        return std::get<TypeIndex<I, Is...>::value>(*this);
     }
 };
 

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -58,9 +58,7 @@ TEST(Annotations, LineAnnotation) {
     AnnotationTest test;
 
     LineString<double> line = {{ { 0, 0 }, { 45, 45 }, { 30, 0 } }};
-    LineAnnotation annotation { line };
-    annotation.color = Color::red();
-    annotation.width = { 5 };
+    LineAnnotation annotation(line, 1.0f, 5, Color::red());
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotation(annotation);
@@ -74,8 +72,7 @@ TEST(Annotations, FillAnnotation) {
     AnnotationTest test;
 
     Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
-    FillAnnotation annotation { polygon };
-    annotation.color = Color::red();
+    FillAnnotation annotation(polygon, 1.0f, Color::red(), {});
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotation(annotation);
@@ -93,14 +90,11 @@ TEST(Annotations, AntimeridianAnnotationSmall) {
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
 
     LineString<double> line = {{ { antimeridian, 20 }, { antimeridian, -20 } }};
-    LineAnnotation lineAnnotation { line };
-    lineAnnotation.color = Color::red();
-    lineAnnotation.width = { 2 };
+    LineAnnotation lineAnnotation(line, 1.0f, 2, Color::red());
     test.map.addAnnotation(lineAnnotation);
 
     Polygon<double> polygon = {{ {{ { antimeridian+10, 0 }, { antimeridian - 10, 10 }, { antimeridian-10, -10 } }} }};
-    FillAnnotation polygonAnnotation { polygon };
-    polygonAnnotation.color = Color::blue();
+    FillAnnotation polygonAnnotation(polygon, 1.0f, Color::blue(), {});
     test.map.addAnnotation(polygonAnnotation);
 
     test.checkRendering("antimeridian_annotation_small");
@@ -114,14 +108,11 @@ TEST(Annotations, AntimeridianAnnotationLarge) {
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
 
     LineString<double> line = {{ { antimeridian, 20 }, { antimeridian, -20 } }};
-    LineAnnotation lineAnnotation { line };
-    lineAnnotation.color = Color::red();
-    lineAnnotation.width = { 2 };
+    LineAnnotation lineAnnotation(line, 1.0f, 2, Color::red());
     test.map.addAnnotation(lineAnnotation);
 
     Polygon<double> polygon = {{ {{ { antimeridian-10, 0 }, { -antimeridian+10, 10 }, { -antimeridian+10, -10 } }} }};
-    FillAnnotation polygonAnnotation { polygon };
-    polygonAnnotation.color = Color::blue();
+    FillAnnotation polygonAnnotation(polygon, 1.0f, Color::blue(), {});
     test.map.addAnnotation(polygonAnnotation);
 
     test.checkRendering("antimeridian_annotation_large");
@@ -131,10 +122,8 @@ TEST(Annotations, OverlappingFillAnnotation) {
     AnnotationTest test;
 
     Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
-    FillAnnotation underlaidAnnotation { polygon };
-    underlaidAnnotation.color = Color::green();
-    FillAnnotation overlaidAnnotation { polygon };
-    overlaidAnnotation.color = Color::red();
+    FillAnnotation underlaidAnnotation(polygon, 1.0f, Color::green(), {});
+    FillAnnotation overlaidAnnotation(polygon, 1.0f, Color::red(), {});
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     test.map.addAnnotation(underlaidAnnotation);
@@ -172,8 +161,7 @@ TEST(Annotations, NonImmediateAdd) {
     test::render(test.map, test.view);
 
     Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
-    FillAnnotation annotation { polygon };
-    annotation.color = Color::red();
+    FillAnnotation annotation(polygon, 1.0f, Color::red(), {});
 
     test.map.addAnnotation(annotation);
     test.checkRendering("non_immediate_add");
@@ -210,9 +198,7 @@ TEST(Annotations, UpdateSymbolAnnotationIcon) {
 TEST(Annotations, UpdateLineAnnotationGeometry) {
     AnnotationTest test;
 
-    LineAnnotation annotation { LineString<double> {{ { 0, 0 }, { 45, 45 }, { 30, 0 } }} };
-    annotation.color = Color::red();
-    annotation.width = { 5 };
+    LineAnnotation annotation(LineString<double> {{ { 0, 0 }, { 45, 45 }, { 30, 0 } }}, 1.0f, 5, Color::red());
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     AnnotationID line = test.map.addAnnotation(annotation);
@@ -227,9 +213,7 @@ TEST(Annotations, UpdateLineAnnotationGeometry) {
 TEST(Annotations, UpdateLineAnnotationStyle) {
     AnnotationTest test;
 
-    LineAnnotation annotation { LineString<double> {{ { 0, 0 }, { 45, 45 }, { 30, 0 } }} };
-    annotation.color = Color::red();
-    annotation.width = { 5 };
+    LineAnnotation annotation(LineString<double> {{ { 0, 0 }, { 45, 45 }, { 30, 0 } }}, 1.0f, 5, Color::red());
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     AnnotationID line = test.map.addAnnotation(annotation);
@@ -245,8 +229,7 @@ TEST(Annotations, UpdateLineAnnotationStyle) {
 TEST(Annotations, UpdateFillAnnotationGeometry) {
     AnnotationTest test;
 
-    FillAnnotation annotation { Polygon<double> {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }} };
-    annotation.color = Color::red();
+    FillAnnotation annotation(Polygon<double> {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }}, 1.0f, Color::red(), {});
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     AnnotationID fill = test.map.addAnnotation(annotation);
@@ -262,8 +245,7 @@ TEST(Annotations, UpdateFillAnnotationStyle) {
     AnnotationTest test;
 
     Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
-    FillAnnotation annotation { polygon };
-    annotation.color = Color::red();
+    FillAnnotation annotation(polygon, 1.0f, Color::red(), {});
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     AnnotationID fill = test.map.addAnnotation(annotation);
@@ -292,9 +274,7 @@ TEST(Annotations, RemoveShape) {
     AnnotationTest test;
 
     LineString<double> line = {{ { 0, 0 }, { 45, 45 } }};
-    LineAnnotation annotation { line };
-    annotation.color = Color::red();
-    annotation.width = { 5 };
+    LineAnnotation annotation(line, 1.0f, 5, Color::red());
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     AnnotationID shape = test.map.addAnnotation(annotation);
@@ -308,7 +288,7 @@ TEST(Annotations, RemoveShape) {
 TEST(Annotations, ImmediateRemoveShape) {
     AnnotationTest test;
 
-    test.map.removeAnnotation(test.map.addAnnotation(LineAnnotation { LineString<double>() }));
+    test.map.removeAnnotation(test.map.addAnnotation(LineAnnotation(LineString<double>(), 1.0f, 1.0f, {})));
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
 
     test::render(test.map, test.view);

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -199,7 +199,7 @@ TEST(Map, StyleExpiredWithAnnotations) {
     fileSource.respond(Resource::Style, response);
     EXPECT_EQ(1u, fileSource.requests.size());
 
-    map.addAnnotation(LineAnnotation { LineString<double> {{ { 0, 0 }, { 10, 10 } }} });
+    map.addAnnotation(LineAnnotation(LineString<double> {{ { 0, 0 }, { 10, 10 } }}, 1.0f, 1.0f, {}));
     EXPECT_EQ(1u, fileSource.requests.size());
 
     fileSource.respond(Resource::Style, response);


### PR DESCRIPTION
Hello mapbox team/tmpsantos!

This commit fixes two compilation errors coming from template depth and using a class after it has been declared. I got errors when I compiled the code with clang.

The maximum template depth problem should actually be fixed by not using tuples as I have understood from the #C++ channel on freenode.