### PR TITLE
Allow ObjectAnimator to animate rotation of MarkerView

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
@@ -266,18 +266,9 @@ public class MarkerView extends Marker {
    * @param rotation the rotation value to animate to.
    */
   public void setRotation(float rotation) {
-    // limit to 0 - 360 degrees
-    float newRotation = rotation;
-    while (newRotation > 360) {
-      newRotation -= 360;
-    }
-    while (newRotation < 0) {
-      newRotation += 360;
-    }
-
-    this.rotation = newRotation;
+    this.rotation = rotation;
     if (markerViewManager != null) {
-      markerViewManager.animateRotationBy(this, newRotation);
+      markerViewManager.setRotation(this, rotation);
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -125,6 +125,14 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
     }
   }
 
+  public void setRotation(@NonNull MarkerView marker, float rotation) {
+    View convertView = markerViewMap.get(marker);
+    if (convertView != null) {
+      convertView.animate().cancel();
+      convertView.setRotation(rotation);
+    }
+  }
+
   /**
    * Animate a MarkerView to a given alpha value.
    * <p>

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/annotation/MarkerViewActivity.java
@@ -3,7 +3,9 @@ package com.mapbox.mapboxsdk.testapp.activity.annotation;
 import android.animation.Animator;
 import android.animation.AnimatorInflater;
 import android.animation.AnimatorListenerAdapter;
+import android.animation.FloatEvaluator;
 import android.animation.ObjectAnimator;
+import android.animation.ValueAnimator;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
@@ -98,7 +100,12 @@ public class MarkerViewActivity extends AppCompatActivity {
         options.title("Hello");
         options.position(new LatLng(38.899774, -77.023237));
         options.flat(true);
-        mapboxMap.addMarker(options);
+        MarkerView markerView = mapboxMap.addMarker(options);
+
+        // Use object animator to rotate MarkerView
+        ValueAnimator markerAnimator = ObjectAnimator.ofObject(markerView, "rotation", new FloatEvaluator(), -90, 90);
+        markerAnimator.setDuration(5000);
+        markerAnimator.start();
 
         MarkerViewActivity.this.mapboxMap.addMarker(new MarkerOptions()
           .title("United States")

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/annotations/MarkerViewTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/annotations/MarkerViewTest.java
@@ -17,9 +17,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class MarkerViewTest {
 
@@ -141,70 +138,6 @@ public class MarkerViewTest {
     MarkerViewOptions markerOptions = new MarkerViewOptions().rotation(-10).position(new LatLng());
     MarkerView marker = markerOptions.getMarker();
     assertEquals(marker.getRotation(), 350, 0);
-  }
-
-  @Test
-  public void testRotationUpdatePositive() {
-    float startRotation = 45;
-    float endRotation = 180;
-
-    // allow calls to our mock
-    when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
-
-    MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(startRotation);
-    MarkerView marker = markerOptions.getMarker();
-    marker.setMapboxMap(mapboxMap);
-
-    marker.setRotation(endRotation);
-    verify(markerViewManager, times(1)).animateRotationBy(marker, endRotation);
-  }
-
-  @Test
-  public void testRotationUpdateNegative() {
-    float startRotation = 10;
-    float endRotation = 270;
-
-    // allow calls to our mock
-    when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
-
-    MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(startRotation);
-    MarkerView marker = markerOptions.getMarker();
-    marker.setMapboxMap(mapboxMap);
-
-    marker.setRotation(endRotation);
-    verify(markerViewManager, times(1)).animateRotationBy(marker, endRotation);
-  }
-
-  @Test
-  public void testRotationUpdateMax() {
-    float startRotation = 359;
-    float endRotation = 0;
-
-    // allow calls to our mock
-    when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
-
-    MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(startRotation);
-    MarkerView marker = markerOptions.getMarker();
-    marker.setMapboxMap(mapboxMap);
-
-    marker.setRotation(endRotation);
-    verify(markerViewManager, times(1)).animateRotationBy(marker, 0);
-  }
-
-  @Test
-  public void testRotationUpdateMin() {
-    float startRotation = 0;
-    float endRotation = 359;
-
-    // allow calls to our mock
-    when(mapboxMap.getMarkerViewManager()).thenReturn(markerViewManager);
-
-    MarkerViewOptions markerOptions = new MarkerViewOptions().position(new LatLng()).rotation(startRotation);
-    MarkerView marker = markerOptions.getMarker();
-    marker.setMapboxMap(mapboxMap);
-
-    marker.setRotation(endRotation);
-    verify(markerViewManager, times(1)).animateRotationBy(marker, endRotation);
   }
 
   @Test


### PR DESCRIPTION
This PR allows to use an `ObjectAnimator` to animate the rotation value instead of doing the animation ourselves. Closes #7798