### PR TITLE
[build] Fix build on Ubuntu 16.04+

### DIFF
--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -7,7 +7,7 @@ mason_use(nunicode VERSION 1.7.1)
 mason_use(libpng VERSION 1.6.25)
 mason_use(libjpeg-turbo VERSION 1.5.0)
 mason_use(webp VERSION 0.5.1)
-mason_use(gtest VERSION 1.8.0)
+mason_use(gtest VERSION 1.8.0${MASON_CXXABI_SUFFIX})
 mason_use(benchmark VERSION 1.0.0-1)
 mason_use(icu VERSION 58.1)
 

--- a/platform/qt/config.cmake
+++ b/platform/qt/config.cmake
@@ -1,7 +1,7 @@
 include(platform/qt/qt.cmake)
 
 mason_use(sqlite VERSION 3.14.2)
-mason_use(gtest VERSION 1.8.0)
+mason_use(gtest VERSION 1.8.0${MASON_CXXABI_SUFFIX})
 
 if(NOT WITH_QT_DECODERS)
     mason_use(libjpeg-turbo VERSION 1.5.0)


### PR DESCRIPTION
gtest was broken because of lack of CXX11ABI support.