### PR TITLE
[Qt] Added QMapboxGL::sourceExists

### DIFF
--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -208,6 +208,7 @@ public:
     QMargins margins() const;
 
     void addSource(const QString &sourceID, const QVariantMap& params);
+    bool sourceExists(const QString &sourceID);
     void updateSource(const QString &sourceID, const QVariantMap& params);
     void removeSource(const QString &sourceID);
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1244,6 +1244,14 @@ void QMapboxGL::addSource(const QString &id, const QVariantMap &params)
 }
 
 /*!
+    Returns true if the layer with given \a id exists, false otherwise.
+*/
+bool QMapboxGL::sourceExists(const QString& sourceID)
+{
+    return !!d_ptr->mapObj->getSource(sourceID.toStdString());
+}
+
+/*!
     Updates the source \a id with new \a params.
 
     If the source does not exist, it will be added like in addSource(). Only


### PR DESCRIPTION
Used by the Qt plugin in addition to `QMapboxGL::layerExists` as a helper tool for handling managed Qt map items.