### PR TITLE
[core] Suppress "stencil mask overflow" warning

### DIFF
--- a/src/mbgl/algorithm/generate_clip_ids_impl.hpp
+++ b/src/mbgl/algorithm/generate_clip_ids_impl.hpp
@@ -76,8 +76,13 @@ void ClipIDGenerator::update(Renderables& renderables) {
         bit_offset += bit_count;
     }
 
-    if (bit_offset > 8) {
+    // Prevent this warning from firing on every frame,
+    // which can be expensive in some platforms.
+    static bool warned = false;
+
+    if (!warned && bit_offset > 8) {
         Log::Error(Event::OpenGL, "stencil mask overflow");
+        warned = true;
     }
 }
 


### PR DESCRIPTION
When it starts, we get a log warning for every frame, which is
expensive. Now we get only one warning.