### PR TITLE
[android] - Transifex intregration and Dutch translations.

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,25 +1,35 @@
 [main]
 host = https://www.transifex.com
-lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 type = STRINGS
 minimum_perc = 80
 
 [mapbox-gl-native.foundationstrings-darwin]
+lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/darwin/resources/Base.lproj/Foundation.strings
 source_lang = en
 file_filter = platform/darwin/resources/<lang>.lproj/Foundation.strings
 
 [mapbox-gl-native.localizablestrings-ios]
+lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/ios/resources/Base.lproj/Localizable.strings
 source_lang = en
 file_filter = platform/ios/resources/<lang>.lproj/Localizable.strings
 
 [mapbox-gl-native.localizablestrings-macos]
+lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/macos/sdk/Base.lproj/Localizable.strings
 source_lang = en
 file_filter = platform/macos/sdk/<lang>.lproj/Localizable.strings
 
 [mapbox-gl-native.rootstrings-ios]
+lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/ios/framework/Settings.bundle/Base.lproj/Root.strings
 source_lang = en
 file_filter = platform/ios/framework/Settings.bundle/<lang>.lproj/Root.strings
+
+[mapbox-gl-native.stringsxml-android]
+file_filter = platform/android/MapboxGLAndroidSDK/src/main/res/values-<lang>/strings.xml
+source_file = platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID
+

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 5.1.0 builds further on 5.0.1 and adds:
 
 * Style wide transition duration and transition offset in milliseconds [#8576](https://github.com/mapbox/mapbox-gl-native/pull/8576)
+* Transifex integration, Catalan & Dutch translations [#8556](https://github.com/mapbox/mapbox-gl-native/pull/8556)
 * LatLngBounds includes with another bounds [#8517](https://github.com/mapbox/mapbox-gl-native/pull/8517)
 * LatLngBounds includes takes in account LatLng on the edges (cfr. core) [#8517](https://github.com/mapbox/mapbox-gl-native/pull/8517)
 * LatLngBounds facility getters/setters for LatLnbg on the edges of the bounds [#8517](https://github.com/mapbox/mapbox-gl-native/pull/8517)

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-ca/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-ca/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_compassContentDescription">Brúixola del mapa. Activa per restablir la rotació del mapa al Nord.</string>
+    <string name="mapbox_attributionsIconContentDescription">Icona d\'atribució. Activa per mostrar el diàleg de l\'atribució.</string>
+    <string name="mapbox_myLocationViewContentDescription">Vista de posició. Mostra la teva posició al mapa.</string>
+    <string name="mapbox_mapActionDescription">Mostrant un mapa creat amb Mapbox. Desplaça\'t arrossegant amb dos dits.  Fes zoom pessigant amb dos dits.</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
+    <string name="mapbox_attributionTelemetryTitle">Millora els mapes de Mapbox</string>
+    <string name="mapbox_attributionTelemetryMessage">Estàs ajudant a millorar els mapes d\'OpenStreetMap i de Mapbox aportant dades d\'ús anònimes.</string>
+    <string name="mapbox_attributionTelemetryPositive">D\'acord</string>
+    <string name="mapbox_attributionTelemetryNegative">Disconforme</string>
+    <string name="mapbox_attributionTelemetryNeutral">Més informació</string>
+    <string name="mapbox_offline_error_region_definition_invalid">La OfflineRegionDefinition proporcionada no encaixa amb els límits del món: %s</string>
+</resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-nl/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-nl/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_compassContentDescription">Kompas van de map. Activeer om de map rotatie te herzetten naar het noorden.</string>
+    <string name="mapbox_attributionsIconContentDescription">Attributie icoon. Activeer voor het tonen van het attributie dialoog. </string>
+    <string name="mapbox_myLocationViewContentDescription">Locatie Element. Dit toont jouw locatie op de map.</string>
+    <string name="mapbox_mapActionDescription">Toont een map gemaakt met Mapbox. Scroll door het slepen met twee vingers. Zoom door vingers te nijpen.</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
+    <string name="mapbox_attributionTelemetryTitle">Maak Mapbox Maps beter</string>
+    <string name="mapbox_attributionTelemetryMessage">U helpt OpenStreetMap en Mapbox maps te verbeteren door het  bijdragen van anonieme gebruikersgegevens. </string>
+    <string name="mapbox_attributionTelemetryPositive">Toestemmen</string>
+    <string name="mapbox_attributionTelemetryNegative">Intrekken</string>
+    <string name="mapbox_attributionTelemetryNeutral">Meer informatie</string>
+    <string name="mapbox_offline_error_region_definition_invalid">Aangeleverde OfflineRegionDefinition past niet in de wereld omtrek: %s</string>
+</resources>


### PR DESCRIPTION
This PR adds [mapbox-gl-native Transifex project](https://www.transifex.com/mapbox/mapbox-gl-native) integration for the Android Mapbox SDK. 
To test integration, Dutch translations were added.

@1ec5 I moved the lang_map of the previous integration to the specific tasks (Android follows
the ISO 639-1 standard). I feel this was the best solution as applying a lang_map to a specific task will not override the project lang_map but will extend it. 

cc @mapbox/android 

