### PR TITLE
[core] Reduce use of RecalculateStyle

### DIFF
--- a/src/mbgl/map/transform.hpp
+++ b/src/mbgl/map/transform.hpp
@@ -4,7 +4,6 @@
 #include <mbgl/map/map_observer.hpp>
 #include <mbgl/map/mode.hpp>
 #include <mbgl/map/transform_state.hpp>
-#include <mbgl/map/update.hpp>
 #include <mbgl/util/chrono.hpp>
 #include <mbgl/util/geo.hpp>
 #include <mbgl/util/noncopyable.hpp>
@@ -128,7 +127,7 @@ public:
 
     // Transitions
     bool inTransition() const;
-    Update updateTransitions(const TimePoint& now);
+    void updateTransitions(const TimePoint& now);
     TimePoint getTransitionStart() const { return transitionStart; }
     Duration getTransitionDuration() const { return transitionDuration; }
     void cancelTransitions();
@@ -153,12 +152,12 @@ private:
 
     void startTransition(const CameraOptions&,
                          const AnimationOptions&,
-                         std::function<Update(double)>,
+                         std::function<void(double)>,
                          const Duration&);
 
     TimePoint transitionStart;
     Duration transitionDuration;
-    std::function<Update(const TimePoint)> transitionFrameFn;
+    std::function<void(const TimePoint)> transitionFrameFn;
     std::function<void()> transitionFinishFn;
 };
 

--- a/src/mbgl/map/zoom_history.hpp
+++ b/src/mbgl/map/zoom_history.hpp
@@ -12,25 +12,30 @@ struct ZoomHistory {
     TimePoint lastIntegerZoomTime;
     bool first = true;
 
-    void update(float z, const TimePoint& now) {
+    bool update(float z, const TimePoint& now) {
         if (first) {
             first = false;
-
             lastIntegerZoom = std::floor(z);
             lastIntegerZoomTime = TimePoint(Duration::zero());
             lastZoom = z;
+            return true;
+        } else {
+            if (std::floor(lastZoom) < std::floor(z)) {
+                lastIntegerZoom = std::floor(z);
+                lastIntegerZoomTime = now;
+            } else if (std::floor(lastZoom) > std::floor(z)) {
+                lastIntegerZoom = std::floor(z + 1);
+                lastIntegerZoomTime = now;
+            }
+
+            if (z != lastZoom) {
+                lastZoom = z;
+                return true;
+            }
+
+            return false;
         }
-
-        if (std::floor(lastZoom) < std::floor(z)) {
-            lastIntegerZoom = std::floor(z);
-            lastIntegerZoomTime = now;
-
-        } else if (std::floor(lastZoom) > std::floor(z)) {
-            lastIntegerZoom = std::floor(z + 1);
-            lastIntegerZoomTime = now;
-        }
-
-        lastZoom = z;
     }
 };
+
 } // namespace mbgl


### PR DESCRIPTION
Followup to #8888, elaborating on:

> rather than tracking pending updates via a set of Update flags held by the Map and passed to the Style, the Style can use its own data to determine what to update

* Don't use `RecalculateStyle` to track zoom changes. Instead, `Style::update` can use the zoom history to check for a change in zoom from the previous frame.
* Don't use `RecalculateStyle` to track active property transitions. Style already knows which layers/light have an active transition, and can re-evaluate only those that do.

This leaves layer property changes as the only use of `RecalculateStyle`.