### PR TITLE
[android] - add all abi target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,6 +462,7 @@ MBGL_ANDROID_ABIS += arm-v8;arm64-v8a
 MBGL_ANDROID_ABIS += x86;x86
 MBGL_ANDROID_ABIS += x86-64;x86_64
 MBGL_ANDROID_ABIS += mips;mips
+MBGL_ANDROID_ABIS += all;all
 
 MBGL_ANDROID_LOCAL_WORK_DIR = /data/local/tmp/core-tests
 MBGL_ANDROID_LIBDIR = lib$(if $(filter arm-v8 x86-64,$1),64)
@@ -620,7 +621,7 @@ run-android-upload-archives: platform/android/configuration.gradle
 # Runs Android UI tests on all connected devices using Spoon
 .PHONY: run-android-ui-test-spoon
 run-android-ui-test-spoon: platform/android/configuration.gradle
-	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis="$(MBGL_ANDROID_ACTIVE_ARCHS)" spoon
+	cd platform/android && $(MBGL_ANDROID_GRADLE) -Pmapbox.abis=all spoon
 
 .PHONY: test-code-android
 test-code-android:


### PR DESCRIPTION
This PR adds the possibility for using `all` where we currently use a specific abi (eg. `arm-v7`). I was hitting the issue that `make android-ui-test` is requiring you to specify an abi. When running tests on AWS Device farm, it's usefull to build for more than one architecture. Adding this seems to work well with  `-Pmapbox.abis=`.

@kkaefer thoughts?