### PR TITLE
Turn missing access token assertion into warning

### DIFF
--- a/platform/macos/app/AppDelegate.m
+++ b/platform/macos/app/AppDelegate.m
@@ -71,7 +71,7 @@ NSString * const MGLLastMapDebugMaskDefaultsKey = @"MGLLastMapDebugMask";
 
 @end
 
-@interface AppDelegate ()
+@interface AppDelegate () <NSWindowDelegate>
 
 @property (weak) IBOutlet NSArrayController *offlinePacksArrayController;
 @property (weak) IBOutlet NSPanel *offlinePacksPanel;
@@ -281,6 +281,15 @@ NSString * const MGLLastMapDebugMaskDefaultsKey = @"MGLLastMapDebugMask";
         return self.offlinePacksArrayController.selectedObjects.count;
     }
     return NO;
+}
+
+#pragma mark NSWindowDelegate methods
+
+- (void)windowWillClose:(NSNotification *)notification {
+    NSWindow *window = notification.object;
+    if (window == self.preferencesWindow) {
+        [window makeFirstResponder:nil];
+    }
 }
 
 @end

--- a/platform/macos/app/Base.lproj/MainMenu.xib
+++ b/platform/macos/app/Base.lproj/MainMenu.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11191" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -703,6 +704,7 @@ CA
                 </constraints>
             </view>
             <connections>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="PNO-Pp-jOX"/>
                 <outlet property="initialFirstResponder" destination="7sb-sf-oJU" id="UZe-di-dnA"/>
             </connections>
             <point key="canvasLocation" x="754" y="221"/>

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -610,12 +610,13 @@ public:
     
     // Default to Streets.
     if (!styleURL) {
-        // An access token is required to load any default style, including
-        // Streets.
-        if (![MGLAccountManager accessToken]) {
-            return;
-        }
         styleURL = [MGLStyle streetsStyleURLWithVersion:MGLStyleDefaultVersion];
+    }
+    
+    // An access token is required to load any default style, including Streets.
+    if (![MGLAccountManager accessToken] && [styleURL.scheme isEqualToString:@"mapbox"]) {
+        NSLog(@"Cannot set the style URL to %@ because no access token has been specified.", styleURL);
+        return;
     }
 
     styleURL = styleURL.mgl_URLByStandardizingScheme;


### PR DESCRIPTION
In a Debug build, if you set the style URL to a mapbox: URL before providing an access token, the following C++ assertion fails:

```
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: You must provide a Mapbox API access token for Mapbox tile sources
```

If you set the style URL to `nil`, however, nothing happens. Instead of crashing or silently bailing, MGLMapView now logs a warning to the console and bails even if the style URL is set to a mapbox: URL. The reason the macOS implementation of `-[MGLMapView setStyleURL:]` bails instead of asserting, as the iOS implementation does, is that the non-modal Preferences window needs a chance to accept the user’s access token before loading the style.

Speaking of which, the Preferences window now takes first responder status away from the Access Token text field as soon as you close the window, thereby committing any changes in the window’s field editor.

/cc @tkrajacic