### PR TITLE
Create .topissuesrc

### DIFF
--- a/.topissuesrc
+++ b/.topissuesrc
@@ -2,8 +2,6 @@
     "labels": {
         "release blocker": 25,
         "beta blocker": 20,
-        "high priority": 7,
-        "medium priority": 5,
         "crash": 5,
         "build": 5,
         "bug": 2

--- a/.topissuesrc
+++ b/.topissuesrc
@@ -1,0 +1,19 @@
+{
+    "labels": {
+        "release blocker": 25,
+        "beta blocker": 20,
+        "high priority": 7,
+        "medium priority": 5,
+        "crash": 5,
+        "build": 5,
+        "bug": 2
+    },
+    "reactions": {
+        "+1": 1,
+        "-1": -1,
+        "laugh": 1,
+        "hooray": 1,
+        "confused": 1,
+        "heart": 1
+    }
+}


### PR DESCRIPTION
There are many reasons why different projects may want to prioritize issues differently. I just added the ability for projects to specify a custom `.topissuesrc` file which determines how labels and reactions are scored. (We may want to add more knobs and dials to this file in the future.)

Some light docs about `.topissuesrc`: https://github.com/mapbox/top-issues/blob/master/README.md#topissuesrc

Note to self: Once this merges it might be nice to reformulate the default top-issues settings to play nicely with the default Github issue labels
