### PR TITLE
Custom vector source

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -365,9 +365,13 @@ set(MBGL_CORE_FILES
     src/mbgl/style/layers/symbol_layer_properties.hpp
 
     # style/sources
+    include/mbgl/style/sources/custom_vector_source.hpp
     include/mbgl/style/sources/geojson_source.hpp
     include/mbgl/style/sources/raster_source.hpp
     include/mbgl/style/sources/vector_source.hpp
+    src/mbgl/style/sources/custom_vector_source.cpp
+    src/mbgl/style/sources/custom_vector_source_impl.cpp
+    src/mbgl/style/sources/custom_vector_source_impl.hpp
     src/mbgl/style/sources/geojson_source.cpp
     src/mbgl/style/sources/geojson_source_impl.cpp
     src/mbgl/style/sources/geojson_source_impl.hpp

--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -422,6 +422,7 @@ set(MBGL_CORE_FILES
     src/mbgl/tile/tile_cache.cpp
     src/mbgl/tile/tile_cache.hpp
     src/mbgl/tile/tile_id.hpp
+    src/mbgl/tile/tile_id_hash.hpp
     src/mbgl/tile/tile_id_io.cpp
     src/mbgl/tile/tile_loader.hpp
     src/mbgl/tile/tile_loader_impl.hpp

--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -80,6 +80,7 @@ set(MBGL_TEST_FILES
     test/style/conversion/stringify.test.cpp
 
     # style
+    test/style/custom_vector_source.test.cpp
     test/style/filter.test.cpp
 
     # style/function

--- a/include/mbgl/style/conversion/geojson_options.hpp
+++ b/include/mbgl/style/conversion/geojson_options.hpp
@@ -14,6 +14,15 @@ struct Converter<GeoJSONOptions> {
     Result<GeoJSONOptions> operator()(const V& value) const {
         GeoJSONOptions options;
 
+        const auto minzoomValue = objectMember(value, "minzoom");
+        if (minzoomValue) {
+            if (toNumber(*minzoomValue)) {
+                options.minzoom = static_cast<uint8_t>(*toNumber(*minzoomValue));
+            } else {
+                return Error{ "GeoJSON source minzoom value must be a number" };
+            }
+        }
+
         const auto maxzoomValue = objectMember(value, "maxzoom");
         if (maxzoomValue) {
             if (toNumber(*maxzoomValue)) {

--- a/include/mbgl/style/sources/custom_vector_source.hpp
+++ b/include/mbgl/style/sources/custom_vector_source.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mbgl/style/source.hpp>
+#include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/geojson.hpp>
+
+namespace mbgl {
+namespace style {
+
+class CustomVectorSource : public Source {
+public:
+    CustomVectorSource(std::string id,
+                       GeoJSONOptions options,
+                       std::function<void(const CanonicalTileID&)> fetchTile);
+
+    void setTileData(const CanonicalTileID&, const mapbox::geojson::geojson&);
+    void reloadTile(const CanonicalTileID&);
+    void reloadRegion(mbgl::LatLngBounds bounds, uint8_t z);
+    void reload();
+
+    // Private implementation
+
+    class Impl;
+    Impl* const impl;
+};
+
+template <>
+inline bool Source::is<CustomVectorSource>() const {
+    return type == SourceType::Vector;
+}
+
+} // namespace style
+} // namespace mbgl

--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/style/source.hpp>
 #include <mbgl/util/geojson.hpp>
 #include <mbgl/util/optional.hpp>
+#include <mbgl/util/constants.hpp>
 
 #include <mapbox/geojson.hpp>
 
@@ -28,6 +29,7 @@ struct GeoJSONOptions {
     // GeoJSON-VT options
     uint8_t minzoom = 0;
     uint8_t maxzoom = 18;
+    uint16_t tileSize = util::tileSize;
     uint16_t buffer = 128;
     double tolerance = 0.375;
 

--- a/include/mbgl/style/sources/geojson_source.hpp
+++ b/include/mbgl/style/sources/geojson_source.hpp
@@ -26,6 +26,7 @@ using SuperclusterPointer = std::unique_ptr<mapbox::supercluster::Supercluster>;
 
 struct GeoJSONOptions {
     // GeoJSON-VT options
+    uint8_t minzoom = 0;
     uint8_t maxzoom = 18;
     uint16_t buffer = 128;
     double tolerance = 0.375;

--- a/platform/darwin/docs/theme/assets/css/jazzy.css.scss
+++ b/platform/darwin/docs/theme/assets/css/jazzy.css.scss
@@ -386,6 +386,7 @@ pre code {
 .nav-group-task[data-name="MGLStyleFunction"],
 .nav-group-task[data-name="MGLStyleLayer"],
 .nav-group-task[data-name="MGLTileSource"],
+.nav-group-task[data-name="MGLAbstractShapeSource"],
 .nav-group-task[data-name="MGLVectorStyleLayer"] {
   .nav-group-task-link::after {
     @extend %nav-group-task-gloss;

--- a/platform/darwin/src/MGLAbstractShapeSource.h
+++ b/platform/darwin/src/MGLAbstractShapeSource.h
@@ -1,0 +1,99 @@
+#import "MGLSource.h"
+
+/**
+ Options for `MGLShapeSource` objects.
+ */
+typedef NSString *MGLShapeSourceOption NS_STRING_ENUM;
+
+/**
+ An `NSNumber` object containing a Boolean enabling or disabling clustering.
+ If the `shape` property contains point shapes, setting this option to
+ `YES` clusters the points by radius into groups. The default value is `NO`.
+ 
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-cluster"><code>cluster</code></a>
+ source property in the Mapbox Style Specification.
+ 
+ This option only affects point features within a shape source.
+ */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClustered;
+
+/**
+ An `NSNumber` object containing an integer; specifies the radius of each
+ cluster if clustering is enabled. A value of 512 produces a radius equal to
+ the width of a tile. The default value is 50.
+ */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClusterRadius;
+
+/**
+ An `NSNumber` object containing an integer; specifies the maximum zoom level at
+ which to cluster points if clustering is enabled. Defaults to one zoom level
+ less than the value of `MGLShapeSourceOptionMaximumZoomLevel` so that, at the
+ maximum zoom level, the shapes are not clustered.
+ 
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-clusterMaxZoom"><code>clusterMaxZoom</code></a>
+ source property in the Mapbox Style Specification.
+ */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering;
+
+/**
+ An `NSNumber` object containing an integer; specifies the minimum zoom level at
+ which to create vector tiles. The default value is 0.
+
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-minzoom"><code>minzoom</code></a>
+ source property in the Mapbox Style Specification.
+ */
+extern const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel;
+
+/**
+ An `NSNumber` object containing an integer; specifies the maximum zoom level at
+ which to create vector tiles. A greater value produces greater detail at high
+ zoom levels. The default value is 18.
+ 
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-maxzoom"><code>maxzoom</code></a>
+ source property in the Mapbox Style Specification.
+ */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel;
+
+/**
+ An `NSNumber` object containing an integer; specifies the size of the tile
+ buffer on each side. A value of 0 produces no buffer. A value of 512 produces a
+ buffer as wide as the tile itself. Larger values produce fewer rendering
+ artifacts near tile edges and slower performance. The default value is 128.
+ 
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-buffer"><code>buffer</code></a>
+ source property in the Mapbox Style Specification.
+ */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
+
+/**
+ An `NSNumber` object containing a double; specifies the Douglas-Peucker
+ simplification tolerance. A greater value produces simpler geometries and
+ improves performance. The default value is 0.375.
+ 
+ This attribute corresponds to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-tolerance"><code>tolerance</code></a>
+ source property in the Mapbox Style Specification.
+ */
+extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
+
+/**
+ `MGLAbstractShapeSource` is an abstract base class for map content sources that
+ supply vector shapes to be shown on the map. A shape source is added to an
+ `MGLStyle` object along with an `MGLVectorStyleLayer` object. The vector style
+ layer defines the appearance of any content supplied by the shape source.
+
+ 
+ Do not create instances of this class directly, and do not create your own
+ subclasses of this class. Instead, create instances of `MGLShapeSource` or
+ `MGLComputedShapeSource`.
+ */
+MGL_EXPORT
+@interface MGLAbstractShapeSource : MGLSource
+
+
+@end

--- a/platform/darwin/src/MGLAbstractShapeSource.mm
+++ b/platform/darwin/src/MGLAbstractShapeSource.mm
@@ -1,0 +1,81 @@
+#import "MGLAbstractShapeSource.h"
+#import "MGLAbstractShapeSource_Private.h"
+
+const MGLShapeSourceOption MGLShapeSourceOptionBuffer = @"MGLShapeSourceOptionBuffer";
+const MGLShapeSourceOption MGLShapeSourceOptionClusterRadius = @"MGLShapeSourceOptionClusterRadius";
+const MGLShapeSourceOption MGLShapeSourceOptionClustered = @"MGLShapeSourceOptionClustered";
+const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel = @"MGLShapeSourceOptionMaximumZoomLevel";
+const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering = @"MGLShapeSourceOptionMaximumZoomLevelForClustering";
+const MGLShapeSourceOption MGLShapeSourceOptionMinimumZoomLevel = @"MGLShapeSourceOptionMinimumZoomLevel";
+const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLShapeSourceOptionSimplificationTolerance";
+
+@interface MGLAbstractShapeSource ()
+
+@end
+
+@implementation MGLAbstractShapeSource
+
+@end
+
+mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NS_DICTIONARY_OF(MGLShapeSourceOption, id) *options) {
+    auto geoJSONOptions = mbgl::style::GeoJSONOptions();
+
+    if (NSNumber *value = options[MGLShapeSourceOptionMinimumZoomLevel]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionMaximumZoomLevel must be an NSNumber."];
+        }
+        geoJSONOptions.minzoom = value.integerValue;
+    }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionMaximumZoomLevel]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionMaximumZoomLevel must be an NSNumber."];
+        }
+        geoJSONOptions.maxzoom = value.integerValue;
+    }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionBuffer]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionBuffer must be an NSNumber."];
+        }
+        geoJSONOptions.buffer = value.integerValue;
+    }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionSimplificationTolerance]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionSimplificationTolerance must be an NSNumber."];
+        }
+        geoJSONOptions.tolerance = value.doubleValue;
+    }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionClusterRadius]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionClusterRadius must be an NSNumber."];
+        }
+        geoJSONOptions.clusterRadius = value.integerValue;
+    }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionMaximumZoomLevelForClustering]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionMaximumZoomLevelForClustering must be an NSNumber."];
+        }
+        geoJSONOptions.clusterMaxZoom = value.integerValue;
+    }
+
+    if (NSNumber *value = options[MGLShapeSourceOptionClustered]) {
+        if (![value isKindOfClass:[NSNumber class]]) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"MGLShapeSourceOptionClustered must be an NSNumber."];
+        }
+        geoJSONOptions.cluster = value.boolValue;
+    }
+
+    return geoJSONOptions;
+}
+

--- a/platform/darwin/src/MGLAbstractShapeSource_Private.h
+++ b/platform/darwin/src/MGLAbstractShapeSource_Private.h
@@ -1,0 +1,18 @@
+#import "MGLAbstractShapeSource.h"
+
+#import "MGLFoundation.h"
+#import "MGLTypes.h"
+#import "MGLShape.h"
+
+#include <mbgl/style/sources/geojson_source.hpp>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MGLAbstractShapeSource (Private)
+
+MGL_EXPORT
+
+mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NS_DICTIONARY_OF(MGLShapeSourceOption, id) *options);
+
+@end
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLComputedShapeSource.h
+++ b/platform/darwin/src/MGLComputedShapeSource.h
@@ -1,0 +1,77 @@
+#import "MGLAbstractShapeSource.h"
+
+#import "MGLFoundation.h"
+#import "MGLGeometry.h"
+#import "MGLTypes.h"
+#import "MGLShape.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MGLFeature;
+
+/**
+ Data source for `MGLComputedShapeSource`. This protocol defines two optional methods for fetching
+ data, one based on tile coordinates, and one based on a bounding box. Classes that implement this
+ protocol must implement one, and only one of the methods.
+ */
+@protocol MGLComputedShapeSourceDataSource <NSObject>
+
+@optional
+/**
+ Fetch features for a tile. This will not be called on the main queue, it will be called on the caller's requestQueue.
+ @param x tile X coordinate
+ @param y tile Y coordinate
+ @param zoomLevel tile zoom level
+ */
+- (NSArray<MGLShape <MGLFeature> *>*)featuresInTileAtX:(NSUInteger)x y:(NSUInteger)y zoomLevel:(NSUInteger)zoomLevel;
+
+/**
+ Fetch features for a tile. This will not be called on the main queue, it will be called on the caller's requestQueue.
+ @param bounds The bounds to fetch data for
+ @param zoomLevel tile zoom level
+ */
+- (NSArray<MGLShape <MGLFeature> *>*)featuresInCoordinateBounds:(MGLCoordinateBounds)bounds zoomLevel:(NSUInteger)zoomLevel;
+
+@end
+
+/**
+ A source for vector data that is fetched one tile at a time. Useful for sources that are
+ too large to fit in memory, or are already divided into tiles, but not in Mapbox Vector Tile format.
+ */
+MGL_EXPORT
+@interface MGLComputedShapeSource : MGLAbstractShapeSource
+
+/**
+ Returns a custom vector data source initialized with an identifier, data source, and a
+ dictionary of options for the source according to the
+ <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson">style
+ specification</a>.
+
+ @param identifier A string that uniquely identifies the source.
+ @param options An `NSDictionary` of options for this source.
+ */
+- (instancetype)initWithIdentifier:(NSString *)identifier options:(nullable NS_DICTIONARY_OF(MGLShapeSourceOption, id) *)options NS_DESIGNATED_INITIALIZER;
+
+/**
+ Request that the source reloads a region.
+ */
+- (void)reloadTileInCoordinateBounds:(MGLCoordinateBounds)bounds zoomLevel:(NSUInteger)zoomLevel;
+
+/**
+ Reload all tiles.
+ */
+- (void)reloadData;
+
+/**
+ An object that implements the `MGLComputedShapeSource` protocol that will be queried for tile data.
+ */
+@property (nonatomic, weak, nullable) id<MGLComputedShapeSourceDataSource> dataSource;
+
+/**
+ A queue that calls to the data source will be made on.
+ */
+@property (nonatomic, readonly) NSOperationQueue *requestQueue;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/src/MGLComputedShapeSource.mm
+++ b/platform/darwin/src/MGLComputedShapeSource.mm
@@ -1,0 +1,180 @@
+#import "MGLComputedShapeSource.h"
+
+#import "MGLMapView_Private.h"
+#import "MGLSource_Private.h"
+#import "MGLShape_Private.h"
+#import "MGLAbstractShapeSource_Private.h"
+#import "MGLGeometry_Private.h"
+
+#include <mbgl/map/map.hpp>
+#include <mbgl/style/sources/custom_vector_source.hpp>
+#include <mbgl/tile/tile_id.hpp>
+#include <mbgl/util/geo.hpp>
+#include <mbgl/util/geojson.hpp>
+
+@interface MGLComputedShapeSource () {
+    std::unique_ptr<mbgl::style::CustomVectorSource> _pendingSource;
+}
+
+@property (nonatomic, readwrite) NSDictionary *options;
+@property (nonnull) mbgl::style::CustomVectorSource *rawSource;
+@property (nonatomic, assign) BOOL dataSourceImplementsFeaturesForTile;
+@property (nonatomic, assign) BOOL dataSourceImplementsFeaturesForBounds;
+
+@end
+
+@interface MGLComputedShapeSourceFetchOperation : NSOperation
+
+@property (nonatomic, readonly) uint8_t z;
+@property (nonatomic, readonly) uint32_t x;
+@property (nonatomic, readonly) uint32_t y;
+@property (nonatomic, assign) BOOL dataSourceImplementsFeaturesForTile;
+@property (nonatomic, assign) BOOL dataSourceImplementsFeaturesForBounds;
+@property (nonatomic, weak, nullable) id<MGLComputedShapeSourceDataSource> dataSource;
+@property (nonatomic, nullable) mbgl::style::CustomVectorSource *rawSource;
+
+- (instancetype)initForSource:(MGLComputedShapeSource*)source tile:(const mbgl::CanonicalTileID&)tileId;
+
+@end
+
+@implementation MGLComputedShapeSourceFetchOperation
+
+- (instancetype)initForSource:(MGLComputedShapeSource*)source tile:(const mbgl::CanonicalTileID&)tileID {
+    self = [super init];
+    _z = tileID.z;
+    _x = tileID.x;
+    _y = tileID.y;
+    _dataSourceImplementsFeaturesForTile = source.dataSourceImplementsFeaturesForTile;
+    _dataSourceImplementsFeaturesForBounds = source.dataSourceImplementsFeaturesForBounds;
+    _dataSource = source.dataSource;
+    mbgl::style::CustomVectorSource *rawSource = (mbgl::style::CustomVectorSource *)source.rawSource;
+    _rawSource = rawSource;
+    return self;
+}
+
+- (void)main {
+    if ([self isCancelled]) {
+        return;
+    }
+
+    NSArray<MGLShape <MGLFeature> *> *data;
+    if(!self.dataSource) {
+        data = nil;
+    } else if(self.dataSourceImplementsFeaturesForTile) {
+        data = [self.dataSource featuresInTileAtX:self.x
+                                                y:self.y
+                                        zoomLevel:self.z];
+    } else {
+        mbgl::CanonicalTileID tileID = mbgl::CanonicalTileID(self.z, self.x, self.y);
+        mbgl::LatLngBounds tileBounds = mbgl::LatLngBounds(tileID);
+        data = [self.dataSource featuresInCoordinateBounds:MGLCoordinateBoundsFromLatLngBounds(tileBounds)
+                                                 zoomLevel:self.z];
+    }
+
+    if(![self isCancelled]) {
+        mbgl::FeatureCollection featureCollection;
+        featureCollection.reserve(data.count);
+        for (MGLShape <MGLFeature> * feature in data) {
+            mbgl::Feature geoJsonObject = [feature geoJSONObject].get<mbgl::Feature>();
+            featureCollection.push_back(geoJsonObject);
+        }
+        const auto geojson = mbgl::GeoJSON{featureCollection};
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            if(![self isCancelled] && self.rawSource) {
+                self.rawSource->setTileData(mbgl::CanonicalTileID(self.z, self.x, self.y), geojson);
+            }
+        });
+    }
+}
+
+- (void)cancel {
+    [super cancel];
+    self.rawSource = NULL;
+}
+
+@end
+
+@implementation MGLComputedShapeSource
+
+- (instancetype)initWithIdentifier:(NSString *)identifier options:(NS_DICTIONARY_OF(MGLShapeSourceOption, id) *)options {
+    if (self = [super initWithIdentifier:identifier]) {
+        _requestQueue = [[NSOperationQueue alloc] init];
+        self.requestQueue.name = [NSString stringWithFormat:@"mgl.MGLComputedShapeSource.%@", identifier];
+        auto geoJSONOptions = MGLGeoJSONOptionsFromDictionary(options);
+        auto source = std::make_unique<mbgl::style::CustomVectorSource>
+        (self.identifier.UTF8String, geoJSONOptions,
+         ^void(const mbgl::CanonicalTileID& tileID)
+         {
+             NSOperation *operation = [[MGLComputedShapeSourceFetchOperation alloc] initForSource:self tile:tileID];
+             [self.requestQueue addOperation:operation];
+         });
+
+        _pendingSource = std::move(source);
+        self.rawSource = _pendingSource.get();
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [self.requestQueue cancelAllOperations];
+}
+
+- (void)setDataSource:(id<MGLComputedShapeSourceDataSource>)dataSource {
+    [self.requestQueue cancelAllOperations];
+    // Check which method the datasource implements, to avoid having to check for each tile
+    self.dataSourceImplementsFeaturesForTile = [dataSource respondsToSelector:@selector(featuresInTileAtX:y:zoomLevel:)];
+    self.dataSourceImplementsFeaturesForBounds = [dataSource respondsToSelector:@selector(featuresInCoordinateBounds:zoomLevel:)];
+
+    if(!self.dataSourceImplementsFeaturesForBounds && !self.dataSourceImplementsFeaturesForTile) {
+        [NSException raise:@"Invalid Datasource" format:@"Datasource does not implement any MGLComputedShapeSourceDataSource methods"];
+    } else if(self.dataSourceImplementsFeaturesForBounds && self.dataSourceImplementsFeaturesForTile) {
+        [NSException raise:@"Invalid Datasource" format:@"Datasource implements multiple MGLComputedShapeSourceDataSource methods"];
+    }
+
+    _dataSource = dataSource;
+}
+
+- (void)addToMapView:(MGLMapView *)mapView {
+    if (_pendingSource == nullptr) {
+        [NSException raise:@"MGLRedundantSourceException"
+                    format:@"This instance %@ was already added to %@. Adding the same source instance " \
+         "to the style more than once is invalid.", self, mapView.style];
+    }
+
+    mapView.mbglMap->addSource(std::move(_pendingSource));
+}
+
+- (void)removeFromMapView:(MGLMapView *)mapView {
+    [self.requestQueue cancelAllOperations];
+    if (self.rawSource != mapView.mbglMap->getSource(self.identifier.UTF8String)) {
+        return;
+    }
+
+    auto removedSource = mapView.mbglMap->removeSource(self.identifier.UTF8String);
+
+    mbgl::style::CustomVectorSource *source = dynamic_cast<mbgl::style::CustomVectorSource *>(removedSource.get());
+    if (!source) {
+        return;
+    }
+
+    removedSource.release();
+
+    _pendingSource = std::unique_ptr<mbgl::style::CustomVectorSource>(source);
+    self.rawSource = _pendingSource.get();
+}
+
+- (void)reloadTileInCoordinateBounds:(MGLCoordinateBounds)bounds zoomLevel:(NSUInteger)zoomLevel {
+    self.rawSource->reloadRegion(MGLLatLngBoundsFromCoordinateBounds(bounds), (uint8_t)zoomLevel);
+}
+
+- (void)setNeedsUpdateAtZoomLevel:(NSUInteger)z x:(NSUInteger)x y:(NSUInteger)y {
+    mbgl::CanonicalTileID tileID = mbgl::CanonicalTileID((uint8_t)z, (uint32_t)x, (uint32_t)y);
+    self.rawSource->reloadTile(tileID);
+}
+
+- (void)reloadData {
+    [self.requestQueue cancelAllOperations];
+    self.rawSource->reload();
+}
+
+@end

--- a/platform/darwin/src/MGLShapeSource.h
+++ b/platform/darwin/src/MGLShapeSource.h
@@ -1,4 +1,4 @@
-#import "MGLSource.h"
+#import "MGLAbstractShapeSource.h"
 
 #import "MGLFoundation.h"
 #import "MGLTypes.h"
@@ -12,72 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
  Options for `MGLShapeSource` objects.
  */
 typedef NSString *MGLShapeSourceOption NS_STRING_ENUM;
-
-/**
- An `NSNumber` object containing a Boolean enabling or disabling clustering.
- If the `shape` property contains point shapes, setting this option to
- `YES` clusters the points by radius into groups. The default value is `NO`.
-
- This attribute corresponds to the
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-cluster"><code>cluster</code></a>
- source property in the Mapbox Style Specification.
-
- This option only affects point features within a shape source.
- */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClustered;
-
-/**
- An `NSNumber` object containing an integer; specifies the radius of each
- cluster if clustering is enabled. A value of 512 produces a radius equal to
- the width of a tile. The default value is 50.
- */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionClusterRadius;
-
-/**
- An `NSNumber` object containing an integer; specifies the maximum zoom level at
- which to cluster points if clustering is enabled. Defaults to one zoom level
- less than the value of `MGLShapeSourceOptionMaximumZoomLevel` so that, at the
- maximum zoom level, the shapes are not clustered.
-
- This attribute corresponds to the
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-clusterMaxZoom"><code>clusterMaxZoom</code></a>
- source property in the Mapbox Style Specification.
- */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering;
-
-/**
- An `NSNumber` object containing an integer; specifies the maximum zoom level at
- which to create vector tiles. A greater value produces greater detail at high
- zoom levels. The default value is 18.
-
- This attribute corresponds to the
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-maxzoom"><code>maxzoom</code></a>
- source property in the Mapbox Style Specification.
- */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel;
-
-/**
- An `NSNumber` object containing an integer; specifies the size of the tile
- buffer on each side. A value of 0 produces no buffer. A value of 512 produces a
- buffer as wide as the tile itself. Larger values produce fewer rendering
- artifacts near tile edges and slower performance. The default value is 128.
-
- This attribute corresponds to the
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-buffer"><code>buffer</code></a>
- source property in the Mapbox Style Specification.
- */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionBuffer;
-
-/**
- An `NSNumber` object containing a double; specifies the Douglas-Peucker
- simplification tolerance. A greater value produces simpler geometries and
- improves performance. The default value is 0.375.
-
- This attribute corresponds to the
- <a href="https://www.mapbox.com/mapbox-gl-style-spec/#sources-geojson-tolerance"><code>tolerance</code></a>
- source property in the Mapbox Style Specification.
- */
-extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance;
 
 /**
  `MGLShapeSource` is a map content source that supplies vector shapes to be
@@ -111,7 +45,7 @@ extern MGL_EXPORT const MGLShapeSourceOption MGLShapeSourceOptionSimplificationT
  ```
  */
 MGL_EXPORT
-@interface MGLShapeSource : MGLSource
+@interface MGLShapeSource : MGLAbstractShapeSource
 
 #pragma mark Initializing a Source
 

--- a/platform/darwin/src/MGLShapeSource.mm
+++ b/platform/darwin/src/MGLShapeSource.mm
@@ -1,4 +1,5 @@
 #import "MGLShapeSource_Private.h"
+#import "MGLAbstractShapeSource_Private.h"
 
 #import "MGLMapView_Private.h"
 #import "MGLSource_Private.h"
@@ -11,12 +12,7 @@
 #include <mbgl/map/map.hpp>
 #include <mbgl/style/sources/geojson_source.hpp>
 
-const MGLShapeSourceOption MGLShapeSourceOptionClustered = @"MGLShapeSourceOptionClustered";
-const MGLShapeSourceOption MGLShapeSourceOptionClusterRadius = @"MGLShapeSourceOptionClusterRadius";
-const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevelForClustering = @"MGLShapeSourceOptionMaximumZoomLevelForClustering";
-const MGLShapeSourceOption MGLShapeSourceOptionMaximumZoomLevel = @"MGLShapeSourceOptionMaximumZoomLevel";
-const MGLShapeSourceOption MGLShapeSourceOptionBuffer = @"MGLShapeSourceOptionBuffer";
-const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLShapeSourceOptionSimplificationTolerance";
+
 
 @interface MGLShapeSource ()
 
@@ -148,57 +144,3 @@ const MGLShapeSourceOption MGLShapeSourceOptionSimplificationTolerance = @"MGLSh
 }
 
 @end
-
-mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NS_DICTIONARY_OF(MGLShapeSourceOption, id) *options) {
-    auto geoJSONOptions = mbgl::style::GeoJSONOptions();
-
-    if (NSNumber *value = options[MGLShapeSourceOptionMaximumZoomLevel]) {
-        if (![value isKindOfClass:[NSNumber class]]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"MGLShapeSourceOptionMaximumZoomLevel must be an NSNumber."];
-        }
-        geoJSONOptions.maxzoom = value.integerValue;
-    }
-
-    if (NSNumber *value = options[MGLShapeSourceOptionBuffer]) {
-        if (![value isKindOfClass:[NSNumber class]]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"MGLShapeSourceOptionBuffer must be an NSNumber."];
-        }
-        geoJSONOptions.buffer = value.integerValue;
-    }
-
-    if (NSNumber *value = options[MGLShapeSourceOptionSimplificationTolerance]) {
-        if (![value isKindOfClass:[NSNumber class]]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"MGLShapeSourceOptionSimplificationTolerance must be an NSNumber."];
-        }
-        geoJSONOptions.tolerance = value.doubleValue;
-    }
-
-    if (NSNumber *value = options[MGLShapeSourceOptionClusterRadius]) {
-        if (![value isKindOfClass:[NSNumber class]]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"MGLShapeSourceOptionClusterRadius must be an NSNumber."];
-        }
-        geoJSONOptions.clusterRadius = value.integerValue;
-    }
-
-    if (NSNumber *value = options[MGLShapeSourceOptionMaximumZoomLevelForClustering]) {
-        if (![value isKindOfClass:[NSNumber class]]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"MGLShapeSourceOptionMaximumZoomLevelForClustering must be an NSNumber."];
-        }
-        geoJSONOptions.clusterMaxZoom = value.integerValue;
-    }
-
-    if (NSNumber *value = options[MGLShapeSourceOptionClustered]) {
-        if (![value isKindOfClass:[NSNumber class]]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"MGLShapeSourceOptionClustered must be an NSNumber."];
-        }
-        geoJSONOptions.cluster = value.boolValue;
-    }
-
-    return geoJSONOptions;
-}

--- a/platform/darwin/src/MGLShapeSource_Private.h
+++ b/platform/darwin/src/MGLShapeSource_Private.h
@@ -16,7 +16,4 @@ namespace mbgl {
 
 @end
 
-MGL_EXPORT
-mbgl::style::GeoJSONOptions MGLGeoJSONOptionsFromDictionary(NS_DICTIONARY_OF(MGLShapeSourceOption, id) *options);
-
 NS_ASSUME_NONNULL_END

--- a/platform/darwin/test/MGLComputedShapeSourceTests.m
+++ b/platform/darwin/test/MGLComputedShapeSourceTests.m
@@ -1,0 +1,25 @@
+#import <XCTest/XCTest.h>
+
+#import <Mapbox/Mapbox.h>
+
+
+@interface MGLComputedShapeSourceTests : XCTestCase
+@end
+
+@implementation MGLComputedShapeSourceTests
+
+- (void)testInitializer {
+    MGLComputedShapeSource *source = [[MGLComputedShapeSource alloc] initWithIdentifier:@"id"
+                                                                                options:@{}];
+    XCTAssertNotNil(source);
+    XCTAssertNotNil(source.requestQueue);
+    XCTAssertNil(source.dataSource);
+}
+
+- (void)testNilOptions {
+    MGLComputedShapeSource *source = [[MGLComputedShapeSource alloc] initWithIdentifier:@"id" options:nil];
+    XCTAssertNotNil(source);
+}
+
+
+@end

--- a/platform/darwin/test/MGLShapeSourceTests.mm
+++ b/platform/darwin/test/MGLShapeSourceTests.mm
@@ -2,6 +2,7 @@
 
 #import <Mapbox/Mapbox.h>
 #import "MGLFeature_Private.h"
+#import "MGLAbstractShapeSource_Private.h"
 #import "MGLShapeSource_Private.h"
 #import "MGLSource_Private.h"
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ## master
 
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
+* Added `MGLComputedShapeSource` source class that allows applications to supply vector data on a per-tile basis.
 
 ## 3.5.0
 

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -72,6 +72,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsRuntimeStylingRows) {
     MBXSettingsRuntimeStylingCountryLabels,
     MBXSettingsRuntimeStylingRouteLine,
     MBXSettingsRuntimeStylingDDSPolygon,
+    MBXSettingsRuntimeStylingCustomLatLonGrid,
 };
 
 typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
@@ -105,7 +106,8 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
 
 @interface MBXViewController () <UITableViewDelegate,
                                  UITableViewDataSource,
-                                 MGLMapViewDelegate>
+                                 MGLMapViewDelegate,
+                                 MGLComputedShapeSourceDataSource>
 
 
 @property (nonatomic) IBOutlet MGLMapView *mapView;
@@ -342,6 +344,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                 [NSString stringWithFormat:@"Label Countries in %@", (_usingLocaleBasedCountryLabels ? @"Local Language" : [[NSLocale currentLocale] displayNameForKey:NSLocaleIdentifier value:[self bestLanguageForUser]])],
                 @"Add Route Line",
                 @"Dynamically Style Polygon",
+                @"Add Custom Lat/Lon Grid",
             ]];
             break;
         case MBXSettingsMiscellaneous:
@@ -580,6 +583,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                     break;
                 case MBXSettingsRuntimeStylingDDSPolygon:
                     [self stylePolygonWithDDS];
+                    break;
+                case MBXSettingsRuntimeStylingCustomLatLonGrid:
+                    [self addLatLonGrid];
                     break;
                 default:
                     NSAssert(NO, @"All runtime styling setting rows should be implemented");
@@ -1330,6 +1336,21 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     [self.mapView.style addLayer:fillStyleLayer];
 }
 
+- (void)addLatLonGrid
+{
+    MGLComputedShapeSource *source = [[MGLComputedShapeSource alloc] initWithIdentifier:@"latlon"
+                                                                              options:@{MGLShapeSourceOptionMaximumZoomLevel:@14}];
+    source.dataSource = self;
+    [self.mapView.style addSource:source];
+    MGLLineStyleLayer *lineLayer = [[MGLLineStyleLayer alloc] initWithIdentifier:@"latlonlines"
+                                                                          source:source];
+    [self.mapView.style addLayer:lineLayer];
+    MGLSymbolStyleLayer *labelLayer = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"latlonlabels"
+                                                                               source:source];
+    labelLayer.text = [MGLStyleValue valueWithRawValue:@"{value}"];
+    [self.mapView.style addLayer:labelLayer];
+}
+
 - (void)styleLabelLanguageForLayersNamed:(NSArray<NSString *> *)layers
 {
     _usingLocaleBasedCountryLabels = !_usingLocaleBasedCountryLabels;
@@ -1809,6 +1830,54 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     if (self.showZoomLevelEnabled) {
         self.hudLabel.text = [NSString stringWithFormat:@" Zoom: %.2f", self.mapView.zoomLevel];
     }
+}
+
+#pragma mark - MGLComputedShapeSourceDataSource
+
+- (NSArray<id <MGLFeature>>*)featuresInCoordinateBounds:(MGLCoordinateBounds)bounds zoomLevel:(NSUInteger)zoom {
+    double gridSpacing;
+    if(zoom >= 13) {
+        gridSpacing = 0.01;
+    } else if(zoom >= 11) {
+        gridSpacing = 0.05;
+    } else if(zoom == 10) {
+        gridSpacing = .1;
+    } else if(zoom == 9) {
+        gridSpacing = 0.25;
+    } else if(zoom == 8) {
+        gridSpacing = 0.5;
+    } else if (zoom >= 6) {
+        gridSpacing = 1;
+    } else if(zoom == 5) {
+        gridSpacing = 2;
+    } else if(zoom >= 4) {
+        gridSpacing = 5;
+    } else if(zoom == 2) {
+        gridSpacing = 10;
+    } else {
+        gridSpacing = 20;
+    }
+
+    NSMutableArray <id <MGLFeature>> * features = [NSMutableArray array];
+    CLLocationCoordinate2D coords[2];
+
+    for (double y = ceil(bounds.ne.latitude / gridSpacing) * gridSpacing; y >= floor(bounds.sw.latitude / gridSpacing) * gridSpacing; y -= gridSpacing) {
+        coords[0] = CLLocationCoordinate2DMake(y, bounds.sw.longitude);
+        coords[1] = CLLocationCoordinate2DMake(y, bounds.ne.longitude);
+        MGLPolylineFeature *feature = [MGLPolylineFeature polylineWithCoordinates:coords count:2];
+        feature.attributes = @{@"value": @(y)};
+        [features addObject:feature];
+    }
+
+    for (double x = floor(bounds.sw.longitude / gridSpacing) * gridSpacing; x <= ceil(bounds.ne.longitude / gridSpacing) * gridSpacing; x += gridSpacing) {
+        coords[0] = CLLocationCoordinate2DMake(bounds.sw.latitude, x);
+        coords[1] = CLLocationCoordinate2DMake(bounds.ne.latitude, x);
+        MGLPolylineFeature *feature = [MGLPolylineFeature polylineWithCoordinates:coords count:2];
+        feature.attributes = @{@"value": @(x)};
+        [features addObject:feature];
+    }
+
+    return features;
 }
 
 @end

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -190,8 +190,13 @@
 		9221B2F11E6F9D1400A2385E /* query-style.json in Resources */ = {isa = PBXBuildFile; fileRef = 9221B2F01E6F9D1400A2385E /* query-style.json */; };
 		88B079A61E363A7200834FAB /* MGLAbstractShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079A51E36371A00834FAB /* MGLAbstractShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88B079A71E363A7300834FAB /* MGLAbstractShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079A51E36371A00834FAB /* MGLAbstractShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88DDFB291DCB7A9200B53BDD /* MGLComputedShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88F0C0811DC8FD8C002DB7AE /* MGLComputedShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88DDFB2A1DCB7AFC00B53BDD /* MGLComputedShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88F0C0811DC8FD8C002DB7AE /* MGLComputedShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88DDFB2F1DCBC21700B53BDD /* MGLAbstractShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88DDFB2C1DCBC21700B53BDD /* MGLAbstractShapeSource.mm */; };
 		88DDFB301DCBC21700B53BDD /* MGLAbstractShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88DDFB2C1DCBC21700B53BDD /* MGLAbstractShapeSource.mm */; };
+		88EF0E6C1E677358008A6617 /* MGLComputedShapeSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88EF0E6A1E677345008A6617 /* MGLComputedShapeSourceTests.m */; };
+		88F0C0851DC8FD8C002DB7AE /* MGLComputedShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88F0C0821DC8FD8C002DB7AE /* MGLComputedShapeSource.mm */; };
+		88F0C0861DC8FD8C002DB7AE /* MGLComputedShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88F0C0821DC8FD8C002DB7AE /* MGLComputedShapeSource.mm */; };
 		968F36B51E4D128D003A5522 /* MGLDistanceFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3557F7AE1E1D27D300CCA5E6 /* MGLDistanceFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96E027231E57C76E004B8E66 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 96E027251E57C76E004B8E66 /* Localizable.strings */; };
 		DA00FC8E1D5EEB0D009AABC8 /* MGLAttributionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DA00FC8C1D5EEB0D009AABC8 /* MGLAttributionInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -651,6 +656,9 @@
 		88B079A51E36371A00834FAB /* MGLAbstractShapeSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAbstractShapeSource.h; sourceTree = "<group>"; };
 		88DDFB2C1DCBC21700B53BDD /* MGLAbstractShapeSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLAbstractShapeSource.mm; sourceTree = "<group>"; tabWidth = 4; };
 		88DDFB311DCBC36E00B53BDD /* MGLAbstractShapeSource_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLAbstractShapeSource_Private.h; sourceTree = "<group>"; };
+		88EF0E6A1E677345008A6617 /* MGLComputedShapeSourceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLComputedShapeSourceTests.m; path = ../../darwin/test/MGLComputedShapeSourceTests.m; sourceTree = "<group>"; };
+		88F0C0811DC8FD8C002DB7AE /* MGLComputedShapeSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLComputedShapeSource.h; sourceTree = "<group>"; };
+		88F0C0821DC8FD8C002DB7AE /* MGLComputedShapeSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLComputedShapeSource.mm; sourceTree = "<group>"; tabWidth = 4; };
 		9660916B1E5BBFD700A9A03B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9660916C1E5BBFD900A9A03B /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9660916D1E5BBFDB00A9A03B /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -960,6 +968,8 @@
 				350098B91D480108004B2AF0 /* MGLVectorSource.h */,
 				DAF0D8121DFE0EC500B28378 /* MGLVectorSource_Private.h */,
 				350098BA1D480108004B2AF0 /* MGLVectorSource.mm */,
+				88F0C0811DC8FD8C002DB7AE /* MGLComputedShapeSource.h */,
+				88F0C0821DC8FD8C002DB7AE /* MGLComputedShapeSource.mm */,
 				88DDFB311DCBC36E00B53BDD /* MGLAbstractShapeSource_Private.h */,
 				88B079A51E36371A00834FAB /* MGLAbstractShapeSource.h */,
 				88DDFB2C1DCBC21700B53BDD /* MGLAbstractShapeSource.mm */,
@@ -1072,6 +1082,7 @@
 			children = (
 				40CFA6501D787579008103BD /* MGLShapeSourceTests.mm */,
 				920A3E5C1E6F995200C16EFC /* MGLSourceQueryTests.m */,
+				88EF0E6A1E677345008A6617 /* MGLComputedShapeSourceTests.m */,
 				4085AF081D933DEA00F11B22 /* MGLTileSetTests.mm */,
 			);
 			name = Sources;
@@ -1648,6 +1659,7 @@
 				DA8848871CBB033F00AB86E3 /* Fabric.h in Headers */,
 				35305D4A1D22AA6A0007D005 /* NSData+MGLAdditions.h in Headers */,
 				359F57461D2FDDA6005217F1 /* MGLUserLocationAnnotationView_Private.h in Headers */,
+				88DDFB2A1DCB7AFC00B53BDD /* MGLComputedShapeSource.h in Headers */,
 				404C26E21D89B877000AA13D /* MGLTileSource.h in Headers */,
 				DA8848841CBB033F00AB86E3 /* FABAttributes.h in Headers */,
 				DA8847FD1CBAFA5100AB86E3 /* MGLTilePyramidOfflineRegion.h in Headers */,
@@ -1670,6 +1682,7 @@
 				DA35A2CA1CCAAAD200E826B2 /* NSValue+MGLAdditions.h in Headers */,
 				350098BC1D480108004B2AF0 /* MGLVectorSource.h in Headers */,
 				353933FC1D3FB7C0003F57D7 /* MGLRasterStyleLayer.h in Headers */,
+				88DDFB291DCB7A9200B53BDD /* MGLComputedShapeSource.h in Headers */,
 				3566C76D1D4A8DFA008152BC /* MGLRasterSource.h in Headers */,
 				DAED38641D62D0FC00D7640F /* NSURL+MGLAdditions.h in Headers */,
 				DABFB85E1CBE99E500D62B32 /* MGLAnnotation.h in Headers */,
@@ -2079,6 +2092,7 @@
 				3598544D1E1D38AA00B29F84 /* MGLDistanceFormatterTests.m in Sources */,
 				DA2DBBCE1D51E80400D38FF9 /* MGLStyleLayerTests.m in Sources */,
 				DA35A2C61CCA9F8300E826B2 /* MGLCompassDirectionFormatterTests.m in Sources */,
+				88EF0E6C1E677358008A6617 /* MGLComputedShapeSourceTests.m in Sources */,
 				DAE7DEC21E245455007505A6 /* MGLNSStringAdditionsTests.m in Sources */,
 				4085AF091D933DEA00F11B22 /* MGLTileSetTests.mm in Sources */,
 				DAEDC4341D603417000224FF /* MGLAttributionInfoTests.m in Sources */,
@@ -2117,6 +2131,7 @@
 				30E578191DAA855E0050F07E /* UIImage+MGLAdditions.mm in Sources */,
 				40EDA1C11CFE0E0500D9EA68 /* MGLAnnotationContainerView.m in Sources */,
 				DA8848541CBAFB9800AB86E3 /* MGLCompactCalloutView.m in Sources */,
+				88F0C0851DC8FD8C002DB7AE /* MGLComputedShapeSource.mm in Sources */,
 				DA8848251CBAFA6200AB86E3 /* MGLPointAnnotation.mm in Sources */,
 				35136D3C1D42272500C20EFD /* MGLCircleStyleLayer.mm in Sources */,
 				350098DE1D484E60004B2AF0 /* NSValue+MGLStyleAttributeAdditions.mm in Sources */,
@@ -2195,6 +2210,7 @@
 				30E5781A1DAA855E0050F07E /* UIImage+MGLAdditions.mm in Sources */,
 				40EDA1C21CFE0E0500D9EA68 /* MGLAnnotationContainerView.m in Sources */,
 				DAA4E4291CBB730400178DFB /* NSBundle+MGLAdditions.m in Sources */,
+				88F0C0861DC8FD8C002DB7AE /* MGLComputedShapeSource.mm in Sources */,
 				DAA4E42E1CBB730400178DFB /* MGLAPIClient.m in Sources */,
 				35136D3D1D42272500C20EFD /* MGLCircleStyleLayer.mm in Sources */,
 				350098DF1D484E60004B2AF0 /* NSValue+MGLStyleAttributeAdditions.mm in Sources */,

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -188,6 +188,10 @@
 		7E016D871D9E890300A29A21 /* MGLPolygon+MGLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E016D831D9E890300A29A21 /* MGLPolygon+MGLAdditions.m */; };
 		920A3E5D1E6F995200C16EFC /* MGLSourceQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 920A3E5C1E6F995200C16EFC /* MGLSourceQueryTests.m */; };
 		9221B2F11E6F9D1400A2385E /* query-style.json in Resources */ = {isa = PBXBuildFile; fileRef = 9221B2F01E6F9D1400A2385E /* query-style.json */; };
+		88B079A61E363A7200834FAB /* MGLAbstractShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079A51E36371A00834FAB /* MGLAbstractShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88B079A71E363A7300834FAB /* MGLAbstractShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079A51E36371A00834FAB /* MGLAbstractShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88DDFB2F1DCBC21700B53BDD /* MGLAbstractShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88DDFB2C1DCBC21700B53BDD /* MGLAbstractShapeSource.mm */; };
+		88DDFB301DCBC21700B53BDD /* MGLAbstractShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88DDFB2C1DCBC21700B53BDD /* MGLAbstractShapeSource.mm */; };
 		968F36B51E4D128D003A5522 /* MGLDistanceFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3557F7AE1E1D27D300CCA5E6 /* MGLDistanceFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96E027231E57C76E004B8E66 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 96E027251E57C76E004B8E66 /* Localizable.strings */; };
 		DA00FC8E1D5EEB0D009AABC8 /* MGLAttributionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DA00FC8C1D5EEB0D009AABC8 /* MGLAttributionInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -644,6 +648,9 @@
 		7E016D831D9E890300A29A21 /* MGLPolygon+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MGLPolygon+MGLAdditions.m"; sourceTree = "<group>"; };
 		920A3E5C1E6F995200C16EFC /* MGLSourceQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLSourceQueryTests.m; path = ../../darwin/test/MGLSourceQueryTests.m; sourceTree = "<group>"; };
 		9221B2F01E6F9D1400A2385E /* query-style.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "query-style.json"; path = "../../darwin/test/query-style.json"; sourceTree = "<group>"; };
+		88B079A51E36371A00834FAB /* MGLAbstractShapeSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAbstractShapeSource.h; sourceTree = "<group>"; };
+		88DDFB2C1DCBC21700B53BDD /* MGLAbstractShapeSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLAbstractShapeSource.mm; sourceTree = "<group>"; tabWidth = 4; };
+		88DDFB311DCBC36E00B53BDD /* MGLAbstractShapeSource_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MGLAbstractShapeSource_Private.h; sourceTree = "<group>"; };
 		9660916B1E5BBFD700A9A03B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9660916C1E5BBFD900A9A03B /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9660916D1E5BBFDB00A9A03B /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -953,6 +960,9 @@
 				350098B91D480108004B2AF0 /* MGLVectorSource.h */,
 				DAF0D8121DFE0EC500B28378 /* MGLVectorSource_Private.h */,
 				350098BA1D480108004B2AF0 /* MGLVectorSource.mm */,
+				88DDFB311DCBC36E00B53BDD /* MGLAbstractShapeSource_Private.h */,
+				88B079A51E36371A00834FAB /* MGLAbstractShapeSource.h */,
+				88DDFB2C1DCBC21700B53BDD /* MGLAbstractShapeSource.mm */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -1586,6 +1596,7 @@
 				DD0902AB1DB192A800C5BDCE /* MGLNetworkConfiguration.h in Headers */,
 				DA8848571CBAFB9800AB86E3 /* MGLMapboxEvents.h in Headers */,
 				DA8848311CBAFA6200AB86E3 /* NSString+MGLAdditions.h in Headers */,
+				88B079A61E363A7200834FAB /* MGLAbstractShapeSource.h in Headers */,
 				353933F81D3FB79F003F57D7 /* MGLLineStyleLayer.h in Headers */,
 				DAAF722D1DA903C700312FA4 /* MGLStyleValue_Private.h in Headers */,
 				DA8847F41CBAFA5100AB86E3 /* MGLOfflinePack.h in Headers */,
@@ -1706,6 +1717,7 @@
 				40F887711D7A1E59008ECB67 /* MGLShapeSource_Private.h in Headers */,
 				DABFB8631CBE99E500D62B32 /* MGLOfflineRegion.h in Headers */,
 				DA35A2B21CCA141D00E826B2 /* MGLCompassDirectionFormatter.h in Headers */,
+				88B079A71E363A7300834FAB /* MGLAbstractShapeSource.h in Headers */,
 				DAF0D8141DFE0EC500B28378 /* MGLVectorSource_Private.h in Headers */,
 				DABFB8731CBE9A9900D62B32 /* Mapbox.h in Headers */,
 				357FE2DE1E02D2B20068B753 /* NSCoder+MGLAdditions.h in Headers */,
@@ -2136,6 +2148,7 @@
 				DA8848321CBAFA6200AB86E3 /* NSString+MGLAdditions.m in Sources */,
 				408AA8581DAEDA1E00022900 /* NSDictionary+MGLAdditions.mm in Sources */,
 				DA35A2A11CC9E95F00E826B2 /* MGLCoordinateFormatter.m in Sources */,
+				88DDFB2F1DCBC21700B53BDD /* MGLAbstractShapeSource.mm in Sources */,
 				35305D481D22AA680007D005 /* NSData+MGLAdditions.mm in Sources */,
 				DA8848291CBAFA6200AB86E3 /* MGLStyle.mm in Sources */,
 				357FE2DF1E02D2B20068B753 /* NSCoder+MGLAdditions.mm in Sources */,
@@ -2213,6 +2226,7 @@
 				DA35A2CC1CCAAAD200E826B2 /* NSValue+MGLAdditions.m in Sources */,
 				408AA8591DAEDA1E00022900 /* NSDictionary+MGLAdditions.mm in Sources */,
 				DAA4E4281CBB730400178DFB /* MGLTypes.m in Sources */,
+				88DDFB301DCBC21700B53BDD /* MGLAbstractShapeSource.mm in Sources */,
 				DA35A2A21CC9E95F00E826B2 /* MGLCoordinateFormatter.m in Sources */,
 				35305D491D22AA680007D005 /* NSData+MGLAdditions.mm in Sources */,
 				357FE2E01E02D2B20068B753 /* NSCoder+MGLAdditions.mm in Sources */,

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -72,6 +72,7 @@ custom_categories:
     children:
       - MGLSource
       - MGLTileSource
+      - MGLAbstractShapeSource
       - MGLShapeSource
       - MGLRasterSource
       - MGLVectorSource

--- a/platform/ios/jazzy.yml
+++ b/platform/ios/jazzy.yml
@@ -74,6 +74,7 @@ custom_categories:
       - MGLTileSource
       - MGLAbstractShapeSource
       - MGLShapeSource
+      - MGLComputedShapeSource
       - MGLRasterSource
       - MGLVectorSource
   - name: Style Layers

--- a/platform/ios/src/Mapbox.h
+++ b/platform/ios/src/Mapbox.h
@@ -49,6 +49,7 @@ FOUNDATION_EXPORT MGL_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLTileSource.h"
 #import "MGLVectorSource.h"
 #import "MGLShapeSource.h"
+#import "MGLAbstractShapeSource.h"
 #import "MGLRasterSource.h"
 #import "MGLTilePyramidOfflineRegion.h"
 #import "MGLTypes.h"

--- a/platform/ios/src/Mapbox.h
+++ b/platform/ios/src/Mapbox.h
@@ -50,6 +50,7 @@ FOUNDATION_EXPORT MGL_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLVectorSource.h"
 #import "MGLShapeSource.h"
 #import "MGLAbstractShapeSource.h"
+#import "MGLComputedShapeSource.h"
 #import "MGLRasterSource.h"
 #import "MGLTilePyramidOfflineRegion.h"
 #import "MGLTypes.h"

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
+* Added `MGLComputedShapeSource` source class that allows applications to supply vector data on a per-tile basis.
 
 ## 0.4.0
 

--- a/platform/macos/app/Base.lproj/MainMenu.xib
+++ b/platform/macos/app/Base.lproj/MainMenu.xib
@@ -544,6 +544,12 @@
                                     <action selector="insertCustomStyleLayer:" target="-1" id="LE5-lz-kx3"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Add Graticule" id="Msk-p2-Lwt">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="insertGraticuleLayer:" target="-1" id="LE5-lz-kx4"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Show All Annnotations" keyEquivalent="A" id="yMj-uM-8SN">
                                 <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>

--- a/platform/macos/app/MapDocument.m
+++ b/platform/macos/app/MapDocument.m
@@ -49,7 +49,7 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     return flattenedShapes;
 }
 
-@interface MapDocument () <NSWindowDelegate, NSSharingServicePickerDelegate, NSMenuDelegate, NSSplitViewDelegate, MGLMapViewDelegate>
+@interface MapDocument () <NSWindowDelegate, NSSharingServicePickerDelegate, NSMenuDelegate, NSSplitViewDelegate, MGLMapViewDelegate, MGLComputedShapeSourceDataSource>
 
 @property (weak) IBOutlet NSArrayController *styleLayersArrayController;
 @property (weak) IBOutlet NSTableView *styleLayersTableView;
@@ -639,6 +639,47 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     [self.mapView.style removeLayer:layer];
 }
 
+- (IBAction)insertGraticuleLayer:(id)sender {
+    [self.undoManager registerUndoWithTarget:self handler:^(id  _Nonnull target) {
+        [self removeGraticuleLayer:sender];
+    }];
+
+    if (!self.undoManager.isUndoing) {
+        [self.undoManager setActionName:@"Add Graticule Layer"];
+    }
+
+    MGLComputedShapeSource *source = [[MGLComputedShapeSource alloc] initWithIdentifier:@"graticule"
+                                                                                options:@{MGLShapeSourceOptionMaximumZoomLevel:@14}];
+    source.dataSource = self;
+    [self.mapView.style addSource:source];
+    MGLLineStyleLayer *lineLayer = [[MGLLineStyleLayer alloc] initWithIdentifier:@"graticule.lines"
+                                                                          source:source];
+    [self.mapView.style addLayer:lineLayer];
+    MGLSymbolStyleLayer *labelLayer = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"graticule.labels"
+                                                                               source:source];
+    labelLayer.text = [MGLStyleValue valueWithRawValue:@"{value}"];
+    [self.mapView.style addLayer:labelLayer];
+}
+
+- (IBAction)removeGraticuleLayer:(id)sender {
+    [self.undoManager registerUndoWithTarget:self handler:^(id  _Nonnull target) {
+        [self insertGraticuleLayer:sender];
+    }];
+
+    if (!self.undoManager.isUndoing) {
+        [self.undoManager setActionName:@"Delete Graticule Layer"];
+    }
+
+    MGLStyleLayer *layer = [self.mapView.style layerWithIdentifier:@"graticule.lines"];
+    [self.mapView.style removeLayer:layer];
+
+    layer = [self.mapView.style layerWithIdentifier:@"graticule.labels"];
+    [self.mapView.style removeLayer:layer];
+
+    MGLSource *source = [self.mapView.style sourceWithIdentifier:@"graticule"];
+    [self.mapView.style removeSource:source];
+}
+
 #pragma mark Offline packs
 
 - (IBAction)addOfflinePack:(id)sender {
@@ -926,6 +967,9 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
     if (menuItem.action == @selector(insertCustomStyleLayer:)) {
         return ![self.mapView.style layerWithIdentifier:@"mbx-custom"];
     }
+    if (menuItem.action == @selector(insertGraticuleLayer:)) {
+        return ![self.mapView.style sourceWithIdentifier:@"graticule"];
+    }
     if (menuItem.action == @selector(showAllAnnotations:) || menuItem.action == @selector(removeAllAnnotations:)) {
         return self.mapView.annotations.count > 0;
     }
@@ -1093,6 +1137,53 @@ NS_ARRAY_OF(id <MGLAnnotation>) *MBXFlattenedShapes(NS_ARRAY_OF(id <MGLAnnotatio
 
 - (CGFloat)mapView:(MGLMapView *)mapView alphaForShapeAnnotation:(MGLShape *)annotation {
     return 0.8;
+}
+
+#pragma mark - MGLComputedShapeSourceDataSource
+- (NSArray<id <MGLFeature>>*)featuresInCoordinateBounds:(MGLCoordinateBounds)bounds zoomLevel:(NSUInteger)zoom {
+    double gridSpacing;
+    if(zoom >= 13) {
+        gridSpacing = 0.01;
+    } else if(zoom >= 11) {
+        gridSpacing = 0.05;
+    } else if(zoom == 10) {
+        gridSpacing = .1;
+    } else if(zoom == 9) {
+        gridSpacing = 0.25;
+    } else if(zoom == 8) {
+        gridSpacing = 0.5;
+    } else if (zoom >= 6) {
+        gridSpacing = 1;
+    } else if(zoom == 5) {
+        gridSpacing = 2;
+    } else if(zoom >= 4) {
+        gridSpacing = 5;
+    } else if(zoom == 2) {
+        gridSpacing = 10;
+    } else {
+        gridSpacing = 20;
+    }
+
+    NSMutableArray <id <MGLFeature>> * features = [NSMutableArray array];
+    CLLocationCoordinate2D coords[2];
+
+    for (double y = ceil(bounds.ne.latitude / gridSpacing) * gridSpacing; y >= floor(bounds.sw.latitude / gridSpacing) * gridSpacing; y -= gridSpacing) {
+        coords[0] = CLLocationCoordinate2DMake(y, bounds.sw.longitude);
+        coords[1] = CLLocationCoordinate2DMake(y, bounds.ne.longitude);
+        MGLPolylineFeature *feature = [MGLPolylineFeature polylineWithCoordinates:coords count:2];
+        feature.attributes = @{@"value": @(y)};
+        [features addObject:feature];
+    }
+
+    for (double x = floor(bounds.sw.longitude / gridSpacing) * gridSpacing; x <= ceil(bounds.ne.longitude / gridSpacing) * gridSpacing; x += gridSpacing) {
+        coords[0] = CLLocationCoordinate2DMake(bounds.sw.latitude, x);
+        coords[1] = CLLocationCoordinate2DMake(bounds.ne.latitude, x);
+        MGLPolylineFeature *feature = [MGLPolylineFeature polylineWithCoordinates:coords count:2];
+        feature.attributes = @{@"value": @(x)};
+        [features addObject:feature];
+    }
+
+    return features;
 }
 
 @end

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -59,6 +59,7 @@ custom_categories:
     children:
       - MGLSource
       - MGLTileSource
+      - MGLAbstractShapeSource
       - MGLShapeSource
       - MGLRasterSource
       - MGLVectorSource

--- a/platform/macos/jazzy.yml
+++ b/platform/macos/jazzy.yml
@@ -61,6 +61,7 @@ custom_categories:
       - MGLTileSource
       - MGLAbstractShapeSource
       - MGLShapeSource
+      - MGLComputedShapeSource
       - MGLRasterSource
       - MGLVectorSource
   - name: Style Layers

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -72,9 +72,12 @@
 		55E2AD111E5B0A6900E8C587 /* MGLOfflineStorageTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 55E2AD101E5B0A6900E8C587 /* MGLOfflineStorageTests.mm */; };
 		920A3E591E6F859D00C16EFC /* MGLSourceQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 920A3E581E6F859D00C16EFC /* MGLSourceQueryTests.m */; };
 		920A3E5B1E6F8E0700C16EFC /* query-style.json in Resources */ = {isa = PBXBuildFile; fileRef = 920A3E5A1E6F8E0700C16EFC /* query-style.json */; };
+		8877024C1E37977D0097E255 /* MGLComputedShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88B079B01E3794F300834FAB /* MGLComputedShapeSource.mm */; };
 		88B079AC1E37941300834FAB /* MGLAbstractShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88B079AA1E3793E000834FAB /* MGLAbstractShapeSource.mm */; };
 		88B079AD1E37942700834FAB /* MGLAbstractShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079A91E3793E000834FAB /* MGLAbstractShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88B079AE1E37943900834FAB /* MGLAbstractShapeSource_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079A81E3793E000834FAB /* MGLAbstractShapeSource_Private.h */; };
+		88B079B21E37957000834FAB /* MGLComputedShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079AF1E3794F300834FAB /* MGLComputedShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88EF0E6F1E6777ED008A6617 /* MGLComputedShapeSourceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88EF0E6D1E6777E8008A6617 /* MGLComputedShapeSourceTests.m */; };
 		96E027311E57C9A7004B8E66 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 96E027331E57C9A7004B8E66 /* Localizable.strings */; };
 		DA00FC8A1D5EEAC3009AABC8 /* MGLAttributionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DA00FC881D5EEAC3009AABC8 /* MGLAttributionInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA00FC8B1D5EEAC3009AABC8 /* MGLAttributionInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA00FC891D5EEAC3009AABC8 /* MGLAttributionInfo.mm */; };
@@ -340,6 +343,9 @@
 		88B079A81E3793E000834FAB /* MGLAbstractShapeSource_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAbstractShapeSource_Private.h; sourceTree = "<group>"; };
 		88B079A91E3793E000834FAB /* MGLAbstractShapeSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAbstractShapeSource.h; sourceTree = "<group>"; };
 		88B079AA1E3793E000834FAB /* MGLAbstractShapeSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLAbstractShapeSource.mm; sourceTree = "<group>"; };
+		88B079AF1E3794F300834FAB /* MGLComputedShapeSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLComputedShapeSource.h; sourceTree = "<group>"; };
+		88B079B01E3794F300834FAB /* MGLComputedShapeSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLComputedShapeSource.mm; sourceTree = "<group>"; };
+		88EF0E6D1E6777E8008A6617 /* MGLComputedShapeSourceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLComputedShapeSourceTests.m; sourceTree = "<group>"; };
 		966091701E5BBFF700A9A03B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		966091711E5BBFF900A9A03B /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		966091721E5BBFFA00A9A03B /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -628,6 +634,8 @@
 		3527427E1D4C242B00A1ECE6 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				88B079AF1E3794F300834FAB /* MGLComputedShapeSource.h */,
+				88B079B01E3794F300834FAB /* MGLComputedShapeSource.mm */,
 				352742831D4C244700A1ECE6 /* MGLRasterSource.h */,
 				DA7DC9821DED647F0027472F /* MGLRasterSource_Private.h */,
 				352742841D4C244700A1ECE6 /* MGLRasterSource.mm */,
@@ -735,6 +743,7 @@
 			isa = PBXGroup;
 			children = (
 				DA87A9961DC9D88400810D09 /* MGLShapeSourceTests.mm */,
+				88EF0E6D1E6777E8008A6617 /* MGLComputedShapeSourceTests.m */,
 				DA87A9971DC9D88400810D09 /* MGLTileSetTests.mm */,
 				920A3E581E6F859D00C16EFC /* MGLSourceQueryTests.m */,
 			);
@@ -1116,6 +1125,7 @@
 				DAE6C3A61CC31E9400DB3429 /* MGLMapViewDelegate.h in Headers */,
 				DAE6C38B1CC31E2A00DB3429 /* MGLOfflinePack_Private.h in Headers */,
 				558DE7A61E56161C00C7916D /* MGLFoundation_Private.h in Headers */,
+				88B079B21E37957000834FAB /* MGLComputedShapeSource.h in Headers */,
 				DACC22141CF3D3E200D220D9 /* MGLFeature.h in Headers */,
 				3538AA231D542685008EC33D /* MGLStyleLayer.h in Headers */,
 				DAE6C35C1CC31E0400DB3429 /* MGLGeometry.h in Headers */,
@@ -1401,6 +1411,7 @@
 				35C5D8481D6DD66D00E95907 /* NSComparisonPredicate+MGLAdditions.mm in Sources */,
 				DA35A2AE1CCA091800E826B2 /* MGLCompassDirectionFormatter.m in Sources */,
 				DA8F258C1D51CA540010E6B5 /* MGLLineStyleLayer.mm in Sources */,
+				8877024C1E37977D0097E255 /* MGLComputedShapeSource.mm in Sources */,
 				408AA8691DAEEE5500022900 /* MGLPolyline+MGLAdditions.m in Sources */,
 				DA8F25941D51CA750010E6B5 /* MGLSymbolStyleLayer.mm in Sources */,
 				3529039C1D6C63B80002C7DF /* NSPredicate+MGLAdditions.mm in Sources */,
@@ -1424,6 +1435,7 @@
 				DA87A9A41DCACC5000810D09 /* MGLSymbolStyleLayerTests.mm in Sources */,
 				40E1601D1DF217D6005EA6D9 /* MGLStyleLayerTests.m in Sources */,
 				DA87A9A61DCACC5000810D09 /* MGLCircleStyleLayerTests.mm in Sources */,
+				88EF0E6F1E6777ED008A6617 /* MGLComputedShapeSourceTests.m in Sources */,
 				DA87A99E1DC9DC2100810D09 /* MGLPredicateTests.mm in Sources */,
 				DD58A4C91D822C6700E1F038 /* MGLExpressionTests.mm in Sources */,
 				DA87A9A71DCACC5000810D09 /* MGLBackgroundStyleLayerTests.mm in Sources */,

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -72,6 +72,9 @@
 		55E2AD111E5B0A6900E8C587 /* MGLOfflineStorageTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 55E2AD101E5B0A6900E8C587 /* MGLOfflineStorageTests.mm */; };
 		920A3E591E6F859D00C16EFC /* MGLSourceQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 920A3E581E6F859D00C16EFC /* MGLSourceQueryTests.m */; };
 		920A3E5B1E6F8E0700C16EFC /* query-style.json in Resources */ = {isa = PBXBuildFile; fileRef = 920A3E5A1E6F8E0700C16EFC /* query-style.json */; };
+		88B079AC1E37941300834FAB /* MGLAbstractShapeSource.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88B079AA1E3793E000834FAB /* MGLAbstractShapeSource.mm */; };
+		88B079AD1E37942700834FAB /* MGLAbstractShapeSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079A91E3793E000834FAB /* MGLAbstractShapeSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88B079AE1E37943900834FAB /* MGLAbstractShapeSource_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 88B079A81E3793E000834FAB /* MGLAbstractShapeSource_Private.h */; };
 		96E027311E57C9A7004B8E66 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 96E027331E57C9A7004B8E66 /* Localizable.strings */; };
 		DA00FC8A1D5EEAC3009AABC8 /* MGLAttributionInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = DA00FC881D5EEAC3009AABC8 /* MGLAttributionInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA00FC8B1D5EEAC3009AABC8 /* MGLAttributionInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = DA00FC891D5EEAC3009AABC8 /* MGLAttributionInfo.mm */; };
@@ -334,6 +337,9 @@
 		55FE0E8D1D100A0900FD240B /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = config.xcconfig; path = ../../build/macos/config.xcconfig; sourceTree = "<group>"; };
 		920A3E581E6F859D00C16EFC /* MGLSourceQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLSourceQueryTests.m; sourceTree = "<group>"; };
 		920A3E5A1E6F8E0700C16EFC /* query-style.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "query-style.json"; path = "../../darwin/test/query-style.json"; sourceTree = "<group>"; };
+		88B079A81E3793E000834FAB /* MGLAbstractShapeSource_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAbstractShapeSource_Private.h; sourceTree = "<group>"; };
+		88B079A91E3793E000834FAB /* MGLAbstractShapeSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLAbstractShapeSource.h; sourceTree = "<group>"; };
+		88B079AA1E3793E000834FAB /* MGLAbstractShapeSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLAbstractShapeSource.mm; sourceTree = "<group>"; };
 		966091701E5BBFF700A9A03B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		966091711E5BBFF900A9A03B /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		966091721E5BBFFA00A9A03B /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -626,6 +632,9 @@
 				DA7DC9821DED647F0027472F /* MGLRasterSource_Private.h */,
 				352742841D4C244700A1ECE6 /* MGLRasterSource.mm */,
 				352742871D4C245800A1ECE6 /* MGLShapeSource.h */,
+				88B079A81E3793E000834FAB /* MGLAbstractShapeSource_Private.h */,
+				88B079A91E3793E000834FAB /* MGLAbstractShapeSource.h */,
+				88B079AA1E3793E000834FAB /* MGLAbstractShapeSource.mm */,
 				DA87A99B1DC9D8DD00810D09 /* MGLShapeSource_Private.h */,
 				352742881D4C245800A1ECE6 /* MGLShapeSource.mm */,
 				3527427F1D4C243B00A1ECE6 /* MGLSource.h */,
@@ -1056,6 +1065,7 @@
 				35C5D8471D6DD66D00E95907 /* NSComparisonPredicate+MGLAdditions.h in Headers */,
 				DAE6C3A31CC31E9400DB3429 /* MGLAnnotationImage.h in Headers */,
 				DAE6C3A41CC31E9400DB3429 /* MGLMapView.h in Headers */,
+				88B079AE1E37943900834FAB /* MGLAbstractShapeSource_Private.h in Headers */,
 				355BA4ED1D41633E00CCC6D5 /* NSColor+MGLAdditions.h in Headers */,
 				DAE6C3611CC31E0400DB3429 /* MGLOfflineStorage.h in Headers */,
 				352742781D4C220900A1ECE6 /* MGLStyleValue.h in Headers */,
@@ -1124,6 +1134,7 @@
 				DAE6C3891CC31E2A00DB3429 /* MGLMultiPoint_Private.h in Headers */,
 				DAE6C3A51CC31E9400DB3429 /* MGLMapView+IBAdditions.h in Headers */,
 				DA35A2AD1CCA091800E826B2 /* MGLCompassDirectionFormatter.h in Headers */,
+				88B079AD1E37942700834FAB /* MGLAbstractShapeSource.h in Headers */,
 				352742851D4C244700A1ECE6 /* MGLRasterSource.h in Headers */,
 				408AA85B1DAEECFE00022900 /* MGLShape_Private.h in Headers */,
 				DACC22181CF3D4F700D220D9 /* MGLFeature_Private.h in Headers */,
@@ -1386,6 +1397,7 @@
 				DAE6C3B51CC31EF300DB3429 /* MGLCompassCell.m in Sources */,
 				DA8F25901D51CA600010E6B5 /* MGLRasterStyleLayer.mm in Sources */,
 				DAD165751CF4CD7A001FF4B9 /* MGLShapeCollection.mm in Sources */,
+				88B079AC1E37941300834FAB /* MGLAbstractShapeSource.mm in Sources */,
 				35C5D8481D6DD66D00E95907 /* NSComparisonPredicate+MGLAdditions.mm in Sources */,
 				DA35A2AE1CCA091800E826B2 /* MGLCompassDirectionFormatter.m in Sources */,
 				DA8F258C1D51CA540010E6B5 /* MGLLineStyleLayer.mm in Sources */,

--- a/platform/macos/src/Mapbox.h
+++ b/platform/macos/src/Mapbox.h
@@ -47,6 +47,7 @@ FOUNDATION_EXPORT MGL_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLTileSource.h"
 #import "MGLVectorSource.h"
 #import "MGLShapeSource.h"
+#import "MGLAbstractShapeSource.h"
 #import "MGLRasterSource.h"
 #import "MGLTilePyramidOfflineRegion.h"
 #import "MGLTypes.h"

--- a/platform/macos/src/Mapbox.h
+++ b/platform/macos/src/Mapbox.h
@@ -48,6 +48,7 @@ FOUNDATION_EXPORT MGL_EXPORT const unsigned char MapboxVersionString[];
 #import "MGLVectorSource.h"
 #import "MGLShapeSource.h"
 #import "MGLAbstractShapeSource.h"
+#import "MGLComputedShapeSource.h"
 #import "MGLRasterSource.h"
 #import "MGLTilePyramidOfflineRegion.h"
 #import "MGLTypes.h"

--- a/src/mbgl/algorithm/generate_clip_ids.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/tile/tile_id.hpp>
+#include <mbgl/tile/tile_id_hash.hpp>
 #include <mbgl/util/clip_id.hpp>
 
 #include <unordered_set>

--- a/src/mbgl/algorithm/update_renderables.hpp
+++ b/src/mbgl/algorithm/update_renderables.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mbgl/tile/tile_id.hpp>
+#include <mbgl/tile/tile_id_hash.hpp>
 #include <mbgl/util/range.hpp>
 #include <mbgl/storage/resource.hpp>
 

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -3,6 +3,7 @@
 #include <mbgl/style/source.hpp>
 
 #include <mbgl/tile/tile_id.hpp>
+#include <mbgl/tile/tile_id_hash.hpp>
 #include <mbgl/tile/tile_observer.hpp>
 #include <mbgl/tile/tile.hpp>
 #include <mbgl/tile/tile_cache.hpp>

--- a/src/mbgl/style/sources/custom_vector_source.cpp
+++ b/src/mbgl/style/sources/custom_vector_source.cpp
@@ -1,0 +1,33 @@
+#include <mbgl/style/sources/custom_vector_source.hpp>
+#include <mbgl/style/sources/custom_vector_source_impl.hpp>
+
+namespace mbgl {
+namespace style {
+
+CustomVectorSource::CustomVectorSource(std::string id,
+                                       const GeoJSONOptions options,
+                                       std::function<void(const CanonicalTileID&)> fetchTile)
+    : Source(SourceType::Vector,
+             std::make_unique<CustomVectorSource::Impl>(std::move(id), *this, options, fetchTile)),
+      impl(static_cast<Impl*>(baseImpl.get())) {
+}
+
+void CustomVectorSource::setTileData(const CanonicalTileID& tileId,
+                                     const mapbox::geojson::geojson& geoJSON) {
+    impl->setTileData(tileId, geoJSON);
+}
+
+void CustomVectorSource::reloadRegion(mbgl::LatLngBounds bounds, uint8_t z) {
+    impl->reloadRegion(bounds, z);
+}
+
+void CustomVectorSource::reloadTile(const CanonicalTileID& tileId) {
+    impl->reloadTile(tileId);
+}
+
+void CustomVectorSource::reload() {
+    impl->reload();
+}
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/custom_vector_source_impl.cpp
+++ b/src/mbgl/style/sources/custom_vector_source_impl.cpp
@@ -1,0 +1,115 @@
+#include <mbgl/style/sources/custom_vector_source_impl.hpp>
+
+#include <mbgl/style/source_observer.hpp>
+#include <mbgl/tile/geojson_tile.hpp>
+#include <mbgl/tile/vector_tile.hpp>
+#include <mbgl/util/tile_cover.hpp>
+
+#include <mapbox/geojsonvt.hpp>
+#include <supercluster.hpp>
+
+namespace mbgl {
+namespace style {
+
+CustomVectorSource::Impl::Impl(std::string id_,
+                               Source& base_,
+                               const GeoJSONOptions options_,
+                               std::function<void(const CanonicalTileID&)> fetchTile_)
+    : Source::Impl(SourceType::Vector, std::move(id_), base_),
+      options(options_),
+      fetchTile(fetchTile_) {
+    loaded = true;
+}
+
+Range<uint8_t> CustomVectorSource::Impl::getZoomRange() const {
+    return { options.minzoom, options.maxzoom };
+}
+
+uint16_t CustomVectorSource::Impl::getTileSize() const {
+    return options.tileSize;
+}
+
+std::unique_ptr<Tile> CustomVectorSource::Impl::createTile(const OverscaledTileID& tileID,
+                                                           const UpdateParameters& parameters) {
+    auto tilePointer = std::make_unique<GeoJSONTile>(tileID, base.getID(), parameters);
+    fetchTile(tileID.canonical);
+    return std::move(tilePointer);
+}
+
+void CustomVectorSource::Impl::setTileData(const CanonicalTileID& tileID,
+                                           const mapbox::geojson::geojson& geoJSON) {
+    constexpr double scale = util::EXTENT / util::tileSize;
+
+    if (geoJSON.is<FeatureCollection>() && geoJSON.get<FeatureCollection>().empty()) {
+        for (auto const& item : tiles) {
+            GeoJSONTile* tile = static_cast<GeoJSONTile*>(item.second.get());
+            if (tile->id.canonical == tileID) {
+                tile->updateData(mapbox::geometry::feature_collection<int16_t>());
+            }
+        }
+    } else {
+        variant<GeoJSONVTPointer, SuperclusterPointer> geoJSONOrSupercluster;
+        if (!options.cluster) {
+            mapbox::geojsonvt::Options vtOptions;
+            vtOptions.maxZoom = options.maxzoom;
+            vtOptions.extent = util::EXTENT;
+            vtOptions.buffer = std::round(scale * options.buffer);
+            vtOptions.tolerance = scale * options.tolerance;
+            geoJSONOrSupercluster =
+                std::make_unique<mapbox::geojsonvt::GeoJSONVT>(geoJSON, vtOptions);
+        } else {
+            mapbox::supercluster::Options clusterOptions;
+            clusterOptions.maxZoom = options.clusterMaxZoom;
+            clusterOptions.extent = util::EXTENT;
+            clusterOptions.radius = std::round(scale * options.clusterRadius);
+
+            const auto& features = geoJSON.get<mapbox::geometry::feature_collection<double>>();
+            geoJSONOrSupercluster =
+                std::make_unique<mapbox::supercluster::Supercluster>(features, clusterOptions);
+        }
+
+        for (auto const& item : tiles) {
+            GeoJSONTile* tile = static_cast<GeoJSONTile*>(item.second.get());
+            if (tile->id.canonical == tileID) {
+                if (geoJSONOrSupercluster.is<GeoJSONVTPointer>()) {
+                    tile->updateData(geoJSONOrSupercluster.get<GeoJSONVTPointer>()
+                                         ->getTile(tileID.z, tileID.x, tileID.y)
+                                         .features);
+                } else {
+                    assert(geoJSONOrSupercluster.is<SuperclusterPointer>());
+                    tile->updateData(geoJSONOrSupercluster.get<SuperclusterPointer>()->getTile(
+                        tileID.z, tileID.x, tileID.y));
+                }
+            }
+        }
+    }
+}
+
+void CustomVectorSource::Impl::reloadTile(const CanonicalTileID& tileId) {
+    if (cache.has(OverscaledTileID(tileId.z, tileId.x, tileId.y))) {
+        cache.clear();
+    }
+    for (auto const& item : tiles) {
+        GeoJSONTile* tile = static_cast<GeoJSONTile*>(item.second.get());
+        if (tile->id.canonical == tileId) {
+            fetchTile(tileId);
+        }
+    }
+}
+
+void CustomVectorSource::Impl::reloadRegion(mbgl::LatLngBounds bounds, const uint8_t z) {
+    for (const auto& tile : mbgl::util::tileCover(bounds, z)) {
+        reloadTile(tile.canonical);
+    }
+}
+
+void CustomVectorSource::Impl::reload() {
+    cache.clear();
+    for (auto const& item : tiles) {
+        GeoJSONTile* tile = static_cast<GeoJSONTile*>(item.second.get());
+        fetchTile(tile->id.canonical);
+    }
+}
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/custom_vector_source_impl.hpp
+++ b/src/mbgl/style/sources/custom_vector_source_impl.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mbgl/style/source_impl.hpp>
+#include <mbgl/style/sources/custom_vector_source.hpp>
+
+namespace mbgl {
+namespace style {
+
+class CustomVectorSource::Impl : public Source::Impl {
+public:
+    Impl(std::string id,
+         Source&,
+         GeoJSONOptions options,
+         std::function<void(const CanonicalTileID&)> fetchTile);
+
+    void loadDescription(FileSource&) final {
+    }
+    void setTileData(const CanonicalTileID& tileID, const mapbox::geojson::geojson&);
+    void reloadTile(const CanonicalTileID& tileID);
+    void reloadRegion(mbgl::LatLngBounds bounds, uint8_t z);
+    void reload();
+
+private:
+    uint16_t getTileSize() const;
+    Range<uint8_t> getZoomRange() const final;
+    std::unique_ptr<Tile> createTile(const OverscaledTileID&, const UpdateParameters&) final;
+
+private:
+    GeoJSONOptions options;
+    std::function<void(const CanonicalTileID&)> fetchTile;
+};
+
+} // namespace style
+} // namespace mbgl

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -155,7 +155,7 @@ void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
 
 Range<uint8_t> GeoJSONSource::Impl::getZoomRange() const {
     assert(loaded);
-    return { 0, options.maxzoom };
+    return { options.minzoom, options.maxzoom };
 }
 
 std::unique_ptr<Tile> GeoJSONSource::Impl::createTile(const OverscaledTileID& tileID,

--- a/src/mbgl/tile/tile_id.hpp
+++ b/src/mbgl/tile/tile_id.hpp
@@ -4,11 +4,11 @@
 
 #include <cstdint>
 #include <array>
+#include <tuple>
 #include <forward_list>
 #include <algorithm>
 #include <iosfwd>
 #include <cassert>
-#include <boost/functional/hash.hpp>
 
 namespace mbgl {
 
@@ -240,36 +240,3 @@ inline float UnwrappedTileID::pixelsToTileUnits(const float pixelValue, const fl
 }
 
 } // namespace mbgl
-
-namespace std {
-
-template <> struct hash<mbgl::CanonicalTileID> {
-    size_t operator()(const mbgl::CanonicalTileID &id) const {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, id.x);
-        boost::hash_combine(seed, id.y);
-        boost::hash_combine(seed, id.z);
-        return seed;
-    }
-};
-
-template <> struct hash<mbgl::UnwrappedTileID> {
-    size_t operator()(const mbgl::UnwrappedTileID &id) const {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, std::hash<mbgl::CanonicalTileID>{}(id.canonical));
-        boost::hash_combine(seed, id.wrap);
-        return seed;
-    }
-};
-
-template <> struct hash<mbgl::OverscaledTileID> {
-    size_t operator()(const mbgl::OverscaledTileID &id) const {
-        std::size_t seed = 0;
-        boost::hash_combine(seed, std::hash<mbgl::CanonicalTileID>{}(id.canonical));
-        boost::hash_combine(seed, id.overscaledZ);
-        return seed;
-    }
-};
-
-} // namespace std
-

--- a/src/mbgl/tile/tile_id_hash.hpp
+++ b/src/mbgl/tile/tile_id_hash.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <mbgl/tile/tile_id.hpp>
+
+#include <boost/functional/hash.hpp>
+
+namespace std {
+
+template <>
+struct hash<mbgl::CanonicalTileID> {
+    size_t operator()(const mbgl::CanonicalTileID& id) const {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, id.x);
+        boost::hash_combine(seed, id.y);
+        boost::hash_combine(seed, id.z);
+        return seed;
+    }
+};
+
+template <>
+struct hash<mbgl::UnwrappedTileID> {
+    size_t operator()(const mbgl::UnwrappedTileID& id) const {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, std::hash<mbgl::CanonicalTileID>{}(id.canonical));
+        boost::hash_combine(seed, id.wrap);
+        return seed;
+    }
+};
+
+template <>
+struct hash<mbgl::OverscaledTileID> {
+    size_t operator()(const mbgl::OverscaledTileID& id) const {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, std::hash<mbgl::CanonicalTileID>{}(id.canonical));
+        boost::hash_combine(seed, id.overscaledZ);
+        return seed;
+    }
+};
+
+} // namespace std

--- a/test/style/conversion/geojson_options.test.cpp
+++ b/test/style/conversion/geojson_options.test.cpp
@@ -30,6 +30,7 @@ TEST(GeoJSONOptions, RetainsDefaults) {
     GeoJSONOptions defaults;
 
     // GeoJSON-VT
+    ASSERT_EQ(converted.minzoom, defaults.minzoom);
     ASSERT_EQ(converted.maxzoom, defaults.maxzoom);
     ASSERT_EQ(converted.buffer, defaults.buffer);
     ASSERT_EQ(converted.tolerance, defaults.tolerance);
@@ -57,6 +58,7 @@ TEST(GeoJSONOptions, FullConversion) {
     GeoJSONOptions converted = *convert<GeoJSONOptions>(raw);
 
     // GeoJSON-VT
+    ASSERT_EQ(converted.minzoom, 0);
     ASSERT_EQ(converted.maxzoom, 1);
     ASSERT_EQ(converted.buffer, 2);
     ASSERT_EQ(converted.tolerance, 3);

--- a/test/style/custom_vector_source.test.cpp
+++ b/test/style/custom_vector_source.test.cpp
@@ -1,0 +1,44 @@
+#include <mbgl/test/util.hpp>
+
+#include <mbgl/style/sources/custom_vector_source.hpp>
+#include <mbgl/style/sources/geojson_source.hpp>
+#include <mbgl/tile/tile_id.hpp>
+#include <mbgl/util/geo.hpp>
+
+using namespace mbgl;
+
+TEST(CustomVectorSource, EmptyData) {
+    mbgl::style::GeoJSONOptions options;
+
+    const auto callback = [](CanonicalTileID) {};
+
+    auto testSource =
+        std::make_unique<mbgl::style::CustomVectorSource>("source", options, callback);
+
+    mbgl::FeatureCollection featureCollection;
+    testSource->setTileData(CanonicalTileID(0, 0, 0), mbgl::GeoJSON{ featureCollection });
+}
+
+TEST(CustomVectorSource, Geometry) {
+    mbgl::style::GeoJSONOptions options;
+
+    const auto callback = [](CanonicalTileID) {};
+
+    auto testSource =
+        std::make_unique<mbgl::style::CustomVectorSource>("source", options, callback);
+
+    Polygon<double> polygon = { { { { 0, 0 }, { 0, 45 }, { 45, 45 }, { 45, 0 } } } };
+    testSource->setTileData(CanonicalTileID(0, 0, 0), mbgl::GeoJSON{ polygon });
+}
+
+TEST(CustomVectorSource, ReloadWithNoTiles) {
+    mbgl::style::GeoJSONOptions options;
+
+    bool called = false;
+    const auto callback = [&called](CanonicalTileID) { called = true; };
+
+    auto testSource =
+        std::make_unique<mbgl::style::CustomVectorSource>("source", options, callback);
+    testSource->reloadRegion(mbgl::LatLngBounds::world(), 0);
+    EXPECT_EQ(called, false);
+}


### PR DESCRIPTION
This is a squashed version of https://github.com/mapbox/mapbox-gl-native/pull/6940, with changes separated by functional units rather than development history. This makes it easier to review the soundness of this pull request.

**Missing:**

- [ ] Android implementation
- [ ] Rendering unit tests

**Needs discussion:**

- [ ] The callback is implemented in a synchronous manner. This has a few implications: When you call `source->setTileData(...)` directly in the callback, the `Tile` object hasn't been added to the list of tiles yet, so `setTileData` does nothing.
- [ ] We are currently iterating through all tiles in the source when adding/reloading tiles. While the number of tiles in the `std::map` is probably low, we might be able to do better than linear search, e.g. by using [`std::equal_range`](http://en.cppreference.com/w/cpp/algorithm/equal_range) and finding all `OverzoomedTileID`s that contain the `CanonicalTileID` we are looking for)
- [ ] Why is there clustering code when adding geometries? I think it should be removed and we should use the generated geometry as is. It is up to the implementor to ensure the right level of detail.
- [ ] We also need to invalidate tiles in the `Source` object's `cache` of abandoned tiles when `setTileData` is called.
- [ ] Why is `reloadRegion()` required?
- [ ] Instead of forcing the implementor to hold on to a pointer of the `CustomVectorSource` object, we could provide a callback function that becomes a no-op if the `Source` object goes away. This makes for a safer API.
- [ ] I think we should rename `CustomVectorSource` to `CustomGeometrySource` to be in line with the naming of `GeometryTile` and `GeometryTileWorker`.

/cc @JesseCrocker @1ec5 @jonkan @frederoni @ivovandongen @incanus