### PR TITLE
[android] - add accessibility support to the Android SDK 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -636,6 +636,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
         viewHolder = (ViewHolder) convertView.getTag();
       }
       viewHolder.imageView.setImageBitmap(marker.getIcon().getBitmap());
+      viewHolder.imageView.setContentDescription(marker.getTitle());
       return convertView;
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -118,6 +118,9 @@ public class MapView extends FrameLayout {
     ImageView attrView = (ImageView) view.findViewById(R.id.attributionView);
     initalizeDrawingSurface(context, options);
 
+    // add accessibility support
+    setContentDescription(context.getString(R.string.mapbox_mapActionDescription));
+
     // create native Map object
     nativeMapView = new NativeMapView(this);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
@@ -56,7 +56,6 @@ public final class CompassView extends AppCompatImageView implements Runnable, F
 
   private void initialize(Context context) {
     setImageDrawable(ContextCompat.getDrawable(getContext(), R.drawable.mapbox_compass_icon));
-    setContentDescription(getResources().getString(R.string.mapbox_compassContentDescription));
     setEnabled(false);
 
     // Layout params

--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -74,6 +74,12 @@
     <!-- Deprecated to use TextureView-->
     <public name="mapbox_renderTextureMode" type="attr" />
 
+    <!-- Exposed content descriptions -->
+    <public name="mapbox_compassContentDescription" type="string" />
+    <public name="mapbox_attributionsIconContentDescription" type="string" />
+    <public name="mapbox_myLocationViewContentDescription" type="string" />
+    <public name="mapbox_logoContentDescription" type="string" />
+
     <!-- Exposed styles -->
     <public name="mapbox_style_mapbox_streets" type="string" />
     <public name="mapbox_style_emerald" type="string" />

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -5,30 +5,34 @@
         android:id="@+id/surfaceView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone" />
+        android:contentDescription="@null"
+        android:visibility="gone"/>
 
     <FrameLayout
         android:id="@+id/markerViewContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@android:color/transparent" />
+        android:background="@android:color/transparent"
+        android:contentDescription="@null"/>
 
     <com.mapbox.mapboxsdk.maps.widgets.MyLocationView
         android:id="@+id/userLocationView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:contentDescription="@string/mapbox_myLocationViewContentDescription"/>
 
     <com.mapbox.mapboxsdk.maps.widgets.CompassView
         android:id="@+id/compassView"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/mapbox_compassContentDescription"/>
 
     <ImageView
         android:id="@+id/logoView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/mapbox_iconContentDescription"
-        android:src="@drawable/mapbox_logo_icon" />
+        android:contentDescription="@null"
+        android:src="@drawable/mapbox_logo_icon"/>
 
     <ImageView
         android:id="@+id/attributionView"
@@ -39,6 +43,6 @@
         android:clickable="true"
         android:contentDescription="@string/mapbox_attributionsIconContentDescription"
         android:padding="7dp"
-        android:src="@drawable/mapbox_info_bg_selector" />
+        android:src="@drawable/mapbox_info_bg_selector"/>
 
 </merge>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_preview.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_preview.xml
@@ -17,8 +17,8 @@
         android:layout_alignParentLeft="true"
         android:layout_marginBottom="@dimen/mapbox_eight_dp"
         android:layout_marginLeft="@dimen/mapbox_eight_dp"
-        android:contentDescription="@string/mapbox_iconContentDescription"
-        android:src="@drawable/mapbox_logo_icon" />
+        android:contentDescription="@null"
+        android:src="@drawable/mapbox_logo_icon"/>
 
     <ImageView
         android:layout_width="wrap_content"

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="mapbox_compassContentDescription">Map compass. Click to reset the map rotation to North.</string>
-    <string name="mapbox_attributionsIconContentDescription">Attribution icon. Click to show attribution dialog.</string>
+    <string name="mapbox_compassContentDescription">Map compass. Activate to reset the map rotation to North.</string>
+    <string name="mapbox_attributionsIconContentDescription">Attribution icon. Activate to show attribution dialog.</string>
+    <string name="mapbox_myLocationViewContentDescription">Location View. This shows your location on the map.</string>
+    <string name="mapbox_mapActionDescription">Showing a Map created with Mapbox. Scroll by dragging two fingers. Zoom by pinching two fingers.</string>
     <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
     <string name="mapbox_attributionTelemetryTitle">Make Mapbox Maps Better</string>
     <string name="mapbox_attributionTelemetryMessage">You are helping to make OpenStreetMap and Mapbox maps better by contributing anonymous usage data.</string>
     <string name="mapbox_attributionTelemetryPositive">Agree</string>
     <string name="mapbox_attributionTelemetryNegative">Disagree</string>
     <string name="mapbox_attributionTelemetryNeutral">More info</string>
-    <string name="mapbox_iconContentDescription">The Mapbox logo.</string>
     <string name="mapbox_infoWindowTitle">Title</string>
     <string name="mapbox_infoWindowDescription">Description</string>
     <string name="mapbox_infoWindowAddress">Address</string>


### PR DESCRIPTION
This PR optimises accessibility support for TalkBack by applying content description to all overlain View elements and removing `setClickable(true)` and `setLongClickable(true)` (these flags introduced some additional talkback responses while the map also works correctly without).

I have been looking into using an [AccesibilityDelegate](https://developer.android.com/reference/android/support/v4/view/ViewCompat.html#setAccessibilityDelegate) but it seems that they only support a limited amount of gestures. (click, longclick) and it's not possible to add custom ones. To work around this I added `mapbox_mapActionDescription ` which has a similar structure as the one generated by AccessibilityDelegateCompat.  