### PR TITLE
[ios] Publish nightly build

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -54,6 +54,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Added a `MGLDistanceFormatter` class for formatting geographic distances. ([#7888](https://github.com/mapbox/mapbox-gl-native/pull/7888))
 * Fixed an issue that was causing the system location indicator to stay on in background after telemetry was disabled. ([#7833](https://github.com/mapbox/mapbox-gl-native/pull/7833))
 * Added support for predicates in rendered feature querying [8256](https://github.com/mapbox/mapbox-gl-native/pull/8246)
+* Added a nightly build of the dynamic framework. ([#8337](https://github.com/mapbox/mapbox-gl-native/pull/8337))
 
 ## 3.4.2 - February 21, 2017
 

--- a/platform/ios/INSTALL.md
+++ b/platform/ios/INSTALL.md
@@ -50,6 +50,10 @@ bash "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework/strip-fra
 
 (The last step, courtesy of [Realm](https://github.com/realm/realm-cocoa/), is required for working around an [iOS App Store bug](http://www.openradar.me/radar?id=6409498411401216) when archiving universal binaries.)
 
+##### Nightly builds
+
+A nightly build of the dynamic framework, based on the master branch, is available for download [here](https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-nightly-dynamic.zip).
+
 #### Static framework
 
 You can alternatively install the SDK as a static framework:
@@ -82,7 +86,15 @@ You can alternatively install the SDK as a static framework:
 To test pre-releases and/or betas, you can reference the pre-release like so in your Podfile:
 
 ```rb
-pod 'Mapbox-iOS-SDK', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/<insert branch or tag>/ios/Mapbox-iOS-SDK.podspec'
+pod 'Mapbox-iOS-SDK', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/<insert branch or tag>/platform/ios/Mapbox-iOS-SDK.podspec'
+```
+
+##### Testing nightly releases with CocoaPods
+
+To test a nightly dynamic framework build, update your app’s `Podfile` to point to:
+
+```rb
+pod 'Mapbox-iOS-SDK-nightly-dynamic', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/master/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec'
 ```
 
 ##### Using your own build with CocoaPods

--- a/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec
+++ b/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |m|
+
+  version = '3.5.0-beta.2'
+
+  m.name    = 'Mapbox-iOS-SDK-nightly-dynamic'
+  m.version = "#{version}-nightly"
+
+  m.summary           = 'Open source vector map solution for iOS with full styling capabilities.'
+  m.description       = 'Open source, OpenGL-based vector map solution for iOS with full styling capabilities and Cocoa Touch APIs.'
+  m.homepage          = 'https://www.mapbox.com/ios-sdk/'
+  m.license           = { :type => 'BSD', :file => 'LICENSE.md' }
+  m.author            = { 'Mapbox' => 'mobile@mapbox.com' }
+  m.screenshot        = "https://www.mapbox.com/ios-sdk/api/#{version}/img/screenshot.png"
+  m.social_media_url  = 'https://twitter.com/mapbox'
+  m.documentation_url = 'https://www.mapbox.com/ios-sdk/api/'
+
+  m.source = {
+    :http => "https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-nightly-dynamic.zip",
+    :flatten => true
+  }
+
+  m.platform              = :ios
+  m.ios.deployment_target = '8.0'
+
+  m.requires_arc = true
+
+  m.vendored_frameworks = 'dynamic/Mapbox.framework'
+  m.module_name = 'Mapbox'
+
+end

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -83,4 +83,5 @@ workflows:
             export FORMAT=dynamic
             make ipackage-strip
             CLOUDWATCH=true platform/ios/scripts/metrics.sh
+            platform/ios/scripts/deploy-nightly.sh
         - is_debug: 'yes'

--- a/platform/ios/scripts/deploy-nightly.sh
+++ b/platform/ios/scripts/deploy-nightly.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+function step { >&2 echo -e "\033[1m\033[36m* $@\033[0m"; }
+function finish { >&2 echo -en "\033[0m"; }
+trap finish EXIT
+
+export TRAVIS_REPO_SLUG=mapbox-gl-native
+
+DATE=`date +%Y-%m-%d`
+NIGHTLY_TYPE="nightly-dynamic"
+
+step "Uploading ${NIGHTLY_TYPE} build for ${DATE} to s3…"
+
+./platform/ios/scripts/publish.sh "${NIGHTLY_TYPE}" "${DATE}"
+
+step "Finished deploying ${NIGHTLY_TYPE} build in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"

--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -24,7 +24,7 @@ fi
 # zip
 #
 cd build/ios/pkg
-ZIP=mapbox-ios-sdk-${PUBLISH_VERSION}${PUBLISH_STYLE}.zip
+ZIP="mapbox-ios-sdk-${PUBLISH_VERSION}${PUBLISH_STYLE}.zip"
 step "Compressing ${ZIP}…"
 rm -f ../${ZIP}
 zip -r ../${ZIP} *
@@ -35,4 +35,15 @@ zip -r ../${ZIP} *
 step "Uploading ${ZIP} to s3…"
 REPO_NAME=$(basename $TRAVIS_REPO_SLUG)
 aws s3 cp ../${ZIP} s3://mapbox/$REPO_NAME/ios/builds/ --acl public-read
-echo http://mapbox.s3.amazonaws.com/$REPO_NAME/ios/builds/${ZIP}
+echo "URL: https://mapbox.s3.amazonaws.com/$REPO_NAME/ios/builds/${ZIP}"
+
+#
+# update nightly
+#
+if [[ ${PUBLISH_VERSION} =~ "nightly" ]]; then
+    step "Updating ${PUBLISH_VERSION} to ${PUBLISH_STYLE}…"
+    GENERIC_NIGHTLY_FILENAME="mapbox-ios-sdk-${PUBLISH_VERSION}.zip"
+    aws s3 cp \
+        s3://mapbox/$REPO_NAME/ios/builds/${ZIP} \
+        s3://mapbox/$REPO_NAME/ios/builds/${GENERIC_NIGHTLY_FILENAME} --acl public-read
+fi


### PR DESCRIPTION
Fixes #4196. Uploads a nightly build to s3 and makes it available via a special podspec.

- Dynamic framework, stripped release build only for now.
- Piggy-backs on @kkaefer’s binary size metrics Bitrise workflow that already runs nightly.
- Uploads both to a [date-versioned file]( https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-nightly-dynamic-2017-03-09.zip) and overwrites a [stable URL file]( https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/builds/mapbox-ios-sdk-nightly-dynamic.zip).
- Adds a `Mapbox-iOS-SDK-nightly-dynamic` podspec that points to the latest nightly.

Use this line in your podfile to test this branch:

```
pod 'Mapbox-iOS-SDK-nightly-dynamic', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/fb-publish-nightly/platform/ios/Mapbox-iOS-SDK-nightly-dynamic.podspec’
```

### To-do

- [x] Update this repo’s install/developing documentation with usage instructions.
- ~~Create new Bitrise workflow with Slack notifications, etc.~~

/cc @mapbox/mobile