### PR TITLE
[ios] [macos] handle 403s same as 404s when downloading tiles

### DIFF
--- a/platform/darwin/src/http_file_source.mm
+++ b/platform/darwin/src/http_file_source.mm
@@ -287,7 +287,8 @@ std::unique_ptr<AsyncRequest> HTTPFileSource::request(const Resource& resource, 
 
                     if (responseCode == 200) {
                         response.data = std::make_shared<std::string>((const char *)[data bytes], [data length]);
-                    } else if (responseCode == 204 || (responseCode == 404 && resource.kind == Resource::Kind::Tile)) {
+                    } else if (responseCode == 204 ||
+                               ((responseCode == 404 || responseCode == 403) && resource.kind == Resource::Kind::Tile)) {
                         response.noContent = true;
                     } else if (responseCode == 304) {
                         response.notModified = true;

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -28,7 +28,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed flickering that occurred when panning past the antimeridian. ([#7574](https://github.com/mapbox/mapbox-gl-native/pull/7574))
 * Fixed an issue that could prevent a cached style from appearing while the device is offline. ([#7770](https://github.com/mapbox/mapbox-gl-native/pull/7770))
 * Added `MGLDistanceFormatter` which can be used to format geographic distances. ([#7888](https://github.com/mapbox/mapbox-gl-native/pull/7888))
-* Fixed an issue where an offline pack downloaded from a server that returns 403s for missing tiles will not complete ([#7904](https://github.com/mapbox/mapbox-gl-native/pull/7904/files))
+* Fixed an issue where an offline pack downloaded from a server that returns 403s for missing tiles will not complete ([#7904](https://github.com/mapbox/mapbox-gl-native/pull/7904))
 
 ## 3.4.1 
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -28,6 +28,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed flickering that occurred when panning past the antimeridian. ([#7574](https://github.com/mapbox/mapbox-gl-native/pull/7574))
 * Fixed an issue that could prevent a cached style from appearing while the device is offline. ([#7770](https://github.com/mapbox/mapbox-gl-native/pull/7770))
 * Added `MGLDistanceFormatter` which can be used to format geographic distances. ([#7888](https://github.com/mapbox/mapbox-gl-native/pull/7888))
+* Fixed an issue where an offline pack downloaded from a server that returns 403s for missing tiles will not complete ([#7904](https://github.com/mapbox/mapbox-gl-native/pull/7904/files))
 
 ## 3.4.1 
 


### PR DESCRIPTION
Without this change, offline region downloads will stall after hitting a few tiles that return 403. 

We encounter this a lot with tile servers coming from s3 buckets. The buckets are configured to return 403 when the tile isn't available. 