### PR TITLE
[Android] Make spinner under Add Markers in Bulk readable

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/styles.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/styles.xml
@@ -6,6 +6,8 @@
         <item name="colorPrimaryDark">@color/primaryDark</item>
         <item name="colorAccent">@color/accent</item>
         <item name="android:windowBackground">@color/white</item>
+        <item name="android:spinnerItemStyle">@style/MySpinnerStyle</item>
+        <item name="android:spinnerDropDownItemStyle">@style/SpinnerItem.DropDownItem</item>
     </style>
 
     <style name="NoActionBar" parent="Theme.AppCompat.NoActionBar">
@@ -23,6 +25,15 @@
 
     <style name="AppTheme.ActionBar" parent="AppTheme">
         <item name="windowActionBarOverlay">false</item>
+    </style>
+
+    <style name="MySpinnerStyle">
+        <item name="android:popupBackground">@android:color/background_light</item>
+        <item name="android:textColor">@android:color/background_light</item>
+    </style>
+
+    <style name="SpinnerItem.DropDownItem" parent="@android:style/Widget.DropDownItem.Spinner">
+        <item name="android:textColor">@android:color/background_light</item>
     </style>
 
     <style name="AppTheme" parent="AppBaseTheme" />


### PR DESCRIPTION
Before:
![Before](https://cloud.githubusercontent.com/assets/5069856/22269273/fad69356-e247-11e6-947e-0a60fd37a867.png)

After:
![After](https://cloud.githubusercontent.com/assets/5069856/22269138/65b2b28c-e247-11e6-87e0-d4fd4452e73b.png)

Tested on a Samsung Galaxy 4 running Android version 5.0.1