### PR TITLE
Traditional Chinese localization

### DIFF
--- a/platform/darwin/resources/zh-Hant.lproj/Foundation.strings
+++ b/platform/darwin/resources/zh-Hant.lproj/Foundation.strings
@@ -1,0 +1,291 @@
+/* Clock position format, long: {hours} o’clock */
+"CLOCK_FMT_LONG" = "%@點";
+
+/* Clock position format, medium: {hours} o’clock */
+"CLOCK_FMT_MEDIUM" = "%@點";
+
+/* Clock position format, short: {hours}:00 */
+"CLOCK_FMT_SHORT" = "%@:00";
+
+/* East, long */
+"COMPASS_E_LONG" = "東";
+
+/* East, short */
+"COMPASS_E_SHORT" = "東";
+
+/* East by north, long */
+"COMPASS_EbN_LONG" = "東微北";
+
+/* East by north, short */
+"COMPASS_EbN_SHORT" = "東微北";
+
+/* East by south, long */
+"COMPASS_EbS_LONG" = "東微南";
+
+/* East by south, short */
+"COMPASS_EbS_SHORT" = "東微南";
+
+/* East-northeast, long */
+"COMPASS_ENE_LONG" = "東北偏東";
+
+/* East-northeast, short */
+"COMPASS_ENE_SHORT" = "東北偏東";
+
+/* East-southeast, long */
+"COMPASS_ESE_LONG" = "東南偏東";
+
+/* East-southeast, short */
+"COMPASS_ESE_SHORT" = "東南偏東";
+
+/* North, long */
+"COMPASS_N_LONG" = "北";
+
+/* North, short */
+"COMPASS_N_SHORT" = "北";
+
+/* North by east, long */
+"COMPASS_NbE_LONG" = "北微東";
+
+/* North by east, short */
+"COMPASS_NbE_SHORT" = "北微東";
+
+/* North by west, long */
+"COMPASS_NbW_LONG" = "北微西";
+
+/* North by west, short */
+"COMPASS_NbW_SHORT" = "北微西";
+
+/* Northeast, long */
+"COMPASS_NE_LONG" = "東北";
+
+/* Northeast, short */
+"COMPASS_NE_SHORT" = "東北";
+
+/* Northeast by east, long */
+"COMPASS_NEbE_LONG" = "東北微東";
+
+/* Northeast by east, short */
+"COMPASS_NEbE_SHORT" = "東北微東";
+
+/* Northeast by north, long */
+"COMPASS_NEbN_LONG" = "東北微北";
+
+/* Northeast by north, short */
+"COMPASS_NEbN_SHORT" = "東北微北";
+
+/* North-northeast, long */
+"COMPASS_NNE_LONG" = "東北偏北";
+
+/* North-northeast, short */
+"COMPASS_NNE_SHORT" = "東北偏北";
+
+/* North-northwest, long */
+"COMPASS_NNW_LONG" = "西北偏北";
+
+/* North-northwest, short */
+"COMPASS_NNW_SHORT" = "西北偏北";
+
+/* Northwest, long */
+"COMPASS_NW_LONG" = "西北";
+
+/* Northwest, short */
+"COMPASS_NW_SHORT" = "西北";
+
+/* Northwest by north, long */
+"COMPASS_NWbN_LONG" = "西北微北";
+
+/* Northwest by north, short */
+"COMPASS_NWbN_SHORT" = "西北微北";
+
+/* Northwest by west, long */
+"COMPASS_NWbW_LONG" = "西北微西";
+
+/* Northwest by west, short */
+"COMPASS_NWbW_SHORT" = "西北微西";
+
+/* South, long */
+"COMPASS_S_LONG" = "南";
+
+/* South, short */
+"COMPASS_S_SHORT" = "南";
+
+/* South by east, long */
+"COMPASS_SbE_LONG" = "南微東";
+
+/* South by east, short */
+"COMPASS_SbE_SHORT" = "南微東";
+
+/* South by west, long */
+"COMPASS_SbW_LONG" = "南微西";
+
+/* South by west, short */
+"COMPASS_SbW_SHORT" = "南微西";
+
+/* Southeast, long */
+"COMPASS_SE_LONG" = "東南";
+
+/* Southeast, short */
+"COMPASS_SE_SHORT" = "東南";
+
+/* Southeast by east, long */
+"COMPASS_SEbE_LONG" = "東南微東";
+
+/* Southeast by east, short */
+"COMPASS_SEbE_SHORT" = "東南微東";
+
+/* Southeast by south, long */
+"COMPASS_SEbS_LONG" = "東南微南";
+
+/* Southeast by south, short */
+"COMPASS_SEbS_SHORT" = "東南微南";
+
+/* South-southeast, long */
+"COMPASS_SSE_LONG" = "東南偏南";
+
+/* South-southeast, short */
+"COMPASS_SSE_SHORT" = "東南偏南";
+
+/* South-southwest, long */
+"COMPASS_SSW_LONG" = "西南偏南";
+
+/* South-southwest, short */
+"COMPASS_SSW_SHORT" = "西南偏南";
+
+/* Southwest, long */
+"COMPASS_SW_LONG" = "西南";
+
+/* Southwest, short */
+"COMPASS_SW_SHORT" = "西南";
+
+/* Southwest by south, long */
+"COMPASS_SWbS_LONG" = "西南偏南";
+
+/* Southwest by south, short */
+"COMPASS_SWbS_SHORT" = "西南偏南";
+
+/* Southwest by west, long */
+"COMPASS_SWbW_LONG" = "西南偏西";
+
+/* Southwest by west, short */
+"COMPASS_SWbW_SHORT" = "西南偏西";
+
+/* West, long */
+"COMPASS_W_LONG" = "西";
+
+/* West, short */
+"COMPASS_W_SHORT" = "西";
+
+/* West by north, long */
+"COMPASS_WbN_LONG" = "西微北";
+
+/* West by north, short */
+"COMPASS_WbN_SHORT" = "西微北";
+
+/* West by south, long */
+"COMPASS_WbS_LONG" = "西微南";
+
+/* West by south, short */
+"COMPASS_WbS_SHORT" = "西微南";
+
+/* West-northwest, long */
+"COMPASS_WNW_LONG" = "西北偏西";
+
+/* West-northwest, short */
+"COMPASS_WNW_SHORT" = "西北偏西";
+
+/* West-southwest, long */
+"COMPASS_WSW_LONG" = "西南偏西";
+
+/* West-southwest, short */
+"COMPASS_WSW_SHORT" = "西南偏西";
+
+/* Degrees format, long */
+"COORD_DEG_LONG" = "%d度";
+
+/* Degrees format, medium: {degrees} */
+"COORD_DEG_MEDIUM" = "%d°";
+
+/* Degrees format, short: {degrees} */
+"COORD_DEG_SHORT" = "%d°";
+
+/* Coordinate format, long: {degrees}{minutes} */
+"COORD_DM_LONG" = "%1$@度%2$@分";
+
+/* Coordinate format, medium: {degrees}{minutes} */
+"COORD_DM_MEDIUM" = "%1$@度%2$@";
+
+/* Coordinate format, short: {degrees}{minutes} */
+"COORD_DM_SHORT" = "%1$@%度2$@";
+
+/* Coordinate format, long: {degrees}{minutes}{seconds} */
+"COORD_DMS_LONG" = "%1$@度%2$@分%3$@秒";
+
+/* Coordinate format, medium: {degrees}{minutes}{seconds} */
+"COORD_DMS_MEDIUM" = "%1$@度%2$@分%3$@秒";
+
+/* Coordinate format, short: {degrees}{minutes}{seconds} */
+"COORD_DMS_SHORT" = "%1$@%度2$@分%3$@秒";
+
+/* East longitude format, long: {longitude} */
+"COORD_E_LONG" = "東經%@";
+
+/* East longitude format, medium: {longitude} */
+"COORD_E_MEDIUM" = "東經%@";
+
+/* East longitude format, short: {longitude} */
+"COORD_E_SHORT" = "%@E";
+
+/* Coordinate pair format, long: {latitude}, {longitude} */
+"COORD_FMT_LONG" = "%1$@，%2$@";
+
+/* Coordinate pair format, medium: {latitude}, {longitude} */
+"COORD_FMT_MEDIUM" = "%1$@，%2$@";
+
+/* Coordinate pair format, short: {latitude}, {longitude} */
+"COORD_FMT_SHORT" = "%1$@，%2$@";
+
+/* Minutes format, long */
+"COORD_MIN_LONG" = "%d分";
+
+/* Minutes format, medium: {minutes} */
+"COORD_MIN_MEDIUM" = "%d′";
+
+/* Minutes format, short: {minutes} */
+"COORD_MIN_SHORT" = "%d′";
+
+/* North latitude format, long: {latitude} */
+"COORD_N_LONG" = "北緯%@";
+
+/* North latitude format, medium: {latitude} */
+"COORD_N_MEDIUM" = "北緯%@";
+
+/* North latitude format, short: {latitude} */
+"COORD_N_SHORT" = "%@N";
+
+/* South latitude format, long: {latitude} */
+"COORD_S_LONG" = "南緯%@";
+
+/* South latitude format, medium: {latitude} */
+"COORD_S_MEDIUM" = "南緯%@";
+
+/* South latitude format, short: {latitude} */
+"COORD_S_SHORT" = "%@S";
+
+/* Seconds format, long */
+"COORD_SEC_LONG" = "%d秒";
+
+/* Seconds format, medium: {seconds} */
+"COORD_SEC_MEDIUM" = "%d″";
+
+/* Seconds format, short: {seconds} */
+"COORD_SEC_SHORT" = "%d″";
+
+/* West longitude format, long: {longitude} */
+"COORD_W_LONG" = "西經%@";
+
+/* West longitude format, medium: {longitude} */
+"COORD_W_MEDIUM" = "西經%@";
+
+/* West longitude format, short: {longitude} */
+"COORD_W_SHORT" = "%@W";
+

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,7 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added support for right-to-left text and Arabic ligatures in labels. ([#6984](https://github.com/mapbox/mapbox-gl-native/pull/6984), [#7123](https://github.com/mapbox/mapbox-gl-native/pull/7123))
 * Improved the line wrapping behavior of point-placed labels, especially labels written in Chinese and Japanese. ([#6828](https://github.com/mapbox/mapbox-gl-native/pull/6828), [#7446](https://github.com/mapbox/mapbox-gl-native/pull/7446))
-* Added a Simplified Chinese localization. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316))
+* Added Simplified and Traditional Chinese localizations. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316), [#7899](https://github.com/mapbox/mapbox-gl-native/pull/7899))
 
 ### Styles
 

--- a/platform/ios/framework/Settings.bundle/zh-Hant.lproj/Root.strings
+++ b/platform/ios/framework/Settings.bundle/zh-Hant.lproj/Root.strings
@@ -1,0 +1,3 @@
+﻿"TELEMETRY_GROUP_TITLE" = "隱私設置";
+"TELEMETRY_SWITCH_TITLE" = "Mapbox傳感數據";
+"TELEMETRY_GROUP_FOOTER" = "此設置允許應用將用戶位置和數據以匿名的方式分享給Mapbox。";

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -810,6 +810,9 @@
 		DAF0D80F1DFE0EA000B28378 /* MGLRasterSource_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLRasterSource_Private.h; sourceTree = "<group>"; };
 		DAF0D8121DFE0EC500B28378 /* MGLVectorSource_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLVectorSource_Private.h; sourceTree = "<group>"; };
 		DAF0D8171DFE6B2800B28378 /* MGLAttributionInfo_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAttributionInfo_Private.h; sourceTree = "<group>"; };
+		DAFBD0D21E3FA7A1000CD6BF /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Foundation.strings"; sourceTree = "<group>"; };
+		DAFBD0D31E3FA7A1000CD6BF /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		DAFBD0D41E3FA7A2000CD6BF /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Root.strings"; sourceTree = "<group>"; };
 		DD0902A21DB18DE700C5BDCE /* MGLNetworkConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfiguration.m; sourceTree = "<group>"; };
 		DD0902A41DB18F1B00C5BDCE /* MGLNetworkConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLNetworkConfiguration.h; sourceTree = "<group>"; };
 		DD4823721D94AE6C00EB71B7 /* fill_filter_style.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fill_filter_style.json; sourceTree = "<group>"; };
@@ -1828,6 +1831,7 @@
 				en,
 				Base,
 				"zh-Hans",
+				"zh-Hant",
 			);
 			mainGroup = DA1DC9411CB6C1C2006E619F;
 			productRefGroup = DA1DC94B1CB6C1C2006E619F /* Products */;
@@ -2202,6 +2206,7 @@
 			children = (
 				DA25D5C51CCDA06800607828 /* Base */,
 				20DABE8A1DF78149007AC5FF /* zh-Hans */,
+				DAFBD0D41E3FA7A2000CD6BF /* zh-Hant */,
 			);
 			name = Root.strings;
 			sourceTree = "<group>";
@@ -2211,6 +2216,7 @@
 			children = (
 				DA8933A01CCC951200E68420 /* Base */,
 				20DABE881DF78148007AC5FF /* zh-Hans */,
+				DAFBD0D31E3FA7A1000CD6BF /* zh-Hant */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -2220,6 +2226,7 @@
 			children = (
 				DA8933BB1CCD2CA100E68420 /* Base */,
 				20DABE861DF78148007AC5FF /* zh-Hans */,
+				DAFBD0D21E3FA7A1000CD6BF /* zh-Hant */,
 			);
 			name = Foundation.strings;
 			sourceTree = "<group>";

--- a/platform/ios/resources/zh-Hant.lproj/Localizable.strings
+++ b/platform/ios/resources/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,84 @@
+/* Accessibility hint */
+"ANNOTATION_A11Y_HINT" = "顯示信息";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_DESC" = "The session data task failed. Original request was: %@";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_REASON" = "The status code was %ld";
+
+/* No comment provided by engineer. */
+"CANCEL" = "取消";
+
+/* Accessibility hint */
+"COMPASS_A11Y_HINT" = "旋轉地圖使正北朝上";
+
+/* Accessibility label */
+"COMPASS_A11Y_LABEL" = "指南針";
+
+/* Compass abbreviation for north */
+"COMPASS_NORTH" = "北";
+
+/* Copyright notice in attribution sheet */
+"COPY_MAPBOX" = "© Mapbox";
+
+/* Copyright notice in attribution sheet */
+"COPY_OSM" = "© OpenStreetMap";
+
+/* Instructions in Interface Builder designable; {key}, {plist file name} */
+"DESIGNABLE" = "在%2$@中將你的access token設爲%1$@可在這裏顯示Mapbox上的地圖\n\n更多說明請見";
+
+/* Setup documentation URL display string; keep as short as possible */
+"FIRST_STEPS_URL" = "mapbox.com/help/first-steps-ios-sdk";
+
+/* Accessibility hint */
+"INFO_A11Y_HINT" = "顯示致謝、用戶反饋及更多";
+
+/* Accessibility label */
+"INFO_A11Y_LABEL" = "關於這個地圖";
+
+/* Accessibility label */
+"LOGO_A11Y_LABEL" = "Mapbox";
+
+/* Accessibility label */
+"MAP_A11Y_LABEL" = "地圖";
+
+/* Map accessibility value */
+"MAP_A11Y_VALUE" = "地圖縮放%1$d倍\n有%2$ld處標記可見";
+
+/* Action in attribution sheet */
+"MAP_FEEDBACK" = "改進地圖";
+
+/* Action sheet title */
+"SDK_NAME" = "Mapbox iOS SDK";
+
+/* Telemetry prompt message */
+"TELEMETRY_DISABLED_MSG" = "你可以提供匿名數據來幫助OpenStreetMap和Mapbox的地圖變得更好。";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_OFF" = "暫不參與";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_ON" = "我要參與";
+
+/* Telemetry prompt message */
+"TELEMETRY_ENABLED_MSG" = "你的匿名數據在幫助OpenStreetMap和Mapbox的地圖變得更好。";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_OFF" = "不再參與";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_ON" = "繼續參與";
+
+/* Telemetry prompt button */
+"TELEMETRY_MORE" = "詳細信息";
+
+/* Action in attribution sheet */
+"TELEMETRY_NAME" = "Mapbox傳感數據";
+
+/* Telemetry prompt title */
+"TELEMETRY_TITLE" = "讓Mapbox地圖變得更好";
+
+/* Default user location annotation title */
+"USER_DOT_TITLE" = "你在這裏";
+

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Added support for right-to-left text and Arabic ligatures in labels. ([#6984](https://github.com/mapbox/mapbox-gl-native/pull/6984), [#7123](https://github.com/mapbox/mapbox-gl-native/pull/7123))
 * Improved the line wrapping behavior of point-placed labels, especially labels written in Chinese and Japanese. ([#6828](https://github.com/mapbox/mapbox-gl-native/pull/6828), [#7446](https://github.com/mapbox/mapbox-gl-native/pull/7446))
-* Added a Simplified Chinese localization. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316), [#7503](https://github.com/mapbox/mapbox-gl-native/pull/7503))
+* Added Simplified and Traditional Chinese localizations. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316), [#7503](https://github.com/mapbox/mapbox-gl-native/pull/7503), [#7899](https://github.com/mapbox/mapbox-gl-native/pull/7899))
 
 ### Styles
 

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -496,6 +496,8 @@
 		DAF0D8151DFE6B1800B28378 /* MGLAttributionInfo_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAttributionInfo_Private.h; sourceTree = "<group>"; };
 		DAF0D81A1DFF567C00B28378 /* MGLVectorSource+MBXAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MGLVectorSource+MBXAdditions.h"; sourceTree = "<group>"; };
 		DAF0D81B1DFF567C00B28378 /* MGLVectorSource+MBXAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLVectorSource+MBXAdditions.m"; sourceTree = "<group>"; };
+		DAFBD0D51E3FA969000CD6BF /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		DAFBD0D61E3FA983000CD6BF /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Foundation.strings"; sourceTree = "<group>"; };
 		DD0902AF1DB1AC6400C5BDCE /* MGLNetworkConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLNetworkConfiguration.m; sourceTree = "<group>"; };
 		DD0902B01DB1AC6400C5BDCE /* MGLNetworkConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLNetworkConfiguration.h; sourceTree = "<group>"; };
 		DD58A4C71D822C6200E1F038 /* MGLExpressionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLExpressionTests.mm; path = ../../darwin/test/MGLExpressionTests.mm; sourceTree = "<group>"; };
@@ -1187,6 +1189,7 @@
 				en,
 				Base,
 				"zh-Hans",
+				"zh-Hant",
 			);
 			mainGroup = DA839E891CC2E3400062CAFB;
 			productRefGroup = DA839E931CC2E3400062CAFB /* Products */;
@@ -1409,6 +1412,7 @@
 			children = (
 				DA8933AC1CCD290700E68420 /* Base */,
 				DA88520F1E0A4D0D009D7AD6 /* zh-Hans */,
+				DAFBD0D51E3FA969000CD6BF /* zh-Hant */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -1418,6 +1422,7 @@
 			children = (
 				DA8933B41CCD2C2500E68420 /* Base */,
 				DA8852101E0A4D3A009D7AD6 /* zh-Hans */,
+				DAFBD0D61E3FA983000CD6BF /* zh-Hant */,
 			);
 			name = Foundation.strings;
 			sourceTree = "<group>";

--- a/platform/macos/sdk/zh-Hant.lproj/Localizable.strings
+++ b/platform/macos/sdk/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+/* Accessibility title */
+"MAP_A11Y_TITLE" = "Mapbox";
+
+/* Label of Zoom In button */
+"ZOOM_IN_LABEL" = "+";
+
+/* Tooltip of Zoom In button */
+"ZOOM_IN_TOOLTIP" = "放大";
+
+/* Label of Zoom Out button; U+2212 MINUS SIGN */
+"ZOOM_OUT_LABEL" = "−";
+
+/* Tooltip of Zoom Out button */
+"ZOOM_OUT_TOOLTIP" = "縮小";
+


### PR DESCRIPTION
Added Traditional Chinese localizations to the iOS and macOS SDKs, using [OpenCC](https://github.com/BYVoid/OpenCC/) to convert the Simplified Chinese localizations added in #7316 and #7503. ([Instructions](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/ios/DEVELOPING.md#adding-a-localization))

I spot-checked the results but would appreciate a review by @lily-chai, @virginiayung, or @jenyuhk. Also, if any of these strings could have more idiomatic translations, we could add Taiwan- or Hong Kong–specific localizations, [again using OpenCC](https://github.com/BYVoid/OpenCC/#預設配置文件).

Fixes #7370.

/cc @YunJieLi @friedbunny