### PR TITLE
Test MGLMapView gesture recognizer example; refer to Night Shift on macOS

### DIFF
--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -42,9 +42,10 @@ underneath.
 The user location annotation view, the attribution button, any buttons in
 callout views, and any items in the navigation bar are influenced by your
 application’s tint color, so choose a tint color that constrasts well with your
-map style. If you intend your style to be used in the dark, consider the impact
-that Night Shift may have on your style’s colors.
+map style.
 <% } -%>
+If you intend your style to be used in the dark, consider the impact that Night
+Shift may have on your style’s colors.
 
 ### Typography and graphics
 

--- a/platform/darwin/scripts/update-examples.js
+++ b/platform/darwin/scripts/update-examples.js
@@ -108,10 +108,10 @@ function completeExamples(os) {
         }
         
         // Resolve conditional compilation blocks.
-        example = example.replace(/^(\s*)#if\s+os\((iOS|macOS)\)\n([^]*?)(?:^\1#else\n([^]*?))?^\1#endif\n/gm,
+        example = example.replace(/^(\s*)#if\s+os\((iOS|macOS)\)\n([^]*?)(?:^\1#else\n([^]*?))?^\1#endif\b\n?/gm,
                                   function (m, indentation, ifOs, ifCase, elseCase) {
           return (os === ifOs ? ifCase : elseCase).replace(new RegExp('^    ', 'gm'), '');
-        });
+        }).replace(/\n$/, '');
         
         // Insert the test method contents into the documentation comment just
         // above the substructure.

--- a/platform/darwin/test/MGLDocumentationExampleTests.swift
+++ b/platform/darwin/test/MGLDocumentationExampleTests.swift
@@ -217,4 +217,25 @@ class MGLDocumentationExampleTests: XCTestCase, MGLMapViewDelegate {
 
         XCTAssertNotNil(mapView.style?.layer(withIdentifier: "contour"))
     }
+    
+    func testMGLMapView() {
+        //#-example-code
+        #if os(macOS)
+            class MapClickGestureRecognizer: NSClickGestureRecognizer {
+                override func shouldRequireFailure(of otherGestureRecognizer: NSGestureRecognizer) -> Bool {
+                    return otherGestureRecognizer is NSClickGestureRecognizer
+                }
+            }
+        #else
+            let mapTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(myCustomFunction))
+            for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
+                mapTapGestureRecognizer.require(toFail: recognizer)
+            }
+            mapView.addGestureRecognizer(mapTapGestureRecognizer)
+        #endif
+        //#-end-example-code
+    }
+    
+    // For testMGLMapView().
+    func myCustomFunction() {}
 }

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -29,8 +29,9 @@ underneath.
 The user location annotation view, the attribution button, any buttons in
 callout views, and any items in the navigation bar are influenced by your
 application’s tint color, so choose a tint color that constrasts well with your
-map style. If you intend your style to be used in the dark, consider the impact
-that Night Shift may have on your style’s colors.
+map style.
+If you intend your style to be used in the dark, consider the impact that Night
+Shift may have on your style’s colors.
 
 ### Typography and graphics
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -84,6 +84,7 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationVerticalAlignment) {
  for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
      mapTapGestureRecognizer.require(toFail: recognizer)
  }
+ mapView.addGestureRecognizer(mapTapGestureRecognizer)
  ```
  
  @note You are responsible for getting permission to use the map data and for

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -26,6 +26,8 @@ style is present. Standard user interface elements such as toolbars, sidebars,
 and sheets often overlap the map view with a translucent, blurred background, so
 make sure the contents of these elements remain legible with the map view
 underneath.
+If you intend your style to be used in the dark, consider the impact that Night
+Shift may have on your style’s colors.
 
 ### Typography and graphics
 


### PR DESCRIPTION
Added the examples from #7816 to the unit tests to fix `make darwin-update-examples` and `make style-code-darwin`.

Also include a mention of Night Shift in the macOS version of “Information for Style Authors”, now that macOS Sierra 10.12.4 beta includes Night Shift.