### PR TITLE
[iOS] Remove geofences when location monitoring is stopped

### DIFF
--- a/platform/ios/src/MGLLocationManager.m
+++ b/platform/ios/src/MGLLocationManager.m
@@ -41,6 +41,9 @@ static NSString * const MGLLocationManagerRegionIdentifier = @"MGLLocationManage
     if ([self isUpdatingLocation]) {
         [self.standardLocationManager stopUpdatingLocation];
         [self.standardLocationManager stopMonitoringSignificantLocationChanges];
+        for (CLRegion *region in self.standardLocationManager.monitoredRegions) {
+            [self.standardLocationManager stopMonitoringForRegion:region];
+        }
         self.updatingLocation = NO;
         if ([self.delegate respondsToSelector:@selector(locationManagerDidStopLocationUpdates:)]) {
             [self.delegate locationManagerDidStopLocationUpdates:self];


### PR DESCRIPTION
I’ve tested this change in an app that was opted out of MBGL location collection and have verified that the iOS location services preferences no longer reported the app as using geofences.

As far as I can tell, without the changes in this commit, the `MGLLocationManager` would errantly attempt to start location updates when the user exited a previously monitored geofence _even if telemetry collection was disabled by the user_. This would occur when the user exited a region that was previously monitored, according to the current logic in `-[MGLLocationManager locationManager:didExitRegion:]`, since they were not removed when `-[MGLLocationManager  stopUpdatingLocation]` was invoked.

Of course, please let me know if I'm missing something here. Thanks!