### PR TITLE
[android] - avoid nullpointer by validating Mapbox.java creation 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/Mapbox.java
@@ -7,7 +7,7 @@ import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
-import com.mapbox.mapboxsdk.exceptions.InvalidAccessTokenException;
+import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
 import com.mapbox.mapboxsdk.location.LocationSource;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
 import com.mapbox.services.android.telemetry.MapboxTelemetry;
@@ -55,20 +55,30 @@ public final class Mapbox {
    * @return Mapbox Access Token
    */
   public static String getAccessToken() {
+    validateMapbox();
     validateAccessToken();
     return INSTANCE.accessToken;
   }
 
   /**
+   * Runtime validation of Mapbox creation.
+   */
+  private static void validateMapbox() throws MapboxConfigurationException {
+    if (INSTANCE == null) {
+      throw new MapboxConfigurationException();
+    }
+  }
+
+  /**
    * Runtime validation of Access Token.
    *
-   * @throws InvalidAccessTokenException exception thrown when not using a valid accessToken
+   * @throws MapboxConfigurationException exception thrown when not using a valid accessToken
    */
-  private static void validateAccessToken() throws InvalidAccessTokenException {
+  private static void validateAccessToken() throws MapboxConfigurationException {
     String accessToken = INSTANCE.accessToken;
     if (TextUtils.isEmpty(accessToken) || (!accessToken.toLowerCase(MapboxConstants.MAPBOX_LOCALE).startsWith("pk.")
       && !accessToken.toLowerCase(MapboxConstants.MAPBOX_LOCALE).startsWith("sk."))) {
-      throw new InvalidAccessTokenException();
+      throw new MapboxConfigurationException();
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/MapboxConfigurationException.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/exceptions/MapboxConfigurationException.java
@@ -1,21 +1,18 @@
 package com.mapbox.mapboxsdk.exceptions;
 
 import android.content.Context;
-import android.os.Bundle;
-
-import com.mapbox.mapboxsdk.maps.MapView;
 
 /**
- * A {@code InvalidAccessTokenException} is thrown by {@link com.mapbox.mapboxsdk.maps.MapboxMap}
- * when there is either no access token set before {@link MapView#onCreate(Bundle)} or an invalid access token
- * is set in {@link com.mapbox.mapboxsdk.Mapbox#getInstance(Context, String)}
- *
- * @see MapView#onCreate(Bundle)
+ * A MapboxConfigurationException is thrown by MapboxMap when the SDK hasn't been properly initialised.
+ * <p>
+ * This occurs either when {@link com.mapbox.mapboxsdk.Mapbox} is not correctly initialised or the provided access token
+ * through {@link com.mapbox.mapboxsdk.Mapbox#getInstance(Context, String)} isn't valid.
+ * </p>
  * @see com.mapbox.mapboxsdk.Mapbox#getInstance(Context, String)
  */
-public class InvalidAccessTokenException extends RuntimeException {
+public class MapboxConfigurationException extends RuntimeException {
 
-  public InvalidAccessTokenException() {
+  public MapboxConfigurationException() {
     super("\nUsing MapView requires setting a valid access token. Use Mapbox.getInstance(Context context, "
       + "String accessToken) to provide one. "
       + "\nPlease see https://www.mapbox.com/help/create-api-access-token/ to learn how to create one."

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/MapboxTest.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
-import com.mapbox.mapboxsdk.exceptions.InvalidAccessTokenException;
+import com.mapbox.mapboxsdk.exceptions.MapboxConfigurationException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +39,7 @@ public class MapboxTest {
     assertSame(accessToken, Mapbox.getAccessToken());
   }
 
-  @Test(expected = InvalidAccessTokenException.class)
+  @Test(expected = MapboxConfigurationException.class)
   public void testGetInvalidAccessToken() {
     final String accessToken = "dummy";
     injectMapboxSingleton(accessToken);


### PR DESCRIPTION
Throw an InvalidateAccessToken exception instead.

Closes #8661 