### PR TITLE
Arrange layers top to bottom in sidebar

### DIFF
--- a/platform/macos/app/Base.lproj/MapDocument.xib
+++ b/platform/macos/app/Base.lproj/MapDocument.xib
@@ -27,6 +27,7 @@
             <declaredKeys>
                 <string>layers</string>
                 <string>name</string>
+                <string>reversedLayers</string>
             </declaredKeys>
             <connections>
                 <binding destination="jxx-uM-ZTC" name="contentObject" keyPath="selection.style" id="60N-aU-tgJ"/>
@@ -38,7 +39,7 @@
                 <string>visible</string>
             </declaredKeys>
             <connections>
-                <binding destination="Xji-k6-iQ4" name="contentArray" keyPath="selection.layers" id="X25-Nb-Brf"/>
+                <binding destination="Xji-k6-iQ4" name="contentArray" keyPath="selection.reversedLayers" id="wtL-d8-GNd"/>
             </connections>
         </arrayController>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>

--- a/platform/macos/app/MGLStyle+MBXAdditions.h
+++ b/platform/macos/app/MGLStyle+MBXAdditions.h
@@ -1,0 +1,7 @@
+#import <Mapbox/Mapbox.h>
+
+@interface MGLStyle (MBXAdditions)
+
+@property (nonatomic, strong) NS_ARRAY_OF(__kindof MGLStyleLayer *) *reversedLayers;
+
+@end

--- a/platform/macos/app/MGLStyle+MBXAdditions.m
+++ b/platform/macos/app/MGLStyle+MBXAdditions.m
@@ -1,0 +1,42 @@
+#import "MGLStyle+MBXAdditions.h"
+
+@implementation MGLStyle (MBXAdditions)
+
++ (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingReversedLayers {
+    return [NSSet setWithObject:@"layers"];
+}
+
+- (NS_ARRAY_OF(__kindof MGLStyleLayer *) *)reversedLayers {
+    return self.layers.reverseObjectEnumerator.allObjects;
+}
+
+- (void)setReversedLayers:(NS_ARRAY_OF(__kindof MGLStyleLayer *) *)reversedLayers {
+    self.layers = reversedLayers.reverseObjectEnumerator.allObjects;
+}
+
+- (NSUInteger)countOfReversedLayers {
+    return self.layers.count;
+}
+
+- (id)objectInReversedLayersAtIndex:(NSUInteger)index {
+    NSArray *layers = self.layers;
+    return layers[layers.count - 1 - index];
+}
+
+- (void)getReversedLayers:(__kindof MGLStyleLayer **)buffer range:(NSRange)inRange {
+    NSArray *layers = self.layers;
+    for (NSUInteger i = inRange.location; i < NSMaxRange(inRange); i++) {
+        MGLStyleLayer *styleLayer = layers[layers.count - 1 - i];
+        buffer[i] = styleLayer;
+    }
+}
+
+- (void)insertObject:(__kindof MGLStyleLayer *)object inReversedLayersAtIndex:(NSUInteger)index {
+    [self insertLayer:object atIndex:self.layers.count - index];
+}
+
+- (void)removeObjectFromReversedLayersAtIndex:(NSUInteger)index {
+    [self removeLayer:[self objectInReversedLayersAtIndex:index]];
+}
+
+@end

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -4,6 +4,7 @@
 #import "LimeGreenStyleLayer.h"
 #import "DroppedPinAnnotation.h"
 
+#import "MGLStyle+MBXAdditions.h"
 #import "MGLVectorSource+MBXAdditions.h"
 
 #import <Mapbox/Mapbox.h>
@@ -256,7 +257,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
 }
 
 - (void)toggleStyleLayersAtArrangedObjectIndexes:(NSIndexSet *)indices {
-    NS_ARRAY_OF(MGLStyleLayer *) *layers = [self.mapView.style.layers objectsAtIndexes:indices];
+    NS_ARRAY_OF(MGLStyleLayer *) *layers = [self.mapView.style.reversedLayers objectsAtIndexes:indices];
     BOOL isVisible = layers.firstObject.visible;
     [self.undoManager registerUndoWithTarget:self handler:^(MapDocument * _Nonnull target) {
         [target toggleStyleLayersAtArrangedObjectIndexes:indices];
@@ -312,7 +313,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
 }
 
 - (void)deleteStyleLayersAtArrangedObjectIndexes:(NSIndexSet *)indices {
-    NS_ARRAY_OF(MGLStyleLayer *) *layers = [self.mapView.style.layers objectsAtIndexes:indices];
+    NS_ARRAY_OF(MGLStyleLayer *) *layers = [self.mapView.style.reversedLayers objectsAtIndexes:indices];
     [self.undoManager registerUndoWithTarget:self handler:^(id  _Nonnull target) {
         [self insertStyleLayers:layers atArrangedObjectIndexes:indices];
     }];
@@ -825,7 +826,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
         if (row == -1) {
             menuItem.title = @"Show";
         } else {
-            BOOL isVisible = self.mapView.style.layers[row].visible;
+            BOOL isVisible = self.mapView.style.reversedLayers[row].visible;
             menuItem.title = isVisible ? @"Hide" : @"Show";
         }
         return row != -1;

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		DAA48EFD1D6A4731006A7E36 /* StyleLayerIconTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DAA48EFC1D6A4731006A7E36 /* StyleLayerIconTransformer.m */; };
 		DAB2CCE51DF632ED001B2FE1 /* LimeGreenStyleLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DAB2CCE41DF632ED001B2FE1 /* LimeGreenStyleLayer.m */; };
 		DAC2ABC51CC6D343006D18C4 /* MGLAnnotationImage_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DAC2ABC41CC6D343006D18C4 /* MGLAnnotationImage_Private.h */; };
+		DACB0C391E18DFFD005DDBEA /* MGLStyle+MBXAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = DACB0C381E18DFFD005DDBEA /* MGLStyle+MBXAdditions.m */; };
 		DACC22141CF3D3E200D220D9 /* MGLFeature.h in Headers */ = {isa = PBXBuildFile; fileRef = DACC22121CF3D3E200D220D9 /* MGLFeature.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DACC22151CF3D3E200D220D9 /* MGLFeature.mm in Sources */ = {isa = PBXBuildFile; fileRef = DACC22131CF3D3E200D220D9 /* MGLFeature.mm */; };
 		DACC22181CF3D4F700D220D9 /* MGLFeature_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = DACC22171CF3D4F700D220D9 /* MGLFeature_Private.h */; };
@@ -395,6 +396,8 @@
 		DAB2CCE31DF632ED001B2FE1 /* LimeGreenStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LimeGreenStyleLayer.h; sourceTree = "<group>"; };
 		DAB2CCE41DF632ED001B2FE1 /* LimeGreenStyleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LimeGreenStyleLayer.m; sourceTree = "<group>"; };
 		DAC2ABC41CC6D343006D18C4 /* MGLAnnotationImage_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAnnotationImage_Private.h; sourceTree = "<group>"; };
+		DACB0C371E18DFFD005DDBEA /* MGLStyle+MBXAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLStyle+MBXAdditions.h"; sourceTree = "<group>"; };
+		DACB0C381E18DFFD005DDBEA /* MGLStyle+MBXAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLStyle+MBXAdditions.m"; sourceTree = "<group>"; };
 		DACC22121CF3D3E200D220D9 /* MGLFeature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLFeature.h; sourceTree = "<group>"; };
 		DACC22131CF3D3E200D220D9 /* MGLFeature.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLFeature.mm; sourceTree = "<group>"; };
 		DACC22171CF3D4F700D220D9 /* MGLFeature_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLFeature_Private.h; sourceTree = "<group>"; };
@@ -636,6 +639,8 @@
 				DA839E9B1CC2E3400062CAFB /* MapDocument.h */,
 				DA839E9C1CC2E3400062CAFB /* MapDocument.m */,
 				DA839E9E1CC2E3400062CAFB /* MapDocument.xib */,
+				DACB0C371E18DFFD005DDBEA /* MGLStyle+MBXAdditions.h */,
+				DACB0C381E18DFFD005DDBEA /* MGLStyle+MBXAdditions.m */,
 				DAF0D81A1DFF567C00B28378 /* MGLVectorSource+MBXAdditions.h */,
 				DAF0D81B1DFF567C00B28378 /* MGLVectorSource+MBXAdditions.m */,
 				DAE6C2E91CC3050F00DB3429 /* OfflinePackNameValueTransformer.h */,
@@ -1239,6 +1244,7 @@
 				DAE6C2EE1CC3050F00DB3429 /* LocationCoordinate2DTransformer.m in Sources */,
 				DAB2CCE51DF632ED001B2FE1 /* LimeGreenStyleLayer.m in Sources */,
 				DAE6C2F11CC3050F00DB3429 /* TimeIntervalTransformer.m in Sources */,
+				DACB0C391E18DFFD005DDBEA /* MGLStyle+MBXAdditions.m in Sources */,
 				DA839E9A1CC2E3400062CAFB /* main.m in Sources */,
 				DA839E971CC2E3400062CAFB /* AppDelegate.m in Sources */,
 				DAF0D81C1DFF567C00B28378 /* MGLVectorSource+MBXAdditions.m in Sources */,


### PR DESCRIPTION
#7484 reversed the `MGLStyle.layers` property to arrange the layers from back to front. In a vertical list, however, the layers should always be arranged from front to back, as if the user is viewing a cross section of the style. This change implements a `reversedLayers` property on MGLStyle via a category specific to macosapp. (Neither SDK is affected.)

Depends on #7539.