### PR TITLE
[Qt] Guarantee QSqlDatabase connection name uniqueness

### DIFF
--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -46,7 +46,7 @@ workflows:
             brew install cmake
             brew unlink node
             brew install awscli node@4
-            brew link node@4
+            brew link node@4 --force
             gem install xcpretty --no-rdoc --no-ri
             make node
     - script:


### PR DESCRIPTION
Guarantee `QSqlDatabase` connection name uniqueness by using a static counter together with the current thread.

Fixes https://bugreports.qt.io/browse/QTBUG-58552.