### PR TITLE
deprecation cleanup for 5.0.0

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/Style.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/Style.java
@@ -23,7 +23,7 @@ public class Style {
    * constants means your map style will always use the latest version and may change as we
    * improve the style
    */
-  @StringDef( {MAPBOX_STREETS, OUTDOORS, EMERALD, LIGHT, DARK, SATELLITE, SATELLITE_STREETS})
+  @StringDef( {MAPBOX_STREETS, OUTDOORS, LIGHT, DARK, SATELLITE, SATELLITE_STREETS})
   @Retention(RetentionPolicy.SOURCE)
   public @interface StyleUrl {
   }
@@ -42,14 +42,6 @@ public class Style {
    * your map style will always use the latest version and may change as we improve the style.
    */
   public static final String OUTDOORS = "mapbox://styles/mapbox/outdoors-v9";
-
-  /**
-   * Emerald: A versatile style, with emphasis on road networks and public transit.
-   *
-   * @deprecated this style has been deprecated and will be removed in future versions.
-   */
-  @Deprecated
-  public static final String EMERALD = "mapbox://styles/mapbox/emerald-v8";
 
   /**
    * Light: Subtle light backdrop for data visualizations. Using this constant means your map

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -824,7 +824,6 @@ public final class MapboxMap {
    * @deprecated use {@link #setStyleUrl(String)} instead with versioned url methods from {@link Style}
    */
   @UiThread
-  @Deprecated
   public void setStyle(@Style.StyleUrl String style) {
     setStyleUrl(style);
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TrackingSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TrackingSettings.java
@@ -153,34 +153,12 @@ public final class TrackingSettings {
   }
 
   /**
-   * Returns if the tracking modes will be dismissed when a gesture occurs.
-   *
-   * @return True to indicate the tracking modes will be dismissed.
-   * @deprecated use @link #isAllDismissTrackingOnGestureinstead
-   */
-  @Deprecated
-  public boolean isDismissTrackingOnGesture() {
-    return dismissLocationTrackingOnGesture && dismissBearingTrackingOnGesture;
-  }
-
-  /**
    * Returns if all tracking modes will be dismissed when a gesture occurs.
    *
    * @return True to indicate that location and bearing tracking will be dismissed.
    */
   public boolean isAllDismissTrackingOnGesture() {
     return dismissLocationTrackingOnGesture && dismissBearingTrackingOnGesture;
-  }
-
-  /**
-   * Set the dismissal of the tracking modes if a gesture occurs.
-   *
-   * @param dismissTrackingOnGesture True to dismiss the tracking modes.
-   * @deprecated use @link #setDismissAllTrackingOnGesture instead
-   */
-  @Deprecated
-  public void setDismissTrackingOnGesture(boolean dismissTrackingOnGesture) {
-    setDismissAllTrackingOnGesture(dismissTrackingOnGesture);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
@@ -18,8 +18,6 @@
      may change as we improve the style. -->
     <string name="mapbox_style_mapbox_streets">mapbox://styles/mapbox/streets-v9</string>
     <string name="mapbox_style_outdoors">mapbox://styles/mapbox/outdoors-v9</string>
-    <!-- Note: Emerald style has been deprecated and will be removed in a future release-->
-    <string name="mapbox_style_emerald">mapbox://styles/mapbox/emerald-v8</string>
     <string name="mapbox_style_light">mapbox://styles/mapbox/light-v9</string>
     <string name="mapbox_style_dark">mapbox://styles/mapbox/dark-v9</string>
     <string name="mapbox_style_satellite">mapbox://styles/mapbox/satellite-v9</string>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_scroll_by.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_scroll_by.xml
@@ -82,7 +82,7 @@
                 android:layout_height="match_parent"
                 app:mapbox_cameraTargetLat="37.176546"
                 app:mapbox_cameraTargetLng="-3.599007"
-                app:mapbox_styleUrl="@string/mapbox_style_emerald"
+                app:mapbox_styleUrl="@string/mapbox_style_dark"
                 app:mapbox_cameraZoom="15" />
 
             <android.support.design.widget.FloatingActionButton

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/TrackingSettingsTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/maps/TrackingSettingsTest.java
@@ -44,15 +44,15 @@ public class TrackingSettingsTest {
 
   @Test
   public void testDismissTrackingModesOnGesture() {
-    trackingSettings.setDismissTrackingOnGesture(false);
-    assertFalse("DismissTrackingOnGesture should be false", trackingSettings.isDismissTrackingOnGesture());
+    trackingSettings.setDismissAllTrackingOnGesture(false);
+    assertFalse("DismissTrackingOnGesture should be false", trackingSettings.isAllDismissTrackingOnGesture());
   }
 
   @Test
   public void testValidateGesturesForTrackingModes() {
-    trackingSettings.setDismissTrackingOnGesture(false);
+    trackingSettings.setDismissAllTrackingOnGesture(false);
     trackingSettings.setMyLocationTrackingMode(MyLocationTracking.TRACKING_FOLLOW);
-    assertFalse("DismissTrackingOnGesture should be false", trackingSettings.isDismissTrackingOnGesture());
+    assertFalse("DismissTrackingOnGesture should be false", trackingSettings.isAllDismissTrackingOnGesture());
   }
 
   @Test


### PR DESCRIPTION
Closes #7575, finalising public api for 5.0.0, cleanup deprecation
- remove deprecated emerald
- remove deprecation annotation for setStyle
- remove deprecated dismiss tracking on gesture

This PR doesn't include the removal of TextureView. 
As proposed [here](https://github.com/mapbox/mapbox-gl-native/issues/7575#issuecomment-270070568), I'm going to pick this up with https://github.com/mapbox/mapbox-gl-native/issues/5766.

Review @zugaldia 
