### PR TITLE
[core] Remove unused include

### DIFF
--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -10,8 +10,6 @@
 #include <mbgl/util/thread_context.hpp>
 #include <mbgl/util/platform.hpp>
 
-#include <pthread.h>
-
 namespace mbgl {
 namespace util {
 


### PR DESCRIPTION
pthread is not used directly, but per platform basis.