### PR TITLE
[android] - post invoking onMapReady to the end of the message queu

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -15,6 +15,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.CallSuper;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
@@ -1006,9 +1007,14 @@ public class MapView extends FrameLayout {
     public void onMapChanged(@MapChange int change) {
       if (change == DID_FINISH_LOADING_STYLE && initialLoad) {
         initialLoad = false;
-        mapboxMap.onPreMapReady();
-        onMapReady();
-        mapboxMap.onPostMapReady();
+        new Handler().post(new Runnable() {
+          @Override
+          public void run() {
+            mapboxMap.onPreMapReady();
+            onMapReady();
+            mapboxMap.onPostMapReady();
+          }
+        });
       } else if (change == REGION_IS_CHANGING || change == REGION_DID_CHANGE || change == DID_FINISH_LOADING_MAP) {
         mapboxMap.onUpdate();
       }


### PR DESCRIPTION
Closes #6999. Inspired from a construction used in #8031, posting invocation of the onMapReady callback results in providing our users with a MapboxMap that is instantiated with measured components while they are unmeasured with current implementation. Been testing this against the issues linked in #6999 and all issues are no longer reproducible. 

Review @ivovandongen @zugaldia 