### PR TITLE
WIP Avoid using double-sized buffers for source functions

### DIFF
--- a/scripts/generate-shaders.js
+++ b/scripts/generate-shaders.js
@@ -41,11 +41,11 @@ require('./style-code');
         return prelude + applyPragmas(source, {
                 define: [
                     "uniform lowp float a_{name}_t;",
-                    "attribute {precision} {a_type} a_{name}_minmax;",
+                    "attribute {precision} {a_type} a_{name};",
                     "varying {precision} {type} {name};"
                 ],
                 initialize: [
-                    "{name} = unpack_mix_{a_type}(a_{name}_minmax, a_{name}_t);"
+                    "{name} = unpack_mix_{a_type}(a_{name}, a_{name}_t);"
                 ]
             });
     }

--- a/src/mbgl/gl/attribute.cpp
+++ b/src/mbgl/gl/attribute.cpp
@@ -38,7 +38,7 @@ void VariableAttributeBinding<T, N>::bind(Context& context,
     MBGL_CHECK_ERROR(glEnableVertexAttribArray(location));
     MBGL_CHECK_ERROR(glVertexAttribPointer(
         location,
-        static_cast<GLint>(N),
+        static_cast<GLint>(attributeSize),
         static_cast<GLenum>(DataTypeOf<T>),
         static_cast<GLboolean>(IsNormalized<T>),
         static_cast<GLsizei>(vertexSize),

--- a/src/mbgl/gl/attribute.hpp
+++ b/src/mbgl/gl/attribute.hpp
@@ -17,10 +17,12 @@ class VariableAttributeBinding {
 public:
     VariableAttributeBinding(BufferID vertexBuffer_,
                              std::size_t vertexSize_,
-                             std::size_t attributeOffset_)
+                             std::size_t attributeOffset_,
+                             std::size_t attributeSize_ = N)
         : vertexBuffer(vertexBuffer_),
           vertexSize(vertexSize_),
-          attributeOffset(attributeOffset_)
+          attributeOffset(attributeOffset_),
+          attributeSize(attributeSize_)
         {}
 
     void bind(Context&, AttributeLocation, optional<VariableAttributeBinding<T, N>>&, std::size_t vertexOffset) const;
@@ -29,13 +31,15 @@ public:
                            const VariableAttributeBinding& rhs) {
         return lhs.vertexBuffer == rhs.vertexBuffer
             && lhs.vertexSize == rhs.vertexSize
-            && lhs.attributeOffset == rhs.attributeOffset;
+            && lhs.attributeOffset == rhs.attributeOffset
+            && lhs.attributeSize == rhs.attributeSize;
     }
 
 private:
     BufferID vertexBuffer;
     std::size_t vertexSize;
     std::size_t attributeOffset;
+    std::size_t attributeSize;
 };
 
 template <class T, std::size_t N>
@@ -61,6 +65,8 @@ private:
 template <class T, std::size_t N>
 class Attribute {
 public:
+    using ValueType = T;
+    static constexpr size_t Dimensions = N;
     using Value = std::array<T, N>;
 
     using VariableBinding = VariableAttributeBinding<T, N>;
@@ -71,10 +77,19 @@ public:
     using Binding = variant<
         ConstantBinding,
         VariableBinding>;
-    
-    using ValueType = T;
-    
-    static constexpr size_t Dimensions = N;
+
+    template <class Vertex, class DrawMode>
+    static VariableBinding variableBinding(const VertexBuffer<Vertex, DrawMode>& buffer,
+                                           std::size_t attributeIndex,
+                                           std::size_t attributeSize = N) {
+        static_assert(std::is_standard_layout<Vertex>::value, "vertex type must use standard layout");
+        return VariableBinding {
+            buffer.buffer,
+            sizeof(Vertex),
+            Vertex::attributeOffsets[attributeIndex],
+            attributeSize
+        };
+    }
 
     static void bind(Context& context,
                      const Location& location,
@@ -227,15 +242,7 @@ public:
 
     template <class DrawMode>
     static Bindings allVariableBindings(const VertexBuffer<Vertex, DrawMode>& buffer) {
-        static_assert(std::is_standard_layout<Vertex>::value, "vertex type must use standard layout");
-
-        return Bindings {
-            typename As::VariableBinding {
-                buffer.buffer,
-                sizeof(Vertex),
-                Vertex::attributeOffsets[Index<As>]
-            }...
-        };
+        return Bindings { As::variableBinding(buffer, Index<As>)... };
     }
 
     static void bind(Context& context,

--- a/src/mbgl/programs/attributes.hpp
+++ b/src/mbgl/programs/attributes.hpp
@@ -29,11 +29,11 @@ struct a_offset : gl::Attribute<int16_t, N> {
 // Paint attributes
 
 template <class Attr>
-struct MinMax : gl::Attribute<typename Attr::ValueType, Attr::Dimensions * 2> {
+struct ZoomInterpolatedAttribute : gl::Attribute<typename Attr::ValueType, Attr::Dimensions * 2> {
     using Value = typename gl::Attribute<typename Attr::ValueType, Attr::Dimensions * 2>::Value;
 
     static auto name() {
-        static const std::string name = Attr::name() + std::string("_minmax");
+        static const std::string name = Attr::name();
         return name.c_str();
     }
     

--- a/src/mbgl/programs/program.hpp
+++ b/src/mbgl/programs/program.hpp
@@ -21,7 +21,7 @@ public:
     using LayoutVertex = typename LayoutAttributes::Vertex;
 
     using PaintPropertyBinders = typename PaintProperties::Binders;
-    using PaintAttributes = typename PaintPropertyBinders::MinMaxAttributes;
+    using PaintAttributes = typename PaintPropertyBinders::Attributes;
     using Attributes = gl::ConcatenateAttributes<LayoutAttributes, PaintAttributes>;
 
     using UniformValues = typename Uniforms::Values;

--- a/src/mbgl/shaders/circle.cpp
+++ b/src/mbgl/shaders/circle.cpp
@@ -94,38 +94,38 @@ uniform vec2 u_extrude_scale;
 attribute vec2 a_pos;
 
 uniform lowp float a_color_t;
-attribute lowp vec4 a_color_minmax;
+attribute lowp vec4 a_color;
 varying lowp vec4 color;
 uniform lowp float a_radius_t;
-attribute mediump vec2 a_radius_minmax;
+attribute mediump vec2 a_radius;
 varying mediump float radius;
 uniform lowp float a_blur_t;
-attribute lowp vec2 a_blur_minmax;
+attribute lowp vec2 a_blur;
 varying lowp float blur;
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_stroke_color_t;
-attribute lowp vec4 a_stroke_color_minmax;
+attribute lowp vec4 a_stroke_color;
 varying lowp vec4 stroke_color;
 uniform lowp float a_stroke_width_t;
-attribute mediump vec2 a_stroke_width_minmax;
+attribute mediump vec2 a_stroke_width;
 varying mediump float stroke_width;
 uniform lowp float a_stroke_opacity_t;
-attribute lowp vec2 a_stroke_opacity_minmax;
+attribute lowp vec2 a_stroke_opacity;
 varying lowp float stroke_opacity;
 
 varying vec2 v_extrude;
 varying lowp float v_antialiasblur;
 
 void main(void) {
-    color = unpack_mix_vec4(a_color_minmax, a_color_t);
-    radius = unpack_mix_vec2(a_radius_minmax, a_radius_t);
-    blur = unpack_mix_vec2(a_blur_minmax, a_blur_t);
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
-    stroke_color = unpack_mix_vec4(a_stroke_color_minmax, a_stroke_color_t);
-    stroke_width = unpack_mix_vec2(a_stroke_width_minmax, a_stroke_width_t);
-    stroke_opacity = unpack_mix_vec2(a_stroke_opacity_minmax, a_stroke_opacity_t);
+    color = unpack_mix_vec4(a_color, a_color_t);
+    radius = unpack_mix_vec2(a_radius, a_radius_t);
+    blur = unpack_mix_vec2(a_blur, a_blur_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+    stroke_color = unpack_mix_vec4(a_stroke_color, a_stroke_color_t);
+    stroke_width = unpack_mix_vec2(a_stroke_width, a_stroke_width_t);
+    stroke_opacity = unpack_mix_vec2(a_stroke_opacity, a_stroke_opacity_t);
 
     // unencode the extrusion vector that we snuck into the a_pos vector
     v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);

--- a/src/mbgl/shaders/fill.cpp
+++ b/src/mbgl/shaders/fill.cpp
@@ -92,15 +92,15 @@ attribute vec2 a_pos;
 uniform mat4 u_matrix;
 
 uniform lowp float a_color_t;
-attribute lowp vec4 a_color_minmax;
+attribute lowp vec4 a_color;
 varying lowp vec4 color;
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 
 void main() {
-    color = unpack_mix_vec4(a_color_minmax, a_color_t);
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
+    color = unpack_mix_vec4(a_color, a_color_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 }

--- a/src/mbgl/shaders/fill_outline.cpp
+++ b/src/mbgl/shaders/fill_outline.cpp
@@ -95,15 +95,15 @@ uniform vec2 u_world;
 varying vec2 v_pos;
 
 uniform lowp float a_outline_color_t;
-attribute lowp vec4 a_outline_color_minmax;
+attribute lowp vec4 a_outline_color;
 varying lowp vec4 outline_color;
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 
 void main() {
-    outline_color = unpack_mix_vec4(a_outline_color_minmax, a_outline_color_t);
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
+    outline_color = unpack_mix_vec4(a_outline_color, a_outline_color_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;

--- a/src/mbgl/shaders/fill_outline_pattern.cpp
+++ b/src/mbgl/shaders/fill_outline_pattern.cpp
@@ -104,11 +104,11 @@ varying vec2 v_pos_b;
 varying vec2 v_pos;
 
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 
 void main() {
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 

--- a/src/mbgl/shaders/fill_pattern.cpp
+++ b/src/mbgl/shaders/fill_pattern.cpp
@@ -102,11 +102,11 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 
 void main() {
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 

--- a/src/mbgl/shaders/line.cpp
+++ b/src/mbgl/shaders/line.cpp
@@ -114,27 +114,27 @@ varying vec2 v_width2;
 varying float v_gamma_scale;
 
 uniform lowp float a_color_t;
-attribute lowp vec4 a_color_minmax;
+attribute lowp vec4 a_color;
 varying lowp vec4 color;
 uniform lowp float a_blur_t;
-attribute lowp vec2 a_blur_minmax;
+attribute lowp vec2 a_blur;
 varying lowp float blur;
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_gapwidth_t;
-attribute mediump vec2 a_gapwidth_minmax;
+attribute mediump vec2 a_gapwidth;
 varying mediump float gapwidth;
 uniform lowp float a_offset_t;
-attribute lowp vec2 a_offset_minmax;
+attribute lowp vec2 a_offset;
 varying lowp float offset;
 
 void main() {
-    color = unpack_mix_vec4(a_color_minmax, a_color_t);
-    blur = unpack_mix_vec2(a_blur_minmax, a_blur_t);
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth_minmax, a_gapwidth_t);
-    offset = unpack_mix_vec2(a_offset_minmax, a_offset_t);
+    color = unpack_mix_vec4(a_color, a_color_t);
+    blur = unpack_mix_vec2(a_blur, a_blur_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    offset = unpack_mix_vec2(a_offset, a_offset_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/mbgl/shaders/line_pattern.cpp
+++ b/src/mbgl/shaders/line_pattern.cpp
@@ -117,23 +117,23 @@ varying float v_linesofar;
 varying float v_gamma_scale;
 
 uniform lowp float a_blur_t;
-attribute lowp vec2 a_blur_minmax;
+attribute lowp vec2 a_blur;
 varying lowp float blur;
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_offset_t;
-attribute lowp vec2 a_offset_minmax;
+attribute lowp vec2 a_offset;
 varying lowp float offset;
 uniform lowp float a_gapwidth_t;
-attribute mediump vec2 a_gapwidth_minmax;
+attribute mediump vec2 a_gapwidth;
 varying mediump float gapwidth;
 
 void main() {
-    blur = unpack_mix_vec2(a_blur_minmax, a_blur_t);
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
-    offset = unpack_mix_vec2(a_offset_minmax, a_offset_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth_minmax, a_gapwidth_t);
+    blur = unpack_mix_vec2(a_blur, a_blur_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+    offset = unpack_mix_vec2(a_offset, a_offset_t);
+    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/mbgl/shaders/line_sdf.cpp
+++ b/src/mbgl/shaders/line_sdf.cpp
@@ -122,27 +122,27 @@ varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
 uniform lowp float a_color_t;
-attribute lowp vec4 a_color_minmax;
+attribute lowp vec4 a_color;
 varying lowp vec4 color;
 uniform lowp float a_blur_t;
-attribute lowp vec2 a_blur_minmax;
+attribute lowp vec2 a_blur;
 varying lowp float blur;
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_gapwidth_t;
-attribute mediump vec2 a_gapwidth_minmax;
+attribute mediump vec2 a_gapwidth;
 varying mediump float gapwidth;
 uniform lowp float a_offset_t;
-attribute lowp vec2 a_offset_minmax;
+attribute lowp vec2 a_offset;
 varying lowp float offset;
 
 void main() {
-    color = unpack_mix_vec4(a_color_minmax, a_color_t);
-    blur = unpack_mix_vec2(a_blur_minmax, a_blur_t);
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
-    gapwidth = unpack_mix_vec2(a_gapwidth_minmax, a_gapwidth_t);
-    offset = unpack_mix_vec2(a_offset_minmax, a_offset_t);
+    color = unpack_mix_vec4(a_color, a_color_t);
+    blur = unpack_mix_vec2(a_blur, a_blur_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+    gapwidth = unpack_mix_vec2(a_gapwidth, a_gapwidth_t);
+    offset = unpack_mix_vec2(a_offset, a_offset_t);
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;

--- a/src/mbgl/shaders/symbol_icon.cpp
+++ b/src/mbgl/shaders/symbol_icon.cpp
@@ -100,7 +100,7 @@ attribute vec4 a_data;
 
 
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 
 // matrix is for the vertex position.
@@ -116,7 +116,7 @@ varying vec2 v_tex;
 varying vec2 v_fade_tex;
 
 void main() {
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
 
 #ifdef MAPBOX_GL_NATIVE
     mediump vec2 a_pos = a_pos_offset.xy;

--- a/src/mbgl/shaders/symbol_sdf.cpp
+++ b/src/mbgl/shaders/symbol_sdf.cpp
@@ -102,19 +102,19 @@ attribute vec4 a_data;
 
 
 uniform lowp float a_fill_color_t;
-attribute lowp vec4 a_fill_color_minmax;
+attribute lowp vec4 a_fill_color;
 varying lowp vec4 fill_color;
 uniform lowp float a_halo_color_t;
-attribute lowp vec4 a_halo_color_minmax;
+attribute lowp vec4 a_halo_color;
 varying lowp vec4 halo_color;
 uniform lowp float a_opacity_t;
-attribute lowp vec2 a_opacity_minmax;
+attribute lowp vec2 a_opacity;
 varying lowp float opacity;
 uniform lowp float a_halo_width_t;
-attribute lowp vec2 a_halo_width_minmax;
+attribute lowp vec2 a_halo_width;
 varying lowp float halo_width;
 uniform lowp float a_halo_blur_t;
-attribute lowp vec2 a_halo_blur_minmax;
+attribute lowp vec2 a_halo_blur;
 varying lowp float halo_blur;
 
 // matrix is for the vertex position.
@@ -135,11 +135,11 @@ varying vec2 v_fade_tex;
 varying float v_gamma_scale;
 
 void main() {
-    fill_color = unpack_mix_vec4(a_fill_color_minmax, a_fill_color_t);
-    halo_color = unpack_mix_vec4(a_halo_color_minmax, a_halo_color_t);
-    opacity = unpack_mix_vec2(a_opacity_minmax, a_opacity_t);
-    halo_width = unpack_mix_vec2(a_halo_width_minmax, a_halo_width_t);
-    halo_blur = unpack_mix_vec2(a_halo_blur_minmax, a_halo_blur_t);
+    fill_color = unpack_mix_vec4(a_fill_color, a_fill_color_t);
+    halo_color = unpack_mix_vec4(a_halo_color, a_halo_color_t);
+    opacity = unpack_mix_vec2(a_opacity, a_opacity_t);
+    halo_width = unpack_mix_vec2(a_halo_width, a_halo_width_t);
+    halo_blur = unpack_mix_vec2(a_halo_blur, a_halo_blur_t);
 
 #ifdef MAPBOX_GL_NATIVE
     mediump vec2 a_pos = a_pos_offset.xy;


### PR DESCRIPTION
- Rename `MinMax` attribute to `ZoomInterpolatedAttribute`, signaling
  intent to use it only for composite functions. The idea is that
  source functions will bind the base `Attribute` instead, so as not to
  use double-sized vertex buffers.
- Change the attribute name string in ^ from `a_{name}_minmax` to just
  `a_{name}`, to match the base attributes, and update the shaders to
  match.  (We're only ever binding the base one or the ZoomInterpolated
  one, never both.)
- Change the specific `*PaintPropertyBinder` types and the general `PaintPropertyBinder` type to use the base attribute for non-composite-function values and the `ZoomInterpolatedAttribute<>` for composite-function values.  **🚧 I think this is the part that I don't have quite right.**

cc @jfirebaugh @mollymerp  (note that this PR is against the branch for https://github.com/mapbox/mapbox-gl-native/pull/8267, not master )