### PR TITLE
[android] - invalidate MarkerView after render invocation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
@@ -342,6 +342,7 @@ public class MarkerView extends Marker {
   public void setPosition(LatLng position) {
     super.setPosition(position);
     if (markerViewManager != null) {
+      markerViewManager.setWaitingForRenderInvoke(true);
       markerViewManager.update();
     }
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -515,9 +515,6 @@ public final class MapboxMap {
   @UiThread
   public final void moveCamera(CameraUpdate update) {
     moveCamera(update, null);
-    // MapChange.REGION_DID_CHANGE_ANIMATED is not called for `jumpTo`
-    // invalidate camera position to provide OnCameraChange event.
-    invalidateCameraPosition();
   }
 
   /**
@@ -534,6 +531,9 @@ public final class MapboxMap {
       @Override
       public void run() {
         transform.moveCamera(MapboxMap.this, update, callback);
+        // MapChange.REGION_DID_CHANGE_ANIMATED is not called for `jumpTo`
+        // invalidate camera position to provide OnCameraChange event.
+        invalidateCameraPosition();
       }
     });
   }


### PR DESCRIPTION
Closes #7782 + fixes that camera position invalidations happen for all moveCamera invocations and inside the actual runnable invoking the `jumpTo`.

Review @zugaldia 