### PR TITLE
[android] - warning log when attempting to update a non-added annotation

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/AnnotationManager.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import timber.log.Timber;
+
 /**
  * Responsible for managing and tracking state of Annotations linked to Map. All events related to
  * annotations that occur on {@link MapboxMap} are forwarded to this class.
@@ -260,24 +262,24 @@ class AnnotationManager {
     return marker;
   }
 
-  void updateMarker(@NonNull Marker updatedMarker, @NonNull MapboxMap mapboxMap) {
-    if (updatedMarker == null) {
+  void updateMarker(@NonNull Marker updatedMarker) {
+    if (!isAddedToMap(updatedMarker)) {
+      Timber.w("Attempting to update non-added Marker with value %s", updatedMarker);
       return;
     }
 
-    if (updatedMarker.getId() == -1) {
-      return;
-    }
-
-    if (!(updatedMarker instanceof MarkerView)) {
-      iconManager.ensureIconLoaded(updatedMarker, mapboxMap);
-    }
-
+    ensureIconLoaded(updatedMarker);
     nativeMapView.updateMarker(updatedMarker);
+    annotations.setValueAt(annotations.indexOfKey(updatedMarker.getId()), updatedMarker);
+  }
 
-    int index = annotations.indexOfKey(updatedMarker.getId());
-    if (index > -1) {
-      annotations.setValueAt(index, updatedMarker);
+  private boolean isAddedToMap(Annotation annotation) {
+    return annotation != null && annotation.getId() != -1 && annotations.indexOfKey(annotation.getId()) != -1;
+  }
+
+  private void ensureIconLoaded(Marker marker) {
+    if (!(marker instanceof MarkerView)) {
+      iconManager.ensureIconLoaded(marker, mapboxMap);
     }
   }
 
@@ -465,21 +467,14 @@ class AnnotationManager {
     return polygons;
   }
 
-  void updatePolygon(Polygon polygon) {
-    if (polygon == null) {
-      return;
-    }
-
-    if (polygon.getId() == -1) {
+  void updatePolygon(@NonNull Polygon polygon) {
+    if (!isAddedToMap(polygon)) {
+      Timber.w("Attempting to update non-added Polygon with value %s", polygon);
       return;
     }
 
     nativeMapView.updatePolygon(polygon);
-
-    int index = annotations.indexOfKey(polygon.getId());
-    if (index > -1) {
-      annotations.setValueAt(index, polygon);
-    }
+    annotations.setValueAt(annotations.indexOfKey(polygon.getId()), polygon);
   }
 
   List<Polygon> getPolygons() {
@@ -546,21 +541,13 @@ class AnnotationManager {
     return polylines;
   }
 
-  void updatePolyline(Polyline polyline) {
-    if (polyline == null) {
-      return;
-    }
-
-    if (polyline.getId() == -1) {
-      return;
+  void updatePolyline(@NonNull Polyline polyline) {
+    if (!isAddedToMap(polyline)) {
+      Timber.w("Attempting to update non-added Polyline with value %s", polyline);
     }
 
     nativeMapView.updatePolyline(polyline);
-
-    int index = annotations.indexOfKey(polyline.getId());
-    if (index > -1) {
-      annotations.setValueAt(index, polyline);
-    }
+    annotations.setValueAt(annotations.indexOfKey(polyline.getId()), polyline);
   }
 
   List<Polyline> getPolylines() {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/MapboxMap.java
@@ -1179,7 +1179,7 @@ public final class MapboxMap {
    */
   @UiThread
   public void updateMarker(@NonNull Marker updatedMarker) {
-    annotationManager.updateMarker(updatedMarker, this);
+    annotationManager.updateMarker(updatedMarker);
   }
 
   /**


### PR DESCRIPTION
closes #7961, adds an additional check if an annotation is not found in `LongSparseArray<Annotation>`. This will avoid the crash mentioned in #7961. 