### PR TITLE
Pass std::exception_ptr in MapObserver::onDidFailLoadingMap

### DIFF
--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <exception>
 
 namespace mbgl {
 
@@ -26,7 +27,7 @@ public:
     virtual void onCameraDidChange(CameraChangeMode) {}
     virtual void onWillStartLoadingMap() {}
     virtual void onDidFinishLoadingMap() {}
-    virtual void onDidFailLoadingMap() {}
+    virtual void onDidFailLoadingMap(std::exception_ptr) {}
     virtual void onWillStartRenderingFrame() {}
     virtual void onDidFinishRenderingFrame(RenderMode) {}
     virtual void onWillStartRenderingMap() {}

--- a/include/mbgl/util/exception.hpp
+++ b/include/mbgl/util/exception.hpp
@@ -20,5 +20,20 @@ struct MisuseException : Exception {
     MisuseException(const std::string &msg) : Exception(msg) {}
 };
 
+struct StyleParseException : Exception {
+    StyleParseException(const char *msg) : Exception(msg) {}
+    StyleParseException(const std::string &msg) : Exception(msg) {}
+};
+
+struct StyleLoadException : Exception {
+    StyleLoadException(const char *msg) : Exception(msg) {}
+    StyleLoadException(const std::string &msg) : Exception(msg) {}
+};
+
+struct NotFoundException : Exception {
+    NotFoundException(const char *msg) : Exception(msg) {}
+    NotFoundException(const std::string &msg) : Exception(msg) {}
+};
+
 } // namespace util
 } // namespace mbgl

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -209,7 +209,7 @@ void NativeMapView::onDidFinishLoadingMap() {
     notifyMapChange(MapChange::MapChangeDidFinishLoadingMap);
 }
 
-void NativeMapView::onDidFailLoadingMap() {
+void NativeMapView::onDidFailLoadingMap(std::exception_ptr) {
     notifyMapChange(MapChange::MapChangeDidFailLoadingMap);
 }
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -23,6 +23,7 @@
 #include "style/layers/layers.hpp"
 #include "style/sources/sources.hpp"
 
+#include <exception>
 #include <string>
 #include <jni.h>
 #include <android/native_window.h>
@@ -62,7 +63,7 @@ public:
     void onCameraDidChange(MapObserver::CameraChangeMode) override;
     void onWillStartLoadingMap() override;
     void onDidFinishLoadingMap() override;
-    void onDidFailLoadingMap() override;
+    void onDidFailLoadingMap(std::exception_ptr) override;
     void onWillStartRenderingFrame() override;
     void onDidFinishRenderingFrame(MapObserver::RenderMode) override;
     void onWillStartRenderingMap() override;

--- a/platform/darwin/src/MGLTypes.h
+++ b/platform/darwin/src/MGLTypes.h
@@ -42,6 +42,10 @@ typedef NS_ENUM(NSInteger, MGLErrorCode) {
     MGLErrorCodeBadServerResponse = 2,
     /** An attempt to establish a connection failed. */
     MGLErrorCodeConnectionFailed = 3,
+    /** A style parse error occurred while attempting to load the map. */
+    MGLErrorCodeParseStyleFailed = 4,
+    /** An attempt to load the style failed. */
+    MGLErrorCodeLoadStyleFailed = 5,
 };
 
 /**

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -55,6 +55,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that was causing the system location indicator to stay on in background after telemetry was disabled. ([#7833](https://github.com/mapbox/mapbox-gl-native/pull/7833))
 * Added support for predicates in rendered feature querying [8256](https://github.com/mapbox/mapbox-gl-native/pull/8246)
 * Added a nightly build of the dynamic framework. ([#8337](https://github.com/mapbox/mapbox-gl-native/pull/8337))
+* Improved the error message when the map fails to load. [8418](https://github.com/mapbox/mapbox-gl-native/pull/8418)
 
 ## 3.4.2 - February 21, 2017
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Fixed flickering that occurred when panning past the antimeridian. ([#7574](https://github.com/mapbox/mapbox-gl-native/pull/7574))
 * Added a `MGLDistanceFormatter` class for formatting geographic distances. ([#7888](https://github.com/mapbox/mapbox-gl-native/pull/7888))
 * Added support for predicates in rendered feature querying [8256](https://github.com/mapbox/mapbox-gl-native/pull/8246)
+* Improved the error message when the map fails to load. [8418](https://github.com/mapbox/mapbox-gl-native/pull/8418)
 
 ## 0.3.1 - February 21, 2017
 

--- a/platform/node/src/node_map.cpp
+++ b/platform/node/src/node_map.cpp
@@ -42,8 +42,8 @@ static const char* releasedMessage() {
 NodeBackend::NodeBackend()
     : HeadlessBackend(sharedDisplay()) {}
 
-void NodeBackend::onDidFailLoadingMap() {
-    throw std::runtime_error("Requires a map style to be a valid style JSON");
+void NodeBackend::onDidFailLoadingMap(std::exception_ptr error) {
+    std::rethrow_exception(error);
 }
 
 void NodeMap::Init(v8::Local<v8::Object> target) {

--- a/platform/node/src/node_map.hpp
+++ b/platform/node/src/node_map.hpp
@@ -7,6 +7,8 @@
 #include <mbgl/gl/headless_backend.hpp>
 #include <mbgl/gl/offscreen_view.hpp>
 
+#include <exception>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -18,7 +20,7 @@ namespace node_mbgl {
 class NodeBackend : public mbgl::HeadlessBackend {
 public:
     NodeBackend();
-    void onDidFailLoadingMap() final;
+    void onDidFailLoadingMap(std::exception_ptr) final;
 };
 
 class NodeMap : public Nan::ObjectWrap,

--- a/platform/node/test/js/map.test.js
+++ b/platform/node/test/js/map.test.js
@@ -311,11 +311,11 @@ test('Map', function(t) {
 
             t.throws(function() {
                 map.load('foo bar');
-            }, /Requires a map style to be a valid style JSON/);
+            }, /Failed to parse style: 1 - Invalid value./);
 
             t.throws(function() {
                 map.load('""');
-            }, /Requires a map style to be a valid style JSON/);
+            }, /Failed to parse style: style must be an object/);
 
             map.release();
             t.end();
@@ -335,7 +335,7 @@ test('Map', function(t) {
 
             t.throws(function() {
                 map.load('invalid');
-            }, /Requires a map style to be a valid style JSON/);
+            }, /Failed to parse style: 0 - Invalid value./);
         });
 
         t.test('accepts an empty stylesheet string', function(t) {

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1602,7 +1602,7 @@ void QMapboxGLPrivate::onDidFinishLoadingMap()
     emit mapChanged(QMapboxGL::MapChangeDidFinishLoadingMap);
 }
 
-void QMapboxGLPrivate::onDidFailLoadingMap()
+void QMapboxGLPrivate::onDidFailLoadingMap(std::exception_ptr)
 {
     emit mapChanged(QMapboxGL::MapChangeDidFailLoadingMap);
 }

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -36,7 +36,7 @@ public:
     void onCameraDidChange(mbgl::MapObserver::CameraChangeMode) final;
     void onWillStartLoadingMap() final;
     void onDidFinishLoadingMap() final;
-    void onDidFailLoadingMap() final;
+    void onDidFailLoadingMap(std::exception_ptr) final;
     void onWillStartRenderingFrame() final;
     void onDidFinishRenderingFrame(mbgl::MapObserver::RenderMode) final;
     void onWillStartRenderingMap() final;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -1102,8 +1102,8 @@ void Map::Impl::onStyleLoaded() {
     observer.onDidFinishLoadingStyle();
 }
 
-void Map::Impl::onStyleError(std::exception_ptr) {
-    observer.onDidFailLoadingMap();
+void Map::Impl::onStyleError(std::exception_ptr error) {
+    observer.onDidFailLoadingMap(error);
 }
 
 void Map::Impl::onResourceError(std::exception_ptr error) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -16,6 +16,7 @@
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
+#include <mbgl/util/exception.hpp>
 #include <mbgl/util/projection.hpp>
 #include <mbgl/util/math.hpp>
 #include <mbgl/util/exception.hpp>
@@ -61,7 +62,7 @@ public:
     void onSourceAttributionChanged(style::Source&, const std::string&) override;
     void onUpdate(Update) override;
     void onStyleLoaded() override;
-    void onStyleError() override;
+    void onStyleError(std::exception_ptr) override;
     void onResourceError(std::exception_ptr) override;
 
     void render(View&);
@@ -364,11 +365,14 @@ void Map::setStyleURL(const std::string& url) {
         if (res.error) {
             if (res.error->reason == Response::Error::Reason::NotFound &&
                 util::mapbox::isMapboxURL(impl->styleURL)) {
-                Log::Error(Event::Setup, "style %s could not be found or is an incompatible legacy map or style", impl->styleURL.c_str());
+                const std::string message = "style " + impl->styleURL + " could not be found or is an incompatible legacy map or style";
+                Log::Error(Event::Setup, message.c_str());
+                impl->onStyleError(std::make_exception_ptr(util::NotFoundException(message)));
             } else {
-                Log::Error(Event::Setup, "loading style failed: %s", res.error->message.c_str());
+                const std::string message = "loading style failed: " + res.error->message;
+                Log::Error(Event::Setup, message.c_str());
+                impl->onStyleError(std::make_exception_ptr(util::StyleLoadException(message)));
             }
-            impl->onStyleError();
             impl->onResourceError(std::make_exception_ptr(std::runtime_error(res.error->message)));
         } else if (res.notModified || res.noContent) {
             return;
@@ -1098,7 +1102,7 @@ void Map::Impl::onStyleLoaded() {
     observer.onDidFinishLoadingStyle();
 }
 
-void Map::Impl::onStyleError() {
+void Map::Impl::onStyleError(std::exception_ptr) {
     observer.onDidFailLoadingMap();
 }
 

--- a/src/mbgl/style/observer.hpp
+++ b/src/mbgl/style/observer.hpp
@@ -5,6 +5,8 @@
 #include <mbgl/style/source_observer.hpp>
 #include <mbgl/map/update.hpp>
 
+#include <exception>
+
 namespace mbgl {
 namespace style {
 
@@ -13,7 +15,7 @@ class Observer : public GlyphAtlasObserver,
                  public SourceObserver {
 public:
     virtual void onUpdate(Update) {}
-    virtual void onStyleError() {}
+    virtual void onStyleError(std::exception_ptr) {}
     virtual void onStyleLoaded() {}
     virtual void onResourceError(std::exception_ptr) {}
 };

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -25,6 +25,7 @@
 #include <mbgl/renderer/render_item.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/util/constants.hpp>
+#include <mbgl/util/exception.hpp>
 #include <mbgl/util/geometry.hpp>
 #include <mbgl/util/string.hpp>
 #include <mbgl/util/logging.hpp>
@@ -110,8 +111,9 @@ void Style::setJSON(const std::string& json) {
     auto error = parser.parse(json);
 
     if (error) {
-        Log::Error(Event::ParseStyle, "Failed to parse style: %s", util::toString(error).c_str());
-        observer->onStyleError();
+        std::string message = "Failed to parse style: " + util::toString(error);
+        Log::Error(Event::ParseStyle, message.c_str());
+        observer->onStyleError(std::make_exception_ptr(util::StyleParseException(message)));
         observer->onResourceError(error);
         return;
     }


### PR DESCRIPTION
Forwards the ~error type and message~ `std::exception_ptr` from style::Observer::onStyleError as well as non-style related errors.

As per @1ec5 comments in #8398:
> This would allow all the SDKs – not only the iOS and macOS SDKs – to provide more information when the map fails to load for some reason.

Fixes #8398.