### PR TITLE
Typo fixes, added line to MGLStyleLayer initializer description

### DIFF
--- a/platform/darwin/src/MGLMapCamera.h
+++ b/platform/darwin/src/MGLMapCamera.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)camera;
 
 /**
- Returns a new camera using based on information about the camera’s viewpoint
+ Returns a new camera based on information about the camera’s viewpoint
  and focus point.
  
  @param centerCoordinate The geographic coordinate on which the map should be

--- a/platform/darwin/src/MGLShapeCollection.h
+++ b/platform/darwin/src/MGLShapeCollection.h
@@ -28,9 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
  convenient to use an `MGLPointCollection`, `MGLMultiPolyline`, or
  `MGLMultiPolygon` object, respectively.
  
- A multipolyline is known as a
- <a href="https://tools.ietf.org/html/rfc7946#section-3.1.8">GeometryCollection</a>
- geometry in GeoJSON.
  */
 @interface MGLShapeCollection : MGLShape
 

--- a/platform/darwin/src/MGLShapeCollection.h
+++ b/platform/darwin/src/MGLShapeCollection.h
@@ -28,6 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
  convenient to use an `MGLPointCollection`, `MGLMultiPolyline`, or
  `MGLMultiPolygon` object, respectively.
  
+ A shape collection is known as a 
+ <a href="https://tools.ietf.org/html/rfc7946#section-3.1.8">GeometryCollection</a> 
+ geometry in GeoJSON.
  */
 @interface MGLShapeCollection : MGLShape
 

--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -29,10 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  After initializing and configuring the style layer, add it to a map view’s
  style using the `-[MGLStyle addLayer:]` or
- `-[MGLStyle insertLayer:belowLayer:]` method. Should not be used to create an 
- instance of MGLStyleLayer directly. Instead, create instances of
- `MGLBackgroundStyleLayer` and the concrete subclasses of
- `MGLForegroundStyleLayer`.
+ `-[MGLStyle insertLayer:belowLayer:]` method. 
  
  @param identifier A string that uniquely identifies the layer in the style to
     which it is added.

--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -27,6 +27,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a style layer object initialized with the given identifier.
  
+ The default implementation of this initializer in MGLStyleLayer creates an
+ invalid style layer. Call this initializer on `MGLBackgroundStyleLayer` or one of
+ the concrete subclasses of `MGLForegroundStyleLayer` to create a valid style
+ layer.
+ 
  After initializing and configuring the style layer, add it to a map view’s
  style using the `-[MGLStyle addLayer:]` or
  `-[MGLStyle insertLayer:belowLayer:]` method. 

--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -29,7 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
  
  After initializing and configuring the style layer, add it to a map view’s
  style using the `-[MGLStyle addLayer:]` or
- `-[MGLStyle insertLayer:belowLayer:]` method.
+ `-[MGLStyle insertLayer:belowLayer:]` method. Should not be used to create an 
+ instance of MGLStyleLayer directly. Instead, create instances of
+ `MGLBackgroundStyleLayer` and the concrete subclasses of
+ `MGLForegroundStyleLayer`.
  
  @param identifier A string that uniquely identifies the layer in the style to
     which it is added.

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -28,7 +28,7 @@ extern const CGFloat MGLMapViewDecelerationRateNormal;
 /** A fast deceleration rate for a map view. */
 extern const CGFloat MGLMapViewDecelerationRateFast;
 
-/** Disables decleration in a map view. */
+/** Disables deceleration in a map view. */
 extern const CGFloat MGLMapViewDecelerationRateImmediate;
 
 /**


### PR DESCRIPTION
- Corrected typos in MGLMapView.h and MGLMapCamera.h
- Removed line from MGLShapeCollection.h
- Inserted a reminder in MGLStyleLayer.h initializer description to remind user not to initialize MGLStyleLayer directly