### PR TITLE
[core] - allow zooming/scaling to use AnimationOptions

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -88,22 +88,22 @@ public:
 
     // Position
     void moveBy(const ScreenCoordinate&, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, optional<ScreenCoordinate>, const Duration& = Duration::zero());
-    void setLatLng(const LatLng&, optional<EdgeInsets>, const Duration& = Duration::zero());
-    void setLatLng(const LatLng&, const Duration& = Duration::zero());
+    void setLatLng(const LatLng&, optional<ScreenCoordinate>, const AnimationOptions& = {});
+    void setLatLng(const LatLng&, optional<EdgeInsets>, const AnimationOptions& = {});
+    void setLatLng(const LatLng&, const AnimationOptions& = {});
     LatLng getLatLng(optional<EdgeInsets> = {}) const;
     void resetPosition(optional<EdgeInsets> = {});
 
     // Scale
-    void scaleBy(double ds, optional<ScreenCoordinate> = {}, const Duration& = Duration::zero());
-    void setScale(double scale, optional<ScreenCoordinate> = {}, const Duration& = Duration::zero());
+    void scaleBy(double ds, optional<ScreenCoordinate> = {}, const AnimationOptions& = {});
+    void setScale(double scale, optional<ScreenCoordinate> = {}, const AnimationOptions& = {});
     double getScale() const;
-    void setZoom(double zoom, const Duration& = Duration::zero());
-    void setZoom(double zoom, optional<ScreenCoordinate>, const Duration& = Duration::zero());
-    void setZoom(double zoom, optional<EdgeInsets>, const Duration& = Duration::zero());
+    void setZoom(double zoom, const AnimationOptions& = {});
+    void setZoom(double zoom, optional<ScreenCoordinate>, const AnimationOptions& = {});
+    void setZoom(double zoom, optional<EdgeInsets>, const AnimationOptions& = {});
     double getZoom() const;
-    void setLatLngZoom(const LatLng&, double zoom, const Duration& = Duration::zero());
-    void setLatLngZoom(const LatLng&, double zoom, optional<EdgeInsets>, const Duration& = Duration::zero());
+    void setLatLngZoom(const LatLng&, double zoom, const AnimationOptions& = {});
+    void setLatLngZoom(const LatLng&, double zoom, optional<EdgeInsets>, const AnimationOptions& = {});
     CameraOptions cameraForLatLngBounds(const LatLngBounds&, optional<EdgeInsets>) const;
     CameraOptions cameraForLatLngs(const std::vector<LatLng>&, optional<EdgeInsets>) const;
     void resetZoom();
@@ -113,17 +113,17 @@ public:
     double getMaxZoom() const;
 
     // Rotation
-    void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const Duration& = Duration::zero());
-    void setBearing(double degrees, const Duration& = Duration::zero());
-    void setBearing(double degrees, optional<ScreenCoordinate>, const Duration& = Duration::zero());
-    void setBearing(double degrees, optional<EdgeInsets>, const Duration& = Duration::zero());
+    void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
+    void setBearing(double degrees, const AnimationOptions& = {});
+    void setBearing(double degrees, optional<ScreenCoordinate>, const AnimationOptions& = {});
+    void setBearing(double degrees, optional<EdgeInsets>, const AnimationOptions& = {});
     double getBearing() const;
-    void resetNorth(const Duration& = Milliseconds(500));
-    void resetNorth(optional<EdgeInsets>, const Duration& = Milliseconds(500));
+    void resetNorth(const AnimationOptions& = {{mbgl::Milliseconds(500)}});
+    void resetNorth(optional<EdgeInsets>, const AnimationOptions& = {{mbgl::Milliseconds(500)}});
 
     // Pitch
-    void setPitch(double pitch, const Duration& = Duration::zero());
-    void setPitch(double pitch, optional<ScreenCoordinate>, const Duration& = Duration::zero());
+    void setPitch(double pitch, const AnimationOptions& = {});
+    void setPitch(double pitch, optional<ScreenCoordinate>, const AnimationOptions& = {});
     double getPitch() const;
 
     // North Orientation

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -352,7 +352,7 @@ jni::Object<LatLng> NativeMapView::getLatLng(JNIEnv& env) {
 }
 
 void NativeMapView::setLatLng(jni::JNIEnv&, jni::jdouble latitude, jni::jdouble longitude, jni::jlong duration) {
-    map->setLatLng(mbgl::LatLng(latitude, longitude), insets, mbgl::Milliseconds(duration));
+    map->setLatLng(mbgl::LatLng(latitude, longitude), insets, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 void NativeMapView::setReachability(jni::JNIEnv&, jni::jboolean reachable) {
@@ -370,17 +370,17 @@ jni::jdouble NativeMapView::getPitch(jni::JNIEnv&) {
 }
 
 void NativeMapView::setPitch(jni::JNIEnv&, jni::jdouble pitch, jni::jlong duration) {
-    map->setPitch(pitch, mbgl::Milliseconds(duration));
+    map->setPitch(pitch, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 void NativeMapView::scaleBy(jni::JNIEnv&, jni::jdouble ds, jni::jdouble cx, jni::jdouble cy, jni::jlong duration) {
     mbgl::ScreenCoordinate center(cx, cy);
-    map->scaleBy(ds, center, mbgl::Milliseconds(duration));
+    map->scaleBy(ds, center, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 void NativeMapView::setScale(jni::JNIEnv&, jni::jdouble scale, jni::jdouble cx, jni::jdouble cy, jni::jlong duration) {
     mbgl::ScreenCoordinate center(cx, cy);
-    map->setScale(scale, center, mbgl::Milliseconds(duration));
+    map->setScale(scale, center, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 jni::jdouble NativeMapView::getScale(jni::JNIEnv&) {
@@ -388,7 +388,7 @@ jni::jdouble NativeMapView::getScale(jni::JNIEnv&) {
 }
 
 void NativeMapView::setZoom(jni::JNIEnv&, jni::jdouble zoom, jni::jlong duration) {
-    map->setZoom(zoom, mbgl::Milliseconds(duration));
+    map->setZoom(zoom, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 jni::jdouble NativeMapView::getZoom(jni::JNIEnv&) {
@@ -418,16 +418,16 @@ jni::jdouble NativeMapView::getMaxZoom(jni::JNIEnv&) {
 void NativeMapView::rotateBy(jni::JNIEnv&, jni::jdouble sx, jni::jdouble sy, jni::jdouble ex, jni::jdouble ey, jni::jlong duration) {
     mbgl::ScreenCoordinate first(sx, sy);
     mbgl::ScreenCoordinate second(ex, ey);
-    map->rotateBy(first, second, mbgl::Milliseconds(duration));
+    map->rotateBy(first, second, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 void NativeMapView::setBearing(jni::JNIEnv&, jni::jdouble degrees, jni::jlong duration) {
-    map->setBearing(degrees, mbgl::Milliseconds(duration));
+    map->setBearing(degrees, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 void NativeMapView::setBearingXY(jni::JNIEnv&, jni::jdouble degrees, jni::jdouble cx, jni::jdouble cy, jni::jlong duration) {
     mbgl::ScreenCoordinate center(cx, cy);
-    map->setBearing(degrees, center, mbgl::Milliseconds(duration));
+    map->setBearing(degrees, center, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 jni::jdouble NativeMapView::getBearing(jni::JNIEnv&) {

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -417,9 +417,9 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
             double now = glfwGetTime();
             if (now - view->lastClick < 0.4 /* ms */) {
                 if (modifiers & GLFW_MOD_SHIFT) {
-                    view->map->scaleBy(0.5, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::Milliseconds(500));
+                    view->map->scaleBy(0.5, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
                 } else {
-                    view->map->scaleBy(2.0, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::Milliseconds(500));
+                    view->map->scaleBy(2.0, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
                 }
             }
             view->lastClick = now;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -484,20 +484,20 @@ void Map::moveBy(const ScreenCoordinate& point, const AnimationOptions& animatio
     impl->onUpdate(Update::Repaint);
 }
 
-void Map::setLatLng(const LatLng& latLng, const Duration& duration) {
+void Map::setLatLng(const LatLng& latLng, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    setLatLng(latLng, optional<ScreenCoordinate> {}, duration);
+    setLatLng(latLng, optional<ScreenCoordinate> {}, animation);
 }
 
-void Map::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, const Duration& duration) {
+void Map::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setLatLng(latLng, padding, duration);
+    impl->transform.setLatLng(latLng, padding, animation);
     impl->onUpdate(Update::Repaint);
 }
 
-void Map::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Map::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setLatLng(latLng, anchor, duration);
+    impl->transform.setLatLng(latLng, anchor, animation);
     impl->onUpdate(Update::Repaint);
 }
 
@@ -520,15 +520,15 @@ void Map::resetPosition(optional<EdgeInsets> padding) {
 
 #pragma mark - Scale
 
-void Map::scaleBy(double ds, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Map::scaleBy(double ds, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.scaleBy(ds, anchor, duration);
+    impl->transform.scaleBy(ds, anchor, animation);
     impl->onUpdate(Update::RecalculateStyle);
 }
 
-void Map::setScale(double scale, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Map::setScale(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setScale(scale, anchor, duration);
+    impl->transform.setScale(scale, anchor, animation);
     impl->onUpdate(Update::RecalculateStyle);
 }
 
@@ -536,20 +536,20 @@ double Map::getScale() const {
     return impl->transform.getScale();
 }
 
-void Map::setZoom(double zoom, const Duration& duration) {
+void Map::setZoom(double zoom, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    setZoom(zoom, optional<EdgeInsets> {}, duration);
+    setZoom(zoom, optional<EdgeInsets> {}, animation);
 }
 
-void Map::setZoom(double zoom, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Map::setZoom(double zoom, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setZoom(zoom, anchor, duration);
+    impl->transform.setZoom(zoom, anchor, animation);
     impl->onUpdate(Update::RecalculateStyle);
 }
 
-void Map::setZoom(double zoom, optional<EdgeInsets> padding, const Duration& duration) {
+void Map::setZoom(double zoom, optional<EdgeInsets> padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setZoom(zoom, padding, duration);
+    impl->transform.setZoom(zoom, padding, animation);
     impl->onUpdate(Update::RecalculateStyle);
 }
 
@@ -557,14 +557,14 @@ double Map::getZoom() const {
     return impl->transform.getZoom();
 }
 
-void Map::setLatLngZoom(const LatLng& latLng, double zoom, const Duration& duration) {
+void Map::setLatLngZoom(const LatLng& latLng, double zoom, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    setLatLngZoom(latLng, zoom, {}, duration);
+    setLatLngZoom(latLng, zoom, {}, animation);
 }
 
-void Map::setLatLngZoom(const LatLng& latLng, double zoom, optional<EdgeInsets> padding, const Duration& duration) {
+void Map::setLatLngZoom(const LatLng& latLng, double zoom, optional<EdgeInsets> padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setLatLngZoom(latLng, zoom, padding, duration);
+    impl->transform.setLatLngZoom(latLng, zoom, padding, animation);
     impl->onUpdate(Update::RecalculateStyle);
 }
 
@@ -674,26 +674,26 @@ Size Map::getSize() const {
 
 #pragma mark - Rotation
 
-void Map::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const Duration& duration) {
+void Map::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.rotateBy(first, second, duration);
+    impl->transform.rotateBy(first, second, animation);
     impl->onUpdate(Update::Repaint);
 }
 
-void Map::setBearing(double degrees, const Duration& duration) {
+void Map::setBearing(double degrees, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    setBearing(degrees, EdgeInsets(), duration);
+    setBearing(degrees, EdgeInsets(), animation);
 }
 
-void Map::setBearing(double degrees, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Map::setBearing(double degrees, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setAngle(-degrees * util::DEG2RAD, anchor, duration);
+    impl->transform.setAngle(-degrees * util::DEG2RAD, anchor, animation);
     impl->onUpdate(Update::Repaint);
 }
 
-void Map::setBearing(double degrees, optional<EdgeInsets> padding, const Duration& duration) {
+void Map::setBearing(double degrees, optional<EdgeInsets> padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setAngle(-degrees * util::DEG2RAD, padding, duration);
+    impl->transform.setAngle(-degrees * util::DEG2RAD, padding, animation);
     impl->onUpdate(Update::Repaint);
 }
 
@@ -701,22 +701,22 @@ double Map::getBearing() const {
     return -impl->transform.getAngle() * util::RAD2DEG;
 }
 
-void Map::resetNorth(const Duration& duration) {
+void Map::resetNorth(const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setAngle(0, duration);
+    impl->transform.setAngle(0, animation);
     impl->onUpdate(Update::Repaint);
 }
 
 #pragma mark - Pitch
 
-void Map::setPitch(double pitch, const Duration& duration) {
+void Map::setPitch(double pitch, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    setPitch(pitch, {}, duration);
+    setPitch(pitch, {}, animation);
 }
 
-void Map::setPitch(double pitch, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Map::setPitch(double pitch, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    impl->transform.setPitch(pitch * util::DEG2RAD, anchor, duration);
+    impl->transform.setPitch(pitch * util::DEG2RAD, anchor, animation);
     impl->onUpdate(Update::Repaint);
 }
 

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -334,19 +334,19 @@ void Transform::moveBy(const ScreenCoordinate& offset, const AnimationOptions& a
     easeTo(camera, animation);
 }
 
-void Transform::setLatLng(const LatLng& latLng, const Duration& duration) {
-    setLatLng(latLng, optional<ScreenCoordinate> {}, duration);
+void Transform::setLatLng(const LatLng& latLng, const AnimationOptions& animation) {
+    setLatLng(latLng, optional<ScreenCoordinate> {}, animation);
 }
 
-void Transform::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, const Duration& duration) {
+void Transform::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, const AnimationOptions& animation) {
     if (!latLng) return;
     CameraOptions camera;
     camera.center = latLng;
     camera.padding = padding;
-    easeTo(camera, duration);
+    easeTo(camera, animation);
 }
 
-void Transform::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Transform::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     if (!latLng) return;
     CameraOptions camera;
     camera.center = latLng;
@@ -358,21 +358,21 @@ void Transform::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> ancho
         padding.right = state.size.width - anchor->x;
         if (padding) camera.padding = padding;
     }
-    easeTo(camera, duration);
+    easeTo(camera, animation);
 }
 
-void Transform::setLatLngZoom(const LatLng& latLng, double zoom, const Duration& duration) {
-    setLatLngZoom(latLng, zoom, EdgeInsets {}, duration);
+void Transform::setLatLngZoom(const LatLng& latLng, double zoom, const AnimationOptions& animation) {
+    setLatLngZoom(latLng, zoom, EdgeInsets {}, animation);
 }
 
-void Transform::setLatLngZoom(const LatLng& latLng, double zoom, optional<EdgeInsets> padding, const Duration& duration) {
+void Transform::setLatLngZoom(const LatLng& latLng, double zoom, optional<EdgeInsets> padding, const AnimationOptions& animation) {
     if (!latLng || std::isnan(zoom)) return;
 
     CameraOptions camera;
     camera.center = latLng;
     camera.padding = padding;
     camera.zoom = zoom;
-    easeTo(camera, duration);
+    easeTo(camera, animation);
 }
 
 LatLng Transform::getLatLng(optional<EdgeInsets> padding) const {
@@ -394,26 +394,26 @@ ScreenCoordinate Transform::getScreenCoordinate(optional<EdgeInsets> padding) co
 
 #pragma mark - Zoom
 
-void Transform::scaleBy(double ds, const Duration& duration) {
-    scaleBy(ds, optional<ScreenCoordinate> {}, duration);
+void Transform::scaleBy(double ds, const AnimationOptions& animation) {
+    scaleBy(ds, optional<ScreenCoordinate> {}, animation);
 }
 
-void Transform::scaleBy(double ds, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Transform::scaleBy(double ds, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     if (std::isnan(ds)) return;
     double scale = util::clamp(state.scale * ds, state.min_scale, state.max_scale);
-    setScale(scale, anchor, duration);
+    setScale(scale, anchor, animation);
 }
 
-void Transform::setZoom(double zoom, const Duration& duration) {
-    setZoom(zoom, optional<ScreenCoordinate> {}, duration);
+void Transform::setZoom(double zoom, const AnimationOptions& animation) {
+    setZoom(zoom, optional<ScreenCoordinate> {}, animation);
 }
 
-void Transform::setZoom(double zoom, optional<ScreenCoordinate> anchor, const Duration& duration) {
-    setScale(state.zoomScale(zoom), anchor, duration);
+void Transform::setZoom(double zoom, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
+    setScale(state.zoomScale(zoom), anchor, animation);
 }
 
-void Transform::setZoom(double zoom, optional<EdgeInsets> padding, const Duration& duration) {
-    setScale(state.zoomScale(zoom), padding, duration);
+void Transform::setZoom(double zoom, optional<EdgeInsets> padding, const AnimationOptions& animation) {
+    setScale(state.zoomScale(zoom), padding, animation);
 }
 
 double Transform::getZoom() const {
@@ -424,22 +424,22 @@ double Transform::getScale() const {
     return state.scale;
 }
 
-void Transform::setScale(double scale, const Duration& duration) {
-    setScale(scale, optional<ScreenCoordinate> {}, duration);
+void Transform::setScale(double scale, const AnimationOptions& animation) {
+    setScale(scale, optional<ScreenCoordinate> {}, animation);
 }
 
-void Transform::setScale(double scale, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Transform::setScale(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     if (std::isnan(scale)) return;
     CameraOptions camera;
     camera.zoom = state.scaleZoom(scale);
     camera.anchor = anchor;
-    easeTo(camera, duration);
+    easeTo(camera, animation);
 }
 
-void Transform::setScale(double scale, optional<EdgeInsets> padding, const Duration& duration) {
+void Transform::setScale(double scale, optional<EdgeInsets> padding, const AnimationOptions& animation) {
     optional<ScreenCoordinate> anchor;
     if (padding) anchor = getScreenCoordinate(padding);
-    setScale(scale, anchor, duration);
+    setScale(scale, anchor, animation);
 }
 
 void Transform::setMinZoom(const double minZoom) {
@@ -454,7 +454,7 @@ void Transform::setMaxZoom(const double maxZoom) {
 
 #pragma mark - Angle
 
-void Transform::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const Duration& duration) {
+void Transform::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second,  const AnimationOptions& animation) {
     ScreenCoordinate center = getScreenCoordinate();
     const ScreenCoordinate offset = first - center;
     const double distance = std::sqrt(std::pow(2, offset.x) + std::pow(2, offset.y));
@@ -470,25 +470,25 @@ void Transform::rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& 
 
     CameraOptions camera;
     camera.angle = state.angle + util::angle_between(first - center, second - center);
-    easeTo(camera, duration);
+    easeTo(camera, animation);
 }
 
-void Transform::setAngle(double angle, const Duration& duration) {
-    setAngle(angle, optional<ScreenCoordinate> {}, duration);
+void Transform::setAngle(double angle, const AnimationOptions& animation) {
+    setAngle(angle, optional<ScreenCoordinate> {}, animation);
 }
 
-void Transform::setAngle(double angle, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Transform::setAngle(double angle, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     if (std::isnan(angle)) return;
     CameraOptions camera;
     camera.angle = angle;
     camera.anchor = anchor;
-    easeTo(camera, duration);
+    easeTo(camera, animation);
 }
 
-void Transform::setAngle(double angle, optional<EdgeInsets> padding, const Duration& duration) {
+void Transform::setAngle(double angle, optional<EdgeInsets> padding, const AnimationOptions& animation) {
     optional<ScreenCoordinate> anchor;
     if (padding && *padding) anchor = getScreenCoordinate(padding);
-    setAngle(angle, anchor, duration);
+    setAngle(angle, anchor, animation);
 }
 
 double Transform::getAngle() const {
@@ -497,16 +497,16 @@ double Transform::getAngle() const {
 
 #pragma mark - Pitch
 
-void Transform::setPitch(double pitch, const Duration& duration) {
-    setPitch(pitch, optional<ScreenCoordinate> {}, duration);
+void Transform::setPitch(double pitch, const AnimationOptions& animation) {
+    setPitch(pitch, optional<ScreenCoordinate> {}, animation);
 }
 
-void Transform::setPitch(double pitch, optional<ScreenCoordinate> anchor, const Duration& duration) {
+void Transform::setPitch(double pitch, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
     if (std::isnan(pitch)) return;
     CameraOptions camera;
     camera.pitch = pitch;
     camera.anchor = anchor;
-    easeTo(camera, duration);
+    easeTo(camera, animation);
 }
 
 double Transform::getPitch() const {

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -45,11 +45,11 @@ public:
         @param offset The distance to pan the map by, measured in pixels from
             top to bottom and from left to right. */
     void moveBy(const ScreenCoordinate& offset, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, const Duration& = Duration::zero());
-    void setLatLng(const LatLng&, optional<EdgeInsets>, const Duration& = Duration::zero());
-    void setLatLng(const LatLng&, optional<ScreenCoordinate>, const Duration& = Duration::zero());
-    void setLatLngZoom(const LatLng&, double zoom, const Duration& = Duration::zero());
-    void setLatLngZoom(const LatLng&, double zoom, optional<EdgeInsets>, const Duration& = Duration::zero());
+    void setLatLng(const LatLng&,  const AnimationOptions& = {});
+    void setLatLng(const LatLng&, optional<EdgeInsets>, const AnimationOptions& = {});
+    void setLatLng(const LatLng&, optional<ScreenCoordinate>, const AnimationOptions& = {});
+    void setLatLngZoom(const LatLng&, double zoom, const AnimationOptions& = {});
+    void setLatLngZoom(const LatLng&, double zoom, optional<EdgeInsets>, const AnimationOptions& = {});
     LatLng getLatLng(optional<EdgeInsets> = {}) const;
     ScreenCoordinate getScreenCoordinate(optional<EdgeInsets> = {}) const;
 
@@ -57,36 +57,36 @@ public:
 
     /** Scales the map, keeping the given point fixed within the view.
         @param ds The difference in scale factors to scale the map by. */
-    void scaleBy(double ds, const Duration& = Duration::zero());
+    void scaleBy(double ds, const AnimationOptions& = {});
     /** Scales the map, keeping the given point fixed within the view.
         @param ds The difference in scale factors to scale the map by.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void scaleBy(double ds, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
+    void scaleBy(double ds, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
     /** Sets the scale factor, keeping the given point fixed within the view.
         @param scale The new scale factor. */
-    void setScale(double scale, const Duration& = Duration::zero());
+    void setScale(double scale, const AnimationOptions& = {});
     /** Sets the scale factor, keeping the given point fixed within the view.
         @param scale The new scale factor.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void setScale(double scale, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
+    void setScale(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
     /** Sets the scale factor, keeping the center point fixed within the inset view.
         @param scale The new scale factor.
         @param padding The viewport padding that affects the fixed center point. */
-    void setScale(double scale, optional<EdgeInsets> padding, const Duration& = Duration::zero());
+    void setScale(double scale, optional<EdgeInsets> padding, const AnimationOptions& = {});
     /** Sets the zoom level, keeping the given point fixed within the view.
         @param zoom The new zoom level. */
-    void setZoom(double zoom, const Duration& = Duration::zero());
+    void setZoom(double zoom, const AnimationOptions& = {});
     /** Sets the zoom level, keeping the given point fixed within the view.
         @param zoom The new zoom level.
         @param anchor A point relative to the top-left corner of the view.
             If unspecified, the center point is fixed within the view. */
-    void setZoom(double zoom, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
+    void setZoom(double zoom, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
     /** Sets the zoom level, keeping the center point fixed within the inset view.
         @param zoom The new zoom level.
         @param padding The viewport padding that affects the fixed center point. */
-    void setZoom(double zoom, optional<EdgeInsets> padding, const Duration& = Duration::zero());
+    void setZoom(double zoom, optional<EdgeInsets> padding, const AnimationOptions& = {});
     /** Returns the zoom level. */
     double getZoom() const;
     /** Returns the scale factor. */
@@ -97,21 +97,21 @@ public:
 
     // Angle
 
-    void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const Duration& = Duration::zero());
+    void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
     /** Sets the angle of rotation.
         @param angle The new angle of rotation, measured in radians
             counterclockwise from true north. */
-    void setAngle(double angle, const Duration& = Duration::zero());
+    void setAngle(double angle, const AnimationOptions& = {});
     /** Sets the angle of rotation, keeping the given point fixed within the view.
         @param angle The new angle of rotation, measured in radians
             counterclockwise from true north.
         @param anchor A point relative to the top-left corner of the view. */
-    void setAngle(double angle, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
+    void setAngle(double angle, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
     /** Sets the angle of rotation, keeping the center point fixed within the inset view.
         @param angle The new angle of rotation, measured in radians
             counterclockwise from true north.
         @param padding The viewport padding that affects the fixed center point. */
-    void setAngle(double angle, optional<EdgeInsets> padding, const Duration& = Duration::zero());
+    void setAngle(double angle, optional<EdgeInsets> padding, const AnimationOptions& = {});
     /** Returns the angle of rotation.
         @return The angle of rotation, measured in radians counterclockwise from
             true north. */
@@ -121,12 +121,12 @@ public:
     /** Sets the pitch angle.
         @param angle The new pitch angle, measured in radians toward the
             horizon. */
-    void setPitch(double pitch, const Duration& = Duration::zero());
+    void setPitch(double pitch, const AnimationOptions& = {});
     /** Sets the pitch angle, keeping the given point fixed within the view.
         @param angle The new pitch angle, measured in radians toward the
             horizon.
         @param anchor A point relative to the top-left corner of the view. */
-    void setPitch(double pitch, optional<ScreenCoordinate> anchor, const Duration& = Duration::zero());
+    void setPitch(double pitch, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
     double getPitch() const;
 
     // North Orientation


### PR DESCRIPTION
This PR enables to use AnimationOptions when performing a zoom/scale transformation (equivalent to #8092 for moveBy). This allows bindings to use an interpolator while doing a zoom/scale transformation.

To showcase the possibilities with this API, here is an example of the double tap zoom gesture using the `easeInOutBack` interpolator with an increased duration:

![ezgif com-video-to-gif 22](https://cloud.githubusercontent.com/assets/2151639/23252487/469f90d2-f9b1-11e6-97d9-4b57c8707cdf.gif)

Note that atm I'm not changing the default behaviour for Android. 
