### PR TITLE
Fix map load error descriptions

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## master
 
+* The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
+
+## 3.5.0
+
 ### Internationalization
 
 * Added support for right-to-left text and Arabic ligatures in labels. ([#6984](https://github.com/mapbox/mapbox-gl-native/pull/6984), [#7123](https://github.com/mapbox/mapbox-gl-native/pull/7123))
@@ -55,7 +59,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed an issue that was causing the system location indicator to stay on in background after telemetry was disabled. ([#7833](https://github.com/mapbox/mapbox-gl-native/pull/7833))
 * Added support for predicates in rendered feature querying [8256](https://github.com/mapbox/mapbox-gl-native/pull/8246)
 * Added a nightly build of the dynamic framework. ([#8337](https://github.com/mapbox/mapbox-gl-native/pull/8337))
-* Improved the error message when the map fails to load. [8418](https://github.com/mapbox/mapbox-gl-native/pull/8418)
 
 ## 3.4.2 - February 21, 2017
 

--- a/platform/ios/resources/Base.lproj/Localizable.strings
+++ b/platform/ios/resources/Base.lproj/Localizable.strings
@@ -31,6 +31,12 @@
 /* Accessibility label */
 "INFO_A11Y_LABEL" = "About this map";
 
+/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "The map failed to load because an unknown error occurred.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "The map failed to load because the style can't be loaded.";
+
 /* Accessibility label */
 "LOGO_A11Y_LABEL" = "Mapbox";
 
@@ -40,8 +46,14 @@
 /* Map accessibility value */
 "MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld annotation(s) visible";
 
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "The map failed to load because the style is corrupted.";
+
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "The map failed to load because the style can’t be found or is incompatible.";
 
 /* Telemetry prompt message */
 "TELEMETRY_DISABLED_MSG" = "You can help make OpenStreetMap and Mapbox maps better by contributing anonymous usage data.";

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5390,18 +5390,21 @@ public:
             std::rethrow_exception(exception);
         } catch (const mbgl::util::StyleParseException&) {
             code = MGLErrorCodeParseStyleFailed;
-            description = NSLocalizedStringWithDefaultValue(@"PARSE_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style is corrupted.", @"");
+            description = NSLocalizedStringWithDefaultValue(@"PARSE_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style is corrupted.", @"User-friendly error description");
         } catch (const mbgl::util::StyleLoadException&) {
             code = MGLErrorCodeLoadStyleFailed;
-            description = NSLocalizedStringWithDefaultValue(@"PARSE_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style can't be loaded.", @"");
+            description = NSLocalizedStringWithDefaultValue(@"LOAD_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style can't be loaded.", @"User-friendly error description");
         } catch (const mbgl::util::NotFoundException&) {
             code = MGLErrorCodeNotFound;
-            description = NSLocalizedStringWithDefaultValue(@"LOAD_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style can’t be found or is incompatible.", @"");
+            description = NSLocalizedStringWithDefaultValue(@"STYLE_NOT_FOUND_DESC", nil, nil, @"The map failed to load because the style can’t be found or is incompatible.", @"User-friendly error description");
         } catch (...) {
             code = MGLErrorCodeUnknown;
-            description = NSLocalizedStringWithDefaultValue(@"LOAD_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because an unknown error occurred.", @"");
+            description = NSLocalizedStringWithDefaultValue(@"LOAD_MAP_FAILED_DESC", nil, nil, @"The map failed to load because an unknown error occurred.", @"User-friendly error description");
         }
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey:description, NSLocalizedFailureReasonErrorKey:@(mbgl::util::toString(exception).c_str())};
+        NSDictionary *userInfo = @{
+            NSLocalizedDescriptionKey: description,
+            NSLocalizedFailureReasonErrorKey: @(mbgl::util::toString(exception).c_str()),
+        };
         NSError *error = [NSError errorWithDomain:MGLErrorDomain code:code userInfo:userInfo];
         [nativeView mapViewDidFailLoadingMapWithError:error];
     }

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
+
+## 0.4.0
+
 ### Internationalization
 
 * Added support for right-to-left text and Arabic ligatures in labels. ([#6984](https://github.com/mapbox/mapbox-gl-native/pull/6984), [#7123](https://github.com/mapbox/mapbox-gl-native/pull/7123))
@@ -49,7 +53,6 @@
 * Fixed flickering that occurred when panning past the antimeridian. ([#7574](https://github.com/mapbox/mapbox-gl-native/pull/7574))
 * Added a `MGLDistanceFormatter` class for formatting geographic distances. ([#7888](https://github.com/mapbox/mapbox-gl-native/pull/7888))
 * Added support for predicates in rendered feature querying [8256](https://github.com/mapbox/mapbox-gl-native/pull/8246)
-* Improved the error message when the map fails to load. [8418](https://github.com/mapbox/mapbox-gl-native/pull/8418)
 
 ## 0.3.1 - February 21, 2017
 

--- a/platform/macos/sdk/Base.lproj/Localizable.strings
+++ b/platform/macos/sdk/Base.lproj/Localizable.strings
@@ -1,5 +1,17 @@
+/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "The map failed to load because an unknown error occurred.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "The map failed to load because the style can't be loaded.";
+
 /* Accessibility title */
 "MAP_A11Y_TITLE" = "Mapbox";
+
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "The map failed to load because the style is corrupted.";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "The map failed to load because the style can’t be found or is incompatible.";
 
 /* Label of Zoom In button */
 "ZOOM_IN_LABEL" = "+";

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2802,18 +2802,21 @@ public:
             std::rethrow_exception(exception);
         } catch (const mbgl::util::StyleParseException&) {
             code = MGLErrorCodeParseStyleFailed;
-            description = NSLocalizedStringWithDefaultValue(@"PARSE_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style is corrupted.", @"");
+            description = NSLocalizedStringWithDefaultValue(@"PARSE_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style is corrupted.", @"User-friendly error description");
         } catch (const mbgl::util::StyleLoadException&) {
             code = MGLErrorCodeLoadStyleFailed;
-            description = NSLocalizedStringWithDefaultValue(@"PARSE_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style can't be loaded.", @"");
+            description = NSLocalizedStringWithDefaultValue(@"LOAD_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style can't be loaded.", @"User-friendly error description");
         } catch (const mbgl::util::NotFoundException&) {
             code = MGLErrorCodeNotFound;
-            description = NSLocalizedStringWithDefaultValue(@"LOAD_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because the style can’t be found or is incompatible.", @"");
+            description = NSLocalizedStringWithDefaultValue(@"STYLE_NOT_FOUND_DESC", nil, nil, @"The map failed to load because the style can’t be found or is incompatible.", @"User-friendly error description");
         } catch (...) {
             code = MGLErrorCodeUnknown;
-            description = NSLocalizedStringWithDefaultValue(@"LOAD_STYLE_FAILED_DESC", nil, nil, @"The map failed to load because an unknown error occurred.", @"");
+            description = NSLocalizedStringWithDefaultValue(@"LOAD_MAP_FAILED_DESC", nil, nil, @"The map failed to load because an unknown error occurred.", @"User-friendly error description");
         }
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey:description, NSLocalizedFailureReasonErrorKey:@(mbgl::util::toString(exception).c_str())};
+        NSDictionary *userInfo = @{
+            NSLocalizedDescriptionKey: description,
+            NSLocalizedFailureReasonErrorKey: @(mbgl::util::toString(exception).c_str()),
+        };
         NSError *error = [NSError errorWithDomain:MGLErrorDomain code:code userInfo:userInfo];
         [nativeView mapViewDidFailLoadingMapWithError:error];
     }


### PR DESCRIPTION
Ensured the uniqueness of localizable string IDs added in #8418 to unbreak `make genstrings`. Ran `make genstrings` to add the `-[MGLMapViewDelegate mapViewDidFailToLoad:withError:]` error description strings to the base localization.

Moved the changelog entries for #8418 to new sections, since #8418 won’t make it into either iOS SDK v3.5.x or macOS SDK v0.4.x.