### PR TITLE
Fix edge case in composite function interpolation

### DIFF
--- a/cmake/test-files.cmake
+++ b/cmake/test-files.cmake
@@ -87,6 +87,7 @@ set(MBGL_TEST_FILES
 
     # style/function
     test/style/function/camera_function.test.cpp
+    test/style/function/composite_function.test.cpp
     test/style/function/source_function.test.cpp
 
     # style

--- a/include/mbgl/style/function/composite_function.hpp
+++ b/include/mbgl/style/function/composite_function.hpp
@@ -56,9 +56,25 @@ public:
                 assert(!s.stops.empty());
                 auto minIt = s.stops.lower_bound(zoom);
                 auto maxIt = s.stops.upper_bound(zoom);
-                if (minIt != s.stops.begin()) {
+                
+                if (minIt == s.stops.end()) minIt--;
+                if (maxIt == s.stops.end()) maxIt--;
+                
+                // minIt is first element >= zoom. if it's >, back up by one.
+                if (minIt != s.stops.begin() && minIt->first > zoom) {
                     minIt--;
                 }
+
+                // if minIt == maxIt, move one of them so we get two different stops
+                // for interpolation; prefer incrementing the upper stop if it's not
+                // already the last one.
+                if (minIt == maxIt && std::next(maxIt) != s.stops.end()) {
+                    maxIt++;
+                }
+                if (minIt == maxIt && minIt != s.stops.begin()) {
+                    minIt--;
+                }
+                
                 return std::make_tuple(
                     Range<float> {
                         minIt == s.stops.end() ? s.stops.rbegin()->first : minIt->first,

--- a/test/style/function/composite_function.test.cpp
+++ b/test/style/function/composite_function.test.cpp
@@ -1,0 +1,46 @@
+#include <mbgl/test/util.hpp>
+#include <mbgl/test/stub_geometry_tile_feature.hpp>
+
+#include <mbgl/style/function/composite_function.hpp>
+
+using namespace mbgl;
+using namespace mbgl::style;
+
+using namespace std::string_literals;
+
+static StubGeometryTileFeature oneInteger {
+    PropertyMap {{ "property", uint64_t(1) }}
+};
+
+TEST(CompositeFunction, ZoomInterpolation) {
+    EXPECT_EQ(40.0f, CompositeFunction<float>("property", CompositeExponentialStops<float>({
+        {0.0f, {{uint64_t(1), 24.0f}}},
+        {1.5f, {{uint64_t(1), 36.0f}}},
+        {3.0f, {{uint64_t(1), 48.0f}}}
+    }), 0.0f)
+    .evaluate(2.0f, oneInteger, -1.0f)) << "Should interpolate between stops";
+    
+    EXPECT_EQ(0.0, CompositeFunction<float>("property", CompositeExponentialStops<float>({
+        {5.0f, {{uint64_t(1), 33.0f}}},
+        {10.0f, {{uint64_t(1), 66.0f}}}
+    }), 0.0f)
+    .evaluate(0.0f, oneInteger, -1.0f)) << "Should interpolate before the first stop";
+    
+    EXPECT_EQ(99.0, CompositeFunction<float>("property", CompositeExponentialStops<float>({
+        {0.0f, {{uint64_t(1), 33.0f}}},
+        {10.0f, {{uint64_t(1), 66.0f}}}
+    }), 0.0f)
+    .evaluate(20.0f, oneInteger, -1.0f)) << "Should interpolate past the last stop";
+
+    EXPECT_EQ(66.0f, CompositeFunction<float>("property", CompositeExponentialStops<float>({
+        {0.0f, {{uint64_t(1), 33.0f}}},
+        {10.0f, {{uint64_t(1), 66.0f}}}
+    }), 0.0f)
+    .evaluate(10.0f, oneInteger, -1.0f)) << "Should interpolate TO the last stop.";
+    
+    EXPECT_EQ(33.0f, CompositeFunction<float>("property", CompositeExponentialStops<float>({
+        {0.0f, {{uint64_t(1), 33.0f}}},
+        {10.0f, {{uint64_t(1), 66.0f}}}
+    }), 0.0f)
+    .evaluate(0.0f, oneInteger, -1.0f)) << "Should interpolate TO the first stop";
+}

--- a/test/style/function/composite_function.test.cpp
+++ b/test/style/function/composite_function.test.cpp
@@ -20,17 +20,17 @@ TEST(CompositeFunction, ZoomInterpolation) {
     }), 0.0f)
     .evaluate(2.0f, oneInteger, -1.0f)) << "Should interpolate between stops";
     
-    EXPECT_EQ(0.0, CompositeFunction<float>("property", CompositeExponentialStops<float>({
+    EXPECT_EQ(33.0, CompositeFunction<float>("property", CompositeExponentialStops<float>({
         {5.0f, {{uint64_t(1), 33.0f}}},
         {10.0f, {{uint64_t(1), 66.0f}}}
     }), 0.0f)
-    .evaluate(0.0f, oneInteger, -1.0f)) << "Should interpolate before the first stop";
+    .evaluate(0.0f, oneInteger, -1.0f)) << "Use first stop output for input values from -inf to first stop";
     
-    EXPECT_EQ(99.0, CompositeFunction<float>("property", CompositeExponentialStops<float>({
+    EXPECT_EQ(66.0, CompositeFunction<float>("property", CompositeExponentialStops<float>({
         {0.0f, {{uint64_t(1), 33.0f}}},
         {10.0f, {{uint64_t(1), 66.0f}}}
     }), 0.0f)
-    .evaluate(20.0f, oneInteger, -1.0f)) << "Should interpolate past the last stop";
+    .evaluate(20.0f, oneInteger, -1.0f)) << "Use last stop output for input values from last stop to +inf";
 
     EXPECT_EQ(66.0f, CompositeFunction<float>("property", CompositeExponentialStops<float>({
         {0.0f, {{uint64_t(1), 33.0f}}},


### PR DESCRIPTION
This fixes a bug where, for a zoom value greater than that of the highest zoom
stop, composite function interpolation would return `nan`. (Blocking a render
test over in https://github.com/mapbox/mapbox-gl-native/pull/8593)