### PR TITLE
Fix Node.js detection for Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ style-code: android-style-code
 
 # Configuration file for running CMake from Gradle within Android Studio.
 platform/android/configuration.gradle:
-	@echo "ext {\n    node = '`command -v node | command -v nodejs`'\n    npm = '`command -v npm`'\n    ccache = '`command -v ccache`'\n}" > $@
+	@echo "ext {\n    node = '`command -v node || command -v nodejs`'\n    npm = '`command -v npm`'\n    ccache = '`command -v ccache`'\n}" > $@
 
 define ANDROID_RULES
 # $1 = arm-v7 (short arch)


### PR DESCRIPTION
In #8662 we added support for `nodejs` when `node` wasn't found, but the check was missing a second `|`. 