### PR TITLE
[android] list layers sources etc

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -257,18 +257,29 @@ public final class MapboxMap {
    */
   @UiThread
   public void addLayer(@NonNull Layer layer) {
-    addLayer(layer, null);
+    nativeMapView.addLayer(layer);
   }
 
   /**
    * Adds the layer to the map. The layer must be newly created and not added to the map before
    *
    * @param layer  the layer to add
-   * @param before the layer id to add this layer before
+   * @param below the layer id to add this layer before
    */
   @UiThread
-  public void addLayer(@NonNull Layer layer, String before) {
-    nativeMapView.addLayer(layer, before);
+  public void addLayerBelow(@NonNull Layer layer, @NonNull String below) {
+    nativeMapView.addLayerBelow(layer, below);
+  }
+
+  /**
+   * Adds the layer to the map. The layer must be newly created and not added to the map before
+   *
+   * @param layer  the layer to add
+   * @param above the layer id to add this layer above
+   */
+  @UiThread
+  public void addLayerAbove(@NonNull Layer layer, @NonNull String above) {
+    nativeMapView.addLayerAbove(layer, above);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -8,6 +8,7 @@ import android.location.Location;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.FloatRange;
+import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
@@ -263,7 +264,7 @@ public final class MapboxMap {
   /**
    * Adds the layer to the map. The layer must be newly created and not added to the map before
    *
-   * @param layer  the layer to add
+   * @param layer the layer to add
    * @param below the layer id to add this layer before
    */
   @UiThread
@@ -274,7 +275,7 @@ public final class MapboxMap {
   /**
    * Adds the layer to the map. The layer must be newly created and not added to the map before
    *
-   * @param layer  the layer to add
+   * @param layer the layer to add
    * @param above the layer id to add this layer above
    */
   @UiThread
@@ -304,6 +305,18 @@ public final class MapboxMap {
   @Nullable
   public Layer removeLayer(@NonNull Layer layer) {
     return nativeMapView.removeLayer(layer);
+  }
+
+  /**
+   * Removes the layer. Any other references to the layer become invalid and should not be used anymore
+   *
+   * @param index the layer index
+   * @return the removed layer or null if not found
+   */
+  @UiThread
+  @Nullable
+  public Layer removeLayerAt(@IntRange(from = 0) int index) {
+    return nativeMapView.removeLayerAt(index);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -284,6 +284,18 @@ public final class MapboxMap {
   }
 
   /**
+   * Adds the layer to the map at the specified index. The layer must be newly
+   * created and not added to the map before
+   *
+   * @param layer the layer to add
+   * @param index the index to insert the layer at
+   */
+  @UiThread
+  public void addLayerAt(@NonNull Layer layer, @IntRange(from = 0) int index) {
+    nativeMapView.addLayerAt(layer, index);
+  }
+
+  /**
    * Removes the layer. Any references to the layer become invalid and should not be used anymore
    *
    * @param layerId the layer to remove

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -350,20 +350,24 @@ public final class MapboxMap {
    * Removes the source. Any references to the source become invalid and should not be used anymore
    *
    * @param sourceId the source to remove
+   * @return the source handle or null if the source was not present
    */
   @UiThread
-  public void removeSource(@NonNull String sourceId) {
-    nativeMapView.removeSource(sourceId);
+  @Nullable
+  public Source removeSource(@NonNull String sourceId) {
+    return nativeMapView.removeSource(sourceId);
   }
 
   /**
    * Removes the source, preserving the reverence for re-use
    *
    * @param source the source to remove
+   * @return the source
    */
   @UiThread
-  public void removeSource(@NonNull Source source) {
-    nativeMapView.removeSource(source);
+  @Nullable
+  public Source removeSource(@NonNull Source source) {
+    return nativeMapView.removeSource(source);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -275,20 +275,24 @@ public final class MapboxMap {
    * Removes the layer. Any references to the layer become invalid and should not be used anymore
    *
    * @param layerId the layer to remove
+   * @return the removed layer or null if not found
    */
   @UiThread
-  public void removeLayer(@NonNull String layerId) {
-    nativeMapView.removeLayer(layerId);
+  @Nullable
+  public Layer removeLayer(@NonNull String layerId) {
+    return nativeMapView.removeLayer(layerId);
   }
 
   /**
    * Removes the layer. The reference is re-usable after this and can be re-added
    *
    * @param layer the layer to remove
+   * @return the layer
    */
   @UiThread
-  public void removeLayer(@NonNull Layer layer) {
-    nativeMapView.removeLayer(layer);
+  @Nullable
+  public Layer removeLayer(@NonNull Layer layer) {
+    return nativeMapView.removeLayer(layer);
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -209,6 +209,22 @@ public final class MapboxMap {
     nativeMapView.setTransitionDelay(delay);
   }
 
+  /**
+   * Retrieve all the layers in the style
+   *
+   * @return all the layers in the current style
+   */
+  @UiThread
+  public List<Layer> getLayers() {
+    return nativeMapView.getLayers();
+  }
+
+  /**
+   * Get the layer by id
+   *
+   * @param layerId the layer's id
+   * @return the layer, if present in the style
+   */
   @Nullable
   @UiThread
   public Layer getLayer(@NonNull String layerId) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -291,6 +291,22 @@ public final class MapboxMap {
     nativeMapView.removeLayer(layer);
   }
 
+  /**
+   * Retrieve all the sources in the style
+   *
+   * @return all the sources in the current style
+   */
+  @UiThread
+  public List<Source> getSources() {
+    return nativeMapView.getSources();
+  }
+
+  /**
+   * Retrieve a source by id
+   *
+   * @param sourceId the source's id
+   * @return the source if present in the current style
+   */
   @Nullable
   @UiThread
   public Source getSource(@NonNull String sourceId) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -783,6 +783,13 @@ final class NativeMapView {
     nativeAddLayerAbove(layer.getNativePtr(), above);
   }
 
+  public void addLayerAt(@NonNull Layer layer, @IntRange(from = 0) int index) {
+    if (isDestroyedOn("addLayerAt")) {
+      return;
+    }
+    nativeAddLayerAt(layer.getNativePtr(), index);
+  }
+
   @Nullable
   public Layer removeLayer(@NonNull String layerId) {
     if (isDestroyedOn("removeLayer")) {
@@ -1103,6 +1110,8 @@ final class NativeMapView {
   private native void nativeAddLayer(long layerPtr, String before) throws CannotAddLayerException;
 
   private native void nativeAddLayerAbove(long layerPtr, String above) throws CannotAddLayerException;
+
+  private native void nativeAddLayerAt(long layerPtr, int index) throws CannotAddLayerException;
 
   private native Layer nativeRemoveLayerById(String layerId);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -768,18 +768,21 @@ final class NativeMapView {
     nativeAddLayer(layer.getNativePtr(), before);
   }
 
-  public void removeLayer(@NonNull String layerId) {
+  @Nullable
+  public Layer removeLayer(@NonNull String layerId) {
     if (isDestroyedOn("removeLayer")) {
-      return;
+      return null;
     }
-    nativeRemoveLayerById(layerId);
+    return nativeRemoveLayerById(layerId);
   }
 
-  public void removeLayer(@NonNull Layer layer) {
+  @Nullable
+  public Layer removeLayer(@NonNull Layer layer) {
     if (isDestroyedOn("removeLayer")) {
-      return;
+      return null;
     }
     nativeRemoveLayer(layer.getNativePtr());
+    return layer;
   }
 
   public List<Source> getSources() {
@@ -1074,7 +1077,7 @@ final class NativeMapView {
 
   private native void nativeAddLayer(long layerPtr, String before) throws CannotAddLayerException;
 
-  private native void nativeRemoveLayerById(String layerId);
+  private native Layer nativeRemoveLayerById(String layerId);
 
   private native void nativeRemoveLayer(long layerId);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -761,11 +761,25 @@ final class NativeMapView {
     return nativeGetLayer(layerId);
   }
 
-  public void addLayer(@NonNull Layer layer, @Nullable String before) {
-    if (isDestroyedOn("")) {
+  public void addLayer(@NonNull Layer layer) {
+    if (isDestroyedOn("addLayer")) {
       return;
     }
-    nativeAddLayer(layer.getNativePtr(), before);
+    nativeAddLayer(layer.getNativePtr(), null);
+  }
+
+  public void addLayerBelow(@NonNull Layer layer, @NonNull String below) {
+    if (isDestroyedOn("addLayerBelow")) {
+      return;
+    }
+    nativeAddLayer(layer.getNativePtr(), below);
+  }
+
+  public void addLayerAbove(@NonNull Layer layer, @NonNull String above) {
+    if (isDestroyedOn("addLayerAbove")) {
+      return;
+    }
+    nativeAddLayerAbove(layer.getNativePtr(), above);
   }
 
   @Nullable
@@ -1078,6 +1092,8 @@ final class NativeMapView {
   private native Layer nativeGetLayer(String layerId);
 
   private native void nativeAddLayer(long layerPtr, String before) throws CannotAddLayerException;
+
+  private native void nativeAddLayerAbove(long layerPtr, String above) throws CannotAddLayerException;
 
   private native Layer nativeRemoveLayerById(String layerId);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -782,6 +782,13 @@ final class NativeMapView {
     nativeRemoveLayer(layer.getNativePtr());
   }
 
+  public List<Source> getSources() {
+    if (isDestroyedOn("getSources")) {
+      return null;
+    }
+    return Arrays.asList(nativeGetSources());
+  }
+
   public Source getSource(@NonNull String sourceId) {
     if (isDestroyedOn("getSource")) {
       return null;
@@ -1070,6 +1077,8 @@ final class NativeMapView {
   private native void nativeRemoveLayerById(String layerId);
 
   private native void nativeRemoveLayer(long layerId);
+
+  private native Source[] nativeGetSources();
 
   private native Source nativeGetSource(String sourceId);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -747,6 +747,13 @@ final class NativeMapView {
     nativeSetTransitionDelay(delay);
   }
 
+  public List<Layer> getLayers() {
+    if (isDestroyedOn("getLayers")) {
+      return null;
+    }
+    return Arrays.asList(nativeGetLayers());
+  }
+
   public Layer getLayer(String layerId) {
     if (isDestroyedOn("getLayer")) {
       return null;
@@ -1053,6 +1060,8 @@ final class NativeMapView {
   private native long nativeGetTransitionDelay();
 
   private native void nativeSetTransitionDelay(long delay);
+
+  private native Layer[] nativeGetLayers();
 
   private native Layer nativeGetLayer(String layerId);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -6,6 +6,7 @@ import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Build;
+import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -799,6 +800,14 @@ final class NativeMapView {
     return layer;
   }
 
+  @Nullable
+  public Layer removeLayerAt(@IntRange(from = 0) int index) {
+    if (isDestroyedOn("removeLayerAt")) {
+      return null;
+    }
+    return nativeRemoveLayerAt(index);
+  }
+
   public List<Source> getSources() {
     if (isDestroyedOn("getSources")) {
       return null;
@@ -1098,6 +1107,8 @@ final class NativeMapView {
   private native Layer nativeRemoveLayerById(String layerId);
 
   private native void nativeRemoveLayer(long layerId);
+
+  private native Layer nativeRemoveLayerAt(int index);
 
   private native Source[] nativeGetSources();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -806,18 +806,20 @@ final class NativeMapView {
     nativeAddSource(source.getNativePtr());
   }
 
-  public void removeSource(@NonNull String sourceId) {
+  @Nullable
+  public Source removeSource(@NonNull String sourceId) {
     if (isDestroyedOn("removeSource")) {
-      return;
+      return null;
     }
-    nativeRemoveSourceById(sourceId);
+    return nativeRemoveSourceById(sourceId);
   }
 
-  public void removeSource(@NonNull Source source) {
+  public Source removeSource(@NonNull Source source) {
     if (isDestroyedOn("removeSource")) {
-      return;
+      return null;
     }
     nativeRemoveSource(source.getNativePtr());
+    return source;
   }
 
   public void addImage(@NonNull String name, @NonNull Bitmap image) {
@@ -1087,7 +1089,7 @@ final class NativeMapView {
 
   private native void nativeAddSource(long nativeSourcePtr) throws CannotAddSourceException;
 
-  private native void nativeRemoveSourceById(String sourceId);
+  private native Source nativeRemoveSourceById(String sourceId);
 
   private native void nativeRemoveSource(long sourcePtr);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/UnknownLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/UnknownLayer.java
@@ -1,0 +1,25 @@
+package com.mapbox.mapboxsdk.style.layers;
+
+import android.support.annotation.UiThread;
+
+/**
+ * An unknown type of layer
+ */
+@UiThread
+public class UnknownLayer extends Layer {
+
+  /**
+   * Creates a UnknownLayer.
+   *
+   * @param nativePtr pointer used by core
+   */
+  UnknownLayer(long nativePtr) {
+    super(nativePtr);
+  }
+
+  protected native void initialize();
+
+  @Override
+  protected native void finalize() throws Throwable;
+
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/UnknownSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/sources/UnknownSource.java
@@ -1,0 +1,25 @@
+package com.mapbox.mapboxsdk.style.sources;
+
+import android.support.annotation.UiThread;
+
+/**
+ * An unknown type of source
+ */
+@UiThread
+public class UnknownSource extends Source {
+
+  /**
+   * Creates a UnknownSource.
+   *
+   * @param nativePtr pointer used by core
+   */
+  UnknownSource(long nativePtr) {
+    super(nativePtr);
+  }
+
+  protected native void initialize();
+
+  @Override
+  protected native void finalize() throws Throwable;
+
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
@@ -147,6 +147,41 @@ public class RuntimeStyleTests {
     });
   }
 
+  public void testAddLayerAt() {
+    ViewUtils.checkViewIsDisplayed(R.id.mapView);
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+      @Override
+      public void perform(UiController uiController, View view) {
+        MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
+
+        List<Layer> layers = mapboxMap.getLayers();
+        Source source = mapboxMap.getSources().get(0);
+
+        // Test inserting out of range
+        try {
+          mapboxMap.addLayerAt(new CircleLayer("invalid-id-layer-test", source.getId()), layers.size());
+          fail("Should have thrown exception");
+        } catch (CannotAddLayerException ex) {
+          // Yeah
+          assertNotNull(ex.getMessage());
+        }
+
+        // Insert at current last position
+        CircleLayer last = new CircleLayer("this is the last one", source.getId());
+        mapboxMap.addLayerAt(last, layers.size() - 1);
+        layers = mapboxMap.getLayers();
+        assertEquals(last.getId(), layers.get(layers.size() - 2).getId());
+
+        // Insert at start
+        CircleLayer second = new CircleLayer("this is the first one", source.getId());
+        mapboxMap.addLayerAt(second, 0);
+        layers = mapboxMap.getLayers();
+        assertEquals(second.getId(), layers.get(0).getId());
+      }
+    });
+  }
+
+
   @Test
   public void testListSources() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
@@ -192,7 +192,8 @@ public class RuntimeStyleTests {
       mapboxMap.addSource(new VectorSource("my-source", "mapbox://mapbox.mapbox-terrain-v2"));
 
       // Remove
-      mapboxMap.removeSource("my-source");
+      Source mySource = mapboxMap.removeSource("my-source");
+      assertNotNull(mySource);
       assertNull(mapboxMap.getLayer("my-source"));
 
       // Add

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
@@ -35,6 +35,8 @@ import org.junit.runner.RunWith;
 
 import java.util.List;
 
+import timber.log.Timber;
+
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
@@ -118,6 +120,29 @@ public class RuntimeStyleTests {
         mapboxMap.addLayerAbove(second, layers.get(0).getId());
         layers = mapboxMap.getLayers();
         assertEquals(second.getId(), layers.get(1).getId());
+      }
+    });
+  }
+
+  @Test
+  public void testRemoveLayerAt() {
+    ViewUtils.checkViewIsDisplayed(R.id.mapView);
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
+
+        // Remove by index
+        Layer firstLayer = mapboxMap.getLayers().get(0);
+        Layer removed = mapboxMap.removeLayerAt(0);
+        assertNotNull(removed);
+        assertNotNull(removed.getId());
+        assertEquals(firstLayer.getId(), removed.getId());
+
+        // Test remove by index bounds checks
+        Timber.i("Remove layer at index > size");
+        assertNull(mapboxMap.removeLayerAt(Integer.MAX_VALUE));
       }
     });
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
@@ -147,7 +147,8 @@ public class RuntimeStyleTests {
       assertNotNull(mapboxMap.getLayer("building"));
 
       // Remove
-      mapboxMap.removeLayer("building");
+      Layer building = mapboxMap.removeLayer("building");
+      assertNotNull(building);
       assertNull(mapboxMap.getLayer("building"));
 
       // Add

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
@@ -86,6 +86,26 @@ public class RuntimeStyleTests {
   }
 
   @Test
+  public void testListSources() {
+    ViewUtils.checkViewIsDisplayed(R.id.mapView);
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
+
+        List<Source> sources = mapboxMap.getSources();
+        assertNotNull(sources);
+        assertTrue(sources.size() > 0);
+        for (Source source: sources) {
+          assertNotNull(source);
+        }
+      }
+
+    });
+  }
+
+  @Test
   public void testAddRemoveSource() {
     ViewUtils.checkViewIsDisplayed(R.id.mapView);
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RuntimeStyleTests.java
@@ -12,6 +12,7 @@ import android.view.View;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.style.layers.CannotAddLayerException;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
+import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.sources.CannotAddSourceException;
@@ -31,9 +32,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.List;
+
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -53,6 +57,26 @@ public class RuntimeStyleTests {
   public void registerIdlingResource() {
     idlingResource = new OnMapReadyIdlingResource(rule.getActivity());
     Espresso.registerIdlingResources(idlingResource);
+  }
+
+  @Test
+  public void testListLayers() {
+    ViewUtils.checkViewIsDisplayed(R.id.mapView);
+    onView(withId(R.id.mapView)).perform(new BaseViewAction() {
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        MapboxMap mapboxMap = rule.getActivity().getMapboxMap();
+
+        List<Layer> layers = mapboxMap.getLayers();
+        assertNotNull(layers);
+        assertTrue(layers.size() > 0);
+        for (Layer layer : layers) {
+          assertNotNull(layer);
+        }
+      }
+
+    });
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/customlayer/CustomLayerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/customlayer/CustomLayerActivity.java
@@ -70,7 +70,7 @@ public class CustomLayerActivity extends AppCompatActivity {
         ExampleCustomLayer.InitializeFunction,
         ExampleCustomLayer.RenderFunction,
         ExampleCustomLayer.DeinitializeFunction);
-      mapboxMap.addLayer(customLayer, "building");
+      mapboxMap.addLayerBelow(customLayer, "building");
       fab.setImageResource(R.drawable.ic_layers_clear);
     }
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/CircleLayerActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/CircleLayerActivity.java
@@ -91,7 +91,7 @@ public class CircleLayerActivity extends AppCompatActivity {
               Timber.e("That's not an url... ", malformedUrlException);
             }
             LineLayer lineLayer = new LineLayer("route_layer", "bus_route");
-            mapboxMap.addLayer(lineLayer, "stops_layer");
+            mapboxMap.addLayerBelow(lineLayer, "stops_layer");
 
             // move camera to start route
             mapboxMap.animateCamera(CameraUpdateFactory.newCameraPosition(

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/CustomSpriteActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/CustomSpriteActivity.java
@@ -77,7 +77,7 @@ public class CustomSpriteActivity extends AppCompatActivity {
               );
 
               // lets add a circle below labels!
-              mapboxMap.addLayer(layer, "waterway-label");
+              mapboxMap.addLayerBelow(layer, "waterway-label");
 
               fab.setImageResource(R.drawable.ic_directions_car_black);
             } else {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -40,6 +40,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import timber.log.Timber;
@@ -150,6 +151,9 @@ public class RuntimeStyleActivity extends AppCompatActivity {
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     switch (item.getItemId()) {
+      case R.id.action_list_layers:
+        listLayers();
+        return true;
       case R.id.action_water_color:
         setWaterColor();
         return true;
@@ -195,6 +199,16 @@ public class RuntimeStyleActivity extends AppCompatActivity {
       default:
         return super.onOptionsItemSelected(item);
     }
+  }
+
+  private void listLayers() {
+    List<Layer> layers = mapboxMap.getLayers();
+    StringBuilder builder = new StringBuilder("Layers:");
+    for (Layer layer : layers) {
+      builder.append("\n");
+      builder.append(layer.getId());
+    }
+    Toast.makeText(this, builder.toString(), Toast.LENGTH_LONG).show();
   }
 
   private void setLayerInvisible() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -40,7 +40,6 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import timber.log.Timber;
@@ -302,7 +301,7 @@ public class RuntimeStyleActivity extends AppCompatActivity {
     // Only show me parks (except westerpark with stroke-width == 3)
     layer.setFilter(all(eq("type", "park"), eq("stroke-width", 2)));
 
-    mapboxMap.addLayer(layer, "building");
+    mapboxMap.addLayerBelow(layer, "building");
     // layer.setPaintProperty(fillColor(Color.RED)); // XXX But not after the object is attached
 
     // Or get the object later and set it. It's all good.

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -154,6 +154,9 @@ public class RuntimeStyleActivity extends AppCompatActivity {
       case R.id.action_list_layers:
         listLayers();
         return true;
+      case R.id.action_list_sources:
+        listSources();
+        return true;
       case R.id.action_water_color:
         setWaterColor();
         return true;
@@ -207,6 +210,16 @@ public class RuntimeStyleActivity extends AppCompatActivity {
     for (Layer layer : layers) {
       builder.append("\n");
       builder.append(layer.getId());
+    }
+    Toast.makeText(this, builder.toString(), Toast.LENGTH_LONG).show();
+  }
+
+  private void listSources() {
+    List<Source> sources = mapboxMap.getSources();
+    StringBuilder builder = new StringBuilder("Sources:");
+    for (Source source : sources) {
+      builder.append("\n");
+      builder.append(source.getId());
     }
     Toast.makeText(this, builder.toString(), Toast.LENGTH_LONG).show();
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_runtime_style.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_runtime_style.xml
@@ -3,6 +3,10 @@
     xmlns:mapbox="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_list_layers"
+        android:title="List all layers in the style"
+        mapbox:showAsAction="never" />
+    <item
         android:id="@+id/action_water_color"
         android:title="Color the water"
         mapbox:showAsAction="never" />

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_runtime_style.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/menu/menu_runtime_style.xml
@@ -7,6 +7,10 @@
         android:title="List all layers in the style"
         mapbox:showAsAction="never" />
     <item
+        android:id="@+id/action_list_sources"
+        android:title="List all sources in the style"
+        mapbox:showAsAction="never" />
+    <item
         android:id="@+id/action_water_color"
         android:title="Color the water"
         mapbox:showAsAction="never" />

--- a/platform/android/checkstyle.xml
+++ b/platform/android/checkstyle.xml
@@ -20,7 +20,7 @@
         <property name="lineSeparator" value="lf" />
     </module> -->
     <module name="FileLength">
-        <property name="max" value="2042"/>
+        <property name="max" value="3000"/>
     </module>
 
     <module name="FileTabCharacter"/>

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -114,6 +114,8 @@ macro(mbgl_platform_core)
         platform/android/src/style/layers/raster_layer.hpp
         platform/android/src/style/layers/symbol_layer.cpp
         platform/android/src/style/layers/symbol_layer.hpp
+        platform/android/src/style/layers/unknown_layer.cpp
+        platform/android/src/style/layers/unknown_layer.hpp
         platform/android/src/style/sources/geojson_source.cpp
         platform/android/src/style/sources/geojson_source.hpp
         platform/android/src/style/sources/source.cpp

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -124,6 +124,8 @@ macro(mbgl_platform_core)
         platform/android/src/style/sources/sources.hpp
         platform/android/src/style/sources/raster_source.cpp
         platform/android/src/style/sources/raster_source.hpp
+        platform/android/src/style/sources/unknown_source.cpp
+        platform/android/src/style/sources/unknown_source.hpp
         platform/android/src/style/sources/vector_source.cpp
         platform/android/src/style/sources/vector_source.hpp
         platform/android/src/style/functions/stop.cpp

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -844,8 +844,13 @@ void NativeMapView::addSource(JNIEnv& env, jni::jlong sourcePtr) {
     }
 }
 
-void NativeMapView::removeSourceById(JNIEnv& env, jni::String id) {
-     map->removeSource(jni::Make<std::string>(env, id));
+jni::Object<Source> NativeMapView::removeSourceById(JNIEnv& env, jni::String id) {
+    std::unique_ptr<mbgl::style::Source> coreSource = map->removeSource(jni::Make<std::string>(env, id));
+    if (coreSource) {
+        return jni::Object<Source>(createJavaSourcePeer(env, *map, *coreSource));
+    } else {
+        return jni::Object<Source>();
+    }
 }
 
 void NativeMapView::removeSource(JNIEnv&, jlong sourcePtr) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -737,6 +737,24 @@ jni::Array<jni::Object<Feature>> NativeMapView::queryRenderedFeaturesForBox(JNIE
     return *convert<jni::Array<jni::Object<Feature>>, std::vector<mbgl::Feature>>(env, map->queryRenderedFeatures(box, layers));
 }
 
+jni::Array<jni::Object<Layer>> NativeMapView::getLayers(JNIEnv& env) {
+
+    // Get the core layers
+    std::vector<style::Layer*> layers = map->getLayers();
+
+    // Convert
+    jni::Array<jni::Object<Layer>> jLayers = jni::Array<jni::Object<Layer>>::New(env, layers.size(), Layer::javaClass);
+    int index = 0;
+    for (auto layer : layers) {
+        auto jLayer = jni::Object<Layer>(createJavaLayerPeer(env, *map, *layer));
+        jLayers.Set(env, index, jLayer);
+        jni::DeleteLocalRef(env, jLayer);
+        index++;
+    }
+
+    return jLayers;
+}
+
 jni::Object<Layer> NativeMapView::getLayer(JNIEnv& env, jni::String layerId) {
 
     // Find the layer
@@ -1333,6 +1351,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::queryPointAnnotations, "nativeQueryPointAnnotations"),
             METHOD(&NativeMapView::queryRenderedFeaturesForPoint, "nativeQueryRenderedFeaturesForPoint"),
             METHOD(&NativeMapView::queryRenderedFeaturesForBox, "nativeQueryRenderedFeaturesForBox"),
+            METHOD(&NativeMapView::getLayers, "nativeGetLayers"),
             METHOD(&NativeMapView::getLayer, "nativeGetLayer"),
             METHOD(&NativeMapView::addLayer, "nativeAddLayer"),
             METHOD(&NativeMapView::removeLayerById, "nativeRemoveLayerById"),

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -780,10 +780,15 @@ void NativeMapView::addLayer(JNIEnv& env, jlong nativeLayerPtr, jni::String befo
 }
 
 /**
- * Remove by layer id. Ownership is not transferred back
+ * Remove by layer id.
  */
-void NativeMapView::removeLayerById(JNIEnv& env, jni::String id) {
-    map->removeLayer(jni::Make<std::string>(env, id));
+jni::Object<Layer> NativeMapView::removeLayerById(JNIEnv& env, jni::String id) {
+    std::unique_ptr<mbgl::style::Layer> coreLayer = map->removeLayer(jni::Make<std::string>(env, id));
+    if (coreLayer) {
+        return jni::Object<Layer>(createJavaLayerPeer(env, *map, std::move(coreLayer)));
+    } else {
+        return jni::Object<Layer>();
+    }
 }
 
 /**

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -799,6 +799,22 @@ void NativeMapView::removeLayer(JNIEnv&, jlong layerPtr) {
     }
 }
 
+jni::Array<jni::Object<Source>> NativeMapView::getSources(JNIEnv& env) {
+    // Get the core sources
+    std::vector<style::Source*> sources = map->getSources();
+
+    // Convert
+    jni::Array<jni::Object<Source>> jSources = jni::Array<jni::Object<Source>>::New(env, sources.size(), Source::javaClass);
+    int index = 0;
+    for (auto source : sources) {
+        auto jSource = jni::Object<Source>(createJavaSourcePeer(env, *map, *source));
+        jSources.Set(env, index, jSource);
+        jni::DeleteLocalRef(env, jSource);
+        index++;
+    }
+
+    return jSources;
+}
 
 jni::Object<Source> NativeMapView::getSource(JNIEnv& env, jni::String sourceId) {
     // Find the source
@@ -1356,6 +1372,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::addLayer, "nativeAddLayer"),
             METHOD(&NativeMapView::removeLayerById, "nativeRemoveLayerById"),
             METHOD(&NativeMapView::removeLayer, "nativeRemoveLayer"),
+            METHOD(&NativeMapView::getSources, "nativeGetSources"),
             METHOD(&NativeMapView::getSource, "nativeGetSource"),
             METHOD(&NativeMapView::addSource, "nativeAddSource"),
             METHOD(&NativeMapView::removeSourceById, "nativeRemoveSourceById"),

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -829,6 +829,27 @@ jni::Object<Layer> NativeMapView::removeLayerById(JNIEnv& env, jni::String id) {
 }
 
 /**
+ * Remove layer at index.
+ */
+jni::Object<Layer> NativeMapView::removeLayerAt(JNIEnv& env, jni::jint index) {
+    auto layers = map->getLayers();
+
+    // Check index
+    int numLayers = layers.size() - 1;
+    if (index > numLayers || index < 0) {
+        Log::Warning(Event::JNI, "Index out of range: %i", index);
+        return jni::Object<Layer>();
+    }
+
+    std::unique_ptr<mbgl::style::Layer> coreLayer = map->removeLayer(layers.at(index)->getID());
+    if (coreLayer) {
+        return jni::Object<Layer>(createJavaLayerPeer(env, *map, std::move(coreLayer)));
+    } else {
+        return jni::Object<Layer>();
+    }
+}
+
+/**
  * Remove with wrapper object id. Ownership is transferred back to the wrapper
  */
 void NativeMapView::removeLayer(JNIEnv&, jlong layerPtr) {
@@ -1419,6 +1440,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::addLayer, "nativeAddLayer"),
             METHOD(&NativeMapView::addLayerAbove, "nativeAddLayerAbove"),
             METHOD(&NativeMapView::removeLayerById, "nativeRemoveLayerById"),
+            METHOD(&NativeMapView::removeLayerAt, "nativeRemoveLayerAt"),
             METHOD(&NativeMapView::removeLayer, "nativeRemoveLayer"),
             METHOD(&NativeMapView::getSources, "nativeGetSources"),
             METHOD(&NativeMapView::getSource, "nativeGetSource"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -211,6 +211,8 @@ public:
 
     void removeLayer(JNIEnv&, jlong);
 
+    jni::Array<jni::Object<Source>> getSources(JNIEnv&);
+
     jni::Object<Source> getSource(JNIEnv&, jni::String);
 
     void addSource(JNIEnv&, jni::jlong);

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -217,7 +217,7 @@ public:
 
     void addSource(JNIEnv&, jni::jlong);
 
-    void removeSourceById(JNIEnv&, jni::String);
+    jni::Object<Source> removeSourceById(JNIEnv&, jni::String);
 
     void removeSource(JNIEnv&, jlong);
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -207,7 +207,7 @@ public:
 
     void addLayer(JNIEnv&, jlong, jni::String);
 
-    void removeLayerById(JNIEnv&, jni::String);
+    jni::Object<Layer> removeLayerById(JNIEnv&, jni::String);
 
     void removeLayer(JNIEnv&, jlong);
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -211,6 +211,8 @@ public:
 
     jni::Object<Layer> removeLayerById(JNIEnv&, jni::String);
 
+    jni::Object<Layer> removeLayerAt(JNIEnv&, jni::jint);
+
     void removeLayer(JNIEnv&, jlong);
 
     jni::Array<jni::Object<Source>> getSources(JNIEnv&);

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -207,6 +207,8 @@ public:
 
     void addLayer(JNIEnv&, jlong, jni::String);
 
+    void addLayerAbove(JNIEnv&, jlong, jni::String);
+
     jni::Object<Layer> removeLayerById(JNIEnv&, jni::String);
 
     void removeLayer(JNIEnv&, jlong);

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -209,6 +209,8 @@ public:
 
     void addLayerAbove(JNIEnv&, jlong, jni::String);
 
+    void addLayerAt(JNIEnv&, jni::jlong, jni::jint);
+
     jni::Object<Layer> removeLayerById(JNIEnv&, jni::String);
 
     jni::Object<Layer> removeLayerAt(JNIEnv&, jni::jint);

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -201,6 +201,8 @@ public:
 
     jni::Array<jni::Object<Feature>> queryRenderedFeaturesForBox(JNIEnv&, jni::jfloat, jni::jfloat, jni::jfloat, jni::jfloat, jni::Array<jni::String>);
 
+    jni::Array<jni::Object<Layer>> getLayers(JNIEnv&);
+
     jni::Object<Layer> getLayer(JNIEnv&, jni::String);
 
     void addLayer(JNIEnv&, jlong, jni::String);

--- a/platform/android/src/style/layers/background_layer.cpp
+++ b/platform/android/src/style/layers/background_layer.cpp
@@ -9,12 +9,25 @@
 namespace mbgl {
 namespace android {
 
+    /**
+     * Creates an owning peer object (for layers not attached to the map) from the JVM side
+     */
     BackgroundLayer::BackgroundLayer(jni::JNIEnv& env, jni::String layerId)
         : Layer(env, std::make_unique<mbgl::style::BackgroundLayer>(jni::Make<std::string>(env, layerId))) {
     }
 
+    /**
+     * Creates a non-owning peer object (for layers currently attached to the map)
+     */
     BackgroundLayer::BackgroundLayer(mbgl::Map& map, mbgl::style::BackgroundLayer& coreLayer)
         : Layer(map, coreLayer) {
+    }
+
+    /**
+     * Creates an owning peer object (for layers not attached to the map)
+     */
+    BackgroundLayer::BackgroundLayer(mbgl::Map& map, std::unique_ptr<mbgl::style::BackgroundLayer> coreLayer)
+        : Layer(map, std::move(coreLayer)) {
     }
 
     BackgroundLayer::~BackgroundLayer() = default;

--- a/platform/android/src/style/layers/background_layer.hpp
+++ b/platform/android/src/style/layers/background_layer.hpp
@@ -22,6 +22,8 @@ public:
 
     BackgroundLayer(mbgl::Map&, mbgl::style::BackgroundLayer&);
 
+    BackgroundLayer(mbgl::Map&, std::unique_ptr<mbgl::style::BackgroundLayer>);
+
     ~BackgroundLayer();
 
     // Property getters

--- a/platform/android/src/style/layers/circle_layer.cpp
+++ b/platform/android/src/style/layers/circle_layer.cpp
@@ -9,12 +9,25 @@
 namespace mbgl {
 namespace android {
 
+    /**
+     * Creates an owning peer object (for layers not attached to the map) from the JVM side
+     */
     CircleLayer::CircleLayer(jni::JNIEnv& env, jni::String layerId, jni::String sourceId)
         : Layer(env, std::make_unique<mbgl::style::CircleLayer>(jni::Make<std::string>(env, layerId), jni::Make<std::string>(env, sourceId))) {
     }
 
+    /**
+     * Creates a non-owning peer object (for layers currently attached to the map)
+     */
     CircleLayer::CircleLayer(mbgl::Map& map, mbgl::style::CircleLayer& coreLayer)
         : Layer(map, coreLayer) {
+    }
+
+    /**
+     * Creates an owning peer object (for layers not attached to the map)
+     */
+    CircleLayer::CircleLayer(mbgl::Map& map, std::unique_ptr<mbgl::style::CircleLayer> coreLayer)
+        : Layer(map, std::move(coreLayer)) {
     }
 
     CircleLayer::~CircleLayer() = default;

--- a/platform/android/src/style/layers/circle_layer.hpp
+++ b/platform/android/src/style/layers/circle_layer.hpp
@@ -22,6 +22,8 @@ public:
 
     CircleLayer(mbgl::Map&, mbgl::style::CircleLayer&);
 
+    CircleLayer(mbgl::Map&, std::unique_ptr<mbgl::style::CircleLayer>);
+
     ~CircleLayer();
 
     // Property getters

--- a/platform/android/src/style/layers/fill_layer.cpp
+++ b/platform/android/src/style/layers/fill_layer.cpp
@@ -9,12 +9,25 @@
 namespace mbgl {
 namespace android {
 
+    /**
+     * Creates an owning peer object (for layers not attached to the map) from the JVM side
+     */
     FillLayer::FillLayer(jni::JNIEnv& env, jni::String layerId, jni::String sourceId)
         : Layer(env, std::make_unique<mbgl::style::FillLayer>(jni::Make<std::string>(env, layerId), jni::Make<std::string>(env, sourceId))) {
     }
 
+    /**
+     * Creates a non-owning peer object (for layers currently attached to the map)
+     */
     FillLayer::FillLayer(mbgl::Map& map, mbgl::style::FillLayer& coreLayer)
         : Layer(map, coreLayer) {
+    }
+
+    /**
+     * Creates an owning peer object (for layers not attached to the map)
+     */
+    FillLayer::FillLayer(mbgl::Map& map, std::unique_ptr<mbgl::style::FillLayer> coreLayer)
+        : Layer(map, std::move(coreLayer)) {
     }
 
     FillLayer::~FillLayer() = default;

--- a/platform/android/src/style/layers/fill_layer.hpp
+++ b/platform/android/src/style/layers/fill_layer.hpp
@@ -22,6 +22,8 @@ public:
 
     FillLayer(mbgl::Map&, mbgl::style::FillLayer&);
 
+    FillLayer(mbgl::Map&, std::unique_ptr<mbgl::style::FillLayer>);
+
     ~FillLayer();
 
     // Property getters

--- a/platform/android/src/style/layers/layer.cpp
+++ b/platform/android/src/style/layers/layer.cpp
@@ -26,7 +26,20 @@ namespace android {
         , layer(*ownedLayer) {
     }
 
+    /**
+     * Takes a non-owning reference. For lookup methods
+     */
     Layer::Layer(mbgl::Map& coreMap, mbgl::style::Layer& coreLayer) : layer(coreLayer) , map(&coreMap) {
+    }
+
+    /**
+     * Takes a owning reference. Ownership is transfered to this peer, eg after removing
+     * from the map
+     */
+    Layer::Layer(mbgl::Map& coreMap, std::unique_ptr<mbgl::style::Layer> coreLayer)
+        : ownedLayer(std::move(coreLayer))
+        , layer(*ownedLayer)
+        , map(&coreMap) {
     }
 
     Layer::~Layer() {

--- a/platform/android/src/style/layers/layer.cpp.ejs
+++ b/platform/android/src/style/layers/layer.cpp.ejs
@@ -14,16 +14,32 @@ namespace mbgl {
 namespace android {
 
 <% if (type === 'background') { -%>
+    /**
+     * Creates an owning peer object (for layers not attached to the map) from the JVM side
+     */
     <%- camelize(type) %>Layer::<%- camelize(type) %>Layer(jni::JNIEnv& env, jni::String layerId)
         : Layer(env, std::make_unique<mbgl::style::<%- camelize(type) %>Layer>(jni::Make<std::string>(env, layerId))) {
 <% } else { -%>
+    /**
+     * Creates an owning peer object (for layers not attached to the map) from the JVM side
+     */
     <%- camelize(type) %>Layer::<%- camelize(type) %>Layer(jni::JNIEnv& env, jni::String layerId, jni::String sourceId)
         : Layer(env, std::make_unique<mbgl::style::<%- camelize(type) %>Layer>(jni::Make<std::string>(env, layerId), jni::Make<std::string>(env, sourceId))) {
 <% } -%>
     }
 
+    /**
+     * Creates a non-owning peer object (for layers currently attached to the map)
+     */
     <%- camelize(type) %>Layer::<%- camelize(type) %>Layer(mbgl::Map& map, mbgl::style::<%- camelize(type) %>Layer& coreLayer)
         : Layer(map, coreLayer) {
+    }
+
+    /**
+     * Creates an owning peer object (for layers not attached to the map)
+     */
+    <%- camelize(type) %>Layer::<%- camelize(type) %>Layer(mbgl::Map& map, std::unique_ptr<mbgl::style::<%- camelize(type) %>Layer> coreLayer)
+        : Layer(map, std::move(coreLayer)) {
     }
 
     <%- camelize(type) %>Layer::~<%- camelize(type) %>Layer() = default;

--- a/platform/android/src/style/layers/layer.hpp
+++ b/platform/android/src/style/layers/layer.hpp
@@ -21,9 +21,14 @@ public:
     static void registerNative(jni::JNIEnv&);
 
     /*
-     * Called when a Java object is created on the c++ side
+     * Called when a non-owning peer object is created on the c++ side
      */
     Layer(mbgl::Map&, mbgl::style::Layer&);
+
+    /*
+     * Called when a owning peer object is created on the c++ side
+     */
+    Layer(mbgl::Map&, std::unique_ptr<mbgl::style::Layer>);
 
     /*
      * Called when a Java object was created from the jvm side

--- a/platform/android/src/style/layers/layer.hpp.ejs
+++ b/platform/android/src/style/layers/layer.hpp.ejs
@@ -30,6 +30,8 @@ public:
 
     <%- camelize(type) %>Layer(mbgl::Map&, mbgl::style::<%- camelize(type) %>Layer&);
 
+    <%- camelize(type) %>Layer(mbgl::Map&, std::unique_ptr<mbgl::style::<%- camelize(type) %>Layer>);
+
     ~<%- camelize(type) %>Layer();
 
     // Property getters

--- a/platform/android/src/style/layers/layers.cpp
+++ b/platform/android/src/style/layers/layers.cpp
@@ -21,31 +21,60 @@
 namespace mbgl {
 namespace android {
 
-Layer* initializeLayerPeer(mbgl::Map& map, mbgl::style::Layer& coreLayer) {
-    Layer* layer;
+static Layer* initializeLayerPeer(mbgl::Map& map, mbgl::style::Layer& coreLayer) {
     if (coreLayer.is<mbgl::style::BackgroundLayer>()) {
-        layer = new BackgroundLayer(map, *coreLayer.as<mbgl::style::BackgroundLayer>());
+        return new BackgroundLayer(map, *coreLayer.as<mbgl::style::BackgroundLayer>());
     } else if (coreLayer.is<mbgl::style::CircleLayer>()) {
-        layer = new CircleLayer(map, *coreLayer.as<mbgl::style::CircleLayer>());
+        return new CircleLayer(map, *coreLayer.as<mbgl::style::CircleLayer>());
     } else if (coreLayer.is<mbgl::style::FillLayer>()) {
-            layer = new FillLayer(map, *coreLayer.as<mbgl::style::FillLayer>());
+        return new FillLayer(map, *coreLayer.as<mbgl::style::FillLayer>());
     } else if (coreLayer.is<mbgl::style::LineLayer>()) {
-            layer = new LineLayer(map, *coreLayer.as<mbgl::style::LineLayer>());
+        return new LineLayer(map, *coreLayer.as<mbgl::style::LineLayer>());
     } else if (coreLayer.is<mbgl::style::RasterLayer>()) {
-            layer = new RasterLayer(map, *coreLayer.as<mbgl::style::RasterLayer>());
+        return new RasterLayer(map, *coreLayer.as<mbgl::style::RasterLayer>());
     } else if (coreLayer.is<mbgl::style::SymbolLayer>()) {
-        layer = new SymbolLayer(map, *coreLayer.as<mbgl::style::SymbolLayer>());
+        return new SymbolLayer(map, *coreLayer.as<mbgl::style::SymbolLayer>());
     } else if (coreLayer.is<mbgl::style::CustomLayer>()) {
-        layer = new CustomLayer(map, *coreLayer.as<mbgl::style::CustomLayer>());
+        return new CustomLayer(map, *coreLayer.as<mbgl::style::CustomLayer>());
     } else {
-        layer = new UnknownLayer(map, coreLayer);
+        return new UnknownLayer(map, coreLayer);
     }
-
-    return layer;
 }
 
-jni::jobject* createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style::Layer& coreLayer) {
+template <class LayerType, class PeerType>
+static PeerType* createPeer(Map& map, std::unique_ptr<mbgl::style::Layer> layer) {
+    return new PeerType(map, std::move(std::unique_ptr<LayerType>(layer.release()->as<LayerType>())));
+}
+
+static Layer* initializeLayerPeer(Map& map, std::unique_ptr<mbgl::style::Layer> coreLayer) {
+    if (coreLayer->is<style::BackgroundLayer>()) {
+        return createPeer<style::BackgroundLayer, BackgroundLayer>(map, std::move(coreLayer));
+    } else if (coreLayer->is<style::CircleLayer>()) {
+        return createPeer<style::CircleLayer, CircleLayer>(map, std::move(coreLayer));
+    } else if (coreLayer->is<style::FillLayer>()) {
+        return createPeer<style::FillLayer, FillLayer>(map, std::move(coreLayer));
+    } else if (coreLayer->is<style::LineLayer>()) {
+        return createPeer<style::LineLayer, LineLayer>(map, std::move(coreLayer));
+    } else if (coreLayer->is<style::RasterLayer>()) {
+        return createPeer<style::RasterLayer, RasterLayer>(map, std::move(coreLayer));
+    } else if (coreLayer->is<style::SymbolLayer>()) {
+        return createPeer<style::SymbolLayer, SymbolLayer>(map, std::move(coreLayer));
+    } else if (coreLayer->is<mbgl::style::CustomLayer>()) {
+        return createPeer<style::SymbolLayer, SymbolLayer>(map, std::move(coreLayer));
+    } else {
+        return new UnknownLayer(map, std::move(coreLayer));
+    }
+}
+
+jni::jobject* createJavaLayerPeer(jni::JNIEnv& env, Map& map, style::Layer& coreLayer) {
     std::unique_ptr<Layer> peerLayer = std::unique_ptr<Layer>(initializeLayerPeer(map, coreLayer));
+    jni::jobject* result = peerLayer->createJavaPeer(env);
+    peerLayer.release();
+    return result;
+}
+
+jni::jobject* createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> coreLayer) {
+    std::unique_ptr<Layer> peerLayer = std::unique_ptr<Layer>(initializeLayerPeer(map, std::move(coreLayer)));
     jni::jobject* result = peerLayer->createJavaPeer(env);
     peerLayer.release();
     return result;

--- a/platform/android/src/style/layers/layers.cpp
+++ b/platform/android/src/style/layers/layers.cpp
@@ -1,5 +1,6 @@
 #include "layers.hpp"
 
+#include <mbgl/style/layer.hpp>
 #include <mbgl/style/layers/background_layer.hpp>
 #include <mbgl/style/layers/circle_layer.hpp>
 #include <mbgl/style/layers/fill_layer.hpp>
@@ -10,11 +11,12 @@
 
 #include "background_layer.hpp"
 #include "circle_layer.hpp"
+#include "custom_layer.hpp"
 #include "fill_layer.hpp"
 #include "line_layer.hpp"
 #include "raster_layer.hpp"
 #include "symbol_layer.hpp"
-#include "custom_layer.hpp"
+#include "unknown_layer.hpp"
 
 namespace mbgl {
 namespace android {
@@ -36,7 +38,7 @@ Layer* initializeLayerPeer(mbgl::Map& map, mbgl::style::Layer& coreLayer) {
     } else if (coreLayer.is<mbgl::style::CustomLayer>()) {
         layer = new CustomLayer(map, *coreLayer.as<mbgl::style::CustomLayer>());
     } else {
-        throw new std::runtime_error("Layer type not implemented");
+        layer = new UnknownLayer(map, coreLayer);
     }
 
     return layer;
@@ -53,11 +55,12 @@ void registerNativeLayers(jni::JNIEnv& env) {
     Layer::registerNative(env);
     BackgroundLayer::registerNative(env);
     CircleLayer::registerNative(env);
+    CustomLayer::registerNative(env);
     FillLayer::registerNative(env);
     LineLayer::registerNative(env);
     RasterLayer::registerNative(env);
     SymbolLayer::registerNative(env);
-    CustomLayer::registerNative(env);
+    UnknownLayer::registerNative(env);
 }
 
 } // namespace android

--- a/platform/android/src/style/layers/layers.hpp
+++ b/platform/android/src/style/layers/layers.hpp
@@ -10,9 +10,15 @@
 namespace mbgl {
 namespace android {
 
-mbgl::android::Layer* initializeLayerPeer(mbgl::Map&, mbgl::style::Layer&);
-
+/**
+ * Create a non-owning peer
+ */
 jni::jobject* createJavaLayerPeer(jni::JNIEnv&, mbgl::Map&, mbgl::style::Layer&);
+
+/**
+ * Create an owning peer
+ */
+jni::jobject* createJavaLayerPeer(jni::JNIEnv& env, mbgl::Map& map, std::unique_ptr<mbgl::style::Layer>);
 
 void registerNativeLayers(jni::JNIEnv&);
 

--- a/platform/android/src/style/layers/line_layer.cpp
+++ b/platform/android/src/style/layers/line_layer.cpp
@@ -9,12 +9,25 @@
 namespace mbgl {
 namespace android {
 
+    /**
+     * Creates an owning peer object (for layers not attached to the map) from the JVM side
+     */
     LineLayer::LineLayer(jni::JNIEnv& env, jni::String layerId, jni::String sourceId)
         : Layer(env, std::make_unique<mbgl::style::LineLayer>(jni::Make<std::string>(env, layerId), jni::Make<std::string>(env, sourceId))) {
     }
 
+    /**
+     * Creates a non-owning peer object (for layers currently attached to the map)
+     */
     LineLayer::LineLayer(mbgl::Map& map, mbgl::style::LineLayer& coreLayer)
         : Layer(map, coreLayer) {
+    }
+
+    /**
+     * Creates an owning peer object (for layers not attached to the map)
+     */
+    LineLayer::LineLayer(mbgl::Map& map, std::unique_ptr<mbgl::style::LineLayer> coreLayer)
+        : Layer(map, std::move(coreLayer)) {
     }
 
     LineLayer::~LineLayer() = default;

--- a/platform/android/src/style/layers/line_layer.hpp
+++ b/platform/android/src/style/layers/line_layer.hpp
@@ -22,6 +22,8 @@ public:
 
     LineLayer(mbgl::Map&, mbgl::style::LineLayer&);
 
+    LineLayer(mbgl::Map&, std::unique_ptr<mbgl::style::LineLayer>);
+
     ~LineLayer();
 
     // Property getters

--- a/platform/android/src/style/layers/raster_layer.cpp
+++ b/platform/android/src/style/layers/raster_layer.cpp
@@ -9,12 +9,25 @@
 namespace mbgl {
 namespace android {
 
+    /**
+     * Creates an owning peer object (for layers not attached to the map) from the JVM side
+     */
     RasterLayer::RasterLayer(jni::JNIEnv& env, jni::String layerId, jni::String sourceId)
         : Layer(env, std::make_unique<mbgl::style::RasterLayer>(jni::Make<std::string>(env, layerId), jni::Make<std::string>(env, sourceId))) {
     }
 
+    /**
+     * Creates a non-owning peer object (for layers currently attached to the map)
+     */
     RasterLayer::RasterLayer(mbgl::Map& map, mbgl::style::RasterLayer& coreLayer)
         : Layer(map, coreLayer) {
+    }
+
+    /**
+     * Creates an owning peer object (for layers not attached to the map)
+     */
+    RasterLayer::RasterLayer(mbgl::Map& map, std::unique_ptr<mbgl::style::RasterLayer> coreLayer)
+        : Layer(map, std::move(coreLayer)) {
     }
 
     RasterLayer::~RasterLayer() = default;

--- a/platform/android/src/style/layers/raster_layer.hpp
+++ b/platform/android/src/style/layers/raster_layer.hpp
@@ -22,6 +22,8 @@ public:
 
     RasterLayer(mbgl::Map&, mbgl::style::RasterLayer&);
 
+    RasterLayer(mbgl::Map&, std::unique_ptr<mbgl::style::RasterLayer>);
+
     ~RasterLayer();
 
     // Property getters

--- a/platform/android/src/style/layers/symbol_layer.cpp
+++ b/platform/android/src/style/layers/symbol_layer.cpp
@@ -9,12 +9,25 @@
 namespace mbgl {
 namespace android {
 
+    /**
+     * Creates an owning peer object (for layers not attached to the map) from the JVM side
+     */
     SymbolLayer::SymbolLayer(jni::JNIEnv& env, jni::String layerId, jni::String sourceId)
         : Layer(env, std::make_unique<mbgl::style::SymbolLayer>(jni::Make<std::string>(env, layerId), jni::Make<std::string>(env, sourceId))) {
     }
 
+    /**
+     * Creates a non-owning peer object (for layers currently attached to the map)
+     */
     SymbolLayer::SymbolLayer(mbgl::Map& map, mbgl::style::SymbolLayer& coreLayer)
         : Layer(map, coreLayer) {
+    }
+
+    /**
+     * Creates an owning peer object (for layers not attached to the map)
+     */
+    SymbolLayer::SymbolLayer(mbgl::Map& map, std::unique_ptr<mbgl::style::SymbolLayer> coreLayer)
+        : Layer(map, std::move(coreLayer)) {
     }
 
     SymbolLayer::~SymbolLayer() = default;

--- a/platform/android/src/style/layers/symbol_layer.hpp
+++ b/platform/android/src/style/layers/symbol_layer.hpp
@@ -22,6 +22,8 @@ public:
 
     SymbolLayer(mbgl::Map&, mbgl::style::SymbolLayer&);
 
+    SymbolLayer(mbgl::Map&, std::unique_ptr<mbgl::style::SymbolLayer>);
+
     ~SymbolLayer();
 
     // Property getters

--- a/platform/android/src/style/layers/unknown_layer.cpp
+++ b/platform/android/src/style/layers/unknown_layer.cpp
@@ -1,0 +1,49 @@
+#include "unknown_layer.hpp"
+
+#include <string>
+
+namespace {
+
+    // Dummy initializer (We don't support initializing this from the JVM)
+    std::unique_ptr<mbgl::android::UnknownLayer> init(jni::JNIEnv&) {
+        throw new std::runtime_error("UnknownLayer should not be initialized from the JVM");
+    }
+
+} // namespace
+
+namespace mbgl {
+namespace android {
+
+    UnknownLayer::UnknownLayer(mbgl::Map& map, mbgl::style::Layer& coreLayer)
+        : Layer(map, coreLayer) {
+    }
+
+    UnknownLayer::UnknownLayer(mbgl::Map& map, std::unique_ptr<mbgl::style::Layer> coreLayer)
+        : Layer(map, std::move(coreLayer)) {
+    }
+
+    jni::Class<UnknownLayer> UnknownLayer::javaClass;
+
+    jni::jobject* UnknownLayer::createJavaPeer(jni::JNIEnv& env) {
+        static auto constructor = UnknownLayer::javaClass.template GetConstructor<jni::jlong>(env);
+        return UnknownLayer::javaClass.New(env, constructor, reinterpret_cast<jni::jlong>(this));
+    }
+
+    void UnknownLayer::registerNative(jni::JNIEnv& env) {
+        // Lookup the class
+        UnknownLayer::javaClass = *jni::Class<UnknownLayer>::Find(env).NewGlobalRef(env).release();
+
+        #define METHOD(MethodPtr, name) jni::MakeNativePeerMethod<decltype(MethodPtr), (MethodPtr)>(name)
+
+        std::function<std::unique_ptr<UnknownLayer>(JNIEnv&)> initializer = nullptr;
+
+        // Register the peer
+        jni::RegisterNativePeer<UnknownLayer>(
+            env, UnknownLayer::javaClass, "nativePtr",
+            init,
+            "initialize",
+            "finalize");
+    }
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/layers/unknown_layer.hpp
+++ b/platform/android/src/style/layers/unknown_layer.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "layer.hpp"
+#include <mbgl/style/layer.hpp>
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace android {
+
+class UnknownLayer : public Layer {
+public:
+
+    static constexpr auto Name() { return "com/mapbox/mapboxsdk/style/layers/UnknownLayer"; };
+
+    static jni::Class<UnknownLayer> javaClass;
+
+    static void registerNative(jni::JNIEnv&);
+
+    UnknownLayer(mbgl::Map&, mbgl::style::Layer&);
+
+    UnknownLayer(mbgl::Map&, std::unique_ptr<mbgl::style::Layer>);
+
+    ~UnknownLayer() = default;
+
+    jni::jobject* createJavaPeer(jni::JNIEnv&);
+
+}; // class UnknownLayer
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/sources/sources.cpp
+++ b/platform/android/src/style/sources/sources.cpp
@@ -8,6 +8,7 @@
 #include "source.hpp"
 #include "geojson_source.hpp"
 #include "raster_source.hpp"
+#include "unknown_source.hpp"
 #include "vector_source.hpp"
 
 namespace mbgl {
@@ -22,7 +23,7 @@ Source* initializeSourcePeer(mbgl::Map& map, mbgl::style::Source& coreSource) {
     } else if (coreSource.is<mbgl::style::GeoJSONSource>()) {
         source = new GeoJSONSource(map, *coreSource.as<mbgl::style::GeoJSONSource>());
     } else {
-        throw new std::runtime_error("Source type not implemented");
+        source = new UnknownSource(map, coreSource);
     }
 
     return source;
@@ -37,9 +38,10 @@ jni::jobject* createJavaSourcePeer(jni::JNIEnv& env, mbgl::Map& map, mbgl::style
 
 void registerNativeSources(jni::JNIEnv& env) {
     Source::registerNative(env);
-    VectorSource::registerNative(env);
-    RasterSource::registerNative(env);
     GeoJSONSource::registerNative(env);
+    RasterSource::registerNative(env);
+    UnknownSource::registerNative(env);
+    VectorSource::registerNative(env);
 }
 
 }

--- a/platform/android/src/style/sources/unknown_source.cpp
+++ b/platform/android/src/style/sources/unknown_source.cpp
@@ -1,0 +1,42 @@
+#include "unknown_source.hpp"
+
+namespace {
+
+    // Dummy initializer (We don't support initializing this from the JVM)
+    std::unique_ptr<mbgl::android::UnknownSource> init(jni::JNIEnv&) {
+        throw new std::runtime_error("UnknownSource should not be initialized from the JVM");
+    }
+
+} // namespace
+
+namespace mbgl {
+namespace android {
+
+    UnknownSource::UnknownSource(mbgl::Map& map, mbgl::style::Source& coreSource)
+        : Source(map, coreSource) {
+    }
+
+    jni::Class<UnknownSource> UnknownSource::javaClass;
+
+    jni::jobject* UnknownSource::createJavaPeer(jni::JNIEnv& env) {
+        static auto constructor = UnknownSource::javaClass.template GetConstructor<jni::jlong>(env);
+        return UnknownSource::javaClass.New(env, constructor, reinterpret_cast<jni::jlong>(this));
+    }
+
+    void UnknownSource::registerNative(jni::JNIEnv& env) {
+        // Lookup the class
+        UnknownSource::javaClass = *jni::Class<UnknownSource>::Find(env).NewGlobalRef(env).release();
+
+        #define METHOD(MethodPtr, name) jni::MakeNativePeerMethod<decltype(MethodPtr), (MethodPtr)>(name)
+
+        // Register the peer
+        jni::RegisterNativePeer<UnknownSource>(
+            env, UnknownSource::javaClass, "nativePtr",
+            init,
+            "initialize",
+            "finalize"
+        );
+    }
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/sources/unknown_source.hpp
+++ b/platform/android/src/style/sources/unknown_source.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "source.hpp"
+#include <mbgl/style/source.hpp>
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace android {
+
+class UnknownSource : public Source {
+public:
+
+    static constexpr auto Name() { return "com/mapbox/mapboxsdk/style/sources/UnknownSource"; };
+
+    static jni::Class<UnknownSource> javaClass;
+
+    static void registerNative(jni::JNIEnv&);
+
+    UnknownSource(mbgl::Map&, mbgl::style::Source&);
+
+    ~UnknownSource() = default;
+
+    jni::jobject* createJavaPeer(jni::JNIEnv&);
+
+}; // class UnknownSource
+
+} // namespace android
+} // namespace mbgl


### PR DESCRIPTION
Fixes #7285

Fixes:
- Layer ownership on remove (no more crashes when accessing a handle to a layer after removing it from the style)

Adds:
- `getLayers`
- `addLayerAbove`
- `addLayerAt`
- `removeLayerAt`
- `getSources`

Other changes:
- `removeLayer` now returns `Layer` handle
- `removeSource` returns `Source` handle