### PR TITLE
Don't treat empty raster tiles as valid

### DIFF
--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -41,13 +41,13 @@ void RasterTile::setData(std::shared_ptr<const std::string> data,
 
 void RasterTile::onParsed(std::unique_ptr<Bucket> result) {
     bucket = std::move(result);
-    availableData = DataAvailability::All;
+    availableData = bucket ? DataAvailability::All : DataAvailability::None;
     observer->onTileChanged(*this);
 }
 
 void RasterTile::onError(std::exception_ptr err) {
     bucket.reset();
-    availableData = DataAvailability::All;
+    availableData = DataAvailability::None;
     observer->onTileError(*this, err);
 }
 

--- a/src/mbgl/tile/raster_tile_worker.cpp
+++ b/src/mbgl/tile/raster_tile_worker.cpp
@@ -1,6 +1,6 @@
 #include <mbgl/tile/raster_tile_worker.hpp>
 #include <mbgl/tile/raster_tile.hpp>
-#include <mbgl/renderer/raster_bucket.cpp>
+#include <mbgl/renderer/raster_bucket.hpp>
 #include <mbgl/actor/actor.hpp>
 #include <mbgl/util/premultiply.hpp>
 

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/style/style.hpp>
 #include <mbgl/style/update_parameters.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/renderer/raster_bucket.hpp>
 
 using namespace mbgl;
 
@@ -45,5 +46,19 @@ TEST(RasterTile, onError) {
     RasterTileTest test;
     RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
     tile.onError(std::make_exception_ptr(std::runtime_error("test")));
+    EXPECT_FALSE(tile.isRenderable());
+}
+
+TEST(RasterTile, onParsed) {
+    RasterTileTest test;
+    RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
+    tile.onParsed(std::make_unique<RasterBucket>(UnassociatedImage{}));
     EXPECT_TRUE(tile.isRenderable());
+}
+
+TEST(RasterTile, onParsedEmpty) {
+    RasterTileTest test;
+    RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
+    tile.onParsed(nullptr);
+    EXPECT_FALSE(tile.isRenderable());
 }


### PR DESCRIPTION
We're currently treating raster tiles that are "empty" or not found as valid by setting `DataAvailability::All`. Tiles that can't be found on the server and that return a 404 code are [treated as valid responses with no content ("empty")](https://github.com/mapbox/mapbox-gl-native/blob/10b8ef644188ee02cdce5b8db35fed1c32688758/platform/darwin/src/http_file_source.mm#L289).

While the concept of an "empty" tile makes sense for vector sources (denoting no features within that tile), it doesn't make sense for raster sources. Instead, we should fall back to lower zoom level tiles. Our [`updateRenderables`](https://github.com/mapbox/mapbox-gl-native/blob/10b8ef644188ee02cdce5b8db35fed1c32688758/src/mbgl/algorithm/update_renderables.hpp) algorithm takes care of loading these lower zoom level tiles iff the loaded tile can't be rendered.

Fixes https://github.com/mapbox/mapbox-gl-native/issues/8151