### PR TITLE
Raise exception when MGLAnnotationView.annotation property is nil

### DIFF
--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -239,7 +239,10 @@
     }
     else if (dragState == MGLAnnotationViewDragStateCanceling)
     {
-        NSAssert(self.annotation, @"Annotation property should not be nil.");
+        if (!self.annotation) {
+            [NSException raise:@"MGLInvalidAnnotationException"
+                        format:@"Annotation property should not be nil."];
+        }
         self.panGestureRecognizer.enabled = NO;
         self.longPressRecognizer.enabled = NO;
         self.center = [self.mapView convertCoordinate:self.annotation.coordinate toPointToView:self.mapView];

--- a/platform/ios/src/MGLAnnotationView.mm
+++ b/platform/ios/src/MGLAnnotationView.mm
@@ -240,7 +240,7 @@
     else if (dragState == MGLAnnotationViewDragStateCanceling)
     {
         if (!self.annotation) {
-            [NSException raise:@"MGLInvalidAnnotationException"
+            [NSException raise:NSInvalidArgumentException
                         format:@"Annotation property should not be nil."];
         }
         self.panGestureRecognizer.enabled = NO;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1519,14 +1519,18 @@ public:
             return nil;
         }
     }
-
+    
     // Handle the case of an offset annotation view by converting the tap point to be the geo location
     // of the annotation itself that the view represents
     for (MGLAnnotationView *view in self.annotationContainerView.annotationViews)
     {
         if (view.centerOffset.dx != 0 || view.centerOffset.dy != 0) {
             if (CGRectContainsPoint(view.frame, tapPoint)) {
-                NSAssert(view.annotation, @"Annotation's view annotation property should not be nil.");
+                if (!view.annotation) {
+                    [NSException raise:@"MGLInvalidAnnotationException"
+                                format:@"Annotation view's annotation property should not be nil."];
+                }
+                
                 CGPoint annotationPoint = [self convertCoordinate:view.annotation.coordinate toPointToView:self];
                 tapPoint = annotationPoint;
             }

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1527,7 +1527,7 @@ public:
         if (view.centerOffset.dx != 0 || view.centerOffset.dy != 0) {
             if (CGRectContainsPoint(view.frame, tapPoint)) {
                 if (!view.annotation) {
-                    [NSException raise:@"MGLInvalidAnnotationException"
+                    [NSException raise:NSInvalidArgumentException
                                 format:@"Annotation view's annotation property should not be nil."];
                 }
                 


### PR DESCRIPTION
Raises an exception outlining the problem.