### PR TITLE
[ios] Copy-edit guides

### DIFF
--- a/platform/ios/docs/guides/Adding Points to a Map.md
+++ b/platform/ios/docs/guides/Adding Points to a Map.md
@@ -4,7 +4,7 @@ Mapbox offers a few different ways to add points to a map, each with different t
 
 ## MGLPointAnnotation
 
-It's straightforward to add an annotation to a map. You can use `MGLPointAnnotation` as is, or you can subclass it to add annotations with richer data.
+It’s straightforward to add an annotation to a map. You can use `MGLPointAnnotation` as is, or you can subclass it to add annotations with richer data.
 
 ```swift
 let annotation = MGLPointAnnotation()
@@ -14,55 +14,55 @@ annotation.subtitle = "Coffeeshop"
 mapView.addAnnotation(annotation)
 ```
 
-See the `MGLMapViewDelegate` method `-mapView:annotationCanShowCallout:` and similar methods for allowing interaction with a callout.
+See the `MGLMapViewDelegate` method `-mapView:annotationCanShowCallout:` and similar methods for allowing interaction with a callout ([example](https://www.mapbox.com/ios-sdk/examples/callout-delegate/)).
 
 ## Displaying annotations
 
-There are two basic ways to display the annotations you've added to a map, each with their own tradeoffs.
+There are two basic ways to display the annotations you’ve added to a map, each with their own tradeoffs.
 
 ### Annotation Images (`MGLAnnotationImage`)
 
-Annotation images are the quickest and most performant ways to display annotations, and you can provide your own custom annotation images ([example](https://www.mapbox.com/ios-sdk/examples/marker-image/)).
+Annotation images are the quickest and most performant way to display annotations, but are also the most basic.
 
-By default, annotations added to the map are displayed with a red pin. If you'd like to customize this annotation, you can implement `MGLMapViewDelegate` `-mapView:imageForAnnotation:`.
+By default, annotations added to the map are displayed with a red pin ([example](https://www.mapbox.com/ios-sdk/examples/marker/)). To use custom images, you can implement `MGLMapViewDelegate` `-mapView:imageForAnnotation:` ([example](https://www.mapbox.com/ios-sdk/examples/marker-image/)).
 
 **Pros**
 
 * The easiest way to display a marker on a map
 * Easily customizable with any `UIImage`
-* High performance as the images are rendered directly in OpenGL
+* High performance, as the images are rendered directly in OpenGL
 
 **Cons**
 
-* Annotation images are purely static
+* Annotation images are purely static and cannot be animated
 * No control over z-ordering
-* Limits to the size and number of images you can add
+* Limits to the number and size of images you can add
 
 ### Annotation Views (`MGLAnnotationView`)
 
-If you're looking to add custom UIViews or have annotations that are dynamic or animatable, consider an `MGLAnnotationView` instead of an `MGLAnnotationImage` ([example](https://www.mapbox.com/ios-sdk/examples/annotation-views/)).
+If you’re looking to add custom `UIView`s or have annotations that are dynamic or animatable, consider an `MGLAnnotationView` instead of an `MGLAnnotationImage` ([example](https://www.mapbox.com/ios-sdk/examples/annotation-views/)).
 
-Annotation views are a big advantage over annotation images when you need every annotation to be unique. For example, annotation views are ideal if as an example you want to show user locations on a map using their profile pictures.
+Annotation views have big advantages over annotation images when you need every annotation to be unique. For example, annotation views are ideal for showing user locations on a map using high-resolution profile pictures.
 
-To use annotation views, you'll need to implement `MGLMapViewDelegate` `-mapView:viewForAnnotation` and provide a custom `MGLAnnotationView` (`UIView`) subclass.
+To use annotation views, implement `MGLMapViewDelegate` `-mapView:viewForAnnotation` and provide a custom `MGLAnnotationView` (`UIView`) subclass.
 
 **Pros**
 
 * Custom, native UIViews
 * No limit on style or image size
 * Full support for animations
-* Familiar API to MapKit
+* Familiar API for MapKit users
 * Relative control over z-ordering using the `zPosition` property on `CALayer`
 
 **Cons**
 
 * Performance implications:
-    * UIViews are inherently slow to render compared to OpenGL, more apparent if you're adding many views or moving the map rapidly
+    * `UIView`s are inherently slow to render compared to OpenGL, more apparent if you’re adding many views or moving the map rapidly
     * In some cases, you might consider runtime styling
 
 ## Advanced: Runtime Styling
 
-If you're looking for absolute full control of how points are displayed on a map, consider [runtime styling](runtime-styling.html).
+For absolute full control of how points are displayed on a map, consider [runtime styling](runtime-styling.html).
 
 You can use `MGLPointFeature` or any of the other [style feature subclasses](Style%20Features.html) to add points and shapes to an `MGLShapeSource`.
 
@@ -81,4 +81,3 @@ From there, you can create one or many `MGLSymbolStyleLayer` or `MGLCircleStyleL
 
 * Currently you must implement your own tap gesture recognizer together with `MGLMapView.visibleFeaturesAtPoint` to recognize taps and manually show callouts ([example](https://www.mapbox.com/ios-sdk/examples/select-feature)).
 * Currently no SDK support for animations. If you need animations, consider using an NSTimer and updating the layer properties accordingly.
-

--- a/platform/ios/docs/guides/Adding Points to a Map.md
+++ b/platform/ios/docs/guides/Adding Points to a Map.md
@@ -42,7 +42,7 @@ By default, annotations added to the map are displayed with a red pin ([example]
 
 If you’re looking to add custom `UIView`s or have annotations that are dynamic or animatable, consider an `MGLAnnotationView` instead of an `MGLAnnotationImage` ([example](https://www.mapbox.com/ios-sdk/examples/annotation-views/)).
 
-Annotation views have big advantages over annotation images when you need every annotation to be unique. For example, annotation views are ideal for showing user locations on a map using high-resolution profile pictures.
+Annotation views have significant advantages over annotation images when you need every annotation to be unique. For example, annotation views are ideal for showing user locations on a map using high-resolution profile pictures.
 
 To use annotation views, implement `MGLMapViewDelegate` `-mapView:viewForAnnotation` and provide a custom `MGLAnnotationView` (`UIView`) subclass.
 
@@ -51,8 +51,8 @@ To use annotation views, implement `MGLMapViewDelegate` `-mapView:viewForAnnotat
 * Custom, native UIViews
 * No limit on style or image size
 * Full support for animations
-* Familiar API for MapKit users
 * Relative control over z-ordering using the `zPosition` property on `CALayer`
+* [Familiar API for MapKit users](https://www.mapbox.com/help/switch-mapkit/#annotations-pins)
 
 **Cons**
 

--- a/platform/ios/docs/guides/Runtime Styling.md
+++ b/platform/ios/docs/guides/Runtime Styling.md
@@ -1,14 +1,14 @@
 # Runtime Styling
 
-Mapbox's runtime styling features allow you direct control over every layer in your maps with code. It's now possible to create dynamic maps and visualizations that aren't possible with other mobile maps SDKs.
+Mapbox’s runtime styling features allow you direct control over every layer in your maps with code. It’s now possible to create dynamic maps and visualizations that aren’t possible with other mobile maps SDKs.
 
 Runtime styling expands upon the design power of [Mapbox Studio](https://www.mapbox.com/mapbox-studio/) and exposes all of the same properties and attributes directly to mobile developers in our SDK.
 
-Beyond the custom styled maps that you can create with Mapbox Studio, you can now change the look and feel of your map on the fly having maps in your app visually respond to user interaction or or context. Or leverage the power of OpenGL for highly performant and complex data visualizations. Now it's possible to mix in your own data and bring your map to life.
+Beyond the custom styled maps that you can create with Mapbox Studio, you can now change the look and feel of your map on the fly having maps in your app visually respond to user interaction or or context. Or leverage the power of OpenGL for highly performant and complex data visualizations. Now it’s possible to mix in your own data and bring your map to life.
 
 ## Example use cases
 
-As an example of what's possible with runtime styling, consider some of the following use cases:
+As an example of what’s possible with runtime styling, consider some of the following use cases:
 
 ### Styling maps on the fly
 
@@ -16,11 +16,11 @@ At runtime, you can tailor the map specifically to your user interface. Tweak co
 
 ![dynamic styles](img/runtime-styling/DynamicStyles.gif "an example showing dynamic styles")
 
-For maps that aren't going to change in response to custom data or user interaction, consider creating a custom map style with [Mapbox Studio](https://www.mapbox.com/mapbox-studio/).
+For maps that aren’t going to change in response to custom data or user interaction, consider creating a custom map style with [Mapbox Studio](https://www.mapbox.com/mapbox-studio/).
 
 ### Map interactivity
 
-You can customize the map to the point of having it respond dynamically based on the actions your users are taking. Increase the text size of streets while a user is driving, emphasize points of interest tailored to a user's preferences, or change your UI if users are at parks, trails, landmarks, or rivers.
+You can customize the map to the point of having it respond dynamically based on the actions your users are taking. Increase the text size of streets while a user is driving, emphasize points of interest tailored to a user’s preferences, or change your UI if users are at parks, trails, landmarks, or rivers.
 
 ![emojis](img/runtime-styling/Emoji.gif "an example showing emoji interaction")
 
@@ -51,5 +51,3 @@ Draw custom shapes on the map the same way you would a custom `UIView` or `CALay
 * [Mapbox Style Specification](https://www.mapbox.com/mapbox-gl-style-spec/)
 * [Mapbox Studio](https://www.mapbox.com/mapbox-studio/)
 * [iOS code examples](https://www.mapbox.com/ios-sdk/examples/)
-
-Contact support@mapbox.com with futher questions about how to leverage runtime styling.

--- a/platform/ios/docs/guides/Working with Mapbox Studio.md
+++ b/platform/ios/docs/guides/Working with Mapbox Studio.md
@@ -1,10 +1,10 @@
 # Working with Mapbox Studio
 
-[Mapbox Studio’s Styles editor](http://mapbox.com/studio) is Mapbox's tool for creating custom map styles. It also serves as an excellent tool for rapidly prototyping dynamic maps and [runtime styling](runtime-styling.html) interactions for iOS.
+[Mapbox Studio’s Styles editor](http://mapbox.com/studio) is Mapbox’s tool for creating custom map styles. It also serves as an excellent tool for rapidly prototyping dynamic maps and [runtime styling](runtime-styling.html) interactions for iOS.
 
 ## Creating a base style
 
-Start by heading to [mapbox.com/studio](http://mapbox.com/studio) and creating a new style. Any style that's close to what you'll be using in your app is ideal.
+Start by heading to [mapbox.com/studio](https://www.mapbox.com/studio) and creating a new style. Any style that’s close to what you’ll be using in your app is ideal.
 
 ## Prototyping with data
 
@@ -13,15 +13,15 @@ The goal in using Mapbox Studio for prototyping runtime styling implementations 
 ### Prototyping with Mapbox data
 The default [Mapbox Streets tileset](https://www.mapbox.com/studio/tilesets/mapbox.mapbox-streets-v7/) might offer data similar to your own that you can use to style before you swap in your own data at runtime.
 
-For example, if you're looking to prototype points of interest, consider the `poi_label` layer; if you want to style GPS traces, the `roads` layer might be a good proxy. Take a look at what's available in [Mapbox Streets](https://www.mapbox.com/studio/tilesets/mapbox.mapbox-streets-v7/): there's probably a layer that closely matches your data.
+For example, if you’re looking to prototype points of interest, consider the `poi_label` layer; if you want to style GPS traces, the `roads` layer might be a good proxy. Take a look at what’s available in [Mapbox Streets](https://www.mapbox.com/studio/tilesets/mapbox.mapbox-streets-v7/): there’s probably a layer that closely matches your data.
 
 ### Importing real data
-If you can't find a good approximation for your data in Mapbox Streets, consider uploading a small subset of your data into Mapbox Studio as a custom tileset.
+If you can’t find a good approximation for your data in Mapbox Streets, consider uploading a small subset of your data into Mapbox Studio as a custom tileset.
 
 From the [Mapbox Studio Dashboard](https://www.mapbox.com/studio/), click `Tilesets` in the sidebar, then click `New Tileset` to get started with most common geo file formats including KML, GPX, GeoJSON, Shapefiles, and CSV.
 
 ### Faking placeholder data
-If you don't have any custom data on hand in a format that works easily with the Tileset importer, you can fake placeholder data with the Dataset Editor.
+If you don’t have any custom data on hand in a format that works easily with the Tileset importer, you can fake placeholder data with the Dataset Editor.
 
 From the [Mapbox Studio Dashboard](https://www.mapbox.com/studio/), click `Datasets` in the sidebar, then click on `New Dataset` to get started.
 
@@ -29,18 +29,18 @@ Zoom into your desired location and use the draw tools on the left to start crea
 
 ![create shapes](img/studio-workflow/create-polygons.gif)
 
-Next, add data properties you'd like to use to drive your style. Consider categorical properties or numeric properties that you'd use to filter and group your data. Text properties can be used to display icons or labels.
+Next, add data properties you’d like to use to drive your style. Consider categorical properties or numeric properties that you’d use to filter and group your data. Text properties can be used to display icons or labels.
 
 ![add properties](img/studio-workflow/add-properties.gif)
 
 **General Guidelines:**
 
 * Text along a line: add line with a text property
-* Text at specific points on a line or polygon: in addition to the line, create points at the specific points you'd like with text properties
-* If you want circles where scale doesn't matter relative to the geography (e.g. always 20 pixels), you can add as a point and style with a circle layer or a symbol
-* If you want circles or arcs where the scale matters (e.g. 10 mile radius), you'll need to approximately freehand a polygon that you can create more precisely later in code.
+* Text at specific points on a line or polygon: in addition to the line, create points at the specific points you’d like with text properties
+* If you want circles where scale doesn’t matter relative to the geography (e.g. always 20 pixels), you can add as a point and style with a circle layer or a symbol
+* If you want circles or arcs where the scale matters (e.g. 10 mile radius), you’ll need to approximately freehand a polygon that you can create more precisely later in code.
 
-When you're done, save your dataset and export as a tileset. When that's complete, add your tileset to your style.
+When you’re done, save your dataset and export as a tileset. When that’s complete, add your tileset to your style.
 
 ### Import into your style
 
@@ -59,33 +59,33 @@ When you're done, save your dataset and export as a tileset. When that's complet
 
 Mapbox Studio shines for styling your data and the process is much faster than attempting to style natively.
 
-There are some nuances to understand between the different layer types and how they work together. Don't be afraid to use the layers sidebar to peek into the techniques used to style the stock Mapbox maps. You can duplicate these layers, re-point the source to your own data, and tweak as needed.
+There are some nuances to understand between the different layer types and how they work together. Don’t be afraid to use the layers sidebar to peek into the techniques used to style the stock Mapbox maps. You can duplicate these layers, re-point the source to your own data, and tweak as needed.
 
 **Best Practices:**
 
 * Layers are cheap, so duplicate and update filters liberally.
-* If you'd like to stroke polygons you'll need to use two layers: one a fill and one a stroked line.
+* If you’d like to stroke polygons you’ll need to use two layers: one a fill and one a stroked line.
 * If you want to stroke a line, create two layers, one for the default stroke and one with a wider width for its casing
 * If you intend to animate properties or transition between values, consider creating separate layers for each state and toggling visibility to visualize the difference.
 
 ## Implement on iOS with runtime styling
 
-Once you're happy with the styles you've created, it's time to [get setup with Mapbox in your app](https://www.mapbox.com/ios-sdk/).
+Once you’re happy with the styles you’ve created, it’s time to [get setup with Mapbox in your app](https://www.mapbox.com/ios-sdk/).
 
 To implement your prototypes with runtime styling:
 
 1. Implement `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]`.
 2. Add your real data as a source:
     * This can be done using vector data from tileset editor ([example](https://www.mapbox.com/ios-sdk/examples/runtime-circle-styles)), custom vector tiles, added as GeoJSON ([example](https://www.mapbox.com/ios-sdk/examples/runtime-add-line), or added manually through the app via `MGLShapeSource` ([example](https://www.mapbox.com/ios-sdk/examples/runtime-multiple-annotations))
-3. For each layer you've prototyped in Studio, add its corresponding `MGLStyleLayer` subclass. See [“Configuring the map content’s appearance”](for-style-authors.html#configuring-the-map-content-s-appearance) for the available style layer classes.
+3. For each layer you’ve prototyped in Studio, add its corresponding `MGLStyleLayer` subclass. See [“Configuring the map content’s appearance”](for-style-authors.html#configuring-the-map-content-s-appearance) for the available style layer classes.
 
 **Translating style attributes from Studio**
-For each property you've edited in Studio, you can hover over the property name to find the corresponding property in the iOS SDK. It’ll generally be the camelCased version of the Property ID, but see [“Configuring the map content’s appearance”](for-style-authors.html#configuring-the-map-content-s-appearance) for a table of properties that differ between Mapbox Studio and the iOS SDK.
+For each property you’ve edited in Studio, you can hover over the property name to find the corresponding property in the iOS SDK. It’ll generally be the camelCased version of the Property ID, but see [“Configuring the map content’s appearance”](for-style-authors.html#configuring-the-map-content-s-appearance) for a table of properties that differ between Mapbox Studio and the iOS SDK.
 
 ![property values](img/studio-workflow/property-values.png)
 
 **Translating stop functions**
-It's possible to use stop functions in Mapbox Studio to transition the style of a layer by its zoom level (e.g. a line that gets wider as you zoom in). These can be translated in the mobile SDKs using `+[MGLSyleValue valueWithInterpolationBase:stops:]`. The rate of change between stops in Studio is represented by `interpolationBase`.
+It’s possible to use stop functions in Mapbox Studio to transition the style of a layer by its zoom level (e.g. a line that gets wider as you zoom in). These can be translated in the mobile SDKs using `+[MGLSyleValue valueWithInterpolationBase:stops:]`. The rate of change between stops in Studio is represented by `interpolationBase`.
 
 ![Stop functions](img/studio-workflow/stop-functions.png)
 


### PR DESCRIPTION
- Clarify and simplify some parts of the annotations guide.
- Add more links to examples, where appropriate.
- Remove support email link.
- Code ticks around `UIView`.
- Smart quotes.