### PR TITLE
Force portrait mode for instrumentation tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/AndroidManifest.xml
@@ -19,8 +19,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".activity.FeatureOverviewActivity"
-            android:launchMode="singleTop"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -564,9 +564,13 @@
         </activity>
 
         <!-- For Instrumentation tests -->
-        <activity android:name=".activity.style.RuntimeStyleTestActivity"/>
-        <activity android:name=".activity.style.RuntimeStyleTimingTestActivity"/>
-        <activity android:name=".activity.espresso.EspressoTestActivity"/>
+        <activity
+            android:name=".activity.style.RuntimeStyleTestActivity"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".activity.style.RuntimeStyleTimingTestActivity"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".activity.espresso.EspressoTestActivity"
+            android:screenOrientation="portrait"/>
 
         <!-- Configuration Settings -->
         <meta-data


### PR DESCRIPTION
One source of flaky instrumentation tests is the device rotation. When set to landscape mode, the map can return different values for the same test case than in portrait mode. This makes making assertions unreliable or we would have to take in account a larger delta. This PR solves this by forcing device orientation to portrait mode.

Review @ivovandongen 