### PR TITLE
Harden telemetry event dispatch

### DIFF
--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -18,6 +18,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 * Polygon holes [#8557](https://github.com/mapbox/mapbox-gl-native/pull/8557) and [#8722](https://github.com/mapbox/mapbox-gl-native/pull/8722)
 * Custom location source [#8710](https://github.com/mapbox/mapbox-gl-native/pull/8710)
 * Ensure surface is created after display and context [#8759](https://github.com/mapbox/mapbox-gl-native/pull/8759)
+* Harden telemetry event dispatch [#8767](https://github.com/mapbox/mapbox-gl-native/pull/8767)
 
 ## 5.0.2 - April 3, 2017
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapGestureDetector.java
@@ -153,9 +153,9 @@ final class MapGestureDetector {
           && uiSettings.isZoomGesturesEnabled();
         if (twoTap) {
           // Confirmed 2nd Finger Down
-          MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapClickEvent(
+          MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapClickEvent(
             getLocationFromGesture(event.getX(), event.getY()),
-            MapboxEvent.GESTURE_TWO_FINGER_SINGLETAP, transform.getZoom()));
+            MapboxEvent.GESTURE_TWO_FINGER_SINGLETAP, transform));
         }
         break;
 
@@ -184,8 +184,8 @@ final class MapGestureDetector {
 
         // Scroll / Pan Has Stopped
         if (scrollInProgress) {
-          MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapDragEndEvent(
-            getLocationFromGesture(event.getX(), event.getY()), transform.getZoom()));
+          MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapDragEndEvent(
+            getLocationFromGesture(event.getX(), event.getY()), transform));
           scrollInProgress = false;
         }
 
@@ -284,9 +284,9 @@ final class MapGestureDetector {
           break;
       }
 
-      MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapClickEvent(
+      MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapClickEvent(
         getLocationFromGesture(e.getX(), e.getY()),
-        MapboxEvent.GESTURE_DOUBLETAP, transform.getZoom()));
+        MapboxEvent.GESTURE_DOUBLETAP, transform));
 
       return true;
     }
@@ -315,9 +315,9 @@ final class MapGestureDetector {
         }
       }
 
-      MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapClickEvent(
+      MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapClickEvent(
         getLocationFromGesture(motionEvent.getX(), motionEvent.getY()),
-        MapboxEvent.GESTURE_SINGLETAP, transform.getZoom()));
+        MapboxEvent.GESTURE_SINGLETAP, transform));
 
       return true;
     }
@@ -377,9 +377,9 @@ final class MapGestureDetector {
     public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
       if (!scrollInProgress) {
         scrollInProgress = true;
-        MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapClickEvent(
+        MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapClickEvent(
           getLocationFromGesture(e1.getX(), e1.getY()),
-          MapboxEvent.GESTURE_PAN_START, transform.getZoom()));
+          MapboxEvent.GESTURE_PAN_START, transform));
       }
       if (!trackingSettings.isScrollGestureCurrentlyEnabled()) {
         return false;
@@ -421,9 +421,9 @@ final class MapGestureDetector {
 
       scaleGestureOccurred = true;
       beginTime = detector.getEventTime();
-      MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapClickEvent(
+      MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapClickEvent(
         getLocationFromGesture(detector.getFocusX(), detector.getFocusY()),
-        MapboxEvent.GESTURE_PINCH_START, transform.getZoom()));
+        MapboxEvent.GESTURE_PINCH_START, transform));
       return true;
     }
 
@@ -513,9 +513,9 @@ final class MapGestureDetector {
       }
 
       beginTime = detector.getEventTime();
-      MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapClickEvent(
+      MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapClickEvent(
         getLocationFromGesture(detector.getFocusX(), detector.getFocusY()),
-        MapboxEvent.GESTURE_ROTATION_START, transform.getZoom()));
+        MapboxEvent.GESTURE_ROTATION_START, transform));
       return true;
     }
 
@@ -594,9 +594,9 @@ final class MapGestureDetector {
       }
 
       beginTime = detector.getEventTime();
-      MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapClickEvent(
+      MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapClickEvent(
         getLocationFromGesture(detector.getFocusX(), detector.getFocusY()),
-        MapboxEvent.GESTURE_PITCH_START, transform.getZoom()));
+        MapboxEvent.GESTURE_PITCH_START, transform));
       return true;
     }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapView.java
@@ -36,7 +36,6 @@ import com.mapbox.mapboxsdk.maps.widgets.CompassView;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationView;
 import com.mapbox.mapboxsdk.maps.widgets.MyLocationViewSettings;
 import com.mapbox.mapboxsdk.net.ConnectivityReceiver;
-import com.mapbox.services.android.telemetry.MapboxEvent;
 import com.mapbox.services.android.telemetry.MapboxTelemetry;
 
 import java.lang.annotation.Retention;
@@ -188,7 +187,7 @@ public class MapView extends FrameLayout {
   @UiThread
   public void onCreate(@Nullable Bundle savedInstanceState) {
     if (savedInstanceState == null) {
-      MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapLoadEvent());
+      MapboxTelemetry.getInstance().pushEvent(MapboxEventWrapper.buildMapLoadEvent());
     } else if (savedInstanceState.getBoolean(MapboxConstants.STATE_HAS_SAVED_STATE)) {
       mapboxMap.onRestoreInstanceState(savedInstanceState);
     }

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxEventWrapper.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxEventWrapper.java
@@ -1,0 +1,48 @@
+package com.mapbox.mapboxsdk.maps;
+
+import android.location.Location;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.mapbox.services.android.telemetry.MapboxEvent;
+
+import java.util.Hashtable;
+
+/**
+ * Wrapper class for MapboxEvent
+ * <p>
+ * Provides facility methods to use Transform and handle the case that the zoom, required for a telemetry event,
+ * isn't available yet.
+ * </p>
+ */
+class MapboxEventWrapper {
+
+  @Nullable
+  static Hashtable<String, Object> buildMapClickEvent(
+    @NonNull Location location, @NonNull String gestureId, Transform transform) {
+    try {
+      return MapboxEvent.buildMapClickEvent(location, gestureId, transform.getZoom());
+    } catch (NullPointerException exception) {
+      // Map/Transform is not ready yet #8650
+      // returning null is valid, event is ignored.
+      return null;
+    }
+  }
+
+  @Nullable
+  static Hashtable<String, Object> buildMapDragEndEvent(
+    @NonNull Location location, Transform transform) {
+    try {
+      return MapboxEvent.buildMapDragEndEvent(location, transform.getZoom());
+    } catch (NullPointerException exception) {
+      // Map/Transform is not ready yet #8650
+      // returning null is valid, event is ignored.
+      return null;
+    }
+  }
+
+  @Nullable
+  static Hashtable<String, Object> buildMapLoadEvent() {
+    return MapboxEvent.buildMapLoadEvent();
+  }
+}

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -168,6 +168,9 @@ final class Transform implements MapView.OnMapChangedListener {
   // Zoom in or out
 
   double getZoom() {
+    if (cameraPosition == null) {
+      invalidateCameraPosition();
+    }
     return cameraPosition.zoom;
   }
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/Transform.java
@@ -168,9 +168,6 @@ final class Transform implements MapView.OnMapChangedListener {
   // Zoom in or out
 
   double getZoom() {
-    if (cameraPosition == null) {
-      invalidateCameraPosition();
-    }
     return cameraPosition.zoom;
   }
 


### PR DESCRIPTION
Closes #8650, this PR introduces a wrapper implementation of MapboxEvent. This is needed to ignore events when the Map isn't ready to handle them (when we don't have a camera position to get the zoom level from). A use-case where this can occur is running monkeyrunner, note that I haven't been able to reproduce with normal behavior. 