### PR TITLE
[build] Give ios/builds s3 permission to Bitrise user

### DIFF
--- a/cloudformation/travis.template
+++ b/cloudformation/travis.template
@@ -199,6 +199,26 @@
                                 }
                             ]
                         }
+                    },
+                    {
+                        "PolicyName": "publish-nightlies",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "s3:DeleteObject",
+                                        "s3:GetObject",
+                                        "s3:GetObjectAcl",
+                                        "s3:PutObject",
+                                        "s3:PutObjectAcl"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        "arn:aws:s3:::mapbox/mapbox-gl-native/ios/builds/*"
+                                    ]
+                                }
+                            ]
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
Fixes #8364 by giving the Bitrise aws user permission to upload to `s3://mapbox/mapbox-gl-native/ios/builds/`.