### PR TITLE
Update CSSColorParser

### DIFF
--- a/src/csscolorparser/csscolorparser.cpp
+++ b/src/csscolorparser/csscolorparser.cpp
@@ -1,5 +1,5 @@
 // (c) Dean McNamee <dean@gmail.com>, 2012.
-// C++ port by Konstantin Käfer <mail@kkaefer.com>, 2014.
+// C++ port by Mapbox, Konstantin Käfer <mail@kkaefer.com>, 2014-2017.
 //
 // https://github.com/deanm/css-color-parser-js
 // https://github.com/kkaefer/css-color-parser-cpp
@@ -27,7 +27,6 @@
 #include <cstdint>
 #include <vector>
 #include <sstream>
-#include <cmath>
 #include <algorithm>
 
 namespace CSSColorParser {
@@ -117,12 +116,12 @@ const size_t namedColorCount = sizeof (namedColors) / sizeof (NamedColor);
 template <typename T>
 uint8_t clamp_css_byte(T i) {  // Clamp to integer 0 .. 255.
     i = ::round(i);  // Seems to be what Chrome does (vs truncation).
-    return i < 0 ? 0 : i > 255 ? 255 : i;
+    return i < 0 ? 0 : i > 255 ? 255 : uint8_t(i);
 }
 
 template <typename T>
 float clamp_css_float(T f) {  // Clamp to float 0.0 .. 1.0.
-    return f < 0 ? 0 : f > 1 ? 1 : f;
+    return f < 0 ? 0 : f > 1 ? 1 : float(f);
 }
 
 float parseFloat(const std::string& str) {
@@ -163,7 +162,7 @@ float css_hue_to_rgb(float m1, float m2, float h) {
         return m2;
     }
     if (h * 3.0f < 2.0f) {
-        return m1 + (m2 - m1) * (2.0 / 3.0 - h) * 6.0f;
+        return m1 + (m2 - m1) * (2.0f / 3.0f - h) * 6.0f;
     }
     return m1;
 }

--- a/src/csscolorparser/csscolorparser.hpp
+++ b/src/csscolorparser/csscolorparser.hpp
@@ -1,5 +1,5 @@
 // (c) Dean McNamee <dean@gmail.com>, 2012.
-// C++ port by Konstantin Käfer <mail@kkaefer.com>, 2014.
+// C++ port by Mapbox, Konstantin Käfer <mail@kkaefer.com>, 2014-2017.
 //
 // https://github.com/deanm/css-color-parser-js
 // https://github.com/kkaefer/css-color-parser-cpp
@@ -26,19 +26,30 @@
 #define CSS_COLOR_PARSER_CPP
 
 #include <string>
+#include <cmath>
 
 namespace CSSColorParser {
 
 struct Color {
-    inline Color() {}
+    inline Color() {
+    }
     inline Color(unsigned char r_, unsigned char g_, unsigned char b_, float a_)
-        : r(r_), g(g_), b(b_), a(a_) {}
+        : r(r_), g(g_), b(b_), a(a_ > 1 ? 1 : a_ < 0 ? 0 : a_) {
+    }
     unsigned char r = 0, g = 0, b = 0;
     float a = 1.0f;
 };
 
+inline bool operator==(const Color& lhs, const Color& rhs) {
+    return lhs.r == rhs.r && lhs.g == rhs.g && lhs.b == rhs.b && ::fabs(lhs.a - lhs.b) < 0.0001f;
+}
+
+inline bool operator!=(const Color& lhs, const Color& rhs) {
+    return !(lhs == rhs);
+}
+
 Color parse(const std::string& css_str);
 
-}
+} // namespace CSSColorParser
 
 #endif


### PR DESCRIPTION
Added fuzzing (no crashes) and did a few (non-critical) number cast fixes on https://github.com/kkaefer/css-color-parser-cpp. This just updates to the most recent version on that repo.