### PR TITLE
[ios, macos] Add `overlays` property to `MGLMapView.mm`

### DIFF
--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -36,6 +36,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a crash or console spew when MGLMapView is initialized with a frame smaller than 64 points wide by 64 points tall. ([#8562](https://github.com/mapbox/mapbox-gl-native/pull/8562))
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 * Fixed an issue rendering polylines that contain duplicate vertices. ([#8808](https://github.com/mapbox/mapbox-gl-native/pull/8808))
+* Added non-null `overlays` property to `MGLMapView`. ([#8617](https://github.com/mapbox/mapbox-gl-native/pull/8617))
 
 ## 3.5.4 - May 9, 2017
 

--- a/platform/ios/CHANGELOG.md
+++ b/platform/ios/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 ## master
 
 * The previously-deprecated support for style classes has been removed. For interface compatibility, the API methods remain, but they are now non-functional.
+* Added an `overlays` property to `MGLMapView`. ([#8617](https://github.com/mapbox/mapbox-gl-native/pull/8617))
 
 ## 3.6.0
 
@@ -36,7 +37,6 @@ Mapbox welcomes participation and contributions from everyone. Please read [CONT
 * Fixed a crash or console spew when MGLMapView is initialized with a frame smaller than 64 points wide by 64 points tall. ([#8562](https://github.com/mapbox/mapbox-gl-native/pull/8562))
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 * Fixed an issue rendering polylines that contain duplicate vertices. ([#8808](https://github.com/mapbox/mapbox-gl-native/pull/8808))
-* Added non-null `overlays` property to `MGLMapView`. ([#8617](https://github.com/mapbox/mapbox-gl-native/pull/8617))
 
 ## 3.5.4 - May 9, 2017
 

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1135,9 +1135,9 @@ IB_DESIGNABLE
 
  The objects in this array must adopt the `MGLOverlay` protocol. If no
  overlays are associated with the map view, the value of this property is
- `nil`.
+ empty array.
  */
-@property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLOverlay>) *overlays;
+@property (nonatomic, readonly, nonnull) NS_ARRAY_OF(id <MGLOverlay>) *overlays;
 
 /**
  Adds a single overlay object to the map.

--- a/platform/ios/src/MGLMapView.h
+++ b/platform/ios/src/MGLMapView.h
@@ -1131,6 +1131,15 @@ IB_DESIGNABLE
 #pragma mark Overlaying the Map
 
 /**
+ The complete list of overlays associated with the receiver. (read-only)
+
+ The objects in this array must adopt the `MGLOverlay` protocol. If no
+ overlays are associated with the map view, the value of this property is
+ `nil`.
+ */
+@property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLOverlay>) *overlays;
+
+/**
  Adds a single overlay object to the map.
 
  To remove an overlay from a map, use the `-removeOverlay:` method.

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3535,7 +3535,7 @@ public:
 {
     if (self.annotations == nil) { return @[]; }
 
-    NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
+    NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray array];
 
     [self.annotations enumerateObjectsUsingBlock:^(id<MGLAnnotation>  _Nonnull annotation, NSUInteger idx, BOOL * _Nonnull stop) {
         if ([annotation conformsToProtocol:@protocol(MGLOverlay)])

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3531,9 +3531,9 @@ public:
     }
 }
 
-- (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays
+- (nonnull NS_ARRAY_OF(id <MGLOverlay>) *)overlays
 {
-    if (self.annotations == nil) { return nil; }
+    if (self.annotations == nil) { return @[]; }
 
     NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
 

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3531,6 +3531,20 @@ public:
     }
 }
 
+- (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays {
+    if (self.annotations == nil) { return nil; }
+
+    NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
+
+    [self.annotations enumerateObjectsUsingBlock:^(id<MGLAnnotation>  _Nonnull annotation, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([annotation conformsToProtocol:@protocol(MGLOverlay)]) {
+            [mutableOverlays addObject:(id<MGLOverlay>)annotation];
+        }
+    }];
+
+    return [NSArray arrayWithArray:mutableOverlays];
+}
+
 - (void)addOverlay:(id <MGLOverlay>)overlay
 {
     [self addOverlays:@[ overlay ]];

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -3531,13 +3531,15 @@ public:
     }
 }
 
-- (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays {
+- (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays
+{
     if (self.annotations == nil) { return nil; }
 
     NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
 
     [self.annotations enumerateObjectsUsingBlock:^(id<MGLAnnotation>  _Nonnull annotation, NSUInteger idx, BOOL * _Nonnull stop) {
-        if ([annotation conformsToProtocol:@protocol(MGLOverlay)]) {
+        if ([annotation conformsToProtocol:@protocol(MGLOverlay)])
+        {
             [mutableOverlays addObject:(id<MGLOverlay>)annotation];
         }
     }];

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * The previously-deprecated support for style classes has been removed. For interface compatibility, the API methods remain, but they are now non-functional.
+* Added an `overlays` property to `MGLMapView`. ([#8617](https://github.com/mapbox/mapbox-gl-native/pull/8617))
 
 ## 0.5.0
 
@@ -25,7 +26,6 @@
 * Fixed a crash or console spew when MGLMapView is initialized with a frame smaller than 64 points wide by 64 points tall. ([#8562](https://github.com/mapbox/mapbox-gl-native/pull/8562))
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 * Fixed an issue rendering polylines that contain duplicate vertices. ([#8808](https://github.com/mapbox/mapbox-gl-native/pull/8808))
-* Added non-null `overlays` property to `MGLMapView`. ([#8617](https://github.com/mapbox/mapbox-gl-native/pull/8617))
 
 ## 0.4.1 - April 8, 2017
 

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fixed a crash or console spew when MGLMapView is initialized with a frame smaller than 64 points wide by 64 points tall. ([#8562](https://github.com/mapbox/mapbox-gl-native/pull/8562))
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 * Fixed an issue rendering polylines that contain duplicate vertices. ([#8808](https://github.com/mapbox/mapbox-gl-native/pull/8808))
+* Added non-null `overlays` property to `MGLMapView`. ([#8617](https://github.com/mapbox/mapbox-gl-native/pull/8617))
 
 ## 0.4.1 - April 8, 2017
 

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -729,6 +729,8 @@ MGL_EXPORT IB_DESIGNABLE
 
 #pragma mark Overlaying the Map
 
+@property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLOverlay>) *overlays;
+
 /**
  Adds a single overlay to the map.
 

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -734,9 +734,9 @@ MGL_EXPORT IB_DESIGNABLE
 
  The objects in this array must adopt the `MGLOverlay` protocol. If no
  overlays are associated with the map view, the value of this property is
- `nil`.
+ empty array.
  */
-@property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLOverlay>) *overlays;
+@property (nonatomic, readonly, nonnull) NS_ARRAY_OF(id <MGLOverlay>) *overlays;
 
 /**
  Adds a single overlay to the map.

--- a/platform/macos/src/MGLMapView.h
+++ b/platform/macos/src/MGLMapView.h
@@ -729,6 +729,13 @@ MGL_EXPORT IB_DESIGNABLE
 
 #pragma mark Overlaying the Map
 
+/**
+ The complete list of overlays associated with the receiver. (read-only)
+
+ The objects in this array must adopt the `MGLOverlay` protocol. If no
+ overlays are associated with the map view, the value of this property is
+ `nil`.
+ */
 @property (nonatomic, readonly, nullable) NS_ARRAY_OF(id <MGLOverlay>) *overlays;
 
 /**

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2413,13 +2413,15 @@ public:
 
 #pragma mark Overlays
 
-- (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays {
+- (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays
+{
     if (self.annotations == nil) { return nil; }
 
     NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
 
     [self.annotations enumerateObjectsUsingBlock:^(id<MGLAnnotation>  _Nonnull annotation, NSUInteger idx, BOOL * _Nonnull stop) {
-        if ([annotation conformsToProtocol:@protocol(MGLOverlay)]) {
+        if ([annotation conformsToProtocol:@protocol(MGLOverlay)])
+        {
             [mutableOverlays addObject:(id<MGLOverlay>)annotation];
         }
     }];

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2414,6 +2414,8 @@ public:
 #pragma mark Overlays
 
 - (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays {
+    if (self.annotations == nil) { return nil; }
+
     NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
 
     [self.annotations enumerateObjectsUsingBlock:^(id<MGLAnnotation>  _Nonnull annotation, NSUInteger idx, BOOL * _Nonnull stop) {

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2417,7 +2417,7 @@ public:
 {
     if (self.annotations == nil) { return @[]; }
 
-    NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
+    NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray array];
 
     [self.annotations enumerateObjectsUsingBlock:^(id<MGLAnnotation>  _Nonnull annotation, NSUInteger idx, BOOL * _Nonnull stop) {
         if ([annotation conformsToProtocol:@protocol(MGLOverlay)])

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2413,9 +2413,9 @@ public:
 
 #pragma mark Overlays
 
-- (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays
+- (nonnull NS_ARRAY_OF(id <MGLOverlay>) *)overlays
 {
-    if (self.annotations == nil) { return nil; }
+    if (self.annotations == nil) { return @[]; }
 
     NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
 

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -2413,6 +2413,18 @@ public:
 
 #pragma mark Overlays
 
+- (nullable NS_ARRAY_OF(id <MGLOverlay>) *)overlays {
+    NS_MUTABLE_ARRAY_OF(id <MGLOverlay>) *mutableOverlays = [NSMutableArray new];
+
+    [self.annotations enumerateObjectsUsingBlock:^(id<MGLAnnotation>  _Nonnull annotation, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([annotation conformsToProtocol:@protocol(MGLOverlay)]) {
+            [mutableOverlays addObject:(id<MGLOverlay>)annotation];
+        }
+    }];
+
+    return [NSArray arrayWithArray:mutableOverlays];
+}
+
 - (void)addOverlay:(id <MGLOverlay>)overlay {
     [self addOverlays:@[overlay]];
 }


### PR DESCRIPTION
Implemented by filtering the `annotations` property for
annotations that conform to `MGLOverlay` protocol.

Fixes #4281.