### PR TITLE
[core] No need to manually set Update::Classes flag after annotation update

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -236,7 +236,6 @@ void Map::Impl::render(View& view) {
 
     if (style->loaded && updateFlags & Update::AnnotationStyle) {
         annotationManager->updateStyle(*style);
-        updateFlags |= Update::Classes;
     }
 
     if (updateFlags & Update::AnnotationData) {

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -956,7 +956,7 @@ std::unique_ptr<Layer> Map::removeLayer(const std::string& id) {
     BackendScope guard(impl->backend);
 
     auto removedLayer = impl->style->removeLayer(id);
-    impl->onUpdate(Update::Classes);
+    impl->onUpdate(Update::Repaint);
 
     return removedLayer;
 }


### PR DESCRIPTION
Since the advent of the runtime styling APIs, the APIs used by `AnnotationManager::updateStyle` will automatically set this flag as needed.