### PR TITLE
fix the animation with two positions too close

### DIFF
--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -211,6 +211,11 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
     /// Length of the flight path as projected onto the ground plane, measured
     /// in pixels from the world image origin at the initial scale.
     double u1 = ::hypot((endPoint - startPoint).x, (endPoint - startPoint).y);
+    //fix: if startpoint and endpoint are too close, we force the distance at 1 px
+    //      otherwise r(x) could return inf
+    if (u1<0.5) {
+        u1 = 0.5;
+    }
 
     /** ρ: The relative amount of zooming that takes place along the flight
         path. A high value maximizes zooming for an exaggerated animation, while


### PR DESCRIPTION
Hello,

We have an issue in animating with the method MapboxMap.animateCamera(...), the zoom is from 16 to 7, the center isn't changed. That make the mapbox in the unstable state, the center and the bounding box are NaN. We must restart the application.

After further investigation, we identify the root cause of the problem : 
In the class transform.cpp, the method Transform::flyTo cause the issue. If endPoint and startPoint are too close (<1) the following piece of code return "inf" due to "std::sqrt(b * b + 1) - b" equals absolute 0 then "std::log(std::sqrt(b * b + 1) - b);" becomes std::log(0) = -inf

` auto r = [=](double i) {
        /// bᵢ
        double b = (w1 * w1 - w0 * w0 + (i ? -1 : 1) * rho2 * rho2 * u1 * u1) / (2 * (i ? w1 : w0) * rho2 * u1);
        return std::log(std::sqrt(b * b + 1) - b);
    };` 

My proposition to fix it is to make a protection if the delta of the  endPoint and startPoint is smaller than 0.5 we set the delta is 0.5. That fix our issue.


 