### PR TITLE
[ios] added check for annotation view animation

### DIFF
--- a/platform/ios/app/MBXAnnotationView.m
+++ b/platform/ios/app/MBXAnnotationView.m
@@ -49,17 +49,4 @@
 
 }
 
-- (nullable id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
-{
-    if (([event isEqualToString:@"transform"] || [event isEqualToString:@"position"])
-        && self.dragState == MGLAnnotationViewDragStateNone)
-    {
-        CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:event];
-        animation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
-        animation.speed = 0.1;
-        return animation;
-    }
-    return [super actionForLayer:layer forKey:event];
-}
-
 @end

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -724,7 +724,8 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         annot.coordinate = self.mapView.centerCoordinate;
         [self.mapView addAnnotation:annot];
         
-        CGPoint point = CGPointMake(-200, CGRectGetMidY(self.view.frame));
+        // Move the annotation to a point that is offscreen.
+        CGPoint point = CGPointMake(self.view.frame.origin.x - 200, CGRectGetMidY(self.view.frame));
         
         CLLocationCoordinate2D coord = [self.mapView convertPoint:point toCoordinateFromView:self.view];
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsAnnotationsRows) {
     MBXSettingsAnnotations100Sprites,
     MBXSettingsAnnotations1000Sprites,
     MBXSettingsAnnotations10000Sprites,
+    MBXSettingsAnnotationAnimation,
     MBXSettingsAnnotationsTestShapes,
     MBXSettingsAnnotationsCustomCallout,
     MBXSettingsAnnotationsQueryAnnotations,
@@ -314,6 +315,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                 @"Add 100 Sprites",
                 @"Add 1,000 Sprites",
                 @"Add 10,000 Sprites",
+                @"Animate an Annotation View",
                 @"Add Test Shapes",
                 @"Add Point With Custom Callout",
                 @"Query Annotations",
@@ -497,6 +499,9 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
                     break;
                 case MBXSettingsAnnotations10000Sprites:
                     [self parseFeaturesAddingCount:10000 usingViews:NO];
+                    break;
+                case MBXSettingsAnnotationAnimation:
+                    [self animateAnnotationView];
                     break;
                 case MBXSettingsAnnotationsTestShapes:
                     [self addTestShapes];
@@ -712,6 +717,22 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
         }
     });
 }
+
+- (void)animateAnnotationView
+    {
+        MGLPointAnnotation *annot = [[MGLPointAnnotation alloc] init];
+        annot.coordinate = self.mapView.centerCoordinate;
+        [self.mapView addAnnotation:annot];
+        
+        CGPoint point = CGPointMake(-200, CGRectGetMidY(self.view.frame));
+        
+        CLLocationCoordinate2D coord = [self.mapView convertPoint:point toCoordinateFromView:self.view];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [UIView animateWithDuration:10 animations:^{
+                annot.coordinate = coord;
+            }];
+        });
+    };
 
 - (void)addTestShapes
 {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -5053,6 +5053,9 @@ public:
             }
             else
             {
+                if (annotationView.layer.animationKeys.count > 0) {
+                    continue;
+                }
                 CGRect adjustedFrame = annotationView.frame;
                 if (annotationView.layer.presentationLayer) {
                     adjustedFrame.origin.x = -CGRectGetWidth(annotationView.layer.presentationLayer.frame) * 10.0;


### PR DESCRIPTION
Checks whether an annotation view has any `animationKeys` in `updateAnnotations` before adding the annotation view to reuse queue. Should prevent annotations that are being moved offscreen from disappearing. 

<img src="https://cloud.githubusercontent.com/assets/12474734/24434076/22fb1d86-13e2-11e7-8aab-1fb85c229b0b.gif" width=200> <img src ="https://cloud.githubusercontent.com/assets/12474734/24434078/24e186da-13e2-11e7-89c3-5b6f272b8c71.gif" width=200>

Bug and Fix

Addresses #8489, uses @boundsj's suggested fix.