### PR TITLE
Convert DefaultFileSource and dependents to actor model

### DIFF
--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -35,8 +35,8 @@ public:
     util::RunLoop loop;
     HeadlessBackend backend;
     OffscreenView view{ backend.getContext(), { 1000, 1000 } };
-    DefaultFileSource fileSource{ "benchmark/fixtures/api/cache.db", "." };
     ThreadPool threadPool{ 4, { "Worker" } };
+    DefaultFileSource fileSource{ threadPool, "benchmark/fixtures/api/cache.db", "." };
     Map map{ backend, view.size, 1, fileSource, threadPool, MapMode::Still };
     ScreenBox box{{ 0, 0 }, { 1000, 1000 }};
 };

--- a/benchmark/api/query.benchmark.cpp
+++ b/benchmark/api/query.benchmark.cpp
@@ -36,7 +36,7 @@ public:
     HeadlessBackend backend;
     OffscreenView view{ backend.getContext(), { 1000, 1000 } };
     DefaultFileSource fileSource{ "benchmark/fixtures/api/cache.db", "." };
-    ThreadPool threadPool{ 4 };
+    ThreadPool threadPool{ 4, { "Worker" } };
     Map map{ backend, view.size, 1, fileSource, threadPool, MapMode::Still };
     ScreenBox box{{ 0, 0 }, { 1000, 1000 }};
 };

--- a/bin/offline.cpp
+++ b/bin/offline.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/util/default_styles.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/io.hpp>
 
@@ -55,7 +56,8 @@ int main(int argc, char *argv[]) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    DefaultFileSource fileSource(output, ".");
+    ThreadPool threadPool{ 2, { "Worker" } };
+    DefaultFileSource fileSource(threadPool, output, ".");
     std::unique_ptr<OfflineRegion> region;
 
     fileSource.setAccessToken(token);

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -69,7 +69,8 @@ int main(int argc, char *argv[]) {
     using namespace mbgl;
 
     util::RunLoop loop;
-    DefaultFileSource fileSource(cache_file, asset_root);
+    ThreadPool threadPool(4, { "Worker" });
+    DefaultFileSource fileSource(threadPool, cache_file, asset_root);
 
     // Try to load the token from the environment.
     if (!token.size()) {
@@ -86,7 +87,6 @@ int main(int argc, char *argv[]) {
 
     HeadlessBackend backend;
     OffscreenView view(backend.getContext(), { width * pixelRatio, height * pixelRatio });
-    ThreadPool threadPool(4, { "Worker" });
     Map map(backend, mbgl::Size { width, height }, pixelRatio, fileSource, threadPool, MapMode::Still);
 
     if (util::isURL(style_path)) {

--- a/bin/render.cpp
+++ b/bin/render.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
 
     HeadlessBackend backend;
     OffscreenView view(backend.getContext(), { width * pixelRatio, height * pixelRatio });
-    ThreadPool threadPool(4);
+    ThreadPool threadPool(4, { "Worker" });
     Map map(backend, mbgl::Size { width, height }, pixelRatio, fileSource, threadPool, MapMode::Still);
 
     if (util::isURL(style_path)) {

--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -8,6 +8,8 @@
 
 namespace mbgl {
 
+class Scheduler;
+
 namespace util {
 template <typename T> class Thread;
 } // namespace util
@@ -21,7 +23,8 @@ public:
      * regions, we want the database to remain fairly small (order tens or low hundreds
      * of megabytes).
      */
-    DefaultFileSource(const std::string& cachePath,
+    DefaultFileSource(Scheduler&,
+                      const std::string& cachePath,
                       const std::string& assetRoot,
                       uint64_t maximumCacheSize = util::DEFAULT_MAX_CACHE_SIZE);
     ~DefaultFileSource() override;

--- a/platform/android/src/asset_file_source.cpp
+++ b/platform/android/src/asset_file_source.cpp
@@ -35,15 +35,6 @@ struct ZipFileHolder {
 
 namespace mbgl {
 
-class AssetFileRequest : public AsyncRequest {
-public:
-    AssetFileRequest(std::unique_ptr<WorkRequest> workRequest_)
-        : workRequest(std::move(workRequest_)) {
-    }
-
-    std::unique_ptr<WorkRequest> workRequest;
-};
-
 class AssetFileSource::Impl {
 public:
     Impl(const std::string& root_)

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -11,6 +11,7 @@
 #include "jni.hpp"
 #include "java_types.hpp"
 #include "native_map_view.hpp"
+#include "shared_thread_pool.hpp"
 #include "connectivity_listener.hpp"
 #include "style/layers/layers.hpp"
 #include "style/sources/sources.hpp"
@@ -1236,7 +1237,8 @@ void nativeScheduleTakeSnapshot(JNIEnv *env, jni::jobject* obj, jlong nativeMapV
 jlong createDefaultFileSource(JNIEnv *env, jni::jobject* obj, jni::jstring* cachePath_, jni::jstring* assetRoot_, jlong maximumCacheSize) {
     std::string cachePath = std_string_from_jstring(env, cachePath_);
     std::string assetRoot = std_string_from_jstring(env, assetRoot_);
-    mbgl::DefaultFileSource *defaultFileSource = new mbgl::DefaultFileSource(cachePath, assetRoot, maximumCacheSize);
+    mbgl::DefaultFileSource* defaultFileSource = new mbgl::DefaultFileSource(
+        mbgl::android::sharedThreadPool(), cachePath, assetRoot, maximumCacheSize);
     jlong defaultFileSourcePtr = reinterpret_cast<jlong>(defaultFileSource);
     return defaultFileSourcePtr;
 }

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -41,7 +41,7 @@ NativeMapView::NativeMapView(JNIEnv *env_, jobject obj_, float pixelRatio, int a
     : env(env_),
       availableProcessors(availableProcessors_),
       totalMemory(totalMemory_),
-      threadPool(4) {
+      threadPool(4, { "Worker" }) {
     mbgl::Log::Debug(mbgl::Event::Android, "NativeMapView::NativeMapView");
 
     assert(env_ != nullptr);

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -4,7 +4,6 @@
 #include <mbgl/map/view.hpp>
 #include <mbgl/map/backend.hpp>
 #include <mbgl/util/noncopyable.hpp>
-#include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/storage/default_file_source.hpp>
 
 #include <string>
@@ -97,7 +96,6 @@ private:
 
     // Ensure these are initialised last
     std::unique_ptr<mbgl::DefaultFileSource> fileSource;
-    mbgl::ThreadPool threadPool;
     std::unique_ptr<mbgl::Map> map;
     mbgl::EdgeInsets insets;
 

--- a/platform/android/src/shared_thread_pool.hpp
+++ b/platform/android/src/shared_thread_pool.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <mbgl/util/default_thread_pool.hpp>
+
+namespace mbgl {
+namespace android {
+
+// May only be called from the main/UI thread.
+inline ThreadPool& sharedThreadPool() {
+    static ThreadPool threadPool{ 4, { "Worker" } };
+    return threadPool;
+}
+
+}
+}

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -5,6 +5,7 @@
 #import "MGLNetworkConfiguration.h"
 #import "MGLOfflinePack_Private.h"
 #import "MGLOfflineRegion_Private.h"
+#import "MGLThreadPool_Private.h"
 #import "MGLTilePyramidOfflineRegion.h"
 #import "NSValue+MGLAdditions.h"
 
@@ -130,7 +131,9 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
             [[NSFileManager defaultManager] moveItemAtPath:subdirectorylessCacheURL.path toPath:cachePath error:NULL];
         }
 
-        _mbglFileSource = new mbgl::DefaultFileSource(cachePath.UTF8String, [NSBundle mainBundle].resourceURL.path.UTF8String);
+        _mbglFileSource = new mbgl::DefaultFileSource(
+            *[MGLThreadPool sharedPool].mbglThreadPool, cachePath.UTF8String,
+            [NSBundle mainBundle].resourceURL.path.UTF8String);
 
         // Observe for changes to the API base URL (and find out the current one).
         [[MGLNetworkConfiguration sharedManager] addObserver:self

--- a/platform/darwin/src/MGLThreadPool.mm
+++ b/platform/darwin/src/MGLThreadPool.mm
@@ -1,0 +1,39 @@
+#import "MGLThreadPool_Private.h"
+
+#import "NSProcessInfo+MGLAdditions.h"
+
+@interface MGLThreadPool ()
+
+@property (nonatomic) mbgl::ThreadPool *mbglThreadPool;
+
+@end
+
+@implementation MGLThreadPool
+
+#pragma mark - Internal
+
++ (instancetype)sharedPool {
+    if (NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent) {
+        return nil;
+    }
+    static dispatch_once_t onceToken;
+    static MGLThreadPool *sharedThreadPool;
+    dispatch_once(&onceToken, ^{
+        sharedThreadPool = [[self alloc] init];
+    });
+    return sharedThreadPool;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _mbglThreadPool = new mbgl::ThreadPool(4, { "Worker" });
+    }
+    return self;
+}
+
+- (void)dealloc {
+    delete _mbglThreadPool;
+    _mbglThreadPool = nullptr;
+}
+
+@end

--- a/platform/darwin/src/MGLThreadPool_Private.h
+++ b/platform/darwin/src/MGLThreadPool_Private.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+#include <mbgl/util/default_thread_pool.hpp>
+
+@interface MGLThreadPool : NSObject
+@end
+
+@interface MGLThreadPool (Private)
+
+/// Returns the shared instance of the `MGLThreadPool` class.
++ (instancetype)sharedPool;
+
+/**
+ The shared thread pool object owned by the shared thread pool object.
+ */
+@property (nonatomic) mbgl::ThreadPool *mbglThreadPool;
+
+@end

--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -1,70 +1,115 @@
 #include <mbgl/storage/asset_file_source.hpp>
 #include <mbgl/storage/response.hpp>
+#include <mbgl/util/io.hpp>
 #include <mbgl/util/string.hpp>
-#include <mbgl/util/thread.hpp>
 #include <mbgl/util/url.hpp>
 #include <mbgl/util/util.hpp>
-#include <mbgl/util/io.hpp>
+#include <mbgl/util/run_loop.hpp>
 
-#include <sys/types.h>
+#include <mbgl/actor/actor.hpp>
+#include <mbgl/actor/actor_ref.hpp>
+
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 namespace mbgl {
 
 class AssetFileSource::Impl {
 public:
-    Impl(std::string root_)
-        : root(std::move(root_)) {
-    }
+    Impl(Scheduler&, const std::string& root);
 
-    void request(const std::string& url, FileSource::Callback callback) {
-        std::string path;
+    class Request;
+    std::unique_ptr<Request> readFile(const Resource&, Callback);
+    void respond(std::weak_ptr<Callback>, Response);
 
-        if (url.size() <= 8 || url[8] == '/') {
-            // This is an empty or absolute path.
-            path = mbgl::util::percentDecode(url.substr(8));
-        } else {
-            // This is a relative path. Prefix with the application root.
-            path = root + "/" + mbgl::util::percentDecode(url.substr(8));
-        }
+private:
+    std::shared_ptr<Mailbox> mailbox{ std::make_shared<Mailbox>(*util::RunLoop::Get()) };
+    class Worker {
+    public:
+        Worker(ActorRef<Worker>, ActorRef<Impl>, std::string root);
 
-        Response response;
+        void readFile(const std::string& url, std::weak_ptr<Callback>);
 
-        struct stat buf;
-        int result = stat(path.c_str(), &buf);
+    private:
+        ActorRef<Impl> impl;
+        const std::string root;
+    };
+    Actor<Worker> worker;
+};
 
-        if (result == 0 && S_ISDIR(buf.st_mode)) {
-            response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-        } else if (result == -1 && errno == ENOENT) {
-            response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-        } else {
-            try {
-                response.data = std::make_shared<std::string>(util::read_file(path));
-            } catch (...) {
-                response.error = std::make_unique<Response::Error>(
-                    Response::Error::Reason::Other,
-                    util::toString(std::current_exception()));
-            }
-        }
-
-        callback(response);
+class AssetFileSource::Impl::Request : public AsyncRequest {
+public:
+    Request(std::shared_ptr<Callback> callback_) : callback(std::move(callback_)) {
     }
 
 private:
-    std::string root;
+    std::shared_ptr<Callback> callback;
 };
 
-AssetFileSource::AssetFileSource(const std::string& root)
-    : thread(std::make_unique<util::Thread<Impl>>(
-        util::ThreadContext{"AssetFileSource", util::ThreadPriority::Low},
-        root)) {
+AssetFileSource::Impl::Worker::Worker(ActorRef<Worker>, ActorRef<Impl> impl_, std::string root_)
+    : impl(std::move(impl_)), root(std::move(root_)) {
+}
+
+void AssetFileSource::Impl::Worker::readFile(const std::string& url,
+                                             std::weak_ptr<Callback> callback) {
+    std::string path;
+
+    if (url.size() <= 8 || url[8] == '/') {
+        // This is an empty or absolute path.
+        path = mbgl::util::percentDecode(url.substr(8));
+    } else {
+        // This is a relative path. Prefix with the application root.
+        path = root + "/" + mbgl::util::percentDecode(url.substr(8));
+    }
+
+    Response response;
+
+    struct stat buf;
+    int result = stat(path.c_str(), &buf);
+
+    if (result == 0 && S_ISDIR(buf.st_mode)) {
+        response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
+    } else if (result == -1 && errno == ENOENT) {
+        response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
+    } else {
+        try {
+            response.data = std::make_shared<std::string>(util::read_file(path));
+        } catch (...) {
+            response.error = std::make_unique<Response::Error>(
+                Response::Error::Reason::Other, util::toString(std::current_exception()));
+        }
+    }
+
+    impl.invoke(&Impl::respond, callback, response);
+}
+
+AssetFileSource::Impl::Impl(Scheduler& scheduler, const std::string& root)
+    : worker(scheduler, ActorRef<Impl>(*this, mailbox), root) {
+}
+
+std::unique_ptr<AssetFileSource::Impl::Request>
+AssetFileSource::Impl::readFile(const Resource& resource, Callback callback) {
+    auto cb = std::make_shared<Callback>(std::move(callback));
+    worker.invoke(&Worker::readFile, resource.url, cb);
+    return std::make_unique<Request>(std::move(cb));
+}
+
+void AssetFileSource::Impl::respond(std::weak_ptr<Callback> callback, Response response) {
+    if (auto locked = callback.lock()) {
+        (*locked)(response);
+    }
+}
+
+AssetFileSource::AssetFileSource(Scheduler& scheduler, const std::string& root)
+    : impl(std::make_unique<Impl>(scheduler, root)) {
 }
 
 AssetFileSource::~AssetFileSource() = default;
 
-std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource, Callback callback) {
-    return thread->invokeWithCallback(&Impl::request, resource.url, callback);
+std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource,
+                                                       Callback callback) {
+    return impl->readFile(resource, std::move(callback));
 }
 
 } // namespace mbgl

--- a/platform/default/asset_file_source.cpp
+++ b/platform/default/asset_file_source.cpp
@@ -1,10 +1,10 @@
 #include <mbgl/storage/asset_file_source.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/util/io.hpp>
+#include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/url.hpp>
 #include <mbgl/util/util.hpp>
-#include <mbgl/util/run_loop.hpp>
 
 #include <mbgl/actor/actor.hpp>
 #include <mbgl/actor/actor_ref.hpp>
@@ -15,101 +15,77 @@
 
 namespace mbgl {
 
-class AssetFileSource::Impl {
+class AssetFileRequest : public AsyncRequest {
 public:
-    Impl(Scheduler&, const std::string& root);
-
-    class Request;
-    std::unique_ptr<Request> readFile(const Resource&, Callback);
-    void respond(std::weak_ptr<Callback>, Response);
-
-private:
-    std::shared_ptr<Mailbox> mailbox{ std::make_shared<Mailbox>(*util::RunLoop::Get()) };
-    class Worker {
-    public:
-        Worker(ActorRef<Worker>, ActorRef<Impl>, std::string root);
-
-        void readFile(const std::string& url, std::weak_ptr<Callback>);
-
-    private:
-        ActorRef<Impl> impl;
-        const std::string root;
-    };
-    Actor<Worker> worker;
-};
-
-class AssetFileSource::Impl::Request : public AsyncRequest {
-public:
-    Request(std::shared_ptr<Callback> callback_) : callback(std::move(callback_)) {
+    AssetFileRequest(std::shared_ptr<FileSource::Callback> callback_)
+        : callback(std::move(callback_)) {
     }
 
 private:
-    std::shared_ptr<Callback> callback;
+    std::shared_ptr<FileSource::Callback> callback;
 };
 
-AssetFileSource::Impl::Worker::Worker(ActorRef<Worker>, ActorRef<Impl> impl_, std::string root_)
-    : impl(std::move(impl_)), root(std::move(root_)) {
-}
-
-void AssetFileSource::Impl::Worker::readFile(const std::string& url,
-                                             std::weak_ptr<Callback> callback) {
-    std::string path;
-
-    if (url.size() <= 8 || url[8] == '/') {
-        // This is an empty or absolute path.
-        path = mbgl::util::percentDecode(url.substr(8));
-    } else {
-        // This is a relative path. Prefix with the application root.
-        path = root + "/" + mbgl::util::percentDecode(url.substr(8));
+class AssetFileSource::Worker {
+public:
+    Worker(ActorRef<Worker>, ActorRef<AssetFileSource> parent_, std::string root_)
+        : parent(std::move(parent_)), root(std::move(root_)) {
     }
+    void readFile(const std::string& url, std::weak_ptr<Callback> callback) {
+        std::string path;
 
-    Response response;
-
-    struct stat buf;
-    int result = stat(path.c_str(), &buf);
-
-    if (result == 0 && S_ISDIR(buf.st_mode)) {
-        response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-    } else if (result == -1 && errno == ENOENT) {
-        response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
-    } else {
-        try {
-            response.data = std::make_shared<std::string>(util::read_file(path));
-        } catch (...) {
-            response.error = std::make_unique<Response::Error>(
-                Response::Error::Reason::Other, util::toString(std::current_exception()));
+        if (url.size() <= 8 || url[8] == '/') {
+            // This is an empty or absolute path.
+            path = mbgl::util::percentDecode(url.substr(8));
+        } else {
+            // This is a relative path. Prefix with the application root.
+            path = root + "/" + mbgl::util::percentDecode(url.substr(8));
         }
+
+        Response response;
+
+        struct stat buf;
+        int result = stat(path.c_str(), &buf);
+
+        if (result == 0 && S_ISDIR(buf.st_mode)) {
+            response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
+        } else if (result == -1 && errno == ENOENT) {
+            response.error = std::make_unique<Response::Error>(Response::Error::Reason::NotFound);
+        } else {
+            try {
+                response.data = std::make_shared<std::string>(util::read_file(path));
+            } catch (...) {
+                response.error = std::make_unique<Response::Error>(
+                    Response::Error::Reason::Other, util::toString(std::current_exception()));
+            }
+        }
+
+        parent.invoke(&AssetFileSource::respond, callback, response);
     }
 
-    impl.invoke(&Impl::respond, callback, response);
-}
-
-AssetFileSource::Impl::Impl(Scheduler& scheduler, const std::string& root)
-    : worker(scheduler, ActorRef<Impl>(*this, mailbox), root) {
-}
-
-std::unique_ptr<AssetFileSource::Impl::Request>
-AssetFileSource::Impl::readFile(const Resource& resource, Callback callback) {
-    auto cb = std::make_shared<Callback>(std::move(callback));
-    worker.invoke(&Worker::readFile, resource.url, cb);
-    return std::make_unique<Request>(std::move(cb));
-}
-
-void AssetFileSource::Impl::respond(std::weak_ptr<Callback> callback, Response response) {
-    if (auto locked = callback.lock()) {
-        (*locked)(response);
-    }
-}
+private:
+    ActorRef<AssetFileSource> parent;
+    const std::string root;
+};
 
 AssetFileSource::AssetFileSource(Scheduler& scheduler, const std::string& root)
-    : impl(std::make_unique<Impl>(scheduler, root)) {
+    : mailbox(std::make_shared<Mailbox>(*util::RunLoop::Get())),
+      worker(std::make_unique<Actor<Worker>>(
+          scheduler, ActorRef<AssetFileSource>(*this, mailbox), root)) {
 }
 
 AssetFileSource::~AssetFileSource() = default;
 
 std::unique_ptr<AsyncRequest> AssetFileSource::request(const Resource& resource,
                                                        Callback callback) {
-    return impl->readFile(resource, std::move(callback));
+    auto cb = std::make_shared<Callback>(std::move(callback));
+    worker->invoke(&Worker::readFile, resource.url, cb);
+    return std::make_unique<AssetFileRequest>(std::move(cb));
+}
+
+void AssetFileSource::respond(std::weak_ptr<Callback> callback, Response response) {
+    if (auto locked = callback.lock()) {
+        (*locked)(response);
+    }
 }
 
 } // namespace mbgl

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -160,13 +160,13 @@ private:
     std::unordered_map<int64_t, std::unique_ptr<OfflineDownload>> downloads;
 };
 
-DefaultFileSource::DefaultFileSource(Scheduler&,
+DefaultFileSource::DefaultFileSource(Scheduler& scheduler,
                                      const std::string& cachePath,
                                      const std::string& assetRoot,
                                      uint64_t maximumCacheSize)
     : thread(std::make_unique<util::Thread<Impl>>(util::ThreadContext{"DefaultFileSource", util::ThreadPriority::Low},
             cachePath, maximumCacheSize)),
-      assetFileSource(std::make_unique<AssetFileSource>(assetRoot)),
+      assetFileSource(std::make_unique<AssetFileSource>(scheduler, assetRoot)),
       localFileSource(std::make_unique<LocalFileSource>()) {
 }
 

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -160,7 +160,8 @@ private:
     std::unordered_map<int64_t, std::unique_ptr<OfflineDownload>> downloads;
 };
 
-DefaultFileSource::DefaultFileSource(const std::string& cachePath,
+DefaultFileSource::DefaultFileSource(Scheduler&,
+                                     const std::string& cachePath,
                                      const std::string& assetRoot,
                                      uint64_t maximumCacheSize)
     : thread(std::make_unique<util::Thread<Impl>>(util::ThreadContext{"DefaultFileSource", util::ThreadPriority::Low},

--- a/platform/default/mbgl/util/default_thread_pool.cpp
+++ b/platform/default/mbgl/util/default_thread_pool.cpp
@@ -1,12 +1,18 @@
 #include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/actor/mailbox.hpp>
+#include <mbgl/util/platform.hpp>
 
 namespace mbgl {
 
-ThreadPool::ThreadPool(std::size_t count) {
+ThreadPool::ThreadPool(std::size_t count, const util::ThreadContext& context) {
     threads.reserve(count);
     for (std::size_t i = 0; i < count; ++i) {
-        threads.emplace_back([this] () {
+        threads.emplace_back([this, context] () {
+            platform::setCurrentThreadName(context.name);
+            if (context.priority == util::ThreadPriority::Low) {
+                platform::makeThreadLowPriority();
+            }
+
             while (true) {
                 std::unique_lock<std::mutex> lock(mutex);
 

--- a/platform/default/mbgl/util/default_thread_pool.hpp
+++ b/platform/default/mbgl/util/default_thread_pool.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/actor/scheduler.hpp>
+#include <mbgl/util/thread_context.hpp>
 
 #include <condition_variable>
 #include <mutex>
@@ -11,7 +12,7 @@ namespace mbgl {
 
 class ThreadPool : public Scheduler {
 public:
-    ThreadPool(std::size_t count);
+    ThreadPool(std::size_t count, const util::ThreadContext&);
     ~ThreadPool() override;
 
     void schedule(std::weak_ptr<Mailbox>) override;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
         fileSource.setAccessToken(std::string(token));
     }
 
-    mbgl::ThreadPool threadPool(4);
+    mbgl::ThreadPool threadPool(4, { "Worker" });
 
     mbgl::Map map(backend, view->getSize(), view->getPixelRatio(), fileSource, threadPool);
 

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -108,7 +108,9 @@ int main(int argc, char *argv[]) {
     GLFWView backend(fullscreen, benchmark);
     view = &backend;
 
-    mbgl::DefaultFileSource fileSource("/tmp/mbgl-cache.db", ".");
+    mbgl::ThreadPool threadPool(4, { "Worker" });
+
+    mbgl::DefaultFileSource fileSource(threadPool, "/tmp/mbgl-cache.db", ".");
 
     // Set access token if present
     const char *token = getenv("MAPBOX_ACCESS_TOKEN");
@@ -117,8 +119,6 @@ int main(int argc, char *argv[]) {
     } else {
         fileSource.setAccessToken(std::string(token));
     }
-
-    mbgl::ThreadPool threadPool(4, { "Worker" });
 
     mbgl::Map map(backend, view->getSize(), view->getPixelRatio(), fileSource, threadPool);
 

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -162,6 +162,10 @@
 		40F887701D7A1E58008ECB67 /* MGLShapeSource_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 40F8876F1D7A1DB8008ECB67 /* MGLShapeSource_Private.h */; };
 		40F887711D7A1E59008ECB67 /* MGLShapeSource_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 40F8876F1D7A1DB8008ECB67 /* MGLShapeSource_Private.h */; };
 		40FDA76B1CCAAA6800442548 /* MBXAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 40FDA76A1CCAAA6800442548 /* MBXAnnotationView.m */; };
+		553B1F0B1E267D9500606163 /* MGLThreadPool_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 553B1F091E267D9500606163 /* MGLThreadPool_Private.h */; };
+		553B1F0C1E267D9500606163 /* MGLThreadPool_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 553B1F091E267D9500606163 /* MGLThreadPool_Private.h */; };
+		553B1F0D1E267D9500606163 /* MGLThreadPool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 553B1F0A1E267D9500606163 /* MGLThreadPool.mm */; };
+		553B1F0E1E267D9500606163 /* MGLThreadPool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 553B1F0A1E267D9500606163 /* MGLThreadPool.mm */; };
 		554180421D2E97DE00012372 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 554180411D2E97DE00012372 /* OpenGLES.framework */; };
 		556660CA1E1BF3A900E2C41B /* MGLFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 556660C91E1BF3A900E2C41B /* MGLFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		556660D81E1D085500E2C41B /* MGLVersionNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = 556660D71E1D085500E2C41B /* MGLVersionNumber.m */; };
@@ -611,6 +615,8 @@
 		40F8876F1D7A1DB8008ECB67 /* MGLShapeSource_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLShapeSource_Private.h; sourceTree = "<group>"; };
 		40FDA7691CCAAA6800442548 /* MBXAnnotationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBXAnnotationView.h; sourceTree = "<group>"; };
 		40FDA76A1CCAAA6800442548 /* MBXAnnotationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBXAnnotationView.m; sourceTree = "<group>"; };
+		553B1F091E267D9500606163 /* MGLThreadPool_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLThreadPool_Private.h; sourceTree = "<group>"; };
+		553B1F0A1E267D9500606163 /* MGLThreadPool.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLThreadPool.mm; sourceTree = "<group>"; };
 		554180411D2E97DE00012372 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		556660C91E1BF3A900E2C41B /* MGLFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLFoundation.h; sourceTree = "<group>"; };
 		556660D71E1D085500E2C41B /* MGLVersionNumber.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MGLVersionNumber.m; path = ../../darwin/test/MGLVersionNumber.m; sourceTree = "<group>"; };
@@ -1149,6 +1155,8 @@
 				DA8847EC1CBAFA5100AB86E3 /* MGLStyle.h */,
 				35E0CFE51D3E501500188327 /* MGLStyle_Private.h */,
 				DA88480F1CBAFA6200AB86E3 /* MGLStyle.mm */,
+				553B1F091E267D9500606163 /* MGLThreadPool_Private.h */,
+				553B1F0A1E267D9500606163 /* MGLThreadPool.mm */,
 				DA8847EE1CBAFA5100AB86E3 /* MGLTypes.h */,
 				DA8848111CBAFA6200AB86E3 /* MGLTypes.m */,
 				DA8848911CBB049300AB86E3 /* reachability */,
@@ -1474,6 +1482,7 @@
 				3510FFF01D6D9D8C00F413B2 /* NSExpression+MGLAdditions.h in Headers */,
 				353AFA141D65AB17005A69F4 /* NSDate+MGLAdditions.h in Headers */,
 				DA8848531CBAFB9800AB86E3 /* MGLCompactCalloutView.h in Headers */,
+				553B1F0B1E267D9500606163 /* MGLThreadPool_Private.h in Headers */,
 				DA8847FB1CBAFA5100AB86E3 /* MGLShape.h in Headers */,
 				353933F51D3FB785003F57D7 /* MGLBackgroundStyleLayer.h in Headers */,
 				DA88485A1CBAFB9800AB86E3 /* MGLUserLocation_Private.h in Headers */,
@@ -1568,6 +1577,7 @@
 				35B82BF91D6C5F8400B1B721 /* NSPredicate+MGLAdditions.h in Headers */,
 				DA35A2CA1CCAAAD200E826B2 /* NSValue+MGLAdditions.h in Headers */,
 				350098BC1D480108004B2AF0 /* MGLVectorSource.h in Headers */,
+				553B1F0C1E267D9500606163 /* MGLThreadPool_Private.h in Headers */,
 				353933FC1D3FB7C0003F57D7 /* MGLRasterStyleLayer.h in Headers */,
 				3566C76D1D4A8DFA008152BC /* MGLRasterSource.h in Headers */,
 				DAED38641D62D0FC00D7640F /* NSURL+MGLAdditions.h in Headers */,
@@ -2003,6 +2013,7 @@
 				350098BD1D480108004B2AF0 /* MGLVectorSource.mm in Sources */,
 				3566C76E1D4A8DFA008152BC /* MGLRasterSource.mm in Sources */,
 				DA88488C1CBB037E00AB86E3 /* SMCalloutView.m in Sources */,
+				553B1F0D1E267D9500606163 /* MGLThreadPool.mm in Sources */,
 				35136D4E1D4277FC00C20EFD /* MGLSource.mm in Sources */,
 				DA35A2B81CCA9A5D00E826B2 /* MGLClockDirectionFormatter.m in Sources */,
 				DAD1657A1CF4CDFF001FF4B9 /* MGLShapeCollection.mm in Sources */,
@@ -2078,6 +2089,7 @@
 				350098BE1D480108004B2AF0 /* MGLVectorSource.mm in Sources */,
 				3566C76F1D4A8DFA008152BC /* MGLRasterSource.mm in Sources */,
 				DAA4E4351CBB730400178DFB /* SMCalloutView.m in Sources */,
+				553B1F0E1E267D9500606163 /* MGLThreadPool.mm in Sources */,
 				35136D4F1D4277FC00C20EFD /* MGLSource.mm in Sources */,
 				DA35A2B91CCA9A5D00E826B2 /* MGLClockDirectionFormatter.m in Sources */,
 				DAD1657B1CF4CDFF001FF4B9 /* MGLShapeCollection.mm in Sources */,

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -421,7 +421,7 @@ public:
     // setup mbgl map
     mbgl::DefaultFileSource *mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
     const float scaleFactor = [UIScreen instancesRespondToSelector:@selector(nativeScale)] ? [[UIScreen mainScreen] nativeScale] : [[UIScreen mainScreen] scale];
-    _mbglThreadPool = new mbgl::ThreadPool(4);
+    _mbglThreadPool = new mbgl::ThreadPool(4, { "Worker" });
     _mbglMap = new mbgl::Map(*_mbglView, self.size, scaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
     [self validateTileCacheSize];
 

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		40B77E461DB11BCD003DA2FE /* NSArray+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 40B77E421DB11BB0003DA2FE /* NSArray+MGLAdditions.mm */; };
 		40E1601D1DF217D6005EA6D9 /* MGLStyleLayerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 40E1601B1DF216E6005EA6D9 /* MGLStyleLayerTests.m */; };
 		52BECB0A1CC5A26F009CD791 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52BECB091CC5A26F009CD791 /* SystemConfiguration.framework */; };
+		553B1F051E267AD900606163 /* MGLThreadPool_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 553B1F021E267AD900606163 /* MGLThreadPool_Private.h */; };
+		553B1F071E267AD900606163 /* MGLThreadPool.mm in Sources */ = {isa = PBXBuildFile; fileRef = 553B1F041E267AD900606163 /* MGLThreadPool.mm */; };
 		5548BE781D09E718005DDE81 /* libmbgl-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE6C3451CC31D1200DB3429 /* libmbgl-core.a */; };
 		556660C61E1BEA0100E2C41B /* MGLFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 556660C51E1BEA0100E2C41B /* MGLFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		556660D61E1D07E400E2C41B /* MGLVersionNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = 556660D51E1D07E400E2C41B /* MGLVersionNumber.m */; };
@@ -305,6 +307,8 @@
 		40E1601A1DF216E6005EA6D9 /* MGLStyleLayerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLStyleLayerTests.h; sourceTree = "<group>"; };
 		40E1601B1DF216E6005EA6D9 /* MGLStyleLayerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLStyleLayerTests.m; sourceTree = "<group>"; };
 		52BECB091CC5A26F009CD791 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		553B1F021E267AD900606163 /* MGLThreadPool_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLThreadPool_Private.h; sourceTree = "<group>"; };
+		553B1F041E267AD900606163 /* MGLThreadPool.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLThreadPool.mm; sourceTree = "<group>"; };
 		5548BE791D0ACBB2005DDE81 /* libmbgl-loop-darwin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-loop-darwin.a"; path = "cmake/Debug/libmbgl-loop-darwin.a"; sourceTree = "<group>"; };
 		5548BE7B1D0ACBBD005DDE81 /* libmbgl-loop-darwin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-loop-darwin.a"; path = "cmake/Debug/libmbgl-loop-darwin.a"; sourceTree = "<group>"; };
 		556660C51E1BEA0100E2C41B /* MGLFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLFoundation.h; sourceTree = "<group>"; };
@@ -916,6 +920,8 @@
 				DAE6C3571CC31E0400DB3429 /* MGLStyle.h */,
 				3537CA731D3F93A600380318 /* MGLStyle_Private.h */,
 				DAE6C37A1CC31E2A00DB3429 /* MGLStyle.mm */,
+				553B1F021E267AD900606163 /* MGLThreadPool_Private.h */,
+				553B1F041E267AD900606163 /* MGLThreadPool.mm */,
 				DAE6C3591CC31E0400DB3429 /* MGLTypes.h */,
 				DAE6C37C1CC31E2A00DB3429 /* MGLTypes.m */,
 				DA87A99F1DC9DC6200810D09 /* MGLValueEvaluator.h */,
@@ -1009,6 +1015,7 @@
 				352742811D4C243B00A1ECE6 /* MGLSource.h in Headers */,
 				DAE6C3C21CC31F4500DB3429 /* Mapbox.h in Headers */,
 				DAE6C3641CC31E0400DB3429 /* MGLPolygon.h in Headers */,
+				553B1F051E267AD900606163 /* MGLThreadPool_Private.h in Headers */,
 				DA35A2BF1CCA9B1A00E826B2 /* MGLClockDirectionFormatter.h in Headers */,
 				35602BFA1D3EA99F0050646F /* MGLFillStyleLayer.h in Headers */,
 				DA35A2A41CC9EB1A00E826B2 /* MGLCoordinateFormatter.h in Headers */,
@@ -1267,6 +1274,7 @@
 				DA35A2D01CCAAED300E826B2 /* NSValue+MGLAdditions.m in Sources */,
 				3538AA241D542685008EC33D /* MGLStyleLayer.mm in Sources */,
 				DA35A2C01CCA9B1A00E826B2 /* MGLClockDirectionFormatter.m in Sources */,
+				553B1F071E267AD900606163 /* MGLThreadPool.mm in Sources */,
 				DAE6C3BA1CC31EF300DB3429 /* MGLOpenGLLayer.mm in Sources */,
 				DAE6C38A1CC31E2A00DB3429 /* MGLMultiPoint.mm in Sources */,
 				DAE6C3961CC31E2A00DB3429 /* MGLTypes.m in Sources */,

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -259,7 +259,7 @@ public:
 
     mbgl::DefaultFileSource* mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
 
-    _mbglThreadPool = new mbgl::ThreadPool(4);
+    _mbglThreadPool = new mbgl::ThreadPool(4, { "Worker" });
     _mbglMap = new mbgl::Map(*_mbglView, self.size, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
     [self validateTileCacheSize];
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1498,7 +1498,7 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
         settings.cacheDatabasePath().toStdString(),
         settings.assetPath().toStdString(),
         settings.cacheDatabaseMaximumSize()))
-    , threadPool(4)
+    , threadPool(4, { "Worker" })
     , mapObj(std::make_unique<mbgl::Map>(
         *this, mbgl::Size{ static_cast<uint32_t>(size.width()), static_cast<uint32_t>(size.height()) },
         pixelRatio, *fileSourceObj, threadPool,

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1494,11 +1494,12 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
     : QObject(q)
     , size(size_)
     , q_ptr(q)
+    , threadPool(4, { "Worker" })
     , fileSourceObj(std::make_unique<mbgl::DefaultFileSource>(
+        threadPool,
         settings.cacheDatabasePath().toStdString(),
         settings.assetPath().toStdString(),
         settings.cacheDatabaseMaximumSize()))
-    , threadPool(4, { "Worker" })
     , mapObj(std::make_unique<mbgl::Map>(
         *this, mbgl::Size{ static_cast<uint32_t>(size.width()), static_cast<uint32_t>(size.height()) },
         pixelRatio, *fileSourceObj, threadPool,

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -37,8 +37,8 @@ public:
 
     QMapboxGL *q_ptr { nullptr };
 
-    std::unique_ptr<mbgl::DefaultFileSource> fileSourceObj;
     mbgl::ThreadPool threadPool;
+    std::unique_ptr<mbgl::DefaultFileSource> fileSourceObj;
     std::unique_ptr<mbgl::Map> mapObj;
 
     bool dirty { false };

--- a/src/mbgl/storage/asset_file_source.hpp
+++ b/src/mbgl/storage/asset_file_source.hpp
@@ -4,20 +4,18 @@
 
 namespace mbgl {
 
-namespace util {
-template <typename T> class Thread;
-} // namespace util
+class Scheduler;
 
 class AssetFileSource : public FileSource {
 public:
-    AssetFileSource(const std::string& assetRoot);
+    AssetFileSource(Scheduler&, const std::string& assetRoot);
     ~AssetFileSource() override;
 
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
 private:
     class Impl;
-    std::unique_ptr<util::Thread<Impl>> thread;
+    const std::unique_ptr<Impl> impl;
 };
 
 } // namespace mbgl

--- a/src/mbgl/storage/asset_file_source.hpp
+++ b/src/mbgl/storage/asset_file_source.hpp
@@ -4,7 +4,9 @@
 
 namespace mbgl {
 
+template <class> class Actor;
 class Scheduler;
+class Mailbox;
 
 class AssetFileSource : public FileSource {
 public:
@@ -14,8 +16,12 @@ public:
     std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override;
 
 private:
-    class Impl;
-    const std::unique_ptr<Impl> impl;
+    void respond(std::weak_ptr<Callback>, Response);
+
+private:
+    std::shared_ptr<Mailbox> mailbox;
+    class Worker;
+    const std::unique_ptr<Actor<Worker>> worker;
 };
 
 } // namespace mbgl

--- a/test/actor/actor.test.cpp
+++ b/test/actor/actor.test.cpp
@@ -19,7 +19,7 @@ TEST(Actor, Construction) {
         };
     };
 
-    ThreadPool pool { 1 };
+    ThreadPool pool { 1, { "ActorConstruction" } };
     bool constructed = false;
     Actor<Test> test(pool, std::ref(constructed));
 
@@ -52,7 +52,7 @@ TEST(Actor, DestructionClosesMailbox) {
         }
     };
 
-    ThreadPool pool { 1 };
+    ThreadPool pool { 1, { "ActorDestructionClosesMailbox" } };
 
     std::promise<void> enteredPromise;
     std::future<void> enteredFuture = enteredPromise.get_future();
@@ -88,7 +88,7 @@ TEST(Actor, OrderedMailbox) {
         }
     };
 
-    ThreadPool pool { 1 };
+    ThreadPool pool { 1, { "ActorOrderedMailbox" } };
 
     std::promise<void> endedPromise;
     std::future<void> endedFuture = endedPromise.get_future();
@@ -124,7 +124,7 @@ TEST(Actor, NonConcurrentMailbox) {
         }
     };
 
-    ThreadPool pool { 10 };
+    ThreadPool pool { 10, { "ActorNonConcurrentMailbox" } };
 
     std::promise<void> endedPromise;
     std::future<void> endedFuture = endedPromise.get_future();

--- a/test/actor/actor_ref.test.cpp
+++ b/test/actor/actor_ref.test.cpp
@@ -30,7 +30,7 @@ TEST(ActorRef, CanOutliveActor) {
         }
     };
 
-    ThreadPool pool { 1 };
+    ThreadPool pool { 1, { "ActorRefCanOutliveActor" } };
     bool died = false;
 
     ActorRef<Test> test = [&] () {

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -26,7 +26,7 @@ public:
     HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext() };
     StubFileSource fileSource;
-    ThreadPool threadPool { 4 };
+    ThreadPool threadPool { 4, { "Worker" } };
     Map map { backend, view.size, 1, fileSource, threadPool, MapMode::Still };
 
     void checkRendering(const char * name) {

--- a/test/api/api_misuse.test.cpp
+++ b/test/api/api_misuse.test.cpp
@@ -24,7 +24,7 @@ TEST(API, RenderWithoutCallback) {
     HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext(), { 128, 512 } };
     StubFileSource fileSource;
-    ThreadPool threadPool(4);
+    ThreadPool threadPool{ 4, { "Worker" } };
 
     std::unique_ptr<Map> map =
         std::make_unique<Map>(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
@@ -49,7 +49,7 @@ TEST(API, RenderWithoutStyle) {
     HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext(), { 128, 512 } };
     StubFileSource fileSource;
-    ThreadPool threadPool(4);
+    ThreadPool threadPool{ 4, { "Worker" } };
 
     Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
 

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -84,18 +84,17 @@ public:
 
 TEST(CustomLayer, Basic) {
     util::RunLoop loop;
+    ThreadPool threadPool{ 4, { "Worker" } };
 
     HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext() };
 
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`
-    DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets.zip");
+    DefaultFileSource fileSource(threadPool, ":memory:", "test/fixtures/api/assets.zip");
 #else
-    DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
+    DefaultFileSource fileSource(threadPool, ":memory:", "test/fixtures/api/assets");
 #endif
-
-    ThreadPool threadPool{ 4, { "Worker" } };
 
     Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/water.json"));

--- a/test/api/custom_layer.test.cpp
+++ b/test/api/custom_layer.test.cpp
@@ -95,7 +95,7 @@ TEST(CustomLayer, Basic) {
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
 #endif
 
-    ThreadPool threadPool(4);
+    ThreadPool threadPool{ 4, { "Worker" } };
 
     Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Still);
     map.setStyleJSON(util::read_file("test/fixtures/api/water.json"));

--- a/test/api/query.test.cpp
+++ b/test/api/query.test.cpp
@@ -29,7 +29,7 @@ public:
     HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext() };
     StubFileSource fileSource;
-    ThreadPool threadPool { 4 };
+    ThreadPool threadPool { 4, { "Worker" } };
     Map map { backend, view.size, 1, fileSource, threadPool, MapMode::Still };
 };
 

--- a/test/api/render_missing.test.cpp
+++ b/test/api/render_missing.test.cpp
@@ -34,7 +34,7 @@ TEST(API, TEST_REQUIRES_SERVER(RenderMissingTile)) {
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
 #endif
 
-    ThreadPool threadPool(4);
+    ThreadPool threadPool{ 4, { "Worker" } };
 
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 

--- a/test/api/render_missing.test.cpp
+++ b/test/api/render_missing.test.cpp
@@ -22,6 +22,7 @@ TEST(API, TEST_REQUIRES_SERVER(RenderMissingTile)) {
     using namespace mbgl;
 
     util::RunLoop loop;
+    ThreadPool threadPool{ 4, { "Worker" } };
 
     const auto style = util::read_file("test/fixtures/api/water_missing_tiles.json");
 
@@ -29,12 +30,10 @@ TEST(API, TEST_REQUIRES_SERVER(RenderMissingTile)) {
     OffscreenView view { backend.getContext(), { 256, 512 } };
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`
-    DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets.zip");
+    DefaultFileSource fileSource(threadPool, ":memory:", "test/fixtures/api/assets.zip");
 #else
-    DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
+    DefaultFileSource fileSource(threadPool, ":memory:", "test/fixtures/api/assets");
 #endif
-
-    ThreadPool threadPool{ 4, { "Worker" } };
 
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 

--- a/test/api/repeated_render.test.cpp
+++ b/test/api/repeated_render.test.cpp
@@ -30,7 +30,7 @@ TEST(API, RepeatedRender) {
     DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
 #endif
 
-    ThreadPool threadPool(4);
+    ThreadPool threadPool{ 4, { "Worker" } };
 
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 

--- a/test/api/repeated_render.test.cpp
+++ b/test/api/repeated_render.test.cpp
@@ -16,8 +16,8 @@ using namespace mbgl;
 
 
 TEST(API, RepeatedRender) {
-
     util::RunLoop loop;
+    ThreadPool threadPool{ 4, { "Worker" } };
 
     const auto style = util::read_file("test/fixtures/api/water.json");
 
@@ -25,12 +25,10 @@ TEST(API, RepeatedRender) {
     OffscreenView view { backend.getContext(), { 256, 512 } };
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`
-    DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets.zip");
+    DefaultFileSource fileSource(threadPool, ":memory:", "test/fixtures/api/assets.zip");
 #else
-    DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
+    DefaultFileSource fileSource(threadPool, ":memory:", "test/fixtures/api/assets");
 #endif
-
-    ThreadPool threadPool{ 4, { "Worker" } };
 
     Log::setObserver(std::make_unique<FixtureLogObserver>());
 

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -47,7 +47,7 @@ TEST(Map, LatLngBehavior) {
 
 TEST(Map, Offline) {
     MapTest test;
-    DefaultFileSource fileSource(":memory:", ".");
+    DefaultFileSource fileSource(test.threadPool, ":memory:", ".");
 
     auto expiredItem = [] (const std::string& path) {
         Response response;
@@ -479,9 +479,9 @@ TEST(Map, TEST_DISABLED_ON_CI(ContinuousRendering)) {
 
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`
-    DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets.zip");
+    DefaultFileSource fileSource(threadPool, ":memory:", "test/fixtures/api/assets.zip");
 #else
-    DefaultFileSource fileSource(":memory:", "test/fixtures/api/assets");
+    DefaultFileSource fileSource(threadPool, ":memory:", "test/fixtures/api/assets");
 #endif
 
     Map map(backend, view.size, 1, fileSource, threadPool, MapMode::Continuous);

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -26,7 +26,7 @@ struct MapTest {
     HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext() };
     StubFileSource fileSource;
-    ThreadPool threadPool { 4 };
+    ThreadPool threadPool{ 4, { "Worker" } };
 };
 
 TEST(Map, LatLngBehavior) {
@@ -475,7 +475,7 @@ TEST(Map, TEST_DISABLED_ON_CI(ContinuousRendering)) {
     util::RunLoop runLoop;
     MockBackend backend { test::sharedDisplay() };
     OffscreenView view { backend.getContext() };
-    ThreadPool threadPool { 4 };
+    ThreadPool threadPool{ 4, { "Worker" } };
 
 #ifdef MBGL_ASSET_ZIP
     // Regenerate with `cd test/fixtures/api/ && zip -r assets.zip assets/`

--- a/test/storage/asset_file_source.test.cpp
+++ b/test/storage/asset_file_source.test.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/util/platform.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/util/thread.hpp>
 
 #include <gtest/gtest.h>
@@ -24,7 +25,8 @@ using namespace mbgl;
 TEST(AssetFileSource, Load) {
     util::RunLoop loop;
 
-    AssetFileSource fs(getFileSourceRoot());
+    ThreadPool threadPool{ 1, { "Worker" } };
+    AssetFileSource fs(threadPool, getFileSourceRoot());
 
     // iOS seems to run out of file descriptors...
 #if TARGET_OS_IPHONE || __ANDROID__
@@ -91,7 +93,8 @@ TEST(AssetFileSource, Load) {
 TEST(AssetFileSource, EmptyFile) {
     util::RunLoop loop;
 
-    AssetFileSource fs(getFileSourceRoot());
+    ThreadPool threadPool{ 1, { "Worker" } };
+    AssetFileSource fs(threadPool, getFileSourceRoot());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://empty" }, [&](Response res) {
         req.reset();
@@ -107,7 +110,8 @@ TEST(AssetFileSource, EmptyFile) {
 TEST(AssetFileSource, NonEmptyFile) {
     util::RunLoop loop;
 
-    AssetFileSource fs(getFileSourceRoot());
+    ThreadPool threadPool{ 1, { "Worker" } };
+    AssetFileSource fs(threadPool, getFileSourceRoot());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://nonempty" }, [&](Response res) {
         req.reset();
@@ -123,7 +127,8 @@ TEST(AssetFileSource, NonEmptyFile) {
 TEST(AssetFileSource, NonExistentFile) {
     util::RunLoop loop;
 
-    AssetFileSource fs(getFileSourceRoot());
+    ThreadPool threadPool{ 1, { "Worker" } };
+    AssetFileSource fs(threadPool, getFileSourceRoot());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://does_not_exist" }, [&](Response res) {
         req.reset();
@@ -140,7 +145,8 @@ TEST(AssetFileSource, NonExistentFile) {
 TEST(AssetFileSource, ReadDirectory) {
     util::RunLoop loop;
 
-    AssetFileSource fs(getFileSourceRoot());
+    ThreadPool threadPool{ 1, { "Worker" } };
+    AssetFileSource fs(threadPool, getFileSourceRoot());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://directory" }, [&](Response res) {
         req.reset();
@@ -157,7 +163,8 @@ TEST(AssetFileSource, ReadDirectory) {
 TEST(AssetFileSource, URLEncoding) {
     util::RunLoop loop;
 
-    AssetFileSource fs(getFileSourceRoot());
+    ThreadPool threadPool{ 1, { "Worker" } };
+    AssetFileSource fs(threadPool, getFileSourceRoot());
 
     std::unique_ptr<AsyncRequest> req = fs.request({ Resource::Unknown, "asset://%6eonempty" }, [&](Response res) {
         req.reset();

--- a/test/storage/default_file_source.test.cpp
+++ b/test/storage/default_file_source.test.cpp
@@ -1,12 +1,14 @@
 #include <mbgl/test/util.hpp>
 #include <mbgl/storage/default_file_source.hpp>
+#include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 using namespace mbgl;
 
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheResponse)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/cache" };
     Response response;
@@ -44,7 +46,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheResponse)) {
 
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheRevalidateSame)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     const Resource revalidateSame { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
     std::unique_ptr<AsyncRequest> req1;
@@ -88,7 +91,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheRevalidateSame)) {
 
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheRevalidateModified)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     const Resource revalidateModified{ Resource::Unknown,
                                        "http://127.0.0.1:3000/revalidate-modified" };
@@ -132,7 +136,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheRevalidateModified)) {
 
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheRevalidateEtag)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     const Resource revalidateEtag { Resource::Unknown, "http://127.0.0.1:3000/revalidate-etag" };
     std::unique_ptr<AsyncRequest> req1;
@@ -187,7 +192,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(CacheRevalidateEtag)) {
 
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(HTTPIssue1369)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     const Resource resource { Resource::Unknown, "http://127.0.0.1:3000/test" };
 
@@ -211,7 +217,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(HTTPIssue1369)) {
 
 TEST(DefaultFileSource, OptionalNonExpired) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", {}, Resource::Optional };
 
@@ -240,7 +247,8 @@ TEST(DefaultFileSource, OptionalNonExpired) {
 
 TEST(DefaultFileSource, OptionalExpired) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", {}, Resource::Optional };
 
@@ -269,7 +277,8 @@ TEST(DefaultFileSource, OptionalExpired) {
 
 TEST(DefaultFileSource, OptionalNotFound) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     const Resource optionalResource { Resource::Unknown, "http://127.0.0.1:3000/test", {}, Resource::Optional };
 
@@ -295,7 +304,8 @@ TEST(DefaultFileSource, OptionalNotFound) {
 // from cache like a regular request
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshEtagNotModified)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     Resource resource { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
     resource.priorEtag.emplace("snowfall");
@@ -329,7 +339,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshEtagNotModified)) {
 // from cache like a regular request
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshEtagModified)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     Resource resource { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
     resource.priorEtag.emplace("sunshine");
@@ -363,7 +374,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshEtagModified)) {
 // from cache like a regular request.
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheFull)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     Resource resource { Resource::Unknown, "http://127.0.0.1:3000/revalidate-same" };
     // Setting any prior field results in skipping the cache.
@@ -398,7 +410,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheFull)) {
 // from cache like a regular request
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshModifiedNotModified)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     Resource resource { Resource::Unknown, "http://127.0.0.1:3000/revalidate-modified" };
     resource.priorModified.emplace(Seconds(1420070400)); // January 1, 2015
@@ -432,7 +445,8 @@ TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshModifiedNotModified))
 // from cache like a regular request
 TEST(DefaultFileSource, TEST_REQUIRES_SERVER(NoCacheRefreshModifiedModified)) {
     util::RunLoop loop;
-    DefaultFileSource fs(":memory:", ".");
+    ThreadPool threadPool{ 1, { "Worker" } };
+    DefaultFileSource fs(threadPool, ":memory:", ".");
 
     Resource resource { Resource::Unknown, "http://127.0.0.1:3000/revalidate-modified" };
     resource.priorModified.emplace(Seconds(1417392000)); // December 1, 2014

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -31,7 +31,7 @@ public:
     StubStyleObserver observer;
     Transform transform;
     TransformState transformState;
-    ThreadPool threadPool { 1 };
+    ThreadPool threadPool{ 1, { "Worker" } };
     AnnotationManager annotationManager { 1.0 };
     style::Style style { fileSource, 1.0 };
 

--- a/test/tile/geojson_tile.test.cpp
+++ b/test/tile/geojson_tile.test.cpp
@@ -22,7 +22,7 @@ public:
     FakeFileSource fileSource;
     TransformState transformState;
     util::RunLoop loop;
-    ThreadPool threadPool { 1 };
+    ThreadPool threadPool{ 1, { "Worker" } };
     AnnotationManager annotationManager { 1.0 };
     style::Style style { fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -17,7 +17,7 @@ public:
     FakeFileSource fileSource;
     TransformState transformState;
     util::RunLoop loop;
-    ThreadPool threadPool { 1 };
+    ThreadPool threadPool{ 1, { "Worker" } };
     AnnotationManager annotationManager { 1.0 };
     style::Style style { fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -23,7 +23,7 @@ public:
     FakeFileSource fileSource;
     TransformState transformState;
     util::RunLoop loop;
-    ThreadPool threadPool { 1 };
+    ThreadPool threadPool{ 1, { "Worker" } };
     AnnotationManager annotationManager { 1.0 };
     style::Style style { fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };

--- a/test/util/memory.test.cpp
+++ b/test/util/memory.test.cpp
@@ -59,7 +59,7 @@ public:
     HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view{ backend.getContext(), { 512, 512 } };
     StubFileSource fileSource;
-    ThreadPool threadPool { 4 };
+    ThreadPool threadPool{ 4, { "Worker" } };
 
 private:
     Response response(const std::string& path) {


### PR DESCRIPTION
Getting started on https://github.com/mapbox/mapbox-gl-native/issues/6426. This is still a work in progress.

A few large changes:
- the `DefaultFileSource` constructor now takes a `Scheduler`
- the `AssetFileSource` does not use its own thread anymore; instead it uses the shared worker threads

Given that our file requests need a way to "cancel" them (i.e. have the callback not invoked, I introduced `AssetFileSource::Impl::Request`, which holds a `shared_ptr` to the callback. If that object gets destroyed, the `weak_ptr` we're passing to the worker thread will be empty, and back on the main thread, the callback obviously can't be fired anymore. I'm not sure if using this violates @jfirebaugh's plea about not using `std::shared_ptr` with actors (since technically, you could try to lock the `weak_ptr` in the worker.

I also added a `MGLThreadPool` object for Darwin, but implemented a global singleton for Android . I believe we should go the global singleton instance for Darwin as well (and remove `MGLThreadPool` again), since Darwin never deallocates the `DefaultFileSource` as part of the regular application workflow anyway (it's a singleton in `MGLOfflineStorage`).