### PR TITLE
Clear out GeometryTileWorker::layers during redoLayout

### DIFF
--- a/include/mbgl/util/optional.hpp
+++ b/include/mbgl/util/optional.hpp
@@ -7,4 +7,7 @@ namespace mbgl {
 template <typename T>
 using optional = std::experimental::optional<T>;
 
+using nullopt_t = std::experimental::nullopt_t;
+constexpr auto nullopt = std::experimental::nullopt;
+
 } // namespace mbgl

--- a/src/mbgl/geometry/feature_index.cpp
+++ b/src/mbgl/geometry/feature_index.cpp
@@ -59,7 +59,8 @@ void FeatureIndex::query(
         const optional<std::vector<std::string>>& filterLayerIDs,
         const GeometryTileData& geometryTileData,
         const CanonicalTileID& tileID,
-        const style::Style& style) const {
+        const style::Style& style,
+        const CollisionTile* collisionTile) const {
 
     mapbox::geometry::box<int16_t> box = mapbox::geometry::envelope(queryGeometry);
 
@@ -152,10 +153,6 @@ optional<GeometryCoordinates> FeatureIndex::translateQueryGeometry(
 
 void FeatureIndex::addBucketLayerName(const std::string& bucketName, const std::string& layerID) {
     bucketLayerIDs[bucketName].push_back(layerID);
-}
-
-void FeatureIndex::setCollisionTile(std::unique_ptr<CollisionTile> collisionTile_) {
-    collisionTile = std::move(collisionTile_);
 }
 
 } // namespace mbgl

--- a/src/mbgl/geometry/feature_index.hpp
+++ b/src/mbgl/geometry/feature_index.hpp
@@ -42,7 +42,8 @@ public:
             const optional<std::vector<std::string>>& layerIDs,
             const GeometryTileData&,
             const CanonicalTileID&,
-            const style::Style&) const;
+            const style::Style&,
+            const CollisionTile*) const;
 
     static optional<GeometryCoordinates> translateQueryGeometry(
             const GeometryCoordinates& queryGeometry,
@@ -52,8 +53,6 @@ public:
             const float pixelsToTileUnits);
 
     void addBucketLayerName(const std::string& bucketName, const std::string& layerName);
-
-    void setCollisionTile(std::unique_ptr<CollisionTile>);
 
 private:
     void addFeature(
@@ -67,7 +66,6 @@ private:
             const float bearing,
             const float pixelsToTileUnits) const;
 
-    std::unique_ptr<CollisionTile> collisionTile;
     GridIndex<IndexedSubfeature> grid;
     unsigned int sortIndex = 0;
 

--- a/src/mbgl/text/collision_tile.cpp
+++ b/src/mbgl/text/collision_tile.cpp
@@ -168,7 +168,7 @@ Box CollisionTile::getTreeBox(const Point<float>& anchor, const CollisionBox& bo
     };
 }
 
-std::vector<IndexedSubfeature> CollisionTile::queryRenderedSymbols(const GeometryCoordinates& queryGeometry, float scale) {
+std::vector<IndexedSubfeature> CollisionTile::queryRenderedSymbols(const GeometryCoordinates& queryGeometry, float scale) const {
     std::vector<IndexedSubfeature> result;
     if (queryGeometry.empty() || (tree.empty() && ignoredTree.empty())) {
         return result;

--- a/src/mbgl/text/collision_tile.hpp
+++ b/src/mbgl/text/collision_tile.hpp
@@ -42,7 +42,7 @@ public:
     float placeFeature(const CollisionFeature&, bool allowOverlap, bool avoidEdges);
     void insertFeature(CollisionFeature&, float minPlacementScale, bool ignorePlacement);
 
-    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, float scale);
+    std::vector<IndexedSubfeature> queryRenderedSymbols(const GeometryCoordinates&, float scale) const;
 
     const PlacementConfig config;
 

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -117,7 +117,7 @@ void GeometryTile::onPlacement(PlacementResult result) {
         availableData = DataAvailability::All;
     }
     symbolBuckets = std::move(result.symbolBuckets);
-    featureIndex->setCollisionTile(std::move(result.collisionTile));
+    collisionTile = std::move(result.collisionTile);
     observer->onTileChanged(*this);
 }
 
@@ -153,7 +153,8 @@ void GeometryTile::queryRenderedFeatures(
                         layerIDs,
                         *data,
                         id.canonical,
-                        style);
+                        style,
+                        collisionTile.get());
 }
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -81,9 +81,11 @@ private:
     optional<PlacementConfig> requestedConfig;
 
     std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
-    std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
     std::unique_ptr<FeatureIndex> featureIndex;
     std::unique_ptr<const GeometryTileData> data;
+
+    std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
+    std::unique_ptr<CollisionTile> collisionTile;
 };
 
 } // namespace mbgl

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -50,7 +50,7 @@ public:
 
     class LayoutResult {
     public:
-        std::unordered_map<std::string, std::shared_ptr<Bucket>> buckets;
+        std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
         std::unique_ptr<FeatureIndex> featureIndex;
         std::unique_ptr<GeometryTileData> tileData;
         uint64_t correlationID;
@@ -59,7 +59,7 @@ public:
 
     class PlacementResult {
     public:
-        std::unordered_map<std::string, std::shared_ptr<Bucket>> buckets;
+        std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
         std::unique_ptr<CollisionTile> collisionTile;
         uint64_t correlationID;
     };
@@ -80,7 +80,8 @@ private:
     uint64_t correlationID = 0;
     optional<PlacementConfig> requestedConfig;
 
-    std::unordered_map<std::string, std::shared_ptr<Bucket>> buckets;
+    std::unordered_map<std::string, std::shared_ptr<Bucket>> nonSymbolBuckets;
+    std::unordered_map<std::string, std::shared_ptr<Bucket>> symbolBuckets;
     std::unique_ptr<FeatureIndex> featureIndex;
     std::unique_ptr<const GeometryTileData> data;
 };

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -215,6 +215,8 @@ void GeometryTileWorker::redoLayout() {
     BucketParameters parameters { id, obsolete, *featureIndex, mode };
 
     std::vector<std::vector<std::unique_ptr<Layer>>> groups = groupByLayout(std::move(*layers));
+    layers = nullopt;
+
     for (auto& group : groups) {
         if (obsolete) {
             return;
@@ -280,7 +282,7 @@ bool GeometryTileWorker::hasPendingSymbolDependencies() const {
 }
 
 void GeometryTileWorker::attemptPlacement() {
-    if (!data || !layers || !placementConfig) {
+    if (!placementConfig) {
         return;
     }
 

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -62,14 +62,6 @@ TEST(VectorTile, Issue7615) {
     auto symbolBucket = std::make_shared<SymbolBucket>(
         MapMode::Continuous, style::SymbolLayoutProperties::Evaluated(), false, false);
 
-    // First onLayout is required so that a non-null FeatureIndex is available.
-    tile.onLayout(GeometryTile::LayoutResult {
-        {},
-        std::make_unique<FeatureIndex>(),
-        nullptr,
-        0
-    });
-
     // Simulate placement of a symbol layer.
     tile.onPlacement(GeometryTile::PlacementResult {
         {{
@@ -80,7 +72,7 @@ TEST(VectorTile, Issue7615) {
         0
     });
 
-    // Second onLayout should not cause the existing symbol bucket to be discarded.
+    // Subsequent onLayout should not cause the existing symbol bucket to be discarded.
     tile.onLayout(GeometryTile::LayoutResult {
         {},
         nullptr,


### PR DESCRIPTION
This avoids a corner case where redoLayout was called with a new set of data, but the layer objects were moved out during the previous call to redoLayout. When setting new data, we call setData() first, then `setLayout()`. The `setData()` call doesn't immediately process the tiles, since it will still be lacking layer data.