### PR TITLE
[android] - keep offline observer when timeout occurs

### DIFF
--- a/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
+++ b/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/offline/OfflineRegion.java
@@ -4,6 +4,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.storage.FileSource;
 
@@ -205,7 +206,7 @@ public class OfflineRegion {
 
   /**
    * Constructor
-   *
+   * <p>
    * For JNI use only, to create a new offline region, use
    * {@link OfflineManager#createOfflineRegion} instead.
    */
@@ -247,7 +248,7 @@ public class OfflineRegion {
    *
    * @param observer the observer to be notified
    */
-  public void setObserver(@NonNull final OfflineRegionObserver observer) {
+  public void setObserver(@Nullable final OfflineRegionObserver observer) {
     setOfflineRegionObserver(new OfflineRegionObserver() {
       @Override
       public void onStatusChanged(final OfflineRegionStatus status) {
@@ -255,7 +256,9 @@ public class OfflineRegion {
           getHandler().post(new Runnable() {
             @Override
             public void run() {
-              observer.onStatusChanged(status);
+              if (observer != null) {
+                observer.onStatusChanged(status);
+              }
             }
           });
         }
@@ -267,7 +270,9 @@ public class OfflineRegion {
           getHandler().post(new Runnable() {
             @Override
             public void run() {
-              observer.onError(error);
+              if (observer != null) {
+                observer.onError(error);
+              }
             }
           });
         }
@@ -279,7 +284,9 @@ public class OfflineRegion {
           getHandler().post(new Runnable() {
             @Override
             public void run() {
-              observer.mapboxTileCountLimitExceeded(limit);
+              if (observer != null) {
+                observer.mapboxTileCountLimitExceeded(limit);
+              }
             }
           });
         }

--- a/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
+++ b/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/offline/OfflineActivity.java
@@ -274,22 +274,20 @@ public class OfflineActivity extends AppCompatActivity
         }
 
         // Debug
-        Timber.d(String.format("%s/%s resources; %s bytes downloaded.",
+        Timber.d("%s/%s resources; %s bytes downloaded.",
           String.valueOf(status.getCompletedResourceCount()),
           String.valueOf(status.getRequiredResourceCount()),
-          String.valueOf(status.getCompletedResourceSize())));
+          String.valueOf(status.getCompletedResourceSize()));
       }
 
       @Override
       public void onError(OfflineRegionError error) {
-        Timber.e("onError reason: " + error.getReason());
-        Timber.e("onError message: " + error.getMessage());
-        offlineRegion.setObserver(null);
+        Timber.e("onError: %s, %s", error.getReason(), error.getMessage());
       }
 
       @Override
       public void mapboxTileCountLimitExceeded(long limit) {
-        Timber.e("Mapbox tile count limit exceeded: " + limit);
+        Timber.e("Mapbox tile count limit exceeded: %s", limit);
       }
     });
 


### PR DESCRIPTION
Closes #8786 
- keep offline observer when timeout occurs (test app code)
 - make observer param nulllable, resetting observer is valid (eg. when download finished downloading)
 - add null checking to observer 
 - fixup log messages, timber has formatting build in