### PR TITLE
Enable debug events in Debug configuration

### DIFF
--- a/include/mbgl/util/event.hpp
+++ b/include/mbgl/util/event.hpp
@@ -40,7 +40,7 @@ struct EventPermutation {
 };
 
 constexpr EventSeverity disabledEventSeverities[] = {
-#ifdef NDEBUG
+#ifndef NDEBUG
     EventSeverity(-1) // Avoid zero size array
 #else
     EventSeverity::Debug


### PR DESCRIPTION
Fixed a typo in 3ae506ee1301bcc3f9961a9282f710b8b7fa8039 for #5359 that suppressed debug events in debug builds and enabled them in release builds.

/cc @anandthakker