### PR TITLE
Copyedit data-driven styling guides

### DIFF
--- a/platform/darwin/docs/guides/Data-Driven Styling.md.ejs
+++ b/platform/darwin/docs/guides/Data-Driven Styling.md.ejs
@@ -12,44 +12,43 @@
 
 # Data-Driven Styling
 
-Mapbox’s data-driven styling features allow you to use data properties to style your maps. You can style map features automatically based on their individual attributes. 
+Mapbox’s data-driven styling features allow you to use attributes in the data to style your maps. You can style map features automatically based on their individual attributes.
 
 Vary POI icons, transit route line colors, city polygon opacity, and more based on any attribute in your data. Need to visualize hotel data by price? You can have your map’s point radii and colors change automatically with your data.
 
 ![available bikes](img/data-driven-styling/citibikes.png) ![subway lines](img/data-driven-styling/polylineExample.png)
 
-# How to use Data-Driven Styling
 This guide uses earthquake data from the [U.S. Geological Survey](https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php) to style a map based on attributes. For more information about how to work with GeoJSON data in our iOS SDK, please see our [working with GeoJSON data](working-with-geojson-data.html) guide.
 
-`MGLStyleFunction`
+## Style functions
 
 There are three subclasses of `MGLStyleFunction`:
 
-* `MGLCameraStyleFunction` - For a style value that changes with zoom level. For example, you can make the radius of a circle increase according to zoom level. 
-* `MGLSourceStyleFunction` - For a style value that changes with the attributes of a feature. For example, you can adjust the radius of a circle based on the magnitude of an earthquake.
-* `MGLCompositeStyleFunction` - For a style value that changes with both zoom level and attribute values. For example, you can add a circle layer where each circle has a radius based on both zoom level and the magnitude of an earthquake.
+* `MGLCameraStyleFunction` is a style value that changes with zoom level. For example, you can make the radius of a circle increase according to zoom level.
+* `MGLSourceStyleFunction` is a style value that changes with the attributes of a feature. For example, you can adjust the radius of a circle based on the magnitude of an earthquake.
+* `MGLCompositeStyleFunction` is a style value that changes with both zoom level and attribute values. For example, you can add a circle layer where each circle has a radius based on both zoom level and the magnitude of an earthquake.
 
-The documentation for individual style properties will note which style functions are enabled for that property.
+The documentation for each individual style layer property notes which style functions are enabled for that property.
 
 ## Stops
 
 Stops are key-value pairs that that determine a style value. With a `MGLCameraSourceFunction` stop, you can use a dictionary with a zoom level for a key and a `MGLStyleValue` for the value. For example, you can use a stops dictionary with zoom levels 0, 10, and 20 as keys, and yellow, orange, and red as the values. A `MGLSourceStyleFunction` uses the relevant attribute value as the key.
 
 ```swift
-let stops = [0: MGLStyleValue(rawValue: UIColor.yellow),
-             2.5: MGLStyleValue(rawValue: UIColor.orange),
-             5: MGLStyleValue(rawValue: UIColor.red),
-             7.5: MGLStyleValue(rawValue: UIColor.blue),
-             10: MGLStyleValue(rawValue: UIColor.white)]
+let stops = [0: MGLStyleValue<<%- cocoaPrefix %>Color>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 ```
 
-## Interpolation Mode
+## Interpolation mode
 
 The effect a key has on the style value is determined by the interpolation mode. There are four interpolation modes that can be used with a source style function: exponential, interval, categorical, and identity. You can also use exponential and interval interpolation modes with a camera style function.
 
 ### Linear
 
-`MGLInterpolationModelExponential` interpolates linearly or exponentially between style function stop values. By default, the `MGLStyleFunction` options parameter `MGLStyleFunctionOptionInterpolationBase` equals `1`, which represents linear interpolation, and doesn’t need to be included in the options dictionary.
+`MGLInterpolationModeExponential` interpolates linearly or exponentially between style function stop values. By default, the `MGLStyleFunction` options parameter `MGLStyleFunctionOptionInterpolationBase` equals `1`, which represents linear interpolation and doesn’t need to be included in the options dictionary.
 
 The stops dictionary below, for example, shows colors that continuously shift from yellow to orange to red to blue to white based on the attribute value.
 
@@ -61,11 +60,11 @@ let symbolLayer = MGLSymbolStyleLayer(identifier: "place-city-sm", source: symbo
 let source = MGLShapeSource(identifier: "earthquakes", url: url, options: nil)
 style.addSource(source)
 
-let stops = [0: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.yellow),
-             2.5: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.orange),
-             5: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.red),
-             7.5: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.blue),
-             10: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.white)]
+let stops = [0: MGLStyleValue<<%- cocoaPrefix %>Color>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 
 let layer = MGLCircleStyleLayer(identifier: "circles", source: source)
 layer.circleColor = MGLStyleValue(interpolationMode: .exponential,
@@ -80,7 +79,7 @@ style.insertLayer(layer, below: symbolLayer)
 
 ### Exponential
 
-`MGLInterpolationModelExponential` combined with any `MGLStyleFunctionOptionInterpolationBase` greater than `0`, you can interpolate between values exponentially, create an accelerated ramp effect.
+By combining `MGLInterpolationModeExponential` with an `MGLStyleFunctionOptionInterpolationBase` greater than `0` (other than `1`), you can interpolate between values exponentially, create an accelerated ramp effect.
 
 Here’s a visualization from Mapbox Studio (see [Working with Mapbox Studio](working-with-mapbox-studio.html)) comparing interpolation base values of `1.5` and `0.5` based on zoom.
 
@@ -106,11 +105,11 @@ layer.circleRadius = MGLStyleValue(interpolationMode: .exponential,
 When we use the stops dictionary given above with an interval interpolation mode, we create ranges where earthquakes with a magnitude of 0 to just less than 2.5 would be yellow, 2.5 to just less than 5 would be orange, and so on.
 
 ``` swift
-let stops = [0: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.yellow),
-             2.5: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.orange),
-             5: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.red),
-             7.5: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.blue),
-             10: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.white)]
+let stops = [0: MGLStyleValue<<%- cocoaPrefix %>Color>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 
 layer.circleColor = MGLStyleValue(interpolationMode: .interval,
                                   sourceStops: stops,
@@ -122,19 +121,19 @@ layer.circleColor = MGLStyleValue(interpolationMode: .interval,
 
 ### Categorical
 
-Returns the output value that is equal to the stop for the function input. We’re going to use a different stops dictionary than we did for the previous two modes.
+At each stop, `MGLInterpolationModeCategorical` produces an output value equal to the function input. We’re going to use a different stops dictionary than we did for the previous two modes.
 
 There are three main types of events in the dataset: earthquakes, explosions, and quarry blasts. In this case, the color of the circle layer will be determined by the type of event, with a default value of green to catch any events that do not fall into any of those categories.
 
 ``` swift
-let categoricalStops = ["earthquake": MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.orange),
-                        "explosion": MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.red),
-                        "quarry blast": MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.yellow)]
+let categoricalStops = ["earthquake": MGLStyleValue<<%- cocoaPrefix %>Color>(rawValue: .orange),
+                        "explosion": MGLStyleValue(rawValue: .red),
+                        "quarry blast": MGLStyleValue(rawValue: .yellow)]
 
 layer.circleColor = MGLStyleValue(interpolationMode: .categorical,
                                   sourceStops: categoricalStops,
                                   attributeName: "type",
-                                  options: [.defaultValue: MGLStyleValue(rawValue: <%- cocoaPrefix %>Color.blue)])
+                                  options: [.defaultValue: MGLStyleValue<<%- cocoaPrefix %>Color>(rawValue: .blue)])
 
 ```
 

--- a/platform/darwin/docs/guides/For Style Authors.md.ejs
+++ b/platform/darwin/docs/guides/For Style Authors.md.ejs
@@ -240,30 +240,6 @@ whose names differ from the style specification are listed below:
 <% for (const type in renamedProperties) { -%>
 <% if (renamedProperties.hasOwnProperty(type)) { -%>
 
-### <%- camelize(type) %> style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the <%- os %> SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
-
 ### <%- camelize(type) %> style layers
 
 In style JSON | In Objective-C | In Swift
@@ -280,9 +256,11 @@ In style JSON | In Objective-C | In Swift
 
 Each property representing a layout or paint attribute is set to an
 `MGLStyleValue` object, which is either an `MGLConstantStyleValue` object (for
-constant values) or an `MGLStyleFunction` object (for zoom level functions). The
+constant values) or an `MGLStyleFunction` object (for style functions). The
 style value object is a container for the raw value or function parameters that
 you want the attribute to be set to.
+
+### Constant style values
 
 In contrast to the JSON type that the style specification defines for each
 layout or paint property, the style value object often contains a more specific
@@ -326,6 +304,40 @@ translation downward. This is the reverse of how `CGVector` is interpreted on
 iOS.
 
 <% } -%>
+### Style functions
+
+A _style function_ allows you to vary the value of a layout or paint attribute
+based on the zoom level, data provided by content sources, or both. For more
+information about style functions that incorporate data from sources, see
+“[Data-Driven Styling](data-driven-styling.html)”.
+
+Each kind of style function is represented by a distinct class, but you
+typically create style functions as you create any other style value, using
+class methods on `MGLStyleValue`:
+
+In style specification     | SDK class                   | SDK factory method
+---------------------------|-----------------------------|-------------------
+zoom function              | `MGLCameraStyleFunction`    | `+[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]`
+property function          | `MGLSourceStyleFunction`    | `+[MGLStyleValue valueWithInterpolationMode:sourceStops:attributeName:options:]`
+zoom-and-property function | `MGLCompositeStyleFunction` | `+[MGLStyleValue valueWithInterpolationMode:compositeStops:attributeName:options:]`
+
+The documentation for each individual style layer property indicates the kinds
+of style functions that are enabled for that property.
+
+When you create a style function, you specify an _interpolation mode_ and a
+series of _stops_. Each stop determines the effective value displayed at a
+particular zoom level (for camera functions) or the effective value on features
+with a particular attribute value in the content source (for source functions).
+The interpolation mode tells the SDK how to calculate the effective value
+between any two stops:
+
+In style specification       | In the SDK
+-----------------------------|-----------
+`exponential`                | `MGLInterpolationModeExponential`
+`interval`                   | `MGLInterpolationModeInterval`
+`categorical`                | `MGLInterpolationModeCategorical`
+`identity`                   | `MGLInterpolationModeIdentity`
+
 ## Filtering sources
 
 You can filter a shape or vector source by setting the

--- a/platform/ios/docs/guides/Data-Driven Styling.md
+++ b/platform/ios/docs/guides/Data-Driven Styling.md
@@ -6,44 +6,43 @@
 
 # Data-Driven Styling
 
-Mapbox’s data-driven styling features allow you to use data properties to style your maps. You can style map features automatically based on their individual attributes. 
+Mapbox’s data-driven styling features allow you to use attributes in the data to style your maps. You can style map features automatically based on their individual attributes.
 
 Vary POI icons, transit route line colors, city polygon opacity, and more based on any attribute in your data. Need to visualize hotel data by price? You can have your map’s point radii and colors change automatically with your data.
 
 ![available bikes](img/data-driven-styling/citibikes.png) ![subway lines](img/data-driven-styling/polylineExample.png)
 
-# How to use Data-Driven Styling
 This guide uses earthquake data from the [U.S. Geological Survey](https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php) to style a map based on attributes. For more information about how to work with GeoJSON data in our iOS SDK, please see our [working with GeoJSON data](working-with-geojson-data.html) guide.
 
-`MGLStyleFunction`
+## Style functions
 
 There are three subclasses of `MGLStyleFunction`:
 
-* `MGLCameraStyleFunction` - For a style value that changes with zoom level. For example, you can make the radius of a circle increase according to zoom level. 
-* `MGLSourceStyleFunction` - For a style value that changes with the attributes of a feature. For example, you can adjust the radius of a circle based on the magnitude of an earthquake.
-* `MGLCompositeStyleFunction` - For a style value that changes with both zoom level and attribute values. For example, you can add a circle layer where each circle has a radius based on both zoom level and the magnitude of an earthquake.
+* `MGLCameraStyleFunction` is a style value that changes with zoom level. For example, you can make the radius of a circle increase according to zoom level.
+* `MGLSourceStyleFunction` is a style value that changes with the attributes of a feature. For example, you can adjust the radius of a circle based on the magnitude of an earthquake.
+* `MGLCompositeStyleFunction` is a style value that changes with both zoom level and attribute values. For example, you can add a circle layer where each circle has a radius based on both zoom level and the magnitude of an earthquake.
 
-The documentation for individual style properties will note which style functions are enabled for that property.
+The documentation for each individual style layer property notes which style functions are enabled for that property.
 
 ## Stops
 
 Stops are key-value pairs that that determine a style value. With a `MGLCameraSourceFunction` stop, you can use a dictionary with a zoom level for a key and a `MGLStyleValue` for the value. For example, you can use a stops dictionary with zoom levels 0, 10, and 20 as keys, and yellow, orange, and red as the values. A `MGLSourceStyleFunction` uses the relevant attribute value as the key.
 
 ```swift
-let stops = [0: MGLStyleValue(rawValue: UIColor.yellow),
-             2.5: MGLStyleValue(rawValue: UIColor.orange),
-             5: MGLStyleValue(rawValue: UIColor.red),
-             7.5: MGLStyleValue(rawValue: UIColor.blue),
-             10: MGLStyleValue(rawValue: UIColor.white)]
+let stops = [0: MGLStyleValue<UIColor>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 ```
 
-## Interpolation Mode
+## Interpolation mode
 
 The effect a key has on the style value is determined by the interpolation mode. There are four interpolation modes that can be used with a source style function: exponential, interval, categorical, and identity. You can also use exponential and interval interpolation modes with a camera style function.
 
 ### Linear
 
-`MGLInterpolationModelExponential` interpolates linearly or exponentially between style function stop values. By default, the `MGLStyleFunction` options parameter `MGLStyleFunctionOptionInterpolationBase` equals `1`, which represents linear interpolation, and doesn’t need to be included in the options dictionary.
+`MGLInterpolationModeExponential` interpolates linearly or exponentially between style function stop values. By default, the `MGLStyleFunction` options parameter `MGLStyleFunctionOptionInterpolationBase` equals `1`, which represents linear interpolation and doesn’t need to be included in the options dictionary.
 
 The stops dictionary below, for example, shows colors that continuously shift from yellow to orange to red to blue to white based on the attribute value.
 
@@ -55,11 +54,11 @@ let symbolLayer = MGLSymbolStyleLayer(identifier: "place-city-sm", source: symbo
 let source = MGLShapeSource(identifier: "earthquakes", url: url, options: nil)
 style.addSource(source)
 
-let stops = [0: MGLStyleValue(rawValue: UIColor.yellow),
-             2.5: MGLStyleValue(rawValue: UIColor.orange),
-             5: MGLStyleValue(rawValue: UIColor.red),
-             7.5: MGLStyleValue(rawValue: UIColor.blue),
-             10: MGLStyleValue(rawValue: UIColor.white)]
+let stops = [0: MGLStyleValue<UIColor>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 
 let layer = MGLCircleStyleLayer(identifier: "circles", source: source)
 layer.circleColor = MGLStyleValue(interpolationMode: .exponential,
@@ -74,7 +73,7 @@ style.insertLayer(layer, below: symbolLayer)
 
 ### Exponential
 
-`MGLInterpolationModelExponential` combined with any `MGLStyleFunctionOptionInterpolationBase` greater than `0`, you can interpolate between values exponentially, create an accelerated ramp effect.
+By combining `MGLInterpolationModeExponential` with an `MGLStyleFunctionOptionInterpolationBase` greater than `0` (other than `1`), you can interpolate between values exponentially, create an accelerated ramp effect.
 
 Here’s a visualization from Mapbox Studio (see [Working with Mapbox Studio](working-with-mapbox-studio.html)) comparing interpolation base values of `1.5` and `0.5` based on zoom.
 
@@ -100,11 +99,11 @@ layer.circleRadius = MGLStyleValue(interpolationMode: .exponential,
 When we use the stops dictionary given above with an interval interpolation mode, we create ranges where earthquakes with a magnitude of 0 to just less than 2.5 would be yellow, 2.5 to just less than 5 would be orange, and so on.
 
 ``` swift
-let stops = [0: MGLStyleValue(rawValue: UIColor.yellow),
-             2.5: MGLStyleValue(rawValue: UIColor.orange),
-             5: MGLStyleValue(rawValue: UIColor.red),
-             7.5: MGLStyleValue(rawValue: UIColor.blue),
-             10: MGLStyleValue(rawValue: UIColor.white)]
+let stops = [0: MGLStyleValue<UIColor>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 
 layer.circleColor = MGLStyleValue(interpolationMode: .interval,
                                   sourceStops: stops,
@@ -116,19 +115,19 @@ layer.circleColor = MGLStyleValue(interpolationMode: .interval,
 
 ### Categorical
 
-Returns the output value that is equal to the stop for the function input. We’re going to use a different stops dictionary than we did for the previous two modes.
+At each stop, `MGLInterpolationModeCategorical` produces an output value equal to the function input. We’re going to use a different stops dictionary than we did for the previous two modes.
 
 There are three main types of events in the dataset: earthquakes, explosions, and quarry blasts. In this case, the color of the circle layer will be determined by the type of event, with a default value of green to catch any events that do not fall into any of those categories.
 
 ``` swift
-let categoricalStops = ["earthquake": MGLStyleValue(rawValue: UIColor.orange),
-                        "explosion": MGLStyleValue(rawValue: UIColor.red),
-                        "quarry blast": MGLStyleValue(rawValue: UIColor.yellow)]
+let categoricalStops = ["earthquake": MGLStyleValue<UIColor>(rawValue: .orange),
+                        "explosion": MGLStyleValue(rawValue: .red),
+                        "quarry blast": MGLStyleValue(rawValue: .yellow)]
 
 layer.circleColor = MGLStyleValue(interpolationMode: .categorical,
                                   sourceStops: categoricalStops,
                                   attributeName: "type",
-                                  options: [.defaultValue: MGLStyleValue(rawValue: UIColor.blue)])
+                                  options: [.defaultValue: MGLStyleValue<UIColor>(rawValue: .blue)])
 
 ```
 

--- a/platform/ios/docs/guides/For Style Authors.md
+++ b/platform/ios/docs/guides/For Style Authors.md
@@ -190,30 +190,6 @@ layer objects. The property names generally correspond to the style JSON
 properties, except for the use of camelCase instead of kebab-case. Properties
 whose names differ from the style specification are listed below:
 
-### Circle style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the iOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
-
 ### Circle style layers
 
 In style JSON | In Objective-C | In Swift
@@ -221,30 +197,6 @@ In style JSON | In Objective-C | In Swift
 `circle-pitch-scale` | `MGLCircleStyleLayer.circleScaleAlignment` | `MGLCircleStyleLayer.circleScaleAlignment`
 `circle-translate` | `MGLCircleStyleLayer.circleTranslation` | `MGLCircleStyleLayer.circleTranslation`
 `circle-translate-anchor` | `MGLCircleStyleLayer.circleTranslationAnchor` | `MGLCircleStyleLayer.circleTranslationAnchor`
-
-### Fill style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the iOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
 
 ### Fill style layers
 
@@ -254,30 +206,6 @@ In style JSON | In Objective-C | In Swift
 `fill-translate` | `MGLFillStyleLayer.fillTranslation` | `MGLFillStyleLayer.fillTranslation`
 `fill-translate-anchor` | `MGLFillStyleLayer.fillTranslationAnchor` | `MGLFillStyleLayer.fillTranslationAnchor`
 
-### Line style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the iOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
-
 ### Line style layers
 
 In style JSON | In Objective-C | In Swift
@@ -286,30 +214,6 @@ In style JSON | In Objective-C | In Swift
 `line-translate` | `MGLLineStyleLayer.lineTranslation` | `MGLLineStyleLayer.lineTranslation`
 `line-translate-anchor` | `MGLLineStyleLayer.lineTranslationAnchor` | `MGLLineStyleLayer.lineTranslationAnchor`
 
-### Raster style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the iOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
-
 ### Raster style layers
 
 In style JSON | In Objective-C | In Swift
@@ -317,30 +221,6 @@ In style JSON | In Objective-C | In Swift
 `raster-brightness-max` | `MGLRasterStyleLayer.maximumRasterBrightness` | `MGLRasterStyleLayer.maximumRasterBrightness`
 `raster-brightness-min` | `MGLRasterStyleLayer.minimumRasterBrightness` | `MGLRasterStyleLayer.minimumRasterBrightness`
 `raster-hue-rotate` | `MGLRasterStyleLayer.rasterHueRotation` | `MGLRasterStyleLayer.rasterHueRotation`
-
-### Symbol style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the iOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
 
 ### Symbol style layers
 
@@ -374,9 +254,11 @@ In style JSON | In Objective-C | In Swift
 
 Each property representing a layout or paint attribute is set to an
 `MGLStyleValue` object, which is either an `MGLConstantStyleValue` object (for
-constant values) or an `MGLStyleFunction` object (for zoom level functions). The
+constant values) or an `MGLStyleFunction` object (for style functions). The
 style value object is a container for the raw value or function parameters that
 you want the attribute to be set to.
+
+### Constant style values
 
 In contrast to the JSON type that the style specification defines for each
 layout or paint property, the style value object often contains a more specific
@@ -401,6 +283,40 @@ For padding attributes, note that the arguments to
 in Swift
 are specified in counterclockwise order, in contrast to the clockwise order
 defined by the style specification.
+
+### Style functions
+
+A _style function_ allows you to vary the value of a layout or paint attribute
+based on the zoom level, data provided by content sources, or both. For more
+information about style functions that incorporate data from sources, see
+“[Data-Driven Styling](data-driven-styling.html)”.
+
+Each kind of style function is represented by a distinct class, but you
+typically create style functions as you create any other style value, using
+class methods on `MGLStyleValue`:
+
+In style specification     | SDK class                   | SDK factory method
+---------------------------|-----------------------------|-------------------
+zoom function              | `MGLCameraStyleFunction`    | `+[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]`
+property function          | `MGLSourceStyleFunction`    | `+[MGLStyleValue valueWithInterpolationMode:sourceStops:attributeName:options:]`
+zoom-and-property function | `MGLCompositeStyleFunction` | `+[MGLStyleValue valueWithInterpolationMode:compositeStops:attributeName:options:]`
+
+The documentation for each individual style layer property indicates the kinds
+of style functions that are enabled for that property.
+
+When you create a style function, you specify an _interpolation mode_ and a
+series of _stops_. Each stop determines the effective value displayed at a
+particular zoom level (for camera functions) or the effective value on features
+with a particular attribute value in the content source (for source functions).
+The interpolation mode tells the SDK how to calculate the effective value
+between any two stops:
+
+In style specification       | In the SDK
+-----------------------------|-----------
+`exponential`                | `MGLInterpolationModeExponential`
+`interval`                   | `MGLInterpolationModeInterval`
+`categorical`                | `MGLInterpolationModeCategorical`
+`identity`                   | `MGLInterpolationModeIdentity`
 
 ## Filtering sources
 

--- a/platform/macos/docs/guides/Data-Driven Styling.md
+++ b/platform/macos/docs/guides/Data-Driven Styling.md
@@ -6,44 +6,43 @@
 
 # Data-Driven Styling
 
-Mapbox’s data-driven styling features allow you to use data properties to style your maps. You can style map features automatically based on their individual attributes. 
+Mapbox’s data-driven styling features allow you to use attributes in the data to style your maps. You can style map features automatically based on their individual attributes.
 
 Vary POI icons, transit route line colors, city polygon opacity, and more based on any attribute in your data. Need to visualize hotel data by price? You can have your map’s point radii and colors change automatically with your data.
 
 ![available bikes](img/data-driven-styling/citibikes.png) ![subway lines](img/data-driven-styling/polylineExample.png)
 
-# How to use Data-Driven Styling
 This guide uses earthquake data from the [U.S. Geological Survey](https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php) to style a map based on attributes. For more information about how to work with GeoJSON data in our iOS SDK, please see our [working with GeoJSON data](working-with-geojson-data.html) guide.
 
-`MGLStyleFunction`
+## Style functions
 
 There are three subclasses of `MGLStyleFunction`:
 
-* `MGLCameraStyleFunction` - For a style value that changes with zoom level. For example, you can make the radius of a circle increase according to zoom level. 
-* `MGLSourceStyleFunction` - For a style value that changes with the attributes of a feature. For example, you can adjust the radius of a circle based on the magnitude of an earthquake.
-* `MGLCompositeStyleFunction` - For a style value that changes with both zoom level and attribute values. For example, you can add a circle layer where each circle has a radius based on both zoom level and the magnitude of an earthquake.
+* `MGLCameraStyleFunction` is a style value that changes with zoom level. For example, you can make the radius of a circle increase according to zoom level.
+* `MGLSourceStyleFunction` is a style value that changes with the attributes of a feature. For example, you can adjust the radius of a circle based on the magnitude of an earthquake.
+* `MGLCompositeStyleFunction` is a style value that changes with both zoom level and attribute values. For example, you can add a circle layer where each circle has a radius based on both zoom level and the magnitude of an earthquake.
 
-The documentation for individual style properties will note which style functions are enabled for that property.
+The documentation for each individual style layer property notes which style functions are enabled for that property.
 
 ## Stops
 
 Stops are key-value pairs that that determine a style value. With a `MGLCameraSourceFunction` stop, you can use a dictionary with a zoom level for a key and a `MGLStyleValue` for the value. For example, you can use a stops dictionary with zoom levels 0, 10, and 20 as keys, and yellow, orange, and red as the values. A `MGLSourceStyleFunction` uses the relevant attribute value as the key.
 
 ```swift
-let stops = [0: MGLStyleValue(rawValue: UIColor.yellow),
-             2.5: MGLStyleValue(rawValue: UIColor.orange),
-             5: MGLStyleValue(rawValue: UIColor.red),
-             7.5: MGLStyleValue(rawValue: UIColor.blue),
-             10: MGLStyleValue(rawValue: UIColor.white)]
+let stops = [0: MGLStyleValue<NSColor>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 ```
 
-## Interpolation Mode
+## Interpolation mode
 
 The effect a key has on the style value is determined by the interpolation mode. There are four interpolation modes that can be used with a source style function: exponential, interval, categorical, and identity. You can also use exponential and interval interpolation modes with a camera style function.
 
 ### Linear
 
-`MGLInterpolationModelExponential` interpolates linearly or exponentially between style function stop values. By default, the `MGLStyleFunction` options parameter `MGLStyleFunctionOptionInterpolationBase` equals `1`, which represents linear interpolation, and doesn’t need to be included in the options dictionary.
+`MGLInterpolationModeExponential` interpolates linearly or exponentially between style function stop values. By default, the `MGLStyleFunction` options parameter `MGLStyleFunctionOptionInterpolationBase` equals `1`, which represents linear interpolation and doesn’t need to be included in the options dictionary.
 
 The stops dictionary below, for example, shows colors that continuously shift from yellow to orange to red to blue to white based on the attribute value.
 
@@ -55,11 +54,11 @@ let symbolLayer = MGLSymbolStyleLayer(identifier: "place-city-sm", source: symbo
 let source = MGLShapeSource(identifier: "earthquakes", url: url, options: nil)
 style.addSource(source)
 
-let stops = [0: MGLStyleValue(rawValue: NSColor.yellow),
-             2.5: MGLStyleValue(rawValue: NSColor.orange),
-             5: MGLStyleValue(rawValue: NSColor.red),
-             7.5: MGLStyleValue(rawValue: NSColor.blue),
-             10: MGLStyleValue(rawValue: NSColor.white)]
+let stops = [0: MGLStyleValue<NSColor>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 
 let layer = MGLCircleStyleLayer(identifier: "circles", source: source)
 layer.circleColor = MGLStyleValue(interpolationMode: .exponential,
@@ -74,7 +73,7 @@ style.insertLayer(layer, below: symbolLayer)
 
 ### Exponential
 
-`MGLInterpolationModelExponential` combined with any `MGLStyleFunctionOptionInterpolationBase` greater than `0`, you can interpolate between values exponentially, create an accelerated ramp effect.
+By combining `MGLInterpolationModeExponential` with an `MGLStyleFunctionOptionInterpolationBase` greater than `0` (other than `1`), you can interpolate between values exponentially, create an accelerated ramp effect.
 
 Here’s a visualization from Mapbox Studio (see [Working with Mapbox Studio](working-with-mapbox-studio.html)) comparing interpolation base values of `1.5` and `0.5` based on zoom.
 
@@ -100,11 +99,11 @@ layer.circleRadius = MGLStyleValue(interpolationMode: .exponential,
 When we use the stops dictionary given above with an interval interpolation mode, we create ranges where earthquakes with a magnitude of 0 to just less than 2.5 would be yellow, 2.5 to just less than 5 would be orange, and so on.
 
 ``` swift
-let stops = [0: MGLStyleValue(rawValue: NSColor.yellow),
-             2.5: MGLStyleValue(rawValue: NSColor.orange),
-             5: MGLStyleValue(rawValue: NSColor.red),
-             7.5: MGLStyleValue(rawValue: NSColor.blue),
-             10: MGLStyleValue(rawValue: NSColor.white)]
+let stops = [0: MGLStyleValue<NSColor>(rawValue: .yellow),
+             2.5: MGLStyleValue(rawValue: .orange),
+             5: MGLStyleValue(rawValue: .red),
+             7.5: MGLStyleValue(rawValue: .blue),
+             10: MGLStyleValue(rawValue: .white)]
 
 layer.circleColor = MGLStyleValue(interpolationMode: .interval,
                                   sourceStops: stops,
@@ -116,19 +115,19 @@ layer.circleColor = MGLStyleValue(interpolationMode: .interval,
 
 ### Categorical
 
-Returns the output value that is equal to the stop for the function input. We’re going to use a different stops dictionary than we did for the previous two modes.
+At each stop, `MGLInterpolationModeCategorical` produces an output value equal to the function input. We’re going to use a different stops dictionary than we did for the previous two modes.
 
 There are three main types of events in the dataset: earthquakes, explosions, and quarry blasts. In this case, the color of the circle layer will be determined by the type of event, with a default value of green to catch any events that do not fall into any of those categories.
 
 ``` swift
-let categoricalStops = ["earthquake": MGLStyleValue(rawValue: NSColor.orange),
-                        "explosion": MGLStyleValue(rawValue: NSColor.red),
-                        "quarry blast": MGLStyleValue(rawValue: NSColor.yellow)]
+let categoricalStops = ["earthquake": MGLStyleValue<NSColor>(rawValue: .orange),
+                        "explosion": MGLStyleValue(rawValue: .red),
+                        "quarry blast": MGLStyleValue(rawValue: .yellow)]
 
 layer.circleColor = MGLStyleValue(interpolationMode: .categorical,
                                   sourceStops: categoricalStops,
                                   attributeName: "type",
-                                  options: [.defaultValue: MGLStyleValue(rawValue: NSColor.blue)])
+                                  options: [.defaultValue: MGLStyleValue<NSColor>(rawValue: .blue)])
 
 ```
 

--- a/platform/macos/docs/guides/For Style Authors.md
+++ b/platform/macos/docs/guides/For Style Authors.md
@@ -179,30 +179,6 @@ layer objects. The property names generally correspond to the style JSON
 properties, except for the use of camelCase instead of kebab-case. Properties
 whose names differ from the style specification are listed below:
 
-### Circle style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the macOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
-
 ### Circle style layers
 
 In style JSON | In Objective-C | In Swift
@@ -210,30 +186,6 @@ In style JSON | In Objective-C | In Swift
 `circle-pitch-scale` | `MGLCircleStyleLayer.circleScaleAlignment` | `MGLCircleStyleLayer.circleScaleAlignment`
 `circle-translate` | `MGLCircleStyleLayer.circleTranslation` | `MGLCircleStyleLayer.circleTranslation`
 `circle-translate-anchor` | `MGLCircleStyleLayer.circleTranslationAnchor` | `MGLCircleStyleLayer.circleTranslationAnchor`
-
-### Fill style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the macOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
 
 ### Fill style layers
 
@@ -243,30 +195,6 @@ In style JSON | In Objective-C | In Swift
 `fill-translate` | `MGLFillStyleLayer.fillTranslation` | `MGLFillStyleLayer.fillTranslation`
 `fill-translate-anchor` | `MGLFillStyleLayer.fillTranslationAnchor` | `MGLFillStyleLayer.fillTranslationAnchor`
 
-### Line style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the macOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
-
 ### Line style layers
 
 In style JSON | In Objective-C | In Swift
@@ -275,30 +203,6 @@ In style JSON | In Objective-C | In Swift
 `line-translate` | `MGLLineStyleLayer.lineTranslation` | `MGLLineStyleLayer.lineTranslation`
 `line-translate-anchor` | `MGLLineStyleLayer.lineTranslationAnchor` | `MGLLineStyleLayer.lineTranslationAnchor`
 
-### Raster style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the macOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
-
 ### Raster style layers
 
 In style JSON | In Objective-C | In Swift
@@ -306,30 +210,6 @@ In style JSON | In Objective-C | In Swift
 `raster-brightness-max` | `MGLRasterStyleLayer.maximumRasterBrightness` | `MGLRasterStyleLayer.maximumRasterBrightness`
 `raster-brightness-min` | `MGLRasterStyleLayer.minimumRasterBrightness` | `MGLRasterStyleLayer.minimumRasterBrightness`
 `raster-hue-rotate` | `MGLRasterStyleLayer.rasterHueRotation` | `MGLRasterStyleLayer.rasterHueRotation`
-
-### Symbol style functions
-
-The runtime styling API introduces `MGLStyleFunction` to the macOS SDK.
-[Data-driven styling](data-driven-styling.html) expands `MGLStyleFunction`.
-Individual style property documentation includes which subclasses of
-`MGLStyleFunction` are enabled for that property. You can use `MGLStyleValue`
-methods to create a `MGLStyleFunction`.
-
-In style specification | In the SDK                    | [MGLStyleValue valueWithInterpolationMode:...]
------------------------|-------------------------------|-------------
-`zoom function`        | `MGLCameraStyleFunction`      | `cameraStops:options:`
-`property function`    | `MGLSourceStyleFunction`      | `sourceStops:attributeName:options:`
-`zoom-and-property functions`| `MGLCompositeStyleFunction` | `compositeStops:attributeName:options:`
-
-Data-driven styling also introduces interpolation mode, which defines the
-relationship between style values and attributes or zoom levels.
-
-In style specification       | In the SDK
------------------------------|-----------
-`exponential`                | `MGLInterpolationModeExponential`
-`interval`                   | `MGLInterpolationModeInterval`
-`categorical`                | `MGLInterpolationModeCategorical`
-`identity`                   | `MGLInterpolationModeIdentity`
 
 ### Symbol style layers
 
@@ -363,9 +243,11 @@ In style JSON | In Objective-C | In Swift
 
 Each property representing a layout or paint attribute is set to an
 `MGLStyleValue` object, which is either an `MGLConstantStyleValue` object (for
-constant values) or an `MGLStyleFunction` object (for zoom level functions). The
+constant values) or an `MGLStyleFunction` object (for style functions). The
 style value object is a container for the raw value or function parameters that
 you want the attribute to be set to.
+
+### Constant style values
 
 In contrast to the JSON type that the style specification defines for each
 layout or paint property, the style value object often contains a more specific
@@ -396,6 +278,40 @@ lower-left corner of the screen. Therefore, a positive `CGVector.dy` means an
 offset or translation upward, while a negative `CGVector.dy` means an offset or
 translation downward. This is the reverse of how `CGVector` is interpreted on
 iOS.
+
+### Style functions
+
+A _style function_ allows you to vary the value of a layout or paint attribute
+based on the zoom level, data provided by content sources, or both. For more
+information about style functions that incorporate data from sources, see
+“[Data-Driven Styling](data-driven-styling.html)”.
+
+Each kind of style function is represented by a distinct class, but you
+typically create style functions as you create any other style value, using
+class methods on `MGLStyleValue`:
+
+In style specification     | SDK class                   | SDK factory method
+---------------------------|-----------------------------|-------------------
+zoom function              | `MGLCameraStyleFunction`    | `+[MGLStyleValue valueWithInterpolationMode:cameraStops:options:]`
+property function          | `MGLSourceStyleFunction`    | `+[MGLStyleValue valueWithInterpolationMode:sourceStops:attributeName:options:]`
+zoom-and-property function | `MGLCompositeStyleFunction` | `+[MGLStyleValue valueWithInterpolationMode:compositeStops:attributeName:options:]`
+
+The documentation for each individual style layer property indicates the kinds
+of style functions that are enabled for that property.
+
+When you create a style function, you specify an _interpolation mode_ and a
+series of _stops_. Each stop determines the effective value displayed at a
+particular zoom level (for camera functions) or the effective value on features
+with a particular attribute value in the content source (for source functions).
+The interpolation mode tells the SDK how to calculate the effective value
+between any two stops:
+
+In style specification       | In the SDK
+-----------------------------|-----------
+`exponential`                | `MGLInterpolationModeExponential`
+`interval`                   | `MGLInterpolationModeInterval`
+`categorical`                | `MGLInterpolationModeCategorical`
+`identity`                   | `MGLInterpolationModeIdentity`
 
 ## Filtering sources
 


### PR DESCRIPTION
Cursorily copy-edited the data-driven styling guide, removing a stray class reference, replacing a redundant h1, and making stops examples platform-agnostic and less redundant.

Fixed an issue in the style authors guide where style function tables appeared under each style layer type table.

Fixes #8524.

/ref #8525
/cc @friedbunny @ericrwolfe