### PR TITLE
Render a circle if either the color or stroke color are visible

### DIFF
--- a/src/mbgl/style/layers/circle_layer_impl.cpp
+++ b/src/mbgl/style/layers/circle_layer_impl.cpp
@@ -14,9 +14,12 @@ void CircleLayer::Impl::cascade(const CascadeParameters& parameters) {
 bool CircleLayer::Impl::evaluate(const PropertyEvaluationParameters& parameters) {
     paint.evaluate(parameters);
 
-    passes = (paint.evaluated.get<CircleRadius>().constantOr(1) > 0
-           && paint.evaluated.get<CircleColor>().constantOr(Color::black()).a > 0
-           && paint.evaluated.get<CircleOpacity>().constantOr(1) > 0)
+    passes = ((paint.evaluated.get<CircleRadius>().constantOr(1) > 0 ||
+               paint.evaluated.get<CircleStrokeWidth>().constantOr(1) > 0)
+           && (paint.evaluated.get<CircleColor>().constantOr(Color::black()).a > 0 ||
+               paint.evaluated.get<CircleStrokeColor>().constantOr(Color::black()).a > 0)
+           && (paint.evaluated.get<CircleOpacity>().constantOr(1) > 0 ||
+               paint.evaluated.get<CircleStrokeOpacity>().constantOr(1) > 0))
         ? RenderPass::Translucent : RenderPass::None;
 
     return paint.hasTransition();


### PR DESCRIPTION
This adds a line to pass the circle layer render check if the circle stroke color is visible. Previously, a transparent circle color would cause the layer to be passed up even if the circle stroke color had
a non-zero alpha.

cc @jfirebaugh @jmkiley

Fixes https://github.com/mapbox/mapbox-gl-native/issues/8077

