### PR TITLE
Add function and interpolation mode to style property docs

### DIFF
--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -280,29 +280,29 @@ global.propertyDoc = function (propertyName, property, layerType, kind) {
             }
             doc += `\n\nThis attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#${anchor}"><code>${property.original}</code></a> layout property in the Mapbox Style Specification.`;
         }
-    }
-    doc += '\n\nThis property can be set to one of the following values:\n\n' +
-           '- `MGLStyleConstantValue`\n';
-    if (property["property-function"]) {
-        doc += '- `MGLCameraStyleFunction` with an interpolation mode of:\n' +
-               '  - `MGLInterpolationModeExponential`\n' +
-               '  - `MGLInterpolationModeInterval`\n' +
-               '- `MGLSourceStyleFunction` with an interpolation mode of:\n' +
-               '  - `MGLInterpolationModeExponential`\n' +
-               '  - `MGLInterpolationModeInterval`\n' +
-               '  - `MGLInterpolationModeCategorical`\n' +
-               '  - `MGLInterpolationModeIdentity`\n' +
-               '- `MGLCompositeStyleFunction` with an interpolation mode of:\n' +
-               '  - `MGLInterpolationModeExponential`\n' +
-               '  - `MGLInterpolationModeInterval`\n' +
-               '  - `MGLInterpolationModeCategorical`\n';
-    } else {
-        if (property.function === "interpolated") {
-            doc += '- `MGLCameraStyleFunction` with an interpolation mode of:\n' +
-                   '  - `MGLInterpolationModeExponential`\n' +
-                   '  - `MGLInterpolationModeInterval`\n';
+        doc += '\n\nYou can set this property to an instance of:\n\n' +
+            '* `MGLStyleConstantValue`\n';
+        if (property["property-function"]) {
+            doc += '* `MGLCameraStyleFunction` with an interpolation mode of:\n' +
+                '  * `MGLInterpolationModeExponential`\n' +
+                '  * `MGLInterpolationModeInterval`\n' +
+                '* `MGLSourceStyleFunction` with an interpolation mode of:\n' +
+                '  * `MGLInterpolationModeExponential`\n' +
+                '  * `MGLInterpolationModeInterval`\n' +
+                '  * `MGLInterpolationModeCategorical`\n' +
+                '  * `MGLInterpolationModeIdentity`\n' +
+                '* `MGLCompositeStyleFunction` with an interpolation mode of:\n' +
+                '  * `MGLInterpolationModeExponential`\n' +
+                '  * `MGLInterpolationModeInterval`\n' +
+                '  * `MGLInterpolationModeCategorical`\n';
         } else {
-            doc += '- `MGLCameraStyleFunction` with an interpolation mode of `MGLInterpolationModeInterval`\n';
+            if (property.function === "interpolated") {
+                doc += '* `MGLCameraStyleFunction` with an interpolation mode of:\n' +
+                    '  * `MGLInterpolationModeExponential`\n' +
+                    '  * `MGLInterpolationModeInterval`\n';
+            } else {
+                doc += '* `MGLCameraStyleFunction` with an interpolation mode of `MGLInterpolationModeInterval`\n';
+            }
         }
     }
     return doc;

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -281,6 +281,19 @@ global.propertyDoc = function (propertyName, property, layerType, kind) {
             doc += `\n\nThis attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#${anchor}"><code>${property.original}</code></a> layout property in the Mapbox Style Specification.`;
         }
     }
+    doc += '`\n\nThis property can be set to one of the following values:\n\n' +
+           '- `MGLStyleConstantValue`\n';
+    if (property["property-function"]) {
+        doc += '- `MGLCameraStyleFunction` with an interpolation mode of `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`\n' +
+               '- `MGLSourceStyleFunction` with an interpolation mode of `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`, `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`\n' + 
+               '- `MGLCompositeStyleFunction` with an interpolation mode of `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or `MGLInterpolationModeCategorical`\n';
+    } else {
+        if (property.function === "interpolated") {
+            doc += '- `MGLCameraStyleFunction` with an interpolation mode of `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`\n';
+        } else {
+            doc += '- `MGLCameraStyleFunction` with an interpolation mode of `MGLInterpolationModeInterval`\n';
+        }
+    }
     return doc;
 };
 

--- a/platform/darwin/scripts/generate-style-code.js
+++ b/platform/darwin/scripts/generate-style-code.js
@@ -281,15 +281,26 @@ global.propertyDoc = function (propertyName, property, layerType, kind) {
             doc += `\n\nThis attribute corresponds to the <a href="https://www.mapbox.com/mapbox-gl-style-spec/#${anchor}"><code>${property.original}</code></a> layout property in the Mapbox Style Specification.`;
         }
     }
-    doc += '`\n\nThis property can be set to one of the following values:\n\n' +
+    doc += '\n\nThis property can be set to one of the following values:\n\n' +
            '- `MGLStyleConstantValue`\n';
     if (property["property-function"]) {
-        doc += '- `MGLCameraStyleFunction` with an interpolation mode of `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`\n' +
-               '- `MGLSourceStyleFunction` with an interpolation mode of `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`, `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`\n' + 
-               '- `MGLCompositeStyleFunction` with an interpolation mode of `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or `MGLInterpolationModeCategorical`\n';
+        doc += '- `MGLCameraStyleFunction` with an interpolation mode of:\n' +
+               '  - `MGLInterpolationModeExponential`\n' +
+               '  - `MGLInterpolationModeInterval`\n' +
+               '- `MGLSourceStyleFunction` with an interpolation mode of:\n' +
+               '  - `MGLInterpolationModeExponential`\n' +
+               '  - `MGLInterpolationModeInterval`\n' +
+               '  - `MGLInterpolationModeCategorical`\n' +
+               '  - `MGLInterpolationModeIdentity`\n' +
+               '- `MGLCompositeStyleFunction` with an interpolation mode of:\n' +
+               '  - `MGLInterpolationModeExponential`\n' +
+               '  - `MGLInterpolationModeInterval`\n' +
+               '  - `MGLInterpolationModeCategorical`\n';
     } else {
         if (property.function === "interpolated") {
-            doc += '- `MGLCameraStyleFunction` with an interpolation mode of `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`\n';
+            doc += '- `MGLCameraStyleFunction` with an interpolation mode of:\n' +
+                   '  - `MGLInterpolationModeExponential`\n' +
+                   '  - `MGLInterpolationModeInterval`\n';
         } else {
             doc += '- `MGLCameraStyleFunction` with an interpolation mode of `MGLInterpolationModeInterval`\n';
         }

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -37,13 +37,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `backgroundPattern` is set to
- `nil`. Otherwise, it is ignored.`
+ `nil`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *backgroundColor;
 #else
@@ -55,13 +56,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `backgroundPattern` is set to
- `nil`. Otherwise, it is ignored.`
+ `nil`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *backgroundColor;
 #endif
@@ -71,20 +73,21 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *backgroundOpacity;
 
 /**
  Name of image in style images to use for drawing an image background. For
  seamless patterns, image width and height must be a factor of two (2, 4, 8,
- ..., 512).`
+ ..., 512).
  
  This property can be set to one of the following values:
  

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -39,12 +39,12 @@ MGL_EXPORT
  This property is only applied to the style if `backgroundPattern` is set to
  `nil`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *backgroundColor;
 #else
@@ -58,12 +58,12 @@ MGL_EXPORT
  This property is only applied to the style if `backgroundPattern` is set to
  `nil`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *backgroundColor;
 #endif
@@ -75,12 +75,12 @@ MGL_EXPORT
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *backgroundOpacity;
 
@@ -89,10 +89,10 @@ MGL_EXPORT
  seamless patterns, image width and height must be a factor of two (2, 4, 8,
  ..., 512).
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *backgroundPattern;

--- a/platform/darwin/src/MGLBackgroundStyleLayer.h
+++ b/platform/darwin/src/MGLBackgroundStyleLayer.h
@@ -37,7 +37,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `backgroundPattern` is set to
- `nil`. Otherwise, it is ignored.
+ `nil`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *backgroundColor;
 #else
@@ -49,7 +55,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `backgroundPattern` is set to
- `nil`. Otherwise, it is ignored.
+ `nil`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *backgroundColor;
 #endif
@@ -59,14 +71,26 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *backgroundOpacity;
 
 /**
  Name of image in style images to use for drawing an image background. For
  seamless patterns, image width and height must be a factor of two (2, 4, 8,
- ..., 512).
+ ..., 512).`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *backgroundPattern;
 

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -9,12 +9,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Controls the scaling behavior of the circle when the map is pitched.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLCircleStyleLayer.circleScaleAlignment`
  property.
@@ -22,34 +16,16 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSUInteger, MGLCircleScaleAlignment) {
     /**
      Circles are scaled according to their apparent distance to the camera.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLCircleScaleAlignmentMap,
     /**
      Circles are not scaled.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLCircleScaleAlignmentViewport,
 };
 
 /**
  Controls the translation reference point.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLCircleStyleLayer.circleTranslationAnchor`
  property.
@@ -57,22 +33,10 @@ typedef NS_ENUM(NSUInteger, MGLCircleScaleAlignment) {
 typedef NS_ENUM(NSUInteger, MGLCircleTranslationAnchor) {
     /**
      The circle is translated relative to the map.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLCircleTranslationAnchorMap,
     /**
      The circle is translated relative to the viewport.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLCircleTranslationAnchorViewport,
 };
@@ -125,21 +89,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleBlur;
 
@@ -151,21 +115,21 @@ MGL_EXPORT
  `UIColor.blackColor`. Set this property to `nil` to reset it to the default
  value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *circleColor;
 #else
@@ -176,21 +140,21 @@ MGL_EXPORT
  `NSColor.blackColor`. Set this property to `nil` to reset it to the default
  value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *circleColor;
 #endif
@@ -202,21 +166,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleOpacity;
 
@@ -229,21 +193,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `5`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleRadius;
 
@@ -258,10 +222,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-pitch-scale"><code>circle-pitch-scale</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleScaleAlignment;
@@ -276,21 +240,21 @@ MGL_EXPORT
  `UIColor.blackColor`. Set this property to `nil` to reset it to the default
  value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *circleStrokeColor;
 #else
@@ -301,21 +265,21 @@ MGL_EXPORT
  `NSColor.blackColor`. Set this property to `nil` to reset it to the default
  value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *circleStrokeColor;
 #endif
@@ -327,21 +291,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleStrokeOpacity;
 
@@ -355,21 +319,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleStrokeWidth;
 
@@ -387,12 +351,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate"><code>circle-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslation;
 #else
@@ -409,12 +373,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate"><code>circle-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslation;
 #endif
@@ -435,10 +399,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate-anchor"><code>circle-translate-anchor</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslationAnchor;

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Controls the scaling behavior of the circle when the map is pitched.`
+ Controls the scaling behavior of the circle when the map is pitched.
  
  This property can be set to one of the following values:
  
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef NS_ENUM(NSUInteger, MGLCircleScaleAlignment) {
     /**
-     Circles are scaled according to their apparent distance to the camera.`
+     Circles are scaled according to their apparent distance to the camera.
      
      This property can be set to one of the following values:
      
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleScaleAlignment) {
      */
     MGLCircleScaleAlignmentMap,
     /**
-     Circles are not scaled.`
+     Circles are not scaled.
      
      This property can be set to one of the following values:
      
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleScaleAlignment) {
 };
 
 /**
- Controls the translation reference point.`
+ Controls the translation reference point.
  
  This property can be set to one of the following values:
  
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleScaleAlignment) {
  */
 typedef NS_ENUM(NSUInteger, MGLCircleTranslationAnchor) {
     /**
-     The circle is translated relative to the map.`
+     The circle is translated relative to the map.
      
      This property can be set to one of the following values:
      
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSUInteger, MGLCircleTranslationAnchor) {
      */
     MGLCircleTranslationAnchorMap,
     /**
-     The circle is translated relative to the viewport.`
+     The circle is translated relative to the viewport.
      
      This property can be set to one of the following values:
      
@@ -123,19 +123,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleBlur;
 
@@ -145,19 +149,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing
  `UIColor.blackColor`. Set this property to `nil` to reset it to the default
- value.`
+ value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *circleColor;
 #else
@@ -166,19 +174,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing
  `NSColor.blackColor`. Set this property to `nil` to reset it to the default
- value.`
+ value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *circleColor;
 #endif
@@ -188,19 +200,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleOpacity;
 
@@ -211,19 +227,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `5`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleRadius;
 
@@ -236,7 +256,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-pitch-scale"><code>circle-pitch-scale</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -254,19 +274,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing
  `UIColor.blackColor`. Set this property to `nil` to reset it to the default
- value.`
+ value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *circleStrokeColor;
 #else
@@ -275,19 +299,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing
  `NSColor.blackColor`. Set this property to `nil` to reset it to the default
- value.`
+ value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *circleStrokeColor;
 #endif
@@ -297,19 +325,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleStrokeOpacity;
 
@@ -321,19 +353,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleStrokeWidth;
 
@@ -349,13 +385,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate"><code>circle-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslation;
 #else
@@ -370,13 +407,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate"><code>circle-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslation;
 #endif
@@ -395,7 +433,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate-anchor"><code>circle-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  

--- a/platform/darwin/src/MGLCircleStyleLayer.h
+++ b/platform/darwin/src/MGLCircleStyleLayer.h
@@ -8,35 +8,71 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Controls the scaling behavior of the circle when the map is pitched.
+ Controls the scaling behavior of the circle when the map is pitched.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLCircleStyleLayer.circleScaleAlignment`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLCircleScaleAlignment) {
     /**
-     Circles are scaled according to their apparent distance to the camera.
+     Circles are scaled according to their apparent distance to the camera.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLCircleScaleAlignmentMap,
     /**
-     Circles are not scaled.
+     Circles are not scaled.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLCircleScaleAlignmentViewport,
 };
 
 /**
- Controls the translation reference point.
+ Controls the translation reference point.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLCircleStyleLayer.circleTranslationAnchor`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLCircleTranslationAnchor) {
     /**
-     The circle is translated relative to the map.
+     The circle is translated relative to the map.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLCircleTranslationAnchorMap,
     /**
-     The circle is translated relative to the viewport.
+     The circle is translated relative to the viewport.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLCircleTranslationAnchorViewport,
 };
@@ -87,7 +123,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleBlur;
 
@@ -97,7 +145,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing
  `UIColor.blackColor`. Set this property to `nil` to reset it to the default
- value.
+ value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *circleColor;
 #else
@@ -106,7 +166,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing
  `NSColor.blackColor`. Set this property to `nil` to reset it to the default
- value.
+ value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *circleColor;
 #endif
@@ -116,7 +188,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleOpacity;
 
@@ -127,7 +211,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `5`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleRadius;
 
@@ -140,7 +236,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-pitch-scale"><code>circle-pitch-scale</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleScaleAlignment;
 
@@ -152,7 +254,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing
  `UIColor.blackColor`. Set this property to `nil` to reset it to the default
- value.
+ value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *circleStrokeColor;
 #else
@@ -161,7 +275,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing
  `NSColor.blackColor`. Set this property to `nil` to reset it to the default
- value.
+ value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *circleStrokeColor;
 #endif
@@ -171,7 +297,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleStrokeOpacity;
 
@@ -183,7 +321,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *circleStrokeWidth;
 
@@ -199,7 +349,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate"><code>circle-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslation;
 #else
@@ -214,7 +370,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate"><code>circle-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslation;
 #endif
@@ -233,7 +395,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-circle-translate-anchor"><code>circle-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *circleTranslationAnchor;
 

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -9,12 +9,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Controls the translation reference point.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLFillStyleLayer.fillTranslationAnchor`
  property.
@@ -22,22 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
     /**
      The fill is translated relative to the map.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLFillTranslationAnchorMap,
     /**
      The fill is translated relative to the viewport.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLFillTranslationAnchorViewport,
 };
@@ -83,10 +65,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-antialias"><code>fill-antialias</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable, getter=isFillAntialiased) MGLStyleValue<NSNumber *> *fillAntialiased;
@@ -104,21 +86,21 @@ MGL_EXPORT
  This property is only applied to the style if `fillPattern` is set to `nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *fillColor;
 #else
@@ -132,21 +114,21 @@ MGL_EXPORT
  This property is only applied to the style if `fillPattern` is set to `nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *fillColor;
 #endif
@@ -159,21 +141,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *fillOpacity;
 
@@ -185,21 +167,21 @@ MGL_EXPORT
  and `fillAntialiased` is set to an `MGLStyleValue` object containing an
  `NSNumber` object containing `YES`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *fillOutlineColor;
 #else
@@ -210,21 +192,21 @@ MGL_EXPORT
  and `fillAntialiased` is set to an `MGLStyleValue` object containing an
  `NSNumber` object containing `YES`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *fillOutlineColor;
 #endif
@@ -233,10 +215,10 @@ MGL_EXPORT
  Name of image in sprite to use for drawing image fills. For seamless patterns,
  image width and height must be a factor of two (2, 4, 8, ..., 512).
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *fillPattern;
@@ -255,12 +237,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate"><code>fill-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslation;
 #else
@@ -277,12 +259,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate"><code>fill-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslation;
 #endif
@@ -303,10 +285,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate-anchor"><code>fill-translate-anchor</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslationAnchor;

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Controls the translation reference point.`
+ Controls the translation reference point.
  
  This property can be set to one of the following values:
  
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
     /**
-     The fill is translated relative to the map.`
+     The fill is translated relative to the map.
      
      This property can be set to one of the following values:
      
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
      */
     MGLFillTranslationAnchorMap,
     /**
-     The fill is translated relative to the viewport.`
+     The fill is translated relative to the viewport.
      
      This property can be set to one of the following values:
      
@@ -81,7 +81,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-antialias"><code>fill-antialias</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -102,19 +102,23 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `fillPattern` is set to `nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *fillColor;
 #else
@@ -126,19 +130,23 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `fillPattern` is set to `nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *fillColor;
 #endif
@@ -149,19 +157,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *fillOpacity;
 
@@ -171,19 +183,23 @@ MGL_EXPORT
  
  This property is only applied to the style if `fillPattern` is set to `nil`,
  and `fillAntialiased` is set to an `MGLStyleValue` object containing an
- `NSNumber` object containing `YES`. Otherwise, it is ignored.`
+ `NSNumber` object containing `YES`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *fillOutlineColor;
 #else
@@ -192,26 +208,30 @@ MGL_EXPORT
  
  This property is only applied to the style if `fillPattern` is set to `nil`,
  and `fillAntialiased` is set to an `MGLStyleValue` object containing an
- `NSNumber` object containing `YES`. Otherwise, it is ignored.`
+ `NSNumber` object containing `YES`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *fillOutlineColor;
 #endif
 
 /**
  Name of image in sprite to use for drawing image fills. For seamless patterns,
- image width and height must be a factor of two (2, 4, 8, ..., 512).`
+ image width and height must be a factor of two (2, 4, 8, ..., 512).
  
  This property can be set to one of the following values:
  
@@ -233,13 +253,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate"><code>fill-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslation;
 #else
@@ -254,13 +275,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate"><code>fill-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslation;
 #endif
@@ -279,7 +301,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate-anchor"><code>fill-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  

--- a/platform/darwin/src/MGLFillStyleLayer.h
+++ b/platform/darwin/src/MGLFillStyleLayer.h
@@ -8,18 +8,36 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Controls the translation reference point.
+ Controls the translation reference point.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLFillStyleLayer.fillTranslationAnchor`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLFillTranslationAnchor) {
     /**
-     The fill is translated relative to the map.
+     The fill is translated relative to the map.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLFillTranslationAnchorMap,
     /**
-     The fill is translated relative to the viewport.
+     The fill is translated relative to the viewport.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLFillTranslationAnchorViewport,
 };
@@ -63,7 +81,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-antialias"><code>fill-antialias</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable, getter=isFillAntialiased) MGLStyleValue<NSNumber *> *fillAntialiased;
 
@@ -78,7 +102,19 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `fillPattern` is set to `nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *fillColor;
 #else
@@ -90,7 +126,19 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `fillPattern` is set to `nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *fillColor;
 #endif
@@ -101,7 +149,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *fillOpacity;
 
@@ -111,7 +171,19 @@ MGL_EXPORT
  
  This property is only applied to the style if `fillPattern` is set to `nil`,
  and `fillAntialiased` is set to an `MGLStyleValue` object containing an
- `NSNumber` object containing `YES`. Otherwise, it is ignored.
+ `NSNumber` object containing `YES`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *fillOutlineColor;
 #else
@@ -120,14 +192,32 @@ MGL_EXPORT
  
  This property is only applied to the style if `fillPattern` is set to `nil`,
  and `fillAntialiased` is set to an `MGLStyleValue` object containing an
- `NSNumber` object containing `YES`. Otherwise, it is ignored.
+ `NSNumber` object containing `YES`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *fillOutlineColor;
 #endif
 
 /**
  Name of image in sprite to use for drawing image fills. For seamless patterns,
- image width and height must be a factor of two (2, 4, 8, ..., 512).
+ image width and height must be a factor of two (2, 4, 8, ..., 512).`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *fillPattern;
 
@@ -143,7 +233,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate"><code>fill-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslation;
 #else
@@ -158,7 +254,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate"><code>fill-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslation;
 #endif
@@ -177,7 +279,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-fill-translate-anchor"><code>fill-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *fillTranslationAnchor;
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- The display of line endings.`
+ The display of line endings.
  
  This property can be set to one of the following values:
  
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSUInteger, MGLLineCap) {
     /**
      A cap with a squared-off end which is drawn to the exact endpoint of the
-     line.`
+     line.
      
      This property can be set to one of the following values:
      
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSUInteger, MGLLineCap) {
     /**
      A cap with a rounded end which is drawn beyond the endpoint of the line at
      a radius of one-half of the line's width and centered on the endpoint of
-     the line.`
+     the line.
      
      This property can be set to one of the following values:
      
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSUInteger, MGLLineCap) {
     MGLLineCapRound,
     /**
      A cap with a squared-off end which is drawn beyond the endpoint of the line
-     at a distance of one-half of the line's width.`
+     at a distance of one-half of the line's width.
      
      This property can be set to one of the following values:
      
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSUInteger, MGLLineCap) {
 };
 
 /**
- The display of lines when joining.`
+ The display of lines when joining.
  
  This property can be set to one of the following values:
  
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSUInteger, MGLLineCap) {
 typedef NS_ENUM(NSUInteger, MGLLineJoin) {
     /**
      A join with a squared-off end which is drawn beyond the endpoint of the
-     line at a distance of one-half of the line's width.`
+     line at a distance of one-half of the line's width.
      
      This property can be set to one of the following values:
      
@@ -83,7 +83,7 @@ typedef NS_ENUM(NSUInteger, MGLLineJoin) {
     /**
      A join with a rounded end which is drawn beyond the endpoint of the line at
      a radius of one-half of the line's width and centered on the endpoint of
-     the line.`
+     the line.
      
      This property can be set to one of the following values:
      
@@ -94,7 +94,7 @@ typedef NS_ENUM(NSUInteger, MGLLineJoin) {
     MGLLineJoinRound,
     /**
      A join with a sharp, angled corner which is drawn with the outer sides
-     beyond the endpoint of the path until they meet.`
+     beyond the endpoint of the path until they meet.
      
      This property can be set to one of the following values:
      
@@ -106,7 +106,7 @@ typedef NS_ENUM(NSUInteger, MGLLineJoin) {
 };
 
 /**
- Controls the translation reference point.`
+ Controls the translation reference point.
  
  This property can be set to one of the following values:
  
@@ -119,7 +119,7 @@ typedef NS_ENUM(NSUInteger, MGLLineJoin) {
  */
 typedef NS_ENUM(NSUInteger, MGLLineTranslationAnchor) {
     /**
-     The line is translated relative to the map.`
+     The line is translated relative to the map.
      
      This property can be set to one of the following values:
      
@@ -129,7 +129,7 @@ typedef NS_ENUM(NSUInteger, MGLLineTranslationAnchor) {
      */
     MGLLineTranslationAnchorMap,
     /**
-     The line is translated relative to the viewport.`
+     The line is translated relative to the viewport.
      
      This property can be set to one of the following values:
      
@@ -180,7 +180,7 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSValue` object containing `MGLLineCapButt`. Set this property to `nil` to
- reset it to the default value.`
+ reset it to the default value.
  
  This property can be set to one of the following values:
  
@@ -195,7 +195,7 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSValue` object containing `MGLLineJoinMiter`. Set this property to `nil` to
- reset it to the default value.`
+ reset it to the default value.
  
  This property can be set to one of the following values:
  
@@ -214,13 +214,14 @@ MGL_EXPORT
  
  This property is only applied to the style if `lineJoin` is set to an
  `MGLStyleValue` object containing an `NSValue` object containing
- `MGLLineJoinMiter`. Otherwise, it is ignored.`
+ `MGLLineJoinMiter`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineMiterLimit;
 
@@ -233,13 +234,14 @@ MGL_EXPORT
  
  This property is only applied to the style if `lineJoin` is set to an
  `MGLStyleValue` object containing an `NSValue` object containing
- `MGLLineJoinRound`. Otherwise, it is ignored.`
+ `MGLLineJoinRound`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineRoundLimit;
 
@@ -252,19 +254,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineBlur;
 
@@ -277,19 +283,23 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `linePattern` is set to `nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *lineColor;
 #else
@@ -301,19 +311,23 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `linePattern` is set to `nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *lineColor;
 #endif
@@ -330,7 +344,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-dasharray"><code>line-dasharray</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -350,19 +364,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineGapWidth;
 
@@ -376,19 +394,23 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineOffset;
 
@@ -397,25 +419,29 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineOpacity;
 
 /**
  Name of image in style images to use for drawing image lines. For seamless
- patterns, image width must be a factor of two (2, 4, 8, ..., 512).`
+ patterns, image width must be a factor of two (2, 4, 8, ..., 512).
  
  This property can be set to one of the following values:
  
@@ -437,13 +463,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate"><code>line-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslation;
 #else
@@ -458,13 +485,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate"><code>line-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslation;
 #endif
@@ -483,7 +511,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate-anchor"><code>line-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -502,13 +530,14 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineWidth;
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -9,12 +9,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The display of line endings.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLLineStyleLayer.lineCap`
  property.
@@ -23,47 +17,23 @@ typedef NS_ENUM(NSUInteger, MGLLineCap) {
     /**
      A cap with a squared-off end which is drawn to the exact endpoint of the
      line.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLLineCapButt,
     /**
      A cap with a rounded end which is drawn beyond the endpoint of the line at
      a radius of one-half of the line's width and centered on the endpoint of
      the line.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLLineCapRound,
     /**
      A cap with a squared-off end which is drawn beyond the endpoint of the line
      at a distance of one-half of the line's width.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLLineCapSquare,
 };
 
 /**
  The display of lines when joining.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLLineStyleLayer.lineJoin`
  property.
@@ -72,47 +42,23 @@ typedef NS_ENUM(NSUInteger, MGLLineJoin) {
     /**
      A join with a squared-off end which is drawn beyond the endpoint of the
      line at a distance of one-half of the line's width.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLLineJoinBevel,
     /**
      A join with a rounded end which is drawn beyond the endpoint of the line at
      a radius of one-half of the line's width and centered on the endpoint of
      the line.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLLineJoinRound,
     /**
      A join with a sharp, angled corner which is drawn with the outer sides
      beyond the endpoint of the path until they meet.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLLineJoinMiter,
 };
 
 /**
  Controls the translation reference point.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLLineStyleLayer.lineTranslationAnchor`
  property.
@@ -120,22 +66,10 @@ typedef NS_ENUM(NSUInteger, MGLLineJoin) {
 typedef NS_ENUM(NSUInteger, MGLLineTranslationAnchor) {
     /**
      The line is translated relative to the map.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLLineTranslationAnchorMap,
     /**
      The line is translated relative to the viewport.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLLineTranslationAnchorViewport,
 };
@@ -182,10 +116,10 @@ MGL_EXPORT
  `NSValue` object containing `MGLLineCapButt`. Set this property to `nil` to
  reset it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineCap;
@@ -197,10 +131,10 @@ MGL_EXPORT
  `NSValue` object containing `MGLLineJoinMiter`. Set this property to `nil` to
  reset it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineJoin;
@@ -216,12 +150,12 @@ MGL_EXPORT
  `MGLStyleValue` object containing an `NSValue` object containing
  `MGLLineJoinMiter`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineMiterLimit;
 
@@ -236,12 +170,12 @@ MGL_EXPORT
  `MGLStyleValue` object containing an `NSValue` object containing
  `MGLLineJoinRound`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineRoundLimit;
 
@@ -256,21 +190,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineBlur;
 
@@ -285,21 +219,21 @@ MGL_EXPORT
  This property is only applied to the style if `linePattern` is set to `nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *lineColor;
 #else
@@ -313,21 +247,21 @@ MGL_EXPORT
  This property is only applied to the style if `linePattern` is set to `nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *lineColor;
 #endif
@@ -346,10 +280,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-dasharray"><code>line-dasharray</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSNumber *> *> *lineDashPattern;
@@ -366,21 +300,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineGapWidth;
 
@@ -396,21 +330,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineOffset;
 
@@ -421,21 +355,21 @@ MGL_EXPORT
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineOpacity;
 
@@ -443,10 +377,10 @@ MGL_EXPORT
  Name of image in style images to use for drawing image lines. For seamless
  patterns, image width must be a factor of two (2, 4, 8, ..., 512).
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *linePattern;
@@ -465,12 +399,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate"><code>line-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslation;
 #else
@@ -487,12 +421,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate"><code>line-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslation;
 #endif
@@ -513,10 +447,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate-anchor"><code>line-translate-anchor</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslationAnchor;
@@ -532,12 +466,12 @@ MGL_EXPORT
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineWidth;
 

--- a/platform/darwin/src/MGLLineStyleLayer.h
+++ b/platform/darwin/src/MGLLineStyleLayer.h
@@ -8,7 +8,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- The display of line endings.
+ The display of line endings.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLLineStyleLayer.lineCap`
  property.
@@ -16,24 +22,48 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSUInteger, MGLLineCap) {
     /**
      A cap with a squared-off end which is drawn to the exact endpoint of the
-     line.
+     line.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLLineCapButt,
     /**
      A cap with a rounded end which is drawn beyond the endpoint of the line at
      a radius of one-half of the line's width and centered on the endpoint of
-     the line.
+     the line.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLLineCapRound,
     /**
      A cap with a squared-off end which is drawn beyond the endpoint of the line
-     at a distance of one-half of the line's width.
+     at a distance of one-half of the line's width.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLLineCapSquare,
 };
 
 /**
- The display of lines when joining.
+ The display of lines when joining.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLLineStyleLayer.lineJoin`
  property.
@@ -41,35 +71,71 @@ typedef NS_ENUM(NSUInteger, MGLLineCap) {
 typedef NS_ENUM(NSUInteger, MGLLineJoin) {
     /**
      A join with a squared-off end which is drawn beyond the endpoint of the
-     line at a distance of one-half of the line's width.
+     line at a distance of one-half of the line's width.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLLineJoinBevel,
     /**
      A join with a rounded end which is drawn beyond the endpoint of the line at
      a radius of one-half of the line's width and centered on the endpoint of
-     the line.
+     the line.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLLineJoinRound,
     /**
      A join with a sharp, angled corner which is drawn with the outer sides
-     beyond the endpoint of the path until they meet.
+     beyond the endpoint of the path until they meet.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLLineJoinMiter,
 };
 
 /**
- Controls the translation reference point.
+ Controls the translation reference point.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLLineStyleLayer.lineTranslationAnchor`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLLineTranslationAnchor) {
     /**
-     The line is translated relative to the map.
+     The line is translated relative to the map.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLLineTranslationAnchorMap,
     /**
-     The line is translated relative to the viewport.
+     The line is translated relative to the viewport.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLLineTranslationAnchorViewport,
 };
@@ -114,7 +180,13 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSValue` object containing `MGLLineCapButt`. Set this property to `nil` to
- reset it to the default value.
+ reset it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineCap;
 
@@ -123,7 +195,13 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSValue` object containing `MGLLineJoinMiter`. Set this property to `nil` to
- reset it to the default value.
+ reset it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineJoin;
 
@@ -136,7 +214,13 @@ MGL_EXPORT
  
  This property is only applied to the style if `lineJoin` is set to an
  `MGLStyleValue` object containing an `NSValue` object containing
- `MGLLineJoinMiter`. Otherwise, it is ignored.
+ `MGLLineJoinMiter`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineMiterLimit;
 
@@ -149,7 +233,13 @@ MGL_EXPORT
  
  This property is only applied to the style if `lineJoin` is set to an
  `MGLStyleValue` object containing an `NSValue` object containing
- `MGLLineJoinRound`. Otherwise, it is ignored.
+ `MGLLineJoinRound`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineRoundLimit;
 
@@ -162,7 +252,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineBlur;
 
@@ -175,7 +277,19 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `linePattern` is set to `nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *lineColor;
 #else
@@ -187,7 +301,19 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `linePattern` is set to `nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *lineColor;
 #endif
@@ -204,7 +330,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-dasharray"><code>line-dasharray</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSNumber *> *> *lineDashPattern;
 
@@ -218,7 +350,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineGapWidth;
 
@@ -232,7 +376,19 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineOffset;
 
@@ -241,13 +397,31 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineOpacity;
 
 /**
  Name of image in style images to use for drawing image lines. For seamless
- patterns, image width must be a factor of two (2, 4, 8, ..., 512).
+ patterns, image width must be a factor of two (2, 4, 8, ..., 512).`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *linePattern;
 
@@ -263,7 +437,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate"><code>line-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslation;
 #else
@@ -278,7 +458,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate"><code>line-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslation;
 #endif
@@ -297,7 +483,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-line-translate-anchor"><code>line-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *lineTranslationAnchor;
 
@@ -310,7 +502,13 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *lineWidth;
 

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -48,13 +48,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-max"><code>raster-brightness-max</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumRasterBrightness;
 
@@ -70,13 +71,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-min"><code>raster-brightness-min</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *minimumRasterBrightness;
 
@@ -87,13 +89,14 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterContrast;
 
@@ -104,13 +107,14 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `300`. Set this property to `nil` to
- reset it to the default value.`
+ reset it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterFadeDuration;
 
@@ -125,13 +129,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-hue-rotate"><code>raster-hue-rotate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterHueRotation;
 
@@ -142,13 +147,14 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterOpacity;
 
@@ -157,13 +163,14 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.`
+ it to the default value.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterSaturation;
 

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -50,12 +50,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-max"><code>raster-brightness-max</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumRasterBrightness;
 
@@ -73,12 +73,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-min"><code>raster-brightness-min</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *minimumRasterBrightness;
 
@@ -91,12 +91,12 @@ MGL_EXPORT
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterContrast;
 
@@ -109,12 +109,12 @@ MGL_EXPORT
  `NSNumber` object containing the float `300`. Set this property to `nil` to
  reset it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterFadeDuration;
 
@@ -131,12 +131,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-hue-rotate"><code>raster-hue-rotate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterHueRotation;
 
@@ -149,12 +149,12 @@ MGL_EXPORT
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterOpacity;
 
@@ -165,12 +165,12 @@ MGL_EXPORT
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
  it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterSaturation;
 

--- a/platform/darwin/src/MGLRasterStyleLayer.h
+++ b/platform/darwin/src/MGLRasterStyleLayer.h
@@ -48,7 +48,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-max"><code>raster-brightness-max</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumRasterBrightness;
 
@@ -64,7 +70,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-brightness-min"><code>raster-brightness-min</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *minimumRasterBrightness;
 
@@ -75,7 +87,13 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterContrast;
 
@@ -86,7 +104,13 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `300`. Set this property to `nil` to
- reset it to the default value.
+ reset it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterFadeDuration;
 
@@ -101,7 +125,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-raster-hue-rotate"><code>raster-hue-rotate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterHueRotation;
 
@@ -112,7 +142,13 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `1`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterOpacity;
 
@@ -121,7 +157,13 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSNumber` object containing the float `0`. Set this property to `nil` to reset
- it to the default value.
+ it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *rasterSaturation;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -9,7 +9,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  In combination with `symbolPlacement`, determines the rotation behavior of
- icons.
+ icons.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.iconRotationAlignment`
  property.
@@ -18,156 +24,336 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, aligns icons
      east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine`,
-     aligns icon x-axes with the line.
+     aligns icon x-axes with the line.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconRotationAlignmentMap,
     /**
      Produces icons whose x-axes are aligned with the x-axis of the viewport,
-     regardless of the value of `symbolPlacement`.
+     regardless of the value of `symbolPlacement`.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconRotationAlignmentViewport,
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, this is
      equivalent to `MGLIconRotationAlignmentViewport`. When `symbolPlacement` is
      set to `MGLSymbolPlacementLine`, this is equivalent to
-     `MGLIconRotationAlignmentMap`.
+     `MGLIconRotationAlignmentMap`.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconRotationAlignmentAuto,
 };
 
 /**
- Scales the icon to fit around the associated text.
+ Scales the icon to fit around the associated text.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.iconTextFit`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
     /**
-     The icon is displayed at its intrinsic aspect ratio.
+     The icon is displayed at its intrinsic aspect ratio.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconTextFitNone,
     /**
-     The icon is scaled in the x-dimension to fit the width of the text.
+     The icon is scaled in the x-dimension to fit the width of the text.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconTextFitWidth,
     /**
-     The icon is scaled in the y-dimension to fit the height of the text.
+     The icon is scaled in the y-dimension to fit the height of the text.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconTextFitHeight,
     /**
-     The icon is scaled in both x- and y-dimensions.
+     The icon is scaled in both x- and y-dimensions.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconTextFitBoth,
 };
 
 /**
- Label placement relative to its geometry.
+ Label placement relative to its geometry.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.symbolPlacement`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
     /**
-     The label is placed at the point where the geometry is located.
+     The label is placed at the point where the geometry is located.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLSymbolPlacementPoint,
     /**
      The label is placed along the line of the geometry. Can only be used on
-     `LineString` and `Polygon` geometries.
+     `LineString` and `Polygon` geometries.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLSymbolPlacementLine,
 };
 
 /**
- Part of the text placed closest to the anchor.
+ Part of the text placed closest to the anchor.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textAnchor`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
     /**
-     The center of the text is placed closest to the anchor.
+     The center of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorCenter,
     /**
-     The left side of the text is placed closest to the anchor.
+     The left side of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorLeft,
     /**
-     The right side of the text is placed closest to the anchor.
+     The right side of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorRight,
     /**
-     The top of the text is placed closest to the anchor.
+     The top of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorTop,
     /**
-     The bottom of the text is placed closest to the anchor.
+     The bottom of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorBottom,
     /**
-     The top left corner of the text is placed closest to the anchor.
+     The top left corner of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorTopLeft,
     /**
-     The top right corner of the text is placed closest to the anchor.
+     The top right corner of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorTopRight,
     /**
-     The bottom left corner of the text is placed closest to the anchor.
+     The bottom left corner of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorBottomLeft,
     /**
-     The bottom right corner of the text is placed closest to the anchor.
+     The bottom right corner of the text is placed closest to the anchor.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorBottomRight,
 };
 
 /**
- Text justification options.
+ Text justification options.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textJustification`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLTextJustification) {
     /**
-     The text is aligned to the left.
+     The text is aligned to the left.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextJustificationLeft,
     /**
-     The text is centered.
+     The text is centered.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextJustificationCenter,
     /**
-     The text is aligned to the right.
+     The text is aligned to the right.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextJustificationRight,
 };
 
 /**
- Orientation of text when map is pitched.
+ Orientation of text when map is pitched.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textPitchAlignment`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLTextPitchAlignment) {
     /**
-     The text is aligned to the plane of the map.
+     The text is aligned to the plane of the map.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextPitchAlignmentMap,
     /**
-     The text is aligned to the plane of the viewport.
+     The text is aligned to the plane of the viewport.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextPitchAlignmentViewport,
     /**
-     Automatically matches the value of `textRotationAlignment`.
+     Automatically matches the value of `textRotationAlignment`.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextPitchAlignmentAuto,
 };
 
 /**
  In combination with `symbolPlacement`, determines the rotation behavior of the
- individual glyphs forming the text.
+ individual glyphs forming the text.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textRotationAlignment`
  property.
@@ -176,74 +362,152 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, aligns text
      east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine`,
-     aligns text x-axes with the line.
+     aligns text x-axes with the line.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextRotationAlignmentMap,
     /**
      Produces glyphs whose x-axes are aligned with the x-axis of the viewport,
-     regardless of the value of `symbolPlacement`.
+     regardless of the value of `symbolPlacement`.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextRotationAlignmentViewport,
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, this is
      equivalent to `MGLTextRotationAlignmentViewport`. When `symbolPlacement` is
      set to `MGLSymbolPlacementLine`, this is equivalent to
-     `MGLTextRotationAlignmentMap`.
+     `MGLTextRotationAlignmentMap`.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextRotationAlignmentAuto,
 };
 
 /**
- Specifies how to capitalize text.
+ Specifies how to capitalize text.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textTransform`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLTextTransform) {
     /**
-     The text is not altered.
+     The text is not altered.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextTransformNone,
     /**
-     Forces all letters to be displayed in uppercase.
+     Forces all letters to be displayed in uppercase.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextTransformUppercase,
     /**
-     Forces all letters to be displayed in lowercase.
+     Forces all letters to be displayed in lowercase.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextTransformLowercase,
 };
 
 /**
- Controls the translation reference point.
+ Controls the translation reference point.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.iconTranslationAnchor`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLIconTranslationAnchor) {
     /**
-     Icons are translated relative to the map.
+     Icons are translated relative to the map.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconTranslationAnchorMap,
     /**
-     Icons are translated relative to the viewport.
+     Icons are translated relative to the viewport.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLIconTranslationAnchorViewport,
 };
 
 /**
- Controls the translation reference point.
+ Controls the translation reference point.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textTranslationAnchor`
  property.
  */
 typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
     /**
-     The text is translated relative to the map.
+     The text is translated relative to the map.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextTranslationAnchorMap,
     /**
-     The text is translated relative to the viewport.
+     The text is translated relative to the viewport.`
+     
+     This property can be set to one of the following values:
+     
+     - `MGLStyleConstantValue`
+     - `MGLCameraStyleFunction` with an interpolation mode of
+     `MGLInterpolationModeInterval`
      */
     MGLTextTranslationAnchorViewport,
 };
@@ -295,7 +559,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-allow-overlap"><code>icon-allow-overlap</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconAllowsOverlap;
 
@@ -314,7 +584,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-ignore-placement"><code>icon-ignore-placement</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconIgnoresPlacement;
 
@@ -326,7 +602,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-image"><code>icon-image</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *iconImageName;
 
@@ -342,7 +624,19 @@ MGL_EXPORT
  downward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconOffset;
 #else
@@ -354,7 +648,19 @@ MGL_EXPORT
  upward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconOffset;
 #endif
@@ -368,7 +674,13 @@ MGL_EXPORT
  the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`, and
- `text` is non-`nil`. Otherwise, it is ignored.
+ `text` is non-`nil`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable, getter=isIconOptional) MGLStyleValue<NSNumber *> *iconOptional;
 
@@ -383,7 +695,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconPadding;
 
@@ -401,7 +719,19 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-rotate"><code>icon-rotate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
+ `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
+ `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconRotation;
 
@@ -417,7 +747,13 @@ MGL_EXPORT
  to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconRotationAlignment;
 
@@ -433,7 +769,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-size"><code>icon-size</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconScale;
 
@@ -448,7 +790,13 @@ MGL_EXPORT
  reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`, and
- `text` is non-`nil`. Otherwise, it is ignored.
+ `text` is non-`nil`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFit;
 
@@ -465,7 +813,13 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`, and
  `text` is non-`nil`, and `iconTextFit` is set to an `MGLStyleValue` object
  containing an `NSValue` object containing `MGLIconTextFitBoth`,
- `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.
+ `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFitPadding;
 #else
@@ -481,7 +835,13 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`, and
  `text` is non-`nil`, and `iconTextFit` is set to an `MGLStyleValue` object
  containing an `NSValue` object containing `MGLIconTextFitBoth`,
- `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.
+ `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFitPadding;
 #endif
@@ -501,7 +861,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-keep-upright"><code>icon-keep-upright</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *keepsIconUpright;
 
@@ -524,7 +890,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-keep-upright"><code>text-keep-upright</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *keepsTextUpright;
 
@@ -546,7 +918,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-max-angle"><code>text-max-angle</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumTextAngle;
 
@@ -567,7 +945,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-max-width"><code>text-max-width</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumTextWidth;
 
@@ -586,7 +970,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-symbol-avoid-edges"><code>symbol-avoid-edges</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *symbolAvoidsEdges;
 
@@ -598,7 +988,13 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSValue` object containing `MGLSymbolPlacementPoint`. Set this property to
- `nil` to reset it to the default value.
+ `nil` to reset it to the default value.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *symbolPlacement;
 
@@ -613,7 +1009,13 @@ MGL_EXPORT
  
  This property is only applied to the style if `symbolPlacement` is set to an
  `MGLStyleValue` object containing an `NSValue` object containing
- `MGLSymbolPlacementLine`. Otherwise, it is ignored.
+ `MGLSymbolPlacementLine`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *symbolSpacing;
 
@@ -626,7 +1028,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-field"><code>text-field</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *text;
 
@@ -646,7 +1054,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-allow-overlap"><code>text-allow-overlap</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textAllowsOverlap;
 
@@ -661,7 +1075,13 @@ MGL_EXPORT
  to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textAnchor;
 
@@ -687,7 +1107,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-font"><code>text-font</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSString *> *> *textFontNames;
 
@@ -708,7 +1134,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-size"><code>text-size</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textFontSize;
 
@@ -727,7 +1159,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-ignore-placement"><code>text-ignore-placement</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textIgnoresPlacement;
 
@@ -746,7 +1184,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-justify"><code>text-justify</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textJustification;
 
@@ -763,7 +1207,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textLetterSpacing;
 
@@ -777,7 +1227,13 @@ MGL_EXPORT
  reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textLineHeight;
 
@@ -792,7 +1248,13 @@ MGL_EXPORT
  ems downward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textOffset;
 #else
@@ -806,7 +1268,13 @@ MGL_EXPORT
  ems upward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textOffset;
 #endif
@@ -820,7 +1288,13 @@ MGL_EXPORT
  the default value.
  
  This property is only applied to the style if `text` is non-`nil`, and
- `iconImageName` is non-`nil`. Otherwise, it is ignored.
+ `iconImageName` is non-`nil`. Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable, getter=isTextOptional) MGLStyleValue<NSNumber *> *textOptional;
 
@@ -835,7 +1309,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textPadding;
 
@@ -847,7 +1327,13 @@ MGL_EXPORT
  `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textPitchAlignment;
 
@@ -865,7 +1351,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-rotate"><code>text-rotate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textRotation;
 
@@ -881,7 +1373,13 @@ MGL_EXPORT
  to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textRotationAlignment;
 
@@ -893,7 +1391,13 @@ MGL_EXPORT
  to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTransform;
 
@@ -909,7 +1413,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *iconColor;
 #else
@@ -922,7 +1432,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *iconColor;
 #endif
@@ -937,7 +1453,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconHaloBlur;
 
@@ -951,7 +1473,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *iconHaloColor;
 #else
@@ -964,7 +1492,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *iconHaloColor;
 #endif
@@ -979,7 +1513,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconHaloWidth;
 
@@ -991,7 +1531,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.
+ Otherwise, it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconOpacity;
 
@@ -1010,7 +1556,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate"><code>icon-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslation;
 #else
@@ -1028,7 +1580,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate"><code>icon-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslation;
 #endif
@@ -1047,7 +1605,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate-anchor"><code>icon-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslationAnchor;
 
@@ -1062,7 +1626,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *textColor;
 #else
@@ -1074,7 +1644,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *textColor;
 #endif
@@ -1089,7 +1665,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textHaloBlur;
 
@@ -1102,7 +1684,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *textHaloColor;
 #else
@@ -1114,7 +1702,13 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *textHaloColor;
 #endif
@@ -1130,7 +1724,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textHaloWidth;
 
@@ -1142,7 +1742,13 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.
+ it is ignored.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textOpacity;
 
@@ -1161,7 +1767,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate"><code>text-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslation;
 #else
@@ -1179,7 +1791,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate"><code>text-translate</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslation;
 #endif
@@ -1198,7 +1816,13 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate-anchor"><code>text-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.
+ layout property in the Mapbox Style Specification.`
+ 
+ This property can be set to one of the following values:
+ 
+ - `MGLStyleConstantValue`
+ - `MGLCameraStyleFunction` with an interpolation mode of
+ `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslationAnchor;
 

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  In combination with `symbolPlacement`, determines the rotation behavior of
- icons.`
+ icons.
  
  This property can be set to one of the following values:
  
@@ -24,7 +24,7 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, aligns icons
      east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine`,
-     aligns icon x-axes with the line.`
+     aligns icon x-axes with the line.
      
      This property can be set to one of the following values:
      
@@ -35,7 +35,7 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
     MGLIconRotationAlignmentMap,
     /**
      Produces icons whose x-axes are aligned with the x-axis of the viewport,
-     regardless of the value of `symbolPlacement`.`
+     regardless of the value of `symbolPlacement`.
      
      This property can be set to one of the following values:
      
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, this is
      equivalent to `MGLIconRotationAlignmentViewport`. When `symbolPlacement` is
      set to `MGLSymbolPlacementLine`, this is equivalent to
-     `MGLIconRotationAlignmentMap`.`
+     `MGLIconRotationAlignmentMap`.
      
      This property can be set to one of the following values:
      
@@ -60,7 +60,7 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
 };
 
 /**
- Scales the icon to fit around the associated text.`
+ Scales the icon to fit around the associated text.
  
  This property can be set to one of the following values:
  
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
  */
 typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
     /**
-     The icon is displayed at its intrinsic aspect ratio.`
+     The icon is displayed at its intrinsic aspect ratio.
      
      This property can be set to one of the following values:
      
@@ -83,7 +83,7 @@ typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
      */
     MGLIconTextFitNone,
     /**
-     The icon is scaled in the x-dimension to fit the width of the text.`
+     The icon is scaled in the x-dimension to fit the width of the text.
      
      This property can be set to one of the following values:
      
@@ -93,7 +93,7 @@ typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
      */
     MGLIconTextFitWidth,
     /**
-     The icon is scaled in the y-dimension to fit the height of the text.`
+     The icon is scaled in the y-dimension to fit the height of the text.
      
      This property can be set to one of the following values:
      
@@ -103,7 +103,7 @@ typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
      */
     MGLIconTextFitHeight,
     /**
-     The icon is scaled in both x- and y-dimensions.`
+     The icon is scaled in both x- and y-dimensions.
      
      This property can be set to one of the following values:
      
@@ -115,7 +115,7 @@ typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
 };
 
 /**
- Label placement relative to its geometry.`
+ Label placement relative to its geometry.
  
  This property can be set to one of the following values:
  
@@ -128,7 +128,7 @@ typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
  */
 typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
     /**
-     The label is placed at the point where the geometry is located.`
+     The label is placed at the point where the geometry is located.
      
      This property can be set to one of the following values:
      
@@ -139,7 +139,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
     MGLSymbolPlacementPoint,
     /**
      The label is placed along the line of the geometry. Can only be used on
-     `LineString` and `Polygon` geometries.`
+     `LineString` and `Polygon` geometries.
      
      This property can be set to one of the following values:
      
@@ -151,7 +151,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
 };
 
 /**
- Part of the text placed closest to the anchor.`
+ Part of the text placed closest to the anchor.
  
  This property can be set to one of the following values:
  
@@ -164,7 +164,7 @@ typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
  */
 typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
     /**
-     The center of the text is placed closest to the anchor.`
+     The center of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -174,7 +174,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
      */
     MGLTextAnchorCenter,
     /**
-     The left side of the text is placed closest to the anchor.`
+     The left side of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -184,7 +184,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
      */
     MGLTextAnchorLeft,
     /**
-     The right side of the text is placed closest to the anchor.`
+     The right side of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -194,7 +194,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
      */
     MGLTextAnchorRight,
     /**
-     The top of the text is placed closest to the anchor.`
+     The top of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -204,7 +204,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
      */
     MGLTextAnchorTop,
     /**
-     The bottom of the text is placed closest to the anchor.`
+     The bottom of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -214,7 +214,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
      */
     MGLTextAnchorBottom,
     /**
-     The top left corner of the text is placed closest to the anchor.`
+     The top left corner of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -224,7 +224,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
      */
     MGLTextAnchorTopLeft,
     /**
-     The top right corner of the text is placed closest to the anchor.`
+     The top right corner of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -234,7 +234,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
      */
     MGLTextAnchorTopRight,
     /**
-     The bottom left corner of the text is placed closest to the anchor.`
+     The bottom left corner of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -244,7 +244,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
      */
     MGLTextAnchorBottomLeft,
     /**
-     The bottom right corner of the text is placed closest to the anchor.`
+     The bottom right corner of the text is placed closest to the anchor.
      
      This property can be set to one of the following values:
      
@@ -256,7 +256,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
 };
 
 /**
- Text justification options.`
+ Text justification options.
  
  This property can be set to one of the following values:
  
@@ -269,7 +269,7 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
  */
 typedef NS_ENUM(NSUInteger, MGLTextJustification) {
     /**
-     The text is aligned to the left.`
+     The text is aligned to the left.
      
      This property can be set to one of the following values:
      
@@ -279,7 +279,7 @@ typedef NS_ENUM(NSUInteger, MGLTextJustification) {
      */
     MGLTextJustificationLeft,
     /**
-     The text is centered.`
+     The text is centered.
      
      This property can be set to one of the following values:
      
@@ -289,7 +289,7 @@ typedef NS_ENUM(NSUInteger, MGLTextJustification) {
      */
     MGLTextJustificationCenter,
     /**
-     The text is aligned to the right.`
+     The text is aligned to the right.
      
      This property can be set to one of the following values:
      
@@ -301,7 +301,7 @@ typedef NS_ENUM(NSUInteger, MGLTextJustification) {
 };
 
 /**
- Orientation of text when map is pitched.`
+ Orientation of text when map is pitched.
  
  This property can be set to one of the following values:
  
@@ -314,7 +314,7 @@ typedef NS_ENUM(NSUInteger, MGLTextJustification) {
  */
 typedef NS_ENUM(NSUInteger, MGLTextPitchAlignment) {
     /**
-     The text is aligned to the plane of the map.`
+     The text is aligned to the plane of the map.
      
      This property can be set to one of the following values:
      
@@ -324,7 +324,7 @@ typedef NS_ENUM(NSUInteger, MGLTextPitchAlignment) {
      */
     MGLTextPitchAlignmentMap,
     /**
-     The text is aligned to the plane of the viewport.`
+     The text is aligned to the plane of the viewport.
      
      This property can be set to one of the following values:
      
@@ -334,7 +334,7 @@ typedef NS_ENUM(NSUInteger, MGLTextPitchAlignment) {
      */
     MGLTextPitchAlignmentViewport,
     /**
-     Automatically matches the value of `textRotationAlignment`.`
+     Automatically matches the value of `textRotationAlignment`.
      
      This property can be set to one of the following values:
      
@@ -347,7 +347,7 @@ typedef NS_ENUM(NSUInteger, MGLTextPitchAlignment) {
 
 /**
  In combination with `symbolPlacement`, determines the rotation behavior of the
- individual glyphs forming the text.`
+ individual glyphs forming the text.
  
  This property can be set to one of the following values:
  
@@ -362,7 +362,7 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
     /**
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, aligns text
      east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine`,
-     aligns text x-axes with the line.`
+     aligns text x-axes with the line.
      
      This property can be set to one of the following values:
      
@@ -373,7 +373,7 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
     MGLTextRotationAlignmentMap,
     /**
      Produces glyphs whose x-axes are aligned with the x-axis of the viewport,
-     regardless of the value of `symbolPlacement`.`
+     regardless of the value of `symbolPlacement`.
      
      This property can be set to one of the following values:
      
@@ -386,7 +386,7 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, this is
      equivalent to `MGLTextRotationAlignmentViewport`. When `symbolPlacement` is
      set to `MGLSymbolPlacementLine`, this is equivalent to
-     `MGLTextRotationAlignmentMap`.`
+     `MGLTextRotationAlignmentMap`.
      
      This property can be set to one of the following values:
      
@@ -398,7 +398,7 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
 };
 
 /**
- Specifies how to capitalize text.`
+ Specifies how to capitalize text.
  
  This property can be set to one of the following values:
  
@@ -411,7 +411,7 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
  */
 typedef NS_ENUM(NSUInteger, MGLTextTransform) {
     /**
-     The text is not altered.`
+     The text is not altered.
      
      This property can be set to one of the following values:
      
@@ -421,7 +421,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
      */
     MGLTextTransformNone,
     /**
-     Forces all letters to be displayed in uppercase.`
+     Forces all letters to be displayed in uppercase.
      
      This property can be set to one of the following values:
      
@@ -431,7 +431,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
      */
     MGLTextTransformUppercase,
     /**
-     Forces all letters to be displayed in lowercase.`
+     Forces all letters to be displayed in lowercase.
      
      This property can be set to one of the following values:
      
@@ -443,7 +443,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
 };
 
 /**
- Controls the translation reference point.`
+ Controls the translation reference point.
  
  This property can be set to one of the following values:
  
@@ -456,7 +456,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
  */
 typedef NS_ENUM(NSUInteger, MGLIconTranslationAnchor) {
     /**
-     Icons are translated relative to the map.`
+     Icons are translated relative to the map.
      
      This property can be set to one of the following values:
      
@@ -466,7 +466,7 @@ typedef NS_ENUM(NSUInteger, MGLIconTranslationAnchor) {
      */
     MGLIconTranslationAnchorMap,
     /**
-     Icons are translated relative to the viewport.`
+     Icons are translated relative to the viewport.
      
      This property can be set to one of the following values:
      
@@ -478,7 +478,7 @@ typedef NS_ENUM(NSUInteger, MGLIconTranslationAnchor) {
 };
 
 /**
- Controls the translation reference point.`
+ Controls the translation reference point.
  
  This property can be set to one of the following values:
  
@@ -491,7 +491,7 @@ typedef NS_ENUM(NSUInteger, MGLIconTranslationAnchor) {
  */
 typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
     /**
-     The text is translated relative to the map.`
+     The text is translated relative to the map.
      
      This property can be set to one of the following values:
      
@@ -501,7 +501,7 @@ typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
      */
     MGLTextTranslationAnchorMap,
     /**
-     The text is translated relative to the viewport.`
+     The text is translated relative to the viewport.
      
      This property can be set to one of the following values:
      
@@ -559,7 +559,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-allow-overlap"><code>icon-allow-overlap</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -584,7 +584,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-ignore-placement"><code>icon-ignore-placement</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -602,7 +602,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-image"><code>icon-image</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -624,19 +624,23 @@ MGL_EXPORT
  downward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconOffset;
 #else
@@ -648,19 +652,23 @@ MGL_EXPORT
  upward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconOffset;
 #endif
@@ -674,7 +682,7 @@ MGL_EXPORT
  the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`, and
- `text` is non-`nil`. Otherwise, it is ignored.`
+ `text` is non-`nil`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
@@ -695,13 +703,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconPadding;
 
@@ -719,19 +728,23 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-rotate"><code>icon-rotate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval`,
- `MGLInterpolationModeCategorical`, or `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential`, `MGLInterpolationModeInterval` or
- `MGLInterpolationModeCategorical`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+ - `MGLSourceStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
+   - `MGLInterpolationModeIdentity`
+ - `MGLCompositeStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
+   - `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconRotation;
 
@@ -747,7 +760,7 @@ MGL_EXPORT
  to `nil` to reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
@@ -769,13 +782,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-size"><code>icon-size</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconScale;
 
@@ -790,7 +804,7 @@ MGL_EXPORT
  reset it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`, and
- `text` is non-`nil`. Otherwise, it is ignored.`
+ `text` is non-`nil`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
@@ -813,13 +827,14 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`, and
  `text` is non-`nil`, and `iconTextFit` is set to an `MGLStyleValue` object
  containing an `NSValue` object containing `MGLIconTextFitBoth`,
- `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.`
+ `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFitPadding;
 #else
@@ -835,13 +850,14 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`, and
  `text` is non-`nil`, and `iconTextFit` is set to an `MGLStyleValue` object
  containing an `NSValue` object containing `MGLIconTextFitBoth`,
- `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.`
+ `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFitPadding;
 #endif
@@ -861,7 +877,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-keep-upright"><code>icon-keep-upright</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -890,7 +906,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-keep-upright"><code>text-keep-upright</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -918,13 +934,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-max-angle"><code>text-max-angle</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumTextAngle;
 
@@ -945,13 +962,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-max-width"><code>text-max-width</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumTextWidth;
 
@@ -970,7 +988,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-symbol-avoid-edges"><code>symbol-avoid-edges</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -988,7 +1006,7 @@ MGL_EXPORT
  
  The default value of this property is an `MGLStyleValue` object containing an
  `NSValue` object containing `MGLSymbolPlacementPoint`. Set this property to
- `nil` to reset it to the default value.`
+ `nil` to reset it to the default value.
  
  This property can be set to one of the following values:
  
@@ -1009,13 +1027,14 @@ MGL_EXPORT
  
  This property is only applied to the style if `symbolPlacement` is set to an
  `MGLStyleValue` object containing an `NSValue` object containing
- `MGLSymbolPlacementLine`. Otherwise, it is ignored.`
+ `MGLSymbolPlacementLine`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *symbolSpacing;
 
@@ -1028,7 +1047,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-field"><code>text-field</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -1054,7 +1073,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-allow-overlap"><code>text-allow-overlap</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -1075,7 +1094,7 @@ MGL_EXPORT
  to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
@@ -1107,7 +1126,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-font"><code>text-font</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -1134,13 +1153,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-size"><code>text-size</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textFontSize;
 
@@ -1159,7 +1179,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-ignore-placement"><code>text-ignore-placement</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -1184,7 +1204,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-justify"><code>text-justify</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -1207,13 +1227,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textLetterSpacing;
 
@@ -1227,13 +1248,14 @@ MGL_EXPORT
  reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textLineHeight;
 
@@ -1248,13 +1270,14 @@ MGL_EXPORT
  ems downward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textOffset;
 #else
@@ -1268,13 +1291,14 @@ MGL_EXPORT
  ems upward. Set this property to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textOffset;
 #endif
@@ -1288,7 +1312,7 @@ MGL_EXPORT
  the default value.
  
  This property is only applied to the style if `text` is non-`nil`, and
- `iconImageName` is non-`nil`. Otherwise, it is ignored.`
+ `iconImageName` is non-`nil`. Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
@@ -1309,13 +1333,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textPadding;
 
@@ -1327,7 +1352,7 @@ MGL_EXPORT
  `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
@@ -1351,13 +1376,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-rotate"><code>text-rotate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textRotation;
 
@@ -1373,7 +1399,7 @@ MGL_EXPORT
  to `nil` to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
@@ -1391,7 +1417,7 @@ MGL_EXPORT
  to reset it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
@@ -1413,13 +1439,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *iconColor;
 #else
@@ -1432,13 +1459,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *iconColor;
 #endif
@@ -1453,13 +1481,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconHaloBlur;
 
@@ -1473,13 +1502,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *iconHaloColor;
 #else
@@ -1492,13 +1522,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *iconHaloColor;
 #endif
@@ -1513,13 +1544,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconHaloWidth;
 
@@ -1531,13 +1563,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `iconImageName` is non-`nil`.
- Otherwise, it is ignored.`
+ Otherwise, it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconOpacity;
 
@@ -1556,13 +1589,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate"><code>icon-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslation;
 #else
@@ -1580,13 +1614,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate"><code>icon-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslation;
 #endif
@@ -1605,7 +1640,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate-anchor"><code>icon-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
@@ -1626,13 +1661,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *textColor;
 #else
@@ -1644,13 +1680,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *textColor;
 #endif
@@ -1665,13 +1702,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textHaloBlur;
 
@@ -1684,13 +1722,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *textHaloColor;
 #else
@@ -1702,13 +1741,14 @@ MGL_EXPORT
  value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *textHaloColor;
 #endif
@@ -1724,13 +1764,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textHaloWidth;
 
@@ -1742,13 +1783,14 @@ MGL_EXPORT
  it to the default value.
  
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
- it is ignored.`
+ it is ignored.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textOpacity;
 
@@ -1767,13 +1809,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate"><code>text-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslation;
 #else
@@ -1791,13 +1834,14 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate"><code>text-translate</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  
  - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeExponential` or `MGLInterpolationModeInterval`
+ - `MGLCameraStyleFunction` with an interpolation mode of:
+   - `MGLInterpolationModeExponential`
+   - `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslation;
 #endif
@@ -1816,7 +1860,7 @@ MGL_EXPORT
  
  This attribute corresponds to the <a
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate-anchor"><code>text-translate-anchor</code></a>
- layout property in the Mapbox Style Specification.`
+ layout property in the Mapbox Style Specification.
  
  This property can be set to one of the following values:
  

--- a/platform/darwin/src/MGLSymbolStyleLayer.h
+++ b/platform/darwin/src/MGLSymbolStyleLayer.h
@@ -10,12 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  In combination with `symbolPlacement`, determines the rotation behavior of
  icons.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.iconRotationAlignment`
  property.
@@ -25,23 +19,11 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, aligns icons
      east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine`,
      aligns icon x-axes with the line.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconRotationAlignmentMap,
     /**
      Produces icons whose x-axes are aligned with the x-axis of the viewport,
      regardless of the value of `symbolPlacement`.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconRotationAlignmentViewport,
     /**
@@ -49,24 +31,12 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
      equivalent to `MGLIconRotationAlignmentViewport`. When `symbolPlacement` is
      set to `MGLSymbolPlacementLine`, this is equivalent to
      `MGLIconRotationAlignmentMap`.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconRotationAlignmentAuto,
 };
 
 /**
  Scales the icon to fit around the associated text.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.iconTextFit`
  property.
@@ -74,54 +44,24 @@ typedef NS_ENUM(NSUInteger, MGLIconRotationAlignment) {
 typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
     /**
      The icon is displayed at its intrinsic aspect ratio.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconTextFitNone,
     /**
      The icon is scaled in the x-dimension to fit the width of the text.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconTextFitWidth,
     /**
      The icon is scaled in the y-dimension to fit the height of the text.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconTextFitHeight,
     /**
      The icon is scaled in both x- and y-dimensions.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconTextFitBoth,
 };
 
 /**
  Label placement relative to its geometry.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.symbolPlacement`
  property.
@@ -129,35 +69,17 @@ typedef NS_ENUM(NSUInteger, MGLIconTextFit) {
 typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
     /**
      The label is placed at the point where the geometry is located.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLSymbolPlacementPoint,
     /**
      The label is placed along the line of the geometry. Can only be used on
      `LineString` and `Polygon` geometries.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLSymbolPlacementLine,
 };
 
 /**
  Part of the text placed closest to the anchor.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textAnchor`
  property.
@@ -165,104 +87,44 @@ typedef NS_ENUM(NSUInteger, MGLSymbolPlacement) {
 typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
     /**
      The center of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorCenter,
     /**
      The left side of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorLeft,
     /**
      The right side of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorRight,
     /**
      The top of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorTop,
     /**
      The bottom of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorBottom,
     /**
      The top left corner of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorTopLeft,
     /**
      The top right corner of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorTopRight,
     /**
      The bottom left corner of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorBottomLeft,
     /**
      The bottom right corner of the text is placed closest to the anchor.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextAnchorBottomRight,
 };
 
 /**
  Text justification options.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textJustification`
  property.
@@ -270,44 +132,20 @@ typedef NS_ENUM(NSUInteger, MGLTextAnchor) {
 typedef NS_ENUM(NSUInteger, MGLTextJustification) {
     /**
      The text is aligned to the left.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextJustificationLeft,
     /**
      The text is centered.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextJustificationCenter,
     /**
      The text is aligned to the right.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextJustificationRight,
 };
 
 /**
  Orientation of text when map is pitched.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textPitchAlignment`
  property.
@@ -315,32 +153,14 @@ typedef NS_ENUM(NSUInteger, MGLTextJustification) {
 typedef NS_ENUM(NSUInteger, MGLTextPitchAlignment) {
     /**
      The text is aligned to the plane of the map.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextPitchAlignmentMap,
     /**
      The text is aligned to the plane of the viewport.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextPitchAlignmentViewport,
     /**
      Automatically matches the value of `textRotationAlignment`.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextPitchAlignmentAuto,
 };
@@ -348,12 +168,6 @@ typedef NS_ENUM(NSUInteger, MGLTextPitchAlignment) {
 /**
  In combination with `symbolPlacement`, determines the rotation behavior of the
  individual glyphs forming the text.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textRotationAlignment`
  property.
@@ -363,23 +177,11 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
      When `symbolPlacement` is set to `MGLSymbolPlacementPoint`, aligns text
      east-west. When `symbolPlacement` is set to `MGLSymbolPlacementLine`,
      aligns text x-axes with the line.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextRotationAlignmentMap,
     /**
      Produces glyphs whose x-axes are aligned with the x-axis of the viewport,
      regardless of the value of `symbolPlacement`.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextRotationAlignmentViewport,
     /**
@@ -387,24 +189,12 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
      equivalent to `MGLTextRotationAlignmentViewport`. When `symbolPlacement` is
      set to `MGLSymbolPlacementLine`, this is equivalent to
      `MGLTextRotationAlignmentMap`.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextRotationAlignmentAuto,
 };
 
 /**
  Specifies how to capitalize text.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textTransform`
  property.
@@ -412,44 +202,20 @@ typedef NS_ENUM(NSUInteger, MGLTextRotationAlignment) {
 typedef NS_ENUM(NSUInteger, MGLTextTransform) {
     /**
      The text is not altered.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextTransformNone,
     /**
      Forces all letters to be displayed in uppercase.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextTransformUppercase,
     /**
      Forces all letters to be displayed in lowercase.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextTransformLowercase,
 };
 
 /**
  Controls the translation reference point.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.iconTranslationAnchor`
  property.
@@ -457,34 +223,16 @@ typedef NS_ENUM(NSUInteger, MGLTextTransform) {
 typedef NS_ENUM(NSUInteger, MGLIconTranslationAnchor) {
     /**
      Icons are translated relative to the map.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconTranslationAnchorMap,
     /**
      Icons are translated relative to the viewport.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLIconTranslationAnchorViewport,
 };
 
 /**
  Controls the translation reference point.
- 
- This property can be set to one of the following values:
- 
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
- `MGLInterpolationModeInterval`
 
  Values of this type are used in the `MGLSymbolStyleLayer.textTranslationAnchor`
  property.
@@ -492,22 +240,10 @@ typedef NS_ENUM(NSUInteger, MGLIconTranslationAnchor) {
 typedef NS_ENUM(NSUInteger, MGLTextTranslationAnchor) {
     /**
      The text is translated relative to the map.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextTranslationAnchorMap,
     /**
      The text is translated relative to the viewport.
-     
-     This property can be set to one of the following values:
-     
-     - `MGLStyleConstantValue`
-     - `MGLCameraStyleFunction` with an interpolation mode of
-     `MGLInterpolationModeInterval`
      */
     MGLTextTranslationAnchorViewport,
 };
@@ -561,10 +297,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-allow-overlap"><code>icon-allow-overlap</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconAllowsOverlap;
@@ -586,10 +322,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-ignore-placement"><code>icon-ignore-placement</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconIgnoresPlacement;
@@ -604,10 +340,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-image"><code>icon-image</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *iconImageName;
@@ -626,21 +362,21 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconOffset;
 #else
@@ -654,21 +390,21 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconOffset;
 #endif
@@ -684,10 +420,10 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`, and
  `text` is non-`nil`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable, getter=isIconOptional) MGLStyleValue<NSNumber *> *iconOptional;
@@ -705,12 +441,12 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconPadding;
 
@@ -730,21 +466,21 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-rotate"><code>icon-rotate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
- - `MGLSourceStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
-   - `MGLInterpolationModeIdentity`
- - `MGLCompositeStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
-   - `MGLInterpolationModeCategorical`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+ * `MGLSourceStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
+   * `MGLInterpolationModeIdentity`
+ * `MGLCompositeStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
+   * `MGLInterpolationModeCategorical`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconRotation;
 
@@ -762,10 +498,10 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconRotationAlignment;
@@ -784,12 +520,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-size"><code>icon-size</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconScale;
 
@@ -806,10 +542,10 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`, and
  `text` is non-`nil`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFit;
@@ -829,12 +565,12 @@ MGL_EXPORT
  containing an `NSValue` object containing `MGLIconTextFitBoth`,
  `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFitPadding;
 #else
@@ -852,12 +588,12 @@ MGL_EXPORT
  containing an `NSValue` object containing `MGLIconTextFitBoth`,
  `MGLIconTextFitWidth`, or `MGLIconTextFitHeight`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTextFitPadding;
 #endif
@@ -879,10 +615,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-icon-keep-upright"><code>icon-keep-upright</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *keepsIconUpright;
@@ -908,10 +644,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-keep-upright"><code>text-keep-upright</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *keepsTextUpright;
@@ -936,12 +672,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-max-angle"><code>text-max-angle</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumTextAngle;
 
@@ -964,12 +700,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-max-width"><code>text-max-width</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *maximumTextWidth;
 
@@ -990,10 +726,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-symbol-avoid-edges"><code>symbol-avoid-edges</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *symbolAvoidsEdges;
@@ -1008,10 +744,10 @@ MGL_EXPORT
  `NSValue` object containing `MGLSymbolPlacementPoint`. Set this property to
  `nil` to reset it to the default value.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *symbolPlacement;
@@ -1029,12 +765,12 @@ MGL_EXPORT
  `MGLStyleValue` object containing an `NSValue` object containing
  `MGLSymbolPlacementLine`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *symbolSpacing;
 
@@ -1049,10 +785,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-field"><code>text-field</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSString *> *text;
@@ -1075,10 +811,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-allow-overlap"><code>text-allow-overlap</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textAllowsOverlap;
@@ -1096,10 +832,10 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textAnchor;
@@ -1128,10 +864,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-font"><code>text-font</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSArray<NSString *> *> *textFontNames;
@@ -1155,12 +891,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-size"><code>text-size</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textFontSize;
 
@@ -1181,10 +917,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-ignore-placement"><code>text-ignore-placement</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textIgnoresPlacement;
@@ -1206,10 +942,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-justify"><code>text-justify</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textJustification;
@@ -1229,12 +965,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textLetterSpacing;
 
@@ -1250,12 +986,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textLineHeight;
 
@@ -1272,12 +1008,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textOffset;
 #else
@@ -1293,12 +1029,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textOffset;
 #endif
@@ -1314,10 +1050,10 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`, and
  `iconImageName` is non-`nil`. Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable, getter=isTextOptional) MGLStyleValue<NSNumber *> *textOptional;
@@ -1335,12 +1071,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textPadding;
 
@@ -1354,10 +1090,10 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textPitchAlignment;
@@ -1378,12 +1114,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#layout-symbol-text-rotate"><code>text-rotate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textRotation;
 
@@ -1401,10 +1137,10 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textRotationAlignment;
@@ -1419,10 +1155,10 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTransform;
@@ -1441,12 +1177,12 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *iconColor;
 #else
@@ -1461,12 +1197,12 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *iconColor;
 #endif
@@ -1483,12 +1219,12 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconHaloBlur;
 
@@ -1504,12 +1240,12 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *iconHaloColor;
 #else
@@ -1524,12 +1260,12 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *iconHaloColor;
 #endif
@@ -1546,12 +1282,12 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconHaloWidth;
 
@@ -1565,12 +1301,12 @@ MGL_EXPORT
  This property is only applied to the style if `iconImageName` is non-`nil`.
  Otherwise, it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *iconOpacity;
 
@@ -1591,12 +1327,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate"><code>icon-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslation;
 #else
@@ -1616,12 +1352,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate"><code>icon-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslation;
 #endif
@@ -1642,10 +1378,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-icon-translate-anchor"><code>icon-translate-anchor</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *iconTranslationAnchor;
@@ -1663,12 +1399,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *textColor;
 #else
@@ -1682,12 +1418,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *textColor;
 #endif
@@ -1704,12 +1440,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textHaloBlur;
 
@@ -1724,12 +1460,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<UIColor *> *textHaloColor;
 #else
@@ -1743,12 +1479,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSColor *> *textHaloColor;
 #endif
@@ -1766,12 +1502,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textHaloWidth;
 
@@ -1785,12 +1521,12 @@ MGL_EXPORT
  This property is only applied to the style if `text` is non-`nil`. Otherwise,
  it is ignored.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSNumber *> *textOpacity;
 
@@ -1811,12 +1547,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate"><code>text-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslation;
 #else
@@ -1836,12 +1572,12 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate"><code>text-translate</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of:
-   - `MGLInterpolationModeExponential`
-   - `MGLInterpolationModeInterval`
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of:
+   * `MGLInterpolationModeExponential`
+   * `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslation;
 #endif
@@ -1862,10 +1598,10 @@ MGL_EXPORT
  href="https://www.mapbox.com/mapbox-gl-style-spec/#paint-text-translate-anchor"><code>text-translate-anchor</code></a>
  layout property in the Mapbox Style Specification.
  
- This property can be set to one of the following values:
+ You can set this property to an instance of:
  
- - `MGLStyleConstantValue`
- - `MGLCameraStyleFunction` with an interpolation mode of
+ * `MGLStyleConstantValue`
+ * `MGLCameraStyleFunction` with an interpolation mode of
  `MGLInterpolationModeInterval`
  */
 @property (nonatomic, null_resettable) MGLStyleValue<NSValue *> *textTranslationAnchor;


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/7935

This adds documentation to each style layer property that specifies the function and interpolation mode combinations that will work for the property. 

In some cases, function and interpolation stop combination values that don't make sense will be coerced into a values that do. For example, a camera function with and exponential interpolation mode that is set on a property that is a piecewise-constant function will be converted into a camera function with an interval interpolation mode.