### PR TITLE
git + npm is run on every CMake invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,27 +3,6 @@ project(mbgl LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 14)
 
 include(cmake/mbgl.cmake)
-
-if(NOT EXISTS ".mason/mason.cmake")
-   execute_process(
-        COMMAND git submodule update --init .mason
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-endif()
-
-if(NOT EXISTS "mapbox-gl-js/package.json")
-   execute_process(
-        COMMAND git submodule update --init mapbox-gl-js
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-   # Symlink mapbox-gl-js/node_modules so that the modules that are
-   # about to be installed get cached between CI runs.
-   execute_process(
-        COMMAND ln -sF ../node_modules .
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/mapbox-gl-js)
-   execute_process(
-        COMMAND npm install
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/mapbox-gl-js)
-endif()
-
 include(.mason/mason.cmake)
 
 option(WITH_CXX11ABI "Use cxx11abi mason packages" OFF)

--- a/cmake/shaders.cmake
+++ b/cmake/shaders.cmake
@@ -6,6 +6,7 @@ function(add_shader VAR name)
     add_custom_command(
        OUTPUT ${shader_source_prefix}/${name}.hpp
        COMMAND ${shader_build_cmd} ${name} ${shader_file_prefix} ${shader_source_prefix}
+       DEPENDS npm-install
        DEPENDS ${CMAKE_SOURCE_DIR}/scripts/build-shaders.js
        DEPENDS ${shader_file_prefix}/${name}.vertex.glsl
        DEPENDS ${shader_file_prefix}/${name}.fragment.glsl


### PR DESCRIPTION
There are [checks](https://github.com/mapbox/mapbox-gl-native/blob/master/CMakeLists.txt#L7-L25) for both of these, but they don't work since the current working directory is not the source directory (it's the build directory). Instead, we'll have to supply the absolute path for these checks to work correctly.