### PR TITLE
[build] Use https for mapbox-gl-js submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,4 +14,4 @@
 	url = https://github.com/AliSoftware/OHHTTPStubs.git
 [submodule "mapbox-gl-js"]
 	path = mapbox-gl-js
-	url = git://github.com/mapbox/mapbox-gl-js.git
+	url = https://github.com/mapbox/mapbox-gl-js.git


### PR DESCRIPTION
This allows pushing directly from the submodule, if you have https authentication set up.