### PR TITLE
fixes #8433: lack of fade in transitions

### DIFF
--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -328,15 +328,13 @@ void Style::recalculate(float z, const TimePoint& timePoint, MapMode mode) {
 
     hasPendingTransitions = false;
     for (const auto& layer : layers) {
-        const bool hasTransitions = layer->baseImpl->evaluate(parameters);
+        hasPendingTransitions |= layer->baseImpl->evaluate(parameters);
 
         // Disable this layer if it doesn't need to be rendered.
         const bool needsRendering = layer->baseImpl->needsRendering(zoomHistory.lastZoom);
         if (!needsRendering) {
             continue;
         }
-
-        hasPendingTransitions |= hasTransitions;
 
         // If this layer has a source, make sure that it gets loaded.
         if (Source* source = getSource(layer->baseImpl->source)) {


### PR DESCRIPTION
See https://github.com/mapbox/mapbox-gl-native/issues/8433#issuecomment-287193423 for the problem outline. This instead always updates the need to iterate on transitions even when layers are skipped in a render pass because they aren't yet iterated from non-visibility. Hat tip to @jfirebaugh for the succinct patch. 

/cc @boundsj @fabian-guerra @1ec5 @ericrwolfe 