### PR TITLE
Move MarkerView click handling back to View#setOnClickListener

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewContainer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewContainer.java
@@ -1,0 +1,30 @@
+package com.mapbox.mapboxsdk.annotations;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+/**
+ * ViewGroup that dispatches TouchEvents to the parent ViewGroup.
+ * <p>
+ * This allows to dispatch touch events that occur on MarkerView to MapView.
+ * https://github.com/mapbox/mapbox-gl-native/issues/5388
+ * </p>
+ */
+public class MarkerViewContainer extends FrameLayout {
+
+  public MarkerViewContainer(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  @Override
+  public boolean dispatchTouchEvent(MotionEvent ev) {
+    final boolean childResult = super.dispatchTouchEvent(ev);
+    if (childResult) {
+      ((ViewGroup) getParent()).onTouchEvent(ev);
+    }
+    return childResult;
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -503,6 +503,21 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
                 }
               }
 
+              adaptedView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(final View v) {
+                  boolean clickHandled = false;
+                  if (onMarkerViewClickListener != null) {
+                    clickHandled = onMarkerViewClickListener.onMarkerClick(marker, v, adapter);
+                  }
+
+                  if (!clickHandled) {
+                    ensureInfoWindowOffset(marker);
+                    select(marker, v, adapter);
+                  }
+                }
+              });
+
               marker.setMapboxMap(mapboxMap);
               markerViewMap.put(marker, adaptedView);
               if (convertView == null) {
@@ -528,34 +543,6 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
     // trigger update to make newly added ViewMarker visible,
     // these would only be updated when the map is moved.
     updateMarkerViewsPosition();
-  }
-
-  /**
-   * When the provided {@link MarkerView} is clicked on by a user, we check if a custom click
-   * event has been created and if not, display a {@link InfoWindow}.
-   *
-   * @param markerView that the click event occurred.
-   */
-  public boolean onClickMarkerView(MarkerView markerView) {
-    boolean clickHandled = false;
-
-    MapboxMap.MarkerViewAdapter adapter = getViewAdapter(markerView);
-    View view = getView(markerView);
-    if (adapter == null || view == null) {
-      // not a valid state
-      return true;
-    }
-
-    if (onMarkerViewClickListener != null) {
-      clickHandled = onMarkerViewClickListener.onMarkerClick(markerView, view, adapter);
-    }
-
-    if (!clickHandled) {
-      ensureInfoWindowOffset(markerView);
-      select(markerView, view, adapter);
-    }
-
-    return clickHandled;
   }
 
   /**

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -10,6 +10,7 @@ import com.mapbox.mapboxsdk.annotations.Annotation;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerOptions;
 import com.mapbox.mapboxsdk.annotations.BaseMarkerViewOptions;
 import com.mapbox.mapboxsdk.annotations.Icon;
+import com.mapbox.mapboxsdk.annotations.IconFactory;
 import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerView;
 import com.mapbox.mapboxsdk.annotations.MarkerViewManager;
@@ -256,7 +257,11 @@ class AnnotationManager {
 
   private MarkerView prepareViewMarker(BaseMarkerViewOptions markerViewOptions) {
     MarkerView marker = markerViewOptions.getMarker();
-    iconManager.loadIconForMarkerView(marker);
+    Icon icon = markerViewOptions.getIcon();
+    if (icon == null) {
+      icon = IconFactory.getInstance(mapView.getContext()).defaultMarkerView();
+    }
+    marker.setIcon(icon);
     return marker;
   }
 
@@ -660,24 +665,16 @@ class AnnotationManager {
           if (annotation.getId() == newSelectedMarkerId) {
             Marker marker = (Marker) annotation;
 
-            if (marker instanceof MarkerView) {
-              handledDefaultClick = markerViewManager.onClickMarkerView((MarkerView) marker);
-            } else {
+            if (!(marker instanceof MarkerView)) {
               if (onMarkerClickListener != null) {
                 // end developer has provided a custom click listener
                 handledDefaultClick = onMarkerClickListener.onMarkerClick(marker);
               }
-            }
-
-            if (annotation instanceof MarkerView) {
-              markerViewManager.onClickMarkerView((MarkerView) annotation);
-            } else {
               if (!handledDefaultClick) {
                 // only select marker if user didn't handle the click event themselves
                 selectMarker(marker);
               }
             }
-
             return true;
           }
         }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/IconManager.java
@@ -71,27 +71,6 @@ class IconManager {
     return icon;
   }
 
-  Icon loadIconForMarkerView(MarkerView marker) {
-    Icon icon = marker.getIcon();
-    int iconSize = icons.size() + 1;
-    if (icon == null) {
-      icon = IconFactory.getInstance(nativeMapView.getContext()).defaultMarkerView();
-      marker.setIcon(icon);
-    }
-    Bitmap bitmap = icon.getBitmap();
-    averageIconHeight = averageIconHeight + (bitmap.getHeight() - averageIconHeight) / iconSize;
-    averageIconWidth = averageIconWidth + (bitmap.getWidth() - averageIconWidth) / iconSize;
-    if (!icons.contains(icon)) {
-      icons.add(icon);
-    } else {
-      Icon oldIcon = icons.get(icons.indexOf(icon));
-      if (!oldIcon.getBitmap().sameAs(icon.getBitmap())) {
-        throw new IconBitmapChangedException();
-      }
-    }
-    return icon;
-  }
-
   int getTopOffsetPixelsForIcon(Icon icon) {
     return (int) (nativeMapView.getTopOffsetPixelsForAnnotationSymbol(icon.getId()) * nativeMapView.getPixelRatio());
   }

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_mapview_internal.xml
@@ -7,7 +7,7 @@
         android:layout_height="match_parent"
         android:visibility="gone" />
 
-    <FrameLayout
+    <com.mapbox.mapboxsdk.annotations.MarkerViewContainer
         android:id="@+id/markerViewContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
Closes #8236, refs # 8159 #5388 #5639

This PR moves touch handling of MarkerViews back to View#setOnClickListener and fixes the issue with the original implementation as shown in #5388.

This change is motivated by 2 items:
 - better UX for users, as we are hooking into the platform default way of handling touch events 
 - better touch target surface (see #8159)







