### PR TITLE
[build] Avoid creating a recursively symlinked node_modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT EXISTS "mapbox-gl-js/package.json")
    # Symlink mapbox-gl-js/node_modules so that the modules that are
    # about to be installed get cached between CI runs.
    execute_process(
-        COMMAND ln -s ../node_modules node_modules
+        COMMAND ln -sF ../node_modules .
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/mapbox-gl-js)
    execute_process(
         COMMAND npm install


### PR DESCRIPTION
With the previous command, the second time it would run generated a node_modules symlink inside the top-level node_modules directory.