### PR TITLE
Use ICU compiled with -Os

### DIFF
--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -20,7 +20,7 @@ mason_use(libzip VERSION 1.1.3)
 mason_use(nunicode VERSION 1.7.1)
 mason_use(sqlite VERSION 3.14.2)
 mason_use(gtest VERSION 1.8.0)
-mason_use(icu VERSION 58.1)
+mason_use(icu VERSION 58.1-min-size)
 
 set(ANDROID_SDK_PROJECT_DIR ${CMAKE_SOURCE_DIR}/platform/android/MapboxGLAndroidSDK)
 set(ANDROID_JNI_TARGET_DIR ${ANDROID_SDK_PROJECT_DIR}/src/main/jniLibs/${ANDROID_ABI})

--- a/platform/ios/config.cmake
+++ b/platform/ios/config.cmake
@@ -1,6 +1,6 @@
 add_definitions(-DMBGL_USE_GLES2=1)
 
-mason_use(icu VERSION 58.1)
+mason_use(icu VERSION 58.1-min-size)
 
 macro(mbgl_platform_core)
     set_xcode_property(mbgl-core IPHONEOS_DEPLOYMENT_TARGET "8.0")

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -9,7 +9,7 @@ mason_use(libjpeg-turbo VERSION 1.5.0)
 mason_use(webp VERSION 0.5.1)
 mason_use(gtest VERSION 1.8.0${MASON_CXXABI_SUFFIX})
 mason_use(benchmark VERSION 1.0.0-1)
-mason_use(icu VERSION 58.1)
+mason_use(icu VERSION 58.1-min-size)
 
 include(cmake/loop-uv.cmake)
 

--- a/platform/macos/config.cmake
+++ b/platform/macos/config.cmake
@@ -4,7 +4,7 @@ mason_use(glfw VERSION 2017-02-09-77a8f10)
 mason_use(boost_libprogram_options VERSION 1.62.0)
 mason_use(gtest VERSION 1.8.0)
 mason_use(benchmark VERSION 1.0.0-1)
-mason_use(icu VERSION 58.1)
+mason_use(icu VERSION 58.1-min-size)
 
 include(cmake/loop-darwin.cmake)
 

--- a/platform/qt/config.cmake
+++ b/platform/qt/config.cmake
@@ -10,7 +10,7 @@ if(NOT WITH_QT_DECODERS)
 endif()
 
 if(NOT WITH_QT_I18N)
-    mason_use(icu VERSION 58.1)
+    mason_use(icu VERSION 58.1-min-size)
 endif()
 
 macro(mbgl_platform_core)


### PR DESCRIPTION
Example size savings for macOS:

```
     VM SIZE                              FILE SIZE
 ++++++++++++++ GROWING                ++++++++++++++
  +2.4% +3.93Ki [None]                 +3.14Ki  +1.8%
  +0.5%    +344 __TEXT,__unwind_info      +344  +0.5%
  +1.2%     +24 __DATA,__got               +24  +1.2%
  +0.0%     +16 __TEXT,__const             +16  +0.0%

 -------------- SHRINKING              --------------
  -2.0% -52.2Ki __TEXT,__text          -52.2Ki  -2.0%
  -0.3%     -80 __DATA,__const             -80  -0.3%
  -0.2%     -10 __TEXT,__stub_helper       -10  -0.2%
  -0.2%      -8 __DATA,__la_symbol_ptr       0  [ = ]
  -0.2%      -6 __TEXT,__stubs              -6  -0.2%

  -1.3% -48.0Ki TOTAL                  -48.8Ki  -1.3%
```

Refs #8035.