### PR TITLE
[core] Replace variant with polymorphic PaintPropertyBinder class

### DIFF
--- a/src/mbgl/renderer/circle_bucket.cpp
+++ b/src/mbgl/renderer/circle_bucket.cpp
@@ -13,8 +13,10 @@ using namespace style;
 CircleBucket::CircleBucket(const BucketParameters& parameters, const std::vector<const Layer*>& layers)
     : mode(parameters.mode) {
     for (const auto& layer : layers) {
-        paintPropertyBinders.emplace(layer->getID(),
-            CircleProgram::PaintPropertyBinders(
+        paintPropertyBinders.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(layer->getID()),
+            std::forward_as_tuple(
                 layer->as<CircleLayer>()->impl->paint.evaluated,
                 parameters.tileID.overscaledZ));
     }

--- a/src/mbgl/renderer/fill_bucket.cpp
+++ b/src/mbgl/renderer/fill_bucket.cpp
@@ -29,8 +29,10 @@ struct GeometryTooLongException : std::exception {};
 
 FillBucket::FillBucket(const BucketParameters& parameters, const std::vector<const Layer*>& layers) {
     for (const auto& layer : layers) {
-        paintPropertyBinders.emplace(layer->getID(),
-            FillProgram::PaintPropertyBinders(
+        paintPropertyBinders.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(layer->getID()),
+            std::forward_as_tuple(
                 layer->as<FillLayer>()->impl->paint.evaluated,
                 parameters.tileID.overscaledZ));
     }

--- a/src/mbgl/renderer/line_bucket.cpp
+++ b/src/mbgl/renderer/line_bucket.cpp
@@ -18,8 +18,10 @@ LineBucket::LineBucket(const BucketParameters& parameters,
     : layout(layout_.evaluate(PropertyEvaluationParameters(parameters.tileID.overscaledZ))),
       overscaling(parameters.tileID.overscaleFactor()) {
     for (const auto& layer : layers) {
-        paintPropertyBinders.emplace(layer->getID(),
-            LineProgram::PaintPropertyBinders(
+        paintPropertyBinders.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(layer->getID()),
+            std::forward_as_tuple(
                 layer->as<LineLayer>()->impl->paint.evaluated,
                 parameters.tileID.overscaledZ));
     }

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -18,10 +18,13 @@ SymbolBucket::SymbolBucket(style::SymbolLayoutProperties::Evaluated layout_,
       sdfIcons(sdfIcons_),
       iconsNeedLinear(iconsNeedLinear_) {
     for (const auto& pair : layerPaintProperties) {
-        paintPropertyBinders.emplace(pair.first, std::make_pair(
-            SymbolIconProgram::PaintPropertyBinders(pair.second.first, zoom),
-            SymbolSDFTextProgram::PaintPropertyBinders(pair.second.second, zoom)
-        ));
+        paintPropertyBinders.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(pair.first),
+            std::forward_as_tuple(
+                std::piecewise_construct,
+                std::forward_as_tuple(pair.second.first, zoom),
+                std::forward_as_tuple(pair.second.second, zoom)));
     }
 }
 

--- a/src/mbgl/style/paint_property_binder.hpp
+++ b/src/mbgl/style/paint_property_binder.hpp
@@ -188,6 +188,9 @@ public:
         (void)z; // Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56958
     }
 
+    PaintPropertyBinders(PaintPropertyBinders&&) = default;
+    PaintPropertyBinders(const PaintPropertyBinders&) = delete;
+
     void populateVertexVectors(const GeometryTileFeature& feature, std::size_t length) {
         util::ignore({
             (binders.template get<Ps>()->populateVertexVector(feature, length), 0)...


### PR DESCRIPTION
```
     VM SIZE                               FILE SIZE
 ++++++++++++++ GROWING                 ++++++++++++++
  +2.0% +4.72Ki __TEXT,__const          +4.72Ki  +2.0%
   +14% +3.31Ki __DATA,__data           +3.31Ki   +14%

 -------------- SHRINKING               --------------
  -1.8% -45.5Ki __TEXT,__text           -45.5Ki  -1.8%
  -0.5%    -783 [None]                  -1.88Ki  -1.1%
 -26.6%    -736 __DATA,__bss                  0  [ = ]
  -0.5%    -453 __TEXT,__cstring           -453  -0.5%
  -0.6%    -432 __TEXT,__unwind_info       -432  -0.6%
  -0.1%    -148 __TEXT,__gcc_except_tab    -148  -0.1%
  -0.2%     -10 __TEXT,__stub_helper        -10  -0.2%
  -0.2%      -8 __DATA,__la_symbol_ptr        0  [ = ]
  -0.2%      -6 __TEXT,__stubs               -6  -0.2%

  -1.1% -40.0Ki TOTAL                   -40.4Ki  -1.1%
```

Refs #8035.