### PR TITLE
Add back MGLStyleFunction and re-document MGLStyleValue

### DIFF
--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -189,6 +189,59 @@ MGL_EXPORT
 MGL_EXPORT
 @interface MGLStyleFunction<T> : MGLStyleValue<T>
 
+#pragma mark Creating a Style Function
+
+/**
+ Creates and returns an `MGLStyleFunction` object representing a camera function. 
+ If the function is set as a style layer property value, it will be interpreted 
+ as a camera function with a linear interpolation curve.
+
+ @note Do not create instances of `MGLStyleFunction` unless it is required for
+    backwards compatiblity with your application code. You should create and use
+    instances of `MGLCameraStyleFunction` to specify how properties will
+    be visualized at different zoom levels.
+
+ @param stops A dictionary associating zoom levels with style values.
+ @return An `MGLStyleFunction` object with the given stops.
+ */
++ (instancetype)functionWithStops:(NSDictionary<id, MGLStyleValue<T> *> *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
+
+/**
+ Creates and returns an `MGLStyleFunction` object representing a camera function.
+ If the function is set as a style layer property value, it will be interpreted 
+ as a camera function with an interpolation curve controlled by the provided 
+ interpolation base.
+
+ @note Do not create instances of `MGLStyleFunction` unless it is required for
+    backwards compatiblity with your application code. You should create and use
+    instances of `MGLCameraStyleFunction` to specify how properties will
+    be visualized at different zoom levels.
+
+ @param interpolationBase The exponential base of the interpolation curve.
+ @param stops A dictionary associating zoom levels with style values.
+ @return An `MGLStyleFunction` object with the given interpolation base and stops.
+ */
++ (instancetype)functionWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary<id, MGLStyleValue<T> *> *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
+
+#pragma mark Initializing a Style Function
+
+/**
+ Returns an `MGLStyleFunction` object representing a camera function. If the 
+ function is set as a style layer property value, it will be interpreted
+ as a camera function with an interpolation curve controlled by the provided
+ interpolation base.
+ 
+ @note Do not create instances of `MGLStyleFunction` unless it is required for
+    backwards compatiblity with your application code. You should create and use
+    instances of `MGLCameraStyleFunction` to specify how properties will
+    be visualized at different zoom levels.
+
+ @param interpolationBase The exponential base of the interpolation curve.
+ @param stops A dictionary associating zoom levels with style values.
+ @return An `MGLStyleFunction` object with the given interpolation base and stops.
+ */
+- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary<id, MGLStyleValue<T> *> *)stops NS_DESIGNATED_INITIALIZER;
+
 #pragma mark Accessing the Parameters of a Function
 
 /**
@@ -207,7 +260,8 @@ MGL_EXPORT
  
  @note This property specifies the exponential base of the interpolation curve 
     of `MGLCameraStyleFunction` and `MGLSourceStyleFunction` functions that use 
-    a `MGLInterpolationModeExponential` `interpolationMode`.
+    a `MGLInterpolationModeExponential` `interpolationMode`. Otherwise, it is
+    ignored.
  */
 @property (nonatomic) CGFloat interpolationBase;
 

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -200,14 +200,11 @@ MGL_EXPORT
 /**
  A dictionary associating zoom levels with style values.
  */
-@property (nonatomic, copy) NSDictionary *stops;
+@property (nonatomic, copy, nullable) NSDictionary *stops;
 
 /**
  The exponential interpolation base of the function’s interpolation curve.
  
- @note This property only applies to `MGLCameraStyleFunction` and 
-    `MGLSourceStyleFunction` functions that use a `MGLInterpolationModeExponential`
-    `interpolationMode`.
  @note This property specifies the exponential base of the interpolation curve 
     of `MGLCameraStyleFunction` and `MGLSourceStyleFunction` functions that use 
     a `MGLInterpolationModeExponential` `interpolationMode`.

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -239,6 +239,12 @@ MGL_EXPORT
 #pragma mark Accessing the Parameters of a Function
 
 /**
+ The modes used to interpolate property values between map zoom level changes or
+ over a range of feature attribute values.
+ */
+@property (nonatomic) MGLInterpolationMode interpolationMode;
+
+/**
  A dictionary associating zoom levels with style values.
  */
 @property (nonatomic, copy, nullable) NSDictionary *stops;
@@ -286,12 +292,6 @@ MGL_EXPORT
 #pragma mark Accessing the Parameters of a Camera Function
 
 /**
- The modes used to interpolate property values between map zoom level changes or
- over a range of feature attribute values.
- */
-@property (nonatomic) MGLInterpolationMode interpolationMode;
-
-/**
  A dictionary associating zoom levels with style values.
 
  Each of the function’s stops is represented by one key-value pair in the
@@ -337,12 +337,6 @@ MGL_EXPORT
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(nullable NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
 #pragma mark Accessing the Parameters of a Source Function
-
-/**
- The modes used to interpolate property values between map zoom level changes or
- over a range of feature attribute values.
- */
-@property (nonatomic) MGLInterpolationMode interpolationMode;
 
 /**
  A string that specifies the feature attribute key whose value be used as the function
@@ -403,12 +397,6 @@ MGL_EXPORT
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
 #pragma mark Accessing the Parameters of a Composite Function
-
-/**
- The modes used to interpolate property values between map zoom level changes or
- over a range of feature attribute values.
- */
-@property (nonatomic) MGLInterpolationMode interpolationMode;
 
 /**
  A string that specifies the feature attribute key whose value be used as the function

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -240,7 +240,7 @@ MGL_EXPORT
  @param stops A dictionary associating zoom levels with style values.
  @return An `MGLStyleFunction` object with the given interpolation base and stops.
  */
-- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 
 #pragma mark Accessing the Parameters of a Function
 
@@ -295,22 +295,6 @@ MGL_EXPORT
  */
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
-#pragma mark Initializing a Camera Function
-
-/**
- Returns an `MGLCameraStyleFunction` object representing a camera function with 
- one or more stops.
-
- @param interpolationMode The mode used to interpolate property values between
-    map zoom level changes.
- @param stops A dictionary associating zoom levels with style values.
- @param options A dictionary containing `MGLStyleFunctionOption` values that
-    specify how a function is applied.
- @return An `MGLCameraStyleFunction` object with the given interpolation mode,
-    camera stops, and options.
- */
-- (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options NS_DESIGNATED_INITIALIZER;
-
 #pragma mark Accessing the Parameters of a Camera Function
 
 /**
@@ -357,23 +341,6 @@ MGL_EXPORT
     source stops, attribute name, and options.
 */
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(nullable NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
-
-#pragma mark Initializing a Source Function
-
-/**
- Returns an `MGLSourceStyleFunction` object representing a source function.
-
- @param interpolationMode The mode used to interpolate property values over a
-    range of feature attribute values.
- @param sourceStops A dictionary associating feature attributes with style values.
- @param attributeName Specifies the feature attribute to take as the function
-    input.
- @param options A dictionary containing `MGLStyleFunctionOption` values that
-    specify how a function is applied.
- @return An `MGLSourceStyleFunction` object with the given interpolation mode,
-    source stops, attribute name, and options.
- */
-- (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(nullable NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options NS_DESIGNATED_INITIALIZER;
 
 #pragma mark Accessing the Parameters of a Source Function
 
@@ -434,24 +401,6 @@ MGL_EXPORT
     composite stops, attribute name, and options.
  */
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
-
-#pragma mark Initializing a Composite Function
-
-/**
- Returns an `MGLCompositeStyleFunction` object representing a composite
- function.
-
- @param interpolationMode The mode used to interpolate property values over a
-    range of feature attribute values for each outer zoom level.
- @param sourceStops A dictionary associating feature attributes with style values.
- @param attributeName Specifies the feature attribute to take as the function
-    input.
- @param options A dictionary containing `MGLStyleFunctionOption` values that
-    specify how a function is applied.
- @return An `MGLCompositeStyleFunction` object with the given interpolation mode,
-    composite stops, attribute name, and options.
- */
-- (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options NS_DESIGNATED_INITIALIZER;
 
 #pragma mark Accessing the Parameters of a Composite Function
 

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -204,6 +204,13 @@ MGL_EXPORT
 
 /**
  The exponential interpolation base of the function’s interpolation curve.
+ 
+ @note This property only applies to `MGLCameraStyleFunction` and 
+    `MGLSourceStyleFunction` functions that use a `MGLInterpolationModeExponential`
+    `interpolationMode`.
+ @note This property specifies the exponential base of the interpolation curve 
+    of `MGLCameraStyleFunction` and `MGLSourceStyleFunction` functions that use 
+    a `MGLInterpolationModeExponential` `interpolationMode`.
  */
 @property (nonatomic) CGFloat interpolationBase;
 

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -204,7 +204,7 @@ MGL_EXPORT
  @param stops A dictionary associating zoom levels with style values.
  @return An `MGLStyleFunction` object with the given stops.
  */
-+ (instancetype)functionWithStops:(NSDictionary<id, MGLStyleValue<T> *> *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
++ (instancetype)functionWithStops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 
 /**
  Creates and returns an `MGLStyleFunction` object representing a camera function.
@@ -221,7 +221,7 @@ MGL_EXPORT
  @param stops A dictionary associating zoom levels with style values.
  @return An `MGLStyleFunction` object with the given interpolation base and stops.
  */
-+ (instancetype)functionWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary<id, MGLStyleValue<T> *> *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
++ (instancetype)functionWithInterpolationBase:(CGFloat)interpolationBase stops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 
 #pragma mark Initializing a Style Function
 
@@ -240,7 +240,7 @@ MGL_EXPORT
  @param stops A dictionary associating zoom levels with style values.
  @return An `MGLStyleFunction` object with the given interpolation base and stops.
  */
-- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary<id, MGLStyleValue<T> *> *)stops NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops NS_DESIGNATED_INITIALIZER;
 
 #pragma mark Accessing the Parameters of a Function
 

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -216,8 +216,8 @@ MGL_EXPORT
 /**
  An `MGLCameraStyleFunction` is a value function defining a style value that changes
  as the zoom level changes. The layout and paint attribute properties of an
- `MGLStyleLayer` object can be set to `MGLCameraStyleFunction` objects. Use a zoom
- level function to create the illusion of depth and control data density.
+ `MGLStyleLayer` object can be set to `MGLCameraStyleFunction` objects. Use a camera
+ function to create the illusion of depth and control data density.
 
  The `MGLCameraStyleFunction` class takes a generic parameter `T` that indicates the
  Foundation class being wrapped by this class.
@@ -228,7 +228,7 @@ MGL_EXPORT
 #pragma mark Creating a Camera Function
 
 /**
- Creates and returns an `MGLCameraStyleFunction` object representing a zoom level 
+ Creates and returns an `MGLCameraStyleFunction` object representing a camera
  function with one or more stops.
 
  @param interpolationMode The mode used to interpolate property values between
@@ -244,8 +244,8 @@ MGL_EXPORT
 #pragma mark Initializing a Camera Function
 
 /**
- Returns an `MGLCameraStyleFunction` object representing a zoom level
- function with one or more stops.
+ Returns an `MGLCameraStyleFunction` object representing a camera function with 
+ one or more stops.
 
  @param interpolationMode The mode used to interpolate property values between
     map zoom level changes.

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -69,7 +69,7 @@ MGL_EXPORT
  @param stops A dictionary associating zoom levels with style values.
  @return An `MGLCameraStyleFunction` object with the given stops.
  */
-+ (instancetype)valueWithStops:(NSDictionary<NSNumber *, MGLStyleValue<T> *> *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
++ (instancetype)valueWithStops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 
 /**
  Creates and returns an `MGLCameraStyleFunction` object representing a camera
@@ -79,7 +79,7 @@ MGL_EXPORT
  @param stops A dictionary associating zoom levels with style values.
  @return An `MGLCameraStyleFunction` object with the given interpolation base and stops.
  */
-+ (instancetype)valueWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary<NSNumber *, MGLStyleValue<T> *> *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
++ (instancetype)valueWithInterpolationBase:(CGFloat)interpolationBase stops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 
 /**
  Creates and returns an `MGLCameraStyleFunction` object representing a camera function

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -245,12 +245,6 @@ MGL_EXPORT
 #pragma mark Accessing the Parameters of a Function
 
 /**
- The modes used to interpolate property values between map zoom level changes or
- over a range of feature attribute values.
- */
-@property (nonatomic) MGLInterpolationMode interpolationMode;
-
-/**
  A dictionary associating zoom levels with style values.
  */
 @property (nonatomic, copy, nullable) NSDictionary *stops;
@@ -298,6 +292,12 @@ MGL_EXPORT
 #pragma mark Accessing the Parameters of a Camera Function
 
 /**
+ The modes used to interpolate property values between map zoom level changes or
+ over a range of feature attribute values.
+ */
+@property (nonatomic) MGLInterpolationMode interpolationMode;
+
+/**
  A dictionary associating zoom levels with style values.
 
  Each of the function’s stops is represented by one key-value pair in the
@@ -343,6 +343,12 @@ MGL_EXPORT
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(nullable NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
 #pragma mark Accessing the Parameters of a Source Function
+
+/**
+ The modes used to interpolate property values between map zoom level changes or
+ over a range of feature attribute values.
+ */
+@property (nonatomic) MGLInterpolationMode interpolationMode;
 
 /**
  A string that specifies the feature attribute key whose value be used as the function
@@ -403,6 +409,12 @@ MGL_EXPORT
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
 #pragma mark Accessing the Parameters of a Composite Function
+
+/**
+ The modes used to interpolate property values between map zoom level changes or
+ over a range of feature attribute values.
+ */
+@property (nonatomic) MGLInterpolationMode interpolationMode;
 
 /**
  A string that specifies the feature attribute key whose value be used as the function

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -112,8 +112,6 @@ MGL_EXPORT
 
 /**
  Creates and returns an `MGLCompositeStyleFunction` object representing a composite
- function made up of one or more outer stops interpreted as a camera function 
- with a single inner stop at each zoom level that is interpreted as a source 
  function.
 
  @param interpolationMode The mode used to interpolate property values over a 
@@ -332,10 +330,10 @@ MGL_EXPORT
 
  Each of the function’s stops is represented by one key-value pair in the
  dictionary. Each key in the dictionary is an object representing a feature 
- attribute key. Each value in the dictionary is an `MGLStyleValue` object 
- containing the value to use when the function is given the associated
- attribute key. An `MGLStyleFunction` object may not be used recursively
- as a stop value.
+ attribute key or interpolation stop. Each value in the dictionary is an 
+ `MGLStyleValue` object containing the value to use when the function is given 
+ the associated attribute key. An `MGLStyleFunction` object may not be used 
+ recursively as a stop value.
  */
 @property (nonatomic, copy, nullable) NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *stops;
 
@@ -365,8 +363,6 @@ MGL_EXPORT
 
 /**
  Creates and returns an `MGLCompositeStyleFunction` object representing a composite
- function made up of one or more outer stops interpreted as a camera function
- with a single inner stop at each zoom level that is interpreted as a source
  function.
 
  @param interpolationMode The mode used to interpolate property values over a
@@ -385,8 +381,6 @@ MGL_EXPORT
 
 /**
  Returns an `MGLCompositeStyleFunction` object representing a composite
- function made up of one or more outer stops interpreted as a camera function
- with a single inner stop at each zoom level that is interpreted as a source
  function.
 
  @param interpolationMode The mode used to interpolate property values over a
@@ -415,10 +409,10 @@ MGL_EXPORT
  Each of the function’s stops is represented by one key-value pair in the
  dictionary. Each key in the dictionary is an `NSNumber` object containing a
  floating-point zoom level. Each value in the dictionary is an inner nested 
- dictionary. The nested dictionary key is an object representing a feature 
- attribute key. The nested dictionary value is an `MGLStyleValue` object 
- containing the value to use when the function is given the associated attribute 
- key at the outer zoom level. An `MGLStyleFunction` object may not be used 
+ dictionary. Each key in the nested dictionary is an object representing a feature
+ attribute key or interpolation stop. Each value in the nested dictionary is an
+ `MGLStyleValue` object containing the value to use when the function is given
+ the associated attribute key. An `MGLStyleFunction` object may not be used
  recursively as a value inside the nested dictionary.
  */
 @property (nonatomic, copy) NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *stops;

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -192,34 +192,28 @@ MGL_EXPORT
 #pragma mark Creating a Style Function
 
 /**
- Creates and returns an `MGLStyleFunction` object representing a camera function. 
- If the function is set as a style layer property value, it will be interpreted 
- as a camera function with a linear interpolation curve.
+ Creates and returns an `MGLCameraStyleFunction` object representing a camera 
+ function with a linear interpolation curve.
 
- @note Do not create instances of `MGLStyleFunction` unless it is required for
-    backwards compatiblity with your application code. You should create and use
-    instances of `MGLCameraStyleFunction` to specify how properties will
-    be visualized at different zoom levels.
+ @note Do not create function instances using this method unless it is required 
+    for backwards compatiblity with your application code.
 
  @param stops A dictionary associating zoom levels with style values.
- @return An `MGLStyleFunction` object with the given stops.
+ @return An `MGLCameraStyleFunction` object with the given stops.
  */
 + (instancetype)functionWithStops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 
 /**
- Creates and returns an `MGLStyleFunction` object representing a camera function.
- If the function is set as a style layer property value, it will be interpreted 
- as a camera function with an interpolation curve controlled by the provided 
- interpolation base.
+ Creates and returns an `MGLCameraStyleFunction` object representing a camera
+ function with an interpolation curve controlled by the provided interpolation 
+ base.
 
- @note Do not create instances of `MGLStyleFunction` unless it is required for
-    backwards compatiblity with your application code. You should create and use
-    instances of `MGLCameraStyleFunction` to specify how properties will
-    be visualized at different zoom levels.
+ @note Do not create function instances using this method unless it is required
+    for backwards compatiblity with your application code.
 
  @param interpolationBase The exponential base of the interpolation curve.
  @param stops A dictionary associating zoom levels with style values.
- @return An `MGLStyleFunction` object with the given interpolation base and stops.
+ @return An `MGLCameraStyleFunction` object with the given interpolation base and stops.
  */
 + (instancetype)functionWithInterpolationBase:(CGFloat)interpolationBase stops:(NS_DICTIONARY_OF(NSNumber *, MGLStyleValue<T> *) *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 

--- a/platform/darwin/src/MGLStyleValue.h
+++ b/platform/darwin/src/MGLStyleValue.h
@@ -30,9 +30,10 @@ typedef NS_ENUM(NSUInteger, MGLInterpolationMode) {
 
  The `MGLStyleValue` class itself represents a class cluster. Under the hood, a
  particular `MGLStyleValue` object may be either an `MGLStyleConstantValue` to
- represent a constant value or an `MGLStyleFunction` to represent a value
- function. Do not initialize an `MGLStyleValue` object directly; instead, use
- one of the class factory methods to create an `MGLStyleValue` object.
+ represent a constant value or one of the concrete subclasses of 
+ `MGLStyleFunction` to represent a value function. Do not initialize an 
+ `MGLStyleValue` object directly; instead, use one of the class factory methods 
+ to create an `MGLStyleValue` object.
 
  The `MGLStyleValue` class takes a generic parameter `T` that indicates the
  Foundation class being wrapped by this class. Common values for `T` include:
@@ -62,32 +63,70 @@ MGL_EXPORT
 #pragma mark Function values
 
 /**
- Creates and returns an `MGLStyleFunction` object representing a linear zoom
- level function with any number of stops.
+ Creates and returns an `MGLCameraStyleFunction` object representing a linear camera
+ function with one or more stops.
 
  @param stops A dictionary associating zoom levels with style values.
- @return An `MGLStyleFunction` object with the given stops.
+ @return An `MGLCameraStyleFunction` object with the given stops.
  */
 + (instancetype)valueWithStops:(NSDictionary<NSNumber *, MGLStyleValue<T> *> *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 
 /**
- Creates and returns an `MGLStyleFunction` object representing a zoom level
- function with an exponential interpolation base and any number of stops.
+ Creates and returns an `MGLCameraStyleFunction` object representing a camera
+ function with an exponential interpolation base and one or more stops.
 
  @param interpolationBase The exponential base of the interpolation curve.
  @param stops A dictionary associating zoom levels with style values.
- @return An `MGLStyleFunction` object with the given interpolation base and stops.
+ @return An `MGLCameraStyleFunction` object with the given interpolation base and stops.
  */
 + (instancetype)valueWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary<NSNumber *, MGLStyleValue<T> *> *)stops __attribute__((deprecated("Use +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]")));
 
-// TODO: API docs
-+ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode cameraStops:(NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
+/**
+ Creates and returns an `MGLCameraStyleFunction` object representing a camera function
+ with one or more stops.
 
-// TODO: API docs
-+ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode sourceStops:(nullable NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
+ @param interpolationMode The mode used to interpolate property values between 
+    map zoom level changes.
+ @param cameraStops A dictionary associating zoom levels with style values.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that 
+    specify how a function is applied.
+ @return An `MGLCameraStyleFunction` object with the given interpolation mode,
+    camera stops, and options.
+ */
++ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode cameraStops:(NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)cameraStops options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
-// TODO: API docs
-+ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode compositeStops:(NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
+/**
+ Creates and returns an `MGLSourceStyleFunction` object representing a source function.
+
+ @param interpolationMode The mode used to interpolate property values over a 
+    range of feature attribute values.
+ @param sourceStops A dictionary associating feature attributes with style values.
+ @param attributeName Specifies the feature attribute to take as the function 
+    input.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that
+    specify how a function is applied.
+ @return An `MGLSourceStyleFunction` object with the given interpolation mode,
+    source stops, attribute name, and options.
+ */
++ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode sourceStops:(nullable NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)sourceStops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
+
+/**
+ Creates and returns an `MGLCompositeStyleFunction` object representing a composite
+ function made up of one or more outer stops interpreted as a camera function 
+ with a single inner stop at each zoom level that is interpreted as a source 
+ function.
+
+ @param interpolationMode The mode used to interpolate property values over a 
+    range of feature attribute values for each outer zoom level.
+ @param sourceStops A dictionary associating feature attributes with style values.
+ @param attributeName Specifies the feature attribute to take as the function
+    input.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that
+    specify how a function is applied.
+ @return An `MGLCompositeStyleFunction` object with the given interpolation mode,
+    composite stops, attribute name, and options.
+ */
++ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode compositeStops:(NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *)compositeStops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
 @end
 
@@ -135,76 +174,260 @@ MGL_EXPORT
 
 @end
 
-MGL_EXPORT
-@interface MGLCameraStyleFunction<T> : MGLStyleValue<T>
+/**
+ An `MGLStyleFunction` is a is an abstract superclass for functions that are 
+ defined by an `MGLCameraStyleFunction`, `MGLSourceStyleFunction`, or
+ `MGLCompositeStyleFunction` object.
+ 
+ Do not create instances of this class directly, and do not create your own
+ subclasses of this class. Instead, use one of the class factory methods in
+ `MGLStyleValue` to create instances of the following concrete subclasses:
+ `MGLCameraStyleFunction`, `MGLSourceStyleFunction`, and
+ `MGLCompositeStyleFunction`.
 
-// TODO: API docs
+ The `MGLStyleFunction` class takes a generic parameter `T` that indicates the
+ Foundation class being wrapped by this class.
+ */
+MGL_EXPORT
+@interface MGLStyleFunction<T> : MGLStyleValue<T>
+
+#pragma mark Accessing the Parameters of a Function
+
+/**
+ The modes used to interpolate property values between map zoom level changes or
+ over a range of feature attribute values.
+ */
+@property (nonatomic) MGLInterpolationMode interpolationMode;
+
+/**
+ A dictionary associating zoom levels with style values.
+ */
+@property (nonatomic, copy) NSDictionary *stops;
+
+/**
+ The exponential interpolation base of the function’s interpolation curve.
+ */
+@property (nonatomic) CGFloat interpolationBase;
+
+@end
+
+/**
+ An `MGLCameraStyleFunction` is a value function defining a style value that changes
+ as the zoom level changes. The layout and paint attribute properties of an
+ `MGLStyleLayer` object can be set to `MGLCameraStyleFunction` objects. Use a zoom
+ level function to create the illusion of depth and control data density.
+
+ The `MGLCameraStyleFunction` class takes a generic parameter `T` that indicates the
+ Foundation class being wrapped by this class.
+ */
+MGL_EXPORT
+@interface MGLCameraStyleFunction<T> : MGLStyleFunction<T>
+
+#pragma mark Creating a Camera Function
+
+/**
+ Creates and returns an `MGLCameraStyleFunction` object representing a zoom level 
+ function with one or more stops.
+
+ @param interpolationMode The mode used to interpolate property values between
+    map zoom level changes.
+ @param stops A dictionary associating zoom levels with style values.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that
+    specify how a function is applied.
+ @return An `MGLCameraStyleFunction` object with the given interpolation mode,
+    camera stops, and options.
+ */
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
-// TODO: API docs
+#pragma mark Initializing a Camera Function
+
+/**
+ Returns an `MGLCameraStyleFunction` object representing a zoom level
+ function with one or more stops.
+
+ @param interpolationMode The mode used to interpolate property values between
+    map zoom level changes.
+ @param stops A dictionary associating zoom levels with style values.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that
+    specify how a function is applied.
+ @return An `MGLCameraStyleFunction` object with the given interpolation mode,
+    camera stops, and options.
+ */
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options NS_DESIGNATED_INITIALIZER;
 
-// TODO: API docs
-@property (nonatomic) MGLInterpolationMode interpolationMode;
+#pragma mark Accessing the Parameters of a Camera Function
 
-// TODO: API docs
+/**
+ A dictionary associating zoom levels with style values.
+
+ Each of the function’s stops is represented by one key-value pair in the
+ dictionary. Each key in the dictionary is an `NSNumber` object containing a
+ floating-point zoom level. Each value in the dictionary is an `MGLStyleValue`
+ object containing the value of the style attribute when the map is at the
+ associated zoom level. An `MGLStyleFunction` object may not be used recursively
+ as a stop value.
+ */
 @property (nonatomic, copy) NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *stops;
 
-// TODO: API docs
-@property (nonatomic) CGFloat interpolationBase;
-
 @end
 
-@compatibility_alias MGLStyleFunction MGLCameraStyleFunction;
+/**
+ An `MGLSourceStyleFunction` is a value function defining a style value that 
+ changes with its properties. The layout and paint attribute properties of an
+ `MGLStyleLayer` object can be set to `MGLSourceStyleFunction` objects.
+ Use source functions to visually differentate types of features within the same 
+ layer or create data visualizations.
 
+ The `MGLSourceStyleFunction` class takes a generic parameter `T` that indicates the
+ Foundation class being wrapped by this class.
+ */
 MGL_EXPORT
-@interface MGLSourceStyleFunction<T> : MGLStyleValue<T>
+@interface MGLSourceStyleFunction<T> : MGLStyleFunction<T>
 
-// TODO: API docs
+#pragma mark Creating a Source Function
+
+/**
+ Creates and returns an `MGLSourceStyleFunction` object representing a source 
+ function.
+
+ @param interpolationMode The mode used to interpolate property values over a
+    range of feature attribute values.
+ @param sourceStops A dictionary associating feature attributes with style values.
+ @param attributeName Specifies the feature attribute to take as the function
+    input.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that
+    specify how a function is applied.
+ @return An `MGLSourceStyleFunction` object with the given interpolation mode,
+    source stops, attribute name, and options.
+*/
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(nullable NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
-// TODO: API docs
+#pragma mark Initializing a Source Function
+
+/**
+ Returns an `MGLSourceStyleFunction` object representing a source function.
+
+ @param interpolationMode The mode used to interpolate property values over a
+    range of feature attribute values.
+ @param sourceStops A dictionary associating feature attributes with style values.
+ @param attributeName Specifies the feature attribute to take as the function
+    input.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that
+    specify how a function is applied.
+ @return An `MGLSourceStyleFunction` object with the given interpolation mode,
+    source stops, attribute name, and options.
+ */
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(nullable NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options NS_DESIGNATED_INITIALIZER;
 
-// TODO: API docs
-@property (nonatomic) MGLInterpolationMode interpolationMode;
+#pragma mark Accessing the Parameters of a Source Function
 
-// TODO: API docs
+/**
+ A string that specifies the feature attribute key whose value be used as the function
+ input.
+*/
 @property (nonatomic, copy) NSString *attributeName;
 
-// TODO: API docs
+/**
+ A dictionary associating attribute values with style values.
+
+ Each of the function’s stops is represented by one key-value pair in the
+ dictionary. Each key in the dictionary is an object representing a feature 
+ attribute key. Each value in the dictionary is an `MGLStyleValue` object 
+ containing the value to use when the function is given the associated
+ attribute key. An `MGLStyleFunction` object may not be used recursively
+ as a stop value.
+ */
 @property (nonatomic, copy, nullable) NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *stops;
 
-// TODO: API docs
+/**
+ An `MGLStyleValue` object containing the default value to use when there is
+ no input to provide to the function.
+ */
 @property (nonatomic, nullable) MGLStyleValue<T> *defaultValue;
-
-// TODO: API docs
-@property (nonatomic) CGFloat interpolationBase;
 
 @end
 
-MGL_EXPORT
-@interface MGLCompositeStyleFunction<T> : MGLStyleValue<T>
+/**
+ An `MGLCompositeStyleFunction` is a value function defining a style value that
+ changes with the feature attributes at each map zoom level. The layout and paint 
+ attribute properties of an `MGLStyleLayer` object can be set to 
+ `MGLCompositeStyleFunction` objects. Use composite functions to allow the 
+ appearance of a map feature to change with both its attributes and the map zoom 
+ level.
 
-// TODO: API docs
+ The `MGLCompositeStyleFunction` class takes a generic parameter `T` that indicates the
+ Foundation class being wrapped by this class.
+ */
+MGL_EXPORT
+@interface MGLCompositeStyleFunction<T> : MGLStyleFunction<T>
+
+#pragma mark Creating a Composite Function
+
+/**
+ Creates and returns an `MGLCompositeStyleFunction` object representing a composite
+ function made up of one or more outer stops interpreted as a camera function
+ with a single inner stop at each zoom level that is interpreted as a source
+ function.
+
+ @param interpolationMode The mode used to interpolate property values over a
+    range of feature attribute values for each outer zoom level.
+ @param sourceStops A dictionary associating feature attributes with style values.
+ @param attributeName Specifies the feature attribute to take as the function
+    input.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that
+    specify how a function is applied.
+ @return An `MGLCompositeStyleFunction` object with the given interpolation mode,
+    composite stops, attribute name, and options.
+ */
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options;
 
+#pragma mark Initializing a Composite Function
+
+/**
+ Returns an `MGLCompositeStyleFunction` object representing a composite
+ function made up of one or more outer stops interpreted as a camera function
+ with a single inner stop at each zoom level that is interpreted as a source
+ function.
+
+ @param interpolationMode The mode used to interpolate property values over a
+    range of feature attribute values for each outer zoom level.
+ @param sourceStops A dictionary associating feature attributes with style values.
+ @param attributeName Specifies the feature attribute to take as the function
+    input.
+ @param options A dictionary containing `MGLStyleFunctionOption` values that
+    specify how a function is applied.
+ @return An `MGLCompositeStyleFunction` object with the given interpolation mode,
+    composite stops, attribute name, and options.
+ */
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *)stops attributeName:(NSString *)attributeName options:(nullable NS_DICTIONARY_OF(MGLStyleFunctionOption, id) *)options NS_DESIGNATED_INITIALIZER;
 
-// TODO: API docs
-@property (nonatomic) MGLInterpolationMode interpolationMode;
+#pragma mark Accessing the Parameters of a Composite Function
 
-// TODO: API docs
+/**
+ A string that specifies the feature attribute key whose value be used as the function
+ input.
+ */
 @property (nonatomic, copy) NSString *attributeName;
 
-// TODO: API docs
+/**
+ A dictionary associating attribute values with style values.
+
+ Each of the function’s stops is represented by one key-value pair in the
+ dictionary. Each key in the dictionary is an `NSNumber` object containing a
+ floating-point zoom level. Each value in the dictionary is an inner nested 
+ dictionary. The nested dictionary key is an object representing a feature 
+ attribute key. The nested dictionary value is an `MGLStyleValue` object 
+ containing the value to use when the function is given the associated attribute 
+ key at the outer zoom level. An `MGLStyleFunction` object may not be used 
+ recursively as a value inside the nested dictionary.
+ */
 @property (nonatomic, copy) NS_DICTIONARY_OF(id, NS_DICTIONARY_OF(id, MGLStyleValue<T> *) *) *stops;
 
-// TODO: API docs
+/**
+ An `MGLStyleValue` object containing the default value to use when there is
+ no input to provide to the function.
+ */
 @property (nonatomic, nullable) MGLStyleValue<T> *defaultValue;
-
-// TODO: API docs
-@property (nonatomic) CGFloat interpolationBase;
 
 @end
 

--- a/platform/darwin/src/MGLStyleValue.mm
+++ b/platform/darwin/src/MGLStyleValue.mm
@@ -104,7 +104,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 }
 
 - (NSUInteger)hash {
-    return  self.stops.hash + self.interpolationBase;
+    return  self.stops.hash + @(self.interpolationBase).hash;
 }
 
 @end
@@ -163,7 +163,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 }
 
 - (NSUInteger)hash {
-    return  self.interpolationMode + self.stops.hash + self.interpolationBase;
+    return  @(self.interpolationMode).hash + self.stops.hash + @(self.interpolationBase).hash;
 }
 
 @end
@@ -233,7 +233,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 }
 
 - (NSUInteger)hash {
-    return self.interpolationMode + self.stops.hash + self.attributeName.hash + self.defaultValue.hash + self.interpolationBase;
+    return @(self.interpolationMode).hash + self.stops.hash + self.attributeName.hash + self.defaultValue.hash + @(self.interpolationBase).hash;
 }
 
 @end
@@ -302,7 +302,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 }
 
 - (NSUInteger)hash {
-    return  self.interpolationMode + self.stops.hash + self.attributeName.hash + self.interpolationBase;
+    return  @(self.interpolationMode).hash + self.stops.hash + self.attributeName.hash + @(self.interpolationBase).hash;
 }
 
 @end

--- a/platform/darwin/src/MGLStyleValue.mm
+++ b/platform/darwin/src/MGLStyleValue.mm
@@ -129,7 +129,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
     }
 
     if (self == [super init]) {
-        _interpolationMode = interpolationMode;
+        self.interpolationMode = interpolationMode;
         self.stops = stops;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionInterpolationBase]) {
@@ -182,9 +182,9 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
     if (self == [super init]) {
-        _interpolationMode = interpolationMode;
-        _attributeName = attributeName;
+        self.interpolationMode = interpolationMode;
         self.stops = stops;
+        _attributeName = attributeName;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {
             if ([options[MGLStyleFunctionOptionDefaultValue] isKindOfClass:[MGLStyleValue class]]) {
@@ -252,9 +252,9 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
     if (self == [super init]) {
-        _interpolationMode = interpolationMode;
-        _attributeName = attributeName;
+        self.interpolationMode = interpolationMode;
         self.stops = stops;
+        _attributeName = attributeName;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {
             if ([options[MGLStyleFunctionOptionDefaultValue] isKindOfClass:[MGLStyleValue class]]) {

--- a/platform/darwin/src/MGLStyleValue.mm
+++ b/platform/darwin/src/MGLStyleValue.mm
@@ -17,16 +17,16 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
     return [MGLCameraStyleFunction functionWithInterpolationMode:MGLInterpolationModeExponential stops:stops options:nil];
 }
 
-+ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode cameraStops:(NSDictionary *)stops options:(NSDictionary *)options {
-    return [MGLCameraStyleFunction functionWithInterpolationMode:interpolationMode stops:stops options:options];
++ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode cameraStops:(NSDictionary *)cameraStops options:(NSDictionary *)options {
+    return [MGLCameraStyleFunction functionWithInterpolationMode:interpolationMode stops:cameraStops options:options];
 }
 
-+ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode sourceStops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
-    return [MGLSourceStyleFunction functionWithInterpolationMode:interpolationMode stops:stops attributeName:attributeName options:options];
++ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode sourceStops:(NSDictionary *)sourceStops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
+    return [MGLSourceStyleFunction functionWithInterpolationMode:interpolationMode stops:sourceStops attributeName:attributeName options:options];
 }
 
-+ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode compositeStops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
-    return [MGLCompositeStyleFunction functionWithInterpolationMode:interpolationMode stops:stops attributeName:attributeName options:options];
++ (instancetype)valueWithInterpolationMode:(MGLInterpolationMode)interpolationMode compositeStops:(NSDictionary *)compositeStops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
+    return [MGLCompositeStyleFunction functionWithInterpolationMode:interpolationMode stops:compositeStops attributeName:attributeName options:options];
 }
 
 @end
@@ -62,9 +62,13 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 @end
 
+@implementation MGLStyleFunction
+
+@end
+
 @implementation MGLCameraStyleFunction
 
-@synthesize interpolationMode = _interpolationMode;
+@dynamic stops;
 
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops options:(NSDictionary *)options {
     return [[self alloc] initWithInterpolationMode:interpolationMode stops:stops options:options];
@@ -82,14 +86,14 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
     }
 
     if (self == [super init]) {
-        _interpolationMode = interpolationMode;
-        _stops = stops;
-        _interpolationBase = 1.0;
+        self.interpolationMode = interpolationMode;
+        self.stops = stops;
+        self.interpolationBase = 1.0;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionInterpolationBase]) {
             if ([options[MGLStyleFunctionOptionInterpolationBase] isKindOfClass:[NSNumber class]]) {
                 NSNumber *value = (NSNumber *)options[MGLStyleFunctionOptionInterpolationBase];
-                _interpolationBase = [value floatValue];
+                self.interpolationBase = [value floatValue];
             } else {
                 [NSException raise:NSInvalidArgumentException format:@"Interpolation base must be an NSNumber that represents a CGFloat."];
             }
@@ -124,7 +128,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 @implementation MGLSourceStyleFunction
 
-@synthesize interpolationMode = _interpolationMode;
+@dynamic stops;
 
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
     return [[self alloc] initWithInterpolationMode:interpolationMode stops:stops attributeName:attributeName options:options];
@@ -136,10 +140,11 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
     if (self == [super init]) {
-        _interpolationMode = interpolationMode;
-        _stops = stops;
+        self.interpolationMode = interpolationMode;
+        self.stops = stops;
+        self.interpolationBase = 1.0;
+
         _attributeName = attributeName;
-        _interpolationBase = 1.0;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {
             if ([options[MGLStyleFunctionOptionDefaultValue] isKindOfClass:[MGLStyleValue class]]) {
@@ -153,7 +158,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
         if ([options.allKeys containsObject:MGLStyleFunctionOptionInterpolationBase]) {
             if ([options[MGLStyleFunctionOptionInterpolationBase] isKindOfClass:[NSNumber class]]) {
                 NSNumber *value = (NSNumber *)options[MGLStyleFunctionOptionInterpolationBase];
-                _interpolationBase = [value floatValue];
+                self.interpolationBase = [value floatValue];
             } else {
                 [NSException raise:NSInvalidArgumentException format:@"Interpolation base must be an NSNumber that represents a CGFloat."];
             }
@@ -195,7 +200,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 @implementation MGLCompositeStyleFunction
 
-@synthesize interpolationMode = _interpolationMode;
+@dynamic stops;
 
 + (instancetype)functionWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
     return [[self alloc] initWithInterpolationMode:interpolationMode stops:stops attributeName:attributeName options:options];
@@ -207,10 +212,11 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
     if (self == [super init]) {
-        _interpolationMode = interpolationMode;
-        _stops = stops;
+        self.interpolationMode = interpolationMode;
+        self.stops = stops;
+        self.interpolationBase = 1.0;
+
         _attributeName = attributeName;
-        _interpolationBase = 1.0;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {
             if ([options[MGLStyleFunctionOptionDefaultValue] isKindOfClass:[MGLStyleValue class]]) {
@@ -224,7 +230,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
         if ([options.allKeys containsObject:MGLStyleFunctionOptionInterpolationBase]) {
             if ([options[MGLStyleFunctionOptionInterpolationBase] isKindOfClass:[NSNumber class]]) {
                 NSNumber *value = (NSNumber *)options[MGLStyleFunctionOptionInterpolationBase];
-                _interpolationBase = [value floatValue];
+                self.interpolationBase = [value floatValue];
             } else {
                 [NSException raise:NSInvalidArgumentException format:@"Interpolation base must be an NSNumber that represents a CGFloat."];
             }

--- a/platform/darwin/src/MGLStyleValue.mm
+++ b/platform/darwin/src/MGLStyleValue.mm
@@ -129,7 +129,7 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
     }
 
     if (self == [super init]) {
-        self.interpolationMode = interpolationMode;
+        _interpolationMode = interpolationMode;
         self.stops = stops;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionInterpolationBase]) {
@@ -182,9 +182,9 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
     if (self == [super init]) {
-        self.interpolationMode = interpolationMode;
-        self.stops = stops;
+        _interpolationMode = interpolationMode;
         _attributeName = attributeName;
+        self.stops = stops;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {
             if ([options[MGLStyleFunctionOptionDefaultValue] isKindOfClass:[MGLStyleValue class]]) {
@@ -252,9 +252,9 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
     if (self == [super init]) {
-        self.interpolationMode = interpolationMode;
-        self.stops = stops;
+        _interpolationMode = interpolationMode;
         _attributeName = attributeName;
+        self.stops = stops;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {
             if ([options[MGLStyleFunctionOptionDefaultValue] isKindOfClass:[MGLStyleValue class]]) {

--- a/platform/darwin/src/MGLStyleValue.mm
+++ b/platform/darwin/src/MGLStyleValue.mm
@@ -64,6 +64,45 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 
 @implementation MGLStyleFunction
 
++ (instancetype)functionWithStops:(NSDictionary *)stops {
+    return [[self alloc] initWithInterpolationBase:1.0 stops:stops];
+}
+
++ (instancetype)functionWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary *)stops {
+    return [[self alloc] initWithInterpolationBase:interpolationBase stops:stops];
+}
+
+- (instancetype)init {
+    return [self initWithInterpolationBase:1.0 stops:@{}];
+}
+
+- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary *)stops {
+    if (self = [super init]) {
+        self.interpolationBase = interpolationBase;
+        self.stops = stops;
+    }
+    return self;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, \
+            stops = %@, \
+            interpolationBase = %f>",
+            NSStringFromClass([self class]), (void *)self,
+            self.stops,
+            self.interpolationBase];
+}
+
+- (BOOL)isEqual:(MGLStyleFunction *)other {
+    return ([other isKindOfClass:[self class]]
+            && [other.stops isEqualToDictionary:self.stops]
+            && other.interpolationBase == self.interpolationBase);
+}
+
+- (NSUInteger)hash {
+    return  self.stops.hash + self.interpolationBase;
+}
+
 @end
 
 @implementation MGLCameraStyleFunction
@@ -74,8 +113,8 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
     return [[self alloc] initWithInterpolationMode:interpolationMode stops:stops options:options];
 }
 
-- (instancetype)init {
-    return [self initWithInterpolationMode:MGLInterpolationModeExponential stops:@{} options:nil];
+- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary *)stops {
+    return [self initWithInterpolationMode:MGLInterpolationModeExponential stops:stops options:@{MGLStyleFunctionOptionInterpolationBase: @(interpolationBase)}];
 }
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops options:(NSDictionary *)options {
@@ -85,10 +124,8 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
         return {};
     }
 
-    if (self == [super init]) {
+    if (self == [super initWithInterpolationBase:1.0 stops:stops]) {
         self.interpolationMode = interpolationMode;
-        self.stops = stops;
-        self.interpolationBase = 1.0;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionInterpolationBase]) {
             if ([options[MGLStyleFunctionOptionInterpolationBase] isKindOfClass:[NSNumber class]]) {
@@ -134,16 +171,13 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
     return [[self alloc] initWithInterpolationMode:interpolationMode stops:stops attributeName:attributeName options:options];
 }
 
-- (instancetype)init {
-    return [self initWithInterpolationMode:MGLInterpolationModeExponential stops:nil attributeName:@"" options:nil];
+- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary *)stops {
+    return [self initWithInterpolationMode:MGLInterpolationModeExponential stops:stops attributeName:@"" options:@{MGLStyleFunctionOptionInterpolationBase: @(interpolationBase)}];
 }
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
-    if (self == [super init]) {
+    if (self == [super initWithInterpolationBase:1.0 stops:stops]) {
         self.interpolationMode = interpolationMode;
-        self.stops = stops;
-        self.interpolationBase = 1.0;
-
         _attributeName = attributeName;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {
@@ -206,16 +240,13 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
     return [[self alloc] initWithInterpolationMode:interpolationMode stops:stops attributeName:attributeName options:options];
 }
 
-- (instancetype)init {
-    return [self initWithInterpolationMode:MGLInterpolationModeExponential stops:@{} attributeName:@"" options:nil];
+- (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary *)stops {
+    return [self initWithInterpolationMode:MGLInterpolationModeExponential stops:stops attributeName:@"" options:@{MGLStyleFunctionOptionInterpolationBase: @(interpolationBase)}];
 }
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
-    if (self == [super init]) {
+    if (self == [super initWithInterpolationBase:1.0 stops:stops]) {
         self.interpolationMode = interpolationMode;
-        self.stops = stops;
-        self.interpolationBase = 1.0;
-
         _attributeName = attributeName;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {

--- a/platform/darwin/src/MGLStyleValue.mm
+++ b/platform/darwin/src/MGLStyleValue.mm
@@ -73,7 +73,11 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 }
 
 - (instancetype)init {
-    return [self initWithInterpolationBase:1.0 stops:@{}];
+    if (self = [super init]) {
+        self.interpolationBase = 1.0;
+        self.stops = @{};
+    }
+    return self;
 }
 
 - (instancetype)initWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary *)stops {
@@ -124,8 +128,9 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
         return {};
     }
 
-    if (self == [super initWithInterpolationBase:1.0 stops:stops]) {
+    if (self == [super init]) {
         self.interpolationMode = interpolationMode;
+        self.stops = stops;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionInterpolationBase]) {
             if ([options[MGLStyleFunctionOptionInterpolationBase] isKindOfClass:[NSNumber class]]) {
@@ -176,8 +181,9 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 }
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
-    if (self == [super initWithInterpolationBase:1.0 stops:stops]) {
+    if (self == [super init]) {
         self.interpolationMode = interpolationMode;
+        self.stops = stops;
         _attributeName = attributeName;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {
@@ -245,8 +251,9 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 }
 
 - (instancetype)initWithInterpolationMode:(MGLInterpolationMode)interpolationMode stops:(NSDictionary *)stops attributeName:(NSString *)attributeName options:(NSDictionary *)options {
-    if (self == [super initWithInterpolationBase:1.0 stops:stops]) {
+    if (self == [super init]) {
         self.interpolationMode = interpolationMode;
+        self.stops = stops;
         _attributeName = attributeName;
 
         if ([options.allKeys containsObject:MGLStyleFunctionOptionDefaultValue]) {

--- a/platform/darwin/src/MGLStyleValue.mm
+++ b/platform/darwin/src/MGLStyleValue.mm
@@ -65,11 +65,11 @@ const MGLStyleFunctionOption MGLStyleFunctionOptionDefaultValue = @"MGLStyleFunc
 @implementation MGLStyleFunction
 
 + (instancetype)functionWithStops:(NSDictionary *)stops {
-    return [[self alloc] initWithInterpolationBase:1.0 stops:stops];
+    return [MGLCameraStyleFunction functionWithInterpolationMode:MGLInterpolationModeExponential stops:stops options:nil];
 }
 
 + (instancetype)functionWithInterpolationBase:(CGFloat)interpolationBase stops:(NSDictionary *)stops {
-    return [[self alloc] initWithInterpolationBase:interpolationBase stops:stops];
+    return [MGLCameraStyleFunction functionWithInterpolationMode:MGLInterpolationModeExponential stops:stops options:@{MGLStyleFunctionOptionInterpolationBase: @(interpolationBase)}];
 }
 
 - (instancetype)init {

--- a/platform/darwin/test/MGLStyleValueTests.swift
+++ b/platform/darwin/test/MGLStyleValueTests.swift
@@ -92,11 +92,11 @@ extension MGLStyleValueTests {
         var circleTranslationTwo = CGVector(dx: 0, dy: 0)
         let circleTranslationValueTwo = NSValue(bytes: &circleTranslationTwo, objCType: "{CGVector=dd}")
 
-        let circleTranslationStops = [
+        let circleTranslationStops: [NSNumber: MGLStyleValue<NSValue>] = [
             0: MGLStyleValue<NSValue>(rawValue: circleTranslationValueOne),
             10: MGLStyleValue<NSValue>(rawValue: circleTranslationValueTwo)
         ]
-        let circleTranslationFunction = MGLStyleFunction(
+        let circleTranslationFunction = MGLStyleFunction<NSValue>(
             interpolationBase: 1.0,
             stops: circleTranslationStops
         )

--- a/platform/darwin/test/MGLStyleValueTests.swift
+++ b/platform/darwin/test/MGLStyleValueTests.swift
@@ -38,6 +38,7 @@ extension MGLStyleValueTests {
     func testDeprecatedFunctions() {
         let shapeSource = MGLShapeSource(identifier: "test", shape: nil, options: nil)
         let symbolStyleLayer = MGLSymbolStyleLayer(identifier: "symbolLayer", source: shapeSource)
+        let circleStyleLayer = MGLCircleStyleLayer(identifier: "circleLayer", source: shapeSource)
 
         // deprecated function, stops with float values
         let iconHaloBlurStyleValue = MGLStyleValue<NSNumber>(interpolationBase: 1.0, stops: [1: MGLStyleValue(rawValue: 0),
@@ -63,6 +64,66 @@ extension MGLStyleValueTests {
             options: nil
         )
         XCTAssertEqual(symbolStyleLayer.iconAllowsOverlap, expectedIconAllowsOverlapStyleValue)
+
+        ///
+        // creating and using MGLStyleFunctions directly
+        ///
+
+        let circleRadiusStops: [NSNumber: MGLStyleValue<NSNumber>] = [
+            0: MGLStyleValue(rawValue: 10),
+            20: MGLStyleValue(rawValue: 5)
+        ]
+        let circleRadiusFunction = MGLStyleFunction<NSNumber>(
+            interpolationBase: 1.0,
+            stops: circleRadiusStops
+        )
+        circleStyleLayer.circleRadius = circleRadiusFunction
+        let expectedCircleRadiusFunction = MGLStyleValue<NSNumber>(
+            interpolationMode: .exponential,
+            cameraStops:
+            circleRadiusStops,
+            options: nil
+        )
+        // setting a data driven property to an MGLStyleFunction should return an exponential camera function
+        XCTAssertEqual(circleStyleLayer.circleRadius, expectedCircleRadiusFunction)
+
+        var circleTranslationOne = CGVector(dx: 100, dy: 0)
+        let circleTranslationValueOne = NSValue(bytes: &circleTranslationOne, objCType: "{CGVector=dd}")
+        var circleTranslationTwo = CGVector(dx: 0, dy: 0)
+        let circleTranslationValueTwo = NSValue(bytes: &circleTranslationTwo, objCType: "{CGVector=dd}")
+
+        let circleTranslationStops = [
+            0: MGLStyleValue<NSValue>(rawValue: circleTranslationValueOne),
+            10: MGLStyleValue<NSValue>(rawValue: circleTranslationValueTwo)
+        ]
+        let circleTranslationFunction = MGLStyleFunction(
+            interpolationBase: 1.0,
+            stops: circleTranslationStops
+        )
+        circleStyleLayer.circleTranslation = circleTranslationFunction
+        let expectedCircleTranslationFunction = MGLStyleValue<NSValue>(
+            interpolationMode: .exponential,
+            cameraStops: circleTranslationStops,
+            options: nil
+        )
+        // setting a non-data driven, interpolatable property to an MGLStyleFunction should return an exponential camera function
+        XCTAssertEqual(circleStyleLayer.circleTranslation, expectedCircleTranslationFunction)
+
+        let iconOptionalStops: [NSNumber: MGLStyleValue<NSNumber>] = [
+            0: MGLStyleValue(rawValue: false),
+            20: MGLStyleValue(rawValue: true)
+        ]
+        let iconOptionalFunction = MGLStyleFunction(
+            interpolationBase: 1.0,
+            stops: iconOptionalStops
+        )
+        symbolStyleLayer.iconOptional = iconOptionalFunction
+        let expectedIconOptionalFunction = MGLStyleValue(
+            interpolationMode: .interval,
+            cameraStops: iconOptionalStops,
+            options: nil
+        )
+        XCTAssertEqual(symbolStyleLayer.iconOptional, expectedIconOptionalFunction)
     }
 
     func testFunctionsWithNonDataDrivenProperties() {

--- a/platform/darwin/test/MGLStyleValueTests.swift
+++ b/platform/darwin/test/MGLStyleValueTests.swift
@@ -293,6 +293,15 @@ extension MGLStyleValueTests {
             }
         }
 
+        // get value back as base class
+        if let returnedCircleRadius = circleStyleLayer.circleRadius as? MGLStyleFunction<NSNumber> {
+            if let returnedStops = returnedCircleRadius.stops as NSDictionary? as? [NSNumber: [NSNumber: MGLStyleValue<NSNumber>]] {
+                let lhs: MGLStyleValue<NSNumber> = returnedStops[0]!.values.first!
+                let rhs: MGLStyleValue<NSNumber> = radiusCompositeExponentialOrIntervalStops[0]!.values.first!
+                XCTAssertEqual(lhs, rhs)
+            }
+        }
+
         // data-driven, composite function with inner interval color stop values nested in outer camera stops
         let expectedCompositeIntervalValue = MGLStyleValue<NSNumber>(
             interpolationMode: .interval,


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-gl-native/issues/7934

Addresses `MGLStyleValue` documentation todos noted in https://github.com/mapbox/mapbox-gl-native/issues/7924:

- [x] Update class documentation for `MGLStyleValue` (as a class cluster it represents something different now)
- [x] +[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]
- [x] +[MGLStyleValue valueWithInterpolationMode:sourceStops:attributeName:options:]
- [x] +[MGLStyleValue valueWithInterpolationMode:compositeStops:attributeName:options:]
- [x] MGLCameraStyleFunction (and all methods and properties)
- [x] MGLSourceStyleFunction (and all methods and properties)
- [x] MGLCompositeStyleFunction (and all methods and properties)
