### PR TITLE
[android] - zoom to rounded levels

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -508,7 +508,7 @@ public class MapView extends FrameLayout {
       if (destroyed) {
         return;
       }
-      mapboxMap.onUpdate();
+      mapboxMap.onUpdateRegionChange();
     }
   }
 
@@ -969,8 +969,10 @@ public class MapView extends FrameLayout {
             mapboxMap.onPostMapReady();
           }
         });
+      } else if (change == DID_FINISH_RENDERING_FRAME || change == DID_FINISH_RENDERING_FRAME_FULLY_RENDERED) {
+        mapboxMap.onUpdateFullyRendered();
       } else if (change == REGION_IS_CHANGING || change == REGION_DID_CHANGE || change == DID_FINISH_LOADING_MAP) {
-        mapboxMap.onUpdate();
+        mapboxMap.onUpdateRegionChange();
       }
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -155,12 +155,16 @@ public final class MapboxMap {
   /**
    * Called when the user
    */
-  void onUpdate() {
-    CameraPosition cameraPosition = transform.invalidateCameraPosition();
-    uiSettings.update(cameraPosition);
-    // FIXME introduce update method with camera position
+  void onUpdateRegionChange() {
     trackingSettings.update();
     annotationManager.update();
+  }
+
+  void onUpdateFullyRendered() {
+    CameraPosition cameraPosition = transform.invalidateCameraPosition();
+    if (cameraPosition != null) {
+      uiSettings.update(cameraPosition);
+    }
   }
 
   // Style

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -61,6 +61,8 @@ final class NativeMapView {
   // Listener invoked to return a bitmap of the map
   private MapboxMap.SnapshotReadyCallback snapshotReadyCallback;
 
+  private static final int CENTER_XY_VALUE = -1;
+
   //
   // Static methods
   //
@@ -382,14 +384,23 @@ final class NativeMapView {
     if (isDestroyedOn("setZoom")) {
       return;
     }
-    setZoom(zoom, 0);
+    setZoom(zoom, CENTER_XY_VALUE, CENTER_XY_VALUE, 0);
   }
 
-  public void setZoom(double zoom, long duration) {
+  public void setZoom(double zoom, double cx, double cy, long duration) {
     if (isDestroyedOn("setZoom")) {
       return;
     }
-    nativeSetZoom(zoom, duration);
+
+    if (cx != CENTER_XY_VALUE) {
+      cx = cx / pixelRatio;
+    }
+
+    if (cy != CENTER_XY_VALUE) {
+      cy = cy / pixelRatio;
+    }
+
+    nativeSetZoom(zoom, cx, cy, duration);
   }
 
   public double getZoom() {
@@ -1019,7 +1030,7 @@ final class NativeMapView {
 
   private native double nativeGetScale();
 
-  private native void nativeSetZoom(double zoom, long duration);
+  private native void nativeSetZoom(double zoom, double cx, double cy, long duration);
 
   private native double nativeGetZoom();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -182,11 +182,15 @@ final class Transform implements MapView.OnMapChangedListener {
     // Cancel any animation
     cancelTransitions();
 
-    if (zoomIn) {
-      mapView.scaleBy(2.0, x, y, MapboxConstants.ANIMATION_DURATION);
-    } else {
-      mapView.scaleBy(0.5, x, y, MapboxConstants.ANIMATION_DURATION);
+    CameraPosition cameraPosition = invalidateCameraPosition();
+    if (cameraPosition != null) {
+      zoom(cameraPosition, zoomIn, x, y);
     }
+  }
+
+  private void zoom(@NonNull CameraPosition cameraPosition, boolean zoomIn, float x, float y) {
+    int newZoom = (int) Math.round(cameraPosition.zoom + (zoomIn ? 1 : -1));
+    mapView.setZoom(newZoom, x, y, MapboxConstants.ANIMATION_DURATION);
   }
 
   void setZoom(double zoom) {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/maplayout/DebugModeActivity.java
@@ -5,7 +5,9 @@ import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+import android.widget.TextView;
 
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -47,8 +49,20 @@ public class DebugModeActivity extends AppCompatActivity {
       @Override
       public void onMapReady(@NonNull MapboxMap map) {
         mapboxMap = map;
+
+        mapboxMap.getUiSettings().setZoomControlsEnabled(true);
+
+        // show current zoom level on screen
+        final TextView textView = (TextView) findViewById(R.id.textZoom);
+        mapboxMap.setOnCameraChangeListener(new MapboxMap.OnCameraChangeListener() {
+          @Override
+          public void onCameraChange(CameraPosition position) {
+            textView.setText(String.format(getString(R.string.debug_zoom), position.zoom));
+          }
+        });
       }
     });
+
 
     FloatingActionButton fabDebug = (FloatingActionButton) findViewById(R.id.fabDebug);
     fabDebug.setOnClickListener(new View.OnClickListener() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_debug_mode.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/layout/activity_debug_mode.xml
@@ -10,7 +10,18 @@
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        app:mapbox_uiAttribution="false"
+        app:mapbox_uiCompass="false"
+        app:mapbox_uiLogo="false"/>
+
+    <TextView
+        android:id="@+id/textZoom"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|start"
+        android:layout_margin="8dp"
+        android:textSize="14sp"/>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fabDebug"

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/res/values/strings.xml
@@ -160,4 +160,5 @@
     <string name="dynamic_marker_chelsea_snippet">Stamford Bridge</string>
     <string name="dynamic_marker_arsenal_title">Arsenal</string>
     <string name="dynamic_marker_arsenal_snippet">Emirates Stadium</string>
+    <string name="debug_zoom">Zoom: %s</string>
 </resources>

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -394,8 +394,8 @@ jni::jdouble NativeMapView::getScale(jni::JNIEnv&) {
     return map->getScale();
 }
 
-void NativeMapView::setZoom(jni::JNIEnv&, jni::jdouble zoom, jni::jlong duration) {
-    map->setZoom(zoom, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
+void NativeMapView::setZoom(jni::JNIEnv&, jni::jdouble zoom, jni::jdouble x, jni::jdouble y, jni::jlong duration) {
+    map->setZoom(zoom, mbgl::ScreenCoordinate{x,y}, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
 jni::jdouble NativeMapView::getZoom(jni::JNIEnv&) {

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -115,7 +115,7 @@ public:
 
     jni::jdouble getScale(jni::JNIEnv&);
 
-    void setZoom(jni::JNIEnv&, jni::jdouble, jni::jlong);
+    void setZoom(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jlong);
 
     jni::jdouble getZoom(jni::JNIEnv&);
 


### PR DESCRIPTION
Follow up from #7630 (but now covers all interactions)
Android equivalent of iOS PR in https://github.com/mapbox/mapbox-gl-native/pull/8027

![ezgif com-video-to-gif 12](https://cloud.githubusercontent.com/assets/2151639/23638932/79aa9972-0299-11e7-9e0f-750198f1a722.gif)

Besides zooming to rounded zoom levels, this PR also fixes the issue of not getting the final value during OnCameraChange event. Without this change I was receiving zoom levels that just not hit the actual value ( eg. 0.9999988 instead of 1.0).


