### PR TITLE
[core] Prefer vector<pair<A, B>> to unordered_map<A, B> for small collections

### DIFF
--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 #include <unordered_set>
-#include <unordered_map>
 
 namespace mbgl {
 

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -21,7 +21,6 @@
 #include <vector>
 #include <array>
 #include <string>
-#include <unordered_map>
 
 namespace mbgl {
 

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -6,6 +6,7 @@
 #include <mbgl/layout/symbol_instance.hpp>
 #include <mbgl/text/bidi.hpp>
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
+#include <mbgl/util/unordered_vector_map.hpp>
 
 #include <memory>
 #include <map>
@@ -51,7 +52,7 @@ public:
 
     State state = Pending;
 
-    std::unordered_map<std::string,
+    util::unordered_vector_map<std::string,
         std::pair<style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>> layerPaintProperties;
 
 private:

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -8,6 +8,7 @@
 #include <mbgl/gl/segment.hpp>
 #include <mbgl/programs/circle_program.hpp>
 #include <mbgl/style/layers/circle_layer_properties.hpp>
+#include <mbgl/util/unordered_vector_map.hpp>
 
 namespace mbgl {
 
@@ -33,7 +34,7 @@ public:
     optional<gl::VertexBuffer<CircleLayoutVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
 
-    std::unordered_map<std::string, CircleProgram::PaintPropertyBinders> paintPropertyBinders;
+    util::unordered_vector_map<std::string, CircleProgram::PaintPropertyBinders> paintPropertyBinders;
 
     const MapMode mode;
 };

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -7,6 +7,7 @@
 #include <mbgl/gl/segment.hpp>
 #include <mbgl/programs/fill_program.hpp>
 #include <mbgl/style/layers/fill_layer_properties.hpp>
+#include <mbgl/util/unordered_vector_map.hpp>
 
 #include <vector>
 
@@ -37,7 +38,7 @@ public:
     optional<gl::IndexBuffer<gl::Lines>> lineIndexBuffer;
     optional<gl::IndexBuffer<gl::Triangles>> triangleIndexBuffer;
 
-    std::unordered_map<std::string, FillProgram::PaintPropertyBinders> paintPropertyBinders;
+    util::unordered_vector_map<std::string, FillProgram::PaintPropertyBinders> paintPropertyBinders;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -7,6 +7,7 @@
 #include <mbgl/gl/segment.hpp>
 #include <mbgl/programs/line_program.hpp>
 #include <mbgl/style/layers/line_layer_properties.hpp>
+#include <mbgl/util/unordered_vector_map.hpp>
 
 #include <vector>
 
@@ -38,7 +39,7 @@ public:
     optional<gl::VertexBuffer<LineLayoutVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
 
-    std::unordered_map<std::string, LineProgram::PaintPropertyBinders> paintPropertyBinders;
+    util::unordered_vector_map<std::string, LineProgram::PaintPropertyBinders> paintPropertyBinders;
 
 private:
     void addGeometry(const GeometryCoordinates&, FeatureType);

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -9,7 +9,7 @@ namespace mbgl {
 using namespace style;
 
 SymbolBucket::SymbolBucket(style::SymbolLayoutProperties::Evaluated layout_,
-                           const std::unordered_map<std::string, std::pair<
+                           const util::unordered_vector_map<std::string, std::pair<
                                style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>>& layerPaintProperties,
                            float zoom,
                            bool sdfIcons_,

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -9,6 +9,7 @@
 #include <mbgl/programs/collision_box_program.hpp>
 #include <mbgl/text/glyph_range.hpp>
 #include <mbgl/style/layers/symbol_layer_properties.hpp>
+#include <mbgl/util/unordered_vector_map.hpp>
 
 #include <vector>
 
@@ -17,7 +18,7 @@ namespace mbgl {
 class SymbolBucket : public Bucket {
 public:
     SymbolBucket(style::SymbolLayoutProperties::Evaluated,
-                 const std::unordered_map<std::string, std::pair<style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>>&,
+                 const util::unordered_vector_map<std::string, std::pair<style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>>&,
                  float zoom,
                  bool sdfIcons,
                  bool iconsNeedLinear);
@@ -33,7 +34,7 @@ public:
     const bool sdfIcons;
     const bool iconsNeedLinear;
 
-    std::unordered_map<std::string, std::pair<
+    util::unordered_vector_map<std::string, std::pair<
         SymbolIconProgram::PaintPropertyBinders,
         SymbolSDFTextProgram::PaintPropertyBinders>> paintPropertyBinders;
 

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -14,6 +14,7 @@
 #include <mbgl/util/interpolate.hpp>
 #include <mbgl/util/indexed_tuple.hpp>
 #include <mbgl/util/ignore.hpp>
+#include <mbgl/util/unordered_vector_map.hpp>
 
 #include <unordered_map>
 #include <utility>
@@ -139,8 +140,8 @@ public:
     }
 
 private:
-    std::unordered_map<ClassID, Value> values;
-    std::unordered_map<ClassID, TransitionOptions> transitions;
+    util::unordered_vector_map<ClassID, Value> values;
+    util::unordered_vector_map<ClassID, TransitionOptions> transitions;
 };
 
 template <class T>

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -16,7 +16,6 @@
 #include <mbgl/util/ignore.hpp>
 #include <mbgl/util/unordered_vector_map.hpp>
 
-#include <unordered_map>
 #include <utility>
 
 namespace mbgl {

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -8,7 +8,6 @@
 
 #include <atomic>
 #include <memory>
-#include <unordered_map>
 
 namespace mbgl {
 

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -5,7 +5,6 @@
 #include <protozero/pbf_reader.hpp>
 
 #include <unordered_map>
-#include <unordered_map>
 #include <functional>
 #include <utility>
 

--- a/src/mbgl/util/unordered_vector_map.hpp
+++ b/src/mbgl/util/unordered_vector_map.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <iterator>
+#include <utility>
+#include <vector>
+
+namespace mbgl {
+namespace util {
+
+/*
+   unordered_vector_map<Key, T> provides a replacement for std::unordered_map<Key, T>
+   that is suitable for cases where the collection will remain small and it is desirable
+   to minimize generated code size.
+
+   unordered_vector_map is backed by a vector, and lookup operations are O(n) linear
+   searches. Unlike unordered_map, modifications may invalidate references and iterators.
+
+   The API is not a complete replacement for unordered_map; only the methods that were
+   so far needed have been implemented.
+*/
+template <class Key, class T>
+class unordered_vector_map {
+private:
+    using vector_type = std::vector<std::pair<const Key, T>>;
+
+    vector_type v;
+
+public:
+    using key_type = Key;
+    using mapped_type = T;
+    using value_type = std::pair<const Key, T>;
+
+    using size_type      = typename vector_type::size_type;
+    using iterator       = typename vector_type::iterator;
+    using const_iterator = typename vector_type::const_iterator;
+
+    bool empty() const {
+        return v.empty();
+    }
+
+    size_type size() const {
+        return v.size();
+    }
+
+    iterator begin() {
+        return v.begin();
+    }
+
+    const_iterator begin() const {
+        return v.begin();
+    }
+
+    const_iterator cbegin() const {
+        return v.cbegin();
+    }
+
+    iterator end() {
+        return v.end();
+    }
+
+    const_iterator end() const {
+        return v.end();
+    }
+
+    const_iterator cend() const {
+        return v.cend();
+    }
+
+    void clear() {
+        v.clear();
+    }
+
+    template <class... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        value_type value(std::forward<Args>(args)...);
+        iterator it = find(value.first);
+        if (it != end()) {
+            return std::make_pair(it, false);
+        }
+        v.push_back(std::move(value));
+        return std::make_pair(std::prev(v.end()), true);
+    }
+
+    T& at(const Key& key) {
+        iterator it = find(key);
+        if (it != end()) {
+            return it->second;
+        }
+        throw std::out_of_range("at");
+    }
+
+    const T& at(const Key& key) const {
+        const_iterator it = find(key);
+        if (it != end()) {
+            return it->second;
+        }
+        throw std::out_of_range("at");
+    }
+
+    T& operator[](const Key& key) {
+        iterator it = find(key);
+        if (it != end()) {
+            return it->second;
+        }
+        v.emplace_back(std::piecewise_construct,
+                       std::forward_as_tuple(key),
+                       std::tuple<>());
+        return std::prev(v.end())->second;
+    }
+
+    T& operator[](Key&& key) {
+        iterator it = find(key);
+        if (it != end()) {
+            return it->second;
+        }
+        v.emplace_back(std::piecewise_construct,
+                       std::forward_as_tuple(std::move(key)),
+                       std::tuple<>());
+        return std::prev(v.end())->second;
+    }
+
+    iterator find(const Key& key) {
+        return std::find_if(v.begin(), v.end(), [&] (const value_type& val) {
+            return val.first == key;
+        });
+    }
+
+    const_iterator find(const Key& key) const {
+        return std::find_if(v.begin(), v.end(), [&] (const value_type& val) {
+            return val.first == key;
+        });
+    }
+};
+
+} // namespace util
+} // namespace mbgl

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -61,7 +61,7 @@ TEST(VectorTile, Issue7615) {
     style::SymbolLayer symbolLayer("symbol", "source");
     auto symbolBucket = std::make_shared<SymbolBucket>(
         style::SymbolLayoutProperties::Evaluated(),
-        std::unordered_map<
+        util::unordered_vector_map<
             std::string,
             std::pair<style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>>(),
         0.0f, false, false);


### PR DESCRIPTION
```
     VM SIZE                               FILE SIZE
 ++++++++++++++ GROWING                 ++++++++++++++
  +0.0%      +3 __TEXT,__cstring             +3  +0.0%

 -------------- SHRINKING               --------------
  -1.2% -29.5Ki __TEXT,__text           -29.5Ki  -1.2%
  -3.2% -5.32Ki [None]                  -1.75Ki  -1.0%
  -0.3% -1.02Ki __TEXT,__gcc_except_tab -1.02Ki  -0.3%
  -0.2%    -164 __TEXT,__unwind_info       -164  -0.2%
  -0.0%     -32 __TEXT,__const              -32  -0.0%

  -1.0% -36.0Ki TOTAL                   -32.4Ki  -0.9%
```

Refs #8035