### PR TITLE
[android] - add make target for javadoc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -624,6 +624,10 @@ android-ndk-stack:
 android-checkstyle:
 	cd platform/android && ./gradlew checkstyle
 
+.PHONY: android-javadoc
+android-javadoc:
+	cd platform/android && ./gradlew :MapboxGLAndroidSDK:javadocrelease
+
 #### Miscellaneous targets #####################################################
 
 .PHONY: style-code


### PR DESCRIPTION
Noticed in #7827 that we don't have a make target for generating Android SDK documentation. This PR introduces the target and will generate the javadoc files in `/platform/android/MapboxGLAndroidSDK/build/docs/release/..`.

Review @ivovandongen 