### PR TITLE
[core] Replace three maps/mutexes in GlyphAtlas with a single map and mutex

### DIFF
--- a/src/mbgl/layout/symbol_layout.cpp
+++ b/src/mbgl/layout/symbol_layout.cpp
@@ -256,7 +256,7 @@ void SymbolLayout::prepare(uintptr_t tileUID,
 
                 // Add the glyphs we need for this label to the glyph atlas.
                 if (result) {
-                    glyphAtlas.addGlyphs(tileUID, text, layout.get<TextFont>(), **glyphSet, face);
+                    glyphAtlas.addGlyphs(tileUID, text, layout.get<TextFont>(), glyphSet, face);
                 }
 
                 return result;

--- a/test/text/glyph_atlas.test.cpp
+++ b/test/text/glyph_atlas.test.cpp
@@ -83,8 +83,7 @@ TEST(GlyphAtlas, LoadingFail) {
         EXPECT_TRUE(error != nullptr);
         EXPECT_EQ(util::toString(error), "Failed by the test case");
 
-        auto glyphSet = test.glyphAtlas.getGlyphSet({{"Test Stack"}});
-        ASSERT_TRUE(glyphSet->getSDFs().empty());
+        ASSERT_TRUE(test.glyphAtlas.getGlyphSet({{"Test Stack"}})->getSDFs().empty());
         ASSERT_FALSE(test.glyphAtlas.hasGlyphRanges({{"Test Stack"}}, {{0, 255}}));
 
         test.end();
@@ -112,8 +111,7 @@ TEST(GlyphAtlas, LoadingCorrupted) {
         EXPECT_TRUE(error != nullptr);
         EXPECT_EQ(util::toString(error), "unknown pbf field type exception");
 
-        auto glyphSet = test.glyphAtlas.getGlyphSet({{"Test Stack"}});
-        ASSERT_TRUE(glyphSet->getSDFs().empty());
+        ASSERT_TRUE(test.glyphAtlas.getGlyphSet({{"Test Stack"}})->getSDFs().empty());
         ASSERT_FALSE(test.glyphAtlas.hasGlyphRanges({{"Test Stack"}}, {{0, 255}}));
 
         test.end();
@@ -144,21 +142,21 @@ TEST(GlyphAtlas, LoadingCancel) {
 }
 
 TEST(GlyphAtlas, InvalidSDFGlyph) {
-    GlyphSet glyphSet;
-    glyphSet.insert(66, SDFGlyph{ 66 /* ASCII 'B' */,
-                                  AlphaImage({7, 7}), /* correct */
-                                  { 1 /* width */, 1 /* height */, 0 /* left */, 0 /* top */,
-                                    0 /* advance */ } });
-    glyphSet.insert(67, SDFGlyph{ 67 /* ASCII 'C' */,
-                                  AlphaImage({518, 8}), /* correct */
-                                  { 512 /* width */, 2 /* height */, 0 /* left */, 0 /* top */,
-                                    0 /* advance */ } });
-
-
     const FontStack fontStack{ "Mock Font" };
 
     GlyphAtlasTest test;
     GlyphPositions positions;
+
+    auto glyphSet = test.glyphAtlas.getGlyphSet(fontStack);
+    glyphSet->insert(66, SDFGlyph{ 66 /* ASCII 'B' */,
+                                  AlphaImage({7, 7}), /* correct */
+                                  { 1 /* width */, 1 /* height */, 0 /* left */, 0 /* top */,
+                                    0 /* advance */ } });
+    glyphSet->insert(67, SDFGlyph{ 67 /* ASCII 'C' */,
+                                  AlphaImage({518, 8}), /* correct */
+                                  { 512 /* width */, 2 /* height */, 0 /* left */, 0 /* top */,
+                                    0 /* advance */ } });
+
     test.glyphAtlas.addGlyphs(1, std::u16string{u"ABC"}, fontStack, glyphSet, positions);
 
     ASSERT_EQ(2u, positions.size());


### PR DESCRIPTION
Fixes the `GlyphAtlas` equivalent of #6835.