### PR TITLE
[core] Prefer std::map to std::unordered_map for smaller binary size

### DIFF
--- a/src/mbgl/annotation/annotation_manager.hpp
+++ b/src/mbgl/annotation/annotation_manager.hpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 #include <unordered_set>
-#include <unordered_map>
 
 namespace mbgl {
 

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -21,7 +21,6 @@
 #include <vector>
 #include <array>
 #include <string>
-#include <unordered_map>
 
 namespace mbgl {
 

--- a/src/mbgl/layout/symbol_layout.hpp
+++ b/src/mbgl/layout/symbol_layout.hpp
@@ -51,7 +51,7 @@ public:
 
     State state = Pending;
 
-    std::unordered_map<std::string,
+    std::map<std::string,
         std::pair<style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>> layerPaintProperties;
 
 private:

--- a/src/mbgl/renderer/circle_bucket.hpp
+++ b/src/mbgl/renderer/circle_bucket.hpp
@@ -33,7 +33,7 @@ public:
     optional<gl::VertexBuffer<CircleLayoutVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
 
-    std::unordered_map<std::string, CircleProgram::PaintPropertyBinders> paintPropertyBinders;
+    std::map<std::string, CircleProgram::PaintPropertyBinders> paintPropertyBinders;
 
     const MapMode mode;
 };

--- a/src/mbgl/renderer/fill_bucket.hpp
+++ b/src/mbgl/renderer/fill_bucket.hpp
@@ -37,7 +37,7 @@ public:
     optional<gl::IndexBuffer<gl::Lines>> lineIndexBuffer;
     optional<gl::IndexBuffer<gl::Triangles>> triangleIndexBuffer;
 
-    std::unordered_map<std::string, FillProgram::PaintPropertyBinders> paintPropertyBinders;
+    std::map<std::string, FillProgram::PaintPropertyBinders> paintPropertyBinders;
 };
 
 } // namespace mbgl

--- a/src/mbgl/renderer/line_bucket.hpp
+++ b/src/mbgl/renderer/line_bucket.hpp
@@ -38,7 +38,7 @@ public:
     optional<gl::VertexBuffer<LineLayoutVertex>> vertexBuffer;
     optional<gl::IndexBuffer<gl::Triangles>> indexBuffer;
 
-    std::unordered_map<std::string, LineProgram::PaintPropertyBinders> paintPropertyBinders;
+    std::map<std::string, LineProgram::PaintPropertyBinders> paintPropertyBinders;
 
 private:
     void addGeometry(const GeometryCoordinates&, FeatureType);

--- a/src/mbgl/renderer/symbol_bucket.cpp
+++ b/src/mbgl/renderer/symbol_bucket.cpp
@@ -9,7 +9,7 @@ namespace mbgl {
 using namespace style;
 
 SymbolBucket::SymbolBucket(style::SymbolLayoutProperties::Evaluated layout_,
-                           const std::unordered_map<std::string, std::pair<
+                           const std::map<std::string, std::pair<
                                style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>>& layerPaintProperties,
                            float zoom,
                            bool sdfIcons_,

--- a/src/mbgl/renderer/symbol_bucket.hpp
+++ b/src/mbgl/renderer/symbol_bucket.hpp
@@ -17,7 +17,7 @@ namespace mbgl {
 class SymbolBucket : public Bucket {
 public:
     SymbolBucket(style::SymbolLayoutProperties::Evaluated,
-                 const std::unordered_map<std::string, std::pair<style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>>&,
+                 const std::map<std::string, std::pair<style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>>&,
                  float zoom,
                  bool sdfIcons,
                  bool iconsNeedLinear);
@@ -33,7 +33,7 @@ public:
     const bool sdfIcons;
     const bool iconsNeedLinear;
 
-    std::unordered_map<std::string, std::pair<
+    std::map<std::string, std::pair<
         SymbolIconProgram::PaintPropertyBinders,
         SymbolSDFTextProgram::PaintPropertyBinders>> paintPropertyBinders;
 

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -15,7 +15,6 @@
 #include <mbgl/util/indexed_tuple.hpp>
 #include <mbgl/util/ignore.hpp>
 
-#include <unordered_map>
 #include <utility>
 
 namespace mbgl {

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -139,8 +139,8 @@ public:
     }
 
 private:
-    std::unordered_map<ClassID, Value> values;
-    std::unordered_map<ClassID, TransitionOptions> transitions;
+    std::map<ClassID, Value> values;
+    std::map<ClassID, TransitionOptions> transitions;
 };
 
 template <class T>

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -8,7 +8,6 @@
 
 #include <atomic>
 #include <memory>
-#include <unordered_map>
 
 namespace mbgl {
 

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -5,7 +5,6 @@
 #include <protozero/pbf_reader.hpp>
 
 #include <unordered_map>
-#include <unordered_map>
 #include <functional>
 #include <utility>
 

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -61,7 +61,7 @@ TEST(VectorTile, Issue7615) {
     style::SymbolLayer symbolLayer("symbol", "source");
     auto symbolBucket = std::make_shared<SymbolBucket>(
         style::SymbolLayoutProperties::Evaluated(),
-        std::unordered_map<
+        std::map<
             std::string,
             std::pair<style::IconPaintProperties::Evaluated, style::TextPaintProperties::Evaluated>>(),
         0.0f, false, false);


### PR DESCRIPTION
Replacement for #8426.

```
     VM SIZE                               FILE SIZE
 ++++++++++++++ GROWING                 ++++++++++++++
  +0.1%     +92 __TEXT,__unwind_info        +92  +0.1%

 -------------- SHRINKING               --------------
  -1.0% -25.7Ki __TEXT,__text           -25.7Ki  -1.0%
  -2.9% -4.80Ki [None]                  -1.12Ki  -0.7%
  -0.5% -1.55Ki __TEXT,__gcc_except_tab -1.55Ki  -0.5%
  -0.0%     -48 __TEXT,__const              -48  -0.0%

  -0.9% -32.0Ki TOTAL                   -28.3Ki  -0.8
```

Refs #8035