### PR TITLE
[ios] Check for NaN when calculating scale bar width

### DIFF
--- a/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
+++ b/platform/ios/ios.xcodeproj/xcshareddata/xcschemes/iosapp.xcscheme
@@ -61,13 +61,6 @@
             ReferencedContainer = "container:ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/platform/ios/src/MGLScaleBar.mm
+++ b/platform/ios/src/MGLScaleBar.mm
@@ -161,7 +161,8 @@ static const CGFloat MGLFeetPerMeter = 3.28084;
 }
 
 - (CGFloat)actualWidth {
-    return self.row.distance / [self unitsPerPoint];
+    CGFloat width = self.row.distance / [self unitsPerPoint];
+    return !isnan(width) ? width : 0;
 }
 
 - (CGFloat)maximumWidth {


### PR DESCRIPTION
Fixes an issue where the scale bar would report its width as `NaN` when hidden, which throws an exception on iOS 8 & 9 (and a warning in iOS 10).

We didn’t see the console warning in iosapp because `OS_ACTIVITY_MODE=disable` (#6382) was still being set, which hid this important message. Xcode 8’s spew has been fixed, so it’s time to remove this.

Fixes #8854 and #8909.

/cc @frederoni