### PR TITLE
[android] don’t crash on map changed callback when OnMapChangedListener throws a runtime exception

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -945,7 +945,11 @@ final class NativeMapView {
   protected void onMapChanged(int rawChange) {
     if (onMapChangedListeners != null) {
       for (MapView.OnMapChangedListener onMapChangedListener : onMapChangedListeners) {
-        onMapChangedListener.onMapChanged(rawChange);
+        try {
+          onMapChangedListener.onMapChanged(rawChange);
+        } catch (RuntimeException err) {
+          Timber.e("Exception (%s) in MapView.OnMapChangedListener: %s", err.getClass(), err.getMessage());
+        }
       }
     }
   }


### PR DESCRIPTION
fixes #8353 