### PR TITLE
[core] Remove forced style cascade

### DIFF
--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -417,9 +417,6 @@ void Map::Impl::loadStyleJSON(const std::string& json) {
     style->setJSON(json);
     styleJSON = json;
 
-    // force style cascade, causing all pending transitions to complete.
-    style->cascade(Clock::now(), mode);
-
     if (!cameraMutated) {
         // Zoom first because it may constrain subsequent operations.
         map.setZoom(map.getDefaultZoom());


### PR DESCRIPTION
This should happen automatically during rendering. After removing, I can no longer replicate the original issue (#1889).