### PR TITLE
Update localizations and stringsdicts from Transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,31 +1,41 @@
 [main]
 host = https://www.transifex.com
 minimum_perc = 80
-type = STRINGS
 
 [mapbox-gl-native.foundationstrings-darwin]
 file_filter = platform/darwin/resources/<lang>.lproj/Foundation.strings
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/darwin/resources/Base.lproj/Foundation.strings
 source_lang = en
+type = STRINGS
 
 [mapbox-gl-native.localizablestrings-ios]
 file_filter = platform/ios/resources/<lang>.lproj/Localizable.strings
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/ios/resources/Base.lproj/Localizable.strings
 source_lang = en
+type = STRINGS
+
+[mapbox-gl-native.localizablestringsdict-ios]
+file_filter = platform/ios/resources/<lang>.lproj/Localizable.stringsdict
+lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
+source_file = platform/ios/resources/en.lproj/Localizable.stringsdict
+source_lang = en
+type = STRINGSDICT
 
 [mapbox-gl-native.localizablestrings-macos]
 file_filter = platform/macos/sdk/<lang>.lproj/Localizable.strings
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/macos/sdk/Base.lproj/Localizable.strings
 source_lang = en
+type = STRINGS
 
 [mapbox-gl-native.rootstrings-ios]
 file_filter = platform/ios/framework/Settings.bundle/<lang>.lproj/Root.strings
 lang_map = pt_BR: pt-BR, pt_PT: pt-PT, zh_CN: zh-Hans, zh_TW: zh-Hant
 source_file = platform/ios/framework/Settings.bundle/Base.lproj/Root.strings
 source_lang = en
+type = STRINGS
 
 [mapbox-gl-native.stringsxml-android]
 file_filter = platform/android/MapboxGLAndroidSDK/src/main/res/values-<lang>/strings.xml

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -36,6 +36,7 @@ Mapbox welcomes participation and contributions from everyone.  If you'd like to
 * Expose Source Layer identifier [#8709](https://github.com/mapbox/mapbox-gl-native/pull/8709)
 * Derived source attribution [#8630](https://github.com/mapbox/mapbox-gl-native/pull/8630)
 * Consistent use of duration unit [#8578](https://github.com/mapbox/mapbox-gl-native/pull/8578)
+* Swedish localization [#8883](https://github.com/mapbox/mapbox-gl-native/pull/8883)
 
 ## 5.0.2 - April 3, 2017
 

--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values-sv/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values-sv/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_compassContentDescription">Kompass. Aktivera för att nollställa kartans rotation mot norr.</string>
+    <string name="mapbox_attributionsIconContentDescription">Tillskrivningsikon. Aktivera för att visa tillskrivningsdialog.</string>
+    <string name="mapbox_myLocationViewContentDescription">Positionsvy. Denna visar din position på kartan.</string>
+    <string name="mapbox_mapActionDescription">Visar en karta skapad med Mapbox. Scrolla genom att dra med två fingrar. Zooma genom att nypa med två fingrar.</string>
+    <string name="mapbox_attributionsDialogTitle">Mapbox Android SDK</string>
+    <string name="mapbox_attributionTelemetryTitle">Gör Mapbox kartor bättre</string>
+    <string name="mapbox_attributionTelemetryMessage">Du hjälper till att göra OpenStreetMap och Mapbox karttjänster bättre genom att bidra med anonymiserad användningsdata.</string>
+    <string name="mapbox_attributionTelemetryPositive">Godkänn</string>
+    <string name="mapbox_attributionTelemetryNegative">Avböj</string>
+    <string name="mapbox_attributionTelemetryNeutral">Visa mer information</string>
+    <string name="mapbox_offline_error_region_definition_invalid">Försedd OfflineRegionDefinition passar inte världens gränser: %s</string>
+
+    </resources>

--- a/platform/ios/ios.xcodeproj/project.pbxproj
+++ b/platform/ios/ios.xcodeproj/project.pbxproj
@@ -736,6 +736,9 @@
 		DA35D0871E1A6309007DED41 /* one-liner.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "one-liner.json"; path = "../../darwin/test/one-liner.json"; sourceTree = "<group>"; };
 		DA3C6FF21E2859E700F962BE /* test-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "test-Bridging-Header.h"; path = "../../darwin/test/test-Bridging-Header.h"; sourceTree = "<group>"; };
 		DA4A26961CB6E795000B7809 /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Mapbox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA57D4AA1EBA8ED300793288 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = es; path = es.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DA57D4AB1EBA909900793288 /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = lt; path = lt.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DA57D4AC1EBA922A00793288 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = vi; path = vi.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		DA6023F11E4CE94300DBFF23 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Foundation.strings; sourceTree = "<group>"; };
 		DA6023F21E4CE94800DBFF23 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = sv; path = sv.lproj/Foundation.stringsdict; sourceTree = "<group>"; };
 		DA618B111E68823600CB7F44 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ru; path = ru.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -927,7 +930,7 @@
 		DD9BE4F61EB263C50079A3AF /* UIViewController+MGLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+MGLAdditions.m"; sourceTree = "<group>"; };
 		FA68F1481E9D656600F9F6C2 /* MGLFillExtrusionStyleLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGLFillExtrusionStyleLayer.h; sourceTree = "<group>"; };
 		FA68F1491E9D656600F9F6C2 /* MGLFillExtrusionStyleLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MGLFillExtrusionStyleLayer.mm; sourceTree = "<group>"; };
-	  FAE1CDC81E9D79C600C40B5B /* MGLFillExtrusionStyleLayerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLFillExtrusionStyleLayerTests.mm; path = ../../darwin/test/MGLFillExtrusionStyleLayerTests.mm; sourceTree = "<group>"; };
+		FAE1CDC81E9D79C600C40B5B /* MGLFillExtrusionStyleLayerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MGLFillExtrusionStyleLayerTests.mm; path = ../../darwin/test/MGLFillExtrusionStyleLayerTests.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2513,6 +2516,9 @@
 				DA618B111E68823600CB7F44 /* ru */,
 				DA618B191E68883700CB7F44 /* ca */,
 				35DE35531EB7CBA8004917C5 /* sv */,
+				DA57D4AA1EBA8ED300793288 /* es */,
+				DA57D4AB1EBA909900793288 /* lt */,
+				DA57D4AC1EBA922A00793288 /* vi */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";

--- a/platform/ios/resources/ca.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/ca.lproj/Localizable.stringsdict
@@ -5,8 +5,19 @@
 	<key>MAP_A11Y_VALUE</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Zoom %dx
+		<string>%#@level@
 %#@count@</string>
+		<key>level</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zoom %dx</string>
+			<key>other</key>
+			<string>Zoom %dx</string>
+		</dict>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/platform/ios/resources/de.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/de.lproj/Localizable.stringsdict
@@ -5,8 +5,19 @@
 	<key>MAP_A11Y_VALUE</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Zoomstufe %d
-%#@count@ sichtbar</string>
+		<string>%#@level@
+%#@count@</string>
+		<key>level</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zoomstufe %d</string>
+			<key>other</key>
+			<string>Zoomstufe %d</string>
+		</dict>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -14,9 +25,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
 			<key>one</key>
-			<string>%d Anmerkung</string>
+			<string>%d Anmerkung sichtbar</string>
 			<key>other</key>
-			<string>%d Anmerkungen</string>
+			<string>%d Anmerkungen sichtbar</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/ios/resources/en.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/en.lproj/Localizable.stringsdict
@@ -5,8 +5,19 @@
 	<key>MAP_A11Y_VALUE</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Zoom %dx
-%#@count@ visible</string>
+		<string>%#@level@
+%#@count@</string>
+		<key>level</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zoom %dx</string>
+			<key>other</key>
+			<string>Zoom %dx</string>
+		</dict>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -14,9 +25,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
 			<key>one</key>
-			<string>%d annotation</string>
+			<string>%d annotation visible</string>
 			<key>other</key>
-			<string>%d annotations</string>
+			<string>%d annotations visible</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/ios/resources/es.lproj/Localizable.strings
+++ b/platform/ios/resources/es.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "MAP_A11Y_LABEL" = "Mapa";
 
 /* Map accessibility value */
-"MAP_A11Y_VALUE" = "Zoom %1$dx\n%2$ld annotation(s) visible";
+"MAP_A11Y_VALUE" = "Zoom %1$dx\nAnotaciones visibles: %2$ld";
 
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";

--- a/platform/ios/resources/es.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/es.lproj/Localizable.stringsdict
@@ -25,9 +25,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
 			<key>one</key>
-			<string>%d annotation visible</string>
+			<string>%d anotación visible</string>
 			<key>other</key>
-			<string>%d annotations visibles</string>
+			<string>%d anotaciones visibles</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/ios/resources/lt.lproj/Localizable.strings
+++ b/platform/ios/resources/lt.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* No comment provided by engineer. */
 "CANCEL" = "Atšaukti";
 
+/* Accessibility hint for closing the selected annotation’s callout view and returning to the map */
+"CLOSE_CALLOUT_A11Y_HINT" = "Grįžta į žemėlapį.";
+
 /* Accessibility hint */
 "COMPASS_A11Y_HINT" = "Pasuka žemėlapį šiaure į viršų";
 
@@ -31,6 +34,12 @@
 /* Accessibility label */
 "INFO_A11Y_LABEL" = "Apie šį žemėlapį";
 
+/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "Nepavyko užkrauti žemėlapio dėl nežinomos klaidos.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "Nepavyko užkrauti žemėlapio, nes nepavyko užkrauti stiliaus.";
+
 /* Accessibility label */
 "LOGO_A11Y_LABEL" = "Mapbox";
 
@@ -38,10 +47,19 @@
 "MAP_A11Y_LABEL" = "Žemėlapis";
 
 /* Map accessibility value */
-"MAP_A11Y_VALUE" = "Priartinimas: %1$dx\nMatomos anotacijos: %2$ld ";
+"MAP_A11Y_VALUE" = "Priartinimas: %1$dx\nMatomos anotacijos: %2$ld";
+
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "Nepavyko užkrauti žemėlapio, nes stilius yra netinkamo formato.";
 
 /* Action sheet title */
 "SDK_NAME" = "Mapbox iOS SDK";
+
+/* Developer-only SDK update notification; {latest version, in format x.x.x} */
+"SDK_UPDATE_AVAILABLE" = "Mapbox iOS SDK versija %@ jau prieinama.";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "Nepavyko užkrauti žemėlapio, nes neįmanoma rasti stiliaus arba jis nėra suderinamas.";
 
 /* Telemetry prompt message */
 "TELEMETRY_DISABLED_MSG" = "Padėkite padaryti OpenStreetMap ir Mapbox žemėlapius geresniais dalindamiesi anoniminiais naudojimosi duomenimis.";

--- a/platform/ios/resources/lt.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/lt.lproj/Localizable.stringsdict
@@ -14,9 +14,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Zoom %dx</string>
+			<string>Priartinimas: %dx</string>
+			<key>few</key>
+			<string>Priartinimas: %dx</string>
 			<key>other</key>
-			<string>Zoom %dx</string>
+			<string>Priartinimas: %dx</string>
 		</dict>
 		<key>count</key>
 		<dict>
@@ -25,9 +27,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
 			<key>one</key>
-			<string>%d annotation visible</string>
+			<string>Matomos anotacijos: %d anotacija</string>
+			<key>few</key>
+			<string>Matomos anotacijos: %d anotacijos</string>
 			<key>other</key>
-			<string>%d annotations visibles</string>
+			<string>Matomos anotacijos: %d anotacijų</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/ios/resources/pt-BR.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/pt-BR.lproj/Localizable.stringsdict
@@ -5,8 +5,19 @@
 	<key>MAP_A11Y_VALUE</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Zoom %dx
+		<string>%#@level@
 %#@count@</string>
+		<key>level</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zoom %dx</string>
+			<key>other</key>
+			<string>Zoom %dx</string>
+		</dict>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/platform/ios/resources/ru.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/ru.lproj/Localizable.stringsdict
@@ -5,8 +5,23 @@
 	<key>MAP_A11Y_VALUE</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Масштаб %dx
-%#@count@ видны</string>
+		<string>%#@level@
+%#@count@</string>
+		<key>level</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Масштаб %dx</string>
+			<key>few</key>
+			<string>Масштаб %dx</string>
+			<key>many</key>
+			<string>Масштаб %dx</string>
+			<key>other</key>
+			<string>Масштаб %dx</string>
+		</dict>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -14,13 +29,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
 			<key>one</key>
-			<string>%d аннотация</string>
+			<string>%d аннотация видны</string>
 			<key>few</key>
-			<string>%d аннотации</string>
+			<string>%d аннотации видны</string>
 			<key>many</key>
-			<string>%d аннотаций</string>
+			<string>%d аннотаций видны</string>
 			<key>other</key>
-			<string>%d аннотации</string>
+			<string>%d аннотации видны</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/ios/resources/sv.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/sv.lproj/Localizable.stringsdict
@@ -5,8 +5,19 @@
 	<key>MAP_A11Y_VALUE</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Zoom %dx
+		<string>%#@level@
 %#@count@</string>
+		<key>level</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zoom %dx</string>
+			<key>other</key>
+			<string>Zoom %dx</string>
+		</dict>
 		<key>count</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/platform/ios/resources/vi.lproj/Localizable.stringsdict
+++ b/platform/ios/resources/vi.lproj/Localizable.stringsdict
@@ -13,10 +13,8 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
-			<key>one</key>
-			<string>Zoom %dx</string>
 			<key>other</key>
-			<string>Zoom %dx</string>
+			<string>Thu phóng gấp %d lần</string>
 		</dict>
 		<key>count</key>
 		<dict>
@@ -24,10 +22,8 @@
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>ld</string>
-			<key>one</key>
-			<string>%d annotation visible</string>
 			<key>other</key>
-			<string>%d annotations visibles</string>
+			<string>%d chú thích đang xuất hiện</string>
 		</dict>
 	</dict>
 </dict>

--- a/platform/macos/sdk/lt.lproj/Localizable.strings
+++ b/platform/macos/sdk/lt.lproj/Localizable.strings
@@ -1,5 +1,17 @@
-﻿/* Accessibility title */
+﻿/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "Nepavyko užkrauti žemėlapio dėl nežinomos klaidos.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "Nepavyko užkrauti žemėlapio, nes nepavyko užkrauti stiliaus.";
+
+/* Accessibility title */
 "MAP_A11Y_TITLE" = "Mapbox";
+
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "Nepavyko užkrauti žemėlapio, nes stilius yra netinkamo formato.";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "Nepavyko užkrauti žemėlapio, nes neįmanoma rasti stiliaus arba jis nėra suderinamas.";
 
 /* Label of Zoom In button */
 "ZOOM_IN_LABEL" = "+";

--- a/platform/macos/sdk/sv.lproj/Localizable.strings
+++ b/platform/macos/sdk/sv.lproj/Localizable.strings
@@ -1,5 +1,17 @@
-﻿/* Accessibility title */
+﻿/* User-friendly error description */
+"LOAD_MAP_FAILED_DESC" = "Kartan kunde inte laddas på grund av ett okänt fel.";
+
+/* User-friendly error description */
+"LOAD_STYLE_FAILED_DESC" = "Kartan kunde inte laddas på grund av att stilen inte kunde laddas.";
+
+/* Accessibility title */
 "MAP_A11Y_TITLE" = "Mapbox";
+
+/* User-friendly error description */
+"PARSE_STYLE_FAILED_DESC" = "Kartan kunde inte laddas på grund av att stilen är skadad.";
+
+/* User-friendly error description */
+"STYLE_NOT_FOUND_DESC" = "Kartan kunde inte laddas på grund av att stilen saknas eller är inkompatibel.";
 
 /* Label of Zoom In button */
 "ZOOM_IN_LABEL" = "+";


### PR DESCRIPTION
This change formally puts the iOS SDK’s Localizable.stringsdict file under Transifex’s control. Although Transifex supports the stringsdict format, it doesn’t allow translators to customize the format. This change splits out a separate `level` key for the same format string and moves any prefixes and suffixes into the `level` and `count` keys. For now, each localization has been updated manually, but future updates will come from Transifex.

Along the way, various localizations have been updated on iOS and macOS, and a Swedish localization has been added to the Android SDK.

/cc @frederoni @langsmith