### PR TITLE
French, German, Japanese, Portuguese, Swedish, Vietnamese

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,6 +1,6 @@
 [main]
 host = https://www.transifex.com
-lang_map = zh_CN: zh-Hans, zh_TW: zh-Hant
+lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 type = STRINGS
 minimum_perc = 80
 

--- a/platform/darwin/resources/de.lproj/Foundation.strings
+++ b/platform/darwin/resources/de.lproj/Foundation.strings
@@ -1,0 +1,291 @@
+﻿/* Clock position format, long: {hours} o’clock */
+"CLOCK_FMT_LONG" = "%@ Uhr";
+
+/* Clock position format, medium: {hours} o’clock */
+"CLOCK_FMT_MEDIUM" = "%@ Uhr";
+
+/* Clock position format, short: {hours}:00 */
+"CLOCK_FMT_SHORT" = "%@:00";
+
+/* East, long */
+"COMPASS_E_LONG" = "Osten";
+
+/* East, short */
+"COMPASS_E_SHORT" = "O";
+
+/* East by north, long */
+"COMPASS_EbN_LONG" = "Ost zu Nord";
+
+/* East by north, short */
+"COMPASS_EbN_SHORT" = "OzN";
+
+/* East by south, long */
+"COMPASS_EbS_LONG" = "Ost zu Süd";
+
+/* East by south, short */
+"COMPASS_EbS_SHORT" = "OzS";
+
+/* East-northeast, long */
+"COMPASS_ENE_LONG" = "Ostnordost";
+
+/* East-northeast, short */
+"COMPASS_ENE_SHORT" = "ONO";
+
+/* East-southeast, long */
+"COMPASS_ESE_LONG" = "Ostsüdost";
+
+/* East-southeast, short */
+"COMPASS_ESE_SHORT" = "OSO";
+
+/* North, long */
+"COMPASS_N_LONG" = "Nord";
+
+/* North, short */
+"COMPASS_N_SHORT" = "N";
+
+/* North by east, long */
+"COMPASS_NbE_LONG" = "Nord zu Ost";
+
+/* North by east, short */
+"COMPASS_NbE_SHORT" = "NzO";
+
+/* North by west, long */
+"COMPASS_NbW_LONG" = "Nord zu West";
+
+/* North by west, short */
+"COMPASS_NbW_SHORT" = "NzW";
+
+/* Northeast, long */
+"COMPASS_NE_LONG" = "Nordost";
+
+/* Northeast, short */
+"COMPASS_NE_SHORT" = "NO";
+
+/* Northeast by east, long */
+"COMPASS_NEbE_LONG" = "Nordost zu Ost";
+
+/* Northeast by east, short */
+"COMPASS_NEbE_SHORT" = "NOzO";
+
+/* Northeast by north, long */
+"COMPASS_NEbN_LONG" = "Nordost zu Nord";
+
+/* Northeast by north, short */
+"COMPASS_NEbN_SHORT" = "NOzN";
+
+/* North-northeast, long */
+"COMPASS_NNE_LONG" = "Nordnordost";
+
+/* North-northeast, short */
+"COMPASS_NNE_SHORT" = "NNO";
+
+/* North-northwest, long */
+"COMPASS_NNW_LONG" = "Nordnordwest";
+
+/* North-northwest, short */
+"COMPASS_NNW_SHORT" = "NNW";
+
+/* Northwest, long */
+"COMPASS_NW_LONG" = "Nordwest";
+
+/* Northwest, short */
+"COMPASS_NW_SHORT" = "NW";
+
+/* Northwest by north, long */
+"COMPASS_NWbN_LONG" = "Nordwest zu Nord";
+
+/* Northwest by north, short */
+"COMPASS_NWbN_SHORT" = "NWzN";
+
+/* Northwest by west, long */
+"COMPASS_NWbW_LONG" = "Nordwest zu West";
+
+/* Northwest by west, short */
+"COMPASS_NWbW_SHORT" = "NWzW";
+
+/* South, long */
+"COMPASS_S_LONG" = "Süd";
+
+/* South, short */
+"COMPASS_S_SHORT" = "S";
+
+/* South by east, long */
+"COMPASS_SbE_LONG" = "Süd zu Ost";
+
+/* South by east, short */
+"COMPASS_SbE_SHORT" = "SzO";
+
+/* South by west, long */
+"COMPASS_SbW_LONG" = "Süd zu West";
+
+/* South by west, short */
+"COMPASS_SbW_SHORT" = "SzW";
+
+/* Southeast, long */
+"COMPASS_SE_LONG" = "Südost";
+
+/* Southeast, short */
+"COMPASS_SE_SHORT" = "SO";
+
+/* Southeast by east, long */
+"COMPASS_SEbE_LONG" = "Südost zu Ost";
+
+/* Southeast by east, short */
+"COMPASS_SEbE_SHORT" = "SOzO";
+
+/* Southeast by south, long */
+"COMPASS_SEbS_LONG" = "Südost zu Süd";
+
+/* Southeast by south, short */
+"COMPASS_SEbS_SHORT" = "SOzS";
+
+/* South-southeast, long */
+"COMPASS_SSE_LONG" = "Südsüdost";
+
+/* South-southeast, short */
+"COMPASS_SSE_SHORT" = "SSO";
+
+/* South-southwest, long */
+"COMPASS_SSW_LONG" = "Südsüdwest";
+
+/* South-southwest, short */
+"COMPASS_SSW_SHORT" = "SSW";
+
+/* Southwest, long */
+"COMPASS_SW_LONG" = "Südwest";
+
+/* Southwest, short */
+"COMPASS_SW_SHORT" = "SW";
+
+/* Southwest by south, long */
+"COMPASS_SWbS_LONG" = "Südwest zu Süd";
+
+/* Southwest by south, short */
+"COMPASS_SWbS_SHORT" = "SWzS";
+
+/* Southwest by west, long */
+"COMPASS_SWbW_LONG" = "Südwest zu West";
+
+/* Southwest by west, short */
+"COMPASS_SWbW_SHORT" = "SWzW";
+
+/* West, long */
+"COMPASS_W_LONG" = "West";
+
+/* West, short */
+"COMPASS_W_SHORT" = "W";
+
+/* West by north, long */
+"COMPASS_WbN_LONG" = "West zu Nord";
+
+/* West by north, short */
+"COMPASS_WbN_SHORT" = "WzN";
+
+/* West by south, long */
+"COMPASS_WbS_LONG" = "West zu Süd";
+
+/* West by south, short */
+"COMPASS_WbS_SHORT" = "WzS";
+
+/* West-northwest, long */
+"COMPASS_WNW_LONG" = "Westnordwest";
+
+/* West-northwest, short */
+"COMPASS_WNW_SHORT" = "WNW";
+
+/* West-southwest, long */
+"COMPASS_WSW_LONG" = "Westsüdwest";
+
+/* West-southwest, short */
+"COMPASS_WSW_SHORT" = "WSW";
+
+/* Degrees format, long */
+"COORD_DEG_LONG" = "%d Grad";
+
+/* Degrees format, medium: {degrees} */
+"COORD_DEG_MEDIUM" = "%d°";
+
+/* Degrees format, short: {degrees} */
+"COORD_DEG_SHORT" = "%d°";
+
+/* Coordinate format, long: {degrees}{minutes} */
+"COORD_DM_LONG" = "%1$@ und %2$@";
+
+/* Coordinate format, medium: {degrees}{minutes} */
+"COORD_DM_MEDIUM" = "%1$@%2$@";
+
+/* Coordinate format, short: {degrees}{minutes} */
+"COORD_DM_SHORT" = "%1$@%2$@";
+
+/* Coordinate format, long: {degrees}{minutes}{seconds} */
+"COORD_DMS_LONG" = "%1$@, %2$@ und %3$@";
+
+/* Coordinate format, medium: {degrees}{minutes}{seconds} */
+"COORD_DMS_MEDIUM" = "%1$@%2$@%3$@";
+
+/* Coordinate format, short: {degrees}{minutes}{seconds} */
+"COORD_DMS_SHORT" = "%1$@%2$@%3$@";
+
+/* East longitude format, long: {longitude} */
+"COORD_E_LONG" = "%@ Ost";
+
+/* East longitude format, medium: {longitude} */
+"COORD_E_MEDIUM" = "%@ Ost";
+
+/* East longitude format, short: {longitude} */
+"COORD_E_SHORT" = "%@O";
+
+/* Coordinate pair format, long: {latitude}, {longitude} */
+"COORD_FMT_LONG" = "%1$@ zu %2$@";
+
+/* Coordinate pair format, medium: {latitude}, {longitude} */
+"COORD_FMT_MEDIUM" = "%1$@, %2$@";
+
+/* Coordinate pair format, short: {latitude}, {longitude} */
+"COORD_FMT_SHORT" = "%1$@, %2$@";
+
+/* Minutes format, long */
+"COORD_MIN_LONG" = "%d Minute(n)";
+
+/* Minutes format, medium: {minutes} */
+"COORD_MIN_MEDIUM" = "%d′";
+
+/* Minutes format, short: {minutes} */
+"COORD_MIN_SHORT" = "%d′";
+
+/* North latitude format, long: {latitude} */
+"COORD_N_LONG" = "%@ Nord";
+
+/* North latitude format, medium: {latitude} */
+"COORD_N_MEDIUM" = "%@ Nord";
+
+/* North latitude format, short: {latitude} */
+"COORD_N_SHORT" = "%@N";
+
+/* South latitude format, long: {latitude} */
+"COORD_S_LONG" = "%@ Süd";
+
+/* South latitude format, medium: {latitude} */
+"COORD_S_MEDIUM" = "%@ Süd";
+
+/* South latitude format, short: {latitude} */
+"COORD_S_SHORT" = "%@S";
+
+/* Seconds format, long */
+"COORD_SEC_LONG" = "%d Sekunde(n)";
+
+/* Seconds format, medium: {seconds} */
+"COORD_SEC_MEDIUM" = "%d″";
+
+/* Seconds format, short: {seconds} */
+"COORD_SEC_SHORT" = "%d″";
+
+/* West longitude format, long: {longitude} */
+"COORD_W_LONG" = "%@ West";
+
+/* West longitude format, medium: {longitude} */
+"COORD_W_MEDIUM" = "%@ West";
+
+/* West longitude format, short: {longitude} */
+"COORD_W_SHORT" = "%@W";
+

--- a/platform/darwin/resources/de.lproj/Foundation.stringsdict
+++ b/platform/darwin/resources/de.lproj/Foundation.stringsdict
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>COORD_MIN_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Minute</string>
+			<key>other</key>
+			<string>%d Minuten</string>
+		</dict>
+	</dict>
+	<key>COORD_SEC_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@seconds@</string>
+		<key>seconds</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Sekunde</string>
+			<key>other</key>
+			<string>%d Sekunden</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/platform/darwin/resources/fr.lproj/Foundation.stringsdict
+++ b/platform/darwin/resources/fr.lproj/Foundation.stringsdict
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>COORD_DEG_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@degrees@</string>
+		<key>degrees</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d degré</string>
+			<key>other</key>
+			<string>%d degrés</string>
+		</dict>
+	</dict>
+	<key>COORD_MIN_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minute</string>
+			<key>other</key>
+			<string>%d minutes</string>
+		</dict>
+	</dict>
+	<key>COORD_SEC_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@seconds@</string>
+		<key>seconds</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d seconde</string>
+			<key>other</key>
+			<string>%d secondes</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/platform/darwin/resources/ja.lproj/Foundation.strings
+++ b/platform/darwin/resources/ja.lproj/Foundation.strings
@@ -1,0 +1,291 @@
+﻿/* Clock position format, long: {hours} o’clock */
+"CLOCK_FMT_LONG" = "%@時方向";
+
+/* Clock position format, medium: {hours} o’clock */
+"CLOCK_FMT_MEDIUM" = "%@時方向";
+
+/* Clock position format, short: {hours}:00 */
+"CLOCK_FMT_SHORT" = "%@:00";
+
+/* East, long */
+"COMPASS_E_LONG" = "東";
+
+/* East, short */
+"COMPASS_E_SHORT" = "東";
+
+/* East by north, long */
+"COMPASS_EbN_LONG" = "東微北";
+
+/* East by north, short */
+"COMPASS_EbN_SHORT" = "東微北";
+
+/* East by south, long */
+"COMPASS_EbS_LONG" = "東微南";
+
+/* East by south, short */
+"COMPASS_EbS_SHORT" = "東微南";
+
+/* East-northeast, long */
+"COMPASS_ENE_LONG" = "東北東";
+
+/* East-northeast, short */
+"COMPASS_ENE_SHORT" = "東北東";
+
+/* East-southeast, long */
+"COMPASS_ESE_LONG" = "東南東";
+
+/* East-southeast, short */
+"COMPASS_ESE_SHORT" = "東南東";
+
+/* North, long */
+"COMPASS_N_LONG" = "北";
+
+/* North, short */
+"COMPASS_N_SHORT" = "北";
+
+/* North by east, long */
+"COMPASS_NbE_LONG" = "北微東";
+
+/* North by east, short */
+"COMPASS_NbE_SHORT" = "北微東";
+
+/* North by west, long */
+"COMPASS_NbW_LONG" = "北微西";
+
+/* North by west, short */
+"COMPASS_NbW_SHORT" = "北微西";
+
+/* Northeast, long */
+"COMPASS_NE_LONG" = "東北";
+
+/* Northeast, short */
+"COMPASS_NE_SHORT" = "東北";
+
+/* Northeast by east, long */
+"COMPASS_NEbE_LONG" = "東北微東";
+
+/* Northeast by east, short */
+"COMPASS_NEbE_SHORT" = "東北微東";
+
+/* Northeast by north, long */
+"COMPASS_NEbN_LONG" = "東北微北";
+
+/* Northeast by north, short */
+"COMPASS_NEbN_SHORT" = "東北微北";
+
+/* North-northeast, long */
+"COMPASS_NNE_LONG" = "北北東";
+
+/* North-northeast, short */
+"COMPASS_NNE_SHORT" = "北北東";
+
+/* North-northwest, long */
+"COMPASS_NNW_LONG" = "北北西";
+
+/* North-northwest, short */
+"COMPASS_NNW_SHORT" = "北北西";
+
+/* Northwest, long */
+"COMPASS_NW_LONG" = "西北";
+
+/* Northwest, short */
+"COMPASS_NW_SHORT" = "西北";
+
+/* Northwest by north, long */
+"COMPASS_NWbN_LONG" = "西北微北";
+
+/* Northwest by north, short */
+"COMPASS_NWbN_SHORT" = "西北微北";
+
+/* Northwest by west, long */
+"COMPASS_NWbW_LONG" = "西北微西";
+
+/* Northwest by west, short */
+"COMPASS_NWbW_SHORT" = "西北微西";
+
+/* South, long */
+"COMPASS_S_LONG" = "南";
+
+/* South, short */
+"COMPASS_S_SHORT" = "南";
+
+/* South by east, long */
+"COMPASS_SbE_LONG" = "南微東";
+
+/* South by east, short */
+"COMPASS_SbE_SHORT" = "南微東";
+
+/* South by west, long */
+"COMPASS_SbW_LONG" = "南微西";
+
+/* South by west, short */
+"COMPASS_SbW_SHORT" = "南微西";
+
+/* Southeast, long */
+"COMPASS_SE_LONG" = "東南";
+
+/* Southeast, short */
+"COMPASS_SE_SHORT" = "東南";
+
+/* Southeast by east, long */
+"COMPASS_SEbE_LONG" = "東南微東";
+
+/* Southeast by east, short */
+"COMPASS_SEbE_SHORT" = "東南微東";
+
+/* Southeast by south, long */
+"COMPASS_SEbS_LONG" = "東南微南";
+
+/* Southeast by south, short */
+"COMPASS_SEbS_SHORT" = "東南微南";
+
+/* South-southeast, long */
+"COMPASS_SSE_LONG" = "南南東";
+
+/* South-southeast, short */
+"COMPASS_SSE_SHORT" = "南南東";
+
+/* South-southwest, long */
+"COMPASS_SSW_LONG" = "南南西";
+
+/* South-southwest, short */
+"COMPASS_SSW_SHORT" = "南南西";
+
+/* Southwest, long */
+"COMPASS_SW_LONG" = "西南";
+
+/* Southwest, short */
+"COMPASS_SW_SHORT" = "西南";
+
+/* Southwest by south, long */
+"COMPASS_SWbS_LONG" = "西南微南";
+
+/* Southwest by south, short */
+"COMPASS_SWbS_SHORT" = "西南微南";
+
+/* Southwest by west, long */
+"COMPASS_SWbW_LONG" = "西南微西";
+
+/* Southwest by west, short */
+"COMPASS_SWbW_SHORT" = "西南微西";
+
+/* West, long */
+"COMPASS_W_LONG" = "西";
+
+/* West, short */
+"COMPASS_W_SHORT" = "西";
+
+/* West by north, long */
+"COMPASS_WbN_LONG" = "西微北";
+
+/* West by north, short */
+"COMPASS_WbN_SHORT" = "西微北";
+
+/* West by south, long */
+"COMPASS_WbS_LONG" = "西微南";
+
+/* West by south, short */
+"COMPASS_WbS_SHORT" = "西微南";
+
+/* West-northwest, long */
+"COMPASS_WNW_LONG" = "西北西";
+
+/* West-northwest, short */
+"COMPASS_WNW_SHORT" = "西北西";
+
+/* West-southwest, long */
+"COMPASS_WSW_LONG" = "西南西";
+
+/* West-southwest, short */
+"COMPASS_WSW_SHORT" = "西南西";
+
+/* Degrees format, long */
+"COORD_DEG_LONG" = "%d度";
+
+/* Degrees format, medium: {degrees} */
+"COORD_DEG_MEDIUM" = "%d°";
+
+/* Degrees format, short: {degrees} */
+"COORD_DEG_SHORT" = "%d°";
+
+/* Coordinate format, long: {degrees}{minutes} */
+"COORD_DM_LONG" = "%1$@度%2$@分";
+
+/* Coordinate format, medium: {degrees}{minutes} */
+"COORD_DM_MEDIUM" = "%1$@度%2$@";
+
+/* Coordinate format, short: {degrees}{minutes} */
+"COORD_DM_SHORT" = "%1$@%度2$@";
+
+/* Coordinate format, long: {degrees}{minutes}{seconds} */
+"COORD_DMS_LONG" = "%1$@度%2$@分%3$@秒";
+
+/* Coordinate format, medium: {degrees}{minutes}{seconds} */
+"COORD_DMS_MEDIUM" = "%1$@度%2$@分%3$@秒";
+
+/* Coordinate format, short: {degrees}{minutes}{seconds} */
+"COORD_DMS_SHORT" = "%1$@%度2$@分%3$@秒";
+
+/* East longitude format, long: {longitude} */
+"COORD_E_LONG" = "東%@";
+
+/* East longitude format, medium: {longitude} */
+"COORD_E_MEDIUM" = "東%@";
+
+/* East longitude format, short: {longitude} */
+"COORD_E_SHORT" = "%@E";
+
+/* Coordinate pair format, long: {latitude}, {longitude} */
+"COORD_FMT_LONG" = "%1$@，%2$@";
+
+/* Coordinate pair format, medium: {latitude}, {longitude} */
+"COORD_FMT_MEDIUM" = "%1$@，%2$@";
+
+/* Coordinate pair format, short: {latitude}, {longitude} */
+"COORD_FMT_SHORT" = "%1$@，%2$@";
+
+/* Minutes format, long */
+"COORD_MIN_LONG" = "%d分";
+
+/* Minutes format, medium: {minutes} */
+"COORD_MIN_MEDIUM" = "%d′";
+
+/* Minutes format, short: {minutes} */
+"COORD_MIN_SHORT" = "%d′";
+
+/* North latitude format, long: {latitude} */
+"COORD_N_LONG" = "北%@";
+
+/* North latitude format, medium: {latitude} */
+"COORD_N_MEDIUM" = "北%@";
+
+/* North latitude format, short: {latitude} */
+"COORD_N_SHORT" = "%@N";
+
+/* South latitude format, long: {latitude} */
+"COORD_S_LONG" = "南%@";
+
+/* South latitude format, medium: {latitude} */
+"COORD_S_MEDIUM" = "南%@";
+
+/* South latitude format, short: {latitude} */
+"COORD_S_SHORT" = "%@S";
+
+/* Seconds format, long */
+"COORD_SEC_LONG" = "%d秒";
+
+/* Seconds format, medium: {seconds} */
+"COORD_SEC_MEDIUM" = "%d″";
+
+/* Seconds format, short: {seconds} */
+"COORD_SEC_SHORT" = "%d″";
+
+/* West longitude format, long: {longitude} */
+"COORD_W_LONG" = "西%@";
+
+/* West longitude format, medium: {longitude} */
+"COORD_W_MEDIUM" = "西%@";
+
+/* West longitude format, short: {longitude} */
+"COORD_W_SHORT" = "%@W";
+

--- a/platform/darwin/resources/pt-BR.lproj/Foundation.stringsdict
+++ b/platform/darwin/resources/pt-BR.lproj/Foundation.stringsdict
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>COORD_DEG_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@degrees@</string>
+		<key>degrees</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d grau</string>
+			<key>other</key>
+			<string>%d graus</string>
+		</dict>
+	</dict>
+	<key>COORD_MIN_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>other</key>
+			<string>%d minutos</string>
+		</dict>
+	</dict>
+	<key>COORD_SEC_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@seconds@</string>
+		<key>seconds</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d segundo</string>
+			<key>other</key>
+			<string>%d segundos</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/platform/darwin/resources/sv.lproj/Foundation.strings
+++ b/platform/darwin/resources/sv.lproj/Foundation.strings
@@ -1,0 +1,291 @@
+﻿/* Clock position format, long: {hours} o’clock */
+"CLOCK_FMT_LONG" = "%@";
+
+/* Clock position format, medium: {hours} o’clock */
+"CLOCK_FMT_MEDIUM" = "%@";
+
+/* Clock position format, short: {hours}:00 */
+"CLOCK_FMT_SHORT" = "%@:00";
+
+/* East, long */
+"COMPASS_E_LONG" = "Öst";
+
+/* East, short */
+"COMPASS_E_SHORT" = "O";
+
+/* East by north, long */
+"COMPASS_EbN_LONG" = "Ost till Nord";
+
+/* East by north, short */
+"COMPASS_EbN_SHORT" = "OtN";
+
+/* East by south, long */
+"COMPASS_EbS_LONG" = "Ost till Syd";
+
+/* East by south, short */
+"COMPASS_EbS_SHORT" = "OtS";
+
+/* East-northeast, long */
+"COMPASS_ENE_LONG" = "Ostnordost";
+
+/* East-northeast, short */
+"COMPASS_ENE_SHORT" = "ONO";
+
+/* East-southeast, long */
+"COMPASS_ESE_LONG" = "Ostsydost";
+
+/* East-southeast, short */
+"COMPASS_ESE_SHORT" = "OSO";
+
+/* North, long */
+"COMPASS_N_LONG" = "Nord";
+
+/* North, short */
+"COMPASS_N_SHORT" = "N";
+
+/* North by east, long */
+"COMPASS_NbE_LONG" = "Nord till Ost";
+
+/* North by east, short */
+"COMPASS_NbE_SHORT" = "NtO";
+
+/* North by west, long */
+"COMPASS_NbW_LONG" = "Nord till Väst";
+
+/* North by west, short */
+"COMPASS_NbW_SHORT" = "NtV";
+
+/* Northeast, long */
+"COMPASS_NE_LONG" = "Nordost";
+
+/* Northeast, short */
+"COMPASS_NE_SHORT" = "NO";
+
+/* Northeast by east, long */
+"COMPASS_NEbE_LONG" = "Nordost till ost";
+
+/* Northeast by east, short */
+"COMPASS_NEbE_SHORT" = "NOtO";
+
+/* Northeast by north, long */
+"COMPASS_NEbN_LONG" = "Nordost till nord";
+
+/* Northeast by north, short */
+"COMPASS_NEbN_SHORT" = "NOtN";
+
+/* North-northeast, long */
+"COMPASS_NNE_LONG" = "Nordnordost";
+
+/* North-northeast, short */
+"COMPASS_NNE_SHORT" = "NNO";
+
+/* North-northwest, long */
+"COMPASS_NNW_LONG" = "Nordnordväst";
+
+/* North-northwest, short */
+"COMPASS_NNW_SHORT" = "NNV";
+
+/* Northwest, long */
+"COMPASS_NW_LONG" = "Nordväst";
+
+/* Northwest, short */
+"COMPASS_NW_SHORT" = "NV";
+
+/* Northwest by north, long */
+"COMPASS_NWbN_LONG" = "Nordväst till nord";
+
+/* Northwest by north, short */
+"COMPASS_NWbN_SHORT" = "NVtN";
+
+/* Northwest by west, long */
+"COMPASS_NWbW_LONG" = "Nordväst till väst";
+
+/* Northwest by west, short */
+"COMPASS_NWbW_SHORT" = "NVtV";
+
+/* South, long */
+"COMPASS_S_LONG" = "Syd";
+
+/* South, short */
+"COMPASS_S_SHORT" = "S";
+
+/* South by east, long */
+"COMPASS_SbE_LONG" = "Syd till ost";
+
+/* South by east, short */
+"COMPASS_SbE_SHORT" = "StO";
+
+/* South by west, long */
+"COMPASS_SbW_LONG" = "Syd till väst";
+
+/* South by west, short */
+"COMPASS_SbW_SHORT" = "StV";
+
+/* Southeast, long */
+"COMPASS_SE_LONG" = "Sydost";
+
+/* Southeast, short */
+"COMPASS_SE_SHORT" = "SO";
+
+/* Southeast by east, long */
+"COMPASS_SEbE_LONG" = "Sydost till ost";
+
+/* Southeast by east, short */
+"COMPASS_SEbE_SHORT" = "SOtO";
+
+/* Southeast by south, long */
+"COMPASS_SEbS_LONG" = "Sydost till syd";
+
+/* Southeast by south, short */
+"COMPASS_SEbS_SHORT" = "SOtS";
+
+/* South-southeast, long */
+"COMPASS_SSE_LONG" = "Sydsydost";
+
+/* South-southeast, short */
+"COMPASS_SSE_SHORT" = "SSO";
+
+/* South-southwest, long */
+"COMPASS_SSW_LONG" = "Sydsydväst";
+
+/* South-southwest, short */
+"COMPASS_SSW_SHORT" = "SSV";
+
+/* Southwest, long */
+"COMPASS_SW_LONG" = "Sydväst";
+
+/* Southwest, short */
+"COMPASS_SW_SHORT" = "SV";
+
+/* Southwest by south, long */
+"COMPASS_SWbS_LONG" = "Sydväst till syd";
+
+/* Southwest by south, short */
+"COMPASS_SWbS_SHORT" = "SVtS";
+
+/* Southwest by west, long */
+"COMPASS_SWbW_LONG" = "Sydväst till väst";
+
+/* Southwest by west, short */
+"COMPASS_SWbW_SHORT" = "SVtV";
+
+/* West, long */
+"COMPASS_W_LONG" = "Väst";
+
+/* West, short */
+"COMPASS_W_SHORT" = "V";
+
+/* West by north, long */
+"COMPASS_WbN_LONG" = "Väst till nord";
+
+/* West by north, short */
+"COMPASS_WbN_SHORT" = "VtN";
+
+/* West by south, long */
+"COMPASS_WbS_LONG" = "Väst till syd";
+
+/* West by south, short */
+"COMPASS_WbS_SHORT" = "VtS";
+
+/* West-northwest, long */
+"COMPASS_WNW_LONG" = "Västnordväst";
+
+/* West-northwest, short */
+"COMPASS_WNW_SHORT" = "VNV";
+
+/* West-southwest, long */
+"COMPASS_WSW_LONG" = "Västsydväst";
+
+/* West-southwest, short */
+"COMPASS_WSW_SHORT" = "VSV";
+
+/* Degrees format, long */
+"COORD_DEG_LONG" = "%d grad(er)";
+
+/* Degrees format, medium: {degrees} */
+"COORD_DEG_MEDIUM" = "%d°";
+
+/* Degrees format, short: {degrees} */
+"COORD_DEG_SHORT" = "%d°";
+
+/* Coordinate format, long: {degrees}{minutes} */
+"COORD_DM_LONG" = "%1$@ och %2$@";
+
+/* Coordinate format, medium: {degrees}{minutes} */
+"COORD_DM_MEDIUM" = "%1$@%2$@";
+
+/* Coordinate format, short: {degrees}{minutes} */
+"COORD_DM_SHORT" = "%1$@%2$@";
+
+/* Coordinate format, long: {degrees}{minutes}{seconds} */
+"COORD_DMS_LONG" = "%1$@, %2$@ och %3$@";
+
+/* Coordinate format, medium: {degrees}{minutes}{seconds} */
+"COORD_DMS_MEDIUM" = "%1$@%2$@%3$@";
+
+/* Coordinate format, short: {degrees}{minutes}{seconds} */
+"COORD_DMS_SHORT" = "%1$@%2$@%3$@";
+
+/* East longitude format, long: {longitude} */
+"COORD_E_LONG" = "%@ Öst";
+
+/* East longitude format, medium: {longitude} */
+"COORD_E_MEDIUM" = "%@ Öst";
+
+/* East longitude format, short: {longitude} */
+"COORD_E_SHORT" = "%@O";
+
+/* Coordinate pair format, long: {latitude}, {longitude} */
+"COORD_FMT_LONG" = "%1$@ till %2$@";
+
+/* Coordinate pair format, medium: {latitude}, {longitude} */
+"COORD_FMT_MEDIUM" = "%1$@, %2$@";
+
+/* Coordinate pair format, short: {latitude}, {longitude} */
+"COORD_FMT_SHORT" = "%1$@, %2$@";
+
+/* Minutes format, long */
+"COORD_MIN_LONG" = "%d minut(er)";
+
+/* Minutes format, medium: {minutes} */
+"COORD_MIN_MEDIUM" = "%dm";
+
+/* Minutes format, short: {minutes} */
+"COORD_MIN_SHORT" = "%dm";
+
+/* North latitude format, long: {latitude} */
+"COORD_N_LONG" = "%@ Nord";
+
+/* North latitude format, medium: {latitude} */
+"COORD_N_MEDIUM" = "%@ Nord";
+
+/* North latitude format, short: {latitude} */
+"COORD_N_SHORT" = "%@N";
+
+/* South latitude format, long: {latitude} */
+"COORD_S_LONG" = "%@ Syd";
+
+/* South latitude format, medium: {latitude} */
+"COORD_S_MEDIUM" = "%@ Syd";
+
+/* South latitude format, short: {latitude} */
+"COORD_S_SHORT" = "%@S";
+
+/* Seconds format, long */
+"COORD_SEC_LONG" = "%d sekund(er)";
+
+/* Seconds format, medium: {seconds} */
+"COORD_SEC_MEDIUM" = "%ds";
+
+/* Seconds format, short: {seconds} */
+"COORD_SEC_SHORT" = "%ds";
+
+/* West longitude format, long: {longitude} */
+"COORD_W_LONG" = "%@ Väst";
+
+/* West longitude format, medium: {longitude} */
+"COORD_W_MEDIUM" = "%@ Väst";
+
+/* West longitude format, short: {longitude} */
+"COORD_W_SHORT" = "%@W";
+

--- a/platform/darwin/resources/sv.lproj/Foundation.stringsdict
+++ b/platform/darwin/resources/sv.lproj/Foundation.stringsdict
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>COORD_DEG_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@degrees@</string>
+		<key>degrees</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d grad</string>
+			<key>other</key>
+			<string>%d grader</string>
+		</dict>
+	</dict>
+	<key>COORD_MIN_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d minut</string>
+			<key>other</key>
+			<string>%d minuter</string>
+		</dict>
+	</dict>
+	<key>COORD_SEC_LONG</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@seconds@</string>
+		<key>seconds</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d sekund</string>
+			<key>other</key>
+			<string>%d sekunder</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/platform/darwin/resources/vi.lproj/Foundation.strings
+++ b/platform/darwin/resources/vi.lproj/Foundation.strings
@@ -1,0 +1,291 @@
+﻿/* Clock position format, long: {hours} o’clock */
+"CLOCK_FMT_LONG" = "%@ giờ";
+
+/* Clock position format, medium: {hours} o’clock */
+"CLOCK_FMT_MEDIUM" = "%@ giờ";
+
+/* Clock position format, short: {hours}:00 */
+"CLOCK_FMT_SHORT" = "%@:00";
+
+/* East, long */
+"COMPASS_E_LONG" = "đông";
+
+/* East, short */
+"COMPASS_E_SHORT" = "Đ";
+
+/* East by north, long */
+"COMPASS_EbN_LONG" = "đông về bắc";
+
+/* East by north, short */
+"COMPASS_EbN_SHORT" = "ĐvB";
+
+/* East by south, long */
+"COMPASS_EbS_LONG" = "đông về nam";
+
+/* East by south, short */
+"COMPASS_EbS_SHORT" = "ĐvN";
+
+/* East-northeast, long */
+"COMPASS_ENE_LONG" = "đông đông bắc";
+
+/* East-northeast, short */
+"COMPASS_ENE_SHORT" = "ĐĐB";
+
+/* East-southeast, long */
+"COMPASS_ESE_LONG" = "đông đông nam";
+
+/* East-southeast, short */
+"COMPASS_ESE_SHORT" = "ĐĐN";
+
+/* North, long */
+"COMPASS_N_LONG" = "bắc";
+
+/* North, short */
+"COMPASS_N_SHORT" = "B";
+
+/* North by east, long */
+"COMPASS_NbE_LONG" = "bắc về đông";
+
+/* North by east, short */
+"COMPASS_NbE_SHORT" = "BvĐ";
+
+/* North by west, long */
+"COMPASS_NbW_LONG" = "bắc về tây";
+
+/* North by west, short */
+"COMPASS_NbW_SHORT" = "BvT";
+
+/* Northeast, long */
+"COMPASS_NE_LONG" = "đông bắc";
+
+/* Northeast, short */
+"COMPASS_NE_SHORT" = "ĐB";
+
+/* Northeast by east, long */
+"COMPASS_NEbE_LONG" = "đông bắc về đông";
+
+/* Northeast by east, short */
+"COMPASS_NEbE_SHORT" = "ĐBvĐ";
+
+/* Northeast by north, long */
+"COMPASS_NEbN_LONG" = "đông bắc về bắc";
+
+/* Northeast by north, short */
+"COMPASS_NEbN_SHORT" = "ĐBvB";
+
+/* North-northeast, long */
+"COMPASS_NNE_LONG" = "bắc đông bắc";
+
+/* North-northeast, short */
+"COMPASS_NNE_SHORT" = "BĐB";
+
+/* North-northwest, long */
+"COMPASS_NNW_LONG" = "bắc tây bắc";
+
+/* North-northwest, short */
+"COMPASS_NNW_SHORT" = "BTB";
+
+/* Northwest, long */
+"COMPASS_NW_LONG" = "tây bắc";
+
+/* Northwest, short */
+"COMPASS_NW_SHORT" = "TB";
+
+/* Northwest by north, long */
+"COMPASS_NWbN_LONG" = "tây bắc về bắc";
+
+/* Northwest by north, short */
+"COMPASS_NWbN_SHORT" = "TBvB";
+
+/* Northwest by west, long */
+"COMPASS_NWbW_LONG" = "tây bắc về tây";
+
+/* Northwest by west, short */
+"COMPASS_NWbW_SHORT" = "TBvT";
+
+/* South, long */
+"COMPASS_S_LONG" = "nam";
+
+/* South, short */
+"COMPASS_S_SHORT" = "N";
+
+/* South by east, long */
+"COMPASS_SbE_LONG" = "nam về đông";
+
+/* South by east, short */
+"COMPASS_SbE_SHORT" = "NvĐ";
+
+/* South by west, long */
+"COMPASS_SbW_LONG" = "nam về tây";
+
+/* South by west, short */
+"COMPASS_SbW_SHORT" = "NvT";
+
+/* Southeast, long */
+"COMPASS_SE_LONG" = "đông nam";
+
+/* Southeast, short */
+"COMPASS_SE_SHORT" = "ĐN";
+
+/* Southeast by east, long */
+"COMPASS_SEbE_LONG" = "đông nam về đông";
+
+/* Southeast by east, short */
+"COMPASS_SEbE_SHORT" = "ĐNvĐ";
+
+/* Southeast by south, long */
+"COMPASS_SEbS_LONG" = "đông nam về nam";
+
+/* Southeast by south, short */
+"COMPASS_SEbS_SHORT" = "ĐNvN";
+
+/* South-southeast, long */
+"COMPASS_SSE_LONG" = "nam đông nam";
+
+/* South-southeast, short */
+"COMPASS_SSE_SHORT" = "NĐN";
+
+/* South-southwest, long */
+"COMPASS_SSW_LONG" = "nam tây nam";
+
+/* South-southwest, short */
+"COMPASS_SSW_SHORT" = "NTN";
+
+/* Southwest, long */
+"COMPASS_SW_LONG" = "tây nam";
+
+/* Southwest, short */
+"COMPASS_SW_SHORT" = "TN";
+
+/* Southwest by south, long */
+"COMPASS_SWbS_LONG" = "tây nam về nam";
+
+/* Southwest by south, short */
+"COMPASS_SWbS_SHORT" = "TNvN";
+
+/* Southwest by west, long */
+"COMPASS_SWbW_LONG" = "tây nam về tây";
+
+/* Southwest by west, short */
+"COMPASS_SWbW_SHORT" = "TNvT";
+
+/* West, long */
+"COMPASS_W_LONG" = "tây";
+
+/* West, short */
+"COMPASS_W_SHORT" = "T";
+
+/* West by north, long */
+"COMPASS_WbN_LONG" = "tây về bắc";
+
+/* West by north, short */
+"COMPASS_WbN_SHORT" = "TvB";
+
+/* West by south, long */
+"COMPASS_WbS_LONG" = "tây về nam";
+
+/* West by south, short */
+"COMPASS_WbS_SHORT" = "TvN";
+
+/* West-northwest, long */
+"COMPASS_WNW_LONG" = "tây tây bắc";
+
+/* West-northwest, short */
+"COMPASS_WNW_SHORT" = "TTB";
+
+/* West-southwest, long */
+"COMPASS_WSW_LONG" = "tây tây nam";
+
+/* West-southwest, short */
+"COMPASS_WSW_SHORT" = "TTN";
+
+/* Degrees format, long */
+"COORD_DEG_LONG" = "%d độ";
+
+/* Degrees format, medium: {degrees} */
+"COORD_DEG_MEDIUM" = "%d°";
+
+/* Degrees format, short: {degrees} */
+"COORD_DEG_SHORT" = "%d°";
+
+/* Coordinate format, long: {degrees}{minutes} */
+"COORD_DM_LONG" = "%1$@ %2$@";
+
+/* Coordinate format, medium: {degrees}{minutes} */
+"COORD_DM_MEDIUM" = "%1$@%2$@";
+
+/* Coordinate format, short: {degrees}{minutes} */
+"COORD_DM_SHORT" = "%1$@%2$@";
+
+/* Coordinate format, long: {degrees}{minutes}{seconds} */
+"COORD_DMS_LONG" = "%1$@, %2$@, %3$@";
+
+/* Coordinate format, medium: {degrees}{minutes}{seconds} */
+"COORD_DMS_MEDIUM" = "%1$@%2$@%3$@";
+
+/* Coordinate format, short: {degrees}{minutes}{seconds} */
+"COORD_DMS_SHORT" = "%1$@%2$@%3$@";
+
+/* East longitude format, long: {longitude} */
+"COORD_E_LONG" = "%@ kinh độ đông";
+
+/* East longitude format, medium: {longitude} */
+"COORD_E_MEDIUM" = "%@ đông";
+
+/* East longitude format, short: {longitude} */
+"COORD_E_SHORT" = "%@Đ";
+
+/* Coordinate pair format, long: {latitude}, {longitude} */
+"COORD_FMT_LONG" = "%1$@ và %2$@";
+
+/* Coordinate pair format, medium: {latitude}, {longitude} */
+"COORD_FMT_MEDIUM" = "%1$@, %2$@";
+
+/* Coordinate pair format, short: {latitude}, {longitude} */
+"COORD_FMT_SHORT" = "%1$@, %2$@";
+
+/* Minutes format, long */
+"COORD_MIN_LONG" = "%d phút";
+
+/* Minutes format, medium: {minutes} */
+"COORD_MIN_MEDIUM" = "%d′";
+
+/* Minutes format, short: {minutes} */
+"COORD_MIN_SHORT" = "%d′";
+
+/* North latitude format, long: {latitude} */
+"COORD_N_LONG" = "%@ vĩ độ bắc";
+
+/* North latitude format, medium: {latitude} */
+"COORD_N_MEDIUM" = "%@ bắc";
+
+/* North latitude format, short: {latitude} */
+"COORD_N_SHORT" = "%@N";
+
+/* South latitude format, long: {latitude} */
+"COORD_S_LONG" = "%@ vĩ độ nam";
+
+/* South latitude format, medium: {latitude} */
+"COORD_S_MEDIUM" = "%@ nam";
+
+/* South latitude format, short: {latitude} */
+"COORD_S_SHORT" = "%@N";
+
+/* Seconds format, long */
+"COORD_SEC_LONG" = "%d giây";
+
+/* Seconds format, medium: {seconds} */
+"COORD_SEC_MEDIUM" = "%d″";
+
+/* Seconds format, short: {seconds} */
+"COORD_SEC_SHORT" = "%d″";
+
+/* West longitude format, long: {longitude} */
+"COORD_W_LONG" = "%@ kinh độ tây";
+
+/* West longitude format, medium: {longitude} */
+"COORD_W_MEDIUM" = "%@ tây";
+
+/* West longitude format, short: {longitude} */
+"COORD_W_SHORT" = "%@T";
+

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -8,7 +8,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 * Added support for right-to-left text and Arabic ligatures in labels. ([#6984](https://github.com/mapbox/mapbox-gl-native/pull/6984), [#7123](https://github.com/mapbox/mapbox-gl-native/pull/7123))
 * Improved the line wrapping behavior of point-placed labels, especially labels written in Chinese and Japanese. ([#6828](https://github.com/mapbox/mapbox-gl-native/pull/6828), [#7446](https://github.com/mapbox/mapbox-gl-native/pull/7446))
-* Added Simplified and Traditional Chinese localizations. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316), [#7899](https://github.com/mapbox/mapbox-gl-native/pull/7899))
+* Added Chinese (Simplified and Traditional), French, German, Japanese, Portuguese (Brazilian), Swedish, and Vietnamese localizations. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316), [#7899](https://github.com/mapbox/mapbox-gl-native/pull/7899), [#7999](https://github.com/mapbox/mapbox-gl-native/pull/7999))
 
 ### Styles
 

--- a/platform/ios/framework/Settings.bundle/de.lproj/Root.strings
+++ b/platform/ios/framework/Settings.bundle/de.lproj/Root.strings
@@ -1,0 +1,3 @@
+﻿"TELEMETRY_GROUP_TITLE" = "Privatsphäre-Einstellungen";
+"TELEMETRY_SWITCH_TITLE" = "Mapbox-Telemetrie";
+"TELEMETRY_GROUP_FOOTER" = "Diese Einstellung erlaubt der Applikation, anonymisierte Orts- und Nutzungsdaten an Mapbox zu senden.";

--- a/platform/ios/framework/Settings.bundle/fr.lproj/Root.strings
+++ b/platform/ios/framework/Settings.bundle/fr.lproj/Root.strings
@@ -1,0 +1,3 @@
+﻿"TELEMETRY_GROUP_TITLE" = "Paramètres de confidentialité";
+"TELEMETRY_SWITCH_TITLE" = "Télémétrie Mapbox";
+"TELEMETRY_GROUP_FOOTER" = "Cette option permet à l’application de partager des données de localisation et d’utilisation anonymes avec Mapbox.";

--- a/platform/ios/framework/Settings.bundle/pt-BR.lproj/Root.strings
+++ b/platform/ios/framework/Settings.bundle/pt-BR.lproj/Root.strings
@@ -1,0 +1,3 @@
+﻿"TELEMETRY_GROUP_TITLE" = "Configurações de privacidade";
+"TELEMETRY_SWITCH_TITLE" = "Telemetria do Mapbox";
+"TELEMETRY_GROUP_FOOTER" = "Essa configuração permite que o aplicativo compartilhe dados de localização e uso anônimos com o Mapbox.";

--- a/platform/ios/framework/Settings.bundle/sv.lproj/Root.strings
+++ b/platform/ios/framework/Settings.bundle/sv.lproj/Root.strings
@@ -1,0 +1,3 @@
+﻿"TELEMETRY_GROUP_TITLE" = "Sekretessinställningar";
+"TELEMETRY_SWITCH_TITLE" = "Mapbox Telemetri";
+"TELEMETRY_GROUP_FOOTER" = "Denna inställning tillåter applikationen att dela anonymiserad plats och användningsdata med Mapbox.";

--- a/platform/ios/framework/Settings.bundle/vi.lproj/Root.strings
+++ b/platform/ios/framework/Settings.bundle/vi.lproj/Root.strings
@@ -1,0 +1,3 @@
+﻿"TELEMETRY_GROUP_TITLE" = "Thiết lập Quyền riêng tư";
+"TELEMETRY_SWITCH_TITLE" = "Trình viễn trắc Mapbox";
+"TELEMETRY_GROUP_FOOTER" = "Tùy chọn này cho phép ứng dụng gửi cho Mapbox các vị trí và dữ liệu sử dụng được vô danh hóa.";

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -679,6 +679,8 @@
 		DA35D0871E1A6309007DED41 /* one-liner.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "one-liner.json"; path = "../../darwin/test/one-liner.json"; sourceTree = "<group>"; };
 		DA3C6FF21E2859E700F962BE /* test-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "test-Bridging-Header.h"; path = "../../darwin/test/test-Bridging-Header.h"; sourceTree = "<group>"; };
 		DA4A26961CB6E795000B7809 /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mapbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA6023F11E4CE94300DBFF23 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DA6023F21E4CE94800DBFF23 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = sv; path = sv.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
 		DA6408D91DA4E7D300908C90 /* MGLVectorStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLVectorStyleLayer.h; sourceTree = "<group>"; };
 		DA6408DA1DA4E7D300908C90 /* MGLVectorStyleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLVectorStyleLayer.m; sourceTree = "<group>"; };
 		DA7262091DEEE3480043BB89 /* MGLOpenGLStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLOpenGLStyleLayer.h; sourceTree = "<group>"; };
@@ -781,6 +783,25 @@
 		DA8F25B91D51D2570010E6B5 /* MGLStyleLayerTests.mm.ejs */ = {isa = PBXFileReference; lastKnownFileType = text; name = MGLStyleLayerTests.mm.ejs; path = ../test/MGLStyleLayerTests.mm.ejs; sourceTree = "<group>"; };
 		DA8F25BA1D51D2570010E6B5 /* MGLStyleLayer.h.ejs */ = {isa = PBXFileReference; lastKnownFileType = text; path = MGLStyleLayer.h.ejs; sourceTree = "<group>"; };
 		DA8F25BB1D51D2570010E6B5 /* MGLStyleLayer.mm.ejs */ = {isa = PBXFileReference; lastKnownFileType = text; path = MGLStyleLayer.mm.ejs; sourceTree = "<group>"; };
+		DA9C012B1E4C7AD900C4742A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "pt-BR"; path = "pt-BR.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
+		DA9C012C1E4C7ADB00C4742A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "pt-BR"; path = "pt-BR.lproj/Foundation.stringsdict"; sourceTree = "<group>"; };
+		DA9C012D1E4C7B1F00C4742A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		DA9C012E1E4C7B6100C4742A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Root.strings"; sourceTree = "<group>"; };
+		DAA32CA11E4C44DB006F8D24 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
+		DAA32CA21E4C44DD006F8D24 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DAA32CA31E4C44F1006F8D24 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DAA32CA41E4C4502006F8D24 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAA32CA51E4C450F006F8D24 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Root.strings; sourceTree = "<group>"; };
+		DAA32CA91E4C4919006F8D24 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DAA32CAB1E4C491A006F8D24 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
+		DAA32CAC1E4C4971006F8D24 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAA32CB11E4C4C8A006F8D24 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Root.strings; sourceTree = "<group>"; };
+		DAA32CB51E4C4CF4006F8D24 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DAA32CB71E4C4ED8006F8D24 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAA32CB81E4C4EE6006F8D24 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Root.strings; sourceTree = "<group>"; };
+		DAA32CBC1E4C4F5D006F8D24 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAA32CBD1E4C4F62006F8D24 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DAA32CBE1E4C4F71006F8D24 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Root.strings; sourceTree = "<group>"; };
 		DAA4E4021CBB5C2F00178DFB /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		DAA4E4041CBB5C9E00178DFB /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		DAA4E4061CBB5CBF00178DFB /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
@@ -1640,7 +1661,6 @@
 				354B83971D2E873E005D9406 /* MGLUserLocationAnnotationView.h in Headers */,
 				DAF0D8111DFE0EA000B28378 /* MGLRasterSource_Private.h in Headers */,
 				DABFB86B1CBE99E500D62B32 /* MGLTilePyramidOfflineRegion.h in Headers */,
-				3557F7B11E1D27D300CCA5E6 /* MGLDistanceFormatter.h in Headers */,
 				4018B1CB1CDC288E00F666AF /* MGLAnnotationView.h in Headers */,
 				DABFB85F1CBE99E500D62B32 /* MGLGeometry.h in Headers */,
 				7E016D851D9E890300A29A21 /* MGLPolygon+MGLAdditions.h in Headers */,
@@ -1834,6 +1854,12 @@
 				Base,
 				"zh-Hans",
 				"zh-Hant",
+				de,
+				fr,
+				ja,
+				sv,
+				vi,
+				"pt-BR",
 			);
 			mainGroup = DA1DC9411CB6C1C2006E619F;
 			productRefGroup = DA1DC94B1CB6C1C2006E619F /* Products */;
@@ -2209,6 +2235,11 @@
 				DA25D5C51CCDA06800607828 /* Base */,
 				20DABE8A1DF78149007AC5FF /* zh-Hans */,
 				DAFBD0D41E3FA7A2000CD6BF /* zh-Hant */,
+				DAA32CA51E4C450F006F8D24 /* de */,
+				DAA32CB11E4C4C8A006F8D24 /* fr */,
+				DAA32CB81E4C4EE6006F8D24 /* sv */,
+				DAA32CBE1E4C4F71006F8D24 /* vi */,
+				DA9C012E1E4C7B6100C4742A /* pt-BR */,
 			);
 			name = Root.strings;
 			sourceTree = "<group>";
@@ -2219,6 +2250,11 @@
 				DA8933A01CCC951200E68420 /* Base */,
 				20DABE881DF78148007AC5FF /* zh-Hans */,
 				DAFBD0D31E3FA7A1000CD6BF /* zh-Hant */,
+				DAA32CA41E4C4502006F8D24 /* de */,
+				DAA32CAC1E4C4971006F8D24 /* fr */,
+				DAA32CB71E4C4ED8006F8D24 /* sv */,
+				DAA32CBC1E4C4F5D006F8D24 /* vi */,
+				DA9C012D1E4C7B1F00C4742A /* pt-BR */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -2229,6 +2265,10 @@
 				DA8933BB1CCD2CA100E68420 /* Base */,
 				20DABE861DF78148007AC5FF /* zh-Hans */,
 				DAFBD0D21E3FA7A1000CD6BF /* zh-Hant */,
+				DAA32CA31E4C44F1006F8D24 /* de */,
+				DAA32CB51E4C4CF4006F8D24 /* ja */,
+				DAA32CBD1E4C4F62006F8D24 /* vi */,
+				DA6023F11E4CE94300DBFF23 /* sv */,
 			);
 			name = Foundation.strings;
 			sourceTree = "<group>";
@@ -2237,6 +2277,10 @@
 			isa = PBXVariantGroup;
 			children = (
 				DA8933BE1CCD2CAD00E68420 /* en */,
+				DAA32CA11E4C44DB006F8D24 /* de */,
+				DAA32CAB1E4C491A006F8D24 /* fr */,
+				DA9C012C1E4C7ADB00C4742A /* pt-BR */,
+				DA6023F21E4CE94800DBFF23 /* sv */,
 			);
 			name = Foundation.stringsdict;
 			sourceTree = "<group>";
@@ -2253,6 +2297,9 @@
 			isa = PBXVariantGroup;
 			children = (
 				DAC49C621CD07D74009E1AA3 /* en */,
+				DAA32CA21E4C44DD006F8D24 /* de */,
+				DAA32CA91E4C4919006F8D24 /* fr */,
+				DA9C012B1E4C7AD900C4742A /* pt-BR */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";

--- a/platform/ios/resources/de.lproj/Localizable.strings
+++ b/platform/ios/resources/de.lproj/Localizable.strings
@@ -1,0 +1,75 @@
+﻿/* Accessibility hint */
+"ANNOTATION_A11Y_HINT" = "Mehr Infos anzeigen";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_DESC" = "Der Data-Task der Sitzung ist fehlgeschlagen. Die ursprüngliche Anfrage war: %@";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_REASON" = "Der Statuscode ist %ld";
+
+/* No comment provided by engineer. */
+"CANCEL" = "Abbrechen";
+
+/* Accessibility hint */
+"COMPASS_A11Y_HINT" = "Dreht die Karte nach Norden";
+
+/* Accessibility label */
+"COMPASS_A11Y_LABEL" = "Kompass";
+
+/* Compass abbreviation for north */
+"COMPASS_NORTH" = "N";
+
+/* Instructions in Interface Builder designable; {key}, {plist file name} */
+"DESIGNABLE" = "Um hier eine von Mapbox-Karte anzuzeigen, muss das Zugriffs-Token als %1$@ in %2$@ eingetragen werden.\n\nFür detaillierte Informationen, siehe:";
+
+/* Setup documentation URL display string; keep as short as possible */
+"FIRST_STEPS_URL" = "mapbox.com/help/first-steps-ios-sdk";
+
+/* Accessibility hint */
+"INFO_A11Y_HINT" = "Zeigt Danksagunen, ein Kontakformular und mehr an";
+
+/* Accessibility label */
+"INFO_A11Y_LABEL" = "Über diese Karte";
+
+/* Accessibility label */
+"LOGO_A11Y_LABEL" = "Mapbox";
+
+/* Accessibility label */
+"MAP_A11Y_LABEL" = "Karte";
+
+/* Map accessibility value */
+"MAP_A11Y_VALUE" = "Zoomstufe %1$d\n%2$ld Anmerkung(en) sichtbar";
+
+/* Action sheet title */
+"SDK_NAME" = "Mapbox iOS SDK";
+
+/* Telemetry prompt message */
+"TELEMETRY_DISABLED_MSG" = "Durch anonymisierte Nutzungsdaten können Sie helfen, OpenStreetMap- und Mapbox-Karten zu verbessern.";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_OFF" = "Nicht teilnehmen";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_ON" = "Teilnehmen";
+
+/* Telemetry prompt message */
+"TELEMETRY_ENABLED_MSG" = "Durch anonymisierte Nutzungsdaten helfen Sie, OpenStreetMap- und Mapbox-Karten zu verbessern.";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_OFF" = "Teilnahme beenden";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_ON" = "Weiterhin teilnehmen";
+
+/* Telemetry prompt button */
+"TELEMETRY_MORE" = "Mehr Informationen";
+
+/* Action in attribution sheet */
+"TELEMETRY_NAME" = "Mapbox-Telemetrie";
+
+/* Telemetry prompt title */
+"TELEMETRY_TITLE" = "Mapbox-Karten verbessern";
+
+/* Default user location annotation title */
+"USER_DOT_TITLE" = "Sie sind hier";
+

--- a/platform/ios/resources/de.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/de.lproj/Localizable.stringsdict
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MAP_A11Y_VALUE</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Zoomstufe %d
+%#@count@ sichtbar</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>%d Anmerkung</string>
+			<key>other</key>
+			<string>%d Anmerkungen</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/platform/ios/resources/fr.lproj/Localizable.strings
+++ b/platform/ios/resources/fr.lproj/Localizable.strings
@@ -1,0 +1,75 @@
+﻿/* Accessibility hint */
+"ANNOTATION_A11Y_HINT" = "Voir plus d’informations";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_DESC" = "La tâche de données pour cette session a échouée. Requête originale : %@";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_REASON" = "Le code d’erreur était %ld";
+
+/* No comment provided by engineer. */
+"CANCEL" = "Annuler";
+
+/* Accessibility hint */
+"COMPASS_A11Y_HINT" = "Tourne la carte vers le nord";
+
+/* Accessibility label */
+"COMPASS_A11Y_LABEL" = "Boussole";
+
+/* Compass abbreviation for north */
+"COMPASS_NORTH" = "N";
+
+/* Instructions in Interface Builder designable; {key}, {plist file name} */
+"DESIGNABLE" = "Pour afficher une carte hébergée par Mapbox, remplacez %1$@ par votre token d’accès dans %2$@\n\nPour plus d’informations, voir :";
+
+/* Setup documentation URL display string; keep as short as possible */
+"FIRST_STEPS_URL" = "mapbox.com/help/first-steps-ios-sdk";
+
+/* Accessibility hint */
+"INFO_A11Y_HINT" = "Montre les crédits, un formulaire de retour d’expérience, et plus.";
+
+/* Accessibility label */
+"INFO_A11Y_LABEL" = "À propos de cette carte";
+
+/* Accessibility label */
+"LOGO_A11Y_LABEL" = "Mapbox";
+
+/* Accessibility label */
+"MAP_A11Y_LABEL" = "Carte";
+
+/* Map accessibility value */
+"MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld annotation(s) visible(s)";
+
+/* Action sheet title */
+"SDK_NAME" = "Mapbox iOS SDK";
+
+/* Telemetry prompt message */
+"TELEMETRY_DISABLED_MSG" = "Vous pouvez contribuer à OpenStreetMap et Mapbox en partageant des données d’utilisation anonymes.";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_OFF" = "Ne pas participer";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_ON" = "Participer";
+
+/* Telemetry prompt message */
+"TELEMETRY_ENABLED_MSG" = "Vous aidez à améliorer OpenStreetMap et Mapbox en partageant des données d’utilisation anonymes.";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_OFF" = "Ne plus participer";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_ON" = "Continuer à participer";
+
+/* Telemetry prompt button */
+"TELEMETRY_MORE" = "En savoir plus";
+
+/* Action in attribution sheet */
+"TELEMETRY_NAME" = "Télémétrie Mapbox";
+
+/* Telemetry prompt title */
+"TELEMETRY_TITLE" = "Améliorez les cartes Mapbox";
+
+/* Default user location annotation title */
+"USER_DOT_TITLE" = "Vous êtes ici";
+

--- a/platform/ios/resources/fr.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/fr.lproj/Localizable.stringsdict
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MAP_A11Y_VALUE</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Zoom %dx
+%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>%d annotation visible</string>
+			<key>other</key>
+			<string>%d annotations visibles</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/platform/ios/resources/pt-BR.lproj/Localizable.strings
+++ b/platform/ios/resources/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,75 @@
+﻿/* Accessibility hint */
+"ANNOTATION_A11Y_HINT" = "Mostrar mais informações";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_DESC" = "The session data task failed. Original request was: %@";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_REASON" = "O código de status foi %ld";
+
+/* No comment provided by engineer. */
+"CANCEL" = "Cancelar";
+
+/* Accessibility hint */
+"COMPASS_A11Y_HINT" = "Rotaciona o mapa com face ao norte";
+
+/* Accessibility label */
+"COMPASS_A11Y_LABEL" = "Compasso";
+
+/* Compass abbreviation for north */
+"COMPASS_NORTH" = "N";
+
+/* Instructions in Interface Builder designable; {key}, {plist file name} */
+"DESIGNABLE" = "To display a Mapbox-hosted map here, set %1$@ to your access token in %2$@\n\nFor detailed instructions, see:";
+
+/* Setup documentation URL display string; keep as short as possible */
+"FIRST_STEPS_URL" = "mapbox.com/help/first-steps-ios-sdk";
+
+/* Accessibility hint */
+"INFO_A11Y_HINT" = "Mostra os créditos, um formulário de avaliação, e mais";
+
+/* Accessibility label */
+"INFO_A11Y_LABEL" = "Sobre este mapa";
+
+/* Accessibility label */
+"LOGO_A11Y_LABEL" = "Mapbox";
+
+/* Accessibility label */
+"MAP_A11Y_LABEL" = "Mapa";
+
+/* Map accessibility value */
+"MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld anotações visíveis";
+
+/* Action sheet title */
+"SDK_NAME" = "Mapbox iOS SDK";
+
+/* Telemetry prompt message */
+"TELEMETRY_DISABLED_MSG" = "You can help make OpenStreetMap and Mapbox maps better by contributing anonymous usage data.";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_OFF" = "Não Participar";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_ON" = "Participar";
+
+/* Telemetry prompt message */
+"TELEMETRY_ENABLED_MSG" = "You are helping to make OpenStreetMap and Mapbox maps better by contributing anonymous usage data.";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_OFF" = "Parar de Participar";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_ON" = "Continuar Participando";
+
+/* Telemetry prompt button */
+"TELEMETRY_MORE" = "Me Diga Mais";
+
+/* Action in attribution sheet */
+"TELEMETRY_NAME" = "Telemetria do Mapbox";
+
+/* Telemetry prompt title */
+"TELEMETRY_TITLE" = "Melhorar os Mapas do Mapbox";
+
+/* Default user location annotation title */
+"USER_DOT_TITLE" = "Você Está Aqui";
+

--- a/platform/ios/resources/pt-BR.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/pt-BR.lproj/Localizable.stringsdict
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MAP_A11Y_VALUE</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Zoom %dx
+%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>%d anotação visível</string>
+			<key>other</key>
+			<string>%d anotações visíveis</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/platform/ios/resources/sv.lproj/Localizable.strings
+++ b/platform/ios/resources/sv.lproj/Localizable.strings
@@ -1,0 +1,75 @@
+﻿/* Accessibility hint */
+"ANNOTATION_A11Y_HINT" = "Visa mer information";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_DESC" = "Sessionens anrop misslyckades. Originalanropet var: %@";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_REASON" = "Statuskoden var %ld";
+
+/* No comment provided by engineer. */
+"CANCEL" = "Avbryt";
+
+/* Accessibility hint */
+"COMPASS_A11Y_HINT" = "Roterar kartan mot norr";
+
+/* Accessibility label */
+"COMPASS_A11Y_LABEL" = "Kompass";
+
+/* Compass abbreviation for north */
+"COMPASS_NORTH" = "N";
+
+/* Instructions in Interface Builder designable; {key}, {plist file name} */
+"DESIGNABLE" = "Sätt %1$@ till din access token i %2$@ för att visa kartan som Mapbox levererar.";
+
+/* Setup documentation URL display string; keep as short as possible */
+"FIRST_STEPS_URL" = "mapbox.com/help/first-steps-ios-sdk";
+
+/* Accessibility hint */
+"INFO_A11Y_HINT" = "Visa medverkande, återkopplingsformulär och mer.";
+
+/* Accessibility label */
+"INFO_A11Y_LABEL" = "Om den här kartan";
+
+/* Accessibility label */
+"LOGO_A11Y_LABEL" = "Mapbox";
+
+/* Accessibility label */
+"MAP_A11Y_LABEL" = "Karta";
+
+/* Map accessibility value */
+"MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld annotation(s) visible";
+
+/* Action sheet title */
+"SDK_NAME" = "Mapbox iOS SDK";
+
+/* Telemetry prompt message */
+"TELEMETRY_DISABLED_MSG" = "Du kan hjälpa till att göra OpenStreetMap och Mapbox karttjänster bättre genom att bidra med anonymiserad användningsdata.";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_OFF" = "Avstå";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_ON" = "Delta";
+
+/* Telemetry prompt message */
+"TELEMETRY_ENABLED_MSG" = "Du hjälper till att göra OpenStreetMap och Mapbox karttjänster bättre genom att bidra med anonymiserad användningsdata.";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_OFF" = "Avsluta deltagandet";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_ON" = "Fortsätt deltagandet";
+
+/* Telemetry prompt button */
+"TELEMETRY_MORE" = "Visa mer";
+
+/* Action in attribution sheet */
+"TELEMETRY_NAME" = "Mapbox Telemetri";
+
+/* Telemetry prompt title */
+"TELEMETRY_TITLE" = "Gör Mapbox kartor bättre";
+
+/* Default user location annotation title */
+"USER_DOT_TITLE" = "Där är här";
+

--- a/platform/ios/resources/vi.lproj/Localizable.strings
+++ b/platform/ios/resources/vi.lproj/Localizable.strings
@@ -1,0 +1,75 @@
+﻿/* Accessibility hint */
+"ANNOTATION_A11Y_HINT" = "Hiển thị thêm thông tin";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_DESC" = "Tác vụ lấy dữ liệu của phiên làm việc bị thất bại. Yêu cầu ban đầu là: %@";
+
+/* No comment provided by engineer. */
+"API_CLIENT_400_REASON" = "Mã trạng thái là %ld";
+
+/* No comment provided by engineer. */
+"CANCEL" = "Hủy bỏ";
+
+/* Accessibility hint */
+"COMPASS_A11Y_HINT" = "Quay bản đồ về hướng bắc";
+
+/* Accessibility label */
+"COMPASS_A11Y_LABEL" = "La bàn";
+
+/* Compass abbreviation for north */
+"COMPASS_NORTH" = "B";
+
+/* Instructions in Interface Builder designable; {key}, {plist file name} */
+"DESIGNABLE" = "Để hiển thị bản đồ do Mapbox phục vụ tại đây, đặt %1$@ là dấu hiệu truy cập của bạn trong %2$@\n\nXem hướng dẫn chi tiết tại:";
+
+/* Setup documentation URL display string; keep as short as possible */
+"FIRST_STEPS_URL" = "mapbox.com/help/first-steps-ios-sdk";
+
+/* Accessibility hint */
+"INFO_A11Y_HINT" = "Hiển thị lời ghi công, biểu mẫu phản hồi, và thêm nữa";
+
+/* Accessibility label */
+"INFO_A11Y_LABEL" = "Giới thiệu về bản đồ này";
+
+/* Accessibility label */
+"LOGO_A11Y_LABEL" = "Mapbox";
+
+/* Accessibility label */
+"MAP_A11Y_LABEL" = "Bản đồ";
+
+/* Map accessibility value */
+"MAP_A11Y_VALUE" = "Thu phóng gấp %1$d lần\n%2$ld chú thích đang xuất hiện";
+
+/* Action sheet title */
+"SDK_NAME" = "Mapbox iOS SDK";
+
+/* Telemetry prompt message */
+"TELEMETRY_DISABLED_MSG" = "Hãy giúp cải tiến các bản đồ OpenStreetMap và Mapbox bằng cách đóng góp dữ liệu vô danh hóa về cách sử dụng.";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_OFF" = "Không Tham gia";
+
+/* Telemetry prompt button */
+"TELEMETRY_DISABLED_ON" = "Tham gia";
+
+/* Telemetry prompt message */
+"TELEMETRY_ENABLED_MSG" = "Bạn đang giúp cải tiến các bản đồ OpenStreetMap và Mapbox bằng cách đóng góp dữ liệu vô danh hóa về cách sử dụng.";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_OFF" = "Ngừng Tham gia";
+
+/* Telemetry prompt button */
+"TELEMETRY_ENABLED_ON" = "Tiếp tục Tham gia";
+
+/* Telemetry prompt button */
+"TELEMETRY_MORE" = "Tìm hiểu Thêm";
+
+/* Action in attribution sheet */
+"TELEMETRY_NAME" = "Trình viễn trắc Mapbox";
+
+/* Telemetry prompt title */
+"TELEMETRY_TITLE" = "Cải tiến các Bản đồ Mapbox";
+
+/* Default user location annotation title */
+"USER_DOT_TITLE" = "Bạn ở Đây";
+

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Added support for right-to-left text and Arabic ligatures in labels. ([#6984](https://github.com/mapbox/mapbox-gl-native/pull/6984), [#7123](https://github.com/mapbox/mapbox-gl-native/pull/7123))
 * Improved the line wrapping behavior of point-placed labels, especially labels written in Chinese and Japanese. ([#6828](https://github.com/mapbox/mapbox-gl-native/pull/6828), [#7446](https://github.com/mapbox/mapbox-gl-native/pull/7446))
-* Added Simplified and Traditional Chinese localizations. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316), [#7503](https://github.com/mapbox/mapbox-gl-native/pull/7503), [#7899](https://github.com/mapbox/mapbox-gl-native/pull/7899))
+* Added Chinese (Simplified and Traditional), French, German, Japanese, Portuguese (Brazilian), Swedish, and Vietnamese localizations. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316), [#7503](https://github.com/mapbox/mapbox-gl-native/pull/7503), [#7899](https://github.com/mapbox/mapbox-gl-native/pull/7899), [#7999](https://github.com/mapbox/mapbox-gl-native/pull/7999))
 
 ### Styles
 

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -345,6 +345,8 @@
 		DA551B801DB496AC0009AFAF /* MGLTileSource_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLTileSource_Private.h; sourceTree = "<group>"; };
 		DA551B811DB496AC0009AFAF /* MGLTileSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLTileSource.mm; sourceTree = "<group>"; };
 		DA5589761D320C41006B7F64 /* wms.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = wms.json; sourceTree = "<group>"; };
+		DA6023EF1E4CE8E500DBFF23 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DA6023F01E4CE8FF00DBFF23 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = sv; path = sv.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
 		DA6408D51DA4E5DA00908C90 /* MGLVectorStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLVectorStyleLayer.h; sourceTree = "<group>"; };
 		DA6408D61DA4E5DA00908C90 /* MGLVectorStyleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLVectorStyleLayer.m; sourceTree = "<group>"; };
 		DA7262051DEEDD460043BB89 /* MGLOpenGLStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLOpenGLStyleLayer.h; sourceTree = "<group>"; };
@@ -394,7 +396,19 @@
 		DA8F25B51D51D2240010E6B5 /* MGLStyleLayerTests.mm.ejs */ = {isa = PBXFileReference; lastKnownFileType = text; name = MGLStyleLayerTests.mm.ejs; path = ../test/MGLStyleLayerTests.mm.ejs; sourceTree = "<group>"; };
 		DA8F25B61D51D2240010E6B5 /* MGLStyleLayer.h.ejs */ = {isa = PBXFileReference; lastKnownFileType = text; path = MGLStyleLayer.h.ejs; sourceTree = "<group>"; };
 		DA8F25B71D51D2240010E6B5 /* MGLStyleLayer.mm.ejs */ = {isa = PBXFileReference; lastKnownFileType = text; path = MGLStyleLayer.mm.ejs; sourceTree = "<group>"; };
+		DA9C01301E4C7B9300C4742A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "pt-BR"; path = "pt-BR.lproj/Foundation.stringsdict"; sourceTree = "<group>"; };
+		DA9C01311E4C7B9F00C4742A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		DAA1BB491E2D425C00ABB750 /* libmbgl-loop.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libmbgl-loop.a"; path = "../../build/macos/Debug/libmbgl-loop.a"; sourceTree = "<group>"; };
+		DAA32CA61E4C4849006F8D24 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAA32CA71E4C486D006F8D24 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DAA32CA81E4C48B9006F8D24 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
+		DAA32CAE1E4C4B03006F8D24 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
+		DAA32CAF1E4C4B0D006F8D24 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAA32CB21E4C4CB7006F8D24 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DAA32CB31E4C4CC3006F8D24 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAA32CBA1E4C4F10006F8D24 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAA32CC01E4C4F89006F8D24 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Foundation.strings; sourceTree = "<group>"; };
+		DAA32CC11E4C4F93006F8D24 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DAA48EFB1D6A4731006A7E36 /* StyleLayerIconTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StyleLayerIconTransformer.h; sourceTree = "<group>"; };
 		DAA48EFC1D6A4731006A7E36 /* StyleLayerIconTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StyleLayerIconTransformer.m; sourceTree = "<group>"; };
 		DAB2CCE31DF632ED001B2FE1 /* LimeGreenStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LimeGreenStyleLayer.h; sourceTree = "<group>"; };
@@ -1190,6 +1204,12 @@
 				Base,
 				"zh-Hans",
 				"zh-Hant",
+				de,
+				fr,
+				ja,
+				sv,
+				vi,
+				"pt-BR",
 			);
 			mainGroup = DA839E891CC2E3400062CAFB;
 			productRefGroup = DA839E931CC2E3400062CAFB /* Products */;
@@ -1413,6 +1433,12 @@
 				DA8933AC1CCD290700E68420 /* Base */,
 				DA88520F1E0A4D0D009D7AD6 /* zh-Hans */,
 				DAFBD0D51E3FA969000CD6BF /* zh-Hant */,
+				DAA32CA61E4C4849006F8D24 /* de */,
+				DAA32CAF1E4C4B0D006F8D24 /* fr */,
+				DAA32CB31E4C4CC3006F8D24 /* ja */,
+				DAA32CBA1E4C4F10006F8D24 /* sv */,
+				DAA32CC11E4C4F93006F8D24 /* vi */,
+				DA9C01311E4C7B9F00C4742A /* pt-BR */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -1423,6 +1449,10 @@
 				DA8933B41CCD2C2500E68420 /* Base */,
 				DA8852101E0A4D3A009D7AD6 /* zh-Hans */,
 				DAFBD0D61E3FA983000CD6BF /* zh-Hant */,
+				DAA32CA71E4C486D006F8D24 /* de */,
+				DAA32CB21E4C4CB7006F8D24 /* ja */,
+				DAA32CC01E4C4F89006F8D24 /* vi */,
+				DA6023EF1E4CE8E500DBFF23 /* sv */,
 			);
 			name = Foundation.strings;
 			sourceTree = "<group>";
@@ -1431,6 +1461,10 @@
 			isa = PBXVariantGroup;
 			children = (
 				DA8933B71CCD2C2D00E68420 /* en */,
+				DAA32CA81E4C48B9006F8D24 /* de */,
+				DAA32CAE1E4C4B03006F8D24 /* fr */,
+				DA9C01301E4C7B9300C4742A /* pt-BR */,
+				DA6023F01E4CE8FF00DBFF23 /* sv */,
 			);
 			name = Foundation.stringsdict;
 			sourceTree = "<group>";

--- a/platform/macos/sdk/de.lproj/Localizable.strings
+++ b/platform/macos/sdk/de.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+﻿/* Accessibility title */
+"MAP_A11Y_TITLE" = "Mapbox";
+
+/* Label of Zoom In button */
+"ZOOM_IN_LABEL" = "+";
+
+/* Tooltip of Zoom In button */
+"ZOOM_IN_TOOLTIP" = "Vergrößern";
+
+/* Label of Zoom Out button; U+2212 MINUS SIGN */
+"ZOOM_OUT_LABEL" = "−";
+
+/* Tooltip of Zoom Out button */
+"ZOOM_OUT_TOOLTIP" = "Verkleinern";
+

--- a/platform/macos/sdk/fr.lproj/Localizable.strings
+++ b/platform/macos/sdk/fr.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+﻿/* Accessibility title */
+"MAP_A11Y_TITLE" = "Mapbox";
+
+/* Label of Zoom In button */
+"ZOOM_IN_LABEL" = "+";
+
+/* Tooltip of Zoom In button */
+"ZOOM_IN_TOOLTIP" = "Zoomer";
+
+/* Label of Zoom Out button; U+2212 MINUS SIGN */
+"ZOOM_OUT_LABEL" = "−";
+
+/* Tooltip of Zoom Out button */
+"ZOOM_OUT_TOOLTIP" = "Dézoomer";
+

--- a/platform/macos/sdk/ja.lproj/Localizable.strings
+++ b/platform/macos/sdk/ja.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+﻿/* Accessibility title */
+"MAP_A11Y_TITLE" = "Mapbox";
+
+/* Label of Zoom In button */
+"ZOOM_IN_LABEL" = "+";
+
+/* Tooltip of Zoom In button */
+"ZOOM_IN_TOOLTIP" = "ズームイン";
+
+/* Label of Zoom Out button; U+2212 MINUS SIGN */
+"ZOOM_OUT_LABEL" = "−";
+
+/* Tooltip of Zoom Out button */
+"ZOOM_OUT_TOOLTIP" = "ズームアウト";
+

--- a/platform/macos/sdk/pt-BR.lproj/Localizable.strings
+++ b/platform/macos/sdk/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+﻿/* Accessibility title */
+"MAP_A11Y_TITLE" = "Mapbox";
+
+/* Label of Zoom In button */
+"ZOOM_IN_LABEL" = "+";
+
+/* Tooltip of Zoom In button */
+"ZOOM_IN_TOOLTIP" = "Aumentar Zoom";
+
+/* Label of Zoom Out button; U+2212 MINUS SIGN */
+"ZOOM_OUT_LABEL" = "−";
+
+/* Tooltip of Zoom Out button */
+"ZOOM_OUT_TOOLTIP" = "Reduzir Zoom";
+

--- a/platform/macos/sdk/sv.lproj/Localizable.strings
+++ b/platform/macos/sdk/sv.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+﻿/* Accessibility title */
+"MAP_A11Y_TITLE" = "Mapbox";
+
+/* Label of Zoom In button */
+"ZOOM_IN_LABEL" = "+";
+
+/* Tooltip of Zoom In button */
+"ZOOM_IN_TOOLTIP" = "Zooma in";
+
+/* Label of Zoom Out button; U+2212 MINUS SIGN */
+"ZOOM_OUT_LABEL" = "−";
+
+/* Tooltip of Zoom Out button */
+"ZOOM_OUT_TOOLTIP" = "Zooma ut";
+

--- a/platform/macos/sdk/vi.lproj/Localizable.strings
+++ b/platform/macos/sdk/vi.lproj/Localizable.strings
@@ -1,0 +1,15 @@
+﻿/* Accessibility title */
+"MAP_A11Y_TITLE" = "Mapbox";
+
+/* Label of Zoom In button */
+"ZOOM_IN_LABEL" = "+";
+
+/* Tooltip of Zoom In button */
+"ZOOM_IN_TOOLTIP" = "Phóng to";
+
+/* Label of Zoom Out button; U+2212 MINUS SIGN */
+"ZOOM_OUT_LABEL" = "−";
+
+/* Tooltip of Zoom Out button */
+"ZOOM_OUT_TOOLTIP" = "Thu nhỏ";
+


### PR DESCRIPTION
Pulled the latest translations from Transifex and added new languages to the iOS and macOS projects. Added .stringsdict files according to issues posted to Transifex by translators. The `tx` configuration included languages with at least one file translated 80% or more. Brazilian Portuguese, French, and Japanese are partial translations at this time.

/cc @friedbunny @frederoni @kkaefer @brunoabinader