### PR TITLE
[node] Cleanup bitrise.yml; split test/publish workflows

### DIFF
--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -3,68 +3,65 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 trigger_map:
 - tag: "node-v*"
-  workflow: primary
+  workflow: publish
 - push_branch: "*"
   workflow: primary
 - pull_request_target_branch: "*"
   workflow: primary
 
+shortcuts:
+  slack: &slack
+    title: Post to Slack
+    inputs:
+    - webhook_url: "$SLACK_HOOK_URL"
+    - channel: "#gl-bots"
+    - from_username: 'Bitrise Node macOS'
+    - from_username_on_error: 'Bitrise Node macOS'
+    - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+        for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+        by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+        passed'
+    - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+        for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+        by ${GIT_CLONE_COMMIT_COMMITER_NAME}
+        failed'
+    - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
+    - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+
 workflows:
   primary:
     steps:
     - script:
-        title: Check for publishing
-        inputs:
-        - content: |-
-            #!/bin/bash
-            PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
-            if [[ "${BITRISE_GIT_TAG:-}" == "node-v${PACKAGE_JSON_VERSION}" ]]; then
-                envman add --key PUBLISH --value true
-            fi
-    - script:
-        title: Run build script
+        title: Test
         inputs:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
             brew update
-            brew install cmake
             brew unlink node
-            brew install awscli node@4
+            brew install cmake awscli node@4
             brew link node@4 --force
             gem install xcpretty --no-rdoc --no-ri
-            make node
-    - script:
-        title: Run test script
-        run_if: '{{enveq "PUBLISH" ""}}'
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            make test-node || envman add --key RESULT --value $?
+            make test-node || RESULT=$?
             ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
+            exit ${RESULT:-0}
+    - slack: *slack
+
+  publish:
+    steps:
     - script:
-        title: Run publish script
+        title: Publish
         inputs:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
+            brew update
+            brew unlink node
+            brew install cmake awscli node@4
+            brew link node@4 --force
+            gem install xcpretty --no-rdoc --no-ri
+            export BUILDTYPE=Release
+            export PUBLISH=true
+            make node
             ./platform/node/scripts/after_success.sh
-            exit ${RESULT:-0}
-    - slack:
-        title: Post to Slack
-        inputs:
-        - webhook_url: "$SLACK_HOOK_URL"
-        - channel: "#gl-bots"
-        - from_username: 'Bitrise Node macOS'
-        - from_username_on_error: 'Bitrise Node macOS'
-        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            passed'
-        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
-            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
-            by ${GIT_CLONE_COMMIT_COMMITER_NAME}
-            failed'
-        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
-        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+    - slack: *slack


### PR DESCRIPTION
This cleans up the node bitrise builds. Most notably, it adds `export BUILDTYPE=Release` which verifies we're creating Release binaries and not debug. 