### PR TITLE
[android] - uninstall apk on device before running a make run-android-*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -568,6 +568,7 @@ run-android-core-test-$1: run-android-core-test-$1-*
 
 .PHONY: run-android-$1
 run-android-$1: android-$1
+	adb uninstall com.mapbox.mapboxsdk.testapp > /dev/null
 	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:install$(BUILDTYPE) && adb shell am start -n com.mapbox.mapboxsdk.testapp/.activity.FeatureOverviewActivity
 
 apackage: android-lib-$1
@@ -607,10 +608,12 @@ android-ui-test:
 
 .PHONY: run-android-ui-test
 run-android-ui-test:
+	adb uninstall com.mapbox.mapboxsdk.testapp > /dev/null
 	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:connectedAndroidTest -i
 
 run-android-ui-test-%:
-		cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="$*"
+	adb uninstall com.mapbox.mapboxsdk.testapp > /dev/null
+	cd platform/android && ./gradlew :MapboxGLAndroidSDKTestApp:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="$*"
 
 .PHONY: run-android-ui-test-aws
 run-android-ui-test-aws:


### PR DESCRIPTION
While doing a git bisect or switching between master and release branches, 
I often hit `INSTALL_FAILED_VERSION_DOWNGRADE` when trying to run tests from the commandline;

> com.android.builder.testing.ConnectedDevice > runTests[Pixel - 7.1.1] FAILED 
        com.android.builder.testing.api.DeviceException: com.android.ddmlib.InstallException: Failed to finalize session : INSTALL_FAILED_VERSION_DOWNGRADE
                at com.android.builder.testing.ConnectedDevice.installPackages(ConnectedDevice.java:147)
FAILURE: Build failed with an exception.

To optimise the flow for developers not working with AS, I'm proposing to remove the current installed application before running any `make run-android-*` that are installed on an Android device.
