### PR TITLE
[node] Fix module_name, check if release

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "gypfile": true,
   "binary": {
-    "module_name": "mapbox-gl-native",
+    "module_name": "mapbox_gl_native",
     "module_path": "./lib/",
     "host": "https://mapbox-node-binary.s3.amazonaws.com",
     "remote_path": "./{name}/v{version}",

--- a/platform/node/scripts/after_success.sh
+++ b/platform/node/scripts/after_success.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 if [[ -n ${PUBLISH:-} ]]; then
-    if [[ "${BUILDTYPE}" == "Debug" ]]; then
+    if [[ "${BUILDTYPE}" != "Release" ]]; then
         echo "Please run this script in release mode (BUILDTYPE=Release)."
         exit 1
     else


### PR DESCRIPTION
Since https://github.com/mapbox/mapbox-gl-native/commit/6b0ad899b3ced4932cf600a4f89b2609512c98be changed the module name, pre gyp was looking for node bindings `mapbox-gl-native` instead of `mapbox_gl_native`.

Also checks whether the build is a release or not instead whether its a debug build.