### PR TITLE
Silence dependency analysis warning

### DIFF
--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		357579871D502AFE000B822E /* MGLLineStyleLayerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 357579861D502AFE000B822E /* MGLLineStyleLayerTests.mm */; };
 		357579891D502B06000B822E /* MGLCircleStyleLayerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 357579881D502B06000B822E /* MGLCircleStyleLayerTests.mm */; };
 		3575798B1D502B0C000B822E /* MGLBackgroundStyleLayerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3575798A1D502B0C000B822E /* MGLBackgroundStyleLayerTests.mm */; };
+		357FB1FC1F7A564700E9A22E /* Root.plist in Resources */ = {isa = PBXBuildFile; fileRef = DA25D5BF1CCD9F8400607828 /* Root.plist */; };
 		357FE2DD1E02D2B20068B753 /* NSCoder+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 357FE2DB1E02D2B20068B753 /* NSCoder+MGLAdditions.h */; };
 		357FE2DE1E02D2B20068B753 /* NSCoder+MGLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 357FE2DB1E02D2B20068B753 /* NSCoder+MGLAdditions.h */; };
 		357FE2DF1E02D2B20068B753 /* NSCoder+MGLAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 357FE2DC1E02D2B20068B753 /* NSCoder+MGLAdditions.mm */; };
@@ -249,7 +250,6 @@
 		DA1DC99F1CB6E088006E619F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA1DC99E1CB6E088006E619F /* Assets.xcassets */; };
 		DA1F8F3D1EBD287B00367E42 /* MGLDocumentationGuideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1F8F3C1EBD287B00367E42 /* MGLDocumentationGuideTests.swift */; };
 		DA2207BF1DC0805F0002F84D /* MGLStyleValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2207BE1DC0805F0002F84D /* MGLStyleValueTests.swift */; };
-		DA25D5C01CCD9F8400607828 /* Root.plist in Resources */ = {isa = PBXBuildFile; fileRef = DA25D5BF1CCD9F8400607828 /* Root.plist */; };
 		DA25D5C61CCDA06800607828 /* Root.strings in Resources */ = {isa = PBXBuildFile; fileRef = DA25D5C41CCDA06800607828 /* Root.strings */; };
 		DA25D5CD1CCDA11500607828 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = DA25D5B91CCD9EDE00607828 /* Settings.bundle */; };
 		DA2784FC1DF02FF4001D5B8D /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA2784FB1DF02FF4001D5B8D /* Media.xcassets */; };
@@ -2109,8 +2109,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				357FB1FC1F7A564700E9A22E /* Root.plist in Resources */,
 				DA25D5C61CCDA06800607828 /* Root.strings in Resources */,
-				DA25D5C01CCD9F8400607828 /* Root.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2719,7 +2719,7 @@
 		DA25D5BC1CCD9EDE00607828 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				INFOPLIST_FILE = framework/Settings.bundle/Root.plist;
+				INFOPLIST_FILE = framework/Info.plist;
 				PRODUCT_NAME = Settings;
 				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = bundle;
@@ -2729,7 +2729,7 @@
 		DA25D5BD1CCD9EDE00607828 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				INFOPLIST_FILE = framework/Settings.bundle/Root.plist;
+				INFOPLIST_FILE = framework/Info.plist;
 				PRODUCT_NAME = Settings;
 				SKIP_INSTALL = YES;
 				WRAPPER_EXTENSION = bundle;


### PR DESCRIPTION
#6948 fixed a compile-time error that started with Xcode 8.1 but introduced a new warning in 8.2

![screenshot 2017-01-12 14 42 28](https://cloud.githubusercontent.com/assets/764476/21892311/7a99dde4-d8d6-11e6-96e6-d7e6bce69690.png)

This PR fixes that by specifying the correct Info.plist instead of the Root.plist that's bundled in settings. 

https://developer.apple.com/library/content/qa/qa1649/_index.html


Verified that the Settings.bundle is still working:
![screenshot 2017-01-12 15 16 25](https://cloud.githubusercontent.com/assets/764476/21893149/25d18d6c-d8da-11e6-80c8-9346ffff15f4.png)




