### PR TITLE
[ios, macos] Updated `maximumZoomLevel` description, cherry-picked #8818

### DIFF
--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -63,12 +63,12 @@ MGL_EXPORT
 @property (nonatomic, assign, getter=isVisible) BOOL visible;
 
 /**
- The maximum zoom level that the layer gets parsed and appears up to (but not including).
+ The exclusive upper bound of the range of zoom levels within which a map would display the layer.
  */
 @property (nonatomic, assign) float maximumZoomLevel;
 
 /**
- The minimum zoom level at which the layer gets parsed and appears.
+ The inclusive lower bound of the range of zoom levels within which a map would display the layer.
  */
 @property (nonatomic, assign) float minimumZoomLevel;
 

--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -63,12 +63,12 @@ MGL_EXPORT
 @property (nonatomic, assign, getter=isVisible) BOOL visible;
 
 /**
- The exclusive upper bound of the range of zoom levels within which a map would display the layer.
+ The maximum zoom level at which the layer gets parsed and appears. This value is a floating-point number.
  */
 @property (nonatomic, assign) float maximumZoomLevel;
 
 /**
- The inclusive lower bound of the range of zoom levels within which a map would display the layer.
+ The minimum zoom level at which the layer gets parsed and appears. This value is a floating-point number.
  */
 @property (nonatomic, assign) float minimumZoomLevel;
 

--- a/platform/darwin/src/MGLStyleLayer.h
+++ b/platform/darwin/src/MGLStyleLayer.h
@@ -63,7 +63,7 @@ MGL_EXPORT
 @property (nonatomic, assign, getter=isVisible) BOOL visible;
 
 /**
- The maximum zoom level at which the layer gets parsed and appears.
+ The maximum zoom level that the layer gets parsed and appears up to (but not including).
  */
 @property (nonatomic, assign) float maximumZoomLevel;
 

--- a/platform/ios/docs/guides/Working with Mapbox Studio.md
+++ b/platform/ios/docs/guides/Working with Mapbox Studio.md
@@ -76,7 +76,7 @@ To implement your prototypes with runtime styling:
 
 1. Implement `-[MGLMapViewDelegate mapView:didFinishLoadingStyle:]`.
 2. Add your real data as a source:
-    * This can be done using vector data from tileset editor ([example](https://www.mapbox.com/ios-sdk/examples/runtime-circle-styles)), custom vector tiles, added as GeoJSON ([example](https://www.mapbox.com/ios-sdk/examples/runtime-add-line), or added manually through the app via `MGLShapeSource` ([example](https://www.mapbox.com/ios-sdk/examples/runtime-multiple-annotations))
+    * This can be done using vector data from tileset editor ([example](https://www.mapbox.com/ios-sdk/examples/dds-circle-layer)), custom vector tiles, added as GeoJSON ([example](https://www.mapbox.com/ios-sdk/examples/runtime-add-line), or added manually through the app via `MGLShapeSource` ([example](https://www.mapbox.com/ios-sdk/examples/runtime-multiple-annotations))
 3. For each layer you’ve prototyped in Studio, add its corresponding `MGLStyleLayer` subclass. See [“Configuring the map content’s appearance”](for-style-authors.html#configuring-the-map-content-s-appearance) for the available style layer classes.
 
 **Translating style attributes from Studio**


### PR DESCRIPTION
The `maximumZoomLevel` for a `MGLStyleLayer` is currently the zoom level that a layer is rendered up to, but not including.

Cherry-picked #8818 so that it can land in v3.5.3.

cc @boundsj  @captainbarbosa 
