### PR TITLE
[core] Add noexcept(false) in MBGL_CHECK_ERROR

### DIFF
--- a/include/mbgl/gl/gl.hpp
+++ b/include/mbgl/gl/gl.hpp
@@ -41,7 +41,7 @@ struct Error : std::runtime_error {
 void checkError(const char *cmd, const char *file, int line);
 
 #ifndef NDEBUG
-#define MBGL_CHECK_ERROR(cmd) ([&]() { struct __MBGL_C_E { ~__MBGL_C_E() { ::mbgl::gl::checkError(#cmd, __FILE__, __LINE__); } } __MBGL_C_E; return cmd; }())
+#define MBGL_CHECK_ERROR(cmd) ([&]() { struct __MBGL_C_E { ~__MBGL_C_E() noexcept(false) { ::mbgl::gl::checkError(#cmd, __FILE__, __LINE__); } } __MBGL_C_E; return cmd; }())
 #else
 #define MBGL_CHECK_ERROR(cmd) (cmd)
 #endif


### PR DESCRIPTION
C++11 destructors are noexcept by default, so the prior definition always called std::terminate without allowing anything to catch the exception.

This explains why the `catch` I added in f0d4411 wasn't catching.