### PR TITLE
Fix compilation with Android NDK r13b

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,84 @@
+version: 2
+
+jobs:
+
+# ------------------------------------------------------------------------------
+  build:
+    docker:
+      - image: mbgl/ci:trigger_job
+    working_directory: /
+    steps:
+      - deploy:
+          name: Trigger 'android-debug-arm-v7'
+          command: trigger_job android-debug-arm-v7
+      - deploy:
+          name: Trigger 'android-release-all'
+          command: trigger_job android-release-all
+
+# ------------------------------------------------------------------------------
+  android-debug-arm-v7:
+    docker:
+      - image: mbgl/android-ci:ndk-r13b
+    working_directory: /src
+    environment:
+      LD_PRELOAD: /usr/lib/libsysconfcpus.so
+      LIBSYSCONFCPUS: 8
+      JOBS: 8
+      BUILDTYPE: Debug
+    steps:
+      - checkout
+      - run:
+          name: Build libmapbox-gl.so for arm-v7
+          command: make android-lib-arm-v7
+      - run:
+          name: Compile Core tests for arm-v7
+          command: make android-test-lib-arm-v7
+      - run:
+          name: Test phone module
+          command: make run-android-unit-test
+      - run:
+          name: Test wear module
+          command: make run-android-wear-unit-test
+      - run:
+          name: Generate Espresso sanity tests
+          command: make test-code-android
+      - run:
+          name: Check Java code style
+          command: make android-checkstyle
+
+# ------------------------------------------------------------------------------
+  android-release-all:
+    docker:
+      - image: mbgl/android-ci:ndk-r13b
+    working_directory: /src
+    environment:
+      LD_PRELOAD: /usr/lib/libsysconfcpus.so
+      LIBSYSCONFCPUS: 8
+      JOBS: 8
+      BUILDTYPE: Release
+    steps:
+      - checkout
+      - run:
+          name: Build libmapbox-gl.so for arm-v7
+          command: make android-lib-arm-v7
+      - run:
+          name: Build libmapbox-gl.so for arm-v8
+          command: make android-lib-arm-v8
+      - run:
+          name: Build libmapbox-gl.so for arm-v5
+          command: make android-lib-arm-v5
+      - run:
+          name: Build libmapbox-gl.so for mips
+          command: make android-lib-mips
+      - run:
+          name: Build libmapbox-gl.so for x86
+          command: make android-lib-x86
+      - run:
+          name: Build libmapbox-gl.so for x86-64
+          command: make android-lib-x86-64
+      - run:
+          name: Build package
+          command: make apackage
+      - run:
+          name: Show statistics
+          command: platform/android/scripts/metrics.sh

--- a/platform/android/src/geojson/multi_point.cpp
+++ b/platform/android/src/geojson/multi_point.cpp
@@ -2,6 +2,8 @@
 
 #include "line_string.hpp"
 
+#include "util.hpp"
+
 namespace mbgl {
 namespace android {
 namespace geojson {
@@ -11,7 +13,7 @@ mapbox::geojson::multi_point MultiPoint::convert(jni::JNIEnv &env, jni::Object<M
 
     if (jMultiPoint) {
         auto jPositionListsList = MultiPoint::getCoordinates(env, jMultiPoint);
-        multiPoint = LineString::convert(env, jPositionListsList);
+        multiPoint = convertExplicit<mapbox::geojson::multi_point>(LineString::convert(env, jPositionListsList));
         jni::DeleteLocalRef(env, jPositionListsList);
     }
 

--- a/platform/android/src/geojson/polygon.cpp
+++ b/platform/android/src/geojson/polygon.cpp
@@ -2,6 +2,8 @@
 
 #include "multi_line_string.hpp"
 
+#include "util.hpp"
+
 namespace mbgl {
 namespace android {
 namespace geojson {
@@ -24,7 +26,9 @@ mapbox::geojson::polygon Polygon::convert(jni::JNIEnv &env, jni::Object<java::ut
     if (jPositionListsList) {
         auto multiLine = MultiLineString::convert(env, jPositionListsList);
         polygon.reserve(multiLine.size());
-        polygon.insert(std::end(polygon), std::begin(multiLine), std::end(multiLine));
+        for (auto&& line : multiLine) {
+            polygon.emplace_back(convertExplicit<mapbox::geojson::linear_ring>(std::move(line)));
+        }
     }
 
     return polygon;

--- a/platform/android/src/geojson/util.hpp
+++ b/platform/android/src/geojson/util.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <type_traits>
+
+namespace mbgl {
+namespace android {
+namespace geojson {
+
+// Clang 3.8 fails to implicitly convert matching types, so we'll have to do it explicitly.
+template <typename To, typename From>
+To convertExplicit(From&& src) {
+    static_assert(std::is_same<typename std::decay_t<From>::container_type,
+                               typename To::container_type>::value,
+                  "container types do not match");
+    static_assert(std::is_rvalue_reference<From&&>::value,
+                  "argument must be rvalue reference");
+    return *reinterpret_cast<std::add_pointer_t<To>>(&src);
+}
+
+} // namespace geojson
+} // namespace android
+} // namespace mbgl


### PR DESCRIPTION
Clang 3.8 and below seems to be unable to implicitly convert derived objects when they inherit from the same base class.