### PR TITLE
[android] - Android Studio 2.3 stable

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -46,6 +46,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    dexOptions {
+        maxProcessCount 8
+        javaMaxHeapSize "2g"
+        preDexLibraries true
+    }
 }
 
 dependencies {

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.2'
         classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.1'
     }

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
     versionCode = 11
     versionName = "5.0.0"
 
-    supportLibVersion = "25.1.1"
+    supportLibVersion = "25.2.0"
     leakCanaryVersion = '1.5'
     wearableVersion = '2.0.0'
 

--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 12 10:58:15 CET 2016
+#Fri Mar 03 10:22:19 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Yesterday Google announced the official release of Android Studio 2.3.0.

This PR:
 - updates the gradle version 
 - updates the android gradle plugin
 - updates to the latest support libraries
 - adds configuration to improve build times (captured from Configure DEX options section in https://developer.android.com/studio/build/gradle-tips.html).
