### PR TITLE
Move Sprite parsing to thread pool

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -221,6 +221,8 @@ set(MBGL_CORE_FILES
     src/mbgl/sprite/sprite_atlas.cpp
     src/mbgl/sprite/sprite_atlas.hpp
     src/mbgl/sprite/sprite_atlas_observer.hpp
+    src/mbgl/sprite/sprite_atlas_worker.cpp
+    src/mbgl/sprite/sprite_atlas_worker.hpp
     src/mbgl/sprite/sprite_image.cpp
     src/mbgl/sprite/sprite_parser.cpp
     src/mbgl/sprite/sprite_parser.hpp

--- a/src/mbgl/annotation/annotation_manager.cpp
+++ b/src/mbgl/annotation/annotation_manager.cpp
@@ -21,19 +21,9 @@ const std::string AnnotationManager::PointLayerID = "com.mapbox.annotations.poin
 
 AnnotationManager::AnnotationManager(float pixelRatio)
     : spriteAtlas({ 1024, 1024 }, pixelRatio) {
-
-    struct NullFileSource : public FileSource {
-        std::unique_ptr<AsyncRequest> request(const Resource&, Callback) override {
-            assert(false);
-            return nullptr;
-        }
-    };
-
-    NullFileSource nullFileSource;
-
-    // This is a special atlas, holding only images added via addIcon. But we need its isLoaded()
-    // method to return true.
-    spriteAtlas.load("", nullFileSource);
+    // This is a special atlas, holding only images added via addIcon, so we always treat it as
+    // loaded.
+    spriteAtlas.markAsLoaded();
 }
 
 AnnotationManager::~AnnotationManager() = default;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -359,7 +359,7 @@ void Map::setStyleURL(const std::string& url) {
     impl->styleJSON.clear();
     impl->styleMutated = false;
 
-    impl->style = std::make_unique<Style>(impl->fileSource, impl->pixelRatio);
+    impl->style = std::make_unique<Style>(impl->scheduler, impl->fileSource, impl->pixelRatio);
 
     impl->styleRequest = impl->fileSource.request(Resource::style(impl->styleURL), [this](Response res) {
         // Once we get a fresh style, or the style is mutated, stop revalidating.
@@ -405,7 +405,7 @@ void Map::setStyleJSON(const std::string& json) {
     impl->styleJSON.clear();
     impl->styleMutated = false;
 
-    impl->style = std::make_unique<Style>(impl->fileSource, impl->pixelRatio);
+    impl->style = std::make_unique<Style>(impl->scheduler, impl->fileSource, impl->pixelRatio);
 
     impl->loadStyleJSON(json);
 }

--- a/src/mbgl/sprite/sprite_atlas.cpp
+++ b/src/mbgl/sprite/sprite_atlas.cpp
@@ -1,4 +1,5 @@
 #include <mbgl/sprite/sprite_atlas.hpp>
+#include <mbgl/sprite/sprite_atlas_worker.hpp>
 #include <mbgl/sprite/sprite_atlas_observer.hpp>
 #include <mbgl/sprite/sprite_parser.hpp>
 #include <mbgl/gl/context.hpp>
@@ -11,6 +12,8 @@
 #include <mbgl/storage/file_source.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
+#include <mbgl/util/run_loop.hpp>
+#include <mbgl/actor/actor.hpp>
 
 #include <cassert>
 #include <cmath>
@@ -21,10 +24,17 @@ namespace mbgl {
 static SpriteAtlasObserver nullObserver;
 
 struct SpriteAtlas::Loader {
+    Loader(Scheduler& scheduler, SpriteAtlas& spriteAtlas)
+        : mailbox(std::make_shared<Mailbox>(*util::RunLoop::Get())),
+          worker(scheduler, ActorRef<SpriteAtlas>(spriteAtlas, mailbox)) {
+    }
+
     std::shared_ptr<const std::string> image;
     std::shared_ptr<const std::string> json;
     std::unique_ptr<AsyncRequest> jsonRequest;
     std::unique_ptr<AsyncRequest> spriteRequest;
+    std::shared_ptr<Mailbox> mailbox;
+    Actor<SpriteAtlasWorker> worker;
 };
 
 SpriteAtlasElement::SpriteAtlasElement(Rect<uint16_t> rect_,
@@ -56,14 +66,14 @@ SpriteAtlas::SpriteAtlas(Size size_, float pixelRatio_)
 
 SpriteAtlas::~SpriteAtlas() = default;
 
-void SpriteAtlas::load(const std::string& url, FileSource& fileSource) {
+void SpriteAtlas::load(const std::string& url, Scheduler& scheduler, FileSource& fileSource) {
     if (url.empty()) {
         // Treat a non-existent sprite as a successfully loaded empty sprite.
-        loaded = true;
+        markAsLoaded();
         return;
     }
 
-    loader = std::make_unique<Loader>();
+    loader = std::make_unique<Loader>(scheduler, *this);
 
     loader->jsonRequest = fileSource.request(Resource::spriteJSON(url, pixelRatio), [this](Response res) {
         if (res.error) {
@@ -102,18 +112,22 @@ void SpriteAtlas::emitSpriteLoadedIfComplete() {
         return;
     }
 
-    auto result = parseSprite(*loader->image, *loader->json);
-    if (result.is<Sprites>()) {
-        loaded = true;
-        setSprites(result.get<Sprites>());
-        observer->onSpriteLoaded();
-        for (auto requestor : requestors) {
-            requestor->onIconsAvailable(this, buildIconMap());
-        }
-        requestors.clear();
-    } else {
-        observer->onSpriteError(result.get<std::exception_ptr>());
+    loader->worker.invoke(&SpriteAtlasWorker::parse, loader->image, loader->json);
+    // TODO: delete the loader?
+}
+
+void SpriteAtlas::onParsed(Sprites&& result) {
+    markAsLoaded();
+    setSprites(result);
+    observer->onSpriteLoaded();
+    for (auto requestor : requestors) {
+        requestor->onIconsAvailable(this, buildIconMap());
     }
+    requestors.clear();
+}
+
+void SpriteAtlas::onError(std::exception_ptr err) {
+    observer->onSpriteError(err);
 }
 
 void SpriteAtlas::setObserver(SpriteAtlasObserver* observer_) {

--- a/src/mbgl/sprite/sprite_atlas.hpp
+++ b/src/mbgl/sprite/sprite_atlas.hpp
@@ -15,6 +15,7 @@
 
 namespace mbgl {
 
+class Scheduler;
 class FileSource;
 class SpriteAtlasObserver;
 
@@ -56,7 +57,11 @@ public:
     SpriteAtlas(Size, float pixelRatio);
     ~SpriteAtlas();
 
-    void load(const std::string& url, FileSource&);
+    void load(const std::string& url, Scheduler&, FileSource&);
+
+    void markAsLoaded() {
+        loaded = true;
+    }
 
     bool isLoaded() const {
         return loaded;
@@ -97,6 +102,10 @@ private:
     void _setSprite(const std::string&, const std::shared_ptr<const SpriteImage>& = nullptr);
     void emitSpriteLoadedIfComplete();
 
+    // Invoked by SpriteAtlasWorker
+    friend class SpriteAtlasWorker;
+    void onParsed(Sprites&& result);
+    void onError(std::exception_ptr);
 
     const Size size;
     const float pixelRatio;

--- a/src/mbgl/sprite/sprite_atlas_worker.cpp
+++ b/src/mbgl/sprite/sprite_atlas_worker.cpp
@@ -1,0 +1,29 @@
+#include <mbgl/sprite/sprite_atlas_worker.hpp>
+#include <mbgl/sprite/sprite_atlas.hpp>
+#include <mbgl/sprite/sprite_parser.hpp>
+
+namespace mbgl {
+
+SpriteAtlasWorker::SpriteAtlasWorker(ActorRef<SpriteAtlasWorker>, ActorRef<SpriteAtlas> parent_)
+    : parent(std::move(parent_)) {
+}
+
+void SpriteAtlasWorker::parse(std::shared_ptr<const std::string> image,
+                              std::shared_ptr<const std::string> json) {
+    try {
+        if (!image) {
+            // This shouldn't happen, since we always invoke it with a non-empty pointer.
+            throw std::runtime_error("missing sprite image");
+        }
+        if (!json) {
+            // This shouldn't happen, since we always invoke it with a non-empty pointer.
+            throw std::runtime_error("missing sprite metadata");
+        }
+
+        parent.invoke(&SpriteAtlas::onParsed, parseSprite(*image, *json));
+    } catch (...) {
+        parent.invoke(&SpriteAtlas::onError, std::current_exception());
+    }
+}
+
+} // namespace mbgl

--- a/src/mbgl/sprite/sprite_atlas_worker.hpp
+++ b/src/mbgl/sprite/sprite_atlas_worker.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <mbgl/actor/actor_ref.hpp>
+#include <mbgl/sprite/sprite_parser.hpp>
+
+#include <memory>
+#include <string>
+
+namespace mbgl {
+
+class SpriteAtlas;
+
+class SpriteAtlasWorker {
+public:
+    SpriteAtlasWorker(ActorRef<SpriteAtlasWorker>, ActorRef<SpriteAtlas>);
+
+    void parse(std::shared_ptr<const std::string> image, std::shared_ptr<const std::string> json);
+
+private:
+    ActorRef<SpriteAtlas> parent;
+};
+
+} // namespace mbgl

--- a/src/mbgl/sprite/sprite_parser.cpp
+++ b/src/mbgl/sprite/sprite_parser.cpp
@@ -84,26 +84,19 @@ bool getBoolean(const JSValue& value, const char* name, const bool def = false) 
 
 } // namespace
 
-SpriteParseResult parseSprite(const std::string& image, const std::string& json) {
-    Sprites sprites;
-    PremultipliedImage raster;
-
-    try {
-        raster = decodeImage(image);
-    } catch (...) {
-        return std::current_exception();
-    }
+Sprites parseSprite(const std::string& image, const std::string& json) {
+    const PremultipliedImage raster = decodeImage(image);
 
     JSDocument doc;
     doc.Parse<0>(json.c_str());
-
     if (doc.HasParseError()) {
         std::stringstream message;
         message << "Failed to parse JSON: " << rapidjson::GetParseError_En(doc.GetParseError()) << " at offset " << doc.GetErrorOffset();
-        return std::make_exception_ptr(std::runtime_error(message.str()));
+        throw std::runtime_error(message.str());
     } else if (!doc.IsObject()) {
-        return std::make_exception_ptr(std::runtime_error("Sprite JSON root must be an object"));
+        throw std::runtime_error("Sprite JSON root must be an object");
     } else {
+        Sprites sprites;
         for (const auto& property : doc.GetObject()) {
             const std::string name = { property.name.GetString(), property.name.GetStringLength() };
             const JSValue& value = property.value;
@@ -122,9 +115,8 @@ SpriteParseResult parseSprite(const std::string& image, const std::string& json)
                 }
             }
         }
+        return sprites;
     }
-
-    return sprites;
 }
 
 } // namespace mbgl

--- a/src/mbgl/sprite/sprite_parser.hpp
+++ b/src/mbgl/sprite/sprite_parser.hpp
@@ -26,12 +26,7 @@ SpriteImagePtr createSpriteImage(const PremultipliedImage&,
 
 using Sprites = std::map<std::string, SpriteImagePtr>;
 
-
-using SpriteParseResult = variant<
-    Sprites,             // success
-    std::exception_ptr>; // error
-
 // Parses an image and an associated JSON file and returns the sprite objects.
-SpriteParseResult parseSprite(const std::string& image, const std::string& json);
+Sprites parseSprite(const std::string& image, const std::string& json);
 
 } // namespace mbgl

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -40,8 +40,9 @@ namespace style {
 
 static Observer nullObserver;
 
-Style::Style(FileSource& fileSource_, float pixelRatio)
-    : fileSource(fileSource_),
+Style::Style(Scheduler& scheduler_, FileSource& fileSource_, float pixelRatio)
+    : scheduler(scheduler_),
+      fileSource(fileSource_),
       glyphAtlas(std::make_unique<GlyphAtlas>(Size{ 2048, 2048 }, fileSource)),
       spriteAtlas(std::make_unique<SpriteAtlas>(Size{ 1024, 1024 }, pixelRatio)),
       lineAtlas(std::make_unique<LineAtlas>(Size{ 256, 512 })),
@@ -133,7 +134,7 @@ void Style::setJSON(const std::string& json) {
     defaultPitch = parser.pitch;
 
     glyphAtlas->setURL(parser.glyphURL);
-    spriteAtlas->load(parser.spriteURL, fileSource);
+    spriteAtlas->load(parser.spriteURL, scheduler, fileSource);
 
     loaded = true;
 

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -30,6 +30,7 @@ class LineAtlas;
 class RenderData;
 class TransformState;
 class RenderedQueryOptions;
+class Scheduler;
 
 namespace style {
 
@@ -43,7 +44,7 @@ class Style : public GlyphAtlasObserver,
               public LayerObserver,
               public util::noncopyable {
 public:
-    Style(FileSource&, float pixelRatio);
+    Style(Scheduler&, FileSource&, float pixelRatio);
     ~Style() override;
 
     void setJSON(const std::string&);
@@ -106,6 +107,7 @@ public:
 
     void dumpDebugLogs() const;
 
+    Scheduler& scheduler;
     FileSource& fileSource;
     std::unique_ptr<GlyphAtlas> glyphAtlas;
     std::unique_ptr<SpriteAtlas> spriteAtlas;

--- a/test/sprite/sprite_atlas.test.cpp
+++ b/test/sprite/sprite_atlas.test.cpp
@@ -9,6 +9,7 @@
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/image.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/util/string.hpp>
 
 #include <utility>
@@ -22,7 +23,7 @@ TEST(SpriteAtlas, Basic) {
                                          util::read_file("test/fixtures/annotations/emerald.json"));
 
     SpriteAtlas atlas({ 63, 112 }, 1);
-    atlas.setSprites(spriteParseResult.get<Sprites>());
+    atlas.setSprites(spriteParseResult);
 
     EXPECT_EQ(1.0f, atlas.getPixelRatio());
     EXPECT_EQ(63u, atlas.getSize().width);
@@ -77,7 +78,7 @@ TEST(SpriteAtlas, Size) {
                                          util::read_file("test/fixtures/annotations/emerald.json"));
 
     SpriteAtlas atlas({ 63, 112 }, 1.4);
-    atlas.setSprites(spriteParseResult.get<Sprites>());
+    atlas.setSprites(spriteParseResult);
 
     EXPECT_DOUBLE_EQ(1.4f, atlas.getPixelRatio());
     EXPECT_EQ(63u, atlas.getSize().width);
@@ -270,6 +271,7 @@ public:
     util::RunLoop loop;
     StubFileSource fileSource;
     StubStyleObserver observer;
+    ThreadPool threadPool { 1 };
     SpriteAtlas spriteAtlas{ { 32, 32 }, 1 };
 
     void run() {
@@ -277,7 +279,7 @@ public:
         Log::setObserver(std::make_unique<Log::NullObserver>());
 
         spriteAtlas.setObserver(&observer);
-        spriteAtlas.load("test/fixtures/resources/sprite", fileSource);
+        spriteAtlas.load("test/fixtures/resources/sprite", threadPool, fileSource);
 
         loop.run();
     }

--- a/test/sprite/sprite_parser.test.cpp
+++ b/test/sprite/sprite_parser.test.cpp
@@ -198,7 +198,7 @@ TEST(Sprite, SpriteParsing) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = util::read_file("test/fixtures/annotations/emerald.json");
 
-    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
+    const auto images = parseSprite(image_1x, json_1x);
 
     std::set<std::string> names;
     std::transform(images.begin(), images.end(), std::inserter(names, names.begin()),
@@ -294,10 +294,14 @@ TEST(Sprite, SpriteParsingInvalidJSON) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": " })JSON";
 
-    const auto error = parseSprite(image_1x, json_1x).get<std::exception_ptr>();
-
-    EXPECT_EQ(util::toString(error),
-              std::string("Failed to parse JSON: Missing a closing quotation mark in string. at offset 14"));
+    try {
+        parseSprite(image_1x, json_1x);
+        FAIL() << "Expected exception";
+    } catch (std::runtime_error& err) {
+        EXPECT_STREQ(
+            "Failed to parse JSON: Missing a closing quotation mark in string. at offset 14",
+            err.what());
+    }
 }
 
 TEST(Sprite, SpriteParsingEmptyImage) {
@@ -306,7 +310,7 @@ TEST(Sprite, SpriteParsingEmptyImage) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": {} })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
+    const auto images = parseSprite(image_1x, json_1x);
     EXPECT_EQ(0u, images.size());
 
     EXPECT_EQ(1u, log.count({
@@ -323,7 +327,7 @@ TEST(Sprite, SpriteParsingSimpleWidthHeight) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": { "width": 32, "height": 32 } })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
+    const auto images = parseSprite(image_1x, json_1x);
     EXPECT_EQ(1u, images.size());
 }
 
@@ -333,7 +337,7 @@ TEST(Sprite, SpriteParsingWidthTooBig) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": { "width": 65536, "height": 32 } })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
+    const auto images = parseSprite(image_1x, json_1x);
     EXPECT_EQ(0u, images.size());
 
     EXPECT_EQ(1u, log.count({
@@ -356,7 +360,7 @@ TEST(Sprite, SpriteParsingNegativeWidth) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": { "width": -1, "height": 32 } })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
+    const auto images = parseSprite(image_1x, json_1x);
     EXPECT_EQ(0u, images.size());
 
     EXPECT_EQ(1u, log.count({
@@ -379,7 +383,7 @@ TEST(Sprite, SpriteParsingNullRatio) {
     const auto image_1x = util::read_file("test/fixtures/annotations/emerald.png");
     const auto json_1x = R"JSON({ "image": { "width": 32, "height": 32, "pixelRatio": 0 } })JSON";
 
-    const auto images = parseSprite(image_1x, json_1x).get<Sprites>();
+    const auto images = parseSprite(image_1x, json_1x);
     EXPECT_EQ(0u, images.size());
 
     EXPECT_EQ(1u, log.count({

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -38,7 +38,7 @@ public:
     TransformState transformState;
     ThreadPool threadPool { 1 };
     AnnotationManager annotationManager { 1.0 };
-    style::Style style { fileSource, 1.0 };
+    style::Style style { threadPool, fileSource, 1.0 };
 
     style::UpdateParameters updateParameters {
         1.0,

--- a/test/style/style.test.cpp
+++ b/test/style/style.test.cpp
@@ -7,6 +7,7 @@
 #include <mbgl/style/layer.hpp>
 #include <mbgl/util/io.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/default_thread_pool.hpp>
 
 #include <memory>
 
@@ -16,8 +17,9 @@ using namespace mbgl::style;
 TEST(Style, UnusedSource) {
     util::RunLoop loop;
 
+    ThreadPool threadPool{ 1 };
     StubFileSource fileSource;
-    Style style { fileSource, 1.0 };
+    Style style { threadPool, fileSource, 1.0 };
 
     auto now = Clock::now();
 
@@ -53,8 +55,9 @@ TEST(Style, UnusedSource) {
 TEST(Style, UnusedSourceActiveViaClassUpdate) {
     util::RunLoop loop;
 
+    ThreadPool threadPool{ 1 };
     StubFileSource fileSource;
-    Style style { fileSource, 1.0 };
+    Style style { threadPool, fileSource, 1.0 };
 
     style.setJSON(util::read_file("test/fixtures/resources/style-unused-sources.json"));
     EXPECT_TRUE(style.addClass("visible"));
@@ -86,8 +89,9 @@ TEST(Style, UnusedSourceActiveViaClassUpdate) {
 TEST(Style, Properties) {
     util::RunLoop loop;
 
+    ThreadPool threadPool{ 1 };
     StubFileSource fileSource;
-    Style style { fileSource, 1.0 };
+    Style style { threadPool, fileSource, 1.0 };
 
     style.setJSON(R"STYLE({"name": "Test"})STYLE");
     ASSERT_EQ("Test", style.getName());
@@ -120,8 +124,9 @@ TEST(Style, Properties) {
 TEST(Style, DuplicateSource) {
     util::RunLoop loop;
 
+    ThreadPool threadPool{ 1 };
     StubFileSource fileSource;
-    Style style { fileSource, 1.0 };
+    Style style { threadPool, fileSource, 1.0 };
 
     style.setJSON(util::read_file("test/fixtures/resources/style-unused-sources.json"));
 

--- a/test/style/style_layer.test.cpp
+++ b/test/style/style_layer.test.cpp
@@ -18,6 +18,7 @@
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
 #include <mbgl/util/color.hpp>
 #include <mbgl/util/run_loop.hpp>
+#include <mbgl/util/default_thread_pool.hpp>
 #include <mbgl/util/io.hpp>
 
 #include <memory>
@@ -279,8 +280,9 @@ TEST(Layer, DuplicateLayer) {
     util::RunLoop loop;
 
     // Setup style
+    ThreadPool threadPool{ 1 };
     StubFileSource fileSource;
-    Style style { fileSource, 1.0 };
+    Style style { threadPool, fileSource, 1.0 };
     style.setJSON(util::read_file("test/fixtures/resources/style-unused-sources.json"));
 
     // Add initial layer

--- a/test/tile/annotation_tile.test.cpp
+++ b/test/tile/annotation_tile.test.cpp
@@ -24,7 +24,7 @@ public:
     util::RunLoop loop;
     ThreadPool threadPool { 1 };
     AnnotationManager annotationManager { 1.0 };
-    style::Style style { fileSource, 1.0 };
+    style::Style style { threadPool, fileSource, 1.0 };
 
     style::UpdateParameters updateParameters {
         1.0,

--- a/test/tile/geojson_tile.test.cpp
+++ b/test/tile/geojson_tile.test.cpp
@@ -24,7 +24,7 @@ public:
     util::RunLoop loop;
     ThreadPool threadPool { 1 };
     AnnotationManager annotationManager { 1.0 };
-    style::Style style { fileSource, 1.0 };
+    style::Style style { threadPool, fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
     style::UpdateParameters updateParameters {

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -20,7 +20,7 @@ public:
     util::RunLoop loop;
     ThreadPool threadPool { 1 };
     AnnotationManager annotationManager { 1.0 };
-    style::Style style { fileSource, 1.0 };
+    style::Style style { threadPool, fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
     style::UpdateParameters updateParameters {

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -26,7 +26,7 @@ public:
     util::RunLoop loop;
     ThreadPool threadPool { 1 };
     AnnotationManager annotationManager { 1.0 };
-    style::Style style { fileSource, 1.0 };
+    style::Style style { threadPool, fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
     style::UpdateParameters updateParameters {


### PR DESCRIPTION
We're currently parsing the sprite + accompanying JSON in the main thread. On some devices, parsing is rather slow and parsing time increases with sprite size. We should move it to a thread pool thread, since sprite loading is asynchronous anyway.