### PR TITLE
[Qt] Remove legacy QOpenGL dependency from Qt5 build

### DIFF
--- a/include/mbgl/gl/gl.hpp
+++ b/include/mbgl/gl/gl.hpp
@@ -22,9 +22,9 @@
     #define GL_GLEXT_PROTOTYPES
     #include <GLES2/gl2.h>
     #include <GLES2/gl2ext.h>
-#elif __QT__
+#elif __QT_ && QT_VERSION >= 0x050000
     #define GL_GLEXT_PROTOTYPES
-    #include <QtOpenGL>
+    #include <QtGui/qopengl.h>
 #else
     #define GL_GLEXT_PROTOTYPES
     #include <GL/gl.h>

--- a/platform/qt/config.cmake
+++ b/platform/qt/config.cmake
@@ -72,7 +72,7 @@ macro(mbgl_platform_test)
 
     target_link_libraries(mbgl-test
         PRIVATE qmapboxgl
-        ${MBGL_QT_LIBRARIES}
+        ${MBGL_QT_TEST_LIBRARIES}
     )
 endmacro()
 

--- a/platform/qt/qt4.cmake
+++ b/platform/qt/qt4.cmake
@@ -8,6 +8,11 @@ set(MBGL_QT_LIBRARIES
     PRIVATE Qt4::QtSql
 )
 
+set(MBGL_QT_TEST_LIBRARIES
+    PRIVATE Qt4::QtCore
+    PRIVATE Qt4::QtOpenGL
+)
+
 target_link_libraries(qmapboxgl
     PRIVATE mbgl-core
     PRIVATE Qt4::QtCore

--- a/platform/qt/qt5.cmake
+++ b/platform/qt/qt5.cmake
@@ -11,8 +11,14 @@ set(MBGL_QT_LIBRARIES
     PRIVATE Qt5::Core
     PRIVATE Qt5::Gui
     PRIVATE Qt5::Network
-    PRIVATE Qt5::OpenGL
     PRIVATE Qt5::Sql
+)
+
+set(MBGL_QT_TEST_LIBRARIES
+    PRIVATE Qt5::Core
+    PRIVATE Qt5::Gui
+    PRIVATE Qt5::Widgets
+    PRIVATE Qt5::OpenGL
 )
 
 target_sources(qmapboxgl
@@ -29,7 +35,6 @@ target_link_libraries(qmapboxgl
     PRIVATE Qt5::Core
     PRIVATE Qt5::Gui
     PRIVATE Qt5::Location
-    PRIVATE Qt5::OpenGL
     PRIVATE Qt5::Quick
     PRIVATE Qt5::Sql
 )

--- a/platform/qt/test/headless_backend_qt.cpp
+++ b/platform/qt/test/headless_backend_qt.cpp
@@ -1,10 +1,11 @@
 #include <mbgl/gl/headless_backend.hpp>
 
-#include <QGLContext>
 #include <QGLWidget>
 
 #if QT_VERSION >= 0x050000
 #include <QOpenGLContext>
+#else
+#include <QGLContext>
 #endif
 
 #include <cassert>


### PR DESCRIPTION
OpenGL on Qt5 is offered via QtGui.