### PR TITLE
[macos] Fix nightly build script

### DIFF
--- a/platform/macos/bitrise.yml
+++ b/platform/macos/bitrise.yml
@@ -54,7 +54,7 @@ workflows:
             #!/bin/bash
             set -eu -o pipefail
             brew install cmake
-            apt-get install -y python-pip python-dev build-essential
             pip install awscli
+            gem install xcpretty --no-rdoc --no-ri
             BUILDTYPE=Release SYMBOLS=NO make xpackage
             CLOUDWATCH=true platform/macos/scripts/metrics.sh


### PR DESCRIPTION
`apt-get install` commands were present when the nightly build was introduced. Prior to 12b99f0085c15ed59d10b6cc2003e6ee367bdce3 they were in a separate section without `set -eu -o pipefail`, so the error was ignored. I assume they are not needed, since the build was succeeding despite the error.

While here, ensure xcpretty is installed.

Fixes #8458