### PR TITLE
move calculation of LatLngBounds to core

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -20,6 +20,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 * Expose source layer identifier [#8709](https://github.com/mapbox/mapbox-gl-native/pull/8709).
 * Ensure surface is created after display and context [#8759](https://github.com/mapbox/mapbox-gl-native/pull/8759)
 * Harden telemetry event dispatch [#8767](https://github.com/mapbox/mapbox-gl-native/pull/8767)
+* Move LatLngBounds calculation for CameraUpdateFactory to core [#8765](https://github.com/mapbox/mapbox-gl-native/pull/8765)
 
 ## 5.0.2 - April 3, 2017
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/camera/CameraPosition.java
@@ -232,24 +232,6 @@ public final class CameraPosition implements Parcelable {
     }
 
     /**
-     * Create Builder from an existing array of doubles.
-     * <p>
-     * These values conform to map.ccp representation of a camera position.
-     * </p>
-     *
-     * @param nativeCameraValues Values containing target, bearing, tilt and zoom
-     */
-    public Builder(double[] nativeCameraValues) {
-      super();
-      if (nativeCameraValues != null && nativeCameraValues.length == 5) {
-        target(new LatLng(nativeCameraValues[0], nativeCameraValues[1]).wrap());
-        bearing(MathUtils.convertNativeBearing(nativeCameraValues[2]));
-        tilt(nativeCameraValues[3]);
-        zoom(nativeCameraValues[4]);
-      }
-    }
-
-    /**
      * Sets the direction that the camera is pointing in, in degrees clockwise from north.
      *
      * @param bearing Bearing

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1521,6 +1521,27 @@ public final class MapboxMap {
     nativeMapView.setLatLngBounds(latLngBounds);
   }
 
+  /**
+   * Gets a camera position that would fit a bounds.
+   *
+   * @param latLngBounds the bounds to constrain the map with
+   */
+  public CameraPosition getCameraForLatLngBounds(@Nullable LatLngBounds latLngBounds, int[] padding) {
+    // calculate and set additional bounds padding
+    int[] mapPadding = getPadding();
+    for (int i = 0; i < padding.length; i++) {
+      padding[i] = mapPadding[i] + padding[i];
+    }
+    projection.setContentPadding(padding, myLocationViewSettings.getPadding());
+
+    // get padded camera position from LatLngBounds
+    CameraPosition cameraPosition = nativeMapView.getCameraForLatLngBounds(latLngBounds);
+
+    // reset map padding
+    setPadding(mapPadding);
+    return cameraPosition;
+  }
+
   //
   // Padding
   //
@@ -1544,7 +1565,11 @@ public final class MapboxMap {
    * @param bottom The bottom margin in pixels.
    */
   public void setPadding(int left, int top, int right, int bottom) {
-    projection.setContentPadding(new int[] {left, top, right, bottom}, myLocationViewSettings.getPadding());
+    setPadding(new int[] {left, top, right, bottom});
+  }
+
+  private void setPadding(int[] padding) {
+    projection.setContentPadding(padding, myLocationViewSettings.getPadding());
     uiSettings.invalidate();
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/NativeMapView.java
@@ -17,6 +17,7 @@ import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.Polygon;
 import com.mapbox.mapboxsdk.annotations.Polyline;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -315,6 +316,13 @@ final class NativeMapView {
     }
     // wrap longitude values coming from core
     return nativeGetLatLng().wrap();
+  }
+
+  public CameraPosition getCameraForLatLngBounds(LatLngBounds latLngBounds) {
+    if (isDestroyedOn("getCameraForLatLngBounds")) {
+      return null;
+    }
+    return nativeGetCameraForLatLngBounds(latLngBounds);
   }
 
   public void resetPosition() {
@@ -676,11 +684,11 @@ final class NativeMapView {
     nativeFlyTo(angle, center.getLatitude(), center.getLongitude(), duration, pitch, zoom);
   }
 
-  public double[] getCameraValues() {
+  public CameraPosition getCameraPosition() {
     if (isDestroyedOn("getCameraValues")) {
-      return new double[] {};
+      return new CameraPosition.Builder().build();
     }
-    return nativeGetCameraValues();
+    return nativeGetCameraPosition();
   }
 
   // Runtime style Api
@@ -970,6 +978,8 @@ final class NativeMapView {
 
   private native LatLng nativeGetLatLng();
 
+  private native CameraPosition nativeGetCameraForLatLngBounds(LatLngBounds latLngBounds);
+
   private native void nativeResetPosition();
 
   private native double nativeGetPitch();
@@ -1054,7 +1064,7 @@ final class NativeMapView {
   private native void nativeFlyTo(double angle, double latitude, double longitude,
                                   long duration, double pitch, double zoom);
 
-  private native double[] nativeGetCameraValues();
+  private native CameraPosition nativeGetCameraPosition();
 
   private native long nativeGetTransitionDuration();
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -135,7 +135,7 @@ final class Transform implements MapView.OnMapChangedListener {
   @Nullable
   CameraPosition invalidateCameraPosition() {
     if (mapView != null) {
-      cameraPosition = new CameraPosition.Builder(mapView.getCameraValues()).build();
+      cameraPosition = mapView.getCameraPosition();
       if (onCameraChangeListener != null) {
         onCameraChangeListener.onCameraChange(this.cameraPosition);
       }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/LatLngBoundsActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/camera/LatLngBoundsActivity.java
@@ -1,9 +1,11 @@
 package com.mapbox.mapboxsdk.testapp.activity.camera;
 
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
+import com.mapbox.mapboxsdk.camera.CameraUpdate;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -11,13 +13,7 @@ import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.maps.UiSettings;
 import com.mapbox.mapboxsdk.testapp.R;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import timber.log.Timber;
 
 /**
  * Test activity showcasing using the LatLngBounds camera API.
@@ -30,6 +26,9 @@ public class LatLngBoundsActivity extends AppCompatActivity implements OnMapRead
 
   private static final LatLng LOS_ANGELES = new LatLng(34.053940, -118.242622);
   private static final LatLng NEW_YORK = new LatLng(40.712730, -74.005953);
+
+  private final LatLng CHINA_BOTTOM_LEFT = new LatLng(15.68169, 73.499857);
+  private final LatLng CHINA_TOP_RIGHT = new LatLng(53.560711, 134.77281);
 
   private MapView mapView;
   private MapboxMap mapboxMap;
@@ -46,41 +45,31 @@ public class LatLngBoundsActivity extends AppCompatActivity implements OnMapRead
   }
 
   @Override
-  public void onMapReady(MapboxMap map) {
+  public void onMapReady(final MapboxMap map) {
     mapboxMap = map;
-    UiSettings uiSettings = mapboxMap.getUiSettings();
-    uiSettings.setAllGesturesEnabled(false);
+    moveToBounds(new LatLngBounds.Builder().include(NEW_YORK).include(LOS_ANGELES).build(), new int[] {0, 0, 0, 0});
+    new Handler().postDelayed(new Runnable() {
+      @Override
+      public void run() {
+        moveToBounds(new LatLngBounds.Builder().include(CHINA_BOTTOM_LEFT).include(CHINA_TOP_RIGHT).build(),
+          new int[] {100, 100, 100, 100 });
+      }
+    }, 5000);
+  }
 
-    mapboxMap.addMarker(new MarkerOptions()
-      .title("Los Angeles")
-      .snippet("City Hall")
-      .position(LOS_ANGELES));
-
-    mapboxMap.addMarker(new MarkerOptions()
-      .title("New York")
-      .snippet("City Hall")
-      .position(NEW_YORK));
-
-    List<LatLng> points = new ArrayList<>();
-    points.add(NEW_YORK);
-    points.add(LOS_ANGELES);
-
-    // Create Bounds
-    final LatLngBounds bounds = new LatLngBounds.Builder()
-      .includes(points)
-      .build();
-
-    // Add map padding
-    int mapPadding = (int) getResources().getDimension(R.dimen.fab_margin);
-    mapboxMap.setPadding(mapPadding, mapPadding, mapPadding, mapPadding);
-
-    // Move camera to the bounds with added padding
-    int padding = (int) getResources().getDimension(R.dimen.coordinatebounds_margin);
-    mapboxMap.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, padding), 1500);
-
-    // Log data
-    Timber.e("Move to bounds: " + bounds.toString());
-    Timber.e("Resulting bounds:" + mapboxMap.getProjection().getVisibleRegion().latLngBounds.toString());
+  private void moveToBounds(LatLngBounds latLngBounds, int[] padding) {
+    mapboxMap.clear();
+    mapboxMap.addMarker(new MarkerOptions().position(latLngBounds.getNorthEast()));
+    mapboxMap.addMarker(new MarkerOptions().position(latLngBounds.getSouthEast()));
+    mapboxMap.addMarker(new MarkerOptions().position(latLngBounds.getSouthWest()));
+    mapboxMap.addMarker(new MarkerOptions().position(latLngBounds.getNorthWest()));
+    CameraUpdate update =
+      CameraUpdateFactory.newLatLngBounds(latLngBounds,
+        padding[0],
+        padding[1],
+        padding[2],
+        padding[3]);
+    mapboxMap.moveCamera(update);
   }
 
   @Override

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/camera/CameraPositionTest.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/test/java/com/mapbox/mapboxsdk/camera/CameraPositionTest.java
@@ -61,22 +61,6 @@ public class CameraPositionTest {
   }
 
   @Test
-  public void testJniBuilder() {
-    double bearing = 180;
-    double zoom = 12;
-    double latitude = 10;
-    double longitude = 11;
-    double tilt = 44;
-
-    double[] cameraVars = new double[]{latitude, longitude, bearing, tilt, zoom};
-    CameraPosition cameraPosition = new CameraPosition.Builder(cameraVars).build();
-    assertEquals("bearing should match", bearing, cameraPosition.bearing, DELTA);
-    assertEquals("latlng should match", new LatLng(latitude, longitude), cameraPosition.target);
-    assertEquals("tilt should match", tilt, cameraPosition.tilt, DELTA);
-    assertEquals("zoom should match", zoom, cameraPosition.zoom, DELTA);
-  }
-
-  @Test
   public void testToString() {
     LatLng latLng = new LatLng(1, 2);
     CameraPosition cameraPosition = new CameraPosition(latLng, 3, 4, 5);

--- a/platform/android/config.cmake
+++ b/platform/android/config.cmake
@@ -110,6 +110,8 @@ add_library(mbgl-android STATIC
     platform/android/src/style/conversion/property_value.hpp
     platform/android/src/style/conversion/types.hpp
     platform/android/src/style/conversion/types_string_values.hpp
+    platform/android/src/map/camera_position.cpp
+    platform/android/src/map/camera_position.hpp
 
     # Style conversion Java -> C++
     platform/android/src/style/android_conversion.hpp

--- a/platform/android/src/jni.cpp
+++ b/platform/android/src/jni.cpp
@@ -159,6 +159,9 @@ void registerNatives(JavaVM *vm) {
     IdentityStops::registerNative(env);
     IntervalStops::registerNative(env);
 
+    // Map
+    CameraPosition::registerNative(env);
+
     // Connectivity
     ConnectivityListener::registerNative(env);
 

--- a/platform/android/src/map/camera_position.cpp
+++ b/platform/android/src/map/camera_position.cpp
@@ -1,0 +1,24 @@
+#include "camera_position.hpp"
+#include "../geometry/lat_lng.hpp"
+
+namespace mbgl {
+namespace android {
+
+jni::Object<CameraPosition> CameraPosition::New(jni::JNIEnv &env, mbgl::CameraOptions options) {
+    static auto constructor = CameraPosition::javaClass.GetConstructor<jni::Object<LatLng>, double, double, double>(env);
+    auto center = options.center.value();
+    center.wrap();
+    return CameraPosition::javaClass.New(env, constructor, LatLng::New(env, center), options.zoom.value_or(0), options.pitch.value_or(0), options.angle.value_or(0));
+}
+
+void CameraPosition::registerNative(jni::JNIEnv &env) {
+    // Lookup the class
+    CameraPosition::javaClass = *jni::Class<CameraPosition>::Find(env).NewGlobalRef(env).release();
+}
+
+jni::Class<CameraPosition> CameraPosition::javaClass;
+
+
+} // namespace android
+} // namespace mb
+

--- a/platform/android/src/map/camera_position.hpp
+++ b/platform/android/src/map/camera_position.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <mbgl/util/noncopyable.hpp>
+#include <mbgl/map/camera.hpp>
+
+#include <jni/jni.hpp>
+
+namespace mbgl {
+namespace android {
+
+class CameraPosition : private mbgl::util::noncopyable {
+public:
+
+    static constexpr auto Name() { return "com/mapbox/mapboxsdk/camera/CameraPosition"; };
+
+    static jni::Object<CameraPosition> New(jni::JNIEnv&, mbgl::CameraOptions);
+
+    static jni::Class<CameraPosition> javaClass;
+
+    static void registerNative(jni::JNIEnv&);
+
+};
+
+
+} // namespace android
+} // namespace mbgl

--- a/platform/android/src/native_map_view.cpp
+++ b/platform/android/src/native_map_view.cpp
@@ -45,6 +45,7 @@
 #include "run_loop_impl.hpp"
 #include "java/util.hpp"
 #include "geometry/lat_lng_bounds.hpp"
+#include "map/camera_position.hpp"
 
 namespace mbgl {
 namespace android {
@@ -449,6 +450,10 @@ void NativeMapView::setLatLng(jni::JNIEnv&, jni::jdouble latitude, jni::jdouble 
     map->setLatLng(mbgl::LatLng(latitude, longitude), insets, mbgl::AnimationOptions{mbgl::Milliseconds(duration)});
 }
 
+jni::Object<CameraPosition> NativeMapView::getCameraForLatLngBounds(jni::JNIEnv& env, jni::Object<LatLngBounds> jBounds) {
+    return CameraPosition::New(env, map->cameraForLatLngBounds(mbgl::android::LatLngBounds::getLatLngBounds(env, jBounds), insets));
+}
+
 void NativeMapView::setReachability(jni::JNIEnv&, jni::jboolean reachable) {
     if (reachable) {
         mbgl::NetworkStatus::Reachable();
@@ -562,21 +567,8 @@ void NativeMapView::enableFps(jni::JNIEnv&, jni::jboolean enable) {
     fpsEnabled = enable;
 }
 
-jni::Array<jni::jdouble> NativeMapView::getCameraValues(jni::JNIEnv& env) {
-    //Create buffer with values
-    jdouble buf[5];
-    mbgl::LatLng latLng = map->getLatLng(insets);
-    buf[0] = latLng.latitude();
-    buf[1] = latLng.longitude();
-    buf[2] = -map->getBearing();
-    buf[3] = map->getPitch();
-    buf[4] = map->getZoom();
-
-    //Convert to Java array
-    auto output = jni::Array<jni::jdouble>::New(env, 5);
-    jni::SetArrayRegion(env, *output, 0, 5, buf);
-
-    return output;
+jni::Object<CameraPosition> NativeMapView::getCameraPosition(jni::JNIEnv& env) {
+    return CameraPosition::New(env, map->getCameraOptions(insets));
 }
 
 void NativeMapView::updateMarker(jni::JNIEnv& env, jni::jlong markerId, jni::jdouble lat, jni::jdouble lon, jni::String jid) {
@@ -1493,6 +1485,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::flyTo, "nativeFlyTo"),
             METHOD(&NativeMapView::getLatLng, "nativeGetLatLng"),
             METHOD(&NativeMapView::setLatLng, "nativeSetLatLng"),
+            METHOD(&NativeMapView::getCameraForLatLngBounds, "nativeGetCameraForLatLngBounds"),
             METHOD(&NativeMapView::setReachability, "nativeSetReachability"),
             METHOD(&NativeMapView::resetPosition, "nativeResetPosition"),
             METHOD(&NativeMapView::getPitch, "nativeGetPitch"),
@@ -1513,7 +1506,7 @@ void NativeMapView::registerNative(jni::JNIEnv& env) {
             METHOD(&NativeMapView::setContentPadding, "nativeSetContentPadding"),
             METHOD(&NativeMapView::scheduleSnapshot, "nativeTakeSnapshot"),
             METHOD(&NativeMapView::enableFps, "nativeSetEnableFps"),
-            METHOD(&NativeMapView::getCameraValues, "nativeGetCameraValues"),
+            METHOD(&NativeMapView::getCameraPosition, "nativeGetCameraPosition"),
             METHOD(&NativeMapView::updateMarker, "nativeUpdateMarker"),
             METHOD(&NativeMapView::addMarkers, "nativeAddMarkers"),
             METHOD(&NativeMapView::setDebug, "nativeSetDebug"),

--- a/platform/android/src/native_map_view.hpp
+++ b/platform/android/src/native_map_view.hpp
@@ -23,6 +23,7 @@
 #include "style/layers/layers.hpp"
 #include "style/sources/sources.hpp"
 #include "geometry/lat_lng_bounds.hpp"
+#include "map/camera_position.hpp"
 
 #include <exception>
 #include <string>
@@ -129,6 +130,8 @@ public:
 
     void setLatLng(jni::JNIEnv&, jni::jdouble, jni::jdouble, jni::jlong);
 
+    jni::Object<CameraPosition> getCameraForLatLngBounds(jni::JNIEnv&, jni::Object<mbgl::android::LatLngBounds>);
+
     void setReachability(jni::JNIEnv&, jni::jboolean);
 
     void resetPosition(jni::JNIEnv&);
@@ -169,7 +172,7 @@ public:
 
     void enableFps(jni::JNIEnv&, jni::jboolean enable);
 
-    jni::Array<jni::jdouble> getCameraValues(jni::JNIEnv&);
+    jni::Object<CameraPosition> getCameraPosition(jni::JNIEnv&);
 
     void updateMarker(jni::JNIEnv&, jni::jlong, jni::jdouble, jni::jdouble, jni::String);
 


### PR DESCRIPTION
closes https://github.com/mapbox/mapbox-gl-native/issues/4796

This PR moves calculating LatLngBounds to core instead of doing it in java. To achieve this I had to expose a `public CameraPosition getCameraForLatLngbounds(LatLngBounds bounds)` on MapboxMap (afaik the only way to make it work with our current `CameraUpdateFactory` setup).

This PR also refactors returning a CameraPosition directly from core instead of an double array. (this refactors the code for `getCameraValues` into `getCameraPosition`.

![ezgif com-video-to-gif 38](https://cloud.githubusercontent.com/assets/2151639/25233360/de177a84-25de-11e7-9d0d-97991f4193fd.gif)

#### TODO:
 - [x] instead or returning double[] containing the camera values (cfr. `NativeMapView#getCameraValues`), it would be cleaner to return an actual CameraPosition object (this refactor needs to happpen for both getCameraForLatLngBounds as for getCameraPosition).
 - [x] cleanup code related to CameraOptions (currently unused and I would prefer going with CameraPosition class instead for consistency). 
 - [x] fix missing padding used by the public API / ticket separately


