### PR TITLE
[core] Move render-related sources out of style directory/namespace

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -162,8 +162,12 @@ set(MBGL_CORE_FILES
     src/mbgl/renderer/bucket.hpp
     src/mbgl/renderer/bucket_parameters.cpp
     src/mbgl/renderer/bucket_parameters.hpp
+    src/mbgl/renderer/cascade_parameters.hpp
     src/mbgl/renderer/circle_bucket.cpp
     src/mbgl/renderer/circle_bucket.hpp
+    src/mbgl/renderer/cross_faded_property_evaluator.cpp
+    src/mbgl/renderer/cross_faded_property_evaluator.hpp
+    src/mbgl/renderer/data_driven_property_evaluator.hpp
     src/mbgl/renderer/debug_bucket.cpp
     src/mbgl/renderer/debug_bucket.hpp
     src/mbgl/renderer/fill_bucket.cpp
@@ -177,6 +181,8 @@ set(MBGL_CORE_FILES
     src/mbgl/renderer/line_bucket.cpp
     src/mbgl/renderer/line_bucket.hpp
     src/mbgl/renderer/paint_parameters.hpp
+    src/mbgl/renderer/paint_property_binder.hpp
+    src/mbgl/renderer/paint_property_statistics.hpp
     src/mbgl/renderer/painter.cpp
     src/mbgl/renderer/painter.hpp
     src/mbgl/renderer/painter_background.cpp
@@ -188,6 +194,9 @@ set(MBGL_CORE_FILES
     src/mbgl/renderer/painter_line.cpp
     src/mbgl/renderer/painter_raster.cpp
     src/mbgl/renderer/painter_symbol.cpp
+    src/mbgl/renderer/possibly_evaluated_property_value.hpp
+    src/mbgl/renderer/property_evaluation_parameters.hpp
+    src/mbgl/renderer/property_evaluator.hpp
     src/mbgl/renderer/raster_bucket.cpp
     src/mbgl/renderer/raster_bucket.hpp
     src/mbgl/renderer/render_background_layer.cpp
@@ -203,22 +212,25 @@ set(MBGL_CORE_FILES
     src/mbgl/renderer/render_item.hpp
     src/mbgl/renderer/render_layer.cpp
     src/mbgl/renderer/render_layer.hpp
+    src/mbgl/renderer/render_light.hpp
     src/mbgl/renderer/render_line_layer.cpp
     src/mbgl/renderer/render_line_layer.hpp
     src/mbgl/renderer/render_pass.hpp
     src/mbgl/renderer/render_raster_layer.cpp
     src/mbgl/renderer/render_raster_layer.hpp
-    src/mbgl/renderer/render_symbol_layer.cpp
-    src/mbgl/renderer/render_symbol_layer.hpp
     src/mbgl/renderer/render_source.cpp
     src/mbgl/renderer/render_source.hpp
     src/mbgl/renderer/render_source_observer.hpp
+    src/mbgl/renderer/render_symbol_layer.cpp
+    src/mbgl/renderer/render_symbol_layer.hpp
     src/mbgl/renderer/render_tile.cpp
     src/mbgl/renderer/render_tile.hpp
     src/mbgl/renderer/symbol_bucket.cpp
     src/mbgl/renderer/symbol_bucket.hpp
     src/mbgl/renderer/tile_pyramid.cpp
     src/mbgl/renderer/tile_pyramid.hpp
+    src/mbgl/renderer/transitioning_property.hpp
+    src/mbgl/renderer/update_parameters.hpp
 
     # renderer/sources
     src/mbgl/renderer/sources/render_geojson_source.cpp
@@ -305,28 +317,18 @@ set(MBGL_CORE_FILES
     include/mbgl/style/transition_options.hpp
     include/mbgl/style/types.hpp
     include/mbgl/style/undefined.hpp
-    src/mbgl/style/cascade_parameters.hpp
     src/mbgl/style/class_dictionary.cpp
     src/mbgl/style/class_dictionary.hpp
-    src/mbgl/style/cross_faded_property_evaluator.cpp
-    src/mbgl/style/cross_faded_property_evaluator.hpp
-    src/mbgl/style/data_driven_property_evaluator.hpp
     src/mbgl/style/image.cpp
     src/mbgl/style/layer.cpp
     src/mbgl/style/layer_impl.cpp
     src/mbgl/style/layer_impl.hpp
     src/mbgl/style/layer_observer.hpp
     src/mbgl/style/layout_property.hpp
-    src/mbgl/style/light_impl.hpp
     src/mbgl/style/observer.hpp
     src/mbgl/style/paint_property.hpp
-    src/mbgl/style/paint_property_binder.hpp
-    src/mbgl/style/paint_property_statistics.hpp
     src/mbgl/style/parser.cpp
     src/mbgl/style/parser.hpp
-    src/mbgl/style/possibly_evaluated_property_value.hpp
-    src/mbgl/style/property_evaluation_parameters.hpp
-    src/mbgl/style/property_evaluator.hpp
     src/mbgl/style/rapidjson_conversion.hpp
     src/mbgl/style/source.cpp
     src/mbgl/style/source_impl.cpp
@@ -336,10 +338,8 @@ set(MBGL_CORE_FILES
     src/mbgl/style/style.hpp
     src/mbgl/style/tile_source_impl.cpp
     src/mbgl/style/tile_source_impl.hpp
-    src/mbgl/style/transitioning_property.hpp
     src/mbgl/style/types.cpp
     src/mbgl/style/update_batch.hpp
-    src/mbgl/style/update_parameters.hpp
 
     # style/conversion
     include/mbgl/style/conversion/constant.hpp

--- a/src/mbgl/annotation/annotation_tile.cpp
+++ b/src/mbgl/annotation/annotation_tile.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/storage/file_source.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/style/style.hpp>
 
 #include <utility>
@@ -10,7 +10,7 @@
 namespace mbgl {
 
 AnnotationTile::AnnotationTile(const OverscaledTileID& overscaledTileID,
-                               const style::UpdateParameters& parameters)
+                               const UpdateParameters& parameters)
     : GeometryTile(overscaledTileID, AnnotationManager::SourceID, parameters,
                    *parameters.style.glyphAtlas,
                    parameters.annotationManager.spriteAtlas),

--- a/src/mbgl/annotation/annotation_tile.hpp
+++ b/src/mbgl/annotation/annotation_tile.hpp
@@ -7,15 +7,12 @@
 namespace mbgl {
 
 class AnnotationManager;
-
-namespace style {
 class UpdateParameters;
-} // namespace style
 
 class AnnotationTile : public GeometryTile {
 public:
     AnnotationTile(const OverscaledTileID&,
-                   const style::UpdateParameters&);
+                   const UpdateParameters&);
     ~AnnotationTile() override;
 
     void setNecessity(Necessity) final;

--- a/src/mbgl/annotation/render_annotation_source.hpp
+++ b/src/mbgl/annotation/render_annotation_source.hpp
@@ -14,7 +14,7 @@ public:
 
     // Called when the camera has changed. May load new tiles, unload obsolete tiles, or
     // trigger re-placement of existing complete tiles.
-    void updateTiles(const style::UpdateParameters&) final;
+    void updateTiles(const UpdateParameters&) final;
 
     // Removes all tiles (by putting them into the cache).
     void removeTiles() final;

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -12,7 +12,7 @@
 #include <mbgl/style/light.hpp>
 #include <mbgl/style/observer.hpp>
 #include <mbgl/style/transition_options.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/storage/file_source.hpp>
@@ -255,7 +255,7 @@ void Map::Impl::render(View& view) {
         style->relayout();
     }
 
-    style::UpdateParameters parameters(pixelRatio,
+    UpdateParameters parameters(pixelRatio,
                                        debugOptions,
                                        transform.getState(),
                                        scheduler,

--- a/src/mbgl/programs/fill_extrusion_program.cpp
+++ b/src/mbgl/programs/fill_extrusion_program.cpp
@@ -1,6 +1,6 @@
 #include <mbgl/programs/fill_extrusion_program.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
-#include <mbgl/style/cross_faded_property_evaluator.hpp>
+#include <mbgl/renderer/cross_faded_property_evaluator.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/map/transform_state.hpp>
 #include <mbgl/util/mat3.hpp>

--- a/src/mbgl/programs/fill_extrusion_program.hpp
+++ b/src/mbgl/programs/fill_extrusion_program.hpp
@@ -10,7 +10,7 @@
 #include <mbgl/util/size.hpp>
 #include <mbgl/style/layers/fill_extrusion_layer_properties.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/style/light_impl.hpp>
+#include <mbgl/renderer/render_light.hpp>
 
 #include <string>
 
@@ -19,10 +19,7 @@ namespace mbgl {
 class SpriteAtlasElement;
 class UnwrappedTileID;
 class TransformState;
-
-namespace style {
 template <class> class Faded;
-} // namespace style
 
 namespace uniforms {
 MBGL_DEFINE_UNIFORM_VECTOR(float, 3, u_lightpos);
@@ -45,7 +42,7 @@ struct FillExtrusionUniforms : gl::Uniforms<
 {
     static Values values(mat4,
                          const TransformState&,
-                         const style::EvaluatedLight&);
+                         const EvaluatedLight&);
 };
 
 struct FillExtrusionPatternUniforms : gl::Uniforms<
@@ -71,11 +68,11 @@ struct FillExtrusionPatternUniforms : gl::Uniforms<
     static Values values(mat4,
                          const SpriteAtlasElement&,
                          const SpriteAtlasElement&,
-                         const style::Faded<std::string>&,
+                         const Faded<std::string>&,
                          const UnwrappedTileID&,
                          const TransformState&,
                          const float,
-                         const style::EvaluatedLight&);
+                         const EvaluatedLight&);
 };
 
 class FillExtrusionProgram : public Program<

--- a/src/mbgl/programs/fill_program.cpp
+++ b/src/mbgl/programs/fill_program.cpp
@@ -1,6 +1,6 @@
 #include <mbgl/programs/fill_program.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
-#include <mbgl/style/cross_faded_property_evaluator.hpp>
+#include <mbgl/renderer/cross_faded_property_evaluator.hpp>
 #include <mbgl/tile/tile_id.hpp>
 #include <mbgl/map/transform_state.hpp>
 

--- a/src/mbgl/programs/fill_program.hpp
+++ b/src/mbgl/programs/fill_program.hpp
@@ -19,10 +19,7 @@ namespace mbgl {
 class SpriteAtlasElement;
 class UnwrappedTileID;
 class TransformState;
-
-namespace style {
 template <class> class Faded;
-} // namespace style
 
 struct FillLayoutAttributes : gl::Attributes<
     attributes::a_pos>
@@ -54,7 +51,7 @@ struct FillPatternUniforms : gl::Uniforms<
                          Size framebufferSize,
                          const SpriteAtlasElement&,
                          const SpriteAtlasElement&,
-                         const style::Faded<std::string>&,
+                         const Faded<std::string>&,
                          const UnwrappedTileID&,
                          const TransformState&);
 };

--- a/src/mbgl/programs/symbol_program.hpp
+++ b/src/mbgl/programs/symbol_program.hpp
@@ -105,7 +105,7 @@ public:
                                                     const style::DataDrivenPropertyValue<float>& sizeProperty,
                                                     const float defaultValue);
 
-    virtual SymbolSizeAttributes::Bindings attributeBindings(const style::PossiblyEvaluatedPropertyValue<float> currentValue) const = 0;
+    virtual SymbolSizeAttributes::Bindings attributeBindings(const PossiblyEvaluatedPropertyValue<float> currentValue) const = 0;
     virtual void populateVertexVector(const GeometryTileFeature& feature) = 0;
     virtual UniformValues uniformValues(float currentZoom) const = 0;
     virtual void upload(gl::Context&) = 0;
@@ -155,7 +155,7 @@ public:
         );
     }
     
-    SymbolSizeAttributes::Bindings attributeBindings(const style::PossiblyEvaluatedPropertyValue<float>) const override {
+    SymbolSizeAttributes::Bindings attributeBindings(const PossiblyEvaluatedPropertyValue<float>) const override {
         return SymbolSizeAttributes::Bindings { SymbolSizeAttributes::Attribute::ConstantBinding {{{0, 0, 0}}} };
     }
     void upload(gl::Context&) override {}
@@ -209,7 +209,7 @@ public:
           defaultValue(defaultValue_) {
     }
 
-    SymbolSizeAttributes::Bindings attributeBindings(const style::PossiblyEvaluatedPropertyValue<float> currentValue) const override {
+    SymbolSizeAttributes::Bindings attributeBindings(const PossiblyEvaluatedPropertyValue<float> currentValue) const override {
         if (currentValue.isConstant()) {
             return SymbolSizeAttributes::Bindings { SymbolSizeAttributes::Attribute::ConstantBinding {{{0, 0, 0}}} };
         }
@@ -266,7 +266,7 @@ public:
             return getCoveringStops(stops, tileZoom, tileZoom + 1); }))
     {}
 
-    SymbolSizeAttributes::Bindings attributeBindings(const style::PossiblyEvaluatedPropertyValue<float> currentValue) const override {
+    SymbolSizeAttributes::Bindings attributeBindings(const PossiblyEvaluatedPropertyValue<float> currentValue) const override {
         if (currentValue.isConstant()) {
             return SymbolSizeAttributes::Bindings { SymbolSizeAttributes::Attribute::ConstantBinding {{{0, 0, 0}}} };
         }
@@ -361,7 +361,7 @@ public:
               UniformValues&& uniformValues,
               const gl::VertexBuffer<LayoutVertex>& layoutVertexBuffer,
               const SymbolSizeBinder& symbolSizeBinder,
-              const style::PossiblyEvaluatedPropertyValue<float>& currentSizeValue,
+              const PossiblyEvaluatedPropertyValue<float>& currentSizeValue,
               const gl::IndexBuffer<DrawMode>& indexBuffer,
               const gl::SegmentVector<Attributes>& segments,
               const PaintPropertyBinders& paintPropertyBinders,

--- a/src/mbgl/renderer/cascade_parameters.hpp
+++ b/src/mbgl/renderer/cascade_parameters.hpp
@@ -7,14 +7,12 @@
 #include <vector>
 
 namespace mbgl {
-namespace style {
 
 class CascadeParameters {
 public:
-    std::vector<ClassID> classes;
+    std::vector<style::ClassID> classes;
     TimePoint now;
-    TransitionOptions transition;
+    style::TransitionOptions transition;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/cross_faded_property_evaluator.cpp
+++ b/src/mbgl/renderer/cross_faded_property_evaluator.cpp
@@ -1,13 +1,12 @@
-#include <mbgl/style/cross_faded_property_evaluator.hpp>
+#include <mbgl/renderer/cross_faded_property_evaluator.hpp>
 #include <mbgl/util/chrono.hpp>
 
 #include <cmath>
 
 namespace mbgl {
-namespace style {
 
 template <typename T>
-Faded<T> CrossFadedPropertyEvaluator<T>::operator()(const Undefined&) const {
+Faded<T> CrossFadedPropertyEvaluator<T>::operator()(const style::Undefined&) const {
     return calculate(defaultValue, defaultValue, defaultValue);
 }
 
@@ -17,7 +16,7 @@ Faded<T> CrossFadedPropertyEvaluator<T>::operator()(const T& constant) const {
 }
 
 template <typename T>
-Faded<T> CrossFadedPropertyEvaluator<T>::operator()(const CameraFunction<T>& function) const {
+Faded<T> CrossFadedPropertyEvaluator<T>::operator()(const style::CameraFunction<T>& function) const {
     return calculate(function.evaluate(parameters.z - 1.0f),
                      function.evaluate(parameters.z),
                      function.evaluate(parameters.z + 1.0f));
@@ -38,5 +37,4 @@ Faded<T> CrossFadedPropertyEvaluator<T>::calculate(const T& min, const T& mid, c
 template class CrossFadedPropertyEvaluator<std::string>;
 template class CrossFadedPropertyEvaluator<std::vector<float>>;
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/cross_faded_property_evaluator.hpp
+++ b/src/mbgl/renderer/cross_faded_property_evaluator.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <mbgl/style/property_value.hpp>
-#include <mbgl/style/property_evaluation_parameters.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
 #include <mbgl/util/interpolate.hpp>
 
 namespace mbgl {
-namespace style {
 
 template <typename T>
 class Faded {
@@ -26,9 +25,9 @@ public:
         : parameters(parameters_),
           defaultValue(std::move(defaultValue_)) {}
 
-    Faded<T> operator()(const Undefined&) const;
+    Faded<T> operator()(const style::Undefined&) const;
     Faded<T> operator()(const T& constant) const;
-    Faded<T> operator()(const CameraFunction<T>&) const;
+    Faded<T> operator()(const style::CameraFunction<T>&) const;
 
 private:
     Faded<T> calculate(const T& min, const T& mid, const T& max) const;
@@ -37,11 +36,9 @@ private:
     T defaultValue;
 };
 
-} // namespace style
-
 namespace util {
 template <typename T>
-struct Interpolator<style::Faded<T>>
+struct Interpolator<Faded<T>>
     : Uninterpolated {};
 } // namespace util
 

--- a/src/mbgl/renderer/data_driven_property_evaluator.hpp
+++ b/src/mbgl/renderer/data_driven_property_evaluator.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <mbgl/style/property_value.hpp>
-#include <mbgl/style/property_evaluation_parameters.hpp>
-#include <mbgl/style/possibly_evaluated_property_value.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
+#include <mbgl/renderer/possibly_evaluated_property_value.hpp>
 
 namespace mbgl {
-namespace style {
 
 template <typename T>
 class DataDrivenPropertyEvaluator {
@@ -16,7 +15,7 @@ public:
         : parameters(parameters_),
           defaultValue(std::move(defaultValue_)) {}
 
-    ResultType operator()(const Undefined&) const {
+    ResultType operator()(const style::Undefined&) const {
         return ResultType(defaultValue);
     }
 
@@ -24,7 +23,7 @@ public:
         return ResultType(constant);
     }
 
-    ResultType operator()(const CameraFunction<T>& function) const {
+    ResultType operator()(const style::CameraFunction<T>& function) const {
         return ResultType(function.evaluate(parameters.z));
     }
 
@@ -38,5 +37,4 @@ private:
     T defaultValue;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/paint_property_binder.hpp
+++ b/src/mbgl/renderer/paint_property_binder.hpp
@@ -4,10 +4,9 @@
 #include <mbgl/gl/attribute.hpp>
 #include <mbgl/gl/uniform.hpp>
 #include <mbgl/util/type_list.hpp>
-#include <mbgl/style/paint_property_statistics.hpp>
+#include <mbgl/renderer/paint_property_statistics.hpp>
 
 namespace mbgl {
-namespace style {
 
 /*
    ZoomInterpolatedAttribute<Attr> is a 'compound' attribute, representing two values of the
@@ -133,7 +132,7 @@ public:
     using Attribute = ZoomInterpolatedAttributeType<A>;
     using AttributeBinding = typename Attribute::Binding;
 
-    SourceFunctionPaintPropertyBinder(SourceFunction<T> function_, T defaultValue_)
+    SourceFunctionPaintPropertyBinder(style::SourceFunction<T> function_, T defaultValue_)
         : function(std::move(function_)),
           defaultValue(std::move(defaultValue_)) {
     }
@@ -167,7 +166,7 @@ public:
     }
 
 private:
-    SourceFunction<T> function;
+    style::SourceFunction<T> function;
     T defaultValue;
     gl::VertexVector<BaseVertex> vertexVector;
     optional<gl::VertexBuffer<BaseVertex>> vertexBuffer;
@@ -184,7 +183,7 @@ public:
     using AttributeBinding = typename Attribute::Binding;
     using Vertex = gl::detail::Vertex<Attribute>;
 
-    CompositeFunctionPaintPropertyBinder(CompositeFunction<T> function_, float zoom, T defaultValue_)
+    CompositeFunctionPaintPropertyBinder(style::CompositeFunction<T> function_, float zoom, T defaultValue_)
         : function(std::move(function_)),
           defaultValue(std::move(defaultValue_)),
           coveringRanges(function.coveringRanges(zoom)) {
@@ -222,8 +221,8 @@ public:
     }
 
 private:
-    using InnerStops = typename CompositeFunction<T>::InnerStops;
-    CompositeFunction<T> function;
+    using InnerStops = typename style::CompositeFunction<T>::InnerStops;
+    style::CompositeFunction<T> function;
     T defaultValue;
     std::tuple<Range<float>, Range<InnerStops>> coveringRanges;
     gl::VertexVector<Vertex> vertexVector;
@@ -237,10 +236,10 @@ PaintPropertyBinder<T, A>::create(const PossiblyEvaluatedPropertyValue<T>& value
         [&] (const T& constant) -> std::unique_ptr<PaintPropertyBinder<T, A>> {
             return std::make_unique<ConstantPaintPropertyBinder<T, A>>(constant);
         },
-        [&] (const SourceFunction<T>& function) {
+        [&] (const style::SourceFunction<T>& function) {
             return std::make_unique<SourceFunctionPaintPropertyBinder<T, A>>(function, defaultValue);
         },
-        [&] (const CompositeFunction<T>& function) {
+        [&] (const style::CompositeFunction<T>& function) {
             return std::make_unique<CompositeFunctionPaintPropertyBinder<T, A>>(function, zoom, defaultValue);
         }
     );
@@ -328,5 +327,4 @@ private:
     Binders binders;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/paint_property_statistics.hpp
+++ b/src/mbgl/renderer/paint_property_statistics.hpp
@@ -3,7 +3,6 @@
 #include <mbgl/util/optional.hpp>
 
 namespace mbgl {
-namespace style {
 
 template <class T>
 class PaintPropertyStatistics {
@@ -27,5 +26,4 @@ private:
     optional<float> _max;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/painter.hpp
+++ b/src/mbgl/renderer/painter.hpp
@@ -158,7 +158,7 @@ private:
     GlyphAtlas* glyphAtlas = nullptr;
     LineAtlas* lineAtlas = nullptr;
 
-    style::EvaluatedLight evaluatedLight;
+    EvaluatedLight evaluatedLight;
 
     FrameHistory frameHistory;
 

--- a/src/mbgl/renderer/possibly_evaluated_property_value.hpp
+++ b/src/mbgl/renderer/possibly_evaluated_property_value.hpp
@@ -7,15 +7,13 @@
 
 namespace mbgl {
 
-namespace style {
-
 template <class T>
 class PossiblyEvaluatedPropertyValue {
 private:
     using Value = variant<
         T,
-        SourceFunction<T>,
-        CompositeFunction<T>>;
+        style::SourceFunction<T>,
+        style::CompositeFunction<T>>;
 
     Value value;
 
@@ -46,25 +44,23 @@ public:
     T evaluate(const Feature& feature, float zoom, T defaultValue) const {
         return this->match(
                 [&] (const T& constant) { return constant; },
-                [&] (const SourceFunction<T>& function) {
+                [&] (const style::SourceFunction<T>& function) {
                     return function.evaluate(feature, defaultValue);
                 },
-                [&] (const CompositeFunction<T>& function) {
+                [&] (const style::CompositeFunction<T>& function) {
                     return function.evaluate(zoom, feature, defaultValue);
                 }
         );
     }
 };
 
-} // namespace style
-
 namespace util {
 
 template <typename T>
-struct Interpolator<style::PossiblyEvaluatedPropertyValue<T>> {
-    style::PossiblyEvaluatedPropertyValue<T> operator()(const style::PossiblyEvaluatedPropertyValue<T>& a,
-                                                        const style::PossiblyEvaluatedPropertyValue<T>& b,
-                                                        const double t) const {
+struct Interpolator<PossiblyEvaluatedPropertyValue<T>> {
+    PossiblyEvaluatedPropertyValue<T> operator()(const PossiblyEvaluatedPropertyValue<T>& a,
+                                                 const PossiblyEvaluatedPropertyValue<T>& b,
+                                                 const double t) const {
         if (a.isConstant() && b.isConstant()) {
             return { interpolate(*a.constant(), *b.constant(), t) };
         } else {

--- a/src/mbgl/renderer/property_evaluation_parameters.hpp
+++ b/src/mbgl/renderer/property_evaluation_parameters.hpp
@@ -4,7 +4,6 @@
 #include <mbgl/util/chrono.hpp>
 
 namespace mbgl {
-namespace style {
 
 class PropertyEvaluationParameters {
 public:
@@ -26,5 +25,4 @@ public:
     Duration defaultFadeDuration;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/property_evaluator.hpp
+++ b/src/mbgl/renderer/property_evaluator.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <mbgl/style/property_value.hpp>
-#include <mbgl/style/property_evaluation_parameters.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
 
 namespace mbgl {
-namespace style {
 
 template <typename T>
 class PropertyEvaluator {
@@ -15,14 +14,13 @@ public:
         : parameters(parameters_),
           defaultValue(std::move(defaultValue_)) {}
 
-    T operator()(const Undefined&) const { return defaultValue; }
+    T operator()(const style::Undefined&) const { return defaultValue; }
     T operator()(const T& constant) const { return constant; }
-    T operator()(const CameraFunction<T>& fn) const { return fn.evaluate(parameters.z); }
+    T operator()(const style::CameraFunction<T>& fn) const { return fn.evaluate(parameters.z); }
 
 private:
     const PropertyEvaluationParameters& parameters;
     T defaultValue;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/render_background_layer.cpp
+++ b/src/mbgl/renderer/render_background_layer.cpp
@@ -19,11 +19,11 @@ std::unique_ptr<Bucket> RenderBackgroundLayer::createBucket(const BucketParamete
     return nullptr;
 }
 
-void RenderBackgroundLayer::cascade(const style::CascadeParameters &parameters) {
+void RenderBackgroundLayer::cascade(const CascadeParameters &parameters) {
     unevaluated = impl->cascading.cascade(parameters, std::move(unevaluated));
 }
 
-bool RenderBackgroundLayer::evaluate(const style::PropertyEvaluationParameters &parameters) {
+bool RenderBackgroundLayer::evaluate(const PropertyEvaluationParameters &parameters) {
     evaluated = unevaluated.evaluate(parameters);
 
     passes = evaluated.get<style::BackgroundOpacity>() > 0 ? RenderPass::Translucent

--- a/src/mbgl/renderer/render_background_layer.hpp
+++ b/src/mbgl/renderer/render_background_layer.hpp
@@ -14,8 +14,8 @@ public:
 
     std::unique_ptr<RenderLayer> clone() const override;
 
-    void cascade(const style::CascadeParameters&) override;
-    bool evaluate(const style::PropertyEvaluationParameters&) override;
+    void cascade(const CascadeParameters&) override;
+    bool evaluate(const PropertyEvaluationParameters&) override;
 
     std::unique_ptr<Bucket> createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const override;
 

--- a/src/mbgl/renderer/render_circle_layer.cpp
+++ b/src/mbgl/renderer/render_circle_layer.cpp
@@ -20,11 +20,11 @@ std::unique_ptr<Bucket> RenderCircleLayer::createBucket(const BucketParameters& 
     return std::make_unique<CircleBucket>(parameters, layers);
 }
 
-void RenderCircleLayer::cascade(const style::CascadeParameters& parameters) {
+void RenderCircleLayer::cascade(const CascadeParameters& parameters) {
     unevaluated = impl->cascading.cascade(parameters, std::move(unevaluated));
 }
 
-bool RenderCircleLayer::evaluate(const style::PropertyEvaluationParameters& parameters) {
+bool RenderCircleLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     evaluated = unevaluated.evaluate(parameters);
 
     passes = ((evaluated.get<style::CircleRadius>().constantOr(1) > 0 ||

--- a/src/mbgl/renderer/render_circle_layer.hpp
+++ b/src/mbgl/renderer/render_circle_layer.hpp
@@ -14,8 +14,8 @@ public:
 
     std::unique_ptr<RenderLayer> clone() const override;
 
-    void cascade(const style::CascadeParameters&) override;
-    bool evaluate(const style::PropertyEvaluationParameters&) override;
+    void cascade(const CascadeParameters&) override;
+    bool evaluate(const PropertyEvaluationParameters&) override;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,

--- a/src/mbgl/renderer/render_custom_layer.cpp
+++ b/src/mbgl/renderer/render_custom_layer.cpp
@@ -13,7 +13,7 @@ std::unique_ptr<RenderLayer> RenderCustomLayer::clone() const {
     return std::make_unique<RenderCustomLayer>(*this);
 }
 
-bool RenderCustomLayer::evaluate(const style::PropertyEvaluationParameters&) {
+bool RenderCustomLayer::evaluate(const PropertyEvaluationParameters&) {
     passes = RenderPass::Translucent;
     return false;
 }

--- a/src/mbgl/renderer/render_custom_layer.hpp
+++ b/src/mbgl/renderer/render_custom_layer.hpp
@@ -13,8 +13,8 @@ public:
 
     std::unique_ptr<RenderLayer> clone() const override;
 
-    void cascade(const style::CascadeParameters&) final {}
-    bool evaluate(const style::PropertyEvaluationParameters&) final;
+    void cascade(const CascadeParameters&) final {}
+    bool evaluate(const PropertyEvaluationParameters&) final;
 
     std::unique_ptr<Bucket> createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const final;
 

--- a/src/mbgl/renderer/render_fill_extrusion_layer.cpp
+++ b/src/mbgl/renderer/render_fill_extrusion_layer.cpp
@@ -20,11 +20,11 @@ std::unique_ptr<Bucket> RenderFillExtrusionLayer::createBucket(const BucketParam
     return std::make_unique<FillExtrusionBucket>(parameters, layers);
 }
 
-void RenderFillExtrusionLayer::cascade(const style::CascadeParameters& parameters) {
+void RenderFillExtrusionLayer::cascade(const CascadeParameters& parameters) {
     unevaluated = impl->cascading.cascade(parameters, std::move(unevaluated));
 }
 
-bool RenderFillExtrusionLayer::evaluate(const style::PropertyEvaluationParameters& parameters) {
+bool RenderFillExtrusionLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     evaluated = unevaluated.evaluate(parameters);
 
     passes = (evaluated.get<style::FillExtrusionOpacity>() > 0) ? RenderPass::Translucent

--- a/src/mbgl/renderer/render_fill_extrusion_layer.hpp
+++ b/src/mbgl/renderer/render_fill_extrusion_layer.hpp
@@ -14,8 +14,8 @@ public:
 
     std::unique_ptr<RenderLayer> clone() const override;
 
-    void cascade(const style::CascadeParameters&) override;
-    bool evaluate(const style::PropertyEvaluationParameters&) override;
+    void cascade(const CascadeParameters&) override;
+    bool evaluate(const PropertyEvaluationParameters&) override;
 
     bool queryIntersectsFeature(
         const GeometryCoordinates&,

--- a/src/mbgl/renderer/render_fill_layer.cpp
+++ b/src/mbgl/renderer/render_fill_layer.cpp
@@ -20,11 +20,11 @@ std::unique_ptr<Bucket> RenderFillLayer::createBucket(const BucketParameters& pa
     return std::make_unique<FillBucket>(parameters, layers);
 }
 
-void RenderFillLayer::cascade(const style::CascadeParameters& parameters) {
+void RenderFillLayer::cascade(const CascadeParameters& parameters) {
     unevaluated = impl->cascading.cascade(parameters, std::move(unevaluated));
 }
 
-bool RenderFillLayer::evaluate(const style::PropertyEvaluationParameters& parameters) {
+bool RenderFillLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     evaluated = unevaluated.evaluate(parameters);
 
     if (unevaluated.get<style::FillOutlineColor>().isUndefined()) {

--- a/src/mbgl/renderer/render_fill_layer.hpp
+++ b/src/mbgl/renderer/render_fill_layer.hpp
@@ -14,8 +14,8 @@ public:
 
     std::unique_ptr<RenderLayer> clone() const override;
 
-    void cascade(const style::CascadeParameters&) override;
-    bool evaluate(const style::PropertyEvaluationParameters&) override;
+    void cascade(const CascadeParameters&) override;
+    bool evaluate(const PropertyEvaluationParameters&) override;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,

--- a/src/mbgl/renderer/render_layer.hpp
+++ b/src/mbgl/renderer/render_layer.hpp
@@ -12,11 +12,8 @@ namespace mbgl {
 
 class Bucket;
 class BucketParameters;
-
-namespace style {
 class CascadeParameters;
 class PropertyEvaluationParameters;
-} // namespace style
 
 class RenderLayer {
 
@@ -33,11 +30,11 @@ public:
     virtual std::unique_ptr<RenderLayer> clone() const = 0;
 
     // Partially evaluate paint properties based on a set of classes.
-    virtual void cascade(const style::CascadeParameters&) = 0;
+    virtual void cascade(const CascadeParameters&) = 0;
 
     // Fully evaluate cascaded paint properties based on a zoom level.
     // Returns true if any paint properties have active transitions.
-    virtual bool evaluate(const style::PropertyEvaluationParameters&) = 0;
+    virtual bool evaluate(const PropertyEvaluationParameters&) = 0;
 
     // Check whether this layer is of the given subtype.
     template <class T>

--- a/src/mbgl/renderer/render_light.hpp
+++ b/src/mbgl/renderer/render_light.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <mbgl/style/light.hpp>
-#include <mbgl/style/transitioning_property.hpp>
-#include <mbgl/style/cascade_parameters.hpp>
-#include <mbgl/style/property_evaluator.hpp>
-#include <mbgl/style/property_evaluation_parameters.hpp>
+#include <mbgl/renderer/transitioning_property.hpp>
+#include <mbgl/renderer/cascade_parameters.hpp>
+#include <mbgl/renderer/property_evaluator.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
 #include <mbgl/util/ignore.hpp>
 
 namespace mbgl {
-namespace style {
 
 template <class TypeList>
 class Transitioning;
@@ -67,8 +66,7 @@ public:
         } {}
 };
 
-using TransitioningLight = Transitioning<LightProperties>;
-using EvaluatedLight     = Evaluated<LightProperties>;
+using TransitioningLight = Transitioning<style::LightProperties>;
+using EvaluatedLight     = Evaluated<style::LightProperties>;
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/render_line_layer.cpp
+++ b/src/mbgl/renderer/render_line_layer.cpp
@@ -20,11 +20,11 @@ std::unique_ptr<Bucket> RenderLineLayer::createBucket(const BucketParameters& pa
     return std::make_unique<LineBucket>(parameters, layers, impl->layout);
 }
 
-void RenderLineLayer::cascade(const style::CascadeParameters& parameters) {
+void RenderLineLayer::cascade(const CascadeParameters& parameters) {
     unevaluated = impl->cascading.cascade(parameters, std::move(unevaluated));
 }
 
-bool RenderLineLayer::evaluate(const style::PropertyEvaluationParameters& parameters) {
+bool RenderLineLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     // for scaling dasharrays
     auto dashArrayParams = parameters;
     dashArrayParams.z = std::floor(dashArrayParams.z);

--- a/src/mbgl/renderer/render_line_layer.hpp
+++ b/src/mbgl/renderer/render_line_layer.hpp
@@ -14,8 +14,8 @@ public:
 
     std::unique_ptr<RenderLayer> clone() const override;
 
-    void cascade(const style::CascadeParameters&) override;
-    bool evaluate(const style::PropertyEvaluationParameters&) override;
+    void cascade(const CascadeParameters&) override;
+    bool evaluate(const PropertyEvaluationParameters&) override;
 
     bool queryIntersectsFeature(
             const GeometryCoordinates&,

--- a/src/mbgl/renderer/render_raster_layer.cpp
+++ b/src/mbgl/renderer/render_raster_layer.cpp
@@ -18,11 +18,11 @@ std::unique_ptr<Bucket> RenderRasterLayer::createBucket(const BucketParameters&,
     return nullptr;
 }
 
-void RenderRasterLayer::cascade(const style::CascadeParameters& parameters) {
+void RenderRasterLayer::cascade(const CascadeParameters& parameters) {
     unevaluated = impl->cascading.cascade(parameters, std::move(unevaluated));
 }
 
-bool RenderRasterLayer::evaluate(const style::PropertyEvaluationParameters& parameters) {
+bool RenderRasterLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     evaluated = unevaluated.evaluate(parameters);
 
     passes = evaluated.get<style::RasterOpacity>() > 0 ? RenderPass::Translucent : RenderPass::None;

--- a/src/mbgl/renderer/render_raster_layer.hpp
+++ b/src/mbgl/renderer/render_raster_layer.hpp
@@ -14,8 +14,8 @@ public:
 
     std::unique_ptr<RenderLayer> clone() const override;
 
-    void cascade(const style::CascadeParameters&) override;
-    bool evaluate(const style::PropertyEvaluationParameters&) override;
+    void cascade(const CascadeParameters&) override;
+    bool evaluate(const PropertyEvaluationParameters&) override;
 
     std::unique_ptr<Bucket> createBucket(const BucketParameters&, const std::vector<const RenderLayer*>&) const override;
 

--- a/src/mbgl/renderer/render_source.hpp
+++ b/src/mbgl/renderer/render_source.hpp
@@ -21,14 +21,11 @@ class RenderedQueryOptions;
 class SourceQueryOptions;
 class Tile;
 class RenderSourceObserver;
+class UpdateParameters;
 
 namespace algorithm {
 class ClipIDGenerator;
 } // namespace algorithm
-
-namespace style {
-class UpdateParameters;
-} // namespace style
 
 class RenderSource : protected TileObserver {
 public:
@@ -39,7 +36,7 @@ public:
 
     // Called when the camera has changed. May load new tiles, unload obsolete tiles, or
     // trigger re-placement of existing complete tiles.
-    virtual void updateTiles(const style::UpdateParameters&) = 0;
+    virtual void updateTiles(const UpdateParameters&) = 0;
 
     // Removes all tiles (by putting them into the cache).
     virtual void removeTiles() = 0;

--- a/src/mbgl/renderer/render_symbol_layer.cpp
+++ b/src/mbgl/renderer/render_symbol_layer.cpp
@@ -2,8 +2,8 @@
 #include <mbgl/layout/symbol_layout.hpp>
 #include <mbgl/renderer/bucket.hpp>
 #include <mbgl/renderer/bucket_parameters.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
 #include <mbgl/style/layers/symbol_layer_impl.hpp>
-#include <mbgl/style/property_evaluation_parameters.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
 
 namespace mbgl {
@@ -34,11 +34,11 @@ std::unique_ptr<SymbolLayout> RenderSymbolLayer::createLayout(const BucketParame
                                           glyphDependencies);
 }
 
-void RenderSymbolLayer::cascade(const style::CascadeParameters& parameters) {
+void RenderSymbolLayer::cascade(const CascadeParameters& parameters) {
     unevaluated = impl->cascading.cascade(parameters, std::move(unevaluated));
 }
 
-bool RenderSymbolLayer::evaluate(const style::PropertyEvaluationParameters& parameters) {
+bool RenderSymbolLayer::evaluate(const PropertyEvaluationParameters& parameters) {
     evaluated = unevaluated.evaluate(parameters);
 
     auto hasIconOpacity = evaluated.get<style::IconColor>().constantOr(Color::black()).a > 0 ||

--- a/src/mbgl/renderer/render_symbol_layer.hpp
+++ b/src/mbgl/renderer/render_symbol_layer.hpp
@@ -66,8 +66,8 @@ public:
 
     std::unique_ptr<RenderLayer> clone() const override;
 
-    void cascade(const style::CascadeParameters&) override;
-    bool evaluate(const style::PropertyEvaluationParameters&) override;
+    void cascade(const CascadeParameters&) override;
+    bool evaluate(const PropertyEvaluationParameters&) override;
 
     style::IconPaintProperties::Evaluated iconPaintProperties() const;
     style::TextPaintProperties::Evaluated textPaintProperties() const;

--- a/src/mbgl/renderer/sources/render_geojson_source.hpp
+++ b/src/mbgl/renderer/sources/render_geojson_source.hpp
@@ -18,7 +18,7 @@ public:
 
     // Called when the camera has changed. May load new tiles, unload obsolete tiles, or
     // trigger re-placement of existing complete tiles.
-    void updateTiles(const style::UpdateParameters&) final;
+    void updateTiles(const UpdateParameters&) final;
 
     // Removes all tiles (by putting them into the cache).
     void removeTiles() final;

--- a/src/mbgl/renderer/sources/render_raster_source.hpp
+++ b/src/mbgl/renderer/sources/render_raster_source.hpp
@@ -14,7 +14,7 @@ public:
 
     // Called when the camera has changed. May load new tiles, unload obsolete tiles, or
     // trigger re-placement of existing complete tiles.
-    void updateTiles(const style::UpdateParameters&) final;
+    void updateTiles(const UpdateParameters&) final;
 
     // Removes all tiles (by putting them into the cache).
     void removeTiles() final;

--- a/src/mbgl/renderer/sources/render_vector_source.hpp
+++ b/src/mbgl/renderer/sources/render_vector_source.hpp
@@ -14,7 +14,7 @@ public:
 
     // Called when the camera has changed. May load new tiles, unload obsolete tiles, or
     // trigger re-placement of existing complete tiles.
-    void updateTiles(const style::UpdateParameters&) final;
+    void updateTiles(const UpdateParameters&) final;
 
     // Removes all tiles (by putting them into the cache).
     void removeTiles() final;

--- a/src/mbgl/renderer/tile_pyramid.cpp
+++ b/src/mbgl/renderer/tile_pyramid.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/render_source.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/map/query.hpp>
 #include <mbgl/text/placement_config.hpp>

--- a/src/mbgl/renderer/tile_pyramid.hpp
+++ b/src/mbgl/renderer/tile_pyramid.hpp
@@ -22,10 +22,7 @@ class TransformState;
 class RenderTile;
 class RenderedQueryOptions;
 class SourceQueryOptions;
-
-namespace style {
 class UpdateParameters;
-} // namespace style
 
 class TilePyramid {
 public:
@@ -36,7 +33,7 @@ public:
 
     // Called when the camera has changed. May load new tiles, unload obsolete tiles, or
     // trigger re-placement of existing complete tiles.
-    void updateTiles(const style::UpdateParameters&,
+    void updateTiles(const UpdateParameters&,
                      SourceType type,
                      uint16_t tileSize,
                      Range<uint8_t> zoomRange,

--- a/src/mbgl/renderer/transitioning_property.hpp
+++ b/src/mbgl/renderer/transitioning_property.hpp
@@ -8,7 +8,6 @@
 #include <utility>
 
 namespace mbgl {
-namespace style {
 
 template <class Value>
 class TransitioningProperty {
@@ -17,7 +16,7 @@ public:
 
     TransitioningProperty(Value value_,
                           TransitioningProperty<Value> prior_,
-                          TransitionOptions transition,
+                          style::TransitionOptions transition,
                           TimePoint now)
         : begin(now + transition.delay.value_or(Duration::zero())),
           end(begin + transition.duration.value_or(Duration::zero())),
@@ -73,5 +72,4 @@ private:
     Value value;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -10,8 +10,8 @@ class FileSource;
 class AnnotationManager;
 
 namespace style {
-
 class Style;
+} // namespace style
 
 class UpdateParameters {
 public:
@@ -22,7 +22,7 @@ public:
                           FileSource& fileSource_,
                           const MapMode mode_,
                           AnnotationManager& annotationManager_,
-                          Style& style_)
+                          style::Style& style_)
         : pixelRatio(pixelRatio_),
           debugOptions(debugOptions_),
           transformState(transformState_),
@@ -41,8 +41,7 @@ public:
     AnnotationManager& annotationManager;
 
     // TODO: remove
-    Style& style;
+    style::Style& style;
 };
 
-} // namespace style
 } // namespace mbgl

--- a/src/mbgl/style/layout_property.hpp
+++ b/src/mbgl/style/layout_property.hpp
@@ -2,14 +2,15 @@
 
 #include <mbgl/style/property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
-#include <mbgl/style/property_evaluator.hpp>
-#include <mbgl/style/data_driven_property_evaluator.hpp>
+#include <mbgl/renderer/property_evaluator.hpp>
+#include <mbgl/renderer/data_driven_property_evaluator.hpp>
 #include <mbgl/util/indexed_tuple.hpp>
 
 namespace mbgl {
-namespace style {
 
 class PropertyEvaluationParameters;
+
+namespace style {
 
 template <class T>
 class LayoutProperty {

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <mbgl/style/transitioning_property.hpp>
 #include <mbgl/style/class_dictionary.hpp>
 #include <mbgl/style/property_value.hpp>
 #include <mbgl/style/data_driven_property_value.hpp>
-#include <mbgl/style/property_evaluator.hpp>
-#include <mbgl/style/cross_faded_property_evaluator.hpp>
-#include <mbgl/style/data_driven_property_evaluator.hpp>
-#include <mbgl/style/property_evaluation_parameters.hpp>
 #include <mbgl/style/transition_options.hpp>
-#include <mbgl/style/cascade_parameters.hpp>
-#include <mbgl/style/paint_property_binder.hpp>
+#include <mbgl/renderer/property_evaluator.hpp>
+#include <mbgl/renderer/cross_faded_property_evaluator.hpp>
+#include <mbgl/renderer/data_driven_property_evaluator.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
+#include <mbgl/renderer/cascade_parameters.hpp>
+#include <mbgl/renderer/transitioning_property.hpp>
+#include <mbgl/renderer/paint_property_binder.hpp>
 #include <mbgl/util/constants.hpp>
 #include <mbgl/util/interpolate.hpp>
 #include <mbgl/util/indexed_tuple.hpp>

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -16,13 +16,13 @@
 #include <mbgl/style/parser.hpp>
 #include <mbgl/style/transition_options.hpp>
 #include <mbgl/style/class_dictionary.hpp>
-#include <mbgl/style/update_parameters.hpp>
-#include <mbgl/style/cascade_parameters.hpp>
-#include <mbgl/style/property_evaluation_parameters.hpp>
 #include <mbgl/sprite/sprite_atlas.hpp>
 #include <mbgl/text/glyph_atlas.hpp>
 #include <mbgl/geometry/line_atlas.hpp>
 #include <mbgl/renderer/render_source.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
+#include <mbgl/renderer/cascade_parameters.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
 #include <mbgl/renderer/render_item.hpp>
 #include <mbgl/renderer/render_tile.hpp>
 #include <mbgl/renderer/render_background_layer.hpp>

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -7,7 +7,7 @@
 #include <mbgl/style/layer_observer.hpp>
 #include <mbgl/style/update_batch.hpp>
 #include <mbgl/renderer/render_layer.hpp>
-#include <mbgl/style/light_impl.hpp>
+#include <mbgl/renderer/render_light.hpp>
 #include <mbgl/text/glyph_atlas_observer.hpp>
 #include <mbgl/sprite/sprite_atlas_observer.hpp>
 #include <mbgl/map/mode.hpp>
@@ -36,11 +36,11 @@ class RenderedQueryOptions;
 class Scheduler;
 class RenderLayer;
 class RenderSource;
+class UpdateParameters;
 
 namespace style {
 
 class Layer;
-class UpdateParameters;
 class QueryParameters;
 
 class Style : public GlyphAtlasObserver,

--- a/src/mbgl/tile/geojson_tile.cpp
+++ b/src/mbgl/tile/geojson_tile.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/map/query.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 
 #include <mapbox/geojsonvt.hpp>
 #include <supercluster.hpp>
@@ -84,7 +84,7 @@ public:
 
 GeoJSONTile::GeoJSONTile(const OverscaledTileID& overscaledTileID,
                          std::string sourceID_,
-                         const style::UpdateParameters& parameters,
+                         const UpdateParameters& parameters,
                          mapbox::geometry::feature_collection<int16_t> features)
     : GeometryTile(overscaledTileID, sourceID_, parameters,
                    *parameters.style.glyphAtlas,

--- a/src/mbgl/tile/geojson_tile.hpp
+++ b/src/mbgl/tile/geojson_tile.hpp
@@ -5,15 +5,13 @@
 
 namespace mbgl {
 
-namespace style {
 class UpdateParameters;
-} // namespace style
 
 class GeoJSONTile : public GeometryTile {
 public:
     GeoJSONTile(const OverscaledTileID&,
                 std::string sourceID,
-                const style::UpdateParameters&,
+                const UpdateParameters&,
                 mapbox::geometry::feature_collection<int16_t>);
 
     void updateData(mapbox::geometry::feature_collection<int16_t>);

--- a/src/mbgl/tile/geometry_tile.cpp
+++ b/src/mbgl/tile/geometry_tile.cpp
@@ -2,10 +2,10 @@
 #include <mbgl/tile/geometry_tile_worker.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/tile/tile_observer.hpp>
-#include <mbgl/style/update_parameters.hpp>
 #include <mbgl/style/layer_impl.hpp>
 #include <mbgl/style/layers/background_layer.hpp>
 #include <mbgl/style/layers/custom_layer.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/renderer/render_background_layer.hpp>
 #include <mbgl/renderer/render_custom_layer.hpp>
 #include <mbgl/renderer/render_symbol_layer.hpp>
@@ -28,7 +28,7 @@ using namespace style;
 
 GeometryTile::GeometryTile(const OverscaledTileID& id_,
                            std::string sourceID_,
-                           const style::UpdateParameters& parameters,
+                           const UpdateParameters& parameters,
                            GlyphAtlas& glyphAtlas_,
                            SpriteAtlas& spriteAtlas_)
     : Tile(id_),

--- a/src/mbgl/tile/geometry_tile.hpp
+++ b/src/mbgl/tile/geometry_tile.hpp
@@ -20,17 +20,17 @@ class FeatureIndex;
 class CollisionTile;
 class RenderLayer;
 class SourceQueryOptions;
+class UpdateParameters;
 
 namespace style {
 class Style;
-class UpdateParameters;
 } // namespace style
 
 class GeometryTile : public Tile, public GlyphRequestor, IconRequestor {
 public:
     GeometryTile(const OverscaledTileID&,
                  std::string sourceID,
-                 const style::UpdateParameters&,
+                 const UpdateParameters&,
                  GlyphAtlas&,
                  SpriteAtlas&);
 

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -249,13 +249,13 @@ static std::vector<std::unique_ptr<RenderLayer>> toRenderLayers(const std::vecto
     for (auto& layer : layers) {
         renderLayers.push_back(layer->baseImpl->createRenderLayer());
 
-        renderLayers.back()->cascade(style::CascadeParameters {
+        renderLayers.back()->cascade(CascadeParameters {
             { ClassID::Default },
             Clock::time_point::max(),
             TransitionOptions()
         });
 
-        renderLayers.back()->evaluate(style::PropertyEvaluationParameters {
+        renderLayers.back()->evaluate(PropertyEvaluationParameters {
             zoom,
             Clock::time_point::max(),
             ZoomHistory(),

--- a/src/mbgl/tile/raster_tile.cpp
+++ b/src/mbgl/tile/raster_tile.cpp
@@ -3,17 +3,17 @@
 #include <mbgl/tile/tile_observer.hpp>
 #include <mbgl/tile/tile_loader_impl.hpp>
 #include <mbgl/style/source.hpp>
-#include <mbgl/style/update_parameters.hpp>
 #include <mbgl/storage/resource.hpp>
 #include <mbgl/storage/response.hpp>
 #include <mbgl/storage/file_source.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/renderer/raster_bucket.hpp>
 #include <mbgl/util/run_loop.hpp>
 
 namespace mbgl {
 
 RasterTile::RasterTile(const OverscaledTileID& id_,
-                       const style::UpdateParameters& parameters,
+                       const UpdateParameters& parameters,
                        const Tileset& tileset)
     : Tile(id_),
       loader(*this, id_, parameters, tileset),

--- a/src/mbgl/tile/raster_tile.hpp
+++ b/src/mbgl/tile/raster_tile.hpp
@@ -8,16 +8,16 @@
 namespace mbgl {
 
 class Tileset;
+class UpdateParameters;
 
 namespace style {
 class Layer;
-class UpdateParameters;
 } // namespace style
 
 class RasterTile : public Tile {
 public:
     RasterTile(const OverscaledTileID&,
-                   const style::UpdateParameters&,
+                   const UpdateParameters&,
                    const Tileset&);
     ~RasterTile() final;
 

--- a/src/mbgl/tile/tile_loader.hpp
+++ b/src/mbgl/tile/tile_loader.hpp
@@ -10,17 +10,14 @@ class FileSource;
 class AsyncRequest;
 class Response;
 class Tileset;
-
-namespace style {
 class UpdateParameters;
-} // namespace style
 
 template <typename T>
 class TileLoader : private util::noncopyable {
 public:
     TileLoader(T&,
                const OverscaledTileID&,
-               const style::UpdateParameters&,
+               const UpdateParameters&,
                const Tileset&);
     ~TileLoader();
 

--- a/src/mbgl/tile/tile_loader_impl.hpp
+++ b/src/mbgl/tile/tile_loader_impl.hpp
@@ -2,7 +2,7 @@
 
 #include <mbgl/tile/tile_loader.hpp>
 #include <mbgl/storage/file_source.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/util/tileset.hpp>
 
 #include <cassert>
@@ -12,7 +12,7 @@ namespace mbgl {
 template <typename T>
 TileLoader<T>::TileLoader(T& tile_,
                           const OverscaledTileID& id,
-                          const style::UpdateParameters& parameters,
+                          const UpdateParameters& parameters,
                           const Tileset& tileset)
     : tile(tile_),
       necessity(Necessity::Optional),

--- a/src/mbgl/tile/vector_tile.cpp
+++ b/src/mbgl/tile/vector_tile.cpp
@@ -2,7 +2,7 @@
 #include <mbgl/tile/tile_loader_impl.hpp>
 #include <mbgl/tile/geometry_tile_data.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 
 #include <protozero/pbf_reader.hpp>
 
@@ -83,7 +83,7 @@ private:
 
 VectorTile::VectorTile(const OverscaledTileID& id_,
                        std::string sourceID_,
-                       const style::UpdateParameters& parameters,
+                       const UpdateParameters& parameters,
                        const Tileset& tileset)
     : GeometryTile(id_, sourceID_, parameters,
                    *parameters.style.glyphAtlas,

--- a/src/mbgl/tile/vector_tile.hpp
+++ b/src/mbgl/tile/vector_tile.hpp
@@ -6,16 +6,13 @@
 namespace mbgl {
 
 class Tileset;
-
-namespace style {
 class UpdateParameters;
-} // namespace style
 
 class VectorTile : public GeometryTile {
 public:
     VectorTile(const OverscaledTileID&,
                std::string sourceID,
-               const style::UpdateParameters&,
+               const UpdateParameters&,
                const Tileset&);
 
     void setNecessity(Necessity) final;

--- a/test/style/function/camera_function.test.cpp
+++ b/test/style/function/camera_function.test.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 #include <mbgl/test/util.hpp>
 
-#include <mbgl/style/property_evaluator.hpp>
-#include <mbgl/style/property_evaluation_parameters.hpp>
+#include <mbgl/renderer/property_evaluator.hpp>
+#include <mbgl/renderer/property_evaluation_parameters.hpp>
 
 using namespace mbgl;
 using namespace mbgl::style;

--- a/test/style/paint_property.test.cpp
+++ b/test/style/paint_property.test.cpp
@@ -1,7 +1,7 @@
 #include <mbgl/test/util.hpp>
 
 #include <mbgl/style/paint_property.hpp>
-#include <mbgl/style/transitioning_property.hpp>
+#include <mbgl/renderer/transitioning_property.hpp>
 
 using namespace mbgl;
 using namespace mbgl::style;

--- a/test/style/source.test.cpp
+++ b/test/style/source.test.cpp
@@ -23,7 +23,7 @@
 
 #include <mbgl/map/transform.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/style/layers/line_layer.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
 #include <mbgl/annotation/annotation_source.hpp>
@@ -46,7 +46,7 @@ public:
     AnnotationManager annotationManager { 1.0 };
     style::Style style { threadPool, fileSource, 1.0 };
 
-    style::UpdateParameters updateParameters {
+    UpdateParameters updateParameters {
         1.0,
         MapDebugOptions(),
         transformState,

--- a/test/tile/annotation_tile.test.cpp
+++ b/test/tile/annotation_tile.test.cpp
@@ -6,7 +6,7 @@
 #include <mbgl/map/transform.hpp>
 #include <mbgl/map/query.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/map/query.hpp>
 #include <mbgl/text/collision_tile.hpp>
 #include <mbgl/geometry/feature_index.hpp>
@@ -26,7 +26,7 @@ public:
     AnnotationManager annotationManager { 1.0 };
     style::Style style { threadPool, fileSource, 1.0 };
 
-    style::UpdateParameters updateParameters {
+    UpdateParameters updateParameters {
         1.0,
         MapDebugOptions(),
         transformState,

--- a/test/tile/geojson_tile.test.cpp
+++ b/test/tile/geojson_tile.test.cpp
@@ -8,7 +8,7 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/style/update_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/style/layers/circle_layer.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
 
@@ -27,7 +27,7 @@ public:
     style::Style style { threadPool, fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
-    style::UpdateParameters updateParameters {
+    UpdateParameters updateParameters {
         1.0,
         MapDebugOptions(),
         transformState,

--- a/test/tile/raster_tile.test.cpp
+++ b/test/tile/raster_tile.test.cpp
@@ -7,8 +7,8 @@
 #include <mbgl/util/run_loop.hpp>
 #include <mbgl/map/transform.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/style/update_parameters.hpp>
 #include <mbgl/annotation/annotation_manager.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/renderer/raster_bucket.hpp>
 
 using namespace mbgl;
@@ -23,7 +23,7 @@ public:
     style::Style style { threadPool, fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
-    style::UpdateParameters updateParameters {
+    UpdateParameters updateParameters {
         1.0,
         MapDebugOptions(),
         transformState,

--- a/test/tile/vector_tile.test.cpp
+++ b/test/tile/vector_tile.test.cpp
@@ -8,8 +8,8 @@
 #include <mbgl/map/transform.hpp>
 #include <mbgl/map/query.hpp>
 #include <mbgl/style/style.hpp>
-#include <mbgl/style/update_parameters.hpp>
 #include <mbgl/style/layers/symbol_layer.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/renderer/symbol_bucket.hpp>
 #include <mbgl/text/collision_tile.hpp>
 #include <mbgl/geometry/feature_index.hpp>
@@ -29,7 +29,7 @@ public:
     style::Style style { threadPool, fileSource, 1.0 };
     Tileset tileset { { "https://example.com" }, { 0, 22 }, "none" };
 
-    style::UpdateParameters updateParameters {
+    UpdateParameters updateParameters {
         1.0,
         MapDebugOptions(),
         transformState,


### PR DESCRIPTION
Moves the following to the renderer directory and out of the style namespace:

* CascadeParameters
* PropertyEvaluationParameters
* UpdateParameters
* PropertyEvaluator
* DataDrivenPropertyEvaluator
* CrossFadedPropertyEvaluator
* PaintPropertyBinder
* PaintProperyStatistics
* PossiblyEvaluatedPropertyValue
* TransitioningLight
* EvaluatedLight