### PR TITLE
Mark MGLStyleFunction as abstract in documentation navigation

### DIFF
--- a/platform/darwin/docs/theme/assets/css/jazzy.css.scss
+++ b/platform/darwin/docs/theme/assets/css/jazzy.css.scss
@@ -383,6 +383,7 @@ pre code {
 .nav-group-task[data-name="MGLMultiPoint"],
 .nav-group-task[data-name="MGLShape"],
 .nav-group-task[data-name="MGLSource"],
+.nav-group-task[data-name="MGLStyleFunction"],
 .nav-group-task[data-name="MGLStyleLayer"],
 .nav-group-task[data-name="MGLTileSource"],
 .nav-group-task[data-name="MGLVectorStyleLayer"] {


### PR DESCRIPTION
Added MGLStyleFunction to the list of classes to mark as abstract classes in the sidebar of the jazzy-generated documentation. MGLStyleFunction became an abstract class in #7943.

/cc @boundsj