### PR TITLE
Make MGLMapView.style property nullable

### DIFF
--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -72,7 +72,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslationAnchor) {
  ])
  layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
  layer.predicate = NSPredicate(format: "%K == %@", "marital-status", "married")
- mapView.style.addLayer(layer)
+ mapView.style?.addLayer(layer)
  ```
  */
 @interface MGLCircleStyleLayer : MGLVectorStyleLayer

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
  layer.sourceLayerIdentifier = "parks"
  layer.fillColor = MGLStyleValue(rawValue: .green)
  layer.predicate = NSPredicate(format: "type == %@", "national-park")
- mapView.style.addLayer(layer)
+ mapView.style?.addLayer(layer)
  ```
  */
 @interface MGLFillStyleLayer : MGLVectorStyleLayer

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -100,7 +100,7 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslationAnchor) {
  layer.lineColor = MGLStyleValue(rawValue: .brown)
  layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
  layer.predicate = NSPredicate(format: "%K == %@", "trail-type", "mountain-biking")
- mapView.style.addLayer(layer)
+ mapView.style?.addLayer(layer)
  ```
  */
 @interface MGLLineStyleLayer : MGLVectorStyleLayer

--- a/platform/darwin/src/MGLRasterSource.h
+++ b/platform/darwin/src/MGLRasterSource.h
@@ -47,7 +47,7 @@ extern const MGLTileSourceOption MGLTileSourceOptionTileSize;
          MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
      ]
  ])
- mapView.style.addSource(source)
+ mapView.style?.addSource(source)
  ```
  */
 @interface MGLRasterSource : MGLTileSource

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  ```swift
  let layer = MGLRasterStyleLayer(identifier: "clouds", source: source)
  layer.rasterOpacity = MGLStyleValue(rawValue: 0.5)
- mapView.style.addLayer(layer)
+ mapView.style?.addLayer(layer)
  ```
  */
 @interface MGLRasterStyleLayer : MGLForegroundStyleLayer

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -105,7 +105,7 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
  let polyline = MGLPolylineFeature(coordinates: &coordinates, count: UInt(coordinates.count))
  let shape = MGLShapeCollectionFeature(shapes: [polyline])
  let source = MGLShapeSource(identifier: "lines", shape: shape, options: nil)
- mapView.style.addSource(source)
+ mapView.style?.addSource(source)
  ```
  */
 @interface MGLShapeSource : MGLSource

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -273,7 +273,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
  layer.textJustification = MGLStyleValue(rawValue: NSValue(mglTextJustification: .left))
  layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
  layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
- mapView.style.addLayer(layer)
+ mapView.style?.addLayer(layer)
  ```
  */
 @interface MGLSymbolStyleLayer : MGLVectorStyleLayer

--- a/platform/darwin/src/MGLVectorSource.h
+++ b/platform/darwin/src/MGLVectorSource.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
          MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
      ]
  ])
- mapView.style.addSource(source)
+ mapView.style?.addSource(source)
  ```
  */
 @interface MGLVectorSource : MGLTileSource

--- a/platform/darwin/src/MGLVectorStyleLayer.h
+++ b/platform/darwin/src/MGLVectorStyleLayer.h
@@ -144,7 +144,7 @@ NS_ASSUME_NONNULL_BEGIN
  let layer = MGLLineStyleLayer(identifier: "contour", source: terrain)
  layer.sourceLayerIdentifier = "contours"
  layer.predicate = NSPredicate(format: "(index == 5 || index == 10) && ele >= 1500.0")
- mapView.style.addLayer(layer)
+ mapView.style?.addLayer(layer)
  ```
  */
 @property (nonatomic, nullable) NSPredicate *predicate;

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -68,10 +68,10 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         let polyline = MGLPolylineFeature(coordinates: &coordinates, count: UInt(coordinates.count))
         let shape = MGLShapeCollectionFeature(shapes: [polyline])
         let source = MGLShapeSource(identifier: "lines", shape: shape, options: nil)
-        mapView.style.addSource(source)
+        mapView.style?.addSource(source)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.source(withIdentifier: "lines"))
+        XCTAssertNotNil(mapView.style?.source(withIdentifier: "lines"))
     }
 
     func testMGLRasterSource() {
@@ -84,10 +84,10 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
                 MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
             ]
         ])
-        mapView.style.addSource(source)
+        mapView.style?.addSource(source)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.source(withIdentifier: "clouds"))
+        XCTAssertNotNil(mapView.style?.source(withIdentifier: "clouds"))
     }
 
     func testMGLVectorSource() {
@@ -99,15 +99,15 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
                 MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
             ]
         ])
-        mapView.style.addSource(source)
+        mapView.style?.addSource(source)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.source(withIdentifier: "pois"))
+        XCTAssertNotNil(mapView.style?.source(withIdentifier: "pois"))
     }
 
     func testMGLCircleStyleLayer() {
         let population = MGLVectorSource(identifier: "population", configurationURL: URL(string: "https://example.com/style.json")!)
-        mapView.style.addSource(population)
+        mapView.style?.addSource(population)
         
         //#-example-code
         let layer = MGLCircleStyleLayer(identifier: "circles", source: population)
@@ -119,15 +119,15 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         ])
         layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
         layer.predicate = NSPredicate(format: "%K == %@", "marital-status", "married")
-        mapView.style.addLayer(layer)
+        mapView.style?.addLayer(layer)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.layer(withIdentifier: "circles"))
+        XCTAssertNotNil(mapView.style?.layer(withIdentifier: "circles"))
     }
 
     func testMGLLineStyleLayer() {
         let trails = MGLVectorSource(identifier: "trails", configurationURL: URL(string: "https://example.com/style.json")!)
-        mapView.style.addSource(trails)
+        mapView.style?.addSource(trails)
 
         //#-example-code
         let layer = MGLLineStyleLayer(identifier: "trails-path", source: trails)
@@ -139,30 +139,30 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         layer.lineColor = MGLStyleValue(rawValue: .brown)
         layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
         layer.predicate = NSPredicate(format: "%K == %@", "trail-type", "mountain-biking")
-        mapView.style.addLayer(layer)
+        mapView.style?.addLayer(layer)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.layer(withIdentifier: "trails-path"))
+        XCTAssertNotNil(mapView.style?.layer(withIdentifier: "trails-path"))
     }
 
     func testMGLFillStyleLayer() {
         let parks = MGLVectorSource(identifier: "parks", configurationURL: URL(string: "https://example.com/style.json")!)
-        mapView.style.addSource(parks)
+        mapView.style?.addSource(parks)
 
         //#-example-code
         let layer = MGLFillStyleLayer(identifier: "parks", source: parks)
         layer.sourceLayerIdentifier = "parks"
         layer.fillColor = MGLStyleValue(rawValue: .green)
         layer.predicate = NSPredicate(format: "type == %@", "national-park")
-        mapView.style.addLayer(layer)
+        mapView.style?.addLayer(layer)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.layer(withIdentifier: "parks"))
+        XCTAssertNotNil(mapView.style?.layer(withIdentifier: "parks"))
     }
 
     func testMGLSymbolStyleLayer() {
         let pois = MGLVectorSource(identifier: "pois", configurationURL: URL(string: "https://example.com/style.json")!)
-        mapView.style.addSource(pois)
+        mapView.style?.addSource(pois)
 
         //#-example-code
         let layer = MGLSymbolStyleLayer(identifier: "coffeeshops", source: pois)
@@ -179,10 +179,10 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
         layer.textJustification = MGLStyleValue(rawValue: NSValue(mglTextJustification: .left))
         layer.textAnchor = MGLStyleValue(rawValue: NSValue(mglTextAnchor: .left))
         layer.predicate = NSPredicate(format: "%K == %@", "venue-type", "coffee")
-        mapView.style.addLayer(layer)
+        mapView.style?.addLayer(layer)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.layer(withIdentifier: "coffeeshops"))
+        XCTAssertNotNil(mapView.style?.layer(withIdentifier: "coffeeshops"))
     }
 
     func testMGLRasterStyleLayer() {
@@ -194,28 +194,28 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
                 MGLAttributionInfo(title: NSAttributedString(string: "© Mapbox"), url: URL(string: "http://mapbox.com"))
             ]
         ])
-        mapView.style.addSource(source)
+        mapView.style?.addSource(source)
 
         //#-example-code
         let layer = MGLRasterStyleLayer(identifier: "clouds", source: source)
         layer.rasterOpacity = MGLStyleValue(rawValue: 0.5)
-        mapView.style.addLayer(layer)
+        mapView.style?.addLayer(layer)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.layer(withIdentifier: "clouds"))
+        XCTAssertNotNil(mapView.style?.layer(withIdentifier: "clouds"))
     }
 
     func testMGLVectorStyleLayer$predicate() {
         let terrain = MGLVectorSource(identifier: "terrain", configurationURL: URL(string: "https://example.com/style.json")!)
-        mapView.style.addSource(terrain)
+        mapView.style?.addSource(terrain)
 
         //#-example-code
         let layer = MGLLineStyleLayer(identifier: "contour", source: terrain)
         layer.sourceLayerIdentifier = "contours"
         layer.predicate = NSPredicate(format: "(index == 5 || index == 10) && ele >= 1500.0")
-        mapView.style.addLayer(layer)
+        mapView.style?.addLayer(layer)
         //#-end-example-code
 
-        XCTAssertNotNil(mapView.style.layer(withIdentifier: "contour"))
+        XCTAssertNotNil(mapView.style?.layer(withIdentifier: "contour"))
     }
 }

--- a/platform/darwin/test/MGLStyleLayerTests.h
+++ b/platform/darwin/test/MGLStyleLayerTests.h
@@ -5,7 +5,6 @@
 @interface MGLStyleLayerTests : XCTestCase <MGLMapViewDelegate>
 
 @property (nonatomic) IBOutlet MGLMapView *mapView;
-@property (nonatomic) XCTestExpectation *expectation;
 @property (nonatomic, copy, readonly, class) NSString *layerType;
 
 - (void)testPropertyName:(NSString *)name isBoolean:(BOOL)isBoolean;

--- a/platform/darwin/test/MGLStyleLayerTests.m
+++ b/platform/darwin/test/MGLStyleLayerTests.m
@@ -4,9 +4,7 @@
 
 #define TEST_STRICT_NAMING_CONVENTIONS 0
 
-@implementation MGLStyleLayerTests {
-    XCTestExpectation *_styleLoadingExpectation;
-}
+@implementation MGLStyleLayerTests
 
 @dynamic layerType;
 
@@ -21,20 +19,19 @@
     [vc view]; // Force load xib
     _mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 256, 256) styleURL:styleURL];
     [vc.view addSubview:_mapView];
-    _mapView.delegate = self;
 #else
     NSWindowController *windowController = [[NSWindowController alloc] initWithWindowNibName:@"MGLStyleLayerTests" owner:self];
-    self.mapView.styleURL = styleURL;
+    NSView *contentView = windowController.window.contentView;
+    _mapView = [[MGLMapView alloc] initWithFrame:contentView.bounds styleURL:styleURL];
+    [contentView addSubview:_mapView];
     [windowController showWindow:nil];
 #endif
-    XCTAssertNil(self.mapView.style);
-    _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
+    _mapView.delegate = self;
+    XCTAssertNil(_mapView.style);
+    [self keyValueObservingExpectationForObject:self.mapView keyPath:@"style" handler:^BOOL(MGLMapView * _Nonnull observedMapView, NSDictionary * _Nonnull change) {
+        return observedMapView.style != nil;
+    }];
     [self waitForExpectationsWithTimeout:1 handler:nil];
-}
-
-- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
-    XCTAssertNotNil(mapView.style);
-    [_styleLoadingExpectation fulfill];
 }
 
 - (void)tearDown {

--- a/platform/darwin/test/MGLStyleLayerTests.m
+++ b/platform/darwin/test/MGLStyleLayerTests.m
@@ -11,18 +11,25 @@
 - (void)setUp {
     [super setUp];
     [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
+    NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
 #if TARGET_OS_IPHONE
     UIApplication *app = [UIApplication sharedApplication];
     UIViewController *vc = [[UIViewController alloc] init];
     app.keyWindow.rootViewController = vc;
     [vc view]; // Force load xib
-    _mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 256, 256)];
+    _mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 256, 256) styleURL:styleURL];
     [vc.view addSubview:_mapView];
     _mapView.delegate = self;
 #else
     NSWindowController *windowController = [[NSWindowController alloc] initWithWindowNibName:@"MGLStyleLayerTests" owner:self];
+    self.mapView.styleURL = styleURL;
     [windowController showWindow:nil];
 #endif
+    XCTAssertNil(self.mapView.style);
+    [self keyValueObservingExpectationForObject:self.mapView keyPath:@"style" handler:^BOOL(MGLMapView * _Nonnull observedMapView, NSDictionary * _Nonnull change) {
+        return observedMapView.style != nil;
+    }];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)tearDown {

--- a/platform/darwin/test/MGLStyleLayerTests.m
+++ b/platform/darwin/test/MGLStyleLayerTests.m
@@ -4,7 +4,9 @@
 
 #define TEST_STRICT_NAMING_CONVENTIONS 0
 
-@implementation MGLStyleLayerTests
+@implementation MGLStyleLayerTests {
+    XCTestExpectation *_styleLoadingExpectation;
+}
 
 @dynamic layerType;
 
@@ -26,10 +28,13 @@
     [windowController showWindow:nil];
 #endif
     XCTAssertNil(self.mapView.style);
-    [self keyValueObservingExpectationForObject:self.mapView keyPath:@"style" handler:^BOOL(MGLMapView * _Nonnull observedMapView, NSDictionary * _Nonnull change) {
-        return observedMapView.style != nil;
-    }];
+    _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
     [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    XCTAssertNotNil(mapView.style);
+    [_styleLoadingExpectation fulfill];
 }
 
 - (void)tearDown {

--- a/platform/darwin/test/MGLStyleLayerTests.xib
+++ b/platform/darwin/test/MGLStyleLayerTests.xib
@@ -1,38 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="16A304a" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="MGLMapViewTests">
-            <connections>
-                <outlet property="mapView" destination="6RL-d9-juy" id="0ch-aR-Um6"/>
-            </connections>
-        </customObject>
+        <customObject id="-2" userLabel="File's Owner" customClass="MGLMapViewTests"/>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="MGLMapViewTests" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="256" height="256"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="256" height="256"/>
                 <autoresizingMask key="autoresizingMask"/>
-                <subviews>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="6RL-d9-juy" customClass="MGLMapView">
-                        <rect key="frame" x="0.0" y="0.0" width="256" height="256"/>
-                        <connections>
-                            <outlet property="delegate" destination="-2" id="6kS-ct-JEg"/>
-                        </connections>
-                    </customView>
-                </subviews>
-                <constraints>
-                    <constraint firstItem="6RL-d9-juy" firstAttribute="leading" secondItem="EiT-Mj-1SZ" secondAttribute="leading" id="KEN-aL-UF0"/>
-                    <constraint firstAttribute="bottom" secondItem="6RL-d9-juy" secondAttribute="bottom" id="V27-f3-xHZ"/>
-                    <constraint firstAttribute="trailing" secondItem="6RL-d9-juy" secondAttribute="trailing" id="vjq-iM-OyA"/>
-                    <constraint firstItem="6RL-d9-juy" firstAttribute="top" secondItem="EiT-Mj-1SZ" secondAttribute="top" id="yWg-v4-wJB"/>
-                </constraints>
             </view>
         </window>
     </objects>

--- a/platform/darwin/test/MGLStyleTests.mm
+++ b/platform/darwin/test/MGLStyleTests.mm
@@ -39,7 +39,13 @@
     [super setUp];
     
     [MGLAccountManager setAccessToken:@"pk.feedcafedeadbeefbadebede"];
-    self.mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+    NSURL *styleURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"one-liner" withExtension:@"json"];
+    self.mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) styleURL:styleURL];
+    XCTAssertNil(self.mapView.style);
+    [self keyValueObservingExpectationForObject:self.mapView keyPath:@"style" handler:^BOOL(MGLMapView * _Nonnull observedMapView, NSDictionary * _Nonnull change) {
+        return observedMapView.style != nil;
+    }];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)tearDown {
@@ -250,12 +256,16 @@
     [self.style insertLayer:layer0 belowLayer:layer1];
     
     NSArray<MGLStyleLayer *> *layers = [self.style layers];
+    NSUInteger startIndex = 0;
+    if ([layers.firstObject.identifier isEqualToString:@"com.mapbox.annotations.points"]) {
+        startIndex++;
+    }
     
-    XCTAssert([[layers[0] identifier] isEqualToString:layer0.identifier]);
-    XCTAssert([[layers[1] identifier] isEqualToString:layer1.identifier]);
-    XCTAssert([[layers[2] identifier] isEqualToString:layer2.identifier]);
-    XCTAssert([[layers[3] identifier] isEqualToString:layer3.identifier]);
-    XCTAssert([[layers[4] identifier] isEqualToString:layer4.identifier]);
+    XCTAssertEqualObjects(layers[startIndex++].identifier, layer0.identifier);
+    XCTAssertEqualObjects(layers[startIndex++].identifier, layer1.identifier);
+    XCTAssertEqualObjects(layers[startIndex++].identifier, layer2.identifier);
+    XCTAssertEqualObjects(layers[startIndex++].identifier, layer3.identifier);
+    XCTAssertEqualObjects(layers[startIndex++].identifier, layer4.identifier);
 }
 
 @end

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -123,6 +123,13 @@ IB_DESIGNABLE
  Unlike the `styleURL` property, this property is set to an object that allows
  you to manipulate every aspect of the style locally.
  
+ If the style is loading, this property is set to `nil` until the style finishes
+ loading. If the style has failed to load, this property is set to `nil`.
+ Because the style loads asynchronously, you should manipulate it in the
+ `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` or
+ `-[MGLMapViewDelegate mapViewDidFinishLoadingMap:]` method. It is not possible
+ to manipulate the style before it has finished loading.
+ 
  @note The default styles provided by Mapbox contain sources and layers with
     identifiers that will change over time. Applications that use APIs that
     manipulate a style's sources and layers must first set the style URL to an
@@ -130,7 +137,7 @@ IB_DESIGNABLE
     `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`'s “Style URL”
     inspectable in Interface Builder, or a manually constructed `NSURL`.
  */
-@property (nonatomic, readonly) MGLStyle *style;
+@property (nonatomic, readonly, nullable) MGLStyle *style;
 
 /**
  URLs of the styles bundled with the library.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -347,6 +347,11 @@ public:
     return self;
 }
 
++ (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingStyle
+{
+    return [NSSet setWithObject:@"styleURL"];
+}
+
 + (NS_SET_OF(NSString *) *)keyPathsForValuesAffectingStyleURL
 {
     return [NSSet setWithObjects:@"styleURL__", nil];
@@ -369,10 +374,8 @@ public:
     }
 
     styleURL = styleURL.mgl_URLByStandardizingScheme;
-    [self willChangeValueForKey:@"style"];
-    _style = [[MGLStyle alloc] initWithMapView:self];
+    self.style = nil;
     _mbglMap->setStyleURL([[styleURL absoluteString] UTF8String]);
-    [self didChangeValueForKey:@"style"];
 }
 
 - (IBAction)reloadStyle:(__unused id)sender {
@@ -4682,11 +4685,7 @@ public:
         }
         case mbgl::MapChangeDidFinishLoadingStyle:
         {
-            [self.style willChangeValueForKey:@"name"];
-            [self.style willChangeValueForKey:@"sources"];
-            [self.style didChangeValueForKey:@"sources"];
-            [self.style willChangeValueForKey:@"layers"];
-            [self.style didChangeValueForKey:@"layers"];
+            self.style = [[MGLStyle alloc] initWithMapView:self];
             if ([self.delegate respondsToSelector:@selector(mapView:didFinishLoadingStyle:)])
             {
                 [self.delegate mapView:self didFinishLoadingStyle:self.style];

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -94,6 +94,13 @@ IB_DESIGNABLE
  Unlike the `styleURL` property, this property is set to an object that allows
  you to manipulate every aspect of the style locally.
  
+ If the style is loading, this property is set to `nil` until the style finishes
+ loading. If the style has failed to load, this property is set to `nil`.
+ Because the style loads asynchronously, you should manipulate it in the
+ `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]` or
+ `-[MGLMapViewDelegate mapViewDidFinishLoadingMap:]` method. It is not possible
+ to manipulate the style before it has finished loading.
+ 
  @note The default styles provided by Mapbox contain sources and layers with
     identifiers that will change over time. Applications that use APIs that
     manipulate a style's sources and layers must first set the style URL to an
@@ -101,7 +108,7 @@ IB_DESIGNABLE
     `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`'s “Style URL”
     inspectable in Interface Builder, or a manually constructed `NSURL`.
  */
-@property (nonatomic, readonly) MGLStyle *style;
+@property (nonatomic, readonly, nullable) MGLStyle *style;
 
 /**
  URL of the style currently displayed in the receiver.


### PR DESCRIPTION
MGLMapView’s `style` property is now nullable (optional in Swift) and is set to `nil` while the style loads and in the event that the style has failed to load. The `styleURL` property remains null-resettable (implicitly-unwrapped-optional in Swift) as before.

Essentially, the API as it exists has a trap: the developer is tempted to have runtime styling code run synchronously after initializing the map view, for example in `-viewDidLoad`. Unfortunately, any runtime styling API operations they perform while the style loads [gets wiped out](https://github.com/mapbox/mapbox-gl-native/blob/5da85bafd8266ebea0c1e48e70f6e93fbbfbeecd/src/mbgl/style/style.cpp#L100-L101). Instead, they must wait until the style has finished loading, in `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]`.

We want developers to have a way of knowing whether the style has finished loading so they can easily find out why their runtime styling code isn’t working as expected. The problem with adding a warning in `-style`, as #7639 does, is that we’d assume the developer intends to use the MGLStyle object they obtain from `MGLMapView.style`. So if the developer calls the `style` getter to check whether the style has loaded, they get console spew. It turns out that, if the developer adds a key-value observer (or binding) to the `style` key, the KVO system calls the `style` getter even just before the style is set (as a side effect of `-willChangeValueForKey:`).

This PR avoids that whole mess by preventing the developer from accessing MGLStyle until MGLStyle can be used fruitfully. Swift developers must acknowledge the possibility that `style` isn’t set yet. Unfortunately, Objective-C developers will have little indication as to the problem without stepping in the debugger.

Fixes #7512.

/ref https://github.com/mapbox/mapbox-gl-native/pull/7639#issuecomment-271427589
/cc @boundsj @ericrwolfe @incanus @frederoni @friedbunny @jfirebaugh