### PR TITLE
Fix exception on certain keyboard shortcuts

### DIFF
--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2486,7 +2486,7 @@ public:
     if (menuItem.action == @selector(giveFeedback:)) {
         return YES;
     }
-    return [super validateMenuItem:menuItem];
+    return NO;
 }
 
 #pragma mark Interface Builder methods


### PR DESCRIPTION
An implementation of `-validateMenuItem:` should rarely call the superclass implementation.

Tested that all the View and Help menu items and their keyboard shortcuts continue to work.

Fixes #7623.

/cc @frederoni