### PR TITLE
[android] Fix a NPE that occurs when MapView is initialized with null options

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -106,7 +106,7 @@ public class MapView extends FrameLayout {
   @UiThread
   public MapView(@NonNull Context context, @Nullable MapboxMapOptions options) {
     super(context);
-    initialise(context, options);
+    initialise(context, options == null ? MapboxMapOptions.createFromAttributes(context, null) : options);
   }
 
   private void initialise(@NonNull final Context context, @NonNull final MapboxMapOptions options) {


### PR DESCRIPTION
This commit fix a NPE that occurs when calling `MapView` constructor with a null `MapboxMapOptions` object.

It crashes when reaching:

```
initalizeDrawingSurface(context, options);
```

on the first line of the method:

```
if (options.getTextureMode()) {
```