### PR TITLE
[android] Link with a version script to restrict symbol visibility

### DIFF
--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -248,6 +248,7 @@ target_compile_options(mapbox-gl
 target_link_libraries(mapbox-gl
     PUBLIC mbgl-core
     PUBLIC -Wl,--gc-sections
+    PUBLIC -Wl,--version-script=${CMAKE_SOURCE_DIR}/platform/android/version-script
 )
 
 # Create a stripped version of the library and copy it to the JNIDIR.
@@ -331,6 +332,7 @@ target_compile_options(example-custom-layer
 target_link_libraries(example-custom-layer
     PRIVATE mapbox-gl
     PUBLIC -Wl,--gc-sections
+    PUBLIC -Wl,--version-script=${CMAKE_SOURCE_DIR}/platform/android/version-script
 )
 
 add_custom_command(TARGET example-custom-layer POST_BUILD

--- a/platform/android/version-script
+++ b/platform/android/version-script
@@ -1,0 +1,4 @@
+{
+  global: JNI_OnLoad;
+  local: *;
+};


### PR DESCRIPTION
Cherry-picks 78d6d07d57d8b2f9a5aa25f9f84cc18b6d3b90e6 to the release branch.