### PR TITLE
Remove gl.hpp include from shaders

### DIFF
--- a/scripts/generate-shaders.js
+++ b/scripts/generate-shaders.js
@@ -65,8 +65,6 @@ require('./style-code');
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/circle.hpp
+++ b/src/mbgl/shaders/circle.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/collision_box.hpp
+++ b/src/mbgl/shaders/collision_box.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/debug.hpp
+++ b/src/mbgl/shaders/debug.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/fill.hpp
+++ b/src/mbgl/shaders/fill.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/fill_outline.hpp
+++ b/src/mbgl/shaders/fill_outline.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/fill_outline_pattern.hpp
+++ b/src/mbgl/shaders/fill_outline_pattern.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/fill_pattern.hpp
+++ b/src/mbgl/shaders/fill_pattern.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/line.hpp
+++ b/src/mbgl/shaders/line.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/line_pattern.hpp
+++ b/src/mbgl/shaders/line_pattern.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/line_sdf.hpp
+++ b/src/mbgl/shaders/line_sdf.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/raster.hpp
+++ b/src/mbgl/shaders/raster.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/symbol_icon.hpp
+++ b/src/mbgl/shaders/symbol_icon.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 

--- a/src/mbgl/shaders/symbol_sdf.hpp
+++ b/src/mbgl/shaders/symbol_sdf.hpp
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <mbgl/gl/gl.hpp>
-
 namespace mbgl {
 namespace shaders {
 


### PR DESCRIPTION
No need to include it; we only define char strings.