### PR TITLE
[android] - cleanup replaced annotation icon

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -641,6 +641,13 @@ final class NativeMapView {
     nativeAddAnnotationIcon(nativeMapViewPtr, symbol, width, height, scale, pixels);
   }
 
+  public void removeAnnotationIcon(String symbol){
+    if(isDestroyedOn("removeAnnotationIcon")){
+      return;
+    }
+    nativeRemoveAnnotationIcon(nativeMapViewPtr, symbol);
+  }
+
   public void setVisibleCoordinateBounds(LatLng[] coordinates, RectF padding, double direction, long duration) {
     if (isDestroyedOn("setVisibleCoordinateBounds")) {
       return;
@@ -1074,6 +1081,8 @@ final class NativeMapView {
 
   private native void nativeAddAnnotationIcon(long nativeMapViewPtr, String symbol,
                                               int width, int height, float scale, byte[] pixels);
+
+  private native void nativeRemoveAnnotationIcon(long nativeMapViewPtr, String symbol);
 
   private native void nativeSetVisibleCoordinateBounds(long nativeMapViewPtr, LatLng[] coordinates,
                                                        RectF padding, double direction, long duration);

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -854,6 +854,16 @@ void nativeAddAnnotationIcon(JNIEnv *env, jni::jobject* obj, jlong nativeMapView
     nativeMapView->getMap().addAnnotationIcon(symbolName, iconImage);
 }
 
+void nativeRemoveAnnotationIcon(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr,
+                                         jni::jstring* symbol) {
+    assert(nativeMapViewPtr != 0);
+    NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
+
+    const std::string symbolName = std_string_from_jstring(env, symbol);
+
+    nativeMapView->getMap().removeAnnotationIcon(symbolName);
+}
+
 void nativeSetVisibleCoordinateBounds(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr,
         jni::jarray<jni::jobject>* coordinates, jni::jobject* padding, jdouble direction, jlong duration) {
     assert(nativeMapViewPtr != 0);
@@ -1902,6 +1912,7 @@ void registerNatives(JavaVM *vm) {
         MAKE_NATIVE_METHOD(nativeRemoveAnnotations, "(J[J)V"),
         MAKE_NATIVE_METHOD(nativeQueryPointAnnotations, "(JLandroid/graphics/RectF;)[J"),
         MAKE_NATIVE_METHOD(nativeAddAnnotationIcon, "(JLjava/lang/String;IIF[B)V"),
+        MAKE_NATIVE_METHOD(nativeRemoveAnnotationIcon, "(JLjava/lang/String;)V"),
         MAKE_NATIVE_METHOD(nativeSetVisibleCoordinateBounds, "(J[Lcom/mapbox/mapboxsdk/geometry/LatLng;Landroid/graphics/RectF;DJ)V"),
         MAKE_NATIVE_METHOD(nativeOnLowMemory, "(J)V"),
         MAKE_NATIVE_METHOD(nativeSetDebug, "(JZ)V"),


### PR DESCRIPTION
WIP, Closes #7343

- [x] provide android binding implementation of `Map::removeAnnotationIcon`
- [ ] call removeAnnotationIcon if older icon isn't referenced by others when annotation updates it's icon

