### PR TITLE
WIP GLSurfaceView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -10,10 +10,10 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Canvas;
 import android.graphics.PointF;
-import android.graphics.SurfaceTexture;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
+import android.opengl.GLSurfaceView;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.IntDef;
@@ -26,10 +26,6 @@ import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
-import android.view.Surface;
-import android.view.SurfaceHolder;
-import android.view.SurfaceView;
-import android.view.TextureView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
@@ -54,6 +50,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
+
+import static android.opengl.GLSurfaceView.RENDERMODE_WHEN_DIRTY;
+
 /**
  * <p>
  * A {@code MapView} provides an embeddable map interface.
@@ -68,12 +69,13 @@ import java.util.List;
  * <strong>Warning:</strong> Please note that you are responsible for getting permission to use the map data,
  * and for ensuring your use adheres to the relevant terms of use.
  */
-public class MapView extends FrameLayout {
+public class MapView extends FrameLayout implements GLSurfaceView.Renderer {
 
   private NativeMapView nativeMapView;
   private boolean destroyed;
   private boolean hasSurface = false;
 
+  private GLSurfaceView glSurfaceView;
   private MapboxMap mapboxMap;
   private MapCallback mapCallback;
   private boolean onStartCalled;
@@ -121,7 +123,7 @@ public class MapView extends FrameLayout {
     CompassView compassView = (CompassView) view.findViewById(R.id.compassView);
     MyLocationView myLocationView = (MyLocationView) view.findViewById(R.id.userLocationView);
     ImageView attrView = (ImageView) view.findViewById(R.id.attributionView);
-    initalizeDrawingSurface(context, options);
+    initialiseDrawingSurface();
 
     // create native Map object
     nativeMapView = new NativeMapView(this);
@@ -170,16 +172,30 @@ public class MapView extends FrameLayout {
     mapboxMap.initialise(context, options);
   }
 
-  private void initalizeDrawingSurface(Context context, MapboxMapOptions options) {
-    if (options.getTextureMode()) {
-      TextureView textureView = new TextureView(context);
-      textureView.setSurfaceTextureListener(new SurfaceTextureListener());
-      addView(textureView, 0);
-    } else {
-      SurfaceView surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
-      surfaceView.getHolder().addCallback(new SurfaceCallback());
-      surfaceView.setVisibility(View.VISIBLE);
-    }
+  private void initialiseDrawingSurface() {
+    glSurfaceView = (GLSurfaceView) findViewById(R.id.surfaceView);
+    glSurfaceView.setEGLContextClientVersion(2);
+    glSurfaceView.setRenderer(this);
+    glSurfaceView.setRenderMode(RENDERMODE_WHEN_DIRTY);
+  }
+
+  @Override
+  public void onSurfaceCreated(GL10 gl10, EGLConfig eglConfig) {
+    nativeMapView.initializeDisplay();
+    nativeMapView.initializeContext();
+    nativeMapView.createSurface(glSurfaceView.getHolder().getSurface());
+    hasSurface = true;
+  }
+
+  @Override
+  public void onSurfaceChanged(GL10 gl10, int i, int i1) {
+    nativeMapView.resizeView(i, i1);
+    nativeMapView.resizeFramebuffer(i, i1);
+  }
+
+  @Override
+  public void onDrawFrame(GL10 gl10) {
+
   }
 
   //
@@ -207,10 +223,6 @@ public class MapView extends FrameLayout {
       mapboxMap.onRestoreInstanceState(savedInstanceState);
     }
 
-    // Initialize EGL
-    nativeMapView.initializeDisplay();
-    nativeMapView.initializeContext();
-
     addOnMapChangedListener(mapCallback = new MapCallback(mapboxMap));
   }
 
@@ -233,8 +245,9 @@ public class MapView extends FrameLayout {
   @UiThread
   public void onStart() {
     onStartCalled = true;
-    mapboxMap.onStart();
     registerConnectivityReceiver();
+    mapboxMap.onStart();
+    glSurfaceView.onResume();
   }
 
   /**
@@ -263,8 +276,9 @@ public class MapView extends FrameLayout {
   @UiThread
   public void onStop() {
     onStopCalled = true;
-    mapboxMap.onStop();
     unregisterConnectivityReceiver();
+    mapboxMap.onStop();
+    glSurfaceView.onPause();
   }
 
   /**
@@ -279,6 +293,7 @@ public class MapView extends FrameLayout {
     }
 
     destroyed = true;
+    hasSurface = false;
     nativeMapView.terminateContext();
     nativeMapView.terminateDisplay();
     nativeMapView.destroySurface();
@@ -449,84 +464,6 @@ public class MapView extends FrameLayout {
 
     if (!isInEditMode()) {
       nativeMapView.resizeView(width, height);
-    }
-  }
-
-  private class SurfaceCallback implements SurfaceHolder.Callback {
-
-    private Surface surface;
-
-    @Override
-    public void surfaceCreated(SurfaceHolder holder) {
-      nativeMapView.createSurface(surface = holder.getSurface());
-      hasSurface = true;
-    }
-
-    @Override
-    public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-      if (destroyed) {
-        return;
-      }
-      nativeMapView.resizeFramebuffer(width, height);
-    }
-
-    @Override
-    public void surfaceDestroyed(SurfaceHolder holder) {
-      hasSurface = false;
-
-      if (nativeMapView != null) {
-        nativeMapView.destroySurface();
-      }
-      surface.release();
-    }
-  }
-
-  // This class handles TextureView callbacks
-  private class SurfaceTextureListener implements TextureView.SurfaceTextureListener {
-
-    private Surface surface;
-
-    // Called when the native surface texture has been created
-    // Must do all EGL/GL ES initialization here
-    @Override
-    public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
-      nativeMapView.createSurface(this.surface = new Surface(surface));
-      nativeMapView.resizeFramebuffer(width, height);
-      hasSurface = true;
-    }
-
-    // Called when the native surface texture has been destroyed
-    // Must do all EGL/GL ES destruction here
-    @Override
-    public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
-      hasSurface = false;
-
-      if (nativeMapView != null) {
-        nativeMapView.destroySurface();
-      }
-      this.surface.release();
-      return true;
-    }
-
-    // Called when the format or size of the native surface texture has been changed
-    // Must handle window resizing here.
-    @Override
-    public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {
-      if (destroyed) {
-        return;
-      }
-
-      nativeMapView.resizeFramebuffer(width, height);
-    }
-
-    // Called when the SurfaceTexure frame is drawn to screen
-    // Must sync with UI here
-    @Override
-    public void onSurfaceTextureUpdated(SurfaceTexture surface) {
-      if (destroyed) {
-        return;
-      }
-      mapboxMap.onUpdate();
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMapOptions.java
@@ -79,9 +79,6 @@ public class MapboxMapOptions implements Parcelable {
 
   private String apiBaseUrl;
 
-  @Deprecated
-  private boolean textureMode;
-
   private String style;
 
   /**
@@ -142,7 +139,6 @@ public class MapboxMapOptions implements Parcelable {
 
     style = in.readString();
     apiBaseUrl = in.readString();
-    textureMode = in.readByte() != 0;
   }
 
   public static Bitmap getBitmapFromDrawable(Drawable drawable) {
@@ -275,8 +271,6 @@ public class MapboxMapOptions implements Parcelable {
       mapboxMapOptions.myLocationAccuracyTint(
         typedArray.getColor(R.styleable.mapbox_MapView_mapbox_myLocationAccuracyTintColor,
           ColorUtils.getPrimaryColor(context)));
-      mapboxMapOptions.textureMode(
-        typedArray.getBoolean(R.styleable.mapbox_MapView_mapbox_renderTextureMode, false));
     } finally {
       typedArray.recycle();
     }
@@ -640,22 +634,6 @@ public class MapboxMapOptions implements Parcelable {
   }
 
   /**
-   * Enable TextureView as rendered surface.
-   * <p>
-   * Since the 4.2.0 release we replaced our TextureView with an SurfaceView implemenation.
-   * Enabling this option will use the deprecated TextureView instead.
-   * </p>
-   *
-   * @param textureMode True to enable texture mode
-   * @return This
-   * @deprecated As of the 4.2.0 release, using TextureView is deprecated.
-   */
-  public MapboxMapOptions textureMode(boolean textureMode) {
-    this.textureMode = textureMode;
-    return this;
-  }
-
-  /**
    * Get the current configured API endpoint base URL.
    *
    * @return Base URL to be used API endpoint.
@@ -935,16 +913,6 @@ public class MapboxMapOptions implements Parcelable {
     return debugActive;
   }
 
-  /**
-   * Returns true if TextureView is being used a render view.
-   *
-   * @return True if TextureView is used.
-   * @deprecated As of the 4.2.0 release, using TextureView is deprecated.
-   */
-  public boolean getTextureMode() {
-    return textureMode;
-  }
-
   public static final Parcelable.Creator<MapboxMapOptions> CREATOR = new Parcelable.Creator<MapboxMapOptions>() {
     public MapboxMapOptions createFromParcel(Parcel in) {
       return new MapboxMapOptions(in);
@@ -1004,7 +972,6 @@ public class MapboxMapOptions implements Parcelable {
 
     dest.writeString(style);
     dest.writeString(apiBaseUrl);
-    dest.writeByte((byte) (textureMode ? 1 : 0));
   }
 
   @Override
@@ -1157,7 +1124,6 @@ public class MapboxMapOptions implements Parcelable {
     result = 31 * result + myLocationAccuracyTintColor;
     result = 31 * result + myLocationAccuracyAlpha;
     result = 31 * result + (apiBaseUrl != null ? apiBaseUrl.hashCode() : 0);
-    result = 31 * result + (textureMode ? 1 : 0);
     result = 31 * result + (style != null ? style.hashCode() : 0);
     return result;
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -57,8 +57,6 @@
     <public name="mapbox_uiAttributionMarginRight" type="attr" />
     <public name="mapbox_uiAttributionMarginBottom" type="attr" />
 
-    <public name="mapbox_renderTextureMode" type="attr" />
-
     <!-- Exposed styles -->
     <public name="mapbox_style_mapbox_streets" type="string" />
     <public name="mapbox_style_emerald" type="string" />

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <SurfaceView
+    <android.opengl.GLSurfaceView
         android:id="@+id/surfaceView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
+        android:layout_height="match_parent" />
 
     <FrameLayout
         android:id="@+id/markerViewContainer"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolygonActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/PolygonActivity.java
@@ -56,8 +56,6 @@ public class PolygonActivity extends AppCompatActivity implements OnMapReadyCall
     // configure inital map state
     MapboxMapOptions options = new MapboxMapOptions()
       .attributionTintColor(RED_COLOR)
-      // deprecated feature!
-      .textureMode(true)
       .compassFadesWhenFacingNorth(false)
       .styleUrl(Style.MAPBOX_STREETS)
       .camera(new CameraPosition.Builder()


### PR DESCRIPTION
WIP, Closes #5766, this PR migrates from using SurfaceView as a drawing surface to a GLSurfaceView implementation. More information on this topic in #5766. 

Current state:
 - [x] replace SurfaceView with GLSurfaceView
 - [x] remove (deprecated) support for TextureView 
 - [x] allow GLSurfaceView to create and maintain GL components (eglContext, eglDisplay, etc).
 - [x] post callbacks coming from the render thread to the main thread (invalidate, mapchange, etc.)
 - [x] cleanup callback code 
 - [ ] move rendering to the render thread*  
 - [ ] ...

*= it's currently unclear what next actions are to resolve this, currently queuing a runnable to be executed on the render thread is resulting in a native crash. I have tried instantiating the map object on the render thread itself but our runloop implementation doesn't agree with that.



