### PR TITLE
Note that canvas sources are unsupported

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -282,9 +282,15 @@ Array (`-padding`) | `NSValue.edgeInsetsValue` | `NSValue.edgeInsetsValue`
 <% } -%>
 
 For padding attributes, note that the arguments to
-`<%- cocoaPrefix %>EdgeInsetsMake()` in Objective-C and
-`EdgeInsets(top:left:bottom:right:)` in Swift are specified in counterclockwise
-order, in contrast to the clockwise order defined by the style specification.
+<% if (iOS) { -%>
+`UIEdgeInsetsMake()` in Objective-C and `UIEdgeInsets(top:left:bottom:right:)`
+in Swift
+<% } else { -%>
+`NSEdgeInsetsMake()` in Objective-C and `EdgeInsets(top:left:bottom:right:)` in
+Swift
+<% } -%>
+are specified in counterclockwise order, in contrast to the clockwise order
+defined by the style specification.
 
 <% if (macOS) { -%>
 Additionally, on macOS, a screen coordinate of (0, 0) is located at the

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -178,7 +178,7 @@ In style JSON | In the SDK
 `raster`      | `MGLRasterSource`
 `vector`      | `MGLVectorSource`
 
-`image` and `video` sources are not supported.
+`canvas`, `image`, and `video` sources are not supported.
 
 ### Tile sources
 

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -127,7 +127,7 @@ In style JSON | In the SDK
 `raster`      | `MGLRasterSource`
 `vector`      | `MGLVectorSource`
 
-`image` and `video` sources are not supported.
+`canvas`, `image`, and `video` sources are not supported.
 
 ### Tile sources
 

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -275,9 +275,10 @@ Array (`-offset`, `-translate`) | `NSValue.CGVectorValue` | `NSValue.cgVectorVal
 Array (`-padding`) | `NSValue.UIEdgeInsetsValue` | `NSValue.uiEdgeInsetsValue`
 
 For padding attributes, note that the arguments to
-`UIEdgeInsetsMake()` in Objective-C and
-`EdgeInsets(top:left:bottom:right:)` in Swift are specified in counterclockwise
-order, in contrast to the clockwise order defined by the style specification.
+`UIEdgeInsetsMake()` in Objective-C and `UIEdgeInsets(top:left:bottom:right:)`
+in Swift
+are specified in counterclockwise order, in contrast to the clockwise order
+defined by the style specification.
 
 ## Filtering sources
 

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -115,7 +115,7 @@ In style JSON | In the SDK
 `raster`      | `MGLRasterSource`
 `vector`      | `MGLVectorSource`
 
-`image` and `video` sources are not supported.
+`canvas`, `image`, and `video` sources are not supported.
 
 ### Tile sources
 

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -263,9 +263,10 @@ Array (`-offset`, `-translate`) | `NSValue` containing `CGVector` | `NSValue` co
 Array (`-padding`) | `NSValue.edgeInsetsValue` | `NSValue.edgeInsetsValue`
 
 For padding attributes, note that the arguments to
-`NSEdgeInsetsMake()` in Objective-C and
-`EdgeInsets(top:left:bottom:right:)` in Swift are specified in counterclockwise
-order, in contrast to the clockwise order defined by the style specification.
+`NSEdgeInsetsMake()` in Objective-C and `EdgeInsets(top:left:bottom:right:)` in
+Swift
+are specified in counterclockwise order, in contrast to the clockwise order
+defined by the style specification.
 
 Additionally, on macOS, a screen coordinate of (0, 0) is located at the
 lower-left corner of the screen. Therefore, a positive `CGVector.dy` means an


### PR DESCRIPTION
mapbox/mapbox-gl-style-spec#656 added a `canvas` source type that only makes sense in a webpage context (but see mapbox/mapbox-gl-native#7471). This PR points out that canvas sources are unsupported in the iOS and macOS SDKs’ “Information for Style Authors” guide. Whereas most of the runtime styling API is generated automatically, the source API is maintained by hand, since each source type requires a unique set of initializers and methods.

Also fixed a typo in the same guide.

/cc @lbud @lucaswoj