### PR TITLE
[core] Fix aliased text on mobile GPUs

### DIFF
--- a/src/mbgl/shaders/symbol_sdf.cpp
+++ b/src/mbgl/shaders/symbol_sdf.cpp
@@ -168,7 +168,7 @@ uniform sampler2D u_fadetexture;
 uniform lowp vec4 u_color;
 uniform lowp float u_opacity;
 uniform lowp float u_buffer;
-uniform lowp float u_gamma;
+uniform highp float u_gamma;
 
 varying vec2 v_tex;
 varying vec2 v_fade_tex;
@@ -177,8 +177,8 @@ varying float v_gamma_scale;
 void main() {
     lowp float dist = texture2D(u_texture, v_tex).a;
     lowp float fade_alpha = texture2D(u_fadetexture, v_fade_tex).a;
-    lowp float gamma = u_gamma * v_gamma_scale;
-    lowp float alpha = smoothstep(u_buffer - gamma, u_buffer + gamma, dist) * fade_alpha;
+    highp float gamma = u_gamma * v_gamma_scale;
+    highp float alpha = smoothstep(u_buffer - gamma, u_buffer + gamma, dist) * fade_alpha;
 
     gl_FragColor = u_color * (alpha * u_opacity);
 


### PR DESCRIPTION
Need highp precision for gamma values on mobile devices. lowp triggers aliasing artifacts at larger font sizes.

Note that this change is a hand-edit to the generated shader sources, rather than pulling https://github.com/mapbox/mapbox-gl-js/pull/4275 and running the generator script. The reason for that is that the upstream shader now assumes support for DDS properties that gl-native does not yet support. Once that support lands in gl-native, we can regenerate the shader source.

Fixes #7599.