### PR TITLE
[android] - transition options for layer properties

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 
 5.1.0 builds further on 5.0.1 and adds:
 
+* Transition Properties for Layer attributes [#8509](https://github.com/mapbox/mapbox-gl-native/pull/8509)
 * Style wide transition duration and transition offset in milliseconds [#8576](https://github.com/mapbox/mapbox-gl-native/pull/8576)
 * Transifex integration, Catalan & Dutch translations [#8556](https://github.com/mapbox/mapbox-gl-native/pull/8556)
 * LatLngBounds includes with another bounds [#8517](https://github.com/mapbox/mapbox-gl-native/pull/8517)

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/BackgroundLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/BackgroundLayer.java
@@ -8,6 +8,8 @@ import android.support.annotation.UiThread;
 
 import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * The background color or pattern of the map.
  *
@@ -75,6 +77,23 @@ public class BackgroundLayer extends Layer {
     }
   }
 
+  /**
+   * Get the BackgroundColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getBackgroundColorTransition() {
+    return nativeGetBackgroundColorTransition();
+  }
+
+  /**
+   * Set the BackgroundColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setBackgroundColorTransition(TransitionOptions options) {
+    nativeSetBackgroundColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the BackgroundPattern property
@@ -87,6 +106,24 @@ public class BackgroundLayer extends Layer {
   }
 
   /**
+   * Get the BackgroundPattern property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getBackgroundPatternTransition() {
+    return nativeGetBackgroundPatternTransition();
+  }
+
+  /**
+   * Set the BackgroundPattern property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setBackgroundPatternTransition(TransitionOptions options) {
+    nativeSetBackgroundPatternTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the BackgroundOpacity property
    *
    * @return property wrapper value around Float
@@ -96,12 +133,41 @@ public class BackgroundLayer extends Layer {
     return (PropertyValue<Float>) new PropertyValue("background-opacity", nativeGetBackgroundOpacity());
   }
 
+  /**
+   * Get the BackgroundOpacity property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getBackgroundOpacityTransition() {
+    return nativeGetBackgroundOpacityTransition();
+  }
+
+  /**
+   * Set the BackgroundOpacity property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setBackgroundOpacityTransition(TransitionOptions options) {
+    nativeSetBackgroundOpacityTransition(options.getDuration(), options.getDelay());
+  }
+
   private native Object nativeGetBackgroundColor();
+
+  private native TransitionOptions nativeGetBackgroundColorTransition();
+
+  private native void nativeSetBackgroundColorTransition(long duration, long delay);
 
   private native Object nativeGetBackgroundPattern();
 
+  private native TransitionOptions nativeGetBackgroundPatternTransition();
+
+  private native void nativeSetBackgroundPatternTransition(long duration, long delay);
+
   private native Object nativeGetBackgroundOpacity();
 
+  private native TransitionOptions nativeGetBackgroundOpacityTransition();
+
+  private native void nativeSetBackgroundOpacityTransition(long duration, long delay);
 
   @Override
   protected native void finalize() throws Throwable;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CircleLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CircleLayer.java
@@ -8,6 +8,8 @@ import android.support.annotation.UiThread;
 
 import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * A filled circle.
  *
@@ -101,6 +103,24 @@ public class CircleLayer extends Layer {
   }
 
   /**
+   * Get the CircleRadius property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getCircleRadiusTransition() {
+    return nativeGetCircleRadiusTransition();
+  }
+
+  /**
+   * Set the CircleRadius property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setCircleRadiusTransition(TransitionOptions options) {
+    nativeSetCircleRadiusTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the CircleColor property
    *
    * @return property wrapper value around String
@@ -126,6 +146,23 @@ public class CircleLayer extends Layer {
     }
   }
 
+  /**
+   * Get the CircleColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getCircleColorTransition() {
+    return nativeGetCircleColorTransition();
+  }
+
+  /**
+   * Set the CircleColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setCircleColorTransition(TransitionOptions options) {
+    nativeSetCircleColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the CircleBlur property
@@ -135,6 +172,24 @@ public class CircleLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getCircleBlur() {
     return (PropertyValue<Float>) new PropertyValue("circle-blur", nativeGetCircleBlur());
+  }
+
+  /**
+   * Get the CircleBlur property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getCircleBlurTransition() {
+    return nativeGetCircleBlurTransition();
+  }
+
+  /**
+   * Set the CircleBlur property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setCircleBlurTransition(TransitionOptions options) {
+    nativeSetCircleBlurTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -148,6 +203,24 @@ public class CircleLayer extends Layer {
   }
 
   /**
+   * Get the CircleOpacity property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getCircleOpacityTransition() {
+    return nativeGetCircleOpacityTransition();
+  }
+
+  /**
+   * Set the CircleOpacity property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setCircleOpacityTransition(TransitionOptions options) {
+    nativeSetCircleOpacityTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the CircleTranslate property
    *
    * @return property wrapper value around Float[]
@@ -155,6 +228,24 @@ public class CircleLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getCircleTranslate() {
     return (PropertyValue<Float[]>) new PropertyValue("circle-translate", nativeGetCircleTranslate());
+  }
+
+  /**
+   * Get the CircleTranslate property transition options
+   *
+   * @return transition options for Float[]
+   */
+  public TransitionOptions getCircleTranslateTransition() {
+    return nativeGetCircleTranslateTransition();
+  }
+
+  /**
+   * Set the CircleTranslate property transition options
+   *
+   * @param options transition options for Float[]
+   */
+  public void setCircleTranslateTransition(TransitionOptions options) {
+    nativeSetCircleTranslateTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -188,6 +279,24 @@ public class CircleLayer extends Layer {
   }
 
   /**
+   * Get the CircleStrokeWidth property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getCircleStrokeWidthTransition() {
+    return nativeGetCircleStrokeWidthTransition();
+  }
+
+  /**
+   * Set the CircleStrokeWidth property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setCircleStrokeWidthTransition(TransitionOptions options) {
+    nativeSetCircleStrokeWidthTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the CircleStrokeColor property
    *
    * @return property wrapper value around String
@@ -213,6 +322,23 @@ public class CircleLayer extends Layer {
     }
   }
 
+  /**
+   * Get the CircleStrokeColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getCircleStrokeColorTransition() {
+    return nativeGetCircleStrokeColorTransition();
+  }
+
+  /**
+   * Set the CircleStrokeColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setCircleStrokeColorTransition(TransitionOptions options) {
+    nativeSetCircleStrokeColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the CircleStrokeOpacity property
@@ -224,15 +350,53 @@ public class CircleLayer extends Layer {
     return (PropertyValue<Float>) new PropertyValue("circle-stroke-opacity", nativeGetCircleStrokeOpacity());
   }
 
+  /**
+   * Get the CircleStrokeOpacity property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getCircleStrokeOpacityTransition() {
+    return nativeGetCircleStrokeOpacityTransition();
+  }
+
+  /**
+   * Set the CircleStrokeOpacity property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setCircleStrokeOpacityTransition(TransitionOptions options) {
+    nativeSetCircleStrokeOpacityTransition(options.getDuration(), options.getDelay());
+  }
+
   private native Object nativeGetCircleRadius();
+
+  private native TransitionOptions nativeGetCircleRadiusTransition();
+
+  private native void nativeSetCircleRadiusTransition(long duration, long delay);
 
   private native Object nativeGetCircleColor();
 
+  private native TransitionOptions nativeGetCircleColorTransition();
+
+  private native void nativeSetCircleColorTransition(long duration, long delay);
+
   private native Object nativeGetCircleBlur();
+
+  private native TransitionOptions nativeGetCircleBlurTransition();
+
+  private native void nativeSetCircleBlurTransition(long duration, long delay);
 
   private native Object nativeGetCircleOpacity();
 
+  private native TransitionOptions nativeGetCircleOpacityTransition();
+
+  private native void nativeSetCircleOpacityTransition(long duration, long delay);
+
   private native Object nativeGetCircleTranslate();
+
+  private native TransitionOptions nativeGetCircleTranslateTransition();
+
+  private native void nativeSetCircleTranslateTransition(long duration, long delay);
 
   private native Object nativeGetCircleTranslateAnchor();
 
@@ -240,10 +404,21 @@ public class CircleLayer extends Layer {
 
   private native Object nativeGetCircleStrokeWidth();
 
+  private native TransitionOptions nativeGetCircleStrokeWidthTransition();
+
+  private native void nativeSetCircleStrokeWidthTransition(long duration, long delay);
+
   private native Object nativeGetCircleStrokeColor();
+
+  private native TransitionOptions nativeGetCircleStrokeColorTransition();
+
+  private native void nativeSetCircleStrokeColorTransition(long duration, long delay);
 
   private native Object nativeGetCircleStrokeOpacity();
 
+  private native TransitionOptions nativeGetCircleStrokeOpacityTransition();
+
+  private native void nativeSetCircleStrokeOpacityTransition(long duration, long delay);
 
   @Override
   protected native void finalize() throws Throwable;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/FillLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/FillLayer.java
@@ -8,6 +8,8 @@ import android.support.annotation.UiThread;
 
 import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * A filled polygon with an optional stroked border.
  *
@@ -111,6 +113,24 @@ public class FillLayer extends Layer {
   }
 
   /**
+   * Get the FillOpacity property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getFillOpacityTransition() {
+    return nativeGetFillOpacityTransition();
+  }
+
+  /**
+   * Set the FillOpacity property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setFillOpacityTransition(TransitionOptions options) {
+    nativeSetFillOpacityTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the FillColor property
    *
    * @return property wrapper value around String
@@ -136,6 +156,23 @@ public class FillLayer extends Layer {
     }
   }
 
+  /**
+   * Get the FillColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getFillColorTransition() {
+    return nativeGetFillColorTransition();
+  }
+
+  /**
+   * Set the FillColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setFillColorTransition(TransitionOptions options) {
+    nativeSetFillColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the FillOutlineColor property
@@ -163,6 +200,23 @@ public class FillLayer extends Layer {
     }
   }
 
+  /**
+   * Get the FillOutlineColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getFillOutlineColorTransition() {
+    return nativeGetFillOutlineColorTransition();
+  }
+
+  /**
+   * Set the FillOutlineColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setFillOutlineColorTransition(TransitionOptions options) {
+    nativeSetFillOutlineColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the FillTranslate property
@@ -172,6 +226,24 @@ public class FillLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getFillTranslate() {
     return (PropertyValue<Float[]>) new PropertyValue("fill-translate", nativeGetFillTranslate());
+  }
+
+  /**
+   * Get the FillTranslate property transition options
+   *
+   * @return transition options for Float[]
+   */
+  public TransitionOptions getFillTranslateTransition() {
+    return nativeGetFillTranslateTransition();
+  }
+
+  /**
+   * Set the FillTranslate property transition options
+   *
+   * @param options transition options for Float[]
+   */
+  public void setFillTranslateTransition(TransitionOptions options) {
+    nativeSetFillTranslateTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -194,20 +266,57 @@ public class FillLayer extends Layer {
     return (PropertyValue<String>) new PropertyValue("fill-pattern", nativeGetFillPattern());
   }
 
+  /**
+   * Get the FillPattern property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getFillPatternTransition() {
+    return nativeGetFillPatternTransition();
+  }
+
+  /**
+   * Set the FillPattern property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setFillPatternTransition(TransitionOptions options) {
+    nativeSetFillPatternTransition(options.getDuration(), options.getDelay());
+  }
+
   private native Object nativeGetFillAntialias();
 
   private native Object nativeGetFillOpacity();
 
+  private native TransitionOptions nativeGetFillOpacityTransition();
+
+  private native void nativeSetFillOpacityTransition(long duration, long delay);
+
   private native Object nativeGetFillColor();
+
+  private native TransitionOptions nativeGetFillColorTransition();
+
+  private native void nativeSetFillColorTransition(long duration, long delay);
 
   private native Object nativeGetFillOutlineColor();
 
+  private native TransitionOptions nativeGetFillOutlineColorTransition();
+
+  private native void nativeSetFillOutlineColorTransition(long duration, long delay);
+
   private native Object nativeGetFillTranslate();
+
+  private native TransitionOptions nativeGetFillTranslateTransition();
+
+  private native void nativeSetFillTranslateTransition(long duration, long delay);
 
   private native Object nativeGetFillTranslateAnchor();
 
   private native Object nativeGetFillPattern();
 
+  private native TransitionOptions nativeGetFillPatternTransition();
+
+  private native void nativeSetFillPatternTransition(long duration, long delay);
 
   @Override
   protected native void finalize() throws Throwable;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/LineLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/LineLayer.java
@@ -8,6 +8,8 @@ import android.support.annotation.UiThread;
 
 import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * A stroked line.
  *
@@ -141,6 +143,24 @@ public class LineLayer extends Layer {
   }
 
   /**
+   * Get the LineOpacity property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getLineOpacityTransition() {
+    return nativeGetLineOpacityTransition();
+  }
+
+  /**
+   * Set the LineOpacity property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setLineOpacityTransition(TransitionOptions options) {
+    nativeSetLineOpacityTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the LineColor property
    *
    * @return property wrapper value around String
@@ -166,6 +186,23 @@ public class LineLayer extends Layer {
     }
   }
 
+  /**
+   * Get the LineColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getLineColorTransition() {
+    return nativeGetLineColorTransition();
+  }
+
+  /**
+   * Set the LineColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setLineColorTransition(TransitionOptions options) {
+    nativeSetLineColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the LineTranslate property
@@ -175,6 +212,24 @@ public class LineLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getLineTranslate() {
     return (PropertyValue<Float[]>) new PropertyValue("line-translate", nativeGetLineTranslate());
+  }
+
+  /**
+   * Get the LineTranslate property transition options
+   *
+   * @return transition options for Float[]
+   */
+  public TransitionOptions getLineTranslateTransition() {
+    return nativeGetLineTranslateTransition();
+  }
+
+  /**
+   * Set the LineTranslate property transition options
+   *
+   * @param options transition options for Float[]
+   */
+  public void setLineTranslateTransition(TransitionOptions options) {
+    nativeSetLineTranslateTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -198,6 +253,24 @@ public class LineLayer extends Layer {
   }
 
   /**
+   * Get the LineWidth property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getLineWidthTransition() {
+    return nativeGetLineWidthTransition();
+  }
+
+  /**
+   * Set the LineWidth property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setLineWidthTransition(TransitionOptions options) {
+    nativeSetLineWidthTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the LineGapWidth property
    *
    * @return property wrapper value around Float
@@ -205,6 +278,24 @@ public class LineLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineGapWidth() {
     return (PropertyValue<Float>) new PropertyValue("line-gap-width", nativeGetLineGapWidth());
+  }
+
+  /**
+   * Get the LineGapWidth property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getLineGapWidthTransition() {
+    return nativeGetLineGapWidthTransition();
+  }
+
+  /**
+   * Set the LineGapWidth property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setLineGapWidthTransition(TransitionOptions options) {
+    nativeSetLineGapWidthTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -218,6 +309,24 @@ public class LineLayer extends Layer {
   }
 
   /**
+   * Get the LineOffset property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getLineOffsetTransition() {
+    return nativeGetLineOffsetTransition();
+  }
+
+  /**
+   * Set the LineOffset property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setLineOffsetTransition(TransitionOptions options) {
+    nativeSetLineOffsetTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the LineBlur property
    *
    * @return property wrapper value around Float
@@ -225,6 +334,24 @@ public class LineLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getLineBlur() {
     return (PropertyValue<Float>) new PropertyValue("line-blur", nativeGetLineBlur());
+  }
+
+  /**
+   * Get the LineBlur property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getLineBlurTransition() {
+    return nativeGetLineBlurTransition();
+  }
+
+  /**
+   * Set the LineBlur property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setLineBlurTransition(TransitionOptions options) {
+    nativeSetLineBlurTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -238,6 +365,24 @@ public class LineLayer extends Layer {
   }
 
   /**
+   * Get the LineDasharray property transition options
+   *
+   * @return transition options for Float[]
+   */
+  public TransitionOptions getLineDasharrayTransition() {
+    return nativeGetLineDasharrayTransition();
+  }
+
+  /**
+   * Set the LineDasharray property transition options
+   *
+   * @param options transition options for Float[]
+   */
+  public void setLineDasharrayTransition(TransitionOptions options) {
+    nativeSetLineDasharrayTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the LinePattern property
    *
    * @return property wrapper value around String
@@ -245,6 +390,24 @@ public class LineLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<String> getLinePattern() {
     return (PropertyValue<String>) new PropertyValue("line-pattern", nativeGetLinePattern());
+  }
+
+  /**
+   * Get the LinePattern property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getLinePatternTransition() {
+    return nativeGetLinePatternTransition();
+  }
+
+  /**
+   * Set the LinePattern property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setLinePatternTransition(TransitionOptions options) {
+    nativeSetLinePatternTransition(options.getDuration(), options.getDelay());
   }
 
   private native Object nativeGetLineCap();
@@ -257,24 +420,59 @@ public class LineLayer extends Layer {
 
   private native Object nativeGetLineOpacity();
 
+  private native TransitionOptions nativeGetLineOpacityTransition();
+
+  private native void nativeSetLineOpacityTransition(long duration, long delay);
+
   private native Object nativeGetLineColor();
 
+  private native TransitionOptions nativeGetLineColorTransition();
+
+  private native void nativeSetLineColorTransition(long duration, long delay);
+
   private native Object nativeGetLineTranslate();
+
+  private native TransitionOptions nativeGetLineTranslateTransition();
+
+  private native void nativeSetLineTranslateTransition(long duration, long delay);
 
   private native Object nativeGetLineTranslateAnchor();
 
   private native Object nativeGetLineWidth();
 
+  private native TransitionOptions nativeGetLineWidthTransition();
+
+  private native void nativeSetLineWidthTransition(long duration, long delay);
+
   private native Object nativeGetLineGapWidth();
+
+  private native TransitionOptions nativeGetLineGapWidthTransition();
+
+  private native void nativeSetLineGapWidthTransition(long duration, long delay);
 
   private native Object nativeGetLineOffset();
 
+  private native TransitionOptions nativeGetLineOffsetTransition();
+
+  private native void nativeSetLineOffsetTransition(long duration, long delay);
+
   private native Object nativeGetLineBlur();
+
+  private native TransitionOptions nativeGetLineBlurTransition();
+
+  private native void nativeSetLineBlurTransition(long duration, long delay);
 
   private native Object nativeGetLineDasharray();
 
+  private native TransitionOptions nativeGetLineDasharrayTransition();
+
+  private native void nativeSetLineDasharrayTransition(long duration, long delay);
+
   private native Object nativeGetLinePattern();
 
+  private native TransitionOptions nativeGetLinePatternTransition();
+
+  private native void nativeSetLinePatternTransition(long duration, long delay);
 
   @Override
   protected native void finalize() throws Throwable;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/RasterLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/RasterLayer.java
@@ -8,6 +8,8 @@ import android.support.annotation.UiThread;
 
 import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * Raster map textures such as satellite imagery.
  *
@@ -81,6 +83,24 @@ public class RasterLayer extends Layer {
   }
 
   /**
+   * Get the RasterOpacity property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getRasterOpacityTransition() {
+    return nativeGetRasterOpacityTransition();
+  }
+
+  /**
+   * Set the RasterOpacity property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setRasterOpacityTransition(TransitionOptions options) {
+    nativeSetRasterOpacityTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the RasterHueRotate property
    *
    * @return property wrapper value around Float
@@ -88,6 +108,24 @@ public class RasterLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterHueRotate() {
     return (PropertyValue<Float>) new PropertyValue("raster-hue-rotate", nativeGetRasterHueRotate());
+  }
+
+  /**
+   * Get the RasterHueRotate property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getRasterHueRotateTransition() {
+    return nativeGetRasterHueRotateTransition();
+  }
+
+  /**
+   * Set the RasterHueRotate property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setRasterHueRotateTransition(TransitionOptions options) {
+    nativeSetRasterHueRotateTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -101,6 +139,24 @@ public class RasterLayer extends Layer {
   }
 
   /**
+   * Get the RasterBrightnessMin property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getRasterBrightnessMinTransition() {
+    return nativeGetRasterBrightnessMinTransition();
+  }
+
+  /**
+   * Set the RasterBrightnessMin property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setRasterBrightnessMinTransition(TransitionOptions options) {
+    nativeSetRasterBrightnessMinTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the RasterBrightnessMax property
    *
    * @return property wrapper value around Float
@@ -108,6 +164,24 @@ public class RasterLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterBrightnessMax() {
     return (PropertyValue<Float>) new PropertyValue("raster-brightness-max", nativeGetRasterBrightnessMax());
+  }
+
+  /**
+   * Get the RasterBrightnessMax property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getRasterBrightnessMaxTransition() {
+    return nativeGetRasterBrightnessMaxTransition();
+  }
+
+  /**
+   * Set the RasterBrightnessMax property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setRasterBrightnessMaxTransition(TransitionOptions options) {
+    nativeSetRasterBrightnessMaxTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -121,6 +195,24 @@ public class RasterLayer extends Layer {
   }
 
   /**
+   * Get the RasterSaturation property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getRasterSaturationTransition() {
+    return nativeGetRasterSaturationTransition();
+  }
+
+  /**
+   * Set the RasterSaturation property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setRasterSaturationTransition(TransitionOptions options) {
+    nativeSetRasterSaturationTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the RasterContrast property
    *
    * @return property wrapper value around Float
@@ -128,6 +220,24 @@ public class RasterLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getRasterContrast() {
     return (PropertyValue<Float>) new PropertyValue("raster-contrast", nativeGetRasterContrast());
+  }
+
+  /**
+   * Get the RasterContrast property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getRasterContrastTransition() {
+    return nativeGetRasterContrastTransition();
+  }
+
+  /**
+   * Set the RasterContrast property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setRasterContrastTransition(TransitionOptions options) {
+    nativeSetRasterContrastTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -140,20 +250,65 @@ public class RasterLayer extends Layer {
     return (PropertyValue<Float>) new PropertyValue("raster-fade-duration", nativeGetRasterFadeDuration());
   }
 
+  /**
+   * Get the RasterFadeDuration property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getRasterFadeDurationTransition() {
+    return nativeGetRasterFadeDurationTransition();
+  }
+
+  /**
+   * Set the RasterFadeDuration property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setRasterFadeDurationTransition(TransitionOptions options) {
+    nativeSetRasterFadeDurationTransition(options.getDuration(), options.getDelay());
+  }
+
   private native Object nativeGetRasterOpacity();
+
+  private native TransitionOptions nativeGetRasterOpacityTransition();
+
+  private native void nativeSetRasterOpacityTransition(long duration, long delay);
 
   private native Object nativeGetRasterHueRotate();
 
+  private native TransitionOptions nativeGetRasterHueRotateTransition();
+
+  private native void nativeSetRasterHueRotateTransition(long duration, long delay);
+
   private native Object nativeGetRasterBrightnessMin();
+
+  private native TransitionOptions nativeGetRasterBrightnessMinTransition();
+
+  private native void nativeSetRasterBrightnessMinTransition(long duration, long delay);
 
   private native Object nativeGetRasterBrightnessMax();
 
+  private native TransitionOptions nativeGetRasterBrightnessMaxTransition();
+
+  private native void nativeSetRasterBrightnessMaxTransition(long duration, long delay);
+
   private native Object nativeGetRasterSaturation();
+
+  private native TransitionOptions nativeGetRasterSaturationTransition();
+
+  private native void nativeSetRasterSaturationTransition(long duration, long delay);
 
   private native Object nativeGetRasterContrast();
 
+  private native TransitionOptions nativeGetRasterContrastTransition();
+
+  private native void nativeSetRasterContrastTransition(long duration, long delay);
+
   private native Object nativeGetRasterFadeDuration();
 
+  private native TransitionOptions nativeGetRasterFadeDurationTransition();
+
+  private native void nativeSetRasterFadeDurationTransition(long duration, long delay);
 
   @Override
   protected native void finalize() throws Throwable;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
@@ -8,6 +8,8 @@ import android.support.annotation.UiThread;
 
 import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * An icon or a text label.
  *
@@ -441,6 +443,24 @@ public class SymbolLayer extends Layer {
   }
 
   /**
+   * Get the IconOpacity property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getIconOpacityTransition() {
+    return nativeGetIconOpacityTransition();
+  }
+
+  /**
+   * Set the IconOpacity property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setIconOpacityTransition(TransitionOptions options) {
+    nativeSetIconOpacityTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the IconColor property
    *
    * @return property wrapper value around String
@@ -466,6 +486,23 @@ public class SymbolLayer extends Layer {
     }
   }
 
+  /**
+   * Get the IconColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getIconColorTransition() {
+    return nativeGetIconColorTransition();
+  }
+
+  /**
+   * Set the IconColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setIconColorTransition(TransitionOptions options) {
+    nativeSetIconColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the IconHaloColor property
@@ -493,6 +530,23 @@ public class SymbolLayer extends Layer {
     }
   }
 
+  /**
+   * Get the IconHaloColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getIconHaloColorTransition() {
+    return nativeGetIconHaloColorTransition();
+  }
+
+  /**
+   * Set the IconHaloColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setIconHaloColorTransition(TransitionOptions options) {
+    nativeSetIconHaloColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the IconHaloWidth property
@@ -502,6 +556,24 @@ public class SymbolLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getIconHaloWidth() {
     return (PropertyValue<Float>) new PropertyValue("icon-halo-width", nativeGetIconHaloWidth());
+  }
+
+  /**
+   * Get the IconHaloWidth property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getIconHaloWidthTransition() {
+    return nativeGetIconHaloWidthTransition();
+  }
+
+  /**
+   * Set the IconHaloWidth property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setIconHaloWidthTransition(TransitionOptions options) {
+    nativeSetIconHaloWidthTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -515,6 +587,24 @@ public class SymbolLayer extends Layer {
   }
 
   /**
+   * Get the IconHaloBlur property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getIconHaloBlurTransition() {
+    return nativeGetIconHaloBlurTransition();
+  }
+
+  /**
+   * Set the IconHaloBlur property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setIconHaloBlurTransition(TransitionOptions options) {
+    nativeSetIconHaloBlurTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the IconTranslate property
    *
    * @return property wrapper value around Float[]
@@ -522,6 +612,24 @@ public class SymbolLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getIconTranslate() {
     return (PropertyValue<Float[]>) new PropertyValue("icon-translate", nativeGetIconTranslate());
+  }
+
+  /**
+   * Get the IconTranslate property transition options
+   *
+   * @return transition options for Float[]
+   */
+  public TransitionOptions getIconTranslateTransition() {
+    return nativeGetIconTranslateTransition();
+  }
+
+  /**
+   * Set the IconTranslate property transition options
+   *
+   * @param options transition options for Float[]
+   */
+  public void setIconTranslateTransition(TransitionOptions options) {
+    nativeSetIconTranslateTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -542,6 +650,24 @@ public class SymbolLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextOpacity() {
     return (PropertyValue<Float>) new PropertyValue("text-opacity", nativeGetTextOpacity());
+  }
+
+  /**
+   * Get the TextOpacity property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getTextOpacityTransition() {
+    return nativeGetTextOpacityTransition();
+  }
+
+  /**
+   * Set the TextOpacity property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setTextOpacityTransition(TransitionOptions options) {
+    nativeSetTextOpacityTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -570,6 +696,23 @@ public class SymbolLayer extends Layer {
     }
   }
 
+  /**
+   * Get the TextColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getTextColorTransition() {
+    return nativeGetTextColorTransition();
+  }
+
+  /**
+   * Set the TextColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setTextColorTransition(TransitionOptions options) {
+    nativeSetTextColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the TextHaloColor property
@@ -597,6 +740,23 @@ public class SymbolLayer extends Layer {
     }
   }
 
+  /**
+   * Get the TextHaloColor property transition options
+   *
+   * @return transition options for String
+   */
+  public TransitionOptions getTextHaloColorTransition() {
+    return nativeGetTextHaloColorTransition();
+  }
+
+  /**
+   * Set the TextHaloColor property transition options
+   *
+   * @param options transition options for String
+   */
+  public void setTextHaloColorTransition(TransitionOptions options) {
+    nativeSetTextHaloColorTransition(options.getDuration(), options.getDelay());
+  }
 
   /**
    * Get the TextHaloWidth property
@@ -606,6 +766,24 @@ public class SymbolLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float> getTextHaloWidth() {
     return (PropertyValue<Float>) new PropertyValue("text-halo-width", nativeGetTextHaloWidth());
+  }
+
+  /**
+   * Get the TextHaloWidth property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getTextHaloWidthTransition() {
+    return nativeGetTextHaloWidthTransition();
+  }
+
+  /**
+   * Set the TextHaloWidth property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setTextHaloWidthTransition(TransitionOptions options) {
+    nativeSetTextHaloWidthTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -619,6 +797,24 @@ public class SymbolLayer extends Layer {
   }
 
   /**
+   * Get the TextHaloBlur property transition options
+   *
+   * @return transition options for Float
+   */
+  public TransitionOptions getTextHaloBlurTransition() {
+    return nativeGetTextHaloBlurTransition();
+  }
+
+  /**
+   * Set the TextHaloBlur property transition options
+   *
+   * @param options transition options for Float
+   */
+  public void setTextHaloBlurTransition(TransitionOptions options) {
+    nativeSetTextHaloBlurTransition(options.getDuration(), options.getDelay());
+  }
+
+  /**
    * Get the TextTranslate property
    *
    * @return property wrapper value around Float[]
@@ -626,6 +822,24 @@ public class SymbolLayer extends Layer {
   @SuppressWarnings("unchecked")
   public PropertyValue<Float[]> getTextTranslate() {
     return (PropertyValue<Float[]>) new PropertyValue("text-translate", nativeGetTextTranslate());
+  }
+
+  /**
+   * Get the TextTranslate property transition options
+   *
+   * @return transition options for Float[]
+   */
+  public TransitionOptions getTextTranslateTransition() {
+    return nativeGetTextTranslateTransition();
+  }
+
+  /**
+   * Set the TextTranslate property transition options
+   *
+   * @param options transition options for Float[]
+   */
+  public void setTextTranslateTransition(TransitionOptions options) {
+    nativeSetTextTranslateTransition(options.getDuration(), options.getDelay());
   }
 
   /**
@@ -708,32 +922,79 @@ public class SymbolLayer extends Layer {
 
   private native Object nativeGetIconOpacity();
 
+  private native TransitionOptions nativeGetIconOpacityTransition();
+
+  private native void nativeSetIconOpacityTransition(long duration, long delay);
+
   private native Object nativeGetIconColor();
+
+  private native TransitionOptions nativeGetIconColorTransition();
+
+  private native void nativeSetIconColorTransition(long duration, long delay);
 
   private native Object nativeGetIconHaloColor();
 
+  private native TransitionOptions nativeGetIconHaloColorTransition();
+
+  private native void nativeSetIconHaloColorTransition(long duration, long delay);
+
   private native Object nativeGetIconHaloWidth();
+
+  private native TransitionOptions nativeGetIconHaloWidthTransition();
+
+  private native void nativeSetIconHaloWidthTransition(long duration, long delay);
 
   private native Object nativeGetIconHaloBlur();
 
+  private native TransitionOptions nativeGetIconHaloBlurTransition();
+
+  private native void nativeSetIconHaloBlurTransition(long duration, long delay);
+
   private native Object nativeGetIconTranslate();
+
+  private native TransitionOptions nativeGetIconTranslateTransition();
+
+  private native void nativeSetIconTranslateTransition(long duration, long delay);
 
   private native Object nativeGetIconTranslateAnchor();
 
   private native Object nativeGetTextOpacity();
 
+  private native TransitionOptions nativeGetTextOpacityTransition();
+
+  private native void nativeSetTextOpacityTransition(long duration, long delay);
+
   private native Object nativeGetTextColor();
+
+  private native TransitionOptions nativeGetTextColorTransition();
+
+  private native void nativeSetTextColorTransition(long duration, long delay);
 
   private native Object nativeGetTextHaloColor();
 
+  private native TransitionOptions nativeGetTextHaloColorTransition();
+
+  private native void nativeSetTextHaloColorTransition(long duration, long delay);
+
   private native Object nativeGetTextHaloWidth();
+
+  private native TransitionOptions nativeGetTextHaloWidthTransition();
+
+  private native void nativeSetTextHaloWidthTransition(long duration, long delay);
 
   private native Object nativeGetTextHaloBlur();
 
+  private native TransitionOptions nativeGetTextHaloBlurTransition();
+
+  private native void nativeSetTextHaloBlurTransition(long duration, long delay);
+
   private native Object nativeGetTextTranslate();
 
-  private native Object nativeGetTextTranslateAnchor();
+  private native TransitionOptions nativeGetTextTranslateTransition();
 
+  private native void nativeSetTextTranslateTransition(long duration, long delay);
+
+  private native Object nativeGetTextTranslateAnchor();
 
   @Override
   protected native void finalize() throws Throwable;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/TransitionOptions.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/TransitionOptions.java
@@ -1,0 +1,56 @@
+package com.mapbox.mapboxsdk.style.layers;
+
+public class TransitionOptions {
+
+  private long duration;
+  private long delay;
+
+  public TransitionOptions(long duration, long delay) {
+    this.duration = duration;
+    this.delay = delay;
+  }
+
+  public static TransitionOptions fromTransitionOptions(long duration, long delay) {
+    return new TransitionOptions(duration, delay);
+  }
+
+  public long getDuration() {
+    return duration;
+  }
+
+  public long getDelay() {
+    return delay;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TransitionOptions that = (TransitionOptions) o;
+
+    if (duration != that.duration) {
+      return false;
+    }
+    return delay == that.delay;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (duration ^ (duration >>> 32));
+    result = 31 * result + (int) (delay ^ (delay >>> 32));
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "TransitionOptions{"
+      + "duration=" + duration
+      + ", delay=" + delay
+      + '}';
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
@@ -13,6 +13,8 @@ import android.support.annotation.UiThread;
 
 import static com.mapbox.mapboxsdk.utils.ColorUtils.rgbaToColor;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * <%- doc %>
  *
@@ -110,8 +112,8 @@ public class <%- camelize(type) %>Layer extends Layer {
   }
 
   // Property getters
-
 <% for (const property of properties) { -%>
+
   /**
    * Get the <%- camelize(property.name) %> property
    *
@@ -138,15 +140,39 @@ public class <%- camelize(type) %>Layer extends Layer {
       throw new RuntimeException("<%- property.name %> was set as a Function");
     }
   }
+<% } -%>
+<% if (property.transition) { -%>
 
+  /**
+   * Get the <%- camelize(property.name) %> property transition options
+   *
+   * @return transition options for <%- propertyType(property) %>
+   */
+  public TransitionOptions get<%- camelize(property.name) %>Transition() {
+    return nativeGet<%- camelize(property.name) %>Transition();
+  }
+
+  /**
+   * Set the <%- camelize(property.name) %> property transition options
+   *
+   * @param options transition options for <%- propertyType(property) %>
+   */
+  public void set<%- camelize(property.name) %>Transition(TransitionOptions options) {
+    nativeSet<%- camelize(property.name) %>Transition(options.getDuration(), options.getDelay());
+  }
+<% } -%>
 <% } -%>
 
-<% } -%>
 <% for (const property of properties) { -%>
   private native Object nativeGet<%- camelize(property.name) %>();
 
-<% } -%>
+<% if (property.transition) { -%>
+  private native TransitionOptions nativeGet<%- camelize(property.name) %>Transition();
 
+  private native void nativeSet<%- camelize(property.name) %>Transition(long duration, long delay);
+
+<% } -%>
+<% } -%>
   @Override
   protected native void finalize() throws Throwable;
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -36,6 +36,8 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * Basic smoke tests for BackgroundLayer
  */
@@ -73,6 +75,18 @@ public class BackgroundLayerTest extends BaseStyleTest {
     // Set
     layer.setProperties(visibility(NONE));
     assertEquals(layer.getVisibility().getValue(), NONE);
+  }
+
+  @Test
+  public void testBackgroundColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("background-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setBackgroundColorTransition(options);
+    assertEquals(layer.getBackgroundColorTransition(), options);
   }
 
   @Test
@@ -124,6 +138,18 @@ public class BackgroundLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testBackgroundPatternTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("background-patternTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setBackgroundPatternTransition(options);
+    assertEquals(layer.getBackgroundPatternTransition(), options);
+  }
+
+  @Test
   public void testBackgroundPatternAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("background-pattern");
@@ -157,6 +183,18 @@ public class BackgroundLayerTest extends BaseStyleTest {
     assertEquals(CameraFunction.class, layer.getBackgroundPattern().getFunction().getClass());
     assertEquals(IntervalStops.class, layer.getBackgroundPattern().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getBackgroundPattern().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testBackgroundOpacityTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("background-opacityTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setBackgroundOpacityTransition(options);
+    assertEquals(layer.getBackgroundOpacityTransition(), options);
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -36,6 +36,8 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * Basic smoke tests for CircleLayer
  */
@@ -79,6 +81,18 @@ public class CircleLayerTest extends BaseStyleTest {
     // Set
     layer.setProperties(visibility(NONE));
     assertEquals(layer.getVisibility().getValue(), NONE);
+  }
+
+  @Test
+  public void testCircleRadiusTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("circle-radiusTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleRadiusTransition(options);
+    assertEquals(layer.getCircleRadiusTransition(), options);
   }
 
   @Test
@@ -227,6 +241,18 @@ public class CircleLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testCircleColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("circle-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleColorTransition(options);
+    assertEquals(layer.getCircleColorTransition(), options);
+  }
+
+  @Test
   public void testCircleColorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("circle-color");
@@ -346,6 +372,18 @@ public class CircleLayerTest extends BaseStyleTest {
     // Set and Get
     layer.setProperties(circleColor(Color.RED));
     assertEquals(layer.getCircleColorAsInt(), Color.RED);
+  }
+
+  @Test
+  public void testCircleBlurTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("circle-blurTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleBlurTransition(options);
+    assertEquals(layer.getCircleBlurTransition(), options);
   }
 
   @Test
@@ -494,6 +532,18 @@ public class CircleLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testCircleOpacityTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("circle-opacityTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleOpacityTransition(options);
+    assertEquals(layer.getCircleOpacityTransition(), options);
+  }
+
+  @Test
   public void testCircleOpacityAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("circle-opacity");
@@ -639,6 +689,18 @@ public class CircleLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testCircleTranslateTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("circle-translateTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleTranslateTransition(options);
+    assertEquals(layer.getCircleTranslateTransition(), options);
+  }
+
+  @Test
   public void testCircleTranslateAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("circle-translate");
@@ -674,6 +736,7 @@ public class CircleLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getCircleTranslate().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getCircleTranslate().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testCircleTranslateAnchorAsConstant() {
@@ -711,6 +774,7 @@ public class CircleLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getCircleTranslateAnchor().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testCirclePitchScaleAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -745,6 +809,18 @@ public class CircleLayerTest extends BaseStyleTest {
     assertEquals(CameraFunction.class, layer.getCirclePitchScale().getFunction().getClass());
     assertEquals(IntervalStops.class, layer.getCirclePitchScale().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getCirclePitchScale().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testCircleStrokeWidthTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("circle-stroke-widthTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleStrokeWidthTransition(options);
+    assertEquals(layer.getCircleStrokeWidthTransition(), options);
   }
 
   @Test
@@ -893,6 +969,18 @@ public class CircleLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testCircleStrokeColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("circle-stroke-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleStrokeColorTransition(options);
+    assertEquals(layer.getCircleStrokeColorTransition(), options);
+  }
+
+  @Test
   public void testCircleStrokeColorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("circle-stroke-color");
@@ -1012,6 +1100,18 @@ public class CircleLayerTest extends BaseStyleTest {
     // Set and Get
     layer.setProperties(circleStrokeColor(Color.RED));
     assertEquals(layer.getCircleStrokeColorAsInt(), Color.RED);
+  }
+
+  @Test
+  public void testCircleStrokeOpacityTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("circle-stroke-opacityTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setCircleStrokeOpacityTransition(options);
+    assertEquals(layer.getCircleStrokeOpacityTransition(), options);
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -36,6 +36,8 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * Basic smoke tests for FillLayer
  */
@@ -81,6 +83,7 @@ public class FillLayerTest extends BaseStyleTest {
     assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
+
   @Test
   public void testFillAntialiasAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -115,6 +118,18 @@ public class FillLayerTest extends BaseStyleTest {
     assertEquals(CameraFunction.class, layer.getFillAntialias().getFunction().getClass());
     assertEquals(IntervalStops.class, layer.getFillAntialias().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getFillAntialias().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testFillOpacityTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("fill-opacityTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillOpacityTransition(options);
+    assertEquals(layer.getFillOpacityTransition(), options);
   }
 
   @Test
@@ -263,6 +278,18 @@ public class FillLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testFillColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("fill-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillColorTransition(options);
+    assertEquals(layer.getFillColorTransition(), options);
+  }
+
+  @Test
   public void testFillColorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("fill-color");
@@ -382,6 +409,18 @@ public class FillLayerTest extends BaseStyleTest {
     // Set and Get
     layer.setProperties(fillColor(Color.RED));
     assertEquals(layer.getFillColorAsInt(), Color.RED);
+  }
+
+  @Test
+  public void testFillOutlineColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("fill-outline-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillOutlineColorTransition(options);
+    assertEquals(layer.getFillOutlineColorTransition(), options);
   }
 
   @Test
@@ -507,6 +546,18 @@ public class FillLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testFillTranslateTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("fill-translateTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillTranslateTransition(options);
+    assertEquals(layer.getFillTranslateTransition(), options);
+  }
+
+  @Test
   public void testFillTranslateAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("fill-translate");
@@ -543,6 +594,7 @@ public class FillLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getFillTranslate().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testFillTranslateAnchorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -577,6 +629,18 @@ public class FillLayerTest extends BaseStyleTest {
     assertEquals(CameraFunction.class, layer.getFillTranslateAnchor().getFunction().getClass());
     assertEquals(IntervalStops.class, layer.getFillTranslateAnchor().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getFillTranslateAnchor().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testFillPatternTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("fill-patternTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setFillPatternTransition(options);
+    assertEquals(layer.getFillPatternTransition(), options);
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -36,6 +36,8 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * Basic smoke tests for LineLayer
  */
@@ -81,6 +83,7 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
+
   @Test
   public void testLineCapAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -117,6 +120,7 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getLineCap().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testLineJoinAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -152,6 +156,7 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getLineJoin().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getLineJoin().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testLineMiterLimitAsConstant() {
@@ -190,6 +195,7 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getLineMiterLimit().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testLineRoundLimitAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -225,6 +231,18 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(ExponentialStops.class, layer.getLineRoundLimit().getFunction().getStops().getClass());
     assertEquals(0.5f, ((ExponentialStops) layer.getLineRoundLimit().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getLineRoundLimit().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testLineOpacityTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-opacityTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineOpacityTransition(options);
+    assertEquals(layer.getLineOpacityTransition(), options);
   }
 
   @Test
@@ -373,6 +391,18 @@ public class LineLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testLineColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineColorTransition(options);
+    assertEquals(layer.getLineColorTransition(), options);
+  }
+
+  @Test
   public void testLineColorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("line-color");
@@ -495,6 +525,18 @@ public class LineLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testLineTranslateTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-translateTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineTranslateTransition(options);
+    assertEquals(layer.getLineTranslateTransition(), options);
+  }
+
+  @Test
   public void testLineTranslateAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("line-translate");
@@ -530,6 +572,7 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getLineTranslate().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getLineTranslate().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testLineTranslateAnchorAsConstant() {
@@ -568,6 +611,18 @@ public class LineLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testLineWidthTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-widthTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineWidthTransition(options);
+    assertEquals(layer.getLineWidthTransition(), options);
+  }
+
+  @Test
   public void testLineWidthAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("line-width");
@@ -602,6 +657,18 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(ExponentialStops.class, layer.getLineWidth().getFunction().getStops().getClass());
     assertEquals(0.5f, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getLineWidth().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testLineGapWidthTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-gap-widthTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineGapWidthTransition(options);
+    assertEquals(layer.getLineGapWidthTransition(), options);
   }
 
   @Test
@@ -750,6 +817,18 @@ public class LineLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testLineOffsetTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-offsetTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineOffsetTransition(options);
+    assertEquals(layer.getLineOffsetTransition(), options);
+  }
+
+  @Test
   public void testLineOffsetAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("line-offset");
@@ -892,6 +971,18 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(0f, stop.in.zoom, 0.001);
     assertEquals(0.3f, stop.in.value, 0.001f);
     assertEquals(0.9f, stop.out, 0.001f);
+  }
+
+  @Test
+  public void testLineBlurTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-blurTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineBlurTransition(options);
+    assertEquals(layer.getLineBlurTransition(), options);
   }
 
   @Test
@@ -1040,6 +1131,18 @@ public class LineLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testLineDasharrayTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-dasharrayTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLineDasharrayTransition(options);
+    assertEquals(layer.getLineDasharrayTransition(), options);
+  }
+
+  @Test
   public void testLineDasharrayAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("line-dasharray");
@@ -1073,6 +1176,18 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(CameraFunction.class, layer.getLineDasharray().getFunction().getClass());
     assertEquals(IntervalStops.class, layer.getLineDasharray().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getLineDasharray().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testLinePatternTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("line-patternTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setLinePatternTransition(options);
+    assertEquals(layer.getLinePatternTransition(), options);
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
@@ -36,6 +36,8 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * Basic smoke tests for RasterLayer
  */
@@ -82,6 +84,18 @@ public class RasterLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testRasterOpacityTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("raster-opacityTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterOpacityTransition(options);
+    assertEquals(layer.getRasterOpacityTransition(), options);
+  }
+
+  @Test
   public void testRasterOpacityAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("raster-opacity");
@@ -116,6 +130,18 @@ public class RasterLayerTest extends BaseStyleTest {
     assertEquals(ExponentialStops.class, layer.getRasterOpacity().getFunction().getStops().getClass());
     assertEquals(0.5f, ((ExponentialStops) layer.getRasterOpacity().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getRasterOpacity().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testRasterHueRotateTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("raster-hue-rotateTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterHueRotateTransition(options);
+    assertEquals(layer.getRasterHueRotateTransition(), options);
   }
 
   @Test
@@ -156,6 +182,18 @@ public class RasterLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testRasterBrightnessMinTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("raster-brightness-minTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterBrightnessMinTransition(options);
+    assertEquals(layer.getRasterBrightnessMinTransition(), options);
+  }
+
+  @Test
   public void testRasterBrightnessMinAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("raster-brightness-min");
@@ -190,6 +228,18 @@ public class RasterLayerTest extends BaseStyleTest {
     assertEquals(ExponentialStops.class, layer.getRasterBrightnessMin().getFunction().getStops().getClass());
     assertEquals(0.5f, ((ExponentialStops) layer.getRasterBrightnessMin().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getRasterBrightnessMin().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testRasterBrightnessMaxTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("raster-brightness-maxTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterBrightnessMaxTransition(options);
+    assertEquals(layer.getRasterBrightnessMaxTransition(), options);
   }
 
   @Test
@@ -230,6 +280,18 @@ public class RasterLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testRasterSaturationTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("raster-saturationTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterSaturationTransition(options);
+    assertEquals(layer.getRasterSaturationTransition(), options);
+  }
+
+  @Test
   public void testRasterSaturationAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("raster-saturation");
@@ -267,6 +329,18 @@ public class RasterLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testRasterContrastTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("raster-contrastTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterContrastTransition(options);
+    assertEquals(layer.getRasterContrastTransition(), options);
+  }
+
+  @Test
   public void testRasterContrastAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("raster-contrast");
@@ -301,6 +375,18 @@ public class RasterLayerTest extends BaseStyleTest {
     assertEquals(ExponentialStops.class, layer.getRasterContrast().getFunction().getStops().getClass());
     assertEquals(0.5f, ((ExponentialStops) layer.getRasterContrast().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getRasterContrast().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testRasterFadeDurationTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("raster-fade-durationTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setRasterFadeDurationTransition(options);
+    assertEquals(layer.getRasterFadeDurationTransition(), options);
   }
 
   @Test

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -36,6 +36,8 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * Basic smoke tests for SymbolLayer
  */
@@ -81,6 +83,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
+
   @Test
   public void testSymbolPlacementAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -116,6 +119,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getSymbolPlacement().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getSymbolPlacement().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testSymbolSpacingAsConstant() {
@@ -154,6 +158,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getSymbolSpacing().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testSymbolAvoidEdgesAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -189,6 +194,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getSymbolAvoidEdges().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getSymbolAvoidEdges().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testIconAllowOverlapAsConstant() {
@@ -226,6 +232,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getIconAllowOverlap().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testIconIgnorePlacementAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -261,6 +268,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconIgnorePlacement().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconIgnorePlacement().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testIconOptionalAsConstant() {
@@ -298,6 +306,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getIconOptional().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testIconRotationAlignmentAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -333,6 +342,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconRotationAlignment().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconRotationAlignment().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testIconSizeAsConstant() {
@@ -371,6 +381,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getIconSize().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testIconTextFitAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -406,6 +417,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconTextFit().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconTextFit().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testIconTextFitPaddingAsConstant() {
@@ -444,6 +456,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getIconTextFitPadding().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testIconImageAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -479,6 +492,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconImage().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconImage().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testIconRotateAsConstant() {
@@ -625,6 +639,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.9f, stop.out, 0.001f);
   }
 
+
   @Test
   public void testIconPaddingAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -662,6 +677,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getIconPadding().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testIconKeepUprightAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -697,6 +713,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconKeepUpright().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconKeepUpright().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testIconOffsetAsConstant() {
@@ -780,6 +797,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconOffset().getFunction().getStops().getClass());
   }
 
+
   @Test
   public void testTextPitchAlignmentAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -816,6 +834,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getTextPitchAlignment().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testTextRotationAlignmentAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -851,6 +870,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextRotationAlignment().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextRotationAlignment().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testTextFieldAsConstant() {
@@ -933,6 +953,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextField().getFunction().getStops().getClass());
   }
 
+
   @Test
   public void testTextFontAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -968,6 +989,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextFont().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextFont().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testTextSizeAsConstant() {
@@ -1006,6 +1028,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextSize().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testTextMaxWidthAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1042,6 +1065,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getTextMaxWidth().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getTextMaxWidth().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testTextLineHeightAsConstant() {
@@ -1080,6 +1104,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextLineHeight().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testTextLetterSpacingAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1117,6 +1142,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextLetterSpacing().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testTextJustifyAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1153,6 +1179,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getTextJustify().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testTextAnchorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1188,6 +1215,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextAnchor().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextAnchor().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testTextMaxAngleAsConstant() {
@@ -1226,6 +1254,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextMaxAngle().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testTextRotateAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1262,6 +1291,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getTextRotate().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getTextRotate().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testTextPaddingAsConstant() {
@@ -1300,6 +1330,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextPadding().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testTextKeepUprightAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1335,6 +1366,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextKeepUpright().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextKeepUpright().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testTextTransformAsConstant() {
@@ -1416,6 +1448,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals("FeaturePropertyA", ((SourceFunction) layer.getTextTransform().getFunction()).getProperty());
     assertEquals(IntervalStops.class, layer.getTextTransform().getFunction().getStops().getClass());
   }
+
 
   @Test
   public void testTextOffsetAsConstant() {
@@ -1499,6 +1532,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextOffset().getFunction().getStops().getClass());
   }
 
+
   @Test
   public void testTextAllowOverlapAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1534,6 +1568,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextAllowOverlap().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextAllowOverlap().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testTextIgnorePlacementAsConstant() {
@@ -1571,6 +1606,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getTextIgnorePlacement().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testTextOptionalAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1605,6 +1641,18 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(CameraFunction.class, layer.getTextOptional().getFunction().getClass());
     assertEquals(IntervalStops.class, layer.getTextOptional().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextOptional().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testIconOpacityTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("icon-opacityTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconOpacityTransition(options);
+    assertEquals(layer.getIconOpacityTransition(), options);
   }
 
   @Test
@@ -1753,6 +1801,18 @@ public class SymbolLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testIconColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("icon-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconColorTransition(options);
+    assertEquals(layer.getIconColorTransition(), options);
+  }
+
+  @Test
   public void testIconColorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("icon-color");
@@ -1875,6 +1935,18 @@ public class SymbolLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testIconHaloColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("icon-halo-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconHaloColorTransition(options);
+    assertEquals(layer.getIconHaloColorTransition(), options);
+  }
+
+  @Test
   public void testIconHaloColorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("icon-halo-color");
@@ -1994,6 +2066,18 @@ public class SymbolLayerTest extends BaseStyleTest {
     // Set and Get
     layer.setProperties(iconHaloColor(Color.RED));
     assertEquals(layer.getIconHaloColorAsInt(), Color.RED);
+  }
+
+  @Test
+  public void testIconHaloWidthTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("icon-halo-widthTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconHaloWidthTransition(options);
+    assertEquals(layer.getIconHaloWidthTransition(), options);
   }
 
   @Test
@@ -2142,6 +2226,18 @@ public class SymbolLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testIconHaloBlurTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("icon-halo-blurTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconHaloBlurTransition(options);
+    assertEquals(layer.getIconHaloBlurTransition(), options);
+  }
+
+  @Test
   public void testIconHaloBlurAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("icon-halo-blur");
@@ -2287,6 +2383,18 @@ public class SymbolLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testIconTranslateTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("icon-translateTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setIconTranslateTransition(options);
+    assertEquals(layer.getIconTranslateTransition(), options);
+  }
+
+  @Test
   public void testIconTranslateAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("icon-translate");
@@ -2323,6 +2431,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getIconTranslate().getFunction().getStops()).size());
   }
 
+
   @Test
   public void testIconTranslateAnchorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -2357,6 +2466,18 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(CameraFunction.class, layer.getIconTranslateAnchor().getFunction().getClass());
     assertEquals(IntervalStops.class, layer.getIconTranslateAnchor().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconTranslateAnchor().getFunction().getStops()).size());
+  }
+
+  @Test
+  public void testTextOpacityTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("text-opacityTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextOpacityTransition(options);
+    assertEquals(layer.getTextOpacityTransition(), options);
   }
 
   @Test
@@ -2505,6 +2626,18 @@ public class SymbolLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testTextColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("text-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextColorTransition(options);
+    assertEquals(layer.getTextColorTransition(), options);
+  }
+
+  @Test
   public void testTextColorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("text-color");
@@ -2627,6 +2760,18 @@ public class SymbolLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testTextHaloColorTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("text-halo-colorTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextHaloColorTransition(options);
+    assertEquals(layer.getTextHaloColorTransition(), options);
+  }
+
+  @Test
   public void testTextHaloColorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("text-halo-color");
@@ -2746,6 +2891,18 @@ public class SymbolLayerTest extends BaseStyleTest {
     // Set and Get
     layer.setProperties(textHaloColor(Color.RED));
     assertEquals(layer.getTextHaloColorAsInt(), Color.RED);
+  }
+
+  @Test
+  public void testTextHaloWidthTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("text-halo-widthTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextHaloWidthTransition(options);
+    assertEquals(layer.getTextHaloWidthTransition(), options);
   }
 
   @Test
@@ -2894,6 +3051,18 @@ public class SymbolLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testTextHaloBlurTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("text-halo-blurTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextHaloBlurTransition(options);
+    assertEquals(layer.getTextHaloBlurTransition(), options);
+  }
+
+  @Test
   public void testTextHaloBlurAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("text-halo-blur");
@@ -3039,6 +3208,18 @@ public class SymbolLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testTextTranslateTransition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("text-translateTransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.setTextTranslateTransition(options);
+    assertEquals(layer.getTextTranslateTransition(), options);
+  }
+
+  @Test
   public void testTextTranslateAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("text-translate");
@@ -3074,6 +3255,7 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getTextTranslate().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getTextTranslate().getFunction().getStops()).size());
   }
+
 
   @Test
   public void testTextTranslateAnchorAsConstant() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -40,6 +40,8 @@ import static org.junit.Assert.*;
 import static com.mapbox.mapboxsdk.style.layers.Property.*;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.*;
 
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
+
 /**
  * Basic smoke tests for <%- camelize(type) %>Layer
  */
@@ -91,6 +93,20 @@ public class <%- camelize(type) %>LayerTest extends BaseStyleTest {
   }
 
 <% for (const property of properties) { -%>
+<% if (property.transition) { -%>
+  @Test
+  public void test<%- camelize(property.name) %>Transition() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("<%- property.name %>TransitionOptions");
+    assertNotNull(layer);
+
+    // Set and Get
+    TransitionOptions options = new TransitionOptions(300, 100);
+    layer.set<%- camelize(property.name) %>Transition(options);
+    assertEquals(layer.get<%- camelize(property.name) %>Transition(), options);
+  }
+<% } -%>
+
   @Test
   public void test<%- camelize(property.name) %>AsConstant() {
     checkViewIsDisplayed(R.id.mapView);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -23,6 +23,7 @@ import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 import com.mapbox.mapboxsdk.style.layers.RasterLayer;
+import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.sources.RasterSource;
 import com.mapbox.mapboxsdk.style.sources.Source;
@@ -95,6 +96,9 @@ public class RuntimeStyleActivity extends AppCompatActivity {
 
         // Center and Zoom (Amsterdam, zoomed to streets)
         mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(new LatLng(52.379189, 4.899431), 14));
+
+        mapboxMap.setTransitionDuration(250);
+        mapboxMap.setTransitionDelay(50);
       }
     });
   }
@@ -257,10 +261,9 @@ public class RuntimeStyleActivity extends AppCompatActivity {
   }
 
   private void setWaterColor() {
-    Layer water = mapboxMap.getLayer("water");
+    FillLayer water = mapboxMap.getLayerAs("water");
     if (water != null) {
-      mapboxMap.setTransitionDuration(5000);
-      mapboxMap.setTransitionDelay(1000);
+      water.setFillColorTransition(new TransitionOptions(7500, 1000));
       water.setProperties(
         visibility(VISIBLE),
         fillColor(Color.RED)
@@ -510,7 +513,8 @@ public class RuntimeStyleActivity extends AppCompatActivity {
 
         if (states != null) {
           states.setFilter(eq("name", "Texas"));
-
+          states.setFillOpacityTransition(new TransitionOptions(2500, 0));
+          states.setFillColorTransition(new TransitionOptions(2500, 0));
           states.setProperties(
             fillColor(Color.RED),
             fillOpacity(0.25f)

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -119,6 +119,8 @@ add_library(mbgl-android STATIC
     platform/android/src/style/conversion/url_or_tileset.hpp
 
     # Style
+    platform/android/src/style/transition_options.cpp
+    platform/android/src/style/transition_options.hpp
     platform/android/src/style/layers/background_layer.cpp
     platform/android/src/style/layers/background_layer.hpp
     platform/android/src/style/layers/circle_layer.cpp

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -37,6 +37,7 @@
 #include "offline/offline_region_definition.hpp"
 #include "offline/offline_region_error.hpp"
 #include "offline/offline_region_status.hpp"
+#include "style/transition_options.hpp"
 #include "style/functions/categorical_stops.hpp"
 #include "style/functions/exponential_stops.hpp"
 #include "style/functions/identity_stops.hpp"
@@ -149,6 +150,7 @@ void registerNatives(JavaVM *vm) {
     BitmapFactory::registerNative(env);
 
     // Style
+    TransitionOptions::registerNative(env);
     registerNativeLayers(env);
     registerNativeSources(env);
     Stop::registerNative(env);

--- a/platform/android/src/style/conversion/transition_options.hpp
+++ b/platform/android/src/style/conversion/transition_options.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "../../conversion/conversion.hpp"
+
+#include <jni/jni.hpp>
+#include "../../jni/local_object.hpp"
+#include "../transition_options.hpp"
+
+namespace mbgl {
+namespace android {
+namespace conversion {
+
+template<>
+struct Converter<jni::Object<TransitionOptions>, mbgl::style::TransitionOptions> {
+    Result<jni::Object<TransitionOptions>> operator()(jni::JNIEnv &env, const mbgl::style::TransitionOptions &value) const {
+
+        // Convert duration
+        jlong duration =  std::chrono::duration_cast<std::chrono::milliseconds>(value.duration.value_or(mbgl::Duration::zero())).count();
+        // Convert delay
+        jlong delay = std::chrono::duration_cast<std::chrono::milliseconds>(value.delay.value_or(mbgl::Duration::zero())).count();
+
+        // Create transition options
+        return TransitionOptions::fromTransitionOptions(env, duration, delay);
+    }
+};
+
+}
+}
+}

--- a/platform/android/src/style/layers/background_layer.cpp
+++ b/platform/android/src/style/layers/background_layer.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../conversion/property_value.hpp"
+#include "../conversion/transition_options.hpp"
 
 namespace mbgl {
 namespace android {
@@ -40,10 +41,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> BackgroundLayer::getBackgroundColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::BackgroundLayer>()->BackgroundLayer::getBackgroundColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void BackgroundLayer::setBackgroundColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::BackgroundLayer>()->BackgroundLayer::setBackgroundColorTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> BackgroundLayer::getBackgroundPattern(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::BackgroundLayer>()->BackgroundLayer::getBackgroundPattern());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> BackgroundLayer::getBackgroundPatternTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::BackgroundLayer>()->BackgroundLayer::getBackgroundPatternTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void BackgroundLayer::setBackgroundPatternTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::BackgroundLayer>()->BackgroundLayer::setBackgroundPatternTransition(options);
     }
 
     jni::Object<jni::ObjectTag> BackgroundLayer::getBackgroundOpacity(jni::JNIEnv& env) {
@@ -51,6 +78,20 @@ namespace android {
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::BackgroundLayer>()->BackgroundLayer::getBackgroundOpacity());
         return jni::Object<jni::ObjectTag>(*converted);
     }
+
+    jni::Object<TransitionOptions> BackgroundLayer::getBackgroundOpacityTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::BackgroundLayer>()->BackgroundLayer::getBackgroundOpacityTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void BackgroundLayer::setBackgroundOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::BackgroundLayer>()->BackgroundLayer::setBackgroundOpacityTransition(options);
+    }
+
 
     jni::Class<BackgroundLayer> BackgroundLayer::javaClass;
 
@@ -71,8 +112,14 @@ namespace android {
             std::make_unique<BackgroundLayer, JNIEnv&, jni::String>,
             "initialize",
             "finalize",
+            METHOD(&BackgroundLayer::getBackgroundColorTransition, "nativeGetBackgroundColorTransition"),
+            METHOD(&BackgroundLayer::setBackgroundColorTransition, "nativeSetBackgroundColorTransition"),
             METHOD(&BackgroundLayer::getBackgroundColor, "nativeGetBackgroundColor"),
+            METHOD(&BackgroundLayer::getBackgroundPatternTransition, "nativeGetBackgroundPatternTransition"),
+            METHOD(&BackgroundLayer::setBackgroundPatternTransition, "nativeSetBackgroundPatternTransition"),
             METHOD(&BackgroundLayer::getBackgroundPattern, "nativeGetBackgroundPattern"),
+            METHOD(&BackgroundLayer::getBackgroundOpacityTransition, "nativeGetBackgroundOpacityTransition"),
+            METHOD(&BackgroundLayer::setBackgroundOpacityTransition, "nativeSetBackgroundOpacityTransition"),
             METHOD(&BackgroundLayer::getBackgroundOpacity, "nativeGetBackgroundOpacity"));
     }
 

--- a/platform/android/src/style/layers/background_layer.hpp
+++ b/platform/android/src/style/layers/background_layer.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "layer.hpp"
+#include "../transition_options.hpp"
 #include <mbgl/style/layers/background_layer.hpp>
 #include <jni/jni.hpp>
 
@@ -26,13 +27,19 @@ public:
 
     ~BackgroundLayer();
 
-    // Property getters
+    // Properties
+
     jni::Object<jni::ObjectTag> getBackgroundColor(jni::JNIEnv&);
+    void setBackgroundColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getBackgroundColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getBackgroundPattern(jni::JNIEnv&);
+    void setBackgroundPatternTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getBackgroundPatternTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getBackgroundOpacity(jni::JNIEnv&);
-
+    void setBackgroundOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getBackgroundOpacityTransition(jni::JNIEnv&);
     jni::jobject* createJavaPeer(jni::JNIEnv&);
 
 }; // class BackgroundLayer

--- a/platform/android/src/style/layers/circle_layer.cpp
+++ b/platform/android/src/style/layers/circle_layer.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../conversion/property_value.hpp"
+#include "../conversion/transition_options.hpp"
 
 namespace mbgl {
 namespace android {
@@ -40,10 +41,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> CircleLayer::getCircleRadiusTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleRadiusTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void CircleLayer::setCircleRadiusTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::CircleLayer>()->CircleLayer::setCircleRadiusTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> CircleLayer::getCircleColor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleColor());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> CircleLayer::getCircleColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void CircleLayer::setCircleColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::CircleLayer>()->CircleLayer::setCircleColorTransition(options);
     }
 
     jni::Object<jni::ObjectTag> CircleLayer::getCircleBlur(jni::JNIEnv& env) {
@@ -52,16 +79,55 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> CircleLayer::getCircleBlurTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleBlurTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void CircleLayer::setCircleBlurTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::CircleLayer>()->CircleLayer::setCircleBlurTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> CircleLayer::getCircleOpacity(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleOpacity());
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> CircleLayer::getCircleOpacityTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleOpacityTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void CircleLayer::setCircleOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::CircleLayer>()->CircleLayer::setCircleOpacityTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> CircleLayer::getCircleTranslate(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleTranslate());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> CircleLayer::getCircleTranslateTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleTranslateTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void CircleLayer::setCircleTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::CircleLayer>()->CircleLayer::setCircleTranslateTransition(options);
     }
 
     jni::Object<jni::ObjectTag> CircleLayer::getCircleTranslateAnchor(jni::JNIEnv& env) {
@@ -82,10 +148,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> CircleLayer::getCircleStrokeWidthTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleStrokeWidthTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void CircleLayer::setCircleStrokeWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::CircleLayer>()->CircleLayer::setCircleStrokeWidthTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> CircleLayer::getCircleStrokeColor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleStrokeColor());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> CircleLayer::getCircleStrokeColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleStrokeColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void CircleLayer::setCircleStrokeColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::CircleLayer>()->CircleLayer::setCircleStrokeColorTransition(options);
     }
 
     jni::Object<jni::ObjectTag> CircleLayer::getCircleStrokeOpacity(jni::JNIEnv& env) {
@@ -93,6 +185,20 @@ namespace android {
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleStrokeOpacity());
         return jni::Object<jni::ObjectTag>(*converted);
     }
+
+    jni::Object<TransitionOptions> CircleLayer::getCircleStrokeOpacityTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::CircleLayer>()->CircleLayer::getCircleStrokeOpacityTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void CircleLayer::setCircleStrokeOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::CircleLayer>()->CircleLayer::setCircleStrokeOpacityTransition(options);
+    }
+
 
     jni::Class<CircleLayer> CircleLayer::javaClass;
 
@@ -113,15 +219,31 @@ namespace android {
             std::make_unique<CircleLayer, JNIEnv&, jni::String, jni::String>,
             "initialize",
             "finalize",
+            METHOD(&CircleLayer::getCircleRadiusTransition, "nativeGetCircleRadiusTransition"),
+            METHOD(&CircleLayer::setCircleRadiusTransition, "nativeSetCircleRadiusTransition"),
             METHOD(&CircleLayer::getCircleRadius, "nativeGetCircleRadius"),
+            METHOD(&CircleLayer::getCircleColorTransition, "nativeGetCircleColorTransition"),
+            METHOD(&CircleLayer::setCircleColorTransition, "nativeSetCircleColorTransition"),
             METHOD(&CircleLayer::getCircleColor, "nativeGetCircleColor"),
+            METHOD(&CircleLayer::getCircleBlurTransition, "nativeGetCircleBlurTransition"),
+            METHOD(&CircleLayer::setCircleBlurTransition, "nativeSetCircleBlurTransition"),
             METHOD(&CircleLayer::getCircleBlur, "nativeGetCircleBlur"),
+            METHOD(&CircleLayer::getCircleOpacityTransition, "nativeGetCircleOpacityTransition"),
+            METHOD(&CircleLayer::setCircleOpacityTransition, "nativeSetCircleOpacityTransition"),
             METHOD(&CircleLayer::getCircleOpacity, "nativeGetCircleOpacity"),
+            METHOD(&CircleLayer::getCircleTranslateTransition, "nativeGetCircleTranslateTransition"),
+            METHOD(&CircleLayer::setCircleTranslateTransition, "nativeSetCircleTranslateTransition"),
             METHOD(&CircleLayer::getCircleTranslate, "nativeGetCircleTranslate"),
             METHOD(&CircleLayer::getCircleTranslateAnchor, "nativeGetCircleTranslateAnchor"),
             METHOD(&CircleLayer::getCirclePitchScale, "nativeGetCirclePitchScale"),
+            METHOD(&CircleLayer::getCircleStrokeWidthTransition, "nativeGetCircleStrokeWidthTransition"),
+            METHOD(&CircleLayer::setCircleStrokeWidthTransition, "nativeSetCircleStrokeWidthTransition"),
             METHOD(&CircleLayer::getCircleStrokeWidth, "nativeGetCircleStrokeWidth"),
+            METHOD(&CircleLayer::getCircleStrokeColorTransition, "nativeGetCircleStrokeColorTransition"),
+            METHOD(&CircleLayer::setCircleStrokeColorTransition, "nativeSetCircleStrokeColorTransition"),
             METHOD(&CircleLayer::getCircleStrokeColor, "nativeGetCircleStrokeColor"),
+            METHOD(&CircleLayer::getCircleStrokeOpacityTransition, "nativeGetCircleStrokeOpacityTransition"),
+            METHOD(&CircleLayer::setCircleStrokeOpacityTransition, "nativeSetCircleStrokeOpacityTransition"),
             METHOD(&CircleLayer::getCircleStrokeOpacity, "nativeGetCircleStrokeOpacity"));
     }
 

--- a/platform/android/src/style/layers/circle_layer.hpp
+++ b/platform/android/src/style/layers/circle_layer.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "layer.hpp"
+#include "../transition_options.hpp"
 #include <mbgl/style/layers/circle_layer.hpp>
 #include <jni/jni.hpp>
 
@@ -26,27 +27,43 @@ public:
 
     ~CircleLayer();
 
-    // Property getters
+    // Properties
+
     jni::Object<jni::ObjectTag> getCircleRadius(jni::JNIEnv&);
+    void setCircleRadiusTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getCircleRadiusTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCircleColor(jni::JNIEnv&);
+    void setCircleColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getCircleColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCircleBlur(jni::JNIEnv&);
+    void setCircleBlurTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getCircleBlurTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCircleOpacity(jni::JNIEnv&);
+    void setCircleOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getCircleOpacityTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCircleTranslate(jni::JNIEnv&);
+    void setCircleTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getCircleTranslateTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCircleTranslateAnchor(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCirclePitchScale(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCircleStrokeWidth(jni::JNIEnv&);
+    void setCircleStrokeWidthTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getCircleStrokeWidthTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCircleStrokeColor(jni::JNIEnv&);
+    void setCircleStrokeColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getCircleStrokeColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getCircleStrokeOpacity(jni::JNIEnv&);
-
+    void setCircleStrokeOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getCircleStrokeOpacityTransition(jni::JNIEnv&);
     jni::jobject* createJavaPeer(jni::JNIEnv&);
 
 }; // class CircleLayer

--- a/platform/android/src/style/layers/fill_layer.cpp
+++ b/platform/android/src/style/layers/fill_layer.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../conversion/property_value.hpp"
+#include "../conversion/transition_options.hpp"
 
 namespace mbgl {
 namespace android {
@@ -46,10 +47,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> FillLayer::getFillOpacityTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::FillLayer>()->FillLayer::getFillOpacityTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void FillLayer::setFillOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::FillLayer>()->FillLayer::setFillOpacityTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> FillLayer::getFillColor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::FillLayer>()->FillLayer::getFillColor());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> FillLayer::getFillColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::FillLayer>()->FillLayer::getFillColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void FillLayer::setFillColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::FillLayer>()->FillLayer::setFillColorTransition(options);
     }
 
     jni::Object<jni::ObjectTag> FillLayer::getFillOutlineColor(jni::JNIEnv& env) {
@@ -58,10 +85,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> FillLayer::getFillOutlineColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::FillLayer>()->FillLayer::getFillOutlineColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void FillLayer::setFillOutlineColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::FillLayer>()->FillLayer::setFillOutlineColorTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> FillLayer::getFillTranslate(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::FillLayer>()->FillLayer::getFillTranslate());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> FillLayer::getFillTranslateTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::FillLayer>()->FillLayer::getFillTranslateTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void FillLayer::setFillTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::FillLayer>()->FillLayer::setFillTranslateTransition(options);
     }
 
     jni::Object<jni::ObjectTag> FillLayer::getFillTranslateAnchor(jni::JNIEnv& env) {
@@ -75,6 +128,20 @@ namespace android {
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::FillLayer>()->FillLayer::getFillPattern());
         return jni::Object<jni::ObjectTag>(*converted);
     }
+
+    jni::Object<TransitionOptions> FillLayer::getFillPatternTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::FillLayer>()->FillLayer::getFillPatternTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void FillLayer::setFillPatternTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::FillLayer>()->FillLayer::setFillPatternTransition(options);
+    }
+
 
     jni::Class<FillLayer> FillLayer::javaClass;
 
@@ -96,11 +163,21 @@ namespace android {
             "initialize",
             "finalize",
             METHOD(&FillLayer::getFillAntialias, "nativeGetFillAntialias"),
+            METHOD(&FillLayer::getFillOpacityTransition, "nativeGetFillOpacityTransition"),
+            METHOD(&FillLayer::setFillOpacityTransition, "nativeSetFillOpacityTransition"),
             METHOD(&FillLayer::getFillOpacity, "nativeGetFillOpacity"),
+            METHOD(&FillLayer::getFillColorTransition, "nativeGetFillColorTransition"),
+            METHOD(&FillLayer::setFillColorTransition, "nativeSetFillColorTransition"),
             METHOD(&FillLayer::getFillColor, "nativeGetFillColor"),
+            METHOD(&FillLayer::getFillOutlineColorTransition, "nativeGetFillOutlineColorTransition"),
+            METHOD(&FillLayer::setFillOutlineColorTransition, "nativeSetFillOutlineColorTransition"),
             METHOD(&FillLayer::getFillOutlineColor, "nativeGetFillOutlineColor"),
+            METHOD(&FillLayer::getFillTranslateTransition, "nativeGetFillTranslateTransition"),
+            METHOD(&FillLayer::setFillTranslateTransition, "nativeSetFillTranslateTransition"),
             METHOD(&FillLayer::getFillTranslate, "nativeGetFillTranslate"),
             METHOD(&FillLayer::getFillTranslateAnchor, "nativeGetFillTranslateAnchor"),
+            METHOD(&FillLayer::getFillPatternTransition, "nativeGetFillPatternTransition"),
+            METHOD(&FillLayer::setFillPatternTransition, "nativeSetFillPatternTransition"),
             METHOD(&FillLayer::getFillPattern, "nativeGetFillPattern"));
     }
 

--- a/platform/android/src/style/layers/fill_layer.hpp
+++ b/platform/android/src/style/layers/fill_layer.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "layer.hpp"
+#include "../transition_options.hpp"
 #include <mbgl/style/layers/fill_layer.hpp>
 #include <jni/jni.hpp>
 
@@ -26,21 +27,31 @@ public:
 
     ~FillLayer();
 
-    // Property getters
+    // Properties
+
     jni::Object<jni::ObjectTag> getFillAntialias(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getFillOpacity(jni::JNIEnv&);
+    void setFillOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getFillOpacityTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getFillColor(jni::JNIEnv&);
+    void setFillColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getFillColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getFillOutlineColor(jni::JNIEnv&);
+    void setFillOutlineColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getFillOutlineColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getFillTranslate(jni::JNIEnv&);
+    void setFillTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getFillTranslateTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getFillTranslateAnchor(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getFillPattern(jni::JNIEnv&);
-
+    void setFillPatternTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getFillPatternTransition(jni::JNIEnv&);
     jni::jobject* createJavaPeer(jni::JNIEnv&);
 
 }; // class FillLayer

--- a/platform/android/src/style/layers/layer.cpp
+++ b/platform/android/src/style/layers/layer.cpp
@@ -3,6 +3,7 @@
 
 #include <jni/jni.hpp>
 
+#include <mbgl/style/transition_options.hpp>
 #include <mbgl/util/logging.hpp>
 
 // Java -> C++ conversion

--- a/platform/android/src/style/layers/layer.cpp.ejs
+++ b/platform/android/src/style/layers/layer.cpp.ejs
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "../conversion/property_value.hpp"
+#include "../conversion/transition_options.hpp"
 
 namespace mbgl {
 namespace android {
@@ -53,7 +54,23 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+<% if (property.transition) { -%>
+    jni::Object<TransitionOptions> <%- camelize(type) %>Layer::get<%- camelize(property.name) %>Transition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::<%- camelize(type) %>Layer>()-><%- camelize(type) %>Layer::get<%- camelize(property.name) %>Transition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void <%- camelize(type) %>Layer::set<%- camelize(property.name) %>Transition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::<%- camelize(type) %>Layer>()-><%- camelize(type) %>Layer::set<%- camelize(property.name) %>Transition(options);
+    }
+
 <% } -%>
+<% } -%>
+
     jni::Class<<%- camelize(type) %>Layer> <%- camelize(type) %>Layer::javaClass;
 
     jni::jobject* <%- camelize(type) %>Layer::createJavaPeer(jni::JNIEnv& env) {
@@ -77,8 +94,11 @@ namespace android {
 <% } -%>
             "initialize",
             "finalize",<% for(var i = 0; i < properties.length; i++) {%>
-            METHOD(&<%- camelize(type) %>Layer::get<%- camelize(properties[i].name) %>, "nativeGet<%- camelize(properties[i].name) %>")<% if(i != (properties.length -1)) {-%>,<% } -%>
-<% } -%>);
+<% if (properties[i].transition) { -%>
+            METHOD(&<%- camelize(type) %>Layer::get<%- camelize(properties[i].name) %>Transition, "nativeGet<%- camelize(properties[i].name) %>Transition"),
+            METHOD(&<%- camelize(type) %>Layer::set<%- camelize(properties[i].name) %>Transition, "nativeSet<%- camelize(properties[i].name) %>Transition"),
+<% } -%>
+            METHOD(&<%- camelize(type) %>Layer::get<%- camelize(properties[i].name) %>, "nativeGet<%- camelize(properties[i].name) %>")<% if(i != (properties.length -1)) {-%>,<% } -%><% } -%>);
     }
 
 } // namespace android

--- a/platform/android/src/style/layers/layer.hpp.ejs
+++ b/platform/android/src/style/layers/layer.hpp.ejs
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "layer.hpp"
+#include "../transition_options.hpp"
 #include <mbgl/style/layers/<%- type.replace('-', '_') %>_layer.hpp>
 #include <jni/jni.hpp>
 
@@ -34,11 +35,16 @@ public:
 
     ~<%- camelize(type) %>Layer();
 
-    // Property getters
+    // Properties
 <% for (const property of properties) { -%>
-    jni::Object<jni::ObjectTag> get<%- camelize(property.name) %>(jni::JNIEnv&);
 
+    jni::Object<jni::ObjectTag> get<%- camelize(property.name) %>(jni::JNIEnv&);
+<% if (property.transition) { -%>
+    void set<%- camelize(property.name) %>Transition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> get<%- camelize(property.name) %>Transition(jni::JNIEnv&);
 <% } -%>
+<% } -%>
+
     jni::jobject* createJavaPeer(jni::JNIEnv&);
 
 }; // class <%- camelize(type) %>Layer

--- a/platform/android/src/style/layers/line_layer.cpp
+++ b/platform/android/src/style/layers/line_layer.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../conversion/property_value.hpp"
+#include "../conversion/transition_options.hpp"
 
 namespace mbgl {
 namespace android {
@@ -64,16 +65,55 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> LineLayer::getLineOpacityTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLineOpacityTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLineOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLineOpacityTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> LineLayer::getLineColor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::LineLayer>()->LineLayer::getLineColor());
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> LineLayer::getLineColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLineColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLineColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLineColorTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> LineLayer::getLineTranslate(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::LineLayer>()->LineLayer::getLineTranslate());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> LineLayer::getLineTranslateTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLineTranslateTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLineTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLineTranslateTransition(options);
     }
 
     jni::Object<jni::ObjectTag> LineLayer::getLineTranslateAnchor(jni::JNIEnv& env) {
@@ -88,10 +128,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> LineLayer::getLineWidthTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLineWidthTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLineWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLineWidthTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> LineLayer::getLineGapWidth(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::LineLayer>()->LineLayer::getLineGapWidth());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> LineLayer::getLineGapWidthTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLineGapWidthTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLineGapWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLineGapWidthTransition(options);
     }
 
     jni::Object<jni::ObjectTag> LineLayer::getLineOffset(jni::JNIEnv& env) {
@@ -100,10 +166,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> LineLayer::getLineOffsetTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLineOffsetTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLineOffsetTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLineOffsetTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> LineLayer::getLineBlur(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::LineLayer>()->LineLayer::getLineBlur());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> LineLayer::getLineBlurTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLineBlurTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLineBlurTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLineBlurTransition(options);
     }
 
     jni::Object<jni::ObjectTag> LineLayer::getLineDasharray(jni::JNIEnv& env) {
@@ -112,11 +204,38 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> LineLayer::getLineDasharrayTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLineDasharrayTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLineDasharrayTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLineDasharrayTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> LineLayer::getLinePattern(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::LineLayer>()->LineLayer::getLinePattern());
         return jni::Object<jni::ObjectTag>(*converted);
     }
+
+    jni::Object<TransitionOptions> LineLayer::getLinePatternTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::LineLayer>()->LineLayer::getLinePatternTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void LineLayer::setLinePatternTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::LineLayer>()->LineLayer::setLinePatternTransition(options);
+    }
+
 
     jni::Class<LineLayer> LineLayer::javaClass;
 
@@ -141,15 +260,33 @@ namespace android {
             METHOD(&LineLayer::getLineJoin, "nativeGetLineJoin"),
             METHOD(&LineLayer::getLineMiterLimit, "nativeGetLineMiterLimit"),
             METHOD(&LineLayer::getLineRoundLimit, "nativeGetLineRoundLimit"),
+            METHOD(&LineLayer::getLineOpacityTransition, "nativeGetLineOpacityTransition"),
+            METHOD(&LineLayer::setLineOpacityTransition, "nativeSetLineOpacityTransition"),
             METHOD(&LineLayer::getLineOpacity, "nativeGetLineOpacity"),
+            METHOD(&LineLayer::getLineColorTransition, "nativeGetLineColorTransition"),
+            METHOD(&LineLayer::setLineColorTransition, "nativeSetLineColorTransition"),
             METHOD(&LineLayer::getLineColor, "nativeGetLineColor"),
+            METHOD(&LineLayer::getLineTranslateTransition, "nativeGetLineTranslateTransition"),
+            METHOD(&LineLayer::setLineTranslateTransition, "nativeSetLineTranslateTransition"),
             METHOD(&LineLayer::getLineTranslate, "nativeGetLineTranslate"),
             METHOD(&LineLayer::getLineTranslateAnchor, "nativeGetLineTranslateAnchor"),
+            METHOD(&LineLayer::getLineWidthTransition, "nativeGetLineWidthTransition"),
+            METHOD(&LineLayer::setLineWidthTransition, "nativeSetLineWidthTransition"),
             METHOD(&LineLayer::getLineWidth, "nativeGetLineWidth"),
+            METHOD(&LineLayer::getLineGapWidthTransition, "nativeGetLineGapWidthTransition"),
+            METHOD(&LineLayer::setLineGapWidthTransition, "nativeSetLineGapWidthTransition"),
             METHOD(&LineLayer::getLineGapWidth, "nativeGetLineGapWidth"),
+            METHOD(&LineLayer::getLineOffsetTransition, "nativeGetLineOffsetTransition"),
+            METHOD(&LineLayer::setLineOffsetTransition, "nativeSetLineOffsetTransition"),
             METHOD(&LineLayer::getLineOffset, "nativeGetLineOffset"),
+            METHOD(&LineLayer::getLineBlurTransition, "nativeGetLineBlurTransition"),
+            METHOD(&LineLayer::setLineBlurTransition, "nativeSetLineBlurTransition"),
             METHOD(&LineLayer::getLineBlur, "nativeGetLineBlur"),
+            METHOD(&LineLayer::getLineDasharrayTransition, "nativeGetLineDasharrayTransition"),
+            METHOD(&LineLayer::setLineDasharrayTransition, "nativeSetLineDasharrayTransition"),
             METHOD(&LineLayer::getLineDasharray, "nativeGetLineDasharray"),
+            METHOD(&LineLayer::getLinePatternTransition, "nativeGetLinePatternTransition"),
+            METHOD(&LineLayer::setLinePatternTransition, "nativeSetLinePatternTransition"),
             METHOD(&LineLayer::getLinePattern, "nativeGetLinePattern"));
     }
 

--- a/platform/android/src/style/layers/line_layer.hpp
+++ b/platform/android/src/style/layers/line_layer.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "layer.hpp"
+#include "../transition_options.hpp"
 #include <mbgl/style/layers/line_layer.hpp>
 #include <jni/jni.hpp>
 
@@ -26,7 +27,8 @@ public:
 
     ~LineLayer();
 
-    // Property getters
+    // Properties
+
     jni::Object<jni::ObjectTag> getLineCap(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineJoin(jni::JNIEnv&);
@@ -36,25 +38,42 @@ public:
     jni::Object<jni::ObjectTag> getLineRoundLimit(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineOpacity(jni::JNIEnv&);
+    void setLineOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLineOpacityTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineColor(jni::JNIEnv&);
+    void setLineColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLineColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineTranslate(jni::JNIEnv&);
+    void setLineTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLineTranslateTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineTranslateAnchor(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineWidth(jni::JNIEnv&);
+    void setLineWidthTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLineWidthTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineGapWidth(jni::JNIEnv&);
+    void setLineGapWidthTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLineGapWidthTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineOffset(jni::JNIEnv&);
+    void setLineOffsetTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLineOffsetTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineBlur(jni::JNIEnv&);
+    void setLineBlurTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLineBlurTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLineDasharray(jni::JNIEnv&);
+    void setLineDasharrayTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLineDasharrayTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getLinePattern(jni::JNIEnv&);
-
+    void setLinePatternTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getLinePatternTransition(jni::JNIEnv&);
     jni::jobject* createJavaPeer(jni::JNIEnv&);
 
 }; // class LineLayer

--- a/platform/android/src/style/layers/raster_layer.cpp
+++ b/platform/android/src/style/layers/raster_layer.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../conversion/property_value.hpp"
+#include "../conversion/transition_options.hpp"
 
 namespace mbgl {
 namespace android {
@@ -40,10 +41,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> RasterLayer::getRasterOpacityTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterOpacityTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void RasterLayer::setRasterOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::RasterLayer>()->RasterLayer::setRasterOpacityTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> RasterLayer::getRasterHueRotate(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterHueRotate());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> RasterLayer::getRasterHueRotateTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterHueRotateTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void RasterLayer::setRasterHueRotateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::RasterLayer>()->RasterLayer::setRasterHueRotateTransition(options);
     }
 
     jni::Object<jni::ObjectTag> RasterLayer::getRasterBrightnessMin(jni::JNIEnv& env) {
@@ -52,10 +79,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> RasterLayer::getRasterBrightnessMinTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterBrightnessMinTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void RasterLayer::setRasterBrightnessMinTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::RasterLayer>()->RasterLayer::setRasterBrightnessMinTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> RasterLayer::getRasterBrightnessMax(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterBrightnessMax());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> RasterLayer::getRasterBrightnessMaxTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterBrightnessMaxTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void RasterLayer::setRasterBrightnessMaxTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::RasterLayer>()->RasterLayer::setRasterBrightnessMaxTransition(options);
     }
 
     jni::Object<jni::ObjectTag> RasterLayer::getRasterSaturation(jni::JNIEnv& env) {
@@ -64,10 +117,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> RasterLayer::getRasterSaturationTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterSaturationTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void RasterLayer::setRasterSaturationTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::RasterLayer>()->RasterLayer::setRasterSaturationTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> RasterLayer::getRasterContrast(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterContrast());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> RasterLayer::getRasterContrastTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterContrastTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void RasterLayer::setRasterContrastTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::RasterLayer>()->RasterLayer::setRasterContrastTransition(options);
     }
 
     jni::Object<jni::ObjectTag> RasterLayer::getRasterFadeDuration(jni::JNIEnv& env) {
@@ -75,6 +154,20 @@ namespace android {
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterFadeDuration());
         return jni::Object<jni::ObjectTag>(*converted);
     }
+
+    jni::Object<TransitionOptions> RasterLayer::getRasterFadeDurationTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::RasterLayer>()->RasterLayer::getRasterFadeDurationTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void RasterLayer::setRasterFadeDurationTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::RasterLayer>()->RasterLayer::setRasterFadeDurationTransition(options);
+    }
+
 
     jni::Class<RasterLayer> RasterLayer::javaClass;
 
@@ -95,12 +188,26 @@ namespace android {
             std::make_unique<RasterLayer, JNIEnv&, jni::String, jni::String>,
             "initialize",
             "finalize",
+            METHOD(&RasterLayer::getRasterOpacityTransition, "nativeGetRasterOpacityTransition"),
+            METHOD(&RasterLayer::setRasterOpacityTransition, "nativeSetRasterOpacityTransition"),
             METHOD(&RasterLayer::getRasterOpacity, "nativeGetRasterOpacity"),
+            METHOD(&RasterLayer::getRasterHueRotateTransition, "nativeGetRasterHueRotateTransition"),
+            METHOD(&RasterLayer::setRasterHueRotateTransition, "nativeSetRasterHueRotateTransition"),
             METHOD(&RasterLayer::getRasterHueRotate, "nativeGetRasterHueRotate"),
+            METHOD(&RasterLayer::getRasterBrightnessMinTransition, "nativeGetRasterBrightnessMinTransition"),
+            METHOD(&RasterLayer::setRasterBrightnessMinTransition, "nativeSetRasterBrightnessMinTransition"),
             METHOD(&RasterLayer::getRasterBrightnessMin, "nativeGetRasterBrightnessMin"),
+            METHOD(&RasterLayer::getRasterBrightnessMaxTransition, "nativeGetRasterBrightnessMaxTransition"),
+            METHOD(&RasterLayer::setRasterBrightnessMaxTransition, "nativeSetRasterBrightnessMaxTransition"),
             METHOD(&RasterLayer::getRasterBrightnessMax, "nativeGetRasterBrightnessMax"),
+            METHOD(&RasterLayer::getRasterSaturationTransition, "nativeGetRasterSaturationTransition"),
+            METHOD(&RasterLayer::setRasterSaturationTransition, "nativeSetRasterSaturationTransition"),
             METHOD(&RasterLayer::getRasterSaturation, "nativeGetRasterSaturation"),
+            METHOD(&RasterLayer::getRasterContrastTransition, "nativeGetRasterContrastTransition"),
+            METHOD(&RasterLayer::setRasterContrastTransition, "nativeSetRasterContrastTransition"),
             METHOD(&RasterLayer::getRasterContrast, "nativeGetRasterContrast"),
+            METHOD(&RasterLayer::getRasterFadeDurationTransition, "nativeGetRasterFadeDurationTransition"),
+            METHOD(&RasterLayer::setRasterFadeDurationTransition, "nativeSetRasterFadeDurationTransition"),
             METHOD(&RasterLayer::getRasterFadeDuration, "nativeGetRasterFadeDuration"));
     }
 

--- a/platform/android/src/style/layers/raster_layer.hpp
+++ b/platform/android/src/style/layers/raster_layer.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "layer.hpp"
+#include "../transition_options.hpp"
 #include <mbgl/style/layers/raster_layer.hpp>
 #include <jni/jni.hpp>
 
@@ -26,21 +27,35 @@ public:
 
     ~RasterLayer();
 
-    // Property getters
+    // Properties
+
     jni::Object<jni::ObjectTag> getRasterOpacity(jni::JNIEnv&);
+    void setRasterOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getRasterOpacityTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getRasterHueRotate(jni::JNIEnv&);
+    void setRasterHueRotateTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getRasterHueRotateTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getRasterBrightnessMin(jni::JNIEnv&);
+    void setRasterBrightnessMinTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getRasterBrightnessMinTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getRasterBrightnessMax(jni::JNIEnv&);
+    void setRasterBrightnessMaxTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getRasterBrightnessMaxTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getRasterSaturation(jni::JNIEnv&);
+    void setRasterSaturationTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getRasterSaturationTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getRasterContrast(jni::JNIEnv&);
+    void setRasterContrastTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getRasterContrastTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getRasterFadeDuration(jni::JNIEnv&);
-
+    void setRasterFadeDurationTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getRasterFadeDurationTransition(jni::JNIEnv&);
     jni::jobject* createJavaPeer(jni::JNIEnv&);
 
 }; // class RasterLayer

--- a/platform/android/src/style/layers/symbol_layer.cpp
+++ b/platform/android/src/style/layers/symbol_layer.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../conversion/property_value.hpp"
+#include "../conversion/transition_options.hpp"
 
 namespace mbgl {
 namespace android {
@@ -244,10 +245,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> SymbolLayer::getIconOpacityTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconOpacityTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setIconOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setIconOpacityTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> SymbolLayer::getIconColor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconColor());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> SymbolLayer::getIconColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setIconColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setIconColorTransition(options);
     }
 
     jni::Object<jni::ObjectTag> SymbolLayer::getIconHaloColor(jni::JNIEnv& env) {
@@ -256,10 +283,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> SymbolLayer::getIconHaloColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconHaloColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setIconHaloColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setIconHaloColorTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> SymbolLayer::getIconHaloWidth(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconHaloWidth());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> SymbolLayer::getIconHaloWidthTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconHaloWidthTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setIconHaloWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setIconHaloWidthTransition(options);
     }
 
     jni::Object<jni::ObjectTag> SymbolLayer::getIconHaloBlur(jni::JNIEnv& env) {
@@ -268,10 +321,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> SymbolLayer::getIconHaloBlurTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconHaloBlurTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setIconHaloBlurTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setIconHaloBlurTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> SymbolLayer::getIconTranslate(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconTranslate());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> SymbolLayer::getIconTranslateTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getIconTranslateTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setIconTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setIconTranslateTransition(options);
     }
 
     jni::Object<jni::ObjectTag> SymbolLayer::getIconTranslateAnchor(jni::JNIEnv& env) {
@@ -286,10 +365,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> SymbolLayer::getTextOpacityTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextOpacityTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setTextOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setTextOpacityTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> SymbolLayer::getTextColor(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextColor());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> SymbolLayer::getTextColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setTextColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setTextColorTransition(options);
     }
 
     jni::Object<jni::ObjectTag> SymbolLayer::getTextHaloColor(jni::JNIEnv& env) {
@@ -298,10 +403,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> SymbolLayer::getTextHaloColorTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextHaloColorTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setTextHaloColorTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setTextHaloColorTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> SymbolLayer::getTextHaloWidth(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextHaloWidth());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> SymbolLayer::getTextHaloWidthTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextHaloWidthTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setTextHaloWidthTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setTextHaloWidthTransition(options);
     }
 
     jni::Object<jni::ObjectTag> SymbolLayer::getTextHaloBlur(jni::JNIEnv& env) {
@@ -310,10 +441,36 @@ namespace android {
         return jni::Object<jni::ObjectTag>(*converted);
     }
 
+    jni::Object<TransitionOptions> SymbolLayer::getTextHaloBlurTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextHaloBlurTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setTextHaloBlurTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setTextHaloBlurTransition(options);
+    }
+
     jni::Object<jni::ObjectTag> SymbolLayer::getTextTranslate(jni::JNIEnv& env) {
         using namespace mbgl::android::conversion;
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextTranslate());
         return jni::Object<jni::ObjectTag>(*converted);
+    }
+
+    jni::Object<TransitionOptions> SymbolLayer::getTextTranslateTransition(jni::JNIEnv& env) {
+        using namespace mbgl::android::conversion;
+        mbgl::style::TransitionOptions options = layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextTranslateTransition();
+        return *convert<jni::Object<TransitionOptions>>(env, options);
+    }
+
+    void SymbolLayer::setTextTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay) {
+        mbgl::style::TransitionOptions options;
+        options.duration.emplace(mbgl::Milliseconds(duration));
+        options.delay.emplace(mbgl::Milliseconds(delay));
+        layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::setTextTranslateTransition(options);
     }
 
     jni::Object<jni::ObjectTag> SymbolLayer::getTextTranslateAnchor(jni::JNIEnv& env) {
@@ -321,6 +478,7 @@ namespace android {
         Result<jni::jobject*> converted = convert<jni::jobject*>(env, layer.as<mbgl::style::SymbolLayer>()->SymbolLayer::getTextTranslateAnchor());
         return jni::Object<jni::ObjectTag>(*converted);
     }
+
 
     jni::Class<SymbolLayer> SymbolLayer::javaClass;
 
@@ -375,18 +533,42 @@ namespace android {
             METHOD(&SymbolLayer::getTextAllowOverlap, "nativeGetTextAllowOverlap"),
             METHOD(&SymbolLayer::getTextIgnorePlacement, "nativeGetTextIgnorePlacement"),
             METHOD(&SymbolLayer::getTextOptional, "nativeGetTextOptional"),
+            METHOD(&SymbolLayer::getIconOpacityTransition, "nativeGetIconOpacityTransition"),
+            METHOD(&SymbolLayer::setIconOpacityTransition, "nativeSetIconOpacityTransition"),
             METHOD(&SymbolLayer::getIconOpacity, "nativeGetIconOpacity"),
+            METHOD(&SymbolLayer::getIconColorTransition, "nativeGetIconColorTransition"),
+            METHOD(&SymbolLayer::setIconColorTransition, "nativeSetIconColorTransition"),
             METHOD(&SymbolLayer::getIconColor, "nativeGetIconColor"),
+            METHOD(&SymbolLayer::getIconHaloColorTransition, "nativeGetIconHaloColorTransition"),
+            METHOD(&SymbolLayer::setIconHaloColorTransition, "nativeSetIconHaloColorTransition"),
             METHOD(&SymbolLayer::getIconHaloColor, "nativeGetIconHaloColor"),
+            METHOD(&SymbolLayer::getIconHaloWidthTransition, "nativeGetIconHaloWidthTransition"),
+            METHOD(&SymbolLayer::setIconHaloWidthTransition, "nativeSetIconHaloWidthTransition"),
             METHOD(&SymbolLayer::getIconHaloWidth, "nativeGetIconHaloWidth"),
+            METHOD(&SymbolLayer::getIconHaloBlurTransition, "nativeGetIconHaloBlurTransition"),
+            METHOD(&SymbolLayer::setIconHaloBlurTransition, "nativeSetIconHaloBlurTransition"),
             METHOD(&SymbolLayer::getIconHaloBlur, "nativeGetIconHaloBlur"),
+            METHOD(&SymbolLayer::getIconTranslateTransition, "nativeGetIconTranslateTransition"),
+            METHOD(&SymbolLayer::setIconTranslateTransition, "nativeSetIconTranslateTransition"),
             METHOD(&SymbolLayer::getIconTranslate, "nativeGetIconTranslate"),
             METHOD(&SymbolLayer::getIconTranslateAnchor, "nativeGetIconTranslateAnchor"),
+            METHOD(&SymbolLayer::getTextOpacityTransition, "nativeGetTextOpacityTransition"),
+            METHOD(&SymbolLayer::setTextOpacityTransition, "nativeSetTextOpacityTransition"),
             METHOD(&SymbolLayer::getTextOpacity, "nativeGetTextOpacity"),
+            METHOD(&SymbolLayer::getTextColorTransition, "nativeGetTextColorTransition"),
+            METHOD(&SymbolLayer::setTextColorTransition, "nativeSetTextColorTransition"),
             METHOD(&SymbolLayer::getTextColor, "nativeGetTextColor"),
+            METHOD(&SymbolLayer::getTextHaloColorTransition, "nativeGetTextHaloColorTransition"),
+            METHOD(&SymbolLayer::setTextHaloColorTransition, "nativeSetTextHaloColorTransition"),
             METHOD(&SymbolLayer::getTextHaloColor, "nativeGetTextHaloColor"),
+            METHOD(&SymbolLayer::getTextHaloWidthTransition, "nativeGetTextHaloWidthTransition"),
+            METHOD(&SymbolLayer::setTextHaloWidthTransition, "nativeSetTextHaloWidthTransition"),
             METHOD(&SymbolLayer::getTextHaloWidth, "nativeGetTextHaloWidth"),
+            METHOD(&SymbolLayer::getTextHaloBlurTransition, "nativeGetTextHaloBlurTransition"),
+            METHOD(&SymbolLayer::setTextHaloBlurTransition, "nativeSetTextHaloBlurTransition"),
             METHOD(&SymbolLayer::getTextHaloBlur, "nativeGetTextHaloBlur"),
+            METHOD(&SymbolLayer::getTextTranslateTransition, "nativeGetTextTranslateTransition"),
+            METHOD(&SymbolLayer::setTextTranslateTransition, "nativeSetTextTranslateTransition"),
             METHOD(&SymbolLayer::getTextTranslate, "nativeGetTextTranslate"),
             METHOD(&SymbolLayer::getTextTranslateAnchor, "nativeGetTextTranslateAnchor"));
     }

--- a/platform/android/src/style/layers/symbol_layer.hpp
+++ b/platform/android/src/style/layers/symbol_layer.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "layer.hpp"
+#include "../transition_options.hpp"
 #include <mbgl/style/layers/symbol_layer.hpp>
 #include <jni/jni.hpp>
 
@@ -26,7 +27,8 @@ public:
 
     ~SymbolLayer();
 
-    // Property getters
+    // Properties
+
     jni::Object<jni::ObjectTag> getSymbolPlacement(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getSymbolSpacing(jni::JNIEnv&);
@@ -96,33 +98,56 @@ public:
     jni::Object<jni::ObjectTag> getTextOptional(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getIconOpacity(jni::JNIEnv&);
+    void setIconOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getIconOpacityTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getIconColor(jni::JNIEnv&);
+    void setIconColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getIconColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getIconHaloColor(jni::JNIEnv&);
+    void setIconHaloColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getIconHaloColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getIconHaloWidth(jni::JNIEnv&);
+    void setIconHaloWidthTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getIconHaloWidthTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getIconHaloBlur(jni::JNIEnv&);
+    void setIconHaloBlurTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getIconHaloBlurTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getIconTranslate(jni::JNIEnv&);
+    void setIconTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getIconTranslateTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getIconTranslateAnchor(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getTextOpacity(jni::JNIEnv&);
+    void setTextOpacityTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getTextOpacityTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getTextColor(jni::JNIEnv&);
+    void setTextColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getTextColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getTextHaloColor(jni::JNIEnv&);
+    void setTextHaloColorTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getTextHaloColorTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getTextHaloWidth(jni::JNIEnv&);
+    void setTextHaloWidthTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getTextHaloWidthTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getTextHaloBlur(jni::JNIEnv&);
+    void setTextHaloBlurTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getTextHaloBlurTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getTextTranslate(jni::JNIEnv&);
+    void setTextTranslateTransition(jni::JNIEnv&, jlong duration, jlong delay);
+    jni::Object<TransitionOptions> getTextTranslateTransition(jni::JNIEnv&);
 
     jni::Object<jni::ObjectTag> getTextTranslateAnchor(jni::JNIEnv&);
-
     jni::jobject* createJavaPeer(jni::JNIEnv&);
 
 }; // class SymbolLayer

--- a/platform/android/src/style/transition_options.cpp
+++ b/platform/android/src/style/transition_options.cpp
@@ -1,0 +1,20 @@
+#include "transition_options.hpp"
+
+namespace mbgl {
+namespace android {
+
+jni::Object<TransitionOptions> TransitionOptions::fromTransitionOptions(jni::JNIEnv& env, jlong duration, jlong delay) {
+    static auto method = TransitionOptions::javaClass.GetStaticMethod<jni::Object<TransitionOptions> (jlong, jlong)>(env, "fromTransitionOptions");
+    return TransitionOptions::javaClass.Call(env, method, duration, delay);
+}
+
+void TransitionOptions::registerNative(jni::JNIEnv& env) {
+    // Lookup the class
+    TransitionOptions::javaClass = *jni::Class<TransitionOptions>::Find(env).NewGlobalRef(env).release();
+}
+
+jni::Class<TransitionOptions> TransitionOptions::javaClass;
+
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/style/transition_options.hpp
+++ b/platform/android/src/style/transition_options.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <mbgl/util/noncopyable.hpp>
+
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace android {
+
+class TransitionOptions : private mbgl::util::noncopyable {
+public:
+
+    static constexpr auto Name() { return "com/mapbox/mapboxsdk/style/layers/TransitionOptions"; };
+
+    static jni::Object<TransitionOptions> fromTransitionOptions(jni::JNIEnv&, jlong duration, jlong offset);
+
+    static jni::Class<TransitionOptions> javaClass;
+
+    static void registerNative(jni::JNIEnv&);
+
+};
+
+
+} // namespace android
+} // namespace mbgl


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-native/issues/8015

This PR adds TransitionOptions to the Android bindings for Layer Properties that support it 
 - eg. [circle-stroke-width](https://github.com/mapbox/mapbox-gl-js/blob/master/src/style-spec/reference/v8.json#L2430).

Todo to finish:
 - [x] replace `jni::Array<jni::jlong>` return type with ~~`jni::Object<jni::ObjectTag>`~~ `jni::Object<TransformOptions>`
 - [x] add sample to Test app

cc @zugaldia @ericrwolfe 