### PR TITLE
Make MGLMapView non opaque by default

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Fixed a build error in the static framework flavor of this SDK caused by a missing header. ([#7844](https://github.com/mapbox/mapbox-gl-native/pull/7844))
 * Fixed an issue causing MGLMapView’s `camera`’s `heading` to be set to a negative value, indicating an undefined heading, when the map view faces northwest. The heading is now wrapped to between zero and 360 degrees, for consistency with MGLMapView’s `direction` property. ([#7724](https://github.com/mapbox/mapbox-gl-native/pull/7724))
+* Fixed an issue causing MGLMapView flash of black. ([#7859](https://github.com/mapbox/mapbox-gl-native/pull/7859))
 
 ## 3.4.0
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -394,7 +394,7 @@ public:
     MGLinitializeRunLoop();
 
     _isTargetingInterfaceBuilder = NSProcessInfo.processInfo.mgl_isInterfaceBuilderDesignablesAgent;
-    _opaque = YES;
+    _opaque = NO;
 
     BOOL background = [UIApplication sharedApplication].applicationState == UIApplicationStateBackground;
     if (!background)


### PR DESCRIPTION
According to #7256 to solve "flash of black" one alternative is set `MGLMapView.opaque = NO` but one concern was how this may affect the performance. Changing `opaque = NO` resulted in a reduction in FPS from an average of 50.63 to 49.61. This is unnoticeable but we can keep tracking this in case something comes up.

(Benchmark tests were done using bench app)