### PR TITLE
[node] bump version, add changelog entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-native",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Renders map tiles with Mapbox GL",
   "keywords": [
     "mapbox",

--- a/platform/node/CHANGELOG.md
+++ b/platform/node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.5.1 - May 8, 2017
+
+- Adds Node v6 binaries. **Note, Node v4 binaries will be removed on August 1st.** ([#8884](https://github.com/mapbox/mapbox-gl-native/pull/8884))
+- Adds linux debug binaries ([#8865](https://github.com/mapbox/mapbox-gl-native/pull/8865))
+
 # 3.5.0 - April 20, 2017
 
 - Fixed an issue where raster tiles that were not found caused `map.render()` to hang ([#8769](https://github.com/mapbox/mapbox-gl-native/pull/8769))


### PR DESCRIPTION
Note, Node v4 binaries will be removed on August 1st.

/cc @tmpsantos @jfirebaugh 