### PR TITLE
Refactor EGL headless implementation

### DIFF
--- a/platform/default/mbgl/gl/headless_backend.hpp
+++ b/platform/default/mbgl/gl/headless_backend.hpp
@@ -37,8 +37,8 @@ private:
 
     void createContext();
 
-    std::unique_ptr<Impl> impl;
     std::shared_ptr<HeadlessDisplay> display;
+    std::unique_ptr<Impl> impl;
 
     bool active = false;
 };

--- a/platform/linux/src/headless_backend_egl.cpp
+++ b/platform/linux/src/headless_backend_egl.cpp
@@ -14,11 +14,13 @@ struct EGLImpl : public HeadlessBackend::Impl {
             : glContext(glContext_),
               display(display_),
               config(config_) {
-#if __ANDROID__
-        // Create a pixel buffer surface (in conjunction with EGL_SURFACE_TYPE, EGL_PBUFFER_BIT).
+        // Create a dummy pbuffer. We will render to framebuffers anyway, but we need a pbuffer to
+        // activate the context.
+        // Note that to be able to create pbuffer surfaces, we need to choose a config that
+        // includes EGL_SURFACE_TYPE, EGL_PBUFFER_BIT in HeadlessDisplay.
         const EGLint surfAttribs[] = {
-            EGL_WIDTH, 512,
-            EGL_HEIGHT, 512,
+            EGL_WIDTH, 8,
+            EGL_HEIGHT, 8,
             EGL_LARGEST_PBUFFER, EGL_TRUE,
             EGL_NONE
         };
@@ -27,7 +29,6 @@ struct EGLImpl : public HeadlessBackend::Impl {
         if (glSurface == EGL_NO_SURFACE) {
             throw std::runtime_error("Could not create surface: " + std::to_string(eglGetError()));
         }
-#endif // __ANDROID__
     }
 
     ~EGLImpl() {

--- a/platform/linux/src/headless_backend_egl.cpp
+++ b/platform/linux/src/headless_backend_egl.cpp
@@ -31,14 +31,14 @@ struct EGLImpl : public HeadlessBackend::Impl {
     }
 
     ~EGLImpl() {
-        if (!eglDestroyContext(display, glContext)) {
-            throw std::runtime_error("Failed to destroy EGL context.\n");
-        }
         if (glSurface != EGL_NO_SURFACE) {
             if (!eglDestroySurface(display, glSurface)) {
-                throw std::runtime_error("Failed to destroy EGL context.\n");
+                throw std::runtime_error("Failed to destroy EGL surface.\n");
             }
             glSurface = EGL_NO_SURFACE;
+        }
+        if (!eglDestroyContext(display, glContext)) {
+            throw std::runtime_error("Failed to destroy EGL context.\n");
         }
     }
 

--- a/platform/linux/src/headless_display_egl.cpp
+++ b/platform/linux/src/headless_display_egl.cpp
@@ -32,11 +32,7 @@ HeadlessDisplay::Impl::Impl() {
     }
 
     const EGLint attribs[] = {
-#if __ANDROID__
-        // Android emulator requires a pixel buffer to generate renderable unit
-        // test results.
         EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
-#endif // __ANDROID__
         EGL_NONE
     };
 


### PR DESCRIPTION
I noticed a few issues with the EGL implementation:

- They only create a surface when compiling with `__ANDROID__` set, however, it seems like we always need a surface given that [manpage for `eglMakeCurrent`](https://www.khronos.org/registry/EGL/sdk/docs/man/html/eglMakeCurrent.xhtml) lists it as a required parameter. This means we also need to remove the `#ifdef __ANDROID__` from `headless_display_egl.cpp`
- `HeadlessBackend` stores a `shared_ptr` to the `HeadlessDisplay` *after* the `Impl` pointer. This means that during destruction, it'll get destructed *before* `Impl`. When there are no other references to the `HeadlessDisplay`, this results in the wrong destruction order for some EGL implementations.
- `~EGLImpl` first tries to destruct the context, then the surface. Instead, it should do it the other way around.

We should also move the EGL implementation to the `default` folder, and away from the `linux` folder, since there's nothing Linux-specific about it.

/cc @brunoabinader @tiagovignatti