### PR TITLE
Optional positioning and stickiness for callout view

### DIFF
--- a/platform/ios/app/MBXCustomCalloutView.h
+++ b/platform/ios/app/MBXCustomCalloutView.h
@@ -7,4 +7,8 @@
  * callout title for demonstration purpose.
  */
 @interface MBXCustomCalloutView : UIView <MGLCalloutView>
+
+@property (nonatomic, assign, getter=isAnchoredToAnnotation) BOOL anchoredToAnnotation;
+@property (nonatomic, assign) BOOL dismissesAutomatically;
+
 @end

--- a/platform/ios/app/MBXCustomCalloutView.m
+++ b/platform/ios/app/MBXCustomCalloutView.m
@@ -17,6 +17,8 @@ static CGFloat const tipWidth = 10.0;
 }
 
 @synthesize representedObject = _representedObject;
+@synthesize anchoredToAnnotation = _anchoredToAnnotation;
+@synthesize dismissesAutomatically = _dismissesAutomatically;
 @synthesize leftAccessoryView = _leftAccessoryView;
 @synthesize rightAccessoryView = _rightAccessoryView;
 @synthesize delegate = _delegate;
@@ -64,6 +66,11 @@ static CGFloat const tipWidth = 10.0;
     {
         [self.delegate performSelector:@selector(calloutViewDidAppear:) withObject:self];
     }
+}
+
+- (void)setCenter:(CGPoint)center {
+    center.y = center.y - CGRectGetMidY(self.bounds);
+    [super setCenter:center];
 }
 
 - (void)dismissCalloutAnimated:(BOOL)animated

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -89,6 +89,8 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 @end
 
 @interface MBXCustomCalloutAnnotation : MGLPointAnnotation
+@property (nonatomic, assign) BOOL anchoredToAnnotation;
+@property (nonatomic, assign) BOOL dismissesAutomatically;
 @end
 
 @implementation MBXCustomCalloutAnnotation
@@ -699,12 +701,28 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 {
     [self.mapView removeAnnotations:self.mapView.annotations];
 
-    MBXCustomCalloutAnnotation *annotation = [[MBXCustomCalloutAnnotation alloc] init];
-    annotation.coordinate = CLLocationCoordinate2DMake(48.8533940, 2.3775439);
-    annotation.title = @"Custom Callout";
+    MBXCustomCalloutAnnotation *firstAnnotation = [[MBXCustomCalloutAnnotation alloc] init];
+    firstAnnotation.coordinate = CLLocationCoordinate2DMake(48.8533940, 2.3775439);
+    firstAnnotation.title = @"Open anchored to annotation";
+    firstAnnotation.anchoredToAnnotation = YES;
+    firstAnnotation.dismissesAutomatically = NO;
+    
+    MBXCustomCalloutAnnotation *secondAnnotation = [[MBXCustomCalloutAnnotation alloc] init];
+    secondAnnotation.coordinate = CLLocationCoordinate2DMake(48.8543940, 2.3775439);
+    secondAnnotation.title = @"Open not anchored to annotation";
+    secondAnnotation.anchoredToAnnotation = NO;
+    secondAnnotation.dismissesAutomatically = NO;
 
-    [self.mapView addAnnotation:annotation];
-    [self.mapView showAnnotations:@[annotation] animated:YES];
+    MBXCustomCalloutAnnotation *thirdAnnotation = [[MBXCustomCalloutAnnotation alloc] init];
+    thirdAnnotation.coordinate = CLLocationCoordinate2DMake(48.8553940, 2.3775439);
+    thirdAnnotation.title = @"Dismisses automatically";
+    thirdAnnotation.anchoredToAnnotation = YES;
+    thirdAnnotation.dismissesAutomatically = YES;
+    
+    NSArray *annotations = @[firstAnnotation, secondAnnotation, thirdAnnotation];
+    [self.mapView addAnnotations:annotations];
+    
+    [self.mapView showAnnotations:annotations animated:YES];
 }
 
 - (void)styleWaterLayer
@@ -1582,8 +1600,11 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     if ([annotation respondsToSelector:@selector(title)]
         && [annotation isKindOfClass:[MBXCustomCalloutAnnotation class]])
     {
+        MBXCustomCalloutAnnotation *customAnnotation = (MBXCustomCalloutAnnotation *)annotation;
         MBXCustomCalloutView *calloutView = [[MBXCustomCalloutView alloc] init];
         calloutView.representedObject = annotation;
+        calloutView.anchoredToAnnotation = customAnnotation.anchoredToAnnotation;
+        calloutView.dismissesAutomatically = customAnnotation.dismissesAutomatically;
         return calloutView;
     }
     return nil;

--- a/platform/ios/src/MGLCalloutView.h
+++ b/platform/ios/src/MGLCalloutView.h
@@ -46,6 +46,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)dismissCalloutAnimated:(BOOL)animated;
 
+@optional
+
+/**
+ A Boolean value indicating whether the callout view should be anchored to
+ the corresponding annotation. You can adjust the callout view’s precise location by
+ overriding -[UIView setCenter:]. The callout view will not be anchored to the
+ annotation if this optional property is unimplemented.
+ */
+@property (nonatomic, readonly, assign, getter=isAnchoredToAnnotation) BOOL anchoredToAnnotation;
+
+/**
+ A Boolean value indicating whether the callout view should be dismissed automatically
+ when the map view’s viewport changes. Note that a single tap on the map view
+ still dismisses the callout view regardless of the value of this property.
+ The callout view will be dismissed if this optional property is unimplemented.
+ */
+@property (nonatomic, readonly, assign) BOOL dismissesAutomatically;
+
 @end
 
 /**

--- a/platform/ios/src/MGLCompactCalloutView.m
+++ b/platform/ios/src/MGLCompactCalloutView.m
@@ -14,6 +14,14 @@
     return [[self alloc] init];
 }
 
+- (BOOL)isAnchoredToAnnotation {
+    return YES;
+}
+
+- (BOOL)dismissesAutomatically {
+    return NO;
+}
+
 - (void)setRepresentedObject:(id <MGLAnnotation>)representedObject
 {
     _representedObject = representedObject;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -4558,21 +4558,34 @@ public:
                 || self.userTrackingMode == MGLUserTrackingModeNone
                 || self.userTrackingState != MGLUserTrackingStateChanged)
             {
-                // Deselect annotation if it lies outside the viewport
-                if (self.selectedAnnotation) {
-                    MGLAnnotationTag tag = [self annotationTagForAnnotation:self.selectedAnnotation];
-                    MGLAnnotationContext &annotationContext = _annotationContextsByAnnotationTag.at(tag);
-                    MGLAnnotationView *annotationView = annotationContext.annotationView;
-                    
-                    CGRect rect = [self positioningRectForCalloutForAnnotationWithTag:tag];
-                    
-                    if (annotationView)
-                    {
-                        rect = annotationView.frame;
-                    }
-                    
-                    if ( ! CGRectIntersectsRect(rect, self.frame)) {
-                        [self deselectAnnotation:self.selectedAnnotation animated:NO];
+                UIView<MGLCalloutView> *calloutView = self.calloutViewForSelectedAnnotation;
+                BOOL dismissesAutomatically = (calloutView
+                                               && [calloutView respondsToSelector:@selector(dismissesAutomatically)]
+                                               && calloutView.dismissesAutomatically);
+                // dismissesAutomatically is an optional property and we want to dismiss
+                // the callout view if it's unimplemented.
+                if (dismissesAutomatically || ![calloutView respondsToSelector:@selector(dismissesAutomatically)])
+                {
+                    [self deselectAnnotation:self.selectedAnnotation animated:NO];
+                }
+                else
+                {
+                    // Deselect annotation if it lies outside the viewport
+                    if (self.selectedAnnotation) {
+                        MGLAnnotationTag tag = [self annotationTagForAnnotation:self.selectedAnnotation];
+                        MGLAnnotationContext &annotationContext = _annotationContextsByAnnotationTag.at(tag);
+                        MGLAnnotationView *annotationView = annotationContext.annotationView;
+                        
+                        CGRect rect = [self positioningRectForCalloutForAnnotationWithTag:tag];
+                        
+                        if (annotationView)
+                        {
+                            rect = annotationView.frame;
+                        }
+                        
+                        if ( ! CGRectIntersectsRect(rect, self.frame)) {
+                            [self deselectAnnotation:self.selectedAnnotation animated:NO];
+                        }
                     }
                 }
             }
@@ -4817,7 +4830,12 @@ public:
     UIView <MGLCalloutView> *calloutView = self.calloutViewForSelectedAnnotation;
     id <MGLAnnotation> annotation = calloutView.representedObject;
     
-    if (calloutView && annotation)
+    BOOL isAnchoredToAnnotation = (calloutView
+                                   && annotation
+                                   && [calloutView respondsToSelector:@selector(isAnchoredToAnnotation)]
+                                   && calloutView.isAnchoredToAnnotation);
+    
+    if (isAnchoredToAnnotation)
     {
         MGLAnnotationTag tag = [self annotationTagForAnnotation:annotation];
         MGLAnnotationContext &annotationContext = _annotationContextsByAnnotationTag.at(tag);


### PR DESCRIPTION
This proposal makes the `MGLCalloutView` a bit more versatile by adding an `anchoredToAnnotation` and a `dismissesAutomatically` property. It also fixes issues like #7483 by falling back to the same behavior as in 3.4.0 beta 4 by default.

![animation](https://cloud.githubusercontent.com/assets/764476/21774093/a0bb04e0-d691-11e6-9aea-76bb6776d7fc.gif)

/cc @friedbunny @1ec5 @boundsj 