### PR TITLE
Notify location listeners of the last known location as soon as the i…

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationServices.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationServices.java
@@ -99,7 +99,7 @@ public class LocationServices implements LostApiClient.ConnectionCallbacks,
     //noinspection MissingPermission
     Location lastLocation = FusedLocationApi.getLastLocation(locationClient);
     if (lastLocation != null) {
-      this.lastLocation = lastLocation;
+      onLocationChanged(lastLocation);
     }
 
     LocationRequest locationRequest;


### PR DESCRIPTION
As discussed with @tobrun, when calling MapboxMap.setMyLocationEnabled(true), the MyLocationView is now notified of the last known position as soon as the LocationServices is connected instead of waiting for the first GPS update.