### PR TITLE
Batch update

### DIFF
--- a/cmake/core.cmake
+++ b/cmake/core.cmake
@@ -5,6 +5,9 @@ add_library(mbgl-core STATIC
 target_compile_options(mbgl-core
     PRIVATE -fPIC
     PRIVATE -fvisibility-inlines-hidden
+    -Wno-misleading-indentation
+    -Wno-terminate
+    -Wno-error=terminate
 )
 
 target_include_directories(mbgl-core

--- a/platform/qt/include/qquickmapboxgl.hpp
+++ b/platform/qt/include/qquickmapboxgl.hpp
@@ -77,11 +77,11 @@ public:
     // Proposed Qt interface implementation.
     QQmlListProperty<QQuickMapboxGLMapParameter> parameters();
 
-    // flush cache after this amount of time (milliseconds)
-    void setBatchTimerInterval(quint32 timeInterval);
+    // flush cache after this amount of time (milliseconds). Less then 1 turns off batch mode.
+    Q_INVOKABLE void setBatchTimerInterval(qint32 timeInterval);
 
     // flush event cache if reach more then this num of events
-    void setBatchSize(qint32 batchSize);
+    Q_INVOKABLE void setBatchSize(qint32 batchSize);
 
 protected:
     // QQmlParserStatus implementation
@@ -180,7 +180,7 @@ private:
     bool m_styleLoaded = false;
     quint32 m_numBatchUpdates = 0;
     qint32  m_updateTimerID = -1;
-    quint32 m_updateTimeIntrval = 250; // milliseconds
+    qint32 m_updateTimeInterval = 0; // milliseconds, less then 1 turns off batch mode
     quint32 m_maxUpdateCachedEvents = 10;
     friend class QQuickMapboxGLRenderer;
 };

--- a/platform/qt/include/qquickmapboxgl.hpp
+++ b/platform/qt/include/qquickmapboxgl.hpp
@@ -13,7 +13,7 @@
 #include <QQmlListProperty>
 #include <QQuickFramebufferObject>
 #include <QQuickItem>
-
+#include <QTimerEvent>
 class QDeclarativeGeoServiceProvider;
 class QQuickMapboxGLRenderer;
 
@@ -77,10 +77,17 @@ public:
     // Proposed Qt interface implementation.
     QQmlListProperty<QQuickMapboxGLMapParameter> parameters();
 
+    // flush cache after this amount of time (milliseconds)
+    void setBatchTimerInterval(quint32 timeInterval);
+
+    // flush event cache if reach more then this num of events
+    void setBatchSize(qint32 batchSize);
+
 protected:
     // QQmlParserStatus implementation
     void componentComplete() override;
-
+    inline void batchUpdate();
+    void timerEvent(QTimerEvent *e);
 signals:
     // Map QML Type signals.
     void minimumZoomLevelChanged();
@@ -171,6 +178,9 @@ private:
 
     int m_syncState = NothingNeedsSync;
     bool m_styleLoaded = false;
-
+    quint32 m_numBatchUpdates = 0;
+    qint32  m_updateTimerID = -1;
+    quint32 m_updateTimeIntrval = 250; // milliseconds
+    quint32 m_maxUpdateCachedEvents = 10;
     friend class QQuickMapboxGLRenderer;
 };


### PR DESCRIPTION
This branch queues the screen updates for the QML platform if one of two events happen:
1) a certain amount of time elapses (user defined. Example 100ms)
2) number of events reach a critical amount (user defined.  Example 10)

By default batchMode is turned off, only by setting the batch timer to something > 1ms and the cached size also greater then 1 does it do anything.

While you do not see that much savings on a desktop computer, I think it will help out a lot for an embedded computer.