### PR TITLE
[android] - fix test app runtime permissions

### DIFF
--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/BaseLocationActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/BaseLocationActivity.java
@@ -1,0 +1,49 @@
+package com.mapbox.mapboxsdk.testapp.activity.userlocation;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.UiThread;
+import android.support.v4.app.ActivityCompat;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
+
+public abstract class BaseLocationActivity extends AppCompatActivity {
+
+  private static final int PERMISSIONS_LOCATION = 0;
+
+  @UiThread
+  protected final void toggleGps(boolean enableGps) {
+    if (enableGps) {
+      if (!PermissionsManager.areLocationPermissionsGranted(this)) {
+        ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.ACCESS_COARSE_LOCATION,
+          Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSIONS_LOCATION);
+      } else {
+        enableLocation(true);
+      }
+    } else {
+      enableLocation(false);
+    }
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    if (requestCode == PERMISSIONS_LOCATION) {
+      if (!isRuntimePermissionsRequired() || isPermissionAccepted(grantResults)) {
+        enableLocation(true);
+      }
+    }
+  }
+
+  private boolean isPermissionAccepted(int[] grantResults) {
+    return grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+  }
+
+  private boolean isRuntimePermissionsRequired() {
+    return android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+  }
+
+  protected abstract void enableLocation(boolean enabled);
+}

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/CustomLocationEngineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/CustomLocationEngineActivity.java
@@ -1,13 +1,7 @@
 package com.mapbox.mapboxsdk.testapp.activity.userlocation;
 
-import android.Manifest;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.UiThread;
 import android.support.design.widget.FloatingActionButton;
-import android.support.v4.app.ActivityCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -15,17 +9,14 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
-import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
 
-public class CustomLocationEngineActivity extends AppCompatActivity {
+public class CustomLocationEngineActivity extends BaseLocationActivity {
 
   private MapView mapView;
   private MapboxMap mapboxMap;
   private FloatingActionButton locationToggleFab;
 
   private LocationEngine locationServices;
-
-  private static final int PERMISSIONS_LOCATION = 0;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -53,6 +44,16 @@ public class CustomLocationEngineActivity extends AppCompatActivity {
         }
       }
     });
+  }
+
+  @Override
+  protected void enableLocation(boolean enabled) {
+    mapboxMap.setMyLocationEnabled(enabled);
+    if (enabled) {
+      locationToggleFab.setImageResource(R.drawable.ic_location_disabled);
+    } else {
+      locationToggleFab.setImageResource(R.drawable.ic_my_location);
+    }
   }
 
   @Override
@@ -95,37 +96,5 @@ public class CustomLocationEngineActivity extends AppCompatActivity {
   public void onLowMemory() {
     super.onLowMemory();
     mapView.onLowMemory();
-  }
-
-  @UiThread
-  public void toggleGps(boolean enableGps) {
-    if (enableGps) {
-      if (!PermissionsManager.areLocationPermissionsGranted(this)) {
-        ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.ACCESS_COARSE_LOCATION,
-          Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSIONS_LOCATION);
-      } else {
-        enableLocation(true);
-      }
-    } else {
-      enableLocation(false);
-    }
-  }
-
-  private void enableLocation(boolean enabled) {
-    mapboxMap.setMyLocationEnabled(enabled);
-    if (enabled) {
-      locationToggleFab.setImageResource(R.drawable.ic_location_disabled);
-    } else {
-      locationToggleFab.setImageResource(R.drawable.ic_my_location);
-    }
-  }
-
-  @Override
-  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-    if (requestCode == PERMISSIONS_LOCATION) {
-      if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-        enableLocation(true);
-      }
-    }
   }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationDrawableActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationDrawableActivity.java
@@ -1,15 +1,10 @@
 package com.mapbox.mapboxsdk.testapp.activity.userlocation;
 
-import android.Manifest;
-import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.location.Location;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -27,9 +22,7 @@ import com.mapbox.services.android.telemetry.location.LocationEngineListener;
 /**
  * Test activity showcasing how to change the MyLocationView drawable.
  */
-public class MyLocationDrawableActivity extends AppCompatActivity implements LocationEngineListener {
-
-  private static final int PERMISSIONS_LOCATION = 0;
+public class MyLocationDrawableActivity extends BaseLocationActivity implements LocationEngineListener {
 
   private MapView mapView;
   private MapboxMap mapboxMap;
@@ -71,24 +64,8 @@ public class MyLocationDrawableActivity extends AppCompatActivity implements Loc
     });
   }
 
-  public void toggleGps(boolean enableGps) {
-    if (enableGps) {
-      if ((ContextCompat.checkSelfPermission(this,
-        Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED)
-        || (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
-        != PackageManager.PERMISSION_GRANTED)) {
-        ActivityCompat.requestPermissions(this, new String[] {
-          Manifest.permission.ACCESS_COARSE_LOCATION,
-          Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSIONS_LOCATION);
-      } else {
-        enableLocation(true);
-      }
-    } else {
-      enableLocation(false);
-    }
-  }
-
-  private void enableLocation(boolean enabled) {
+  @Override
+  protected void enableLocation(boolean enabled) {
     if (enabled) {
       mapboxMap.setMyLocationEnabled(true);
       Location location = mapboxMap.getMyLocation();
@@ -99,15 +76,6 @@ public class MyLocationDrawableActivity extends AppCompatActivity implements Loc
       }
     } else {
       mapboxMap.setMyLocationEnabled(false);
-    }
-  }
-
-  @Override
-  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-    if (requestCode == PERMISSIONS_LOCATION) {
-      if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-        enableLocation(true);
-      }
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationTintActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationTintActivity.java
@@ -1,18 +1,13 @@
 package com.mapbox.mapboxsdk.testapp.activity.userlocation;
 
-import android.Manifest;
 import android.app.Activity;
-import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.location.Location;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -30,13 +25,11 @@ import com.mapbox.services.android.telemetry.location.LocationEngineListener;
 /**
  * Test activity showcasing how to tint the MyLocationView.
  */
-public class MyLocationTintActivity extends AppCompatActivity implements LocationEngineListener {
+public class MyLocationTintActivity extends BaseLocationActivity implements LocationEngineListener {
 
   private MapView mapView;
   private MapboxMap mapboxMap;
   private boolean firstRun;
-
-  private static final int PERMISSIONS_LOCATION = 0;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -180,25 +173,8 @@ public class MyLocationTintActivity extends AppCompatActivity implements Locatio
     mapView.onSaveInstanceState(outState);
   }
 
-  @UiThread
-  public void toggleGps(boolean enableGps) {
-    if (enableGps) {
-      if ((ContextCompat.checkSelfPermission(this,
-        Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED)
-        || (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
-        != PackageManager.PERMISSION_GRANTED)) {
-        ActivityCompat.requestPermissions(this, new String[] {
-          Manifest.permission.ACCESS_COARSE_LOCATION,
-          Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSIONS_LOCATION);
-      } else {
-        enableLocation(true);
-      }
-    } else {
-      enableLocation(false);
-    }
-  }
-
-  private void enableLocation(boolean enabled) {
+  @Override
+  protected void enableLocation(boolean enabled) {
     if (enabled) {
       mapboxMap.setMyLocationEnabled(true);
       if (mapboxMap.getMyLocation() != null) {
@@ -208,15 +184,6 @@ public class MyLocationTintActivity extends AppCompatActivity implements Locatio
       }
     } else {
       mapboxMap.setMyLocationEnabled(false);
-    }
-  }
-
-  @Override
-  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-    if (requestCode == PERMISSIONS_LOCATION) {
-      if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-        enableLocation(true);
-      }
     }
   }
 

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationToggleActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/userlocation/MyLocationToggleActivity.java
@@ -1,14 +1,8 @@
 package com.mapbox.mapboxsdk.testapp.activity.userlocation;
 
-import android.Manifest;
-import android.content.pm.PackageManager;
 import android.location.Location;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.UiThread;
 import android.support.design.widget.FloatingActionButton;
-import android.support.v4.app.ActivityCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
@@ -20,9 +14,8 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.testapp.R;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngineListener;
-import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
 
-public class MyLocationToggleActivity extends AppCompatActivity {
+public class MyLocationToggleActivity extends BaseLocationActivity {
 
   private MapView mapView;
   private MapboxMap mapboxMap;
@@ -30,8 +23,6 @@ public class MyLocationToggleActivity extends AppCompatActivity {
 
   private LocationEngine locationServices;
   private LocationEngineListener locationListener;
-
-  private static final int PERMISSIONS_LOCATION = 0;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -107,21 +98,8 @@ public class MyLocationToggleActivity extends AppCompatActivity {
     mapView.onLowMemory();
   }
 
-  @UiThread
-  public void toggleGps(boolean enableGps) {
-    if (enableGps) {
-      if (!PermissionsManager.areLocationPermissionsGranted(this)) {
-        ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.ACCESS_COARSE_LOCATION,
-          Manifest.permission.ACCESS_FINE_LOCATION}, PERMISSIONS_LOCATION);
-      } else {
-        enableLocation(true);
-      }
-    } else {
-      enableLocation(false);
-    }
-  }
-
-  private void enableLocation(boolean enabled) {
+  @Override
+  protected void enableLocation(boolean enabled) {
     if (enabled) {
       // To move the camera instantly, we attempt to get the last known location and either
       // ease or animate the camera to that position depending on the zoom level.
@@ -156,14 +134,4 @@ public class MyLocationToggleActivity extends AppCompatActivity {
     }
     mapboxMap.setMyLocationEnabled(enabled);
   }
-
-  @Override
-  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-    if (requestCode == PERMISSIONS_LOCATION) {
-      if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-        enableLocation(true);
-      }
-    }
-  }
-
 }


### PR DESCRIPTION
closes #8806, this patches up the test app code related to requesting runtime permissions on older android OS versions. This is the second bug we had related to test app code and runtime permissions. I'm proposing to start looking into using [Dexter](https://github.com/Karumi/Dexter).