### PR TITLE
[ios] Silence incompatible type warning for callout view

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -4,8 +4,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 
 ## 3.5.1
 
-### Other changes
-
 * Fixed an issue that caused the return type of a map view delegate method to bridge incorrectly to applications written in Swift. ([#8541](https://github.com/mapbox/mapbox-gl-native/pull/8541))
 
 ## 3.5.0

--- a/platform/ios/app/MBXViewController.m
+++ b/platform/ios/app/MBXViewController.m
@@ -1739,7 +1739,7 @@ typedef NS_ENUM(NSInteger, MBXSettingsMiscellaneousRows) {
     }];
 }
 
-- (UIView<MGLCalloutView> *)mapView:(__unused MGLMapView *)mapView calloutViewForAnnotation:(id<MGLAnnotation>)annotation
+- (nullable id <MGLCalloutView>)mapView:(__unused MGLMapView *)mapView calloutViewForAnnotation:(id<MGLAnnotation>)annotation
 {
     if ([annotation respondsToSelector:@selector(title)]
         && [annotation isKindOfClass:[MBXCustomCalloutAnnotation class]])

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3761,7 +3761,12 @@ public:
         UIView <MGLCalloutView> *calloutView;
         if ([self.delegate respondsToSelector:@selector(mapView:calloutViewForAnnotation:)])
         {
-            calloutView = [self.delegate mapView:self calloutViewForAnnotation:annotation];
+            id providedCalloutView = [self.delegate mapView:self calloutViewForAnnotation:annotation];
+            if (providedCalloutView) {
+                NSAssert([providedCalloutView isKindOfClass:[UIView class]], @"callout view should be a kind of UIView");
+                NSAssert([providedCalloutView conformsToProtocol:@protocol(MGLCalloutView)], @"callout view should conform to MGLCalloutView");
+                calloutView = providedCalloutView;
+            }
         }
         if (!calloutView)
         {

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3763,8 +3763,10 @@ public:
         {
             id providedCalloutView = [self.delegate mapView:self calloutViewForAnnotation:annotation];
             if (providedCalloutView) {
-                NSAssert([providedCalloutView isKindOfClass:[UIView class]], @"callout view should be a kind of UIView");
-                NSAssert([providedCalloutView conformsToProtocol:@protocol(MGLCalloutView)], @"callout view should conform to MGLCalloutView");
+                if (![providedCalloutView isKindOfClass:[UIView class]]) {
+                    [NSException raise:NSInvalidArgumentException format:@"Callout view must be a kind of UIView"];
+                }
+                NSAssert([providedCalloutView conformsToProtocol:@protocol(MGLCalloutView)], @"callout view must conform to MGLCalloutView");
                 calloutView = providedCalloutView;
             }
         }


### PR DESCRIPTION
Continuation of https://github.com/mapbox/mapbox-gl-native/issues/8420.
Fixes warning introduced in https://github.com/mapbox/mapbox-gl-native/pull/8541

This silences a compatibility warning that was introduced in a previous refactor that changed the return type of the callout view for annotation delegate method. This also adds checks to ensure that the callout view provided by the delegate to the map view is of the correct type and conforms to the correct protocol.