### PR TITLE
Default to system font in attribution titles

### DIFF
--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -26,9 +26,20 @@
     // Apply a bogus, easily detectable style rule to any feedback link, since
     // NSAttributedString doesn’t preserve the class attribute.
     NSMutableString *css = [NSMutableString stringWithString:
+                            @"html { font-family: -apple-system, -apple-system-font, sans-serif; }"
                             @".mapbox-improve-map { -webkit-text-stroke-width: 1000px; }"];
     if (fontSize) {
-        [css appendFormat:@"html { font-size: %.1fpx; }", fontSize];
+        NSString *sizeRule = [NSString stringWithFormat:@"font-size: %.1fpx;", fontSize];
+#if !TARGET_OS_IPHONE
+        if (fontSize == [NSFont systemFontSizeForControlSize:NSMiniControlSize]) {
+            sizeRule = @"font: -webkit-mini-control";
+        } else if (fontSize == [NSFont systemFontSizeForControlSize:NSSmallControlSize]) {
+            sizeRule = @"font: -webkit-small-control";
+        } else if (fontSize == [NSFont systemFontSizeForControlSize:NSRegularControlSize]) {
+            sizeRule = @"font: -webkit-control";
+        }
+#endif
+        [css appendFormat:@"html { %@ }", sizeRule];
     }
     if (linkColor) {
         CGFloat red;


### PR DESCRIPTION
The inline stylesheet used when converting an attribution HTML string to an attributed string now specifies the system font as the default font. It still isn’t clear to me why macosapp has been defaulting to the system font, but it makes sense to me that the default default font would be Times without this change. This change makes use of WebKit’s proprietary `-apple-system` keyword, which [Apple recommends](https://webkit.org/blog/3709/using-the-system-font-in-web-content/) for this purpose.

There is still a slight difference between macosapp and an application outside macos.xcworkspace, but I think the two results are close enough:

<img width="239" alt="fonts" src="https://cloud.githubusercontent.com/assets/1231218/21957417/76aa3d30-da4a-11e6-815b-f0acfbee77d3.png">

Fixes #7722.

/cc @frederoni @friedbunny