### PR TITLE
Document simpler types for style values in Swift

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -269,9 +269,9 @@ In style JSON | In Objective-C        | In Swift
 Color         | `<%- cocoaPrefix %>Color` | `<%- cocoaPrefix %>Color`
 Enum          | `NSValue` (see `NSValue(MGLAdditions)`) | `NSValue` (see `NSValue(MGLAdditions)`)
 String        | `NSString`            | `String`
-Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
-Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
-Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
+Boolean       | `NSNumber.boolValue`  | `Bool`
+Number        | `NSNumber.floatValue` | `Float`
+Array (`-dasharray`) | `NSArray<NSNumber>` | `[Float]`
 Array (`-font`) | `NSArray<NSString>` | `[String]`
 <% if (iOS) { -%>
 Array (`-offset`, `-translate`) | `NSValue.CGVectorValue` | `NSValue.cgVectorValue`

--- a/platform/darwin/docs/guides/Working with GeoJSON Data.md
+++ b/platform/darwin/docs/guides/Working with GeoJSON Data.md
@@ -93,7 +93,7 @@ types when they occur as feature identifiers or property values:
 GeoJSON data type  | Objective-C representation | Swift representation
 -------------------|----------------------------|---------------------
 `null`             | `NSNull`                   | `NSNull`
-`true`, `false`    | `NSNumber.boolValue`       | `NSNumber.boolValue`
-Integer            | `NSNumber.unsignedLongLongValue`, `NSNumber.longLongValue` | `NSNumber.uint64Value`, `NSNumber.int64Value`
-Floating-point number | `NSNumber.doubleValue`  | `NSNumber.doubleValue`
+`true`, `false`    | `NSNumber.boolValue`       | `Bool`
+Integer            | `NSNumber.unsignedLongLongValue`, `NSNumber.longLongValue` | `UInt64`, `Int64`
+Floating-point number | `NSNumber.doubleValue`  | `Double`
 String             | `NSString`                 | `String`

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -267,9 +267,9 @@ In style JSON | In Objective-C        | In Swift
 Color         | `UIColor` | `UIColor`
 Enum          | `NSValue` (see `NSValue(MGLAdditions)`) | `NSValue` (see `NSValue(MGLAdditions)`)
 String        | `NSString`            | `String`
-Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
-Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
-Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
+Boolean       | `NSNumber.boolValue`  | `Bool`
+Number        | `NSNumber.floatValue` | `Float`
+Array (`-dasharray`) | `NSArray<NSNumber>` | `[Float]`
 Array (`-font`) | `NSArray<NSString>` | `[String]`
 Array (`-offset`, `-translate`) | `NSValue.CGVectorValue` | `NSValue.cgVectorValue`
 Array (`-padding`) | `NSValue.UIEdgeInsetsValue` | `NSValue.uiEdgeInsetsValue`

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -255,9 +255,9 @@ In style JSON | In Objective-C        | In Swift
 Color         | `NSColor` | `NSColor`
 Enum          | `NSValue` (see `NSValue(MGLAdditions)`) | `NSValue` (see `NSValue(MGLAdditions)`)
 String        | `NSString`            | `String`
-Boolean       | `NSNumber.boolValue`  | `NSNumber.boolValue`
-Number        | `NSNumber.floatValue` | `NSNumber.floatValue`
-Array (`-dasharray`) | `NSArray<NSNumber>` | `[NSNumber]`
+Boolean       | `NSNumber.boolValue`  | `Bool`
+Number        | `NSNumber.floatValue` | `Float`
+Array (`-dasharray`) | `NSArray<NSNumber>` | `[Float]`
 Array (`-font`) | `NSArray<NSString>` | `[String]`
 Array (`-offset`, `-translate`) | `NSValue` containing `CGVector` | `NSValue` containing `CGVector`
 Array (`-padding`) | `NSValue.edgeInsetsValue` | `NSValue.edgeInsetsValue`


### PR DESCRIPTION
For numeric style attributes, the generic argument to MGLStyleValue is technically an NSNumber in Swift, but you don’t need to use NSNumber `*Value` properties with it:

```swift
layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
let value = layer.circleOpacity as! MGLStyleConstantValue
assert(Float(value) == 0.7)
```

This PR replaces NSNumber properties with standard Swift types in the Swift column of type correspondence tables. I think we need to do this, because I see a lot of instances where developers unnecessarily write, for instance:

```swift
layer.circleOpacity = MGLStyleValue(rawValue: NSNumber(value: 0.7))
```

There’s a risk that the developer would read this and think they can write the following:

```swift
let opacity = layer.circleOpacity as! MGLStyleConstantValue
let percentage: Float = opacity
```

In which case the compiler will provide a fix-it that inserts a full-width conversion:

```swift
let opacity = layer.circleOpacity as! MGLStyleConstantValue
let percentage: Float = Float(opacity)
```

However, there is no fix-it for code like this:

```swift
let opacity = layer.circleOpacity as! MGLStyleConstantValue
let percentage = opacity * 100
```

I think getting into language-specific details is already slightly out of scope for these guides, but we do need to find a concise way to avoid misleading developers.