### PR TITLE
Unify update and render into a single step

### DIFF
--- a/src/mbgl/map/update.hpp
+++ b/src/mbgl/map/update.hpp
@@ -6,10 +6,9 @@ namespace mbgl {
 
 enum class Update {
     Nothing                   = 0,
+    Repaint                   = 1 << 0,
     Classes                   = 1 << 2,
     RecalculateStyle          = 1 << 3,
-    RenderStill               = 1 << 4,
-    Repaint                   = 1 << 5,
     AnnotationStyle           = 1 << 6,
     AnnotationData            = 1 << 7,
     Layout                    = 1 << 8


### PR DESCRIPTION
Update only when, and just prior to, rendering, giving no opportunity to interleave unexpected state changes. Abandon the use of `AsyncTask` in continuous mode; instead call `backend.invalidate()` whenever something occurs that needs to trigger a update/render, relying on the platform implementation of invalidate to perform coalescing.

This fixes #7040.

/cc @jfirebaugh @pveugen 