### PR TITLE
[core] AddedMap::{set,get}LatLngBounds

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -117,6 +117,10 @@ public:
     double getMinZoom() const;
     void setMaxZoom(double);
     double getMaxZoom() const;
+    void setMinPitch(double);
+    double getMinPitch() const;
+    void setMaxPitch(double);
+    double getMaxPitch() const;
 
     // Rotation
     void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -109,9 +109,11 @@ public:
     CameraOptions cameraForLatLngs(const std::vector<LatLng>&, optional<EdgeInsets>) const;
     LatLngBounds latLngBoundsForCamera(const CameraOptions&) const;
     void resetZoom();
-    void setMinZoom(const double minZoom);
+
+    // Bounds
+    void setMinZoom(double);
     double getMinZoom() const;
-    void setMaxZoom(const double maxZoom);
+    void setMaxZoom(double);
     double getMaxZoom() const;
 
     // Rotation

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -111,6 +111,8 @@ public:
     void resetZoom();
 
     // Bounds
+    void setLatLngBounds(const LatLngBounds&);
+    LatLngBounds getLatLngBounds() const;
     void setMinZoom(double);
     double getMinZoom() const;
     void setMaxZoom(double);

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mbgl/math/clamp.hpp>
 #include <mbgl/math/wrap.hpp>
 #include <mbgl/util/constants.hpp>
 
@@ -120,6 +121,10 @@ public:
     // Constructs a LatLngBounds object with the tile's exact boundaries.
     LatLngBounds(const CanonicalTileID&);
 
+    bool valid() const {
+        return (sw.latitude() <= ne.latitude()) && (sw.longitude() <= ne.longitude());
+    }
+
     double south() const { return sw.latitude(); }
     double west()  const { return sw.longitude(); }
     double north() const { return ne.latitude(); }
@@ -133,6 +138,16 @@ public:
     LatLng center() const {
         return LatLng((sw.latitude() + ne.latitude()) / 2,
                       (sw.longitude() + ne.longitude()) / 2);
+    }
+
+    LatLng constrain(const LatLng& p) const {
+        if (contains(p)) {
+            return p;
+        }
+        return LatLng {
+            util::clamp(p.latitude(), sw.latitude(), ne.latitude()),
+            util::clamp(p.longitude(), sw.longitude(), ne.longitude())
+        };
     }
 
     void extend(const LatLng& point) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -698,6 +698,28 @@ double Map::getMaxZoom() const {
     return impl->transform.getState().getMaxZoom();
 }
 
+void Map::setMinPitch(double minPitch) {
+    impl->transform.setMinPitch(minPitch * util::DEG2RAD);
+    if (getPitch() < minPitch) {
+        setPitch(minPitch);
+    }
+}
+
+double Map::getMinPitch() const {
+    return impl->transform.getState().getMinPitch() * util::RAD2DEG;
+}
+
+void Map::setMaxPitch(double maxPitch) {
+    impl->transform.setMaxPitch(maxPitch * util::DEG2RAD);
+    if (getPitch() > maxPitch) {
+        setPitch(maxPitch);
+    }
+}
+
+double Map::getMaxPitch() const {
+    return impl->transform.getState().getMaxPitch() * util::RAD2DEG;
+}
+
 #pragma mark - Size
 
 void Map::setSize(const Size size) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -664,6 +664,9 @@ void Map::resetZoom() {
     setZoom(0);
 }
 
+#pragma mark - Bounds
+
+
 void Map::setMinZoom(const double minZoom) {
     impl->transform.setMinZoom(minZoom);
     if (getZoom() < minZoom) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -666,6 +666,15 @@ void Map::resetZoom() {
 
 #pragma mark - Bounds
 
+LatLngBounds Map::getLatLngBounds() const {
+    return impl->transform.getState().getLatLngBounds();
+}
+
+void Map::setLatLngBounds(const LatLngBounds& bounds) {
+    impl->cameraMutated = true;
+    impl->transform.setLatLngBounds(bounds);
+    impl->onUpdate(Update::Repaint);
+}
 
 void Map::setMinZoom(const double minZoom) {
     impl->transform.setMinZoom(minZoom);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -435,6 +435,12 @@ void Transform::setScale(double scale, optional<EdgeInsets> padding, const Anima
 
 #pragma mark - Bounds
 
+void Transform::setLatLngBounds(const LatLngBounds& bounds) {
+    if (bounds.valid()) {
+        state.setLatLngBounds(bounds);
+    }
+}
+
 void Transform::setMinZoom(const double minZoom) {
     if (std::isnan(minZoom)) return;
     state.setMinZoom(minZoom);

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -120,7 +120,7 @@ void Transform::easeTo(const CameraOptions& camera, const AnimationOptions& anim
     // Constrain camera options.
     zoom = util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
     const double scale = state.zoomScale(zoom);
-    pitch = util::clamp(pitch, 0., util::PITCH_MAX);
+    pitch = util::clamp(pitch, state.min_pitch, state.max_pitch);
 
     Update update = state.getZoom() == zoom ? Update::Repaint : Update::RecalculateStyle;
 
@@ -188,7 +188,7 @@ void Transform::flyTo(const CameraOptions &camera, const AnimationOptions &anima
 
     // Constrain camera options.
     zoom = util::clamp(zoom, state.getMinZoom(), state.getMaxZoom());
-    pitch = util::clamp(pitch, 0., util::PITCH_MAX);
+    pitch = util::clamp(pitch, state.min_pitch, state.max_pitch);
 
     // Minimize rotation by taking the shorter path around the circle.
     angle = _normalizeAngle(angle, state.angle);
@@ -449,6 +449,16 @@ void Transform::setMinZoom(const double minZoom) {
 void Transform::setMaxZoom(const double maxZoom) {
     if (std::isnan(maxZoom)) return;
     state.setMaxZoom(maxZoom);
+}
+
+void Transform::setMinPitch(double minPitch) {
+    if (std::isnan(minPitch)) return;
+    state.setMinPitch(minPitch);
+}
+
+void Transform::setMaxPitch(double maxPitch) {
+    if (std::isnan(maxPitch)) return;
+    state.setMaxPitch(maxPitch);
 }
 
 #pragma mark - Angle

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -433,6 +433,8 @@ void Transform::setScale(double scale, optional<EdgeInsets> padding, const Anima
     setScale(scale, anchor, animation);
 }
 
+#pragma mark - Bounds
+
 void Transform::setMinZoom(const double minZoom) {
     if (std::isnan(minZoom)) return;
     state.setMinZoom(minZoom);

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -60,6 +60,8 @@ public:
     void setLatLngBounds(const LatLngBounds&);
     void setMinZoom(double);
     void setMaxZoom(double);
+    void setMinPitch(double);
+    void setMaxPitch(double);
 
     // Zoom
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -55,6 +55,11 @@ public:
     LatLng getLatLng(optional<EdgeInsets> = {}) const;
     ScreenCoordinate getScreenCoordinate(optional<EdgeInsets> = {}) const;
 
+    // Bounds
+
+    void setMinZoom(double);
+    void setMaxZoom(double);
+
     // Zoom
 
     /** Scales the map, keeping the given point fixed within the view.
@@ -93,9 +98,6 @@ public:
     double getZoom() const;
     /** Returns the scale factor. */
     double getScale() const;
-
-    void setMinZoom(const double minZoom);
-    void setMaxZoom(const double maxZoom);
 
     // Angle
 

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -57,6 +57,7 @@ public:
 
     // Bounds
 
+    void setLatLngBounds(const LatLngBounds&);
     void setMinZoom(double);
     void setMaxZoom(double);
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -140,6 +140,8 @@ double TransformState::getScale() const {
     return scale;
 }
 
+#pragma mark - Bounds
+
 void TransformState::setMinZoom(const double minZoom) {
     if (minZoom <= getMaxZoom()) {
         min_scale = zoomScale(util::clamp(minZoom, util::MIN_ZOOM, util::MAX_ZOOM));

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -176,6 +176,25 @@ double TransformState::getMaxZoom() const {
     return scaleZoom(max_scale);
 }
 
+void TransformState::setMinPitch(double minPitch) {
+    if (minPitch <= getMaxPitch()) {
+        min_pitch = minPitch;
+    }
+}
+
+double TransformState::getMinPitch() const {
+    return min_pitch;
+}
+
+void TransformState::setMaxPitch(double maxPitch) {
+    if (maxPitch >= getMinPitch()) {
+        max_pitch = maxPitch;
+    }
+}
+
+double TransformState::getMaxPitch() const {
+    return max_pitch;
+}
 
 #pragma mark - Rotation
 

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -49,9 +49,11 @@ public:
     double getZoom() const;
     int32_t getIntegerZoom() const;
     double getZoomFraction() const;
-    void setMinZoom(const double minZoom);
+
+    // Bounds
+    void setMinZoom(double);
     double getMinZoom() const;
-    void setMaxZoom(const double maxZoom);
+    void setMaxZoom(double);
     double getMaxZoom() const;
 
     // Rotation

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -51,6 +51,8 @@ public:
     double getZoomFraction() const;
 
     // Bounds
+    void setLatLngBounds(const LatLngBounds&);
+    LatLngBounds getLatLngBounds() const;
     void setMinZoom(double);
     double getMinZoom() const;
     void setMaxZoom(double);
@@ -83,6 +85,8 @@ public:
 private:
     bool rotatedNorth() const;
     void constrain(double& scale, double& x, double& y) const;
+
+    LatLngBounds bounds = LatLngBounds::world();
 
     // Limit the amount of zooming possible on the map.
     double min_scale = std::pow(2, 0);

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -57,6 +57,10 @@ public:
     double getMinZoom() const;
     void setMaxZoom(double);
     double getMaxZoom() const;
+    void setMinPitch(double);
+    double getMinPitch() const;
+    void setMaxPitch(double);
+    double getMaxPitch() const;
 
     // Rotation
     float getAngle() const;
@@ -91,6 +95,8 @@ private:
     // Limit the amount of zooming possible on the map.
     double min_scale = std::pow(2, 0);
     double max_scale = std::pow(2, 20);
+    double min_pitch = 0.0;
+    double max_pitch = util::PITCH_MAX;
 
     NorthOrientation orientation = NorthOrientation::Upwards;
 

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -573,3 +573,21 @@ TEST(Transform, LatLngBounds) {
     ASSERT_EQ(transform.getLatLng().latitude(), 0.0);
     ASSERT_EQ(transform.getLatLng().longitude(), 0.0);
 }
+
+TEST(Transform, PitchBounds) {
+    Transform transform;
+    transform.resize({ 1000, 1000 });
+    transform.setLatLngZoom({ 0, 0 }, transform.getState().getMaxZoom());
+
+    ASSERT_DOUBLE_EQ(transform.getState().getPitch() * util::RAD2DEG, 0.0);
+    ASSERT_DOUBLE_EQ(transform.getState().getMinPitch() * util::RAD2DEG, 0.0);
+    ASSERT_DOUBLE_EQ(transform.getState().getMaxPitch() * util::RAD2DEG, 60.0);
+
+    transform.setMinPitch(45.0 * util::DEG2RAD);
+    transform.setPitch(0.0 * util::DEG2RAD);
+    ASSERT_NEAR(transform.getState().getPitch() * util::RAD2DEG, 45.0, 1e-5);
+
+    transform.setMaxPitch(55.0 * util::DEG2RAD);
+    transform.setPitch(60.0 * util::DEG2RAD);
+    ASSERT_NEAR(transform.getState().getPitch() * util::RAD2DEG, 55.0, 1e-5);
+}

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -534,3 +534,42 @@ TEST(Transform, DefaultTransform) {
     ASSERT_DOUBLE_EQ(point.x, center.x);
     ASSERT_DOUBLE_EQ(point.y, center.y);
 }
+
+TEST(Transform, LatLngBounds) {
+    const LatLng nullIsland {};
+    const LatLng sanFrancisco { 37.7749, -122.4194 };
+
+    Transform transform;
+    transform.resize({ 1000, 1000 });
+    transform.setLatLngZoom({ 0, 0 }, transform.getState().getMaxZoom());
+
+    // Default bounds.
+    ASSERT_EQ(transform.getState().getLatLngBounds(), LatLngBounds::world());
+    ASSERT_EQ(transform.getLatLng(), nullIsland);
+
+    // Invalid bounds.
+    transform.setLatLngBounds(LatLngBounds::empty());
+    ASSERT_EQ(transform.getState().getLatLngBounds(), LatLngBounds::world());
+
+    transform.setLatLng(sanFrancisco);
+    ASSERT_EQ(transform.getLatLng(), sanFrancisco);
+
+    // Single location.
+    transform.setLatLngBounds(LatLngBounds::singleton(sanFrancisco));
+    ASSERT_EQ(transform.getLatLng(), sanFrancisco);
+
+    transform.setLatLngBounds(LatLngBounds::hull({ -90.0, -180.0 }, { 0.0, 180.0 }));
+    transform.setLatLng(sanFrancisco);
+    ASSERT_EQ(transform.getLatLng().latitude(), 0.0);
+    ASSERT_EQ(transform.getLatLng().longitude(), sanFrancisco.longitude());
+
+    transform.setLatLngBounds(LatLngBounds::hull({ -90.0, 0.0 }, { 90.0, 180.0 }));
+    transform.setLatLng(sanFrancisco);
+    ASSERT_EQ(transform.getLatLng().latitude(), sanFrancisco.latitude());
+    ASSERT_EQ(transform.getLatLng().longitude(), 0.0);
+
+    transform.setLatLngBounds(LatLngBounds::hull({ -90.0, 0.0 }, { 0.0, 180.0 }));
+    transform.setLatLng(sanFrancisco);
+    ASSERT_EQ(transform.getLatLng().latitude(), 0.0);
+    ASSERT_EQ(transform.getLatLng().longitude(), 0.0);
+}


### PR DESCRIPTION
Implements a setter and getter for coordinate bounds in `Map` API - which can be used e.g. to limit the boundaries in which the user can set geographical coordinates.

Related: #3602.