### PR TITLE
[build] Revert checking codestyle in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ matrix:
       script:
         - git fetch origin master:refs/remotes/origin/master
         - make check
-        - make codestyle
 
     # EGL - Node - Clang 3.8 - Debug
     - os: linux


### PR DESCRIPTION
This caused a build failure right away: https://travis-ci.org/mapbox/mapbox-gl-native/jobs/195965940, and in general I think this is something that is going to be more trouble than it's worth to rigorously enforce.