### PR TITLE
Synchronize display/context initalisation with surface creation

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 * OfflineRegion are validated if the bounds is found in the world bounds, else onError will be invoked [#8517](https://github.com/mapbox/mapbox-gl-native/pull/8517)
 * Polygon holes [#8557](https://github.com/mapbox/mapbox-gl-native/pull/8557) and [#8722](https://github.com/mapbox/mapbox-gl-native/pull/8722)
 * Custom location source [#8710](https://github.com/mapbox/mapbox-gl-native/pull/8710)
+* Ensure surface is created after display and context [#8759](https://github.com/mapbox/mapbox-gl-native/pull/8759)
 
 ## 5.0.2 - April 3, 2017
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -62,6 +62,7 @@ import java.util.List;
 public class MapView extends FrameLayout {
 
   private NativeMapView nativeMapView;
+  private boolean textureMode;
   private boolean destroyed;
   private boolean hasSurface;
 
@@ -105,12 +106,14 @@ public class MapView extends FrameLayout {
       return;
     }
 
+    // determine render surface
+    textureMode = options.getTextureMode();
+
     // inflate view
     View view = LayoutInflater.from(context).inflate(R.layout.mapbox_mapview_internal, this);
     CompassView compassView = (CompassView) view.findViewById(R.id.compassView);
     MyLocationView myLocationView = (MyLocationView) view.findViewById(R.id.userLocationView);
     ImageView attrView = (ImageView) view.findViewById(R.id.attributionView);
-    initalizeDrawingSurface(context, options);
 
     // add accessibility support
     setContentDescription(context.getString(R.string.mapbox_mapActionDescription));
@@ -167,18 +170,6 @@ public class MapView extends FrameLayout {
     mapboxMap.initialise(context, options);
   }
 
-  private void initalizeDrawingSurface(Context context, MapboxMapOptions options) {
-    if (options.getTextureMode()) {
-      TextureView textureView = new TextureView(context);
-      textureView.setSurfaceTextureListener(new SurfaceTextureListener());
-      addView(textureView, 0);
-    } else {
-      SurfaceView surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
-      surfaceView.getHolder().addCallback(new SurfaceCallback());
-      surfaceView.setVisibility(View.VISIBLE);
-    }
-  }
-
   //
   // Lifecycle events
   //
@@ -202,11 +193,22 @@ public class MapView extends FrameLayout {
       mapboxMap.onRestoreInstanceState(savedInstanceState);
     }
 
-    // Initialize EGL
+    initialiseDrawingSurface(textureMode);
+    addOnMapChangedListener(mapCallback = new MapCallback(mapboxMap));
+  }
+
+  private void initialiseDrawingSurface(boolean textureMode) {
     nativeMapView.initializeDisplay();
     nativeMapView.initializeContext();
-
-    addOnMapChangedListener(mapCallback = new MapCallback(mapboxMap));
+    if (textureMode) {
+      TextureView textureView = new TextureView(getContext());
+      textureView.setSurfaceTextureListener(new SurfaceTextureListener());
+      addView(textureView, 0);
+    } else {
+      SurfaceView surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
+      surfaceView.getHolder().addCallback(new SurfaceCallback());
+      surfaceView.setVisibility(View.VISIBLE);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #7553, this PR hardens the call to `NativeMapView#createSurface` by ensuring it's called after    `NativeMapView#initializeDisplay` & `NativeMapView#InitializeContext`.

