### PR TITLE
Fix rendering 180° line joins

### DIFF
--- a/src/mbgl/programs/line_program.hpp
+++ b/src/mbgl/programs/line_program.hpp
@@ -49,7 +49,7 @@ struct LineAttributes : gl::Attributes<
                 static_cast<int16_t>((p.y * 2) | t.y)
             },
             {
-                // add 128 to store an byte in an unsigned byte
+                // add 128 to store a byte in an unsigned byte
                 static_cast<uint8_t>(::round(extrudeScale * e.x) + 128),
                 static_cast<uint8_t>(::round(extrudeScale * e.y) + 128),
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/7778, a alternative fix for https://github.com/mapbox/mapbox-gl-js/pull/4008

@lbud  I am using a different fix: I found that computing the unit vector of (0, 0) on native [returns a vector of (0, 0)](https://github.com/mapbox/mapbox-gl-native/commit/768c259#commitcomment-20538139), while JS uses NaN. I investigated a little further and ultimately found that this makes `miterLength` NaN as well on JS. Instead of using NaN all the way down, this patch uses an explicit value of `0`, and sets the `miterLimit` to Infinity in that case. This change also fixes the missing line caps we saw on native (which was also a result of the different way of computing `unit(0, 0)`).

I think we should port this change back to JS as well, since it removes division by zero.