### PR TITLE
[core] Omnibus Style::update method

### DIFF
--- a/cmake/core-files.cmake
+++ b/cmake/core-files.cmake
@@ -231,6 +231,7 @@ set(MBGL_CORE_FILES
     src/mbgl/renderer/tile_pyramid.cpp
     src/mbgl/renderer/tile_pyramid.hpp
     src/mbgl/renderer/transitioning_property.hpp
+    src/mbgl/renderer/update_parameters.hpp
 
     # renderer/sources
     src/mbgl/renderer/sources/render_geojson_source.cpp

--- a/src/mbgl/map/map.cpp
+++ b/src/mbgl/map/map.cpp
@@ -12,7 +12,7 @@
 #include <mbgl/style/light.hpp>
 #include <mbgl/style/observer.hpp>
 #include <mbgl/style/transition_options.hpp>
-#include <mbgl/renderer/tile_parameters.hpp>
+#include <mbgl/renderer/update_parameters.hpp>
 #include <mbgl/renderer/painter.hpp>
 #include <mbgl/renderer/render_source.hpp>
 #include <mbgl/storage/file_source.hpp>
@@ -243,28 +243,17 @@ void Map::Impl::render(View& view) {
         annotationManager->updateData();
     }
 
-    if (updateFlags & Update::Classes) {
-        style->cascade(timePoint, mode);
-    }
-
-    if (updateFlags & Update::Classes || updateFlags & Update::RecalculateStyle) {
-        style->recalculate(transform.getZoom(), timePoint, mode);
-    }
-
-    if (updateFlags & Update::Layout) {
-        style->relayout();
-    }
-
-    TileParameters parameters(pixelRatio,
-                              debugOptions,
-                              transform.getState(),
-                              scheduler,
-                              fileSource,
-                              mode,
-                              *annotationManager,
-                              *style);
-
-    style->updateTiles(parameters);
+    style->update({
+        mode,
+        updateFlags,
+        pixelRatio,
+        debugOptions,
+        timePoint,
+        transform.getState(),
+        scheduler,
+        fileSource,
+        *annotationManager
+    });
 
     updateFlags = Update::Nothing;
 

--- a/src/mbgl/map/update.hpp
+++ b/src/mbgl/map/update.hpp
@@ -10,8 +10,7 @@ enum class Update {
     Classes                   = 1 << 2,
     RecalculateStyle          = 1 << 3,
     AnnotationStyle           = 1 << 6,
-    AnnotationData            = 1 << 7,
-    Layout                    = 1 << 8
+    AnnotationData            = 1 << 7
 };
 
 constexpr Update operator|(Update lhs, Update rhs) {

--- a/src/mbgl/renderer/property_evaluation_parameters.hpp
+++ b/src/mbgl/renderer/property_evaluation_parameters.hpp
@@ -8,13 +8,15 @@ namespace mbgl {
 class PropertyEvaluationParameters {
 public:
     explicit PropertyEvaluationParameters(float z_)
-        : z(z_) {}
-
-    PropertyEvaluationParameters(float z_,
-                          TimePoint now_,
-                          ZoomHistory zoomHistory_,
-                          Duration defaultFadeDuration_)
         : z(z_),
+          now(Clock::time_point::max()),
+          zoomHistory(),
+          defaultFadeDuration(0) {}
+
+    PropertyEvaluationParameters(ZoomHistory zoomHistory_,
+                          TimePoint now_,
+                          Duration defaultFadeDuration_)
+        : z(zoomHistory_.lastZoom),
           now(std::move(now_)),
           zoomHistory(std::move(zoomHistory_)),
           defaultFadeDuration(std::move(defaultFadeDuration_)) {}

--- a/src/mbgl/renderer/update_parameters.hpp
+++ b/src/mbgl/renderer/update_parameters.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <mbgl/map/mode.hpp>
+#include <mbgl/map/update.hpp>
+
+namespace mbgl {
+
+class TransformState;
+class Scheduler;
+class FileSource;
+class AnnotationManager;
+
+class UpdateParameters {
+public:
+    const MapMode mode;
+    const Update updateFlags;
+    const float pixelRatio;
+    const MapDebugOptions debugOptions;
+    const TimePoint timePoint;
+    const TransformState& transformState;
+    Scheduler& scheduler;
+    FileSource& fileSource;
+    AnnotationManager& annotationManager;
+};
+
+} // namespace mbgl

--- a/src/mbgl/style/style.hpp
+++ b/src/mbgl/style/style.hpp
@@ -36,7 +36,7 @@ class RenderedQueryOptions;
 class Scheduler;
 class RenderLayer;
 class RenderSource;
-class TileParameters;
+class UpdateParameters;
 
 namespace style {
 
@@ -59,13 +59,7 @@ public:
 
     bool isLoaded() const;
 
-    // Fetch the tiles needed by the current viewport and emit a signal when
-    // a tile is ready so observers can render the tile.
-    void updateTiles(const TileParameters&);
-
-    void relayout();
-    void cascade(const TimePoint&, MapMode);
-    void recalculate(float z, const TimePoint&, MapMode);
+    void update(const UpdateParameters&);
 
     bool hasTransitions() const;
 

--- a/src/mbgl/tile/geometry_tile_worker.cpp
+++ b/src/mbgl/tile/geometry_tile_worker.cpp
@@ -256,10 +256,7 @@ static std::vector<std::unique_ptr<RenderLayer>> toRenderLayers(const std::vecto
         });
 
         renderLayers.back()->evaluate(PropertyEvaluationParameters {
-            zoom,
-            Clock::time_point::max(),
-            ZoomHistory(),
-            Duration(0)
+            zoom
         });
     }
     return renderLayers;

--- a/test/style/paint_property.test.cpp
+++ b/test/style/paint_property.test.cpp
@@ -8,10 +8,12 @@ using namespace mbgl::style;
 using namespace std::literals::chrono_literals;
 
 float evaluate(TransitioningProperty<PropertyValue<float>>& property, Duration delta = Duration::zero()) {
+    ZoomHistory zoomHistory;
+    zoomHistory.update(0, TimePoint::min() + delta);
+
     PropertyEvaluationParameters parameters {
-        0,
+        zoomHistory,
         TimePoint::min() + delta,
-        ZoomHistory(),
         Duration::zero()
     };
 
@@ -24,10 +26,12 @@ float evaluate(TransitioningProperty<PropertyValue<float>>& property, Duration d
 }
 
 PossiblyEvaluatedPropertyValue<float> evaluate(TransitioningProperty<DataDrivenPropertyValue<float>>& property, Duration delta = Duration::zero()) {
+    ZoomHistory zoomHistory;
+    zoomHistory.update(0, TimePoint::min() + delta);
+
     PropertyEvaluationParameters parameters {
-        0,
+        zoomHistory,
         TimePoint::min() + delta,
-        ZoomHistory(),
         Duration::zero()
     };
     


### PR DESCRIPTION
Combine `Style::cascade`, `recalculate`, `relayout`, and `updateTiles` into a single method. This allows multiple loops over sources and layers to be consolidated and prepares for additional Style-Map decoupling: rather than tracking pending updates via a set of `Update` flags held by the Map and passed to the Style, the Style can use its own data to determine what to update. To start out with, this replaces `Update::Layout` with use of the `UpdateBatch::sourceIDs` that the Style already tracks.