### PR TITLE
Analysis of mapbox-gl-native source code by PVS-Studio

### DIFF
--- a/src/mbgl/util/thread_local.hpp
+++ b/src/mbgl/util/thread_local.hpp
@@ -12,8 +12,7 @@ namespace util {
 template <class T>
 class ThreadLocal : public noncopyable {
 public:
-    ThreadLocal(T* val) {
-        ThreadLocal();
+    ThreadLocal(T* val) : ThreadLocal() {
         set(val);
     }
 


### PR DESCRIPTION
To demonstrate the abilities of PVS-Studio analyzer, we decided to find several bugs.
I would like to suggest a variant of the way to fix the error, detected with the help of V603 diagnostic: The object was created but it is not being used. If you wish to call constructor, 'this->ThreadLocal::ThreadLocal(....)' should be used.

PVS-Studio is a tool for bug detection in the source code of programs, written in C, C++ and C#. It works in Windows and Linux environment. https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.