### PR TITLE
[android] - disable building x86-64 on CI for snapshot builds

### DIFF
--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -142,12 +142,12 @@ workflows:
         - content: |-
             #!/bin/bash
             echo "Compile libmapbox-gl.so for all supportd abi's:"
-            make android-lib-arm-v5
-            make android-lib-arm-v7
-            make android-lib-arm-v8
-            make android-lib-x86
-            make android-lib-mips
-            cd platform/android && ./gradlew :MapboxGLAndroidSDK:assembleRelease
+            BUILDTYPE=Release make android-lib-arm-v5
+            BUILDTYPE=Release make android-lib-arm-v7
+            BUILDTYPE=Release make android-lib-arm-v8
+            BUILDTYPE=Release make android-lib-x86
+            BUILDTYPE=Release make android-lib-mips
+            cd platform/android && ./gradlew -Pmapbox.abis=armeabi-v7a MapboxGLAndroidSDK:assembleRelease
     - script:
         title: Publish to maven
         inputs:

--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -142,7 +142,12 @@ workflows:
         - content: |-
             #!/bin/bash
             echo "Compile libmapbox-gl.so for all supportd abi's:"
-            export BUILDTYPE=Release make apackage
+            make android-lib-arm-v5
+            make android-lib-arm-v7
+            make android-lib-arm-v8
+            make android-lib-x86
+            make android-lib-mips
+            cd platform/android && ./gradlew :MapboxGLAndroidSDK:assembleRelease
     - script:
         title: Publish to maven
         inputs:

--- a/platform/android/bitrise.yml
+++ b/platform/android/bitrise.yml
@@ -147,6 +147,7 @@ workflows:
             BUILDTYPE=Release make android-lib-arm-v8
             BUILDTYPE=Release make android-lib-x86
             BUILDTYPE=Release make android-lib-mips
+            BUILDTYPE=Release make android-lib-mips-64
             cd platform/android && ./gradlew -Pmapbox.abis=armeabi-v7a MapboxGLAndroidSDK:assembleRelease
     - script:
         title: Publish to maven


### PR DESCRIPTION
Currently CI is failing for x86-64 ABI since Bitrise uses NDK14. 
This PR disables building that ABI so we can continue publishing snapshots for now.