### PR TITLE
Manage translations in Transifex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.transifexrc
 *.pyc
 *.gcno
 *.gcda

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,25 @@
+[main]
+host = https://www.transifex.com
+lang_map = zh_CN: zh-Hans, zh_TW: zh-Hant
+type = STRINGS
+minimum_perc = 80
+
+[mapbox-gl-native.foundationstrings-darwin]
+source_file = platform/darwin/resources/Base.lproj/Foundation.strings
+source_lang = en
+file_filter = platform/darwin/resources/<lang>.lproj/Foundation.strings
+
+[mapbox-gl-native.localizablestrings-ios]
+source_file = platform/ios/resources/Base.lproj/Localizable.strings
+source_lang = en
+file_filter = platform/ios/resources/<lang>.lproj/Localizable.strings
+
+[mapbox-gl-native.localizablestrings-macos]
+source_file = platform/macos/sdk/Base.lproj/Localizable.strings
+source_lang = en
+file_filter = platform/macos/sdk/<lang>.lproj/Localizable.strings
+
+[mapbox-gl-native.rootstrings-ios]
+source_file = platform/ios/framework/Settings.bundle/Base.lproj/Root.strings
+source_lang = en
+file_filter = platform/ios/framework/Settings.bundle/<lang>.lproj/Root.strings

--- a/platform/ios/DEVELOPING.md
+++ b/platform/ios/DEVELOPING.md
@@ -112,12 +112,24 @@ To add or update text that the user may see in the iOS SDK:
 
 ### Adding a localization
 
-To add a localization to the iOS SDK:
+Translations of all the Mapbox GL Native SDKs are managed [in Transifex](https://www.transifex.com/mapbox/mapbox-gl-native/). If your language already has a translation, feel free to complete or proofread it. Otherwise, please [request your language](https://www.transifex.com/mapbox/mapbox-gl-native/languages/). Note that we’re primarily interested in languages that iOS supports as system languages.
+
+Once you’ve finished translating the SDK into a new language in Transifex, perform these steps to make Xcode aware of the translation:
 
 1. In ios.xcworkspace, open the project editor for ios.xcodeproj. Using the project editor’s sidebar or tab bar dropdown, go to the “ios” project; under the Localizations section of the Info tab, click the + button to add your language to the project.
-1. In the sheet that appears, select all the .strings and .stringsdict files but not the .storyboard file. (LaunchScreen.storyboard is part of the iosapp example application, which is not localized.)
-1. In the Project navigator, expand each .strings and .stringsdict file in the project. An additional version for your localization should be listed; translate it. Translate everything on the right side of the equals sign. Leave the left side and any comments unmodified. See Apple’s documentation on the [.strings](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html) and [.stringsdict](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html) formats.
-1. You’re already most of the way towards localizing the macOS SDK too – consider [completing that localization](../macos/DEVELOPING.md#adding-a-localization).
+1. In the sheet that appears, select all the .strings and .stringsdict files but not the .storyboard file. (LaunchScreen.storyboard is part of the iosapp example application, which is not localized.) If your language lacks declension and pluralization, as in the case of Chinese, omit the .stringsdict files.
+1. In the Project navigator, expand each .stringsdict file in the project. An additional version for your localization should be listed; translate it. See Apple’s documentation on the [.stringsdict format](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html).
+1. Repeat the steps above in macos.xcworkspace.
+
+The .strings files should still be in the original English – that’s expected. Now you can pull your translations into this repository:
+
+1. _(First time only.)_ Download the [`tx` command line tool](https://docs.transifex.com/client/installing-the-client) and [configure your .transifexrc](https://docs.transifex.com/client/client-configuration).
+1. Run `tx pull -a`.
+1. Convert any added .strings files from UTF-16 encoding to UTF-8 encoding to facilitate diffing and merging. You can convert the file encoding using Xcode’s File inspector or the following command (substituting _MYLANG_ for the locale code):
+
+```
+find platform/{darwin,ios}/resources platform/macos/sdk -path '*/MYLANG.lproj/*.strings' -exec textutil -convert txt -extension strings -inputencoding UTF-16 -encoding UTF-8 {} -output {} \;
+```
 
 ### Adding a code example
 

--- a/platform/macos/DEVELOPING.md
+++ b/platform/macos/DEVELOPING.md
@@ -89,12 +89,24 @@ To add or update text that the user may see in the macOS SDK:
 
 ### Adding a localization
 
-To add a localization to the macOS SDK:
+Translations of all the Mapbox GL Native SDKs are managed [in Transifex](https://www.transifex.com/mapbox/mapbox-gl-native/). If your language already has a translation, feel free to complete or proofread it. Otherwise, please [request your language](https://www.transifex.com/mapbox/mapbox-gl-native/languages/). Note that we’re primarily interested in languages that macOS supports as system languages.
+
+Once you’ve finished translating the SDK into a new language in Transifex, perform these steps to make Xcode aware of the translation:
 
 1. In macos.xcworkspace, open the project editor for macos.xcodeproj. Using the project editor’s sidebar or tab bar dropdown, go to the “macos” project; under the Localizations section of the Info tab, click the + button to add your language to the project.
-1. In the sheet that appears, select all the .strings and .stringsdict files but no .xib file. (Most of the XIBs are part of the macosapp example application, which is not localized, while MGLAnnotationCallout.xib contains no localizable strings.)
-1. In the Project navigator, expand each .strings and .stringsdict file in the project. An additional version for your localization should be listed; translate it. Translate everything on the right side of the equals sign. Leave the left side and any comments unmodified. See Apple’s documentation on the [.strings](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html) and [.stringsdict](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html) formats.
-1. You’re already most of the way towards localizing the iOS SDK too – consider [completing that localization](../ios/DEVELOPING.md#adding-a-localization).
+1. In the sheet that appears, select all the .strings and .stringsdict files but no .xib file. (Most of the XIBs are part of the macosapp example application, which is not localized, while MGLAnnotationCallout.xib contains no localizable strings.) If your language lacks declension and pluralization, as in the case of Chinese, omit the .stringsdict files.
+1. In the Project navigator, expand each .stringsdict file in the project. An additional version for your localization should be listed; translate it. See Apple’s documentation on the [.stringsdict format](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html).
+1. Repeat the steps above in ios.xcworkspace.
+
+The .strings files should still be in the original English – that’s expected. Now you can pull your translations into this repository:
+
+1. _(First time only.)_ Download the [`tx` command line tool](https://docs.transifex.com/client/installing-the-client) and [configure your .transifexrc](https://docs.transifex.com/client/client-configuration).
+1. Run `tx pull -a`.
+1. Convert any added .strings files from UTF-16 encoding to UTF-8 encoding to facilitate diffing and merging. You can convert the file encoding using Xcode’s File inspector or the following command (substituting _MYLANG_ for the locale code):
+
+```
+find platform/{darwin,ios}/resources platform/macos/sdk -path '*/MYLANG.lproj/*.strings' -exec textutil -convert txt -extension strings -inputencoding UTF-16 -encoding UTF-8 {} -output {} \;
+```
 
 ### Adding a code example
 


### PR DESCRIPTION
This PR configures and documents a workflow for pulling translations of the iOS and macOS SDKs from the [Mapbox GL Native project on Transifex](https://www.transifex.com/mapbox/mapbox-gl-native/). This setup can easily be generalized to manage any localizable strings in the Android SDK.

Although the `tx` tool is considerably slower than the REST API usage in iD and osrm-text-instructions, I like the various conveniences built the tool. One area for future improvement would be automating adding a new language to the Xcode projects using [node-xcode](https://github.com/alunny/node-xcode/tree/master/lib) or the [xcodeproj](https://github.com/CocoaPods/Xcodeproj) gem.

/cc @bhousel @freenerd