### PR TITLE
[core][Qt] Use Qt for UTF16, since `codecvt` is not always available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,7 @@ matrix:
       dist: trusty
       language: cpp
       compiler: "qt5-gcc5-release"
-      env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5
+      env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5 WITH_QT_I18N=1
       addons: *qt5
       before_script:
         - mapbox_start_xvfb

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -79,6 +79,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/android/src/logging_android.cpp
         PRIVATE platform/default/string_stdlib.cpp
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/utf.cpp
 
         # Image handling
         PRIVATE platform/default/image.cpp

--- a/platform/default/utf.cpp
+++ b/platform/default/utf.cpp
@@ -1,0 +1,16 @@
+#include <mbgl/util/utf.hpp>
+
+#include <memory>
+#include <locale>
+#include <codecvt>
+
+namespace mbgl {
+namespace util {
+
+std::u16string utf8_to_utf16::convert(std::string const& utf8) {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
+    return converter.from_bytes(utf8);
+}
+
+} // namespace util
+} // namespace mbgl

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -41,6 +41,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/utf.cpp
 
         # Image handling
         PRIVATE platform/darwin/src/image.mm

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -72,6 +72,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/default/string_stdlib.cpp
         PRIVATE platform/default/thread.cpp
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/utf.cpp
 
         # Image handling
         PRIVATE platform/default/image.cpp

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -37,6 +37,7 @@ macro(mbgl_platform_core)
         PRIVATE platform/darwin/src/nsthread.mm
         PRIVATE platform/darwin/src/string_nsstring.mm
         PRIVATE platform/default/bidi.cpp
+        PRIVATE platform/default/utf.cpp
 
         # Image handling
         PRIVATE platform/darwin/src/image.mm

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -48,6 +48,7 @@ set(MBGL_QT_FILES
     PRIVATE platform/qt/src/string_stdlib.cpp
     PRIVATE platform/qt/src/timer.cpp
     PRIVATE platform/qt/src/timer_impl.hpp
+    PRIVATE platform/qt/src/utf.cpp
 )
 
 include_directories(

--- a/platform/qt/src/bidi.cpp
+++ b/platform/qt/src/bidi.cpp
@@ -12,12 +12,11 @@ public:
 };
 
 std::u16string applyArabicShaping(const std::u16string& input) {
-    QString utf16string = QString::fromStdU16String(input);
-    return utf16string.toStdU16String();
+    return input;
 }
 
 void BiDi::mergeParagraphLineBreaks(std::set<std::size_t>& lineBreakPoints) {
-    lineBreakPoints.insert(static_cast<std::size_t>(bidi.impl->string.length()));
+    lineBreakPoints.insert(static_cast<std::size_t>(impl->string.length()));
 }
 
 std::vector<std::u16string>
@@ -27,7 +26,7 @@ BiDi::applyLineBreaking(std::set<std::size_t> lineBreakPoints) {
     std::vector<std::u16string> transformedLines;
     std::size_t start = 0;
     for (std::size_t lineBreakPoint : lineBreakPoints) {
-        transformedLines.push_back(bidi.getLine(start, lineBreakPoint));
+        transformedLines.push_back(getLine(start, lineBreakPoint));
         start = lineBreakPoint;
     }
 
@@ -41,12 +40,13 @@ BiDi::BiDi() : impl(std::make_unique<BiDiImpl>())
 BiDi::~BiDi() = default;
 
 std::vector<std::u16string> BiDi::processText(const std::u16string& input, std::set<std::size_t> lineBreakPoints) {
-    impl->string = QString::fromStdU16String(input);
+    impl->string = QString::fromUtf16(reinterpret_cast<const ushort*>(input.data()), int(input.size()));
     return applyLineBreaking(lineBreakPoints);
 }
 
 std::u16string BiDi::getLine(std::size_t start, std::size_t end) {
-    return impl->string.mid(static_cast<int32_t>(start), static_cast<int32_t>(end - start)).toStdU16String();
+    auto utf16 = impl->string.mid(static_cast<int32_t>(start), static_cast<int32_t>(end - start));
+    return std::u16string(reinterpret_cast<const char16_t*>(utf16.utf16()), utf16.length());
 }
 
 } // end namespace mbgl

--- a/platform/qt/src/string_stdlib.cpp
+++ b/platform/qt/src/string_stdlib.cpp
@@ -9,13 +9,13 @@ namespace mbgl {
 namespace platform {
 
 std::string uppercase(const std::string& str) {
-    auto upper = QString::fromUtf8(str.c_str()).toUpper().toUtf8();
+    auto upper = QString::fromUtf8(str.data(), str.length()).toUpper().toUtf8();
 
     return std::string(upper.constData(), upper.size());
 }
 
 std::string lowercase(const std::string& str) {
-    auto lower = QString::fromUtf8(str.c_str()).toLower().toUtf8();
+    auto lower = QString::fromUtf8(str.data(), str.length()).toLower().toUtf8();
 
     return std::string(lower.constData(), lower.size());
 }

--- a/platform/qt/src/utf.cpp
+++ b/platform/qt/src/utf.cpp
@@ -1,0 +1,17 @@
+#include <mbgl/util/utf.hpp>
+
+#include <QString>
+
+namespace mbgl {
+namespace util {
+
+std::u16string utf8_to_utf16::convert(std::string const& utf8) {
+    auto utf16 = QString::fromUtf8(utf8.data(), utf8.length());
+
+    // Newers Qt have QString::toStdU16String(), but this is how it is
+    // implemented. Do it here to keep compatibility with older versions.
+    return std::u16string(reinterpret_cast<const char16_t*>(utf16.utf16()), utf16.length());
+}
+
+} // namespace util
+} // namespace mbgl

--- a/src/mbgl/util/utf.hpp
+++ b/src/mbgl/util/utf.hpp
@@ -1,19 +1,13 @@
 #pragma once
 
-#include <memory>
-
-#include <locale>
-#include <codecvt>
+#include <string>
 
 namespace mbgl {
 namespace util {
 
 class utf8_to_utf16 {
 public:
-    static std::u16string convert(std::string const& utf8) {
-        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter;
-        return converter.from_bytes(utf8);
-    }
+    static std::u16string convert(std::string const&);
 };
 
 } // namespace util


### PR DESCRIPTION
Instead, use Qt's codec.