### PR TITLE
[ios] Modify return type so callout bridges with protocol in Swift

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## 3.5.1
+
+### Other changes
+
+* Fixed an issue that caused the return type of a map view delegate method to bridge incorrectly to applications written in Swift. ([#8541](https://github.com/mapbox/mapbox-gl-native/pull/8541))
+
 ## 3.5.0
 
 ### Packaging

--- a/platform/ios/src/MGLMapViewDelegate.h
+++ b/platform/ios/src/MGLMapViewDelegate.h
@@ -456,7 +456,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return A view conforming to the `MGLCalloutView` protocol, or `nil` to use the
     default callout view.
  */
-- (nullable UIView <MGLCalloutView> *)mapView:(MGLMapView *)mapView calloutViewForAnnotation:(id <MGLAnnotation>)annotation;
+- (nullable id <MGLCalloutView>)mapView:(MGLMapView *)mapView calloutViewForAnnotation:(id <MGLAnnotation>)annotation;
 
 /**
  Returns the view to display on the left side of the standard callout bubble.


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-native/issues/8420

`- (nullable UIView <MGLCalloutView> *)mapView:(MGLMapView *)mapView calloutViewForAnnotation:(id <MGLAnnotation>)annotation;` bridges with a `UIView?` return type in Swift. This changes replaces the `UIView` type in the method signature so that, when bridged to Swift, the returned object is defined as `MGLCalloutView?`.

