### PR TITLE
[core] Inline GlyphPBF into GlyphAtlas

### DIFF
--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -4,7 +4,6 @@
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/rect.hpp>
 #include <mbgl/util/traits.hpp>
-#include <mbgl/util/image.hpp>
 
 #include <cstdint>
 #include <vector>
@@ -82,21 +81,6 @@ class Shaping {
     WritingModeType writingMode;
 
     explicit operator bool() const { return !positionedGlyphs.empty(); }
-};
-
-class SDFGlyph {
-public:
-    // We're using this value throughout the Mapbox GL ecosystem. If this is different, the glyphs
-    // also need to be reencoded.
-    static constexpr const uint8_t borderSize = 3;
-
-    GlyphID id = 0;
-
-    // A signed distance field of the glyph with a border (see above).
-    AlphaImage bitmap;
-
-    // Glyph metrics
-    GlyphMetrics metrics;
 };
 
 enum class WritingModeType : uint8_t {

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -18,6 +18,8 @@ class GlyphAtlasObserver;
 class AsyncRequest;
 class FileSource;
 
+std::vector<SDFGlyph> parseGlyphPBF(const GlyphRange&, const std::string& data);
+
 class GlyphPBF : private util::noncopyable {
 public:
     GlyphPBF(GlyphAtlas*,

--- a/src/mbgl/text/glyph_pbf.hpp
+++ b/src/mbgl/text/glyph_pbf.hpp
@@ -1,42 +1,29 @@
 #pragma once
 
 #include <mbgl/text/glyph.hpp>
-#include <mbgl/util/font_stack.hpp>
-#include <mbgl/util/noncopyable.hpp>
+#include <mbgl/text/glyph_range.hpp>
+#include <mbgl/util/image.hpp>
 
-#include <atomic>
-#include <functional>
 #include <string>
-#include <memory>
-#include <unordered_map>
+#include <vector>
 
 namespace mbgl {
 
-class GlyphAtlas;
-class GlyphRequestor;
-class GlyphAtlasObserver;
-class AsyncRequest;
-class FileSource;
+class SDFGlyph {
+public:
+    // We're using this value throughout the Mapbox GL ecosystem. If this is different, the glyphs
+    // also need to be reencoded.
+    static constexpr const uint8_t borderSize = 3;
+
+    GlyphID id = 0;
+
+    // A signed distance field of the glyph with a border (see above).
+    AlphaImage bitmap;
+
+    // Glyph metrics
+    GlyphMetrics metrics;
+};
 
 std::vector<SDFGlyph> parseGlyphPBF(const GlyphRange&, const std::string& data);
-
-class GlyphPBF : private util::noncopyable {
-public:
-    GlyphPBF(GlyphAtlas*,
-             const FontStack&,
-             const GlyphRange&,
-             GlyphAtlasObserver*,
-             FileSource&);
-    ~GlyphPBF();
-
-    bool isParsed() const {
-        return parsed;
-    }
-
-    bool parsed;
-    std::unique_ptr<AsyncRequest> req;
-    GlyphAtlasObserver* observer = nullptr;
-    std::unordered_map<GlyphRequestor*, std::shared_ptr<GlyphDependencies>> requestors;
-};
 
 } // namespace mbgl

--- a/src/mbgl/text/glyph_set.cpp
+++ b/src/mbgl/text/glyph_set.cpp
@@ -3,11 +3,11 @@
 
 namespace mbgl {
 
-void GlyphSet::insert(uint32_t id, SDFGlyph&& glyph) {
-    auto it = sdfs.find(id);
+void GlyphSet::insert(SDFGlyph&& glyph) {
+    auto it = sdfs.find(glyph.id);
     if (it == sdfs.end()) {
         // Glyph doesn't exist yet.
-        sdfs.emplace(id, std::move(glyph));
+        sdfs.emplace(glyph.id, std::move(glyph));
     } else if (it->second.metrics == glyph.metrics) {
         if (it->second.bitmap != glyph.bitmap) {
             // The actual bitmap was updated; this is unsupported.

--- a/src/mbgl/text/glyph_set.hpp
+++ b/src/mbgl/text/glyph_set.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <mbgl/text/glyph.hpp>
-#include <mbgl/util/geometry.hpp>
+#include <mbgl/text/glyph_pbf.hpp>
+
+#include <map>
 
 namespace mbgl {
 

--- a/src/mbgl/text/glyph_set.hpp
+++ b/src/mbgl/text/glyph_set.hpp
@@ -7,7 +7,7 @@ namespace mbgl {
 
 class GlyphSet {
 public:
-    void insert(uint32_t id, SDFGlyph&&);
+    void insert(SDFGlyph&&);
     const std::map<uint32_t, SDFGlyph>& getSDFs() const;
 
 private:

--- a/test/text/glyph_atlas.test.cpp
+++ b/test/text/glyph_atlas.test.cpp
@@ -166,11 +166,11 @@ TEST(GlyphAtlas, InvalidSDFGlyph) {
     GlyphAtlasTest test;
 
     auto& glyphSet = test.glyphAtlas.getGlyphSet(fontStack);
-    glyphSet.insert(66, SDFGlyph{ 66 /* ASCII 'B' */,
+    glyphSet.insert(SDFGlyph{ 66 /* ASCII 'B' */,
                                   AlphaImage({7, 7}), /* correct */
                                   { 1 /* width */, 1 /* height */, 0 /* left */, 0 /* top */,
                                     0 /* advance */ } });
-    glyphSet.insert(67, SDFGlyph{ 67 /* ASCII 'C' */,
+    glyphSet.insert(SDFGlyph{ 67 /* ASCII 'C' */,
                                   AlphaImage({518, 8}), /* correct */
                                   { 512 /* width */, 2 /* height */, 0 /* left */, 0 /* top */,
                                     0 /* advance */ } });

--- a/test/text/glyph_pbf.test.cpp
+++ b/test/text/glyph_pbf.test.cpp
@@ -1,73 +1,23 @@
 #include <mbgl/test/util.hpp>
 
-#include <mbgl/text/glyph_set.hpp>
-#include <mbgl/text/glyph_atlas_observer.hpp>
-#include <mbgl/text/glyph_atlas.hpp>
 #include <mbgl/text/glyph_pbf.hpp>
-#include <mbgl/storage/default_file_source.hpp>
-#include <mbgl/util/run_loop.hpp>
-#include <mbgl/util/string.hpp>
-
-#include <future>
+#include <mbgl/util/io.hpp>
 
 using namespace mbgl;
 
-using namespace std::string_literals;
-
-class MockGlyphAtlasObserver : public GlyphAtlasObserver {
-public:
-    std::function<void(const FontStack&, const GlyphRange&)> glyphsLoaded;
-    std::function<void(const FontStack&, const GlyphRange&, std::exception_ptr)> glyphsError;
-
-    void onGlyphsLoaded(const FontStack& fontStack, const GlyphRange& glyphRange) override {
-        if (glyphsLoaded) {
-            glyphsLoaded(fontStack, glyphRange);
-        }
-    }
-    void onGlyphsError(const FontStack& fontStack, const GlyphRange& glyphRange, std::exception_ptr error) override {
-        if (glyphsError) {
-            glyphsError(fontStack, glyphRange, error);
-        }
-    }
-};
-
 TEST(GlyphPBF, Parsing) {
-    util::RunLoop loop;
-    DefaultFileSource fileSource{ ":memory:", "." };
-    GlyphAtlas glyphAtlas{ { 1024, 1024 }, fileSource };
-    FontStack fontStack{ "fake_glyphs" };
-    GlyphRange glyphRange{ 0, 255 };
+    // The fake glyphs contain a number of invalid glyphs, which should be skipped by the parser.
+    auto sdfs = parseGlyphPBF(GlyphRange { 0, 255 }, util::read_file("test/fixtures/resources/fake_glyphs-0-255.pbf"));
+    EXPECT_TRUE(sdfs.size() == 1);
 
-    glyphAtlas.setURL("asset://test/fixtures/resources/{fontstack}-{range}.pbf");
-
-    MockGlyphAtlasObserver glyphAtlasObserver;
-    glyphAtlasObserver.glyphsLoaded = [&](const FontStack&, const GlyphRange&) {
-        loop.stop();
-
-        const auto& sdfs = glyphAtlas.getGlyphSet(fontStack).getSDFs();
-
-        // The fake glyphs don't contain a glyph that has the ID 0; it only contains glyphs with
-        // undefined IDs, but the parser should remove them.
-
-        EXPECT_TRUE(sdfs.size() == 1);
-        EXPECT_TRUE(sdfs.find(69) != sdfs.end());
-        auto& sdf = sdfs.at(69);
-        AlphaImage expected({7, 7});
-        expected.fill('x');
-        EXPECT_EQ(expected, sdf.bitmap);
-        EXPECT_EQ(1u, sdf.metrics.width);
-        EXPECT_EQ(1u, sdf.metrics.height);
-        EXPECT_EQ(20, sdf.metrics.left);
-        EXPECT_EQ(2, sdf.metrics.top);
-        EXPECT_EQ(8u, sdf.metrics.advance);
-    };
-
-    glyphAtlasObserver.glyphsError = [&](const FontStack&, const GlyphRange&, std::exception_ptr error) {
-        loop.stop();
-        FAIL() << util::toString(error);
-    };
-
-    GlyphPBF pbf(&glyphAtlas, fontStack, glyphRange, &glyphAtlasObserver, fileSource);
-
-    loop.run();
+    auto& sdf = sdfs[0];
+    EXPECT_EQ(69u, sdf.id);
+    AlphaImage expected({7, 7});
+    expected.fill('x');
+    EXPECT_EQ(expected, sdf.bitmap);
+    EXPECT_EQ(1u, sdf.metrics.width);
+    EXPECT_EQ(1u, sdf.metrics.height);
+    EXPECT_EQ(20, sdf.metrics.left);
+    EXPECT_EQ(2, sdf.metrics.top);
+    EXPECT_EQ(8u, sdf.metrics.advance);
 }


### PR DESCRIPTION
First of several followup refactors to #8341: the split between `GlyphAtlas` and `GlyphPBF` was awkward. Inline `GlyphPBF`, while leaving the actual PBF parsing code independent and tested in isolation.