### PR TITLE
Note that MGLShapeSource.shape must be set on main thread

### DIFF
--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -187,14 +187,14 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
 
 /**
  The contents of the source. A shape can represent a GeoJSON geometry, a
- feature, or a collection of features. 
+ feature, or a collection of features.
 
  If the receiver was initialized using `-initWithIdentifier:URL:options:`, this
  property is set to `nil`. This property is unavailable until the receiver is
  passed into `-[MGLStyle addSource:]`.
  
- You can get/set the shapes within a collection via this property. Setting
- this property must be performed on the application's main thread.
+ You can get/set the shapes within a collection via this property. Actions must 
+ be performed on the application's main thread.
  */
 @property (nonatomic, copy, nullable) MGLShape *shape;
 

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -187,11 +187,14 @@ extern const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
 
 /**
  The contents of the source. A shape can represent a GeoJSON geometry, a
- feature, or a collection of features.
+ feature, or a collection of features. 
 
  If the receiver was initialized using `-initWithIdentifier:URL:options:`, this
  property is set to `nil`. This property is unavailable until the receiver is
  passed into `-[MGLStyle addSource:]`.
+ 
+ You can get/set the shapes within a collection via this property. Setting
+ this property must be performed on the application's main thread.
  */
 @property (nonatomic, copy, nullable) MGLShape *shape;
 


### PR DESCRIPTION
Like #7683, but based on the release-ios-v3.4.0 branch.

/cc @nitrag