### PR TITLE
Run style layer tests headlessly

### DIFF
--- a/platform/darwin/test/MGLStyleLayerTests.m
+++ b/platform/darwin/test/MGLStyleLayerTests.m
@@ -4,7 +4,9 @@
 
 #define TEST_STRICT_NAMING_CONVENTIONS 0
 
-@implementation MGLStyleLayerTests
+@implementation MGLStyleLayerTests {
+    XCTestExpectation *_styleLoadingExpectation;
+}
 
 @dynamic layerType;
 
@@ -24,13 +26,20 @@
 #endif
     _mapView.delegate = self;
     XCTAssertNil(_mapView.style);
-    [self keyValueObservingExpectationForObject:self.mapView keyPath:@"style" handler:^BOOL(MGLMapView * _Nonnull observedMapView, NSDictionary * _Nonnull change) {
-        return observedMapView.style != nil;
-    }];
+    _styleLoadingExpectation = [self expectationWithDescription:@"Map view should finish loading style."];
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    XCTAssertNotNil(mapView.style);
+    XCTAssertEqual(mapView.style, style);
+    XCTAssertNil(style.name);
+    
+    [_styleLoadingExpectation fulfill];
+}
+
 - (void)tearDown {
+    _styleLoadingExpectation = nil;
     _mapView = nil;
     
     [super tearDown];

--- a/platform/darwin/test/MGLStyleLayerTests.m
+++ b/platform/darwin/test/MGLStyleLayerTests.m
@@ -20,11 +20,7 @@
     _mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 256, 256) styleURL:styleURL];
     [vc.view addSubview:_mapView];
 #else
-    NSWindowController *windowController = [[NSWindowController alloc] initWithWindowNibName:@"MGLStyleLayerTests" owner:self];
-    NSView *contentView = windowController.window.contentView;
-    _mapView = [[MGLMapView alloc] initWithFrame:contentView.bounds styleURL:styleURL];
-    [contentView addSubview:_mapView];
-    [windowController showWindow:nil];
+    _mapView = [[MGLMapView alloc] initWithFrame:NSMakeRect(0, 0, 256, 256) styleURL:styleURL];
 #endif
     _mapView.delegate = self;
     XCTAssertNil(_mapView.style);


### PR DESCRIPTION
This change fixes the spurious integration test failures in `-[MGL*LayerTests testPropertyNames]` seemingly introduced in #7664 by paring the tests back. They no longer test integration within a real window or view hierarchy, which is always risky business in the supposedly headless environment of XCTest. Integration tests involving MGLMapView are more properly the domain of XCUITest (#4837) anyhow.

/cc @friedbunny