### PR TITLE
clang 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,20 @@ git:
 addons:
   apt:
     sources:
-      - &common_sources [ 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
+      - &common_sources [ 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports', 'llvm-toolchain-trusty-3.9' ]
     packages:
       - &common_packages [ 'libllvm3.8v4', 'cmake', 'cmake-data' ]
-      - &clang38_packages [ 'clang-3.8', 'libstdc++-5-dev', 'libstdc++6' ]
+      - &clang39_packages [ 'clang-3.9', 'libstdc++-5-dev', 'libstdc++6' ]
       - &gcc5_packages [ 'gcc-5', 'g++-5' ]
       - &glfw_packages [ 'libxrandr-dev', 'libxcursor-dev', 'libxinerama-dev' ]
 
 addons_shortcuts:
-  addons_clang38: &clang38
+  addons_clang39: &clang39
     apt:
       sources: *common_sources
       packages:
         - *common_packages
-        - *clang38_packages
+        - *clang39_packages
         - *glfw_packages
   addons_gcc5: &gcc5
     apt:
@@ -81,14 +81,14 @@ matrix:
         - git fetch origin master:refs/remotes/origin/master
         - make check
 
-    # EGL - Node - Clang 3.8 - Debug
+    # EGL - Node - Clang 3.9 - Debug
     - os: linux
       sudo: required
       dist: trusty
       language: node
-      compiler: "egl-node4-clang38-debug"
-      env: BUILDTYPE=Debug _CXX=clang++-3.8 _CC=clang-3.8 WITH_EGL=1
-      addons: *clang38
+      compiler: "egl-node4-clang39-debug"
+      env: BUILDTYPE=Debug _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
+      addons: *clang39
       before_script:
         - mapbox_install_logbt
         - mapbox_start_xvfb
@@ -104,14 +104,14 @@ matrix:
       after_failure:
         - aws s3 cp . s3://mapbox/mapbox-gl-native/render-tests/$TRAVIS_JOB_NUMBER --recursive --exclude "*" --include "*.trace"
 
-    # EGL - Node - Clang 3.8 - Release
+    # EGL - Node - Clang 3.9 - Release
     - os: linux
       sudo: required
       dist: trusty
       language: node
-      compiler: "egl-node4-clang38-release"
-      env: BUILDTYPE=Release _CXX=clang++-3.8 _CC=clang-3.8 WITH_EGL=1
-      addons: *clang38
+      compiler: "egl-node4-clang39-release"
+      env: BUILDTYPE=Release _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
+      addons: *clang39
       before_script:
         # fglrx causes the GLX extension to be unavailable
         - sudo apt-get purge -qq fglrx
@@ -148,14 +148,14 @@ matrix:
         - ccache --show-stats
         - ./platform/linux/scripts/coveralls.sh
 
-    # EGL - Clang 3.8 - Debug
+    # EGL - Clang 3.9 - Debug
     - os: linux
       sudo: required
       dist: trusty
       language: cpp
-      compiler: "egl-clang38-debug"
-      env: BUILDTYPE=Debug _CXX=clang++-3.8 _CC=clang-3.8 WITH_EGL=1
-      addons: *clang38
+      compiler: "egl-clang39-debug"
+      env: BUILDTYPE=Debug _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
+      addons: *clang39
       before_script:
         - mapbox_start_xvfb
         - mapbox_export_mesa_library_path

--- a/include/mbgl/util/enum.hpp
+++ b/include/mbgl/util/enum.hpp
@@ -11,26 +11,26 @@ namespace mbgl {
 template <typename T>
 class Enum {
 public:
-    using Value = std::pair<const T, const char *>;
-
-    static const char * toString(T t) {
-        auto it = std::find_if(begin, end, [&] (const auto& v) { return t == v.first; });
-        assert(it != end); return it->second;
-    }
-
-    static optional<T> toEnum(const std::string& s) {
-        auto it = std::find_if(begin, end, [&] (const auto& v) { return s == v.second; });
-        return it == end ? optional<T>() : it->first;
-    }
-
-private:
-    static const Value* begin;
-    static const Value* end;
+    static const char * toString(T);
+    static optional<T> toEnum(const std::string&);
 };
 
-#define MBGL_DEFINE_ENUM(type, strings...) \
-const constexpr Enum<type>::Value type##_names[] = strings; \
-template <> const Enum<type>::Value* Enum<type>::begin = std::begin(type##_names); \
-template <> const Enum<type>::Value* Enum<type>::end = std::end(type##_names)
+#define MBGL_DEFINE_ENUM(T, values...)                                          \
+                                                                                \
+static const constexpr std::pair<const T, const char *> T##_names[] = values;   \
+                                                                                \
+template <>                                                                     \
+const char * Enum<T>::toString(T t) {                                           \
+    auto it = std::find_if(std::begin(T##_names), std::end(T##_names),          \
+        [&] (const auto& v) { return t == v.first; });                          \
+    assert(it != std::end(T##_names)); return it->second;                       \
+}                                                                               \
+                                                                                \
+template <>                                                                     \
+optional<T> Enum<T>::toEnum(const std::string& s) {                             \
+    auto it = std::find_if(std::begin(T##_names), std::end(T##_names),          \
+        [&] (const auto& v) { return s == v.second; });                         \
+    return it == std::end(T##_names) ? optional<T>() : it->first;               \
+}
 
 } // namespace mbgl

--- a/test/api/annotations.test.cpp
+++ b/test/api/annotations.test.cpp
@@ -73,7 +73,7 @@ TEST(Annotations, LineAnnotation) {
 TEST(Annotations, FillAnnotation) {
     AnnotationTest test;
 
-    Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
+    Polygon<double> polygon = { {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} };
     FillAnnotation annotation { polygon };
     annotation.color = Color::red();
 
@@ -98,7 +98,7 @@ TEST(Annotations, AntimeridianAnnotationSmall) {
     lineAnnotation.width = { 2 };
     test.map.addAnnotation(lineAnnotation);
 
-    Polygon<double> polygon = {{ {{ { antimeridian+10, 0 }, { antimeridian - 10, 10 }, { antimeridian-10, -10 } }} }};
+    Polygon<double> polygon = { {{ { antimeridian+10, 0 }, { antimeridian - 10, 10 }, { antimeridian-10, -10 } }} };
     FillAnnotation polygonAnnotation { polygon };
     polygonAnnotation.color = Color::blue();
     test.map.addAnnotation(polygonAnnotation);
@@ -119,7 +119,7 @@ TEST(Annotations, AntimeridianAnnotationLarge) {
     lineAnnotation.width = { 2 };
     test.map.addAnnotation(lineAnnotation);
 
-    Polygon<double> polygon = {{ {{ { antimeridian-10, 0 }, { -antimeridian+10, 10 }, { -antimeridian+10, -10 } }} }};
+    Polygon<double> polygon = { {{ { antimeridian-10, 0 }, { -antimeridian+10, 10 }, { -antimeridian+10, -10 } }} };
     FillAnnotation polygonAnnotation { polygon };
     polygonAnnotation.color = Color::blue();
     test.map.addAnnotation(polygonAnnotation);
@@ -130,7 +130,7 @@ TEST(Annotations, AntimeridianAnnotationLarge) {
 TEST(Annotations, OverlappingFillAnnotation) {
     AnnotationTest test;
 
-    Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
+    Polygon<double> polygon = { {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} };
     FillAnnotation underlaidAnnotation { polygon };
     underlaidAnnotation.color = Color::green();
     FillAnnotation overlaidAnnotation { polygon };
@@ -145,7 +145,7 @@ TEST(Annotations, OverlappingFillAnnotation) {
 TEST(Annotations, StyleSourcedShapeAnnotation) {
     AnnotationTest test;
 
-    Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
+    Polygon<double> polygon = { {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} };
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/annotation.json"));
     test.map.addAnnotation(StyleSourcedAnnotation { polygon, "annotation" });
@@ -171,7 +171,7 @@ TEST(Annotations, NonImmediateAdd) {
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
     test::render(test.map, test.view);
 
-    Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
+    Polygon<double> polygon = { {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} };
     FillAnnotation annotation { polygon };
     annotation.color = Color::red();
 
@@ -245,7 +245,7 @@ TEST(Annotations, UpdateLineAnnotationStyle) {
 TEST(Annotations, UpdateFillAnnotationGeometry) {
     AnnotationTest test;
 
-    FillAnnotation annotation { Polygon<double> {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }} };
+    FillAnnotation annotation { Polygon<double> { {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} } };
     annotation.color = Color::red();
 
     test.map.setStyleJSON(util::read_file("test/fixtures/api/empty.json"));
@@ -253,7 +253,7 @@ TEST(Annotations, UpdateFillAnnotationGeometry) {
 
     test::render(test.map, test.view);
 
-    annotation.geometry = Polygon<double> {{ {{ { 0, 0 }, { 0, 45 }, { 45, 0 } }} }};
+    annotation.geometry = Polygon<double> { {{ { 0, 0 }, { 0, 45 }, { 45, 0 } }} };
     test.map.updateAnnotation(fill, annotation);
     test.checkRendering("update_fill_geometry");
 }
@@ -261,7 +261,7 @@ TEST(Annotations, UpdateFillAnnotationGeometry) {
 TEST(Annotations, UpdateFillAnnotationStyle) {
     AnnotationTest test;
 
-    Polygon<double> polygon = {{ {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} }};
+    Polygon<double> polygon = { {{ { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } }} };
     FillAnnotation annotation { polygon };
     annotation.color = Color::red();
 


### PR DESCRIPTION
Fix compile errors on clang 3.9; build in CI with it.

No changes to binary size with the enum.hpp changes.

Fixes #7702.