### PR TITLE
Add .idea, .mason and cmake-build-debug folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ xcuserdata
 /documentation
 test/fixtures/api/assets.zip
 test/fixtures/storage/assets.zip
+/.idea
+/cmake-build-debug


### PR DESCRIPTION
`.idea`, `.mason` and `cmake-build-debug` folders weren't included in `.gitignore`.

Cc/ @kkaefer 