### PR TITLE
[tests] Sidestep a gcc or gtest bug

### DIFF
--- a/test/style/functions.test.cpp
+++ b/test/style/functions.test.cpp
@@ -71,9 +71,9 @@ TEST(Function, Stops) {
     EXPECT_EQ("string2", evaluate(discrete_0, 10));
 
     Function<bool> discreteBool({{1, false}, {3, true}}, 1);
-    EXPECT_EQ(false, evaluate(discreteBool, 0));
-    EXPECT_EQ(false, evaluate(discreteBool, 1));
-    EXPECT_EQ(false, evaluate(discreteBool, 2));
-    EXPECT_EQ(true, evaluate(discreteBool, 3));
-    EXPECT_EQ(true, evaluate(discreteBool, 4));
+    EXPECT_FALSE(evaluate(discreteBool, 0));
+    EXPECT_FALSE(evaluate(discreteBool, 1));
+    EXPECT_FALSE(evaluate(discreteBool, 2));
+    EXPECT_TRUE(evaluate(discreteBool, 3));
+    EXPECT_TRUE(evaluate(discreteBool, 4));
 }


### PR DESCRIPTION
Fixes the following error:

```
../../../mason_packages/linux-x86_64/gtest/1.7.0/include/gtest/internal/gtest-internal.h:133:55: error: converting ‘false’ to pointer type for argument 1 of ‘char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)’ [-Werror=conversion-null]
     (sizeof(::testing::internal::IsNullLiteralHelper(x)) == 1)
                                                       ^
```

Related upstream issues:

https://github.com/google/googletest/issues/458
https://github.com/google/googletest/issues/322

Not seen in CI because of https://github.com/mapbox/mapbox-gl-native/blob/0ef52d7f7ceee670e8961e811364d215fde7e980/scripts/travis_setup.sh#L17-L22