### PR TITLE
[android] - show error message when no browser is installed 

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
+++ b/platform/android/MapboxGLAndroidSDK/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="mapbox_attributionTelemetryPositive">Agree</string>
     <string name="mapbox_attributionTelemetryNegative">Disagree</string>
     <string name="mapbox_attributionTelemetryNeutral">More info</string>
+    <string name="mapbox_attributionErrorNoBrowser">No web browser installed on device, can\'t open web page.</string>
     <string name="mapbox_offline_error_region_definition_invalid">Provided OfflineRegionDefinition doesn\'t fit the world bounds: %s</string>
     <string name="mapbox_telemetrySettings">Telemetry Settings</string>
     <string name="mapbox_telemetryLink" translatable="false">https://www.mapbox.com/telemetry/</string>


### PR DESCRIPTION
Closes #8899, this PR refactors the code to have a try/catch block around the `Intent.ACTION_VIEW` for browser intents. Capturing from the issue that it's possible to run in ActivityNotFound exception if you don't have a browser installed.