### PR TITLE
[core] Ignore shortest path in Map::cameraForLatLngs

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -586,7 +586,7 @@ CameraOptions Map::cameraForLatLngs(const std::vector<LatLng>& latLngs, const Ed
     ScreenCoordinate swPixel = {INFINITY, INFINITY};
     double viewportHeight = getSize().height;
     for (LatLng latLng : latLngs) {
-        ScreenCoordinate pixel = pixelForLatLng(latLng);
+        ScreenCoordinate pixel = impl->transform.latLngToScreenCoordinate(latLng);
         swPixel.x = std::min(swPixel.x, pixel.x);
         nePixel.x = std::max(nePixel.x, pixel.x);
         swPixel.y = std::min(swPixel.y, viewportHeight - pixel.y);
@@ -811,7 +811,12 @@ LatLng Map::latLngForProjectedMeters(const ProjectedMeters& projectedMeters) con
 }
 
 ScreenCoordinate Map::pixelForLatLng(const LatLng& latLng) const {
-    return impl->transform.latLngToScreenCoordinate(latLng);
+    // If the center and point longitudes are not in the same side of the
+    // antimeridian, we unwrap the point longitude so it would be seen if
+    // e.g. the next antimeridian side is visible.
+    LatLng unwrappedLatLng = latLng.wrapped();
+    unwrappedLatLng.unwrapForShortestPath(getLatLng());
+    return impl->transform.latLngToScreenCoordinate(unwrappedLatLng);
 }
 
 LatLng Map::latLngForPixel(const ScreenCoordinate& pixel) const {

--- a/src/mbgl/map/transform.cpp
+++ b/src/mbgl/map/transform.cpp
@@ -621,12 +621,7 @@ void Transform::setGestureInProgress(bool inProgress) {
 #pragma mark Conversion and projection
 
 ScreenCoordinate Transform::latLngToScreenCoordinate(const LatLng& latLng) const {
-    // If the center and point longitudes are not in the same side of the
-    // antimeridian, we unwrap the point longitude so it would be seen if
-    // e.g. the next antimeridian side is visible.
-    LatLng unwrappedLatLng = latLng.wrapped();
-    unwrappedLatLng.unwrapForShortestPath(getLatLng());
-    ScreenCoordinate point = state.latLngToScreenCoordinate(unwrappedLatLng);
+    ScreenCoordinate point = state.latLngToScreenCoordinate(latLng);
     point.y = state.size.height - point.y;
     return point;
 }

--- a/test/map/map.test.cpp
+++ b/test/map/map.test.cpp
@@ -69,6 +69,18 @@ TEST(Map, LatLngBehavior) {
     ASSERT_DOUBLE_EQ(latLng1.longitude(), latLng2.longitude());
 }
 
+TEST(Map, LatLngBoundsToCamera) {
+    MapTest test;
+    Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);
+
+    map.setLatLngZoom({ 40.712730, -74.005953 }, 16.0);
+
+    LatLngBounds bounds = LatLngBounds::hull({15.68169,73.499857}, {53.560711, 134.77281});
+
+    CameraOptions virtualCamera = map.cameraForLatLngBounds(bounds, {});
+    ASSERT_TRUE(bounds.contains(*virtualCamera.center));
+}
+
 TEST(Map, CameraToLatLngBounds) {
     MapTest test;
     Map map(test.backend, test.view.getSize(), 1, test.fileSource, test.threadPool, MapMode::Still);

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -125,17 +125,17 @@ TEST(Transform, UnwrappedLatLng) {
     ASSERT_NEAR(fromScreenCoordinate.latitude(),   37.999999999999829, 0.0001); // 1.71E-13
     ASSERT_NEAR(fromScreenCoordinate.longitude(), -76.999999999999773, 0.0001); // 2.27E-13
 
-    LatLng wrappedForwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, 283 }));
-    ASSERT_NEAR(wrappedForwards.latitude(), 37.999999999999716, 0.0001); // 2.84E-13
-    ASSERT_NEAR(wrappedForwards.longitude(), 282.99999999988751, 0.0001); // 1.1249E-11
-    wrappedForwards.wrap();
-    ASSERT_NEAR(wrappedForwards.longitude(), -77.000000000112493, 0.001); // 1.1249E-11
+    LatLng wrappedRightwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, 283 }));
+    ASSERT_NEAR(wrappedRightwards.latitude(), 37.999999999999716, 0.0001); // 2.84E-13
+    ASSERT_NEAR(wrappedRightwards.longitude(), 282.99999999988751, 0.0001); // 1.1249E-11
+    wrappedRightwards.wrap();
+    ASSERT_NEAR(wrappedRightwards.longitude(), -77.000000000112493, 0.001); // 1.1249E-11
 
-    LatLng wrappedBackwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, -437 }));
-    ASSERT_NEAR(wrappedBackwards.latitude(), wrappedForwards.latitude(), 0.001);
-    ASSERT_NEAR(wrappedBackwards.longitude(), -436.99999999988728, 0.001); // 1.1272E-11
-    wrappedBackwards.wrap();
-    ASSERT_NEAR(wrappedBackwards.longitude(), -76.99999999988728, 0.001); // 1.1272E-11
+    LatLng wrappedLeftwards = state.screenCoordinateToLatLng(state.latLngToScreenCoordinate({ 38, -437 }));
+    ASSERT_NEAR(wrappedLeftwards.latitude(), wrappedRightwards.latitude(), 0.001);
+    ASSERT_NEAR(wrappedLeftwards.longitude(), -436.99999999988728, 0.001); // 1.1272E-11
+    wrappedLeftwards.wrap();
+    ASSERT_NEAR(wrappedLeftwards.longitude(), -76.99999999988728, 0.001); // 1.1272E-11
 }
 
 TEST(Transform, ConstrainHeightOnly) {
@@ -333,21 +333,30 @@ TEST(Transform, Antimeridian) {
     transform.resize({ 1000, 1000 });
     transform.setLatLngZoom({ 0, 0 }, 1);
 
+    // San Francisco
     const LatLng coordinateSanFrancisco { 37.7833, -122.4167 };
     ScreenCoordinate pixelSF = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
     ASSERT_NEAR(151.79409149185352, pixelSF.x, 1e-2);
     ASSERT_NEAR(383.76774094913071, pixelSF.y, 1e-2);
 
     transform.setLatLng({ 0, -181 });
-    ScreenCoordinate pixelSFBackwards = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
-    ASSERT_NEAR(666.63617954008976, pixelSFBackwards.x, 1e-2);
-    ASSERT_DOUBLE_EQ(pixelSF.y, pixelSFBackwards.y);
+
+    ScreenCoordinate pixelSFLongest = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
+    ASSERT_NEAR(-357.36306616412816, pixelSFLongest.x, 1e-2);
+    ASSERT_DOUBLE_EQ(pixelSF.y, pixelSFLongest.y);
+    LatLng unwrappedSF = coordinateSanFrancisco.wrapped();
+    unwrappedSF.unwrapForShortestPath(transform.getLatLng());
+
+    ScreenCoordinate pixelSFShortest = transform.latLngToScreenCoordinate(unwrappedSF);
+    ASSERT_NEAR(666.63617954008976, pixelSFShortest.x, 1e-2);
+    ASSERT_DOUBLE_EQ(pixelSF.y, pixelSFShortest.y);
 
     transform.setLatLng({ 0, 179 });
-    ScreenCoordinate pixelSFForwards = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
-    ASSERT_DOUBLE_EQ(pixelSFBackwards.x, pixelSFForwards.x);
-    ASSERT_DOUBLE_EQ(pixelSFBackwards.y, pixelSFForwards.y);
+    pixelSFShortest = transform.latLngToScreenCoordinate(coordinateSanFrancisco);
+    ASSERT_DOUBLE_EQ(pixelSFLongest.x, pixelSFShortest.x);
+    ASSERT_DOUBLE_EQ(pixelSFLongest.y, pixelSFShortest.y);
 
+    // Waikiri
     const LatLng coordinateWaikiri{ -16.9310, 179.9787 };
     transform.setLatLngZoom(coordinateWaikiri, 10);
     ScreenCoordinate pixelWaikiri = transform.latLngToScreenCoordinate(coordinateWaikiri);
@@ -355,18 +364,26 @@ TEST(Transform, Antimeridian) {
     ASSERT_NEAR(500, pixelWaikiri.y, 1e-2);
 
     transform.setLatLng({ coordinateWaikiri.latitude(), 180.0213 });
-    ScreenCoordinate pixelWaikiriForwards = transform.latLngToScreenCoordinate(coordinateWaikiri);
-    ASSERT_NEAR(437.95953728819512, pixelWaikiriForwards.x, 1e-2);
-    ASSERT_DOUBLE_EQ(pixelWaikiri.y, pixelWaikiriForwards.y);
-    LatLng coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriForwards);
+    ScreenCoordinate pixelWaikiriLongest = transform.latLngToScreenCoordinate(coordinateWaikiri);
+    ASSERT_NEAR(524725.96438108233, pixelWaikiriLongest.x, 1e-2);
+    ASSERT_DOUBLE_EQ(pixelWaikiri.y, pixelWaikiriLongest.y);
+
+    LatLng unwrappedWaikiri = coordinateWaikiri.wrapped();
+    unwrappedWaikiri.unwrapForShortestPath(transform.getLatLng());
+    ScreenCoordinate pixelWaikiriShortest = transform.latLngToScreenCoordinate(unwrappedWaikiri);
+    ASSERT_NEAR(437.95953728819512, pixelWaikiriShortest.x, 1e-2);
+    ASSERT_DOUBLE_EQ(pixelWaikiri.y, pixelWaikiriShortest.y);
+
+    LatLng coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriLongest);
     ASSERT_NEAR(coordinateWaikiri.latitude(), coordinateFromPixel.latitude(), 0.000001);
     ASSERT_NEAR(coordinateWaikiri.longitude(), coordinateFromPixel.longitude(), 0.000001);
 
     transform.setLatLng({ coordinateWaikiri.latitude(), -179.9787 });
-    ScreenCoordinate pixelWaikiriBackwards = transform.latLngToScreenCoordinate(coordinateWaikiri);
-    ASSERT_DOUBLE_EQ(pixelWaikiriForwards.x, pixelWaikiriBackwards.x);
-    ASSERT_DOUBLE_EQ(pixelWaikiriForwards.y, pixelWaikiriBackwards.y);
-    coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriBackwards);
+    pixelWaikiriShortest = transform.latLngToScreenCoordinate(coordinateWaikiri);
+    ASSERT_DOUBLE_EQ(pixelWaikiriLongest.x, pixelWaikiriShortest.x);
+    ASSERT_DOUBLE_EQ(pixelWaikiriLongest.y, pixelWaikiriShortest.y);
+
+    coordinateFromPixel = transform.screenCoordinateToLatLng(pixelWaikiriShortest);
     ASSERT_NEAR(coordinateWaikiri.latitude(), coordinateFromPixel.latitude(), 0.000001);
     ASSERT_NEAR(coordinateWaikiri.longitude(), coordinateFromPixel.longitude(), 0.000001);
 }


### PR DESCRIPTION
When calculating the screen coordinates for the given geographical coordinates boundaries in `Map::cameraForLatLngs`, we use `Map::pixelForLatLng`, which is implemented by calling `Transform::latLngToScreenCoordinate`.

The latter assumed that all conversions were required to be using the longitude shortest path. This is not true for `Map::cameraForLatLngs`, in which we require the longest path to properly calculate the virtual camera center.

Fixes #8737.

/cc @tobrun @jfirebaugh 