### PR TITLE
macOS: reuse OpenGL context when switching screens

### DIFF
--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Improved the line wrapping behavior of point-placed labels, especially labels written in Chinese and Japanese. ([#6828](https://github.com/mapbox/mapbox-gl-native/pull/6828), [#7446](https://github.com/mapbox/mapbox-gl-native/pull/7446))
 * CJK characters now remain upright in vertically oriented labels that have line placement, such as road labels. ([#7114](https://github.com/mapbox/mapbox-gl-native/issues/7114))
 * Added Chinese (Simplified and Traditional), French, German, Japanese, Portuguese (Brazilian), Swedish, and Vietnamese localizations. ([#7316](https://github.com/mapbox/mapbox-gl-native/pull/7316), [#7503](https://github.com/mapbox/mapbox-gl-native/pull/7503), [#7899](https://github.com/mapbox/mapbox-gl-native/pull/7899), [#7999](https://github.com/mapbox/mapbox-gl-native/pull/7999))
+* Fixed an issue that let the app crash when moving the window between screens. ([#8004](https://github.com/mapbox/mapbox-gl-native/pull/8004))
 
 ### Styles
 

--- a/platform/macos/src/MGLOpenGLLayer.mm
+++ b/platform/macos/src/MGLOpenGLLayer.mm
@@ -2,7 +2,9 @@
 
 #import "MGLMapView_Private.h"
 
-@implementation MGLOpenGLLayer
+@implementation MGLOpenGLLayer {
+    NSOpenGLContext *_context;
+}
 
 - (MGLMapView *)mapView {
     return (MGLMapView *)super.view;
@@ -18,6 +20,13 @@
 
 - (CGRect)frame {
     return self.view.bounds;
+}
+
+- (NSOpenGLContext *)openGLContextForPixelFormat:(NSOpenGLPixelFormat *)pixelFormat {
+    if (!_context) {
+        _context = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
+    }
+    return _context;
 }
 
 - (NSOpenGLPixelFormat *)openGLPixelFormatForDisplayMask:(uint32_t)mask {


### PR DESCRIPTION
Fixes #6654