### PR TITLE
Document requirement about adding sources and layers

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -40,10 +40,10 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  via `-[MGLMapView style]` by updating the style's data sources or layers.
  
  @note Wait until the map style has finished loading before modifying a map's
-    style via any of the `MGLStyle` instance methods below.
-    You can use the `MGLMapViewDelegate` methods `-mapViewDidFinishLoadingMap:`
-    or `-mapView:didFinishLoadingStyle:` as indicators that it's safe
-    to modify the map's style.
+    style via any of the `MGLStyle` instance methods below. You can use the 
+    `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` or
+    `-[MGLMapViewDelegate mapViewDidFinishLoadingMap:]` methods as indicators
+    that it's safe to modify the map's style.
  */
 @interface MGLStyle : NSObject
 
@@ -213,10 +213,12 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  @note Adding the same source instance more than once will result in a
     `MGLRedundantSourceException`. Reusing the same source identifier, even with
     different source instances, will result in a 
-    `MGLRedundantSourceIdentifierException`. Sources should be added in 
-    `MGLMapViewDelegates`'s `mapView:didFinishLoadingStyle:` or
-    `mapViewDidFinishLoadingMap:` methods to ensure that the map has loaded
-    the style and is ready to accept a new source or layer.
+    `MGLRedundantSourceIdentifierException`. 
+ 
+ @note Sources should be added in 
+    `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` or
+    `-[MGLMapViewDelegate mapViewDidFinishLoadingMap:]` to ensure that the map 
+    has loaded the style and is ready to accept a new source.
 
  @param source The source to add to the current style.
  */
@@ -267,10 +269,12 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  
  @note Adding the same layer instance more than once will result in a
     `MGLRedundantLayerException`. Reusing the same layer identifer, even with
-    different layer instances, will also result in an exception. Layers should 
-    be added in `MGLMapViewDelegates`'s `mapView:didFinishLoadingStyle:` or
-    `mapViewDidFinishLoadingMap:` methods to ensure that the map has loaded
-    the style and is ready to accept a new source or layer.
+    different layer instances, will also result in an exception. 
+ 
+ @note Layers should be added in 
+    `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` or
+    `-[MGLMapViewDelegate mapViewDidFinishLoadingMap:]` to ensure that the map 
+    has loaded the style and is ready to accept a new layer.
 
  @param layer The layer object to add to the map view. This object must be an
     instance of a concrete subclass of `MGLStyleLayer`.
@@ -282,10 +286,12 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  
  @note Adding the same layer instance more than once will result in a
     `MGLRedundantLayerException`. Reusing the same layer identifer, even with
-    different layer instances, will also result in an exception. Layers should
-    be added in `MGLMapViewDelegates`'s `mapView:didFinishLoadingStyle:` or
-    `mapViewDidFinishLoadingMap:` methods to ensure that the map has loaded
-    the style and is ready to accept a new source or layer.
+    different layer instances, will also result in an exception. 
+ 
+ @note Layers should be added in
+    `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` or
+    `-[MGLMapViewDelegate mapViewDidFinishLoadingMap:]` to ensure that the map 
+    has loaded the style and is ready to accept a new layer.
 
  @param layer The layer to insert.
  @param index The index at which to insert the layer. An index of 0 would send

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -213,8 +213,11 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  @note Adding the same source instance more than once will result in a
     `MGLRedundantSourceException`. Reusing the same source identifier, even with
     different source instances, will result in a 
-    `MGLRedundantSourceIdentifierException`.
- 
+    `MGLRedundantSourceIdentifierException`. Sources should be added in 
+    `MGLMapViewDelegates`'s `mapView:didFinishLoadingStyle:` or
+    `mapViewDidFinishLoadingMap:` methods to ensure that the map has loaded
+    the style and is ready to accept a new source or layer.
+
  @param source The source to add to the current style.
  */
 - (void)addSource:(MGLSource *)source;
@@ -264,7 +267,10 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  
  @note Adding the same layer instance more than once will result in a
     `MGLRedundantLayerException`. Reusing the same layer identifer, even with
-    different layer instances, will also result in an exception.
+    different layer instances, will also result in an exception. Layers should 
+    be added in `MGLMapViewDelegates`'s `mapView:didFinishLoadingStyle:` or
+    `mapViewDidFinishLoadingMap:` methods to ensure that the map has loaded
+    the style and is ready to accept a new source or layer.
 
  @param layer The layer object to add to the map view. This object must be an
     instance of a concrete subclass of `MGLStyleLayer`.
@@ -276,7 +282,10 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  
  @note Adding the same layer instance more than once will result in a
     `MGLRedundantLayerException`. Reusing the same layer identifer, even with
-    different layer instances, will also result in an exception.
+    different layer instances, will also result in an exception. Layers should
+    be added in `MGLMapViewDelegates`'s `mapView:didFinishLoadingStyle:` or
+    `mapViewDidFinishLoadingMap:` methods to ensure that the map has loaded
+    the style and is ready to accept a new source or layer.
 
  @param layer The layer to insert.
  @param index The index at which to insert the layer. An index of 0 would send

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1615,6 +1615,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     }
     
     MGLPointAnnotation *point = annotation;
+    MGLPointAnnotation *point = (MGLPointAnnotation *)annotation;
     point.coordinate = [self.mapView convertPoint:self.mapView.center toCoordinateFromView:self.mapView];
 }
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1613,8 +1613,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     {
         return;
     }
-    
-    MGLPointAnnotation *point = annotation;
+
     MGLPointAnnotation *point = (MGLPointAnnotation *)annotation;
     point.coordinate = [self.mapView convertPoint:self.mapView.center toCoordinateFromView:self.mapView];
 }


### PR DESCRIPTION
Sources and layers added outside of mapView:didFinishLoadingStyle: and mapViewDidFinishLoadingMap: are not guaranteed to appear since the map may not be fully loaded and ready to accept new sources and layers.

This also fixes a compiler warning in iosapp.

ref https://github.com/mapbox/mapbox-gl-native/issues/7492