### PR TITLE
[ios] new eviction strategy to fix ambient caching when offline resources are downloaded

### DIFF
--- a/platform/default/mbgl/storage/offline_database.hpp
+++ b/platform/default/mbgl/storage/offline_database.hpp
@@ -108,11 +108,15 @@ private:
     T getPragma(const char *);
 
     uint64_t maximumCacheSize;
+    uint64_t insertedSinceEvictCheck;
 
     uint64_t offlineMapboxTileCountLimit = util::mapbox::DEFAULT_OFFLINE_TILE_COUNT_LIMIT;
     optional<uint64_t> offlineMapboxTileCount;
 
+    bool checkEvict(uint64_t neededFreeSize);
     bool evict(uint64_t neededFreeSize);
+    bool evict();
+
 };
 
 } // namespace mbgl

--- a/platform/default/mbgl/storage/offline_schema.cpp.include
+++ b/platform/default/mbgl/storage/offline_schema.cpp.include
@@ -46,6 +46,8 @@ static const char * schema =
 "ON resources (accessed);\n"
 "CREATE INDEX tiles_accessed\n"
 "ON tiles (accessed);\n"
+"CREATE INDEX tile_id\n"
+"ON tiles (id);\n"
 "CREATE INDEX region_resources_resource_id\n"
 "ON region_resources (resource_id);\n"
 "CREATE INDEX region_tiles_tile_id\n"

--- a/platform/default/mbgl/storage/offline_schema.sql
+++ b/platform/default/mbgl/storage/offline_schema.sql
@@ -55,8 +55,12 @@ ON resources (accessed);
 CREATE INDEX tiles_accessed
 ON tiles (accessed);
 
+CREATE INDEX tile_id
+ON tiles (id);
+
 CREATE INDEX region_resources_resource_id
 ON region_resources (resource_id);
 
 CREATE INDEX region_tiles_tile_id
 ON region_tiles (tile_id);
+

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -141,6 +141,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that could prevent a cached style from appearing while the device is offline. ([#7770](https://github.com/mapbox/mapbox-gl-native/pull/7770))
 * Fixed an issue that could prevent a style from loading when reestablishing a network connection. ([#7902](https://github.com/mapbox/mapbox-gl-native/pull/7902))
 * `MGLOfflineStorage` instances now support a delegate conforming to `MGLOfflineStorageDelegate`, which allows altering URLs before they are requested from the Internet. ([#8084](https://github.com/mapbox/mapbox-gl-native/pull/8084))
+* Changed the eviction strategy. The entire maximumCacheSize is now available for ambiently cached items.
 
 ### Other changes
 


### PR DESCRIPTION
This is a new eviction policy to address: https://github.com/mapbox/mapbox-gl-native/issues/4411 

With this strategy, the entire maxCacheSize is available for ambiently cached items. Instead of checking for file space on every insert of an ambient item, it keeps a running tally of the size of inserted tiles, and checks if it needs to purge every maxCacheSize/10.

On an iPhone 5S, with a 500MB offline database, running the purge operation takes 0.2 seconds. Checking if it needs to purge takes 0.02 seconds. On the iphone 7, about 0.1 seconds to check and 0.3 to purge. Maybe the thread is more likely to be interrupted there?

The database is still vacuumed only after offline packs are deleted. 
