### PR TITLE
[core] Prefer std::tie usage

### DIFF
--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -217,9 +217,8 @@ std::unordered_map<std::string, std::vector<Feature>> Source::Impl::queryRendere
 
 
     auto sortRenderTiles = [](const RenderTile& a, const RenderTile& b) {
-        return a.id.canonical.z != b.id.canonical.z ? a.id.canonical.z < b.id.canonical.z :
-               a.id.canonical.y != b.id.canonical.y ? a.id.canonical.y < b.id.canonical.y :
-               a.id.wrap != b.id.wrap ? a.id.wrap < b.id.wrap : a.id.canonical.x < b.id.canonical.x;
+        return std::tie(a.id.canonical.z, a.id.canonical.y, a.id.wrap, a.id.canonical.x) <
+            std::tie(b.id.canonical.z, b.id.canonical.y, b.id.wrap, b.id.canonical.x);
     };
     std::vector<std::reference_wrapper<const RenderTile>> sortedTiles;
     std::transform(renderTiles.cbegin(), renderTiles.cend(), std::back_inserter(sortedTiles),

--- a/src/mbgl/tile/tile_id.hpp
+++ b/src/mbgl/tile/tile_id.hpp
@@ -108,7 +108,7 @@ inline bool CanonicalTileID::operator!=(const CanonicalTileID& rhs) const {
 }
 
 inline bool CanonicalTileID::operator<(const CanonicalTileID& rhs) const {
-    return z != rhs.z ? z < rhs.z : x != rhs.x ? x < rhs.x : y < rhs.y;
+    return std::tie(z, x, y) < std::tie(rhs.z, rhs.x, rhs.y);
 }
 
 inline bool CanonicalTileID::isChildOf(const CanonicalTileID& parent) const {
@@ -170,7 +170,7 @@ inline bool OverscaledTileID::operator!=(const OverscaledTileID& rhs) const {
 }
 
 inline bool OverscaledTileID::operator<(const OverscaledTileID& rhs) const {
-    return overscaledZ != rhs.overscaledZ ? overscaledZ < rhs.overscaledZ : canonical < rhs.canonical;
+    return std::tie(overscaledZ, canonical) < std::tie(rhs.overscaledZ, rhs.canonical);
 }
 
 inline uint32_t OverscaledTileID::overscaleFactor() const {
@@ -211,7 +211,7 @@ inline bool UnwrappedTileID::operator!=(const UnwrappedTileID& rhs) const {
 }
 
 inline bool UnwrappedTileID::operator<(const UnwrappedTileID& rhs) const {
-    return wrap != rhs.wrap ? wrap < rhs.wrap : canonical < rhs.canonical;
+    return std::tie(wrap, canonical) < std::tie(rhs.wrap, rhs.canonical);
 }
 
 inline bool UnwrappedTileID::isChildOf(const UnwrappedTileID& parent) const {

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -109,8 +109,7 @@ std::vector<UnwrappedTileID> tileCover(const Point<double>& tl,
 
     // Sort first by distance, then by x/y.
     std::sort(t.begin(), t.end(), [](const ID& a, const ID& b) {
-        return (a.sqDist != b.sqDist) ? (a.sqDist < b.sqDist)
-                                      : ((a.x != b.x) ? (a.x < b.x) : (a.y < b.y));
+        return std::tie(a.sqDist, a.x, a.y) < std::tie(b.sqDist, b.x, b.y);
     });
 
     // Erase duplicate tile IDs (they typically occur at the common side of both triangles).


### PR DESCRIPTION
Follow-up to #7737.

Integration query tests as well as unit tests in `test/tile/tile_id.test.cpp` and `test/util/tile_cover.cpp` should cover this.