### PR TITLE
Adhere to node module naming requirements

### DIFF
--- a/cmake/node.cmake
+++ b/cmake/node.cmake
@@ -49,7 +49,7 @@ target_add_mason_package(mbgl-node PRIVATE geojson)
 add_custom_command(
     TARGET mbgl-node
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mbgl-node> ${CMAKE_SOURCE_DIR}/lib/mapbox-gl-native.node
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mbgl-node> ${CMAKE_SOURCE_DIR}/lib/mapbox_gl_native.node
 )
 
 mbgl_platform_node()

--- a/platform/node/index.js
+++ b/platform/node/index.js
@@ -2,7 +2,7 @@
 
 // Shim to wrap req.respond while preserving callback-passing API
 
-var mbgl = require('../../lib/mapbox-gl-native.node');
+var mbgl = require('../../lib/mapbox_gl_native.node');
 var constructor = mbgl.Map.prototype.constructor;
 
 var Map = function(options) {

--- a/platform/node/test/js/require.js
+++ b/platform/node/test/js/require.js
@@ -1,1 +1,1 @@
-var mbgl = require('../../../../lib/mapbox-gl-native');
+var mbgl = require('../../../../lib/mapbox_gl_native');


### PR DESCRIPTION
https://nodejs.org/api/addons.html#addons_building specifies that 

> The module_name must match the filename of the final binary (excluding the .node suffix)."

While the mismatch between `mapbox-gl-native` and `mapbox_gl_native` hasn't caused issues so far, we should play by the book. We use the [underscore version in our code](https://github.com/mapbox/mapbox-gl-native/blob/node-module-name/platform/node/src/node_mapbox_gl_native.cpp#L80), and can't change that one to dashes, since it must be a valid C identifier.