### PR TITLE
[core] Clean up symbol-related code

### DIFF
--- a/src/mbgl/geometry/anchor.hpp
+++ b/src/mbgl/geometry/anchor.hpp
@@ -6,17 +6,15 @@
 
 namespace mbgl {
 
-struct Anchor {
+class Anchor {
+public:
     Point<float> point;
     float angle = 0.0f;
     float scale = 0.0f;
     int segment = -1;
 
-    explicit Anchor(float x_, float y_, float angle_, float scale_)
-        : point(x_, y_), angle(angle_), scale(scale_) {}
-    explicit Anchor(float x_, float y_, float angle_, float scale_, int segment_)
+    Anchor(float x_, float y_, float angle_, float scale_, int segment_ = -1)
         : point(x_, y_), angle(angle_), scale(scale_), segment(segment_) {}
-
 };
 
 typedef std::vector<Anchor> Anchors;

--- a/src/mbgl/layout/symbol_instance.cpp
+++ b/src/mbgl/layout/symbol_instance.cpp
@@ -5,12 +5,22 @@ namespace mbgl {
 
 using namespace style;
 
-SymbolInstance::SymbolInstance(Anchor& anchor, const GeometryCoordinates& line,
-        const std::pair<Shaping, Shaping>& shapedTextOrientations, const PositionedIcon& shapedIcon,
-        const SymbolLayoutProperties::Evaluated& layout, const bool addToBuffers, const uint32_t index_,
-        const float textBoxScale, const float textPadding, const SymbolPlacementType textPlacement,
-        const float iconBoxScale, const float iconPadding, const SymbolPlacementType iconPlacement,
-        const GlyphPositions& face, const IndexedSubfeature& indexedFeature, const std::size_t featureIndex_) :
+SymbolInstance::SymbolInstance(Anchor& anchor,
+                               const GeometryCoordinates& line,
+                               const std::pair<Shaping, Shaping>& shapedTextOrientations,
+                               const PositionedIcon& shapedIcon,
+                               const SymbolLayoutProperties::Evaluated& layout,
+                               const bool addToBuffers,
+                               const uint32_t index_,
+                               const float textBoxScale,
+                               const float textPadding,
+                               const SymbolPlacementType textPlacement,
+                               const float iconBoxScale,
+                               const float iconPadding,
+                               const SymbolPlacementType iconPlacement,
+                               const GlyphPositions& face,
+                               const IndexedSubfeature& indexedFeature,
+                               const std::size_t featureIndex_) :
     point(anchor.point),
     index(index_),
     hasText(shapedTextOrientations.first || shapedTextOrientations.second),

--- a/src/mbgl/layout/symbol_instance.hpp
+++ b/src/mbgl/layout/symbol_instance.hpp
@@ -7,17 +7,27 @@
 
 namespace mbgl {
 
-struct Anchor;
+class Anchor;
 class IndexedSubfeature;
 
 class SymbolInstance {
 public:
-    explicit SymbolInstance(Anchor& anchor, const GeometryCoordinates& line,
-            const std::pair<Shaping, Shaping>& shapedTextOrientations, const PositionedIcon& shapedIcon,
-            const style::SymbolLayoutProperties::Evaluated&, const bool inside, const uint32_t index,
-            const float textBoxScale, const float textPadding, style::SymbolPlacementType textPlacement,
-            const float iconBoxScale, const float iconPadding, style::SymbolPlacementType iconPlacement,
-            const GlyphPositions& face, const IndexedSubfeature& indexedfeature, const std::size_t featureIndex);
+    SymbolInstance(Anchor& anchor,
+                   const GeometryCoordinates& line,
+                   const std::pair<Shaping, Shaping>& shapedTextOrientations,
+                   const PositionedIcon& shapedIcon,
+                   const style::SymbolLayoutProperties::Evaluated&,
+                   const bool inside,
+                   const uint32_t index,
+                   const float textBoxScale,
+                   const float textPadding,
+                   style::SymbolPlacementType textPlacement,
+                   const float iconBoxScale,
+                   const float iconPadding,
+                   style::SymbolPlacementType iconPlacement,
+                   const GlyphPositions& face,
+                   const IndexedSubfeature&,
+                   const std::size_t featureIndex);
 
     Point<float> point;
     uint32_t index;

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -19,14 +19,13 @@ class CollisionTile;
 class SpriteAtlas;
 class GlyphAtlas;
 class SymbolBucket;
+class Anchor;
 
 namespace style {
 class BucketParameters;
 class Filter;
 class Layer;
 } // namespace style
-
-struct Anchor;
 
 class SymbolLayout {
 public:

--- a/src/mbgl/text/check_max_angle.cpp
+++ b/src/mbgl/text/check_max_angle.cpp
@@ -14,7 +14,7 @@ struct Corner {
 };
 
 bool checkMaxAngle(const GeometryCoordinates& line,
-                   Anchor& anchor,
+                   const Anchor& anchor,
                    const float labelLength,
                    const float windowSize,
                    const float maxAngle) {

--- a/src/mbgl/text/check_max_angle.cpp
+++ b/src/mbgl/text/check_max_angle.cpp
@@ -13,9 +13,11 @@ struct Corner {
     float angleDelta;
 };
 
-bool checkMaxAngle(const GeometryCoordinates &line, Anchor &anchor, const float labelLength,
-        const float windowSize, const float maxAngle) {
-
+bool checkMaxAngle(const GeometryCoordinates& line,
+                   Anchor& anchor,
+                   const float labelLength,
+                   const float windowSize,
+                   const float maxAngle) {
     // horizontal labels always pass
     if (anchor.segment < 0) return true;
 
@@ -74,8 +76,6 @@ bool checkMaxAngle(const GeometryCoordinates &line, Anchor &anchor, const float 
 
     // no part of the line had an angle greater than the maximum allowed. check passes.
     return true;
-
-
 }
 
 } // namespace mbgl

--- a/src/mbgl/text/check_max_angle.hpp
+++ b/src/mbgl/text/check_max_angle.hpp
@@ -4,9 +4,12 @@
 
 namespace mbgl {
 
-struct Anchor;
+class Anchor;
 
-bool checkMaxAngle(const GeometryCoordinates &line, Anchor &anchor, const float labelLength,
-        const float windowSize, const float maxAngle);
+bool checkMaxAngle(const GeometryCoordinates& line,
+                   Anchor& anchor,
+                   const float labelLength,
+                   const float windowSize,
+                   const float maxAngle);
 
 } // namespace mbgl

--- a/src/mbgl/text/check_max_angle.hpp
+++ b/src/mbgl/text/check_max_angle.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 class Anchor;
 
 bool checkMaxAngle(const GeometryCoordinates& line,
-                   Anchor& anchor,
+                   const Anchor& anchor,
                    const float labelLength,
                    const float windowSize,
                    const float maxAngle);

--- a/src/mbgl/text/collision_feature.cpp
+++ b/src/mbgl/text/collision_feature.cpp
@@ -3,12 +3,18 @@
 
 namespace mbgl {
 
-CollisionFeature::CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
-        const float top, const float bottom, const float left, const float right,
-        const float boxScale, const float padding, const style::SymbolPlacementType placement, IndexedSubfeature indexedFeature_,
-        const bool straight)
+CollisionFeature::CollisionFeature(const GeometryCoordinates& line,
+                                   const Anchor& anchor,
+                                   const float top,
+                                   const float bottom,
+                                   const float left,
+                                   const float right,
+                                   const float boxScale,
+                                   const float padding,
+                                   const style::SymbolPlacementType placement,
+                                   IndexedSubfeature indexedFeature_,
+                                   const bool straight)
         : indexedFeature(std::move(indexedFeature_)) {
-
     if (top == 0 && bottom == 0 && left == 0 && right == 0) return;
 
     const float y1 = top * boxScale - padding;
@@ -40,9 +46,8 @@ CollisionFeature::CollisionFeature(const GeometryCoordinates &line, const Anchor
     }
 }
 
-void CollisionFeature::bboxifyLabel(const GeometryCoordinates &line,
-        GeometryCoordinate &anchorPoint, const int segment, const float labelLength, const float boxSize) {
-
+void CollisionFeature::bboxifyLabel(const GeometryCoordinates& line, GeometryCoordinate& anchorPoint,
+                                    const int segment, const float labelLength, const float boxSize) {
     const float step = boxSize / 2;
     const unsigned int nBoxes = std::floor(labelLength / step);
 
@@ -100,6 +105,5 @@ void CollisionFeature::bboxifyLabel(const GeometryCoordinates &line,
         boxes.emplace_back(boxAnchor, -boxSize / 2, -boxSize / 2, boxSize / 2, boxSize / 2, maxScale);
     }
 }
-
 
 } // namespace mbgl

--- a/src/mbgl/text/collision_feature.hpp
+++ b/src/mbgl/text/collision_feature.hpp
@@ -8,57 +8,69 @@
 #include <vector>
 
 namespace mbgl {
-    class CollisionBox {
-        public:
-            explicit CollisionBox(Point<float> _anchor, float _x1, float _y1, float _x2, float _y2, float _maxScale) :
-                anchor(std::move(_anchor)), x1(_x1), y1(_y1), x2(_x2), y2(_y2), maxScale(_maxScale) {}
 
-            // the box is centered around the anchor point
-            Point<float> anchor;
+class CollisionBox {
+public:
+    CollisionBox(Point<float> _anchor, float _x1, float _y1, float _x2, float _y2, float _maxScale) :
+        anchor(std::move(_anchor)), x1(_x1), y1(_y1), x2(_x2), y2(_y2), maxScale(_maxScale) {}
 
-            // distances to the edges from the anchor
-            float x1;
-            float y1;
-            float x2;
-            float y2;
+    // the box is centered around the anchor point
+    Point<float> anchor;
 
-            // the box is only valid for scales < maxScale.
-            // The box does not block other boxes at scales >= maxScale;
-            float maxScale;
+    // distances to the edges from the anchor
+    float x1;
+    float y1;
+    float x2;
+    float y2;
 
-            // the scale at which the label can first be shown
-            float placementScale = 0.0f;
-    };
+    // the box is only valid for scales < maxScale.
+    // The box does not block other boxes at scales >= maxScale;
+    float maxScale;
 
-    class CollisionFeature {
-        public:
-            // for text
-            explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
-                    const Shaping &shapedText,
-                    const float boxScale, const float padding, const style::SymbolPlacementType placement, const IndexedSubfeature& indexedFeature_)
-                : CollisionFeature(line, anchor,
-                        shapedText.top, shapedText.bottom, shapedText.left, shapedText.right,
-                        boxScale, padding, placement, indexedFeature_, false) {}
+    // the scale at which the label can first be shown
+    float placementScale = 0.0f;
+};
 
-            // for icons
-            explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
-                    const PositionedIcon &shapedIcon,
-                    const float boxScale, const float padding, const style::SymbolPlacementType placement, const IndexedSubfeature& indexedFeature_)
-                : CollisionFeature(line, anchor,
-                        shapedIcon.top, shapedIcon.bottom, shapedIcon.left, shapedIcon.right,
-                        boxScale, padding, placement, indexedFeature_, true) {}
+class CollisionFeature {
+public:
+    // for text
+    CollisionFeature(const GeometryCoordinates& line,
+                     const Anchor& anchor,
+                     const Shaping& shapedText,
+                     const float boxScale,
+                     const float padding,
+                     const style::SymbolPlacementType placement,
+                     const IndexedSubfeature& indexedFeature_)
+        : CollisionFeature(line, anchor, shapedText.top, shapedText.bottom, shapedText.left, shapedText.right, boxScale, padding, placement, indexedFeature_, false) {}
 
-            explicit CollisionFeature(const GeometryCoordinates &line, const Anchor &anchor,
-                    const float top, const float bottom, const float left, const float right,
-                    const float boxScale, const float padding, const style::SymbolPlacementType placement,
-                    IndexedSubfeature, const bool straight);
+    // for icons
+    CollisionFeature(const GeometryCoordinates& line,
+                     const Anchor& anchor,
+                     const PositionedIcon& shapedIcon,
+                     const float boxScale,
+                     const float padding,
+                     const style::SymbolPlacementType placement,
+                     const IndexedSubfeature& indexedFeature_)
+        : CollisionFeature(line, anchor, shapedIcon.top, shapedIcon.bottom, shapedIcon.left, shapedIcon.right, boxScale, padding, placement, indexedFeature_, true) {}
 
+    CollisionFeature(const GeometryCoordinates& line,
+                     const Anchor& anchor,
+                     const float top,
+                     const float bottom,
+                     const float left,
+                     const float right,
+                     const float boxScale,
+                     const float padding,
+                     const style::SymbolPlacementType placement,
+                     IndexedSubfeature,
+                     const bool straight);
 
-            std::vector<CollisionBox> boxes;
-            IndexedSubfeature indexedFeature;
+    std::vector<CollisionBox> boxes;
+    IndexedSubfeature indexedFeature;
 
-        private:
-            void bboxifyLabel(const GeometryCoordinates &line, GeometryCoordinate &anchorPoint,
-                    const int segment, const float length, const float height);
-    };
+private:
+    void bboxifyLabel(const GeometryCoordinates& line, GeometryCoordinate& anchorPoint,
+                      const int segment, const float length, const float height);
+};
+
 } // namespace mbgl

--- a/src/mbgl/text/get_anchors.cpp
+++ b/src/mbgl/text/get_anchors.cpp
@@ -8,9 +8,14 @@
 
 namespace mbgl {
 
-Anchors resample(const GeometryCoordinates &line, const float offset, const float spacing,
-        const float angleWindowSize, const float maxAngle, const float labelLength, const bool continuedLine, const bool placeAtMiddle) {
-
+static Anchors resample(const GeometryCoordinates& line,
+                        const float offset,
+                        const float spacing,
+                        const float angleWindowSize,
+                        const float maxAngle,
+                        const float labelLength,
+                        const bool continuedLine,
+                        const bool placeAtMiddle) {
     const float halfLabelLength = labelLength / 2.0f;
     float lineLength = 0;
     for (auto it = line.begin(), end = line.end() - 1; it != end; it++) {
@@ -26,8 +31,8 @@ Anchors resample(const GeometryCoordinates &line, const float offset, const floa
 
     int i = 0;
     for (auto it = line.begin(), end = line.end() - 1; it != end; it++, i++) {
-        const GeometryCoordinate &a = *(it);
-        const GeometryCoordinate &b = *(it + 1);
+        const GeometryCoordinate& a = *(it);
+        const GeometryCoordinate& b = *(it + 1);
 
         const float segmentDist = util::dist<float>(a, b);
         const float angle = util::angle_to(b, a);
@@ -68,11 +73,19 @@ Anchors resample(const GeometryCoordinates &line, const float offset, const floa
     return anchors;
 }
 
-Anchors getAnchors(const GeometryCoordinates &line, float spacing,
-        const float maxAngle, const float textLeft, const float textRight,
-        const float iconLeft, const float iconRight,
-        const float glyphSize, const float boxScale, const float overscaling) {
-    if (line.empty()) return {};
+Anchors getAnchors(const GeometryCoordinates& line,
+                   float spacing,
+                   const float maxAngle,
+                   const float textLeft,
+                   const float textRight,
+                   const float iconLeft,
+                   const float iconRight,
+                   const float glyphSize,
+                   const float boxScale,
+                   const float overscaling) {
+    if (line.empty()) {
+        return {};
+    }
 
     // Resample a line to get anchor points for labels and check that each
     // potential label passes text-max-angle check and has enough froom to fit

--- a/src/mbgl/text/get_anchors.hpp
+++ b/src/mbgl/text/get_anchors.hpp
@@ -6,8 +6,15 @@
 
 namespace mbgl {
 
-Anchors getAnchors(const GeometryCoordinates &line, float spacing,
-        const float maxAngle, const float textLeft, const float textRight,
-        const float iconLeft, const float iconRight,
-        const float glyphSize, const float boxScale, const float overscaling);
+Anchors getAnchors(const GeometryCoordinates& line,
+                   float spacing,
+                   const float maxAngle,
+                   const float textLeft,
+                   const float textRight,
+                   const float iconLeft,
+                   const float iconRight,
+                   const float glyphSize,
+                   const float boxScale,
+                   const float overscaling);
+
 } // namespace mbgl

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -14,7 +14,7 @@ using namespace style;
 
 const float globalMinScale = 0.5f; // underscale by 1 zoom level
 
-SymbolQuad getIconQuad(Anchor& anchor,
+SymbolQuad getIconQuad(const Anchor& anchor,
                        const PositionedIcon& shapedIcon,
                        const GeometryCoordinates& line,
                        const SymbolLayoutProperties::Evaluated& layout,

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -5,6 +5,7 @@
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/constants.hpp>
+
 #include <cassert>
 
 namespace mbgl {
@@ -13,10 +14,12 @@ using namespace style;
 
 const float globalMinScale = 0.5f; // underscale by 1 zoom level
 
-SymbolQuad getIconQuad(Anchor& anchor, const PositionedIcon& shapedIcon,
-        const GeometryCoordinates& line, const SymbolLayoutProperties::Evaluated& layout,
-        const style::SymbolPlacementType placement, const Shaping& shapedText) {
-
+SymbolQuad getIconQuad(Anchor& anchor,
+                       const PositionedIcon& shapedIcon,
+                       const GeometryCoordinates& line,
+                       const SymbolLayoutProperties::Evaluated& layout,
+                       const style::SymbolPlacementType placement, 
+                       const Shaping& shapedText) {
     auto image = *(shapedIcon.image);
 
     const float border = 1.0;
@@ -38,7 +41,7 @@ SymbolQuad getIconQuad(Anchor& anchor, const PositionedIcon& shapedIcon,
         auto textTop = shapedText.top * size;
         auto textBottom = shapedText.bottom * size;
         auto textWidth = textRight - textLeft;
-        auto textHeight = textBottom - textTop;;
+        auto textHeight = textBottom - textTop;
         auto padT = layout.get<IconTextFitPadding>()[0];
         auto padR = layout.get<IconTextFitPadding>()[1];
         auto padB = layout.get<IconTextFitPadding>()[2];
@@ -75,7 +78,6 @@ SymbolQuad getIconQuad(Anchor& anchor, const PositionedIcon& shapedIcon,
         }
     }
 
-
     if (angle) {
         // Compute the transformation matrix.
         float angle_sin = std::sin(angle);
@@ -106,9 +108,12 @@ struct GlyphInstance {
 
 typedef std::vector<GlyphInstance> GlyphInstances;
 
-void getSegmentGlyphs(std::back_insert_iterator<GlyphInstances> glyphs, Anchor &anchor,
-        float offset, const GeometryCoordinates &line, int segment, bool forward) {
-
+void getSegmentGlyphs(std::back_insert_iterator<GlyphInstances> glyphs,
+                      Anchor& anchor,
+                      float offset,
+                      const GeometryCoordinates& line,
+                      int segment,
+                      bool forward) {
     const bool upsideDown = !forward;
 
     if (offset < 0)
@@ -162,10 +167,13 @@ void getSegmentGlyphs(std::back_insert_iterator<GlyphInstances> glyphs, Anchor &
     }
 }
 
-SymbolQuads getGlyphQuads(Anchor& anchor, const Shaping& shapedText,
-        const float boxScale, const GeometryCoordinates& line, const SymbolLayoutProperties::Evaluated& layout,
-        const style::SymbolPlacementType placement, const GlyphPositions& face) {
-
+SymbolQuads getGlyphQuads(Anchor& anchor,
+                          const Shaping& shapedText,
+                          const float boxScale,
+                          const GeometryCoordinates& line,
+                          const SymbolLayoutProperties::Evaluated& layout,
+                          const style::SymbolPlacementType placement,
+                          const GlyphPositions& face) {
     const float textRotate = layout.get<TextRotate>() * util::DEG2RAD;
     const bool keepUpright = layout.get<TextKeepUpright>();
 
@@ -191,7 +199,6 @@ SymbolQuads getGlyphQuads(Anchor& anchor, const Shaping& shapedText,
             getSegmentGlyphs(std::back_inserter(glyphInstances), anchor, centerX, line, anchor.segment, true);
             if (keepUpright)
                 getSegmentGlyphs(std::back_inserter(glyphInstances), anchor, centerX, line, anchor.segment, false);
-
         } else {
             glyphInstances.emplace_back(GlyphInstance{anchor.point});
         }
@@ -220,7 +227,6 @@ SymbolQuads getGlyphQuads(Anchor& anchor, const Shaping& shapedText,
         }
 
         for (const GlyphInstance &instance : glyphInstances) {
-
             Point<float> tl = otl;
             Point<float> tr = otr;
             Point<float> bl = obl;
@@ -244,9 +250,7 @@ SymbolQuads getGlyphQuads(Anchor& anchor, const Shaping& shapedText,
             const float anchorAngle = std::fmod((anchor.angle + instance.offset + 2 * M_PI), (2 * M_PI));
             const float glyphAngle = std::fmod((instance.angle + instance.offset + 2 * M_PI), (2 * M_PI));
             quads.emplace_back(tl, tr, bl, br, rect, anchorAngle, glyphAngle, instance.anchorPoint, glyphMinScale, instance.maxScale, shapedText.writingMode);
-
         }
-
     }
 
     return quads;

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -51,7 +51,7 @@ public:
 
 typedef std::vector<SymbolQuad> SymbolQuads;
 
-SymbolQuad getIconQuad(Anchor& anchor,
+SymbolQuad getIconQuad(const Anchor& anchor,
                        const PositionedIcon& shapedIcon,
                        const GeometryCoordinates& line,
                        const style::SymbolLayoutProperties::Evaluated&,

--- a/src/mbgl/text/quads.hpp
+++ b/src/mbgl/text/quads.hpp
@@ -9,13 +9,22 @@
 
 namespace mbgl {
 
-struct Anchor;
+class Anchor;
 class PositionedIcon;
 
-struct SymbolQuad {
-    explicit SymbolQuad(Point<float> tl_, Point<float> tr_, Point<float> bl_, Point<float> br_,
-            Rect<uint16_t> tex_, float anchorAngle_, float glyphAngle_, Point<float> anchorPoint_,
-            float minScale_, float maxScale_, WritingModeType writingMode_)
+class SymbolQuad {
+public:
+    SymbolQuad(Point<float> tl_,
+               Point<float> tr_,
+               Point<float> bl_,
+               Point<float> br_,
+               Rect<uint16_t> tex_,
+               float anchorAngle_,
+               float glyphAngle_,
+               Point<float> anchorPoint_,
+               float minScale_,
+               float maxScale_,
+               WritingModeType writingMode_)
         : tl(std::move(tl_)),
         tr(std::move(tr_)),
         bl(std::move(bl_)),
@@ -28,22 +37,33 @@ struct SymbolQuad {
         maxScale(maxScale_),
         writingMode(writingMode_) {}
 
-    Point<float> tl, tr, bl, br;
+    Point<float> tl;
+    Point<float> tr;
+    Point<float> bl;
+    Point<float> br;
     Rect<uint16_t> tex;
     float anchorAngle, glyphAngle;
     Point<float> anchorPoint;
-    float minScale, maxScale;
+    float minScale;
+    float maxScale;
     WritingModeType writingMode;
 };
 
 typedef std::vector<SymbolQuad> SymbolQuads;
 
-SymbolQuad getIconQuad(Anchor& anchor, const PositionedIcon& shapedIcon,
-        const GeometryCoordinates& line, const style::SymbolLayoutProperties::Evaluated&,
-        style::SymbolPlacementType placement, const Shaping& shapedText);
+SymbolQuad getIconQuad(Anchor& anchor,
+                       const PositionedIcon& shapedIcon,
+                       const GeometryCoordinates& line,
+                       const style::SymbolLayoutProperties::Evaluated&,
+                       style::SymbolPlacementType placement,
+                       const Shaping& shapedText);
 
-SymbolQuads getGlyphQuads(Anchor& anchor, const Shaping& shapedText,
-        const float boxScale, const GeometryCoordinates& line, const style::SymbolLayoutProperties::Evaluated&,
-        style::SymbolPlacementType placement, const GlyphPositions& face);
+SymbolQuads getGlyphQuads(Anchor& anchor,
+                          const Shaping& shapedText,
+                          const float boxScale,
+                          const GeometryCoordinates& line,
+                          const style::SymbolLayoutProperties::Evaluated&,
+                          style::SymbolPlacementType placement,
+                          const GlyphPositions& face);
 
 } // namespace mbgl


### PR DESCRIPTION
Cosmetic stuff: fixing `&` placement, converting long parameter lists to one-parameter-per-line, etc.