### PR TITLE
[glfw] Include gl.hpp first to avoid redefinition of GLAPIENTRY

### DIFF
--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/gl/gl.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/view.hpp>
 #include <mbgl/map/backend.hpp>


### PR DESCRIPTION
Mesa does not check if GLAPIENTRY was defined before before defining
it, what makes the compiler sad. So we make Mesa define it first,
before GLFW.

Follow-up of #8017.

/cc @kkaefer