### PR TITLE
Make annotation view rotation alignment configurable

### DIFF
--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -152,7 +152,7 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
  The default value of this property is `NO`. Set this property to `YES` if the
  view’s rotation is important.
  */
-@property (nonatomic, assign) BOOL rotatesWithMap;
+@property (nonatomic, assign) BOOL rotatesToMatchCamera;
 
 #pragma mark Managing the Selection State
 

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
 
 /**
  A Boolean value that determines whether the annotation view rotates together
- with the mapview.
+ with the map.
 
  When the value of this property is `YES` and the map is rotated, the annotation
  view rotates. This is also the behavior of `MGLAnnotationImage` objects. When the

--- a/platform/ios/src/MGLAnnotationView.h
+++ b/platform/ios/src/MGLAnnotationView.h
@@ -141,6 +141,19 @@ typedef NS_ENUM(NSUInteger, MGLAnnotationViewDragState) {
  */
 @property (nonatomic, assign) BOOL scalesWithViewingDistance;
 
+/**
+ A Boolean value that determines whether the annotation view rotates together
+ with the mapview.
+
+ When the value of this property is `YES` and the map is rotated, the annotation
+ view rotates. This is also the behavior of `MGLAnnotationImage` objects. When the
+ value of this property is `NO` the annotation has its rotation angle fixed.
+
+ The default value of this property is `NO`. Set this property to `YES` if the
+ view’s rotation is important.
+ */
+@property (nonatomic, assign) BOOL rotatesWithMap;
+
 #pragma mark Managing the Selection State
 
 /**

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -103,6 +103,7 @@
 
     super.center = center;
     [self updateScaleTransformForViewingDistance];
+    [self updateRotateTransform];
 }
 
 - (void)setScalesWithViewingDistance:(BOOL)scalesWithViewingDistance

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -11,6 +11,7 @@
 
 @property (nonatomic, readwrite, nullable) NSString *reuseIdentifier;
 @property (nonatomic, readwrite) CATransform3D lastAppliedScaleTransform;
+@property (nonatomic, readwrite) CATransform3D lastAppliedRotateTransform;
 @property (nonatomic, weak) UIPanGestureRecognizer *panGestureRecognizer;
 @property (nonatomic, weak) UILongPressGestureRecognizer *longPressRecognizer;
 @property (nonatomic, weak) MGLMapView *mapView;
@@ -25,8 +26,10 @@
     if (self)
     {
         _lastAppliedScaleTransform = CATransform3DIdentity;
+        _lastAppliedRotateTransform = CATransform3DIdentity;
         _reuseIdentifier = [reuseIdentifier copy];
         _scalesWithViewingDistance = YES;
+        _rotatesWithMap = NO;
         _enabled = YES;
     }
     return self;
@@ -42,6 +45,7 @@
         _annotation = [decoder decodeObjectOfClass:[NSObject class] forKey:@"annotation"];
         _centerOffset = [decoder decodeCGVectorForKey:@"centerOffset"];
         _scalesWithViewingDistance = [decoder decodeBoolForKey:@"scalesWithViewingDistance"];
+        _rotatesWithMap = [decoder decodeBoolForKey:@"rotatesWithMap"];
         _selected = [decoder decodeBoolForKey:@"selected"];
         _enabled = [decoder decodeBoolForKey:@"enabled"];
         self.draggable = [decoder decodeBoolForKey:@"draggable"];
@@ -55,6 +59,7 @@
     [coder encodeObject:_annotation forKey:@"annotation"];
     [coder encodeCGVector:_centerOffset forKey:@"centerOffset"];
     [coder encodeBool:_scalesWithViewingDistance forKey:@"scalesWithViewingDistance"];
+    [coder encodeBool:_rotatesWithMap forKey:@"rotatesWithMap"];
     [coder encodeBool:_selected forKey:@"selected"];
     [coder encodeBool:_enabled forKey:@"enabled"];
     [coder encodeBool:_draggable forKey:@"draggable"];
@@ -144,6 +149,29 @@
         self.layer.transform = CATransform3DConcat(self.layer.transform, effectiveTransform);
         _lastAppliedScaleTransform = newScaleTransform;
     }
+}
+
+- (void)setRotatesWithMap:(BOOL)rotatesWithMap
+{
+    if (_rotatesWithMap != rotatesWithMap)
+    {
+        _rotatesWithMap = rotatesWithMap;
+        [self updateRotateTransform];
+    }
+}
+
+- (void)updateRotateTransform
+{
+    if (self.rotatesWithMap == NO) return;
+
+    CATransform3D undoOfLastRotateTransform = CATransform3DInvert(_lastAppliedRotateTransform);
+
+    CGFloat directionRad = self.mapView.direction * M_PI / 180.0;
+    CATransform3D newRotateTransform = CATransform3DMakeRotation(-directionRad, 0, 0, 1);
+    CATransform3D effectiveTransform = CATransform3DConcat(undoOfLastRotateTransform, newRotateTransform);
+
+    self.layer.transform = CATransform3DConcat(self.layer.transform, effectiveTransform);
+    _lastAppliedRotateTransform = newRotateTransform;
 }
 
 #pragma mark - Draggable

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -29,7 +29,7 @@
         _lastAppliedRotateTransform = CATransform3DIdentity;
         _reuseIdentifier = [reuseIdentifier copy];
         _scalesWithViewingDistance = YES;
-        _rotatesWithMap = NO;
+        _rotatesToMatchCamera = NO;
         _enabled = YES;
     }
     return self;
@@ -45,7 +45,7 @@
         _annotation = [decoder decodeObjectOfClass:[NSObject class] forKey:@"annotation"];
         _centerOffset = [decoder decodeCGVectorForKey:@"centerOffset"];
         _scalesWithViewingDistance = [decoder decodeBoolForKey:@"scalesWithViewingDistance"];
-        _rotatesWithMap = [decoder decodeBoolForKey:@"rotatesWithMap"];
+        _rotatesToMatchCamera = [decoder decodeBoolForKey:@"rotatesToMatchCamera"];
         _selected = [decoder decodeBoolForKey:@"selected"];
         _enabled = [decoder decodeBoolForKey:@"enabled"];
         self.draggable = [decoder decodeBoolForKey:@"draggable"];
@@ -59,7 +59,7 @@
     [coder encodeObject:_annotation forKey:@"annotation"];
     [coder encodeCGVector:_centerOffset forKey:@"centerOffset"];
     [coder encodeBool:_scalesWithViewingDistance forKey:@"scalesWithViewingDistance"];
-    [coder encodeBool:_rotatesWithMap forKey:@"rotatesWithMap"];
+    [coder encodeBool:_rotatesToMatchCamera forKey:@"rotatesToMatchCamera"];
     [coder encodeBool:_selected forKey:@"selected"];
     [coder encodeBool:_enabled forKey:@"enabled"];
     [coder encodeBool:_draggable forKey:@"draggable"];
@@ -151,18 +151,18 @@
     }
 }
 
-- (void)setRotatesWithMap:(BOOL)rotatesWithMap
+- (void)setRotatesToMatchCamera:(BOOL)rotatesToMatchCamera
 {
-    if (_rotatesWithMap != rotatesWithMap)
+    if (_rotatesToMatchCamera != rotatesToMatchCamera)
     {
-        _rotatesWithMap = rotatesWithMap;
+        _rotatesToMatchCamera = rotatesToMatchCamera;
         [self updateRotateTransform];
     }
 }
 
 - (void)updateRotateTransform
 {
-    if (self.rotatesWithMap == NO) return;
+    if (self.rotatesToMatchCamera == NO) return;
 
     CATransform3D undoOfLastRotateTransform = CATransform3DInvert(_lastAppliedRotateTransform);
 


### PR DESCRIPTION
This PR adds `rotatesWithMap` property to `MGLAnnotationView`. This
property, when set to `YES` fixes the annotation to a map such that view
follows map's rotation angle. This is useful when user wants to display
rotation-dependent annotations (e.g. sector lights).

Defaults to `NO`. Encoded.