### PR TITLE
[build] Remove custom bitrise 'skip ci' stuff

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -14,22 +14,7 @@ workflows:
   primary:
     steps:
     - script:
-        title: Check for skipping CI
-        inputs:
-        - content: |-
-            #!/bin/bash
-
-            if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[ci skip\]/p')" ]]; then
-                envman add --key SKIPCI --value true
-            else
-                envman add --key SKIPCI --value false
-            fi
-    - script:
         title: Run Checkstyle
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -37,7 +22,6 @@ workflows:
             cd platform/android && ./gradlew checkstyle
     - script:
         title: Configure Google Cloud SDK
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -58,7 +42,6 @@ workflows:
             wget -O secret.json "$BITRISEIO_GCLOUD_SERVICE_ACCOUNT_JSON_URL"
     - script:
         title: Build libmapbox-gl.so for armeabi-v7a
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -67,7 +50,6 @@ workflows:
             make android-lib-arm-v7
     - script:
         title: Compile Core tests
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -75,7 +57,6 @@ workflows:
             BUILDTYPE=Debug make android-test-lib-arm-v7
     - script:
         title: Run local JVM Unit tests on phone module
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -83,7 +64,6 @@ workflows:
             make run-android-unit-test
     - script:
         title: Run local JVM Unit tests on wear module
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -91,7 +71,6 @@ workflows:
             make run-android-wear-unit-test
     - script:
         title: Generate Espresso sanity tests
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -99,7 +78,6 @@ workflows:
             make test-code-android
     - script:
         title: Run Firebase instrumentation tests
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -115,7 +93,6 @@ workflows:
             gcloud beta test android run --type instrumentation --app platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug.apk --test platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk/MapboxGLAndroidSDKTestApp-debug-androidTest.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 15m --test-targets "class com.mapbox.mapboxsdk.testapp.maps.widgets.AttributionTest"
     - script:
         title: Download Firebase results
-        run_if: '{{enveq "SKIPCI" "false"}}'
         is_always_run: true
         inputs:
         - content: |-
@@ -131,13 +108,11 @@ workflows:
             find platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk -type f -name "logcat" -print0 | xargs -0 -Imylogcat mv -i mylogcat ./
             cat logcat | ndk-stack -sym build/android-arm-v7/Debug
     - deploy-to-bitrise-io:
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - deploy_path: platform/android/MapboxGLAndroidSDKTestApp/build/outputs/apk
         - is_compress: 'true'
         - notify_user_groups: none
     - slack:
-        run_if: '{{enveq "SKIPCI" "false"}}'
         title: Post to Slack
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"

--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -11,22 +11,7 @@ workflows:
   primary:
     steps:
     - script:
-        title: Check for skipping CI
-        inputs:
-        - content: |-
-            #!/bin/bash
-
-            if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[ci skip\]/p')" ]]; then
-                envman add --key SKIPCI --value true
-            else
-                envman add --key SKIPCI --value false
-            fi
-    - script:
         title: Install Dependencies
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -37,7 +22,6 @@ workflows:
         - is_debug: 'yes'
     - script:
         title: Generate Workspace
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -47,18 +31,15 @@ workflows:
         - is_debug: 'yes'
     - xcode-test:
         title: Run SDK Unit Tests
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - project_path: platform/ios/ios.xcworkspace
         - scheme: CI
     - deploy-to-bitrise-io:
         title: Deploy to Bitrise.io
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - notify_user_groups: none
     - slack:
         title: Post to Slack
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"

--- a/platform/macos/bitrise.yml
+++ b/platform/macos/bitrise.yml
@@ -12,21 +12,7 @@ workflows:
   primary:
     steps:
     - script:
-        title: Check for skipping CI
-        inputs:
-        - content: |-
-            #!/bin/bash
-            if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[ci skip\]/p')" ]]; then
-                envman add --key SKIPCI --value true
-            else
-                envman add --key SKIPCI --value false
-            fi
-    - script:
         title: Install Dependencies
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -36,7 +22,6 @@ workflows:
         - is_debug: 'yes'
     - script:
         title: Generate Workspace
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -46,7 +31,6 @@ workflows:
         - is_debug: 'yes'
     - script:
         title: Run Core and SDK Unit Tests
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -57,14 +41,12 @@ workflows:
         - is_debug: 'yes'
     - deploy-to-bitrise-io:
         title: Deploy to Bitrise.io
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - deploy_path: "test/fixtures"
         - notify_user_groups: none
         - is_compress: 'true'
     - slack:
         title: Post to Slack
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -13,21 +13,7 @@ workflows:
   primary:
     steps:
     - script:
-        title: Check for skipping CI
-        inputs:
-        - content: |-
-            #!/bin/bash
-            if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[ci skip\]/p')" ]]; then
-                envman add --key SKIPCI --value true
-            else
-                envman add --key SKIPCI --value false
-            fi
-    - script:
         title: Check for publishing
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -37,7 +23,6 @@ workflows:
             fi
     - script:
         title: Run build script
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -51,7 +36,7 @@ workflows:
             make node
     - script:
         title: Run test script
-        run_if: '{{and (enveq "SKIPCI" "false") (enveq "PUBLISH" "")}}'
+        run_if: '{{enveq "PUBLISH" ""}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -60,7 +45,6 @@ workflows:
             ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
     - script:
         title: Run publish script
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -69,7 +53,6 @@ workflows:
             exit ${RESULT:-0}
     - slack:
         title: Post to Slack
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"

--- a/platform/qt/bitrise-qt4.yml
+++ b/platform/qt/bitrise-qt4.yml
@@ -9,22 +9,7 @@ workflows:
   primary:
     steps:
     - script:
-        title: Check for skipping CI
-        inputs:
-        - content: |-
-            #!/bin/bash
-
-            if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[ci skip\]/p')" ]]; then
-                envman add --key SKIPCI --value true
-            else
-                envman add --key SKIPCI --value false
-            fi
-    - script:
         title: Run build
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -40,7 +25,6 @@ workflows:
         - is_debug: 'yes'
     - slack:
         title: Post to Slack
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"

--- a/platform/qt/bitrise-qt5.yml
+++ b/platform/qt/bitrise-qt5.yml
@@ -9,22 +9,7 @@ workflows:
   primary:
     steps:
     - script:
-        title: Check for skipping CI
-        inputs:
-        - content: |-
-            #!/bin/bash
-
-            if [[ -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[skip ci\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_SUBJECT | sed -n '/\[ci skip\]/p')"  ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[skip ci\]/p')" ||
-                  -n "$(echo $GIT_CLONE_COMMIT_MESSAGE_BODY    | sed -n 's/\[ci skip\]/p')" ]]; then
-                envman add --key SKIPCI --value true
-            else
-                envman add --key SKIPCI --value false
-            fi
-    - script:
         title: Run build
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - content: |-
             #!/bin/bash
@@ -43,14 +28,12 @@ workflows:
         - is_debug: 'yes'
     - deploy-to-bitrise-io:
         title: Deploy to Bitrise.io
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - deploy_path: "test/fixtures"
         - notify_user_groups: none
         - is_compress: 'true'
     - slack:
         title: Post to Slack
-        run_if: '{{enveq "SKIPCI" "false"}}'
         inputs:
         - webhook_url: "$SLACK_HOOK_URL"
         - channel: "#gl-bots"


### PR DESCRIPTION
Replaces #6525. Fixes #6523.

Bitrise's [built in](http://devcenter.bitrise.io/tips-and-tricks/skip-a-build/) feature seems to be buggy, in that it ran three of the five builds even though the commit was tagged `[skip ci]`. But since our workaround was pretty poor (the builds still ran, they just did less), and we rarely skip builds, let's just remove it anyway.