### PR TITLE
[android] - don't disable tracking when animating the camera bearing.

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TrackingSettings.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TrackingSettings.java
@@ -281,7 +281,7 @@ public final class TrackingSettings {
    */
   void resetTrackingModesIfRequired(CameraPosition cameraPosition) {
     if (isDismissTrackingModesForCameraPositionChange()) {
-      resetTrackingModesIfRequired(cameraPosition.target != null, cameraPosition.bearing != -1);
+      resetTrackingModesIfRequired(cameraPosition.target != null, false);
     }
   }
 


### PR DESCRIPTION
Closes #7878 