### PR TITLE
Fix link in “Working with GeoJSON Data” guide

### DIFF
--- a/platform/darwin/docs/guides/Working with GeoJSON Data.md
+++ b/platform/darwin/docs/guides/Working with GeoJSON Data.md
@@ -21,7 +21,7 @@ be a local file URL, an HTTP URL, or an HTTPS URL.
 Once you’ve added the GeoJSON file to the map via an `MGLShapeSource` object,
 you can configure the appearance of its data and control what data is visible
 using `MGLStyleLayer` objects, you can
-[access the data programmatically](#Extracting GeoJSON data from the map).
+[access the data programmatically](#extracting-geojson-data-from-the-map).
 
 ## Converting GeoJSON data into shape objects
 


### PR DESCRIPTION
jazzy kebab-cases anchors in guides.