### PR TITLE
[android] - improved fling gesture 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -50,7 +50,12 @@ public class MapboxConstants {
   /**
    * Animation time of a fling gesture
    */
-  public static final long ANIMATION_DURATION_FLING = 350;
+  public static final long ANIMATION_DURATION_FLING_BASE = ANIMATION_DURATION_SHORT;
+
+  /**
+   * Velocity threshold for a fling gesture
+   */
+  public static final long VELOCITY_THRESHOLD_IGNORE_FLING = 1000;
 
   /**
    * The currently supported minimum zoom level.


### PR DESCRIPTION
This PR attempts to improve our fling gesture with:
 - ignore small fling gestures that can occur after other gestures (see https://github.com/mapbox/mapbox-gl-native/issues/7536 for more information)
 - calculate animation duration based on the velocity of the fling see https://github.com/mapbox/mapbox-gl-native/issues/7549#issuecomment-271207473.

This solution relies on https://github.com/mapbox/mapbox-gl-native/pull/7675 getting merged first.