### PR TITLE
Render parent raster tiles when tiles can't be loaded

### DIFF
--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -17,6 +17,8 @@ module.exports = function (style, options, callback) {
             request(req.url, {encoding: null}, function (err, response, body) {
                 if (err) {
                     callback(err);
+                } else if (response.statusCode == 404) {
+                    callback();
                 } else if (response.statusCode != 200) {
                     callback(new Error(response.statusMessage));
                 } else {

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -28,6 +28,8 @@ void RasterTile::cancel() {
 }
 
 void RasterTile::setError(std::exception_ptr err) {
+    loaded = true;
+    renderable = false;
     observer->onTileError(*this, err);
 }
 
@@ -41,13 +43,15 @@ void RasterTile::setData(std::shared_ptr<const std::string> data,
 
 void RasterTile::onParsed(std::unique_ptr<Bucket> result) {
     bucket = std::move(result);
-    availableData = bucket ? DataAvailability::All : DataAvailability::None;
+    loaded = true;
+    renderable = bucket ? true : false;
     observer->onTileChanged(*this);
 }
 
 void RasterTile::onError(std::exception_ptr err) {
     bucket.reset();
-    availableData = DataAvailability::None;
+    loaded = true;
+    renderable = false;
     observer->onTileError(*this, err);
 }
 

--- a/src/mbgl/tile/tile.hpp
+++ b/src/mbgl/tile/tile.hpp
@@ -74,11 +74,23 @@ public:
     // partial state is still waiting for network resources but can also
     // be rendered, although layers will be missing.
     bool isRenderable() const {
-        return availableData != DataAvailability::None;
+        return renderable;
     }
 
+    // A tile is "Loaded" when we have received a response from a FileSource, and have attempted to
+    // parse the tile (if applicable). Tile implementations should set this to true when a load
+    // error occurred, or after the tile was parsed successfully.
+    bool isLoaded() const {
+        return loaded;
+    }
+
+    // "Completion" of a tile means that we have attempted to load it, and parsed it completely,
+    // i.e. no parsing or placement operations are pending for that tile.
+    // Completeness doesn't mean that the tile can be rendered, but merely that we have exhausted
+    // all options to get this tile to a renderable state. Some tiles may not be renderable, but
+    // complete, e.g. when a raster tile couldn't be loaded, or parsing failed.
     bool isComplete() const {
-        return availableData == DataAvailability::All;
+        return loaded && !pending;
     }
 
     void dumpDebugLogs() const;
@@ -92,21 +104,9 @@ public:
 
 protected:
     bool triedOptional = false;
-
-    enum class DataAvailability : uint8_t {
-        // Still waiting for data to load or parse.
-        None,
-
-        // Tile is partially parsed, some buckets are still waiting for dependencies
-        // to arrive, but it is good for rendering. Partial tiles can also be re-parsed,
-        // but might remain in the same state if dependencies are still missing.
-        Some,
-
-        // Tile is fully parsed, and all buckets are available if they exist.
-        All,
-    };
-
-    DataAvailability availableData = DataAvailability::None;
+    bool renderable = false;
+    bool pending = false;
+    bool loaded = false;
 
     TileObserver* observer = nullptr;
 };

--- a/test/algorithm/mock.hpp
+++ b/test/algorithm/mock.hpp
@@ -34,8 +34,13 @@ struct MockTileData {
         return renderable;
     }
 
+    bool isLoaded() const {
+        return loaded;
+    }
+
     bool renderable = false;
     bool triedOptional = false;
+    bool loaded = false;
     const mbgl::OverscaledTileID tileID;
 };
 

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -40,6 +40,8 @@ TEST(RasterTile, setError) {
     RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
     tile.setError(std::make_exception_ptr(std::runtime_error("test")));
     EXPECT_FALSE(tile.isRenderable());
+    EXPECT_TRUE(tile.isLoaded());
+    EXPECT_TRUE(tile.isComplete());
 }
 
 TEST(RasterTile, onError) {
@@ -47,6 +49,8 @@ TEST(RasterTile, onError) {
     RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
     tile.onError(std::make_exception_ptr(std::runtime_error("test")));
     EXPECT_FALSE(tile.isRenderable());
+    EXPECT_TRUE(tile.isLoaded());
+    EXPECT_TRUE(tile.isComplete());
 }
 
 TEST(RasterTile, onParsed) {
@@ -54,6 +58,8 @@ TEST(RasterTile, onParsed) {
     RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
     tile.onParsed(std::make_unique<RasterBucket>(UnassociatedImage{}));
     EXPECT_TRUE(tile.isRenderable());
+    EXPECT_TRUE(tile.isLoaded());
+    EXPECT_TRUE(tile.isComplete());
 }
 
 TEST(RasterTile, onParsedEmpty) {
@@ -61,4 +67,6 @@ TEST(RasterTile, onParsedEmpty) {
     RasterTile tile(OverscaledTileID(0, 0, 0), test.updateParameters, test.tileset);
     tile.onParsed(nullptr);
     EXPECT_FALSE(tile.isRenderable());
+    EXPECT_TRUE(tile.isLoaded());
+    EXPECT_TRUE(tile.isComplete());
 }

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -46,13 +46,17 @@ TEST(VectorTile, setError) {
     VectorTile tile(OverscaledTileID(0, 0, 0), "source", test.updateParameters, test.tileset);
     tile.setError(std::make_exception_ptr(std::runtime_error("test")));
     EXPECT_FALSE(tile.isRenderable());
+    EXPECT_TRUE(tile.isLoaded());
+    EXPECT_TRUE(tile.isComplete());
 }
 
 TEST(VectorTile, onError) {
     VectorTileTest test;
     VectorTile tile(OverscaledTileID(0, 0, 0), "source", test.updateParameters, test.tileset);
     tile.onError(std::make_exception_ptr(std::runtime_error("test")));
-    EXPECT_TRUE(tile.isRenderable());
+    EXPECT_FALSE(tile.isRenderable());
+    EXPECT_TRUE(tile.isLoaded());
+    EXPECT_TRUE(tile.isComplete());
 }
 
 TEST(VectorTile, Issue7615) {


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-gl-native/pull/8164, we implemented raster tile overzooming. However, this fails in non-continuous rendering modes ("Still image rendering").

I believe this is a combination of two bugs, one of them in the node bindings, the other in `updateRenderables`:

- Node `FileSource` doesn't support optional, so the code path for loading parent tiles is never triggered, and all tiles we attempt to load are not in `complete` state,
- Still image rendering relies on tiles being marked as `complete`, but that never happens when a tile can't be loaded. This isn't an issue for continuous rendering because we just render what we have, but it's a termination condition for Still image rendering.

JS test is in https://github.com/mapbox/mapbox-gl-js/pull/4612

/cc @tmpsantos @bsudekum 