### PR TITLE
Deprecate style methods

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -361,7 +361,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 /**
  Currently active style classes, represented as an array of string identifiers.
  */
-@property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses;
+@property (nonatomic) NS_ARRAY_OF(NSString *) *styleClasses __attribute__((deprecated("This property will be removed.")));
 
 /**
  Returns a Boolean value indicating whether the style class with the given
@@ -370,14 +370,14 @@ static const NSInteger MGLStyleDefaultVersion = 9;
  @param styleClass The style class to query for.
  @return Whether the style class is currently active.
  */
-- (BOOL)hasStyleClass:(NSString *)styleClass;
+- (BOOL)hasStyleClass:(NSString *)styleClass __attribute__((deprecated("This method will be removed in a future release. Runtime styling is :sunglasses:")));
 
 /**
  Activates the style class with the given identifier.
 
  @param styleClass The style class to activate.
  */
-- (void)addStyleClass:(NSString *)styleClass;
+- (void)addStyleClass:(NSString *)styleClass __attribute__((deprecated("This method will be removed in a future release. Runtime styling is :sunglasses:")));
 
 /**
  Deactivates the style class with the given identifier.
@@ -392,7 +392,7 @@ static const NSInteger MGLStyleDefaultVersion = 9;
 
  @param styleClass The style class to deactivate.
  */
-- (void)removeStyleClass:(NSString *)styleClass;
+- (void)removeStyleClass:(NSString *)styleClass __attribute__((deprecated("This method will be removed in a future release. Runtime styling is :sunglasses:")));
 
 #pragma mark Managing a Style’s Images
 


### PR DESCRIPTION
According to #7577 and #2875 we should mark style methods and properties as deprecated because we will not support them on future releases.

The Android SDK has already deprecated same API.

This is a temporarily PR to branch release-ios-v3.4.0, this should be included in release-ios-v3.4.1