### PR TITLE
[core] Add pause/resume to the Thread class

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -115,6 +115,9 @@ public:
      */
     void setOfflineMapboxTileCountLimit(uint64_t) const;
 
+    void pause();
+    void resume();
+
     // For testing only.
     void put(const Resource&, const Response&);
 

--- a/platform/default/default_file_source.cpp
+++ b/platform/default/default_file_source.cpp
@@ -261,6 +261,14 @@ void DefaultFileSource::setOfflineMapboxTileCountLimit(uint64_t limit) const {
     thread->invokeSync(&Impl::setOfflineMapboxTileCountLimit, limit);
 }
 
+void DefaultFileSource::pause() {
+    thread->pause();
+}
+
+void DefaultFileSource::resume() {
+    thread->resume();
+}
+
 // For testing only:
 
 void DefaultFileSource::put(const Resource& resource, const Response& response) {

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -109,10 +109,11 @@ GLFWView::GLFWView(bool fullscreen_, bool benchmark_)
     printf("- Press `7` through `0` to add increasing numbers of shape annotations for testing\n");
     printf("\n");
     printf("- Press `Q` to remove annotations\n");
-    printf("- Press `P` to add a random custom runtime imagery annotation\n");
+    printf("- Press `K` to add a random custom runtime imagery annotation\n");
     printf("- Press `L` to add a random line annotation\n");
     printf("- Press `W` to pop the last-added annotation off\n");
     printf("\n");
+    printf("- Press `P` to pause tile requests\n");
     printf("- `Control` + mouse drag to rotate\n");
     printf("- `Shift` + mouse drag to tilt\n");
     printf("\n");
@@ -200,10 +201,13 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
             auto result = view->map->queryPointAnnotations({ {}, { double(view->getSize().width), double(view->getSize().height) } });
             printf("visible point annotations: %lu\n", result.size());
         } break;
+        case GLFW_KEY_P:
+            view->pauseResumeCallback();
+            break;
         case GLFW_KEY_C:
             view->clearAnnotations();
             break;
-        case GLFW_KEY_P:
+        case GLFW_KEY_K:
             view->addRandomCustomPointAnnotations(1);
             break;
         case GLFW_KEY_L:

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -27,6 +27,10 @@ public:
     // The expected action is to set a new style, different to the current one.
     void setChangeStyleCallback(std::function<void()> callback);
 
+    void setPauseResumeCallback(std::function<void()> callback) {
+        pauseResumeCallback = callback;
+    };
+
     void setShouldClose();
 
     void setWindowTitle(const std::string&);
@@ -104,6 +108,7 @@ private:
     double lastClick = -1;
 
     std::function<void()> changeStyleCallback;
+    std::function<void()> pauseResumeCallback;
 
     mbgl::util::RunLoop runLoop;
     mbgl::util::Timer frameTick;

--- a/platform/glfw/main.cpp
+++ b/platform/glfw/main.cpp
@@ -153,6 +153,18 @@ int main(int argc, char *argv[]) {
         mbgl::Log::Info(mbgl::Event::Setup, "Changed style to: %s", newStyle.name);
     });
 
+    view->setPauseResumeCallback([&fileSource] () {
+        static bool isPaused = false;
+
+        if (isPaused) {
+            fileSource.resume();
+        } else {
+            fileSource.pause();
+        }
+
+        isPaused = !isPaused;
+    });
+
     // Load style
     if (style.empty()) {
         const char *url = getenv("MAPBOX_STYLE_URL");

--- a/src/mbgl/util/thread.hpp
+++ b/src/mbgl/util/thread.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <future>
 #include <thread>
 #include <atomic>
@@ -9,6 +10,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/util/thread_context.hpp>
 #include <mbgl/util/platform.hpp>
+#include <mbgl/util/util.hpp>
 
 namespace mbgl {
 namespace util {
@@ -47,6 +49,8 @@ public:
     // Invoke object->fn(args...) asynchronously, but wait for the result.
     template <typename Fn, class... Args>
     auto invokeSync(Fn fn, Args&&... args) {
+        assert(!paused);
+
         using R = std::result_of_t<Fn(Object, Args&&...)>;
         std::packaged_task<R ()> task(std::bind(fn, object, args...));
         std::future<R> future = task.get_future();
@@ -54,7 +58,39 @@ public:
         return future.get();
     }
 
+    void pause() {
+        MBGL_VERIFY_THREAD(tid);
+
+        assert(!paused);
+
+        paused = std::make_unique<std::promise<void>>();
+        resumed = std::make_unique<std::promise<void>>();
+
+        auto pausing = paused->get_future();
+
+        loop->invoke([this] {
+            auto resuming = resumed->get_future();
+            paused->set_value();
+            resuming.get();
+        });
+
+        pausing.get();
+    }
+
+    void resume() {
+        MBGL_VERIFY_THREAD(tid);
+
+        assert(paused);
+
+        resumed->set_value();
+
+        resumed.reset();
+        paused.reset();
+    }
+
 private:
+    MBGL_STORE_THREAD(tid);
+
     Thread(const Thread&) = delete;
     Thread(Thread&&) = delete;
     Thread& operator=(const Thread&) = delete;
@@ -72,6 +108,9 @@ private:
 
     std::promise<void> running;
     std::promise<void> joinable;
+
+    std::unique_ptr<std::promise<void>> paused;
+    std::unique_ptr<std::promise<void>> resumed;
 
     std::thread thread;
 
@@ -119,6 +158,12 @@ void Thread<Object>::run(P&& params, std::index_sequence<I...>) {
 
 template <class Object>
 Thread<Object>::~Thread() {
+    MBGL_VERIFY_THREAD(tid);
+
+    if (paused) {
+        resume();
+    }
+
     loop->stop();
     joinable.set_value();
     thread.join();


### PR DESCRIPTION
Make a thread completely halt and not process any message on the message queue until resume() is called.

Sending a sync message to a halted thread will result on a deadlock, thus the assertion.

Deleting a paused thread will trigger a resume.