### PR TITLE
[android] - build SNAPSHOT from release branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -133,4 +133,4 @@ jobs:
       - deploy:
           name: Publish to Maven
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then make run-android-upload-archives ; fi
+            if [ "${CIRCLE_BRANCH}" == "release-ios-v3.6.0-android-v5.1.0" ]; then make run-android-upload-archives ; fi


### PR DESCRIPTION
This PR changes Circle CI configuration to build a SNAPSHOT when a PR is merged to `release-ios-v3.6.0-android-v5.1.0` instead of `master`.