### PR TITLE
Persist user tracking mode despite programmatic camera changes

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 3.4.2
+
+* Programmatic camera changes no longer resets user tracking mode. ([#7856](https://github.com/mapbox/mapbox-gl-native/pull/7856))
+
 ## 3.4.1 
 
 * Fixed a build error in the static framework flavor of this SDK caused by a missing header. ([#7844](https://github.com/mapbox/mapbox-gl-native/pull/7844))

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -2532,7 +2532,6 @@ public:
 
 - (void)setCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration animationTimingFunction:(nullable CAMediaTimingFunction *)function completionHandler:(nullable void (^)(void))completion
 {
-    self.userTrackingMode = MGLUserTrackingModeNone;
     _mbglMap->cancelTransitions();
     if ([self.camera isEqual:camera])
     {
@@ -2572,8 +2571,6 @@ public:
 
 - (void)flyToCamera:(MGLMapCamera *)camera withDuration:(NSTimeInterval)duration peakAltitude:(CLLocationDistance)peakAltitude completionHandler:(nullable void (^)(void))completion
 {
-    self.userTrackingMode = MGLUserTrackingModeNone;
-
     [self _flyToCamera:camera edgePadding:self.contentInset withDuration:duration peakAltitude:peakAltitude completionHandler:completion];
 }
 


### PR DESCRIPTION
Fixes #7789 

The stuttering effect is not as noticeable as I first thought. Concurrent animations (#3625) might still be a blocker though.

![animation](https://cloud.githubusercontent.com/assets/764476/22298180/e2e964d4-e31f-11e6-9213-b76a60aef6b6.gif)

The transition is more or less smooth depending on the timing of the subsequent location update.

@bsudekum 👀 