### PR TITLE
Rename qt5 formula to qt

### DIFF
--- a/platform/qt/bitrise-qt5.yml
+++ b/platform/qt/bitrise-qt5.yml
@@ -16,12 +16,12 @@ workflows:
             set -eu -o pipefail
             sudo chown -R $USER /usr/local
             brew install cmake
-            brew install qt5
-            brew link qt5 --force
-            brew linkapps qt5
-            export HOMEBREW_QT5_VERSION=$(brew list --versions qt5 | rev | cut -d' ' -f1 | rev)
-            ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
-            ln -s /usr/local/Cellar/qt5/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
+            brew install qt
+            brew link qt --force
+            brew linkapps qt
+            export HOMEBREW_QT5_VERSION=$(brew list --versions qt | rev | cut -d' ' -f1 | rev)
+            ln -s /usr/local/Cellar/qt/$HOMEBREW_QT5_VERSION/mkspecs /usr/local/mkspecs
+            ln -s /usr/local/Cellar/qt/$HOMEBREW_QT5_VERSION/plugins /usr/local/plugins
             export BUILDTYPE=Debug
             make qt-app
             make run-qt-test


### PR DESCRIPTION
Updated the Qt5 macOS Bitrise bot’s configuration to reflect the `qt5` formula’s rename to `qt` in Homebrew/homebrew-core@b92c519bbd3cb869b4861017210e07fc42a0cc5f.

Fixes #8691.