### PR TITLE
Move the simple map activity to a "Basic" section, always listed first

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -390,7 +390,7 @@
             android:label="@string/activity_simple_map">
             <meta-data
                 android:name="@string/category"
-                android:value="@string/category_first"/>
+                android:value="@string/category_basic"/>
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity"/>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -390,7 +390,7 @@
             android:label="@string/activity_simple_map">
             <meta-data
                 android:name="@string/category"
-                android:value="@string/category_maplayout"/>
+                android:value="@string/category_first"/>
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".activity.FeatureOverviewActivity"/>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/adapter/FeatureSectionAdapter.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/adapter/FeatureSectionAdapter.java
@@ -91,7 +91,8 @@ public class FeatureSectionAdapter extends RecyclerView.Adapter<RecyclerView.Vie
   @Override
   public void onBindViewHolder(RecyclerView.ViewHolder sectionViewHolder, int position) {
     if (isSectionHeaderPosition(position)) {
-      ((SectionViewHolder) sectionViewHolder).title.setText(sections.get(position).title);
+      String cleanTitle = sections.get(position).title.toString().replace("_", " ");
+      ((SectionViewHolder) sectionViewHolder).title.setText(cleanTitle);
     } else {
       adapter.onBindViewHolder(sectionViewHolder, getConvertedPosition(position));
     }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
     <string name="menuitem_title_reset">Reset</string>
 
     <string name="category">category</string>
+    <string name="category_first">_Basic</string>
     <string name="category_annotation">Annotation</string>
     <string name="category_camera">Camera</string>
     <string name="category_custom_layer">Custom Layer</string>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -124,7 +124,7 @@
     <string name="menuitem_title_reset">Reset</string>
 
     <string name="category">category</string>
-    <string name="category_first">_Basic</string>
+    <string name="category_basic">_Basic</string>
     <string name="category_annotation">Annotation</string>
     <string name="category_camera">Camera</string>
     <string name="category_custom_layer">Custom Layer</string>


### PR DESCRIPTION
Useful to be able to easily access a simple map activity to test basic map features.


