### PR TITLE
[ios, macos] Implement default value for identity functions

### DIFF
--- a/platform/darwin/test/MGLStyleValueTests.swift
+++ b/platform/darwin/test/MGLStyleValueTests.swift
@@ -164,7 +164,7 @@ extension MGLStyleValueTests {
                 interpolationMode: .identity,
                 sourceStops: nil,
                 attributeName: "size",
-                options: nil
+                options: [.defaultValue: MGLStyleValue<UIColor>(rawValue: .green)]
             )
             circleStyleLayer.circleColor = expectedSourceIdentityValue
             XCTAssertEqual(circleStyleLayer.circleColor, expectedSourceIdentityValue)


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-gl-native/pull/7596 I missed adding default value support to identity functions. This adds it so that source functions with any interpolation mode can use default values.

cc @jfirebaugh @1ec5 @incanus 