### PR TITLE
[core] Reset observers of removed Sources and Layers

### DIFF
--- a/src/mbgl/style/layer_impl.cpp
+++ b/src/mbgl/style/layer_impl.cpp
@@ -12,7 +12,7 @@ std::unique_ptr<Layer> Layer::Impl::copy(const std::string& id_,
 }
 
 void Layer::Impl::setObserver(LayerObserver* observer_) {
-    observer = observer_;
+    observer = observer_ ? observer_ : &nullObserver;
 }
 
 } // namespace style

--- a/src/mbgl/style/source_impl.cpp
+++ b/src/mbgl/style/source_impl.cpp
@@ -20,7 +20,7 @@ void Source::Impl::dumpDebugLogs() const {
 }
 
 void Source::Impl::setObserver(SourceObserver* observer_) {
-    observer = observer_;
+    observer = observer_ ? observer_ : &nullObserver;
 }
 
 } // namespace style

--- a/src/mbgl/style/style.cpp
+++ b/src/mbgl/style/style.cpp
@@ -192,6 +192,7 @@ std::unique_ptr<Source> Style::removeSource(const std::string& id) {
     });
 
     auto source = std::move(*it);
+    source->baseImpl->setObserver(nullptr);
     sources.erase(it);
     updateBatch.sourceIDs.erase(id);
 
@@ -264,6 +265,7 @@ std::unique_ptr<Layer> Style::removeLayer(const std::string& id) {
         customLayer->impl->deinitialize();
     }
 
+    layer->baseImpl->setObserver(nullptr);
     layers.erase(it);
     removeRenderLayer(id);
     return layer;


### PR DESCRIPTION
This ensures that the observer is not an invalid reference if the removed Source/Layer is retained, but the Style is deallocated.

This would have caused memory corruption in the following sequence:

1. Remove a source/layer from the style, retaining a reference
2. Change the style URL
3. Mutate the source/layer via the retained reference (e.g. `GeoJSONSource::setURL`, `Layer::setFilter`, or any other setter)
