### PR TITLE
[android] Make BubbleLayout public

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BubbleLayout.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BubbleLayout.java
@@ -14,7 +14,7 @@ import com.mapbox.mapboxsdk.R;
 /**
  * Bubble View for Android with custom stroke width and color, arrow size, position and direction.
  */
-class BubbleLayout extends LinearLayout {
+public class BubbleLayout extends LinearLayout {
 
   public static final float DEFAULT_STROKE_WIDTH = -1;
   private ArrowDirection arrowDirection;


### PR DESCRIPTION
Lint is complaining about the visibility of `BubbleLayout`:

```
:MapboxGLAndroidSDKTestApp:compileReleaseSources
/bitrise/src/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/BubbleLayout.java:38: Error: This class should be public (com.mapbox.mapboxsdk.annotations.BubbleLayout) [Instantiatable]
  public BubbleLayout(Context context, AttributeSet attrs, int defStyleAttr) {
         ~~~~~~~~~~~~

   Explanation for issues of type "Instantiatable":
   Activities, services, broadcast receivers etc. registered in the manifest
   file (or for custom views, in a layout file) must be "instantiatable" by
   the system, which means that the class must be public, it must have an
   empty public constructor, and if it's an inner class, it must be a static
   inner class.

1 errors, 0 warnings
```

Instead of adding a custom lint `disable 'Instantiatable'` rule, let's simply make the class public as suggested.
