### PR TITLE
[ios] Stop including framework stripping script in built product

### DIFF
--- a/platform/ios/framework/strip-frameworks.sh
+++ b/platform/ios/framework/strip-frameworks.sh
@@ -35,8 +35,18 @@ code_sign() {
   /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$1"
 }
 
-echo "Stripping frameworks"
+# Set working directory to product’s embedded frameworks 
 cd "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
+if [ "$ACTION" = "install" ]; then
+  echo "Copy .bcsymbolmap files to .xcarchive"
+  find . -name '*.bcsymbolmap' -type f -exec mv {} "${CONFIGURATION_BUILD_DIR}" \;
+else
+  # Delete *.bcsymbolmap files from framework bundle unless archiving
+  find . -name '*.bcsymbolmap' -type f -exec rm -rf "{}" +\;
+fi
+
+echo "Stripping frameworks"
 
 for file in $(find . -type f -perm +111); do
   # Skip non-dynamic libraries
@@ -60,14 +70,6 @@ for file in $(find . -type f -perm +111); do
     fi
   fi
 done
-
-if [ "$ACTION" = "install" ]; then
-  echo "Copy .bcsymbolmap files to .xcarchive"
-  find . -name '*.bcsymbolmap' -type f -exec mv {} "${CONFIGURATION_BUILD_DIR}" \;
-else
-  # Delete *.bcsymbolmap files from framework bundle unless archiving
-  find . -name '*.bcsymbolmap' -type f -exec rm -rf "{}" +\;
-fi
 
 # When this script finishes executing, delete itself from the built product
 function finish {

--- a/platform/ios/framework/strip-frameworks.sh
+++ b/platform/ios/framework/strip-frameworks.sh
@@ -68,3 +68,12 @@ else
   # Delete *.bcsymbolmap files from framework bundle unless archiving
   find . -name '*.bcsymbolmap' -type f -exec rm -rf "{}" +\;
 fi
+
+# When this script finishes executing, delete itself from the built product
+function finish {
+  if [[ $0 == "${BUILT_PRODUCTS_DIR}"* ]]; then
+    rm -f $0;
+  fi
+}
+
+trap finish EXIT


### PR DESCRIPTION
This self-deletes `strip-frameworks.sh` during the build script phase, after it’s done doing its deed. Without this trap, the script is distributed to users in released apps in Mapbox.framework.

Does not address the CocoaPods use-case, where this script is unnecessary and not executed, but still ultimately included in the built app.

/cc @boundsj