### PR TITLE
[android] - keep MapboxMap reference when MarkerView out of viewport

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -474,7 +474,6 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
           if (adapter.getMarkerClass().equals(marker.getClass())) {
             adapter.prepareViewForReuse(marker, convertView);
             adapter.releaseView(convertView);
-            marker.setMapboxMap(null);
             iterator.remove();
           }
         }


### PR DESCRIPTION
Closes #8032, This PR enables updating the underlying Marker of a MarkerView when that MarkerView isn't found in the current Viewport. 