### PR TITLE
Increase binary size duration chart to 60 days

### DIFF
--- a/scripts/publish_binary_size.sh
+++ b/scripts/publish_binary_size.sh
@@ -24,9 +24,9 @@ function publish_binary_size {
     local DATE_END=$(date -u +${DATE_FORMAT})
 
     if [ `uname -s` = 'Darwin' ]; then # BSD date
-        local DATE_BEGIN=$(date -jf "${DATE_FORMAT}" -v-30d "${DATE_END}" +"${DATE_FORMAT}")
+        local DATE_BEGIN=$(date -jf "${DATE_FORMAT}" -v-60d "${DATE_END}" +"${DATE_FORMAT}")
     else # GNU date
-        local DATE_BEGIN=$(date --date="${DATE_END} - 30 days" +"${DATE_FORMAT}")
+        local DATE_BEGIN=$(date --date="${DATE_END} - 60 days" +"${DATE_FORMAT}")
     fi
 
     # Download the metrics, gzip, and upload to S3.


### PR DESCRIPTION
We currently publish the most recent 30 days, which doesn't seem enough.

https://github.com/mapbox/mapbox-gl-native/issues/8035#issuecomment-285089819