### PR TITLE
[ios, macos] Document DDS enumerations

### DIFF
--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -6,20 +6,70 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// TODO: API docs
+/**
+ Options for `MGLStyleValue` function objects.
+ */
 typedef NSString *MGLStyleFunctionOption NS_STRING_ENUM;
 
-// TODO: API docs
+/**
+ An `NSNumber` object containing an integer.
+ 
+ The exponential interpolation base controls the rate at which the function’s 
+ output values increase. A value of 1 causes the function to increase linearly 
+ by zoom level. A higher exponential interpolation base causes the function’s 
+ output values to vary exponentially, increasing more rapidly towards the high 
+ end of the function’s range. The default value of this property is 1, for a 
+ linear curve.
+
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#function-base"><code>base</code></a>
+ function property in the Mapbox Style Specification.
+
+ This option only applies to functions that use an 
+ `MGLInterpolationModeExponential` interpolation mode that are assigned to
+ interpolatable style layer properties.
+ */
 extern MGL_EXPORT const MGLStyleFunctionOption MGLStyleFunctionOptionInterpolationBase;
 
-// TODO: API docs
+/**
+ An `MGLStyleConstantValue` object.
+
+ A default value can be used to set the value of a style layer property that
+ is not otherwise set by a function. For example, a source function with a
+ `MGLInterpolationModeCategorical` interpolation mode with stops that specify
+ color values to use based on a feature's attributes would set any feature
+ that does not have attributes that match the stop key values to this 
+ default value.
+ 
+ This option only applies to `MGLSourceStyleFunction` and
+ `MGLCompositeStyleFunction` functions.
+ */
 extern MGL_EXPORT const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue;
 
-// TODO: API docs
+/** 
+ The modes used to interpolate property values between map zoom level changes
+ or over a range of feature attribute values.
+ */
 typedef NS_ENUM(NSUInteger, MGLInterpolationMode) {
+    /**
+     Values between two stops are interpolated exponentially or linearly if the
+     `MGLStyleFunctionOptionInterpolationBase` is 1.
+     */
     MGLInterpolationModeExponential = 0,
+    /**
+     Values between two stops are not interpolated. Instead, properties are set
+     to the value of the stop just less than the function input.
+     */
     MGLInterpolationModeInterval,
+    /**
+     Values between two stops are not interpolated. Instead, properties are set
+     to the value of the stop equal to the function input's key value.
+     */
     MGLInterpolationModeCategorical,
+    /**
+     Values between two stops are not interpolated. Instead, values are set 
+     to their input value.
+     */
     MGLInterpolationModeIdentity
 };
 

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -7,12 +7,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Options for `MGLStyleValue` function objects.
+ Options for `MGLStyleFunction` objects.
  */
 typedef NSString *MGLStyleFunctionOption NS_STRING_ENUM;
 
 /**
- An `NSNumber` object containing an integer.
+ An `NSNumber` object containing an integer that determines the style function's 
+ exponential interpolation base.
  
  The exponential interpolation base controls the rate at which the function’s 
  output values increase. A value of 1 causes the function to increase linearly 
@@ -32,7 +33,8 @@ typedef NSString *MGLStyleFunctionOption NS_STRING_ENUM;
 extern MGL_EXPORT const MGLStyleFunctionOption MGLStyleFunctionOptionInterpolationBase;
 
 /**
- An `MGLStyleConstantValue` object.
+ An `MGLStyleConstantValue` object that specifies a default value that a style
+ function can use when it can't otherwise determine a value.
 
  A default value can be used to set the value of a style layer property that
  is not otherwise set by a function. For example, a source function with a


### PR DESCRIPTION
Addresses enumeration todos noted in https://github.com/mapbox/mapbox-gl-native/issues/7924

- [x] MGLStyleFunctionOption string enum
  - [x] MGLStyleFunctionOptionInterpolationBase
  - [x] MGLStyleFunctionOptionDefaultValue
- [x] MGLInterpolationMode enum
  - [x] MGLInterpolationModeExponential
  - [x] MGLInterpolationModeInterval
  - [x] MGLInterpolationModeCategorical
  - [x] MGLInterpolationModeIdentity