### PR TITLE
Darwin static libs: don't rely on static variable initialization

### DIFF
--- a/platform/darwin/src/MGLFoundation.mm
+++ b/platform/darwin/src/MGLFoundation.mm
@@ -1,4 +1,6 @@
 #import "MGLFoundation_Private.h"
 
 /// Initializes the run loop shim that lives on the main thread.
-mbgl::util::RunLoop mgl_runLoop;
+void MGLInitializeRunLoop() {
+    static mbgl::util::RunLoop runLoop;
+}

--- a/platform/darwin/src/MGLFoundation_Private.h
+++ b/platform/darwin/src/MGLFoundation_Private.h
@@ -2,4 +2,4 @@
 
 #include <mbgl/util/run_loop.hpp>
 
-extern mbgl::util::RunLoop mgl_runLoop;
+void MGLInitializeRunLoop();

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -1,5 +1,6 @@
 #import "MGLOfflineStorage_Private.h"
 
+#import "MGLFoundation_Private.h"
 #import "MGLAccountManager_Private.h"
 #import "MGLGeometry_Private.h"
 #import "MGLNetworkConfiguration.h"
@@ -170,6 +171,8 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
 }
 
 - (instancetype)init {
+    MGLInitializeRunLoop();
+
     if (self = [super init]) {
         NSURL *cacheURL = [[self class] cacheURLIncludingSubdirectory:YES];
         NSString *cachePath = cacheURL.path ?: @"";


### PR DESCRIPTION
We should explicitly initialize rather than use a global static variables for the main thread's `RunLoop`.

When linking Mapbox GL as a static library, the object file (MGLFoundation.o) containing the global static variable initialization was not linked into the resulting binary since it was not referenced. This resulted in the RunLoop not being initialized in the main thread.

Reverts 03a14ff0003e976a4ded70d284bc80adf54bc6c9 in  https://github.com/mapbox/mapbox-gl-native/pull/8084