### PR TITLE
[core] Remove unnecessary Source::Impl::enabled assignment

### DIFF
--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -176,9 +176,7 @@ std::unique_ptr<AnnotationTileData> AnnotationManager::getTileData(const Canonic
 void AnnotationManager::updateStyle(Style& style) {
     // Create annotation source, point layer, and point bucket
     if (!style.getSource(SourceID)) {
-        std::unique_ptr<Source> source = std::make_unique<AnnotationSource>();
-        source->baseImpl->enabled = true;
-        style.addSource(std::move(source));
+        style.addSource(std::make_unique<AnnotationSource>());
 
         std::unique_ptr<SymbolLayer> layer = std::make_unique<SymbolLayer>(PointLayerID, SourceID);
 


### PR DESCRIPTION
This flag will get set automatically by `Style::recalculate`:

* [`Map::Impl::render` sets `Update::Classes` after calling `AnnotationManager::updateStyle`](https://github.com/mapbox/mapbox-gl-native/blob/09a22715769c629ad433b405908b60e1b9fa969b/src/mbgl/map/map.cpp#L238-L238)
* [When `Update::Classes` is set, `Style::recalculate` gets called](https://github.com/mapbox/mapbox-gl-native/blob/09a22715769c629ad433b405908b60e1b9fa969b/src/mbgl/map/map.cpp#L250-L250)
* [`Style::recalculate` resets all `enabled` flags, then re-enables them as needed](https://github.com/mapbox/mapbox-gl-native/blob/5e53d0586fe97db1d49b4b63313c96efb7bf71f8/src/mbgl/style/style.cpp#L312-L316)