### PR TITLE
[core] Fix symbol flickering during tile reload

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -90,6 +90,7 @@ set(MBGL_TEST_FILES
     test/text/quads.test.cpp
 
     # tile
+    test/tile/geojson_tile.test.cpp
     test/tile/geometry_tile_data.test.cpp
     test/tile/raster_tile.test.cpp
     test/tile/tile_coordinate.test.cpp

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -151,8 +151,8 @@ optional<GeometryCoordinates> FeatureIndex::translateQueryGeometry(
     return translated;
 }
 
-void FeatureIndex::addBucketLayerName(const std::string& bucketName, const std::string& layerID) {
-    bucketLayerIDs[bucketName].push_back(layerID);
+void FeatureIndex::setBucketLayerIDs(const std::string& bucketName, const std::vector<std::string>& layerIDs) {
+    bucketLayerIDs[bucketName] = layerIDs;
 }
 
 } // namespace mbgl

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -59,7 +59,8 @@ void FeatureIndex::query(
         const optional<std::vector<std::string>>& filterLayerIDs,
         const GeometryTileData& geometryTileData,
         const CanonicalTileID& tileID,
-        const style::Style& style) const {
+        const style::Style& style,
+        const CollisionTile* collisionTile) const {
 
     mapbox::geometry::box<int16_t> box = mapbox::geometry::envelope(queryGeometry);
 
@@ -152,10 +153,6 @@ optional<GeometryCoordinates> FeatureIndex::translateQueryGeometry(
 
 void FeatureIndex::addBucketLayerName(const std::string& bucketName, const std::string& layerID) {
     bucketLayerIDs[bucketName].push_back(layerID);
-}
-
-void FeatureIndex::setCollisionTile(std::unique_ptr<CollisionTile> collisionTile_) {
-    collisionTile = std::move(collisionTile_);
 }
 
 } // namespace mbgl

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -42,7 +42,8 @@ public:
             const optional<std::vector<std::string>>& layerIDs,
             const GeometryTileData&,
             const CanonicalTileID&,
-            const style::Style&) const;
+            const style::Style&,
+            const CollisionTile*) const;
 
     static optional<GeometryCoordinates> translateQueryGeometry(
             const GeometryCoordinates& queryGeometry,
@@ -52,8 +53,6 @@ public:
             const float pixelsToTileUnits);
 
     void addBucketLayerName(const std::string& bucketName, const std::string& layerName);
-
-    void setCollisionTile(std::unique_ptr<CollisionTile>);
 
 private:
     void addFeature(
@@ -67,7 +66,6 @@ private:
             const float bearing,
             const float pixelsToTileUnits) const;
 
-    std::unique_ptr<CollisionTile> collisionTile;
     GridIndex<IndexedSubfeature> grid;
     unsigned int sortIndex = 0;
 

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -52,7 +52,7 @@ public:
             const float bearing,
             const float pixelsToTileUnits);
 
-    void addBucketLayerName(const std::string& bucketName, const std::string& layerName);
+    void setBucketLayerIDs(const std::string& bucketName, const std::vector<std::string>& layerIDs);
 
 private:
     void addFeature(

--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -27,7 +27,7 @@ namespace mbgl {
 
 using namespace style;
 
-SymbolLayout::SymbolLayout(std::vector<std::unique_ptr<Layer>> layers_,
+SymbolLayout::SymbolLayout(std::vector<std::string> layerIDs_,
                            std::string sourceLayerName_,
                            uint32_t overscaling_,
                            float zoom_,
@@ -37,7 +37,7 @@ SymbolLayout::SymbolLayout(std::vector<std::unique_ptr<Layer>> layers_,
                            style::SymbolLayoutProperties::Evaluated layout_,
                            float textMaxSize_,
                            SpriteAtlas& spriteAtlas_)
-    : layers(std::move(layers_)),
+    : layerIDs(std::move(layerIDs_)),
       sourceLayerName(std::move(sourceLayerName_)),
       overscaling(overscaling_),
       zoom(zoom_),
@@ -254,7 +254,7 @@ void SymbolLayout::addFeature(const SymbolFeature& feature,
                                                   ? SymbolPlacementType::Point
                                                   : layout.get<SymbolPlacement>();
     const float textRepeatDistance = symbolSpacing / 2;
-    IndexedSubfeature indexedFeature = {feature.index, sourceLayerName, layers.at(0)->getID(), symbolInstances.size()};
+    IndexedSubfeature indexedFeature = {feature.index, sourceLayerName, layerIDs.at(0), symbolInstances.size()};
 
     auto addSymbolInstance = [&] (const GeometryCoordinates& line, Anchor& anchor) {
         // https://github.com/mapbox/vector-tile-spec/tree/master/2.1#41-layers

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -28,7 +28,7 @@ struct Anchor;
 
 class SymbolLayout {
 public:
-    SymbolLayout(std::vector<std::unique_ptr<style::Layer>>,
+    SymbolLayout(std::vector<std::string> layerIDs_,
                  std::string sourceLayerName_,
                  uint32_t overscaling,
                  float zoom,
@@ -56,7 +56,7 @@ public:
 
     State state = Pending;
 
-    const std::vector<std::unique_ptr<style::Layer>> layers;
+    const std::vector<std::string> layerIDs;
     const std::string sourceLayerName;
 
 private:

--- a/src/mbgl/style/group_by_layout.cpp
+++ b/src/mbgl/style/group_by_layout.cpp
@@ -32,16 +32,15 @@ std::string layoutKey(const Layer& layer) {
     return s.GetString();
 }
 
-std::vector<std::vector<std::unique_ptr<Layer>>> groupByLayout(std::vector<std::unique_ptr<Layer>> layers) {
-    std::unordered_map<std::string, std::vector<std::unique_ptr<Layer>>> map;
+std::vector<std::vector<const Layer*>> groupByLayout(const std::vector<std::unique_ptr<Layer>>& layers) {
+    std::unordered_map<std::string, std::vector<const Layer*>> map;
     for (auto& layer : layers) {
-        auto& vector = map[layoutKey(*layer)];
-        vector.push_back(std::move(layer));
+        map[layoutKey(*layer)].push_back(layer.get());
     }
 
-    std::vector<std::vector<std::unique_ptr<Layer>>> result;
+    std::vector<std::vector<const Layer*>> result;
     for (auto& pair : map) {
-        result.push_back(std::move(pair.second));
+        result.push_back(pair.second);
     }
 
     return result;

--- a/src/mbgl/style/group_by_layout.hpp
+++ b/src/mbgl/style/group_by_layout.hpp
@@ -8,7 +8,7 @@ namespace style {
 
 class Layer;
 
-std::vector<std::vector<std::unique_ptr<Layer>>> groupByLayout(std::vector<std::unique_ptr<Layer>>);
+std::vector<std::vector<const Layer*>> groupByLayout(const std::vector<std::unique_ptr<Layer>>&);
 
 } // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layers/symbol_layer_impl.cpp
+++ b/src/mbgl/style/layers/symbol_layer_impl.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<Bucket> SymbolLayer::Impl::createBucket(BucketParameters&, const
 
 std::unique_ptr<SymbolLayout> SymbolLayer::Impl::createLayout(BucketParameters& parameters,
                                                               const GeometryTileLayer& layer,
-                                                              std::vector<std::unique_ptr<Layer>> group) const {
+                                                              std::vector<std::string> group) const {
     PropertyEvaluationParameters p(parameters.tileID.overscaledZ);
     SymbolLayoutProperties::Evaluated evaluated = layout.evaluate(p);
 

--- a/src/mbgl/style/layers/symbol_layer_impl.hpp
+++ b/src/mbgl/style/layers/symbol_layer_impl.hpp
@@ -52,7 +52,7 @@ public:
 
     std::unique_ptr<Bucket> createBucket(BucketParameters&, const GeometryTileLayer&) const override;
     std::unique_ptr<SymbolLayout> createLayout(BucketParameters&, const GeometryTileLayer&,
-                                               std::vector<std::unique_ptr<Layer>>) const;
+                                               std::vector<std::string>) const;
 
     SymbolPropertyValues iconPropertyValues(const SymbolLayoutProperties::Evaluated&) const;
     SymbolPropertyValues textPropertyValues(const SymbolLayoutProperties::Evaluated&) const;

--- a/src/mbgl/text/collision_tile.cpp
+++ b/src/mbgl/text/collision_tile.cpp
@@ -168,7 +168,7 @@ Box CollisionTile::getTreeBox(const Point<float>& anchor, const CollisionBox& bo
     };
 }
 
-std::vector<IndexedSubfeature> CollisionTile::queryRenderedSymbols(const GeometryCoordinates& queryGeometry, float scale) {
+std::vector<IndexedSubfeature> CollisionTile::queryRenderedSymbols(const GeometryCoordinates& queryGeometry, float scale) const {
     std::vector<IndexedSubfeature> result;
     if (queryGeometry.empty() || (tree.empty() && ignoredTree.empty())) {
         return result;

--- a/src/mbgl/text/collision_tile.hpp
+++ b/src/mbgl/text/collision_tile.hpp
@@ -42,7 +42,7 @@ public:
     float placeFeature(const CollisionFeature&, bool allowOverlap, bool avoidEdges);
     void insertFeature(CollisionFeature&, float minPlacementScale, bool ignorePlacement);
 
-    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, float scale);
+    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, float scale) const;
 
     const PlacementConfig config;
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -117,7 +117,7 @@ void GeometryTile::onPlacement(PlacementResult result) {
         availableData = DataAvailability::All;
     }
     symbolBuckets = std::move(result.symbolBuckets);
-    featureIndex->setCollisionTile(std::move(result.collisionTile));
+    collisionTile = std::move(result.collisionTile);
     observer->onTileChanged(*this);
 }
 
@@ -153,7 +153,8 @@ void GeometryTile::queryRenderedFeatures(
                         layerIDs,
                         *data,
                         id.canonical,
-                        style);
+                        style,
+                        collisionTile.get());
 }
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -81,9 +81,11 @@ private:
     optional<PlacementConfig> requestedConfig;
 
     std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
-    std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
     std::unique_ptr<FeatureIndex> featureIndex;
     std::unique_ptr<const GeometryTileData> data;
+
+    std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
+    std::unique_ptr<CollisionTile> collisionTile;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -50,7 +50,7 @@ public:
 
     class LayoutResult {
     public:
-        std::unordered_map<std::string, std::shared_ptr<Bucket>> buckets;
+        std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
         std::unique_ptr<FeatureIndex> featureIndex;
         std::unique_ptr<GeometryTileData> tileData;
         uint64_t correlationID;
@@ -59,7 +59,7 @@ public:
 
     class PlacementResult {
     public:
-        std::unordered_map<std::string, std::shared_ptr<Bucket>> buckets;
+        std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
         std::unique_ptr<CollisionTile> collisionTile;
         uint64_t correlationID;
     };
@@ -80,7 +80,8 @@ private:
     uint64_t correlationID = 0;
     optional<PlacementConfig> requestedConfig;
 
-    std::unordered_map<std::string, std::shared_ptr<Bucket>> buckets;
+    std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
+    std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
     std::unique_ptr<FeatureIndex> featureIndex;
     std::unique_ptr<const GeometryTileData> data;
 };

--- a/test/src/mbgl/test/stub_tile_observer.hpp
+++ b/test/src/mbgl/test/stub_tile_observer.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <mbgl/tile/tile_observer.hpp>
+
+using namespace mbgl;
+
+/**
+ * An implementation of TileObserver that forwards all methods to dynamically-settable lambas.
+ */
+class StubTileObserver : public TileObserver {
+public:
+    void onTileChanged(Tile& tile) override {
+        if (tileChanged) tileChanged(tile);
+    }
+
+    void onTileError(Tile& tile, std::exception_ptr error) override {
+        if (tileError) tileError(tile, error);
+    }
+
+    std::function<void (Tile&)> tileChanged;
+    std::function<void (Tile&, std::exception_ptr)> tileError;
+};

--- a/test/style/group_by_layout.test.cpp
+++ b/test/style/group_by_layout.test.cpp
@@ -12,7 +12,7 @@ TEST(GroupByLayout, Related) {
     std::vector<std::unique_ptr<Layer>> layers;
     layers.push_back(std::make_unique<LineLayer>("a", "source"));
     layers.push_back(std::make_unique<LineLayer>("b", "source"));
-    auto result = groupByLayout(std::move(layers));
+    auto result = groupByLayout(layers);
     ASSERT_EQ(1u, result.size());
     ASSERT_EQ(2u, result[0].size());
 }
@@ -21,7 +21,7 @@ TEST(GroupByLayout, UnrelatedType) {
     std::vector<std::unique_ptr<Layer>> layers;
     layers.push_back(std::make_unique<BackgroundLayer>("background"));
     layers.push_back(std::make_unique<CircleLayer>("circle", "source"));
-    auto result = groupByLayout(std::move(layers));
+    auto result = groupByLayout(layers);
     ASSERT_EQ(2u, result.size());
 }
 
@@ -30,7 +30,7 @@ TEST(GroupByLayout, UnrelatedFilter) {
     layers.push_back(std::make_unique<LineLayer>("a", "source"));
     layers.push_back(std::make_unique<LineLayer>("b", "source"));
     layers[0]->as<LineLayer>()->setFilter(EqualsFilter());
-    auto result = groupByLayout(std::move(layers));
+    auto result = groupByLayout(layers);
     ASSERT_EQ(2u, result.size());
 }
 
@@ -39,6 +39,6 @@ TEST(GroupByLayout, UnrelatedLayout) {
     layers.push_back(std::make_unique<LineLayer>("a", "source"));
     layers.push_back(std::make_unique<LineLayer>("b", "source"));
     layers[0]->as<LineLayer>()->setLineCap(LineCapType::Square);
-    auto result = groupByLayout(std::move(layers));
+    auto result = groupByLayout(layers);
     ASSERT_EQ(2u, result.size());
 }

--- a/test/tile/geojson_tile.test.cpp
+++ b/test/tile/geojson_tile.test.cpp
@@ -1,0 +1,72 @@
+#include <mbgl/test/util.hpp>
+#include <mbgl/test/fake_file_source.hpp>
+#include <mbgl/test/stub_tile_observer.hpp>
+#include <mbgl/tile/geojson_tile.hpp>
+#include <mbgl/tile/tile_loader_impl.hpp>
+
+#include <mbgl/util/default_thread_pool.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/map/transform.hpp>
+#include <mbgl/style/style.hpp>
+#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/style/layers/circle_layer.hpp>
+#include <mbgl/annotation/annotation_manager.hpp>
+
+#include <memory>
+
+using namespace mbgl;
+using namespace mbgl::style;
+
+class GeoJSONTileTest {
+public:
+    FakeFileSource fileSource;
+    TransformState transformState;
+    util::RunLoop loop;
+    ThreadPool threadPool { 1 };
+    AnnotationManager annotationManager { 1.0 };
+    style::Style style { fileSource, 1.0 };
+    Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
+
+    style::UpdateParameters updateParameters {
+        1.0,
+        MapDebugOptions(),
+        transformState,
+        threadPool,
+        fileSource,
+        MapMode::Continuous,
+        annotationManager,
+        style
+    };
+};
+
+TEST(GeoJSONTile, Issue7648) {
+    GeoJSONTileTest test;
+    GeoJSONTile tile(OverscaledTileID(0, 0, 0), "source", test.updateParameters);
+
+    test.style.addLayer(std::make_unique<CircleLayer>("circle", "source"));
+
+    StubTileObserver observer;
+    observer.tileChanged = [&] (const Tile&) {
+        // Once present, the bucket should never "disappear", which would cause
+        // flickering.
+        ASSERT_NE(nullptr, tile.getBucket(*test.style.getLayer("circle")));
+    };
+    tile.setObserver(&observer);
+
+    tile.setPlacementConfig({});
+
+    mapbox::geometry::feature_collection<int16_t> features;
+    features.push_back(mapbox::geometry::feature<int16_t> {
+        mapbox::geometry::point<int16_t>(0, 0)
+    });
+
+    tile.updateData(features);
+    while (!tile.isComplete()) {
+        test.loop.runOnce();
+    }
+
+    tile.updateData(features);
+    while (!tile.isComplete()) {
+        test.loop.runOnce();
+    }
+}

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -62,14 +62,6 @@ TEST(VectorTile, Issue7615) {
     auto symbolBucket = std::make_shared<SymbolBucket>(
         MapMode::Continuous, style::SymbolLayoutProperties::Evaluated(), false, false);
 
-    // First onLayout is required so that a non-null FeatureIndex is available.
-    tile.onLayout(GeometryTile::LayoutResult {
-        {},
-        std::make_unique<FeatureIndex>(),
-        nullptr,
-        0
-    });
-
     // Simulate placement of a symbol layer.
     tile.onPlacement(GeometryTile::PlacementResult {
         {{
@@ -80,7 +72,7 @@ TEST(VectorTile, Issue7615) {
         0
     });
 
-    // Second onLayout should not cause the existing symbol bucket to be discarded.
+    // Subsequent onLayout should not cause the existing symbol bucket to be discarded.
     tile.onLayout(GeometryTile::LayoutResult {
         {},
         nullptr,


### PR DESCRIPTION
Discard prior symbol buckets only when new symbol buckets became available, in order to eliminate flickering when tiles are refreshed. Plus followup refactor.

Fixes #7615