### PR TITLE
Don't add trailing spaces in generate-style-code.js

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Property.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Property.java
@@ -22,13 +22,12 @@ public abstract class Property<T> {
    */
   public static final String NONE = "none";
 
-  @StringDef( {
+  @StringDef({
     VISIBLE,
-    NONE
+    NONE,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface VISIBILITY {
-  }
+  public @interface VISIBILITY {}
 
   // LINE_CAP: The display of line endings.
 
@@ -50,14 +49,13 @@ public abstract class Property<T> {
   /**
    * The display of line endings.
    */
-  @StringDef( {
+  @StringDef({
     LINE_CAP_BUTT,
     LINE_CAP_ROUND,
     LINE_CAP_SQUARE,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface LINE_CAP {
-  }
+  public @interface LINE_CAP {}
 
   // LINE_JOIN: The display of lines when joining.
 
@@ -80,14 +78,13 @@ public abstract class Property<T> {
   /**
    * The display of lines when joining.
    */
-  @StringDef( {
+  @StringDef({
     LINE_JOIN_BEVEL,
     LINE_JOIN_ROUND,
     LINE_JOIN_MITER,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface LINE_JOIN {
-  }
+  public @interface LINE_JOIN {}
 
   // SYMBOL_PLACEMENT: Label placement relative to its geometry.
 
@@ -103,13 +100,12 @@ public abstract class Property<T> {
   /**
    * Label placement relative to its geometry.
    */
-  @StringDef( {
+  @StringDef({
     SYMBOL_PLACEMENT_POINT,
     SYMBOL_PLACEMENT_LINE,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface SYMBOL_PLACEMENT {
-  }
+  public @interface SYMBOL_PLACEMENT {}
 
   // ICON_ROTATION_ALIGNMENT: In combination with `symbol-placement`, determines the rotation behavior of icons.
 
@@ -133,14 +129,13 @@ public abstract class Property<T> {
   /**
    * In combination with `symbol-placement`, determines the rotation behavior of icons.
    */
-  @StringDef( {
+  @StringDef({
     ICON_ROTATION_ALIGNMENT_MAP,
     ICON_ROTATION_ALIGNMENT_VIEWPORT,
     ICON_ROTATION_ALIGNMENT_AUTO,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface ICON_ROTATION_ALIGNMENT {
-  }
+  public @interface ICON_ROTATION_ALIGNMENT {}
 
   // ICON_TEXT_FIT: Scales the icon to fit around the associated text.
 
@@ -164,15 +159,14 @@ public abstract class Property<T> {
   /**
    * Scales the icon to fit around the associated text.
    */
-  @StringDef( {
+  @StringDef({
     ICON_TEXT_FIT_NONE,
     ICON_TEXT_FIT_WIDTH,
     ICON_TEXT_FIT_HEIGHT,
     ICON_TEXT_FIT_BOTH,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface ICON_TEXT_FIT {
-  }
+  public @interface ICON_TEXT_FIT {}
 
   // TEXT_PITCH_ALIGNMENT: Orientation of text when map is pitched.
 
@@ -192,14 +186,13 @@ public abstract class Property<T> {
   /**
    * Orientation of text when map is pitched.
    */
-  @StringDef( {
+  @StringDef({
     TEXT_PITCH_ALIGNMENT_MAP,
     TEXT_PITCH_ALIGNMENT_VIEWPORT,
     TEXT_PITCH_ALIGNMENT_AUTO,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface TEXT_PITCH_ALIGNMENT {
-  }
+  public @interface TEXT_PITCH_ALIGNMENT {}
 
   // TEXT_ROTATION_ALIGNMENT: In combination with `symbol-placement`, determines the rotation behavior of the individual
   // glyphs forming the text.
@@ -224,14 +217,13 @@ public abstract class Property<T> {
   /**
    * In combination with `symbol-placement`, determines the rotation behavior of the individual glyphs forming the text.
    */
-  @StringDef( {
+  @StringDef({
     TEXT_ROTATION_ALIGNMENT_MAP,
     TEXT_ROTATION_ALIGNMENT_VIEWPORT,
     TEXT_ROTATION_ALIGNMENT_AUTO,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface TEXT_ROTATION_ALIGNMENT {
-  }
+  public @interface TEXT_ROTATION_ALIGNMENT {}
 
   // TEXT_JUSTIFY: Text justification options.
 
@@ -251,14 +243,13 @@ public abstract class Property<T> {
   /**
    * Text justification options.
    */
-  @StringDef( {
+  @StringDef({
     TEXT_JUSTIFY_LEFT,
     TEXT_JUSTIFY_CENTER,
     TEXT_JUSTIFY_RIGHT,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface TEXT_JUSTIFY {
-  }
+  public @interface TEXT_JUSTIFY {}
 
   // TEXT_ANCHOR: Part of the text placed closest to the anchor.
 
@@ -302,7 +293,7 @@ public abstract class Property<T> {
   /**
    * Part of the text placed closest to the anchor.
    */
-  @StringDef( {
+  @StringDef({
     TEXT_ANCHOR_CENTER,
     TEXT_ANCHOR_LEFT,
     TEXT_ANCHOR_RIGHT,
@@ -314,8 +305,7 @@ public abstract class Property<T> {
     TEXT_ANCHOR_BOTTOM_RIGHT,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface TEXT_ANCHOR {
-  }
+  public @interface TEXT_ANCHOR {}
 
   // TEXT_TRANSFORM: Specifies how to capitalize text, similar to the CSS `text-transform` property.
 
@@ -335,14 +325,13 @@ public abstract class Property<T> {
   /**
    * Specifies how to capitalize text, similar to the CSS `text-transform` property.
    */
-  @StringDef( {
+  @StringDef({
     TEXT_TRANSFORM_NONE,
     TEXT_TRANSFORM_UPPERCASE,
     TEXT_TRANSFORM_LOWERCASE,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface TEXT_TRANSFORM {
-  }
+  public @interface TEXT_TRANSFORM {}
 
   // FILL_TRANSLATE_ANCHOR: Controls the translation reference point.
 
@@ -358,13 +347,12 @@ public abstract class Property<T> {
   /**
    * Controls the translation reference point.
    */
-  @StringDef( {
+  @StringDef({
     FILL_TRANSLATE_ANCHOR_MAP,
     FILL_TRANSLATE_ANCHOR_VIEWPORT,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface FILL_TRANSLATE_ANCHOR {
-  }
+  public @interface FILL_TRANSLATE_ANCHOR {}
 
   // LINE_TRANSLATE_ANCHOR: Controls the translation reference point.
 
@@ -380,13 +368,12 @@ public abstract class Property<T> {
   /**
    * Controls the translation reference point.
    */
-  @StringDef( {
+  @StringDef({
     LINE_TRANSLATE_ANCHOR_MAP,
     LINE_TRANSLATE_ANCHOR_VIEWPORT,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface LINE_TRANSLATE_ANCHOR {
-  }
+  public @interface LINE_TRANSLATE_ANCHOR {}
 
   // ICON_TRANSLATE_ANCHOR: Controls the translation reference point.
 
@@ -402,13 +389,12 @@ public abstract class Property<T> {
   /**
    * Controls the translation reference point.
    */
-  @StringDef( {
+  @StringDef({
     ICON_TRANSLATE_ANCHOR_MAP,
     ICON_TRANSLATE_ANCHOR_VIEWPORT,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface ICON_TRANSLATE_ANCHOR {
-  }
+  public @interface ICON_TRANSLATE_ANCHOR {}
 
   // TEXT_TRANSLATE_ANCHOR: Controls the translation reference point.
 
@@ -424,13 +410,12 @@ public abstract class Property<T> {
   /**
    * Controls the translation reference point.
    */
-  @StringDef( {
+  @StringDef({
     TEXT_TRANSLATE_ANCHOR_MAP,
     TEXT_TRANSLATE_ANCHOR_VIEWPORT,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface TEXT_TRANSLATE_ANCHOR {
-  }
+  public @interface TEXT_TRANSLATE_ANCHOR {}
 
   // CIRCLE_TRANSLATE_ANCHOR: Controls the translation reference point.
 
@@ -446,13 +431,12 @@ public abstract class Property<T> {
   /**
    * Controls the translation reference point.
    */
-  @StringDef( {
+  @StringDef({
     CIRCLE_TRANSLATE_ANCHOR_MAP,
     CIRCLE_TRANSLATE_ANCHOR_VIEWPORT,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface CIRCLE_TRANSLATE_ANCHOR {
-  }
+  public @interface CIRCLE_TRANSLATE_ANCHOR {}
 
   // CIRCLE_PITCH_SCALE: Controls the scaling behavior of the circle when the map is pitched.
 
@@ -468,13 +452,12 @@ public abstract class Property<T> {
   /**
    * Controls the scaling behavior of the circle when the map is pitched.
    */
-  @StringDef( {
+  @StringDef({
     CIRCLE_PITCH_SCALE_MAP,
     CIRCLE_PITCH_SCALE_VIEWPORT,
   })
   @Retention(RetentionPolicy.SOURCE)
-  public @interface CIRCLE_PITCH_SCALE {
-  }
+  public @interface CIRCLE_PITCH_SCALE {}
 
   // Class definition
   public final String name;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java
@@ -891,7 +891,7 @@ public class PropertyFactory {
   }
 
   /**
-   * The width of the circle's stroke. Strokes are placed outside of the "circle-radius".
+   * The width of the circle's stroke. Strokes are placed outside of the {@link PropertyFactory#circleRadius}.
    *
    * @param value a Float value
    * @return property wrapper around Float
@@ -901,7 +901,7 @@ public class PropertyFactory {
   }
 
   /**
-   * The width of the circle's stroke. Strokes are placed outside of the "circle-radius".
+   * The width of the circle's stroke. Strokes are placed outside of the {@link PropertyFactory#circleRadius}.
    *
    * @param function a wrapper function for Float
    * @return property wrapper around a Float function

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
@@ -3,15 +3,18 @@
   const properties = locals.properties;
   const doc = locals.doc;
 -%>
-// This file is generated. Edit android/platform/scripts/generate-style-code.js, then run `make android-style-code`.
 package com.mapbox.mapboxsdk.style.layers;
+// This file is generated. Edit android/platform/scripts/generate-style-code.js, then run `make android-style-code`.
 
-import android.support.annotation.UiThread;
-
+<% if (type != 'raster') { -%>
 import android.support.annotation.ColorInt;
+<% } -%>
 import android.support.annotation.NonNull;
+import android.support.annotation.UiThread;
+<% if (type != 'raster') { -%>
 
-import static com.mapbox.mapboxsdk.utils.ColorUtils.*;
+import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
+<% } -%>
 
 /**
  * <%- doc %>
@@ -21,151 +24,153 @@ import static com.mapbox.mapboxsdk.utils.ColorUtils.*;
 @UiThread
 public class <%- camelize(type) %>Layer extends Layer {
 
-    /**
-     * Creates a <%- camelize(type) %>Layer.
-     *
-     * @param nativePtr pointer used by core
-     */
-    public <%- camelize(type) %>Layer(long nativePtr) {
-        super(nativePtr);
-    }
+  /**
+   * Creates a <%- camelize(type) %>Layer.
+   *
+   * @param nativePtr pointer used by core
+   */
+  public <%- camelize(type) %>Layer(long nativePtr) {
+    super(nativePtr);
+  }
 
 <% if (type === 'background') { -%>
-    /**
-     * Creates a <%- camelize(type) %>Layer.
-     *
-     * @param layerId  the id of the layer
-     */
-    public <%- camelize(type) %>Layer(String layerId) {
-        initialize(layerId);
-    }
+  /**
+   * Creates a <%- camelize(type) %>Layer.
+   *
+   * @param layerId the id of the layer
+   */
+  public <%- camelize(type) %>Layer(String layerId) {
+    initialize(layerId);
+  }
 
-    protected native void initialize(String layerId);
+  protected native void initialize(String layerId);
 <% } else { -%>
-    /**
-     * Creates a <%- camelize(type) %>Layer.
-     *
-     * @param layerId  the id of the layer
-     * @param sourceId the id of the source
-     */
-    public <%- camelize(type) %>Layer(String layerId, String sourceId) {
-        initialize(layerId, sourceId);
-    }
+  /**
+   * Creates a <%- camelize(type) %>Layer.
+   *
+   * @param layerId  the id of the layer
+   * @param sourceId the id of the source
+   */
+  public <%- camelize(type) %>Layer(String layerId, String sourceId) {
+    initialize(layerId, sourceId);
+  }
 
-    protected native void initialize(String layerId, String sourceId);
+  protected native void initialize(String layerId, String sourceId);
 
-    /**
-     * Set the source layer.
-     *
-     * @param sourceLayer the source layer to set
-     */
-    public void setSourceLayer(String sourceLayer) {
-        nativeSetSourceLayer(sourceLayer);
-    }
+  /**
+   * Set the source layer.
+   *
+   * @param sourceLayer the source layer to set
+   */
+  public void setSourceLayer(String sourceLayer) {
+    nativeSetSourceLayer(sourceLayer);
+  }
 
-    /**
-     * Set the source Layer.
-     *
-     * @param sourceLayer the source layer to set
-     * @return This
-     */
-    public <%- camelize(type) %>Layer withSourceLayer(String sourceLayer) {
-        setSourceLayer(sourceLayer);
-        return this;
-    }
+  /**
+   * Set the source Layer.
+   *
+   * @param sourceLayer the source layer to set
+   * @return This
+   */
+  public <%- camelize(type) %>Layer withSourceLayer(String sourceLayer) {
+    setSourceLayer(sourceLayer);
+    return this;
+  }
 <% } -%>
 <% if (type !== 'background' && type !== 'raster') { -%>
-    /**
-     * Set a single filter.
-     *
-     * @param filter the filter to set
-     */
-    public void setFilter(Filter.Statement filter) {
-        this.setFilter(filter.toArray());
-    }
 
-    /**
-     * Set an array of filters.
-     *
-     * @param filter the filter array to set
-     */
-    public void setFilter(Object[] filter) {
-        nativeSetFilter(filter);
-    }
+  /**
+   * Set a single filter.
+   *
+   * @param filter the filter to set
+   */
+  public void setFilter(Filter.Statement filter) {
+    this.setFilter(filter.toArray());
+  }
 
-    /**
-     * Set an array of filters.
-     *
-     * @param filter tthe filter array to set
-     * @return This
-     */
-    public <%- camelize(type) %>Layer withFilter(Object[] filter) {
-        setFilter(filter);
-        return this;
-    }
+  /**
+   * Set an array of filters.
+   *
+   * @param filter the filter array to set
+   */
+  public void setFilter(Object[] filter) {
+    nativeSetFilter(filter);
+  }
 
-    /**
-     * Set a single filter.
-     *
-     * @param filter the filter to set
-     * @return This
-     */
-    public <%- camelize(type) %>Layer withFilter(Filter.Statement filter) {
-        setFilter(filter);
-        return this;
-    }
+  /**
+   * Set an array of filters.
+   *
+   * @param filter tthe filter array to set
+   * @return This
+   */
+  public <%- camelize(type) %>Layer withFilter(Object[] filter) {
+    setFilter(filter);
+    return this;
+  }
+
+  /**
+   * Set a single filter.
+   *
+   * @param filter the filter to set
+   * @return This
+   */
+  public <%- camelize(type) %>Layer withFilter(Filter.Statement filter) {
+    setFilter(filter);
+    return this;
+  }
 
 <% } -%>
 
-    /**
-     * Set a property or properties.
-     *
-     * @param properties the var-args properties
-     * @return This
-     */
-    public <%- camelize(type) %>Layer withProperties(@NonNull Property<?>... properties) {
-        setProperties(properties);
-        return this;
-    }
+  /**
+   * Set a property or properties.
+   *
+   * @param properties the var-args properties
+   * @return This
+   */
+  public <%- camelize(type) %>Layer withProperties(@NonNull Property<?>... properties) {
+    setProperties(properties);
+    return this;
+  }
 
-    // Property getters
+  // Property getters
 
 <% for (const property of properties) { -%>
-    /**
-     * Get the <%- camelize(property.name) %> property
-     *
-     * @return property wrapper value around <%- propertyType(property) %>
-     */
-    @SuppressWarnings("unchecked")
-    public PropertyValue<<%- propertyType(property) %>> get<%- camelize(property.name) %>() {
-        return (PropertyValue<<%- propertyType(property) %>>) new PropertyValue(nativeGet<%- camelize(property.name) %>());
-    }
- <% if (property.type == 'color') { -%>
-    /**
-     * <%- property.doc %>
-     *
-     * @return int representation of a rgba string color
-     * @throws RuntimeException thrown if property isn't a value
-     */
-    @ColorInt
-    public int get<%- camelize(property.name) %>AsInt() {
-        PropertyValue<<%- propertyType(property) %>> value = get<%- camelize(property.name) %>();
-        if (value.isValue()) {
-            return rgbaToColor(value.getValue());
-        } else {
-            throw new RuntimeException("<%- property.name %> was set as a Function");
-        }
-    }
+  /**
+   * Get the <%- camelize(property.name) %> property
+   *
+   * @return property wrapper value around <%- propertyType(property) %>
+   */
+  @SuppressWarnings("unchecked")
+  public PropertyValue<<%- propertyType(property) %>> get<%- camelize(property.name) %>() {
+    return (PropertyValue<<%- propertyType(property) %>>) new PropertyValue(nativeGet<%- camelize(property.name) %>());
+  }
+<% if (property.type == 'color') { -%>
 
- <% } -%>
+  /**
+<%- property.doc.wrap(117, 3, '* ') %>
+   *
+   * @return int representation of a rgba string color
+   * @throws RuntimeException thrown if property isn't a value
+   */
+  @ColorInt
+  public int get<%- camelize(property.name) %>AsInt() {
+    PropertyValue<<%- propertyType(property) %>> value = get<%- camelize(property.name) %>();
+    if (value.isValue()) {
+      return rgbaToColor(value.getValue());
+    } else {
+      throw new RuntimeException("<%- property.name %> was set as a Function");
+    }
+  }
+
+<% } -%>
 
 <% } -%>
 <% for (const property of properties) { -%>
-    private native Object nativeGet<%- camelize(property.name) %>();
+  private native Object nativeGet<%- camelize(property.name) %>();
 
 <% } -%>
 
-    @Override
-    protected native void finalize() throws Throwable;
+  @Override
+  protected native void finalize() throws Throwable;
 
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/property.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/property.java.ejs
@@ -1,8 +1,8 @@
 <%
   const properties = locals.properties;
 -%>
-// This file is generated. Edit android/platform/scripts/generate-style-code.js, then run `make android-style-code`.
 package com.mapbox.mapboxsdk.style.layers;
+// This file is generated. Edit android/platform/scripts/generate-style-code.js, then run `make android-style-code`.
 
 import android.support.annotation.StringDef;
 
@@ -14,54 +14,52 @@ import java.lang.annotation.RetentionPolicy;
  */
 public abstract class Property<T> {
 
-    // VISIBILITY: Whether this layer is displayed.
+  // VISIBILITY: Whether this layer is displayed.
 
-    /**
-     * The layer is shown.
-     */
-    public static final String VISIBLE = "visible";
-    /**
-     * The layer is hidden.
-     */
-    public static final String NONE = "none";
+  /**
+   * The layer is shown.
+   */
+  public static final String VISIBLE = "visible";
+  /**
+   * The layer is hidden.
+   */
+  public static final String NONE = "none";
 
-    @StringDef({
-            VISIBLE,
-            NONE
-    })
-    @Retention(RetentionPolicy.SOURCE)
-    public @interface VISIBILITY {}
+  @StringDef({
+    VISIBLE,
+    NONE,
+  })
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface VISIBILITY {}
 
 <% for (const property of properties) { -%>
-    // <%- snakeCaseUpper(property.name) %>: <%- property.doc %>
+<%- (snakeCaseUpper(property.name) + ": " + property.doc).wrap(117, 2, '// ') %>
 
 <% for (const value in property.values) { -%>
-    /**
-     * <%- propertyValueDoc(property, value) %>
-     */
-    public static final String <%- snakeCaseUpper(property.name) %>_<%- snakeCaseUpper(value) %> = "<%- value %>";
+  /**
+<%- propertyValueDoc(property, value).wrap(115, 3, '* ') %>
+   */
+  public static final String <%- snakeCaseUpper(property.name) %>_<%- snakeCaseUpper(value) %> = "<%- value %>";
 <% } -%>
 
-    /**
-     * <%- property.doc %>
-     */
-    @StringDef({
-    <% for (const value of Object.keys(property.values)) { -%>
-        <%- snakeCaseUpper(property.name) %>_<%- snakeCaseUpper(value) %>,
-    <% } -%>
-    })
-    @Retention(RetentionPolicy.SOURCE)
-    public @interface <%- snakeCaseUpper(property.name) %> {}
+  /**
+   * <%- property.doc %>
+   */
+  @StringDef({
+<% for (const value of Object.keys(property.values)) { -%>
+    <%- snakeCaseUpper(property.name) %>_<%- snakeCaseUpper(value) %>,
+<% } -%>
+  })
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface <%- snakeCaseUpper(property.name) %> {}
 
 <% } -%>
+  // Class definition
+  public final String name;
+  public final T value;
 
-    // Class definition
-    public final String name;
-    public final T value;
-
-    /* package */ Property(String name, T value) {
-        this.name = name;
-        this.value = value;
-    }
-
+  /* package */ Property(String name, T value) {
+    this.name = name;
+    this.value = value;
+  }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/property_factory.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/property_factory.java.ejs
@@ -2,8 +2,8 @@
   const paintProperties = locals.paintProperties;
   const layoutProperties = locals.layoutProperties;
 -%>
-// This file is generated. Edit android/platform/scripts/generate-style-code.js, then run `make android-style-code`.
 package com.mapbox.mapboxsdk.style.layers;
+// This file is generated. Edit android/platform/scripts/generate-style-code.js, then run `make android-style-code`.
 
 import android.annotation.SuppressLint;
 import android.support.annotation.ColorInt;
@@ -15,85 +15,86 @@ import android.support.annotation.ColorInt;
  */
 public class PropertyFactory {
 
-    /**
-     * Set the property visibility.
-     *
-     * @param value the visibility value
-     * @return property wrapper around visibility
-     */
-    public static Property<String> visibility(@Property.VISIBILITY String value) {
-        return new LayoutProperty<>("visibility", value);
-    }
+  /**
+   * Set the property visibility.
+   *
+   * @param value the visibility value
+   * @return property wrapper around visibility
+   */
+  public static Property<String> visibility(@Property.VISIBILITY String value) {
+    return new LayoutProperty<>("visibility", value);
+  }
 
-    /**
-     * Set the property visibility.
-     *
-     * @param function the visibility function
-     * @return property wrapper around a String function
-     */
-    public static Property<Function<String>> visibility(Function<String> function) {
-        return new LayoutProperty<>("visibility", function);
-    }
+  /**
+   * Set the property visibility.
+   *
+   * @param function the visibility function
+   * @return property wrapper around a String function
+   */
+  public static Property<Function<String>> visibility(Function<String> function) {
+    return new LayoutProperty<>("visibility", function);
+  }
 
 <% for (const property of paintProperties) { -%>
 <% if (property.type == 'color') { -%>
-    /**
-     * <%- propertyFactoryMethodDoc(property) %>
-     *
-     * @param value a int color value
-     * @return property wrapper around String color
-     */
-    public static Property<String> <%- camelizeWithLeadingLowercase(property.name) %>(@ColorInt int value) {
-        return new PaintProperty<>("<%-  property.name %>", colorToRgbaString(value));
-    }
+  /**
+<%- propertyFactoryMethodDoc(property).wrap(117, 3, '* ') %>
+   *
+   * @param value a int color value
+   * @return property wrapper around String color
+   */
+  public static Property<String> <%- camelizeWithLeadingLowercase(property.name) %>(@ColorInt int value) {
+    return new PaintProperty<>("<%-  property.name %>", colorToRgbaString(value));
+  }
 
 <% } -%>
-    /**
-     * <%- propertyFactoryMethodDoc(property) %>
-     *
-     * @param value a <%- propertyType(property) %> value
-     * @return property wrapper around <%- propertyType(property) %>
-     */
-    public static Property<<%- propertyType(property) %>> <%- camelizeWithLeadingLowercase(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
-        return new PaintProperty<>("<%-  property.name %>", value);
-    }
+  /**
+<%- propertyFactoryMethodDoc(property).wrap(117, 3, '* ') %>
+   *
+   * @param value a <%- propertyType(property) %> value
+   * @return property wrapper around <%- propertyType(property) %>
+   */
+  public static Property<<%- propertyType(property) %>> <%- camelizeWithLeadingLowercase(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
+    return new PaintProperty<>("<%-  property.name %>", value);
+  }
 
-    /**
-     * <%- propertyFactoryMethodDoc(property) %>
-     *
-     * @param function a wrapper function for <%- propertyType(property) %>
-     * @return property wrapper around a <%- propertyType(property) %> function
-     */
-    public static Property<Function<<%- propertyType(property) %>>> <%- camelizeWithLeadingLowercase(property.name) %>(Function<<%- propertyType(property) %>> function) {
-        return new PaintProperty<>("<%-  property.name %>", function);
-    }
+  /**
+<%- propertyFactoryMethodDoc(property).wrap(117, 3, '* ') %>
+   *
+   * @param function a wrapper function for <%- propertyType(property) %>
+   * @return property wrapper around a <%- propertyType(property) %> function
+   */
+  public static Property<Function<<%- propertyType(property) %>>> <%- camelizeWithLeadingLowercase(property.name) %>(Function<<%- propertyType(property) %>> function) {
+    return new PaintProperty<>("<%-  property.name %>", function);
+  }
 
 <% } -%>
 <% for (const property of layoutProperties) { -%>
-    /**
-     * <%- propertyFactoryMethodDoc(property) %>
-     *
-     * @param value a <%- propertyType(property) %> value
-     * @return property wrapper around <%- propertyType(property) %>
-     */
-    public static Property<<%- propertyType(property) %>> <%- camelizeWithLeadingLowercase(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
-        return new LayoutProperty<>("<%-  property.name %>", value);
-    }
+  /**
+<%- propertyFactoryMethodDoc(property).wrap(117, 3, '* ') %>
+   *
+   * @param value a <%- propertyType(property) %> value
+   * @return property wrapper around <%- propertyType(property) %>
+   */
+  public static Property<<%- propertyType(property) %>> <%- camelizeWithLeadingLowercase(property.name) %>(<%- propertyTypeAnnotation(property) %><%- iff(() => propertyTypeAnnotation(property), " ") %><%- propertyType(property) %> value) {
+    return new LayoutProperty<>("<%-  property.name %>", value);
+  }
 
-    /**
-     * <%- propertyFactoryMethodDoc(property) %>
-     *
-     * @param function a wrapper function for <%- propertyType(property) %>
-     * @return property wrapper around a <%- propertyType(property) %> function
-     */
-    public static Property<Function<<%- propertyType(property) %>>> <%- camelizeWithLeadingLowercase(property.name) %>(Function<<%- propertyType(property) %>> function) {
-        return new LayoutProperty<>("<%-  property.name %>", function);
-    }
+  /**
+<%- propertyFactoryMethodDoc(property).wrap(117, 3, '* ') %>
+   *
+   * @param function a wrapper function for <%- propertyType(property) %>
+   * @return property wrapper around a <%- propertyType(property) %> function
+   */
+  public static Property<Function<<%- propertyType(property) %>>> <%- camelizeWithLeadingLowercase(property.name) %>(Function<<%- propertyType(property) %>> function) {
+    return new LayoutProperty<>("<%-  property.name %>", function);
+  }
 
 <% } -%>
-    @SuppressLint("DefaultLocale")
-    static String colorToRgbaString(@ColorInt int value) {
-        return String.format("rgba(%d, %d, %d, %d)", (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF, (value >> 24) & 0xFF);
-    }
+  @SuppressLint("DefaultLocale")
+  static String colorToRgbaString(@ColorInt int value) {
+    return String.format("rgba(%d, %d, %d, %d)", (value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF,
+      (value >> 24) & 0xFF);
+  }
 
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/activity.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/activity/activity.junit.ejs
@@ -25,13 +25,13 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 @RunWith(AndroidJUnit4.class)
 public class <%- activity %>Test extends BaseActivityTest {
 
-    @Test
-    public void testSanity() {
-        onView(withId(R.id.mapView)).check(matches(isDisplayed()));
-    }
+  @Test
+  public void testSanity() {
+    onView(withId(R.id.mapView)).check(matches(isDisplayed()));
+  }
 
-    @Override
-    protected Class getActivityClass() {
-        return <%- activity %>.class;
-    }
+  @Override
+  protected Class getActivityClass() {
+    return <%- activity %>.class;
+  }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -82,7 +82,8 @@ public class BackgroundLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(backgroundColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getBackgroundColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getBackgroundColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -114,7 +115,8 @@ public class BackgroundLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(backgroundPattern("pedestrian-polygon"));
-    assertEquals((String) layer.getBackgroundPattern().getValue(), (String) "pedestrian-polygon");
+    assertEquals((String) layer.getBackgroundPattern().getValue(),
+                 (String) "pedestrian-polygon");
   }
 
   @Test
@@ -130,7 +132,8 @@ public class BackgroundLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(backgroundOpacity(0.3f));
-    assertEquals((Float) layer.getBackgroundOpacity().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getBackgroundOpacity().getValue(),
+                 (Float) 0.3f);
   }
 
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -103,7 +103,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleRadius(0.3f));
-    assertEquals((Float) layer.getCircleRadius().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getCircleRadius().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -125,7 +126,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getCircleColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getCircleColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -169,7 +171,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleBlur(0.3f));
-    assertEquals((Float) layer.getCircleBlur().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getCircleBlur().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -191,7 +194,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleOpacity(0.3f));
-    assertEquals((Float) layer.getCircleOpacity().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getCircleOpacity().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -213,7 +217,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleTranslate(new Float[] {0f, 0f}));
-    assertEquals((Float[]) layer.getCircleTranslate().getValue(), (Float[]) new Float[] {0f, 0f});
+    assertEquals((Float[]) layer.getCircleTranslate().getValue(),
+                 (Float[]) new Float[] {0f, 0f});
   }
 
   @Test
@@ -235,7 +240,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleTranslateAnchor(CIRCLE_TRANSLATE_ANCHOR_MAP));
-    assertEquals((String) layer.getCircleTranslateAnchor().getValue(), (String) CIRCLE_TRANSLATE_ANCHOR_MAP);
+    assertEquals((String) layer.getCircleTranslateAnchor().getValue(),
+                 (String) CIRCLE_TRANSLATE_ANCHOR_MAP);
   }
 
   @Test
@@ -257,7 +263,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circlePitchScale(CIRCLE_PITCH_SCALE_MAP));
-    assertEquals((String) layer.getCirclePitchScale().getValue(), (String) CIRCLE_PITCH_SCALE_MAP);
+    assertEquals((String) layer.getCirclePitchScale().getValue(),
+                 (String) CIRCLE_PITCH_SCALE_MAP);
   }
 
   @Test
@@ -279,7 +286,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleStrokeWidth(0.3f));
-    assertEquals((Float) layer.getCircleStrokeWidth().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getCircleStrokeWidth().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -301,7 +309,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleStrokeColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getCircleStrokeColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getCircleStrokeColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -345,7 +354,8 @@ public class CircleLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(circleStrokeOpacity(0.3f));
-    assertEquals((Float) layer.getCircleStrokeOpacity().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getCircleStrokeOpacity().getValue(),
+                 (Float) 0.3f);
   }
 
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -99,7 +99,8 @@ public class FillLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(fillAntialias(true));
-    assertEquals((Boolean) layer.getFillAntialias().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getFillAntialias().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -121,7 +122,8 @@ public class FillLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(fillOpacity(0.3f));
-    assertEquals((Float) layer.getFillOpacity().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getFillOpacity().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -143,7 +145,8 @@ public class FillLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(fillColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getFillColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getFillColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -187,7 +190,8 @@ public class FillLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(fillOutlineColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getFillOutlineColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getFillOutlineColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -231,7 +235,8 @@ public class FillLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(fillTranslate(new Float[] {0f, 0f}));
-    assertEquals((Float[]) layer.getFillTranslate().getValue(), (Float[]) new Float[] {0f, 0f});
+    assertEquals((Float[]) layer.getFillTranslate().getValue(),
+                 (Float[]) new Float[] {0f, 0f});
   }
 
   @Test
@@ -253,7 +258,8 @@ public class FillLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(fillTranslateAnchor(FILL_TRANSLATE_ANCHOR_MAP));
-    assertEquals((String) layer.getFillTranslateAnchor().getValue(), (String) FILL_TRANSLATE_ANCHOR_MAP);
+    assertEquals((String) layer.getFillTranslateAnchor().getValue(),
+                 (String) FILL_TRANSLATE_ANCHOR_MAP);
   }
 
   @Test
@@ -275,7 +281,8 @@ public class FillLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(fillPattern("pedestrian-polygon"));
-    assertEquals((String) layer.getFillPattern().getValue(), (String) "pedestrian-polygon");
+    assertEquals((String) layer.getFillPattern().getValue(),
+                 (String) "pedestrian-polygon");
   }
 
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -108,7 +108,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineCap(LINE_CAP_BUTT));
-    assertEquals((String) layer.getLineCap().getValue(), (String) LINE_CAP_BUTT);
+    assertEquals((String) layer.getLineCap().getValue(),
+                 (String) LINE_CAP_BUTT);
   }
 
   @Test
@@ -130,7 +131,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineJoin(LINE_JOIN_BEVEL));
-    assertEquals((String) layer.getLineJoin().getValue(), (String) LINE_JOIN_BEVEL);
+    assertEquals((String) layer.getLineJoin().getValue(),
+                 (String) LINE_JOIN_BEVEL);
   }
 
   @Test
@@ -152,7 +154,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineMiterLimit(0.3f));
-    assertEquals((Float) layer.getLineMiterLimit().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getLineMiterLimit().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -174,7 +177,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineRoundLimit(0.3f));
-    assertEquals((Float) layer.getLineRoundLimit().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getLineRoundLimit().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -196,7 +200,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineOpacity(0.3f));
-    assertEquals((Float) layer.getLineOpacity().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getLineOpacity().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -218,7 +223,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getLineColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getLineColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -262,7 +268,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineTranslate(new Float[] {0f, 0f}));
-    assertEquals((Float[]) layer.getLineTranslate().getValue(), (Float[]) new Float[] {0f, 0f});
+    assertEquals((Float[]) layer.getLineTranslate().getValue(),
+                 (Float[]) new Float[] {0f, 0f});
   }
 
   @Test
@@ -284,7 +291,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineTranslateAnchor(LINE_TRANSLATE_ANCHOR_MAP));
-    assertEquals((String) layer.getLineTranslateAnchor().getValue(), (String) LINE_TRANSLATE_ANCHOR_MAP);
+    assertEquals((String) layer.getLineTranslateAnchor().getValue(),
+                 (String) LINE_TRANSLATE_ANCHOR_MAP);
   }
 
   @Test
@@ -306,7 +314,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineWidth(0.3f));
-    assertEquals((Float) layer.getLineWidth().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getLineWidth().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -328,7 +337,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineGapWidth(0.3f));
-    assertEquals((Float) layer.getLineGapWidth().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getLineGapWidth().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -350,7 +360,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineOffset(0.3f));
-    assertEquals((Float) layer.getLineOffset().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getLineOffset().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -372,7 +383,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineBlur(0.3f));
-    assertEquals((Float) layer.getLineBlur().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getLineBlur().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -394,7 +406,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(lineDasharray(new Float[] {}));
-    assertEquals((Float[]) layer.getLineDasharray().getValue(), (Float[]) new Float[] {});
+    assertEquals((Float[]) layer.getLineDasharray().getValue(),
+                 (Float[]) new Float[] {});
   }
 
   @Test
@@ -416,7 +429,8 @@ public class LineLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(linePattern("pedestrian-polygon"));
-    assertEquals((String) layer.getLinePattern().getValue(), (String) "pedestrian-polygon");
+    assertEquals((String) layer.getLinePattern().getValue(),
+                 (String) "pedestrian-polygon");
   }
 
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
@@ -97,7 +97,8 @@ public class RasterLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(rasterOpacity(0.3f));
-    assertEquals((Float) layer.getRasterOpacity().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getRasterOpacity().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -119,7 +120,8 @@ public class RasterLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(rasterHueRotate(0.3f));
-    assertEquals((Float) layer.getRasterHueRotate().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getRasterHueRotate().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -141,7 +143,8 @@ public class RasterLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(rasterBrightnessMin(0.3f));
-    assertEquals((Float) layer.getRasterBrightnessMin().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getRasterBrightnessMin().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -163,7 +166,8 @@ public class RasterLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(rasterBrightnessMax(0.3f));
-    assertEquals((Float) layer.getRasterBrightnessMax().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getRasterBrightnessMax().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -185,7 +189,8 @@ public class RasterLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(rasterSaturation(0.3f));
-    assertEquals((Float) layer.getRasterSaturation().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getRasterSaturation().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -207,7 +212,8 @@ public class RasterLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(rasterContrast(0.3f));
-    assertEquals((Float) layer.getRasterContrast().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getRasterContrast().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -229,7 +235,8 @@ public class RasterLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(rasterFadeDuration(0.3f));
-    assertEquals((Float) layer.getRasterFadeDuration().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getRasterFadeDuration().getValue(),
+                 (Float) 0.3f);
   }
 
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -149,7 +149,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(symbolPlacement(SYMBOL_PLACEMENT_POINT));
-    assertEquals((String) layer.getSymbolPlacement().getValue(), (String) SYMBOL_PLACEMENT_POINT);
+    assertEquals((String) layer.getSymbolPlacement().getValue(),
+                 (String) SYMBOL_PLACEMENT_POINT);
   }
 
   @Test
@@ -171,7 +172,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(symbolSpacing(0.3f));
-    assertEquals((Float) layer.getSymbolSpacing().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getSymbolSpacing().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -193,7 +195,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(symbolAvoidEdges(true));
-    assertEquals((Boolean) layer.getSymbolAvoidEdges().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getSymbolAvoidEdges().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -215,7 +218,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconAllowOverlap(true));
-    assertEquals((Boolean) layer.getIconAllowOverlap().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getIconAllowOverlap().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -237,7 +241,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconIgnorePlacement(true));
-    assertEquals((Boolean) layer.getIconIgnorePlacement().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getIconIgnorePlacement().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -259,7 +264,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconOptional(true));
-    assertEquals((Boolean) layer.getIconOptional().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getIconOptional().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -281,7 +287,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconRotationAlignment(ICON_ROTATION_ALIGNMENT_MAP));
-    assertEquals((String) layer.getIconRotationAlignment().getValue(), (String) ICON_ROTATION_ALIGNMENT_MAP);
+    assertEquals((String) layer.getIconRotationAlignment().getValue(),
+                 (String) ICON_ROTATION_ALIGNMENT_MAP);
   }
 
   @Test
@@ -303,7 +310,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconSize(0.3f));
-    assertEquals((Float) layer.getIconSize().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getIconSize().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -325,7 +333,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconTextFit(ICON_TEXT_FIT_NONE));
-    assertEquals((String) layer.getIconTextFit().getValue(), (String) ICON_TEXT_FIT_NONE);
+    assertEquals((String) layer.getIconTextFit().getValue(),
+                 (String) ICON_TEXT_FIT_NONE);
   }
 
   @Test
@@ -347,7 +356,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconTextFitPadding(new Float[] {0f, 0f, 0f, 0f}));
-    assertEquals((Float[]) layer.getIconTextFitPadding().getValue(), (Float[]) new Float[] {0f, 0f, 0f, 0f});
+    assertEquals((Float[]) layer.getIconTextFitPadding().getValue(),
+                 (Float[]) new Float[] {0f, 0f, 0f, 0f});
   }
 
   @Test
@@ -369,7 +379,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconImage("undefined"));
-    assertEquals((String) layer.getIconImage().getValue(), (String) "undefined");
+    assertEquals((String) layer.getIconImage().getValue(),
+                 (String) "undefined");
   }
 
   @Test
@@ -391,7 +402,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconRotate(0.3f));
-    assertEquals((Float) layer.getIconRotate().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getIconRotate().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -413,7 +425,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconPadding(0.3f));
-    assertEquals((Float) layer.getIconPadding().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getIconPadding().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -435,7 +448,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconKeepUpright(true));
-    assertEquals((Boolean) layer.getIconKeepUpright().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getIconKeepUpright().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -457,7 +471,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconOffset(new Float[] {0f, 0f}));
-    assertEquals((Float[]) layer.getIconOffset().getValue(), (Float[]) new Float[] {0f, 0f});
+    assertEquals((Float[]) layer.getIconOffset().getValue(),
+                 (Float[]) new Float[] {0f, 0f});
   }
 
   @Test
@@ -479,7 +494,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textPitchAlignment(TEXT_PITCH_ALIGNMENT_MAP));
-    assertEquals((String) layer.getTextPitchAlignment().getValue(), (String) TEXT_PITCH_ALIGNMENT_MAP);
+    assertEquals((String) layer.getTextPitchAlignment().getValue(),
+                 (String) TEXT_PITCH_ALIGNMENT_MAP);
   }
 
   @Test
@@ -501,7 +517,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textRotationAlignment(TEXT_ROTATION_ALIGNMENT_MAP));
-    assertEquals((String) layer.getTextRotationAlignment().getValue(), (String) TEXT_ROTATION_ALIGNMENT_MAP);
+    assertEquals((String) layer.getTextRotationAlignment().getValue(),
+                 (String) TEXT_ROTATION_ALIGNMENT_MAP);
   }
 
   @Test
@@ -523,7 +540,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textField(""));
-    assertEquals((String) layer.getTextField().getValue(), (String) "");
+    assertEquals((String) layer.getTextField().getValue(),
+                 (String) "");
   }
 
   @Test
@@ -545,8 +563,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textFont(new String[] {"Open Sans Regular", "Arial Unicode MS Regular"}));
-    assertEquals((String[]) layer.getTextFont().getValue(), (String[]) new String[] {"Open Sans Regular",
-      "Arial Unicode MS Regular"});
+    assertEquals((String[]) layer.getTextFont().getValue(),
+                 (String[]) new String[] {"Open Sans Regular", "Arial Unicode MS Regular"});
   }
 
   @Test
@@ -568,7 +586,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textSize(0.3f));
-    assertEquals((Float) layer.getTextSize().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextSize().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -590,7 +609,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textMaxWidth(0.3f));
-    assertEquals((Float) layer.getTextMaxWidth().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextMaxWidth().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -612,7 +632,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textLineHeight(0.3f));
-    assertEquals((Float) layer.getTextLineHeight().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextLineHeight().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -634,7 +655,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textLetterSpacing(0.3f));
-    assertEquals((Float) layer.getTextLetterSpacing().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextLetterSpacing().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -656,7 +678,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textJustify(TEXT_JUSTIFY_LEFT));
-    assertEquals((String) layer.getTextJustify().getValue(), (String) TEXT_JUSTIFY_LEFT);
+    assertEquals((String) layer.getTextJustify().getValue(),
+                 (String) TEXT_JUSTIFY_LEFT);
   }
 
   @Test
@@ -678,7 +701,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textAnchor(TEXT_ANCHOR_CENTER));
-    assertEquals((String) layer.getTextAnchor().getValue(), (String) TEXT_ANCHOR_CENTER);
+    assertEquals((String) layer.getTextAnchor().getValue(),
+                 (String) TEXT_ANCHOR_CENTER);
   }
 
   @Test
@@ -700,7 +724,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textMaxAngle(0.3f));
-    assertEquals((Float) layer.getTextMaxAngle().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextMaxAngle().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -722,7 +747,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textRotate(0.3f));
-    assertEquals((Float) layer.getTextRotate().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextRotate().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -744,7 +770,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textPadding(0.3f));
-    assertEquals((Float) layer.getTextPadding().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextPadding().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -766,7 +793,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textKeepUpright(true));
-    assertEquals((Boolean) layer.getTextKeepUpright().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getTextKeepUpright().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -788,7 +816,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textTransform(TEXT_TRANSFORM_NONE));
-    assertEquals((String) layer.getTextTransform().getValue(), (String) TEXT_TRANSFORM_NONE);
+    assertEquals((String) layer.getTextTransform().getValue(),
+                 (String) TEXT_TRANSFORM_NONE);
   }
 
   @Test
@@ -810,7 +839,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textOffset(new Float[] {0f, 0f}));
-    assertEquals((Float[]) layer.getTextOffset().getValue(), (Float[]) new Float[] {0f, 0f});
+    assertEquals((Float[]) layer.getTextOffset().getValue(),
+                 (Float[]) new Float[] {0f, 0f});
   }
 
   @Test
@@ -832,7 +862,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textAllowOverlap(true));
-    assertEquals((Boolean) layer.getTextAllowOverlap().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getTextAllowOverlap().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -854,7 +885,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textIgnorePlacement(true));
-    assertEquals((Boolean) layer.getTextIgnorePlacement().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getTextIgnorePlacement().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -876,7 +908,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textOptional(true));
-    assertEquals((Boolean) layer.getTextOptional().getValue(), (Boolean) true);
+    assertEquals((Boolean) layer.getTextOptional().getValue(),
+                 (Boolean) true);
   }
 
   @Test
@@ -898,7 +931,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconOpacity(0.3f));
-    assertEquals((Float) layer.getIconOpacity().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getIconOpacity().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -920,7 +954,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getIconColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getIconColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -964,7 +999,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconHaloColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getIconHaloColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getIconHaloColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -1008,7 +1044,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconHaloWidth(0.3f));
-    assertEquals((Float) layer.getIconHaloWidth().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getIconHaloWidth().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -1030,7 +1067,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconHaloBlur(0.3f));
-    assertEquals((Float) layer.getIconHaloBlur().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getIconHaloBlur().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -1052,7 +1090,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconTranslate(new Float[] {0f, 0f}));
-    assertEquals((Float[]) layer.getIconTranslate().getValue(), (Float[]) new Float[] {0f, 0f});
+    assertEquals((Float[]) layer.getIconTranslate().getValue(),
+                 (Float[]) new Float[] {0f, 0f});
   }
 
   @Test
@@ -1074,7 +1113,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(iconTranslateAnchor(ICON_TRANSLATE_ANCHOR_MAP));
-    assertEquals((String) layer.getIconTranslateAnchor().getValue(), (String) ICON_TRANSLATE_ANCHOR_MAP);
+    assertEquals((String) layer.getIconTranslateAnchor().getValue(),
+                 (String) ICON_TRANSLATE_ANCHOR_MAP);
   }
 
   @Test
@@ -1096,7 +1136,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textOpacity(0.3f));
-    assertEquals((Float) layer.getTextOpacity().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextOpacity().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -1118,7 +1159,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getTextColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getTextColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -1162,7 +1204,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textHaloColor("rgba(0, 0, 0, 1)"));
-    assertEquals((String) layer.getTextHaloColor().getValue(), (String) "rgba(0, 0, 0, 1)");
+    assertEquals((String) layer.getTextHaloColor().getValue(),
+                 (String) "rgba(0, 0, 0, 1)");
   }
 
   @Test
@@ -1206,7 +1249,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textHaloWidth(0.3f));
-    assertEquals((Float) layer.getTextHaloWidth().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextHaloWidth().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -1228,7 +1272,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textHaloBlur(0.3f));
-    assertEquals((Float) layer.getTextHaloBlur().getValue(), (Float) 0.3f);
+    assertEquals((Float) layer.getTextHaloBlur().getValue(),
+                 (Float) 0.3f);
   }
 
   @Test
@@ -1250,7 +1295,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textTranslate(new Float[] {0f, 0f}));
-    assertEquals((Float[]) layer.getTextTranslate().getValue(), (Float[]) new Float[] {0f, 0f});
+    assertEquals((Float[]) layer.getTextTranslate().getValue(),
+                 (Float[]) new Float[] {0f, 0f});
   }
 
   @Test
@@ -1272,7 +1318,8 @@ public class SymbolLayerTest extends BaseStyleTest {
 
     // Set and Get
     layer.setProperties(textTranslateAnchor(TEXT_TRANSLATE_ANCHOR_MAP));
-    assertEquals((String) layer.getTextTranslateAnchor().getValue(), (String) TEXT_TRANSLATE_ANCHOR_MAP);
+    assertEquals((String) layer.getTextTranslateAnchor().getValue(),
+                 (String) TEXT_TRANSLATE_ANCHOR_MAP);
   }
 
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -1,15 +1,21 @@
 <%
   const type = locals.type;
   const properties = locals.properties;
+  const propertyNames = locals.properties.map((property) => property.name).sort();
+  const enumNames = locals.properties
+    .filter((property) => property.type == 'enum')
+    .map((property) => snakeCaseUpper(property.name) + "_" + snakeCaseUpper(Object.keys(property.values)[0]))
+    .concat(['NONE', 'VISIBLE']).sort();
 -%>
-// This file is generated. Edit android/platform/scripts/generate-style-code.js, then run `make android-style-code`.
 package com.mapbox.mapboxsdk.testapp.style;
+// This file is generated. Edit android/platform/scripts/generate-style-code.js, then run `make android-style-code`.
 
+<% if (type != 'raster') { -%>
 import android.graphics.Color;
+<% } -%>
 import android.support.test.espresso.Espresso;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import timber.log.Timber;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.<%- camelize(type) %>Layer;
@@ -23,9 +29,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
-import static com.mapbox.mapboxsdk.style.layers.Property.*;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
+import timber.log.Timber;
+
+<% for (const name of enumNames) { -%>
+import static com.mapbox.mapboxsdk.style.layers.Property.<%- name %>;
+<% } -%>
+<% for (const name of propertyNames) { -%>
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.<%- camelizeWithLeadingLowercase(name) %>;
+<% } -%>
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Basic smoke tests for <%- camelize(type) %>Layer
@@ -33,112 +47,113 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 @RunWith(AndroidJUnit4.class)
 public class <%- camelize(type) %>LayerTest extends BaseStyleTest {
 
-    @Rule
-    public final ActivityTestRule<RuntimeStyleTestActivity> rule = new ActivityTestRule<>(RuntimeStyleTestActivity.class);
+  @Rule
+  public final ActivityTestRule<RuntimeStyleTestActivity> rule = new ActivityTestRule<>(RuntimeStyleTestActivity.class);
 
-    private <%- camelize(type) %>Layer layer;
+  private <%- camelize(type) %>Layer layer;
 
-    private OnMapReadyIdlingResource idlingResource;
+  private OnMapReadyIdlingResource idlingResource;
 
-    private MapboxMap mapboxMap;
+  private MapboxMap mapboxMap;
 
-    @Before
-    public void setup() {
-        idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
-        Espresso.registerIdlingResources(idlingResource);
-    }
+  @Before
+  public void setup() {
+    idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
+    Espresso.registerIdlingResources(idlingResource);
+  }
 
-    @Test
-    public void testSetVisibility() {
-        checkViewIsDisplayed(R.id.mapView);
+  @Test
+  public void testSetVisibility() {
+    checkViewIsDisplayed(R.id.mapView);
 
-        mapboxMap = rule.getActivity().getMapboxMap();
+    mapboxMap = rule.getActivity().getMapboxMap();
 
 <% if (type === 'background') { -%>
-        Timber.i("Retrieving layer");
-        layer = mapboxMap.getLayerAs("background");
+    Timber.i("Retrieving layer");
+    layer = mapboxMap.getLayerAs("background");
 <% } else { -%>
-        if ((layer = mapboxMap.getLayerAs("my-layer")) == null) {
-            Timber.i("Adding layer");
-            layer = new <%- camelize(type) %>Layer("my-layer", "composite");
-            layer.setSourceLayer("composite");
-            mapboxMap.addLayer(layer);
-            // Layer reference is now stale, get new reference
-            layer = mapboxMap.getLayerAs("my-layer");
-        }
-<% } -%>
-        Timber.i("visibility");
-        assertNotNull(layer);
-
-        // Get initial
-        assertEquals(layer.getVisibility().getValue(), VISIBLE);
-
-        // Set
-        layer.setProperties(visibility(NONE));
-        assertEquals(layer.getVisibility().getValue(), NONE);
+    if ((layer = mapboxMap.getLayerAs("my-layer")) == null) {
+      Timber.i("Adding layer");
+      layer = new <%- camelize(type) %>Layer("my-layer", "composite");
+      layer.setSourceLayer("composite");
+      mapboxMap.addLayer(layer);
+      // Layer reference is now stale, get new reference
+      layer = mapboxMap.getLayerAs("my-layer");
     }
+<% } -%>
+    Timber.i("visibility");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getVisibility().getValue(), VISIBLE);
+
+    // Set
+    layer.setProperties(visibility(NONE));
+    assertEquals(layer.getVisibility().getValue(), NONE);
+  }
 
 <% for (const property of properties) { -%>
-    @Test
-    public void test<%- camelize(property.name) %>() {
-        checkViewIsDisplayed(R.id.mapView);
+  @Test
+  public void test<%- camelize(property.name) %>() {
+    checkViewIsDisplayed(R.id.mapView);
 
-        mapboxMap = rule.getActivity().getMapboxMap();
+    mapboxMap = rule.getActivity().getMapboxMap();
 
 <% if (type === 'background') { -%>
-        Timber.i("Retrieving layer");
-        layer = mapboxMap.getLayerAs("background");
+    Timber.i("Retrieving layer");
+    layer = mapboxMap.getLayerAs("background");
 <% } else { -%>
-        if ((layer = mapboxMap.getLayerAs("my-layer")) == null) {
-            Timber.i("Adding layer");
-            layer = new <%- camelize(type) %>Layer("my-layer", "composite");
-            layer.setSourceLayer("composite");
-            mapboxMap.addLayer(layer);
-            // Layer reference is now stale, get new reference
-            layer = mapboxMap.getLayerAs("my-layer");
-        }
-<% } -%>
-        Timber.i("<%- property.name %>");
-        assertNotNull(layer);
-
-        // Set and Get
-        layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(<%- defaultValueJava(property) %>));
-        assertEquals((<%- propertyType(property) %>) layer.get<%- camelize(property.name) %>().getValue(), (<%- propertyType(property) %>) <%- defaultValueJava(property) %>);
+    if ((layer = mapboxMap.getLayerAs("my-layer")) == null) {
+      Timber.i("Adding layer");
+      layer = new <%- camelize(type) %>Layer("my-layer", "composite");
+      layer.setSourceLayer("composite");
+      mapboxMap.addLayer(layer);
+      // Layer reference is now stale, get new reference
+      layer = mapboxMap.getLayerAs("my-layer");
     }
+<% } -%>
+    Timber.i("<%- property.name %>");
+    assertNotNull(layer);
+
+    // Set and Get
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(<%- defaultValueJava(property) %>));
+    assertEquals((<%- propertyType(property) %>) layer.get<%- camelize(property.name) %>().getValue(),
+                 (<%- propertyType(property) %>) <%- defaultValueJava(property) %>);
+  }
 <% if (property.type == 'color') { -%>
 
-    @Test
-    public void test<%- camelize(property.name) %>AsInt() {
-        checkViewIsDisplayed(R.id.mapView);
+  @Test
+  public void test<%- camelize(property.name) %>AsInt() {
+    checkViewIsDisplayed(R.id.mapView);
 
-        mapboxMap = rule.getActivity().getMapboxMap();
+    mapboxMap = rule.getActivity().getMapboxMap();
 
 <% if (type === 'background') { -%>
-        Timber.i("Retrieving layer");
-        layer = mapboxMap.getLayerAs("background");
+    Timber.i("Retrieving layer");
+    layer = mapboxMap.getLayerAs("background");
 <% } else { -%>
-        if ((layer = mapboxMap.getLayerAs("my-layer")) == null) {
-            Timber.i("Adding layer");
-            layer = new <%- camelize(type) %>Layer("my-layer", "composite");
-            layer.setSourceLayer("composite");
-            mapboxMap.addLayer(layer);
-            // Layer reference is now stale, get new reference
-            layer = mapboxMap.getLayerAs("my-layer");
-        }
-<% } -%>
-        Timber.i("<%- property.name %>");
-        assertNotNull(layer);
-
-        // Set and Get
-        layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(Color.RED));
-        assertEquals(layer.get<%- camelize(property.name) %>AsInt(), Color.RED);
+    if ((layer = mapboxMap.getLayerAs("my-layer")) == null) {
+      Timber.i("Adding layer");
+      layer = new <%- camelize(type) %>Layer("my-layer", "composite");
+      layer.setSourceLayer("composite");
+      mapboxMap.addLayer(layer);
+      // Layer reference is now stale, get new reference
+      layer = mapboxMap.getLayerAs("my-layer");
     }
 <% } -%>
+    Timber.i("<%- property.name %>");
+    assertNotNull(layer);
+
+    // Set and Get
+    layer.setProperties(<%- camelizeWithLeadingLowercase(property.name) %>(Color.RED));
+    assertEquals(layer.get<%- camelize(property.name) %>AsInt(), Color.RED);
+  }
+<% } -%>
 
 <% } -%>
 
-   @After
-   public void unregisterIntentServiceIdlingResource() {
-       Espresso.unregisterIdlingResources(idlingResource);
-   }
+  @After
+  public void unregisterIntentServiceIdlingResource() {
+    Espresso.unregisterIdlingResources(idlingResource);
+  }
 }

--- a/platform/android/scripts/generate-style-code.js
+++ b/platform/android/scripts/generate-style-code.js
@@ -7,6 +7,11 @@ const _ = require('lodash');
 
 require('../../../scripts/style-code');
 
+///
+// Temporarily IGNORE layers that are in the spec yet still not supported in mbgl core
+///
+delete spec.layer.type.values['fill-extrusion'];
+
 // Specification parsing //
 
 // Collect layer types from spec
@@ -120,7 +125,7 @@ global.defaultValueJava = function(property) {
         return '"pedestrian-polygon"';
     }
     if(property.name.endsWith("-font")) {
-        return 'new String[]{"Open Sans Regular", "Arial Unicode MS Regular"}';
+        return 'new String[] {"Open Sans Regular", "Arial Unicode MS Regular"}';
     }
      switch (property.type) {
       case 'boolean':
@@ -138,11 +143,11 @@ global.defaultValueJava = function(property) {
               case 'string':
                 return '[' + property['default'] + "]";
               case 'number':
-                var result ='new Float[]{';
+                var result ='new Float[] {';
                 for (var i = 0; i < property.length; i++) {
                     result += "0f";
                     if (i +1 != property.length) {
-                        result += ",";
+                        result += ", ";
                     }
                 }
                 return result + "}";

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -55,15 +55,6 @@ _.forOwn(cocoaConventions, function (properties, kind) {
     })
 });
 
-String.prototype.wrap = function (cols, indent) {
-	let wrapRe = new RegExp(`(.{1,${cols - indent}})(?: +|\n|$)`, "gm");
-	return this.replace(wrapRe, "$1\n").replace(/\s+$/, "").indent(indent);
-};
-
-String.prototype.indent = function (cols) {
-	return this.replace(/^|\n/g, "$&" + " ".repeat(cols)).replace(/(^|\n)\s+(?=\n)/g, "$1");
-};
-
 global.camelize = function (str) {
     return str.replace(/(?:^|-)(.)/g, function (_, x) {
         return x.toUpperCase();

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -61,7 +61,7 @@ String.prototype.wrap = function (cols, indent) {
 };
 
 String.prototype.indent = function (cols) {
-	return this.replace(/^|\n/g, "$&" + " ".repeat(cols));
+	return this.replace(/^|\n/g, "$&" + " ".repeat(cols)).replace(/(^|\n)\s+(?=\n)/g, "$1");
 };
 
 global.camelize = function (str) {

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -177,7 +177,7 @@ MGL_EXPORT
 
 /**
  The width of the circle's stroke. Strokes are placed outside of the
- "circle-radius".
+ `circleRadius`.
 
  This property is measured in points.
 

--- a/scripts/style-code.js
+++ b/scripts/style-code.js
@@ -1,5 +1,7 @@
 // Global functions //
 
+'use strict';
+
 const fs = require('fs');
 
 global.iff = function (condition, val) {
@@ -33,4 +35,19 @@ global.writeIfModified = function(filename, newContent) {
   }
   fs.writeFileSync(filename, newContent);
   console.warn(`* Updating outdated file '${filename}'`);
+};
+
+String.prototype.wrap = function (cols, indent, prefix) {
+  if (!prefix) prefix = '';
+  let wrapRe = new RegExp(`(.{1,${cols - indent}})(?: +|\n|$)`, "gm");
+
+  return this.replace(/\{@link /g, "{@link:")
+             .replace(wrapRe, prefix + "$1\n")
+             .replace(/\{@link:/g, "{@link ")
+             .replace(/\s+$/, "")
+             .indent(indent);
+};
+
+String.prototype.indent = function (cols) {
+  return this.replace(/^|\n/g, "$&" + " ".repeat(cols)).replace(/(^|\n)\s+(?=\n)/g, "$1");
 };


### PR DESCRIPTION
Our `indent` function adds trailing spaces for multi line strings when generating the code. Follow up to #7875