### PR TITLE
update LOST to 2.3.0-SNAPSHOT

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/build.gradle
+++ b/platform/android/MapboxGLAndroidSDK/build.gradle
@@ -6,7 +6,9 @@ dependencies {
     compile rootProject.ext.dep.supportDesign
     compile rootProject.ext.dep.timber
     compile rootProject.ext.dep.okhttp3
-    compile rootProject.ext.dep.lost
+    compile(rootProject.ext.dep.lost) {
+        exclude module: 'support-compat'
+    }
 
     // Mapbox Android Services (GeoJSON support)
     compile(rootProject.ext.dep.mapboxJavaGeoJSON) {

--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationSource.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/location/LocationSource.java
@@ -135,14 +135,4 @@ public class LocationSource extends LocationEngine implements
       listener.onLocationChanged(location);
     }
   }
-
-  @Override
-  public void onProviderDisabled(String provider) {
-    Log.d(LOG_TAG, "Provider disabled: " + provider);
-  }
-
-  @Override
-  public void onProviderEnabled(String provider) {
-    Log.d(LOG_TAG, "Provider enabled: " + provider);
-  }
 }

--- a/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
+++ b/platform/android/MapboxGLAndroidSDKTestApp/build.gradle
@@ -61,10 +61,7 @@ dependencies {
     }
 
     // Support libraries
-    compile rootProject.ext.dep.supportAnnotations
-    compile rootProject.ext.dep.supportV4
     compile rootProject.ext.dep.supportAppcompatV7
-    compile rootProject.ext.dep.supportDesign
     compile rootProject.ext.dep.supportRecyclerView
 
     // Leak Canary

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 

--- a/platform/android/dependencies.gradle
+++ b/platform/android/dependencies.gradle
@@ -7,21 +7,21 @@ ext {
     versionCode = 11
     versionName = "5.0.0"
 
-    supportLibVersion = "25.3.1"
-    leakCanaryVersion = '1.5'
+    mapboxServicesVersion = "2.2.0-SNAPSHOT"
+    supportLibVersion = "25.1.0"
     wearableVersion = '2.0.0'
-
     espressoVersion = '2.2.2'
     testRunnerVersion = '0.5'
+    leakCanaryVersion = '1.5'
 
     dep = [
             // mapbox
-            mapboxJavaServices     : 'com.mapbox.mapboxsdk:mapbox-java-services:2.1.0@jar',
-            mapboxJavaGeoJSON      : 'com.mapbox.mapboxsdk:mapbox-java-geojson:2.1.0@jar',
-            mapboxAndroidTelemetry : 'com.mapbox.mapboxsdk:mapbox-android-telemetry:2.1.0@aar',
+            mapboxJavaServices     : "com.mapbox.mapboxsdk:mapbox-java-services:${mapboxServicesVersion}@jar",
+            mapboxJavaGeoJSON      : "com.mapbox.mapboxsdk:mapbox-java-geojson:${mapboxServicesVersion}@jar",
+            mapboxAndroidTelemetry : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${mapboxServicesVersion}@aar",
 
             // mapzen lost
-            lost                   : 'com.mapzen.android:lost:2.2.0',
+            lost                   : 'com.mapzen.android:lost:2.3.0-SNAPSHOT',
 
             // unit test
             junit                  : 'junit:junit:4.12',


### PR DESCRIPTION
This PR updates the LOST dependency to v2.3.0-SNAPSHOT. This allows us to test if this new version resolves the reported issue in https://github.com/mapzen/lost/issues/173 and allows us to ship this in our own SNAPSHOT builds. 