### PR TITLE
Qt: Correctly restore FBOs

### DIFF
--- a/platform/qt/app/mapwindow.cpp
+++ b/platform/qt/app/mapwindow.cpp
@@ -399,5 +399,9 @@ void MapWindow::paintGL()
 {
     m_frameDraws++;
     m_map->resize(size(), size() * pixelRatio());
+#if QT_VERSION >= 0x050400
+    // When we're using QOpenGLWidget, we need to tell Mapbox GL about the framebuffer we're using.
+    m_map->setFramebufferObject(defaultFramebufferObject());
+#endif
     m_map->render();
 }

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -192,6 +192,7 @@ public:
     void rotateBy(const QPointF &first, const QPointF &second);
 
     void resize(const QSize &size, const QSize &framebufferSize);
+    void setFramebufferObject(quint32 fbo);
 
     double metersPerPixelAtLatitude(double latitude, double zoom) const;
     QMapbox::ProjectedMeters projectedMetersForCoordinate(const QMapbox::Coordinate &) const;

--- a/platform/qt/qt4.cmake
+++ b/platform/qt/qt4.cmake
@@ -13,6 +13,10 @@ set(MBGL_QT_TEST_LIBRARIES
     PRIVATE Qt4::QtOpenGL
 )
 
+target_compile_options(qmapboxgl
+    PRIVATE -Wno-inconsistent-missing-override
+)
+
 target_link_libraries(qmapboxgl
     PRIVATE mbgl-core
     PRIVATE Qt4::QtCore

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -20,17 +20,18 @@ public:
     explicit QMapboxGLPrivate(QMapboxGL *, const QMapboxGLSettings &, const QSize &size, qreal pixelRatio);
     virtual ~QMapboxGLPrivate();
 
-    // mbgl::View implementation.
-    float getPixelRatio() const;
-    void bind() final;
-    std::array<uint16_t, 2> getSize() const;
-    std::array<uint16_t, 2> getFramebufferSize() const;
+    mbgl::Size framebufferSize() const;
+    void updateViewBinding();
 
+    // mbgl::View implementation.
+    void bind() final;
+
+    // mbgl::Backend implementation.
+    void invalidate() final;
     void activate() final {}
     void deactivate() final {}
-    void invalidate() final;
 
-    // mbgl::Backend (mbgl::MapObserver) implementation.
+    // mbgl::MapObserver implementation.
     void onCameraWillChange(mbgl::MapObserver::CameraChangeMode) final;
     void onCameraIsChanging() final;
     void onCameraDidChange(mbgl::MapObserver::CameraChangeMode) final;
@@ -47,6 +48,7 @@ public:
     mbgl::EdgeInsets margins;
     QSize size { 0, 0 };
     QSize fbSize { 0, 0 };
+    quint32 fbObject = 0;
 
     QMapboxGL *q_ptr { nullptr };
 

--- a/platform/qt/test/qmapboxgl.cpp
+++ b/platform/qt/test/qmapboxgl.cpp
@@ -2,24 +2,28 @@
 #include <mbgl/util/io.hpp>
 
 #include <QApplication>
-#include <QGLWidget>
 #include <QMapbox>
 #include <QMapboxGL>
+
+// We're using QGLFramebufferObject, which is only available in Qt 5 and up.
+#if QT_VERSION >= 0x050000
+
+#include <QGLWidget>
+#include <QGLFramebufferObject>
 
 class QMapboxGLTest : public QObject, public ::testing::Test {
     Q_OBJECT
 
 public:
-    QMapboxGLTest() : map(nullptr, settings) {
+    QMapboxGLTest() : fbo((assert(widget.context()->isValid()), widget.makeCurrent(), QSize(512, 512))), map(nullptr, settings) {
         connect(&map, SIGNAL(mapChanged(QMapboxGL::MapChange)),
                 this, SLOT(onMapChanged(QMapboxGL::MapChange)));
         connect(&map, SIGNAL(needsRendering()),
                 this, SLOT(onNeedsRendering()));
-
-        widget.makeCurrent();
         QMapbox::initializeGLExtensions();
 
-        map.resize(QSize(512, 512), QSize(512, 512));
+        map.resize(fbo.size(), fbo.size());
+        map.setFramebufferObject(fbo.handle());
         map.setCoordinateZoom(QMapbox::Coordinate(60.170448, 24.942046), 14);
     }
 
@@ -36,6 +40,7 @@ public:
 
 private:
     QGLWidget widget;
+    QGLFramebufferObject fbo;
 
 protected:
     QMapboxGLSettings settings;
@@ -51,6 +56,9 @@ private slots:
     };
 
     void onNeedsRendering() {
+        widget.makeCurrent();
+        fbo.bind();
+        glViewport(0, 0, fbo.width(), fbo.height());
         map.render();
     };
 };
@@ -88,3 +96,5 @@ TEST_F(QMapboxGLTest, TEST_DISABLED_ON_CI(styleUrl)) {
 }
 
 #include "qmapboxgl.moc"
+
+#endif


### PR DESCRIPTION
Our renderer sometimes needs to rebind the originally bound framebuffer, and does so by calling `view.bind()`. This is currently implemented as binding FBO 0 in all cases, but this is incorrect because it depends on the Widget implementation that we're rendering to: `QGLWidget` uses a default FBO of 0, but `QOpenGLWidget` doesn't and returns the correct FBO with `defaultFramebufferObject()`. We need a way for implementations to supply the correct FBO and update the sample application accordingly.