### PR TITLE
[build] Post nightly iOS build status to Slack

### DIFF
--- a/platform/ios/bitrise.yml
+++ b/platform/ios/bitrise.yml
@@ -85,3 +85,18 @@ workflows:
             CLOUDWATCH=true platform/ios/scripts/metrics.sh
             platform/ios/scripts/deploy-nightly.sh
         - is_debug: 'yes'
+    - slack:
+        title: Post to Slack
+        inputs:
+        - webhook_url: "$SLACK_HOOK_URL"
+        - channel: "#gl-bots"
+        - from_username: 'Bitrise iOS Nightly \U0001F31D'
+        - from_username_on_error: 'Bitrise iOS Nightly \U0001F31D'
+        - message: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}@%7B1day%7D...${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            completed successfully.'
+        - message_on_error: '<${BITRISE_BUILD_URL}|Build #${BITRISE_BUILD_NUMBER}>
+            for <https://github.com/mapbox/mapbox-gl-native/compare/${BITRISE_GIT_BRANCH}@%7B1day%7D...${BITRISE_GIT_BRANCH}|mapbox/mapbox-gl-native@${BITRISE_GIT_BRANCH}>
+            failed.'
+        - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
+        - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png


### PR DESCRIPTION
Posts a notification to #gl-bots on Slack that reports the success/failure of the nightly iOS Bitrise workflow.

(Note that I already added this through Bitrise’s web interface as a test run for tonight — will remove that once this is merged.)

/cc @boundsj @kkaefer