### PR TITLE
Distance formatter fixes #3331

### DIFF
--- a/platform/darwin/resources/Base.lproj/Foundation.strings
+++ b/platform/darwin/resources/Base.lproj/Foundation.strings
@@ -289,3 +289,33 @@
 /* West longitude format, short: {longitude} */
 "COORD_W_SHORT" = "%@W";
 
+/* Distance format, long: {1 foot} */
+"DISTANCE_FOOT_LONG" = "%@ foot/feet";
+
+/* Distance format, short: {1 ft} */
+"DISTANCE_FOOT_SHORT" = "%@ ft";
+
+/* Distance format, long: {1 kilometer} */
+"DISTANCE_KILOMETER_LONG" = "%@ kilometer(s)";
+
+/* Distance format, short: {1 km} */
+"DISTANCE_KILOMETER_SHORT" = "%@ km";
+
+/* Distance format, long: {1 meter} */
+"DISTANCE_METER_LONG" = "%@ meter(s)";
+
+/* Distance format, short: {1 m} */
+"DISTANCE_METER_SHORT" = "%@ m";
+
+/* Distance format, long: {1 mile} */
+"DISTANCE_MILE_LONG" = "%@ mile(s)";
+
+/* Distance format, short: {1 mi} */
+"DISTANCE_MILE_SHORT" = "%@ mi";
+
+/* Distance format, long: {1 yard} */
+"DISTANCE_YARD_LONG" = "%@ yard(s)";
+
+/* Distance format, short: {1 yd} */
+"DISTANCE_YARD_SHORT" = "%@ yd";
+

--- a/platform/darwin/resources/en.lproj/Foundation.stringsdict
+++ b/platform/darwin/resources/en.lproj/Foundation.stringsdict
@@ -50,5 +50,85 @@
 			<string>%d seconds</string>
 		</dict>
 	</dict>
+    <key>DISTANCE_METER_LONG</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@meter@</string>
+        <key>meter</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>@</string>
+            <key>one</key>
+            <string>%@ meter</string>
+            <key>other</key>
+            <string>%@ meters</string>
+        </dict>
+    </dict>
+    <key>DISTANCE_KILOMETER_LONG</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@kilometer@</string>
+        <key>kilometer</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>@</string>
+            <key>one</key>
+            <string>%@ kilometer</string>
+            <key>other</key>
+            <string>%@ kilometers</string>
+        </dict>
+    </dict>
+    <key>DISTANCE_FOOT_LONG</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@foot@</string>
+        <key>foot</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>@</string>
+            <key>one</key>
+            <string>%@ foot</string>
+            <key>other</key>
+            <string>%@ feet</string>
+        </dict>
+    </dict>
+    <key>DISTANCE_MILE_LONG</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@mile@</string>
+        <key>mile</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>@</string>
+            <key>one</key>
+            <string>%@ mile</string>
+            <key>other</key>
+            <string>%@ miles</string>
+        </dict>
+    </dict>
+    <key>DISTANCE_YARD_LONG</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@yard@</string>
+        <key>yard</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>@</string>
+            <key>one</key>
+            <string>%@ yard</string>
+            <key>other</key>
+            <string>%@ yards</string>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/platform/darwin/src/MGLDistanceFormatter.h
+++ b/platform/darwin/src/MGLDistanceFormatter.h
@@ -1,0 +1,65 @@
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ `MGLDistanceFormatter` implements a formatter object meant to be used for
+ geographic distances. By default, the resulting string will be based on the user’s
+ current locale but can be overriden in order to force a measurement system of your choice.
+ */
+@interface MGLDistanceFormatter : NSFormatter
+
+/**
+ Determines what system of measurement to use.
+ */
+typedef NS_ENUM(NSUInteger, MGLDistanceFormatterUnits) {
+    // Measurement system will be based on the current locale.
+    MGLDistanceFormatterUnitsDefault,
+    // Use the metric system.
+    MGLDistanceFormatterUnitsMetric,
+    // Imperial units using feets.
+    MGLDistanceFormatterUnitsImperial,
+    // Imperial units using yards.
+    MGLDistanceFormatterUnitsImperialWithYards
+};
+
+/**
+ Determines if the localized unit string should be abbreviated or spelled out.
+ */
+typedef NS_ENUM(NSUInteger, MGLDistanceFormatterUnitStyle) {
+    MGLDistanceFormatterUnitStyleDefault,
+    // Abbreviate units (i.e. 1 km).
+    MGLDistanceFormatterUnitStyleAbbreviated,
+    // Full style (i.e. 2 kilometers).
+    MGLDistanceFormatterUnitStyleFull
+};
+
+/**
+ Determines what system of measurement to use.
+ 
+ Based on the user’s locale by default.
+ */
+@property (nonatomic, assign) MGLDistanceFormatterUnits units;
+
+/**
+ Determines how to output the localized unit string.
+ */
+@property (nonatomic, assign) MGLDistanceFormatterUnitStyle unitStyle;
+
+/**
+ Returns a localized formatted string for the provided distance.
+ 
+ @param distance The distance, measured in meters. Negative distance will return nil.
+ @return A localized formatted distance string including units.
+ */
+- (NSString *)stringFromDistance:(CLLocationDistance)distance;
+
+/**
+ This method is not supported for the `MGLDistanceFormatter` class.
+ */
+- (BOOL)getObjectValue:(out id __nullable * __nullable)obj forString:(NSString *)string errorDescription:(out NSString * __nullable * __nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLDistanceFormatter.m
+++ b/platform/darwin/src/MGLDistanceFormatter.m
@@ -1,0 +1,139 @@
+#import "MGLDistanceFormatter.h"
+
+#import "NSBundle+MGLAdditions.h"
+
+
+@interface MGLDistanceFormatter()
+@property (nonatomic) NSNumberFormatter *numberFormatter;
+@end
+
+@implementation MGLDistanceFormatter
+
+static const CLLocationDistance METERS_PER_KM = 1000;
+static const CLLocationDistance METERS_PER_MILE = 1609.34;
+static const CLLocationDistance METERS_PER_YARD = 0.9144;
+static const CLLocationDistance METERS_PER_FOOT = 0.3048;
+
+typedef NS_ENUM(NSUInteger, MGLDistanceFormatterUnit) {
+    MGLDistanceFormatterUnitMeter,
+    MGLDistanceFormatterUnitKilometer,
+    MGLDistanceFormatterUnitFoot,
+    MGLDistanceFormatterUnitMile,
+    MGLDistanceFormatterUnitYard
+};
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _unitStyle = MGLDistanceFormatterUnitStyleDefault;
+        
+        _numberFormatter = [[NSNumberFormatter alloc] init];
+        _numberFormatter.minimumFractionDigits = 0;
+        _numberFormatter.roundingMode = NSNumberFormatterRoundHalfUp;
+    }
+    return self;
+}
+
+- (NSString *)stringFromDistance:(CLLocationDistance)distance {
+    if (distance < 0)
+        return nil;
+    
+    NSString *format = [self formatForDistance:distance];
+    NSNumber *convertedDistance = @([self convertedDistance:distance]);
+    
+    MGLDistanceFormatterUnit unit = [self unitForDistance:distance];
+    
+    switch (self.preferredUnits) {
+        case MGLDistanceFormatterUnitsDefault:
+        case MGLDistanceFormatterUnitsMetric:
+            _numberFormatter.maximumFractionDigits = unit == MGLDistanceFormatterUnitMeter ? 0 : 1;
+            return [NSString stringWithFormat:format, [self.numberFormatter numberFromString:[self.numberFormatter stringFromNumber:convertedDistance]]];
+        case MGLDistanceFormatterUnitsImperial:
+            _numberFormatter.maximumFractionDigits = unit == MGLDistanceFormatterUnitFoot ? 0 : 1;
+            return [NSString stringWithFormat:format, [self.numberFormatter numberFromString:[self.numberFormatter stringFromNumber:convertedDistance]]];
+        case MGLDistanceFormatterUnitsImperialWithYards:
+            _numberFormatter.maximumFractionDigits = unit == MGLDistanceFormatterUnitYard ? 0 : 1;
+            return [NSString stringWithFormat:format, [self.numberFormatter numberFromString:[self.numberFormatter stringFromNumber:convertedDistance]]];
+    }
+}
+
+- (CLLocationDistance)convertedDistance:(CLLocationDistance)distance {
+    MGLDistanceFormatterUnit unit = [self unitForDistance:distance];
+    switch (unit) {
+        case MGLDistanceFormatterUnitMeter:
+            return distance;
+        case MGLDistanceFormatterUnitKilometer:
+            return distance / METERS_PER_KM;
+        case MGLDistanceFormatterUnitFoot:
+            return distance / METERS_PER_FOOT;
+        case MGLDistanceFormatterUnitMile:
+            return distance / METERS_PER_MILE;
+        case MGLDistanceFormatterUnitYard:
+            return distance / METERS_PER_YARD;
+    }
+}
+
+- (NSString *)formatForDistance:(CLLocationDistance)distance {
+    MGLDistanceFormatterUnit unit = [self unitForDistance:distance];
+    
+    switch (self.unitStyle) {
+        case MGLDistanceFormatterUnitStyleDefault:
+        case MGLDistanceFormatterUnitStyleAbbreviated:
+            switch (unit) {
+                case MGLDistanceFormatterUnitMeter:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_METER_SHORT", @"Foundation", nil, @"%@ m", @"Distance format, short: {1 m}");
+                case MGLDistanceFormatterUnitKilometer:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_KILOMETER_SHORT", @"Foundation", nil, @"%@ km", @"Distance format, short: {1 km}");
+                case MGLDistanceFormatterUnitFoot:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_FOOT_SHORT", @"Foundation", nil, @"%@ ft", @"Distance format, short: {1 ft}");
+                case MGLDistanceFormatterUnitMile:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_MILE_SHORT", @"Foundation", nil, @"%@ mi", @"Distance format, short: {1 mi}");
+                case MGLDistanceFormatterUnitYard:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_YARD_SHORT", @"Foundation", nil, @"%@ yd", @"Distance format, short: {1 yd}");
+            }
+        case MGLDistanceFormatterUnitStyleFull:
+            switch (unit) {
+                case MGLDistanceFormatterUnitMeter:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_METER_LONG", @"Foundation", nil, @"%@ meter(s)", @"Distance format, long: {1 meter}");
+                case MGLDistanceFormatterUnitKilometer:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_KILOMETER_LONG", @"Foundation", nil, @"%@ kilometer(s)", @"Distance format, long: {1 kilometer}");
+                case MGLDistanceFormatterUnitFoot:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_FOOT_LONG", @"Foundation", nil, @"%@ foot/feet", @"Distance format, long: {1 foot}");
+                case MGLDistanceFormatterUnitMile:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_MILE_LONG", @"Foundation", nil, @"%@ mile(s)", @"Distance format, long: {1 mile}");
+                case MGLDistanceFormatterUnitYard:
+                    return NSLocalizedStringWithDefaultValue(@"DISTANCE_YARD_LONG", @"Foundation", nil, @"%@ yard(s)", @"Distance format, long: {1 yard}");
+            }
+    }
+}
+
+- (MGLDistanceFormatterUnit)unitForDistance:(CLLocationDistance)distance {
+    switch (self.preferredUnits) {
+        // MGLDistanceFormatterUnitsDefault is only added to make the switch statement
+        // exhaustive, it is never returned from -[MGLDistanceFormatter preferredUnits]
+        case MGLDistanceFormatterUnitsDefault:
+        case MGLDistanceFormatterUnitsMetric:
+            return distance < METERS_PER_KM ? MGLDistanceFormatterUnitMeter : MGLDistanceFormatterUnitKilometer;
+        case MGLDistanceFormatterUnitsImperial: {
+            double ft = distance / METERS_PER_FOOT;
+            return ft < 1000 ? MGLDistanceFormatterUnitFoot : MGLDistanceFormatterUnitMile;
+        }
+        case MGLDistanceFormatterUnitsImperialWithYards: {
+            double yd = distance / METERS_PER_YARD;
+            return yd < 1000 ? MGLDistanceFormatterUnitYard : MGLDistanceFormatterUnitMile;
+        }
+    }
+}
+
+- (MGLDistanceFormatterUnits)preferredUnits {
+    if (self.units == MGLDistanceFormatterUnitsDefault) {
+        BOOL usesMetric = [[[NSLocale currentLocale] objectForKey:NSLocaleUsesMetricSystem] boolValue];
+        return usesMetric ? MGLDistanceFormatterUnitsMetric : MGLDistanceFormatterUnitsImperial;
+    }
+    return self.units;
+}
+
+- (BOOL)getObjectValue:(out id __nullable * __nullable)obj forString:(NSString *)string errorDescription:(out NSString * __nullable * __nullable)error {
+    return NO;
+}
+
+@end

--- a/platform/darwin/test/MGLDistanceFormatterTests.m
+++ b/platform/darwin/test/MGLDistanceFormatterTests.m
@@ -1,0 +1,100 @@
+#import <XCTest/XCTest.h>
+#import <Mapbox/Mapbox.h>
+
+@interface MGLDistanceFormatter(Private)
+@property (nonatomic) NSNumberFormatter *numberFormatter;
+@end
+
+@interface MGLDistanceFormatterTests : XCTestCase
+@end
+
+@implementation MGLDistanceFormatterTests
+
+- (void)testMetricAbbreviated {
+    MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
+    formatter.units = MGLDistanceFormatterUnitsMetric;
+    formatter.unitStyle = MGLDistanceFormatterUnitStyleAbbreviated;
+    
+    XCTAssertEqualObjects([formatter stringFromDistance:0], [self testStringWithDistance:0 formatter:formatter unit:@"m"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:10.5], [self testStringWithDistance:11 formatter:formatter unit:@"m"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:50], [self testStringWithDistance:50 formatter:formatter unit:@"m"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:500], [self testStringWithDistance:500 formatter:formatter unit:@"m"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:999], [self testStringWithDistance:999 formatter:formatter unit:@"m"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1000], [self testStringWithDistance:1 formatter:formatter unit:@"km"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1100], [self testStringWithDistance:1.1 formatter:formatter unit:@"km"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1100], [self testStringWithDistance:1.1 formatter:formatter unit:@"km"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:32450], [self testStringWithDistance:32.5 formatter:formatter unit:@"km"]);
+}
+
+- (void)testMetric {
+    MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
+    formatter.units = MGLDistanceFormatterUnitsMetric;
+    formatter.unitStyle = MGLDistanceFormatterUnitStyleFull;
+    
+    XCTAssertEqualObjects([formatter stringFromDistance:0], [self testStringWithDistance:0 formatter:formatter unit:@"meters"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1], [self testStringWithDistance:1 formatter:formatter unit:@"meter"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:2], [self testStringWithDistance:2 formatter:formatter unit:@"meters"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:500], [self testStringWithDistance:500 formatter:formatter unit:@"meters"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:999], [self testStringWithDistance:999 formatter:formatter unit:@"meters"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1000], [self testStringWithDistance:1 formatter:formatter unit:@"kilometer"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1500], [self testStringWithDistance:1.5 formatter:formatter unit:@"kilometers"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:2000], [self testStringWithDistance:2 formatter:formatter unit:@"kilometers"]);
+}
+
+- (void)testImperialAbbreviated {
+    MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
+    formatter.units = MGLDistanceFormatterUnitsImperial;
+    formatter.unitStyle = MGLDistanceFormatterUnitStyleAbbreviated;
+    
+    XCTAssertEqualObjects([formatter stringFromDistance:0], [self testStringWithDistance:0 formatter:formatter unit:@"ft"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:10], [self testStringWithDistance:33 formatter:formatter unit:@"ft"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:30.48], [self testStringWithDistance:100 formatter:formatter unit:@"ft"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:152.4], [self testStringWithDistance:500 formatter:formatter unit:@"ft"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1609.34], [self testStringWithDistance:1 formatter:formatter unit:@"mi"]);
+}
+
+- (void)testImperial {
+    MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
+    formatter.units = MGLDistanceFormatterUnitsImperial;
+    formatter.unitStyle = MGLDistanceFormatterUnitStyleFull;
+    
+    XCTAssertEqualObjects([formatter stringFromDistance:0], [self testStringWithDistance:0 formatter:formatter unit:@"feet"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:0.3048], [self testStringWithDistance:1 formatter:formatter unit:@"foot"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:0.6096], [self testStringWithDistance:2 formatter:formatter unit:@"feet"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:304.495], [self testStringWithDistance:999 formatter:formatter unit:@"feet"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1609.34], [self testStringWithDistance:1 formatter:formatter unit:@"mile"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1609.34], [self testStringWithDistance:1 formatter:formatter unit:@"mile"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:2414.01], [self testStringWithDistance:1.5 formatter:formatter unit:@"miles"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:3218.68], [self testStringWithDistance:2 formatter:formatter unit:@"miles"]);
+}
+
+- (void)testImperialWithYardsAbbreviated {
+    MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
+    formatter.units = MGLDistanceFormatterUnitsImperialWithYards;
+    formatter.unitStyle = MGLDistanceFormatterUnitStyleAbbreviated;
+    
+    XCTAssertEqualObjects([formatter stringFromDistance:0], [self testStringWithDistance:0 formatter:formatter unit:@"yd"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:457.2], [self testStringWithDistance:500 formatter:formatter unit:@"yd"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:913.486], [self testStringWithDistance:999 formatter:formatter unit:@"yd"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1609.34], [self testStringWithDistance:1 formatter:formatter unit:@"mi"]);
+}
+
+- (void)testImperialWithYards {
+    MGLDistanceFormatter *formatter = [[MGLDistanceFormatter alloc] init];
+    formatter.units = MGLDistanceFormatterUnitsImperialWithYards;
+    formatter.unitStyle = MGLDistanceFormatterUnitStyleFull;
+    
+    XCTAssertEqualObjects([formatter stringFromDistance:0], [self testStringWithDistance:0 formatter:formatter unit:@"yards"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:0.9144], [self testStringWithDistance:1 formatter:formatter unit:@"yard"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:457.2], [self testStringWithDistance:500 formatter:formatter unit:@"yards"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:913.486], [self testStringWithDistance:999 formatter:formatter unit:@"yards"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:1609.34], [self testStringWithDistance:1 formatter:formatter unit:@"mile"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:2414.02], [self testStringWithDistance:1.5 formatter:formatter unit:@"miles"]);
+    XCTAssertEqualObjects([formatter stringFromDistance:3218.68], [self testStringWithDistance:2 formatter:formatter unit:@"miles"]);
+}
+
+- (NSString *)testStringWithDistance:(CLLocationDistance)distance formatter:(MGLDistanceFormatter *)formatter unit:(NSString *)unit {
+    return [NSString stringWithFormat:@"%@ %@", [formatter.numberFormatter numberFromString:[formatter.numberFormatter stringFromNumber:@(distance)]], unit];
+}
+
+@end

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -99,6 +99,11 @@
 		357FE2E01E02D2B20068B753 /* NSCoder+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 357FE2DC1E02D2B20068B753 /* NSCoder+MGLAdditions.mm */; };
 		3599A3E61DF708BC00E77FB2 /* MGLStyleValueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3599A3E51DF708BC00E77FB2 /* MGLStyleValueTests.m */; };
 		359F57461D2FDDA6005217F1 /* MGLUserLocationAnnotationView_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 359F57451D2FDBD5005217F1 /* MGLUserLocationAnnotationView_Private.h */; };
+		35B6684A1E0D5369003FC042 /* MGLDistanceFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B668481E0D5369003FC042 /* MGLDistanceFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35B6684B1E0D5369003FC042 /* MGLDistanceFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B668481E0D5369003FC042 /* MGLDistanceFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35B6684C1E0D5369003FC042 /* MGLDistanceFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B668491E0D5369003FC042 /* MGLDistanceFormatter.m */; };
+		35B6684D1E0D5369003FC042 /* MGLDistanceFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B668491E0D5369003FC042 /* MGLDistanceFormatter.m */; };
+		35B6684F1E0D54BB003FC042 /* MGLDistanceFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B6684E1E0D54BB003FC042 /* MGLDistanceFormatterTests.m */; };
 		35B82BF81D6C5F8400B1B721 /* NSPredicate+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B82BF61D6C5F8400B1B721 /* NSPredicate+MGLAdditions.h */; };
 		35B82BF91D6C5F8400B1B721 /* NSPredicate+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B82BF61D6C5F8400B1B721 /* NSPredicate+MGLAdditions.h */; };
 		35B82BFA1D6C5F8400B1B721 /* NSPredicate+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35B82BF71D6C5F8400B1B721 /* NSPredicate+MGLAdditions.mm */; };
@@ -568,6 +573,9 @@
 		357FE2DC1E02D2B20068B753 /* NSCoder+MGLAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "NSCoder+MGLAdditions.mm"; path = "../../darwin/src/NSCoder+MGLAdditions.mm"; sourceTree = "<group>"; };
 		3599A3E51DF708BC00E77FB2 /* MGLStyleValueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLStyleValueTests.m; path = ../../darwin/test/MGLStyleValueTests.m; sourceTree = "<group>"; };
 		359F57451D2FDBD5005217F1 /* MGLUserLocationAnnotationView_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLUserLocationAnnotationView_Private.h; sourceTree = "<group>"; };
+		35B668481E0D5369003FC042 /* MGLDistanceFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLDistanceFormatter.h; sourceTree = "<group>"; };
+		35B668491E0D5369003FC042 /* MGLDistanceFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLDistanceFormatter.m; sourceTree = "<group>"; };
+		35B6684E1E0D54BB003FC042 /* MGLDistanceFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLDistanceFormatterTests.m; path = ../../darwin/test/MGLDistanceFormatterTests.m; sourceTree = "<group>"; };
 		35B82BF61D6C5F8400B1B721 /* NSPredicate+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSPredicate+MGLAdditions.h"; sourceTree = "<group>"; };
 		35B82BF71D6C5F8400B1B721 /* NSPredicate+MGLAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSPredicate+MGLAdditions.mm"; sourceTree = "<group>"; };
 		35B8E08B1D6C8B5100E768D2 /* MGLFilterTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLFilterTests.mm; path = ../../darwin/test/MGLFilterTests.mm; sourceTree = "<group>"; };
@@ -1096,6 +1104,7 @@
 				DA35A2C31CCA9F8300E826B2 /* MGLClockDirectionFormatterTests.m */,
 				DA35A2C41CCA9F8300E826B2 /* MGLCompassDirectionFormatterTests.m */,
 				DA35A2A91CCA058D00E826B2 /* MGLCoordinateFormatterTests.m */,
+				35B6684E1E0D54BB003FC042 /* MGLDistanceFormatterTests.m */,
 				6407D66F1E0085FD00F6A9C3 /* MGLDocumentationExampleTests.swift */,
 				DA0CD58F1CF56F6A00A5F5A5 /* MGLFeatureTests.mm */,
 				DA2E885C1CC0382C00F24E7B /* MGLGeometryTests.mm */,
@@ -1315,6 +1324,8 @@
 				DA35A2B01CCA141D00E826B2 /* MGLCompassDirectionFormatter.m */,
 				DA35A29D1CC9E94C00E826B2 /* MGLCoordinateFormatter.h */,
 				DA35A2A01CC9E95F00E826B2 /* MGLCoordinateFormatter.m */,
+				35B668481E0D5369003FC042 /* MGLDistanceFormatter.h */,
+				35B668491E0D5369003FC042 /* MGLDistanceFormatter.m */,
 			);
 			name = Formatters;
 			sourceTree = "<group>";
@@ -1544,6 +1555,7 @@
 				DA8848851CBB033F00AB86E3 /* FABKitProtocol.h in Headers */,
 				DA88481B1CBAFA6200AB86E3 /* MGLGeometry_Private.h in Headers */,
 				3510FFF91D6DCC4700F413B2 /* NSCompoundPredicate+MGLAdditions.h in Headers */,
+				35B6684A1E0D5369003FC042 /* MGLDistanceFormatter.h in Headers */,
 				DA72620B1DEEE3480043BB89 /* MGLOpenGLStyleLayer.h in Headers */,
 				404C26E71D89C55D000AA13D /* MGLTileSource_Private.h in Headers */,
 				DA88485C1CBAFB9800AB86E3 /* MGLFaux3DUserLocationAnnotationView.h in Headers */,
@@ -1624,6 +1636,7 @@
 				354B83971D2E873E005D9406 /* MGLUserLocationAnnotationView.h in Headers */,
 				DAF0D8111DFE0EA000B28378 /* MGLRasterSource_Private.h in Headers */,
 				DABFB86B1CBE99E500D62B32 /* MGLTilePyramidOfflineRegion.h in Headers */,
+				35B6684B1E0D5369003FC042 /* MGLDistanceFormatter.h in Headers */,
 				4018B1CB1CDC288E00F666AF /* MGLAnnotationView.h in Headers */,
 				DABFB85F1CBE99E500D62B32 /* MGLGeometry.h in Headers */,
 				7E016D851D9E890300A29A21 /* MGLPolygon+MGLAdditions.h in Headers */,
@@ -1989,6 +2002,7 @@
 				DA2E88651CC0382C00F24E7B /* MGLStyleTests.mm in Sources */,
 				DA2E88611CC0382C00F24E7B /* MGLGeometryTests.mm in Sources */,
 				357579801D501E09000B822E /* MGLFillStyleLayerTests.m in Sources */,
+				35B6684F1E0D54BB003FC042 /* MGLDistanceFormatterTests.m in Sources */,
 				35D9DDE21DA25EEC00DAAD69 /* MGLCodingTests.m in Sources */,
 				DA2E88641CC0382C00F24E7B /* MGLOfflineStorageTests.m in Sources */,
 				DA2DBBCE1D51E80400D38FF9 /* MGLStyleLayerTests.m in Sources */,
@@ -2048,6 +2062,7 @@
 				35136D451D42275100C20EFD /* MGLSymbolStyleLayer.mm in Sources */,
 				35599DED1D46F14E0048254D /* MGLStyleValue.mm in Sources */,
 				DA8848211CBAFA6200AB86E3 /* MGLOfflinePack.mm in Sources */,
+				35B6684C1E0D5369003FC042 /* MGLDistanceFormatter.m in Sources */,
 				DA8848591CBAFB9800AB86E3 /* MGLMapView.mm in Sources */,
 				DA8848501CBAFB9800AB86E3 /* MGLAnnotationImage.m in Sources */,
 				DA8848281CBAFA6200AB86E3 /* MGLShape.mm in Sources */,
@@ -2124,6 +2139,7 @@
 				DAA4E4251CBB730400178DFB /* MGLShape.mm in Sources */,
 				35136D461D42275100C20EFD /* MGLSymbolStyleLayer.mm in Sources */,
 				35599DEE1D46F14E0048254D /* MGLStyleValue.mm in Sources */,
+				35B6684D1E0D5369003FC042 /* MGLDistanceFormatter.m in Sources */,
 				DAA4E42B1CBB730400178DFB /* NSString+MGLAdditions.m in Sources */,
 				DAA4E4261CBB730400178DFB /* MGLStyle.mm in Sources */,
 				DAA4E41D1CBB730400178DFB /* MGLGeometry.mm in Sources */,

--- a/platform/ios/src/Mapbox.h
+++ b/platform/ios/src/Mapbox.h
@@ -14,6 +14,7 @@ FOUNDATION_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLClockDirectionFormatter.h"
 #import "MGLCompassDirectionFormatter.h"
 #import "MGLCoordinateFormatter.h"
+#import "MGLDistanceFormatter.h"
 #import "MGLFeature.h"
 #import "MGLGeometry.h"
 #import "MGLMapCamera.h"

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		35C5D8481D6DD66D00E95907 /* NSComparisonPredicate+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35C5D8441D6DD66D00E95907 /* NSComparisonPredicate+MGLAdditions.mm */; };
 		35C5D8491D6DD66D00E95907 /* NSCompoundPredicate+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35C5D8451D6DD66D00E95907 /* NSCompoundPredicate+MGLAdditions.h */; };
 		35C5D84A1D6DD66D00E95907 /* NSCompoundPredicate+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35C5D8461D6DD66D00E95907 /* NSCompoundPredicate+MGLAdditions.mm */; };
+		35CD5D3E1E1C0738007BD03D /* MGLDistanceFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 35CD5D3C1E1C0738007BD03D /* MGLDistanceFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		35CD5D3F1E1C0738007BD03D /* MGLDistanceFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 35CD5D3D1E1C0738007BD03D /* MGLDistanceFormatter.m */; };
+		35CD5D411E1C07A2007BD03D /* MGLDistanceFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35CD5D401E1C07A2007BD03D /* MGLDistanceFormatterTests.m */; };
 		35D65C5A1D65AD5500722C23 /* NSDate+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D65C581D65AD5500722C23 /* NSDate+MGLAdditions.h */; };
 		35D65C5B1D65AD5500722C23 /* NSDate+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 35D65C591D65AD5500722C23 /* NSDate+MGLAdditions.mm */; };
 		4032C5C51DE1FE930062E8BD /* NSValue+MGLStyleEnumAttributeAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4032C5B91DE1EEBA0062E8BD /* NSValue+MGLStyleEnumAttributeAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -288,6 +291,9 @@
 		35C5D8451D6DD66D00E95907 /* NSCompoundPredicate+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSCompoundPredicate+MGLAdditions.h"; sourceTree = "<group>"; };
 		35C5D8461D6DD66D00E95907 /* NSCompoundPredicate+MGLAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSCompoundPredicate+MGLAdditions.mm"; sourceTree = "<group>"; };
 		35C5D84B1D6DD75B00E95907 /* MGLFilterTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLFilterTests.mm; sourceTree = "<group>"; };
+		35CD5D3C1E1C0738007BD03D /* MGLDistanceFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLDistanceFormatter.h; sourceTree = "<group>"; };
+		35CD5D3D1E1C0738007BD03D /* MGLDistanceFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLDistanceFormatter.m; sourceTree = "<group>"; };
+		35CD5D401E1C07A2007BD03D /* MGLDistanceFormatterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLDistanceFormatterTests.m; path = ../../darwin/test/MGLDistanceFormatterTests.m; sourceTree = "<group>"; };
 		35D65C581D65AD5500722C23 /* NSDate+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+MGLAdditions.h"; sourceTree = "<group>"; };
 		35D65C591D65AD5500722C23 /* NSDate+MGLAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "NSDate+MGLAdditions.mm"; sourceTree = "<group>"; };
 		4032C5B91DE1EEBA0062E8BD /* NSValue+MGLStyleEnumAttributeAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSValue+MGLStyleEnumAttributeAdditions.h"; sourceTree = "<group>"; };
@@ -756,6 +762,8 @@
 				DA35A2AC1CCA091800E826B2 /* MGLCompassDirectionFormatter.m */,
 				DA35A2A31CC9EB1A00E826B2 /* MGLCoordinateFormatter.h */,
 				DA35A2A51CC9EB2700E826B2 /* MGLCoordinateFormatter.m */,
+				35CD5D3C1E1C0738007BD03D /* MGLDistanceFormatter.h */,
+				35CD5D3D1E1C0738007BD03D /* MGLDistanceFormatter.m */,
 			);
 			name = Formatters;
 			sourceTree = "<group>";
@@ -887,6 +895,7 @@
 				DA35A2C11CCA9F4A00E826B2 /* MGLClockDirectionFormatterTests.m */,
 				DA35A2B51CCA14D700E826B2 /* MGLCompassDirectionFormatterTests.m */,
 				DA35A2A71CC9F41600E826B2 /* MGLCoordinateFormatterTests.m */,
+				35CD5D401E1C07A2007BD03D /* MGLDistanceFormatterTests.m */,
 				DA0CD58D1CF56F5800A5F5A5 /* MGLFeatureTests.mm */,
 				DAE6C3C81CC34BD800DB3429 /* MGLGeometryTests.mm */,
 				DAE6C3C91CC34BD800DB3429 /* MGLOfflinePackTests.m */,
@@ -1024,6 +1033,7 @@
 				DAE6C39A1CC31E2A00DB3429 /* NSProcessInfo+MGLAdditions.h in Headers */,
 				DA8F258B1D51CA540010E6B5 /* MGLLineStyleLayer.h in Headers */,
 				DA8F25B21D51CB270010E6B5 /* NSValue+MGLStyleAttributeAdditions.h in Headers */,
+				35CD5D3E1E1C0738007BD03D /* MGLDistanceFormatter.h in Headers */,
 				359819591E02F611008FC139 /* NSCoder+MGLAdditions.h in Headers */,
 				DAE6C38E1CC31E2A00DB3429 /* MGLOfflineStorage_Private.h in Headers */,
 				408AA8661DAEEE3600022900 /* MGLPolyline+MGLAdditions.h in Headers */,
@@ -1266,6 +1276,7 @@
 				DAE6C3941CC31E2A00DB3429 /* MGLStyle.mm in Sources */,
 				DAE6C3871CC31E2A00DB3429 /* MGLGeometry.mm in Sources */,
 				3527428E1D4C24AB00A1ECE6 /* MGLCircleStyleLayer.mm in Sources */,
+				35CD5D3F1E1C0738007BD03D /* MGLDistanceFormatter.m in Sources */,
 				35602C011D3EA9B40050646F /* MGLForegroundStyleLayer.m in Sources */,
 				408AA86A1DAEEE5D00022900 /* NSDictionary+MGLAdditions.mm in Sources */,
 				DA8F25881D51C9E10010E6B5 /* MGLBackgroundStyleLayer.mm in Sources */,
@@ -1318,6 +1329,7 @@
 				DAE6C3D61CC34C9900DB3429 /* MGLStyleTests.mm in Sources */,
 				DAEDC4371D606291000224FF /* MGLAttributionButtonTests.m in Sources */,
 				DA35A2B61CCA14D700E826B2 /* MGLCompassDirectionFormatterTests.m in Sources */,
+				35CD5D411E1C07A2007BD03D /* MGLDistanceFormatterTests.m in Sources */,
 				DAE6C3D21CC34C9900DB3429 /* MGLGeometryTests.mm in Sources */,
 				DA87A9A41DCACC5000810D09 /* MGLSymbolStyleLayerTests.m in Sources */,
 				DAE6C3D51CC34C9900DB3429 /* MGLOfflineStorageTests.m in Sources */,

--- a/platform/macos/src/Mapbox.h
+++ b/platform/macos/src/Mapbox.h
@@ -12,6 +12,7 @@ FOUNDATION_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLClockDirectionFormatter.h"
 #import "MGLCompassDirectionFormatter.h"
 #import "MGLCoordinateFormatter.h"
+#import "MGLDistanceFormatter.h"
 #import "MGLFeature.h"
 #import "MGLGeometry.h"
 #import "MGLMapCamera.h"


### PR DESCRIPTION
Fixes #3331

This PR adds a formatter that is meant to be used for geographic distances. (i.e. #7432)

It supports localization and pluralization. By default, it uses the user‘s current locale and opts for feet over yards unlike NSLengthFormatter.