### PR TITLE
[core] Do not throw on ctor and dtor

### DIFF
--- a/platform/default/sqlite3.cpp
+++ b/platform/default/sqlite3.cpp
@@ -30,7 +30,7 @@ public:
 
         const int error = sqlite3_close(db);
         if (error != SQLITE_OK) {
-            throw Exception { error, sqlite3_errmsg(db) };
+            mbgl::Log::Error(mbgl::Event::Database, "%s (Code %i)", sqlite3_errmsg(db), error);
         }
     }
 

--- a/src/mbgl/util/thread_local.hpp
+++ b/src/mbgl/util/thread_local.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <mbgl/util/logging.hpp>
 #include <mbgl/util/noncopyable.hpp>
 
+#include <cassert>
 #include <stdexcept>
 
 #include <pthread.h>
@@ -29,7 +31,8 @@ public:
 
     ~ThreadLocal() {
         if (pthread_key_delete(key)) {
-            throw std::runtime_error("Failed to delete local storage key.");
+            Log::Error(Event::General, "Failed to delete local storage key.");
+            assert(false);
         }
     }
 


### PR DESCRIPTION
Fix build on GCC6. C+11 defaults ctors to nothrow.