### PR TITLE
Revert "[Qt] Don't regen BackendScope on every QMapboxGL::render() call"

### DIFF
--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1510,9 +1510,7 @@ void QMapboxGL::render()
 #endif
 
     // The OpenGL implementation automatically enables the OpenGL context for us.
-    if (!d_ptr->backendScope) {
-        d_ptr->backendScope = std::make_unique<mbgl::BackendScope>(*d_ptr, mbgl::BackendScope::ScopeType::Implicit);
-    }
+    mbgl::BackendScope scope { *d_ptr, mbgl::BackendScope::ScopeType::Implicit };
 
     d_ptr->dirty = false;
     d_ptr->mapObj->render(*d_ptr);

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -55,7 +55,6 @@ public:
     std::unique_ptr<mbgl::DefaultFileSource> fileSourceObj;
     std::shared_ptr<mbgl::ThreadPool> threadPool;
     std::unique_ptr<mbgl::Map> mapObj;
-    std::unique_ptr<mbgl::BackendScope> backendScope;
 
     bool dirty { false };
 


### PR DESCRIPTION
This reverts commit 806da5d940aed7021f921ab98b9ae8e4e364f732 as per discussion in https://github.com/mapbox/mapbox-gl-native/pull/8887#issuecomment-299202658.