### PR TITLE
[core] Expose Source::getZoomRange

### DIFF
--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/util/feature.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/range.hpp>
 #include <mbgl/style/types.hpp>
 #include <mbgl/style/query.hpp>
 
@@ -55,7 +56,9 @@ public:
     std::unique_ptr<Source> copy(const std::string& id) const;
 
     optional<std::string> getAttribution() const;
-    
+
+    Range<uint8_t> getZoomRange() const;
+
     std::vector<Feature> querySourceFeatures(const SourceQueryOptions& options = {});
 
     // Private implementation

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -14,7 +14,7 @@ AnnotationSource::Impl::Impl(Source& base_)
     : Source::Impl(SourceType::Annotations, AnnotationManager::SourceID, base_) {
 }
 
-Range<uint8_t> AnnotationSource::Impl::getZoomRange() {
+Range<uint8_t> AnnotationSource::Impl::getZoomRange() const {
     return { 0, 22 };
 }
 

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -20,7 +20,7 @@ public:
 
 private:
     uint16_t getTileSize() const final { return util::tileSize; }
-    Range<uint8_t> getZoomRange() final;
+    Range<uint8_t> getZoomRange() const final;
 
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const style::UpdateParameters&) final;
 };

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -17,7 +17,11 @@ const std::string& Source::getID() const {
 optional<std::string> Source::getAttribution() const {
     return baseImpl->getAttribution();
 }
-    
+
+Range<uint8_t> Source::getZoomRange() const {
+    return baseImpl->getZoomRange();
+}
+
 std::vector<Feature> Source::querySourceFeatures(const SourceQueryOptions& options) {
     return baseImpl->querySourceFeatures(options);
 }

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -83,6 +83,7 @@ public:
     const std::string id;
 
     virtual optional<std::string> getAttribution() const { return {}; };
+    virtual Range<uint8_t> getZoomRange() const = 0;
 
     bool loaded = false;
 
@@ -109,7 +110,6 @@ private:
     void onTileError(Tile&, std::exception_ptr) override;
 
     virtual uint16_t getTileSize() const = 0;
-    virtual Range<uint8_t> getZoomRange() = 0;
     virtual std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) = 0;
 
     std::map<UnwrappedTileID, RenderTile> renderTiles;

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -153,7 +153,7 @@ void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
     });
 }
 
-Range<uint8_t> GeoJSONSource::Impl::getZoomRange() {
+Range<uint8_t> GeoJSONSource::Impl::getZoomRange() const {
     assert(loaded);
     return { 0, options.maxzoom };
 }

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -28,10 +28,11 @@ public:
         return util::tileSize;
     }
 
+    Range<uint8_t> getZoomRange() const final;
+
 private:
     void _setGeoJSON(const GeoJSON&);
 
-    Range<uint8_t> getZoomRange() final;
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
 
     GeoJSONOptions options;

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -113,7 +113,7 @@ void TileSourceImpl::loadDescription(FileSource& fileSource) {
     });
 }
 
-Range<uint8_t> TileSourceImpl::getZoomRange() {
+Range<uint8_t> TileSourceImpl::getZoomRange() const {
     assert(loaded);
     return tileset.zoomRange;
 }

--- a/src/mbgl/style/tile_source_impl.hpp
+++ b/src/mbgl/style/tile_source_impl.hpp
@@ -36,9 +36,9 @@ public:
 
     optional<std::string> getAttribution() const override;
 
-protected:
-    Range<uint8_t> getZoomRange() final;
+    Range<uint8_t> getZoomRange() const final;
 
+protected:
     const variant<std::string, Tileset> urlOrTileset;
     const uint16_t tileSize;
 

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -19,6 +19,7 @@
 #include <mbgl/style/update_parameters.hpp>
 #include <mbgl/style/layers/line_layer.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/annotation/annotation_source.hpp>
 
 #include <mapbox/geojsonvt.hpp>
 
@@ -64,6 +65,29 @@ public:
         loop.stop();
     }
 };
+
+TEST(Source, DefaultZoomRange) {
+    VectorSource vectorSource("vectorSource", "url");
+    vectorSource.baseImpl->loaded = true;
+    EXPECT_EQ(vectorSource.getZoomRange().min, 0u);
+    EXPECT_EQ(vectorSource.getZoomRange().max, 22u);
+
+    GeoJSONSource geojsonSource("source");
+    geojsonSource.baseImpl->loaded = true;
+    EXPECT_EQ(geojsonSource.getZoomRange().min, 0u);
+    EXPECT_EQ(geojsonSource.getZoomRange().max, 18u);
+
+    Tileset tileset;
+    RasterSource rasterSource("source", tileset, 512);
+    rasterSource.baseImpl->loaded = true;
+    EXPECT_EQ(rasterSource.getZoomRange().min, 0u);
+    EXPECT_EQ(rasterSource.getZoomRange().max, 22u);
+    EXPECT_EQ(rasterSource.getZoomRange(), tileset.zoomRange);
+
+    AnnotationSource annotationSource;
+    EXPECT_EQ(annotationSource.getZoomRange().min, 0u);
+    EXPECT_EQ(annotationSource.getZoomRange().max, 22u);
+}
 
 TEST(Source, LoadingFail) {
     SourceTest test;


### PR DESCRIPTION
Expose `Source::getZoomRange` as part of `Source` public API, also marking it `const`.

Part of #6584.