### PR TITLE
Update localizations from Transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,31 +1,31 @@
 [main]
 host = https://www.transifex.com
-type = STRINGS
 minimum_perc = 80
+type = STRINGS
 
 [mapbox-gl-native.foundationstrings-darwin]
+file_filter = platform/darwin/resources/<lang>.lproj/Foundation.strings
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/darwin/resources/Base.lproj/Foundation.strings
 source_lang = en
-file_filter = platform/darwin/resources/<lang>.lproj/Foundation.strings
 
 [mapbox-gl-native.localizablestrings-ios]
+file_filter = platform/ios/resources/<lang>.lproj/Localizable.strings
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/ios/resources/Base.lproj/Localizable.strings
 source_lang = en
-file_filter = platform/ios/resources/<lang>.lproj/Localizable.strings
 
 [mapbox-gl-native.localizablestrings-macos]
+file_filter = platform/macos/sdk/<lang>.lproj/Localizable.strings
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/macos/sdk/Base.lproj/Localizable.strings
 source_lang = en
-file_filter = platform/macos/sdk/<lang>.lproj/Localizable.strings
 
 [mapbox-gl-native.rootstrings-ios]
+file_filter = platform/ios/framework/Settings.bundle/<lang>.lproj/Root.strings
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/ios/framework/Settings.bundle/Base.lproj/Root.strings
 source_lang = en
-file_filter = platform/ios/framework/Settings.bundle/<lang>.lproj/Root.strings
 
 [mapbox-gl-native.stringsxml-android]
 file_filter = platform/android/MapboxGLAndroidSDK/src/main/res/values-<lang>/strings.xml

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -21,6 +21,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 * Ensure surface is created after display and context [#8759](https://github.com/mapbox/mapbox-gl-native/pull/8759)
 * Harden telemetry event dispatch [#8767](https://github.com/mapbox/mapbox-gl-native/pull/8767)
 * Move LatLngBounds calculation for CameraUpdateFactory to core [#8765](https://github.com/mapbox/mapbox-gl-native/pull/8765)
+* Spanish, Lithuanian, and Vietnamese localizations [#8852](https://github.com/mapbox/mapbox-gl-native/pull/8852)
 
 ## 5.0.2 - April 3, 2017
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-es/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-es/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_compassContentDescription">Brújula del mapa. Actívala para restablecer la rotación del mapa al norte.</string>
+    <string name="mapbox_attributionsIconContentDescription">Ícono de atribución. Actívalo para mostrar el diálogo de atribución.</string>
+    <string name="mapbox_myLocationViewContentDescription">Vista de ubicación. Muestra tu ubicación en el mapa.</string>
+    <string name="mapbox_mapActionDescription">Se está mostrando un mapa creado con Mapbox. Arrastra dos dedos para desplazarte o pellizca para acercar.</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
+    <string name="mapbox_attributionTelemetryTitle">Ayúdanos a mejorar los mapas de Mapbox</string>
+    <string name="mapbox_attributionTelemetryMessage">Gracias a tu contribución de datos anónimos de uso, ayudas a mejorar OpenStreetMap y Mapbox.</string>
+    <string name="mapbox_attributionTelemetryPositive">Aceptar</string>
+    <string name="mapbox_attributionTelemetryNegative">Rechazar</string>
+    <string name="mapbox_attributionTelemetryNeutral">Más información</string>
+    <string name="mapbox_offline_error_region_definition_invalid">El parámetro OfflineRegionDefinition que se ingresó no coincide con los límites mundiales: %s</string>
+
+    </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-lt/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-lt/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_compassContentDescription">Žemėlapio kompasas. Spustelk, kad atstatytum žemėlapio pasukimą į šiaurę.</string>
+    <string name="mapbox_attributionsIconContentDescription">Įnašo ikona. Paspausk norėdamas pamatyti dialogą su detalėmis</string>
+    <string name="mapbox_myLocationViewContentDescription">Vartotojo vietos vaizdas. Nurodo tavo poziciją žemėlapyje</string>
+    <string name="mapbox_mapActionDescription">Rodomas Mapbox kurtas žemėlapis. Naviguok tempdamas du pirštus. Valdyk žemėlapio pritraukimą suimdamas/atitolindamas du pirštus.</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
+    <string name="mapbox_attributionTelemetryTitle">Prisidėk prie Mapbox žemėlapių tobulinimo</string>
+    <string name="mapbox_attributionTelemetryMessage">Jūs padedate padaryti OpenStreetMap ir Mapbox žemėlapius geresniais dalindamiesi anoniminiais naudojimosi duomenimis.</string>
+    <string name="mapbox_attributionTelemetryPositive">Sutikti</string>
+    <string name="mapbox_attributionTelemetryNegative">Nesutikti</string>
+    <string name="mapbox_attributionTelemetryNeutral">Daugiau informacijos</string>
+    <string name="mapbox_offline_error_region_definition_invalid">Pasirinktas OfflineRegionDefinition netalpa į rėžius:  %s</string>
+
+    </resources>

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-vi/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-vi/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_compassContentDescription">La bàn bản đồ. Kích hoạt để quay bản đồ lại hướng bắc.</string>
+    <string name="mapbox_attributionsIconContentDescription">Biểu tượng ghi công. Kích hoạt để xem hộp thoại ghi công.</string>
+    <string name="mapbox_myLocationViewContentDescription">Cái chỉ vị trí. Cái này chỉ vị trí của bạn trên bản đồ.</string>
+    <string name="mapbox_mapActionDescription">Đang xem bản đồ được xây dựng dùng Mapbox. Kéo hai ngón tay để cuộn. Chụm các ngón tay lại để phóng to. Tách các ngón tay ra để thu nhỏ.</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
+    <string name="mapbox_attributionTelemetryTitle">Cải tiến các Bản đồ Mapbox</string>
+    <string name="mapbox_attributionTelemetryMessage">Bạn đang giúp cải tiến các bản đồ OpenStreetMap và Mapbox bằng cách đóng góp dữ liệu vô danh hóa về cách sử dụng.</string>
+    <string name="mapbox_attributionTelemetryPositive">Đồng ý</string>
+    <string name="mapbox_attributionTelemetryNegative">Phản đối</string>
+    <string name="mapbox_attributionTelemetryNeutral">Thông tin thêm</string>
+    <string name="mapbox_offline_error_region_definition_invalid">OfflineRegionDefinition được cung cấp không vừa thế giới: %s</string>
+
+    </resources>

--- a/platform/darwin/resources/es.lproj/Foundation.strings
+++ b/platform/darwin/resources/es.lproj/Foundation.strings
@@ -1,0 +1,291 @@
+﻿/* Clock position format, long: {hours} o’clock */
+"CLOCK_FMT_LONG" = "%@ en punto";
+
+/* Clock position format, medium: {hours} o’clock */
+"CLOCK_FMT_MEDIUM" = "%@ en punto";
+
+/* Clock position format, short: {hours}:00 */
+"CLOCK_FMT_SHORT" = "%@:00";
+
+/* East, long */
+"COMPASS_E_LONG" = "este";
+
+/* East, short */
+"COMPASS_E_SHORT" = "E";
+
+/* East by north, long */
+"COMPASS_EbN_LONG" = "este por el norte";
+
+/* East by north, short */
+"COMPASS_EbN_SHORT" = "EpN";
+
+/* East by south, long */
+"COMPASS_EbS_LONG" = "este por el sur";
+
+/* East by south, short */
+"COMPASS_EbS_SHORT" = "EpS";
+
+/* East-northeast, long */
+"COMPASS_ENE_LONG" = "estenordeste";
+
+/* East-northeast, short */
+"COMPASS_ENE_SHORT" = "ENE";
+
+/* East-southeast, long */
+"COMPASS_ESE_LONG" = "estesudeste";
+
+/* East-southeast, short */
+"COMPASS_ESE_SHORT" = "ESE";
+
+/* North, long */
+"COMPASS_N_LONG" = "norte";
+
+/* North, short */
+"COMPASS_N_SHORT" = "N";
+
+/* North by east, long */
+"COMPASS_NbE_LONG" = "norte por el este";
+
+/* North by east, short */
+"COMPASS_NbE_SHORT" = "NpE";
+
+/* North by west, long */
+"COMPASS_NbW_LONG" = "norte por el oeste";
+
+/* North by west, short */
+"COMPASS_NbW_SHORT" = "NpO";
+
+/* Northeast, long */
+"COMPASS_NE_LONG" = "nordeste";
+
+/* Northeast, short */
+"COMPASS_NE_SHORT" = "NE";
+
+/* Northeast by east, long */
+"COMPASS_NEbE_LONG" = "nordeste por el este";
+
+/* Northeast by east, short */
+"COMPASS_NEbE_SHORT" = "NEpE";
+
+/* Northeast by north, long */
+"COMPASS_NEbN_LONG" = "nordeste por el norte";
+
+/* Northeast by north, short */
+"COMPASS_NEbN_SHORT" = "NEpN";
+
+/* North-northeast, long */
+"COMPASS_NNE_LONG" = "nornordeste";
+
+/* North-northeast, short */
+"COMPASS_NNE_SHORT" = "NNE";
+
+/* North-northwest, long */
+"COMPASS_NNW_LONG" = "nornoroeste";
+
+/* North-northwest, short */
+"COMPASS_NNW_SHORT" = "NNO";
+
+/* Northwest, long */
+"COMPASS_NW_LONG" = "noroeste";
+
+/* Northwest, short */
+"COMPASS_NW_SHORT" = "NO";
+
+/* Northwest by north, long */
+"COMPASS_NWbN_LONG" = "noroeste por el norte";
+
+/* Northwest by north, short */
+"COMPASS_NWbN_SHORT" = "NOpN";
+
+/* Northwest by west, long */
+"COMPASS_NWbW_LONG" = "noroeste por el oeste";
+
+/* Northwest by west, short */
+"COMPASS_NWbW_SHORT" = "NOpO";
+
+/* South, long */
+"COMPASS_S_LONG" = "sur";
+
+/* South, short */
+"COMPASS_S_SHORT" = "S";
+
+/* South by east, long */
+"COMPASS_SbE_LONG" = "sur por el este";
+
+/* South by east, short */
+"COMPASS_SbE_SHORT" = "SpE";
+
+/* South by west, long */
+"COMPASS_SbW_LONG" = "sur por el oeste";
+
+/* South by west, short */
+"COMPASS_SbW_SHORT" = "SpO";
+
+/* Southeast, long */
+"COMPASS_SE_LONG" = "sudeste";
+
+/* Southeast, short */
+"COMPASS_SE_SHORT" = "SE";
+
+/* Southeast by east, long */
+"COMPASS_SEbE_LONG" = "sudeste por el este";
+
+/* Southeast by east, short */
+"COMPASS_SEbE_SHORT" = "SEpE";
+
+/* Southeast by south, long */
+"COMPASS_SEbS_LONG" = "sudeste por el sur";
+
+/* Southeast by south, short */
+"COMPASS_SEbS_SHORT" = "SEpS";
+
+/* South-southeast, long */
+"COMPASS_SSE_LONG" = "sudsudeste";
+
+/* South-southeast, short */
+"COMPASS_SSE_SHORT" = "SSE";
+
+/* South-southwest, long */
+"COMPASS_SSW_LONG" = "sudsudoeste";
+
+/* South-southwest, short */
+"COMPASS_SSW_SHORT" = "SSO";
+
+/* Southwest, long */
+"COMPASS_SW_LONG" = "sudoeste";
+
+/* Southwest, short */
+"COMPASS_SW_SHORT" = "SO";
+
+/* Southwest by south, long */
+"COMPASS_SWbS_LONG" = "sudoeste por el sur";
+
+/* Southwest by south, short */
+"COMPASS_SWbS_SHORT" = "SOpS";
+
+/* Southwest by west, long */
+"COMPASS_SWbW_LONG" = "sudoeste por el oeste";
+
+/* Southwest by west, short */
+"COMPASS_SWbW_SHORT" = "SOpO";
+
+/* West, long */
+"COMPASS_W_LONG" = "oeste";
+
+/* West, short */
+"COMPASS_W_SHORT" = "O";
+
+/* West by north, long */
+"COMPASS_WbN_LONG" = "oeste por el norte";
+
+/* West by north, short */
+"COMPASS_WbN_SHORT" = "OpN";
+
+/* West by south, long */
+"COMPASS_WbS_LONG" = "oeste por el sur";
+
+/* West by south, short */
+"COMPASS_WbS_SHORT" = "OpS";
+
+/* West-northwest, long */
+"COMPASS_WNW_LONG" = "oesnoroeste";
+
+/* West-northwest, short */
+"COMPASS_WNW_SHORT" = "ONO";
+
+/* West-southwest, long */
+"COMPASS_WSW_LONG" = "oesudoeste";
+
+/* West-southwest, short */
+"COMPASS_WSW_SHORT" = "OSO";
+
+/* Degrees format, long */
+"COORD_DEG_LONG" = "%d grado(s)";
+
+/* Degrees format, medium: {degrees} */
+"COORD_DEG_MEDIUM" = "%d°";
+
+/* Degrees format, short: {degrees} */
+"COORD_DEG_SHORT" = "%d°";
+
+/* Coordinate format, long: {degrees}{minutes} */
+"COORD_DM_LONG" = "%1$@ y %2$@";
+
+/* Coordinate format, medium: {degrees}{minutes} */
+"COORD_DM_MEDIUM" = "%1$@%2$@";
+
+/* Coordinate format, short: {degrees}{minutes} */
+"COORD_DM_SHORT" = "%1$@%2$@";
+
+/* Coordinate format, long: {degrees}{minutes}{seconds} */
+"COORD_DMS_LONG" = "%1$@, %2$@ y %3$@";
+
+/* Coordinate format, medium: {degrees}{minutes}{seconds} */
+"COORD_DMS_MEDIUM" = "%1$@%2$@%3$@";
+
+/* Coordinate format, short: {degrees}{minutes}{seconds} */
+"COORD_DMS_SHORT" = "%1$@%2$@%3$@";
+
+/* East longitude format, long: {longitude} */
+"COORD_E_LONG" = "%@ este";
+
+/* East longitude format, medium: {longitude} */
+"COORD_E_MEDIUM" = "%@ este";
+
+/* East longitude format, short: {longitude} */
+"COORD_E_SHORT" = "%@E";
+
+/* Coordinate pair format, long: {latitude}, {longitude} */
+"COORD_FMT_LONG" = "%1$@ por %2$@";
+
+/* Coordinate pair format, medium: {latitude}, {longitude} */
+"COORD_FMT_MEDIUM" = "%1$@, %2$@";
+
+/* Coordinate pair format, short: {latitude}, {longitude} */
+"COORD_FMT_SHORT" = "%1$@, %2$@";
+
+/* Minutes format, long */
+"COORD_MIN_LONG" = "%d minuto(s)";
+
+/* Minutes format, medium: {minutes} */
+"COORD_MIN_MEDIUM" = "%d′";
+
+/* Minutes format, short: {minutes} */
+"COORD_MIN_SHORT" = "%d′";
+
+/* North latitude format, long: {latitude} */
+"COORD_N_LONG" = "%@ norte";
+
+/* North latitude format, medium: {latitude} */
+"COORD_N_MEDIUM" = "%@ norte";
+
+/* North latitude format, short: {latitude} */
+"COORD_N_SHORT" = "%@N";
+
+/* South latitude format, long: {latitude} */
+"COORD_S_LONG" = "%@ sur";
+
+/* South latitude format, medium: {latitude} */
+"COORD_S_MEDIUM" = "%@ sur";
+
+/* South latitude format, short: {latitude} */
+"COORD_S_SHORT" = "%@S";
+
+/* Seconds format, long */
+"COORD_SEC_LONG" = "%d segundo(s)";
+
+/* Seconds format, medium: {seconds} */
+"COORD_SEC_MEDIUM" = "%d″";
+
+/* Seconds format, short: {seconds} */
+"COORD_SEC_SHORT" = "%d″";
+
+/* West longitude format, long: {longitude} */
+"COORD_W_LONG" = "%@ oeste";
+
+/* West longitude format, medium: {longitude} */
+"COORD_W_MEDIUM" = "%@ oeste";
+
+/* West longitude format, short: {longitude} */
+"COORD_W_SHORT" = "%@O";
+

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -613,6 +613,7 @@
 		35D13AC11D3D19DD00AFB4E0 /* MGLFillStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLFillStyleLayer.h; sourceTree = "<group>"; };
 		35D13AC21D3D19DD00AFB4E0 /* MGLFillStyleLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLFillStyleLayer.mm; sourceTree = "<group>"; };
 		35D9DDE11DA25EEC00DAAD69 /* MGLCodingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLCodingTests.m; path = ../../darwin/test/MGLCodingTests.m; sourceTree = "<group>"; };
+		35DE35531EB7CBA8004917C5 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = sv; path = sv.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		35E0CFE51D3E501500188327 /* MGLStyle_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLStyle_Private.h; sourceTree = "<group>"; };
 		35E1A4D71D74336F007AA97F /* MGLValueEvaluator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLValueEvaluator.h; sourceTree = "<group>"; };
 		35E208A61D24210F00EC9A46 /* MGLNSDataAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGLNSDataAdditionsTests.m; sourceTree = "<group>"; };
@@ -2503,6 +2504,7 @@
 				DA9C012B1E4C7AD900C4742A /* pt-BR */,
 				DA618B111E68823600CB7F44 /* ru */,
 				DA618B191E68883700CB7F44 /* ca */,
+				35DE35531EB7CBA8004917C5 /* sv */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -904,6 +904,7 @@
 		DAE7DEC11E245455007505A6 /* MGLNSStringAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLNSStringAdditionsTests.m; path = ../../darwin/test/MGLNSStringAdditionsTests.m; sourceTree = "<group>"; };
 		DAE8CCAD1E6E8C70009B5CB0 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DAE8CCAE1E6E8C76009B5CB0 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Root.strings; sourceTree = "<group>"; };
+		DAE9E0F11EB7BF1B001E8E8B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DAED38611D62D0FC00D7640F /* NSURL+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+MGLAdditions.h"; sourceTree = "<group>"; };
 		DAED38621D62D0FC00D7640F /* NSURL+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+MGLAdditions.m"; sourceTree = "<group>"; };
 		DAEDC4331D603417000224FF /* MGLAttributionInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLAttributionInfoTests.m; path = ../../darwin/test/MGLAttributionInfoTests.m; sourceTree = "<group>"; };
@@ -2462,6 +2463,7 @@
 				DA6023F11E4CE94300DBFF23 /* sv */,
 				DA618B1C1E6888EC00CB7F44 /* ca */,
 				DA618B251E68920500CB7F44 /* lt */,
+				DAE9E0F11EB7BF1B001E8E8B /* es */,
 			);
 			name = Foundation.strings;
 			sourceTree = "<group>";

--- a/platform/ios/resources/ca.lproj/Localizable.strings
+++ b/platform/ios/resources/ca.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* No comment provided by engineer. */
 "CANCEL" = "Cancel·lar";
 
+/* Accessibility hint for closing the selected annotation’s callout view and returning to the map */
+"CLOSE_CALLOUT_A11Y_HINT" = "Torna al mapa";
+
 /* Accessibility hint */
 "COMPASS_A11Y_HINT" = "Orienta el mapa amb rumb nord";
 
@@ -31,6 +34,12 @@
 /* Accessibility label */
 "INFO_A11Y_LABEL" = "Sobre aquest mapa";
 
+/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "El mapa no s’ha carregat a causa d’un error desconegut.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "El mapa no s’ha carregat perquè l’estil no es pot carregar.";
+
 /* Accessibility label */
 "LOGO_A11Y_LABEL" = "Mapbox";
 
@@ -40,8 +49,17 @@
 /* Map accessibility value */
 "MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld anotació (ns) visibles";
 
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "El mapa no s’ha carregat perquè s’ha corromput l’estil.";
+
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";
+
+/* Developer-only SDK update notification; {latest version, in format x.x.x} */
+"SDK_UPDATE_AVAILABLE" = "La versió %@ del Mapbox iOS SDK està disponible:";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "El mapa no s’ha carregat perquè no es troba l’estil o bé és incompatible.";
 
 /* Telemetry prompt message */
 "TELEMETRY_DISABLED_MSG" = "Pots ajudar a millorar els mapes d’OpenStreetMap i de Mapbox aportant dades d’ús anònimes.";

--- a/platform/ios/resources/ca.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/ca.lproj/Localizable.stringsdict
@@ -6,7 +6,7 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Zoom %dx
-%#@count@ visible</string>
+%#@count@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -14,9 +14,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
 			<key>one</key>
-			<string>%d anotació</string>
+			<string>%d anotació visible</string>
 			<key>other</key>
-			<string>%d anotacions</string>
+			<string>%d anotacions visibles</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/ios/resources/ru.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/ru.lproj/Localizable.stringsdict
@@ -5,8 +5,8 @@
 	<key>MAP_A11Y_VALUE</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Zoom %dx
-%#@count@ visible</string>
+		<string>Масштаб %dx
+%#@count@ видны</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/platform/ios/resources/sv.lproj/Localizable.strings
+++ b/platform/ios/resources/sv.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* No comment provided by engineer. */
 "CANCEL" = "Avbryt";
 
+/* Accessibility hint for closing the selected annotation’s callout view and returning to the map */
+"CLOSE_CALLOUT_A11Y_HINT" = "Återgår till kartan";
+
 /* Accessibility hint */
 "COMPASS_A11Y_HINT" = "Roterar kartan mot norr";
 
@@ -31,6 +34,12 @@
 /* Accessibility label */
 "INFO_A11Y_LABEL" = "Om den här kartan";
 
+/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "Kartan kunde inte laddas på grund av att ett okänt fel inträffade.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "The map failed to load because the style can't be loaded.";
+
 /* Accessibility label */
 "LOGO_A11Y_LABEL" = "Mapbox";
 
@@ -38,10 +47,19 @@
 "MAP_A11Y_LABEL" = "Karta";
 
 /* Map accessibility value */
-"MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld annotation(s) visible";
+"MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld annotering(ar) synliga";
+
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "The map failed to load because the style is corrupted.";
 
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";
+
+/* Developer-only SDK update notification; {latest version, in format x.x.x} */
+"SDK_UPDATE_AVAILABLE" = "Mapbox iOS SDK version %@ är nu tillgängligt:";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "The map failed to load because the style can’t be found or is incompatible.";
 
 /* Telemetry prompt message */
 "TELEMETRY_DISABLED_MSG" = "Du kan hjälpa till att göra OpenStreetMap och Mapbox karttjänster bättre genom att bidra med anonymiserad användningsdata.";
@@ -71,5 +89,5 @@
 "TELEMETRY_TITLE" = "Gör Mapbox kartor bättre";
 
 /* Default user location annotation title */
-"USER_DOT_TITLE" = "Där är här";
+"USER_DOT_TITLE" = "Du är här";
 

--- a/platform/ios/resources/sv.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/sv.lproj/Localizable.stringsdict
@@ -6,7 +6,7 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>Zoom %dx
-%#@count@ visible</string>
+%#@count@</string>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/platform/ios/resources/sv.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/sv.lproj/Localizable.stringsdict
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>MAP_A11Y_VALUE</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Zoom %dx
+%#@count@ visible</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>%d annotering synlig</string>
+			<key>other</key>
+			<string>%d annoteringar synliga</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/platform/ios/resources/vi.lproj/Localizable.strings
+++ b/platform/ios/resources/vi.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* No comment provided by engineer. */
 "CANCEL" = "Hủy bỏ";
 
+/* Accessibility hint for closing the selected annotation’s callout view and returning to the map */
+"CLOSE_CALLOUT_A11Y_HINT" = "Quay lại bản đồ";
+
 /* Accessibility hint */
 "COMPASS_A11Y_HINT" = "Quay bản đồ về hướng bắc";
 
@@ -31,6 +34,12 @@
 /* Accessibility label */
 "INFO_A11Y_LABEL" = "Giới thiệu về bản đồ này";
 
+/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "Bản đồ bị thất bại khi tải vì lỗi không rõ.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "Bản đồ bị thất bại khi tải vì không thể tải bảng kiểu.";
+
 /* Accessibility label */
 "LOGO_A11Y_LABEL" = "Mapbox";
 
@@ -40,8 +49,17 @@
 /* Map accessibility value */
 "MAP_A11Y_VALUE" = "Thu phóng gấp %1$d lần\n%2$ld chú thích đang xuất hiện";
 
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "Bản đồ bị thất bại khi tải vì bảng kiểu bị hỏng.";
+
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";
+
+/* Developer-only SDK update notification; {latest version, in format x.x.x} */
+"SDK_UPDATE_AVAILABLE" = "Mapbox iOS SDK mới ra phiên bản %@:";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "Bản đồ bị thất bại khi tải vì không tìm thấy bảng kiểu hoặc bảng kiểu không tương thích.";
 
 /* Telemetry prompt message */
 "TELEMETRY_DISABLED_MSG" = "Hãy giúp cải tiến các bản đồ OpenStreetMap và Mapbox bằng cách đóng góp dữ liệu vô danh hóa về cách sử dụng.";

--- a/platform/ios/resources/zh-Hans.lproj/Localizable.strings
+++ b/platform/ios/resources/zh-Hans.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Accessibility hint */
+﻿/* Accessibility hint */
 "ANNOTATION_A11Y_HINT" = "显示信息";
 
 /* No comment provided by engineer. */
@@ -10,6 +10,9 @@
 /* No comment provided by engineer. */
 "CANCEL" = "取消";
 
+/* Accessibility hint for closing the selected annotation’s callout view and returning to the map */
+"CLOSE_CALLOUT_A11Y_HINT" = "Returns to the map";
+
 /* Accessibility hint */
 "COMPASS_A11Y_HINT" = "旋转地图使正北朝上";
 
@@ -18,12 +21,6 @@
 
 /* Compass abbreviation for north */
 "COMPASS_NORTH" = "北";
-
-/* Copyright notice in attribution sheet */
-"COPY_MAPBOX" = "© Mapbox";
-
-/* Copyright notice in attribution sheet */
-"COPY_OSM" = "© OpenStreetMap";
 
 /* Instructions in Interface Builder designable; {key}, {plist file name} */
 "DESIGNABLE" = "在%2$@中将你的access token设为%1$@可在这里显示Mapbox上的地图\n\n更多说明请见";
@@ -37,6 +34,12 @@
 /* Accessibility label */
 "INFO_A11Y_LABEL" = "关于这个地图";
 
+/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "The map failed to load because an unknown error occurred.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "The map failed to load because the style can't be loaded.";
+
 /* Accessibility label */
 "LOGO_A11Y_LABEL" = "Mapbox";
 
@@ -46,11 +49,17 @@
 /* Map accessibility value */
 "MAP_A11Y_VALUE" = "地图缩放%1$d倍\n有%2$ld处标记可见";
 
-/* Action in attribution sheet */
-"MAP_FEEDBACK" = "改进地图";
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "The map failed to load because the style is corrupted.";
 
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";
+
+/* Developer-only SDK update notification; {latest version, in format x.x.x} */
+"SDK_UPDATE_AVAILABLE" = "Mapbox iOS SDK version %@ is now available:";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "The map failed to load because the style can’t be found or is incompatible.";
 
 /* Telemetry prompt message */
 "TELEMETRY_DISABLED_MSG" = "你可以提供匿名数据来帮助OpenStreetMap和Mapbox的地图变得更好。";

--- a/platform/macos/macos.xcodeproj/project.pbxproj
+++ b/platform/macos/macos.xcodeproj/project.pbxproj
@@ -552,6 +552,7 @@
 		DAE8CCAA1E6E8605009B5CB0 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ru; path = ru.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
 		DAE8CCAB1E6E8B72009B5CB0 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DAE8CCAC1E6E8B8D009B5CB0 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		DAE9E0F21EB7BF39001E8E8B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DAED385D1D62CED700D7640F /* NSURL+MGLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+MGLAdditions.h"; sourceTree = "<group>"; };
 		DAED385E1D62CED700D7640F /* NSURL+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+MGLAdditions.m"; sourceTree = "<group>"; };
 		DAEDC4311D6033F1000224FF /* MGLAttributionInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MGLAttributionInfoTests.m; path = ../../darwin/test/MGLAttributionInfoTests.m; sourceTree = "<group>"; };
@@ -1580,6 +1581,7 @@
 				DA6023EF1E4CE8E500DBFF23 /* sv */,
 				DA618B171E68876C00CB7F44 /* ca */,
 				DA618B231E6891ED00CB7F44 /* lt */,
+				DAE9E0F21EB7BF39001E8E8B /* es */,
 			);
 			name = Foundation.strings;
 			sourceTree = "<group>";


### PR DESCRIPTION
Pulled the latest Catalan, Simplified Chinese, Spanish, Swedish, and Vietnamese localizations of the iOS and macOS SDKs from Transifex. Added Lithuanian, Spanish, and Vietnamese localizations of the Android SDK from Transifex as well.

@langsmith, are any other changes needed on the Android side besides adding these files in the resource directory?

/cc @eimantas @rroset @frederoni