### PR TITLE
[android] - build only SDK module with make apackage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -601,7 +601,7 @@ run-android-ui-test-spoon:
 
 .PHONY: apackage
 apackage:
-	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) assemble$(BUILDTYPE)
+	cd platform/android && ./gradlew --parallel --max-workers=$(JOBS) :MapboxGLAndroidSDK:assemble$(BUILDTYPE)
 
 .PHONY: test-code-android
 test-code-android:


### PR DESCRIPTION
closes #7641, TODO need to test publishing a SNAPSHOT.
Review @zugaldia 