### PR TITLE
Revert "[build] Add --track-origins=yes to valgrind arguments"

### DIFF
--- a/scripts/valgrind.sh
+++ b/scripts/valgrind.sh
@@ -6,7 +6,6 @@ set -o pipefail
 VALGRIND_PREFIX=$(scripts/mason.sh PREFIX valgrind VERSION 3.12.0)
 
 PARAMS="\
-    --track-origins=yes \
     --leak-check=full \
     --show-leak-kinds=definite \
     --errors-for-leak-kinds=definite \


### PR DESCRIPTION
This reverts commit 090fb92fbf073728e1a9b5196e880a216f11e109.

Fixes #8103.