### PR TITLE
[ios] Feature/cachebykey

### DIFF
--- a/include/mbgl/storage/resource.hpp
+++ b/include/mbgl/storage/resource.hpp
@@ -23,6 +23,7 @@ public:
 
     struct TileData {
         std::string urlTemplate;
+        std::string cacheKey;
         uint8_t pixelRatio;
         int32_t x;
         int32_t y;
@@ -44,6 +45,7 @@ public:
     static Resource style(const std::string& url);
     static Resource source(const std::string& url);
     static Resource tile(const std::string& urlTemplate,
+                         const std::string& cacheKey,
                          float pixelRatio,
                          int32_t x,
                          int32_t y,

--- a/include/mbgl/style/conversion/tileset.hpp
+++ b/include/mbgl/style/conversion/tileset.hpp
@@ -65,6 +65,17 @@ public:
             }
             result.attribution = std::move(*attribution);
         }
+      
+        auto cacheKeyValue = objectMember(value, "cacheKey");
+        if (cacheKeyValue) {
+          optional<std::string> cacheKey = toString(*cacheKeyValue);
+          if (!cacheKey) {
+            return Error { "source cacheKey must be a string" };
+          }
+          result.cacheKey = std::move(*cacheKey);
+        } else {
+          result.cacheKey = result.tiles[0];
+        }
 
         return result;
     }

--- a/include/mbgl/util/tileset.hpp
+++ b/include/mbgl/util/tileset.hpp
@@ -15,6 +15,7 @@ public:
     std::vector<std::string> tiles;
     Range<uint8_t> zoomRange { 0, 22 };
     std::string attribution;
+    std::string cacheKey;
     Scheme scheme = Scheme::XYZ;
 
     // TileJSON also includes center, zoom, and bounds, but they are not used by mbgl.

--- a/platform/darwin/src/MGLTileSource.h
+++ b/platform/darwin/src/MGLTileSource.h
@@ -41,6 +41,14 @@ extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMinimumZoomLevel;
  */
 extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel;
 
+/**
+ A string to use to cache this source. This is useful
+ if the url for this source may change.
+ 
+ By default, the url template for the source is used
+ */
+extern MGL_EXPORT const MGLTileSourceOption MGLTileSourceOptionCacheKey;
+
 #if TARGET_OS_IPHONE
 /**
  An HTML string defining the buttons to be displayed in an action sheet when the

--- a/platform/darwin/src/MGLTileSource.mm
+++ b/platform/darwin/src/MGLTileSource.mm
@@ -16,6 +16,7 @@ const MGLTileSourceOption MGLTileSourceOptionMaximumZoomLevel = @"MGLTileSourceO
 const MGLTileSourceOption MGLTileSourceOptionAttributionHTMLString = @"MGLTileSourceOptionAttributionHTMLString";
 const MGLTileSourceOption MGLTileSourceOptionAttributionInfos = @"MGLTileSourceOptionAttributionInfos";
 const MGLTileSourceOption MGLTileSourceOptionTileCoordinateSystem = @"MGLTileSourceOptionTileCoordinateSystem";
+const MGLTileSourceOption MGLTileSourceOptionCacheKey = @"MGLTileSourceOptionCacheKey";
 
 @implementation MGLTileSource
 
@@ -123,6 +124,16 @@ mbgl::Tileset MGLTileSetFromTileURLTemplates(NS_ARRAY_OF(NSString *) *tileURLTem
                 tileSet.scheme = mbgl::Tileset::Scheme::TMS;
                 break;
         }
+    }
+
+    if (NSString *cacheKey = options[MGLTileSourceOptionCacheKey]) {
+      if (![cacheKey isKindOfClass:[NSString class]]) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"MGLTileSourceOptionCacheKey must be set to a string."];
+      }
+      tileSet.cacheKey = cacheKey.UTF8String;
+    } else {
+      tileSet.cacheKey = tileSet.tiles[0];
     }
 
     return tileSet;

--- a/platform/default/mbgl/storage/offline_database.cpp
+++ b/platform/default/mbgl/storage/offline_database.cpp
@@ -357,7 +357,7 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource:
     // clang-format on
 
     accessedStmt->bind(1, util::now());
-    accessedStmt->bind(2, tile.urlTemplate);
+    accessedStmt->bind(2, tile.cacheKey);
     accessedStmt->bind(3, tile.pixelRatio);
     accessedStmt->bind(4, tile.x);
     accessedStmt->bind(5, tile.y);
@@ -376,7 +376,7 @@ optional<std::pair<Response, uint64_t>> OfflineDatabase::getTile(const Resource:
         "  AND z            = ?5 ");
     // clang-format on
 
-    stmt->bind(1, tile.urlTemplate);
+    stmt->bind(1, tile.cacheKey);
     stmt->bind(2, tile.pixelRatio);
     stmt->bind(3, tile.x);
     stmt->bind(4, tile.y);
@@ -419,7 +419,7 @@ optional<int64_t> OfflineDatabase::hasTile(const Resource::TileData& tile) {
         "  AND z            = ?5 ");
     // clang-format on
 
-    stmt->bind(1, tile.urlTemplate);
+    stmt->bind(1, tile.cacheKey);
     stmt->bind(2, tile.pixelRatio);
     stmt->bind(3, tile.x);
     stmt->bind(4, tile.y);
@@ -451,7 +451,7 @@ bool OfflineDatabase::putTile(const Resource::TileData& tile,
 
         update->bind(1, util::now());
         update->bind(2, response.expires);
-        update->bind(3, tile.urlTemplate);
+        update->bind(3, tile.cacheKey);
         update->bind(4, tile.pixelRatio);
         update->bind(5, tile.x);
         update->bind(6, tile.y);
@@ -486,7 +486,7 @@ bool OfflineDatabase::putTile(const Resource::TileData& tile,
     update->bind(2, response.etag);
     update->bind(3, response.expires);
     update->bind(4, util::now());
-    update->bind(7, tile.urlTemplate);
+    update->bind(7, tile.cacheKey);
     update->bind(8, tile.pixelRatio);
     update->bind(9, tile.x);
     update->bind(10, tile.y);
@@ -512,7 +512,7 @@ bool OfflineDatabase::putTile(const Resource::TileData& tile,
         "VALUES            (?1,           ?2,          ?3, ?4, ?5, ?6,        ?7,    ?8,       ?9,        ?10,  ?11) ");
     // clang-format on
 
-    insert->bind(1, tile.urlTemplate);
+    insert->bind(1, tile.cacheKey);
     insert->bind(2, tile.pixelRatio);
     insert->bind(3, tile.x);
     insert->bind(4, tile.y);
@@ -648,7 +648,7 @@ bool OfflineDatabase::markUsed(int64_t regionID, const Resource& resource) {
 
         const Resource::TileData& tile = *resource.tileData;
         insert->bind(1, regionID);
-        insert->bind(2, tile.urlTemplate);
+        insert->bind(2, tile.cacheKey);
         insert->bind(3, tile.pixelRatio);
         insert->bind(4, tile.x);
         insert->bind(5, tile.y);
@@ -673,7 +673,7 @@ bool OfflineDatabase::markUsed(int64_t regionID, const Resource& resource) {
         // clang-format on
 
         select->bind(1, regionID);
-        select->bind(2, tile.urlTemplate);
+        select->bind(2, tile.cacheKey);
         select->bind(3, tile.pixelRatio);
         select->bind(4, tile.x);
         select->bind(5, tile.y);

--- a/platform/default/mbgl/storage/offline_download.cpp
+++ b/platform/default/mbgl/storage/offline_download.cpp
@@ -243,7 +243,7 @@ void OfflineDownload::queueTiles(SourceType type, uint16_t tileSize, const Tiles
     for (const auto& tile : definition.tileCover(type, tileSize, tileset.zoomRange)) {
         status.requiredResourceCount++;
         resourcesRemaining.push_back(
-            Resource::tile(tileset.tiles[0], definition.pixelRatio, tile.x, tile.y, tile.z, tileset.scheme));
+            Resource::tile(tileset.tiles[0], tileset.cacheKey, definition.pixelRatio, tile.x, tile.y, tile.z, tileset.scheme));
     }
 }
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -28,6 +28,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed flickering that occurred when panning past the antimeridian. ([#7574](https://github.com/mapbox/mapbox-gl-native/pull/7574))
 * Fixed an issue that could prevent a cached style from appearing while the device is offline. ([#7770](https://github.com/mapbox/mapbox-gl-native/pull/7770))
 * Added `MGLDistanceFormatter` which can be used to format geographic distances. ([#7888](https://github.com/mapbox/mapbox-gl-native/pull/7888))
+* Added optional cacheKey to tilesets to allow caching of tile sources by key instead of url template
 
 ## 3.4.1 
 

--- a/src/mbgl/storage/resource.cpp
+++ b/src/mbgl/storage/resource.cpp
@@ -83,6 +83,7 @@ Resource Resource::glyphs(const std::string& urlTemplate, const FontStack& fontS
 }
 
 Resource Resource::tile(const std::string& urlTemplate,
+                        const std::string& cacheKey,
                         float pixelRatio,
                         int32_t x,
                         int32_t y,
@@ -119,6 +120,7 @@ Resource Resource::tile(const std::string& urlTemplate,
         }),
         Resource::TileData {
             urlTemplate,
+            cacheKey,
             uint8_t(supportsRatio && pixelRatio > 1.0 ? 2 : 1),
             x,
             y,

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -18,6 +18,7 @@ TileLoader<T>::TileLoader(T& tile_,
       necessity(Necessity::Optional),
       resource(Resource::tile(
         tileset.tiles.at(0),
+        tileset.cacheKey,
         parameters.pixelRatio,
         id.canonical.x,
         id.canonical.y,


### PR DESCRIPTION
Added an optional cachekey for tilesets. If present, it is used instead of the url template for caching in the database. This is useful when tile servers urls changed, but you still want the offline cache to work. 

This happens often for tile servers that have the access key as part of the url. But we've also used it before when changing USGS topographic servers or aerial imagery servers to different providers. 

You specify the cacheKey in the tilejson and via a MGLTileSourceOption