### PR TITLE
Use newer GLFW version that supports automated graphic switching

### DIFF
--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -42,6 +42,8 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
         height = videoMode->height;
     }
 
+    glfwWindowHint(GLFW_COCOA_GRAPHICS_SWITCHING, GL_TRUE);
+
 #ifdef DEBUG
     glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
 #endif

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -1,4 +1,4 @@
-mason_use(glfw VERSION 3.2.1)
+mason_use(glfw VERSION 2017-02-09-77a8f10)
 mason_use(mesa VERSION 13.0.4)
 mason_use(boost_libprogram_options VERSION 1.62.0${MASON_CXXABI_SUFFIX})
 mason_use(sqlite VERSION 3.14.2)

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -1,6 +1,6 @@
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
 
-mason_use(glfw VERSION 3.2.1)
+mason_use(glfw VERSION 2017-02-09-77a8f10)
 mason_use(boost_libprogram_options VERSION 1.62.0)
 mason_use(gtest VERSION 1.8.0)
 mason_use(benchmark VERSION 1.0.0-1)


### PR DESCRIPTION
Makes testing/comparison with https://github.com/mapbox/mapbox-gl-native/issues/7820 easier.