### PR TITLE
Flush telemetry cache when data collection is paused

### DIFF
--- a/platform/ios/src/MGLAPIClient.h
+++ b/platform/ios/src/MGLAPIClient.h
@@ -9,7 +9,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)postEvents:(NS_ARRAY_OF(MGLMapboxEventAttributes *) *)events completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
 - (void)postEvent:(MGLMapboxEventAttributes *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
-- (void)cancelAll;
 
 @end
 

--- a/platform/ios/src/MGLAPIClient.m
+++ b/platform/ios/src/MGLAPIClient.m
@@ -21,7 +21,6 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
 @property (nonatomic, copy) NSData *geoTrustCert;
 @property (nonatomic, copy) NSData *testServerCert;
 @property (nonatomic, copy) NSString *userAgent;
-@property (nonatomic) NSMutableArray *dataTasks;
 @property (nonatomic) BOOL usesTestServer;
 
 @end
@@ -33,7 +32,6 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
     if (self) {
         _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
                                                  delegate:self delegateQueue:nil];
-        _dataTasks = [NSMutableArray array];
         [self loadCertificates];
         [self setupBaseURL];
         [self setupUserAgent];
@@ -59,22 +57,13 @@ static NSString * const MGLAPIClientHTTPMethodPost = @"POST";
             error = error ?: statusError;
             completionHandler(error);
         }
-        [self.dataTasks removeObject:dataTask];
         dataTask = nil;
     }];
     [dataTask resume];
-    if (dataTask) {
-        [self.dataTasks addObject:dataTask];
-    }
 }
 
 - (void)postEvent:(nonnull MGLMapboxEventAttributes *)event completionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler {
     [self postEvents:@[event] completionHandler:completionHandler];
-}
-
-- (void)cancelAll {
-    [self.dataTasks makeObjectsPerformSelector:@selector(cancel)];
-    [self.dataTasks removeAllObjects];
 }
 
 #pragma mark Utilities

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -434,21 +434,15 @@ const NSTimeInterval MGLFlushInterval = 180;
     return nil;
 }
 
-- (void)updateDictionary:(NSMutableDictionary *)dictionary withKey:(NSString *)key value:(id)value {
-    if (key && value) {
-        [dictionary setValue:value forKey:key];
-    }
-}
-
 - (MGLMapboxEventAttributes *)locationEventWithAttributes:(MGLMapboxEventAttributes *)attributeDictionary {
     MGLMutableMapboxEventAttributes *attributes = [NSMutableDictionary dictionary];
-    [self updateDictionary:attributes withKey:MGLEventKeyEvent value:MGLEventTypeLocation];
-    [self updateDictionary:attributes withKey:MGLEventKeySource value:MGLEventSource];
-    [self updateDictionary:attributes withKey:MGLEventKeySessionId value:self.instanceID];
-    [self updateDictionary:attributes withKey:MGLEventKeyOperatingSystem value:self.data.iOSVersion];
+    attributes[MGLEventKeyEvent] = MGLEventTypeLocation;
+    attributes[MGLEventKeySource] = MGLEventSource;
+    attributes[MGLEventKeySessionId] = self.instanceID;
+    attributes[MGLEventKeyOperatingSystem] = self.data.iOSVersion;
     NSString *currentApplicationState = [self applicationState];
     if (![currentApplicationState isEqualToString:MGLApplicationStateUnknown]) {
-        [self updateDictionary:attributes withKey:MGLEventKeyApplicationState value:currentApplicationState];
+        attributes[MGLEventKeyApplicationState] = currentApplicationState;
     }
 
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
@@ -456,37 +450,37 @@ const NSTimeInterval MGLFlushInterval = 180;
 
 - (MGLMapboxEventAttributes *)mapLoadEventWithAttributes:(MGLMapboxEventAttributes *)attributeDictionary {
     MGLMutableMapboxEventAttributes *attributes = [NSMutableDictionary dictionary];
-    [self updateDictionary:attributes withKey:MGLEventKeyEvent value:MGLEventTypeMapLoad];
-    [self updateDictionary:attributes withKey:MGLEventKeyCreated value:[self.rfc3339DateFormatter stringFromDate:[NSDate date]]];
-    [self updateDictionary:attributes withKey:MGLEventKeyVendorID value:self.data.vendorId];
-    [self updateDictionary:attributes withKey:MGLEventKeyModel value:self.data.model];
-    [self updateDictionary:attributes withKey:MGLEventKeyOperatingSystem value:self.data.iOSVersion];
-    [self updateDictionary:attributes withKey:MGLEventKeyResolution value:@(self.data.scale)];
-    [self updateDictionary:attributes withKey:MGLEventKeyAccessibilityFontScale value:@([self contentSizeScale])];
-    [self updateDictionary:attributes withKey:MGLEventKeyOrientation value:[self deviceOrientation]];
-    [self updateDictionary:attributes withKey:MGLEventKeyWifi value:@([[MGLReachability reachabilityForLocalWiFi] isReachableViaWiFi])];
+    attributes[MGLEventKeyEvent] = MGLEventTypeMapLoad;
+    attributes[MGLEventKeyCreated] = [self.rfc3339DateFormatter stringFromDate:[NSDate date]];
+    attributes[MGLEventKeyVendorID] = self.data.vendorId;
+    attributes[MGLEventKeyModel] = self.data.model;
+    attributes[MGLEventKeyOperatingSystem] = self.data.iOSVersion;
+    attributes[MGLEventKeyResolution] = @(self.data.scale);
+    attributes[MGLEventKeyAccessibilityFontScale] = @([self contentSizeScale]);
+    attributes[MGLEventKeyOrientation] = [self deviceOrientation];
+    attributes[MGLEventKeyWifi] = @([[MGLReachability reachabilityForLocalWiFi] isReachableViaWiFi]);
 
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
 }
 
 - (MGLMapboxEventAttributes *)mapClickEventWithAttributes:(MGLMapboxEventAttributes *)attributeDictionary {
     MGLMutableMapboxEventAttributes *attributes = [self interactionEvent];
-    [self updateDictionary:attributes withKey:MGLEventKeyEvent value:MGLEventTypeMapTap];
+    attributes[MGLEventKeyEvent] = MGLEventTypeMapTap;
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
 }
 
 - (MGLMapboxEventAttributes *)mapDragEndEventWithAttributes:(MGLMapboxEventAttributes *)attributeDictionary {
     MGLMutableMapboxEventAttributes *attributes = [self interactionEvent];
-    [self updateDictionary:attributes withKey:MGLEventKeyEvent value:MGLEventTypeMapDragEnd];
+    attributes[MGLEventKeyEvent] = MGLEventTypeMapDragEnd;
 
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
 }
 
 - (MGLMutableMapboxEventAttributes *)interactionEvent {
     MGLMutableMapboxEventAttributes *attributes = [NSMutableDictionary dictionary];
-    [self updateDictionary:attributes withKey:MGLEventKeyCreated value:[self.rfc3339DateFormatter stringFromDate:[NSDate date]]];
-    [self updateDictionary:attributes withKey:MGLEventKeyOrientation value:[self deviceOrientation]];
-    [self updateDictionary:attributes withKey:MGLEventKeyWifi value:@([[MGLReachability reachabilityForLocalWiFi] isReachableViaWiFi])];
+    attributes[MGLEventKeyCreated] = [self.rfc3339DateFormatter stringFromDate:[NSDate date]];
+    attributes[MGLEventKeyOrientation] = [self deviceOrientation];
+    attributes[MGLEventKeyWifi] = @([[MGLReachability reachabilityForLocalWiFi] isReachableViaWiFi]);
 
     return attributes;
 }

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -278,6 +278,7 @@ const NSTimeInterval MGLFlushInterval = 180;
     if (self.paused && enabled) {
         [self resumeMetricsCollection];
     } else if (!self.paused && !enabled) {
+        [self flush];
         [self pauseMetricsCollection];
     }
 }
@@ -433,51 +434,63 @@ const NSTimeInterval MGLFlushInterval = 180;
     return nil;
 }
 
+- (void)updateDictionary:(NSMutableDictionary *)dictionary withKey:(NSString *)key value:(id)value {
+    if (key && value) {
+        [dictionary setValue:value forKey:key];
+    }
+}
+
 - (MGLMapboxEventAttributes *)locationEventWithAttributes:(MGLMapboxEventAttributes *)attributeDictionary {
-    MGLMutableMapboxEventAttributes *attributes = [@{MGLEventKeyEvent: MGLEventTypeLocation,
-                                                     MGLEventKeySource: MGLEventSource,
-                                                     MGLEventKeySessionId: self.instanceID,
-                                                     MGLEventKeyOperatingSystem: self.data.iOSVersion} mutableCopy];
+    MGLMutableMapboxEventAttributes *attributes = [NSMutableDictionary dictionary];
+    [self updateDictionary:attributes withKey:MGLEventKeyEvent value:MGLEventTypeLocation];
+    [self updateDictionary:attributes withKey:MGLEventKeySource value:MGLEventSource];
+    [self updateDictionary:attributes withKey:MGLEventKeySessionId value:self.instanceID];
+    [self updateDictionary:attributes withKey:MGLEventKeyOperatingSystem value:self.data.iOSVersion];
     [self addApplicationStateToAttributes:attributes];
+
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
 }
 
 - (MGLMapboxEventAttributes *)mapLoadEventWithAttributes:(MGLMapboxEventAttributes *)attributeDictionary {
-    MGLMutableMapboxEventAttributes *attributes = [@{MGLEventKeyEvent: MGLEventTypeMapLoad,
-                                                     MGLEventKeyCreated: [self.rfc3339DateFormatter stringFromDate:[NSDate date]],
-                                                     MGLEventKeyVendorID: self.data.vendorId,
-                                                     MGLEventKeyModel: self.data.model,
-                                                     MGLEventKeyOperatingSystem: self.data.iOSVersion,
-                                                     MGLEventKeyResolution: @(self.data.scale),
-                                                     MGLEventKeyAccessibilityFontScale: @([self contentSizeScale]),
-                                                     MGLEventKeyOrientation: [self deviceOrientation],
-                                                     MGLEventKeyWifi: @([[MGLReachability reachabilityForLocalWiFi] isReachableViaWiFi])} mutableCopy];
-    [self addBatteryStateToAttributes:attributes];
+    MGLMutableMapboxEventAttributes *attributes = [NSMutableDictionary dictionary];
+    [self updateDictionary:attributes withKey:MGLEventKeyEvent value:MGLEventTypeMapLoad];
+    [self updateDictionary:attributes withKey:MGLEventKeyCreated value:[self.rfc3339DateFormatter stringFromDate:[NSDate date]]];
+    [self updateDictionary:attributes withKey:MGLEventKeyVendorID value:self.data.vendorId];
+    [self updateDictionary:attributes withKey:MGLEventKeyModel value:self.data.model];
+    [self updateDictionary:attributes withKey:MGLEventKeyOperatingSystem value:self.data.iOSVersion];
+    [self updateDictionary:attributes withKey:MGLEventKeyResolution value:@(self.data.scale)];
+    [self updateDictionary:attributes withKey:MGLEventKeyAccessibilityFontScale value:@([self contentSizeScale])];
+    [self updateDictionary:attributes withKey:MGLEventKeyOrientation value:[self deviceOrientation]];
+    [self updateDictionary:attributes withKey:MGLEventKeyWifi value:@([[MGLReachability reachabilityForLocalWiFi] isReachableViaWiFi])];
+
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
 }
 
 - (MGLMapboxEventAttributes *)mapClickEventWithAttributes:(MGLMapboxEventAttributes *)attributeDictionary {
     MGLMutableMapboxEventAttributes *attributes = [self interactionEvent];
-    attributes[MGLEventKeyEvent] = MGLEventTypeMapTap;
+    [self updateDictionary:attributes withKey:MGLEventKeyEvent value:MGLEventTypeMapTap];
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
 }
 
 - (MGLMapboxEventAttributes *)mapDragEndEventWithAttributes:(MGLMapboxEventAttributes *)attributeDictionary {
     MGLMutableMapboxEventAttributes *attributes = [self interactionEvent];
-    attributes[MGLEventKeyEvent] = MGLEventTypeMapDragEnd;
+    [self updateDictionary:attributes withKey:MGLEventKeyEvent value:MGLEventTypeMapDragEnd];
+
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
 }
 
 - (MGLMutableMapboxEventAttributes *)interactionEvent {
-    MGLMutableMapboxEventAttributes *attributes = [@{MGLEventKeyCreated: [self.rfc3339DateFormatter stringFromDate:[NSDate date]],
-                                                     MGLEventKeyOrientation: [self deviceOrientation],
-                                                     MGLEventKeyWifi: @([[MGLReachability reachabilityForLocalWiFi] isReachableViaWiFi])} mutableCopy];
-    [self addBatteryStateToAttributes:attributes];
+    MGLMutableMapboxEventAttributes *attributes = [NSMutableDictionary dictionary];
+    [self updateDictionary:attributes withKey:MGLEventKeyCreated value:[self.rfc3339DateFormatter stringFromDate:[NSDate date]]];
+    [self updateDictionary:attributes withKey:MGLEventKeyOrientation value:[self deviceOrientation]];
+    [self updateDictionary:attributes withKey:MGLEventKeyWifi value:@([[MGLReachability reachabilityForLocalWiFi] isReachableViaWiFi])];
+
     return attributes;
 }
 
 - (MGLMapboxEventAttributes *)eventForAttributes:(MGLMutableMapboxEventAttributes *)attributes attributeDictionary:(MGLMapboxEventAttributes *)attributeDictionary {
     [attributes addEntriesFromDictionary:attributeDictionary];
+
     return [attributes copy];
 }
 

--- a/platform/ios/src/MGLMapboxEvents.m
+++ b/platform/ios/src/MGLMapboxEvents.m
@@ -446,7 +446,10 @@ const NSTimeInterval MGLFlushInterval = 180;
     [self updateDictionary:attributes withKey:MGLEventKeySource value:MGLEventSource];
     [self updateDictionary:attributes withKey:MGLEventKeySessionId value:self.instanceID];
     [self updateDictionary:attributes withKey:MGLEventKeyOperatingSystem value:self.data.iOSVersion];
-    [self addApplicationStateToAttributes:attributes];
+    NSString *currentApplicationState = [self applicationState];
+    if (![currentApplicationState isEqualToString:MGLApplicationStateUnknown]) {
+        [self updateDictionary:attributes withKey:MGLEventKeyApplicationState value:currentApplicationState];
+    }
 
     return [self eventForAttributes:attributes attributeDictionary:attributeDictionary];
 }
@@ -605,29 +608,6 @@ const NSTimeInterval MGLFlushInterval = 180;
     }
     
     return result;
-}
-
-- (void)addBatteryStateToAttributes:(MGLMutableMapboxEventAttributes *)attributes {
-    UIDeviceBatteryState batteryState = [[UIDevice currentDevice] batteryState];
-    switch (batteryState) {
-        case UIDeviceBatteryStateCharging:
-        case UIDeviceBatteryStateFull:
-            attributes[MGLEventKeyPluggedIn] = @(YES);
-            break;
-        case UIDeviceBatteryStateUnplugged:
-            attributes[MGLEventKeyPluggedIn] = @(NO);
-            break;
-        default:
-            // do nothing
-            break;
-    }
-}
-
-- (void)addApplicationStateToAttributes:(MGLMutableMapboxEventAttributes *)attributes {
-    NSString *currentApplicationState = [self applicationState];
-    if (![currentApplicationState isEqualToString:MGLApplicationStateUnknown]) {
-        attributes[MGLEventKeyApplicationState] = currentApplicationState;
-    }
 }
 
 + (void)ensureMetricsOptoutExists {


### PR DESCRIPTION
This flushes the cache just before pausing so that data collected before the pause is not thrown away. It also refactors event creation to avoid possible nil value inserts into dictionaries
and adds a small optimization to avoid creating immutable dictionaries to help create mutable ones.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/7578