### PR TITLE
Add MGLShape from GeoJSON example

### DIFF
--- a/platform/darwin/scripts/update-examples.js
+++ b/platform/darwin/scripts/update-examples.js
@@ -100,7 +100,7 @@ function completeExamples(os) {
         }
         
         // Get the contents of the test method whose name matches the symbol path.
-        let testMethodName = symbolPath.join('$').replace(/$[+-]/, '').replace(/:/g, '_');
+        let testMethodName = symbolPath.join('$').replace(/\$[+-]/, '$').replace(/:/g, '_');
         let example = examples[testMethodName];
         if (!example) {
           console.error(`MGLDocumentationExampleTests.${testMethodName}() not found.`);

--- a/platform/darwin/src/MGLShape.h
+++ b/platform/darwin/src/MGLShape.h
@@ -37,6 +37,14 @@ NS_ASSUME_NONNULL_BEGIN
  collection object, the returned value is an instance of
  `MGLShapeCollectionFeature`.
  
+ ### Example
+ 
+ ```swift
+ let url = mainBundle.url(forResource: "amsterdam", withExtension: "geojson")!
+ let data = try! Data(contentsOf: url)
+ let feature = try! MGLShape(data: data, encoding: String.Encoding.utf8.rawValue) as! MGLShapeCollectionFeature
+ ```
+ 
  @param data String data containing GeoJSON source code.
  @param encoding The encoding used by `data`.
  @param outError Upon return, if an error has occurred, a pointer to an

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -46,6 +46,18 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         styleLoadingExpectation.fulfill()
     }
+    
+    func testMGLShape$shapeWithData_encoding_error_() {
+        let mainBundle = Bundle(for: MGLDocumentationExampleTests.self)
+        
+        //#-example-code
+        let url = mainBundle.url(forResource: "amsterdam", withExtension: "geojson")!
+        let data = try! Data(contentsOf: url)
+        let feature = try! MGLShape(data: data, encoding: String.Encoding.utf8.rawValue) as! MGLShapeCollectionFeature
+        //#-end-example-code
+        
+        XCTAssertNotNil(feature.shapes.first as? MGLPolygonFeature)
+    }
 
     func testMGLShapeSource() {
         //#-example-code


### PR DESCRIPTION
Added an example of deserializing an MGLShape from a GeoJSON file.

/ref https://github.com/mapbox/mapbox-gl-native/issues/7622#issuecomment-271118434
/cc @nitrag