### PR TITLE
[android] - convert camera position values coming from core

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/widgets/CompassView.java
@@ -108,8 +108,7 @@ public final class CompassView extends AppCompatImageView implements Runnable, F
    * @param bearing the direction value of the map
    */
   public void update(final double bearing) {
-    // compass needs reverse bearing #8123
-    rotation = (float) -bearing;
+    rotation = (float) bearing;
 
     if (!isEnabled()) {
       return;

--- a/platform/android/src/map/camera_position.cpp
+++ b/platform/android/src/map/camera_position.cpp
@@ -6,9 +6,24 @@ namespace android {
 
 jni::Object<CameraPosition> CameraPosition::New(jni::JNIEnv &env, mbgl::CameraOptions options) {
     static auto constructor = CameraPosition::javaClass.GetConstructor<jni::Object<LatLng>, double, double, double>(env);
+
+    // wrap LatLng values coming from core
     auto center = options.center.value();
     center.wrap();
-    return CameraPosition::javaClass.New(env, constructor, LatLng::New(env, center), options.zoom.value_or(0), options.pitch.value_or(0), options.angle.value_or(0));
+
+    // convert bearing, core ranges from [−π rad, π rad], android from 0 to 360 degrees
+    double bearing_degrees = options.angle.value_or(-M_PI) * 180.0 / M_PI;
+    while (bearing_degrees > 360) {
+        bearing_degrees -= 360;
+    }
+    while (bearing_degrees < 0) {
+        bearing_degrees += 360;
+    }
+
+    // convert tilt, core ranges from  [0 rad, 1,0472 rad], android ranges from 0 to 60
+    double tilt_degrees = options.pitch.value_or(0) * 180 / M_PI;
+
+    return CameraPosition::javaClass.New(env, constructor, LatLng::New(env, center), options.zoom.value_or(0), tilt_degrees, bearing_degrees);
 }
 
 void CameraPosition::registerNative(jni::JNIEnv &env) {


### PR DESCRIPTION
Closes #8792, regression from #4796, the camera position values weren't correctly converted. (eg. angle + pitch from core are in rad while in the Android binding they are in degrees). 



