### PR TITLE
[glfw] Include the GL header before GLFW header

### DIFF
--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -17,6 +17,7 @@ target_compile_options(mbgl-glfw
 
 target_include_directories(mbgl-glfw
     PRIVATE platform/default
+    PRIVATE src
 )
 
 target_link_libraries(mbgl-glfw

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -11,6 +11,9 @@
 #define GLFW_INCLUDE_ES2
 #endif
 #define GL_GLEXT_PROTOTYPES
+
+#include <mbgl/gl/gl.hpp>
+
 #include <GLFW/glfw3.h>
 
 class GLFWView : public mbgl::View, public mbgl::Backend {


### PR DESCRIPTION
Fixes the GLFW build for Linux in newer distros e.g. Ubuntu 16.04.