### PR TITLE
Flatten point collections, not multipoints

### DIFF
--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -22,10 +22,13 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     NSMutableArray *flattenedShapes = [NSMutableArray arrayWithCapacity:shapes.count];
     for (id <MGLAnnotation> shape in shapes) {
         NSArray *subshapes;
-        // Flatten multipoints but not polylines or polygons.
-        if ([shape isMemberOfClass:[MGLMultiPoint class]]) {
-            NSUInteger pointCount = [(MGLMultiPoint *)shape pointCount];
-            CLLocationCoordinate2D *coordinates = [(MGLMultiPoint *)shape coordinates];
+        if ([shape isKindOfClass:[MGLMultiPolyline class]]) {
+            subshapes = [(MGLMultiPolyline *)shape polylines];
+        } else if ([shape isKindOfClass:[MGLMultiPolygon class]]) {
+            subshapes = [(MGLMultiPolygon *)shape polygons];
+        } else if ([shape isKindOfClass:[MGLPointCollection class]]) {
+            NSUInteger pointCount = [(MGLPointCollection *)shape pointCount];
+            CLLocationCoordinate2D *coordinates = [(MGLPointCollection *)shape coordinates];
             NSMutableArray *pointAnnotations = [NSMutableArray arrayWithCapacity:pointCount];
             for (NSUInteger i = 0; i < pointCount; i++) {
                 MGLPointAnnotation *pointAnnotation = [[MGLPointAnnotation alloc] init];
@@ -33,10 +36,6 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
                 [pointAnnotations addObject:pointAnnotation];
             }
             subshapes = pointAnnotations;
-        } else if ([shape isKindOfClass:[MGLMultiPolyline class]]) {
-            subshapes = [(MGLMultiPolyline *)shape polylines];
-        } else if ([shape isKindOfClass:[MGLMultiPolygon class]]) {
-            subshapes = [(MGLMultiPolygon *)shape polygons];
         } else if ([shape isKindOfClass:[MGLShapeCollection class]]) {
             subshapes = MBXFlattenedShapes([(MGLShapeCollection *)shape shapes]);
         }


### PR DESCRIPTION
As of #6742, we no longer overload MGLMultiPoint for GeoJSON multipoints, instead representing those shapes with MGLPointCollection. However, the function in macosapp that “flattens” some of the more exotic GeoJSON types into annotation-compatible types was still attempting to flatten MGLMultiPoints. This function is used when feeding feature querying results back to the map as annotations.

/cc @boundsj @frederoni