### PR TITLE
Transform::moveBy with AnimationOptions

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -9,6 +9,7 @@
 #include <mbgl/util/size.hpp>
 #include <mbgl/annotation/annotation.hpp>
 #include <mbgl/style/transition_options.hpp>
+#include <mbgl/map/camera.hpp>
 
 #include <cstdint>
 #include <string>
@@ -86,7 +87,7 @@ public:
     void flyTo(const CameraOptions&, const AnimationOptions&);
 
     // Position
-    void moveBy(const ScreenCoordinate&, const Duration& = Duration::zero());
+    void moveBy(const ScreenCoordinate&, const AnimationOptions& = {});
     void setLatLng(const LatLng&, optional<ScreenCoordinate>, const Duration& = Duration::zero());
     void setLatLng(const LatLng&, optional<EdgeInsets>, const Duration& = Duration::zero());
     void setLatLng(const LatLng&, const Duration& = Duration::zero());

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -484,7 +484,14 @@ void nativeMoveBy(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jdoubl
                           jlong duration) {
     assert(nativeMapViewPtr != 0);
     NativeMapView *nativeMapView = reinterpret_cast<NativeMapView *>(nativeMapViewPtr);
-    nativeMapView->getMap().moveBy({dx, dy}, mbgl::Milliseconds(duration));
+
+    mbgl::AnimationOptions animationOptions;
+    if (duration > 0) {
+       animationOptions.duration.emplace(mbgl::Milliseconds(duration));
+       animationOptions.easing.emplace(mbgl::util::UnitBezier { 0, 0.3, 0.6, 1.0 });
+    }
+
+    nativeMapView->getMap().moveBy({dx, dy}, animationOptions);
 }
 
 void nativeSetLatLng(JNIEnv *env, jni::jobject* obj, jlong nativeMapViewPtr, jdouble latitude, jdouble longitude, jlong duration) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -477,9 +477,9 @@ void Map::flyTo(const CameraOptions& camera, const AnimationOptions& animation) 
 
 #pragma mark - Position
 
-void Map::moveBy(const ScreenCoordinate& point, const Duration& duration) {
+void Map::moveBy(const ScreenCoordinate& point, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.moveBy(point, duration);
+    impl->transform.moveBy(point, animation);
     impl->onUpdate(Update::Repaint);
 }
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -322,7 +322,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
 
 #pragma mark - Position
 
-void Transform::moveBy(const ScreenCoordinate& offset, const Duration& duration) {
+void Transform::moveBy(const ScreenCoordinate& offset, const AnimationOptions& animation) {
     ScreenCoordinate centerOffset = {
         offset.x,
         -offset.y,
@@ -331,7 +331,7 @@ void Transform::moveBy(const ScreenCoordinate& offset, const Duration& duration)
 
     CameraOptions camera;
     camera.center = state.screenCoordinateToLatLng(centerPoint);
-    easeTo(camera, duration);
+    easeTo(camera, animation);
 }
 
 void Transform::setLatLng(const LatLng& latLng, const Duration& duration) {

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -44,7 +44,7 @@ public:
     /** Pans the map by the given amount.
         @param offset The distance to pan the map by, measured in pixels from
             top to bottom and from left to right. */
-    void moveBy(const ScreenCoordinate& offset, const Duration& = Duration::zero());
+    void moveBy(const ScreenCoordinate& offset, const AnimationOptions& = {});
     void setLatLng(const LatLng&, const Duration& = Duration::zero());
     void setLatLng(const LatLng&, optional<EdgeInsets>, const Duration& = Duration::zero());
     void setLatLng(const LatLng&, optional<ScreenCoordinate>, const Duration& = Duration::zero());


### PR DESCRIPTION
Closes #8081, this PR enables to use AnimationOptions when performing a moveBy transformation.
For Android I'm adding `mbgl::util::UnitBezier { 0, 0.3, 0.6, 1.0 }` as interpolator to get a better UX for current fling gesture:

Before:
![ezgif com-video-to-gif 19](https://cloud.githubusercontent.com/assets/2151639/23063390/97d294b4-f50a-11e6-941d-53fa28de9166.gif)

After:
![ezgif com-video-to-gif 20](https://cloud.githubusercontent.com/assets/2151639/23074947/f8078c24-f53a-11e6-86f9-bd81ae4588b1.gif)


