### PR TITLE
Test Android NDK r15 beta1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ jobs:
 # ------------------------------------------------------------------------------
   android-debug-arm-v7:
     docker:
-      - image: mbgl/ci:r2-android-ndk-r13b-gradle
+      - image: mbgl/ci:r2-android-ndk-r15beta1-gradle
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 6
@@ -83,7 +83,7 @@ jobs:
 # ------------------------------------------------------------------------------
   android-release-all:
     docker:
-      - image: mbgl/ci:r2-android-ndk-r13b-gradle
+      - image: mbgl/ci:r2-android-ndk-r15beta1-gradle
     working_directory: /src
     environment:
       LIBSYSCONFCPUS: 6


### PR DESCRIPTION
Google released the [NDK r15 beta1](https://github.com/android-ndk/ndk/wiki); we should try it out.

Things to check for:

- In r14, Clang segfaulted when compiling boost::rtree for x86_64 (we're still using r13b on Circle CI)
- Should also contain a fix for https://github.com/android-ndk/ndk/issues/323
- Unified headers are enabled by default