### PR TITLE
[qt] Added support for features as input for GeoJSON source

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -258,6 +258,30 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
             }
         }
         break;
+    case Qt::Key_5: {
+            if (m_map->layerExists("circleLayer")) {
+                m_map->removeLayer("circleLayer");
+                m_map->removeSource("circleSource");
+            } else {
+                QMapbox::CoordinatesCollections geometry { { { m_map->coordinate() } } };
+                QMapbox::Feature feature { QMapbox::Feature::PointType, geometry, {}, {} };
+
+                QVariantMap circleSource;
+                circleSource["type"] = "geojson";
+                circleSource["data"] = QVariant::fromValue<QMapbox::Feature>(feature);
+                m_map->addSource("circleSource", circleSource);
+
+                QVariantMap circle;
+                circle["id"] = "circleLayer";
+                circle["type"] = "circle";
+                circle["source"] = "circleSource";
+                m_map->addLayer(circle);
+
+                m_map->setPaintProperty("circleLayer", "circle-radius", 10.0);
+                m_map->setPaintProperty("circleLayer", "circle-color", QColor("black"));
+            }
+        }
+        break;
     case Qt::Key_Tab:
         m_map->cycleDebugOptions();
         break;

--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -220,7 +220,7 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
                 QMapbox::Coordinate topLeft     = m_map->coordinateForPixel({ 0, 0 });
                 QMapbox::Coordinate bottomRight = m_map->coordinateForPixel({ qreal(size().width()), qreal(size().height()) });
                 QMapbox::CoordinatesCollections geometry { { { topLeft, bottomRight } } };
-                QMapbox::LineAnnotation line { { QMapbox::ShapeAnnotationGeometry::Type::LineStringType, geometry }, 0.5f, 1.0f, Qt::red };
+                QMapbox::LineAnnotation line { { QMapbox::ShapeAnnotationGeometry::LineStringType, geometry }, 0.5f, 1.0f, Qt::red };
                 m_lineAnnotationId = m_map->addAnnotation(QVariant::fromValue<QMapbox::LineAnnotation>(line));
             } else {
                 m_map->removeAnnotation(m_lineAnnotationId.toUInt());
@@ -235,7 +235,7 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
                 QMapbox::Coordinate bottomLeft  = m_map->coordinateForPixel({ qreal(size().width()), 0 });
                 QMapbox::Coordinate bottomRight = m_map->coordinateForPixel({ qreal(size().width()), qreal(size().height()) });
                 QMapbox::CoordinatesCollections geometry { { { bottomLeft, bottomRight, topRight, topLeft, bottomLeft } } };
-                QMapbox::FillAnnotation fill { { QMapbox::ShapeAnnotationGeometry::Type::PolygonType, geometry }, 0.5f, Qt::green, QVariant::fromValue<QColor>(QColor(Qt::black)) };
+                QMapbox::FillAnnotation fill { { QMapbox::ShapeAnnotationGeometry::PolygonType, geometry }, 0.5f, Qt::green, QVariant::fromValue<QColor>(QColor(Qt::black)) };
                 m_fillAnnotationId = m_map->addAnnotation(QVariant::fromValue<QMapbox::FillAnnotation>(fill));
             } else {
                 m_map->removeAnnotation(m_fillAnnotationId.toUInt());
@@ -250,7 +250,7 @@ void MapWindow::keyPressEvent(QKeyEvent *ev)
                 QMapbox::Coordinate bottomLeft  = m_map->coordinateForPixel({ qreal(size().width()), 0 });
                 QMapbox::Coordinate bottomRight = m_map->coordinateForPixel({ qreal(size().width()), qreal(size().height()) });
                 QMapbox::CoordinatesCollections geometry { { { bottomLeft, bottomRight, topRight, topLeft, bottomLeft } } };
-                QMapbox::StyleSourcedAnnotation styleSourced { { QMapbox::ShapeAnnotationGeometry::Type::PolygonType, geometry }, "water" };
+                QMapbox::StyleSourcedAnnotation styleSourced { { QMapbox::ShapeAnnotationGeometry::PolygonType, geometry }, "water" };
                 m_styleSourcedAnnotationId = m_map->addAnnotation(QVariant::fromValue<QMapbox::StyleSourcedAnnotation>(styleSourced));
             } else {
                 m_map->removeAnnotation(m_styleSourcedAnnotationId.toUInt());

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -11,18 +11,31 @@
 
 namespace QMapbox {
 
-// Reflects mapbox::geometry::point<double>.
+// Reflects mbgl::Point<double>.
 typedef QPair<double, double> Coordinate;
 typedef QPair<Coordinate, double> CoordinateZoom;
 
-// Reflects mapbox::geometry::line_string<double> and mapbox::geometry::linear_ring<double>.
+// Reflects mbgl::{LineString,LinearRing,MultiPoint}<double>.
 typedef QList<Coordinate> Coordinates;
 
-// Reflects mapbox::geometry::multi_line_string<double> and mapbox::geometry::polygon<double>.
+// Reflects mbgl::{MultiLineString,Polygon}<double>.
 typedef QList<Coordinates> CoordinatesCollection;
 
-// Reflects mapbox::geometry::multi_polygon<double>.
+// Reflects mbgl::MultiPolygon<double>.
 typedef QList<CoordinatesCollection> CoordinatesCollections;
+
+// Reflects mbgl::Feature.
+struct Q_DECL_EXPORT Feature {
+    enum Type {
+        PointType = 1,
+        LineStringType,
+        PolygonType
+    };
+    Type type;
+    CoordinatesCollections geometry;
+    QVariantMap properties;
+    QVariant id;
+};
 
 // Reflects mbgl::ShapeAnnotationGeometry.
 struct Q_DECL_EXPORT ShapeAnnotationGeometry {
@@ -105,6 +118,7 @@ Q_DECLARE_METATYPE(QMapbox::Coordinate);
 Q_DECLARE_METATYPE(QMapbox::Coordinates);
 Q_DECLARE_METATYPE(QMapbox::CoordinatesCollection);
 Q_DECLARE_METATYPE(QMapbox::CoordinatesCollections);
+Q_DECLARE_METATYPE(QMapbox::Feature);
 
 Q_DECLARE_METATYPE(QMapbox::SymbolAnnotation);
 Q_DECLARE_METATYPE(QMapbox::ShapeAnnotationGeometry);

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -221,6 +221,7 @@ public:
         void* context,
         char* before = NULL);
     void addLayer(const QVariantMap &params);
+    bool layerExists(const QString &id);
     void removeLayer(const QString &id);
 
     void setFilter(const QString &layer, const QVariant &filter);

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/map/change.hpp>
 #include <mbgl/storage/network_status.hpp>
 #include <mbgl/util/default_styles.hpp>
+#include <mbgl/util/geometry.hpp>
 #include <mbgl/util/traits.hpp>
 
 #if QT_VERSION >= 0x050000
@@ -15,6 +16,11 @@
 // mbgl::NetworkStatus::Status
 static_assert(mbgl::underlying_type(QMapbox::Online) == mbgl::underlying_type(mbgl::NetworkStatus::Status::Online), "error");
 static_assert(mbgl::underlying_type(QMapbox::Offline) == mbgl::underlying_type(mbgl::NetworkStatus::Status::Offline), "error");
+
+// mbgl::FeatureType
+static_assert(mbgl::underlying_type(QMapbox::Feature::PointType) == mbgl::underlying_type(mbgl::FeatureType::Point), "error");
+static_assert(mbgl::underlying_type(QMapbox::Feature::LineStringType) == mbgl::underlying_type(mbgl::FeatureType::LineString), "error");
+static_assert(mbgl::underlying_type(QMapbox::Feature::PolygonType) == mbgl::underlying_type(mbgl::FeatureType::Polygon), "error");
 
 namespace QMapbox {
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1390,7 +1390,15 @@ void QMapboxGL::addLayer(const QVariantMap &params)
 }
 
 /*!
-    Removes the layer \a id.
+    Returns true if the layer with given \a id exists, false otherwise.
+*/
+bool QMapboxGL::layerExists(const QString& id)
+{
+    return !!d_ptr->mapObj->getLayer(id.toStdString());
+}
+
+/*!
+    Removes the layer with given \a id.
 */
 void QMapboxGL::removeLayer(const QString& id)
 {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -836,68 +836,26 @@ void QMapboxGL::setTransitionOptions(qint64 duration, qint64 delay) {
     d_ptr->mapObj->setTransitionOptions(mbgl::style::TransitionOptions{ convert(duration), convert(delay) });
 }
 
-mbgl::ShapeAnnotationGeometry asMapboxGLGeometry(const QMapbox::ShapeAnnotationGeometry &geometry) {
-    auto asMapboxGLLineString = [&](const QMapbox::Coordinates &lineString) {
-        mbgl::LineString<double> mbglLineString;
-        mbglLineString.reserve(lineString.size());
-        for (const auto &coordinate : lineString) {
-            mbglLineString.emplace_back(mbgl::Point<double> { coordinate.second, coordinate.first });
-        }
-        return mbglLineString;
-    };
-
-    auto asMapboxGLMultiLineString = [&](const QMapbox::CoordinatesCollection &multiLineString) {
-        mbgl::MultiLineString<double> mbglMultiLineString;
-        mbglMultiLineString.reserve(multiLineString.size());
-        for (const auto &lineString : multiLineString) {
-            mbglMultiLineString.emplace_back(std::forward<mbgl::LineString<double>>(asMapboxGLLineString(lineString)));
-        }
-        return mbglMultiLineString;
-    };
-
-    auto asMapboxGLPolygon = [&](const QMapbox::CoordinatesCollection &polygon) {
-        mbgl::Polygon<double> mbglPolygon;
-        mbglPolygon.reserve(polygon.size());
-        for (const auto &linearRing : polygon) {
-            mbgl::LinearRing<double> mbglLinearRing;
-            mbglLinearRing.reserve(linearRing.size());
-            for (const auto &coordinate: linearRing) {
-                mbglLinearRing.emplace_back(mbgl::Point<double> { coordinate.second, coordinate.first });
-            }
-            mbglPolygon.emplace_back(std::move(mbglLinearRing));
-        }
-        return mbglPolygon;
-    };
-
-    auto asMapboxGLMultiPolygon = [&](const QMapbox::CoordinatesCollections &multiPolygon) {
-        mbgl::MultiPolygon<double> mbglMultiPolygon;
-        mbglMultiPolygon.reserve(multiPolygon.size());
-        for (const auto &polygon : multiPolygon) {
-            mbglMultiPolygon.emplace_back(std::forward<mbgl::Polygon<double>>(asMapboxGLPolygon(polygon)));
-        }
-        return mbglMultiPolygon;
-    };
-
-    mbgl::ShapeAnnotationGeometry result;
-    switch (geometry.type) {
-    case QMapbox::ShapeAnnotationGeometry::LineStringType:
-        result = { asMapboxGLLineString(geometry.geometry.first().first()) };
-        break;
-    case QMapbox::ShapeAnnotationGeometry::PolygonType:
-        result = { asMapboxGLPolygon(geometry.geometry.first()) };
-        break;
-    case QMapbox::ShapeAnnotationGeometry::MultiLineStringType:
-        result = { asMapboxGLMultiLineString(geometry.geometry.first()) };
-        break;
-    case QMapbox::ShapeAnnotationGeometry::MultiPolygonType:
-        result = { asMapboxGLMultiPolygon(geometry.geometry) };
-        break;
-    }
-
-    return result;
-}
-
 mbgl::Annotation asMapboxGLAnnotation(const QMapbox::Annotation & annotation) {
+    auto asMapboxGLGeometry = [](const QMapbox::ShapeAnnotationGeometry &geometry) {
+        mbgl::ShapeAnnotationGeometry result;
+        switch (geometry.type) {
+        case QMapbox::ShapeAnnotationGeometry::LineStringType:
+            result = { asMapboxGLLineString(geometry.geometry.first().first()) };
+            break;
+        case QMapbox::ShapeAnnotationGeometry::PolygonType:
+            result = { asMapboxGLPolygon(geometry.geometry.first()) };
+            break;
+        case QMapbox::ShapeAnnotationGeometry::MultiLineStringType:
+            result = { asMapboxGLMultiLineString(geometry.geometry.first()) };
+            break;
+        case QMapbox::ShapeAnnotationGeometry::MultiPolygonType:
+            result = { asMapboxGLMultiPolygon(geometry.geometry) };
+            break;
+        }
+        return result;
+    };
+
     if (annotation.canConvert<QMapbox::SymbolAnnotation>()) {
         QMapbox::SymbolAnnotation symbolAnnotation = annotation.value<QMapbox::SymbolAnnotation>();
         QMapbox::Coordinate& pair = symbolAnnotation.geometry;

--- a/platform/qt/src/qt_conversion.hpp
+++ b/platform/qt/src/qt_conversion.hpp
@@ -4,6 +4,8 @@
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/optional.hpp>
 
+#include <QMapbox>
+
 #include <QColor>
 #include <QVariant>
 

--- a/platform/qt/src/qt_conversion.hpp
+++ b/platform/qt/src/qt_conversion.hpp
@@ -30,7 +30,13 @@ inline QVariant arrayMember(const QVariant& value, std::size_t i) {
 }
 
 inline bool isObject(const QVariant& value) {
-    return value.canConvert(QVariant::Map) || value.type() == QVariant::ByteArray;
+    return value.canConvert(QVariant::Map)
+        || value.type() == QVariant::ByteArray
+#if QT_VERSION >= 0x050000
+        || QString(value.typeName()) == QStringLiteral("QMapbox::Feature");
+#else
+        || QString(value.typeName()) == QString("QMapbox::Feature");
+#endif
 }
 
 inline optional<QVariant> objectMember(const QVariant& value, const char* key) {

--- a/platform/qt/src/qt_geojson.hpp
+++ b/platform/qt/src/qt_geojson.hpp
@@ -7,6 +7,7 @@
 #include <QMapbox>
 
 #include <QByteArray>
+#include <QDebug>
 #include <QVariant>
 
 #include <sstream>
@@ -14,11 +15,24 @@
 
 namespace QMapbox {
 
+mbgl::Point<double> asMapboxGLPoint(const QMapbox::Coordinate &coordinate) {
+    return mbgl::Point<double> { coordinate.second, coordinate.first };
+}
+
+mbgl::MultiPoint<double> asMapboxGLMultiPoint(const QMapbox::Coordinates &multiPoint) {
+    mbgl::MultiPoint<double> mbglMultiPoint;
+    mbglMultiPoint.reserve(multiPoint.size());
+    for (const auto &point: multiPoint) {
+        mbglMultiPoint.emplace_back(asMapboxGLPoint(point));
+    }
+    return mbglMultiPoint;
+};
+
 mbgl::LineString<double> asMapboxGLLineString(const QMapbox::Coordinates &lineString) {
     mbgl::LineString<double> mbglLineString;
     mbglLineString.reserve(lineString.size());
     for (const auto &coordinate : lineString) {
-        mbglLineString.emplace_back(mbgl::Point<double> { coordinate.second, coordinate.first });
+        mbglLineString.emplace_back(asMapboxGLPoint(coordinate));
     }
     return mbglLineString;
 };
@@ -39,7 +53,7 @@ mbgl::Polygon<double> asMapboxGLPolygon(const QMapbox::CoordinatesCollection &po
         mbgl::LinearRing<double> mbglLinearRing;
         mbglLinearRing.reserve(linearRing.size());
         for (const auto &coordinate: linearRing) {
-            mbglLinearRing.emplace_back(mbgl::Point<double> { coordinate.second, coordinate.first });
+            mbglLinearRing.emplace_back(asMapboxGLPoint(coordinate));
         }
         mbglPolygon.emplace_back(std::move(mbglLinearRing));
     }
@@ -53,6 +67,110 @@ mbgl::MultiPolygon<double> asMapboxGLMultiPolygon(const QMapbox::CoordinatesColl
         mbglMultiPolygon.emplace_back(std::forward<mbgl::Polygon<double>>(asMapboxGLPolygon(polygon)));
     }
     return mbglMultiPolygon;
+};
+
+mbgl::Value asMapboxGLPropertyValue(const QVariant &value) {
+    auto valueList = [](const QVariantList &list) {
+        std::vector<mbgl::Value> mbglList;
+        mbglList.reserve(list.size());
+        for (const auto& listValue : list) {
+            mbglList.emplace_back(asMapboxGLPropertyValue(listValue));
+        }
+        return mbglList;
+    };
+
+    auto valueMap = [](const QVariantMap &map) {
+        std::unordered_map<std::string, mbgl::Value> mbglMap;
+        mbglMap.reserve(map.size());
+        auto it = map.constBegin();
+        while (it != map.constEnd()) {
+            mbglMap.emplace(std::make_pair(it.key().toStdString(), asMapboxGLPropertyValue(it.value())));
+            ++it;
+        }
+        return mbglMap;
+    };
+
+    switch (value.type()) {
+#if QT_VERSION >= 0x050000
+    case QMetaType::UnknownType:
+#else
+    case QVariant::Invalid:
+#endif
+        return mbgl::NullValue {};
+    case QMetaType::Bool:
+        return { value.toBool() };
+    case QMetaType::ULongLong:
+        return { uint64_t(value.toULongLong()) };
+    case QMetaType::LongLong:
+        return { int64_t(value.toLongLong()) };
+    case QMetaType::Double:
+        return { value.toDouble() };
+    case QMetaType::QString:
+        return { value.toString().toStdString() };
+    case QMetaType::QVariantList:
+        return valueList(value.toList());
+    case QMetaType::QVariantMap:
+        return valueMap(value.toMap());
+    default:
+        qWarning() << "Unsupported feature property value:" << value;
+        return {};
+    }
+}
+
+mbgl::FeatureIdentifier asMapboxGLFeatureIdentifier(const QVariant &id) {
+    switch (id.type()) {
+#if QT_VERSION >= 0x050000
+    case QMetaType::UnknownType:
+#else
+    case QVariant::Invalid:
+#endif
+        return {};
+    case QMetaType::ULongLong:
+        return { uint64_t(id.toULongLong()) };
+    case QMetaType::LongLong:
+        return { int64_t(id.toLongLong()) };
+    case QMetaType::Double:
+        return { id.toDouble() };
+    case QMetaType::QString:
+        return { id.toString().toStdString() };
+    default:
+        qWarning() << "Unsupported feature identifier:" << id;
+        return {};
+    }
+}
+
+mbgl::Feature asMapboxGLFeature(const QMapbox::Feature &feature) {
+    mbgl::PropertyMap properties;
+    properties.reserve(feature.properties.size());
+    auto it = feature.properties.constBegin();
+    while (it != feature.properties.constEnd()) {
+        properties.emplace(std::make_pair(it.key().toStdString(), asMapboxGLPropertyValue(it.value())));
+    }
+
+    mbgl::FeatureIdentifier id = asMapboxGLFeatureIdentifier(feature.id);
+
+    if (feature.type == QMapbox::Feature::PointType) {
+        const QMapbox::Coordinates &points = feature.geometry.first().first();
+        if (points.size() == 1) {
+            return { asMapboxGLPoint(points.first()), std::move(properties), std::move(id) };
+        } else {
+            return { asMapboxGLMultiPoint(points), std::move(properties), std::move(id) };
+        }
+    } else if (feature.type == QMapbox::Feature::LineStringType) {
+        const QMapbox::CoordinatesCollection &lineStrings = feature.geometry.first();
+        if (lineStrings.size() == 1) {
+            return { asMapboxGLLineString(lineStrings.first()), std::move(properties), std::move(id) };
+        } else {
+            return { asMapboxGLMultiLineString(lineStrings), std::move(properties), std::move(id) };
+        }
+    } else { // PolygonType
+        const QMapbox::CoordinatesCollections &polygons = feature.geometry;
+        if (polygons.size() == 1) {
+            return { asMapboxGLPolygon(polygons.first()), std::move(properties), std::move(id) };
+        } else {
+            return { asMapboxGLMultiPolygon(polygons), std::move(properties), std::move(id) };
+        }
+    }
 };
 
 } // namespace QMapbox


### PR DESCRIPTION
Using a mix of runtime styles and annotations API, we can e.g. create a circle layer using `AnnotationManage::SourceID` as source, and then later adding a `StyleSourcedAnnotation` passing that newly-created layer ID.

The technique above already works for most annotation geometry types - except `Point`. This PR:
1. Adds support for `Point<double>` in `ShapeAnnotationGeometry` variant, used by `StyleSourcedAnnotation` to store the annotation's geometry
2. Adds support for `CircleLayer` in `StyleSourcedAnnotation`
3. Forwards API changes into QMapbox{GL} API

This makes it possible for implementing [MapCircle](http://doc.qt.io/qt-5/qml-qtlocation-mapcircle.html) QML item natively for our QtLocation Mapbox GL plugin.