### PR TITLE
Update changelog, podspecs for macOS SDK v0.4.1

### DIFF
--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 0.4.1
 
+This version of the Mapbox macOS SDK corresponds to version 3.5.2 of the Mapbox iOS SDK.
+
 * Fixed an issue causing code signing failures and bloating the framework. ([#8640](https://github.com/mapbox/mapbox-gl-native/pull/8640))
 * Fixed an issue that could cause a crash if annotations unknown to the map view were interacted with. ([#8686](https://github.com/mapbox/mapbox-gl-native/pull/8686))
-* Renamed the "Data-Driven Styling" guide to "Using Style Functions at Runtime" and clarified the meaning of data-driven styling in the guide's discussion of runtime style functions. ([#8627](https://github.com/mapbox/mapbox-gl-native/pull/8627))
+* Renamed the “Data-Driven Styling” guide to “Using Style Functions at Runtime” and clarified the meaning of data-driven styling in the guide’s discussion of runtime style functions. ([#8627](https://github.com/mapbox/mapbox-gl-native/pull/8627))
 
-## 0.4.0
+## 0.4.0 - April 2, 2017
 
 This version of the Mapbox macOS SDK corresponds to version 3.5.1 of the Mapbox iOS SDK.
 

--- a/platform/macos/Mapbox-macOS-SDK-symbols.podspec
+++ b/platform/macos/Mapbox-macOS-SDK-symbols.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '0.4.0'
+  version = '0.4.1'
 
   m.name    = 'Mapbox-macOS-SDK-symbols'
   m.version = "#{version}-symbols"

--- a/platform/macos/Mapbox-macOS-SDK.podspec
+++ b/platform/macos/Mapbox-macOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '0.4.0'
+  version = '0.4.1'
 
   m.name    = 'Mapbox-macOS-SDK'
   m.version = version

--- a/platform/qt/bitrise-qt5.yml
+++ b/platform/qt/bitrise-qt5.yml
@@ -31,12 +31,12 @@ workflows:
             set -eu -o pipefail
             sudo chown -R $USER /usr/local
             brew install cmake
-            brew install qt5
-            brew link qt5 --force
-            brew linkapps qt5
-            export HOMEBREW_QT5_VERSION=$(brew list --versions qt5 | rev | cut -d' ' -f1 | rev)
-            ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
-            ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
+            brew install qt
+            brew link qt --force
+            brew linkapps qt
+            export HOMEBREW_QT5_VERSION=$(brew list --versions qt | rev | cut -d' ' -f1 | rev)
+            ln -s /usr/local/Cellar/qt/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
+            ln -s /usr/local/Cellar/qt/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
             export BUILDTYPE=Debug
             make qt-app
             make run-qt-test


### PR DESCRIPTION
Updated the changelog and podspecs for macOS SDK v0.4.1 and cherry-picked #8692 to keep the Qt5 macOS build passing.

/cc @frederoni @boundsj