### PR TITLE
[android] - wrap longitude values from core

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -36,6 +36,8 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
   - Avoid calls to onFling when while pinch zooming [#7666](https://github.com/mapbox/mapbox-gl-native/issues/7666)
 * Support for style-wide transition animation duration and delay [#6779](https://github.com/mapbox/mapbox-gl-native/issues/6779)
 * Support for all animated camera changes to configure dismissing tracking modes [#7854](https://github.com/mapbox/mapbox-gl-native/issues/7854)
+* LatLng objects produced by the SDK are wrapped by default [#4522](https://github.com/mapbox/mapbox-gl-native/issues/4522)
+* LatLng objects produced by the SDK are wrapped by default for [compatibility](https://developers.google.com/android/reference/com/google/android/gms/maps/model/LatLng) with the Google Maps API on Android [#4522](https://github.com/mapbox/mapbox-gl-native/issues/4522)
 
 ## 4.2.2 - January 27, 2017
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
@@ -242,7 +242,7 @@ public final class CameraPosition implements Parcelable {
     public Builder(double[] nativeCameraValues) {
       super();
       if (nativeCameraValues != null && nativeCameraValues.length == 5) {
-        target(new LatLng(nativeCameraValues[0], nativeCameraValues[1]));
+        target(new LatLng(nativeCameraValues[0], nativeCameraValues[1]).wrap());
         bearing(MathUtils.convertNativeBearing(nativeCameraValues[2]));
         tilt(nativeCameraValues[3]);
         zoom(nativeCameraValues[4]);

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLng.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/LatLng.java
@@ -127,13 +127,8 @@ public class LatLng implements ILatLng, Parcelable {
    * @return New LatLng object with wrapped Longitude
    */
   public LatLng wrap() {
-    LatLng wrappedVersion = new LatLng(this);
-    double lon = wrappedVersion.getLongitude();
-    if (lon < GeoConstants.MIN_LONGITUDE || lon > GeoConstants.MAX_LONGITUDE) {
-      wrappedVersion.setLongitude(MathUtils.wrap(wrappedVersion.getLongitude(), GeoConstants.MIN_LONGITUDE,
-        GeoConstants.MAX_LONGITUDE));
-    }
-    return wrappedVersion;
+    longitude = MathUtils.wrap(longitude, GeoConstants.MIN_LONGITUDE, GeoConstants.MAX_LONGITUDE);
+    return this;
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -353,7 +353,8 @@ final class NativeMapView {
     if (isDestroyedOn("")) {
       return new LatLng();
     }
-    return nativeGetLatLng(nativeMapViewPtr);
+    // wrap longitude values coming from core
+    return nativeGetLatLng(nativeMapViewPtr).wrap();
   }
 
   public void resetPosition() {
@@ -708,7 +709,7 @@ final class NativeMapView {
       return new LatLng();
     }
     return nativeLatLngForProjectedMeters(nativeMapViewPtr, projectedMeters.getNorthing(),
-      projectedMeters.getEasting());
+      projectedMeters.getEasting()).wrap();
   }
 
   public PointF pixelForLatLng(LatLng latLng) {
@@ -724,7 +725,7 @@ final class NativeMapView {
     if (isDestroyedOn("latLngForPixel")) {
       return new LatLng();
     }
-    return nativeLatLngForPixel(nativeMapViewPtr, pixel.x / pixelRatio, pixel.y / pixelRatio);
+    return nativeLatLngForPixel(nativeMapViewPtr, pixel.x / pixelRatio, pixel.y / pixelRatio).wrap();
   }
 
   public double getTopOffsetPixelsForAnnotationSymbol(String symbolName) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/geometry/LatLngTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -181,17 +180,13 @@ public class LatLngTest {
 
   @Test
   public void testWrapped() {
-    LatLng latLng = new LatLng(45.0, -185.0);
-    LatLng wrapped = latLng.wrap();
-    assertNotSame(latLng, wrapped);
-    assertEquals("longitude wrapped value", wrapped.getLongitude(), 175.0, DELTA);
+    LatLng latLng = new LatLng(45.0, -185.0).wrap();
+    assertEquals("longitude wrapped value", latLng.getLongitude(), 175.0, DELTA);
   }
 
   @Test
   public void testUnnecessaryWrapped() {
-    LatLng latLng = new LatLng(45.0, 50.0);
-    LatLng wrapped = latLng.wrap();
-    assertNotSame(latLng, wrapped);
-    assertEquals("longitude wrapped value", wrapped.getLongitude(), 50.0, DELTA);
+    LatLng latLng = new LatLng(45.0, 50.0).wrap();
+    assertEquals("longitude wrapped value", latLng.getLongitude(), 50.0, DELTA);
   }
 }


### PR DESCRIPTION
Closes #4522, this PR wraps every longitude value coming from core and replaces the previous wrap implementation. Before merging we will need some additional testing for animating around the dateline. 

Review @zugaldia 