### PR TITLE
[core] More complete fix for composite function interpolation edge case

### DIFF
--- a/include/mbgl/style/function/composite_function.hpp
+++ b/include/mbgl/style/function/composite_function.hpp
@@ -100,9 +100,6 @@ public:
     T evaluate(float zoom, const GeometryTileFeature& feature, T finalDefaultValue) const {
         std::tuple<Range<float>, Range<InnerStops>> ranges = coveringRanges(zoom);
         Range<T> resultRange = evaluate(std::get<1>(ranges), feature, finalDefaultValue);
-        // If the covering stop range is constant, just return the output value directly.
-        if (resultRange.min == resultRange.max) return resultRange.min;
-        // Otherwise, interpolate between the two stops.
         return util::interpolate(
             resultRange.min,
             resultRange.max,

--- a/src/mbgl/util/interpolate.cpp
+++ b/src/mbgl/util/interpolate.cpp
@@ -8,7 +8,9 @@ namespace util {
 float interpolationFactor(float base, Range<float> range, float z) {
     const float zoomDiff = range.max - range.min;
     const float zoomProgress = z - range.min;
-    if (base == 1.0f) {
+    if (zoomDiff == 0) {
+        return 0;
+    } else if (base == 1.0f) {
         return zoomProgress / zoomDiff;
     } else {
         return (std::pow(base, zoomProgress) - 1) / (std::pow(base, zoomDiff) - 1);


### PR DESCRIPTION
b5b4549 / #8613 handled the edge case for layout properties, but not paint properties. Move the check for a degenerate range to interpolationFactor in order to handle both correctly.