### PR TITLE
[ios] Only use non nil presentationLayers to adjust annotation views

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4797,7 +4797,12 @@ public:
             else
             {
                 CGRect adjustedFrame = annotationView.frame;
-                adjustedFrame.origin.x = CGRectGetWidth(annotationView.layer.presentationLayer.frame) * -2.0;
+                if (annotationView.layer.presentationLayer) {
+                    adjustedFrame.origin.x = -CGRectGetWidth(annotationView.layer.presentationLayer.frame) * 10.0;
+                } else {
+                    // views that are added off screen do not have a presentationLayer
+                    adjustedFrame.origin.x = -CGRectGetWidth(adjustedFrame) * 10.0;
+                }
                 annotationView.frame = adjustedFrame;
                 [self enqueueAnnotationViewForAnnotationContext:annotationContext];
             }


### PR DESCRIPTION
Views that are added outside of the viewport do not always have an instantiated presentationLayer. Attempting to use a nil presentationLayer to move a view offscreen resulted in the view being pinned to the left side of the view port (at x == 0).

Fixes https://github.com/mapbox/mapbox-gl-native/issues/7558