### PR TITLE
Wrap camera heading

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 3.4.1
+
+* Fixed an issue causing MGLMapView’s `camera`’s `heading` to be set to a negative value, indicating an undefined heading, when the map view faces northwest. The heading is now wrapped to between zero and 360 degrees, for consistency with MGLMapView’s `direction` property. ([#7724](https://github.com/mapbox/mapbox-gl-native/pull/7724))
+
 ## 3.4.0
 
 ### Packaging

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2625,7 +2625,7 @@ public:
 {
     CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : _mbglMap->getLatLng());
     double zoomLevel = cameraOptions.zoom ? *cameraOptions.zoom : self.zoomLevel;
-    CLLocationDirection direction = cameraOptions.angle ? -MGLDegreesFromRadians(*cameraOptions.angle) : self.direction;
+    CLLocationDirection direction = cameraOptions.angle ? mbgl::util::wrap(-MGLDegreesFromRadians(*cameraOptions.angle), 0., 360.) : self.direction;
     CGFloat pitch = cameraOptions.pitch ? MGLDegreesFromRadians(*cameraOptions.pitch) : _mbglMap->getPitch();
     CLLocationDistance altitude = MGLAltitudeForZoomLevel(zoomLevel, pitch, centerCoordinate.latitude, self.frame.size);
     return [MGLMapCamera cameraLookingAtCenterCoordinate:centerCoordinate fromDistance:altitude pitch:pitch heading:direction];

--- a/platform/ios/uitest/MapViewTests.m
+++ b/platform/ios/uitest/MapViewTests.m
@@ -260,7 +260,7 @@
                                @"disabling pan gesture should disallow horizontal panning");
 }
 
-- (void)testRotate {
+- (void)testRotateClockwise {
     CLLocationDirection startAngle = tester.mapView.direction;
 
     XCTAssertNotEqual(startAngle,
@@ -272,6 +272,21 @@
     XCTAssertGreaterThanOrEqual(fabs(tester.mapView.direction - startAngle),
                                 20,
                                 @"rotating map should change angle");
+}
+
+- (void)testRotateCounterclockwise {
+    CLLocationDirection startAngle = tester.mapView.direction;
+    
+    XCTAssertNotEqual(startAngle,
+                      -45,
+                      @"start angle must not be destination angle");
+    
+    [tester.mapView twoFingerRotateAtPoint:tester.mapView.center angle:-45];
+    
+    XCTAssertGreaterThanOrEqual(fabs(tester.mapView.direction - startAngle),
+                                -20,
+                                @"rotating map should change angle");
+    XCTAssertGreaterThan(tester.mapView.camera.heading, 0, @"camera should not go negative");
 }
 
 - (void)testRotateDisabled {

--- a/platform/ios/uitest/MapViewTests.m
+++ b/platform/ios/uitest/MapViewTests.m
@@ -283,8 +283,8 @@
     
     [tester.mapView twoFingerRotateAtPoint:tester.mapView.center angle:-45];
     
-    XCTAssertGreaterThanOrEqual(fabs(tester.mapView.direction - startAngle),
-                                -20,
+    XCTAssertGreaterThanOrEqual(fabs(startAngle - tester.mapView.direction),
+                                20,
                                 @"rotating map should change angle");
     XCTAssertGreaterThan(tester.mapView.camera.heading, 0, @"camera should not go negative");
 }

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Mapbox macOS SDK
 
+## 0.3.1
+
+This version of the Mapbox macOS SDK corresponds to version 3.4.1 of the Mapbox iOS SDK. The two SDKs have very similar feature sets. The main differences are the lack of user location tracking and annotation views. Some APIs have been adapted to macOS conventions, particularly the use of NSPopover for callout views.
+
+* Fixed an issue causing MGLMapView’s `camera`’s `heading` to be set to a negative value, indicating an undefined heading, when the map view faces northwest. The heading is now wrapped to between zero and 360 degrees, for consistency with MGLMapView’s `direction` property. ([#7724](https://github.com/mapbox/mapbox-gl-native/pull/7724))
+
 ## 0.3.0
 
 This version of the Mapbox macOS SDK corresponds to version 3.4.0 of the Mapbox iOS SDK. The two SDKs have very similar feature sets. The main differences are the lack of user location tracking and annotation views. Some APIs have been adapted to macOS conventions, particularly the use of NSPopover for callout views.

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -1249,7 +1249,7 @@ public:
 - (MGLMapCamera *)cameraForCameraOptions:(const mbgl::CameraOptions &)cameraOptions {
     CLLocationCoordinate2D centerCoordinate = MGLLocationCoordinate2DFromLatLng(cameraOptions.center ? *cameraOptions.center : _mbglMap->getLatLng());
     double zoomLevel = cameraOptions.zoom ? *cameraOptions.zoom : self.zoomLevel;
-    CLLocationDirection direction = cameraOptions.angle ? -MGLDegreesFromRadians(*cameraOptions.angle) : self.direction;
+    CLLocationDirection direction = cameraOptions.angle ? mbgl::util::wrap(-MGLDegreesFromRadians(*cameraOptions.angle), 0., 360.) : self.direction;
     CGFloat pitch = cameraOptions.pitch ? MGLDegreesFromRadians(*cameraOptions.pitch) : _mbglMap->getPitch();
     CLLocationDistance altitude = MGLAltitudeForZoomLevel(zoomLevel, pitch,
                                                           centerCoordinate.latitude,


### PR DESCRIPTION
Fixed an issue causing MGLMapView’s `camera`’s `heading` to be set to a negative value, indicating an undefined heading, when the map view faces northwest. The heading is now wrapped to between zero and 360 degrees, for consistency with MGLMapView’s `direction` property.

Fixes #7723.

/cc @friedbunny