### PR TITLE
[core] Fix HeadlessBackend context management

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -104,11 +104,13 @@ set(MBGL_CORE_FILES
 
     # map
     include/mbgl/map/backend.hpp
+    include/mbgl/map/backend_scope.hpp
     include/mbgl/map/camera.hpp
     include/mbgl/map/map.hpp
     include/mbgl/map/mode.hpp
     include/mbgl/map/view.hpp
     src/mbgl/map/backend.cpp
+    src/mbgl/map/backend_scope.cpp
     src/mbgl/map/change.hpp
     src/mbgl/map/map.cpp
     src/mbgl/map/transform.cpp

--- a/include/mbgl/map/backend.hpp
+++ b/include/mbgl/map/backend.hpp
@@ -47,18 +47,4 @@ private:
     friend class BackendScope;
 };
 
-class BackendScope {
-public:
-    BackendScope(Backend& backend_) : backend(backend_) {
-        backend.activate();
-    }
-
-    ~BackendScope() {
-        backend.deactivate();
-    }
-
-private:
-    Backend& backend;
-};
-
 } // namespace mbgl

--- a/include/mbgl/map/backend.hpp
+++ b/include/mbgl/map/backend.hpp
@@ -41,8 +41,7 @@ protected:
     virtual void activate() = 0;
     virtual void deactivate() = 0;
 
-private:
-    const std::unique_ptr<gl::Context> context;
+    std::unique_ptr<gl::Context> context;
 
     friend class BackendScope;
 };

--- a/include/mbgl/map/backend_scope.hpp
+++ b/include/mbgl/map/backend_scope.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace mbgl {
+
+class Backend;
+
+class BackendScope {
+public:
+    BackendScope(Backend&);
+    ~BackendScope();
+
+private:
+    Backend* priorBackend;
+    Backend& backend;
+};
+
+} // namespace mbgl

--- a/include/mbgl/map/backend_scope.hpp
+++ b/include/mbgl/map/backend_scope.hpp
@@ -10,7 +10,8 @@ public:
     ~BackendScope();
 
 private:
-    Backend* priorBackend;
+    BackendScope* priorScope;
+    BackendScope* nextScope;
     Backend& backend;
 };
 

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -16,6 +16,7 @@
 #include <mbgl/util/logging.hpp>
 #include <mbgl/gl/extension.hpp>
 #include <mbgl/gl/context.hpp>
+#include <mbgl/map/backend_scope.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/image.hpp>
 

--- a/platform/default/mbgl/gl/headless_backend.cpp
+++ b/platform/default/mbgl/gl/headless_backend.cpp
@@ -18,7 +18,6 @@ HeadlessBackend::HeadlessBackend(std::shared_ptr<HeadlessDisplay> display_)
 
 HeadlessBackend::~HeadlessBackend() {
     deactivate();
-    destroyContext();
 }
 
 void HeadlessBackend::activate() {
@@ -31,7 +30,8 @@ void HeadlessBackend::activate() {
         createContext();
     }
 
-    activateContext();
+    assert(hasContext());
+    impl->activateContext();
 
     if (!extensionsLoaded) {
         gl::InitializeExtensions(initializeExtension);
@@ -40,27 +40,13 @@ void HeadlessBackend::activate() {
 }
 
 void HeadlessBackend::deactivate() {
-    deactivateContext();
+    assert(hasContext());
+    impl->deactivateContext();
     active = false;
 }
 
 void HeadlessBackend::invalidate() {
     assert(false);
-}
-
-void HeadlessBackend::destroyContext() {
-    assert(hasContext());
-    impl.reset();
-}
-
-void HeadlessBackend::activateContext() {
-    assert(hasContext());
-    impl->activateContext();
-}
-
-void HeadlessBackend::deactivateContext() {
-    assert(hasContext());
-    impl->deactivateContext();
 }
 
 void HeadlessBackend::notifyMapChange(MapChange change) {

--- a/platform/default/mbgl/gl/headless_backend.cpp
+++ b/platform/default/mbgl/gl/headless_backend.cpp
@@ -8,16 +8,13 @@
 namespace mbgl {
 
 HeadlessBackend::HeadlessBackend() {
-    activate();
 }
 
 HeadlessBackend::HeadlessBackend(std::shared_ptr<HeadlessDisplay> display_)
         : display(std::move(display_)) {
-    activate();
 }
 
 HeadlessBackend::~HeadlessBackend() {
-    deactivate();
 }
 
 void HeadlessBackend::activate() {

--- a/platform/default/mbgl/gl/headless_backend.cpp
+++ b/platform/default/mbgl/gl/headless_backend.cpp
@@ -1,5 +1,7 @@
 #include <mbgl/gl/headless_backend.hpp>
 #include <mbgl/gl/headless_display.hpp>
+#include <mbgl/gl/context.hpp>
+#include <mbgl/map/backend_scope.hpp>
 
 #include <cassert>
 #include <stdexcept>
@@ -15,6 +17,8 @@ HeadlessBackend::HeadlessBackend(std::shared_ptr<HeadlessDisplay> display_)
 }
 
 HeadlessBackend::~HeadlessBackend() {
+    BackendScope scope(*this);
+    context.reset();
 }
 
 void HeadlessBackend::activate() {

--- a/platform/default/mbgl/gl/headless_backend.hpp
+++ b/platform/default/mbgl/gl/headless_backend.hpp
@@ -18,8 +18,6 @@ public:
     ~HeadlessBackend() override;
 
     void invalidate() override;
-    void activate() override;
-    void deactivate() override;
     void notifyMapChange(MapChange) override;
 
     void setMapChangeCallback(std::function<void(MapChange)>&& cb) { mapChangeCallback = std::move(cb); }
@@ -33,6 +31,9 @@ public:
 private:
     // Implementation specific functions
     static gl::glProc initializeExtension(const char*);
+
+    void activate() override;
+    void deactivate() override;
 
     bool hasContext() const { return bool(impl); }
     bool hasDisplay();

--- a/platform/default/mbgl/gl/headless_backend.hpp
+++ b/platform/default/mbgl/gl/headless_backend.hpp
@@ -39,12 +39,6 @@ private:
 
     void createContext();
 
-private:
-    void destroyContext();
-
-    void activateContext();
-    void deactivateContext();
-
     std::unique_ptr<Impl> impl;
     std::shared_ptr<HeadlessDisplay> display;
 

--- a/src/mbgl/map/backend_scope.cpp
+++ b/src/mbgl/map/backend_scope.cpp
@@ -1,0 +1,26 @@
+#include <mbgl/map/backend_scope.hpp>
+#include <mbgl/map/backend.hpp>
+#include <mbgl/util/thread_local.hpp>
+
+namespace mbgl {
+
+static util::ThreadLocal<Backend> currentBackend;
+
+BackendScope::BackendScope(Backend& backend_)
+    : priorBackend(currentBackend.get()),
+      backend(backend_) {
+    backend.activate();
+    currentBackend.set(&backend);
+}
+
+BackendScope::~BackendScope() {
+    if (priorBackend) {
+        priorBackend->activate();
+        currentBackend.set(priorBackend);
+    } else {
+        backend.deactivate();
+        currentBackend.set(nullptr);
+    }
+}
+
+} // namespace mbgl

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -2,6 +2,7 @@
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/view.hpp>
 #include <mbgl/map/backend.hpp>
+#include <mbgl/map/backend_scope.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>

--- a/test/gl/object.test.cpp
+++ b/test/gl/object.test.cpp
@@ -1,5 +1,6 @@
 #include <mbgl/test/util.hpp>
 
+#include <mbgl/map/backend_scope.hpp>
 #include <mbgl/gl/headless_backend.hpp>
 #include <mbgl/gl/offscreen_view.hpp>
 
@@ -62,6 +63,7 @@ TEST(GLObject, Value) {
 TEST(GLObject, Store) {
     HeadlessBackend backend { test::sharedDisplay() };
     OffscreenView view(backend.getContext());
+    BackendScope scope { backend };
 
     gl::Context context;
     EXPECT_TRUE(context.empty());
@@ -77,6 +79,4 @@ TEST(GLObject, Store) {
 
     context.reset();
     EXPECT_TRUE(context.empty());
-
-    backend.deactivate();
 }

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/test/fixture_log_observer.hpp>
 
 #include <mbgl/map/map.hpp>
+#include <mbgl/map/backend_scope.hpp>
 #include <mbgl/gl/headless_backend.hpp>
 #include <mbgl/gl/offscreen_view.hpp>
 #include <mbgl/gl/context.hpp>
@@ -574,6 +575,7 @@ TEST(Map, TEST_DISABLED_ON_CI(ContinuousRendering)) {
             });
         }
 
+        BackendScope scope(backend);
         map.render(view);
     }};
 

--- a/test/util/offscreen_texture.test.cpp
+++ b/test/util/offscreen_texture.test.cpp
@@ -4,6 +4,7 @@
 #include <mbgl/gl/context.hpp>
 #include <mbgl/gl/headless_backend.hpp>
 #include <mbgl/gl/offscreen_view.hpp>
+#include <mbgl/map/backend_scope.hpp>
 
 #include <mbgl/util/offscreen_texture.hpp>
 
@@ -11,6 +12,7 @@ using namespace mbgl;
 
 TEST(OffscreenTexture, EmptyRed) {
     HeadlessBackend backend { test::sharedDisplay() };
+    BackendScope scope { backend };
     OffscreenView view(backend.getContext(), { 512, 256 });
     view.bind();
 
@@ -68,6 +70,7 @@ struct Buffer {
 
 TEST(OffscreenTexture, RenderToTexture) {
     HeadlessBackend backend { test::sharedDisplay() };
+    BackendScope scope { backend };
     auto& context = backend.getContext();
 
     MBGL_CHECK_ERROR(glEnable(GL_BLEND));
@@ -116,50 +119,45 @@ void main() {
     Buffer triangleBuffer({ 0, 0.5, 0.5, -0.5, -0.5, -0.5 });
     Buffer viewportBuffer({ -1, -1, 1, -1, -1, 1, 1, 1 });
 
-    // Make sure the texture gets destructed before we call context.reset();
-    {
-        OffscreenView view(context, { 512, 256 });
-        view.bind();
+    OffscreenView view(context, { 512, 256 });
+    view.bind();
 
-        // First, draw red to the bound FBO.
-        context.clear(Color::red(), {}, {});
+    // First, draw red to the bound FBO.
+    context.clear(Color::red(), {}, {});
 
-        // Then, create a texture, bind it, and render yellow to that texture. This should not
-        // affect the originally bound FBO.
-        OffscreenTexture texture(context, { 128, 128 });
-        texture.bind();
+    // Then, create a texture, bind it, and render yellow to that texture. This should not
+    // affect the originally bound FBO.
+    OffscreenTexture texture(context, { 128, 128 });
+    texture.bind();
 
-        context.clear(Color(), {}, {});
+    context.clear(Color(), {}, {});
 
-        MBGL_CHECK_ERROR(glUseProgram(paintShader.program));
-        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, triangleBuffer.buffer));
-        MBGL_CHECK_ERROR(glEnableVertexAttribArray(paintShader.a_pos));
-        MBGL_CHECK_ERROR(
-            glVertexAttribPointer(paintShader.a_pos, 2, GL_FLOAT, GL_FALSE, 0, nullptr));
-        MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 3));
+    MBGL_CHECK_ERROR(glUseProgram(paintShader.program));
+    MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, triangleBuffer.buffer));
+    MBGL_CHECK_ERROR(glEnableVertexAttribArray(paintShader.a_pos));
+    MBGL_CHECK_ERROR(
+        glVertexAttribPointer(paintShader.a_pos, 2, GL_FLOAT, GL_FALSE, 0, nullptr));
+    MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 3));
 
-        auto image = texture.readStillImage();
-        test::checkImage("test/fixtures/offscreen_texture/render-to-texture", image, 0, 0);
+    auto image = texture.readStillImage();
+    test::checkImage("test/fixtures/offscreen_texture/render-to-texture", image, 0, 0);
 
-        // Now reset the FBO back to normal and retrieve the original (restored) framebuffer.
-        view.bind();
+    // Now reset the FBO back to normal and retrieve the original (restored) framebuffer.
+    view.bind();
 
-        image = view.readStillImage();
-        test::checkImage("test/fixtures/offscreen_texture/render-to-fbo", image, 0, 0);
+    image = view.readStillImage();
+    test::checkImage("test/fixtures/offscreen_texture/render-to-fbo", image, 0, 0);
 
-        // Now, composite the Framebuffer texture we've rendered to onto the main FBO.
-        context.bindTexture(texture.getTexture(), 0, gl::TextureFilter::Linear);
-        MBGL_CHECK_ERROR(glUseProgram(compositeShader.program));
-        MBGL_CHECK_ERROR(glUniform1i(u_texture, 0));
-        MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, viewportBuffer.buffer));
-        MBGL_CHECK_ERROR(glEnableVertexAttribArray(compositeShader.a_pos));
-        MBGL_CHECK_ERROR(
-            glVertexAttribPointer(compositeShader.a_pos, 2, GL_FLOAT, GL_FALSE, 0, nullptr));
-        MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
+    // Now, composite the Framebuffer texture we've rendered to onto the main FBO.
+    context.bindTexture(texture.getTexture(), 0, gl::TextureFilter::Linear);
+    MBGL_CHECK_ERROR(glUseProgram(compositeShader.program));
+    MBGL_CHECK_ERROR(glUniform1i(u_texture, 0));
+    MBGL_CHECK_ERROR(glBindBuffer(GL_ARRAY_BUFFER, viewportBuffer.buffer));
+    MBGL_CHECK_ERROR(glEnableVertexAttribArray(compositeShader.a_pos));
+    MBGL_CHECK_ERROR(
+        glVertexAttribPointer(compositeShader.a_pos, 2, GL_FLOAT, GL_FALSE, 0, nullptr));
+    MBGL_CHECK_ERROR(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
 
-        image = view.readStillImage();
-        test::checkImage("test/fixtures/offscreen_texture/render-to-fbo-composited", image, 0, 0.1);
-    }
-
-    context.reset();
+    image = view.readStillImage();
+    test::checkImage("test/fixtures/offscreen_texture/render-to-fbo-composited", image, 0, 0.1);
 }


### PR DESCRIPTION
Eliminate manual activate/deactivate, and always use `BackendScope`. `BackendScope` now works as a stack, pushing the new context when coming into scope and restoring the prior context when going out of scope.

Fixes #7681
Fixes #8076
