### PR TITLE
[android] - expose source layer identifier

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 * OfflineRegion are validated if the bounds is found in the world bounds, else onError will be invoked [#8517](https://github.com/mapbox/mapbox-gl-native/pull/8517)
 * Polygon holes [#8557](https://github.com/mapbox/mapbox-gl-native/pull/8557) and [#8722](https://github.com/mapbox/mapbox-gl-native/pull/8722)
 * Custom location source [#8710](https://github.com/mapbox/mapbox-gl-native/pull/8710)
+* Expose source layer identifier [#8709](https://github.com/mapbox/mapbox-gl-native/pull/8709).
 
 ## 5.0.2 - April 3, 2017
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CircleLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/CircleLayer.java
@@ -60,6 +60,15 @@ public class CircleLayer extends Layer {
   }
 
   /**
+   * Get the source layer.
+   *
+   * @return sourceLayer the source layer to get
+   */
+  public String getSourceLayer() {
+    return nativeGetSourceLayer();
+  }
+
+  /**
    * Set a single filter.
    *
    * @param filter the filter to set

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/FillLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/FillLayer.java
@@ -60,6 +60,15 @@ public class FillLayer extends Layer {
   }
 
   /**
+   * Get the source layer.
+   *
+   * @return sourceLayer the source layer to get
+   */
+  public String getSourceLayer() {
+    return nativeGetSourceLayer();
+  }
+
+  /**
    * Set a single filter.
    *
    * @param filter the filter to set

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/Layer.java
@@ -73,6 +73,8 @@ public abstract class Layer {
 
   protected native void nativeSetSourceLayer(String sourceLayer);
 
+  protected native String nativeGetSourceLayer();
+
   protected native float nativeGetMinZoom();
 
   protected native float nativeGetMaxZoom();

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/LineLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/LineLayer.java
@@ -60,6 +60,15 @@ public class LineLayer extends Layer {
   }
 
   /**
+   * Get the source layer.
+   *
+   * @return sourceLayer the source layer to get
+   */
+  public String getSourceLayer() {
+    return nativeGetSourceLayer();
+  }
+
+  /**
    * Set a single filter.
    *
    * @param filter the filter to set

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/SymbolLayer.java
@@ -60,6 +60,15 @@ public class SymbolLayer extends Layer {
   }
 
   /**
+   * Get the source layer.
+   *
+   * @return sourceLayer the source layer to get
+   */
+  public String getSourceLayer() {
+    return nativeGetSourceLayer();
+  }
+
+  /**
    * Set a single filter.
    *
    * @param filter the filter to set

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/layer.java.ejs
@@ -80,6 +80,15 @@ public class <%- camelize(type) %>Layer extends Layer {
 <% } -%>
 <% if (type !== 'background' && type !== 'raster') { -%>
   /**
+   * Get the source layer.
+   *
+   * @return sourceLayer the source layer to get
+   */
+  public String getSourceLayer() {
+    return nativeGetSourceLayer();
+  }
+
+  /**
    * Set a single filter.
    *
    * @param filter the filter to set

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/BackgroundLayerTest.java
@@ -234,7 +234,6 @@ public class BackgroundLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getBackgroundOpacity().getFunction().getStops()).size());
   }
 
-
   @After
   public void unregisterIntentServiceIdlingResource() {
     Espresso.unregisterIdlingResources(idlingResource);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/CircleLayerTest.java
@@ -84,6 +84,21 @@ public class CircleLayerTest extends BaseStyleTest {
   }
 
   @Test
+  public void testSourceLayer() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("Visibility");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
+
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
+  }
+
+  @Test
   public void testCircleRadiusTransition() {
     checkViewIsDisplayed(R.id.mapView);
     Timber.i("circle-radiusTransitionOptions");
@@ -737,7 +752,6 @@ public class CircleLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getCircleTranslate().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testCircleTranslateAnchorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -773,7 +787,6 @@ public class CircleLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getCircleTranslateAnchor().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getCircleTranslateAnchor().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testCirclePitchScaleAsConstant() {
@@ -1258,7 +1271,6 @@ public class CircleLayerTest extends BaseStyleTest {
     assertEquals(0.3f, stop.in.value, 0.001f);
     assertEquals(0.9f, stop.out, 0.001f);
   }
-
 
   @After
   public void unregisterIntentServiceIdlingResource() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/FillLayerTest.java
@@ -83,6 +83,20 @@ public class FillLayerTest extends BaseStyleTest {
     assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
+  @Test
+  public void testSourceLayer() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("Visibility");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
+
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
+  }
 
   @Test
   public void testFillAntialiasAsConstant() {
@@ -594,7 +608,6 @@ public class FillLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getFillTranslate().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testFillTranslateAnchorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -678,7 +691,6 @@ public class FillLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getFillPattern().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getFillPattern().getFunction().getStops()).size());
   }
-
 
   @After
   public void unregisterIntentServiceIdlingResource() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/LineLayerTest.java
@@ -83,6 +83,20 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
+  @Test
+  public void testSourceLayer() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("Visibility");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
+
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
+  }
 
   @Test
   public void testLineCapAsConstant() {
@@ -120,7 +134,6 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getLineCap().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testLineJoinAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -156,7 +169,6 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getLineJoin().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getLineJoin().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testLineMiterLimitAsConstant() {
@@ -194,7 +206,6 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getLineMiterLimit().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getLineMiterLimit().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testLineRoundLimitAsConstant() {
@@ -572,7 +583,6 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getLineTranslate().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getLineTranslate().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testLineTranslateAnchorAsConstant() {
@@ -1225,7 +1235,6 @@ public class LineLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getLinePattern().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getLinePattern().getFunction().getStops()).size());
   }
-
 
   @After
   public void unregisterIntentServiceIdlingResource() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/RasterLayerTest.java
@@ -426,7 +426,6 @@ public class RasterLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getRasterFadeDuration().getFunction().getStops()).size());
   }
 
-
   @After
   public void unregisterIntentServiceIdlingResource() {
     Espresso.unregisterIdlingResources(idlingResource);

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/SymbolLayerTest.java
@@ -83,6 +83,20 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(layer.getVisibility().getValue(), NONE);
   }
 
+  @Test
+  public void testSourceLayer() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("Visibility");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
+
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
+  }
 
   @Test
   public void testSymbolPlacementAsConstant() {
@@ -119,7 +133,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getSymbolPlacement().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getSymbolPlacement().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testSymbolSpacingAsConstant() {
@@ -158,7 +171,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getSymbolSpacing().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testSymbolAvoidEdgesAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -194,7 +206,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getSymbolAvoidEdges().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getSymbolAvoidEdges().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testIconAllowOverlapAsConstant() {
@@ -232,7 +243,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getIconAllowOverlap().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testIconIgnorePlacementAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -268,7 +278,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconIgnorePlacement().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconIgnorePlacement().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testIconOptionalAsConstant() {
@@ -306,7 +315,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getIconOptional().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testIconRotationAlignmentAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -342,7 +350,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconRotationAlignment().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconRotationAlignment().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testIconSizeAsConstant() {
@@ -380,7 +387,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getIconSize().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getIconSize().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testIconSizeAsIdentitySourceFunction() {
@@ -526,7 +532,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getIconTextFit().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testIconTextFitPaddingAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -564,7 +569,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getIconTextFitPadding().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testIconImageAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -600,7 +604,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconImage().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconImage().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testIconImageAsIdentitySourceFunction() {
@@ -792,7 +795,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.9f, stop.out, 0.001f);
   }
 
-
   @Test
   public void testIconPaddingAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -830,7 +832,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getIconPadding().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testIconKeepUprightAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -866,7 +867,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconKeepUpright().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getIconKeepUpright().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testIconOffsetAsConstant() {
@@ -950,7 +950,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getIconOffset().getFunction().getStops().getClass());
   }
 
-
   @Test
   public void testTextPitchAlignmentAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -987,7 +986,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getTextPitchAlignment().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testTextRotationAlignmentAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1023,7 +1021,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextRotationAlignment().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextRotationAlignment().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testTextFieldAsConstant() {
@@ -1106,7 +1103,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextField().getFunction().getStops().getClass());
   }
 
-
   @Test
   public void testTextFontAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1142,7 +1138,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextFont().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextFont().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testTextSizeAsConstant() {
@@ -1180,7 +1175,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getTextSize().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getTextSize().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testTextSizeAsIdentitySourceFunction() {
@@ -1327,7 +1321,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextMaxWidth().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testTextLineHeightAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1364,7 +1357,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getTextLineHeight().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getTextLineHeight().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testTextLetterSpacingAsConstant() {
@@ -1403,7 +1395,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextLetterSpacing().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testTextJustifyAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1440,7 +1431,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getTextJustify().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testTextAnchorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1476,7 +1466,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextAnchor().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextAnchor().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testTextMaxAngleAsConstant() {
@@ -1515,7 +1504,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextMaxAngle().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testTextRotateAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1552,7 +1540,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(0.5f, ((ExponentialStops) layer.getTextRotate().getFunction().getStops()).getBase(), 0.001);
     assertEquals(1, ((ExponentialStops) layer.getTextRotate().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testTextRotateAsIdentitySourceFunction() {
@@ -1699,7 +1686,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextPadding().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testTextKeepUprightAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1735,7 +1721,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextKeepUpright().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextKeepUpright().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testTextTransformAsConstant() {
@@ -1817,7 +1802,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals("FeaturePropertyA", ((SourceFunction) layer.getTextTransform().getFunction()).getProperty());
     assertEquals(IntervalStops.class, layer.getTextTransform().getFunction().getStops().getClass());
   }
-
 
   @Test
   public void testTextOffsetAsConstant() {
@@ -1901,7 +1885,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextOffset().getFunction().getStops().getClass());
   }
 
-
   @Test
   public void testTextAllowOverlapAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1938,7 +1921,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((IntervalStops) layer.getTextAllowOverlap().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testTextIgnorePlacementAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -1974,7 +1956,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextIgnorePlacement().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextIgnorePlacement().getFunction().getStops()).size());
   }
-
 
   @Test
   public void testTextOptionalAsConstant() {
@@ -2800,7 +2781,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getIconTranslate().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testIconTranslateAnchorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -3625,7 +3605,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(1, ((ExponentialStops) layer.getTextTranslate().getFunction().getStops()).size());
   }
 
-
   @Test
   public void testTextTranslateAnchorAsConstant() {
     checkViewIsDisplayed(R.id.mapView);
@@ -3661,7 +3640,6 @@ public class SymbolLayerTest extends BaseStyleTest {
     assertEquals(IntervalStops.class, layer.getTextTranslateAnchor().getFunction().getStops().getClass());
     assertEquals(1, ((IntervalStops) layer.getTextTranslateAnchor().getFunction().getStops()).size());
   }
-
 
   @After
   public void unregisterIntentServiceIdlingResource() {

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/androidTest/java/com/mapbox/mapboxsdk/testapp/style/layer.junit.ejs
@@ -91,9 +91,26 @@ public class <%- camelize(type) %>LayerTest extends BaseStyleTest {
     layer.setProperties(visibility(NONE));
     assertEquals(layer.getVisibility().getValue(), NONE);
   }
+<% if (!(type === 'background' || type === 'raster')) { -%>
 
+  @Test
+  public void testSourceLayer() {
+    checkViewIsDisplayed(R.id.mapView);
+    Timber.i("Visibility");
+    assertNotNull(layer);
+
+    // Get initial
+    assertEquals(layer.getSourceLayer(), "composite");
+
+    // Set
+    final String sourceLayer = "test";
+    layer.setSourceLayer(sourceLayer);
+    assertEquals(layer.getSourceLayer(), sourceLayer);
+  }
+<% } -%>
 <% for (const property of properties) { -%>
 <% if (property.transition) { -%>
+
   @Test
   public void test<%- camelize(property.name) %>Transition() {
     checkViewIsDisplayed(R.id.mapView);
@@ -363,7 +380,6 @@ public class <%- camelize(type) %>LayerTest extends BaseStyleTest {
     assertEquals(layer.get<%- camelize(property.name) %>AsInt(), Color.RED);
   }
 <% } -%>
-
 <% } -%>
 
   @After

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/style/RuntimeStyleActivity.java
@@ -17,12 +17,14 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.style.functions.Function;
 import com.mapbox.mapboxsdk.style.functions.stops.ExponentialStops;
 import com.mapbox.mapboxsdk.style.functions.stops.Stop;
+import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyValue;
 import com.mapbox.mapboxsdk.style.layers.RasterLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.layers.TransitionOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.sources.RasterSource;
@@ -41,6 +43,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import timber.log.Timber;
@@ -408,7 +411,25 @@ public class RuntimeStyleActivity extends AppCompatActivity {
       lineWidth(20f)
     );
 
-    mapboxMap.addLayer(layer);
+    // adding layers below "road" layers
+    List<Layer> layers = mapboxMap.getLayers();
+    Layer latestLayer = null;
+    Collections.reverse(layers);
+    for (Layer currentLayer : layers) {
+      if (currentLayer instanceof FillLayer && ((FillLayer) currentLayer).getSourceLayer().equals("road")) {
+        latestLayer = currentLayer;
+      } else if (currentLayer instanceof CircleLayer && ((CircleLayer) currentLayer).getSourceLayer().equals("road")) {
+        latestLayer = currentLayer;
+      } else if (currentLayer instanceof SymbolLayer && ((SymbolLayer) currentLayer).getSourceLayer().equals("road")) {
+        latestLayer = currentLayer;
+      } else if (currentLayer instanceof LineLayer && ((LineLayer) currentLayer).getSourceLayer().equals("road")) {
+        latestLayer = currentLayer;
+      }
+    }
+
+    if (latestLayer != null) {
+      mapboxMap.addLayerBelow(layer, latestLayer.getId());
+    }
 
     // Need to get a fresh handle
     layer = mapboxMap.getLayerAs("terrainLayer");

--- a/platform/android/src/style/layers/layer.cpp
+++ b/platform/android/src/style/layers/layer.cpp
@@ -144,6 +144,25 @@ namespace android {
         }
     }
 
+    jni::String Layer::getSourceLayer(jni::JNIEnv& env) {
+        using namespace mbgl::style;
+
+        std::string sourceLayerId;
+        if (layer.is<FillLayer>()) {
+            sourceLayerId = layer.as<FillLayer>()->getSourceLayer();
+        } else if (layer.is<LineLayer>()) {
+            sourceLayerId = layer.as<LineLayer>()->getSourceLayer();
+        } else if (layer.is<SymbolLayer>()) {
+            sourceLayerId = layer.as<SymbolLayer>()->getSourceLayer();
+        } else if (layer.is<CircleLayer>()) {
+            sourceLayerId = layer.as<CircleLayer>()->getSourceLayer();
+        } else {
+            mbgl::Log::Warning(mbgl::Event::JNI, "Layer doesn't support source layer");
+        }
+
+        return jni::Make<jni::String>(env, sourceLayerId);
+    }
+
     jni::jfloat Layer::getMinZoom(jni::JNIEnv&){
         return layer.getMinZoom();
     }
@@ -180,6 +199,7 @@ namespace android {
             METHOD(&Layer::setPaintProperty, "nativeSetPaintProperty"),
             METHOD(&Layer::setFilter, "nativeSetFilter"),
             METHOD(&Layer::setSourceLayer, "nativeSetSourceLayer"),
+            METHOD(&Layer::getSourceLayer, "nativeGetSourceLayer"),
             METHOD(&Layer::getMinZoom, "nativeGetMinZoom"),
             METHOD(&Layer::getMaxZoom, "nativeGetMaxZoom"),
             METHOD(&Layer::setMinZoom, "nativeSetMinZoom"),

--- a/platform/android/src/style/layers/layer.hpp
+++ b/platform/android/src/style/layers/layer.hpp
@@ -66,9 +66,11 @@ public:
 
     /* common properties, but not shared by all */
 
-    void setFilter(jni::JNIEnv& env, jni::Array<jni::Object<>> jfilter);
+    void setFilter(jni::JNIEnv&, jni::Array<jni::Object<>>);
 
-    void setSourceLayer(jni::JNIEnv& env, jni::String sourceLayer);
+    void setSourceLayer(jni::JNIEnv&, jni::String);
+
+    jni::String getSourceLayer(jni::JNIEnv&);
 
     // Property getters
 

--- a/platform/android/src/style/layers/layer.hpp.ejs
+++ b/platform/android/src/style/layers/layer.hpp.ejs
@@ -44,7 +44,6 @@ public:
     jni::Object<TransitionOptions> get<%- camelize(property.name) %>Transition(jni::JNIEnv&);
 <% } -%>
 <% } -%>
-
     jni::jobject* createJavaPeer(jni::JNIEnv&);
 
 }; // class <%- camelize(type) %>Layer


### PR DESCRIPTION
Closes #8663, need to fixup some whitespacing in the `.ejs` template file before reviewing.
This PR add a getter for source layer identifier on the layer classes that support it. Exposing this allows to iterate all layers and check for a specfic source layer identifiers, eg. `road`.