### PR TITLE
[android] - ignore device dependant tests

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/maps/MapboxMapTest.java
@@ -107,6 +107,7 @@ public class MapboxMapTest {
   }
 
   @Test
+  @Ignore
   public void testInitialZoomLevels() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = activity.getMapboxMap();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraAnimateTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraAnimateTest.java
@@ -22,6 +22,7 @@ import com.mapbox.mapboxsdk.testapp.utils.ViewUtils;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -44,6 +45,7 @@ public class CameraAnimateTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToCameraPositionTarget() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -66,6 +68,7 @@ public class CameraAnimateTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToCameraPositionTargetZoom() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -114,6 +117,7 @@ public class CameraAnimateTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToBounds() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -142,6 +146,7 @@ public class CameraAnimateTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToMoveBy() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -161,6 +166,7 @@ public class CameraAnimateTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToZoomIn() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -175,6 +181,7 @@ public class CameraAnimateTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToZoomOut() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -190,6 +197,7 @@ public class CameraAnimateTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToZoomBy() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -205,6 +213,7 @@ public class CameraAnimateTest {
   }
 
   @Test
+  @Ignore
   public void testAnimateToZoomTo() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraEaseTest.java
@@ -22,6 +22,7 @@ import com.mapbox.mapboxsdk.testapp.utils.ViewUtils;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -44,6 +45,7 @@ public class CameraEaseTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToCameraPositionTarget() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -66,6 +68,7 @@ public class CameraEaseTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToCameraPositionTargetZoom() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -84,6 +87,7 @@ public class CameraEaseTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToCameraPosition() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -142,6 +146,7 @@ public class CameraEaseTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToMoveBy() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -161,6 +166,7 @@ public class CameraEaseTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToZoomIn() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -175,6 +181,7 @@ public class CameraEaseTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToZoomOut() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -189,6 +196,7 @@ public class CameraEaseTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToZoomBy() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -204,6 +212,7 @@ public class CameraEaseTest {
   }
 
   @Test
+  @Ignore
   public void testEaseToZoomTo() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraInternalApiTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraInternalApiTest.java
@@ -19,6 +19,7 @@ import com.mapbox.mapboxsdk.testapp.utils.ViewUtils;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -44,6 +45,7 @@ public class CameraInternalApiTest {
   }
 
   @Test
+  @Ignore
   public void testBearing() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     EspressoTestActivity activity = rule.getActivity();
@@ -59,6 +61,7 @@ public class CameraInternalApiTest {
   }
 
   @Test
+  @Ignore
   public void testTilt() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     EspressoTestActivity activity = rule.getActivity();
@@ -74,6 +77,7 @@ public class CameraInternalApiTest {
   }
 
   @Test
+  @Ignore
   public void testLatLng() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     EspressoTestActivity activity = rule.getActivity();

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraMoveTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/camera/CameraMoveTest.java
@@ -22,6 +22,7 @@ import com.mapbox.mapboxsdk.testapp.utils.ViewUtils;
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -44,6 +45,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToCameraPositionTarget() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -66,6 +68,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToCameraPositionTargetZoom() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -84,6 +87,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToCameraPosition() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -114,6 +118,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToBounds() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -142,6 +147,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToMoveBy() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -161,6 +167,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToZoomIn() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -175,6 +182,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToZoomOut() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -190,6 +198,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToZoomBy() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
@@ -205,6 +214,7 @@ public class CameraMoveTest {
   }
 
   @Test
+  @Ignore
   public void testMoveToZoomTo() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
     final MapboxMap mapboxMap = rule.getActivity().getMapboxMap();


### PR DESCRIPTION
Refs #7221, been running our instrumentation tests on a range of Android devices. this PR fixes up master to ignore tests that can result in false positives on larger screen devices. Next actions to resolve this are documented in https://github.com/mapbox/mapbox-gl-native/issues/7221#issuecomment-279980479. 

