### PR TITLE
Revert "[node] Temporary: exit(0) on exception in Painter::render"

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -26,7 +26,6 @@
 #include <mbgl/util/tile_coordinate.hpp>
 #include <mbgl/actor/scheduler.hpp>
 #include <mbgl/util/logging.hpp>
-#include <mbgl/util/string.hpp>
 #include <mbgl/math/log2.hpp>
 
 namespace mbgl {
@@ -328,15 +327,10 @@ void Map::Impl::render(View& view) {
 
         backend.updateAssumedState();
 
-        try {
-            painter->render(*style,
-                            frameData,
-                            view,
-                            annotationManager->getSpriteAtlas());
-        } catch (...) {
-            Log::Error(Event::General, "Exception in render: %s", util::toString(std::current_exception()).c_str());
-            exit(1);
-        }
+        painter->render(*style,
+                        frameData,
+                        view,
+                        annotationManager->getSpriteAtlas());
 
         auto request = std::move(stillImageRequest);
         request->callback(nullptr);


### PR DESCRIPTION
This reverts commit f0d4411871d43012dc9e24a376ebc70ec6ca9224, which was intended to be a temporary change to help diagnose an OpenGL error (which it did!).