### PR TITLE
Update version number and changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-native",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.4.4 - January 10, 2017
+
+- Updates the node binary publish location on s3 to reflect new package name ([#7653](https://github.com/mapbox/mapbox-gl-native/pull/7653))
+
 # 3.4.3 - January 9, 2017
 
 - Adds `map.addImage()` and `map.removeImage()` APIs ([#7610](https://github.com/mapbox/mapbox-gl-native/pull/7610))


### PR DESCRIPTION
Although we initially thought we could simply re-run the publish binary travis test, it looks like node-pre-gyp is complaining:

```
de-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@0.6.32
node-pre-gyp info using node@4.7.2 | darwin | x64
node-pre-gyp info package packing /Users/vagrant/git/lib
node-pre-gyp info package packing /Users/vagrant/git/lib/mapbox-gl-native.node
node-pre-gyp info package Binary staged at "build/stage/@mapbox/mapbox-gl-native/v3.4.3/node-v46-darwin-x64.tar.gz"
node-pre-gyp info publish Detecting s3 credentials
node-pre-gyp info publish Authenticating with s3
node-pre-gyp info publish Checking for existing binary at https://mapbox-node-binary.s3.amazonaws.com/@mapbox/mapbox-gl-native/v3.4.3/node-v46-darwin-x64.tar.gz
node-pre-gyp info publish {"AcceptRanges":"bytes","LastModified":"Tue, 10 Jan 2017 02:29:58 GMT","ContentLength":"3021529","ETag":"\"e8520d60c4bc04bab940dd6961137c30\"","ContentType":"application/octet-stream","Metadata":{}}
node-pre-gyp ERR! publish Cannot publish over existing version
node-pre-gyp ERR! publish Update the 'version' field in package.json and try again
node-pre-gyp ERR! publish If the previous version was published in error see:
node-pre-gyp ERR! publish 	 node-pre-gyp unpublish
node-pre-gyp ERR! publish error 
node-pre-gyp ERR! stack Error: Failed publishing to https://mapbox-node-binary.s3.amazonaws.com/@mapbox/mapbox-gl-native/v3.4.3/node-v46-darwin-x64.tar.gz
```
> Found at: https://www.bitrise.io/build/5487fe56cafd7e05

ref: https://github.com/mapbox/mapbox-gl-native/pull/7653