### PR TITLE
[build] Improve 'linux-core' build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ linux: glfw-app render offline
 
 .PHONY: linux-core
 linux-core: $(LINUX_BUILD)
-	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C $(LINUX_OUTPUT_PATH) mbgl-core
+	$(NINJA) $(NINJA_ARGS) -j$(JOBS) -C $(LINUX_OUTPUT_PATH) mbgl-core mbgl-loop-uv
 
 .PHONY: test
 test: $(LINUX_BUILD)

--- a/platform/default/bidi.cpp
+++ b/platform/default/bidi.cpp
@@ -118,7 +118,7 @@ std::u16string BiDi::getLine(std::size_t start, std::size_t end) {
     // UBIDI_DO_MIRRORING: Apply unicode mirroring of characters like parentheses
     // UBIDI_REMOVE_BIDI_CONTROLS: Now that all the lines are set, remove control characters so that
     // they don't show up on screen (some fonts have glyphs representing them)
-    ubidi_writeReordered(impl->bidiLine, &outputText[0], outputLength,
+    ubidi_writeReordered(impl->bidiLine, mbgl::utf16char_cast<UChar*>(&outputText[0]), outputLength,
                          UBIDI_DO_MIRRORING | UBIDI_REMOVE_BIDI_CONTROLS, &errorCode);
 
     if (U_FAILURE(errorCode)) {

--- a/platform/default/png_reader.cpp
+++ b/platform/default/png_reader.cpp
@@ -98,7 +98,7 @@ PremultipliedImage decodePNG(const uint8_t* data, size_t size) {
     int color_type = 0;
     png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type, nullptr, nullptr, nullptr);
 
-    UnassociatedImage image({ width, height });
+    UnassociatedImage image({ static_cast<uint32_t>(width), static_cast<uint32_t>(height) });
 
     if (color_type == PNG_COLOR_TYPE_PALETTE)
         png_set_expand(png_ptr);

--- a/platform/linux/config.cmake
+++ b/platform/linux/config.cmake
@@ -88,6 +88,7 @@ macro(mbgl_platform_core)
         # Thread pool
         PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
         PRIVATE platform/default/mbgl/util/default_thread_pool.cpp
+        PRIVATE platform/default/mbgl/util/shared_thread_pool.cpp
     )
 
     target_include_directories(mbgl-core


### PR DESCRIPTION
Fixes compilation issues when building `linux-core` target using older lib{icu,png} versions, and added extra steps for a minimal default runtime on Linux desktop.