### PR TITLE
More GlyphAtlas refactoring

### DIFF
--- a/src/mbgl/text/glyph.hpp
+++ b/src/mbgl/text/glyph.hpp
@@ -4,6 +4,7 @@
 #include <mbgl/util/font_stack.hpp>
 #include <mbgl/util/rect.hpp>
 #include <mbgl/util/traits.hpp>
+#include <mbgl/util/optional.hpp>
 
 #include <cstdint>
 #include <vector>
@@ -19,17 +20,11 @@ typedef std::set<GlyphID> GlyphIDs;
 GlyphRange getGlyphRange(GlyphID glyph);
 
 struct GlyphMetrics {
-    explicit operator bool() const {
-        return !(width == 0 && height == 0 && advance == 0);
-    }
-
-    // Glyph metrics.
     uint32_t width = 0;
     uint32_t height = 0;
     int32_t left = 0;
     int32_t top = 0;
     uint32_t advance = 0;
-
 };
 
 inline bool operator==(const GlyphMetrics& lhs, const GlyphMetrics& rhs) {
@@ -41,19 +36,12 @@ inline bool operator==(const GlyphMetrics& lhs, const GlyphMetrics& rhs) {
 }
 
 struct Glyph {
-    explicit Glyph() : rect(0, 0, 0, 0), metrics() {}
-    explicit Glyph(Rect<uint16_t> rect_, GlyphMetrics metrics_)
-        : rect(std::move(rect_)), metrics(std::move(metrics_)) {}
-
-    explicit operator bool() const {
-        return metrics || rect.hasArea();
-    }
-
-    const Rect<uint16_t> rect;
-    const GlyphMetrics metrics;
+    Rect<uint16_t> rect;
+    GlyphMetrics metrics;
 };
 
-typedef std::map<GlyphID, Glyph> GlyphPositions;
+typedef std::map<GlyphID, optional<Glyph>> GlyphPositions;
+typedef std::map<FontStack, GlyphPositions> GlyphPositionMap;
 
 class PositionedGlyph {
 public:
@@ -111,7 +99,6 @@ constexpr WritingModeType operator~(WritingModeType value) {
 
 typedef std::map<FontStack,GlyphIDs> GlyphDependencies;
 typedef std::map<FontStack,GlyphRangeSet> GlyphRangeDependencies;
-typedef std::map<FontStack,GlyphPositions> GlyphPositionMap;
 
 
 } // end namespace mbgl

--- a/src/mbgl/text/glyph_atlas.cpp
+++ b/src/mbgl/text/glyph_atlas.cpp
@@ -96,10 +96,14 @@ void GlyphAtlas::processResponse(const Response& res, const FontStack& fontStack
         }
 
         for (auto& glyph : glyphs) {
-            auto it = entry.sdfs.find(glyph.id);
-            if (it == entry.sdfs.end()) {
+            auto it = entry.glyphs.find(glyph.id);
+            if (it == entry.glyphs.end()) {
                 // Glyph doesn't exist yet.
-                entry.sdfs.emplace(glyph.id, std::move(glyph));
+                entry.glyphs.emplace(glyph.id, GlyphValue {
+                    std::move(glyph.bitmap),
+                    std::move(glyph.metrics),
+                    {}, {}
+                });
             } else if (it->second.metrics == glyph.metrics) {
                 if (it->second.bitmap != glyph.bitmap) {
                     // The actual bitmap was updated; this is unsupported.
@@ -146,17 +150,19 @@ void GlyphAtlas::addGlyphs(GlyphRequestor& requestor, const GlyphDependencies& g
         Entry& entry = entries[fontStack];
 
         for (const auto& glyphID : glyphIDs) {
+            // Make a glyph position entry even if we didn't get an SDF for the glyph. During layout,
+            // an empty optional is treated as "loaded but nothing to show", wheras no entry in the
+            // positions map means "not loaded yet".
             optional<Glyph>& glyph = positions[glyphID];
 
-            auto it = entry.sdfs.find(glyphID);
-            if (it == entry.sdfs.end())
+            auto it = entry.glyphs.find(glyphID);
+            if (it == entry.glyphs.end())
                 continue;
 
-            addGlyph(requestor, fontStack, it->second);
+            it->second.ids.insert(&requestor);
 
-            auto valueIt = entry.glyphValues.find(glyphID);
             glyph = Glyph {
-                valueIt == entry.glyphValues.end() ? Rect<uint16_t>() : valueIt->second.rect,
+                addGlyph(it->second),
                 it->second.metrics
             };
         }
@@ -165,31 +171,21 @@ void GlyphAtlas::addGlyphs(GlyphRequestor& requestor, const GlyphDependencies& g
     requestor.onGlyphsAvailable(glyphPositions);
 }
 
-void GlyphAtlas::addGlyph(GlyphRequestor& requestor,
-                          const FontStack& fontStack,
-                          const SDFGlyph& glyph)
-{
-    std::map<uint32_t, GlyphValue>& face = entries[fontStack].glyphValues;
-    auto it = face.find(glyph.id);
-
+Rect<uint16_t> GlyphAtlas::addGlyph(GlyphValue& value) {
     // The glyph is already in this texture.
-    if (it != face.end()) {
-        GlyphValue& value = it->second;
-        value.ids.insert(&requestor);
-        return;
+    if (value.rect) {
+        return *value.rect;
     }
 
-    // Guard against glyphs that are too large, or that we don't need to place into the atlas since
-    // they don't have any pixels.
-    if (glyph.metrics.width == 0 || glyph.metrics.width >= 256 ||
-        glyph.metrics.height == 0 || glyph.metrics.height >= 256) {
-        return;
+    // We don't need to add glyphs without a bitmap (e.g. whitespace).
+    if (!value.bitmap.valid()) {
+        return {};
     }
 
     // Add a 1px border around every image.
     const uint32_t padding = 1;
-    uint16_t width = glyph.bitmap.size.width + 2 * padding;
-    uint16_t height = glyph.bitmap.size.height + 2 * padding;
+    uint16_t width = value.bitmap.size.width + 2 * padding;
+    uint16_t height = value.bitmap.size.height + 2 * padding;
 
     // Increase to next number divisible by 4, but at least 1.
     // This is so we can scale down the texture coordinates and pack them
@@ -200,23 +196,21 @@ void GlyphAtlas::addGlyph(GlyphRequestor& requestor,
     Rect<uint16_t> rect = bin.allocate(width, height);
     if (rect.w == 0) {
         Log::Error(Event::OpenGL, "glyph bitmap overflow");
-        return;
+        return {};
     }
 
-    face.emplace(glyph.id, GlyphValue { rect, &requestor });
-
-    AlphaImage::copy(glyph.bitmap, image, { 0, 0 }, { rect.x + padding, rect.y + padding }, glyph.bitmap.size);
-
+    AlphaImage::copy(value.bitmap, image, { 0, 0 }, { rect.x + padding, rect.y + padding }, value.bitmap.size);
+    value.rect = rect;
     dirty = true;
+
+    return rect;
 }
 
-void GlyphAtlas::removeGlyphValues(GlyphRequestor& requestor, std::map<uint32_t, GlyphValue>& face) {
-    for (auto it = face.begin(); it != face.end(); /* we advance in the body */) {
+void GlyphAtlas::removeGlyphValues(GlyphRequestor& requestor, std::map<GlyphID, GlyphValue>& values) {
+    for (auto it = values.begin(); it != values.end(); it++) {
         GlyphValue& value = it->second;
-        value.ids.erase(&requestor);
-
-        if (value.ids.empty()) {
-            const Rect<uint16_t>& rect = value.rect;
+        if (value.ids.erase(&requestor) && value.ids.empty() && value.rect) {
+            const Rect<uint16_t>& rect = *value.rect;
 
             // Clear out the bitmap.
             uint8_t *target = image.data.get();
@@ -228,14 +222,7 @@ void GlyphAtlas::removeGlyphValues(GlyphRequestor& requestor, std::map<uint32_t,
             }
 
             bin.release(rect);
-
-            // Make sure to post-increment the iterator: This will return the
-            // current iterator, but will go to the next position before we
-            // erase the element from the map. That way, the iterator stays
-            // valid.
-            face.erase(it++);
-        } else {
-            ++it;
+            value.rect = {};
         }
     }
 }
@@ -248,7 +235,7 @@ void GlyphAtlas::removePendingRanges(mbgl::GlyphRequestor& requestor, std::map<G
 
 void GlyphAtlas::removeGlyphs(GlyphRequestor& requestor) {
     for (auto& entry : entries) {
-        removeGlyphValues(requestor, entry.second.glyphValues);
+        removeGlyphValues(requestor, entry.second.glyphs);
         removePendingRanges(requestor, entry.second.ranges);
     }
 }

--- a/src/mbgl/text/glyph_atlas.hpp
+++ b/src/mbgl/text/glyph_atlas.hpp
@@ -31,7 +31,7 @@ class Context;
 
 class GlyphRequestor {
 public:
-    virtual void onGlyphsAvailable(GlyphPositionMap, GlyphRangeSet) = 0;
+    virtual void onGlyphsAvailable(GlyphPositionMap) = 0;
 };
     
 class GlyphAtlas : public util::noncopyable {

--- a/src/mbgl/text/glyph_atlas.hpp
+++ b/src/mbgl/text/glyph_atlas.hpp
@@ -3,7 +3,6 @@
 #include <mbgl/text/glyph.hpp>
 #include <mbgl/text/glyph_atlas_observer.hpp>
 #include <mbgl/text/glyph_range.hpp>
-#include <mbgl/text/glyph_pbf.hpp>
 #include <mbgl/geometry/binpack.hpp>
 #include <mbgl/util/noncopyable.hpp>
 #include <mbgl/util/optional.hpp>
@@ -71,9 +70,9 @@ private:
     std::string glyphURL;
 
     struct GlyphValue {
-        GlyphValue(Rect<uint16_t> rect_, GlyphRequestor* id)
-            : rect(std::move(rect_)), ids({ id }) {}
-        Rect<uint16_t> rect;
+        AlphaImage bitmap;
+        GlyphMetrics metrics;
+        optional<Rect<uint16_t>> rect;
         std::unordered_set<GlyphRequestor*> ids;
     };
 
@@ -85,8 +84,7 @@ private:
 
     struct Entry {
         std::map<GlyphRange, GlyphRequest> ranges;
-        std::map<uint32_t, SDFGlyph> sdfs;
-        std::map<uint32_t, GlyphValue> glyphValues;
+        std::map<GlyphID, GlyphValue> glyphs;
     };
 
     std::unordered_map<FontStack, Entry, FontStackHash> entries;
@@ -95,9 +93,9 @@ private:
     void processResponse(const Response&, const FontStack&, const GlyphRange&);
 
     void addGlyphs(GlyphRequestor&, const GlyphDependencies&);
-    void addGlyph(GlyphRequestor&, const FontStack&, const SDFGlyph&);
+    Rect<uint16_t> addGlyph(GlyphValue&);
 
-    void removeGlyphValues(GlyphRequestor&, std::map<uint32_t, GlyphValue>&);
+    void removeGlyphValues(GlyphRequestor&, std::map<GlyphID, GlyphValue>&);
     void removePendingRanges(GlyphRequestor&, std::map<GlyphRange, GlyphRequest>&);
 
     GlyphAtlasObserver* observer = nullptr;

--- a/src/mbgl/text/quads.cpp
+++ b/src/mbgl/text/quads.cpp
@@ -303,17 +303,11 @@ SymbolQuads getGlyphQuads(Anchor& anchor,
 
     for (const PositionedGlyph &positionedGlyph: shapedText.positionedGlyphs) {
         auto face_it = face.find(positionedGlyph.glyph);
-        if (face_it == face.end())
-            continue;
-        const Glyph &glyph = face_it->second;
-        const Rect<uint16_t> &rect = glyph.rect;
-
-        if (!glyph)
+        if (face_it == face.end() || !face_it->second || !(*face_it->second).rect.hasArea())
             continue;
 
-        if (!rect.hasArea())
-            continue;
-
+        const Glyph& glyph = *face_it->second;
+        const Rect<uint16_t>& rect = glyph.rect;
         const float centerX = (positionedGlyph.x + glyph.metrics.advance / 2.0f) * boxScale;
 
         GlyphInstances glyphInstances;

--- a/src/mbgl/text/shaping.cpp
+++ b/src/mbgl/text/shaping.cpp
@@ -56,8 +56,8 @@ void justifyLine(std::vector<PositionedGlyph>& positionedGlyphs,
     
     PositionedGlyph& glyph = positionedGlyphs[end];
     auto it = glyphs.find(glyph.glyph);
-    if (it != glyphs.end()) {
-        const uint32_t lastAdvance = it->second.metrics.advance;
+    if (it != glyphs.end() && it->second) {
+        const uint32_t lastAdvance = it->second->metrics.advance;
         const float lineIndent = float(glyph.x + lastAdvance) * justify;
         
         for (std::size_t j = start; j <= end; j++) {
@@ -74,8 +74,8 @@ float determineAverageLineWidth(const std::u16string& logicalInput,
     
     for (char16_t chr : logicalInput) {
         auto it = glyphs.find(chr);
-        if (it != glyphs.end()) {
-            totalWidth += it->second.metrics.advance + spacing;
+        if (it != glyphs.end() && it->second) {
+            totalWidth += it->second->metrics.advance + spacing;
         }
     }
     
@@ -185,8 +185,8 @@ std::set<std::size_t> determineLineBreaks(const std::u16string& logicalInput,
     for (std::size_t i = 0; i < logicalInput.size(); i++) {
         const char16_t codePoint = logicalInput[i];
         auto it = glyphs.find(codePoint);
-        if (it != glyphs.end() && !boost::algorithm::is_any_of(u" \t\n\v\f\r")(codePoint)) {
-            currentX += it->second.metrics.advance + spacing;
+        if (it != glyphs.end() && it->second && !boost::algorithm::is_any_of(u" \t\n\v\f\r")(codePoint)) {
+            currentX += it->second->metrics.advance + spacing;
         }
         
         // Ideographic characters, spaces, and word-breaking punctuation that often appear without
@@ -234,11 +234,11 @@ void shapeLines(Shaping& shaping,
         std::size_t lineStartIndex = shaping.positionedGlyphs.size();
         for (char16_t chr : line) {
             auto it = glyphs.find(chr);
-            if (it == glyphs.end()) {
+            if (it == glyphs.end() || !it->second) {
                 continue;
             }
             
-            const Glyph& glyph = it->second;
+            const Glyph& glyph = *it->second;
             
             if (writingMode == WritingModeType::Horizontal || !util::i18n::hasUprightVerticalOrientation(chr)) {
                 shaping.positionedGlyphs.emplace_back(chr, x, y, 0);

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -133,8 +133,8 @@ void GeometryTile::onError(std::exception_ptr err) {
     observer->onTileError(*this, err);
 }
     
-void GeometryTile::onGlyphsAvailable(GlyphPositionMap glyphPositions, GlyphRangeSet loadedRanges) {
-    worker.invoke(&GeometryTileWorker::onGlyphsAvailable, std::move(glyphPositions), std::move(loadedRanges));
+void GeometryTile::onGlyphsAvailable(GlyphPositionMap glyphPositions) {
+    worker.invoke(&GeometryTileWorker::onGlyphsAvailable, std::move(glyphPositions));
 }
 
 void GeometryTile::getGlyphs(GlyphDependencies glyphDependencies) {

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -40,7 +40,7 @@ public:
     void setPlacementConfig(const PlacementConfig&) override;
     void redoLayout() override;
     
-    void onGlyphsAvailable(GlyphPositionMap, GlyphRangeSet) override;
+    void onGlyphsAvailable(GlyphPositionMap) override;
     void onIconsAvailable(SpriteAtlas*, IconMap) override;
     
     void getGlyphs(GlyphDependencies);

--- a/src/mbgl/tile/geometry_tile_worker.hpp
+++ b/src/mbgl/tile/geometry_tile_worker.hpp
@@ -35,7 +35,7 @@ public:
     void setData(std::unique_ptr<const GeometryTileData>, uint64_t correlationID);
     void setPlacementConfig(PlacementConfig, uint64_t correlationID);
     
-    void onGlyphsAvailable(GlyphPositionMap glyphs, GlyphRangeSet loadedRanges);
+    void onGlyphsAvailable(GlyphPositionMap glyphs);
     void onIconsAvailable(IconAtlasMap icons);
 
 private:


### PR DESCRIPTION
* Replace `GlyphRangeSet` in `onGlyphsAvailable` with optionals in the map. `GlyphRangeSet` isn't keyed by `FontStack`, so using it to indicate that a particular range was loaded could have produced false positives.
* Combine the two `GlyphID`-keyed maps in `GlyphAtlas::Entry` into one.