### PR TITLE
Remove link attribute from attribution text

### DIFF
--- a/platform/darwin/src/MGLAttributionInfo.mm
+++ b/platform/darwin/src/MGLAttributionInfo.mm
@@ -93,7 +93,12 @@
             return;
         }
 
-        MGLAttributionInfo *info = [[MGLAttributionInfo alloc] initWithTitle:title URL:value];
+        // Remove the link, because it forces the text to be blue on macOS 10.12
+        // and above.
+        NSMutableAttributedString *unlinkedTitle = [title mutableCopy];
+        [unlinkedTitle removeAttribute:NSLinkAttributeName range:unlinkedTitle.mgl_wholeRange];
+        
+        MGLAttributionInfo *info = [[MGLAttributionInfo alloc] initWithTitle:unlinkedTitle URL:value];
         info.feedbackLink = isFeedbackLink;
         [infos addObject:info];
     }];

--- a/platform/darwin/test/MGLAttributionInfoTests.m
+++ b/platform/darwin/test/MGLAttributionInfoTests.m
@@ -68,7 +68,7 @@
     XCTAssertEqual(infos.count, 1);
 
     XCTAssertEqualObjects(infos[0].title.string, @"Mapbox");
-    XCTAssertEqualObjects([infos[0].title attribute:NSLinkAttributeName atIndex:0 effectiveRange:nil], [NSURL URLWithString:@"https://www.mapbox.com/"]);
+    XCTAssertNil([infos[0].title attribute:NSLinkAttributeName atIndex:0 effectiveRange:nil]);
     XCTAssertEqualObjects([infos[0].title attribute:NSUnderlineStyleAttributeName atIndex:0 effectiveRange:nil], @(NSUnderlineStyleSingle));
 
 #if TARGET_OS_IPHONE

--- a/platform/macos/CHANGELOG.md
+++ b/platform/macos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* Fixed an issue causing attribution button text to appear blue instead of black. ([#8701](https://github.com/mapbox/mapbox-gl-native/pull/8701))
 * The error passed into `-[MGLMapViewDelegate mapViewDidFailLoadingMap:withError:]` now includes a more specific description and failure reason. ([#8418](https://github.com/mapbox/mapbox-gl-native/pull/8418))
 
 ## 0.4.0


### PR DESCRIPTION
Fixed an issue causing the attribution button text to appear blue instead of black. On macOS 10.12 and above, hyperlinks in attributed strings are blue regardless of any color attributes applied to the same run of text. The link attribute is unnecessary because the button already handles click events and the URL in the tooltip.

Fixes #8618.

/cc @friedbunny @frederoni