### PR TITLE
[node] Start publishing both release+debug builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,8 @@ matrix:
       env: BUILDTYPE=Debug _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
       addons: *clang39
       before_script:
+        - export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
+        - export PUBLISH=$([[ "${TRAVIS_TAG:-}" == "node-v${PACKAGE_JSON_VERSION}" ]] && echo true)
         - mapbox_install_logbt
         - mapbox_start_xvfb
         - mapbox_export_mesa_library_path
@@ -130,6 +132,8 @@ matrix:
       after_script:
         - ccache --show-stats
         - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
+      after_success:
+        - ./platform/node/scripts/after_success.sh
       after_failure:
         - aws s3 cp . s3://mapbox/mapbox-gl-native/render-tests/$TRAVIS_JOB_NUMBER --recursive --exclude "*" --include "*.trace"
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "module_path": "./lib/",
     "host": "https://mapbox-node-binary.s3.amazonaws.com",
     "remote_path": "./{name}/v{version}",
-    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+    "package_name": "{node_abi}-{platform}-{arch}-{configuration}.tar.gz"
   }
 }

--- a/platform/node/scripts/after_success.sh
+++ b/platform/node/scripts/after_success.sh
@@ -4,10 +4,9 @@ set -e
 set -o pipefail
 
 if [[ -n ${PUBLISH:-} ]]; then
-    if [[ "${BUILDTYPE}" != "Release" ]]; then
-        echo "Please run this script in release mode (BUILDTYPE=Release)."
-        exit 1
-    else
+    if [[ "${BUILDTYPE}" == "Release" ]]; then
         ./node_modules/.bin/node-pre-gyp package publish info
+    else
+        ./node_modules/.bin/node-pre-gyp package publish info --debug
     fi
 fi


### PR DESCRIPTION
Debug builds are an important way to find bugs that otherwise might be silent (because release builds remove `assert`) and to provide line numbers for crash reports (aka backtraces).

This enables the ability to publish both release the debug builds for the linux node bindings.

Release builds will still be the default. To install the debug build in a downstream app the developer would need to do:

```
npm install --debug
```

More info on debug builds: https://github.com/mapbox/cpp/blob/master/glossary.md#debug-build

Next steps:

 - [x] @bsudekum tries a dev tag to ensure this works
 - [ ] @bsudekum tests downstream, confirms improved backtrace detail (line numbers, etc)
 - [ ] merge