### PR TITLE
Fix miscellaneous static analyzer warnings

### DIFF
--- a/platform/darwin/src/MGLNetworkConfiguration.m
+++ b/platform/darwin/src/MGLNetworkConfiguration.m
@@ -1,5 +1,4 @@
 #import "MGLNetworkConfiguration.h"
-#import "NSProcessInfo+MGLAdditions.h"
 
 @implementation MGLNetworkConfiguration
 
@@ -12,9 +11,6 @@
 }
 
 + (instancetype)sharedManager {
-    if (NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent) {
-        return nil;
-    }
     static dispatch_once_t onceToken;
     static MGLNetworkConfiguration *_sharedManager;
     void (^setupBlock)() = ^{

--- a/platform/darwin/src/MGLRasterSource.mm
+++ b/platform/darwin/src/MGLRasterSource.mm
@@ -51,7 +51,7 @@ static const CGFloat MGLRasterSourceRetinaTileSize = 512;
     if (self = [super initWithIdentifier:identifier tileURLTemplates:tileURLTemplates options:options]) {
         mbgl::Tileset tileSet = MGLTileSetFromTileURLTemplates(tileURLTemplates, options);
         
-        uint16_t tileSize;
+        uint16_t tileSize = MGLRasterSourceRetinaTileSize;
         if (NSNumber *tileSizeNumber = options[MGLTileSourceOptionTileSize]) {
             if (![tileSizeNumber isKindOfClass:[NSNumber class]]) {
                 [NSException raise:NSInvalidArgumentException

--- a/platform/darwin/src/MGLShape.mm
+++ b/platform/darwin/src/MGLShape.mm
@@ -94,9 +94,7 @@ bool operator==(const CLLocationCoordinate2D lhs, const CLLocationCoordinate2D r
 
 - (NSUInteger)hash
 {
-    NSUInteger hash;
-    hash += _title.hash;
-    hash += _subtitle.hash;
+    NSUInteger hash = _title.hash + _subtitle.hash;
 #if !TARGET_OS_IPHONE
     hash += _toolTip.hash;
 #endif

--- a/platform/ios/src/MGLAnnotationImage.m
+++ b/platform/ios/src/MGLAnnotationImage.m
@@ -57,15 +57,11 @@
     
     return ((!_reuseIdentifier && !otherAnnotationImage.reuseIdentifier) || [_reuseIdentifier isEqualToString:otherAnnotationImage.reuseIdentifier])
     && _enabled == otherAnnotationImage.enabled
-    && ((!_image && !otherAnnotationImage.image) || [UIImagePNGRepresentation(_image) isEqualToData:UIImagePNGRepresentation(otherAnnotationImage.image)]);
+    && ((!_image && !otherAnnotationImage.image) || [_image isEqual:otherAnnotationImage.image]);
 }
 
 - (NSUInteger)hash {
-    NSUInteger hash;
-    hash += [_reuseIdentifier hash];
-    hash += _enabled;
-    hash += [_image hash];
-    return hash;
+    return _reuseIdentifier.hash + _enabled + _image.hash;
 }
 
 - (void)setImage:(UIImage *)image {

--- a/platform/ios/src/MGLAnnotationImage.m
+++ b/platform/ios/src/MGLAnnotationImage.m
@@ -55,9 +55,10 @@
     
     MGLAnnotationImage *otherAnnotationImage = other;
     
-    return ((!_reuseIdentifier && !otherAnnotationImage.reuseIdentifier) || [_reuseIdentifier isEqualToString:otherAnnotationImage.reuseIdentifier])
+    return ((!_reuseIdentifier && !otherAnnotationImage.reuseIdentifier)
+            || [_reuseIdentifier isEqualToString:otherAnnotationImage.reuseIdentifier])
     && _enabled == otherAnnotationImage.enabled
-    && ((!_image && !otherAnnotationImage.image) || [_image isEqual:otherAnnotationImage.image]);
+    && (_image == otherAnnotationImage.image || [UIImagePNGRepresentation(_image) isEqualToData:UIImagePNGRepresentation(otherAnnotationImage.image)]);
 }
 
 - (NSUInteger)hash {

--- a/platform/macos/src/MGLAnnotationImage.m
+++ b/platform/macos/src/MGLAnnotationImage.m
@@ -53,7 +53,7 @@
     return ((!_reuseIdentifier && !otherAnnotationImage.reuseIdentifier) || [_reuseIdentifier isEqualToString:otherAnnotationImage.reuseIdentifier])
     && _selectable == otherAnnotationImage.selectable
     && ((!_cursor && !otherAnnotationImage.cursor) || [_cursor isEqual:otherAnnotationImage.cursor])
-    && ((!_image && !otherAnnotationImage.image) || [[_image TIFFRepresentation] isEqualToData:[otherAnnotationImage.image TIFFRepresentation]]);
+    && (_image == otherAnnotationImage.image || [[_image TIFFRepresentation] isEqualToData:[otherAnnotationImage.image TIFFRepresentation]]);
 }
 
 - (NSUInteger)hash {

--- a/platform/macos/src/MGLAnnotationImage.m
+++ b/platform/macos/src/MGLAnnotationImage.m
@@ -57,11 +57,7 @@
 }
 
 - (NSUInteger)hash {
-    NSUInteger hash;
-    hash += [_reuseIdentifier hash];
-    hash += _selectable;
-    hash += [_image hash];
-    return hash;
+    return _reuseIdentifier.hash + @(_selectable).hash + _image.hash;
 }
 
 @end

--- a/platform/macos/src/NSImage+MGLAdditions.mm
+++ b/platform/macos/src/NSImage+MGLAdditions.mm
@@ -6,7 +6,7 @@
     std::string png = encodePNG(spriteImage->image);
     NSData *data = [[NSData alloc] initWithBytes:png.data() length:png.size()];
     NSBitmapImageRep *rep = [NSBitmapImageRep imageRepWithData:data];
-    if ([self initWithSize:NSMakeSize(spriteImage->getWidth(), spriteImage->getHeight())]) {
+    if (self = [self initWithSize:NSMakeSize(spriteImage->getWidth(), spriteImage->getHeight())]) {
         [self addRepresentation:rep];
         [self setTemplate:spriteImage->sdf];
     }


### PR DESCRIPTION
This PR fixes the following static analyzer warnings, which were introduced in #6709, #7377, #6559, and #7300:

```
/path/to/mapbox-gl-native/platform/darwin/src/MGLNetworkConfiguration.m:16:9: Null is returned from a method that is expected to return a non-null value
/path/to/mapbox-gl-native/platform/darwin/src/MGLRasterSource.mm:63:23: Function call argument is an uninitialized value (within a call to 'make_unique')
/path/to/mapbox-gl-native/platform/darwin/src/MGLShape.mm:98:10: The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage
/path/to/mapbox-gl-native/platform/ios/src/MGLAnnotationImage.m:60:54: Null passed to a callee that requires a non-null 1st parameter
/path/to/mapbox-gl-native/platform/ios/src/MGLAnnotationImage.m:65:10: The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage
/path/to/mapbox-gl-native/platform/macos/src/MGLAnnotationImage.m:61:10: The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage
/path/to/mapbox-gl-native/platform/macos/src/NSImage+MGLAdditions.mm:13:5: Returning 'self' while it is not set to the result of '[(super or self) init...]'
```

Working towards #7668.

/cc @frederoni @incanus