### PR TITLE
[ios] Crash fix on render with view-backed annotations

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3044,7 +3044,10 @@ public:
                 continue;
             }
             MGLAnnotationContext annotationContext = _annotationContextsByAnnotationTag.at(annotationTag);
-            [annotations addObject:annotationContext.annotation];
+            if (annotationContext.annotation)
+            {
+                [annotations addObject:annotationContext.annotation];
+            }
         }
 
         return [annotations copy];


### PR DESCRIPTION
Fixes #8163 while this is only a nil check, we need to continue investigating why `annotationContext.annotation` is nil when calling `visibleAnnotationsInRect` 