### PR TITLE
[ios, build] Change version checker URL to ios-sdk site

### DIFF
--- a/platform/ios/scripts/deploy-packages.sh
+++ b/platform/ios/scripts/deploy-packages.sh
@@ -47,24 +47,6 @@ buildPackageStyle() {
     fi
 }
 
-bumpVersionForUpdateChecker() {
-    if [[ $( echo ${PUBLISH_VERSION} | awk '/[0-9]-/' ) ]]; then
-        step "Skipping version checker bump because this is a pre-release"
-        return
-    fi
-
-    step "Updating version checker to ${PUBLISH_VERSION}…"
-
-    CHECKER_FILENAME="latest_version"
-    CHECKER_PATH=${BINARY_DIRECTORY}/${CHECKER_FILENAME}
-
-    echo ${PUBLISH_VERSION} > ${CHECKER_PATH}
-    aws s3 cp ${CHECKER_PATH} s3://mapbox/${GITHUB_REPO}/ios/${CHECKER_FILENAME} --acl public-read --content-type text/plain
-
-    verification=$( curl -L http://mapbox.s3.amazonaws.com/${GITHUB_REPO}/ios/${CHECKER_FILENAME} )
-    echo "Updated version checker to ${verification}"
-}
-
 export TRAVIS_REPO_SLUG=mapbox-gl-native
 export GITHUB_USER=mapbox
 export GITHUB_REPO=mapbox-gl-native
@@ -131,7 +113,5 @@ buildPackageStyle "ipackage-strip"
 buildPackageStyle "iframework" "symbols-dynamic"
 buildPackageStyle "iframework SYMBOLS=NO" "dynamic"
 buildPackageStyle "ifabric" "fabric"
-
-bumpVersionForUpdateChecker
 
 step "Finished deploying ${PUBLISH_VERSION} in $(($SECONDS / 60)) minutes and $(($SECONDS % 60)) seconds"

--- a/platform/ios/src/MGLSDKUpdateChecker.mm
+++ b/platform/ios/src/MGLSDKUpdateChecker.mm
@@ -20,7 +20,7 @@
         return;
     }
 
-    NSURL *url = [NSURL URLWithString:@"https://mapbox.s3.amazonaws.com/mapbox-gl-native/ios/latest_version"];
+    NSURL *url = [NSURL URLWithString:@"https://www.mapbox.com/ios-sdk/latest_version"];
     [[NSURLSession.sharedSession dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (error || ((NSHTTPURLResponse *)response).statusCode != 200) {
             return;


### PR DESCRIPTION
Decouple the version checker (https://github.com/mapbox/mapbox-gl-native/pull/8282) updating from the deploy process. File is now hosted on the ios-sdk site.

/cc @1ec5 @boundsj 