### PR TITLE
Pass ICU to libtool in package script

### DIFF
--- a/platform/ios/scripts/package.sh
+++ b/platform/ios/scripts/package.sh
@@ -117,7 +117,7 @@ if [[ ${BUILD_FOR_DEVICE} == true ]]; then
             -o ${OUTPUT}/static/${NAME}.framework/${NAME} \
             ${LIBS[@]/#/${PRODUCTS}/${BUILDTYPE}-iphoneos/lib} \
             ${LIBS[@]/#/${PRODUCTS}/${BUILDTYPE}-iphonesimulator/lib} \
-            `find mason_packages/ios-${IOS_SDK_VERSION} -type f -name libgeojson.a`
+            `cmake -LA -N ${DERIVED_DATA} | grep MASON_PACKAGE_icu_LIBRARIES | cut -d= -f2`
 
         cp -rv ${PRODUCTS}/${BUILDTYPE}-iphoneos/${NAME}.bundle ${STATIC_BUNDLE_DIR}
     fi
@@ -157,7 +157,7 @@ else
         libtool -static -no_warning_for_no_symbols \
             -o ${OUTPUT}/static/${NAME}.framework/${NAME} \
             ${LIBS[@]/#/${PRODUCTS}/${BUILDTYPE}-iphonesimulator/lib} \
-            `find mason_packages/ios-${IOS_SDK_VERSION} -type f -name libgeojson.a`
+            `cmake -LA -N ${DERIVED_DATA} | grep MASON_PACKAGE_icu_LIBRARIES | cut -d= -f2`
 
         cp -rv ${PRODUCTS}/${BUILDTYPE}-iphonesimulator/${NAME}.bundle ${STATIC_BUNDLE_DIR}
     fi


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-gl-native/pull/6984 we started using [ICU](https://github.com/mapbox/mason/pull/275) in core. This causes linker errors in an iOS application that uses a static build of the Mapbox iOS SDK.

This passes ICU (via Mason) to libtool when the iOS static build is created so that the dependency is available when the Mapbox iOS SDK is used in a host iOS application. 

The ICU lib actually replaces libgeojson. On our build machines libgeojson was not actually getting passed to libtool since the path used was provided by {IOS_SDK_VERSION} (created with `xcrun --sdk iphonesimulator|iphoneos --show-sdk-version` was greater than the `8.0` value that is [currently hard coded in the mason.sh script](https://github.com/mapbox/mason/blob/master/mason.sh#L70). I'm still unclear about why `libgeojson` was added but it does seem safe to remove it.

~~To attempt to start to sync up with the mason.sh file, this also adds a `MASON_PLATFORM_VERSION` variable to the iOS package.sh script that is now hardcoded to 8.0 just like the mason.sh script. This is required to get things to link but is fragile and I'm unclear about how this dependency should actually be handled in the various scripts. I'm not sure that hard coding this value in mason itself is a good idea.~~

** edit **

As noted below, we ended up using the cmake cache to find the ICU archive and to avoid having the package script know about the mason and ICU versions that are already specified in the cmake config.

cc @1ec5 @ChrisLoer @jfirebaugh 