### PR TITLE
Update SDK dependency to MAS beta.1

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -13,12 +13,12 @@ dependencies {
     compile 'com.jakewharton.timber:timber:4.3.1'
 
     // Mapbox Android Services (GeoJSON support)
-    compile('com.mapbox.mapboxsdk:mapbox-java-geojson:2.0.0-SNAPSHOT@jar') {
+    compile('com.mapbox.mapboxsdk:mapbox-java-geojson:2.0.0-beta.1@jar') {
         transitive = true
     }
 
     // Mapbox Android Services (Telemetry support)
-    compile('com.mapbox.mapboxsdk:mapbox-android-telemetry:2.0.0-SNAPSHOT@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-telemetry:2.0.0-beta.1@aar') {
         transitive = true
     }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     testCompile "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
 
     // Mapbox Android Services (Java component)
-    compile('com.mapbox.mapboxsdk:mapbox-java-services:2.0.0-SNAPSHOT@jar') {
+    compile('com.mapbox.mapboxsdk:mapbox-java-services:2.0.0-beta.1@jar') {
         transitive = true
     }
 

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -13,7 +12,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 


### PR DESCRIPTION
Progress towards https://github.com/mapbox/mapbox-gl-native/issues/7643.

Background on the new version of MAS is on https://github.com/mapbox/mapbox-java/issues/322.
