### PR TITLE
[android] - fixup location permissions pre Android Marshmallow

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/FeatureOverviewActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/FeatureOverviewActivity.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
@@ -132,7 +133,7 @@ public class FeatureOverviewActivity extends AppCompatActivity {
 
   @Override
   public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-    if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+    if (!isRuntimePermissionsRequired() || isPermissionAccepted(grantResults)) {
       startFeature(features.get(requestCode));
     } else {
       Snackbar.make(
@@ -140,6 +141,14 @@ public class FeatureOverviewActivity extends AppCompatActivity {
         "Can't open without accepting the location permission.",
         Snackbar.LENGTH_SHORT).show();
     }
+  }
+
+  private boolean isRuntimePermissionsRequired() {
+    return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+  }
+
+  private boolean isPermissionAccepted(@NonNull int[] grantResults) {
+    return grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
   }
 
   @Override


### PR DESCRIPTION
closes #8424 

@Guardiola31337 I went a head a patched this up, needed this for testing. Feel free to tackle improvements related to requesting runtime permissions in the test app in a separate ticket.