### PR TITLE
[Qt] Make datatypes compatible with the default implementation

### DIFF
--- a/platform/qt/src/sqlite3.cpp
+++ b/platform/qt/src/sqlite3.cpp
@@ -189,10 +189,7 @@ Statement::operator bool() const {
     return impl.operator bool();
 }
 
-template void Statement::bind(int, int8_t);
-template void Statement::bind(int, int32_t);
 template void Statement::bind(int, int64_t);
-template void Statement::bind(int, uint8_t);
 
 template <typename T>
 void Statement::bind(int offset, T value) {
@@ -211,8 +208,23 @@ void Statement::bind(int offset, std::nullptr_t) {
 }
 
 template <>
+void Statement::bind(int offset, int32_t value) {
+    bind(offset, static_cast<int64_t>(value));
+}
+
+template <>
 void Statement::bind(int offset, bool value) {
     bind(offset, static_cast<int>(value));
+}
+
+template <>
+void Statement::bind(int offset, int8_t value) {
+    bind(offset, static_cast<int64_t>(value));
+}
+
+template <>
+void Statement::bind(int offset, uint8_t value) {
+    bind(offset, static_cast<int64_t>(value));
 }
 
 template <>


### PR DESCRIPTION
On the default all integers map to `sqlite3_bind_int64`.