### PR TITLE
[core] Redo approach to unsupported VAO extension

### DIFF
--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -39,6 +39,8 @@ public:
     UniqueProgram createProgram(ShaderID vertexShader, ShaderID fragmentShader);
     void linkProgram(ProgramID);
     UniqueTexture createTexture();
+
+    bool supportsVertexArrays() const;
     UniqueVertexArray createVertexArray();
 
     template <class Vertex, class DrawMode>


### PR DESCRIPTION
Previously, if VAOs were not supported, a VAO with ID 0 was getting into `Context::abandonedVertexArrays`, and a crash ensued when trying to call `gl::DeleteVertexArrays`.

Fixes #8079