### PR TITLE
Include leading / in URL path

### DIFF
--- a/src/mbgl/util/mapbox.cpp
+++ b/src/mbgl/util/mapbox.cpp
@@ -56,7 +56,7 @@ std::string normalizeStyleURL(const std::string& baseURL,
         return str;
     }
 
-    const auto tpl = baseURL + "/styles/v1/{path}?access_token=" + accessToken;
+    const auto tpl = baseURL + "/styles/v1{path}?access_token=" + accessToken;
     return transformURL(tpl, str, url);
 }
 
@@ -74,7 +74,7 @@ std::string normalizeSpriteURL(const std::string& baseURL,
     }
 
     const auto tpl =
-        baseURL + "/styles/v1/{directory}{filename}/sprite{extension}?access_token=" + accessToken;
+        baseURL + "/styles/v1{directory}{filename}/sprite{extension}?access_token=" + accessToken;
     return transformURL(tpl, str, url);
 }
 
@@ -91,7 +91,7 @@ std::string normalizeGlyphsURL(const std::string& baseURL,
         return str;
     }
 
-    const auto tpl = baseURL + "/fonts/v1/{path}?access_token=" + accessToken;
+    const auto tpl = baseURL + "/fonts/v1{path}?access_token=" + accessToken;
     return transformURL(tpl, str, url);
 }
 
@@ -108,13 +108,13 @@ std::string normalizeTileURL(const std::string& baseURL,
         return str;
     }
 
-    const auto tpl = baseURL + "/v4/{path}?access_token=" + accessToken;
+    const auto tpl = baseURL + "/v4{path}?access_token=" + accessToken;
     return transformURL(tpl, str, url);
 }
 
 std::string
 canonicalizeTileURL(const std::string& str, const SourceType type, const uint16_t tileSize) {
-    const char* version = "v4/";
+    const char* version = "/v4/";
     const size_t versionLen = strlen(version);
 
     const URL url(str);

--- a/src/mbgl/util/url.cpp
+++ b/src/mbgl/util/url.cpp
@@ -107,11 +107,6 @@ URL::URL(const std::string& str)
           if (isData) {
               // Skip comma
               pathPos++;
-          } else {
-              // Skip optional leading slash
-              while (pathPos < query.first && (str[pathPos] == '/')) {
-                  ++pathPos;
-              }
           }
           return { pathPos, query.first - pathPos };
       }()) {

--- a/test/util/url.test.cpp
+++ b/test/util/url.test.cpp
@@ -102,6 +102,17 @@ TEST(Path, Directory) {
     EXPECT_EQ(Path::Segment({ 0, 0 }), Path("foo").directory);
     EXPECT_EQ(Path::Segment({ 0, 0 }), Path("foo.png").directory);
     EXPECT_EQ(Path::Segment({ 0, 0 }), Path("").directory);
+
+    EXPECT_EQ(Path::Segment({ 0, 9 }), Path("/foo/bar/baz.ext").directory);
+    EXPECT_EQ(Path::Segment({ 0, 9 }), Path("/foo.bar/baz.ext").directory);
+    EXPECT_EQ(Path::Segment({ 0, 9 }), Path("/foo.bar/baz").directory);
+    EXPECT_EQ(Path::Segment({ 0, 9 }), Path("/foo/bar/.ext").directory);
+    EXPECT_EQ(Path::Segment({ 0, 5 }), Path("/foo/bar@2x.png").directory);
+    EXPECT_EQ(Path::Segment({ 0, 5 }), Path("/foo/b").directory);
+    EXPECT_EQ(Path::Segment({ 0, 5 }), Path("/foo/").directory);
+    EXPECT_EQ(Path::Segment({ 0, 1 }), Path("/foo").directory);
+    EXPECT_EQ(Path::Segment({ 0, 1 }), Path("/foo.png").directory);
+    EXPECT_EQ(Path::Segment({ 0, 1 }), Path("/").directory);
 }
 
 TEST(Path, URLDirectory) {
@@ -141,6 +152,18 @@ TEST(Path, Extension) {
     EXPECT_EQ(Path::Segment({ 3, 0 }), Path("foo").extension);
     EXPECT_EQ(Path::Segment({ 3, 4 }), Path("foo.png").extension);
     EXPECT_EQ(Path::Segment({ 0, 0 }), Path("").extension);
+
+    EXPECT_EQ(Path::Segment({ 12, 4 }), Path("/foo/bar/baz.ext").extension);
+    EXPECT_EQ(Path::Segment({ 12, 4 }), Path("/foo.bar/baz.ext").extension);
+    EXPECT_EQ(Path::Segment({ 19, 4 }), Path("/foo.bar/baz.vector.pbf").extension);
+    EXPECT_EQ(Path::Segment({ 12, 0 }), Path("/foo.bar/baz").extension);
+    EXPECT_EQ(Path::Segment({ 9, 4 }), Path("/foo/bar/.ext").extension);
+    EXPECT_EQ(Path::Segment({ 8, 7 }), Path("/foo/bar@2x.png").extension);
+    EXPECT_EQ(Path::Segment({ 6, 0 }), Path("/foo/b").extension);
+    EXPECT_EQ(Path::Segment({ 5, 0 }), Path("/foo/").extension);
+    EXPECT_EQ(Path::Segment({ 4, 0 }), Path("/foo").extension);
+    EXPECT_EQ(Path::Segment({ 4, 4 }), Path("/foo.png").extension);
+    EXPECT_EQ(Path::Segment({ 1, 0 }), Path("/").extension);
 }
 
 TEST(Path, URLExtension) {
@@ -179,6 +202,17 @@ TEST(Path, Filename) {
     EXPECT_EQ(Path::Segment({ 0, 3 }), Path("foo").filename);
     EXPECT_EQ(Path::Segment({ 0, 3 }), Path("foo.png").filename);
     EXPECT_EQ(Path::Segment({ 0, 0 }), Path("").filename);
+
+    EXPECT_EQ(Path::Segment({ 9, 3 }), Path("/foo/bar/baz.ext").filename);
+    EXPECT_EQ(Path::Segment({ 9, 3 }), Path("/foo.bar/baz.ext").filename);
+    EXPECT_EQ(Path::Segment({ 9, 3 }), Path("/foo.bar/baz").filename);
+    EXPECT_EQ(Path::Segment({ 9, 0 }), Path("/foo/bar/.ext").filename);
+    EXPECT_EQ(Path::Segment({ 5, 3 }), Path("/foo/bar@2x.png").filename);
+    EXPECT_EQ(Path::Segment({ 5, 1 }), Path("/foo/b").filename);
+    EXPECT_EQ(Path::Segment({ 5, 0 }), Path("/foo/").filename);
+    EXPECT_EQ(Path::Segment({ 1, 3 }), Path("/foo").filename);
+    EXPECT_EQ(Path::Segment({ 1, 3 }), Path("/foo.png").filename);
+    EXPECT_EQ(Path::Segment({ 1, 0 }), Path("/").filename);
 }
 
 TEST(Path, URLFilename) {

--- a/test/util/url.test.cpp
+++ b/test/util/url.test.cpp
@@ -76,15 +76,15 @@ TEST(URL, Domain) {
 }
 
 TEST(URL, Path) {
-    EXPECT_EQ(URL::Segment({ 19, 4 }), URL("http://example.com/test?query=foo").path);
-    EXPECT_EQ(URL::Segment({ 19, 4 }), URL("http://example.com/test?query=foo#bar").path);
-    EXPECT_EQ(URL::Segment({ 19, 4 }), URL("http://example.com/test#bar").path);
+    EXPECT_EQ(URL::Segment({ 18, 5 }), URL("http://example.com/test?query=foo").path);
+    EXPECT_EQ(URL::Segment({ 18, 5 }), URL("http://example.com/test?query=foo#bar").path);
+    EXPECT_EQ(URL::Segment({ 18, 5 }), URL("http://example.com/test#bar").path);
     EXPECT_EQ(URL::Segment({ 18, 0 }), URL("http://example.com?query=foo").path);
     EXPECT_EQ(URL::Segment({ 18, 0 }), URL("http://example.com#?query=foo").path);
-    EXPECT_EQ(URL::Segment({ 19, 0 }), URL("http://example.com/?query=foo").path);
+    EXPECT_EQ(URL::Segment({ 18, 1 }), URL("http://example.com/?query=foo").path);
     EXPECT_EQ(URL::Segment({ 3, 0 }), URL(":::").path);
     EXPECT_EQ(URL::Segment({ 13, 0 }), URL("http://domain").path);
-    EXPECT_EQ(URL::Segment({ 7, 3 }), URL("domain/foo?bar").path);
+    EXPECT_EQ(URL::Segment({ 6, 4 }), URL("domain/foo?bar").path);
     EXPECT_EQ(URL::Segment({ 6, 17 }), URL("data:,Hello%2C%20World!").path);
     EXPECT_EQ(URL::Segment({ 23, 24 }), URL("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D").path);
 }
@@ -105,26 +105,26 @@ TEST(Path, Directory) {
 }
 
 TEST(Path, URLDirectory) {
-    EXPECT_EQ(Path::Segment({ 19, 8 }), URLPath("http://example.com/foo/bar/baz.ext").directory);
-    EXPECT_EQ(Path::Segment({ 19, 8 }), URLPath("http://example.com/foo/bar/baz.ext?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 8 }), URLPath("http://example.com/foo.bar/baz.ext").directory);
-    EXPECT_EQ(Path::Segment({ 19, 8 }), URLPath("http://example.com/foo.bar/baz.ext?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 8 }), URLPath("http://example.com/foo.bar/baz").directory);
-    EXPECT_EQ(Path::Segment({ 19, 8 }), URLPath("http://example.com/foo.bar/baz?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 8 }), URLPath("http://example.com/foo/bar/.ext").directory);
-    EXPECT_EQ(Path::Segment({ 19, 8 }), URLPath("http://example.com/foo/bar/.ext?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 4 }), URLPath("http://example.com/foo/bar@2x.png").directory);
-    EXPECT_EQ(Path::Segment({ 19, 4 }), URLPath("http://example.com/foo/bar@2x.png?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 4 }), URLPath("http://example.com/foo/b").directory);
-    EXPECT_EQ(Path::Segment({ 19, 4 }), URLPath("http://example.com/foo/b?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 4 }), URLPath("http://example.com/foo/").directory);
-    EXPECT_EQ(Path::Segment({ 19, 4 }), URLPath("http://example.com/foo/?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 0 }), URLPath("http://example.com/foo").directory);
-    EXPECT_EQ(Path::Segment({ 19, 0 }), URLPath("http://example.com/foo?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 0 }), URLPath("http://example.com/foo.png").directory);
-    EXPECT_EQ(Path::Segment({ 19, 0 }), URLPath("http://example.com/foo.png?query=foo.bar").directory);
-    EXPECT_EQ(Path::Segment({ 19, 0 }), URLPath("http://example.com/").directory);
-    EXPECT_EQ(Path::Segment({ 19, 0 }), URLPath("http://example.com/?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 9 }), URLPath("http://example.com/foo/bar/baz.ext").directory);
+    EXPECT_EQ(Path::Segment({ 18, 9 }), URLPath("http://example.com/foo/bar/baz.ext?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 9 }), URLPath("http://example.com/foo.bar/baz.ext").directory);
+    EXPECT_EQ(Path::Segment({ 18, 9 }), URLPath("http://example.com/foo.bar/baz.ext?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 9 }), URLPath("http://example.com/foo.bar/baz").directory);
+    EXPECT_EQ(Path::Segment({ 18, 9 }), URLPath("http://example.com/foo.bar/baz?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 9 }), URLPath("http://example.com/foo/bar/.ext").directory);
+    EXPECT_EQ(Path::Segment({ 18, 9 }), URLPath("http://example.com/foo/bar/.ext?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 5 }), URLPath("http://example.com/foo/bar@2x.png").directory);
+    EXPECT_EQ(Path::Segment({ 18, 5 }), URLPath("http://example.com/foo/bar@2x.png?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 5 }), URLPath("http://example.com/foo/b").directory);
+    EXPECT_EQ(Path::Segment({ 18, 5 }), URLPath("http://example.com/foo/b?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 5 }), URLPath("http://example.com/foo/").directory);
+    EXPECT_EQ(Path::Segment({ 18, 5 }), URLPath("http://example.com/foo/?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 1 }), URLPath("http://example.com/foo").directory);
+    EXPECT_EQ(Path::Segment({ 18, 1 }), URLPath("http://example.com/foo?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 1 }), URLPath("http://example.com/foo.png").directory);
+    EXPECT_EQ(Path::Segment({ 18, 1 }), URLPath("http://example.com/foo.png?query=foo.bar").directory);
+    EXPECT_EQ(Path::Segment({ 18, 1 }), URLPath("http://example.com/").directory);
+    EXPECT_EQ(Path::Segment({ 18, 1 }), URLPath("http://example.com/?query=foo.bar").directory);
     EXPECT_EQ(Path::Segment({ 18, 0 }), URLPath("http://example.com").directory);
     EXPECT_EQ(Path::Segment({ 18, 0 }), URLPath("http://example.com?query=foo.bar").directory);
 }


### PR DESCRIPTION
Our URL class added in https://github.com/mapbox/mapbox-gl-native/pull/7464 does not include the leading `/` of the pathname. @jfirebaugh notes in https://github.com/mapbox/mapbox-gl-native/pull/7485#discussion_r96322459 that this is inconsistent with the definitions of path elsewhere, e.g. [`window.Location`](https://developer.mozilla.org/en-US/docs/Web/API/Location), [node](https://nodejs.org/api/url.html#url_urlobject_pathname), [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.3).