### PR TITLE
Prepare String resources for Transifex integration

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res-public/values/public.xml
@@ -90,6 +90,16 @@
     <public name="mapbox_style_satellite_streets" type="string" />
 
     <!-- Exposed error messages -->
+    <public name="mapbox_compassContentDescription" type="string" />
+    <public name="mapbox_attributionsIconContentDescription" type="string" />
+    <public name="mapbox_myLocationViewContentDescription" type="string" />
+    <public name="mapbox_mapActionDescription" type="string" />
+    <public name="mapbox_attributionsDialogTitle" type="string" />
+    <public name="mapbox_attributionTelemetryTitle" type="string" />
+    <public name="mapbox_attributionTelemetryMessage" type="string" />
+    <public name="mapbox_attributionTelemetryPositive" type="string" />
+    <public name="mapbox_attributionTelemetryNegative" type="string" />
+    <public name="mapbox_attributionTelemetryNeutral" type="string" />
     <public name="mapbox_offline_error_region_definition_invalid" type="string" />
 
     <!-- Exposed drawables -->

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_infowindow_content.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/layout/mapbox_infowindow_content.xml
@@ -24,7 +24,6 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="2dp"
         android:maxEms="17"
-        android:text="@string/mapbox_infoWindowTitle"
         android:textColor="@android:color/black"
         android:textSize="18sp"
         android:textStyle="bold"/>
@@ -37,7 +36,6 @@
         android:layout_marginTop="2dp"
         android:lineSpacingExtra="1dp"
         android:maxEms="17"
-        android:text="@string/mapbox_infoWindowDescription"
         android:textColor="@color/mapbox_gray"
         android:textSize="14sp"/>
 
@@ -46,7 +44,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:maxEms="17"
-        android:text="@string/mapbox_infoWindowAddress"
         android:textColor="@android:color/black"
         android:textSize="12sp"
         android:visibility="gone"/>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
@@ -10,18 +10,15 @@
     <string name="mapbox_attributionTelemetryPositive">Agree</string>
     <string name="mapbox_attributionTelemetryNegative">Disagree</string>
     <string name="mapbox_attributionTelemetryNeutral">More info</string>
-    <string name="mapbox_infoWindowTitle">Title</string>
-    <string name="mapbox_infoWindowDescription">Description</string>
-    <string name="mapbox_infoWindowAddress">Address</string>
     <string name="mapbox_offline_error_region_definition_invalid">Provided OfflineRegionDefinition doesn\'t fit the world bounds: %s</string>
 
     <!-- these are public -->
     <!-- Using one of these constants means your map style will always use the latest version and
      may change as we improve the style. -->
-    <string name="mapbox_style_mapbox_streets">mapbox://styles/mapbox/streets-v9</string>
-    <string name="mapbox_style_outdoors">mapbox://styles/mapbox/outdoors-v9</string>
-    <string name="mapbox_style_light">mapbox://styles/mapbox/light-v9</string>
-    <string name="mapbox_style_dark">mapbox://styles/mapbox/dark-v9</string>
-    <string name="mapbox_style_satellite">mapbox://styles/mapbox/satellite-v9</string>
-    <string name="mapbox_style_satellite_streets">mapbox://styles/mapbox/satellite-streets-v9</string>
+    <string name="mapbox_style_mapbox_streets" translatable="false">mapbox://styles/mapbox/streets-v9</string>
+    <string name="mapbox_style_outdoors" translatable="false">mapbox://styles/mapbox/outdoors-v9</string>
+    <string name="mapbox_style_light" translatable="false">mapbox://styles/mapbox/light-v9</string>
+    <string name="mapbox_style_dark" translatable="false">mapbox://styles/mapbox/dark-v9</string>
+    <string name="mapbox_style_satellite" translatable="false">mapbox://styles/mapbox/satellite-v9</string>
+    <string name="mapbox_style_satellite_streets" translatable="false">mapbox://styles/mapbox/satellite-streets-v9</string>
 </resources>


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-gl-native/issues/8155, Preparation work for integrating transfix into the Android code. 
  - mark non-translatable resources 
  - remove debug string resources  
  - expose strings in public.xml for resource overloading.