### PR TITLE
Flip CGVector-typed properties on macOS

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -286,6 +286,14 @@ For padding attributes, note that the arguments to
 `EdgeInsets(top:left:bottom:right:)` in Swift are specified in counterclockwise
 order, in contrast to the clockwise order defined by the style specification.
 
+<% if (macOS) { -%>
+Additionally, on macOS, a screen coordinate of (0, 0) is located at the
+lower-left corner of the screen. Therefore, a positive `CGVector.dy` means an
+offset or translation upward, while a negative `CGVector.dy` means an offset or
+translation downward. This is the reverse of how `CGVector` is interpreted on
+iOS.
+
+<% } -%>
 ## Filtering sources
 
 You can filter a shape or vector source by setting the

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -281,6 +281,11 @@ Array (`-offset`, `-translate`) | `NSValue` containing `CGVector` | `NSValue` co
 Array (`-padding`) | `NSValue.edgeInsetsValue` | `NSValue.edgeInsetsValue`
 <% } -%>
 
+For padding attributes, note that the arguments to
+`<%- cocoaPrefix %>EdgeInsetsMake()` in Objective-C and
+`EdgeInsets(top:left:bottom:right:)` in Swift are specified in counterclockwise
+order, in contrast to the clockwise order defined by the style specification.
+
 ## Filtering sources
 
 You can filter a shape or vector source by setting the

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -261,7 +261,8 @@ you want the attribute to be set to.
 In contrast to the JSON type that the style specification defines for each
 layout or paint property, the style value object often contains a more specific
 Foundation or Cocoa type. General rules for attribute types are listed below.
-Pay close attention to the SDK documentation for the attribute you want to set.
+Pay close attention to the SDK documentation for the attribute you want to get
+or set.
 
 In style JSON | In Objective-C        | In Swift
 --------------|-----------------------|---------
@@ -272,8 +273,13 @@ Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
 Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
 Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
 Array (`-font`) | `NSArray<NSString>` | `[String]`
-Array (`-offset`, `-translate`) | `CGVector` | `CGVector`
-Array (`-padding`) | `<%- cocoaPrefix %>EdgeInsets` | `<%- cocoaPrefix %>EdgeInsets`
+<% if (iOS) { -%>
+Array (`-offset`, `-translate`) | `NSValue.CGVectorValue` | `NSValue.cgVectorValue`
+Array (`-padding`) | `NSValue.UIEdgeInsetsValue` | `NSValue.uiEdgeInsetsValue`
+<% } else { -%>
+Array (`-offset`, `-translate`) | `NSValue` containing `CGVector` | `NSValue` containing `CGVector`
+Array (`-padding`) | `NSValue.edgeInsetsValue` | `NSValue.edgeInsetsValue`
+<% } -%>
 
 ## Filtering sources
 

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -273,7 +273,7 @@ global.describeValue = function (value, property, layerType) {
                     return 'an `NSValue` object containing an `NSEdgeInsets` or `UIEdgeInsets` struct set to' + ` ${value[0]}${units} on the top, ${value[3]}${units} on the left, ${value[2]}${units} on the bottom, and ${value[1]}${units} on the right`;
                 case 'offset':
                 case 'translate':
-                    return 'an `NSValue` object containing a `CGVector` struct set to' + ` ${value[0]}${units} from the left and ${value[1]}${units} from the top`;
+                    return 'an `NSValue` object containing a `CGVector` struct set to' + ` ${value[0]}${units} rightward and ${value[1]}${units} downward`;
                 default:
                     return 'the array `' + value.join('`, `') + '`';
             }
@@ -417,6 +417,17 @@ function duplicatePlatformDecls(src) {
         return `\
 #if TARGET_OS_IPHONE
 ${iosComment}${decl}
+#else
+${macosComment}${decl}
+#endif`;
+    })
+        // Do the same for CGVector-typed properties.
+        .replace(/(\/\*\*(?:\*[^\/]|[^*])*?\bCGVector\b[\s\S]*?\*\/)(\s*.+?;)/g,
+                       (match, comment, decl) => {
+        let macosComment = comment.replace(/\bdownward\b/g, 'upward');
+        return `\
+#if TARGET_OS_IPHONE
+${comment}${decl}
 #else
 ${macosComment}${decl}
 #endif`;

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  This property is only applied to the style if `backgroundPattern` is set to
  `nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *backgroundColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *backgroundColor;
 #else
 /**
  The color with which the background will be drawn.
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  This property is only applied to the style if `backgroundPattern` is set to
  `nil`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *backgroundColor;
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *backgroundColor;
 #endif
 
 /**

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -97,7 +97,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslationAnchor) {
  `UIColor.blackColor`. Set this property to `nil` to reset it to the default
  value.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *circleColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *circleColor;
 #else
 /**
  The fill color of the circle.
@@ -106,7 +106,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslationAnchor) {
  `NSColor.blackColor`. Set this property to `nil` to reset it to the default
  value.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *circleColor;
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *circleColor;
 #endif
 
 /**

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -144,21 +144,37 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslationAnchor) {
 
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circlePitchScale __attribute__((unavailable("Use circleScaleAlignment instead.")));
 
+#if TARGET_OS_IPHONE
 /**
  The geometry's offset.
  
  This property is measured in points.
  
  The default value of this property is an `MGLStyleValue` object containing an
- `NSValue` object containing a `CGVector` struct set to 0 points from the left
- and 0 points from the top. Set this property to `nil` to reset it to the
- default value.
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points downward. Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate"><code>circle-translate</code></a>
  layout property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslation;
+#else
+/**
+ The geometry's offset.
+ 
+ This property is measured in points.
+ 
+ The default value of this property is an `MGLStyleValue` object containing an
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points upward. Set this property to `nil` to reset it to the default value.
+ 
+ This attribute corresponds to the <a
+ href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate"><code>circle-translate</code></a>
+ layout property in the Mapbox Style Specification.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslation;
+#endif
 
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslate __attribute__((unavailable("Use circleTranslation instead.")));
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -118,21 +118,37 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *fillPattern;
 
+#if TARGET_OS_IPHONE
 /**
  The geometry's offset.
  
  This property is measured in points.
  
  The default value of this property is an `MGLStyleValue` object containing an
- `NSValue` object containing a `CGVector` struct set to 0 points from the left
- and 0 points from the top. Set this property to `nil` to reset it to the
- default value.
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points downward. Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate"><code>fill-translate</code></a>
  layout property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslation;
+#else
+/**
+ The geometry's offset.
+ 
+ This property is measured in points.
+ 
+ The default value of this property is an `MGLStyleValue` object containing an
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points upward. Set this property to `nil` to reset it to the default value.
+ 
+ This attribute corresponds to the <a
+ href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate"><code>fill-translate</code></a>
+ layout property in the Mapbox Style Specification.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslation;
+#endif
 
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslate __attribute__((unavailable("Use fillTranslation instead.")));
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
  This property is only applied to the style if `fillPattern` is set to `nil`.
  Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *fillColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *fillColor;
 #else
 /**
  The color of the filled part of this layer.
@@ -90,7 +90,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
  This property is only applied to the style if `fillPattern` is set to `nil`.
  Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *fillColor;
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *fillColor;
 #endif
 
 /**
@@ -103,6 +103,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *fillOpacity;
 
+#if TARGET_OS_IPHONE
 /**
  The outline color of the fill. Matches the value of `fillColor` if unspecified.
  
@@ -110,7 +111,17 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
  and `fillAntialiased` is set to an `MGLStyleValue` object containing an
  `NSNumber` object containing `YES`. Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *fillOutlineColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *fillOutlineColor;
+#else
+/**
+ The outline color of the fill. Matches the value of `fillColor` if unspecified.
+ 
+ This property is only applied to the style if `fillPattern` is set to `nil`,
+ and `fillAntialiased` is set to an `MGLStyleValue` object containing an
+ `NSNumber` object containing `YES`. Otherwise, it is ignored.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *fillOutlineColor;
+#endif
 
 /**
  Name of image in sprite to use for drawing image fills. For seamless patterns,

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -249,21 +249,37 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslationAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *linePattern;
 
+#if TARGET_OS_IPHONE
 /**
  The geometry's offset.
  
  This property is measured in points.
  
  The default value of this property is an `MGLStyleValue` object containing an
- `NSValue` object containing a `CGVector` struct set to 0 points from the left
- and 0 points from the top. Set this property to `nil` to reset it to the
- default value.
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points downward. Set this property to `nil` to reset it to the default value.
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate"><code>line-translate</code></a>
  layout property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslation;
+#else
+/**
+ The geometry's offset.
+ 
+ This property is measured in points.
+ 
+ The default value of this property is an `MGLStyleValue` object containing an
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points upward. Set this property to `nil` to reset it to the default value.
+ 
+ This attribute corresponds to the <a
+ href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate"><code>line-translate</code></a>
+ layout property in the Mapbox Style Specification.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslation;
+#endif
 
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslate __attribute__((unavailable("Use lineTranslation instead.")));
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -175,7 +175,7 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslationAnchor) {
  This property is only applied to the style if `linePattern` is set to `nil`.
  Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *lineColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *lineColor;
 #else
 /**
  The color with which the line will be drawn.
@@ -187,7 +187,7 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslationAnchor) {
  This property is only applied to the style if `linePattern` is set to `nil`.
  Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *lineColor;
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *lineColor;
 #endif
 
 /**

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -450,14 +450,15 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFit;
 
+#if TARGET_OS_IPHONE
 /**
  Size of the additional area added to dimensions determined by `iconTextFit`.
  
  This property is measured in points.
  
  The default value of this property is an `MGLStyleValue` object containing an
- `NSValue` object containing `NSEdgeInsetsZero` or `UIEdgeInsetsZero`. Set this
- property to `nil` to reset it to the default value.
+ `NSValue` object containing `UIEdgeInsetsZero`. Set this property to `nil` to
+ reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`, and
  `text` is non-`nil`, and `iconTextFit` is set to an `MGLStyleValue` object
@@ -465,6 +466,23 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFitPadding;
+#else
+/**
+ Size of the additional area added to dimensions determined by `iconTextFit`.
+ 
+ This property is measured in points.
+ 
+ The default value of this property is an `MGLStyleValue` object containing an
+ `NSValue` object containing `NSEdgeInsetsZero`. Set this property to `nil` to
+ reset it to the default value.
+ 
+ This property is only applied to the style if `iconImageName` is non-`nil`, and
+ `text` is non-`nil`, and `iconTextFit` is set to an `MGLStyleValue` object
+ containing an `NSValue` object containing `MGLIconTextFitBoth`,
+ `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFitPadding;
+#endif
 
 /**
  If true, the icon may be flipped to prevent it from being rendered upside-down.
@@ -891,7 +909,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *iconColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *iconColor;
 #else
 /**
  The tint color to apply to the icon. The `iconImageName` property must be set
@@ -904,7 +922,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *iconColor;
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *iconColor;
 #endif
 
 /**
@@ -933,7 +951,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *iconHaloColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *iconHaloColor;
 #else
 /**
  The color of the icon’s halo. The `iconImageName` property must be set to a
@@ -946,7 +964,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *iconHaloColor;
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *iconHaloColor;
 #endif
 
 /**
@@ -1044,7 +1062,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *textColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *textColor;
 #else
 /**
  The color with which the text will be drawn.
@@ -1056,7 +1074,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *textColor;
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *textColor;
 #endif
 
 /**
@@ -1084,7 +1102,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *textHaloColor;
+@property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *textHaloColor;
 #else
 /**
  The color of the text's halo, which helps it stand out from backgrounds.
@@ -1096,7 +1114,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  */
-@property (nonatomic, null_resettable) MGLStyleValue<MGLColor *> *textHaloColor;
+@property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *textHaloColor;
 #endif
 
 /**

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -331,17 +331,31 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
 
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *iconImage __attribute__((unavailable("Use iconImageName instead.")));
 
+#if TARGET_OS_IPHONE
 /**
  Offset distance of icon from its anchor.
  
  The default value of this property is an `MGLStyleValue` object containing an
- `NSValue` object containing a `CGVector` struct set to 0 from the left and 0
- from the top. Set this property to `nil` to reset it to the default value.
+ `NSValue` object containing a `CGVector` struct set to 0 rightward and 0
+ downward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconOffset;
+#else
+/**
+ Offset distance of icon from its anchor.
+ 
+ The default value of this property is an `MGLStyleValue` object containing an
+ `NSValue` object containing a `CGVector` struct set to 0 rightward and 0
+ upward. Set this property to `nil` to reset it to the default value.
+ 
+ This property is only applied to the style if `iconImageName` is non-`nil`.
+ Otherwise, it is ignored.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconOffset;
+#endif
 
 /**
  If true, text will display without their corresponding icons when the icon
@@ -747,20 +761,35 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textLineHeight;
 
+#if TARGET_OS_IPHONE
 /**
  Offset distance of text from its anchor.
  
  This property is measured in ems.
  
  The default value of this property is an `MGLStyleValue` object containing an
- `NSValue` object containing a `CGVector` struct set to 0 ems from the left and
- 0 ems from the top. Set this property to `nil` to reset it to the default
- value.
+ `NSValue` object containing a `CGVector` struct set to 0 ems rightward and 0
+ ems downward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textOffset;
+#else
+/**
+ Offset distance of text from its anchor.
+ 
+ This property is measured in ems.
+ 
+ The default value of this property is an `MGLStyleValue` object containing an
+ `NSValue` object containing a `CGVector` struct set to 0 ems rightward and 0
+ ems upward. Set this property to `nil` to reset it to the default value.
+ 
+ This property is only applied to the style if `text` is non-`nil`. Otherwise,
+ it is ignored.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textOffset;
+#endif
 
 /**
  If true, icons will display without their corresponding text when the text
@@ -946,15 +975,15 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconOpacity;
 
+#if TARGET_OS_IPHONE
 /**
  Distance that the icon's anchor is moved from its original placement.
  
  This property is measured in points.
  
  The default value of this property is an `MGLStyleValue` object containing an
- `NSValue` object containing a `CGVector` struct set to 0 points from the left
- and 0 points from the top. Set this property to `nil` to reset it to the
- default value.
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points downward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
@@ -964,6 +993,25 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  layout property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslation;
+#else
+/**
+ Distance that the icon's anchor is moved from its original placement.
+ 
+ This property is measured in points.
+ 
+ The default value of this property is an `MGLStyleValue` object containing an
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points upward. Set this property to `nil` to reset it to the default value.
+ 
+ This property is only applied to the style if `iconImageName` is non-`nil`.
+ Otherwise, it is ignored.
+ 
+ This attribute corresponds to the <a
+ href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate"><code>icon-translate</code></a>
+ layout property in the Mapbox Style Specification.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslation;
+#endif
 
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslate __attribute__((unavailable("Use iconTranslation instead.")));
 
@@ -1078,15 +1126,15 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textOpacity;
 
+#if TARGET_OS_IPHONE
 /**
  Distance that the text's anchor is moved from its original placement.
  
  This property is measured in points.
  
  The default value of this property is an `MGLStyleValue` object containing an
- `NSValue` object containing a `CGVector` struct set to 0 points from the left
- and 0 points from the top. Set this property to `nil` to reset it to the
- default value.
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points downward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
@@ -1096,6 +1144,25 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  layout property in the Mapbox Style Specification.
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslation;
+#else
+/**
+ Distance that the text's anchor is moved from its original placement.
+ 
+ This property is measured in points.
+ 
+ The default value of this property is an `MGLStyleValue` object containing an
+ `NSValue` object containing a `CGVector` struct set to 0 points rightward and 0
+ points upward. Set this property to `nil` to reset it to the default value.
+ 
+ This property is only applied to the style if `text` is non-`nil`. Otherwise,
+ it is ignored.
+ 
+ This attribute corresponds to the <a
+ href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate"><code>text-translate</code></a>
+ layout property in the Mapbox Style Specification.
+ */
+@property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslation;
+#endif
 
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslate __attribute__((unavailable("Use textTranslation instead.")));
 

--- a/platform/darwin/src/NSValue+MGLStyleAttributeAdditions.mm
+++ b/platform/darwin/src/NSValue+MGLStyleAttributeAdditions.mm
@@ -12,6 +12,11 @@
 + (instancetype)mgl_valueWithOffsetArray:(std::array<float, 2>)offsetArray
 {
     CGVector vector = CGVectorMake(offsetArray[0], offsetArray[1]);
+#if !TARGET_OS_IPHONE
+    // Style specification assumes an origin at the upper-left corner.
+    // macOS defines an origin at the lower-left corner.
+    vector.dy *= -1;
+#endif
     return [NSValue value:&vector withObjCType:@encode(CGVector)];
 }
 
@@ -33,6 +38,9 @@
     NSAssert(strcmp(self.objCType, @encode(CGVector)) == 0, @"Value does not represent a CGVector");
     CGVector vector;
     [self getValue:&vector];
+#if !TARGET_OS_IPHONE
+    vector.dy *= -1;
+#endif
     return {
         static_cast<float>(vector.dx),
         static_cast<float>(vector.dy),

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -259,7 +259,8 @@ you want the attribute to be set to.
 In contrast to the JSON type that the style specification defines for each
 layout or paint property, the style value object often contains a more specific
 Foundation or Cocoa type. General rules for attribute types are listed below.
-Pay close attention to the SDK documentation for the attribute you want to set.
+Pay close attention to the SDK documentation for the attribute you want to get
+or set.
 
 In style JSON | In Objective-C        | In Swift
 --------------|-----------------------|---------
@@ -270,8 +271,8 @@ Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
 Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
 Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
 Array (`-font`) | `NSArray<NSString>` | `[String]`
-Array (`-offset`, `-translate`) | `CGVector` | `CGVector`
-Array (`-padding`) | `UIEdgeInsets` | `UIEdgeInsets`
+Array (`-offset`, `-translate`) | `NSValue.CGVectorValue` | `NSValue.cgVectorValue`
+Array (`-padding`) | `NSValue.UIEdgeInsetsValue` | `NSValue.uiEdgeInsetsValue`
 
 ## Filtering sources
 

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -274,6 +274,11 @@ Array (`-font`) | `NSArray<NSString>` | `[String]`
 Array (`-offset`, `-translate`) | `NSValue.CGVectorValue` | `NSValue.cgVectorValue`
 Array (`-padding`) | `NSValue.UIEdgeInsetsValue` | `NSValue.uiEdgeInsetsValue`
 
+For padding attributes, note that the arguments to
+`UIEdgeInsetsMake()` in Objective-C and
+`EdgeInsets(top:left:bottom:right:)` in Swift are specified in counterclockwise
+order, in contrast to the clockwise order defined by the style specification.
+
 ## Filtering sources
 
 You can filter a shape or vector source by setting the

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -247,7 +247,8 @@ you want the attribute to be set to.
 In contrast to the JSON type that the style specification defines for each
 layout or paint property, the style value object often contains a more specific
 Foundation or Cocoa type. General rules for attribute types are listed below.
-Pay close attention to the SDK documentation for the attribute you want to set.
+Pay close attention to the SDK documentation for the attribute you want to get
+or set.
 
 In style JSON | In Objective-C        | In Swift
 --------------|-----------------------|---------
@@ -258,8 +259,8 @@ Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
 Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
 Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
 Array (`-font`) | `NSArray<NSString>` | `[String]`
-Array (`-offset`, `-translate`) | `CGVector` | `CGVector`
-Array (`-padding`) | `NSEdgeInsets` | `NSEdgeInsets`
+Array (`-offset`, `-translate`) | `NSValue` containing `CGVector` | `NSValue` containing `CGVector`
+Array (`-padding`) | `NSValue.edgeInsetsValue` | `NSValue.edgeInsetsValue`
 
 ## Filtering sources
 

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -267,6 +267,12 @@ For padding attributes, note that the arguments to
 `EdgeInsets(top:left:bottom:right:)` in Swift are specified in counterclockwise
 order, in contrast to the clockwise order defined by the style specification.
 
+Additionally, on macOS, a screen coordinate of (0, 0) is located at the
+lower-left corner of the screen. Therefore, a positive `CGVector.dy` means an
+offset or translation upward, while a negative `CGVector.dy` means an offset or
+translation downward. This is the reverse of how `CGVector` is interpreted on
+iOS.
+
 ## Filtering sources
 
 You can filter a shape or vector source by setting the

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -262,6 +262,11 @@ Array (`-font`) | `NSArray<NSString>` | `[String]`
 Array (`-offset`, `-translate`) | `NSValue` containing `CGVector` | `NSValue` containing `CGVector`
 Array (`-padding`) | `NSValue.edgeInsetsValue` | `NSValue.edgeInsetsValue`
 
+For padding attributes, note that the arguments to
+`NSEdgeInsetsMake()` in Objective-C and
+`EdgeInsets(top:left:bottom:right:)` in Swift are specified in counterclockwise
+order, in contrast to the clockwise order defined by the style specification.
+
 ## Filtering sources
 
 You can filter a shape or vector source by setting the


### PR DESCRIPTION
On macOS, `CGVector` is now interpreted as extending upward instead of downward, for consistency with the [predominant screen origin](https://developer.apple.com/library/content/documentation/General/Conceptual/Devpedia-CocoaApp/CoordinateSystem.html) on that platform. It is possible to flip the screen coordinate system by setting `NSView.flipped`. However, I’d rather not support that decidedly less common setup, since that would require each MGLStyleLayer instance to maintain a backpointer to MGLMapView.

Documentation comments for color-, offset-, and edge insets–typed properties are clearer about their types. In some cases, this meant some additional conditional compilation. There are no longer any references to the `MGLColor` macro within the style layer headers.

This PR goes in the opposite direction as #6763. I think the result is a net benefit for developers, because Quick Help and jazzy documentation are clearer. For developers who prefer to read the headers, command-clicking leads to the right version of the property. (Command-clicking in Swift code will omit the irrelevant version of the property.)

The “Information for Style Authors” guide explicitly calls out the fact that NSEdgeInsets, UIEdgeInsets, and EdgeInsets are all in counterclockwise order as opposed to the style specification’s clockwise order. For macOS, it also points out that `CGVector` points upward instead of downward. The guide also indicates the NSValue accessors used for `CGVector` and `NSEdgeInsets`/`UIEdgeInsets` values.

Fixes #6066.

/cc @frederoni @incanus @boundsj