### PR TITLE
Add Glyph Atlas debug window back

### DIFF
--- a/src/mbgl/text/glyph_atlas.cpp
+++ b/src/mbgl/text/glyph_atlas.cpp
@@ -187,6 +187,13 @@ void GlyphAtlas::upload(gl::Context& context, gl::TextureUnit unit) {
         context.updateTexture(*texture, image, unit);
     }
 
+// #if not MBGL_USE_GLES2
+//     if (dirty) {
+//         platform::showDebugImage("Glyph Atlas", reinterpret_cast<const char*>(image.data.get()),
+//                                  image.size.width, image.size.height);
+//     }
+// #endif // MBGL_USE_GLES2
+
     dirty = false;
 }
 


### PR DESCRIPTION
At some point we lost the commented out code that shows the glyph window in GLFW.