### PR TITLE
[core] Replace mbgl::MapChange with mbgl::MapObserver

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -107,6 +107,7 @@ set(MBGL_CORE_FILES
     include/mbgl/map/backend_scope.hpp
     include/mbgl/map/camera.hpp
     include/mbgl/map/map.hpp
+    include/mbgl/map/map_observer.hpp
     include/mbgl/map/mode.hpp
     include/mbgl/map/query.hpp
     include/mbgl/map/view.hpp

--- a/include/mbgl/map/backend.hpp
+++ b/include/mbgl/map/backend.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mbgl/map/change.hpp>
+#include <mbgl/map/map_observer.hpp>
 
 #include <memory>
 
@@ -12,7 +12,7 @@ class Context;
 
 class BackendScope;
 
-class Backend {
+class Backend : public MapObserver {
 public:
     Backend();
     virtual ~Backend();
@@ -23,9 +23,6 @@ public:
     // Called when the map needs to be rendered; the backend should call Map::render() at some point
     // in the near future. (Not called for Map::renderStill() mode.)
     virtual void invalidate() = 0;
-
-    // Notifies a watcher of map x/y/scale/rotation changes.
-    virtual void notifyMapChange(MapChange change);
 
 protected:
     // Called when the backend's GL context needs to be made active or inactive. These are called,

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -2,6 +2,7 @@
 
 #include <mbgl/util/optional.hpp>
 #include <mbgl/util/chrono.hpp>
+#include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/mode.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/feature.hpp>

--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+
+namespace mbgl {
+
+class MapObserver {
+public:
+    static MapObserver& nullObserver() {
+        static MapObserver mapObserver;
+        return mapObserver;
+    }
+
+    enum class CameraChangeMode : uint32_t {
+        Immediate,
+        Animated
+    };
+
+    enum class RenderMode : uint32_t {
+        Partial,
+        Full
+    };
+
+    virtual void onCameraWillChange(CameraChangeMode) {}
+    virtual void onCameraIsChanging() {}
+    virtual void onCameraDidChange(CameraChangeMode) {}
+    virtual void onWillStartLoadingMap() {}
+    virtual void onDidFinishLoadingMap() {}
+    virtual void onDidFailLoadingMap() {}
+    virtual void onWillStartRenderingFrame() {}
+    virtual void onDidFinishRenderingFrame(RenderMode) {}
+    virtual void onWillStartRenderingMap() {}
+    virtual void onDidFinishRenderingMap(RenderMode) {}
+    virtual void onDidFinishLoadingStyle() {}
+    virtual void onSourceDidChange() {}
+};
+
+} // namespace mbgl

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -181,6 +181,70 @@ void NativeMapView::notifyMapChange(mbgl::MapChange change) {
     javaPeer->Call(*_env, onMapChanged, (int) change);
 }
 
+void NativeMapView::onCameraWillChange(MapObserver::CameraChangeMode mode) {
+    if (mode == MapObserver::CameraChangeMode::Immediate) {
+        notifyMapChange(MapChange::MapChangeRegionWillChange);
+    } else {
+        notifyMapChange(MapChange::MapChangeRegionWillChangeAnimated);
+    }
+}
+
+void NativeMapView::onCameraIsChanging() {
+    notifyMapChange(MapChange::MapChangeRegionIsChanging);
+}
+
+void NativeMapView::onCameraDidChange(MapObserver::CameraChangeMode mode) {
+    if (mode == MapObserver::CameraChangeMode::Immediate) {
+        notifyMapChange(MapChange::MapChangeRegionDidChange);
+    } else {
+        notifyMapChange(MapChange::MapChangeRegionDidChangeAnimated);
+    }
+}
+
+void NativeMapView::onWillStartLoadingMap() {
+    notifyMapChange(MapChange::MapChangeWillStartLoadingMap);
+}
+
+void NativeMapView::onDidFinishLoadingMap() {
+    notifyMapChange(MapChange::MapChangeDidFinishLoadingMap);
+}
+
+void NativeMapView::onDidFailLoadingMap() {
+    notifyMapChange(MapChange::MapChangeDidFailLoadingMap);
+}
+
+void NativeMapView::onWillStartRenderingFrame() {
+    notifyMapChange(MapChange::MapChangeWillStartRenderingFrame);
+}
+
+void NativeMapView::onDidFinishRenderingFrame(MapObserver::RenderMode mode) {
+    if (mode == MapObserver::RenderMode::Partial) {
+        notifyMapChange(MapChange::MapChangeDidFinishRenderingFrame);
+    } else {
+        notifyMapChange(MapChange::MapChangeDidFinishRenderingFrameFullyRendered);
+    }
+}
+
+void NativeMapView::onWillStartRenderingMap() {
+    notifyMapChange(MapChange::MapChangeWillStartRenderingMap);
+}
+
+void NativeMapView::onDidFinishRenderingMap(MapObserver::RenderMode mode) {
+    if (mode == MapObserver::RenderMode::Partial) {
+        notifyMapChange(MapChange::MapChangeDidFinishRenderingMap);
+    } else {
+        notifyMapChange(MapChange::MapChangeDidFinishRenderingMapFullyRendered);
+    }
+}
+
+void NativeMapView::onDidFinishLoadingStyle() {
+    notifyMapChange(MapChange::MapChangeDidFinishLoadingStyle);
+}
+
+void NativeMapView::onSourceDidChange() {
+    notifyMapChange(MapChange::MapChangeSourceDidChange);
+}
+
 // JNI Methods //
 
 void NativeMapView::initializeDisplay(jni::JNIEnv&) {

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/map/backend.hpp>
+#include <mbgl/map/change.hpp>
 #include <mbgl/map/camera.hpp>
 #include <mbgl/map/map.hpp>
 #include <mbgl/map/view.hpp>
@@ -51,7 +52,23 @@ public:
     // mbgl::Backend //
 
     void invalidate() override;
-    void notifyMapChange(mbgl::MapChange) override;
+
+    // Deprecated //
+    void notifyMapChange(mbgl::MapChange);
+
+    // mbgl::Backend (mbgl::MapObserver) //
+    void onCameraWillChange(MapObserver::CameraChangeMode) override;
+    void onCameraIsChanging() override;
+    void onCameraDidChange(MapObserver::CameraChangeMode) override;
+    void onWillStartLoadingMap() override;
+    void onDidFinishLoadingMap() override;
+    void onDidFailLoadingMap() override;
+    void onWillStartRenderingFrame() override;
+    void onDidFinishRenderingFrame(MapObserver::RenderMode) override;
+    void onWillStartRenderingMap() override;
+    void onDidFinishRenderingMap(MapObserver::RenderMode) override;
+    void onDidFinishLoadingStyle() override;
+    void onSourceDidChange() override;
 
     // JNI //
 

--- a/platform/default/mbgl/gl/headless_backend.cpp
+++ b/platform/default/mbgl/gl/headless_backend.cpp
@@ -50,10 +50,4 @@ void HeadlessBackend::invalidate() {
     assert(false);
 }
 
-void HeadlessBackend::notifyMapChange(MapChange change) {
-    if (mapChangeCallback) {
-        mapChangeCallback(change);
-    }
-}
-
 } // namespace mbgl

--- a/platform/default/mbgl/gl/headless_backend.hpp
+++ b/platform/default/mbgl/gl/headless_backend.hpp
@@ -18,9 +18,6 @@ public:
     ~HeadlessBackend() override;
 
     void invalidate() override;
-    void notifyMapChange(MapChange) override;
-
-    void setMapChangeCallback(std::function<void(MapChange)>&& cb) { mapChangeCallback = std::move(cb); }
 
     struct Impl {
         virtual ~Impl() {}
@@ -45,8 +42,6 @@ private:
 
     bool extensionsLoaded = false;
     bool active = false;
-
-    std::function<void(MapChange)> mapChangeCallback;
 };
 
 } // namespace mbgl

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -538,16 +538,6 @@ void GLFWView::setWindowTitle(const std::string& title) {
     glfwSetWindowTitle(window, (std::string { "Mapbox GL: " } + title).c_str());
 }
 
-void GLFWView::setMapChangeCallback(std::function<void(mbgl::MapChange)> callback) {
-    this->mapChangeCallback = callback;
-}
-
-void GLFWView::notifyMapChange(mbgl::MapChange change) {
-    if (mapChangeCallback) {
-        mapChangeCallback(change);
-    }
-}
-
 namespace mbgl {
 namespace platform {
 

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -60,9 +60,6 @@ private:
     // Internal
     void report(float duration);
 
-    void setMapChangeCallback(std::function<void(mbgl::MapChange)> callback);
-    void notifyMapChange(mbgl::MapChange change) override;
-
     mbgl::Color makeRandomColor() const;
     mbgl::Point<double> makeRandomPoint() const;
     static std::shared_ptr<const mbgl::SpriteImage>
@@ -80,8 +77,6 @@ private:
 
     mbgl::AnnotationIDs annotationIDs;
     std::vector<std::string> spriteIDs;
-
-    std::function<void(mbgl::MapChange)> mapChangeCallback;
 
 private:
     mbgl::Map* map = nullptr;

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -820,131 +820,149 @@ public:
     [self.layer setNeedsDisplay];
 }
 
-- (void)notifyMapChange:(mbgl::MapChange)change {
-    // Ignore map updates when the Map object isn't set.
+- (void)cameraWillChangeAnimated:(BOOL)animated {
     if (!_mbglMap) {
         return;
     }
 
-    switch (change) {
-        case mbgl::MapChangeRegionWillChange:
-        case mbgl::MapChangeRegionWillChangeAnimated:
-        {
-            if ([self.delegate respondsToSelector:@selector(mapView:cameraWillChangeAnimated:)]) {
-                BOOL animated = change == mbgl::MapChangeRegionWillChangeAnimated;
-                [self.delegate mapView:self cameraWillChangeAnimated:animated];
-            }
-            break;
-        }
-        case mbgl::MapChangeRegionIsChanging:
-        {
-            // Update a minimum of UI that needs to stay attached to the map
-            // while animating.
-            [self updateCompass];
-            [self updateAnnotationCallouts];
-
-            if ([self.delegate respondsToSelector:@selector(mapViewCameraIsChanging:)]) {
-                [self.delegate mapViewCameraIsChanging:self];
-            }
-            break;
-        }
-        case mbgl::MapChangeRegionDidChange:
-        case mbgl::MapChangeRegionDidChangeAnimated:
-        {
-            // Update all UI at the end of an animation or atomic change to the
-            // viewport. More expensive updates can happen here, but care should
-            // still be taken to minimize the work done here because scroll
-            // gesture recognition and momentum scrolling is performed as a
-            // series of atomic changes, not an animation.
-            [self updateZoomControls];
-            [self updateCompass];
-            [self updateAnnotationCallouts];
-            [self updateAnnotationTrackingAreas];
-
-            if ([self.delegate respondsToSelector:@selector(mapView:cameraDidChangeAnimated:)]) {
-                BOOL animated = change == mbgl::MapChangeRegionDidChangeAnimated;
-                [self.delegate mapView:self cameraDidChangeAnimated:animated];
-            }
-            break;
-        }
-        case mbgl::MapChangeWillStartLoadingMap:
-        {
-            if ([self.delegate respondsToSelector:@selector(mapViewWillStartLoadingMap:)]) {
-                [self.delegate mapViewWillStartLoadingMap:self];
-            }
-            break;
-        }
-        case mbgl::MapChangeDidFinishLoadingMap:
-        {
-            [self.style willChangeValueForKey:@"sources"];
-            [self.style didChangeValueForKey:@"sources"];
-            [self.style willChangeValueForKey:@"layers"];
-            [self.style didChangeValueForKey:@"layers"];
-            if ([self.delegate respondsToSelector:@selector(mapViewDidFinishLoadingMap:)]) {
-                [self.delegate mapViewDidFinishLoadingMap:self];
-            }
-            break;
-        }
-        case mbgl::MapChangeDidFailLoadingMap:
-        {
-            if ([self.delegate respondsToSelector:@selector(mapViewDidFailLoadingMap:withError:)]) {
-                NSError *error = [NSError errorWithDomain:MGLErrorDomain code:0 userInfo:nil];
-                [self.delegate mapViewDidFailLoadingMap:self withError:error];
-            }
-            break;
-        }
-        case mbgl::MapChangeWillStartRenderingMap:
-        {
-            if ([self.delegate respondsToSelector:@selector(mapViewWillStartRenderingMap:)]) {
-                [self.delegate mapViewWillStartRenderingMap:self];
-            }
-            break;
-        }
-        case mbgl::MapChangeDidFinishRenderingMap:
-        case mbgl::MapChangeDidFinishRenderingMapFullyRendered:
-        {
-            if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingMap:fullyRendered:)]) {
-                BOOL fullyRendered = change == mbgl::MapChangeDidFinishRenderingMapFullyRendered;
-                [self.delegate mapViewDidFinishRenderingMap:self fullyRendered:fullyRendered];
-            }
-            break;
-        }
-        case mbgl::MapChangeWillStartRenderingFrame:
-        {
-            if ([self.delegate respondsToSelector:@selector(mapViewWillStartRenderingFrame:)]) {
-                [self.delegate mapViewWillStartRenderingFrame:self];
-            }
-            break;
-        }
-        case mbgl::MapChangeDidFinishRenderingFrame:
-        case mbgl::MapChangeDidFinishRenderingFrameFullyRendered:
-        {
-            if (_isChangingAnnotationLayers) {
-                _isChangingAnnotationLayers = NO;
-                [self.style didChangeValueForKey:@"layers"];
-            }
-            if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingFrame:fullyRendered:)]) {
-                BOOL fullyRendered = change == mbgl::MapChangeDidFinishRenderingFrameFullyRendered;
-                [self.delegate mapViewDidFinishRenderingFrame:self fullyRendered:fullyRendered];
-            }
-            break;
-        }
-        case mbgl::MapChangeDidFinishLoadingStyle:
-        {
-            self.style = [[MGLStyle alloc] initWithMapView:self];
-            if ([self.delegate respondsToSelector:@selector(mapView:didFinishLoadingStyle:)])
-            {
-                [self.delegate mapView:self didFinishLoadingStyle:self.style];
-            }
-            break;
-        }
-        case mbgl::MapChangeSourceDidChange:
-        {
-            [self installAttributionView];
-            self.needsUpdateConstraints = YES;
-            break;
-        }
+    if ([self.delegate respondsToSelector:@selector(mapView:cameraWillChangeAnimated:)]) {
+        [self.delegate mapView:self cameraWillChangeAnimated:animated];
     }
+}
+
+- (void)cameraIsChanging {
+    if (!_mbglMap) {
+        return;
+    }
+
+    // Update a minimum of UI that needs to stay attached to the map
+    // while animating.
+    [self updateCompass];
+    [self updateAnnotationCallouts];
+
+    if ([self.delegate respondsToSelector:@selector(mapViewCameraIsChanging:)]) {
+        [self.delegate mapViewCameraIsChanging:self];
+    }
+}
+
+- (void)cameraDidChangeAnimated:(BOOL)animated {
+    if (!_mbglMap) {
+        return;
+    }
+
+    // Update all UI at the end of an animation or atomic change to the
+    // viewport. More expensive updates can happen here, but care should
+    // still be taken to minimize the work done here because scroll
+    // gesture recognition and momentum scrolling is performed as a
+    // series of atomic changes, not an animation.
+    [self updateZoomControls];
+    [self updateCompass];
+    [self updateAnnotationCallouts];
+    [self updateAnnotationTrackingAreas];
+
+    if ([self.delegate respondsToSelector:@selector(mapView:cameraDidChangeAnimated:)]) {
+        [self.delegate mapView:self cameraDidChangeAnimated:animated];
+    }
+}
+
+- (void)mapViewWillStartLoadingMap {
+    if (!_mbglMap) {
+        return;
+    }
+
+    if ([self.delegate respondsToSelector:@selector(mapViewWillStartLoadingMap:)]) {
+        [self.delegate mapViewWillStartLoadingMap:self];
+    }
+}
+
+- (void)mapViewDidFinishLoadingMap {
+    if (!_mbglMap) {
+        return;
+    }
+
+    [self.style willChangeValueForKey:@"sources"];
+    [self.style didChangeValueForKey:@"sources"];
+    [self.style willChangeValueForKey:@"layers"];
+    [self.style didChangeValueForKey:@"layers"];
+    if ([self.delegate respondsToSelector:@selector(mapViewDidFinishLoadingMap:)]) {
+        [self.delegate mapViewDidFinishLoadingMap:self];
+    }
+}
+
+- (void)mapViewDidFailLoadingMap {
+    if (!_mbglMap) {
+        return;
+    }
+
+    if ([self.delegate respondsToSelector:@selector(mapViewDidFailLoadingMap:withError:)]) {
+        NSError *error = [NSError errorWithDomain:MGLErrorDomain code:0 userInfo:nil];
+        [self.delegate mapViewDidFailLoadingMap:self withError:error];
+    }
+}
+
+- (void)MapViewWillStartRenderingFrame {
+    if (!_mbglMap) {
+        return;
+    }
+
+    if ([self.delegate respondsToSelector:@selector(mapViewWillStartRenderingFrame:)]) {
+        [self.delegate mapViewWillStartRenderingFrame:self];
+    }
+}
+
+- (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered {
+    if (!_mbglMap) {
+        return;
+    }
+
+    if (_isChangingAnnotationLayers) {
+        _isChangingAnnotationLayers = NO;
+        [self.style didChangeValueForKey:@"layers"];
+    }
+    if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingFrame:fullyRendered:)]) {
+        [self.delegate mapViewDidFinishRenderingFrame:self fullyRendered:fullyRendered];
+    }
+}
+
+- (void)mapViewWillStartRenderingMap {
+    if (!_mbglMap) {
+        return;
+    }
+
+    if ([self.delegate respondsToSelector:@selector(mapViewWillStartRenderingMap:)]) {
+        [self.delegate mapViewWillStartRenderingMap:self];
+    }
+}
+
+- (void)mapViewDidFinishRenderingMapFullyRendered:(BOOL)fullyRendered {
+    if (!_mbglMap) {
+        return;
+    }
+
+    if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingMap:fullyRendered:)]) {
+        [self.delegate mapViewDidFinishRenderingMap:self fullyRendered:fullyRendered];
+    }
+}
+
+- (void)mapViewDidFinishLoadingStyle {
+    if (!_mbglMap) {
+        return;
+    }
+
+    self.style = [[MGLStyle alloc] initWithMapView:self];
+    if ([self.delegate respondsToSelector:@selector(mapView:didFinishLoadingStyle:)])
+    {
+        [self.delegate mapView:self didFinishLoadingStyle:self.style];
+    }
+}
+
+- (void)sourceDidChange {
+    if (!_mbglMap) {
+        return;
+    }
+
+    [self installAttributionView];
+    self.needsUpdateConstraints = YES;
 }
 
 #pragma mark Printing
@@ -2754,8 +2772,56 @@ public:
     MGLMapViewImpl(MGLMapView *nativeView_)
         : nativeView(nativeView_) {}
 
-    void notifyMapChange(mbgl::MapChange change) override {
-        [nativeView notifyMapChange:change];
+    void onCameraWillChange(mbgl::MapObserver::CameraChangeMode mode) override {
+        bool animated = mode == mbgl::MapObserver::CameraChangeMode::Animated;
+        [nativeView cameraWillChangeAnimated:animated];
+    }
+
+    void onCameraIsChanging() override {
+        [nativeView cameraIsChanging];
+    }
+
+    void onCameraDidChange(mbgl::MapObserver::CameraChangeMode mode) override {
+        bool animated = mode == mbgl::MapObserver::CameraChangeMode::Animated;
+        [nativeView cameraDidChangeAnimated:animated];
+    }
+
+    void onWillStartLoadingMap() override {
+        [nativeView mapViewWillStartLoadingMap];
+    }
+
+    void onDidFinishLoadingMap() override {
+        [nativeView mapViewDidFinishLoadingMap];
+    }
+
+    void onDidFailLoadingMap() override {
+        [nativeView mapViewDidFailLoadingMap];
+    }
+
+    void onWillStartRenderingFrame() override {
+        [nativeView MapViewWillStartRenderingFrame];
+    }
+
+    void onDidFinishRenderingFrame(mbgl::MapObserver::RenderMode mode) override {
+        bool fullyRendered = mode == mbgl::MapObserver::RenderMode::Full;
+        [nativeView mapViewDidFinishRenderingFrameFullyRendered:fullyRendered];
+    }
+
+    void onWillStartRenderingMap() override {
+        [nativeView mapViewWillStartRenderingMap];
+    }
+
+    void onDidFinishRenderingMap(mbgl::MapObserver::RenderMode mode) override {
+        bool fullyRendered = mode == mbgl::MapObserver::RenderMode::Full;
+        [nativeView mapViewDidFinishRenderingMapFullyRendered:fullyRendered];
+    }
+
+    void onDidFinishLoadingStyle() override {
+        [nativeView mapViewDidFinishLoadingStyle];
+    }
+
+    void onSourceDidChange() override {
+        [nativeView sourceDidChange];
     }
 
     void invalidate() override {

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -15,6 +15,12 @@
 
 namespace node_mbgl {
 
+class NodeBackend : public mbgl::HeadlessBackend {
+public:
+    NodeBackend();
+    void onDidFailLoadingMap() final;
+};
+
 class NodeMap : public Nan::ObjectWrap,
                 public mbgl::FileSource {
 public:
@@ -59,7 +65,7 @@ public:
     std::unique_ptr<mbgl::AsyncRequest> request(const mbgl::Resource&, mbgl::FileSource::Callback);
 
     const float pixelRatio;
-    mbgl::HeadlessBackend backend;
+    NodeBackend backend;
     std::unique_ptr<mbgl::OffscreenView> view;
     NodeThreadPool threadpool;
     std::unique_ptr<mbgl::Map> map;

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -94,7 +94,6 @@ class Q_DECL_EXPORT QMapboxGL : public QObject
     Q_PROPERTY(QMargins margins READ margins WRITE setMargins)
 
 public:
-    // Reflects mbgl::MapChange.
     enum MapChange {
         MapChangeRegionWillChange = 0,
         MapChangeRegionWillChangeAnimated,

--- a/platform/qt/src/qmapbox.cpp
+++ b/platform/qt/src/qmapbox.cpp
@@ -1,7 +1,6 @@
 #include "qmapbox.hpp"
 
 #include <mbgl/gl/extension.hpp>
-#include <mbgl/map/change.hpp>
 #include <mbgl/storage/network_status.hpp>
 #include <mbgl/util/default_styles.hpp>
 #include <mbgl/util/geometry.hpp>

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -29,7 +29,20 @@ public:
     void activate() final {}
     void deactivate() final {}
     void invalidate() final;
-    void notifyMapChange(mbgl::MapChange) final;
+
+    // mbgl::Backend (mbgl::MapObserver) implementation.
+    void onCameraWillChange(mbgl::MapObserver::CameraChangeMode) final;
+    void onCameraIsChanging() final;
+    void onCameraDidChange(mbgl::MapObserver::CameraChangeMode) final;
+    void onWillStartLoadingMap() final;
+    void onDidFinishLoadingMap() final;
+    void onDidFailLoadingMap() final;
+    void onWillStartRenderingFrame() final;
+    void onDidFinishRenderingFrame(mbgl::MapObserver::RenderMode) final;
+    void onWillStartRenderingMap() final;
+    void onDidFinishRenderingMap(mbgl::MapObserver::RenderMode) final;
+    void onDidFinishLoadingStyle() final;
+    void onSourceDidChange() final;
 
     mbgl::EdgeInsets margins;
     QSize size { 0, 0 };

--- a/src/mbgl/map/backend.cpp
+++ b/src/mbgl/map/backend.cpp
@@ -14,9 +14,4 @@ gl::Context& Backend::getContext() {
 
 Backend::~Backend() = default;
 
-void Backend::notifyMapChange(MapChange) {
-    // no-op
-}
-
-
 } // namespace mbgl

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -70,6 +70,7 @@ public:
     void loadStyleJSON(const std::string&);
 
     Map& map;
+    MapObserver& observer;
     Backend& backend;
     FileSource& fileSource;
     Scheduler& scheduler;
@@ -134,10 +135,11 @@ Map::Impl::Impl(Map& map_,
                 ConstrainMode constrainMode_,
                 ViewportMode viewportMode_)
     : map(map_),
+      observer(backend_),
       backend(backend_),
       fileSource(fileSource_),
       scheduler(scheduler_),
-      transform([this](MapChange change) { backend.notifyMapChange(change); },
+      transform(observer,
                 constrainMode_,
                 viewportMode_),
       mode(mode_),
@@ -264,10 +266,10 @@ void Map::Impl::render(View& view) {
 
     if (mode == MapMode::Continuous) {
         if (renderState == RenderState::Never) {
-            backend.notifyMapChange(MapChangeWillStartRenderingMap);
+            observer.onWillStartRenderingMap();
         }
 
-        backend.notifyMapChange(MapChangeWillStartRenderingFrame);
+        observer.onWillStartRenderingFrame();
 
         FrameData frameData { timePoint,
                               pixelRatio,
@@ -282,18 +284,16 @@ void Map::Impl::render(View& view) {
 
         painter->cleanup();
 
-        backend.notifyMapChange(style->isLoaded() ?
-            MapChangeDidFinishRenderingFrameFullyRendered :
-            MapChangeDidFinishRenderingFrame);
+        observer.onDidFinishRenderingFrame(style->isLoaded() ? MapObserver::RenderMode::Full : MapObserver::RenderMode::Partial);
 
         if (!style->isLoaded()) {
             renderState = RenderState::Partial;
         } else if (renderState != RenderState::Fully) {
             renderState = RenderState::Fully;
-            backend.notifyMapChange(MapChangeDidFinishRenderingMapFullyRendered);
+            observer.onDidFinishRenderingMap(MapObserver::RenderMode::Full);
             if (loading) {
                 loading = false;
-                backend.notifyMapChange(MapChangeDidFinishLoadingMap);
+                observer.onDidFinishLoadingMap();
             }
         }
 
@@ -341,7 +341,7 @@ void Map::setStyleURL(const std::string& url) {
 
     impl->loading = true;
 
-    impl->backend.notifyMapChange(MapChangeWillStartLoadingMap);
+    impl->observer.onWillStartLoadingMap();
 
     impl->styleRequest = nullptr;
     impl->styleURL = url;
@@ -385,7 +385,7 @@ void Map::setStyleJSON(const std::string& json) {
 
     impl->loading = true;
 
-    impl->backend.notifyMapChange(MapChangeWillStartLoadingMap);
+    impl->observer.onWillStartLoadingMap();
 
     impl->styleURL.clear();
     impl->styleJSON.clear();
@@ -1086,7 +1086,7 @@ void Map::onLowMemory() {
 }
 
 void Map::Impl::onSourceAttributionChanged(style::Source&, const std::string&) {
-    backend.notifyMapChange(MapChangeSourceDidChange);
+    observer.onSourceDidChange();
 }
 
 void Map::Impl::onUpdate(Update flags) {
@@ -1095,11 +1095,11 @@ void Map::Impl::onUpdate(Update flags) {
 }
 
 void Map::Impl::onStyleLoaded() {
-    backend.notifyMapChange(MapChangeDidFinishLoadingStyle);
+    observer.onDidFinishLoadingStyle();
 }
 
 void Map::Impl::onStyleError() {
-    backend.notifyMapChange(MapChangeDidFailLoadingMap);
+    observer.onDidFailLoadingMap();
 }
 
 void Map::Impl::onResourceError(std::exception_ptr error) {

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <mbgl/map/camera.hpp>
+#include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/mode.hpp>
-#include <mbgl/map/change.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/map/update.hpp>
 #include <mbgl/util/chrono.hpp>
@@ -18,7 +18,7 @@ namespace mbgl {
 
 class Transform : private util::noncopyable {
 public:
-    Transform(std::function<void(MapChange)> = nullptr,
+    Transform(MapObserver& = MapObserver::nullObserver(),
               ConstrainMode = ConstrainMode::HeightOnly,
               ViewportMode = ViewportMode::Default);
 
@@ -163,8 +163,7 @@ public:
     LatLng screenCoordinateToLatLng(const ScreenCoordinate&) const;
 
 private:
-    std::function<void(MapChange)> callback;
-
+    MapObserver& observer;
     TransformState state;
 
     void startTransition(const CameraOptions&,

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -215,7 +215,7 @@ TEST(Transform, ConstrainHeightOnly) {
 TEST(Transform, ConstrainWidthAndHeight) {
     LatLng loc;
 
-    Transform transform(nullptr, ConstrainMode::WidthAndHeight);
+    Transform transform(MapObserver::nullObserver(), ConstrainMode::WidthAndHeight);
     transform.resize({ 1000, 1000 });
     transform.setScale(std::pow(2, util::MAX_ZOOM));
 

--- a/test/tile/tile_coordinate.test.cpp
+++ b/test/tile/tile_coordinate.test.cpp
@@ -1,6 +1,5 @@
 #include <mbgl/test/util.hpp>
 
-#include <mbgl/map/change.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/tile/tile.hpp>
@@ -13,17 +12,35 @@
 using namespace mbgl;
 
 TEST(TileCoordinate, FromLatLng) {
+
     size_t changeCount = 0;
-    std::vector<MapChange> changes = {
-        MapChangeRegionWillChange,
-        MapChangeRegionDidChange,
-    };
-    auto onMapChange = [&](MapChange change) {
-        ASSERT_EQ(change, changes[changeCount]);
-        ++changeCount;
+    struct TransformObserver : public mbgl::MapObserver {
+        void onCameraWillChange(MapObserver::CameraChangeMode mode) final {
+            if (mode == MapObserver::CameraChangeMode::Immediate && cameraWillChangeImmediateCallback) {
+                cameraWillChangeImmediateCallback();
+            }
+        }
+
+        void onCameraDidChange(MapObserver::CameraChangeMode mode) final {
+            if (mode == MapObserver::CameraChangeMode::Immediate && cameraDidChangeImmediateCallback) {
+                cameraDidChangeImmediateCallback();
+            }
+        }
+
+        std::function<void()> cameraWillChangeImmediateCallback;
+        std::function<void()> cameraDidChangeImmediateCallback;
     };
 
-    Transform transform(onMapChange);
+    TransformObserver observer;
+    observer.cameraWillChangeImmediateCallback = [&]() {
+        ASSERT_EQ(changeCount, 0u);
+        ++changeCount;
+    };
+    observer.cameraDidChangeImmediateCallback = [&]() {
+        ASSERT_EQ(changeCount, 1u);
+    };
+
+    Transform transform(observer);
 
     const double max = util::tileSize;
     transform.resize({ static_cast<uint32_t>(max), static_cast<uint32_t>(max) });


### PR DESCRIPTION
Implements `mbgl::MapObserver`, replacing `mbgl::MapChange` enumerator and `mbgl::Backend::notifyMapChange`. Now `mbgl::Backend` inherits from `mbgl::MapObserver`, which provides non-pure virtual equivalents for the enumerator items.

Caveats:
- Qt preserves the `QMapboxGL::MapChange` enumerator from the public API.
- Android refactor still requires `mbgl::MapChange` - this is not necessary but finishing up this platform refactor can happen on a separate PR. Once we finish cleaning up the Android platform, then we can safely remove `mbgl::MapChange` source code entirely.

Added suggested reviewers for platform-specific patches as well as core changes - please replace yourself with someone else from the mobile team otherwise.

Fixes #6383.