### PR TITLE
Avoid clobbering Style URL inspectable

### DIFF
--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -231,7 +231,11 @@ public:
 - (void)awakeFromNib {
     [super awakeFromNib];
 
-    self.styleURL = nil;
+    // If the Style URL inspectable was not set, make sure to go through
+    // -setStyleURL: to load the default style.
+    if (_mbglMap->getStyleURL().empty()) {
+        self.styleURL = nil;
+    }
 }
 
 + (NSArray *)restorableStateKeyPaths {


### PR DESCRIPTION
`-[MGLMapView awakeFromNib]` nils out the `styleURL` property to ensure a style is always present on load. However, if the style URL is specified in the Style URL inspectable, it is set somewhere between `-initWithCoder:` and `-awakeFromNib`; nilling out the `styleURL` property in `-awakeFromNib` thus resets the style to the default. This change guards against nilling out a non-nil style URL, ensuring that `-setStyleURL:` is called once and only once on launch.

Unlike the macOS implementation of MGLMapView, the iOS implementation nils out the `styleURL` property within `-initWithCoder:`. While that approach would also work for macOS, `-setStyleURL:` would end up getting called twice, and Mapbox Streets v9 would get loaded briefly, wastefully, even if the second call to `-setStyleURL:` specifies a different style.

Fixes #7764.

/cc @frederoni