### PR TITLE
macOS: Allow use of integrated GPU

### DIFF
--- a/platform/darwin/src/headless_display_cgl.cpp
+++ b/platform/darwin/src/headless_display_cgl.cpp
@@ -20,6 +20,8 @@ HeadlessDisplay::Impl::Impl() {
     CGLPixelFormatAttribute attributes[] = {
         kCGLPFAOpenGLProfile,
         static_cast<CGLPixelFormatAttribute>(kCGLOGLPVersion_Legacy),
+        kCGLPFASupportsAutomaticGraphicsSwitching,
+        kCGLPFAAllowOfflineRenderers, // Allows using the integrated GPU
         static_cast<CGLPixelFormatAttribute>(0)
     };
 

--- a/platform/darwin/src/headless_display_cgl.cpp
+++ b/platform/darwin/src/headless_display_cgl.cpp
@@ -18,8 +18,14 @@ HeadlessDisplay::Impl::Impl() {
     // TODO: test if OpenGL 4.1 with GL_ARB_ES2_compatibility is supported
     // If it is, use kCGLOGLPVersion_3_2_Core and enable that extension.
     CGLPixelFormatAttribute attributes[] = {
-        kCGLPFAOpenGLProfile,
-        static_cast<CGLPixelFormatAttribute>(kCGLOGLPVersion_Legacy),
+        kCGLPFAOpenGLProfile, static_cast<CGLPixelFormatAttribute>(kCGLOGLPVersion_Legacy),
+        // Not adding kCGLPFAAccelerated, as this will make headless rendering impossible when running in VMs.
+        kCGLPFAClosestPolicy,
+        kCGLPFAAccumSize, static_cast<CGLPixelFormatAttribute>(32),
+        kCGLPFAColorSize, static_cast<CGLPixelFormatAttribute>(24),
+        kCGLPFAAlphaSize, static_cast<CGLPixelFormatAttribute>(8),
+        kCGLPFADepthSize, static_cast<CGLPixelFormatAttribute>(16),
+        kCGLPFAStencilSize, static_cast<CGLPixelFormatAttribute>(8),
         kCGLPFASupportsAutomaticGraphicsSwitching,
         kCGLPFAAllowOfflineRenderers, // Allows using the integrated GPU
         static_cast<CGLPixelFormatAttribute>(0)

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fixed an issue where translucent point annotations along tile boundaries would be drawn darker than expected. ([#6832](https://github.com/mapbox/mapbox-gl-native/pull/6832))
 * Fixed flickering that occurred when panning past the antimeridian. ([#7574](https://github.com/mapbox/mapbox-gl-native/pull/7574))
 * Fixed an issue that could prevent a cached style from appearing while the computer is offline. ([#7770](https://github.com/mapbox/mapbox-gl-native/pull/7770))
+* Allows use of the integrated GPU on machines that have more than one GPU. Follow [Apple’s Technical QA1734](https://developer.apple.com/library/content/qa/qa1734/_index.html) to enable this in your app. ([#7834](https://github.com/mapbox/mapbox-gl-native/pull/7834))
 
 ## 0.3.0
 

--- a/platform/macos/app/Info.plist
+++ b/platform/macos/app/Info.plist
@@ -52,5 +52,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 </dict>
 </plist>

--- a/platform/macos/src/MGLOpenGLLayer.mm
+++ b/platform/macos/src/MGLOpenGLLayer.mm
@@ -22,6 +22,7 @@
 
 - (NSOpenGLPixelFormat *)openGLPixelFormatForDisplayMask:(uint32_t)mask {
     NSOpenGLPixelFormatAttribute pfas[] = {
+        NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersionLegacy,
         NSOpenGLPFAAccelerated,
         NSOpenGLPFAClosestPolicy,
         NSOpenGLPFAAccumSize, 32,

--- a/platform/macos/src/MGLOpenGLLayer.mm
+++ b/platform/macos/src/MGLOpenGLLayer.mm
@@ -30,6 +30,7 @@
         NSOpenGLPFADepthSize, 16,
         NSOpenGLPFAStencilSize, 8,
         NSOpenGLPFAScreenMask, mask,
+        NSOpenGLPFAAllowOfflineRenderers, // Allows using the integrated GPU
         0
     };
     return [[NSOpenGLPixelFormat alloc] initWithAttributes:pfas];


### PR DESCRIPTION
On computers that have more than one GPU, macOS automatically switches to the discrete one if the app doesn't opt in to also using the integrated GPU: https://developer.apple.com/library/content/qa/qa1734/_index.html