### PR TITLE
Allow new s3 publish location

### DIFF
--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -77,7 +77,7 @@
                                         "s3:PutObjectAcl"
                                     ],
                                     "Resource": [
-                                        "arn:aws:s3:::mapbox-node-binary/@mapbox/gl-native/*"
+                                        "arn:aws:s3:::mapbox-node-binary/@mapbox/mapbox-gl-native/*"
                                     ],
                                     "Effect": "Allow"
                                 }

--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -77,7 +77,7 @@
                                         "s3:PutObjectAcl"
                                     ],
                                     "Resource": [
-                                        "arn:aws:s3:::mapbox-node-binary/mapbox-gl-native/*"
+                                        "arn:aws:s3:::mapbox-node-binary/@mapbox/gl-native/*"
                                     ],
                                     "Effect": "Allow"
                                 }


### PR DESCRIPTION
Since we've moved to npm + orgs (@mapbox/package), we'll need to update the allowed s3 publish location.

#### prerequisite 
- [x] https://github.com/mapbox/mapbox-gl-native/pull/7652

#### post merge
- [ ] update travis user 

/cc @lucaswoj 
