### PR TITLE
[build] Autodetect Qt{4,5}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,7 @@ matrix:
       dist: trusty
       language: cpp
       compiler: "qt4-gcc5-release"
-      env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5 WITH_QT_4=1
+      env: BUILDTYPE=Release _CXX=g++-5 _CC=gcc-5
       addons: *qt4
       before_script:
         - mapbox_start_xvfb

--- a/platform/qt/bitrise-qt4.yml
+++ b/platform/qt/bitrise-qt4.yml
@@ -19,7 +19,6 @@ workflows:
             brew link qt
             brew linkapps qt
             export BUILDTYPE=Debug
-            export WITH_QT_4=1
             make qt-app
             make run-qt-test
         - is_debug: 'yes'

--- a/scripts/check-qt.sh
+++ b/scripts/check-qt.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+if [ ! $(command -v qmake 2> /dev/null) ]; then
+    echo "No qmake found - missing Qt development files"
+    exit 1
+fi


### PR DESCRIPTION
Detects the Qt version based on the `qmake` found in the user path - we'll no longer need to specify `WITH_QT_4=1` when e.g. building using Qt 4.