### PR TITLE
[core] Revert use of optional<EdgeInsets>

### DIFF
--- a/include/mbgl/map/camera.hpp
+++ b/include/mbgl/map/camera.hpp
@@ -17,7 +17,7 @@ struct CameraOptions {
 
     /** Padding around the interior of the view that affects the frame of
         reference for `center`. */
-    optional<EdgeInsets> padding;
+    EdgeInsets padding;
 
     /** Point of reference for `zoom` and `angle`, assuming an origin at the
         top-left corner of the view. */

--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -82,7 +82,7 @@ public:
     bool isPanning() const;
 
     // Camera
-    CameraOptions getCameraOptions(optional<EdgeInsets>) const;
+    CameraOptions getCameraOptions(const EdgeInsets&) const;
     void jumpTo(const CameraOptions&);
     void easeTo(const CameraOptions&, const AnimationOptions&);
     void flyTo(const CameraOptions&, const AnimationOptions&);
@@ -90,10 +90,10 @@ public:
     // Position
     void moveBy(const ScreenCoordinate&, const AnimationOptions& = {});
     void setLatLng(const LatLng&, optional<ScreenCoordinate>, const AnimationOptions& = {});
-    void setLatLng(const LatLng&, optional<EdgeInsets>, const AnimationOptions& = {});
+    void setLatLng(const LatLng&, const EdgeInsets&, const AnimationOptions& = {});
     void setLatLng(const LatLng&, const AnimationOptions& = {});
-    LatLng getLatLng(optional<EdgeInsets> = {}) const;
-    void resetPosition(optional<EdgeInsets> = {});
+    LatLng getLatLng(const EdgeInsets& = {}) const;
+    void resetPosition(const EdgeInsets& = {});
 
     // Scale
     void scaleBy(double ds, optional<ScreenCoordinate> = {}, const AnimationOptions& = {});
@@ -101,12 +101,12 @@ public:
     double getScale() const;
     void setZoom(double zoom, const AnimationOptions& = {});
     void setZoom(double zoom, optional<ScreenCoordinate>, const AnimationOptions& = {});
-    void setZoom(double zoom, optional<EdgeInsets>, const AnimationOptions& = {});
+    void setZoom(double zoom, const EdgeInsets&, const AnimationOptions& = {});
     double getZoom() const;
     void setLatLngZoom(const LatLng&, double zoom, const AnimationOptions& = {});
-    void setLatLngZoom(const LatLng&, double zoom, optional<EdgeInsets>, const AnimationOptions& = {});
-    CameraOptions cameraForLatLngBounds(const LatLngBounds&, optional<EdgeInsets>) const;
-    CameraOptions cameraForLatLngs(const std::vector<LatLng>&, optional<EdgeInsets>) const;
+    void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const AnimationOptions& = {});
+    CameraOptions cameraForLatLngBounds(const LatLngBounds&, const EdgeInsets&) const;
+    CameraOptions cameraForLatLngs(const std::vector<LatLng>&, const EdgeInsets&) const;
     LatLngBounds latLngBoundsForCamera(const CameraOptions&) const;
     void resetZoom();
 
@@ -126,10 +126,10 @@ public:
     void rotateBy(const ScreenCoordinate& first, const ScreenCoordinate& second, const AnimationOptions& = {});
     void setBearing(double degrees, const AnimationOptions& = {});
     void setBearing(double degrees, optional<ScreenCoordinate>, const AnimationOptions& = {});
-    void setBearing(double degrees, optional<EdgeInsets>, const AnimationOptions& = {});
+    void setBearing(double degrees, const EdgeInsets&, const AnimationOptions& = {});
     double getBearing() const;
     void resetNorth(const AnimationOptions& = {{mbgl::Milliseconds(500)}});
-    void resetNorth(optional<EdgeInsets>, const AnimationOptions& = {{mbgl::Milliseconds(500)}});
+    void resetNorth(const EdgeInsets&, const AnimationOptions& = {{mbgl::Milliseconds(500)}});
 
     // Pitch
     void setPitch(double pitch, const AnimationOptions& = {});

--- a/include/mbgl/util/geo.hpp
+++ b/include/mbgl/util/geo.hpp
@@ -221,6 +221,9 @@ public:
     EdgeInsets(const double t, const double l, const double b, const double r)
         : top(t), left(l), bottom(b), right(r) {}
 
+    bool isFlush() const {
+        return top == 0 && left == 0 && bottom == 0 && right == 0;
+    }
 
     void operator+=(const EdgeInsets& o) {
         top += o.top;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -468,7 +468,7 @@ bool Map::isPanning() const {
 
 #pragma mark -
 
-CameraOptions Map::getCameraOptions(optional<EdgeInsets> padding) const {
+CameraOptions Map::getCameraOptions(const EdgeInsets& padding) const {
     return impl->transform.getCameraOptions(padding);
 }
 
@@ -503,7 +503,7 @@ void Map::setLatLng(const LatLng& latLng, const AnimationOptions& animation) {
     setLatLng(latLng, optional<ScreenCoordinate> {}, animation);
 }
 
-void Map::setLatLng(const LatLng& latLng, optional<EdgeInsets> padding, const AnimationOptions& animation) {
+void Map::setLatLng(const LatLng& latLng, const EdgeInsets& padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
     impl->transform.setLatLng(latLng, padding, animation);
     impl->onUpdate(Update::Repaint);
@@ -515,11 +515,11 @@ void Map::setLatLng(const LatLng& latLng, optional<ScreenCoordinate> anchor, con
     impl->onUpdate(Update::Repaint);
 }
 
-LatLng Map::getLatLng(optional<EdgeInsets> padding) const {
+LatLng Map::getLatLng(const EdgeInsets& padding) const {
     return impl->transform.getLatLng(padding);
 }
 
-void Map::resetPosition(optional<EdgeInsets> padding) {
+void Map::resetPosition(const EdgeInsets& padding) {
     impl->cameraMutated = true;
     CameraOptions camera;
     camera.angle = 0;
@@ -552,7 +552,7 @@ double Map::getScale() const {
 
 void Map::setZoom(double zoom, const AnimationOptions& animation) {
     impl->cameraMutated = true;
-    setZoom(zoom, optional<EdgeInsets> {}, animation);
+    setZoom(zoom, EdgeInsets(), animation);
 }
 
 void Map::setZoom(double zoom, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
@@ -561,7 +561,7 @@ void Map::setZoom(double zoom, optional<ScreenCoordinate> anchor, const Animatio
     impl->onUpdate(Update::RecalculateStyle);
 }
 
-void Map::setZoom(double zoom, optional<EdgeInsets> padding, const AnimationOptions& animation) {
+void Map::setZoom(double zoom, const EdgeInsets& padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
     impl->transform.setZoom(zoom, padding, animation);
     impl->onUpdate(Update::RecalculateStyle);
@@ -576,13 +576,13 @@ void Map::setLatLngZoom(const LatLng& latLng, double zoom, const AnimationOption
     setLatLngZoom(latLng, zoom, {}, animation);
 }
 
-void Map::setLatLngZoom(const LatLng& latLng, double zoom, optional<EdgeInsets> padding, const AnimationOptions& animation) {
+void Map::setLatLngZoom(const LatLng& latLng, double zoom, const EdgeInsets& padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
     impl->transform.setLatLngZoom(latLng, zoom, padding, animation);
     impl->onUpdate(Update::RecalculateStyle);
 }
 
-CameraOptions Map::cameraForLatLngBounds(const LatLngBounds& bounds, optional<EdgeInsets> padding) const {
+CameraOptions Map::cameraForLatLngBounds(const LatLngBounds& bounds, const EdgeInsets& padding) const {
     return cameraForLatLngs({
         bounds.northwest(),
         bounds.southwest(),
@@ -591,7 +591,7 @@ CameraOptions Map::cameraForLatLngBounds(const LatLngBounds& bounds, optional<Ed
     }, padding);
 }
 
-CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional<EdgeInsets> padding) const {
+CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, const EdgeInsets& padding) const {
     CameraOptions options;
     if (latLngs.empty()) {
         return options;
@@ -616,10 +616,8 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
     if (width > 0 || height > 0) {
         double scaleX = double(getSize().width) / width;
         double scaleY = double(getSize().height) / height;
-        if (padding) {
-            scaleX -= (padding->left + padding->right) / width;
-            scaleY -= (padding->top + padding->bottom) / height;
-        }
+        scaleX -= (padding.left + padding.right) / width;
+        scaleY -= (padding.top + padding.bottom) / height;
         minScale = util::min(scaleX, scaleY);
     }
     double zoom = util::log2(getScale() * minScale);
@@ -627,17 +625,15 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, optional
 
     // Calculate the center point of a virtual bounds that is extended in all directions by padding.
     ScreenCoordinate centerPixel = nePixel + swPixel;
-    if (padding) {
-        ScreenCoordinate paddedNEPixel = {
-            padding->right / minScale,
-            padding->top / minScale,
-        };
-        ScreenCoordinate paddedSWPixel = {
-            padding->left / minScale,
-            padding->bottom / minScale,
-        };
-        centerPixel = centerPixel + paddedNEPixel - paddedSWPixel;
-    }
+    ScreenCoordinate paddedNEPixel = {
+        padding.right / minScale,
+        padding.top / minScale,
+    };
+    ScreenCoordinate paddedSWPixel = {
+        padding.left / minScale,
+        padding.bottom / minScale,
+    };
+    centerPixel = centerPixel + paddedNEPixel - paddedSWPixel;
     centerPixel /= 2.0;
 
     // CameraOptions origin is at the top-left corner.
@@ -750,7 +746,7 @@ void Map::setBearing(double degrees, optional<ScreenCoordinate> anchor, const An
     impl->onUpdate(Update::Repaint);
 }
 
-void Map::setBearing(double degrees, optional<EdgeInsets> padding, const AnimationOptions& animation) {
+void Map::setBearing(double degrees, const EdgeInsets& padding, const AnimationOptions& animation) {
     impl->cameraMutated = true;
     impl->transform.setAngle(-degrees * util::DEG2RAD, padding, animation);
     impl->onUpdate(Update::Repaint);

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -29,7 +29,7 @@ public:
 
     // Camera
     /** Returns the current camera options. */
-    CameraOptions getCameraOptions(optional<EdgeInsets>) const;
+    CameraOptions getCameraOptions(const EdgeInsets&) const;
 
     /** Instantaneously, synchronously applies the given camera options. */
     void jumpTo(const CameraOptions&);
@@ -47,13 +47,13 @@ public:
         @param offset The distance to pan the map by, measured in pixels from
             top to bottom and from left to right. */
     void moveBy(const ScreenCoordinate& offset, const AnimationOptions& = {});
-    void setLatLng(const LatLng&,  const AnimationOptions& = {});
-    void setLatLng(const LatLng&, optional<EdgeInsets>, const AnimationOptions& = {});
+    void setLatLng(const LatLng&, const AnimationOptions& = {});
+    void setLatLng(const LatLng&, const EdgeInsets&, const AnimationOptions& = {});
     void setLatLng(const LatLng&, optional<ScreenCoordinate>, const AnimationOptions& = {});
     void setLatLngZoom(const LatLng&, double zoom, const AnimationOptions& = {});
-    void setLatLngZoom(const LatLng&, double zoom, optional<EdgeInsets>, const AnimationOptions& = {});
-    LatLng getLatLng(optional<EdgeInsets> = {}) const;
-    ScreenCoordinate getScreenCoordinate(optional<EdgeInsets> = {}) const;
+    void setLatLngZoom(const LatLng&, double zoom, const EdgeInsets&, const AnimationOptions& = {});
+    LatLng getLatLng(const EdgeInsets& = {}) const;
+    ScreenCoordinate getScreenCoordinate(const EdgeInsets& = {}) const;
 
     // Bounds
 
@@ -84,7 +84,7 @@ public:
     /** Sets the scale factor, keeping the center point fixed within the inset view.
         @param scale The new scale factor.
         @param padding The viewport padding that affects the fixed center point. */
-    void setScale(double scale, optional<EdgeInsets> padding, const AnimationOptions& = {});
+    void setScale(double scale, const EdgeInsets& padding, const AnimationOptions& = {});
     /** Sets the zoom level, keeping the given point fixed within the view.
         @param zoom The new zoom level. */
     void setZoom(double zoom, const AnimationOptions& = {});
@@ -96,7 +96,7 @@ public:
     /** Sets the zoom level, keeping the center point fixed within the inset view.
         @param zoom The new zoom level.
         @param padding The viewport padding that affects the fixed center point. */
-    void setZoom(double zoom, optional<EdgeInsets> padding, const AnimationOptions& = {});
+    void setZoom(double zoom, const EdgeInsets& padding, const AnimationOptions& = {});
     /** Returns the zoom level. */
     double getZoom() const;
     /** Returns the scale factor. */
@@ -118,7 +118,7 @@ public:
         @param angle The new angle of rotation, measured in radians
             counterclockwise from true north.
         @param padding The viewport padding that affects the fixed center point. */
-    void setAngle(double angle, optional<EdgeInsets> padding, const AnimationOptions& = {});
+    void setAngle(double angle, const EdgeInsets& padding, const AnimationOptions& = {});
     /** Returns the angle of rotation.
         @return The angle of rotation, measured in radians counterclockwise from
             true north. */


### PR DESCRIPTION
`EdgeInsets` has a natural "empty" state. It can always be considered to be present, with a default value of "no insets".

Fixes #8693, replaces #8707.