### PR TITLE
[all] Remove redundant scale-related camera methods

### DIFF
--- a/include/mbgl/map/map.hpp
+++ b/include/mbgl/map/map.hpp
@@ -95,10 +95,7 @@ public:
     LatLng getLatLng(const EdgeInsets& = {}) const;
     void resetPosition(const EdgeInsets& = {});
 
-    // Scale
-    void scaleBy(double ds, optional<ScreenCoordinate> = {}, const AnimationOptions& = {});
-    void setScale(double scale, optional<ScreenCoordinate> = {}, const AnimationOptions& = {});
-    double getScale() const;
+    // Zoom
     void setZoom(double zoom, const AnimationOptions& = {});
     void setZoom(double zoom, optional<ScreenCoordinate>, const AnimationOptions& = {});
     void setZoom(double zoom, const EdgeInsets&, const AnimationOptions& = {});

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -230,7 +230,7 @@ final class MapGestureDetector {
           float scrollDist = event.getAxisValue(MotionEvent.AXIS_VSCROLL);
 
           // Scale the map by the appropriate power of two factor
-          transform.zoomBy(Math.pow(2.0, scrollDist), event.getX(), event.getY());
+          transform.zoomBy(scrollDist, event.getX(), event.getY());
 
           return true;
 
@@ -479,17 +479,17 @@ final class MapGestureDetector {
       // Scale the map
       if (focalPoint != null) {
         // arround user provided focal point
-        transform.zoomBy(detector.getScaleFactor(), focalPoint.x, focalPoint.y);
+        transform.zoomBy(Math.log(detector.getScaleFactor()) / Math.log(2), focalPoint.x, focalPoint.y);
       } else if (quickZoom) {
         // clamp scale factors we feed to core #7514
         float scaleFactor = MathUtils.clamp(detector.getScaleFactor(),
           MapboxConstants.MINIMUM_SCALE_FACTOR_CLAMP,
           MapboxConstants.MAXIMUM_SCALE_FACTOR_CLAMP);
         // around center map
-        transform.zoomBy(scaleFactor, uiSettings.getWidth() / 2, uiSettings.getHeight() / 2);
+        transform.zoomBy(Math.log(scaleFactor) / Math.log(2), uiSettings.getWidth() / 2, uiSettings.getHeight() / 2);
       } else {
         // around gesture
-        transform.zoomBy(detector.getScaleFactor(), detector.getFocusX(), detector.getFocusY());
+        transform.zoomBy(Math.log(detector.getScaleFactor()) / Math.log(2), detector.getFocusX(), detector.getFocusY());
       }
 
       return true;

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -330,55 +330,6 @@ final class NativeMapView {
     nativeSetPitch(pitch, duration);
   }
 
-  public void scaleBy(double ds) {
-    if (isDestroyedOn("scaleBy")) {
-      return;
-    }
-    scaleBy(ds, Double.NaN, Double.NaN);
-  }
-
-  public void scaleBy(double ds, double cx, double cy) {
-    if (isDestroyedOn("scaleBy")) {
-      return;
-    }
-    scaleBy(ds, cx, cy, 0);
-  }
-
-  public void scaleBy(double ds, double cx, double cy, long duration) {
-    if (isDestroyedOn("scaleBy")) {
-      return;
-    }
-    nativeScaleBy(ds, cx / pixelRatio, cy / pixelRatio, duration);
-  }
-
-  public void setScale(double scale) {
-    if (isDestroyedOn("setScale")) {
-      return;
-    }
-    setScale(scale, Double.NaN, Double.NaN);
-  }
-
-  public void setScale(double scale, double cx, double cy) {
-    if (isDestroyedOn("setScale")) {
-      return;
-    }
-    setScale(scale, cx, cy, 0);
-  }
-
-  public void setScale(double scale, double cx, double cy, long duration) {
-    if (isDestroyedOn("setScale")) {
-      return;
-    }
-    nativeSetScale(scale, cx / pixelRatio, cy / pixelRatio, duration);
-  }
-
-  public double getScale() {
-    if (isDestroyedOn("getScale")) {
-      return 0;
-    }
-    return nativeGetScale();
-  }
-
   public void setZoom(double zoom, PointF focalPoint, long duration) {
     if (isDestroyedOn("setZoom")) {
       return;
@@ -1014,12 +965,6 @@ final class NativeMapView {
   private native double nativeGetPitch();
 
   private native void nativeSetPitch(double pitch, long duration);
-
-  private native void nativeScaleBy(double ds, double cx, double cy, long duration);
-
-  private native void nativeSetScale(double scale, double cx, double cy, long duration);
-
-  private native double nativeGetScale();
 
   private native void nativeSetZoom(double zoom, double cx, double cy, long duration);
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Projection.java
@@ -125,6 +125,6 @@ public class Projection {
    * @return zoom level that fits the MapView.
    */
   public double calculateZoom(float minScale) {
-    return Math.log(nativeMapView.getScale() * minScale) / Math.log(2);
+    return nativeMapView.getZoom() + Math.log(minScale) / Math.log(2);
   }
 }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -273,8 +273,8 @@ final class Transform implements MapView.OnMapChangedListener {
     }
   }
 
-  void zoomBy(double pow, float x, float y) {
-    mapView.scaleBy(pow, x, y);
+  void zoomBy(double z, float x, float y) {
+    mapView.setZoom(mapView.getZoom() + z, new PointF(x, y), 0);
   }
 
   void moveBy(double offsetX, double offsetY, long duration) {

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -457,20 +457,6 @@ void NativeMapView::setPitch(jni::JNIEnv&, jni::jdouble pitch, jni::jlong durati
     map->setPitch(pitch, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
-void NativeMapView::scaleBy(jni::JNIEnv&, jni::jdouble ds, jni::jdouble cx, jni::jdouble cy, jni::jlong duration) {
-    mbgl::ScreenCoordinate center(cx, cy);
-    map->scaleBy(ds, center, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
-}
-
-void NativeMapView::setScale(jni::JNIEnv&, jni::jdouble scale, jni::jdouble cx, jni::jdouble cy, jni::jlong duration) {
-    mbgl::ScreenCoordinate center(cx, cy);
-    map->setScale(scale, center, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
-}
-
-jni::jdouble NativeMapView::getScale(jni::JNIEnv&) {
-    return map->getScale();
-}
-
 void NativeMapView::setZoom(jni::JNIEnv&, jni::jdouble zoom, jni::jdouble x, jni::jdouble y, jni::jlong duration) {
     map->setZoom(zoom, mbgl::ScreenCoordinate{x,y}, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
@@ -1500,9 +1486,6 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::resetPosition, "nativeResetPosition"),
             METHOD(&NativeMapView::getPitch, "nativeGetPitch"),
             METHOD(&NativeMapView::setPitch, "nativeSetPitch"),
-            METHOD(&NativeMapView::scaleBy, "nativeScaleBy"),
-            METHOD(&NativeMapView::getScale, "nativeGetScale"),
-            METHOD(&NativeMapView::setScale, "nativeSetScale"),
             METHOD(&NativeMapView::getZoom, "nativeGetZoom"),
             METHOD(&NativeMapView::setZoom, "nativeSetZoom"),
             METHOD(&NativeMapView::resetZoom, "nativeResetZoom"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -134,12 +134,6 @@ public:
 
     void setPitch(jni::JNIEnv&, jni::jdouble, jni::jlong);
 
-    void scaleBy(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jlong);
-
-    void setScale(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jlong);
-
-    jni::jdouble getScale(jni::JNIEnv&);
-
     void setZoom(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jdouble, jni::jlong);
 
     jni::jdouble getZoom(jni::JNIEnv&);

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -367,7 +367,7 @@ void GLFWView::onScroll(GLFWwindow *window, double /*xOffset*/, double yOffset) 
         scale = 1.0 / scale;
     }
 
-    view->map->scaleBy(scale, mbgl::ScreenCoordinate { view->lastX, view->lastY });
+    view->map->setZoom(view->map->getZoom() + std::log2(scale), mbgl::ScreenCoordinate { view->lastX, view->lastY });
 }
 
 void GLFWView::onWindowResize(GLFWwindow *window, int width, int height) {
@@ -408,9 +408,9 @@ void GLFWView::onMouseClick(GLFWwindow *window, int button, int action, int modi
             double now = glfwGetTime();
             if (now - view->lastClick < 0.4 /* ms */) {
                 if (modifiers & GLFW_MOD_SHIFT) {
-                    view->map->scaleBy(0.5, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
+                    view->map->setZoom(view->map->getZoom() - 1, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
                 } else {
-                    view->map->scaleBy(2.0, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
+                    view->map->setZoom(view->map->getZoom() + 1, mbgl::ScreenCoordinate { view->lastX, view->lastY }, mbgl::AnimationOptions{{mbgl::Milliseconds(500)}});
                 }
             }
             view->lastClick = now;

--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1264,7 +1264,7 @@ public:
     {
         [self trackGestureEvent:MGLEventGesturePinchStart forRecognizer:pinch];
 
-        self.scale = _mbglMap->getScale();
+        self.scale = powf(2, _mbglMap->getZoom());
 
         [self notifyGestureDidBegin];
     }
@@ -1280,7 +1280,7 @@ public:
         if (![self.delegate respondsToSelector:@selector(mapView:shouldChangeFromCamera:toCamera:)] ||
             [self.delegate mapView:self shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
-            _mbglMap->setScale(newScale, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
+            _mbglMap->setZoom(zoom, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
         }
         // The gesture recognizer only reports the gesture’s current center
         // point, so use the previous center point to anchor the transition.
@@ -1338,7 +1338,7 @@ public:
         } else {
             if (drift)
             {
-                _mbglMap->setScale(newScale, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }, MGLDurationFromTimeInterval(duration));
+                _mbglMap->setZoom(zoom, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y }, MGLDurationFromTimeInterval(duration));
             }
         }
 
@@ -1616,7 +1616,7 @@ public:
     {
         [self trackGestureEvent:MGLEventGestureQuickZoom forRecognizer:quickZoom];
 
-        self.scale = _mbglMap->getScale();
+        self.scale = powf(2, _mbglMap->getZoom());
 
         self.quickZoomStart = [quickZoom locationInView:quickZoom.view].y;
 
@@ -1633,18 +1633,12 @@ public:
         CGPoint centerPoint = [self anchorPointForGesture:quickZoom];
         
         MGLMapCamera *oldCamera = self.camera;
-        
-        double zoom = self.zoomLevel;
-        double scale = powf(2, newZoom) / _mbglMap->getScale();
-        
-        double estimatedZoom = zoom * scale;
-        
-        MGLMapCamera *toCamera = [self cameraByZoomingToZoomLevel:estimatedZoom aroundAnchorPoint:centerPoint];
+        MGLMapCamera *toCamera = [self cameraByZoomingToZoomLevel:newZoom aroundAnchorPoint:centerPoint];
         
         if (![self.delegate respondsToSelector:@selector(mapView:shouldChangeFromCamera:toCamera:)] ||
             [self.delegate mapView:self shouldChangeFromCamera:oldCamera toCamera:toCamera])
         {
-            _mbglMap->scaleBy(scale, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
+            _mbglMap->setZoom(newZoom, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
         }
 
         [self cameraIsChanging];
@@ -2407,7 +2401,7 @@ public:
     {
         centerPoint = self.userLocationAnnotationViewCenter;
     }
-    _mbglMap->scaleBy(scaleFactor, mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
+    _mbglMap->setZoom(_mbglMap->getZoom() + log2(scaleFactor), mbgl::ScreenCoordinate { centerPoint.x, centerPoint.y });
     [self unrotateIfNeededForGesture];
 
     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, self.accessibilityValue);

--- a/platform/macos/src/MGLMapView.mm
+++ b/platform/macos/src/MGLMapView.mm
@@ -157,7 +157,7 @@ public:
     NSMagnificationGestureRecognizer *_magnificationGestureRecognizer;
     NSRotationGestureRecognizer *_rotationGestureRecognizer;
     NSClickGestureRecognizer *_singleClickRecognizer;
-    double _scaleAtBeginningOfGesture;
+    double _zoomAtBeginningOfGesture;
     CLLocationDirection _directionAtBeginningOfGesture;
     CGFloat _pitchAtBeginningOfGesture;
     BOOL _didHideCursorDuringGesture;
@@ -1037,31 +1037,12 @@ public:
     [self didChangeValueForKey:@"zoomLevel"];
 }
 
-- (void)zoomBy:(double)zoomDelta animated:(BOOL)animated {
-    [self setZoomLevel:round(self.zoomLevel) + zoomDelta animated:animated];
-}
-
-- (void)zoomBy:(double)zoomDelta atPoint:(NSPoint)point animated:(BOOL)animated {
-    [self willChangeValueForKey:@"centerCoordinate"];
-    [self willChangeValueForKey:@"zoomLevel"];
-    double newZoom = round(self.zoomLevel) + zoomDelta;
-    MGLMapCamera *oldCamera = self.camera;
-    mbgl::ScreenCoordinate center(point.x, self.bounds.size.height - point.y);
-    _mbglMap->setZoom(newZoom, center, MGLDurationFromTimeInterval(animated ? MGLAnimationDuration : 0));
-    if ([self.delegate respondsToSelector:@selector(mapView:shouldChangeFromCamera:toCamera:)]
-        && ![self.delegate mapView:self shouldChangeFromCamera:oldCamera toCamera:self.camera]) {
-        self.camera = oldCamera;
-    }
-    [self didChangeValueForKey:@"zoomLevel"];
-    [self didChangeValueForKey:@"centerCoordinate"];
-}
-
-- (void)scaleBy:(double)scaleFactor atPoint:(NSPoint)point animated:(BOOL)animated {
+- (void)setZoomLevel:(double)zoomLevel atPoint:(NSPoint)point animated:(BOOL)animated {
     [self willChangeValueForKey:@"centerCoordinate"];
     [self willChangeValueForKey:@"zoomLevel"];
     MGLMapCamera *oldCamera = self.camera;
     mbgl::ScreenCoordinate center(point.x, self.bounds.size.height - point.y);
-    _mbglMap->scaleBy(scaleFactor, center, MGLDurationFromTimeInterval(animated ? MGLAnimationDuration : 0));
+    _mbglMap->setZoom(zoomLevel, center, MGLDurationFromTimeInterval(animated ? MGLAnimationDuration : 0));
     if ([self.delegate respondsToSelector:@selector(mapView:shouldChangeFromCamera:toCamera:)]
         && ![self.delegate mapView:self shouldChangeFromCamera:oldCamera toCamera:self.camera]) {
         self.camera = oldCamera;
@@ -1402,10 +1383,10 @@ public:
         _mbglMap->cancelTransitions();
 
         if (gestureRecognizer.state == NSGestureRecognizerStateBegan) {
-            _scaleAtBeginningOfGesture = _mbglMap->getScale();
+            _zoomAtBeginningOfGesture = _mbglMap->getZoom();
         } else if (gestureRecognizer.state == NSGestureRecognizerStateChanged) {
-            CGFloat newZoomLevel = log2f(_scaleAtBeginningOfGesture) - delta.y / 75;
-            [self scaleBy:powf(2, newZoomLevel) / _mbglMap->getScale() atPoint:startPoint animated:NO];
+            CGFloat newZoomLevel = _zoomAtBeginningOfGesture - delta.y / 75;
+            [self setZoomLevel:newZoomLevel atPoint:startPoint animated:NO];
         }
     } else if (flags & NSAlternateKeyMask) {
         // Option-drag to rotate and/or tilt.
@@ -1466,7 +1447,7 @@ public:
 
     if (gestureRecognizer.state == NSGestureRecognizerStateBegan) {
         _mbglMap->setGestureInProgress(true);
-        _scaleAtBeginningOfGesture = _mbglMap->getScale();
+        _zoomAtBeginningOfGesture = _mbglMap->getZoom();
     } else if (gestureRecognizer.state == NSGestureRecognizerStateChanged) {
         NSPoint zoomInPoint = [gestureRecognizer locationInView:self];
         mbgl::ScreenCoordinate center(zoomInPoint.x, self.bounds.size.height - zoomInPoint.y);
@@ -1474,7 +1455,7 @@ public:
             [self willChangeValueForKey:@"zoomLevel"];
             [self willChangeValueForKey:@"centerCoordinate"];
             MGLMapCamera *oldCamera = self.camera;
-            _mbglMap->setScale(_scaleAtBeginningOfGesture * (1 + gestureRecognizer.magnification), center);
+            _mbglMap->setZoom(_zoomAtBeginningOfGesture * (1 + gestureRecognizer.magnification), center);
             if ([self.delegate respondsToSelector:@selector(mapView:shouldChangeFromCamera:toCamera:)]
                 && ![self.delegate mapView:self shouldChangeFromCamera:oldCamera toCamera:self.camera]) {
                 self.camera = oldCamera;
@@ -1526,7 +1507,7 @@ public:
     _mbglMap->cancelTransitions();
 
     NSPoint gesturePoint = [gestureRecognizer locationInView:self];
-    [self zoomBy:1 atPoint:gesturePoint animated:YES];
+    [self setZoomLevel:round(self.zoomLevel) + 1 atPoint:gesturePoint animated:YES];
 }
 
 - (void)smartMagnifyWithEvent:(NSEvent *)event {
@@ -1538,7 +1519,7 @@ public:
 
     // Tap with two fingers (“right-click”) to zoom out on mice but not trackpads.
     NSPoint gesturePoint = [self convertPoint:event.locationInWindow fromView:nil];
-    [self zoomBy:-1 atPoint:gesturePoint animated:YES];
+    [self setZoomLevel:round(self.zoomLevel) - 1 atPoint:gesturePoint animated:YES];
 }
 
 /// Rotate fingers to rotate.
@@ -1591,7 +1572,7 @@ public:
                 }
 
                 NSPoint gesturePoint = [self convertPoint:event.locationInWindow fromView:nil];
-                [self scaleBy:scale atPoint:gesturePoint animated:NO];
+                [self setZoomLevel:self.zoomLevel + log2(scale) atPoint:gesturePoint animated:NO];
             }
         }
     } else if (self.scrollEnabled
@@ -1699,13 +1680,13 @@ public:
 
 - (IBAction)moveToBeginningOfParagraph:(__unused id)sender {
     if (self.zoomEnabled) {
-        [self zoomBy:1 animated:YES];
+        [self setZoomLevel:round(self.zoomLevel) + 1 animated:YES];
     }
 }
 
 - (IBAction)moveToEndOfParagraph:(__unused id)sender {
     if (self.zoomEnabled) {
-        [self zoomBy:-1 animated:YES];
+        [self setZoomLevel:round(self.zoomLevel) - 1 animated:YES];
     }
 }
 

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -565,12 +565,12 @@ void QMapboxGL::setLongitude(double longitude_)
 */
 double QMapboxGL::scale() const
 {
-    return d_ptr->mapObj->getScale();
+    return std::pow(2.0, d_ptr->mapObj->getZoom());
 }
 
 void QMapboxGL::setScale(double scale_, const QPointF &center)
 {
-    d_ptr->mapObj->setScale(scale_, mbgl::ScreenCoordinate { center.x(), center.y() });
+    d_ptr->mapObj->setZoom(std::log2(scale_), mbgl::ScreenCoordinate { center.x(), center.y() });
 }
 
 /*!
@@ -1055,7 +1055,7 @@ void QMapboxGL::moveBy(const QPointF &offset)
     can be used for implementing a pinch gesture.
 */
 void QMapboxGL::scaleBy(double scale_, const QPointF &center) {
-    d_ptr->mapObj->scaleBy(scale_, mbgl::ScreenCoordinate { center.x(), center.y() });
+    d_ptr->mapObj->setZoom(d_ptr->mapObj->getZoom() + std::log2(scale_), mbgl::ScreenCoordinate { center.x(), center.y() });
 }
 
 /*!

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -532,23 +532,7 @@ void Map::resetPosition(const EdgeInsets& padding) {
 }
 
 
-#pragma mark - Scale
-
-void Map::scaleBy(double ds, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    impl->cameraMutated = true;
-    impl->transform.scaleBy(ds, anchor, animation);
-    impl->onUpdate(Update::RecalculateStyle);
-}
-
-void Map::setScale(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    impl->cameraMutated = true;
-    impl->transform.setScale(scale, anchor, animation);
-    impl->onUpdate(Update::RecalculateStyle);
-}
-
-double Map::getScale() const {
-    return impl->transform.getScale();
-}
+#pragma mark - Zoom
 
 void Map::setZoom(double zoom, const AnimationOptions& animation) {
     impl->cameraMutated = true;
@@ -620,7 +604,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, const Ed
         scaleY -= (padding.top + padding.bottom) / height;
         minScale = util::min(scaleX, scaleY);
     }
-    double zoom = util::log2(getScale() * minScale);
+    double zoom = getZoom() + util::log2(minScale);
     zoom = util::clamp(zoom, getMinZoom(), getMaxZoom());
 
     // Calculate the center point of a virtual bounds that is extended in all directions by padding.

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -384,52 +384,28 @@ ScreenCoordinate Transform::getScreenCoordinate(const EdgeInsets& padding) const
 
 #pragma mark - Zoom
 
-void Transform::scaleBy(double ds, const AnimationOptions& animation) {
-    scaleBy(ds, optional<ScreenCoordinate> {}, animation);
-}
-
-void Transform::scaleBy(double ds, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    if (std::isnan(ds)) return;
-    double scale = util::clamp(state.scale * ds, state.min_scale, state.max_scale);
-    setScale(scale, anchor, animation);
-}
-
 void Transform::setZoom(double zoom, const AnimationOptions& animation) {
-    setZoom(zoom, optional<ScreenCoordinate> {}, animation);
+    CameraOptions camera;
+    camera.zoom = zoom;
+    easeTo(camera, animation);
 }
 
 void Transform::setZoom(double zoom, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    setScale(state.zoomScale(zoom), anchor, animation);
-}
-
-void Transform::setZoom(double zoom, const EdgeInsets& padding, const AnimationOptions& animation) {
-    setScale(state.zoomScale(zoom), padding, animation);
-}
-
-double Transform::getZoom() const {
-    return state.getZoom();
-}
-
-double Transform::getScale() const {
-    return state.scale;
-}
-
-void Transform::setScale(double scale, const AnimationOptions& animation) {
-    setScale(scale, optional<ScreenCoordinate> {}, animation);
-}
-
-void Transform::setScale(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& animation) {
-    if (std::isnan(scale)) return;
     CameraOptions camera;
-    camera.zoom = state.scaleZoom(scale);
+    camera.zoom = zoom;
     camera.anchor = anchor;
     easeTo(camera, animation);
 }
 
-void Transform::setScale(double scale, const EdgeInsets& padding, const AnimationOptions& animation) {
-    optional<ScreenCoordinate> anchor;
-    if (!padding.isFlush()) anchor = getScreenCoordinate(padding);
-    setScale(scale, anchor, animation);
+void Transform::setZoom(double zoom, const EdgeInsets& padding, const AnimationOptions& animation) {
+    CameraOptions camera;
+    camera.zoom = zoom;
+    if (!padding.isFlush()) camera.anchor = getScreenCoordinate(padding);
+    easeTo(camera, animation);
+}
+
+double Transform::getZoom() const {
+    return state.getZoom();
 }
 
 #pragma mark - Bounds

--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -65,26 +65,6 @@ public:
 
     // Zoom
 
-    /** Scales the map, keeping the given point fixed within the view.
-        @param ds The difference in scale factors to scale the map by. */
-    void scaleBy(double ds, const AnimationOptions& = {});
-    /** Scales the map, keeping the given point fixed within the view.
-        @param ds The difference in scale factors to scale the map by.
-        @param anchor A point relative to the top-left corner of the view.
-            If unspecified, the center point is fixed within the view. */
-    void scaleBy(double ds, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
-    /** Sets the scale factor, keeping the given point fixed within the view.
-        @param scale The new scale factor. */
-    void setScale(double scale, const AnimationOptions& = {});
-    /** Sets the scale factor, keeping the given point fixed within the view.
-        @param scale The new scale factor.
-        @param anchor A point relative to the top-left corner of the view.
-            If unspecified, the center point is fixed within the view. */
-    void setScale(double scale, optional<ScreenCoordinate> anchor, const AnimationOptions& = {});
-    /** Sets the scale factor, keeping the center point fixed within the inset view.
-        @param scale The new scale factor.
-        @param padding The viewport padding that affects the fixed center point. */
-    void setScale(double scale, const EdgeInsets& padding, const AnimationOptions& = {});
     /** Sets the zoom level, keeping the given point fixed within the view.
         @param zoom The new zoom level. */
     void setZoom(double zoom, const AnimationOptions& = {});
@@ -99,8 +79,6 @@ public:
     void setZoom(double zoom, const EdgeInsets& padding, const AnimationOptions& = {});
     /** Returns the zoom level. */
     double getZoom() const;
-    /** Returns the scale factor. */
-    double getScale() const;
 
     // Angle
 

--- a/src/mbgl/map/transform_state.cpp
+++ b/src/mbgl/map/transform_state.cpp
@@ -136,10 +136,6 @@ double TransformState::getZoomFraction() const {
     return getZoom() - getIntegerZoom();
 }
 
-double TransformState::getScale() const {
-    return scale;
-}
-
 #pragma mark - Bounds
 
 void TransformState::setLatLngBounds(const LatLngBounds& bounds_) {

--- a/src/mbgl/map/transform_state.hpp
+++ b/src/mbgl/map/transform_state.hpp
@@ -45,7 +45,6 @@ public:
     double pixel_y() const;
 
     // Zoom
-    double getScale() const;
     double getZoom() const;
     int32_t getIntegerZoom() const;
     double getZoomFraction() const;


### PR DESCRIPTION
We don't need to have two different measurement systems for map zoom.

Tested:

* Scroll zoom, pinch zoom, double click zoom, +/-, menu items in macosapp.
* Pinch zoom, tap-and-drag zoom, double tap zoom in iosapp.
* Pinch zoom, tap-and-drag zoom, double tap zoom in Android test app.
* Scroll zoom, double click zoom in glfw-app.