### PR TITLE
Make Source::getZoomRange return an optional range

### DIFF
--- a/include/mbgl/style/source.hpp
+++ b/include/mbgl/style/source.hpp
@@ -56,8 +56,7 @@ public:
     std::unique_ptr<Source> copy(const std::string& id) const;
 
     optional<std::string> getAttribution() const;
-
-    Range<uint8_t> getZoomRange() const;
+    optional<Range<uint8_t>> getZoomRange() const;
 
     std::vector<Feature> querySourceFeatures(const SourceQueryOptions& options = {});
 

--- a/src/mbgl/annotation/annotation_source.cpp
+++ b/src/mbgl/annotation/annotation_source.cpp
@@ -14,8 +14,8 @@ AnnotationSource::Impl::Impl(Source& base_)
     : Source::Impl(SourceType::Annotations, AnnotationManager::SourceID, base_) {
 }
 
-Range<uint8_t> AnnotationSource::Impl::getZoomRange() const {
-    return { 0, 22 };
+optional<Range<uint8_t>> AnnotationSource::Impl::getZoomRange() const {
+    return { { 0, 22 } };
 }
 
 void AnnotationSource::Impl::loadDescription(FileSource&) {

--- a/src/mbgl/annotation/annotation_source.hpp
+++ b/src/mbgl/annotation/annotation_source.hpp
@@ -18,9 +18,10 @@ public:
 
     void loadDescription(FileSource&) final;
 
+    optional<Range<uint8_t>> getZoomRange() const final;
+
 private:
     uint16_t getTileSize() const final { return util::tileSize; }
-    Range<uint8_t> getZoomRange() const final;
 
     std::unique_ptr<Tile> createTile(const OverscaledTileID&, const style::UpdateParameters&) final;
 };

--- a/src/mbgl/style/source.cpp
+++ b/src/mbgl/style/source.cpp
@@ -18,7 +18,7 @@ optional<std::string> Source::getAttribution() const {
     return baseImpl->getAttribution();
 }
 
-Range<uint8_t> Source::getZoomRange() const {
+optional<Range<uint8_t>> Source::getZoomRange() const {
     return baseImpl->getZoomRange();
 }
 

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -91,15 +91,15 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
     }
 
     const uint16_t tileSize = getTileSize();
-    const Range<uint8_t> zoomRange = getZoomRange();
+    const optional<Range<uint8_t>> zoomRange = getZoomRange();
 
     // Determine the overzooming/underzooming amounts and required tiles.
     int32_t overscaledZoom = util::coveringZoomLevel(parameters.transformState.getZoom(), type, tileSize);
     int32_t tileZoom = overscaledZoom;
 
     std::vector<UnwrappedTileID> idealTiles;
-    if (overscaledZoom >= zoomRange.min) {
-        int32_t idealZoom = std::min<int32_t>(zoomRange.max, overscaledZoom);
+    if (overscaledZoom >= zoomRange->min) {
+        int32_t idealZoom = std::min<int32_t>(zoomRange->max, overscaledZoom);
 
         // Make sure we're not reparsing overzoomed raster tiles.
         if (type == SourceType::Raster) {
@@ -142,7 +142,7 @@ void Source::Impl::updateTiles(const UpdateParameters& parameters) {
 
     renderTiles.clear();
     algorithm::updateRenderables(getTileFn, createTileFn, retainTileFn, renderTileFn,
-                                 idealTiles, zoomRange, tileZoom);
+                                 idealTiles, *zoomRange, tileZoom);
 
     if (type != SourceType::Annotations) {
         size_t conservativeCacheSize =

--- a/src/mbgl/style/source_impl.hpp
+++ b/src/mbgl/style/source_impl.hpp
@@ -83,7 +83,7 @@ public:
     const std::string id;
 
     virtual optional<std::string> getAttribution() const { return {}; };
-    virtual Range<uint8_t> getZoomRange() const = 0;
+    virtual optional<Range<uint8_t>> getZoomRange() const = 0;
 
     bool loaded = false;
 

--- a/src/mbgl/style/sources/geojson_source_impl.cpp
+++ b/src/mbgl/style/sources/geojson_source_impl.cpp
@@ -153,9 +153,11 @@ void GeoJSONSource::Impl::loadDescription(FileSource& fileSource) {
     });
 }
 
-Range<uint8_t> GeoJSONSource::Impl::getZoomRange() const {
-    assert(loaded);
-    return { 0, options.maxzoom };
+optional<Range<uint8_t>> GeoJSONSource::Impl::getZoomRange() const {
+    if (loaded) {
+        return { { 0, options.maxzoom }};
+    }
+    return {};
 }
 
 std::unique_ptr<Tile> GeoJSONSource::Impl::createTile(const OverscaledTileID& tileID,

--- a/src/mbgl/style/sources/geojson_source_impl.hpp
+++ b/src/mbgl/style/sources/geojson_source_impl.hpp
@@ -28,7 +28,7 @@ public:
         return util::tileSize;
     }
 
-    Range<uint8_t> getZoomRange() const final;
+    optional<Range<uint8_t>> getZoomRange() const final;
 
 private:
     void _setGeoJSON(const GeoJSON&);

--- a/src/mbgl/style/tile_source_impl.cpp
+++ b/src/mbgl/style/tile_source_impl.cpp
@@ -113,9 +113,11 @@ void TileSourceImpl::loadDescription(FileSource& fileSource) {
     });
 }
 
-Range<uint8_t> TileSourceImpl::getZoomRange() const {
-    assert(loaded);
-    return tileset.zoomRange;
+optional<Range<uint8_t>> TileSourceImpl::getZoomRange() const {
+    if (loaded) {
+        return tileset.zoomRange;
+    }
+    return {};
 }
 
 optional<std::string> TileSourceImpl::getAttribution() const {

--- a/src/mbgl/style/tile_source_impl.hpp
+++ b/src/mbgl/style/tile_source_impl.hpp
@@ -35,8 +35,7 @@ public:
     }
 
     optional<std::string> getAttribution() const override;
-
-    Range<uint8_t> getZoomRange() const final;
+    optional<Range<uint8_t>> getZoomRange() const final;
 
 protected:
     const variant<std::string, Tileset> urlOrTileset;

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -13,6 +13,8 @@
 #include <mbgl/util/tileset.hpp>
 #include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/util/logging.hpp>
+#include <mbgl/util/optional.hpp>
+#include <mbgl/util/range.hpp>
 
 #include <mbgl/map/transform.hpp>
 #include <mbgl/style/style.hpp>
@@ -22,6 +24,8 @@
 #include <mbgl/annotation/annotation_source.hpp>
 
 #include <mapbox/geojsonvt.hpp>
+
+#include <cstdint>
 
 using namespace mbgl;
 
@@ -68,25 +72,28 @@ public:
 
 TEST(Source, DefaultZoomRange) {
     VectorSource vectorSource("vectorSource", "url");
+    EXPECT_FALSE(vectorSource.getZoomRange());
     vectorSource.baseImpl->loaded = true;
-    EXPECT_EQ(vectorSource.getZoomRange().min, 0u);
-    EXPECT_EQ(vectorSource.getZoomRange().max, 22u);
+    EXPECT_EQ(vectorSource.getZoomRange()->min, 0u);
+    EXPECT_EQ(vectorSource.getZoomRange()->max, 22u);
 
     GeoJSONSource geojsonSource("source");
+    EXPECT_FALSE(geojsonSource.getZoomRange());
     geojsonSource.baseImpl->loaded = true;
-    EXPECT_EQ(geojsonSource.getZoomRange().min, 0u);
-    EXPECT_EQ(geojsonSource.getZoomRange().max, 18u);
+    EXPECT_EQ(geojsonSource.getZoomRange()->min, 0u);
+    EXPECT_EQ(geojsonSource.getZoomRange()->max, 18u);
 
     Tileset tileset;
     RasterSource rasterSource("source", tileset, 512);
+    EXPECT_FALSE(rasterSource.getZoomRange());
     rasterSource.baseImpl->loaded = true;
-    EXPECT_EQ(rasterSource.getZoomRange().min, 0u);
-    EXPECT_EQ(rasterSource.getZoomRange().max, 22u);
-    EXPECT_EQ(rasterSource.getZoomRange(), tileset.zoomRange);
+    EXPECT_EQ(rasterSource.getZoomRange()->min, 0u);
+    EXPECT_EQ(rasterSource.getZoomRange()->max, 22u);
+    EXPECT_EQ(*rasterSource.getZoomRange(), tileset.zoomRange);
 
     AnnotationSource annotationSource;
-    EXPECT_EQ(annotationSource.getZoomRange().min, 0u);
-    EXPECT_EQ(annotationSource.getZoomRange().max, 22u);
+    EXPECT_EQ(annotationSource.getZoomRange()->min, 0u);
+    EXPECT_EQ(annotationSource.getZoomRange()->max, 22u);
 }
 
 TEST(Source, LoadingFail) {


### PR DESCRIPTION
Based on https://github.com/mapbox/mapbox-gl-native/pull/8472#discussion_r107035011 - we want to have the return value from `Source::getZoomRange` optional e.g. in all `Source` implementations except annotation, we'll return a valid zoom range only after the source has been loaded.