### PR TITLE
[tests] Disable timing-based Timer tests in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ option(WITH_CXX11ABI "Use cxx11abi mason packages" OFF)
 option(WITH_COVERAGE "Enable coverage reports" OFF)
 option(WITH_OSMESA   "Use OSMesa headless backend" OFF)
 option(WITH_EGL      "Use EGL backend" OFF)
-option(IS_CI_BUILD   "Continuous integration build" OFF)
 
 if(WITH_CXX11ABI)
     set(MASON_CXXABI_SUFFIX -cxx11abi)
@@ -23,7 +22,7 @@ if(WITH_EGL)
     add_definitions(-DMBGL_USE_GLES2=1)
 endif()
 
-if(IS_CI_BUILD)
+if($ENV{CI})
     add_compile_options(-DCI_BUILD=1)
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,6 @@ $(LINUX_BUILD): $(BUILD_DEPS)
 		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
 		-DWITH_CXX11ABI=$(shell scripts/check-cxx11abi.sh) \
 		-DWITH_COVERAGE=${WITH_COVERAGE} \
-		-DIS_CI_BUILD=${CI} \
 		-DWITH_OSMESA=${WITH_OSMESA} \
 		-DWITH_EGL=${WITH_EGL})
 
@@ -391,8 +390,7 @@ $(QT_BUILD): $(BUILD_DEPS)
 		-DWITH_QT_I18N=${WITH_QT_I18N} \
 		-DWITH_QT_4=${WITH_QT_4} \
 		-DWITH_CXX11ABI=$(shell scripts/check-cxx11abi.sh) \
-		-DWITH_COVERAGE=${WITH_COVERAGE} \
-		-DIS_CI_BUILD=${CI})
+		-DWITH_COVERAGE=${WITH_COVERAGE})
 
 ifeq ($(HOST_PLATFORM), macos)
 
@@ -407,8 +405,7 @@ $(MACOS_QT_PROJ_PATH): $(BUILD_DEPS)
 		-DWITH_QT_I18N=${WITH_QT_I18N} \
 		-DWITH_QT_4=${WITH_QT_4} \
 		-DWITH_CXX11ABI=$(shell scripts/check-cxx11abi.sh) \
-		-DWITH_COVERAGE=${WITH_COVERAGE} \
-		-DIS_CI_BUILD=${CI})
+		-DWITH_COVERAGE=${WITH_COVERAGE})
 
 	@# Create Xcode schemes so that we can use xcodebuild from the command line. CMake doesn't
 	@# create these automatically.

--- a/test/src/mbgl/test/util.hpp
+++ b/test/src/mbgl/test/util.hpp
@@ -21,7 +21,7 @@
 #define TEST_IS_SIMULATOR 0
 #endif
 
-#if !TEST_IS_SIMULATOR
+#if !TEST_IS_SIMULATOR && !CI_BUILD
 #define TEST_REQUIRES_ACCURATE_TIMING(name) name
 #else
 #define TEST_REQUIRES_ACCURATE_TIMING(name) DISABLED_ ## name


### PR DESCRIPTION
These tests have always been flaky (https://github.com/mapbox/mapbox-gl-native/issues/5364), and started failing more consistently on macOS CI after upgrading the Bitrise stack.