### PR TITLE
Bring all architectures back to CI builds

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -290,10 +290,7 @@ workflows:
             #!/bin/bash
             echo "Compile libmapbox-gl.so for all supportd abi's:"
             export BUILDTYPE=Release
-            make android-lib-arm-v5
-            make android-lib-arm-v7
-            make android-lib-arm-v8
-            make android-lib-x86
+            make apackage
             cd platform/android && ./gradlew :MapboxGLAndroidSDK:assembleRelease
     - script:
         title: Log metrics

--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -198,11 +198,7 @@ workflows:
             #!/bin/bash
             echo "Compile libmapbox-gl.so for all supportd abi's:"
             export BUILDTYPE=Release
-            make android-lib-arm-v5
-            make android-lib-arm-v7
-            make android-lib-arm-v8
-            make android-lib-x86
-            make android-lib-x86-64
+            make apackage
             cd platform/android && ./gradlew :MapboxGLAndroidSDK:assembleRelease
     - script:
         title: Publish to maven


### PR DESCRIPTION
With the improved setup on CI, I'm no longer getting timeouts when doing `make apackage`, this PR brings that behavior back to our `nightly` and `scheduled` builds:

![image](https://cloud.githubusercontent.com/assets/6964/23139389/45d25f7e-f77a-11e6-9d28-5ab3cbd5d7ee.png)

Fixes https://github.com/mapbox/mapbox-gl-native/issues/7733.

@tobrun Please review.
