### PR TITLE
Preserve symlinks when zipping framework

### DIFF
--- a/platform/ios/scripts/publish.sh
+++ b/platform/ios/scripts/publish.sh
@@ -27,7 +27,7 @@ cd build/ios/pkg
 ZIP=mapbox-ios-sdk-${PUBLISH_VERSION}${PUBLISH_STYLE}.zip
 step "Compressing ${ZIP}…"
 rm -f ../${ZIP}
-zip -r ../${ZIP} *
+zip -yr ../${ZIP} *
 
 #
 # upload

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Mapbox macOS SDK
 
+## 0.4.1
+
+* Fixed an issue causing code signing failures and bloating the framework. ([#8640](https://github.com/mapbox/mapbox-gl-native/pull/8640))
+
 ## 0.4.0
 
 This version of the Mapbox macOS SDK corresponds to version 3.5.1 of the Mapbox iOS SDK.

--- a/platform/macos/scripts/deploy-packages.sh
+++ b/platform/macos/scripts/deploy-packages.sh
@@ -37,7 +37,7 @@ buildPackageStyle() {
     step "Compressing ${file_name}…"
     cd build/macos/pkg
     rm -f ../deploy/${file_name}
-    zip -r ../deploy/${file_name} *
+    zip -yr ../deploy/${file_name} *
     cd -
     if [[ "${GITHUB_RELEASE}" == true ]]; then
         echo "Uploading ${file_name} to GitHub"


### PR DESCRIPTION
When zipping the framework for deployment, preserve symlinks instead of resolving them. Prior to this change, the published framework bundle contained multiple copies of the Mapbox executable and of every resource file, because the standard layout for a framework on macOS requires symlinks from the root folder and Versions/Current/ to Versions/A/.

Fixes #8636.

/cc @kkaefer @frederoni