### PR TITLE
[core] Improve tile cache sizing calculation

### DIFF
--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -139,7 +139,7 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
     algorithm::updateRenderables(getTileFn, createTileFn, retainTileFn, renderTileFn,
                                  idealTiles, zoomRange, tileZoom);
 
-    if (type != SourceType::Annotations && cache.getSize() == 0) {
+    if (type != SourceType::Annotations) {
         size_t conservativeCacheSize =
             std::max((float)parameters.transformState.getSize().width / tileSize, 1.0f) *
             std::max((float)parameters.transformState.getSize().height / tileSize, 1.0f) *

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -141,8 +141,8 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
 
     if (type != SourceType::Annotations && cache.getSize() == 0) {
         size_t conservativeCacheSize =
-            std::max((float)parameters.transformState.getSize().width / util::tileSize, 1.0f) *
-            std::max((float)parameters.transformState.getSize().height / util::tileSize, 1.0f) *
+            std::max((float)parameters.transformState.getSize().width / tileSize, 1.0f) *
+            std::max((float)parameters.transformState.getSize().height / tileSize, 1.0f) *
             (parameters.transformState.getMaxZoom() - parameters.transformState.getMinZoom() + 1) *
             0.5;
         cache.setSize(conservativeCacheSize);


### PR DESCRIPTION
`TileCacheStrategy` can now be passed on `Map` ctor as a hint for the style sources about their cache strategy:
- `NoCache`: Do not retain tiles.
- `ConservativeCache`: Retain visible tiles from all zoom levels.
- `DoubleCache`: Twice as conservative.

This is also combined with updating the cache size whenever the transform dimensions or zoom range changes.