### PR TITLE
[core] don’t use stale collision tile in feature queries

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -101,6 +101,7 @@ set(MBGL_TEST_FILES
     test/text/quads.test.cpp
 
     # tile
+    test/tile/annotation_tile.test.cpp
     test/tile/geojson_tile.test.cpp
     test/tile/geometry_tile_data.test.cpp
     test/tile/raster_tile.test.cpp

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -45,7 +45,11 @@ public:
     AnnotationTileLayer(std::string);
 
     std::size_t featureCount() const override { return features.size(); }
-    std::unique_ptr<GeometryTileFeature> getFeature(std::size_t i) const override { return std::make_unique<AnnotationTileFeature>(features[i]); }
+
+    std::unique_ptr<GeometryTileFeature> getFeature(std::size_t i) const override {
+        return std::make_unique<AnnotationTileFeature>(features.at(i));
+    }
+
     std::string getName() const override { return name; };
 
     std::vector<AnnotationTileFeature> features;

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -113,6 +113,7 @@ void GeometryTile::onLayout(LayoutResult result) {
     nonSymbolBuckets = std::move(result.nonSymbolBuckets);
     featureIndex = std::move(result.featureIndex);
     data = std::move(result.tileData);
+    collisionTile.reset();
     observer->onTileChanged(*this);
 }
 

--- a/test/tile/annotation_tile.test.cpp
+++ b/test/tile/annotation_tile.test.cpp
@@ -1,0 +1,88 @@
+#include <mbgl/test/util.hpp>
+#include <mbgl/test/fake_file_source.hpp>
+
+#include <mbgl/util/default_thread_pool.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/map/transform.hpp>
+#include <mbgl/map/query.hpp>
+#include <mbgl/style/style.hpp>
+#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/map/query.hpp>
+#include <mbgl/text/collision_tile.hpp>
+#include <mbgl/geometry/feature_index.hpp>
+#include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/annotation/annotation_tile.hpp>
+
+#include <memory>
+
+using namespace mbgl;
+
+class AnnotationTileTest {
+public:
+    FakeFileSource fileSource;
+    TransformState transformState;
+    util::RunLoop loop;
+    ThreadPool threadPool { 1 };
+    AnnotationManager annotationManager { 1.0 };
+    style::Style style { fileSource, 1.0 };
+
+    style::UpdateParameters updateParameters {
+        1.0,
+        MapDebugOptions(),
+        transformState,
+        threadPool,
+        fileSource,
+        MapMode::Continuous,
+        annotationManager,
+        style
+    };
+};
+
+// Don't query stale collision tile
+TEST(AnnotationTile, Issue8289) {
+    AnnotationTileTest test;
+    AnnotationTile tile(OverscaledTileID(0, 0, 0), test.updateParameters);
+
+    auto data = std::make_unique<AnnotationTileData>();
+    data->layers.emplace("test", AnnotationTileLayer("test"));
+    data->layers.at("test").features.push_back(AnnotationTileFeature(0, FeatureType::Point, GeometryCollection()));
+
+    // Simulate layout and placement of a symbol layer.
+    tile.onLayout(GeometryTile::LayoutResult {
+        {},
+            std::make_unique<FeatureIndex>(),
+            std::move(data),
+            0
+    });
+
+    auto collisionTile = std::make_unique<CollisionTile>(PlacementConfig());
+
+    IndexedSubfeature subfeature { 0, "", "", 0 };
+    CollisionFeature feature(GeometryCoordinates(), Anchor(0, 0, 0, 0), -5, 5, -5, 5, 1, 0, style::SymbolPlacementType::Point, subfeature, false);
+    collisionTile->insertFeature(feature, 0, true);
+    collisionTile->placeFeature(feature, false, false);
+
+    tile.onPlacement(GeometryTile::PlacementResult {
+        {},
+            std::move(collisionTile),
+            0
+    });
+
+    // Simulate a second layout with empty data.
+    tile.onLayout(GeometryTile::LayoutResult {
+        {},
+            std::make_unique<FeatureIndex>(),
+            std::make_unique<AnnotationTileData>(),
+            0
+    });
+
+    std::unordered_map<std::string, std::vector<Feature>> result;
+    GeometryCoordinates queryGeometry {{ Point<int16_t>(0, 0) }};
+    TransformState transformState;
+    RenderedQueryOptions options;
+
+    tile.queryRenderedFeatures(result, queryGeometry, transformState, options);
+
+    EXPECT_TRUE(result.empty());
+}
+


### PR DESCRIPTION
fixes #8289

We could make this check more granular since the `FeatureIndex` is still usable in this case, but since it's an edge case, I don't know if it's worth it.