### PR TITLE
Pass source object in MapObserver::onSourceChanged

### DIFF
--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <mbgl/style/source.hpp>
+
 #include <cstdint>
 #include <exception>
+#include <string>
 
 namespace mbgl {
 
@@ -33,7 +36,7 @@ public:
     virtual void onWillStartRenderingMap() {}
     virtual void onDidFinishRenderingMap(RenderMode) {}
     virtual void onDidFinishLoadingStyle() {}
-    virtual void onSourceDidChange() {}
+    virtual void onSourceChanged(style::Source&) {}
 };
 
 } // namespace mbgl

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -241,7 +241,7 @@ void NativeMapView::onDidFinishLoadingStyle() {
     notifyMapChange(MapChange::MapChangeDidFinishLoadingStyle);
 }
 
-void NativeMapView::onSourceDidChange() {
+void NativeMapView::onSourceChanged(mbgl::style::Source&) {
     notifyMapChange(MapChange::MapChangeSourceDidChange);
 }
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -69,7 +69,7 @@ public:
     void onWillStartRenderingMap() override;
     void onDidFinishRenderingMap(MapObserver::RenderMode) override;
     void onDidFinishLoadingStyle() override;
-    void onSourceDidChange() override;
+    void onSourceChanged(mbgl::style::Source&) override;
 
     // JNI //
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2843,7 +2843,7 @@ public:
         [nativeView mapViewDidFinishLoadingStyle];
     }
 
-    void onSourceDidChange() override {
+    void onSourceChanged(mbgl::style::Source&) override {
         [nativeView sourceDidChange];
     }
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1640,7 +1640,7 @@ void QMapboxGLPrivate::onDidFinishLoadingStyle()
     emit mapChanged(QMapboxGL::MapChangeDidFinishLoadingStyle);
 }
 
-void QMapboxGLPrivate::onSourceDidChange()
+void QMapboxGLPrivate::onSourceChanged(mbgl::style::Source&)
 {
     std::string attribution;
     for (const auto& source : mapObj->getSources()) {

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -42,7 +42,7 @@ public:
     void onWillStartRenderingMap() final;
     void onDidFinishRenderingMap(mbgl::MapObserver::RenderMode) final;
     void onDidFinishLoadingStyle() final;
-    void onSourceDidChange() final;
+    void onSourceChanged(mbgl::style::Source&) final;
 
     mbgl::EdgeInsets margins;
     QSize size { 0, 0 };

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -59,7 +59,7 @@ public:
          ConstrainMode,
          ViewportMode);
 
-    void onSourceAttributionChanged(style::Source&, const std::string&) override;
+    void onSourceChanged(style::Source&) override;
     void onUpdate(Update) override;
     void onStyleLoaded() override;
     void onStyleError(std::exception_ptr) override;
@@ -1089,8 +1089,8 @@ void Map::onLowMemory() {
     }
 }
 
-void Map::Impl::onSourceAttributionChanged(style::Source&, const std::string&) {
-    observer.onSourceDidChange();
+void Map::Impl::onSourceChanged(style::Source& source) {
+    observer.onSourceChanged(source);
 }
 
 void Map::Impl::onUpdate(Update flags) {

--- a/src/mbgl/style/source_observer.hpp
+++ b/src/mbgl/style/source_observer.hpp
@@ -17,7 +17,7 @@ public:
     virtual ~SourceObserver() = default;
 
     virtual void onSourceLoaded(Source&) {}
-    virtual void onSourceAttributionChanged(Source&, const std::string&) {}
+    virtual void onSourceChanged(Source&) {}
     virtual void onSourceError(Source&, std::exception_ptr) {}
 
     // Source description needs to be reloaded

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -593,8 +593,8 @@ void Style::onSourceLoaded(Source& source) {
     observer->onUpdate(Update::Repaint);
 }
 
-void Style::onSourceAttributionChanged(Source& source, const std::string& attribution) {
-    observer->onSourceAttributionChanged(source, attribution);
+void Style::onSourceChanged(Source& source) {
+    observer->onSourceChanged(source);
 }
 
 void Style::onSourceError(Source& source, std::exception_ptr error) {

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -140,7 +140,7 @@ private:
 
     // SourceObserver implementation.
     void onSourceLoaded(Source&) override;
-    void onSourceAttributionChanged(Source&, const std::string&) override;
+    void onSourceChanged(Source&) override;
     void onSourceError(Source&, std::exception_ptr) override;
     void onSourceDescriptionChanged(Source&) override;
     void onTileChanged(Source&, const OverscaledTileID&) override;

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -107,7 +107,7 @@ void TileSourceImpl::loadDescription(FileSource& fileSource) {
 
             observer->onSourceLoaded(base);
             if (attributionChanged) {
-                observer->onSourceAttributionChanged(base, newTileset.attribution);
+                observer->onSourceChanged(base);
             }
         }
     });

--- a/test/src/mbgl/test/stub_style_observer.hpp
+++ b/test/src/mbgl/test/stub_style_observer.hpp
@@ -30,8 +30,8 @@ public:
         if (sourceLoaded) sourceLoaded(source);
     }
 
-    void onSourceAttributionChanged(Source& source, const std::string& attribution) override {
-        if (sourceAttributionChanged) sourceAttributionChanged(source, attribution);
+    void onSourceChanged(Source& source) override {
+        if (sourceChanged) sourceChanged(source);
     }
 
     void onSourceError(Source& source, std::exception_ptr error) override {
@@ -60,7 +60,7 @@ public:
     std::function<void ()> spriteLoaded;
     std::function<void (std::exception_ptr)> spriteError;
     std::function<void (Source&)> sourceLoaded;
-    std::function<void (Source&, std::string)> sourceAttributionChanged;
+    std::function<void (Source&)> sourceChanged;
     std::function<void (Source&, std::exception_ptr)> sourceError;
     std::function<void (Source&)> sourceDescriptionChanged;
     std::function<void (Source&, const OverscaledTileID&)> tileChanged;

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -364,8 +364,8 @@ TEST(Source, RasterTileAttribution) {
         return response;
     };
 
-    test.observer.sourceAttributionChanged = [&] (Source&, std::string attribution) {
-        EXPECT_EQ(mapboxOSM, attribution);
+    test.observer.sourceChanged = [&] (Source& source) {
+        EXPECT_EQ(mapboxOSM, source.getAttribution());
         EXPECT_FALSE(mapboxOSM.find("©️ OpenStreetMap") == std::string::npos);
         test.end();
     };


### PR DESCRIPTION
Rename `MapObserver::onSourceDidChange` to `MapObserver::onSourceAttributionChanged`, passing both `sourceID` and `attribution` as strings.

Fixes #8397.