### PR TITLE
[android] - remove unused telem constants

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/constants/MapboxConstants.java
@@ -13,16 +13,6 @@ public class MapboxConstants {
   public static final Locale MAPBOX_LOCALE = Locale.US;
 
   /**
-   * Key used to store staging data server url in AndroidManifest.xml
-   */
-  public static final String KEY_META_DATA_STAGING_SERVER = "com.mapbox.TestEventsServer";
-
-  /**
-   * Key used to store staging data server access token in AndroidManifest.xml
-   */
-  public static final String KEY_META_DATA_STAGING_ACCESS_TOKEN = "com.mapbox.TestEventsAccessToken";
-
-  /**
    * Key used to switch storage to external in AndroidManifest.xml
    */
   public static final String KEY_META_DATA_SET_STORAGE_EXTERNAL = "com.mapbox.SetStorageExternal";
@@ -144,10 +134,4 @@ public class MapboxConstants {
   public static final String STATE_ATTRIBUTION_MARGIN_BOTTOM = "atrrMarginBottom";
   public static final String STATE_ATTRIBUTION_ENABLED = "atrrEnabled";
 
-  public static final String MAPBOX_SHARED_PREFERENCES_FILE = "MapboxSharedPreferences";
-  public static final String MAPBOX_SHARED_PREFERENCE_KEY_VENDORID = "mapboxVendorId";
-  public static final String MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_ENABLED = "mapboxTelemetryEnabled";
-  public static final String MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STAGING_URL = "mapboxTelemetryStagingUrl";
-  public static final String MAPBOX_SHARED_PREFERENCE_KEY_TELEMETRY_STAGING_ACCESS_TOKEN =
-    "mapboxTelemetryStagingAccessToken";
 }


### PR DESCRIPTION
I noticed we had some unused telemetry constants in `MapboxConstants.java`.
Looking more into this I'm seeing that these are now included in external telem library [here](https://github.com/mapbox/mapbox-java/blob/master/mapbox/libandroid-telemetry/src/main/java/com/mapbox/services/android/telemetry/constants/TelemetryConstants.java#L25-L40). 
Good to remove @zugaldia?