### PR TITLE
[android] Renames MultiPoint to BasePointCollection

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BasePointCollection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BasePointCollection.java
@@ -8,12 +8,12 @@ import java.util.List;
 /**
  * Multipoint is an abstract annotation for combining geographical locations.
  */
-public abstract class MultiPoint extends Annotation {
+public abstract class BasePointCollection extends Annotation {
 
   private List<LatLng> points;
   private float alpha = 1.0f;
 
-  protected MultiPoint() {
+  protected BasePointCollection() {
     super();
     points = new ArrayList<>();
   }
@@ -58,7 +58,7 @@ public abstract class MultiPoint extends Annotation {
   }
 
   /**
-   * Set this {@link MultiPoint}s alpha.
+   * Set this {@link BasePointCollection}s alpha.
    *
    * @param alpha float value between 0 and 1.
    */

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Polygon.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Polygon.java
@@ -7,7 +7,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 /**
  * Polygon is a geometry annotation that's a closed loop of coordinates.
  */
-public final class Polygon extends MultiPoint {
+public final class Polygon extends BasePointCollection {
 
   private int fillColor = Color.BLACK; // default fillColor is black
   private int strokeColor = Color.BLACK; // default strokeColor is black

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Polyline.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/Polyline.java
@@ -7,7 +7,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 /**
  * Polyline is a geometry feature with an unclosed list of coordinates drawn as a line
  */
-public final class Polyline extends MultiPoint {
+public final class Polyline extends BasePointCollection {
 
   private int color = Color.BLACK; // default color is black
   private float width = 10; // As specified by Google API Docs (in pixels)


### PR DESCRIPTION
This PR renames `MultiPoint` to `BasePointCollection` to avoid name clashing with the actual GeoJSON object, which we also support via [`mapbox-java-geojson`](https://github.com/mapbox/mapbox-java/blob/master/mapbox/libjava-geojson/src/main/java/com/mapbox/services/commons/geojson/MultiPoint.java)

Fixes https://github.com/mapbox/mapbox-gl-native/issues/3288.
