### PR TITLE
Avoid clustering unclusterable GeoJSON

### DIFF
--- a/platform/darwin/test/MGLShapeSourceTests.mm
+++ b/platform/darwin/test/MGLShapeSourceTests.mm
@@ -37,6 +37,19 @@
     XCTAssertNil(source.shape);
 }
 
+- (void)testUnclusterableShape {
+    NSDictionary *options = @{
+        MGLShapeSourceOptionClustered: @YES,
+    };
+    
+    MGLShapeSource *source = [[MGLShapeSource alloc] initWithIdentifier:@"id" shape:[[MGLPointFeature alloc] init] options:options];
+    XCTAssertTrue([source.shape isKindOfClass:[MGLPointFeature class]]);
+    
+    MGLShapeCollectionFeature *feature = [MGLShapeCollectionFeature shapeCollectionWithShapes:@[]];
+    source = [[MGLShapeSource alloc] initWithIdentifier:@"id" shape:feature options:options];
+    XCTAssertTrue([source.shape isKindOfClass:[MGLShapeCollectionFeature class]]);
+}
+
 - (void)testMGLShapeSourceWithDataMultipleFeatures {
     
     NSString *geoJSON = @"{\"type\": \"FeatureCollection\",\"features\": [{\"type\": \"Feature\",\"properties\": {},\"geometry\": {\"type\": \"LineString\",\"coordinates\": [[-107.75390625,40.329795743702064],[-104.34814453125,37.64903402157866]]}}]}";

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -63,15 +63,9 @@ void GeoJSONSource::Impl::_setGeoJSON(const GeoJSON& geoJSON) {
 
     cache.clear();
 
-    if (!options.cluster) {
-        mapbox::geojsonvt::Options vtOptions;
-        vtOptions.maxZoom = options.maxzoom;
-        vtOptions.extent = util::EXTENT;
-        vtOptions.buffer = std::round(scale * options.buffer);
-        vtOptions.tolerance = scale * options.tolerance;
-        geoJSONOrSupercluster = std::make_unique<mapbox::geojsonvt::GeoJSONVT>(geoJSON, vtOptions);
-
-    } else {
+    if (options.cluster
+        && geoJSON.is<mapbox::geometry::feature_collection<double>>()
+        && !geoJSON.get<mapbox::geometry::feature_collection<double>>().empty()) {
         mapbox::supercluster::Options clusterOptions;
         clusterOptions.maxZoom = options.clusterMaxZoom;
         clusterOptions.extent = util::EXTENT;
@@ -80,6 +74,13 @@ void GeoJSONSource::Impl::_setGeoJSON(const GeoJSON& geoJSON) {
         const auto& features = geoJSON.get<mapbox::geometry::feature_collection<double>>();
         geoJSONOrSupercluster =
             std::make_unique<mapbox::supercluster::Supercluster>(features, clusterOptions);
+    } else {
+        mapbox::geojsonvt::Options vtOptions;
+        vtOptions.maxZoom = options.maxzoom;
+        vtOptions.extent = util::EXTENT;
+        vtOptions.buffer = std::round(scale * options.buffer);
+        vtOptions.tolerance = scale * options.tolerance;
+        geoJSONOrSupercluster = std::make_unique<mapbox::geojsonvt::GeoJSONVT>(geoJSON, vtOptions);
     }
 
     for (auto const &item : tiles) {


### PR DESCRIPTION
Ignore empty feature collections or non–feature collections for the purposes of deciding whether to cluster or tile the GeoJSON. A source’s clustering option can only be set when the source is constructed, but `setGeoJSON()` enables the developer to swap a clusterable feature for an unclusterable geometry and back.

Added iOS/macOS unit tests of creating shape sources with unclusterable shapes. The second of these tests depends on #7632 to pass.

Fixes #7622.

/cc @boundsj