### PR TITLE
[core] Avoid some string copies in bidi implementation

### DIFF
--- a/platform/default/bidi.cpp
+++ b/platform/default/bidi.cpp
@@ -74,6 +74,8 @@ std::vector<std::u16string> BiDi::applyLineBreaking(std::set<std::size_t> lineBr
     mergeParagraphLineBreaks(lineBreakPoints);
 
     std::vector<std::u16string> transformedLines;
+    transformedLines.reserve(lineBreakPoints.size());
+
     std::size_t start = 0;
     for (std::size_t lineBreakPoint : lineBreakPoints) {
         transformedLines.push_back(getLine(start, lineBreakPoint));


### PR DESCRIPTION
As of C++11, it's safe to preallocate `std::[u16]string` and write to the buffer via `&s[0]` (C++17 makes it possible via `.data()` as well).