### PR TITLE
[ios] Revert self-deletion of framework stripping script

### DIFF
--- a/platform/ios/framework/strip-frameworks.sh
+++ b/platform/ios/framework/strip-frameworks.sh
@@ -71,11 +71,3 @@ for file in $(find . -type f -perm +111); do
   fi
 done
 
-# When this script finishes executing, delete itself from the built product
-function finish {
-  if [[ $0 == "${BUILT_PRODUCTS_DIR}"* ]]; then
-    rm -f $0;
-  fi
-}
-
-trap finish EXIT


### PR DESCRIPTION
Reverts part of #7895.

Unfortunately, Xcode expects this script to be cached after the first build and will fail on subsequent incremental builds when it’s missing. There appears to be no reasonable way to detect if a build is intended for archive/app store distribution, nor to fix the Run Script Phase path in such a way that it’s more resilient. 😞