### PR TITLE
[android] - add unit test for Mapbox

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -43,7 +43,7 @@ public final class Mapbox {
     return INSTANCE;
   }
 
-  private Mapbox(@NonNull Context context, @NonNull String accessToken) {
+  Mapbox(@NonNull Context context, @NonNull String accessToken) {
     this.context = context;
     this.accessToken = accessToken;
   }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
@@ -1,0 +1,92 @@
+package com.mapbox.mapboxsdk;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+import com.mapbox.mapboxsdk.exceptions.InvalidAccessTokenException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MapboxTest {
+
+  private Context context;
+  private Context appContext;
+
+  @Before
+  public void before() {
+    context = mock(Context.class);
+    appContext = mock(Context.class);
+    when(context.getApplicationContext()).thenReturn(appContext);
+  }
+
+  @Test
+  public void testGetAccessToken() {
+    final String accessToken = "pk.0000000001";
+    injectMapboxSingleton(accessToken);
+    assertSame(accessToken, Mapbox.getAccessToken());
+  }
+
+  @Test(expected = InvalidAccessTokenException.class)
+  public void testGetInvalidAccessToken() {
+    final String accessToken = "dummy";
+    injectMapboxSingleton(accessToken);
+    assertSame(accessToken, Mapbox.getAccessToken());
+  }
+
+  @Test
+  public void testApplicationContext() {
+    injectMapboxSingleton("dummy");
+    assertNotNull(Mapbox.getApplicationContext());
+    assertNotEquals(context, appContext);
+    assertEquals(appContext, appContext);
+  }
+
+  @Test
+  public void testConnected() {
+    injectMapboxSingleton("dummy");
+
+    // test Android connectivity
+    ConnectivityManager connectivityManager = mock(ConnectivityManager.class);
+    NetworkInfo networkInfo = mock(NetworkInfo.class);
+    when(appContext.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(connectivityManager);
+    when(connectivityManager.getActiveNetworkInfo()).thenReturn(networkInfo);
+    when(networkInfo.isConnected()).thenReturn(false);
+    assertFalse(Mapbox.isConnected());
+    when(networkInfo.isConnected()).thenReturn(true);
+    assertTrue(Mapbox.isConnected());
+
+    // test manual connectivity
+    Mapbox.setConnected(true);
+    assertTrue(Mapbox.isConnected());
+    Mapbox.setConnected(false);
+    assertFalse(Mapbox.isConnected());
+
+    // reset to Android connectivity
+    Mapbox.setConnected(null);
+    assertTrue(Mapbox.isConnected());
+  }
+
+  private void injectMapboxSingleton(String accessToken) {
+    Mapbox mapbox = new Mapbox(appContext, accessToken);
+    try {
+      Field field = Mapbox.class.getDeclaredField("INSTANCE");
+      field.setAccessible(true);
+      field.set(mapbox, mapbox);
+    } catch (Exception exception) {
+      throw new AssertionError();
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a java unit test for Mapbox and tests the following:
 - accessToken validation
 - enforcing applicationContext
 - switching between Android Connectivity change events and manually managing them

Code coverage after adding the test:
<img width="650" alt="screen shot 2017-02-28 at 17 24 49" src="https://cloud.githubusercontent.com/assets/2151639/23437107/e3815a20-fdda-11e6-9756-499d8e381151.png">
