### PR TITLE
[android] - unblock building nightly builds

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -200,14 +200,19 @@ workflows:
             #!/bin/bash
             echo "Compile libmapbox-gl.so for all supportd abi's:"
             export BUILDTYPE=Release
-            make apackage
+            make android-lib-arm-v5
+            make android-lib-arm-v7
+            make android-lib-arm-v8
+            make android-lib-x86
+            make android-lib-x86-64
+            cd platform/android && ./gradlew :MapboxGLAndroidSDK:assembleRelease
     - script:
         title: Publish to maven
         inputs:
         - content: |-
             #!/bin/bash
             echo "Upload aar file to maven:"
-            cd platform/android && ./gradlew uploadArchives
+            cd platform/android && ./gradlew :MapboxGLAndroidSDK:uploadArchives
     - slack:
         title: Post to Slack
         inputs:
@@ -293,7 +298,12 @@ workflows:
             #!/bin/bash
             echo "Compile libmapbox-gl.so for all supportd abi's:"
             export BUILDTYPE=Release
-            make apackage
+            make android-lib-arm-v5
+            make android-lib-arm-v7
+            make android-lib-arm-v8
+            make android-lib-x86
+            make android-lib-x86-64
+            cd platform/android && ./gradlew :MapboxGLAndroidSDK:assembleRelease
     - script:
         title: Log metrics
         inputs:


### PR DESCRIPTION
Refs #7733, this PR [disables building for MIPS](https://github.com/mapbox/mapbox-gl-native/issues/7733#issuecomment-273502978) for our nightly builds (both SNAPSHOTS as metrics). 
This is no final solution but will unblock us for the time beeing.

Review @zugaldia 
