### PR TITLE
iOS/Android: Use shared thread pool

### DIFF
--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -73,6 +73,8 @@ macro(mbgl_platform_core)
         PRIVATE platform/android/src/image.cpp
 
         # Thread pool
+        PRIVATE platform/default/mbgl/util/shared_thread_pool.cpp
+        PRIVATE platform/default/mbgl/util/shared_thread_pool.hpp
         PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
         PRIVATE platform/default/mbgl/util/default_thread_pool.hpp
 

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -18,6 +18,7 @@
 #include <mbgl/gl/context.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/image.hpp>
+#include <mbgl/util/shared_thread_pool.hpp>
 
 #include "bitmap.hpp"
 
@@ -29,7 +30,7 @@ NativeMapView::NativeMapView(JNIEnv *env_, jobject obj_, float pixelRatio, int a
       availableProcessors(availableProcessors_),
       totalMemory(totalMemory_),
       fileSource(defaultFileSource(mbgl::android::cachePath + "/mbgl-offline.db", mbgl::android::apkPath)),
-      threadPool(4) {
+      threadPool(sharedThreadPool()) {
 
     assert(env_ != nullptr);
     assert(obj_ != nullptr);
@@ -47,7 +48,7 @@ NativeMapView::NativeMapView(JNIEnv *env_, jobject obj_, float pixelRatio, int a
 
     map = std::make_unique<mbgl::Map>(
         *this, mbgl::Size{ static_cast<uint32_t>(width), static_cast<uint32_t>(height) },
-        pixelRatio, fileSource, threadPool, MapMode::Continuous);
+        pixelRatio, fileSource, *threadPool, MapMode::Continuous);
 
     float zoomFactor   = map->getMaxZoom() - map->getMinZoom() + 1;
     float cpuFactor    = availableProcessors;

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -97,7 +97,7 @@ private:
 
     // Ensure these are initialised last
     mbgl::DefaultFileSource& fileSource;
-    mbgl::ThreadPool threadPool;
+    std::shared_ptr<mbgl::ThreadPool> threadPool;
     std::unique_ptr<mbgl::Map> map;
     mbgl::EdgeInsets insets;
 

--- a/platform/default/mbgl/util/default_thread_pool.cpp
+++ b/platform/default/mbgl/util/default_thread_pool.cpp
@@ -1,12 +1,16 @@
 #include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/actor/mailbox.hpp>
+#include <mbgl/util/platform.hpp>
+#include <mbgl/util/string.hpp>
 
 namespace mbgl {
 
 ThreadPool::ThreadPool(std::size_t count) {
     threads.reserve(count);
     for (std::size_t i = 0; i < count; ++i) {
-        threads.emplace_back([this] () {
+        threads.emplace_back([this, i]() {
+            platform::setCurrentThreadName(std::string{ "Worker " } + util::toString(i + 1));
+
             while (true) {
                 std::unique_lock<std::mutex> lock(mutex);
 

--- a/platform/default/mbgl/util/shared_thread_pool.cpp
+++ b/platform/default/mbgl/util/shared_thread_pool.cpp
@@ -1,0 +1,14 @@
+#include "shared_thread_pool.hpp"
+
+namespace mbgl {
+
+std::shared_ptr<ThreadPool> sharedThreadPool() {
+    static std::weak_ptr<ThreadPool> weak;
+    auto pool = weak.lock();
+    if (!pool) {
+        weak = pool = std::make_shared<ThreadPool>(4);
+    }
+    return pool;
+}
+
+} // namespace mbgl

--- a/platform/default/mbgl/util/shared_thread_pool.hpp
+++ b/platform/default/mbgl/util/shared_thread_pool.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <mbgl/util/default_thread_pool.hpp>
+
+namespace mbgl {
+
+std::shared_ptr<ThreadPool> sharedThreadPool();
+
+} // namespace mbgl

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -58,6 +58,8 @@ macro(mbgl_platform_core)
         PRIVATE platform/default/mbgl/gl/offscreen_view.hpp
 
         # Thread pool
+        PRIVATE platform/default/mbgl/util/shared_thread_pool.cpp
+        PRIVATE platform/default/mbgl/util/shared_thread_pool.hpp
         PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
         PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
     )

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -54,6 +54,8 @@ macro(mbgl_platform_core)
         PRIVATE platform/default/mbgl/gl/offscreen_view.hpp
 
         # Thread pool
+        PRIVATE platform/default/mbgl/util/shared_thread_pool.cpp
+        PRIVATE platform/default/mbgl/util/shared_thread_pool.hpp
         PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
         PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
     )

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -11,6 +11,7 @@
 #import "MGLMultiPoint_Private.h"
 #import "MGLOfflineStorage_Private.h"
 #import "MGLStyle_Private.h"
+#import "MGLFoundation_Private.h"
 
 #import "MGLAccountManager.h"
 #import "MGLMapCamera.h"
@@ -35,6 +36,7 @@
 #import <mbgl/util/constants.hpp>
 #import <mbgl/util/chrono.hpp>
 #import <mbgl/util/run_loop.hpp>
+#import <mbgl/util/shared_thread_pool.hpp>
 
 #import <map>
 #import <unordered_map>
@@ -146,7 +148,7 @@ public:
     /// Cross-platform map view controller.
     mbgl::Map *_mbglMap;
     MGLMapViewImpl *_mbglView;
-    mbgl::ThreadPool *_mbglThreadPool;
+    std::shared_ptr<mbgl::ThreadPool> _mbglThreadPool;
 
     NSPanGestureRecognizer *_panGestureRecognizer;
     NSMagnificationGestureRecognizer *_magnificationGestureRecognizer;
@@ -260,7 +262,7 @@ public:
 
     mbgl::DefaultFileSource* mbglFileSource = [MGLOfflineStorage sharedOfflineStorage].mbglFileSource;
 
-    _mbglThreadPool = new mbgl::ThreadPool(4);
+    _mbglThreadPool = mbgl::sharedThreadPool();
     _mbglMap = new mbgl::Map(*_mbglView, self.size, [NSScreen mainScreen].backingScaleFactor, *mbglFileSource, *_mbglThreadPool, mbgl::MapMode::Continuous, mbgl::GLContextMode::Unique, mbgl::ConstrainMode::None, mbgl::ViewportMode::Default);
     [self validateTileCacheSize];
 
@@ -514,10 +516,6 @@ public:
     if (_mbglView) {
         delete _mbglView;
         _mbglView = nullptr;
-    }
-    if (_mbglThreadPool) {
-        delete _mbglThreadPool;
-        _mbglThreadPool = nullptr;
     }
 }
 

--- a/platform/qt/qt.cmake
+++ b/platform/qt/qt.cmake
@@ -31,8 +31,10 @@ set(MBGL_QT_FILES
     PRIVATE platform/default/logging_stderr.cpp
 
     # Thread pool
+    PRIVATE platform/default/mbgl/util/shared_thread_pool.cpp
+    PRIVATE platform/default/mbgl/util/shared_thread_pool.hpp
     PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
-    PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
+    PRIVATE platform/default/mbgl/util/default_thread_pool.hpp
 
     # Platform integration
     PRIVATE platform/qt/src/async_task.cpp

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -22,6 +22,7 @@
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/shared_thread_pool.hpp>
 #include <mbgl/util/traits.hpp>
 
 #if QT_VERSION >= 0x050000
@@ -1532,10 +1533,10 @@ QMapboxGLPrivate::QMapboxGLPrivate(QMapboxGL *q, const QMapboxGLSettings &settin
         settings.cacheDatabasePath().toStdString(),
         settings.assetPath().toStdString(),
         settings.cacheDatabaseMaximumSize()))
-    , threadPool(4)
+    , threadPool(mbgl::sharedThreadPool())
     , mapObj(std::make_unique<mbgl::Map>(
         *this, mbgl::Size{ static_cast<uint32_t>(size.width()), static_cast<uint32_t>(size.height()) },
-        pixelRatio, *fileSourceObj, threadPool,
+        pixelRatio, *fileSourceObj, *threadPool,
         mbgl::MapMode::Continuous,
         static_cast<mbgl::GLContextMode>(settings.contextMode()),
         static_cast<mbgl::ConstrainMode>(settings.constrainMode()),

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -38,7 +38,7 @@ public:
     QMapboxGL *q_ptr { nullptr };
 
     std::unique_ptr<mbgl::DefaultFileSource> fileSourceObj;
-    mbgl::ThreadPool threadPool;
+    std::shared_ptr<mbgl::ThreadPool> threadPool;
     std::unique_ptr<mbgl::Map> mapObj;
 
     bool dirty { false };


### PR DESCRIPTION
Currently, every map object creates its own thread pool, but we should use a shared thread pool, possibly with a static function cache holding on to weak `shared_ptr` so that the thread pool gets destructed when the last map object ceases to exist.