### PR TITLE
fixes #8522: don't alter tint color on annotation views

### DIFF
--- a/platform/ios/src/MGLMapView.mm
+++ b/platform/ios/src/MGLMapView.mm
@@ -1162,6 +1162,9 @@ public:
 
 - (void)updateTintColorForView:(UIView *)view
 {
+    // stop at recursing container & annotation views (#8522)
+    if ([view isEqual:self.annotationContainerView]) return;
+
     if ([view respondsToSelector:@selector(setTintColor:)]) view.tintColor = self.tintColor;
 
     for (UIView *subview in view.subviews) [self updateTintColorForView:subview];


### PR DESCRIPTION
Uses a simple and performant pointer equality test to bail early on view hierarchy recursion so as to not accidentally alter user-defined tint colors. 

Not applicable to macOS. 

/cc @jmkiley @boundsj 