### PR TITLE
Expand feature querying documentation

### DIFF
--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -211,18 +211,32 @@ MGL_EXPORT
 @property (nonatomic, copy, nullable) NSURL *URL;
 
 /**
- Returns an array of map features for this source, filtered by the given predicate.
+ Returns an array of map features for this source, filtered by the given
+ predicate.
 
  Each object in the returned array represents a feature for the current style
- and provides access to attributes specified by the source
+ and provides access to attributes specified via the `shape` property.
 
  Features come from tiled GeoJSON data that is converted to tiles internally,
  so feature geometries are clipped at tile boundaries and features
- may appear duplicated across tiles.
+ may appear duplicated across tiles. For example, suppose this source contains a
+ long polyline representing a road. The resulting array includes those parts of
+ the road that lie within the map tiles that the source has loaded, even if the
+ road extends into other tiles. The portion of the road within each map tile is
+ included individually.
+ 
+ Returned features may not necessarily be visible to the user at the time they
+ are loaded: the style may lack a layer that draws the features in question. To
+ obtain only _visible_ features, use the
+ `-[MGLMapView visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:]`
+ or
+ `-[MGLMapView visibleFeaturesInRect:inStyleLayersWithIdentifiers:predicate:]`
+ method.
 
- @param predicate A predicate to filter the returned features.
+ @param predicate A predicate to filter the returned features. Use `nil` to
+    include all features in the source.
  @return An array of objects conforming to the `MGLFeature` protocol that
- represent features in the sources used by the current style.
+    represent features in the source that match the predicate.
  */
 - (NS_ARRAY_OF(id <MGLFeature>) *)featuresMatchingPredicate:(nullable NSPredicate *)predicate;
 

--- a/platform/darwin/src/MGLTileSource.h
+++ b/platform/darwin/src/MGLTileSource.h
@@ -135,6 +135,10 @@ typedef NS_ENUM(NSUInteger, MGLTileCoordinateSystem) {
  A tile source is added to an `MGLStyle` object along with one or more
  `MGLRasterStyleLayer` or `MGLVectorStyleLayer` objects. Use a style layer to
  control the appearance of content supplied by the tile source.
+ 
+ A tile source is also known as a tile set. To learn about the structure of a
+ Mapbox-hosted tile set, view it in
+ <a href="https://www.mapbox.com/studio/tilesets/">Mapbox Studio’s Tilesets editor</a>.
 
  Do not create instances of this class directly, and do not create your own
  subclasses of this class. Instead, create instances of `MGLRasterSource` and

--- a/platform/darwin/src/MGLVectorSource.h
+++ b/platform/darwin/src/MGLVectorSource.h
@@ -26,6 +26,12 @@ NS_ASSUME_NONNULL_BEGIN
  (<var>extent</var>&nbsp;×&nbsp;2)&nbsp;−&nbsp;1, inclusive. Any vector style
  layer initialized with a vector source must have a non-`nil` value in its
  `sourceLayerIdentifier` property.
+ 
+ Commonly used vector sources include
+ <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets</a>,
+ <a href="https://www.mapbox.com/vector-tiles/mapbox-terrain/">Mapbox Terrain</a>,
+ and
+ <a href="https://www.mapbox.com/vector-tiles/mapbox-traffic-v1/">Mapbox Traffic</a>.
 
  ### Example
 
@@ -52,23 +58,39 @@ MGL_EXPORT
 #pragma mark Accessing a Source’s Content
 
 /**
- Returns an array of map features loaded by this source, restricted to the
- given source layers and filtered by the given predicate.
+ Returns an array of map features loaded by this source, restricted to the given
+ source layers and filtered by the given predicate.
 
- Each object in the returned array represents a feature for the
- current style and provides access to attributes specified by the
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources">source</a>.
+ Each object in the returned array represents a feature loaded by the source and
+ provides access to attributes specified as part of the loaded feature. The
+ source loads a feature if the source is added to an `MGLMapView`’s style; that
+ style has a layer that uses the source; and the map view has recently scrolled
+ to the region containing the feature.
 
- Features come from tiled vector data that is converted to tiles internally,
- so feature geometries are clipped at tile boundaries and features
- may appear duplicated across tiles.
+ Features come from tiled vector data that is converted to tiles internally, so
+ feature geometries are clipped at tile boundaries and features may appear
+ duplicated across tiles. For example, suppose part of a lengthy polyline
+ representing a road has recently scrolled into view. The resulting array
+ includes those parts of the road that lie within the map tiles that the source
+ has loaded, even if the road extends into other tiles. The portion of the road
+ within each map tile is included individually.
+ 
+ Returned features may not necessarily be visible to the user at the time they
+ are loaded: the style may contain a layer that forces the source’s tiles to
+ load but filters out the features in question, preventing them from being
+ drawn. To obtain only _visible_ features, use the
+ `-[MGLMapView visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:]`
+ or
+ `-[MGLMapView visibleFeaturesInRect:inStyleLayersWithIdentifiers:predicate:]`
+ method.
 
- @param sourceLayerIdentifiers The source layers to include in the query. Only the
-    features contained in these source layers are included in the returned array. At
-    least one source layer is required.
- @param predicate A predicate to filter the returned features.
+ @param sourceLayerIdentifiers The source layers to include in the query. Only
+    the features contained in these source layers are included in the returned
+    array. This array may not be empty.
+ @param predicate A predicate to filter the returned features. Use `nil` to
+    include all loaded features.
  @return An array of objects conforming to the `MGLFeature` protocol that
-    represent features in the sources used by the current style.
+    represent features loaded by the source that match the predicate.
  */
 - (NS_ARRAY_OF(id <MGLFeature>) *)featuresInSourceLayersWithIdentifiers:(NS_SET_OF(NSString *) *)sourceLayerIdentifiers predicate:(nullable NSPredicate *)predicate NS_SWIFT_NAME(features(sourceLayerIdentifiers:predicate:));
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1171,10 +1171,11 @@ IB_DESIGNABLE
  Returns an array of rendered map features that intersect with a given point,
  restricted to the given style layers.
  
- This method may return all features from the specified layers. To filter
- the returned features, use the
- `-visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:` method. For more
- information about searching for map features, see that method’s documentation.
+ This method returns all the intersecting features from the specified layers. To
+ filter the returned features, use the
+ `-visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:` method. For
+ more information about searching for map features, see that method’s
+ documentation.
  
  @param point A point expressed in the map view’s coordinate system.
  @param styleLayerIdentifiers A set of strings that correspond to the names 
@@ -1187,17 +1188,17 @@ IB_DESIGNABLE
 
 /**
  Returns an array of rendered map features that intersect with a given point,
- restricted to the given style layers and filtered by the given
- predicate.
+ restricted to the given style layers and filtered by the given predicate.
 
  Each object in the returned array represents a feature rendered by the
- current style and provides access to attributes specified by the relevant
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources">tile sources</a>.
- The returned array includes features specified in vector and GeoJSON tile
- sources but does not include anything from raster, image, or video sources.
+ current style and provides access to attributes specified by the relevant map
+ content sources. The returned array includes features loaded by
+ `MGLShapeSource` and `MGLVectorSource` objects but does not include anything
+ from `MGLRasterSource` objects, or from image, video, or canvas sources, which
+ are unsupported by this SDK.
 
- Only visible features are returned. For example, suppose the current style uses
- the
+ The returned features are drawn by a style layer in the current style. For
+ example, suppose the current style uses the
  <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets source</a>,
  but none of the specified style layers includes features that have the `maki`
  property set to `bus`. If you pass a point corresponding to the location of a
@@ -1224,13 +1225,18 @@ IB_DESIGNABLE
  To find out the layer names in a particular style, view the style in
  <a href="https://www.mapbox.com/studio/">Mapbox Studio</a>.
 
+ Only visible features are returned. To obtain features regardless of
+ visibility, use the
+ `-[MGLVectorSource featuresInSourceLayersWithIdentifiers:predicate:]` and
+ `-[MGLShapeSource featuresMatchingPredicate:]` methods on the relevant sources.
+
  @note Layer identifiers are not guaranteed to exist across styles or different
-    versions of the same style. Applications that use this API must first set the
-    style URL to an explicitly versioned style using a convenience method like
-    `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`’s “Style URL”
+    versions of the same style. Applications that use this API must first set
+    the style URL to an explicitly versioned style using a convenience method
+    like `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`’s “Style URL”
     inspectable in Interface Builder, or a manually constructed `NSURL`. This
-    approach also avoids layer identifer name changes that will occur in the default
-    style’s layers over time.
+    approach also avoids layer identifer name changes that will occur in the
+    default style’s layers over time.
 
  @param point A point expressed in the map view’s coordinate system.
  @param styleLayerIdentifiers A set of strings that correspond to the names of
@@ -1261,9 +1267,9 @@ IB_DESIGNABLE
  Returns an array of rendered map features that intersect with the given
  rectangle, restricted to the given style layers.
  
- This method may return all features from the specified layers. To filter 
- the returned features, use the
- `-visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:` method. For 
+ This method returns all the intersecting features from the specified layers. To
+ filter the returned features, use the
+ `-visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:` method. For
  more information about searching for map features, see that method’s 
  documentation.
 
@@ -1282,13 +1288,14 @@ IB_DESIGNABLE
  predicate.
  
  Each object in the returned array represents a feature rendered by the
- current style and provides access to attributes specified by the relevant
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources">tile sources</a>.
- The returned array includes features specified in vector and GeoJSON tile
- sources but does not include anything from raster, image, or video sources.
+ current style and provides access to attributes specified by the relevant map
+ content sources. The returned array includes features loaded by
+ `MGLShapeSource` and `MGLVectorSource` objects but does not include anything
+ from `MGLRasterSource` objects, or from image, video, or canvas sources, which
+ are unsupported by this SDK.
 
- Only visible features are returned. For example, suppose the current style uses
- the
+ The returned features are drawn by a style layer in the current style. For
+ example, suppose the current style uses the
  <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets source</a>,
  but none of the specified style layers includes features that have the `maki`
  property set to `bus`. If you pass a rectangle containing the location of a bus
@@ -1316,6 +1323,11 @@ IB_DESIGNABLE
  To find out the layer names in a particular style, view the style in
  <a href="https://www.mapbox.com/studio/">Mapbox Studio</a>.
 
+ Only visible features are returned. To obtain features regardless of
+ visibility, use the
+ `-[MGLVectorSource featuresInSourceLayersWithIdentifiers:predicate:]` and
+ `-[MGLShapeSource featuresMatchingPredicate:]` methods on the relevant sources.
+
  @note Layer identifiers are not guaranteed to exist across styles or different
  versions of the same style. Applications that use this API must first set the
  style URL to an explicitly versioned style using a convenience method like
@@ -1323,6 +1335,14 @@ IB_DESIGNABLE
  inspectable in Interface Builder, or a manually constructed `NSURL`. This
  approach also avoids layer identifer name changes that will occur in the default
  style’s layers over time.
+ 
+ @note Layer identifiers are not guaranteed to exist across styles or different
+    versions of the same style. Applications that use this API must first set
+    the style URL to an explicitly versioned style using a convenience method
+    like `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`’s “Style URL”
+    inspectable in Interface Builder, or a manually constructed `NSURL`. This
+    approach also avoids layer identifer name changes that will occur in the
+    default style’s layers over time.
  
  @param rect A rectangle expressed in the map view’s coordinate system.
  @param styleLayerIdentifiers A set of strings that correspond to the names of

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -783,24 +783,17 @@ MGL_EXPORT IB_DESIGNABLE
  @return An array of objects conforming to the `MGLFeature` protocol that
     represent features in the sources used by the current style.
  */
-- (NS_ARRAY_OF(id <MGLFeature>) *)visibleFeaturesAtPoint:(NSPoint)point NS_SWIFT_NAME(visibleFeatures(_:));
+- (NS_ARRAY_OF(id <MGLFeature>) *)visibleFeaturesAtPoint:(NSPoint)point NS_SWIFT_NAME(visibleFeatures(at:));
 
 /**
  Returns an array of rendered map features that intersect with a given point,
  restricted to the given style layers.
 
- This method may return all features from the specified layers. To filter
- the returned features, use the
- `-visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:` method. For more
- information about searching for map features, see that method’s documentation.
-
- @note Layer identifiers are not guaranteed to exist across styles or different
-    versions of the same style. Applications that use this API must first set the
-    style URL to an explicitly versioned style using a convenience method like
-    `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`’s “Style URL”
-    inspectable in Interface Builder, or a manually constructed `NSURL`. This
-    approach also avoids layer identifer name changes that will occur in the default
-    style’s layers over time.
+ This method returns all the intersecting features from the specified layers. To
+ filter the returned features, use the
+ `-visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:` method. For
+ more information about searching for map features, see that method’s
+ documentation.
 
  @param point A point expressed in the map view’s coordinate system.
  @param styleLayerIdentifiers A set of strings that correspond to the names of
@@ -813,17 +806,17 @@ MGL_EXPORT IB_DESIGNABLE
 
 /**
  Returns an array of rendered map features that intersect with a given point,
- restricted to the given style layers and filtered by the given
- predicate.
+ restricted to the given style layers and filtered by the given predicate.
  
  Each object in the returned array represents a feature rendered by the
- current style and provides access to attributes specified by the relevant
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources">tile sources</a>.
- The returned array includes features specified in vector and GeoJSON tile
- sources but does not include anything from raster, image, or video sources.
+ current style and provides access to attributes specified by the relevant map
+ content sources. The returned array includes features loaded by
+ `MGLShapeSource` and `MGLVectorSource` objects but does not include anything
+ from `MGLRasterSource` objects, or from image, video, or canvas sources, which
+ are unsupported by this SDK.
 
- Only visible features are returned. For example, suppose the current style uses
- the
+ The returned features are drawn by a style layer in the current style. For
+ example, suppose the current style uses the
  <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets source</a>,
  but none of the specified style layers includes features that have the `maki`
  property set to `bus`. If you pass a point corresponding to the location of a
@@ -849,22 +842,27 @@ MGL_EXPORT IB_DESIGNABLE
 
  To find out the layer names in a particular style, view the style in
  <a href="https://www.mapbox.com/studio/">Mapbox Studio</a>.
+ 
+ Only visible features are returned. To obtain features regardless of
+ visibility, use the
+ `-[MGLVectorSource featuresInSourceLayersWithIdentifiers:predicate:]` and
+ `-[MGLShapeSource featuresMatchingPredicate:]` methods on the relevant sources.
 
  @note Layer identifiers are not guaranteed to exist across styles or different
- versions of the same style. Applications that use this API must first set the
- style URL to an explicitly versioned style using a convenience method like
- `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`’s “Style URL”
- inspectable in Interface Builder, or a manually constructed `NSURL`. This
- approach also avoids layer identifer name changes that will occur in the default
- style’s layers over time.
+    versions of the same style. Applications that use this API must first set
+    the style URL to an explicitly versioned style using a convenience method
+    like `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`’s “Style URL”
+    inspectable in Interface Builder, or a manually constructed `NSURL`. This
+    approach also avoids layer identifer name changes that will occur in the
+    default style’s layers over time.
  
  @param point A point expressed in the map view’s coordinate system.
  @param styleLayerIdentifiers A set of strings that correspond to the names of
- layers defined in the current style. Only the features contained in these
- layers are included in the returned array.
+    layers defined in the current style. Only the features contained in these
+    layers are included in the returned array.
  @param predicate A predicate to filter the returned features.
  @return An array of objects conforming to the `MGLFeature` protocol that
- represent features in the sources used by the current style.
+    represent features in the sources used by the current style.
  */
 - (NS_ARRAY_OF(id <MGLFeature>) *)visibleFeaturesAtPoint:(NSPoint)point inStyleLayersWithIdentifiers:(nullable NS_SET_OF(NSString *) *)styleLayerIdentifiers predicate:(nullable NSPredicate *)predicate NS_SWIFT_NAME(visibleFeatures(at:styleLayerIdentifiers:predicate:));
 
@@ -881,14 +879,14 @@ MGL_EXPORT IB_DESIGNABLE
  @return An array of objects conforming to the `MGLFeature` protocol that
     represent features in the sources used by the current style.
  */
-- (NS_ARRAY_OF(id <MGLFeature>) *)visibleFeaturesInRect:(NSRect)rect NS_SWIFT_NAME(visibleFeatures(_:));
+- (NS_ARRAY_OF(id <MGLFeature>) *)visibleFeaturesInRect:(NSRect)rect NS_SWIFT_NAME(visibleFeatures(in:));
 
 /**
  Returns an array of rendered map features that intersect with the given
  rectangle, restricted to the given style layers.
  
- This method may return all features from the specified layers. To filter
- the returned features, use the
+ This method returns all the intersecting features from the specified layers. To
+ filter the returned features, use the
  `-visibleFeaturesAtPoint:inStyleLayersWithIdentifiers:predicate:` method. For
  more information about searching for map features, see that method’s
  documentation.
@@ -906,16 +904,16 @@ MGL_EXPORT IB_DESIGNABLE
  Returns an array of rendered map features that intersect with the given
  rectangle, restricted to the given style layers and filtered by the given
  predicate.
-
  
  Each object in the returned array represents a feature rendered by the
- current style and provides access to attributes specified by the relevant
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources">tile sources</a>.
- The returned array includes features specified in vector and GeoJSON tile
- sources but does not include anything from raster, image, or video sources.
+ current style and provides access to attributes specified by the relevant map
+ content sources. The returned array includes features loaded by
+ `MGLShapeSource` and `MGLVectorSource` objects but does not include anything
+ from `MGLRasterSource` objects, or from image, video, or canvas sources, which
+ are unsupported by this SDK.
 
- Only visible features are returned. For example, suppose the current style uses
- the
+ The returned features are drawn by a style layer in the current style. For
+ example, suppose the current style uses the
  <a href="https://www.mapbox.com/vector-tiles/mapbox-streets/">Mapbox Streets source</a>,
  but none of the specified style layers includes features that have the `maki`
  property set to `bus`. If you pass a rectangle containing the location of a bus
@@ -942,22 +940,27 @@ MGL_EXPORT IB_DESIGNABLE
 
  To find out the layer names in a particular style, view the style in
  <a href="https://www.mapbox.com/studio/">Mapbox Studio</a>.
+ 
+ Only visible features are returned. To obtain features regardless of
+ visibility, use the
+ `-[MGLVectorSource featuresInSourceLayersWithIdentifiers:predicate:]` and
+ `-[MGLShapeSource featuresMatchingPredicate:]` methods on the relevant sources.
 
  @note Layer identifiers are not guaranteed to exist across styles or different
- versions of the same style. Applications that use this API must first set the
- style URL to an explicitly versioned style using a convenience method like
- `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`’s “Style URL”
- inspectable in Interface Builder, or a manually constructed `NSURL`. This
- approach also avoids layer identifer name changes that will occur in the default
- style’s layers over time.
+    versions of the same style. Applications that use this API must first set
+    the style URL to an explicitly versioned style using a convenience method
+    like `+[MGLStyle outdoorsStyleURLWithVersion:]`, `MGLMapView`’s “Style URL”
+    inspectable in Interface Builder, or a manually constructed `NSURL`. This
+    approach also avoids layer identifer name changes that will occur in the
+    default style’s layers over time.
  
  @param rect A rectangle expressed in the map view’s coordinate system.
  @param styleLayerIdentifiers A set of strings that correspond to the names of
- layers defined in the current style. Only the features contained in these
- layers are included in the returned array.
+    layers defined in the current style. Only the features contained in these
+    layers are included in the returned array.
  @param predicate A predicate to filter the returned features.
  @return An array of objects conforming to the `MGLFeature` protocol that
- represent features in the sources used by the current style.
+    represent features in the sources used by the current style.
  */
 - (NS_ARRAY_OF(id <MGLFeature>) *)visibleFeaturesInRect:(NSRect)rect inStyleLayersWithIdentifiers:(nullable NS_SET_OF(NSString *) *)styleLayerIdentifiers predicate:(nullable NSPredicate *)predicate NS_SWIFT_NAME(visibleFeatures(in:styleLayerIdentifiers:predicate:));
 


### PR DESCRIPTION
Copyedited and expanded documentation about visible feature querying and source feature querying. Linked the two APIs together. Now that runtime styling is supported, visible feature querying documentation can talk about MGLSource subclasses instead of linking out to the style specification.

A possible future improvement would be factoring this documentation out into the MGLMapView class documentation comment or even a jazzy guide. That would require some code examples and screenshots, so that can happen for a later release.

Also fixed a couple incorrect Swift method names on macOS.

/cc @jmkiley @ivovandongen