### PR TITLE
Tighten size check

### DIFF
--- a/include/mbgl/util/image.hpp
+++ b/include/mbgl/util/image.hpp
@@ -58,7 +58,7 @@ public:
     }
 
     bool valid() const {
-        return size && data.get() != nullptr;
+        return !size.isEmpty() && data.get() != nullptr;
     }
 
     template <typename T = Image>

--- a/include/mbgl/util/size.hpp
+++ b/include/mbgl/util/size.hpp
@@ -7,8 +7,7 @@ namespace mbgl {
 
 class Size {
 public:
-    constexpr Size() : width(0), height(0) {
-    }
+    constexpr Size() = default;
 
     constexpr Size(const uint32_t width_, const uint32_t height_) : width(width_), height(height_) {
     }
@@ -17,12 +16,12 @@ public:
         return width * height;
     }
 
-    constexpr explicit operator bool() const {
-        return width > 0 && height > 0;
+    constexpr bool isEmpty() const {
+        return width == 0 || height == 0;
     }
 
-    uint32_t width;
-    uint32_t height;
+    uint32_t width = 0;
+    uint32_t height = 0;
 };
 
 constexpr inline bool operator==(const Size& a, const Size& b) {

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.2'
         classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.1'
     }

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -73,6 +73,10 @@ NativeMapView::NativeMapView(jni::JNIEnv& _env,
         MapMode::Continuous, GLContextMode::Unique, ConstrainMode::HeightOnly,
         ViewportMode::Default, jni::Make<std::string>(_env, _programCacheDir));
 
+    recalculateSourceTileCacheSize();
+}
+
+void NativeMapView::recalculateSourceTileCacheSize() {
     //Calculate a fitting cache size based on device parameters
     float zoomFactor   = map->getMaxZoom() - map->getMinZoom() + 1;
     float cpuFactor    = availableProcessors;
@@ -324,6 +328,7 @@ void NativeMapView::resizeView(jni::JNIEnv&, int w, int h) {
     width = util::max(64, w);
     height = util::max(64, h);
     map->setSize({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
+    recalculateSourceTileCacheSize();
 }
 
 void NativeMapView::resizeFramebuffer(jni::JNIEnv&, int w, int h) {
@@ -480,6 +485,7 @@ void NativeMapView::resetZoom(jni::JNIEnv&) {
 
 void NativeMapView::setMinZoom(jni::JNIEnv&, jni::jdouble zoom) {
     map->setMinZoom(zoom);
+    recalculateSourceTileCacheSize();
 }
 
 jni::jdouble NativeMapView::getMinZoom(jni::JNIEnv&) {
@@ -488,6 +494,7 @@ jni::jdouble NativeMapView::getMinZoom(jni::JNIEnv&) {
 
 void NativeMapView::setMaxZoom(jni::JNIEnv&, jni::jdouble zoom) {
     map->setMaxZoom(zoom);
+    recalculateSourceTileCacheSize();
 }
 
 jni::jdouble NativeMapView::getMaxZoom(jni::JNIEnv&) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -15,6 +15,7 @@
 #include <jni/jni.hpp>
 
 #include <mbgl/map/backend_scope.hpp>
+#include <mbgl/math/minmax.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/event.hpp>
 #include <mbgl/util/exception.hpp>
@@ -320,8 +321,8 @@ void NativeMapView::update(jni::JNIEnv&) {
 }
 
 void NativeMapView::resizeView(jni::JNIEnv&, int w, int h) {
-    width = w;
-    height = h;
+    width = util::max(64, w);
+    height = util::max(64, h);
     map->setSize({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
 }
 

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -315,10 +315,12 @@ private:
     bool firstRender = true;
     double fps = 0.0;
 
-    int width = 0;
-    int height = 0;
-    int fbWidth = 0;
-    int fbHeight = 0;
+    // Minimum texture size according to OpenGL ES 2.0 specification.
+    int width = 64;
+    int height = 64;
+    int fbWidth = 64;
+    int fbHeight = 64;
+
     bool framebufferSizeChanged = true;
 
     int availableProcessors = 0;

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -287,6 +287,7 @@ private:
     void updateFps();
 
 private:
+    void recalculateSourceTileCacheSize();
 
     JavaVM *vm = nullptr;
     jni::UniqueWeakObject<NativeMapView> javaPeer;

--- a/platform/default/mbgl/gl/offscreen_view.cpp
+++ b/platform/default/mbgl/gl/offscreen_view.cpp
@@ -12,7 +12,7 @@ namespace mbgl {
 class OffscreenView::Impl {
 public:
     Impl(gl::Context& context_, const Size size_) : context(context_), size(std::move(size_)) {
-        assert(size);
+        assert(!size.isEmpty());
     }
 
     void bind() {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -576,8 +576,11 @@ public:
 
 - (mbgl::Size)size
 {
-    return { static_cast<uint32_t>(self.bounds.size.width),
-             static_cast<uint32_t>(self.bounds.size.height) };
+    // check for minimum texture size supported by OpenGL ES 2.0
+    //
+    CGSize size = CGSizeMake(MAX(self.bounds.size.width, 64), MAX(self.bounds.size.height, 64));
+    return { static_cast<uint32_t>(size.width),
+             static_cast<uint32_t>(size.height) };
 }
 
 - (mbgl::Size)framebufferSize

--- a/platform/ios/test/MGLAnnotationViewTests.m
+++ b/platform/ios/test/MGLAnnotationViewTests.m
@@ -51,7 +51,7 @@ static NSString * const MGLTestAnnotationReuseIdentifer = @"MGLTestAnnotationReu
 - (void)setUp
 {
     [super setUp];
-    _mapView = [[MGLMapView alloc] initWithFrame:CGRectZero];
+    _mapView = [[MGLMapView alloc] initWithFrame:CGRectMake(0, 0, 64, 64)];
     _mapView.delegate = self;
 }
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -307,8 +307,11 @@ public:
 }
 
 - (mbgl::Size)size {
-    return { static_cast<uint32_t>(self.bounds.size.width),
-             static_cast<uint32_t>(self.bounds.size.height) };
+    // check for minimum texture size supported by OpenGL ES 2.0
+    //
+    CGSize size = CGSizeMake(MAX(self.bounds.size.width, 64), MAX(self.bounds.size.height, 64));
+    return { static_cast<uint32_t>(size.width),
+             static_cast<uint32_t>(size.height) };
 }
 
 - (mbgl::Size)framebufferSize {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -45,9 +45,13 @@ Transform::Transform(MapObserver& observer_,
 
 #pragma mark - Map View
 
-bool Transform::resize(const Size size) {
+void Transform::resize(const Size size) {
+    if (size.isEmpty()) {
+        throw std::runtime_error("failed to resize: size is empty");
+    }
+
     if (state.size == size) {
-        return false;
+        return;
     }
 
     observer.onCameraWillChange(MapObserver::CameraChangeMode::Immediate);
@@ -56,8 +60,6 @@ bool Transform::resize(const Size size) {
     state.constrain(state.scale, state.x, state.y);
 
     observer.onCameraDidChange(MapObserver::CameraChangeMode::Immediate);
-
-    return true;
 }
 
 #pragma mark - Camera

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -25,7 +25,7 @@ public:
     Transform(const TransformState &state_) : observer(MapObserver::nullObserver()), state(state_) {}
 
     // Map view
-    bool resize(Size size);
+    void resize(Size size);
 
     // Camera
     /** Returns the current camera options. */

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -27,6 +27,9 @@ void TransformState::matrixFor(mat4& matrix, const UnwrappedTileID& tileID) cons
 }
 
 void TransformState::getProjMatrix(mat4& projMatrix) const {
+    if (size.isEmpty()) {
+        return;
+    }
 
      // Find the distance from the center point [width/2, height/2] to the
     // center top point [width/2, 0] in Z units, using the law of sines.
@@ -216,7 +219,7 @@ double TransformState::scaleZoom(double s) const {
 }
 
 ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) const {
-    if (!size) {
+    if (size.isEmpty()) {
         return {};
     }
 
@@ -229,7 +232,7 @@ ScreenCoordinate TransformState::latLngToScreenCoordinate(const LatLng& latLng) 
 }
 
 LatLng TransformState::screenCoordinateToLatLng(const ScreenCoordinate& point, LatLng::WrapMode wrapMode) const {
-    if (!size) {
+    if (size.isEmpty()) {
         return {};
     }
 

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -74,6 +74,10 @@ public:
     double zoomScale(double zoom) const;
     double scaleZoom(double scale) const;
 
+    bool valid() const {
+        return !size.isEmpty() && (scale >= min_scale && scale <= max_scale);
+    }
+
 private:
     bool rotatedNorth() const;
     void constrain(double& scale, double& x, double& y) const;

--- a/src/mbgl/util/offscreen_texture.cpp
+++ b/src/mbgl/util/offscreen_texture.cpp
@@ -9,7 +9,7 @@ namespace mbgl {
 class OffscreenTexture::Impl {
 public:
     Impl(gl::Context& context_, const Size size_) : context(context_), size(std::move(size_)) {
-        assert(size);
+        assert(!size.isEmpty());
     }
 
     void bind() {
@@ -45,7 +45,7 @@ private:
 
 OffscreenTexture::OffscreenTexture(gl::Context& context, const Size size)
     : impl(std::make_unique<Impl>(context, std::move(size))) {
-    assert(size);
+    assert(!size.isEmpty());
 }
 
 OffscreenTexture::~OffscreenTexture() = default;

--- a/src/mbgl/util/tile_cover.cpp
+++ b/src/mbgl/util/tile_cover.cpp
@@ -156,6 +156,8 @@ std::vector<UnwrappedTileID> tileCover(const LatLngBounds& bounds_, int32_t z) {
 }
 
 std::vector<UnwrappedTileID> tileCover(const TransformState& state, int32_t z) {
+    assert(state.valid());
+
     const double w = state.getSize().width;
     const double h = state.getSize().height;
     return tileCover(


### PR DESCRIPTION
Some platforms provide their own size type defaulting to -1 in both width and height e.g. Qt's [QSize](http://doc-snapshots.qt.io/qt5-5.9/qsize.html). We should special case this and make this part of the assertion check.