### PR TITLE
[ios][macos] Document that transitions using setStyleURL are not supported

### DIFF
--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -194,8 +194,11 @@ MGL_EXPORT
 @property (nonatomic, strong) NS_SET_OF(__kindof MGLSource *) *sources;
 
 /**
- Values describing animated transitions to styling changes, either to the style URL 
- or to individual properties.
+ Values describing animated transitions to styling changes on individual 
+ paint properties. 
+ 
+ @note Transitions between styles changed using `-[MGLMapView setStyleURL:]`
+    are not currently supported.
  */
 @property (nonatomic) MGLTransition transition;
 

--- a/platform/darwin/src/MGLStyle.h
+++ b/platform/darwin/src/MGLStyle.h
@@ -194,11 +194,8 @@ MGL_EXPORT
 @property (nonatomic, strong) NS_SET_OF(__kindof MGLSource *) *sources;
 
 /**
- Values describing animated transitions to styling changes on individual 
- paint properties. 
- 
- @note Transitions between styles changed using `-[MGLMapView setStyleURL:]`
-    are not currently supported.
+ Values describing animated transitions to changes on a style's individual
+ paint properties.
  */
 @property (nonatomic) MGLTransition transition;
 


### PR DESCRIPTION
Unless I'm mistaken, transitions via `-[MGLMapView setStyleURL:]` are not currently supported.

/cc @1ec5 @incanus 