### PR TITLE
Android: use system-provided image decoding + encoding

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1604,18 +1604,8 @@ public final class MapboxMap {
    * @param bitmap   A pre-allocated bitmap.
    */
   @UiThread
-  public void snapshot(@NonNull SnapshotReadyCallback callback, @Nullable final Bitmap bitmap) {
-    nativeMapView.addSnapshotCallback(callback, bitmap);
-  }
-
-  /**
-   * Takes a snapshot of the map.
-   *
-   * @param callback Callback method invoked when the snapshot is taken.
-   */
-  @UiThread
   public void snapshot(@NonNull SnapshotReadyCallback callback) {
-    snapshot(callback, null);
+    nativeMapView.addSnapshotCallback(callback);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxsdk.maps;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Build;
@@ -54,7 +53,7 @@ final class NativeMapView {
   private CopyOnWriteArrayList<MapView.OnMapChangedListener> onMapChangedListeners;
 
   // Listener invoked to return a bitmap of the map
-  private SnapshotRequest snapshotRequest;
+  private MapboxMap.SnapshotReadyCallback snapshotReadyCallback;
 
   //
   // Static methods
@@ -935,18 +934,9 @@ final class NativeMapView {
     mapView.onFpsChanged(fps);
   }
 
-  protected void onSnapshotReady(byte[] bytes) {
-    if (snapshotRequest != null && bytes != null) {
-      BitmapFactory.Options options = new BitmapFactory.Options();
-      options.inBitmap = snapshotRequest.getBitmap();  // the old Bitmap to be reused
-      options.inMutable = true;
-      options.inSampleSize = 1;
-      Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
-
-      MapboxMap.SnapshotReadyCallback callback = snapshotRequest.getCallback();
-      if (callback != null) {
-        callback.onSnapshotReady(bitmap);
-      }
+  protected void onSnapshotReady(Bitmap bitmap) {
+    if (snapshotReadyCallback != null && bitmap != null) {
+      snapshotReadyCallback.onSnapshotReady(bitmap);
     }
   }
 
@@ -1187,27 +1177,9 @@ final class NativeMapView {
   // Snapshot
   //
 
-  void addSnapshotCallback(@NonNull MapboxMap.SnapshotReadyCallback callback, @Nullable Bitmap bitmap) {
-    snapshotRequest = new SnapshotRequest(bitmap, callback);
+  void addSnapshotCallback(@NonNull MapboxMap.SnapshotReadyCallback callback) {
+    snapshotReadyCallback = callback;
     scheduleTakeSnapshot();
     render();
-  }
-
-  private static class SnapshotRequest {
-    private Bitmap bitmap;
-    private MapboxMap.SnapshotReadyCallback callback;
-
-    SnapshotRequest(Bitmap bitmap, MapboxMap.SnapshotReadyCallback callback) {
-      this.bitmap = bitmap;
-      this.callback = callback;
-    }
-
-    public Bitmap getBitmap() {
-      return bitmap;
-    }
-
-    public MapboxMap.SnapshotReadyCallback getCallback() {
-      return callback;
-    }
   }
 }

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -19,8 +19,6 @@ if ((ANDROID_ABI STREQUAL "armeabi") OR (ANDROID_ABI STREQUAL "armeabi-v7a") OR 
 endif()
 
 mason_use(jni.hpp VERSION 2.0.0 HEADER_ONLY)
-mason_use(libjpeg-turbo VERSION 1.5.0)
-mason_use(libpng VERSION 1.6.25)
 mason_use(libzip VERSION 1.1.3)
 mason_use(nunicode VERSION 1.7.1)
 mason_use(sqlite VERSION 3.14.2)
@@ -82,10 +80,12 @@ macro(mbgl_platform_core)
         PRIVATE platform/default/utf.cpp
 
         # Image handling
-        PRIVATE platform/default/image.cpp
         PRIVATE platform/default/png_writer.cpp
-        PRIVATE platform/default/png_reader.cpp
-        PRIVATE platform/default/jpeg_reader.cpp
+        PRIVATE platform/android/src/bitmap.cpp
+        PRIVATE platform/android/src/bitmap.hpp
+        PRIVATE platform/android/src/bitmap_factory.cpp
+        PRIVATE platform/android/src/bitmap_factory.hpp
+        PRIVATE platform/android/src/image.cpp
 
         # Thread pool
         PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
@@ -161,8 +161,6 @@ macro(mbgl_platform_core)
 
     target_add_mason_package(mbgl-core PUBLIC sqlite)
     target_add_mason_package(mbgl-core PUBLIC nunicode)
-    target_add_mason_package(mbgl-core PUBLIC libpng)
-    target_add_mason_package(mbgl-core PUBLIC libjpeg-turbo)
     target_add_mason_package(mbgl-core PUBLIC libzip)
     target_add_mason_package(mbgl-core PUBLIC geojson)
     target_add_mason_package(mbgl-core PUBLIC jni.hpp)
@@ -179,6 +177,7 @@ macro(mbgl_platform_core)
     target_link_libraries(mbgl-core
         PUBLIC -llog
         PUBLIC -landroid
+        PUBLIC -ljnigraphics
         PUBLIC -lEGL
         PUBLIC -lGLESv2
         PUBLIC -lstdc++

--- a/platform/android/src/bitmap.cpp
+++ b/platform/android/src/bitmap.cpp
@@ -1,0 +1,132 @@
+#include "bitmap.hpp"
+
+#include <android/bitmap.h>
+
+namespace mbgl {
+namespace android {
+
+class PixelGuard {
+public:
+    PixelGuard(jni::JNIEnv& env_, jni::Object<Bitmap> bitmap_) : env(env_), bitmap(bitmap_) {
+        const int result = AndroidBitmap_lockPixels(&env, jni::Unwrap(*bitmap),
+                                                    reinterpret_cast<void**>(&address));
+        if (result != ANDROID_BITMAP_RESULT_SUCCESS) {
+            throw std::runtime_error("bitmap decoding: could not lock pixels");
+        }
+    }
+    ~PixelGuard() {
+        const int result = AndroidBitmap_unlockPixels(&env, jni::Unwrap(*bitmap));
+        if (result != ANDROID_BITMAP_RESULT_SUCCESS) {
+            throw std::runtime_error("bitmap decoding: could not unlock pixels");
+        }
+    }
+
+    auto* get() {
+        return address;
+    }
+
+    const auto* get() const {
+        return address;
+    }
+
+private:
+    jni::JNIEnv& env;
+    jni::Object<Bitmap> bitmap;
+    uint8_t* address;
+};
+
+void Bitmap::Config::registerNative(jni::JNIEnv& env) {
+    _class = *jni::Class<Config>::Find(env).NewGlobalRef(env).release();
+}
+
+jni::Class<Bitmap::Config> Bitmap::Config::_class;
+
+jni::Object<Bitmap::Config> Bitmap::Config::Create(jni::JNIEnv& env, Value value) {
+    switch (value) {
+    case ALPHA_8:
+        return _class.Get(env,
+                          jni::StaticField<Config, jni::Object<Config>>(env, _class, "ALPHA_8"));
+    case ARGB_4444:
+        return _class.Get(env,
+                          jni::StaticField<Config, jni::Object<Config>>(env, _class, "ARGB_4444"));
+    case ARGB_8888:
+        return _class.Get(env,
+                          jni::StaticField<Config, jni::Object<Config>>(env, _class, "ARGB_8888"));
+    case RGB_565:
+        return _class.Get(env,
+                          jni::StaticField<Config, jni::Object<Config>>(env, _class, "RGB_565"));
+    default:
+        throw std::runtime_error("invalid enum value for Bitmap.Config");
+    }
+}
+
+void Bitmap::registerNative(jni::JNIEnv& env) {
+    _class = *jni::Class<Bitmap>::Find(env).NewGlobalRef(env).release();
+    Config::registerNative(env);
+}
+
+jni::Class<Bitmap> Bitmap::_class;
+
+jni::Object<Bitmap> Bitmap::CreateBitmap(jni::JNIEnv& env,
+                                         jni::jint width,
+                                         jni::jint height,
+                                         jni::Object<Config> config) {
+    using Signature = jni::Object<Bitmap>(jni::jint, jni::jint, jni::Object<Config>);
+    auto method = _class.GetStaticMethod<Signature>(env, "createBitmap");
+    return _class.Call(env, method, width, height, config);
+}
+
+jni::Object<Bitmap> Bitmap::CreateBitmap(jni::JNIEnv& env, const PremultipliedImage& image) {
+    auto bitmap = CreateBitmap(env, image.size.width, image.size.height, Config::ARGB_8888);
+
+    AndroidBitmapInfo info;
+    const int result = AndroidBitmap_getInfo(&env, jni::Unwrap(*bitmap), &info);
+    if (result != ANDROID_BITMAP_RESULT_SUCCESS) {
+        // TODO: more specific information
+        throw std::runtime_error("bitmap creation: couldn't get bitmap info");
+    }
+
+    assert(info.width == image.size.width);
+    assert(info.height == image.size.height);
+    assert(info.format == ANDROID_BITMAP_FORMAT_RGBA_8888);
+
+    PixelGuard guard(env, bitmap);
+
+    // Copy the PremultipliedImage into the Android Bitmap
+    for (uint32_t y = 0; y < image.size.height; y++) {
+        auto begin = image.data.get() + y * image.stride();
+        std::copy(begin, begin + image.stride(), guard.get() + y * info.stride);
+    }
+
+    return bitmap;
+}
+
+PremultipliedImage Bitmap::GetImage(jni::JNIEnv& env, jni::Object<Bitmap> bitmap) {
+    AndroidBitmapInfo info;
+    const int result = AndroidBitmap_getInfo(&env, jni::Unwrap(*bitmap), &info);
+    if (result != ANDROID_BITMAP_RESULT_SUCCESS) {
+        // TODO: more specific information
+        throw std::runtime_error("bitmap decoding: couldn't get bitmap info");
+    }
+
+    if (info.format != ANDROID_BITMAP_FORMAT_RGBA_8888) {
+        // TODO: convert
+        throw std::runtime_error("bitmap decoding: bitmap format invalid");
+    }
+
+    const PixelGuard guard(env, bitmap);
+
+    // Copy the Android Bitmap into the PremultipliedImage.
+    auto pixels =
+        std::make_unique<uint8_t[]>(info.width * info.height * PremultipliedImage::channels);
+    for (uint32_t y = 0; y < info.height; y++) {
+        auto begin = guard.get() + y * info.stride;
+        std::copy(begin, begin + info.width * PremultipliedImage::channels,
+                  pixels.get() + y * info.width * PremultipliedImage::channels);
+    }
+
+    return { Size{ info.width, info.height }, std::move(pixels) };
+}
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/bitmap.hpp
+++ b/platform/android/src/bitmap.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <mbgl/util/image.hpp>
+
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace android {
+
+class Bitmap {
+public:
+    class Config {
+    public:
+        static constexpr auto Name() {
+            return "android/graphics/Bitmap$Config";
+        };
+        static void registerNative(jni::JNIEnv&);
+
+        enum Value {
+            ALPHA_8,
+            ARGB_4444,
+            ARGB_8888,
+            RGB_565,
+        };
+
+        static jni::Object<Config> Create(jni::JNIEnv&, Value);
+
+    private:
+        static jni::Class<Config> _class;
+    };
+
+    static constexpr auto Name() {
+        return "android/graphics/Bitmap";
+    };
+    static void registerNative(jni::JNIEnv&);
+
+    static jni::Object<Bitmap>
+    CreateBitmap(jni::JNIEnv&, jni::jint width, jni::jint height, jni::Object<Config>);
+    static jni::Object<Bitmap>
+    CreateBitmap(jni::JNIEnv& env, jni::jint width, jni::jint height, Config::Value config) {
+        return CreateBitmap(env, width, height, Config::Create(env, config));
+    }
+
+    static PremultipliedImage GetImage(jni::JNIEnv&, jni::Object<Bitmap>);
+    static jni::Object<Bitmap> CreateBitmap(jni::JNIEnv&, const PremultipliedImage&);
+
+private:
+    static jni::Class<Bitmap> _class;
+};
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/bitmap_factory.cpp
+++ b/platform/android/src/bitmap_factory.cpp
@@ -1,0 +1,25 @@
+#include "bitmap_factory.hpp"
+
+namespace mbgl {
+namespace android {
+
+void BitmapFactory::registerNative(jni::JNIEnv& env) {
+    _class = *jni::Class<BitmapFactory>::Find(env).NewGlobalRef(env).release();
+}
+
+jni::Class<BitmapFactory> BitmapFactory::_class;
+
+jni::Object<Bitmap> BitmapFactory::DecodeByteArray(jni::JNIEnv& env,
+                                                   jni::Array<jni::jbyte> data,
+                                                   jni::jint offset,
+                                                   jni::jint length) {
+
+    // Images are loaded with ARGB_8888 config, and premultiplied by default, which is exactly
+    // what we want, so we're not providing a BitmapFactory.Options object.
+    using Signature = jni::Object<Bitmap>(jni::Array<jni::jbyte>, jni::jint, jni::jint);
+    auto method = _class.GetStaticMethod<Signature>(env, "decodeByteArray");
+    return _class.Call(env, method, data, offset, length);
+}
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/bitmap_factory.hpp
+++ b/platform/android/src/bitmap_factory.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <jni/jni.hpp>
+
+#include "bitmap.hpp"
+
+namespace mbgl {
+namespace android {
+
+class BitmapFactory {
+public:
+    static constexpr auto Name() {
+        return "android/graphics/BitmapFactory";
+    };
+    static void registerNative(jni::JNIEnv&);
+
+    static jni::Object<Bitmap>
+    DecodeByteArray(jni::JNIEnv&, jni::Array<jni::jbyte> data, jni::jint offset, jni::jint length);
+
+private:
+    static jni::Class<BitmapFactory> _class;
+};
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/image.cpp
+++ b/platform/android/src/image.cpp
@@ -1,0 +1,22 @@
+#include <mbgl/util/image.hpp>
+#include <mbgl/util/string.hpp>
+
+#include <string>
+
+#include "attach_env.hpp"
+#include "bitmap_factory.hpp"
+
+namespace mbgl {
+
+PremultipliedImage decodeImage(const std::string& string) {
+    auto env{ android::AttachEnv() };
+
+    auto array = jni::Array<jni::jbyte>::New(*env, string.size());
+    jni::SetArrayRegion(*env, *array, 0, string.size(),
+                        reinterpret_cast<const signed char*>(string.data()));
+
+    auto bitmap = android::BitmapFactory::DecodeByteArray(*env, array, 0, string.size());
+    return android::Bitmap::GetImage(*env, bitmap);
+}
+
+} // namespace mbgl

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -11,6 +11,8 @@
 #include "jni.hpp"
 #include "java_types.hpp"
 #include "native_map_view.hpp"
+#include "bitmap.hpp"
+#include "bitmap_factory.hpp"
 #include "connectivity_listener.hpp"
 #include "style/layers/layers.hpp"
 #include "style/sources/sources.hpp"
@@ -1766,6 +1768,8 @@ void registerNatives(JavaVM *vm) {
     mbgl::android::RegisterNativeHTTPRequest(env);
 
     java::registerNatives(env);
+    Bitmap::registerNative(env);
+    BitmapFactory::registerNative(env);
     registerNativeLayers(env);
     registerNativeSources(env);
     ConnectivityListener::registerNative(env);
@@ -1841,7 +1845,7 @@ void registerNatives(JavaVM *vm) {
     onInvalidateId = &jni::GetMethodID(env, nativeMapViewClass, "onInvalidate", "()V");
     onMapChangedId = &jni::GetMethodID(env, nativeMapViewClass, "onMapChanged", "(I)V");
     onFpsChangedId = &jni::GetMethodID(env, nativeMapViewClass, "onFpsChanged", "(D)V");
-    onSnapshotReadyId = &jni::GetMethodID(env, nativeMapViewClass, "onSnapshotReady","([B)V");
+    onSnapshotReadyId = &jni::GetMethodID(env, nativeMapViewClass, "onSnapshotReady","(Landroid/graphics/Bitmap;)V");
 
     #define MAKE_NATIVE_METHOD(name, sig) jni::MakeNativeMethod<decltype(name), name>( #name, sig )
 

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -18,6 +18,8 @@
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/image.hpp>
 
+#include "bitmap.hpp"
+
 namespace mbgl {
 namespace android {
 
@@ -172,14 +174,10 @@ void NativeMapView::render() {
 
          // take snapshot
          auto image = getContext().readFramebuffer<mbgl::PremultipliedImage>(getFramebufferSize());
-
-         // encode and convert to jbytes
-         std::string string = encodePNG(image);
-         jbyteArray arr = env->NewByteArray(string.length());
-         env->SetByteArrayRegion(arr,0,string.length(),(jbyte*)string.c_str());
+         auto bitmap = Bitmap::CreateBitmap(*env, std::move(image));
 
          // invoke Mapview#OnSnapshotReady
-         env->CallVoidMethod(obj, onSnapshotReadyId, arr);
+         env->CallVoidMethod(obj, onSnapshotReadyId, jni::Unwrap(*bitmap));
          if (env->ExceptionCheck()) {
              env->ExceptionDescribe();
          }

--- a/platform/android/src/test/main.jni.cpp
+++ b/platform/android/src/test/main.jni.cpp
@@ -1,17 +1,11 @@
 #include "../jni.hpp"
 
-#include <android/log.h>
-#include <jni/jni.hpp>
 #include <jni/jni.hpp>
 
 #include <mbgl/util/logging.hpp>
 #include <mbgl/test.hpp>
 
 #include <vector>
-
-#pragma clang diagnostic ignored "-Wunused-parameter"
-
-#define MAKE_NATIVE_METHOD(name, sig) jni::MakeNativeMethod<decltype(name), name>( #name, sig )
 
 namespace {
 
@@ -48,31 +42,26 @@ struct Main {
 
 } // namespace
 
-// JNI Bindings to stub the android.util.Log implementation
-
-static jboolean isLoggable(JNIEnv* env, jni::jobject* clazz, jni::jstring* tag, jint level) {
-    return true;
-}
-
-static jint println_native(JNIEnv* env, jni::jobject* clazz, jint bufID, jint priority, jni::jstring* jtag, jni::jstring* jmessage) {
-    if (jtag == nullptr || jmessage == nullptr) {
-        return false;
-    }
-
-    std::string tag = jni::Make<std::string>(*env, jni::String(jtag));
-    std::string message = jni::Make<std::string>(*env, jni::String(jmessage));
-
-    return __android_log_print(priority, tag.c_str(), "%s", message.c_str());
-}
-
-static jint logger_entry_max_payload_native(JNIEnv* env, jni::jobject* clazz) {
-    return static_cast<jint>(4068);
-}
-
+// We're declaring the function, which is libandroid_runtime.so.
+// It is defined in AndroidRuntime.cpp:
+// https://github.com/android/platform_frameworks_base/blob/master/core/jni/AndroidRuntime.cpp
+// Once this symbol goes away, we'll have to revisit.
+// This method loads and registers all of the Android-native frameworks so that we can use
+// android.util.Log, android.graphics.Bitmap and so on.
+// Setting the weak attribute tells the linker that this symbol is loaded at runtime and avoids
+// a missing symbol error.
+namespace android {
+struct AndroidRuntime {
+    static int startReg(JNIEnv* env)  __attribute__((weak));
+};
+} // namespace android
 
 // Main entry point
+extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *) {
+    // Load Android-native jni bindings
+    jni::JNIEnv& env = jni::GetEnv(*vm, jni::jni_version_1_6);
+    android::AndroidRuntime::startReg(&env);
 
-extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     // Load the main library jni bindings
     mbgl::Log::Info(mbgl::Event::JNI, "Registering main JNI Methods");
     mbgl::android::registerNatives(vm);
@@ -80,22 +69,8 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     // Load the test library jni bindings
     mbgl::Log::Info(mbgl::Event::JNI, "Registering test JNI Methods");
 
-    jni::JNIEnv& env = jni::GetEnv(*vm, jni::jni_version_1_6);
-
     jni::RegisterNatives(env, jni::Class<Main>::Find(env),
                          jni::MakeNativeMethod<decltype(Main::runAllTests), &Main::runAllTests>("runAllTests"));
-
-    // Bindings for system classes
-    struct Log { static constexpr auto Name() { return "android/util/Log"; } };
-    try {
-        jni::RegisterNatives(env, jni::Class<Log>::Find(env),
-            MAKE_NATIVE_METHOD(isLoggable, "(Ljava/lang/String;I)Z"),
-            MAKE_NATIVE_METHOD(logger_entry_max_payload_native, "()I"),
-            MAKE_NATIVE_METHOD(println_native, "(IILjava/lang/String;Ljava/lang/String;)I")
-        );
-    } catch (jni::PendingJavaException ex) {
-        env.ThrowNew(jni::JavaErrorClass(env), "Could not register Log mocks");
-    }
 
     return JNI_VERSION_1_6;
 }


### PR DESCRIPTION
Another take at #7329.

- Removes `libjpeg-turbo` and `libpng` in favor of calls to [`BitmapFactory.decodeByteArray`](https://developer.android.com/reference/android/graphics/BitmapFactory.html#decodeByteArray(byte%5B%5D,%20int,%20int,%20android.graphics.BitmapFactory.Options)). We're doing a bunch of copies, but I don't think we can avoid any of them. I implemented a version that used `java.nio.ByteBuffer` and supplying the pointer address directly, but Java can't generate a `byte[]` required for `decodeByteArray`. We could alternatively implement a `NativeInputStream` (similar to the `NativeOutputStream` contained in this PR) and use [`BitmapFactory.decodeStream`](https://developer.android.com/reference/android/graphics/BitmapFactory.html#decodeStream(java.io.InputStream)) to avoid one copy. We are doing a second copy from the decoded Bitmap object to memory we manage ourselves (using [`libjnigraphics`](https://developer.android.com/ndk/reference/group___bitmap.html). Instead, we could completely replace `util::Image` for android builds with a version that keeps around the `Bitmap` object and keeps the pixels locked so they don't go away.
- Removes indirection for the snapshot functionality: Previously, we were compressing to a PNG, only to decompress to a `Bitmap` object right away. Instead, we're now directly converting the raw C++ `PremultipliedImage` to a Java `Bitmap` object. This reduces the snapshotting time on my test device from ~550ms to ~80ms.

Build size for Release/arm-v8 drops from 5620 KB to 5259 KB.

Fixes #7329, #6238.