### PR TITLE
Removed arch from bitrise script so snapshots build

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -298,7 +298,6 @@ workflows:
             make android-lib-arm-v7
             make android-lib-arm-v8
             make android-lib-x86
-            make android-lib-x86-64
             cd platform/android && ./gradlew :MapboxGLAndroidSDK:assembleRelease
     - script:
         title: Log metrics


### PR DESCRIPTION
Currently our SNAPSHOTs are timing out, removing this should fix the issue.

cc: @zugaldia 