### PR TITLE
[android] - correct anchoring when Icon is updated

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerView.java
@@ -390,6 +390,15 @@ public class MarkerView extends Marker {
   }
 
   /**
+   * Invalidates the MarkerView resulting in remeasuring the View.
+   */
+  void invalidate() {
+    width = height = 0;
+    offsetX = offsetY = MapboxConstants.UNMEASURED;
+    markerViewManager.invalidateViewMarkersInVisibleRegion();
+  }
+
+  /**
    * Get the String representation of a MarkerView.
    *
    * @return the String representation.

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/annotations/MarkerViewManager.java
@@ -233,6 +233,7 @@ public class MarkerViewManager implements MapView.OnMapChangedListener {
     View convertView = markerViewMap.get(markerView);
     if (convertView != null && convertView instanceof ImageView) {
       ((ImageView) convertView).setImageBitmap(markerView.getIcon().getBitmap());
+      markerView.invalidate();
     }
   }
 


### PR DESCRIPTION
closes #8511 

Before:
![ezgif com-video-to-gif 28](https://cloud.githubusercontent.com/assets/2151639/24296436/6ea4dfc4-109f-11e7-9aab-e87e905a0acb.gif)

After:
![ezgif com-video-to-gif 29](https://cloud.githubusercontent.com/assets/2151639/24296439/7096f06a-109f-11e7-8e2b-0d59d30d4c17.gif)
