### PR TITLE
Convert NSColor/UIColor expressions to CSS color string values

### DIFF
--- a/platform/darwin/src/MGLFeature.h
+++ b/platform/darwin/src/MGLFeature.h
@@ -83,12 +83,21 @@ NS_ASSUME_NONNULL_BEGIN
  `MGLVectorStyleLayer.predicate` to an `NSPredicate` with the format
  `importance > 50`.
 
- You can also configure some attributes of an `MGLSymbolStyleLayer` object to
- include the value of an attribute in this dictionary whenever it renders this
- feature. For example, to label features in an `MGLShapeSource` object by their
- names, you can assign a `name` attribute to each of the source’s features, then
- set `MGLSymbolStyleLayer.textField` to an `MGLStyleValue` object containing the
- string `{name}`.
+ You can also configure many layout and paint attributes of an `MGLStyleLayer`
+ object to match the value of an attribute in this dictionary whenever it
+ renders this feature. For example, if you display features in an
+ `MGLShapeSource` using an `MGLCircleStyleLayer`, you can assign a `halfway`
+ attribute to each of the source’s features, then set
+ `MGLCircleStyleLayer.circleRadius` to an `MGLStyleValue` object with an
+ interpolation mode of `MGLInterpolationModeIdentity` and an attribute name of
+ `halfway`.
+ 
+ The `MGLSymbolStyleLayer.textField` and `MGLSymbolStyleLayer.iconImageName`
+ properties allow you to use attributes yet another way. For example, to label
+ features in an `MGLShapeSource` object by their names, you can assign a `name`
+ attribute to each of the source’s features, then set
+ `MGLSymbolStyleLayer.textField` to an `MGLStyleValue` object containing the
+ raw string value `{name}`.
 
  In vector tiles loaded by `MGLVectorSource` objects, the keys and values of
  each feature’s attribute dictionary are determined by the source. Each
@@ -115,6 +124,15 @@ NS_ASSUME_NONNULL_BEGIN
  and
  <a href="https://www.mapbox.com/vector-tiles/mapbox-terrain/">Mapbox Terrain</a>
  layer references.
+ 
+ When adding a feature to an `MGLShapeSource`, use the same Foundation types
+ listed above for each attribute value. In addition to the Foundation types, you
+ may also set an attribute to an `NSColor` (macOS) or `UIColor` (iOS), which
+ will be converted into its
+ <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/#types-color">CSS string representation</a>
+ when the feature is added to an `MGLShapeSource`. This can be convenient when
+ using the attribute to supply a value for a color-typed layout or paint
+ attribute via the `MGLInterpolationModeIdentity` interpolation mode.
 
  Note that while it is possible to change this value on feature
  instances obtained from `-[MGLMapView visibleFeaturesAtPoint:]` and related

--- a/platform/darwin/src/NSExpression+MGLAdditions.mm
+++ b/platform/darwin/src/NSExpression+MGLAdditions.mm
@@ -1,5 +1,12 @@
 #import "NSExpression+MGLAdditions.h"
 
+#import "MGLTypes.h"
+#if TARGET_OS_IPHONE
+    #import "UIColor+MGLAdditions.h"
+#else
+    #import "NSColor+MGLAdditions.h"
+#endif
+
 @implementation NSExpression (MGLAdditions)
 
 - (std::vector<mbgl::Value>)mgl_aggregateMBGLValue {
@@ -56,6 +63,9 @@
             // We use long long here to avoid any truncation.
             return { (int64_t)number.longLongValue };
         }
+    } else if ([value isKindOfClass:[MGLColor class]]) {
+        auto hexString = [(MGLColor *)value mgl_color].stringify();
+        return { hexString };
     } else if (value && value != [NSNull null]) {
         [NSException raise:NSInvalidArgumentException
                     format:@"Can’t convert %s:%@ to mbgl::Value", [value objCType], value];

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -26,6 +26,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed artifacts when drawing particularly acute line joins. ([#7786](https://github.com/mapbox/mapbox-gl-native/pull/7786))
 * Fixed an issue in which a vector style layer predicate involving the `$id` key path would exclude all features from the layer. ([#7989](https://github.com/mapbox/mapbox-gl-native/pull/7989), [#7971](https://github.com/mapbox/mapbox-gl-native/pull/7971))
 * Fixed an issue causing vector style layer predicates to be evaluated as if each feature had a `$type` attribute of 1, 2, or 3. The `$type` key path can now be compared to `Point`, `LineString`, or `Polygon`, as described in the documentation. ([#7971](https://github.com/mapbox/mapbox-gl-native/pull/7971))
+* When setting an `MGLShapeSource`’s shape to an `MGLFeature` instance, any `UIColor` attribute value is now converted to the equivalent CSS string representation for use with `MGLInterpolationModeIdentity` in style functions. ([#8025](https://github.com/mapbox/mapbox-gl-native/pull/8025))
 
 ### User interaction
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fixed artifacts when drawing particularly acute line joins. ([#7786](https://github.com/mapbox/mapbox-gl-native/pull/7786))
 * Fixed an issue in which a vector style layer predicate involving the `$id` key path would exclude all features from the layer. ([#7989](https://github.com/mapbox/mapbox-gl-native/pull/7989), [#7971](https://github.com/mapbox/mapbox-gl-native/pull/7971))
 * Fixed an issue causing vector style layer predicates to be evaluated as if each feature had a `$type` attribute of 1, 2, or 3. The `$type` key path can now be compared to `Point`, `LineString`, or `Polygon`, as described in the documentation. ([#7971](https://github.com/mapbox/mapbox-gl-native/pull/7971))
+* When setting an `MGLShapeSource`’s shape to an `MGLFeature` instance, any `NSColor` attribute value is now converted to the equivalent CSS string representation for use with `MGLInterpolationModeIdentity` in style functions. ([#8025](https://github.com/mapbox/mapbox-gl-native/pull/8025))
 
 ### User interaction
 


### PR DESCRIPTION
When converting a constant NSExpression to an `mbgl::Value`, turn an NSColor or UIColor into an `std::string` containing a CSS color string. This allows developers to set an attribute of an MGLFeature to an NSColor or UIColor (rather than a CSS color string, which would be foreign), then use it in an MGLStyleFunction with identity interpolation.

Along the way, I added language to `MGLFeature.attributes`’ documentation to talk about the use of feature attributes in identity-interpolated style functions. I also simplified the NSExpression unit tests to more specifically test the category methods that convert constant NSExpressions to `mbgl::Value`s, without going through NSPredicate. Normally I’d be hesitant to rely so heavily on macros, which makes debugging more difficult, but the existing tests rely on `for` loops, which make test failures just as difficult to diagnose.

/cc @boundsj @jfirebaugh