### PR TITLE
Include subheadings in release notes

### DIFF
--- a/platform/macos/scripts/document.sh
+++ b/platform/macos/scripts/document.sh
@@ -25,7 +25,7 @@ README=/tmp/mbgl/README.md
 cp platform/macos/docs/doc-README.md "${README}"
 # http://stackoverflow.com/a/4858011/4585461
 echo "## Changes in version ${RELEASE_VERSION}" >> "${README}"
-sed -n -e '/^## /{' -e ':a' -e 'n' -e '/^##/q' -e 'p' -e 'ba' -e '}' platform/macos/CHANGELOG.md >> "${README}"
+sed -n -e '/^## /{' -e ':a' -e 'n' -e '/^## /q' -e 'p' -e 'ba' -e '}' platform/macos/CHANGELOG.md >> "${README}"
 
 rm -rf ${OUTPUT}
 mkdir -p ${OUTPUT}


### PR DESCRIPTION
Updated changelog parsing code in the documentation generation script to handle subheadings within the current release’s release notes. Previously, the “Changes in version …” section stopped at the first subheading. The corresponding iOS code was updated in #5552.