### PR TITLE
[node] Temporary: exit(1) on exception in Painter::render

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -24,6 +24,7 @@
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/string.hpp>
 #include <mbgl/math/log2.hpp>
 
 namespace mbgl {
@@ -314,10 +315,15 @@ void Map::Impl::render(View& view) {
                               contextMode,
                               debugOptions };
 
-        painter->render(*style,
-                        frameData,
-                        view,
-                        annotationManager->getSpriteAtlas());
+        try {
+            painter->render(*style,
+                            frameData,
+                            view,
+                            annotationManager->getSpriteAtlas());
+        } catch (...) {
+            Log::Error(Event::General, "Exception in render: %s", util::toString(std::current_exception()).c_str());
+            exit(1);
+        }
 
         auto request = std::move(stillImageRequest);
         request->callback(nullptr);


### PR DESCRIPTION
Hope to get complete apitrace with a clean exit rather than an abort. I plan to revert this change once we fix the underlying issue in https://github.com/mapbox/mapbox-gl-native/issues/7681#issuecomment-277826166.