### PR TITLE
[build] Suppress GLFW redefining GLAPIENTRY error

### DIFF
--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -11,6 +11,17 @@ target_sources(mbgl-glfw
     PRIVATE platform/default/mbgl/util/default_styles.cpp
 )
 
+# Our GL implementation is internal to mbgl-core, which causes the GL header to
+# be included after GLFW's own header. They both attempt to define GLAPIENTRY,
+# but unfortunately the GL header doesn't check if it was previously defined,
+# causing a macro redefinition compiler error.
+# There is no particular compiler warning flag to ignore this check on GCC
+# neither it does accept ignoring '-Werror' via diagnostics pragmas. We can
+# only suppress this by either replacing the header path inclusion from -I to
+# -isystem, or completely suppressing errors. Until the former solution is not
+# available, we'll suppress the errors from that definition file.
+set_source_files_properties(platform/glfw/glfw_view.cpp PROPERTIES COMPILE_FLAGS -Wno-error)
+
 target_compile_options(mbgl-glfw
     PRIVATE -fvisibility-inlines-hidden
 )

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -10,6 +10,13 @@
 #include <mbgl/map/backend_scope.hpp>
 #include <mbgl/map/camera.hpp>
 
+#if MBGL_USE_GLES2
+#define GLFW_INCLUDE_ES2
+#endif // MBGL_USE_GLES2
+
+#define GL_GLEXT_PROTOTYPES
+#include <GLFW/glfw3.h>
+
 #include <cassert>
 #include <cstdlib>
 

--- a/platform/glfw/glfw_view.hpp
+++ b/platform/glfw/glfw_view.hpp
@@ -7,11 +7,7 @@
 #include <mbgl/util/timer.hpp>
 #include <mbgl/util/geometry.hpp>
 
-#if MBGL_USE_GLES2
-#define GLFW_INCLUDE_ES2
-#endif
-#define GL_GLEXT_PROTOTYPES
-#include <GLFW/glfw3.h>
+struct GLFWwindow;
 
 class GLFWView : public mbgl::View, public mbgl::Backend {
 public:


### PR DESCRIPTION
Workaround for fixing the GLFW build on Linux until we fix https://github.com/mapbox/mason/issues/406.