### PR TITLE
For data-driven paint setters, transition immediately to target value

### DIFF
--- a/include/mbgl/style/property_value.hpp
+++ b/include/mbgl/style/property_value.hpp
@@ -29,6 +29,7 @@ public:
     bool isUndefined()      const { return value.which() == 0; }
     bool isConstant()       const { return value.which() == 1; }
     bool isCameraFunction() const { return value.which() == 2; }
+    bool isDataDriven()     const { return false; }
 
     const                T & asConstant()       const { return value.template get<               T >(); }
     const CameraFunction<T>& asCameraFunction() const { return value.template get<CameraFunction<T>>(); }

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -44,11 +44,18 @@ public:
     template <class Evaluator>
     auto evaluate(const Evaluator& evaluator, TimePoint now) {
         auto finalValue = value.evaluate(evaluator);
+        
         if (!prior) {
             // No prior value.
             return finalValue;
         } else if (now >= end) {
             // Transition from prior value is now complete.
+            prior = {};
+            return finalValue;
+        } else if (value.isDataDriven()) {
+            // Transitions to data-driven properties are not supported.
+            // We snap immediately to the data-driven value so that, when we perform layout,
+            // we see the data-driven function and can use it to populate vertex buffers.
             prior = {};
             return finalValue;
         } else if (now < begin) {
@@ -60,7 +67,7 @@ public:
             return util::interpolate(prior->get().evaluate(evaluator, now), finalValue, util::DEFAULT_TRANSITION_EASE.solve(t, 0.001));
         }
     }
-
+    
     bool hasTransition() const {
         return bool(prior);
     }

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -44,7 +44,6 @@ public:
     template <class Evaluator>
     auto evaluate(const Evaluator& evaluator, TimePoint now) {
         auto finalValue = value.evaluate(evaluator);
-        
         if (!prior) {
             // No prior value.
             return finalValue;
@@ -67,7 +66,7 @@ public:
             return util::interpolate(prior->get().evaluate(evaluator, now), finalValue, util::DEFAULT_TRANSITION_EASE.solve(t, 0.001));
         }
     }
-    
+
     bool hasTransition() const {
         return bool(prior);
     }


### PR DESCRIPTION
Closes #8237