### PR TITLE
Add support for node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,29 +81,6 @@ matrix:
         - git fetch origin master:refs/remotes/origin/master
         - make check
 
-    # EGL - Node v4 - Clang 3.9 - Debug
-    - os: linux
-      sudo: required
-      dist: trusty
-      language: node
-      compiler: "egl-node4-clang39-debug"
-      env: BUILDTYPE=Debug _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
-      addons: *clang39
-      before_script:
-        - mapbox_install_logbt
-        - mapbox_start_xvfb
-        - mapbox_export_mesa_library_path
-      script:
-        - nvm install 4
-        - nvm use 4
-        - make node
-        - ./logbt -- $(scripts/mason.sh PREFIX apitrace VERSION 6a30de1)/bin/apitrace trace --api=egl -v make test-node
-      after_script:
-        - ccache --show-stats
-        - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
-      after_failure:
-        - aws s3 cp . s3://mapbox/mapbox-gl-native/render-tests/$TRAVIS_JOB_NUMBER --recursive --exclude "*" --include "*.trace"
-
     # EGL - Node v4 - Clang 3.9 - Release
     - os: linux
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ matrix:
         - git fetch origin master:refs/remotes/origin/master
         - make check
 
-    # EGL - Node - Clang 3.9 - Debug
+    # EGL - Node v4 - Clang 3.9 - Debug
     - os: linux
       sudo: required
       dist: trusty
@@ -104,7 +104,7 @@ matrix:
       after_failure:
         - aws s3 cp . s3://mapbox/mapbox-gl-native/render-tests/$TRAVIS_JOB_NUMBER --recursive --exclude "*" --include "*.trace"
 
-    # EGL - Node - Clang 3.9 - Release
+    # EGL - Node v4 - Clang 3.9 - Release
     - os: linux
       sudo: required
       dist: trusty
@@ -123,6 +123,58 @@ matrix:
       script:
         - nvm install 4
         - nvm use 4
+        - make node
+        - ./logbt -- $(scripts/mason.sh PREFIX apitrace VERSION 6a30de1)/bin/apitrace trace --api=egl -v make test-node
+      after_script:
+        - ccache --show-stats
+        - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
+      after_success:
+        - ./platform/node/scripts/after_success.sh
+      after_failure:
+        - aws s3 cp . s3://mapbox/mapbox-gl-native/render-tests/$TRAVIS_JOB_NUMBER --recursive --exclude "*" --include "*.trace"
+
+    # EGL - Node v6 - Clang 3.9 - Debug
+    - os: linux
+      sudo: required
+      dist: trusty
+      language: node
+      compiler: "egl-node6-clang39-debug"
+      env: BUILDTYPE=Debug _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
+      addons: *clang39
+      before_script:
+        - mapbox_install_logbt
+        - mapbox_start_xvfb
+        - mapbox_export_mesa_library_path
+      script:
+        - nvm install 6
+        - nvm use 6
+        - make node
+        - ./logbt -- $(scripts/mason.sh PREFIX apitrace VERSION 6a30de1)/bin/apitrace trace --api=egl -v make test-node
+      after_script:
+        - ccache --show-stats
+        - ./platform/node/scripts/after_script.sh ${TRAVIS_JOB_NUMBER}
+      after_failure:
+        - aws s3 cp . s3://mapbox/mapbox-gl-native/render-tests/$TRAVIS_JOB_NUMBER --recursive --exclude "*" --include "*.trace"
+
+    # EGL - Node v6 - Clang 3.9 - Release
+    - os: linux
+      sudo: required
+      dist: trusty
+      language: node
+      compiler: "egl-node6-clang39-release"
+      env: BUILDTYPE=Release _CXX=clang++-3.9 _CC=clang-3.9 WITH_EGL=1
+      addons: *clang39
+      before_script:
+        # fglrx causes the GLX extension to be unavailable
+        - sudo apt-get purge -qq fglrx
+        - export PACKAGE_JSON_VERSION=$(node -e "console.log(require('./package.json').version)")
+        - export PUBLISH=$([[ "${TRAVIS_TAG:-}" == "node-v${PACKAGE_JSON_VERSION}" ]] && echo true)
+        - mapbox_install_logbt
+        - mapbox_start_xvfb
+        - mapbox_export_mesa_library_path
+      script:
+        - nvm install 6
+        - nvm use 6
         - make node
         - ./logbt -- $(scripts/mason.sh PREFIX apitrace VERSION 6a30de1)/bin/apitrace trace --api=egl -v make test-node
       after_script:

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "module_path": "./lib/",
     "host": "https://mapbox-node-binary.s3.amazonaws.com",
     "remote_path": "./{name}/v{version}",
-    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+    "package_name": "{node_abi}-{platform}-{arch}-{configuration}.tar.gz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "module_path": "./lib/",
     "host": "https://mapbox-node-binary.s3.amazonaws.com",
     "remote_path": "./{name}/v{version}",
-    "package_name": "{node_abi}-{platform}-{arch}-{configuration}.tar.gz"
+    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
   }
 }

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -29,18 +29,54 @@ shortcuts:
     - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
 
 workflows:
+    primary:
+      steps:
+      - script:
+          title: Test node v4
+          inputs:
+          - content: |-
+              #!/bin/bash
+              set -eu -o pipefail
+              brew update
+              brew unlink node
+              brew install cmake awscli node@4
+              brew link node@4 --force
+              gem install xcpretty --no-rdoc --no-ri
+              make test-node || RESULT=$?
+              ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
+              exit ${RESULT:-0}
+      - slack: *slack
+
+    publish:
+      steps:
+      - script:
+          title: Publish node v4
+          inputs:
+          - content: |-
+              #!/bin/bash
+              set -eu -o pipefail
+              brew update
+              brew unlink node
+              brew install cmake awscli node@4
+              brew link node@4 --force
+              gem install xcpretty --no-rdoc --no-ri
+              export BUILDTYPE=Release
+              export PUBLISH=true
+              make test-node
+              ./platform/node/scripts/after_success.sh
+      - slack: *slack
   primary:
     steps:
     - script:
-        title: Test
+        title: Test node v6
         inputs:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
             brew update
             brew unlink node
-            brew install cmake awscli node@4
-            brew link node@4 --force
+            brew install cmake awscli node@6
+            brew link node@6 --force
             gem install xcpretty --no-rdoc --no-ri
             make test-node || RESULT=$?
             ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
@@ -50,15 +86,15 @@ workflows:
   publish:
     steps:
     - script:
-        title: Publish
+        title: Publish node v6
         inputs:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
             brew update
             brew unlink node
-            brew install cmake awscli node@4
-            brew link node@4 --force
+            brew install cmake awscli node@6
+            brew link node@6 --force
             gem install xcpretty --no-rdoc --no-ri
             export BUILDTYPE=Release
             export PUBLISH=true

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -66,10 +66,9 @@ workflows:
             gem install xcpretty --no-rdoc --no-ri
             export BUILDTYPE=Release
             export PUBLISH=true
-            make test-node
+            make test-node && ./platform/node/scripts/after_success.sh
             brew unlink node@4
             brew link --overwrite node@6 --force
             make clean
-            make test-node
-            ./platform/node/scripts/after_success.sh
+            make test-node && ./platform/node/scripts/after_success.sh
     - slack: *slack

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -32,16 +32,19 @@ workflows:
   primary:
     steps:
     - script:
-        title: Test node v4
+        title: Test
         inputs:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
             brew update
             brew unlink node
-            brew install cmake awscli node@4
+            brew install cmake awscli node@4 node@6
             brew link node@4 --force
             gem install xcpretty --no-rdoc --no-ri
+            make test-node || RESULT=$?
+            brew unlink node
+            brew link node@6 --force
             make test-node || RESULT=$?
             ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
             exit ${RESULT:-0}
@@ -50,55 +53,21 @@ workflows:
   publish:
     steps:
     - script:
-        title: Publish node v4
+        title: Publish
         inputs:
         - content: |-
             #!/bin/bash
             set -eu -o pipefail
             brew update
             brew unlink node
-            brew install cmake awscli node@4
+            brew install cmake awscli node@4 node@6
             brew link node@4 --force
             gem install xcpretty --no-rdoc --no-ri
             export BUILDTYPE=Release
             export PUBLISH=true
             make test-node
-            ./platform/node/scripts/after_success.sh
-    - slack: *slack
-
-  primary:
-    steps:
-    - script:
-        title: Test node v6
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            brew update
             brew unlink node
-            brew install cmake awscli node@6
             brew link node@6 --force
-            gem install xcpretty --no-rdoc --no-ri
-            make test-node || RESULT=$?
-            ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
-            exit ${RESULT:-0}
-    - slack: *slack
-
-  publish:
-    steps:
-    - script:
-        title: Publish node v6
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eu -o pipefail
-            brew update
-            brew unlink node
-            brew install cmake awscli node@6
-            brew link node@6 --force
-            gem install xcpretty --no-rdoc --no-ri
-            export BUILDTYPE=Release
-            export PUBLISH=true
             make test-node
             ./platform/node/scripts/after_success.sh
     - slack: *slack

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -45,6 +45,7 @@ workflows:
             make test-node || RESULT=$?
             brew unlink node@4
             brew link --overwrite node@6  --force
+            make clean
             make test-node || RESULT=$?
             ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
             exit ${RESULT:-0}
@@ -68,6 +69,7 @@ workflows:
             make test-node
             brew unlink node@4
             brew link --overwrite node@6 --force
+            make clean
             make test-node
             ./platform/node/scripts/after_success.sh
     - slack: *slack

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -29,42 +29,43 @@ shortcuts:
     - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
 
 workflows:
-    primary:
-      steps:
-      - script:
-          title: Test node v4
-          inputs:
-          - content: |-
-              #!/bin/bash
-              set -eu -o pipefail
-              brew update
-              brew unlink node
-              brew install cmake awscli node@4
-              brew link node@4 --force
-              gem install xcpretty --no-rdoc --no-ri
-              make test-node || RESULT=$?
-              ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
-              exit ${RESULT:-0}
-      - slack: *slack
+  primary:
+    steps:
+    - script:
+        title: Test node v4
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            brew update
+            brew unlink node
+            brew install cmake awscli node@4
+            brew link node@4 --force
+            gem install xcpretty --no-rdoc --no-ri
+            make test-node || RESULT=$?
+            ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
+            exit ${RESULT:-0}
+    - slack: *slack
 
-    publish:
-      steps:
-      - script:
-          title: Publish node v4
-          inputs:
-          - content: |-
-              #!/bin/bash
-              set -eu -o pipefail
-              brew update
-              brew unlink node
-              brew install cmake awscli node@4
-              brew link node@4 --force
-              gem install xcpretty --no-rdoc --no-ri
-              export BUILDTYPE=Release
-              export PUBLISH=true
-              make test-node
-              ./platform/node/scripts/after_success.sh
-      - slack: *slack
+  publish:
+    steps:
+    - script:
+        title: Publish node v4
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eu -o pipefail
+            brew update
+            brew unlink node
+            brew install cmake awscli node@4
+            brew link node@4 --force
+            gem install xcpretty --no-rdoc --no-ri
+            export BUILDTYPE=Release
+            export PUBLISH=true
+            make test-node
+            ./platform/node/scripts/after_success.sh
+    - slack: *slack
+
   primary:
     steps:
     - script:

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -44,7 +44,7 @@ workflows:
             gem install xcpretty --no-rdoc --no-ri
             make test-node || RESULT=$?
             brew unlink node@4
-            brew link --overwrite node@6
+            brew link --overwrite node@6  --force
             make test-node || RESULT=$?
             ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
             exit ${RESULT:-0}
@@ -67,7 +67,7 @@ workflows:
             export PUBLISH=true
             make test-node
             brew unlink node@4
-            brew link --overwrite node@6
+            brew link --overwrite node@6 --force
             make test-node
             ./platform/node/scripts/after_success.sh
     - slack: *slack

--- a/platform/node/bitrise.yml
+++ b/platform/node/bitrise.yml
@@ -43,8 +43,8 @@ workflows:
             brew link node@4 --force
             gem install xcpretty --no-rdoc --no-ri
             make test-node || RESULT=$?
-            brew unlink node
-            brew link node@6 --force
+            brew unlink node@4
+            brew link --overwrite node@6
             make test-node || RESULT=$?
             ./platform/node/scripts/after_script.sh ${BITRISE_BUILD_NUMBER}
             exit ${RESULT:-0}
@@ -66,8 +66,8 @@ workflows:
             export BUILDTYPE=Release
             export PUBLISH=true
             make test-node
-            brew unlink node
-            brew link node@6 --force
+            brew unlink node@4
+            brew link --overwrite node@6
             make test-node
             ./platform/node/scripts/after_success.sh
     - slack: *slack


### PR DESCRIPTION
It's time to add support for node v6. I think this should be fairly straightforward quest:

- [x] Verify no dependencies need to be updated for v6
- [x] Update test matrix to begin testing both node v4 and v6
- [ ] Merge this
- [ ] Add new release with v6 binaries

/cc @tmpsantos @jfirebaugh @springmeyer 