### PR TITLE
[build] Remove mkdirp from node deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "ejs": "^2.4.1",
     "express": "^4.11.1",
     "lodash": "^4.16.4",
-    "mkdirp": "^0.5.1",
     "node-cmake": "^1.2.1",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.0.0",

--- a/scripts/build-shaders.js
+++ b/scripts/build-shaders.js
@@ -2,7 +2,7 @@
 
 var path = require('path');
 var fs = require('fs');
-var mkdirp = require('mkdirp');
+var tools = require('./tools');
 
 var shaderName = process.argv[2];
 var inputPath = process.argv[3];
@@ -71,5 +71,5 @@ var content = "#pragma once\n" +
 "} // namespace shaders\n" +
 "} // namespace mbgl\n";
 
-mkdirp.sync(outputPath);
+tools.mkdirRecursive(outputPath);
 fs.writeFileSync(path.join(outputPath, shaderName + '.hpp'), content);

--- a/scripts/build-version.js
+++ b/scripts/build-version.js
@@ -3,8 +3,8 @@
 var path = require('path');
 var fs = require('fs');
 var util = require('util');
-var mkdirp = require('mkdirp');
 var execSync = require('child_process').execSync;
+var tools = require('./tools');
 
 const DEFAULT_TAG = [0, 0, 0];
 const DEFAULT_REV = 'unknown';
@@ -76,6 +76,7 @@ var header = '// NOTE: DO NOT CHANGE THIS FILE. IT IS AUTOMATICALLY GENERATED.\n
     '} // namespace version\n' +
     '} // namespace mbgl\n';
 
-var header_path = path.join(output_dir, 'include/mbgl/util/version.hpp')
-mkdirp.sync(path.dirname(header_path));
-fs.writeFileSync(header_path, header);
+var headerPath = path.join(output_dir, 'include/mbgl/util/version.hpp')
+
+tools.mkdirRecursive(path.dirname(headerPath));
+fs.writeFileSync(headerPath, header);

--- a/scripts/tools.js
+++ b/scripts/tools.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+var path = require('path');
+var fs = require('fs');
+
+module.exports = {
+    // http://stackoverflow.com/a/40686853/2810637
+    mkdirRecursive: function(recursiveDir) {
+        if (!fs.existsSync(recursiveDir)) {
+            recursiveDir.split('/').forEach((dir, index, splits) => {
+                const parentDir = splits.slice(0, index).join('/');
+                const dirPath = path.resolve(parentDir, dir);
+                if (!fs.existsSync(dirPath)) {
+                    fs.mkdirSync(dirPath);
+                }
+            });
+        }
+    }
+};


### PR DESCRIPTION
Simple replacement for `mkdirp`, reducing the amount of npm development dependencies.