### PR TITLE
[build] Added linux-core target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ option(WITH_EGL      "Use EGL backend" OFF)
 
 if(WITH_CXX11ABI)
     set(MASON_CXXABI_SUFFIX -cxx11abi)
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+else()
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 endif()
 
 if(WITH_OSMESA AND WITH_EGL)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 export BUILDTYPE ?= Debug
+export WITH_CXX11ABI ?= $(shell scripts/check-cxx11abi.sh)
 
 ifeq ($(BUILDTYPE), Release)
 else ifeq ($(BUILDTYPE), Debug)
@@ -293,7 +294,7 @@ $(LINUX_BUILD): $(BUILD_DEPS)
 	(cd $(LINUX_OUTPUT_PATH) && cmake -G Ninja ../../.. \
 		-DCMAKE_BUILD_TYPE=$(BUILDTYPE) \
 		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-		-DWITH_CXX11ABI=$(shell scripts/check-cxx11abi.sh) \
+		-DWITH_CXX11ABI=${WITH_CXX11ABI} \
 		-DWITH_COVERAGE=${WITH_COVERAGE} \
 		-DWITH_OSMESA=${WITH_OSMESA} \
 		-DWITH_EGL=${WITH_EGL})

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ test: $(LINUX_BUILD)
 benchmark: $(LINUX_BUILD)
 	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C $(LINUX_OUTPUT_PATH) mbgl-benchmark
 
-ifneq (,$(shell command -v gdb))
+ifneq (,$(shell command -v gdb 2> /dev/null))
   GDB = gdb -batch -return-child-result -ex 'set print thread-events off' -ex 'run' -ex 'thread apply all bt' --args
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,10 @@ $(LINUX_BUILD): $(BUILD_DEPS)
 .PHONY: linux
 linux: glfw-app render offline
 
+.PHONY: linux-core
+linux-core: $(LINUX_BUILD)
+	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C $(LINUX_OUTPUT_PATH) mbgl-core
+
 .PHONY: test
 test: $(LINUX_BUILD)
 	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C $(LINUX_OUTPUT_PATH) mbgl-test


### PR DESCRIPTION
Used for cases where we only need to build a static library containing the C++ core API.