### PR TITLE
[Qt] FBO handling should happen outside of QMapboxGL::render

### DIFF
--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -10,10 +10,6 @@
 #include <QString>
 #include <QStringList>
 
-#if QT_VERSION >= 0x050000
-#include <QOpenGLFramebufferObject>
-#endif
-
 class QMapboxGLPrivate;
 
 // This header follows the Qt coding style: https://wiki.qt.io/Qt_Coding_Style
@@ -231,11 +227,7 @@ public:
     void setFilter(const QString &layer, const QVariant &filter);
 
 public slots:
-#if QT_VERSION >= 0x050000
-    void render(QOpenGLFramebufferObject *fbo = NULL);
-#else
     void render();
-#endif
     void connectionEstablished();
 
 signals:

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -28,7 +28,6 @@
 #if QT_VERSION >= 0x050000
 #include <QGuiApplication>
 #include <QWindow>
-#include <QOpenGLFramebufferObject>
 #include <QOpenGLContext>
 #else
 #include <QCoreApplication>
@@ -1492,17 +1491,9 @@ void QMapboxGL::setFilter(const QString& layer, const QVariant& filter)
     This function should be called only after the signal needsRendering() is
     emitted at least once.
 */
-#if QT_VERSION >= 0x050000
-void QMapboxGL::render(QOpenGLFramebufferObject *fbo)
-{
-    d_ptr->dirty = false;
-    d_ptr->fbo = fbo;
-    d_ptr->mapObj->render(*d_ptr);
-}
-#else
 void QMapboxGL::render()
 {
-#if defined(__APPLE__)
+#if defined(__APPLE__) && QT_VERSION < 0x050000
     // FIXME Qt 4.x provides an incomplete FBO at start.
     // See https://bugreports.qt.io/browse/QTBUG-36802 for details.
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
@@ -1513,7 +1504,6 @@ void QMapboxGL::render()
     d_ptr->dirty = false;
     d_ptr->mapObj->render(*d_ptr);
 }
-#endif
 
 /*!
     Informs the map that the network connection has been established, causing
@@ -1582,24 +1572,12 @@ QMapboxGLPrivate::~QMapboxGLPrivate()
 {
 }
 
-#if QT_VERSION >= 0x050000
-void QMapboxGLPrivate::bind() {
-    if (fbo) {
-        fbo->bind();
-        getContext().bindFramebuffer.setDirty();
-        getContext().viewport = {
-            0, 0, { static_cast<uint32_t>(fbo->width()), static_cast<uint32_t>(fbo->height()) }
-        };
-    }
-}
-#else
 void QMapboxGLPrivate::bind() {
     getContext().bindFramebuffer = 0;
     getContext().viewport = {
         0, 0, { static_cast<uint32_t>(fbSize.width()), static_cast<uint32_t>(fbSize.height()) }
     };
 }
-#endif
 
 void QMapboxGLPrivate::invalidate()
 {

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -43,10 +43,6 @@ public:
 
     bool dirty { false };
 
-#if QT_VERSION >= 0x050000
-    QOpenGLFramebufferObject *fbo { nullptr };
-#endif
-
 public slots:
     void connectionEstablished();
 

--- a/platform/qt/src/qquickmapboxglrenderer.cpp
+++ b/platform/qt/src/qquickmapboxglrenderer.cpp
@@ -38,7 +38,9 @@ QOpenGLFramebufferObject* QQuickMapboxGLRenderer::createFramebufferObject(const 
 
 void QQuickMapboxGLRenderer::render()
 {
-    m_map->render(framebufferObject());
+    framebufferObject()->bind();
+    m_map->render();
+    framebufferObject()->release();
 }
 
 void QQuickMapboxGLRenderer::synchronize(QQuickFramebufferObject *item)


### PR DESCRIPTION
We don't really need to handle FBO internally - FBO size is obtained via `QMapboxGL::resize` already and thus allows the client platform to have complete control over it.