### PR TITLE
[core] Avoid unnecessary convert template instantiations

### DIFF
--- a/benchmark/parse/filter.benchmark.cpp
+++ b/benchmark/parse/filter.benchmark.cpp
@@ -14,7 +14,7 @@ using namespace mbgl;
 style::Filter parse(const char* expression) {
     rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> doc;
     doc.Parse<0>(expression);
-    return *style::conversion::convert<style::Filter>(doc);
+    return *style::conversion::convert<style::Filter, JSValue>(doc);
 }
 
 static void Parse_Filter(benchmark::State& state) {

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -24,7 +24,7 @@ Tileset TileSourceImpl::parseTileJSON(const std::string& json, const std::string
         throw std::runtime_error(message.str());
     }
 
-    conversion::Result<Tileset> result = conversion::convert<Tileset>(document);
+    conversion::Result<Tileset> result = conversion::convert<Tileset, JSValue>(document);
     if (!result) {
         throw std::runtime_error(result.error().message);
     }

--- a/test/style/conversion/function.test.cpp
+++ b/test/style/conversion/function.test.cpp
@@ -13,7 +13,7 @@ using namespace mbgl::style::conversion;
 auto parseFunction(const std::string& src) {
     JSDocument doc;
     doc.Parse<0>(src);
-    return convert<CameraFunction<float>>(doc);
+    return convert<CameraFunction<float>, JSValue>(doc);
 }
 
 TEST(StyleConversion, Function) {

--- a/test/style/filter.test.cpp
+++ b/test/style/filter.test.cpp
@@ -16,7 +16,7 @@ using namespace mbgl::style;
 Filter parse(const char * expression) {
     rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> doc;
     doc.Parse<0>(expression);
-    return *conversion::convert<Filter>(doc);
+    return *conversion::convert<Filter, JSValue>(doc);
 }
 
 Feature feature(const PropertyMap& properties, const Geometry<double>& geometry = Point<double>()) {


### PR DESCRIPTION
``` 
    VM SIZE                                                                                        FILE SIZE
 ++++++++++++++ GROWING                                                                          ++++++++++++++
  +0.9%      +6 mbgl::style::conversion::Result<mapbox::util::variant<std::__1::basic_string<cha      +6  +0.9%

 -------------- SHRINKING                                                                        --------------
  [DEL] -2.41Ki mbgl::style::conversion::Result<mbgl::Tileset> mbgl::style::conversion::Converte -2.41Ki  [DEL]
  -0.3% -1.43Ki [None]                                                                           -1.49Ki  -0.3%
 -32.6%    -172 GCC_except_table104                                                                 -172 -32.6%
  -0.1%      -2 mbgl::style::conversion::Result<mbgl::Tileset> mbgl::style::conversion::Converte      -2  -0.1%

  -0.1% -4.00Ki TOTAL                                                                            -4.06Ki  -0.1%
```