### PR TITLE
[node] Work around a link error on macOS release builds

### DIFF
--- a/include/mbgl/style/layers/custom_layer.hpp
+++ b/include/mbgl/style/layers/custom_layer.hpp
@@ -65,9 +65,7 @@ public:
 };
 
 template <>
-inline bool Layer::is<CustomLayer>() const {
-    return type == Type::Custom;
-}
+bool Layer::is<CustomLayer>() const;
 
 } // namespace style
 } // namespace mbgl

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -62,6 +62,6 @@ workflows:
             gem install xcpretty --no-rdoc --no-ri
             export BUILDTYPE=Release
             export PUBLISH=true
-            make node
+            make test-node
             ./platform/node/scripts/after_success.sh
     - slack: *slack

--- a/src/mbgl/style/layers/custom_layer.cpp
+++ b/src/mbgl/style/layers/custom_layer.cpp
@@ -20,5 +20,10 @@ CustomLayer::CustomLayer(const Impl& other)
 
 CustomLayer::~CustomLayer() = default;
 
+template <>
+bool Layer::is<CustomLayer>() const {
+    return type == Type::Custom;
+}
+
 } // namespace style
 } // namespace mbgl


### PR DESCRIPTION
Fixes:

```
module.js:434
  return process.dlopen(module, path._makeLong(filename));
                 ^

Error: dlopen(/Users/john/Development/mapbox-gl-native/lib/mapbox_gl_native.node, 1): Symbol not found: __ZNK4mbgl5style5Layer2isINS0_11CustomLayerEEEbv
  Referenced from: /Users/john/Development/mapbox-gl-native/lib/mapbox_gl_native.node
  Expected in: flat namespace
 in /Users/john/Development/mapbox-gl-native/lib/mapbox_gl_native.node
    at Error (native)
    at Object.Module._extensions..node (module.js:434:18)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/john/Development/mapbox-gl-native/platform/node/index.js:5:12)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
```

I don't know why this occurs.

cc @bsudekum 