### PR TITLE
[ios] Don't crash on tap when an AnnotationVIew doesn’t have an annotation

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1542,13 +1542,8 @@ public:
     // of the annotation itself that the view represents
     for (MGLAnnotationView *view in self.annotationContainerView.annotationViews)
     {
-        if (view.centerOffset.dx != 0 || view.centerOffset.dy != 0) {
+        if (view.annotation && (view.centerOffset.dx != 0 || view.centerOffset.dy != 0)) {
             if (CGRectContainsPoint(view.frame, tapPoint)) {
-                if (!view.annotation) {
-                    [NSException raise:NSInvalidArgumentException
-                                format:@"Annotation view's annotation property should not be nil."];
-                }
-                
                 CGPoint annotationPoint = [self convertCoordinate:view.annotation.coordinate toPointToView:self];
                 tapPoint = annotationPoint;
             }


### PR DESCRIPTION
Fixes #8754
MGLAnnotationView.annotation is marked as nullable, and i think there is a good case to be made that custom annotations views should be able to set their annotation to nil when removed from the map, so enforcing non-null here seems like a bug, and one that there is no easy way to workaround because it is throwing an exception in a call to UIGestureRecognizerDelegate.