### PR TITLE
[android] - rounded zoom when zooming with zoom button controller

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -4,7 +4,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 ## 5.0.0 - TBA
 
-<<<<<<< HEAD
+* MapZoomButtonController zooms to rounded zoom levels [#7630](https://github.com/mapbox/mapbox-gl-native/pull/7630)
 * Consistent double tap zoom acceleration [#7514](https://github.com/mapbox/mapbox-gl-native/issues/7514)
 * Cleanup inconsistencies float vs double [#4445](https://github.com/mapbox/mapbox-gl-native/issues/4445)
 * Add `mapbox_` prefix to attributes [#6482](https://github.com/mapbox/mapbox-gl-native/issues/6482)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -9,7 +9,6 @@ import android.view.InputDevice;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.ViewConfiguration;
-import android.widget.ZoomButtonsController;
 
 import com.almeros.android.multitouch.gesturedetectors.RotateGestureDetector;
 import com.almeros.android.multitouch.gesturedetectors.ShoveGestureDetector;
@@ -592,34 +591,6 @@ final class MapGestureDetector {
       dragStarted = true;
 
       return true;
-    }
-  }
-
-  // This class handles input events from the zoom control buttons
-  // Zoom controls allow single touch only devices to zoom in and out
-  private static class OnZoomListener implements ZoomButtonsController.OnZoomListener {
-
-    private UiSettings uiSettings;
-    private Transform transform;
-
-    OnZoomListener(UiSettings uiSettings, Transform transform) {
-      this.uiSettings = uiSettings;
-      this.transform = transform;
-    }
-
-    // Not used
-    @Override
-    public void onVisibilityChanged(boolean visible) {
-      // Ignore
-    }
-
-    // Called when user pushes a zoom button
-    @Override
-    public void onZoom(boolean zoomIn) {
-      if (!uiSettings.isZoomGesturesEnabled()) {
-        return;
-      }
-      transform.zoom(zoomIn);
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -174,7 +174,7 @@ final class Transform implements MapView.OnMapChangedListener {
   void zoom(boolean zoomIn) {
     CameraPosition currentPosition = invalidateCameraPosition();
     if (currentPosition != null) {
-      int newZoom = (int) Math.round(currentPosition.zoom + (zoomIn? 1 : -1));
+      int newZoom = (int) Math.round(currentPosition.zoom + (zoomIn ? 1 : -1));
       mapView.setZoom(newZoom, MapboxConstants.ANIMATION_DURATION);
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -172,7 +172,11 @@ final class Transform implements MapView.OnMapChangedListener {
   }
 
   void zoom(boolean zoomIn) {
-    zoom(zoomIn, -1.0f, -1.0f);
+    CameraPosition currentPosition = invalidateCameraPosition();
+    if (currentPosition != null) {
+      int newZoom = (int) Math.round(currentPosition.zoom + (zoomIn? 1 : -1));
+      mapView.setZoom(newZoom, MapboxConstants.ANIMATION_DURATION);
+    }
   }
 
   void zoom(boolean zoomIn, float x, float y) {


### PR DESCRIPTION
This PR enables the zoom button controller to zoom to rounded values. 
eg. map with zoom 1.435 will zoom in to 2 and 3 instead of current 2.435 and 3.435. 

This PR also cleans up some duplicate code in MapGestureDetector related to zoom button controller.

cc  @lorntao @1ec5
Review @zugaldia