### PR TITLE
Guard against over calling pause or resume

### DIFF
--- a/include/mbgl/storage/default_file_source.hpp
+++ b/include/mbgl/storage/default_file_source.hpp
@@ -120,9 +120,6 @@ public:
      *
      * If pause is called then no revalidation or network request activity
      * will occur.
-     *
-     * Note: Calling pause and then calling getAPIBaseURL or getAccessToken
-     * will lock the thread that those calls are made on.
      */
     void pause();
 

--- a/platform/darwin/src/MGLOfflineStorage.mm
+++ b/platform/darwin/src/MGLOfflineStorage.mm
@@ -31,6 +31,7 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
 
 @property (nonatomic, strong, readwrite) NS_MUTABLE_ARRAY_OF(MGLOfflinePack *) *packs;
 @property (nonatomic) mbgl::DefaultFileSource *mbglFileSource;
+@property (nonatomic, getter=isPaused) BOOL paused;
 
 @end
 
@@ -53,11 +54,19 @@ NSString * const MGLOfflinePackMaximumCountUserInfoKey = MGLOfflinePackUserInfoK
 
 #if TARGET_OS_IPHONE || TARGET_OS_SIMULATOR
 - (void)pauseFileSource:(__unused NSNotification *)notification {
+    if (self.isPaused) {
+        return;
+    }
     _mbglFileSource->pause();
+    self.paused = YES;
 }
 
 - (void)unpauseFileSource:(__unused NSNotification *)notification {
+    if (!self.isPaused) {
+        return;
+    }
     _mbglFileSource->resume();
+    self.paused = NO;
 }
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/8464

Calls to the file source pause and resume method are triggered by UIApplicationDidEnterBackgroundNotification and UIApplicationWillEnterForegroundNotification notifications. Testing has shown that those notifications may happen more than once on device. This adds a local guard to protect against unbalanced calls to pause and resume.