### PR TITLE
Remove unneeded <regex> includes

### DIFF
--- a/test/util/http_timeout.test.cpp
+++ b/test/util/http_timeout.test.cpp
@@ -2,8 +2,6 @@
 
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/http_timeout.hpp>
-#include <regex>
-#include <iostream>
 
 using namespace mbgl;
 using namespace mbgl::http;

--- a/test/util/mapbox.test.cpp
+++ b/test/util/mapbox.test.cpp
@@ -3,8 +3,7 @@
 #include <mbgl/util/logging.hpp>
 #include <mbgl/util/mapbox.hpp>
 #include <mbgl/util/constants.hpp>
-#include <regex>
-#include <iostream>
+#include <stdexcept>
 
 using namespace mbgl;
 


### PR DESCRIPTION
Removes a few unneeded includes from tests, adds one that is needed.