### PR TITLE
[ios] Added a timing note for two delegate methods

### DIFF
--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -22,12 +22,13 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Responding to Map Position Changes
 
 /**
- Tells the delegate that the viewpoint depicted by the map view is about to
- change.
-
- This method is called whenever the currently displayed map camera will start
- changing for any reason.
-
+ Tells the delegate that the viewpoint depicted by the map view is changing.
+ 
+ This method is called whenever the currently displayed map camera has finished
+ changing, after any calls to `-mapViewRegionIsChanging:` due to animation.
+ 
+ This method can be called before the map view has finished loading.
+ 
  @param mapView The map view whose viewpoint will change.
  @param animated Whether the change will cause an animated effect on the map.
  */
@@ -38,10 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called as the currently displayed map camera changes as part of
  an animation, whether due to a user gesture or due to a call to a method such
- as `-[MGLMapView setCamera:animated:]`. During the animation, this method may
- be called many times to report updates to the viewpoint. Therefore, your
- implementation of this method should be as lightweight as possible to avoid
- affecting performance.
+ as `-[MGLMapView setCamera:animated:]`. This method can be called before the map 
+ view has finished loading.
+ 
+ During the animation, this method may be called many times to report updates to 
+ the viewpoint. Therefore, your implementation of this method should be as lightweight 
+ as possible to avoid affecting performance.
 
  @param mapView The map view whose viewpoint is changing.
  */
@@ -52,7 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
  changing.
 
  This method is called whenever the currently displayed map camera has finished
- changing, after any calls to `-mapViewRegionIsChanging:` due to animation.
+ changing, after any calls to `-mapViewRegionIsChanging:` due to animation. Therefore, 
+ this method can be called before the map view has finished loading.
 
  @param mapView The map view whose viewpoint has changed.
  @param animated Whether the change caused an animated effect on the map.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -39,8 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called as the currently displayed map camera changes as part of
  an animation, whether due to a user gesture or due to a call to a method such
- as `-[MGLMapView setCamera:animated:]`. This method can be called before the map 
- view has finished loading.
+ as `-[MGLMapView setCamera:animated:]`. This method can be called before
+ `-mapViewDidFinishLoadingMap:` is called.
  
  During the animation, this method may be called many times to report updates to 
  the viewpoint. Therefore, your implementation of this method should be as lightweight 
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called whenever the currently displayed map camera has finished
  changing, after any calls to `-mapViewRegionIsChanging:` due to animation. Therefore, 
- this method can be called before the map view has finished loading.
+ this method can be called before `-mapViewDidFinishLoadingMap:` is called.
 
  @param mapView The map view whose viewpoint has changed.
  @param animated Whether the change caused an animated effect on the map.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -22,10 +22,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Responding to Map Position Changes
 
 /**
- Tells the delegate that the viewpoint depicted by the map view is changing.
+ Tells the delegate that the viewpoint depicted by the map view is about to change.
  
- This method is called whenever the currently displayed map camera has finished
- changing, after any calls to `-mapViewRegionIsChanging:` due to animation.
+ This method is called whenever the currently displayed map camera will start
+ changing for any reason.
  
  @param mapView The map view whose viewpoint will change.
  @param animated Whether the change will cause an animated effect on the map.

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -27,8 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
  This method is called whenever the currently displayed map camera has finished
  changing, after any calls to `-mapViewRegionIsChanging:` due to animation.
  
- This method can be called before the map view has finished loading.
- 
  @param mapView The map view whose viewpoint will change.
  @param animated Whether the change will cause an animated effect on the map.
  */

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -40,10 +40,12 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called as the currently displayed map camera changes as part of
  an animation, whether due to a user gesture or due to a call to a method such
- as `-[MGLMapView setCamera:animated:]`. During the animation, this method may
- be called many times to report updates to the viewpoint. Therefore, your
- implementation of this method should be as lightweight as possible to avoid
- affecting performance.
+ as `-[MGLMapView setCamera:animated:]`.  This method can be called before the
+ map view has finished loading.
+ 
+ During the animation, this method may be called many times to report updates 
+ to the viewpoint. Therefore, your implementation of this method should be as 
+ lightweight as possible to avoid affecting performance.
 
  @param mapView The map view whose viewpoint is changing.
  */
@@ -55,7 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called whenever the currently displayed map camera has finished
  changing, after any calls to `-mapViewRegionIsChanging:` due to animation.
-
+ Therefore, this method can be called before the map view has finished loading.
+ 
  @param mapView The map view whose viewpoint has changed.
  @param animated Whether the change caused an animated effect on the map.
  */

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -40,8 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called as the currently displayed map camera changes as part of
  an animation, whether due to a user gesture or due to a call to a method such
- as `-[MGLMapView setCamera:animated:]`.  This method can be called before the
- map view has finished loading.
+ as `-[MGLMapView setCamera:animated:]`.  This method can be called before
+ `-mapViewDidFinishLoadingMap:` is called.
  
  During the animation, this method may be called many times to report updates 
  to the viewpoint. Therefore, your implementation of this method should be as 
@@ -57,7 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called whenever the currently displayed map camera has finished
  changing, after any calls to `-mapViewRegionIsChanging:` due to animation.
- Therefore, this method can be called before the map view has finished loading.
+ Therefore, this method can be called before `-mapViewDidFinishLoadingMap:` is 
+ called.
  
  @param mapView The map view whose viewpoint has changed.
  @param animated Whether the change caused an animated effect on the map.

--- a/platform/macos/src/MGLMapViewDelegate.h
+++ b/platform/macos/src/MGLMapViewDelegate.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called as the currently displayed map camera changes as part of
  an animation, whether due to a user gesture or due to a call to a method such
- as `-[MGLMapView setCamera:animated:]`.  This method can be called before
+ as `-[MGLMapView setCamera:animated:]`. This method can be called before
  `-mapViewDidFinishLoadingMap:` is called.
  
  During the animation, this method may be called many times to report updates 
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  This method is called whenever the currently displayed map camera has finished
  changing, after any calls to `-mapViewRegionIsChanging:` due to animation.
- Therefore, this method can be called before `-mapViewDidFinishLoadingMap:` is 
+ This method can be called before `-mapViewDidFinishLoadingMap:` is 
  called.
  
  @param mapView The map view whose viewpoint has changed.


### PR DESCRIPTION
Added a sentence to `regionIsChanging` and `regionDidChangeAnimated` to state that these delegate methods can be called before the map view has finished loading. 