### PR TITLE
Fix outline rendering

### DIFF
--- a/src/mbgl/renderer/painter_fill.cpp
+++ b/src/mbgl/renderer/painter_fill.cpp
@@ -109,7 +109,7 @@ void Painter::renderFill(PaintParameters& parameters,
         };
 
         if (properties.get<FillAntialias>() && !layer.impl->paint.unevaluated.get<FillOutlineColor>().isUndefined() && pass == RenderPass::Translucent) {
-            draw(2,
+            draw(0,
                  parameters.programs.fillOutline,
                  gl::Lines { 2.0f },
                  *bucket.lineIndexBuffer,

--- a/src/mbgl/shaders/fill_outline.cpp
+++ b/src/mbgl/shaders/fill_outline.cpp
@@ -41,7 +41,7 @@ void main() {
     
 
     float dist = length(v_pos - gl_FragCoord.xy);
-    float alpha = smoothstep(1.0, 0.0, dist);
+    float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
     gl_FragColor = outline_color * (alpha * opacity);
 
 #ifdef OVERDRAW_INSPECTOR

--- a/src/mbgl/shaders/fill_outline_pattern.cpp
+++ b/src/mbgl/shaders/fill_outline_pattern.cpp
@@ -68,7 +68,7 @@ void main() {
     // find distance to outline for alpha interpolation
 
     float dist = length(v_pos - gl_FragCoord.xy);
-    float alpha = smoothstep(1.0, 0.0, dist);
+    float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
 
 
     gl_FragColor = mix(color1, color2, u_mix) * alpha * opacity;

--- a/src/mbgl/shaders/preludes.cpp
+++ b/src/mbgl/shaders/preludes.cpp
@@ -48,8 +48,9 @@ vec4 evaluate_zoom_function_4(const vec4 value0, const vec4 value1, const vec4 v
 // packed like so:
 // packedValue = floor(input[0]) * 256 + input[1],
 vec2 unpack_float(const float packedValue) {
-    float v0 = floor(packedValue / 256.0);
-    return vec2(v0, packedValue - v0 * 256.0);
+    int packedIntValue = int(packedValue);
+    int v0 = packedIntValue / 256;
+    return vec2(v0, packedIntValue - v0 * 256);
 }
 
 


### PR DESCRIPTION
@jfirebaugh discovered in https://github.com/mapbox/mapbox-gl-native/issues/8751 that we are using undefined behavior in the `fill_outline` shader: https://github.com/mapbox/mapbox-gl-js/blob/c0dcee76ed5c7d0559bf271ed85692b1b81c654c/src/shaders/fill_outline.fragment.glsl#L11

It seems that some implementations correctly interpolate between 1.0 and 0.0 based on the `t` value, but per the [spec](https://www.khronos.org/registry/OpenGL-Refpages/es3/html/smoothstep.xhtml), it's undefined behavior.

It also fixes outline rendering, which has regressed at some point.

Current behavior when drawing an outline with a color different from the fill color:

![actual](https://cloud.githubusercontent.com/assets/52399/25136048/36a63460-2454-11e7-8ce0-51ebd0ac3e77.png)

New (and correct) behavior:

![expected](https://cloud.githubusercontent.com/assets/52399/25136114/5aa1494a-2454-11e7-89b5-f8775a254a26.png)

We are drawing outlines as antialiased `GL_LINES` around the polygon. When the color is identical to the fill color, we are clipping the outline at the polygon bounds (see first image), but we can't do that when the color is different. Therefore, we either render the fill below or above the line. At some point, this regressed into rendering it always below (and in this case, it's clipped/covered by the fill).