### PR TITLE
[Qt] Use Qt's OpenGL header

### DIFF
--- a/include/mbgl/gl/gl.hpp
+++ b/include/mbgl/gl/gl.hpp
@@ -22,6 +22,9 @@
     #define GL_GLEXT_PROTOTYPES
     #include <GLES2/gl2.h>
     #include <GLES2/gl2ext.h>
+#elif __QT__
+    #define GL_GLEXT_PROTOTYPES
+    #include <QtOpenGL>
 #else
     #define GL_GLEXT_PROTOTYPES
     #include <GL/gl.h>


### PR DESCRIPTION
Better compatibility when compiling to the several platforms supported by Qt.