### PR TITLE
fixes #6688: assert remaining map view notification responses are main thread

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -641,6 +641,8 @@ public:
 
 - (void)reachabilityChanged:(NSNotification *)notification
 {
+    MGLAssertIsMainThread();
+
     MGLReachability *reachability = [notification object];
     if ( ! _isWaitingForRedundantReachableNotification && [reachability isReachable])
     {
@@ -707,6 +709,8 @@ public:
 
 - (void)didReceiveMemoryWarning
 {
+    MGLAssertIsMainThread();
+
     _mbglMap->onLowMemory();
 }
 


### PR DESCRIPTION
![sign-colors](https://cloud.githubusercontent.com/assets/17722/22271418/51f87a4a-e249-11e6-84bf-700d91799569.jpg)
