### PR TITLE
[core] Safeguard ICU UChar usage

### DIFF
--- a/include/mbgl/util/traits.hpp
+++ b/include/mbgl/util/traits.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <type_traits>
 
 namespace mbgl {
@@ -7,6 +8,21 @@ namespace mbgl {
 template<typename T>
 constexpr auto underlying_type(T t) -> typename std::underlying_type_t<T> {
     return typename std::underlying_type_t<T>(t);
+}
+
+template <typename T> struct is_utf16char_like: std::false_type {};
+template <typename T> struct is_utf16char_like<const T>: is_utf16char_like<T> {};
+template <> struct is_utf16char_like<char16_t>: std::true_type {};
+template <> struct is_utf16char_like<wchar_t>: std::true_type {};
+template <> struct is_utf16char_like<uint16_t>: std::true_type {};
+
+template <typename T> using is_utf16char_like_pointer = std::integral_constant<bool, std::is_pointer<T>::value
+                                                                                     && is_utf16char_like<typename std::remove_pointer<T>::type>::value>;
+
+template <class OutPointer, class InChar>
+typename std::enable_if<is_utf16char_like<InChar>::value && is_utf16char_like_pointer<OutPointer>::value, OutPointer>::type utf16char_cast(InChar *in)
+{
+    return reinterpret_cast<OutPointer>(in);
 }
 
 } // namespace mbgl

--- a/platform/default/bidi.cpp
+++ b/platform/default/bidi.cpp
@@ -1,8 +1,10 @@
-#include <memory>
-
 #include <mbgl/text/bidi.hpp>
+#include <mbgl/util/traits.hpp>
+
 #include <unicode/ubidi.h>
 #include <unicode/ushape.h>
+
+#include <memory>
 
 namespace mbgl {
 
@@ -28,7 +30,7 @@ std::u16string applyArabicShaping(const std::u16string& input) {
     UErrorCode errorCode = U_ZERO_ERROR;
 
     const int32_t outputLength =
-        u_shapeArabic(input.c_str(), static_cast<int32_t>(input.size()), NULL, 0,
+        u_shapeArabic(mbgl::utf16char_cast<const UChar*>(input.c_str()), static_cast<int32_t>(input.size()), NULL, 0,
                       (U_SHAPE_LETTERS_SHAPE & U_SHAPE_LETTERS_MASK) |
                           (U_SHAPE_TEXT_DIRECTION_LOGICAL & U_SHAPE_TEXT_DIRECTION_MASK),
                       &errorCode);
@@ -38,7 +40,7 @@ std::u16string applyArabicShaping(const std::u16string& input) {
 
     std::u16string outputText(outputLength, 0);
 
-    u_shapeArabic(input.c_str(), static_cast<int32_t>(input.size()), &outputText[0], outputLength,
+    u_shapeArabic(mbgl::utf16char_cast<const UChar*>(input.c_str()), static_cast<int32_t>(input.size()), mbgl::utf16char_cast<UChar*>(&outputText[0]), outputLength,
                   (U_SHAPE_LETTERS_SHAPE & U_SHAPE_LETTERS_MASK) |
                       (U_SHAPE_TEXT_DIRECTION_LOGICAL & U_SHAPE_TEXT_DIRECTION_MASK),
                   &errorCode);
@@ -89,7 +91,7 @@ std::vector<std::u16string> BiDi::processText(const std::u16string& input,
                                               std::set<std::size_t> lineBreakPoints) {
     UErrorCode errorCode = U_ZERO_ERROR;
 
-    ubidi_setPara(impl->bidiText, input.c_str(), static_cast<int32_t>(input.size()),
+    ubidi_setPara(impl->bidiText, mbgl::utf16char_cast<const UChar*>(input.c_str()), static_cast<int32_t>(input.size()),
                   UBIDI_DEFAULT_LTR, NULL, &errorCode);
 
     if (U_FAILURE(errorCode)) {


### PR DESCRIPTION
In environments where `Uchar*` cannot be implicitly convertible to `char16_t*` (e.g. when using a system-provided ICU in which `UCHAR_TYPE` was not defined in compile time), we need to safeguard parameter passing from `std::u16string` types.