### PR TITLE
[android] - disable requiring supported languages for test applications

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -27,6 +27,7 @@ android {
     lintOptions {
         checkAllWarnings true
         warningsAsErrors true
+        disable 'MissingTranslation'
         disable 'IconDensities'
         disable 'InvalidPackage'
     }

--- a/platform/android/MapboxGLAndroidSDKWearTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKWearTestApp/build.gradle
@@ -12,6 +12,10 @@ android {
         versionName rootProject.ext.versionName
     }
 
+    lintOptions {
+        disable 'MissingTranslation'
+    }
+
     buildTypes {
         debug {
             testCoverageEnabled = true


### PR DESCRIPTION
Because of Transiflex integration, lint is complaining that the test application is not being translated.