### PR TITLE
[Qt] Use ICU whenever available

### DIFF
--- a/icu_dependency.pri
+++ b/icu_dependency.pri
@@ -1,0 +1,13 @@
+win32 {
+    CONFIG(static, static|shared) {
+        CONFIG(debug, debug|release) {
+            LIBS_PRIVATE += -lsicuind -lsicuucd -lsicudtd
+        } else {
+            LIBS_PRIVATE += -lsicuin -lsicuuc -lsicudt
+        }
+    } else {
+        LIBS_PRIVATE += -licuin -licuuc -licudt
+    }
+} else {
+    LIBS_PRIVATE += -licui18n -licuuc -licudata
+}

--- a/mapbox-gl-native.pro
+++ b/mapbox-gl-native.pro
@@ -460,7 +460,6 @@ SOURCES += \
     platform/default/mbgl/util/default_thread_pool.cpp \
     platform/default/online_file_source.cpp \
     platform/qt/src/async_task.cpp \
-    platform/qt/src/bidi.cpp \
     platform/qt/src/http_file_source.cpp \
     platform/qt/src/http_request.cpp \
     platform/qt/src/image.cpp \
@@ -578,3 +577,13 @@ qtConfig(system-zlib) {
 
 # QTBUG-59035
 TR_EXCLUDE += $$PWD/*
+
+qtConfig(icu) {
+    include(icu_dependency.pri)
+
+    SOURCES += \
+        platform/default/src/bidi.cpp
+} else {
+    SOURCES += \
+        platform/qt/src/bidi.cpp
+}


### PR DESCRIPTION
Take advantage of `qtConfig(icu)` provided via QMake to let Mapbox GL native know when to use the default ICU-based bidi pimpl over the stub Qt one.